### PR TITLE
fix(transcript): clone round-indexed records in snapshotFromMemory

### DIFF
--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1168,8 +1168,11 @@ export class StreamSnapshotStore {
   /**
    * Assemble the snapshot from already-hydrated in-memory accumulators.
    * Clones the round-indexed records (same as the public getOutputFiles/
-   * getMissingOutputs/getCompileFailures accessors) so a caller mutating the
-   * returned snapshot can't corrupt these live accumulators.
+   * getMissingOutputs/getCompileFailures accessors) so a caller reassigning
+   * or pushing/splicing a returned per-round array can't corrupt these live
+   * accumulators. Per cloneRoundIndexed's own contract, item objects
+   * themselves are not cloned — they're treated as immutable value objects,
+   * same as every other schema-derived type in this codebase.
    */
   private snapshotFromMemory(streamId: StreamTabId): StreamSnapshot {
     return assembleSnapshot(streamId, {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1165,13 +1165,18 @@ export class StreamSnapshotStore {
     return assembleSnapshot(streamId, await readStreamData(this.kv(streamId)));
   }
 
-  /** Assemble the snapshot from already-hydrated in-memory accumulators. */
+  /**
+   * Assemble the snapshot from already-hydrated in-memory accumulators.
+   * Clones the round-indexed records (same as the public getOutputFiles/
+   * getMissingOutputs/getCompileFailures accessors) so a caller mutating the
+   * returned snapshot can't corrupt these live accumulators.
+   */
   private snapshotFromMemory(streamId: StreamTabId): StreamSnapshot {
     return assembleSnapshot(streamId, {
       meta: this.meta.get(streamId),
-      outputFiles: this.outputFiles.get(streamId) ?? {},
-      missingOutputs: this.missingOutputs.get(streamId) ?? {},
-      compileFailures: this.compileFailures.get(streamId) ?? {},
+      outputFiles: cloneRoundIndexed(this.outputFiles.get(streamId)),
+      missingOutputs: cloneRoundIndexed(this.missingOutputs.get(streamId)),
+      compileFailures: cloneRoundIndexed(this.compileFailures.get(streamId)),
       usage: this.usage.get(streamId) ?? new Map(),
       usageUnparsed: this.usageUnparsed.get(streamId) ?? new Map(),
       workPlan: this.getWorkPlan(streamId),


### PR DESCRIPTION
Closes #7546.

## What the issue flagged

`snapshotFromMemory` (`StreamSnapshotStore.ts:1169`) passed `this.outputFiles`/`missingOutputs`/`compileFailures` directly to `assembleSnapshot`, unlike the public `getOutputFiles`/`getMissingOutputs`/`getCompileFailures` getters, which already wrap the same accesses in `cloneRoundIndexed()` specifically to prevent a caller mutating the returned value from reaching back into the live in-memory accumulators.

## What I verified before fixing

I checked whether this is currently exploitable, since `assembleSnapshot` validates through `StreamSnapshotSchema.parse()` before returning. Empirically (a standalone check against this repo's zod), `z.record(_, z.array(ItemSchema)).parse()` returns **neither** the same array reference **nor** the same item-object references as its input — Zod v4 fully reconstructs both. I also added a regression test exercising `read()` on a seeded stream, mutated the returned snapshot's array, and confirmed no corruption occurred **even without this fix** — then removed that test since it couldn't actually distinguish fixed from unfixed behavior (it passed identically either way), which would have been a misleading regression test.

**Conclusion:** this specific mutation-corruption path isn't currently reproducible through `read()`, because `assembleSnapshot`'s zod validation already breaks the reference chain. This PR is defense-in-depth / consistency with the getters' established convention, not a fix for an actively-exploitable bug — but it's the right change regardless: it stops `snapshotFromMemory` from being the one caller that relies on `assembleSnapshot`'s specific zod-parse behavior to stay safe, which the getters already independently decided not to do. If that schema ever changes (e.g., a leaner validation path that skips reconstruction), this path would otherwise become exploitable with no test able to catch it in advance.

## Fix

`snapshotFromMemory` now wraps all three round-indexed accesses in `cloneRoundIndexed()`, matching the getters exactly. `cloneRoundIndexed` already handles `undefined` (returns `{}`), so this also drops the redundant `?? {}` fallbacks.

## Verification

- `tsc --noEmit` (root) and `tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` — 28/28 passing.
- `eslint` on the changed file — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path defensive copying only; no persistence or mutation logic changes, and behavior for typical `read()` callers should stay the same.
> 
> **Overview**
> **`snapshotFromMemory`** now passes **`cloneRoundIndexed()`**-wrapped copies of `outputFiles`, `missingOutputs`, and `compileFailures` into `assembleSnapshot`, instead of handing over the live in-memory maps directly.
> 
> That matches the existing **`getOutputFiles` / `getMissingOutputs` / `getCompileFailures`** pattern so callers cannot mutate returned per-round arrays and corrupt the store’s accumulators. `cloneRoundIndexed` already treats `undefined` as `{}`, so the redundant `?? {}` fallbacks were removed. Documentation was expanded to spell out the cloning contract.
> 
> This is **defense-in-depth**: `read()` → `assembleSnapshot`’s Zod parse already reconstructs records today, but this path no longer depends on that behavior staying true if validation ever changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9b734c9278c6e0d3d7fcdd4762dcafd915305c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->