### PR TITLE
refactor(settings): move profile wiring into SettingsViewHost

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -6,9 +6,6 @@ import {
   isAllowedLatexInstallCommand,
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
-import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
-import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
-import { buildProviderKeyStatuses } from '@controllers/settingsView/SettingsProfileController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import {
@@ -60,7 +57,6 @@ import {
   dispatchSettingsViewInbound,
   SettingsViewInboundMessageSchema,
   type LatexSettingsStatus,
-  type ProviderKeyStatus,
   type ReasoningLevel,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
@@ -259,44 +255,74 @@ export function createDesktopSettingsIpc(
         await options.showInfoMessage?.(message);
       },
     },
-  });
-  const profileKeyController = new SettingsProfileKeyController({
-    prompt: {
-      input: (input) =>
-        options.promptSecret?.({
-          title: input.title ?? input.prompt ?? 'Set API key',
-          prompt: input.prompt ?? 'Enter API key',
-        }) ?? Promise.resolve(undefined),
-      info: async (message) => {
-        await options.showInfoMessage?.(message);
-        return undefined;
+    profile: {
+      globalState,
+      providerIds: API_PROVIDERS,
+      providerVscodeSettings: {},
+      providerDisplayNames: PROVIDER_DISPLAY_NAMES,
+      providerKeyUrls: PROVIDER_URLS,
+      loadProviderKeyStatuses: () =>
+        loadApiKeyStatusMap(secrets, API_PROVIDERS),
+      getProviderDisplayName,
+      getProviderKeyUrl,
+      getProviderStreaming,
+      getProviderEndpoint,
+      supportsCustomEndpoint,
+      getConfig: (key, defaultValue) =>
+        getConfigProvider().get(key, defaultValue),
+      updateConfig: (key, value) =>
+        getConfigProvider().update(key, value, 'global'),
+      setUseIncludedModelAccess: (enabled) =>
+        options.setApiAccessMode?.(enabled ? 'included' : 'personal') ??
+        Promise.resolve(),
+      invalidateModelOptionsCache,
+    },
+    profileKey: {
+      prompt: {
+        input: (input) =>
+          options.promptSecret?.({
+            title: input.title ?? input.prompt ?? 'Set API key',
+            prompt: input.prompt ?? 'Enter API key',
+          }) ?? Promise.resolve(undefined),
+        info: async (message) => {
+          await options.showInfoMessage?.(message);
+          return undefined;
+        },
+        confirm: (message, promptOptions) =>
+          options.confirmAction?.(message, promptOptions?.confirmLabel) ??
+          Promise.resolve(true),
       },
-      confirm: (message, promptOptions) =>
-        options.confirmAction?.(message, promptOptions?.confirmLabel) ??
-        Promise.resolve(true),
+      externalOpener: {
+        openExternal: (url) =>
+          options.openExternalUrl?.(url) ?? Promise.resolve(),
+      },
+      getProviderDisplayName: (provider) =>
+        getProviderDisplayName(
+          provider,
+          PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+        ),
+      getProviderKeyUrl: (provider) => {
+        const defaultUrl = PROVIDER_URLS[provider];
+        return defaultUrl ? getProviderKeyUrl(provider, defaultUrl) : undefined;
+      },
+      getApiKeySecretName: (provider) => {
+        if (!isApiProvider(provider)) {
+          throw new Error(`Unknown API provider: ${provider}`);
+        }
+        return apiKeySecretName(provider);
+      },
+      setSecret: (key, value) => secrets.set(key, value),
+      deleteSecret: (key) => secrets.delete(key),
+      refreshAfterKeyChange: () => refreshAfterCredentialChange(),
     },
-    externalOpener: {
-      openExternal: (url) =>
-        options.openExternalUrl?.(url) ?? Promise.resolve(),
+    providerConfig: {
+      isApiProvider,
+      onUnknownProvider: (provider) =>
+        options.showErrorMessage?.(`Unknown API provider: ${provider}`),
+      setProviderStreaming,
+      setProviderEndpoint,
+      setGlobalStreaming,
     },
-    getProviderDisplayName: (provider) =>
-      getProviderDisplayName(
-        provider,
-        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
-      ),
-    getProviderKeyUrl: (provider) => {
-      const defaultUrl = PROVIDER_URLS[provider];
-      return defaultUrl ? getProviderKeyUrl(provider, defaultUrl) : undefined;
-    },
-    getApiKeySecretName: (provider) => {
-      if (!isApiProvider(provider)) {
-        throw new Error(`Unknown API provider: ${provider}`);
-      }
-      return apiKeySecretName(provider);
-    },
-    setSecret: (key, value) => secrets.set(key, value),
-    deleteSecret: (key) => secrets.delete(key),
-    refreshAfterKeyChange: () => refreshAfterCredentialChange(),
   });
 
   function readCurrentGitAuthorSettings() {
@@ -389,33 +415,8 @@ export function createDesktopSettingsIpc(
     );
   }
 
-  // Desktop has no VS Code settings, so `getProviderVscodeSettings` returns [];
-  // the rest of the mapping is shared with the extension via
-  // `buildProviderKeyStatuses` so the wire shape stays in one place.
-  function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
-    return buildProviderKeyStatuses({
-      providerIds: API_PROVIDERS,
-      loadProviderKeyStatuses: () =>
-        loadApiKeyStatusMap(secrets, API_PROVIDERS),
-      getProviderDisplayName: (provider) =>
-        getProviderDisplayName(
-          provider,
-          PROVIDER_DISPLAY_NAMES[provider] ?? provider,
-        ),
-      getProviderKeyUrl: (provider) =>
-        getProviderKeyUrl(provider, PROVIDER_URLS[provider] ?? ''),
-      getProviderStreaming,
-      getProviderEndpoint,
-      supportsCustomEndpoint,
-      getProviderVscodeSettings: () => [],
-    });
-  }
-
   async function postProfileData(): Promise<void> {
-    const message = await buildProfileMessage({
-      getProviderKeyStatuses: () => getProviderKeyStatuses(),
-    });
-    options.postToRenderer(message);
+    await settingsHost.sendProfileData();
   }
 
   async function postChatGptAuthStatus(): Promise<void> {
@@ -652,50 +653,33 @@ export function createDesktopSettingsIpc(
     provider: string,
     submittedApiKey?: string,
   ): Promise<void> {
-    if (!isApiProvider(provider)) {
-      await options.showErrorMessage?.(`Unknown API provider: ${provider}`);
-      return;
-    }
-    if (submittedApiKey != null) {
-      await profileKeyController.commitProviderKey(provider, submittedApiKey);
-      return;
-    }
-    await profileKeyController.setProviderKey(provider);
+    await settingsHost.setProviderKey(provider, submittedApiKey);
   }
 
   async function removeProviderKey(provider: string): Promise<void> {
-    if (!isApiProvider(provider)) {
-      await options.showErrorMessage?.(`Unknown API provider: ${provider}`);
-      return;
-    }
-    await profileKeyController.removeProviderKey(provider);
+    await settingsHost.removeProviderKey(provider);
   }
 
   async function openProviderKeyUrl(provider: string): Promise<void> {
-    const defaultUrl = PROVIDER_URLS[provider];
-    if (!defaultUrl) return;
-    await profileKeyController.openProviderKeyUrl(provider);
+    await settingsHost.openProviderKeyUrl(provider);
   }
 
   async function updateProviderStreaming(input: {
     provider: string;
     enabled: boolean;
   }): Promise<void> {
-    await setProviderStreaming(input.provider, input.enabled);
-    await postProfileData();
+    await settingsHost.setProviderStreaming(input.provider, input.enabled);
   }
 
   async function updateProviderEndpoint(input: {
     provider: string;
     endpoint: string;
   }): Promise<void> {
-    await setProviderEndpoint(input.provider, input.endpoint);
-    await postProfileData();
+    await settingsHost.setProviderEndpoint(input.provider, input.endpoint);
   }
 
   async function updateGlobalStreaming(enabled: boolean): Promise<void> {
-    await setGlobalStreaming(enabled);
-    await postProfileData();
+    await settingsHost.setGlobalStreaming(enabled);
   }
 
   async function signIn(): Promise<void> {
@@ -720,15 +704,7 @@ export function createDesktopSettingsIpc(
   async function setApiAccessMode(
     mode: 'included' | 'personal',
   ): Promise<void> {
-    await options.setApiAccessMode?.(mode);
-    if (
-      mode === 'included' &&
-      globalState.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
-    ) {
-      await globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-    }
-    invalidateModelOptionsCache();
-    await Promise.all([postProfileData(), postModelSelectionData()]);
+    await settingsHost.setApiAccessMode(mode);
     // Switching included ↔ personal access mode changes the credential
     // predicate (`getUseIncludedModelAccess()`), so refresh the onboarding
     // funnel — otherwise a user enabling included access stays on

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -11,8 +11,6 @@
 import * as vscode from 'vscode';
 
 // Shared schemas and dispatchers
-import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
-import { SettingsProfileController } from '@controllers/settingsView/SettingsProfileController';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import {
   buildToolDashboardItems,
@@ -124,8 +122,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly githubHandlers: GitHubSubscriptionHandlers;
   private readonly chatgptHandlers: ChatGptSubscriptionHandlers;
   private readonly settingsHost: SettingsViewHost;
-  private readonly profileController: SettingsProfileController;
-  private readonly profileKeyController: SettingsProfileKeyController;
   private readonly goalController: SettingsGoalController;
 
   constructor(context: vscode.ExtensionContext) {
@@ -151,39 +147,51 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           getServerSideKeyService().getUseIncludedModelAccess(),
         getUserTier: () => getServerSideKeyService().getUserTier() ?? undefined,
       },
-    });
-    this.profileController = new SettingsProfileController({
-      globalState: globalSM,
-      providerIds: SecretManager.API_PROVIDERS,
-      providerVscodeSettings: PROVIDER_VSCODE_SETTINGS,
-      providerDisplayNames: PROVIDER_DISPLAY_NAMES,
-      providerKeyUrls: PROVIDER_URLS,
-      loadProviderKeyStatuses: () =>
-        loadApiKeyStatusMap(platform().secrets, SecretManager.API_PROVIDERS),
-      getProviderDisplayName,
-      getProviderKeyUrl,
-      getProviderStreaming,
-      getProviderEndpoint,
-      supportsCustomEndpoint,
-      getConfig,
-      updateConfig: (key, value) =>
-        updateConfig(key, value, { target: 'global', prefix: false }),
-      setUseIncludedModelAccess: (enabled) =>
-        getServerSideKeyService().setUseIncludedModelAccess(enabled),
-      invalidateModelOptionsCache,
-    });
-    this.profileKeyController = new SettingsProfileKeyController({
-      prompt: new VscodePromptHost(),
-      externalOpener: new VscodeExternalOpener(),
-      getProviderDisplayName: (provider) =>
-        this.profileController.getProviderDisplayName(provider),
-      getProviderKeyUrl: (provider) =>
-        this.profileController.getProviderKeyUrl(provider),
-      getApiKeySecretName: (provider) =>
-        SecretManager.getApiKeySecretName(provider as ApiProvider),
-      setSecret: (key, value) => SecretManager.set(key, value),
-      deleteSecret: (key) => SecretManager.delete(key),
-      refreshAfterKeyChange: () => this.refreshAfterKeyChange(),
+      profile: {
+        globalState: globalSM,
+        providerIds: SecretManager.API_PROVIDERS,
+        providerVscodeSettings: PROVIDER_VSCODE_SETTINGS,
+        providerDisplayNames: PROVIDER_DISPLAY_NAMES,
+        providerKeyUrls: PROVIDER_URLS,
+        loadProviderKeyStatuses: () =>
+          loadApiKeyStatusMap(platform().secrets, SecretManager.API_PROVIDERS),
+        getProviderDisplayName,
+        getProviderKeyUrl,
+        getProviderStreaming,
+        getProviderEndpoint,
+        supportsCustomEndpoint,
+        getConfig,
+        updateConfig: (key, value) =>
+          updateConfig(key, value, { target: 'global', prefix: false }),
+        setUseIncludedModelAccess: (enabled) =>
+          getServerSideKeyService().setUseIncludedModelAccess(enabled),
+        invalidateModelOptionsCache,
+      },
+      profileKey: {
+        prompt: new VscodePromptHost(),
+        externalOpener: new VscodeExternalOpener(),
+        getProviderDisplayName: (provider) =>
+          getProviderDisplayName(
+            provider,
+            PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+          ),
+        getProviderKeyUrl: (provider) => {
+          const defaultUrl = PROVIDER_URLS[provider];
+          return defaultUrl
+            ? getProviderKeyUrl(provider, defaultUrl)
+            : undefined;
+        },
+        getApiKeySecretName: (provider) =>
+          SecretManager.getApiKeySecretName(provider as ApiProvider),
+        setSecret: (key, value) => SecretManager.set(key, value),
+        deleteSecret: (key) => SecretManager.delete(key),
+        refreshAfterKeyChange: () => this.refreshAfterKeyChange(),
+      },
+      providerConfig: {
+        setProviderStreaming,
+        setProviderEndpoint,
+        setGlobalStreaming,
+      },
     });
     this.agentHandlers = new AgentHandlers(ctx, (selectedToolUseAgent) =>
       this.refreshAfterAgentMutation(selectedToolUseAgent),
@@ -293,24 +301,26 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           }),
         setProviderKey: (provider) =>
           this.runProviderKeyAction(provider, 'set', (targetProvider) =>
-            this.profileKeyController.setProviderKey(targetProvider),
+            this.settingsHost.setProviderKey(targetProvider),
           ),
         removeProviderKey: (provider) =>
           this.runProviderKeyAction(provider, 'remove', (targetProvider) =>
-            this.profileKeyController.removeProviderKey(targetProvider),
+            this.settingsHost.removeProviderKey(targetProvider),
           ),
         openProviderKeyUrl: (provider) =>
-          this.profileKeyController.openProviderKeyUrl(provider),
+          this.settingsHost.openProviderKeyUrl(provider),
         setProviderStreaming: (provider, enabled) =>
-          this.updateProfileSetting(() =>
-            setProviderStreaming(provider, enabled),
+          this.settingsHost.setProviderStreaming(provider, enabled, (message) =>
+            this.postMessageToActiveWebview(message),
           ),
         setProviderEndpoint: (provider, endpoint) =>
-          this.updateProfileSetting(() =>
-            setProviderEndpoint(provider, endpoint),
+          this.settingsHost.setProviderEndpoint(provider, endpoint, (message) =>
+            this.postMessageToActiveWebview(message),
           ),
         setGlobalStreaming: (enabled) =>
-          this.updateProfileSetting(() => setGlobalStreaming(enabled)),
+          this.settingsHost.setGlobalStreaming(enabled, (message) =>
+            this.postMessageToActiveWebview(message),
+          ),
         setProviderVscodeSetting: (data) =>
           this.handleSetProviderVscodeSetting(data),
         openExternalUrl: (url) => this.openExternalUrl(url),
@@ -663,8 +673,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendProfileData(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage(
-      await this.profileController.buildProfileMessage(),
+    await this.settingsHost.sendProfileData((message) =>
+      webview.postMessage(message),
     );
   }
 
@@ -691,7 +701,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         workspaceState: workspaceSM,
         globalState: globalSM,
         getReliabilitySettings: () =>
-          this.profileController.getReliabilitySettings(),
+          this.settingsHost.getReliabilitySettings(),
       }),
     );
   }
@@ -897,9 +907,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetApiAccessMode(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_API_ACCESS_MODE>,
   ): Promise<void> {
-    const update = await this.profileController.setApiAccessMode(data.mode);
-    await this.withActiveWebview(async (w) => {
-      await this.sendProfileAndModelSelectionData(w);
+    const update = await this.settingsHost.setApiAccessMode(data.mode, {
+      respond: (message) => this.postMessageToActiveWebview(message),
     });
     const modeLabel =
       update.mode === 'included' ? 'Included Access' : 'My Own Keys';
@@ -921,7 +930,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to ${verb} ${this.profileController.getProviderDisplayName(provider)} API key`,
+        `Failed to ${verb} ${this.settingsHost.getProviderDisplayName(provider)} API key`,
         error,
       );
       // On error, still refresh settings view to reflect current key state.
@@ -977,7 +986,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderVscodeSetting(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_VSCODE_SETTING>,
   ): Promise<void> {
-    const result = await this.profileController.setProviderVscodeSetting(data);
+    const result = await this.settingsHost.setProviderVscodeSetting(data);
     if (result.kind === 'rejected') {
       this.logger.warn(
         this.channel,
@@ -1030,13 +1039,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview(async (webview) => {
       await webview.postMessage(message);
     });
-  }
-
-  private async updateProfileSetting(
-    update: () => Promise<void>,
-  ): Promise<void> {
-    await update();
-    await this.withActiveWebview((w) => this.sendProfileData(w));
   }
 
   private async setModelEnabled(

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -10,39 +10,38 @@ import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
 import { buildProfileMessage } from './ProfileMessageBuilder';
 import type { StateStore } from '@platform/interfaces';
 
-export type SettingsReliabilitySetting = Omit<NumberVscodeSetting, 'value'> & {
+type SettingsReliabilitySetting = Omit<NumberVscodeSetting, 'value'> & {
   defaultValue: number;
 };
 
-export const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] =
-  [
-    {
-      key: 'texra.model.compactionThresholdPercent',
-      label: 'Compaction threshold',
-      description:
-        'Context window percentage to trigger automatic context compaction. Set to 0 to disable.',
-      min: 0,
-      max: 100,
-      unit: '%',
-      defaultValue: 75,
-    },
-    {
-      key: 'texra.model.retry.maxAttempts',
-      label: 'Retry attempts',
-      description:
-        'Automatic retry attempts before showing a manual retry button. Set to 0 for manual-only.',
-      min: 0,
-      defaultValue: 0,
-    },
-    {
-      key: 'texra.model.retry.backoffMs',
-      label: 'Retry backoff',
-      description: 'Base delay between retry attempts.',
-      min: 0,
-      unit: 'ms',
-      defaultValue: 1000,
-    },
-  ];
+const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
+  {
+    key: 'texra.model.compactionThresholdPercent',
+    label: 'Compaction threshold',
+    description:
+      'Context window percentage to trigger automatic context compaction. Set to 0 to disable.',
+    min: 0,
+    max: 100,
+    unit: '%',
+    defaultValue: 75,
+  },
+  {
+    key: 'texra.model.retry.maxAttempts',
+    label: 'Retry attempts',
+    description:
+      'Automatic retry attempts before showing a manual retry button. Set to 0 for manual-only.',
+    min: 0,
+    defaultValue: 0,
+  },
+  {
+    key: 'texra.model.retry.backoffMs',
+    label: 'Retry backoff',
+    description: 'Base delay between retry attempts.',
+    min: 0,
+    unit: 'ms',
+    defaultValue: 1000,
+  },
+];
 
 export type SettingsProfileConfigValue = boolean | number;
 
@@ -83,7 +82,7 @@ export interface SettingsProfileControllerDeps {
  * these the same way, except `getProviderVscodeSettings`: the VS Code extension
  * fills it from config while the desktop app returns [].
  */
-export interface ProviderKeyStatusSources {
+interface ProviderKeyStatusSources {
   readonly providerIds: readonly string[];
   loadProviderKeyStatuses(): Promise<
     Record<string, ProviderKeyStatus['status']>
@@ -97,11 +96,10 @@ export interface ProviderKeyStatusSources {
 }
 
 /**
- * Map every provider id to its `ProviderKeyStatus`. Shared by the VS Code
- * extension controller and the desktop settings IPC so the wire shape lives in
- * exactly one place and the two hosts cannot drift.
+ * Map every provider id to its `ProviderKeyStatus`, keeping the settings
+ * profile wire shape in one place.
  */
-export async function buildProviderKeyStatuses(
+async function buildProviderKeyStatuses(
   sources: ProviderKeyStatusSources,
 ): Promise<ProviderKeyStatus[]> {
   const secretStatuses = await sources.loadProviderKeyStatuses();

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -17,6 +17,17 @@ import {
   createModelSelectionController,
   type ModelSelectionExtras,
 } from './SettingsModelSelectionControllerFactory';
+import {
+  SettingsProfileController,
+  type ApiAccessModeUpdate,
+  type ProviderVscodeSettingUpdateResult,
+  type SettingsProfileConfigValue,
+  type SettingsProfileControllerDeps,
+} from './SettingsProfileController';
+import {
+  SettingsProfileKeyController,
+  type SettingsProfileKeyControllerDeps,
+} from './SettingsProfileKeyController';
 import type { SettingsMemoryController } from './SettingsMemoryController';
 import type { SettingsModelSelectionController } from './SettingsModelSelectionController';
 
@@ -35,6 +46,23 @@ type SetReasoningLevelInput = Omit<
   SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL>,
   'command'
 >;
+type ApiAccessModeInput = SettingsMessageFor<
+  typeof SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE
+>['mode'];
+
+interface SettingsViewHostProviderConfigPorts {
+  readonly isApiProvider?: (provider: string) => boolean;
+  readonly onUnknownProvider?: (provider: string) => Awaitable<void>;
+  readonly setProviderStreaming?: (
+    provider: string,
+    enabled: boolean,
+  ) => Awaitable<void>;
+  readonly setProviderEndpoint?: (
+    provider: string,
+    endpoint: string,
+  ) => Awaitable<void>;
+  readonly setGlobalStreaming?: (enabled: boolean) => Awaitable<void>;
+}
 
 export interface SettingsViewHostOptions {
   readonly state: SettingsStatePorts;
@@ -43,9 +71,14 @@ export interface SettingsViewHostOptions {
   readonly setMemoryEnabled?: SettingsMemoryControllerFactoryOptions['setMemoryEnabled'];
   readonly modelSelectionExtras?: ModelSelectionExtras;
   readonly beforeModelSelectionMessage?: () => Awaitable<void>;
+  readonly profile?: SettingsProfileControllerDeps;
+  readonly profileKey?: SettingsProfileKeyControllerDeps;
+  readonly providerConfig?: SettingsViewHostProviderConfigPorts;
   readonly controllers?: {
     readonly memory?: SettingsMemoryController;
     readonly modelSelection?: SettingsModelSelectionController;
+    readonly profile?: SettingsProfileController;
+    readonly profileKey?: SettingsProfileKeyController;
   };
 }
 
@@ -54,9 +87,16 @@ export interface SettingsViewHostMutationOptions {
   readonly afterPost?: () => Awaitable<void>;
 }
 
+interface SettingsViewHostApiAccessModeOptions {
+  readonly respond?: SettingsRespond;
+  readonly afterPost?: (update: ApiAccessModeUpdate) => Awaitable<void>;
+}
+
 export class SettingsViewHost {
   readonly memoryController: SettingsMemoryController;
   readonly modelSelectionController: SettingsModelSelectionController;
+  private readonly profileController?: SettingsProfileController;
+  private readonly profileKeyController?: SettingsProfileKeyController;
 
   constructor(private readonly options: SettingsViewHostOptions) {
     this.memoryController =
@@ -72,6 +112,16 @@ export class SettingsViewHost {
         options.state,
         options.modelSelectionExtras,
       );
+    this.profileController =
+      options.controllers?.profile ??
+      (options.profile
+        ? new SettingsProfileController(options.profile)
+        : undefined);
+    this.profileKeyController =
+      options.controllers?.profileKey ??
+      (options.profileKey
+        ? new SettingsProfileKeyController(options.profileKey)
+        : undefined);
   }
 
   async sendMemoryData(respond?: SettingsRespond): Promise<void> {
@@ -177,6 +227,98 @@ export class SettingsViewHost {
     await this.postModelSelectionMutation(options);
   }
 
+  async sendProfileData(respond?: SettingsRespond): Promise<void> {
+    await this.post(
+      await this.requireProfileController().buildProfileMessage(),
+      respond,
+    );
+  }
+
+  async setProviderKey(provider: string, apiKey?: string): Promise<void> {
+    if (!(await this.acceptKnownProvider(provider))) return;
+    const controller = this.requireProfileKeyController();
+    if (apiKey != null) {
+      await controller.commitProviderKey(provider, apiKey);
+      return;
+    }
+    await controller.setProviderKey(provider);
+  }
+
+  async removeProviderKey(provider: string): Promise<void> {
+    if (!(await this.acceptKnownProvider(provider))) return;
+    await this.requireProfileKeyController().removeProviderKey(provider);
+  }
+
+  async openProviderKeyUrl(provider: string): Promise<void> {
+    await this.requireProfileKeyController().openProviderKeyUrl(provider);
+  }
+
+  async setProviderStreaming(
+    provider: string,
+    enabled: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    const setProviderStreaming =
+      this.options.providerConfig?.setProviderStreaming;
+    if (!setProviderStreaming) {
+      throw new Error('SettingsViewHost has no provider streaming port.');
+    }
+    await setProviderStreaming(provider, enabled);
+    await this.sendProfileData(respond);
+  }
+
+  async setProviderEndpoint(
+    provider: string,
+    endpoint: string,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    const setProviderEndpoint =
+      this.options.providerConfig?.setProviderEndpoint;
+    if (!setProviderEndpoint) {
+      throw new Error('SettingsViewHost has no provider endpoint port.');
+    }
+    await setProviderEndpoint(provider, endpoint);
+    await this.sendProfileData(respond);
+  }
+
+  async setGlobalStreaming(
+    enabled: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    const setGlobalStreaming = this.options.providerConfig?.setGlobalStreaming;
+    if (!setGlobalStreaming) {
+      throw new Error('SettingsViewHost has no global streaming port.');
+    }
+    await setGlobalStreaming(enabled);
+    await this.sendProfileData(respond);
+  }
+
+  async setApiAccessMode(
+    mode: ApiAccessModeInput,
+    options?: SettingsViewHostApiAccessModeOptions,
+  ): Promise<ApiAccessModeUpdate> {
+    const update = await this.requireProfileController().setApiAccessMode(mode);
+    await this.sendProfileData(options?.respond);
+    await this.sendModelSelectionData(options?.respond);
+    await options?.afterPost?.(update);
+    return update;
+  }
+
+  getProviderDisplayName(provider: string): string {
+    return this.requireProfileController().getProviderDisplayName(provider);
+  }
+
+  getReliabilitySettings() {
+    return this.requireProfileController().getReliabilitySettings();
+  }
+
+  setProviderVscodeSetting(input: {
+    key: string;
+    value: SettingsProfileConfigValue;
+  }): Promise<ProviderVscodeSettingUpdateResult> {
+    return this.requireProfileController().setProviderVscodeSetting(input);
+  }
+
   getVisibleModels(): string[] {
     return this.modelSelectionController.getVisibleModels();
   }
@@ -205,6 +347,27 @@ export class SettingsViewHost {
   ): Promise<void> {
     if (message == null) return;
     await this.post(message, respond);
+  }
+
+  private requireProfileController(): SettingsProfileController {
+    if (!this.profileController) {
+      throw new Error('SettingsViewHost has no profile controller.');
+    }
+    return this.profileController;
+  }
+
+  private requireProfileKeyController(): SettingsProfileKeyController {
+    if (!this.profileKeyController) {
+      throw new Error('SettingsViewHost has no profile key controller.');
+    }
+    return this.profileKeyController;
+  }
+
+  private async acceptKnownProvider(provider: string): Promise<boolean> {
+    const isApiProvider = this.options.providerConfig?.isApiProvider;
+    if (!isApiProvider || isApiProvider(provider)) return true;
+    await this.options.providerConfig?.onUnknownProvider?.(provider);
+    return false;
   }
 }
 

--- a/src/test-kernel/controllers/SettingsViewHost.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewHost.vitest.ts
@@ -6,6 +6,7 @@ import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHo
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ModelOptionData } from '@shared/schemas';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { StateStore } from '@platform/interfaces';
 
 function createStateStore(): StateStore {
@@ -101,6 +102,92 @@ function createModelSelectionController() {
   };
 }
 
+function createProfileHost(options: {
+  readonly messages: unknown[];
+  readonly globalState?: StateStore;
+  readonly secretValues?: Map<string, string>;
+  readonly refreshAfterKeyChange?: () => Promise<void>;
+  readonly setUseIncludedModelAccess?: (enabled: boolean) => Promise<void>;
+  readonly setProviderStreaming?: (
+    provider: string,
+    enabled: boolean,
+  ) => Promise<void>;
+  readonly setProviderEndpoint?: (
+    provider: string,
+    endpoint: string,
+  ) => Promise<void>;
+  readonly setGlobalStreaming?: (enabled: boolean) => Promise<void>;
+}) {
+  const modelSelection = createModelSelectionController();
+  const config = new Map<string, unknown>();
+  const globalState = options.globalState ?? createStateStore();
+  const secretValues = options.secretValues ?? new Map<string, string>();
+  return createSettingsViewHost({
+    state: {
+      workspaceState: createStateStore(),
+      globalState,
+    },
+    memoryPrompt: {
+      confirm: async () => true,
+      warning: async () => undefined,
+    },
+    respond: (message) => {
+      options.messages.push(message);
+    },
+    controllers: {
+      modelSelection: modelSelection.controller,
+    },
+    profile: {
+      globalState,
+      providerIds: ['openai'],
+      providerVscodeSettings: {},
+      providerDisplayNames: { openai: 'OpenAI' },
+      providerKeyUrls: { openai: 'https://platform.openai.com/api-keys' },
+      loadProviderKeyStatuses: async () => ({ openai: 'set' }),
+      getProviderDisplayName: (_provider, defaultName) => defaultName,
+      getProviderKeyUrl: (_provider, defaultUrl) => defaultUrl,
+      getProviderStreaming: () => true,
+      getProviderEndpoint: () => '',
+      supportsCustomEndpoint: () => true,
+      getConfig: (key, defaultValue) =>
+        (config.has(key) ? config.get(key) : defaultValue) as never,
+      updateConfig: async (key, value) => {
+        config.set(key, value);
+      },
+      setUseIncludedModelAccess:
+        options.setUseIncludedModelAccess ?? (async () => undefined),
+      invalidateModelOptionsCache: () => undefined,
+    },
+    profileKey: {
+      prompt: {
+        input: async () => 'prompted-key',
+        info: async () => undefined,
+        confirm: async () => true,
+      },
+      externalOpener: {
+        openExternal: async () => undefined,
+      },
+      getProviderDisplayName: () => 'OpenAI',
+      getProviderKeyUrl: () => 'https://platform.openai.com/api-keys',
+      getApiKeySecretName: (provider) => `${provider}-secret`,
+      setSecret: async (key, value) => {
+        secretValues.set(key, value);
+      },
+      deleteSecret: async (key) => {
+        secretValues.delete(key);
+      },
+      refreshAfterKeyChange:
+        options.refreshAfterKeyChange ?? (async () => undefined),
+    },
+    providerConfig: {
+      isApiProvider: (provider) => provider === 'openai',
+      setProviderStreaming: options.setProviderStreaming,
+      setProviderEndpoint: options.setProviderEndpoint,
+      setGlobalStreaming: options.setGlobalStreaming,
+    },
+  });
+}
+
 describe('SettingsViewHost', () => {
   it('posts memory and model-selection messages through shared host wiring', async () => {
     const memory = createMemoryController();
@@ -154,5 +241,103 @@ describe('SettingsViewHost', () => {
     });
     expect(modelSelection.state.enabledModels).toEqual(['sonnet46T']);
     expect(modelRefreshes).toBe(2);
+  });
+
+  it('posts profile data through shared host wiring', async () => {
+    const messages: unknown[] = [];
+    const host = createProfileHost({ messages });
+
+    await host.sendProfileData();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      providerKeyStatuses: [
+        expect.objectContaining({
+          provider: 'openai',
+          displayName: 'OpenAI',
+          status: 'set',
+        }),
+      ],
+    });
+  });
+
+  it('updates provider config ports and reposts profile data', async () => {
+    const messages: unknown[] = [];
+    const calls: unknown[] = [];
+    const host = createProfileHost({
+      messages,
+      setProviderStreaming: async (provider, enabled) => {
+        calls.push(['streaming', provider, enabled]);
+      },
+      setProviderEndpoint: async (provider, endpoint) => {
+        calls.push(['endpoint', provider, endpoint]);
+      },
+      setGlobalStreaming: async (enabled) => {
+        calls.push(['global', enabled]);
+      },
+    });
+
+    await host.setProviderStreaming('openai', false);
+    await host.setProviderEndpoint('openai', 'https://example.test');
+    await host.setGlobalStreaming(true);
+
+    expect(calls).toEqual([
+      ['streaming', 'openai', false],
+      ['endpoint', 'openai', 'https://example.test'],
+      ['global', true],
+    ]);
+    expect(
+      messages.filter(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toHaveLength(3);
+  });
+
+  it('delegates provider-key writes and removals through the shared host', async () => {
+    const messages: unknown[] = [];
+    const secretValues = new Map<string, string>();
+    let refreshes = 0;
+    const host = createProfileHost({
+      messages,
+      secretValues,
+      refreshAfterKeyChange: async () => {
+        refreshes += 1;
+      },
+    });
+
+    await host.setProviderKey('openai', '  sk-test  ');
+    await host.removeProviderKey('openai');
+
+    expect(secretValues.has('openai-secret')).toBe(false);
+    expect(refreshes).toBe(2);
+  });
+
+  it('sets API access mode, disables OpenRouter for included access, and posts profile plus model selection', async () => {
+    const messages: unknown[] = [];
+    const globalState = createStateStore();
+    await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
+    let includedAccess: boolean | undefined;
+    const host = createProfileHost({
+      messages,
+      globalState,
+      setUseIncludedModelAccess: async (enabled) => {
+        includedAccess = enabled;
+      },
+    });
+
+    const update = await host.setApiAccessMode('included');
+
+    expect(update).toEqual({ mode: 'included', openRouterDisabled: true });
+    expect(includedAccess).toBe(true);
+    expect(globalState.get(GlobalStateKey.USE_OPENROUTER, true)).toBe(false);
+    expect(
+      messages.map((message) => (message as { command: string }).command),
+    ).toEqual([
+      SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
+    ]);
   });
 });


### PR DESCRIPTION
Part of #6972.

## Summary

- Moves shared Profile-tab data and provider-key/provider-config command wiring into `SettingsViewHost`.
- Rewires VS Code settings view and desktop settings IPC to use the shared host for profile data, provider key set/remove/open, provider streaming/endpoint/global streaming, and API access mode updates.
- Keeps host-specific effects in the adapters: authentication commands, VS Code-only provider settings, extension notifications/command refreshes, desktop onboarding callbacks, and desktop-only ChatGPT/crash-reporting flows.

This is the next F2 slice after #7525: the shared host now owns memory, model-selection, and the common profile/provider core, while deliberate host behavior remains outside.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/SettingsViewHost.vitest.ts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/desktop/desktopSettingsIpc.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`: passed, 4 files / 48 tests.
- `npm run typecheck`: passed.
- `CI=true corepack pnpm exec eslint src/controllers/settingsView/SettingsViewHost.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsViewHost.vitest.ts`: passed.
- `corepack pnpm exec prettier --check src/controllers/settingsView/SettingsViewHost.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/desktop/src/main/desktopSettingsIpc.ts src/test-kernel/controllers/SettingsViewHost.vitest.ts`: passed.
- `git diff --check`: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors API key storage, access mode, and provider config paths used by both extension and desktop; behavior is intended to be unchanged but mistakes could affect credentials and model availability.
> 
> **Overview**
> **Centralizes** the Settings Profile tab in **`SettingsViewHost`**, alongside memory and model selection. The host now constructs **`SettingsProfileController`** / **`SettingsProfileKeyController`** from injected `profile`, `profileKey`, and `providerConfig` ports and exposes shared commands (profile refresh, API keys, streaming/endpoint, API access mode, reliability/VS Code provider settings).
> 
> **VS Code** (`SettingsViewMessageHandler`) and **desktop** (`desktopSettingsIpc`) stop holding their own profile controllers and duplicate `buildProviderKeyStatuses` logic; they call `settingsHost` for those flows. Host-specific behavior stays in adapters (auth commands, VS Code-only provider settings + command refreshes, desktop unknown-provider errors and onboarding callbacks).
> 
> **`SettingsProfileController`** narrows surface area by making `buildProviderKeyStatuses` and related helpers module-private. **Tests** in `SettingsViewHost.vitest.ts` cover profile posting, provider config ports, key write/remove, and included-access + OpenRouter handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b464af04f03058b56342f4cb3d86ca928747fc7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->