### PR TITLE
fix(desktop): preserve parent stream on resume

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1162,6 +1162,9 @@ export class DesktopProgressBridge {
         return {
           runState: resumeState.runState,
           executionId: resumeState.executionId,
+          ...(resumeState.parentStreamId !== undefined && {
+            parentStreamId: resumeState.parentStreamId,
+          }),
         };
       },
       resumeToolUseSnapshot: (snapshot) =>

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2692,14 +2692,25 @@ describe('DesktopProgressBridge', () => {
   });
 
   it('resumes tool-use streams through the shared snapshot path', async () => {
-    const retrieveSessionResumeData = vi.fn(async () => ({
-      type: 'toolUse',
-      snapshot: {
-        executionId: 'ec1001',
-        streamId: 'stream-1',
-        agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG,
-      },
-    }));
+    const parentStreamId = 'stream-parent' as StreamTabId;
+    const retrieveSessionResumeData = vi.fn(
+      async (
+        _streamId: StreamTabId,
+        _executionId: string,
+        _runState: unknown,
+        options?: { parentStreamId?: StreamTabId },
+      ) => ({
+        type: 'toolUse',
+        snapshot: {
+          executionId: 'ec1001',
+          streamId: 'stream-1',
+          agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG,
+          ...(options?.parentStreamId !== undefined && {
+            parentStreamId: options.parentStreamId,
+          }),
+        },
+      }),
+    );
     const resumeToolUseFromSnapshot = vi.fn(async () => {});
     const messages: unknown[] = [];
     const bridge = await createBridge(messages, {
@@ -2714,6 +2725,10 @@ describe('DesktopProgressBridge', () => {
         executionId: 'ec1001',
         taskState,
       });
+      bridge.handleProgressEvent('setParentStream', {
+        childStreamId: 'stream-1',
+        parentStreamId,
+      });
       bridgeFollowUps(bridge).enqueue(
         'stream-1',
         { text: 'queued follow-up' },
@@ -2725,11 +2740,13 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         'ec1001',
         taskState.agentConfig,
+        { parentStreamId },
       );
       expect(resumeToolUseFromSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({
           executionId: 'ec1001',
           streamId: 'stream-1',
+          parentStreamId,
         }),
         expect.objectContaining({ emit: expect.any(Function) }),
         expect.objectContaining({ setupSession: expect.any(Function) }),


### PR DESCRIPTION
## Summary

Forward the recovered `parentStreamId` from the desktop resume adapter into the shared resume orchestrator. #7545 taught desktop to recover the parent edge from snapshot metadata, but the adapter return object dropped it before `resolveAndResumeStream()` could rebuild the tool-use snapshot.

## Issue acceptance gates

Addresses the remaining desktop host gap from #7543 after #7545 merged: delegated native subagents resumed through the desktop generic host path keep their orchestrator parent stream.

## Single source of truth

`StreamSnapshotStore` remains the source of truth for persisted parent-stream metadata; `DesktopProgressBridge.resolveResumeState()` now carries that recovered fact through `ResolvedResumeState` instead of losing it at the desktop adapter boundary.

## Duplication and abstraction budget

No new abstraction. This removes the accidental desktop divergence from the extension adapter by forwarding the same recovered parent identity into the existing shared resume path.

## Host impact

Extension: No behavior change; the extension adapter already forwarded `parentStreamId`.

Desktop: Fixes delegated native-subagent resume parentage after process restart.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm test` (601 passed, 1 skipped; 5202 tests passed, 4 skipped)
- `git diff --check`

Closes #7543