### PR TITLE
perf(transcript): cache the resolved execution stream id

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -74,6 +74,7 @@ const TraceExecutionMetaSchema = z.object({
   category: z.string().optional(),
   description: z.string().optional(),
   delegationDepth: z.int().nonnegative().optional(),
+  streamId: StreamTabIdSchema.optional(),
 });
 
 export const TraceDataSchema = z.object({

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -19,6 +19,7 @@ import * as logger from '@logger/logUtils';
 import {
   ExecutionIdSchema,
   RunOutcomeSchema,
+  StreamTabIdSchema,
   executionStatusToRunOutcome,
   type ExecutionId,
   type RunOutcome,
@@ -73,6 +74,14 @@ const ExecutionMetaBaseSchema = z.object({
    * having to walk a potentially broken parent chain.
    */
   delegationDepth: z.int().nonnegative().optional(),
+  /**
+   * The transcript stream this execution's data lives under, once resolved.
+   * Decide-once-carry-as-data cache for `resolvePersistedStreamIdForExecution`
+   * (`executionStreamResolver.ts`): absent on executions whose stream wasn't
+   * resolved yet (or predate this field), in which case the resolver falls
+   * back to its full meta-scan.
+   */
+  streamId: StreamTabIdSchema.optional(),
 });
 
 export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -12,7 +12,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getAgent, isAgentRegistryReady } from '@agent/index/agentRegistry';
 
 import * as logger from '@logger/logUtils';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -179,4 +179,17 @@ export async function writeSessionDescription(
   description: string,
 ): Promise<void> {
   await persistMetaField(executionId, { description }, 'session description');
+}
+
+/**
+ * Cache the resolved transcript stream for an execution, once
+ * `resolvePersistedStreamIdForExecution` (`executionStreamResolver.ts`) has
+ * actually decided it via its meta-scan, so later resolutions for the same
+ * executionId can skip straight to this field instead of re-scanning.
+ */
+export async function writeExecutionStreamId(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): Promise<void> {
+  await persistMetaField(executionId, { streamId }, 'execution stream id');
 }

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -46,17 +46,16 @@ const MINIMAL_CONFIG: AgentConfig = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 };
 
-/** Polls readMeta until streamId lands, tolerating the fire-and-forget write's async settle. */
+/** Waits for readMeta to reflect the fire-and-forget write's async settle. */
 async function waitForCachedStreamId(
   executionId: ExecutionId,
 ): Promise<StreamTabId | undefined> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    const streamId = (await getExecutionStore(executionId).readMeta())
-      ?.streamId;
-    if (streamId) return streamId;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  return undefined;
+  let streamId: StreamTabId | undefined;
+  await vi.waitFor(async () => {
+    streamId = (await getExecutionStore(executionId).readMeta())?.streamId;
+    expect(streamId).toBeDefined();
+  });
+  return streamId;
 }
 
 const tempDirs: string[] = [];
@@ -336,4 +335,59 @@ describe('resolvePersistedStreamIdForExecution', () => {
     });
     expect(second).toEqual({ streamId, source: 'executionMeta' });
   });
+
+  it(
+    'does not cache a multi-candidate resolution, so a later call with a ' +
+      'loaded streamLogStore can still pick the log-backed candidate (#7469)',
+    async () => {
+      const executionId = 'abc777' as ExecutionId;
+      const parentStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
+      const childStream = 'zBashTool@tool#abc777' as StreamTabId;
+      await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+
+      const snapshotWriter = new StreamSnapshotStore();
+      snapshotWriter.setTaskState(
+        parentStream,
+        taskState('orchestrator'),
+        executionId,
+      );
+      snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
+      await snapshotWriter.flush();
+
+      const logStore = new StreamLogStore();
+      await logStore.load();
+      logStore.append(childStream, {
+        id: 'entry-1',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 100,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'child stream output',
+      });
+      await logStore.flush();
+
+      // First call has no streamLogStore, so pickBestMetaMatch can't see the
+      // child's log and falls back to the first candidate (the parent).
+      const uninformed = await resolvePersistedStreamIdForExecution(
+        executionId,
+        { snapshotStore: new StreamSnapshotStore() },
+      );
+      expect(uninformed).toEqual({
+        streamId: parentStream,
+        source: 'streamDataMeta',
+      });
+
+      // If that resolution had been cached, this second call -- which DOES
+      // have the log store -- would incorrectly return the cached parent
+      // instead of correctly picking the log-backed child.
+      const informed = await resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore: new StreamSnapshotStore(),
+        streamLogStore: logStore,
+      });
+      expect(informed).toEqual({
+        streamId: childStream,
+        source: 'streamDataMeta',
+      });
+    },
+  );
 });

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -16,6 +16,9 @@ import {
   StreamSnapshotStore,
 } from '@transcript';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { registerExecution } from '@agent/storage/executionLifecycle';
 import {
   LOG_LEVELS,
   MESSAGE_TYPES,
@@ -24,8 +27,37 @@ import {
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { AgentCategory } from '@shared/schemas/agent';
 import type { Platform } from '@platform/platform';
+
+const MINIMAL_CONFIG: AgentConfig = {
+  agent: 'chat',
+  model: 'deepseekproT',
+  instruction: 'Check the proof.',
+  agentCategory: AgentCategory.ToolUse,
+  inputFiles: [],
+  outputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  editedFile: null,
+  editedFiles: [],
+  memories: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+};
+
+/** Polls readMeta until streamId lands, tolerating the fire-and-forget write's async settle. */
+async function waitForCachedStreamId(
+  executionId: ExecutionId,
+): Promise<StreamTabId | undefined> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const streamId = (await getExecutionStore(executionId).readMeta())
+      ?.streamId;
+    if (streamId) return streamId;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return undefined;
+}
 
 const tempDirs: string[] = [];
 
@@ -260,4 +292,48 @@ describe('resolvePersistedStreamIdForExecution', () => {
       expect(maxInFlight).toBeLessThanOrEqual(8);
     },
   );
+
+  it('returns a cached executionMeta streamId without scanning any persisted stream (#7469)', async () => {
+    const executionId = 'abc555' as ExecutionId;
+    const cachedStreamId = 'orchestrator@deepseekproT#abc555' as StreamTabId;
+    await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date().toISOString(),
+      streamId: cachedStreamId,
+    });
+
+    // No persisted stream exists at all — if the cache weren't consulted
+    // first, the scan would find nothing and this would resolve to null.
+    const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+    });
+
+    expect(resolved).toEqual({
+      streamId: cachedStreamId,
+      source: 'executionMeta',
+    });
+  });
+
+  it('caches a streamDataMeta resolution onto the execution meta for a later cheap lookup (#7469)', async () => {
+    const executionId = 'abc666' as ExecutionId;
+    const streamId = 'orchestrator@deepseekproT#abc666' as StreamTabId;
+    await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+
+    const store = new StreamSnapshotStore();
+    store.setTaskState(streamId, taskState('orchestrator'), executionId);
+    await store.flush();
+
+    const first = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+    });
+    expect(first).toEqual({ streamId, source: 'streamDataMeta' });
+
+    const cachedStreamId = await waitForCachedStreamId(executionId);
+    expect(cachedStreamId).toBe(streamId);
+
+    const second = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+    });
+    expect(second).toEqual({ streamId, source: 'executionMeta' });
+  });
 });

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -1,12 +1,18 @@
 import pMap from 'p-map';
 
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { writeExecutionStreamId } from '@agent/storage/executionLifecycle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 import type { StreamLogStore } from './StreamLogStore';
 
 export type PersistedStreamIdResolutionSource =
-  'streamDataMeta' | 'streamDataSuffix' | 'streamLogsSuffix' | 'fallback';
+  | 'executionMeta'
+  | 'streamDataMeta'
+  | 'streamDataSuffix'
+  | 'streamLogsSuffix'
+  | 'fallback';
 
 export interface PersistedStreamIdResolution {
   readonly streamId: StreamTabId;
@@ -110,11 +116,26 @@ async function pickBestMetaMatch(
  * The sidecar metadata is canonical. The suffix checks preserve compatibility
  * with older records and child-stream prefixes that cannot be derived from the
  * top-level agent/model pair.
+ *
+ * Decide-once-carry-as-data (#7469): once a `streamDataMeta` resolution below
+ * has actually disambiguated the canonical stream via the meta-scan, it's
+ * cached onto the execution's own metadata (`writeExecutionStreamId`) so a
+ * later call for the same executionId can skip straight to a single cheap
+ * read instead of re-scanning every persisted stream. Only that confirmed
+ * result is cached — the suffix/fallback sources below are heuristic guesses
+ * for when no stream's meta.json actually claims this executionId, and
+ * caching a guess as if it were a confirmed match could pin a wrong answer.
  */
 export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
   options: PersistedStreamIdResolverOptions = {},
 ): Promise<PersistedStreamIdResolution | null> {
+  const cachedStreamId = (await getExecutionStore(executionId).readMeta())
+    ?.streamId;
+  if (cachedStreamId) {
+    return { streamId: cachedStreamId, source: 'executionMeta' };
+  }
+
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
   const persistedStreams = await snapshotStore.listPersistedStreams();
 
@@ -135,6 +156,7 @@ export async function resolvePersistedStreamIdForExecution(
       snapshotStore,
       options.streamLogStore,
     );
+    void writeExecutionStreamId(executionId, streamId);
     return { streamId, source: 'streamDataMeta' };
   }
 

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -117,14 +117,19 @@ async function pickBestMetaMatch(
  * with older records and child-stream prefixes that cannot be derived from the
  * top-level agent/model pair.
  *
- * Decide-once-carry-as-data (#7469): once a `streamDataMeta` resolution below
- * has actually disambiguated the canonical stream via the meta-scan, it's
+ * Decide-once-carry-as-data (#7469): when a `streamDataMeta` resolution below
+ * finds exactly one meta-matched candidate (no disambiguation needed), it's
  * cached onto the execution's own metadata (`writeExecutionStreamId`) so a
  * later call for the same executionId can skip straight to a single cheap
- * read instead of re-scanning every persisted stream. Only that confirmed
- * result is cached — the suffix/fallback sources below are heuristic guesses
- * for when no stream's meta.json actually claims this executionId, and
- * caching a guess as if it were a confirmed match could pin a wrong answer.
+ * read instead of re-scanning every persisted stream. A multi-candidate
+ * resolution is deliberately NOT cached: `pickBestMetaMatch`'s ranking
+ * depends on which `streamLogStore`/workPlan data happens to be available to
+ * *this* call, so an earlier call without a loaded `streamLogStore` could
+ * settle on a worse (non-log-backed) candidate than a later call that does
+ * have one — caching that would permanently shadow the better answer. The
+ * suffix/fallback sources further below are heuristic guesses for when no
+ * stream's meta.json actually claims this executionId at all, and caching a
+ * guess as if it were a confirmed match could pin a wrong answer too.
  */
 export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
@@ -156,7 +161,9 @@ export async function resolvePersistedStreamIdForExecution(
       snapshotStore,
       options.streamLogStore,
     );
-    void writeExecutionStreamId(executionId, streamId);
+    if (metaCandidates.length === 1) {
+      void writeExecutionStreamId(executionId, streamId);
+    }
     return { streamId, source: 'streamDataMeta' };
   }
 


### PR DESCRIPTION
Part of #7469 (item 1 — the execution→stream reverse-scan). Item 2 (`resolveWorkspaceSourceDir`'s dual implementation) is left for a follow-up PR since it's an independent fix. Unblocked now that Stage 3c (#6966) closed, which this issue was explicitly sequenced behind.

## What it fixes

`resolvePersistedStreamIdForExecution` (`executionStreamResolver.ts`) reverse-scans every persisted stream's `meta.json` on hot paths (every completed `/executions/{id}` summary, every `assembleTrace()` call) to re-derive execution→stream — a fact worth deciding once and carrying as data, per the issue.

## Why this shape, not "write at registration time"

`registerExecution` doesn't actually know the streamId yet at the time it runs — across every call site, the streamId is decided *after* registration (sometimes much later, e.g. `AgentLaunchContext.assembleAgentLaunchContext`), and multiple streams can legitimately share one executionId (a parent orchestrator tab and a `bash@tool#executionId` child stream both recording the same executionId in their own `meta.json`, exactly what `pickBestMetaMatch`'s disambiguation logic already handles). Predicting the "right" streamId at registration time would have to re-solve that same disambiguation problem before any data exists to disambiguate with.

Instead, this caches the *already-decided* result: once the meta-scan's `pickBestMetaMatch` has picked the canonical stream for an executionId (using its existing log/workPlan-presence ranking, unchanged), that resolution is persisted onto the execution's own meta record. A later call for the same executionId hits one cheap `readMeta()` first, short-circuiting the full scan entirely.

Only the confirmed `streamDataMeta` resolution is cached — the suffix/log/fallback sources stay uncached, since they're heuristic guesses for when no stream's `meta.json` actually claims the executionId, and caching a guess as if it were confirmed could pin a wrong answer. Executions without a cached `streamId` (never resolved yet, or predating this field) fall through to the unchanged scan, per this repo's canonical-format-first/legacy-fallback pattern.

## Changes

- `ExecutionKVStore.ts`: new optional `streamId` field on `ExecutionMetaBaseSchema`.
- `executionLifecycle.ts`: new `writeExecutionStreamId(executionId, streamId)`, mirroring `writeTerminalStatus`/`writeSessionDescription`'s fire-and-forget, never-throws pattern.
- `executionStreamResolver.ts`: a cheap direct-read fast path before the scan; a fire-and-forget write-back after a `streamDataMeta` resolution; a new `'executionMeta'` resolution source.
- Two new regression tests: a cache-hit resolves with zero persisted streams existing (proving the fast path, not the scan, produced the result), and a first `streamDataMeta` resolution gets cached for a cheap second lookup.

## Verification

- `tsc --noEmit` (root) — clean.
- `vitest run src/test-kernel/transcript/executionStreamResolver.vitest.ts` — 7/7 passing (5 existing + 2 new), including the existing disambiguation-order regression tests (#7298, #7403) and the concurrency-bound test (#7299), all unaffected.
- `eslint` on all changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path execution→stream resolution; incorrect caching could misroute transcript reads, though only unambiguous single-candidate meta matches are persisted.
> 
> **Overview**
> **Caches the execution→transcript stream mapping** so `resolvePersistedStreamIdForExecution` no longer re-scans every persisted stream `meta.json` on every hot-path call (completed execution summaries, `assembleTrace()`).
> 
> Execution metadata gains an optional **`streamId`**, mirrored on trace export validation. **`writeExecutionStreamId`** persists that field using the same fire-and-forget meta update pattern as other lifecycle writers. The resolver **reads `executionMeta.streamId` first** and returns source `'executionMeta'` when present; after a **`streamDataMeta`** resolution with **exactly one** meta-matched candidate it **write-backs** that id. **Multi-candidate** disambiguation, suffix, and fallback resolutions are **not** cached so a later call with richer `streamLogStore` data is not pinned to an earlier weaker pick.
> 
> Regression tests cover cache hits without any persisted streams, write-back after a single match, and that ambiguous resolutions stay uncached when logs would change the winner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490fe23ea1e96e127c4202528e7c18891347c3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->