### PR TITLE
refactor(progress): share progress view host wiring

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -4,10 +4,7 @@ import path from 'node:path';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
-import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
-import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
-import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
-import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
+import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
@@ -195,9 +192,10 @@ export class DesktopProgressBridge {
   private readonly backend: ProgressBackend;
   private readonly state: ProgressBackend['state'];
   readonly streamLogs: ProgressBackend['state']['streamLogs'];
-  private readonly agentProposalController: ProgressAgentProposalController;
-  private readonly workflowActions: ProgressWorkflowActionsController;
-  private readonly workflowFileActions: ProgressWorkflowFileActionsController;
+  private readonly progressHost: ProgressViewHost;
+  private readonly agentProposalController: ProgressViewHost['agentProposalController'];
+  private readonly workflowActions: ProgressViewHost['workflowActionsController'];
+  private readonly workflowFileActions: ProgressViewHost['workflowFileActionsController'];
   /**
    * Shown-but-unresolved approval prompts, one {@link ApprovalRequestHandler}
    * per kind. These back the shared pending-permissions guard against view
@@ -366,223 +364,219 @@ export class DesktopProgressBridge {
         listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
       },
     );
-    // Shared run-new path (mirrors the extension wiring). Only `getTaskState`
-    // and `executeAgent` matter here: diff/file-operation actions are routed
-    // through `workflowFileActions`/`fileActions`, so those deps stay unwired.
-    this.workflowActions = new ProgressWorkflowActionsController({
-      state: {
-        getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
-        getExecutionId: (stream) => this.getStreamExecutionId(stream),
-        getOutputFiles: (stream) => this.state.snapshots.getOutputFiles(stream),
-        getKnownWorkspaceOutputPaths: () => new Set(),
-      },
-      executeAgent: async (request) => {
-        const validated = validateExecutionRequest(request);
-        if (!validated.valid) {
-          this.logger.error('Invalid desktop workflow execution request', {
-            data: validated.issue,
-          });
-          await this.options.showErrorMessage?.(validated.message);
-          return;
-        }
-        await this.runExecution(validated.request);
-      },
-      runDiff: () => {
-        throw new Error('Desktop diff is routed through workflowFileActions');
-      },
-      runFileOperation: () => {
-        throw new Error(
-          'Desktop file operations are routed through workflowFileActions',
-        );
-      },
-    });
-    this.workflowFileActions = new ProgressWorkflowFileActionsController({
-      state: {
-        getActiveStream: () => this.state.activeStream,
-        getExecutionId: (stream) => this.getStreamExecutionId(stream),
-        getOutputFiles: (stream) => this.state.snapshots.getOutputFiles(stream),
-        // The desktop bridge has no quick-pick UI, so Accept always replaces
-        // the workspace file. Returning undefined keeps the controller from
-        // building copy metadata that the desktop host would silently drop.
-        getAgentModel: () => undefined,
-      },
-      host: {
-        compareFiles: (baseFile, editedFile) =>
-          this.fileActions.compareFiles(baseFile, editedFile),
-        acceptEditedFile: (baseFile, editedFile) =>
-          this.fileActions.acceptEditedFile(baseFile, editedFile),
-        mergeFile: (baseFile, editedFile) =>
-          this.fileActions.runMergeFile(baseFile, editedFile),
-        latexdiffFile: (baseFile, editedFile) =>
-          this.runLatexdiffFile(baseFile, editedFile),
-        openDirectory: async (directory) => {
-          await this.options.openPath?.(directory);
-        },
-        openLabel: (label) => this.fileActions.findAndOpenLabel(label),
-        readFile: (file) => readFile(file, 'utf8'),
-        showInfo: async (message) => {
-          await this.options.showInfoMessage?.(message);
-        },
-        showError: async (message) => {
-          await this.options.showErrorMessage?.(message);
-        },
-        logError: (message, error) => {
-          this.logger.error(message, {
-            data: error instanceof Error ? error : { error },
-          });
-        },
-      },
-      sendFollowUp: async (stream, text) => {
-        await this.sendFollowUp(stream, text);
-      },
-    });
-    this.agentProposalController = new ProgressAgentProposalController({
-      getPendingProposal: (proposalId) =>
-        this.approvalHandlers.agentProposal.get(proposalId),
-      restoreTaskState: async (taskState) => {
-        let state: MainViewPersistedState;
-        try {
-          state = buildMainViewState(taskState);
-        } catch {
-          return false;
-        }
-        this.postToRenderer({
-          command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
-          route: 'main',
-        });
-        this.postToRenderer({
-          command: COMMON_COMMANDS.STATE_RESTORE,
-          state,
-        });
-        return true;
-      },
-      settleProposal: (proposalId, result) => {
-        const resolved = this.session.interactions.resolve(proposalId, {
-          kind: 'proposal',
-          action: result.action,
-          value: result,
-        });
-        if (!resolved) {
-          this.logger.warn(
-            `No pending desktop host interaction found for proposal: ${proposalId}`,
-          );
-        }
-      },
-      onMissingProposal: (proposalId) => {
-        this.logger.warn(
-          `No pending desktop agent proposal found for setup: ${proposalId}`,
-        );
-      },
-      onInvalidProposal: (issues) => {
-        this.logger.warn('Invalid desktop agent proposal config', {
-          data: { errors: issues },
-        });
-      },
-      onSetupComplete: (proposal) => {
-        this.logger.info(
-          `Desktop agent proposal ${proposal.proposalId} set up in main view`,
-          {
-            data: { agent: proposal.agent },
-          },
-        );
-      },
-    });
+    this.progressHost = this.createProgressViewHost();
+    this.workflowActions = this.progressHost.workflowActionsController;
+    this.workflowFileActions = this.progressHost.workflowFileActionsController;
+    this.agentProposalController = this.progressHost.agentProposalController;
     this.progressViewInboundHandlers = this.createProgressViewInboundHandlers();
   }
 
-  private createProgressViewInboundHandlers(): ProgressViewInboundHandlerRegistry {
-    const sharedHandlers = createProgressViewCommandHandlers({
-      lifecycle: {
-        setActiveStream: (stream) => this.setActiveStream(stream),
-        setAgentFilter: (filter) => this.setAgentFilter(filter),
-        deleteStream: (stream) => this.deleteStream(stream),
-        deleteAllStreams: () => this.deleteAllStreams(),
-        stopStream: (stream) => this.stopStream(stream),
-      },
-      run: {
-        resumeStream: async (stream) => {
-          await this.tryResumeStream(stream);
+  private createProgressViewHost(): ProgressViewHost {
+    return new ProgressViewHost({
+      // Shared run-new path (mirrors the extension wiring). Only
+      // `getTaskState` and `executeAgent` matter here: diff/file-operation
+      // actions are routed through `workflowFileActions`/`fileActions`, so
+      // those deps stay unwired.
+      workflowActions: {
+        state: {
+          getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
+          getExecutionId: (stream) => this.getStreamExecutionId(stream),
+          getOutputFiles: (stream) =>
+            this.state.snapshots.getOutputFiles(stream),
+          getKnownWorkspaceOutputPaths: () => new Set(),
         },
-        runNewStream: (stream) => this.workflowActions.runNew(stream),
-      },
-      followUp: {
-        sendFollowUp: ({ stream, text, mediaFiles }) =>
-          this.sendFollowUp(stream, text, mediaFiles),
-        reportImageSaveError: (image, error) => {
-          this.logger.warn(
-            `Failed to save pasted follow-up image ${image.fileName}`,
-            { data: error instanceof Error ? error : { error } },
+        executeAgent: async (request) => {
+          const validated = validateExecutionRequest(request);
+          if (!validated.valid) {
+            this.logger.error('Invalid desktop workflow execution request', {
+              data: validated.issue,
+            });
+            await this.options.showErrorMessage?.(validated.message);
+            return;
+          }
+          await this.runExecution(validated.request);
+        },
+        runDiff: () => {
+          throw new Error('Desktop diff is routed through workflowFileActions');
+        },
+        runFileOperation: () => {
+          throw new Error(
+            'Desktop file operations are routed through workflowFileActions',
           );
         },
       },
-      bypass: {
-        runtimeHost: this.runtimeHost,
-      },
-      file: {
-        openFile: async (file, line) => {
-          await this.options.openPath?.(file, line);
+      workflowFileActions: {
+        state: {
+          getActiveStream: () => this.state.activeStream,
+          getExecutionId: (stream) => this.getStreamExecutionId(stream),
+          getOutputFiles: (stream) =>
+            this.state.snapshots.getOutputFiles(stream),
+          // The desktop bridge has no quick-pick UI, so Accept always replaces
+          // the workspace file. Returning undefined keeps the controller from
+          // building copy metadata that the desktop host would silently drop.
+          getAgentModel: () => undefined,
         },
-        openFileCompile: (file) => this.openFileCompile(file),
-        openTaskStorage: (stream) =>
-          this.workflowFileActions.openTaskStorage(stream),
-        compareOriginal: (file, base) =>
-          this.workflowFileActions.compareOriginal(file, base),
-        comparePrevious: (file, base, previous) =>
-          this.workflowFileActions.comparePrevious(file, base, previous),
-        acceptFile: (file, base) =>
-          this.workflowFileActions.acceptFile(file, base),
-        mergeFile: (file, base) =>
-          this.workflowFileActions.mergeFile(file, base),
-        latexdiffFile: (file, base) =>
-          this.workflowFileActions.latexdiffFile(file, base),
-        openLabel: (label) => this.workflowFileActions.openLabel(label),
+        host: {
+          compareFiles: (baseFile, editedFile) =>
+            this.fileActions.compareFiles(baseFile, editedFile),
+          acceptEditedFile: (baseFile, editedFile) =>
+            this.fileActions.acceptEditedFile(baseFile, editedFile),
+          mergeFile: (baseFile, editedFile) =>
+            this.fileActions.runMergeFile(baseFile, editedFile),
+          latexdiffFile: (baseFile, editedFile) =>
+            this.runLatexdiffFile(baseFile, editedFile),
+          openDirectory: async (directory) => {
+            await this.options.openPath?.(directory);
+          },
+          openLabel: (label) => this.fileActions.findAndOpenLabel(label),
+          readFile: (file) => readFile(file, 'utf8'),
+          showInfo: async (message) => {
+            await this.options.showInfoMessage?.(message);
+          },
+          showError: async (message) => {
+            await this.options.showErrorMessage?.(message);
+          },
+          logError: (message, error) => {
+            this.logger.error(message, {
+              data: error instanceof Error ? error : { error },
+            });
+          },
+        },
+        sendFollowUp: async (stream, text) => {
+          await this.sendFollowUp(stream, text);
+        },
       },
-      approval: {
-        handleToolEditApprovalAction: (message) =>
-          this.toolEditApprovals.handleAction(message),
-        onUnsupportedToolEditApproval: (message) => {
-          this.logger.warn('Unsupported desktop tool-edit approval action', {
-            data: {
-              requestId: message.requestId,
-              action: message.action,
-            },
+      agentProposal: {
+        getPendingProposal: (proposalId) =>
+          this.approvalHandlers.agentProposal.get(proposalId),
+        restoreTaskState: async (taskState) => {
+          let state: MainViewPersistedState;
+          try {
+            state = buildMainViewState(taskState);
+          } catch {
+            return false;
+          }
+          this.postToRenderer({
+            command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+            route: 'main',
+          });
+          this.postToRenderer({
+            command: COMMON_COMMANDS.STATE_RESTORE,
+            state,
+          });
+          return true;
+        },
+        settleProposal: (proposalId, result) => {
+          const resolved = this.session.interactions.resolve(proposalId, {
+            kind: 'proposal',
+            action: result.action,
+            value: result,
+          });
+          if (!resolved) {
+            this.logger.warn(
+              `No pending desktop host interaction found for proposal: ${proposalId}`,
+            );
+          }
+        },
+        onMissingProposal: (proposalId) => {
+          this.logger.warn(
+            `No pending desktop agent proposal found for setup: ${proposalId}`,
+          );
+        },
+        onInvalidProposal: (issues) => {
+          this.logger.warn('Invalid desktop agent proposal config', {
+            data: { errors: issues },
           });
         },
-        handleBashApprovalAction: (message) =>
-          void this.session.interactions.resolve(message.requestId, {
-            kind: 'bash',
-            action: message.action,
-            feedback: message.feedback,
-          }),
-        handlePlanApprovalAction: (message) => {
-          this.session.interactions.resolve(message.approvalId, {
-            kind: 'plan',
-            action: message.action,
-            ...(message.action === 'reject' && {
+        onSetupComplete: (proposal) => {
+          this.logger.info(
+            `Desktop agent proposal ${proposal.proposalId} set up in main view`,
+            {
+              data: { agent: proposal.agent },
+            },
+          );
+        },
+      },
+      commands: {
+        lifecycle: {
+          setActiveStream: (stream) => this.setActiveStream(stream),
+          setAgentFilter: (filter) => this.setAgentFilter(filter),
+          deleteStream: (stream) => this.deleteStream(stream),
+          deleteAllStreams: () => this.deleteAllStreams(),
+          stopStream: (stream) => this.stopStream(stream),
+        },
+        run: {
+          resumeStream: async (stream) => {
+            await this.tryResumeStream(stream);
+          },
+        },
+        followUp: {
+          sendFollowUp: ({ stream, text, mediaFiles }) =>
+            this.sendFollowUp(stream, text, mediaFiles),
+          reportImageSaveError: (image, error) => {
+            this.logger.warn(
+              `Failed to save pasted follow-up image ${image.fileName}`,
+              { data: error instanceof Error ? error : { error } },
+            );
+          },
+        },
+        bypass: {
+          runtimeHost: this.runtimeHost,
+        },
+        file: {
+          openFile: async (file, line) => {
+            await this.options.openPath?.(file, line);
+          },
+          openFileCompile: (file) => this.openFileCompile(file),
+        },
+        approval: {
+          handleToolEditApprovalAction: (message) =>
+            this.toolEditApprovals.handleAction(message),
+          onUnsupportedToolEditApproval: (message) => {
+            this.logger.warn('Unsupported desktop tool-edit approval action', {
+              data: {
+                requestId: message.requestId,
+                action: message.action,
+              },
+            });
+          },
+          handleBashApprovalAction: (message) =>
+            void this.session.interactions.resolve(message.requestId, {
+              kind: 'bash',
+              action: message.action,
               feedback: message.feedback,
             }),
-          });
+          handlePlanApprovalAction: (message) => {
+            this.session.interactions.resolve(message.approvalId, {
+              kind: 'plan',
+              action: message.action,
+              ...(message.action === 'reject' && {
+                feedback: message.feedback,
+              }),
+            });
+          },
+          handleUserQuestionAction: (message) => {
+            this.session.interactions.resolve(message.requestId, {
+              kind: 'userQuestion',
+              action: message.action,
+              value: message.answers,
+              feedback: message.feedback,
+            });
+            return undefined;
+          },
         },
-        handleUserQuestionAction: (message) => {
-          this.session.interactions.resolve(message.requestId, {
-            kind: 'userQuestion',
-            action: message.action,
-            value: message.answers,
-            feedback: message.feedback,
-          });
-          return undefined;
+        externalInquiry: {
+          logWarn: (message, context) =>
+            this.logger.warn(message, { data: context }),
+          sessionContext: { session: this.session },
         },
-        handleAgentProposalAction: (message) =>
-          this.agentProposalController.handleAction(message),
-      },
-      externalInquiry: {
-        logWarn: (message, context) =>
-          this.logger.warn(message, { data: context }),
-        sessionContext: { session: this.session },
       },
     });
+  }
+
+  private createProgressViewInboundHandlers(): ProgressViewInboundHandlerRegistry {
     return {
-      ...sharedHandlers,
+      ...this.progressHost.commandHandlers,
       // Getting-started actions from the progress empty-state. openWalkthrough
       // has a desktop equivalent; the remaining four actions are VS Code-only.
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { createProgressViewCommandHandlers } from '@controllers/progressView/ProgressViewCommandHandlers';
+import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
 import {
   ProgressFollowUpController,
@@ -10,10 +10,7 @@ import {
   ProgressFollowUpPolishController,
   type ProgressFollowUpPolishResult,
 } from '@controllers/progressView/ProgressFollowUpPolishController';
-import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import { ProgressApiKeyRetryController } from '@controllers/progressView/ProgressApiKeyRetryController';
-import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
-import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
@@ -72,10 +69,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private readonly recordingManager: RecordingManager;
+  private readonly progressHost: ProgressViewHost;
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
-  private readonly workflowActionsController: ProgressWorkflowActionsController;
-  private readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
-  private readonly agentProposalController: ProgressAgentProposalController;
+  private readonly workflowActionsController: ProgressViewHost['workflowActionsController'];
+  private readonly workflowFileActionsController: ProgressViewHost['workflowFileActionsController'];
+  private readonly agentProposalController: ProgressViewHost['agentProposalController'];
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly followUpPolishController: ProgressFollowUpPolishController;
@@ -107,11 +105,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       progressTitle: 'Transcribing follow-up message',
     });
 
+    this.progressHost = this.createProgressViewHost();
+    this.workflowActionsController =
+      this.progressHost.workflowActionsController;
     this.workflowFileActionsController =
-      this.createWorkflowFileActionsController();
+      this.progressHost.workflowFileActionsController;
+    this.agentProposalController = this.progressHost.agentProposalController;
     this.streamLifecycleController = this.createStreamLifecycleController();
-    this.workflowActionsController = this.createWorkflowActionsController();
-    this.agentProposalController = this.createAgentProposalController();
     this.apiKeyRetryController = this.createApiKeyRetryController();
     this.followUpController = this.createFollowUpController();
     this.followUpPolishController = new ProgressFollowUpPolishController();
@@ -166,107 +166,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.popBackToSidebar(),
 
       // Shared progress command groups
-      ...createProgressViewCommandHandlers({
-        lifecycle: {
-          setActiveStream: (stream) => this.provider.setActiveStream(stream),
-          setAgentFilter: (filter) => {
-            this.provider.state.agentCategoryFilter = filter;
-            this.provider.syncFullView();
-          },
-          deleteStream: (stream) =>
-            this.streamLifecycleController.deleteStream(stream),
-          deleteAllStreams: () => this.handleDeleteAll(),
-          stopStream: (stream) =>
-            this.streamLifecycleController.stopStream(stream),
-        },
-        run: {
-          resumeStream: (stream) =>
-            this.workflowActionsController.resume(stream),
-          runNewStream: (stream) =>
-            this.workflowActionsController.runNew(stream),
-        },
-        followUp: {
-          sendFollowUp: async ({ stream, text, mediaFiles }) => {
-            await safeExecuteCommand(
-              'texra.sendFollowUp',
-              [
-                {
-                  stream,
-                  text,
-                  ...(mediaFiles && mediaFiles.length > 0
-                    ? { mediaFiles }
-                    : {}),
-                },
-              ],
-              this.viewName,
-            );
-          },
-          reportImageSaveError: (_image, error) => {
-            // Best-effort: a failed image save must not block the text, but log
-            // it so a missing attachment is diagnosable.
-            this.logger.warn(
-              this.channel,
-              `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
-            );
-          },
-        },
-        bypass: {
-          runtimeHost: extensionAgentRuntimeHost,
-          showInfo: (message) => this.host.info(message),
-        },
-        file: {
-          openFile: async (file, line) => {
-            await safeExecuteCommand(
-              'texra.openFile',
-              [file, line],
-              this.viewName,
-            );
-          },
-          openFileCompile: async (file) => {
-            await safeExecuteCommand(
-              'texra.openFileCompile',
-              [file],
-              this.viewName,
-            );
-          },
-          openTaskStorage: (stream) =>
-            this.workflowFileActionsController.openTaskStorage(stream),
-          compareOriginal: (file, base) =>
-            this.workflowFileActionsController.compareOriginal(file, base),
-          comparePrevious: (file, base, previous) =>
-            this.workflowFileActionsController.comparePrevious(
-              file,
-              base,
-              previous,
-            ),
-          acceptFile: (file, base) =>
-            this.workflowFileActionsController.acceptFile(file, base),
-          mergeFile: (file, base) =>
-            this.workflowFileActionsController.mergeFile(file, base),
-          latexdiffFile: (file, base) =>
-            this.workflowFileActionsController.latexdiffFile(file, base),
-          openLabel: (label) =>
-            this.workflowFileActionsController.openLabel(label),
-        },
-        approval: {
-          handleToolEditApprovalAction: async (message) => {
-            await handleProgressViewToolEditApprovalAction(message);
-            return true;
-          },
-          handleBashApprovalAction: (message) =>
-            this.handleBashApprovalAction(message),
-          handlePlanApprovalAction: (message) =>
-            this.handlePlanApprovalAction(message),
-          handleUserQuestionAction: (message) =>
-            this.handleUserQuestionAction(message),
-          handleAgentProposalAction: (message) =>
-            this.agentProposalController.handleAction(message),
-        },
-        externalInquiry: {
-          logWarn: (message, context) =>
-            this.logger.warn(this.channel, message, { data: context }),
-        },
-      }),
+      ...this.progressHost.commandHandlers,
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) => {
         await safeExecuteCommand(
           'texra.compactResponse',
@@ -436,180 +336,252 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private createWorkflowActionsController(): ProgressWorkflowActionsController {
-    return new ProgressWorkflowActionsController({
-      state: {
-        getTaskState: (stream) =>
-          this.provider.state.snapshots.getTaskState(stream),
-        getExecutionId: (stream) =>
-          this.provider.state.snapshots.getExecutionId(stream),
-        getOutputFiles: (stream) =>
-          this.provider.state.snapshots.getOutputFiles(stream),
-        getKnownWorkspaceOutputPaths: (stream) =>
-          this.provider.state.snapshots.getKnownFilePaths(stream, {
-            workspaceOnly: true,
-          }),
-      },
-      executeAgent: async (request) => {
-        await this.executeValidated(request);
-      },
-      runDiff: async (request) => {
-        await safeExecuteCommand(
-          'texra.runLatexdiff',
-          [request],
-          this.viewName,
-        );
-      },
-      runFileOperation: async (operation, request) => {
-        await safeExecuteCommand(
-          `texra.${operation}`,
-          [request],
-          this.viewName,
-        );
-      },
-    });
-  }
-
-  private createWorkflowFileActionsController(): ProgressWorkflowFileActionsController {
-    return new ProgressWorkflowFileActionsController({
-      state: {
-        getActiveStream: () => this.provider.state.activeStream,
-        getExecutionId: (stream) =>
-          this.provider.state.snapshots.getExecutionId(stream),
-        getOutputFiles: (stream) =>
-          this.provider.state.snapshots.getOutputFiles(stream),
-        getAgentModel: (stream) => {
-          const taskState = this.provider.state.snapshots.getTaskState(stream);
-          return taskState
-            ? {
-                agent: taskState.agentConfig.agent,
-                model: taskState.agentConfig.model,
-              }
-            : undefined;
+  private createProgressViewHost(): ProgressViewHost {
+    return new ProgressViewHost({
+      workflowActions: {
+        state: {
+          getTaskState: (stream) =>
+            this.provider.state.snapshots.getTaskState(stream),
+          getExecutionId: (stream) =>
+            this.provider.state.snapshots.getExecutionId(stream),
+          getOutputFiles: (stream) =>
+            this.provider.state.snapshots.getOutputFiles(stream),
+          getKnownWorkspaceOutputPaths: (stream) =>
+            this.provider.state.snapshots.getKnownFilePaths(stream, {
+              workspaceOnly: true,
+            }),
         },
-      },
-      host: {
-        compareFiles: async (baseFile, editedFile) => {
+        executeAgent: async (request) => {
+          await this.executeValidated(request);
+        },
+        runDiff: async (request) => {
           await safeExecuteCommand(
-            'texra.compare',
-            [
-              pathToLocation(''), // inputFile unused
-              pathToLocation(baseFile),
-              pathToLocation(editedFile),
-            ],
+            'texra.runLatexdiff',
+            [request],
             this.viewName,
           );
         },
-        acceptEditedFile: async (baseFile, editedFile, copyMeta) => {
-          return safeExecuteCommand<boolean>(
-            'texra.acceptEdited',
-            [
-              pathToLocation(''), // inputFile unused
-              pathToLocation(baseFile),
-              pathToLocation(editedFile),
-              copyMeta,
-            ],
-            this.viewName,
-          );
-        },
-        mergeFile: async (baseFile, editedFile) => {
+        runFileOperation: async (operation, request) => {
           await safeExecuteCommand(
-            'texra.merge',
-            [undefined, baseFile, editedFile],
+            `texra.${operation}`,
+            [request],
             this.viewName,
           );
         },
-        latexdiffFile: async (baseFile, editedFile) => {
+      },
+      workflowFileActions: {
+        state: {
+          getActiveStream: () => this.provider.state.activeStream,
+          getExecutionId: (stream) =>
+            this.provider.state.snapshots.getExecutionId(stream),
+          getOutputFiles: (stream) =>
+            this.provider.state.snapshots.getOutputFiles(stream),
+          getAgentModel: (stream) => {
+            const taskState =
+              this.provider.state.snapshots.getTaskState(stream);
+            return taskState
+              ? {
+                  agent: taskState.agentConfig.agent,
+                  model: taskState.agentConfig.model,
+                }
+              : undefined;
+          },
+        },
+        host: {
+          compareFiles: async (baseFile, editedFile) => {
+            await safeExecuteCommand(
+              'texra.compare',
+              [
+                pathToLocation(''), // inputFile unused
+                pathToLocation(baseFile),
+                pathToLocation(editedFile),
+              ],
+              this.viewName,
+            );
+          },
+          acceptEditedFile: async (baseFile, editedFile, copyMeta) => {
+            return safeExecuteCommand<boolean>(
+              'texra.acceptEdited',
+              [
+                pathToLocation(''), // inputFile unused
+                pathToLocation(baseFile),
+                pathToLocation(editedFile),
+                copyMeta,
+              ],
+              this.viewName,
+            );
+          },
+          mergeFile: async (baseFile, editedFile) => {
+            await safeExecuteCommand(
+              'texra.merge',
+              [undefined, baseFile, editedFile],
+              this.viewName,
+            );
+          },
+          latexdiffFile: async (baseFile, editedFile) => {
+            await safeExecuteCommand(
+              'texra.latexdiff',
+              [undefined, baseFile, editedFile],
+              this.viewName,
+            );
+          },
+          openDirectory: async (directory) => {
+            await safeExecuteCommand(
+              'revealFileInOS',
+              [vscode.Uri.file(directory)],
+              this.viewName,
+            );
+          },
+          openLabel: async (label) => {
+            return (
+              (await safeExecuteCommand<boolean>(
+                'texra.openLabel',
+                [label, { notifyNotFound: false }],
+                this.viewName,
+              )) ?? false
+            );
+          },
+          readFile: (file) => FlexibleFS.read(createExternalLocation(file)),
+          showInfo: async (message) => {
+            await this.host.info(message);
+          },
+          showError: async (message) => {
+            await this.host.error(message);
+          },
+          logError: (message, error) => {
+            this.logger.error(this.channel, message, {
+              data: error instanceof Error ? error : undefined,
+            });
+          },
+        },
+        sendFollowUp: async (stream, text) => {
           await safeExecuteCommand(
-            'texra.latexdiff',
-            [undefined, baseFile, editedFile],
+            'texra.sendFollowUp',
+            [{ stream, text }],
             this.viewName,
           );
         },
-        openDirectory: async (directory) => {
-          await safeExecuteCommand(
-            'revealFileInOS',
-            [vscode.Uri.file(directory)],
-            this.viewName,
-          );
-        },
-        openLabel: async (label) => {
+      },
+      agentProposal: {
+        getPendingProposal: (proposalId) =>
+          this.provider.getPendingAgentProposal(proposalId),
+        restoreTaskState: async (taskState) => {
           return (
             (await safeExecuteCommand<boolean>(
-              'texra.openLabel',
-              [label, { notifyNotFound: false }],
+              'texra.restoreState',
+              [taskState],
               this.viewName,
-            )) ?? false
+            )) === true
           );
         },
-        readFile: (file) => FlexibleFS.read(createExternalLocation(file)),
-        showInfo: async (message) => {
-          await this.host.info(message);
-        },
-        showError: async (message) => {
-          await this.host.error(message);
-        },
-        logError: (message, error) => {
-          this.logger.error(this.channel, message, {
-            data: error instanceof Error ? error : undefined,
+        settleProposal: (proposalId, result) => {
+          const resolved = this.interactions.resolve(proposalId, {
+            kind: 'proposal',
+            action: result.action,
+            value: result,
           });
+          if (!resolved) {
+            this.logger.warn(
+              this.channel,
+              `No pending host interaction found for proposal: ${proposalId}`,
+            );
+          }
         },
-      },
-      sendFollowUp: async (stream, text) => {
-        await safeExecuteCommand(
-          'texra.sendFollowUp',
-          [{ stream, text }],
-          this.viewName,
-        );
-      },
-    });
-  }
-
-  private createAgentProposalController(): ProgressAgentProposalController {
-    return new ProgressAgentProposalController({
-      getPendingProposal: (proposalId) =>
-        this.provider.getPendingAgentProposal(proposalId),
-      restoreTaskState: async (taskState) => {
-        return (
-          (await safeExecuteCommand<boolean>(
-            'texra.restoreState',
-            [taskState],
-            this.viewName,
-          )) === true
-        );
-      },
-      settleProposal: (proposalId, result) => {
-        const resolved = this.interactions.resolve(proposalId, {
-          kind: 'proposal',
-          action: result.action,
-          value: result,
-        });
-        if (!resolved) {
+        onMissingProposal: (proposalId) => {
           this.logger.warn(
             this.channel,
-            `No pending host interaction found for proposal: ${proposalId}`,
+            `No pending agent proposal found for setup: ${proposalId}`,
           );
-        }
+        },
+        onInvalidProposal: (issues) => {
+          this.logger.warn(this.channel, 'Invalid proposal config', {
+            data: { errors: issues },
+          });
+        },
+        onSetupComplete: (proposal) => {
+          this.logger.info(
+            this.channel,
+            `Agent proposal ${proposal.proposalId} set up in main view`,
+            {
+              data: { agent: proposal.agent },
+            },
+          );
+        },
       },
-      onMissingProposal: (proposalId) => {
-        this.logger.warn(
-          this.channel,
-          `No pending agent proposal found for setup: ${proposalId}`,
-        );
-      },
-      onInvalidProposal: (issues) => {
-        this.logger.warn(this.channel, 'Invalid proposal config', {
-          data: { errors: issues },
-        });
-      },
-      onSetupComplete: (proposal) => {
-        this.logger.info(
-          this.channel,
-          `Agent proposal ${proposal.proposalId} set up in main view`,
-          {
-            data: { agent: proposal.agent },
+      commands: {
+        lifecycle: {
+          setActiveStream: (stream) => this.provider.setActiveStream(stream),
+          setAgentFilter: (filter) => {
+            this.provider.state.agentCategoryFilter = filter;
+            this.provider.syncFullView();
           },
-        );
+          deleteStream: (stream) =>
+            this.streamLifecycleController.deleteStream(stream),
+          deleteAllStreams: () => this.handleDeleteAll(),
+          stopStream: (stream) =>
+            this.streamLifecycleController.stopStream(stream),
+        },
+        followUp: {
+          sendFollowUp: async ({ stream, text, mediaFiles }) => {
+            await safeExecuteCommand(
+              'texra.sendFollowUp',
+              [
+                {
+                  stream,
+                  text,
+                  ...(mediaFiles && mediaFiles.length > 0
+                    ? { mediaFiles }
+                    : {}),
+                },
+              ],
+              this.viewName,
+            );
+          },
+          reportImageSaveError: (_image, error) => {
+            // Best-effort: a failed image save must not block the text, but log
+            // it so a missing attachment is diagnosable.
+            this.logger.warn(
+              this.channel,
+              `Failed to save pasted follow-up image: ${toErrorMessage(error)}`,
+            );
+          },
+        },
+        bypass: {
+          runtimeHost: extensionAgentRuntimeHost,
+          showInfo: (message) => this.host.info(message),
+        },
+        file: {
+          openFile: async (file, line) => {
+            await safeExecuteCommand(
+              'texra.openFile',
+              [file, line],
+              this.viewName,
+            );
+          },
+          openFileCompile: async (file) => {
+            await safeExecuteCommand(
+              'texra.openFileCompile',
+              [file],
+              this.viewName,
+            );
+          },
+        },
+        approval: {
+          handleToolEditApprovalAction: async (message) => {
+            await handleProgressViewToolEditApprovalAction(message);
+            return true;
+          },
+          handleBashApprovalAction: (message) =>
+            this.handleBashApprovalAction(message),
+          handlePlanApprovalAction: (message) =>
+            this.handlePlanApprovalAction(message),
+          handleUserQuestionAction: (message) =>
+            this.handleUserQuestionAction(message),
+        },
+        externalInquiry: {
+          logWarn: (message, context) =>
+            this.logger.warn(this.channel, message, { data: context }),
+        },
       },
     });
   }

--- a/src/controllers/progressView/ProgressViewHost.ts
+++ b/src/controllers/progressView/ProgressViewHost.ts
@@ -1,0 +1,129 @@
+// Local imports - controllers
+import {
+  createProgressViewCommandHandlers,
+  type ProgressViewApprovalCommandActions,
+  type ProgressViewBypassCommandOptions,
+  type ProgressViewExternalInquiryCommandActions,
+  type ProgressViewFileCommandActions,
+  type ProgressViewFollowUpCommandActions,
+  type ProgressViewLifecycleCommandActions,
+  type ProgressViewRunCommandActions,
+} from './ProgressViewCommandHandlers';
+import {
+  ProgressAgentProposalController,
+  type ProgressAgentProposalControllerDeps,
+} from './ProgressAgentProposalController';
+import {
+  ProgressWorkflowActionsController,
+  type ProgressWorkflowActionsControllerDeps,
+} from './ProgressWorkflowActionsController';
+import {
+  ProgressWorkflowFileActionsController,
+  type ProgressWorkflowFileActionsControllerDeps,
+} from './ProgressWorkflowFileActionsController';
+
+type ProgressViewFileHostActions = Pick<
+  ProgressViewFileCommandActions,
+  'openFile' | 'openFileCompile'
+> &
+  Partial<Omit<ProgressViewFileCommandActions, 'openFile' | 'openFileCompile'>>;
+
+type ProgressViewApprovalHostActions = Omit<
+  ProgressViewApprovalCommandActions,
+  'handleAgentProposalAction'
+> &
+  Partial<
+    Pick<ProgressViewApprovalCommandActions, 'handleAgentProposalAction'>
+  >;
+
+export interface ProgressViewHostCommandOptions {
+  readonly lifecycle: ProgressViewLifecycleCommandActions;
+  readonly run?: Partial<ProgressViewRunCommandActions>;
+  readonly followUp: ProgressViewFollowUpCommandActions;
+  readonly bypass: ProgressViewBypassCommandOptions;
+  readonly file: ProgressViewFileHostActions;
+  readonly approval: ProgressViewApprovalHostActions;
+  readonly externalInquiry: ProgressViewExternalInquiryCommandActions;
+}
+
+export interface ProgressViewHostOptions {
+  readonly workflowActions: ProgressWorkflowActionsControllerDeps;
+  readonly workflowFileActions: ProgressWorkflowFileActionsControllerDeps;
+  readonly agentProposal: ProgressAgentProposalControllerDeps;
+  readonly commands: ProgressViewHostCommandOptions;
+}
+
+export class ProgressViewHost {
+  readonly workflowActionsController: ProgressWorkflowActionsController;
+  readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
+  readonly agentProposalController: ProgressAgentProposalController;
+  readonly commandHandlers: ReturnType<
+    typeof createProgressViewCommandHandlers
+  >;
+
+  constructor(options: ProgressViewHostOptions) {
+    this.workflowActionsController = new ProgressWorkflowActionsController(
+      options.workflowActions,
+    );
+    this.workflowFileActionsController =
+      new ProgressWorkflowFileActionsController(options.workflowFileActions);
+    this.agentProposalController = new ProgressAgentProposalController(
+      options.agentProposal,
+    );
+    this.commandHandlers = createProgressViewCommandHandlers({
+      lifecycle: options.commands.lifecycle,
+      run: {
+        resumeStream:
+          options.commands.run?.resumeStream ??
+          ((stream) => this.workflowActionsController.resume(stream)),
+        runNewStream:
+          options.commands.run?.runNewStream ??
+          ((stream) => this.workflowActionsController.runNew(stream)),
+      },
+      followUp: options.commands.followUp,
+      bypass: options.commands.bypass,
+      file: {
+        openFile: options.commands.file.openFile,
+        openFileCompile: options.commands.file.openFileCompile,
+        openTaskStorage:
+          options.commands.file.openTaskStorage ??
+          ((stream) =>
+            this.workflowFileActionsController.openTaskStorage(stream)),
+        compareOriginal:
+          options.commands.file.compareOriginal ??
+          ((file, base) =>
+            this.workflowFileActionsController.compareOriginal(file, base)),
+        comparePrevious:
+          options.commands.file.comparePrevious ??
+          ((file, base, previous) =>
+            this.workflowFileActionsController.comparePrevious(
+              file,
+              base,
+              previous,
+            )),
+        acceptFile:
+          options.commands.file.acceptFile ??
+          ((file, base) =>
+            this.workflowFileActionsController.acceptFile(file, base)),
+        mergeFile:
+          options.commands.file.mergeFile ??
+          ((file, base) =>
+            this.workflowFileActionsController.mergeFile(file, base)),
+        latexdiffFile:
+          options.commands.file.latexdiffFile ??
+          ((file, base) =>
+            this.workflowFileActionsController.latexdiffFile(file, base)),
+        openLabel:
+          options.commands.file.openLabel ??
+          ((label) => this.workflowFileActionsController.openLabel(label)),
+      },
+      approval: {
+        ...options.commands.approval,
+        handleAgentProposalAction:
+          options.commands.approval.handleAgentProposalAction ??
+          ((message) => this.agentProposalController.handleAction(message)),
+      },
+      externalInquiry: options.commands.externalInquiry,
+    });
+  }
+}

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -1,0 +1,128 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it, vi } from 'vitest';
+
+// Local imports - controllers
+import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
+import type { TaskState } from '@agent/core/state/TaskState';
+
+// Local imports - shared
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+
+// Local imports - test support
+import { createWorkflowTaskState } from '../support/ProgressControllerHarnesses';
+
+function createTaskState(): TaskState {
+  return createWorkflowTaskState();
+}
+
+describe('ProgressViewHost', () => {
+  it('constructs shared controllers and command handlers from host adapters', async () => {
+    const taskState = createTaskState();
+    const executed: unknown[] = [];
+    const openedLabels: string[] = [];
+    const infoMessages: string[] = [];
+    const settledProposals: unknown[] = [];
+
+    const host = new ProgressViewHost({
+      workflowActions: {
+        state: {
+          getTaskState: () => taskState,
+          getExecutionId: () => 'exec-1',
+          getOutputFiles: () => ({}),
+          getKnownWorkspaceOutputPaths: () => new Set(),
+        },
+        executeAgent: async (request) => {
+          executed.push(request);
+        },
+        runDiff: vi.fn(),
+        runFileOperation: vi.fn(),
+      },
+      workflowFileActions: {
+        state: {
+          getActiveStream: () => 'stream-a',
+          getExecutionId: () => 'exec-1',
+          getOutputFiles: () => ({}),
+          getAgentModel: () => undefined,
+        },
+        host: {
+          compareFiles: vi.fn(),
+          acceptEditedFile: vi.fn(),
+          mergeFile: vi.fn(),
+          latexdiffFile: vi.fn(),
+          openDirectory: vi.fn(),
+          openLabel: async (label) => {
+            openedLabels.push(label);
+            return false;
+          },
+          readFile: async () => '',
+          showInfo: async (message) => {
+            infoMessages.push(message);
+          },
+          showError: vi.fn(),
+        },
+        sendFollowUp: vi.fn(),
+      },
+      agentProposal: {
+        getPendingProposal: () => undefined,
+        restoreTaskState: async () => false,
+        settleProposal: (proposalId, result) => {
+          settledProposals.push({ proposalId, result });
+        },
+      },
+      commands: {
+        lifecycle: {
+          setActiveStream: vi.fn(),
+          setAgentFilter: vi.fn(),
+          deleteStream: vi.fn(),
+          deleteAllStreams: vi.fn(),
+          stopStream: vi.fn(),
+        },
+        followUp: {
+          sendFollowUp: vi.fn(),
+          reportImageSaveError: vi.fn(),
+        },
+        bypass: {
+          runtimeHost: { emit: vi.fn() },
+        },
+        file: {
+          openFile: vi.fn(),
+          openFileCompile: vi.fn(),
+        },
+        approval: {
+          handleToolEditApprovalAction: vi.fn(),
+          handleBashApprovalAction: vi.fn(),
+          handlePlanApprovalAction: vi.fn(),
+          handleUserQuestionAction: vi.fn(),
+        },
+        externalInquiry: {
+          logWarn: vi.fn(),
+        },
+      },
+    });
+
+    await host.commandHandlers[PROGRESS_VIEW_COMMANDS.RUN_NEW]?.({
+      command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
+      stream: 'stream-a',
+    });
+    await host.commandHandlers[PROGRESS_VIEW_COMMANDS.OPEN_LABEL]?.({
+      command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL,
+      label: 'main-thm',
+    });
+    await host.commandHandlers[PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]?.({
+      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+      proposalId: 'proposal-1',
+      action: 'approve',
+    });
+
+    assert.deepEqual(executed, [{ config: taskState.agentConfig }]);
+    assert.deepEqual(openedLabels, ['main-thm']);
+    assert.deepEqual(infoMessages, ['Label "main-thm" not found.']);
+    assert.deepEqual(settledProposals, [
+      {
+        proposalId: 'proposal-1',
+        result: { action: 'approve' },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Part of #6953. Final F2 execution/progress host-factory slice after the settings-host work in #7525 and #7548.

## Summary

- add `ProgressViewHost` as the shared progress-view composition owner for host-neutral controller construction
- move shared `ProgressWorkflowActionsController`, `ProgressWorkflowFileActionsController`, `ProgressAgentProposalController`, and default progress command-handler wiring behind that host
- rewire the VS Code progress view and desktop progress bridge to use the shared host while keeping concrete host effects in their adapters
- add focused `ProgressViewHost` coverage for default run, file, and agent-proposal command paths

## Issue acceptance gates

- Settings command wiring was moved into `SettingsViewHost` by #7525 and #7548.
- This PR completes the remaining execution/progress host-factory seam from #6972.
- Existing focused controller, desktop, typecheck, and full test gates are green locally.

## Single source of truth

`ProgressViewHost` is now the single composition point for shared progress-view controller construction and default inbound command-handler wiring. Host adapters provide concrete effects; they no longer each author the same shared progress controller setup.

## Duplication and abstraction budget

This removes duplicate extension/desktop construction of progress workflow, workflow-file, agent-proposal controllers, and default command maps. The PR is net +223 LoC because it introduces the shared owner plus direct coverage; that added mass lives in the host-factory seam needed to delete duplicated host wiring.

## Host impact

Extension: Progress view command wiring now delegates shared controller setup to `ProgressViewHost`; VS Code commands and UI effects stay in the extension adapter.

Desktop: Desktop progress bridge uses the same shared controller setup; desktop-specific file actions, session effects, and unsupported command handling stay in the desktop adapter.

CLI: No behavior change.

## Scheduled refactoring

None. No shim, projection, dual-write, alias, fallback, or migration path is introduced.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts src/test-kernel/controllers/ProgressWorkflowFileActionsController.vitest.ts src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts src/test-kernel/controllers/ProgressViewHost.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `CI=true corepack pnpm exec eslint src/controllers/progressView/ProgressViewHost.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/controllers/ProgressViewHost.vitest.ts`
- `corepack pnpm exec prettier --check src/controllers/progressView/ProgressViewHost.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/controllers/ProgressViewHost.vitest.ts`
- `npm run check:dead-code-ratchet`
- `npm run typecheck`
- `npm test` (601 passed, 1 skipped; 5204 tests passed, 4 skipped)
- `git diff --check`

Closes #6972