### PR TITLE
refactor(runtime): make follow-up sent session-scoped

### DIFF
--- a/packages/cli/src/chat/tui/state/compactionRequest.ts
+++ b/packages/cli/src/chat/tui/state/compactionRequest.ts
@@ -1,5 +1,5 @@
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ManualCompactionRequestResult } from '@agent/runtime/executionRegistry';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface CliCompactionRequestOptions {
@@ -9,7 +9,7 @@ export interface CliCompactionRequestOptions {
   ) => ManualCompactionRequestResult;
   readonly notifyFollowUpSent: (
     streamId: StreamTabId,
-    runtimeHost?: AgentRuntimeHost,
+    session?: SessionHandle,
   ) => void;
   readonly appendTranscript: (message: string, streamId?: StreamTabId) => void;
 }
@@ -35,7 +35,7 @@ export function requestCliCompaction({
       );
       return;
     case 'requested':
-      notifyFollowUpSent(result.streamId, result.runtimeHost);
+      notifyFollowUpSent(result.streamId, result.session);
       appendTranscript(
         'Context compaction requested. The agent will process it on the next model call.',
         result.streamId,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -416,8 +416,18 @@ export function attachTuiRunFactSubscription(
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
-      if (sessionEvent.event.type === 'setParentStream') {
-        applyParentStream(sessionEvent.event.payload);
+      switch (sessionEvent.event.type) {
+        case 'setParentStream':
+          applyParentStream(sessionEvent.event.payload);
+          return;
+        case 'followUpSent':
+          // Active-session follow-ups enter the same queue before the wait node
+          // consumes them; refresh immediately so the status bar shows the
+          // pending message instead of only seeing the later drain event.
+          refreshQueuedFollowUps(sessionEvent.event.payload.streamId);
+          return;
+        default:
+          return;
       }
     },
     { scope: 'session' },
@@ -676,14 +686,6 @@ function applyToState<K extends ProgressEvent>(
       } else {
         appendGoalPausedTranscriptNotice(p);
       }
-      return;
-    }
-    case 'followUpSent': {
-      // Active-session follow-ups enter the same queue before the wait node
-      // consumes them; refresh immediately so the status bar shows the pending
-      // message instead of only seeing the later drain event.
-      const p = payload as ProgressEventPayloads['followUpSent'];
-      refreshQueuedFollowUps(p.streamId);
       return;
     }
     default:

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -29,7 +29,7 @@ export async function compactResponse(streamId: StreamTabId): Promise<void> {
       );
       return;
     case 'requested':
-      notifyFollowUpSent(result.streamId, result.runtimeHost);
+      notifyFollowUpSent(result.streamId, result.session);
       await vscode.window.showInformationMessage(
         'Context compaction requested. The agent will process it on the next model call.',
       );

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -16,7 +16,7 @@ import {
   currentSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import type { FollowUpQueueInput } from './FollowUpQueue';
@@ -134,7 +134,7 @@ export function onFollowUpSent(
 
 export function notifyFollowUpSent(
   streamId: StreamTabId,
-  runtimeHost?: AgentRuntimeHost,
+  session?: SessionHandle,
 ): void {
   for (const observer of followUpSentObservers) {
     try {
@@ -145,7 +145,7 @@ export function notifyFollowUpSent(
       });
     }
   }
-  runtimeHost?.emit('followUpSent', { streamId });
+  emitRuntimeEvent('followUpSent', { streamId }, session);
 }
 
 /**
@@ -200,7 +200,7 @@ export async function sendFollowUp(
 
   if (target.kind === 'active') {
     target.context.session.appendFollowUp(item);
-    notifyFollowUpSent(streamId, target.context.runtimeHost);
+    notifyFollowUpSent(streamId, ownerSession);
     return { status: 'sent' };
   }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -9,7 +9,10 @@ import {
   modelHandlerCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
-import { currentSession } from '@agent/runtime/SessionHandle';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
@@ -114,6 +117,7 @@ export function getToolUseFlowErrorResult(
 }
 
 export interface ToolUseFlowContext {
+  readonly ownerSession: SessionHandle;
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: ToolUseServices['modelHandler'];
   readonly runtimeHost: AgentRuntimeHost;
@@ -270,6 +274,7 @@ export async function runToolUseFlow<C = unknown>(
   };
 
   const flowContext: ToolUseFlowContext = {
+    ownerSession: runSession,
     session: sessionLifecycle,
     get modelHandler() {
       return services.modelHandler;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -9,6 +9,7 @@ import pDefer from 'p-defer';
 
 import type { AgentTrace, ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import {
   STREAM_STATUS,
@@ -40,6 +41,7 @@ export interface ExecutionHandle {
 }
 
 export interface LiveToolUseFlowContext {
+  readonly ownerSession?: SessionHandle;
   readonly session: {
     appendFollowUp(followUp: FollowUpQueueInput): void;
   };

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -4,6 +4,7 @@ import type { AgentEvent } from '@agent/trace';
 import { createChannelTrace } from '@logger';
 import type {
   ClearMissingOutputsPayload,
+  FollowUpSentPayload,
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
   SetActiveStreamPayload,
@@ -38,6 +39,10 @@ export type SessionFact =
   | {
       readonly type: 'updateQueuedFollowUps';
       readonly payload: UpdateQueuedFollowUpsPayload;
+    }
+  | {
+      readonly type: 'followUpSent';
+      readonly payload: FollowUpSentPayload;
     }
   | {
       readonly type: 'setActiveStream';

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -8,6 +8,7 @@
 import { writeTerminalStatus } from '@agent/storage';
 import type { ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   StreamStatusService,
   type StreamStatusEmitOptions,
@@ -115,7 +116,7 @@ export type ManualCompactionRequestResult =
   | {
       readonly kind: 'requested';
       readonly streamId: StreamTabId;
-      readonly runtimeHost?: AgentRuntimeHost;
+      readonly session?: SessionHandle;
     }
   | {
       readonly kind: 'unsupported';
@@ -398,7 +399,7 @@ export class ExecutionRegistry {
     return {
       kind: 'requested',
       streamId,
-      ...(context.runtimeHost && { runtimeHost: context.runtimeHost }),
+      ...(context.ownerSession && { session: context.ownerSession }),
     };
   }
 

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -110,9 +110,6 @@ export interface ProgressEventPayloads {
   updateProcessOutput: UpdateProcessOutputPayload;
   updateStreamDescription: UpdateStreamDescriptionPayload;
   setParentStream: SetParentStreamPayload;
-  /** A follow-up message was sent to an active tool-use session.
-   *  Listened by blocking tools (e.g. ExecutionsTool wait) to abort early. */
-  followUpSent: { streamId: StreamTabId };
 
   /** Request the progress view to remove a stream tab (used by short-lived
    *  child streams that should auto-close once their work is done). */

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -43,10 +43,8 @@ export function attachSessionProgressEventProjection(
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
-      emitProjectedProgressEvent(
-        runtimeHost,
-        projectSessionFactToProgressEvent(sessionEvent.event),
-      );
+      const projected = projectSessionFactToProgressEvent(sessionEvent.event);
+      if (projected) emitProjectedProgressEvent(runtimeHost, projected);
     },
     { scope: 'session' },
   );
@@ -93,7 +91,7 @@ export function toUpdateStreamUsagePayload(
 
 export function projectSessionFactToProgressEvent(
   fact: SessionFact,
-): ProjectedProgressEvent {
+): ProjectedProgressEvent | undefined {
   switch (fact.type) {
     case 'goalStateChanged':
       return { event: 'goalStateChanged', payload: fact.payload };
@@ -103,6 +101,8 @@ export function projectSessionFactToProgressEvent(
       return { event: 'clearMissingOutputs', payload: fact.payload };
     case 'updateQueuedFollowUps':
       return { event: 'updateQueuedFollowUps', payload: fact.payload };
+    case 'followUpSent':
+      return undefined;
     case 'setActiveStream':
       return { event: 'setActiveStream', payload: fact.payload };
     case 'updateStreamDescription':

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -133,9 +133,8 @@ export class ProgressBackend {
     const detachSessionFacts = this.session.events.subscribe(
       (sessionEvent) => {
         if (sessionEvent.scope !== 'session') return;
-        this.handleProjectedProgressEvent(
-          projectSessionFactToProgressEvent(sessionEvent.event),
-        );
+        const projected = projectSessionFactToProgressEvent(sessionEvent.event);
+        if (projected) this.handleProjectedProgressEvent(projected);
       },
       { scope: 'session' },
     );

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -141,6 +141,10 @@ export interface UpdateQueuedFollowUpsPayload {
   streamId: StreamTabId;
 }
 
+export interface FollowUpSentPayload {
+  streamId: StreamTabId;
+}
+
 /**
  * Host-agnostic action tokens for {@link RequestShowInstructionPayload}.
  * The agent core emits a token; each host maps it to its own UI affordance

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -15,6 +15,7 @@ import {
   SharedExecutionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { onFollowUpSent, sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
@@ -26,6 +27,7 @@ const streamId = 'stream:follow-up' as StreamTabId;
 describe('tool-use follow-up progress events', () => {
   let unsubscribeFollowUpObserver: (() => void) | undefined;
   const trackedExecutionIds = new Set<string>();
+  const sessions = new Set<SessionHandle>();
 
   afterEach(() => {
     unsubscribeFollowUpObserver?.();
@@ -34,6 +36,10 @@ describe('tool-use follow-up progress events', () => {
       SharedExecutionRegistry.untrack(executionId);
     }
     trackedExecutionIds.clear();
+    for (const session of sessions) {
+      session.dispose({ keepActiveExecutions: true });
+    }
+    sessions.clear();
     clearAllStreamStatusesForTest(StreamStatusService);
   });
 
@@ -42,11 +48,13 @@ describe('tool-use follow-up progress events', () => {
     host = noopAgentRuntimeHost,
     appendFollowUp,
     executionId = `exec-${stream}`,
+    session,
   }: {
     readonly stream?: StreamTabId;
     readonly host?: AgentRuntimeHost;
     readonly appendFollowUp: LiveToolUseFlowContext['session']['appendFollowUp'];
     readonly executionId?: string;
+    readonly session?: SessionHandle;
   }): void {
     const handle = new AgentExecutionHandle(
       executionId,
@@ -57,6 +65,7 @@ describe('tool-use follow-up progress events', () => {
       host,
     );
     handle.attachToolUseFlow({
+      ...(session ? { ownerSession: session } : {}),
       session: { appendFollowUp },
       modelHandler: { supportsManualCompaction: true },
       runtimeHost: host,
@@ -65,17 +74,34 @@ describe('tool-use follow-up progress events', () => {
       switchModel: async () => {},
       interrupt: () => {},
     });
-    SharedExecutionRegistry.track(handle);
-    trackedExecutionIds.add(executionId);
+    if (session) {
+      session.executions.track(handle);
+    } else {
+      SharedExecutionRegistry.track(handle);
+      trackedExecutionIds.add(executionId);
+    }
   }
 
-  it('publishes sent follow-up events through the active runtime host', async () => {
+  it('publishes sent follow-up events through the owning session fact hub', async () => {
     const { events, host } = createRecordingHost();
+    const session = new SessionHandle();
+    sessions.add(session);
+    const facts: unknown[] = [];
+    const detachFacts = session.events.subscribe((event) => {
+      facts.push(event);
+    });
     const appendFollowUp = vi.fn();
 
-    trackToolUseFlow({ host, appendFollowUp });
+    trackToolUseFlow({ host, appendFollowUp, session });
 
-    const result = await sendFollowUp(streamId, 'please continue');
+    const result = await sendFollowUp(
+      streamId,
+      'please continue',
+      undefined,
+      undefined,
+      session,
+    );
+    detachFacts();
 
     expect(result).toEqual({ status: 'sent' });
     expect(appendFollowUp).toHaveBeenCalledWith({
@@ -83,12 +109,16 @@ describe('tool-use follow-up progress events', () => {
       mediaFiles: undefined,
       displayText: undefined,
     });
-    expect(events).toEqual([
+    expect(facts).toEqual([
       {
-        event: 'followUpSent',
-        payload: { streamId },
+        scope: 'session',
+        event: {
+          type: 'followUpSent',
+          payload: { streamId },
+        },
       },
     ]);
+    expect(events).toEqual([]);
   });
 
   it('notifies local follow-up observers through onFollowUpSent', async () => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -17,6 +17,7 @@ import {
   SessionEventHub,
   type SessionEvent,
 } from '@agent/runtime/SessionEventHub';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   RUN_OUTCOME,
@@ -980,7 +981,9 @@ describe('executionRegistry', () => {
     const unsupportedStreamId =
       'stream-manual-compaction-unsupported-test' as StreamTabId;
     const requestImmediateCompaction = vi.fn();
+    const ownerSession = {} as SessionHandle;
     const context: LiveToolUseFlowContext = {
+      ownerSession,
       session: {
         appendFollowUp: vi.fn(),
       },
@@ -1043,7 +1046,7 @@ describe('executionRegistry', () => {
       expect(registry.requestManualCompaction(streamId)).toEqual({
         kind: 'requested',
         streamId,
-        runtimeHost: explicit.host,
+        session: ownerSession,
       });
       expect(requestImmediateCompaction).toHaveBeenCalledOnce();
     } finally {

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -120,6 +120,27 @@ describe('attachCliSessionProgressProjection', () => {
     }
   });
 
+  it('does not project session-local follow-up sent facts onto host progress', () => {
+    const hub = new SessionEventHub();
+    const host = createRecordingHost();
+    const streamId = 'stream:follow-up' as StreamTabId;
+
+    const detach = attachCliSessionProgressProjection(hub, host.host);
+    try {
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'followUpSent',
+          payload: { streamId },
+        },
+      });
+
+      expect(host.events).toEqual([]);
+    } finally {
+      detach();
+    }
+  });
+
   it('projects run config updates onto retained CLI task-state events', () => {
     const hub = new SessionEventHub();
     const host = createRecordingHost();

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3449,13 +3449,21 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   });
 
   it('refreshes queued follow-up display when an active follow-up is sent', () => {
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
     const wrapped = wrapRuntimeHost(makeHost());
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     const queue = ToolUseFollowUpQueue.acquire(root);
 
     try {
       queue.enqueue({ text: 'Keep the proof under one page.' });
-      wrapped.emit('followUpSent', { streamId: root });
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'followUpSent',
+          payload: { streamId: root },
+        },
+      });
 
       let slice = streams.get().get(root);
       expect(slice?.queuedFollowUps).toBe(1);
@@ -3470,6 +3478,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       expect(slice?.queuedFollowUps).toBe(0);
       expect(slice?.queuedFollowUpMessages).toEqual([]);
     } finally {
+      detach();
       ToolUseFollowUpQueue.release(root);
     }
   });


### PR DESCRIPTION
## Summary

Moves `followUpSent` off the frozen host progress-event rail and onto the session fact plane. Active follow-up delivery and manual compaction now notify through the owning `SessionHandle`, while the local in-process observer remains available for wait cancellation.

This also lets the CLI TUI consume `followUpSent` from its direct session-fact subscription and removes the `followUpSent` key from `ProgressEventPayloads`. Session-to-host projectors can now decline session-local facts instead of forcing every session fact through the retained host-progress vocabulary.

Part of #6968.

## Verification

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CompactionRequest.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing import-order warnings)
- `corepack pnpm run compile:fast`
- `CI=true corepack pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow-up notification and CLI status-bar refresh across runtime, CLI TUI, and extension; behavior change is intentional but easy to miss if a host still expected host-progress `followUpSent`.
> 
> **Overview**
> **`followUpSent` is no longer a frozen host progress event.** Active follow-up delivery and manual compaction now notify through the owning **`SessionHandle`** via `emitRuntimeEvent('followUpSent', …)` instead of `runtimeHost.emit`. Session-to-host projectors **skip** this fact so it does not appear on the legacy `AgentRuntimeHost` rail; the CLI TUI refreshes queued follow-ups from a **direct session-fact** subscription.
> 
> **`LiveToolUseFlowContext` / manual compaction** carry **`ownerSession`** (wired from `runToolUseFlow`) so CLI and extension compaction commands pass the right session into `notifyFollowUpSent`. The in-process **`onFollowUpSent`** observer path is unchanged for wait cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e5709f8abb665d59fd975c33ad0eda5de8a085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->