### PR TITLE
fix(transcript): await stream cache write-through

### DIFF
--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -46,7 +46,7 @@ const MINIMAL_CONFIG: AgentConfig = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 };
 
-/** Waits for readMeta to reflect the fire-and-forget write's async settle. */
+/** Reads the stream id cached by a completed resolver write-through. */
 async function waitForCachedStreamId(
   executionId: ExecutionId,
 ): Promise<StreamTabId | undefined> {

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -119,7 +119,7 @@ async function pickBestMetaMatch(
  *
  * Decide-once-carry-as-data (#7469): when a `streamDataMeta` resolution below
  * finds exactly one meta-matched candidate (no disambiguation needed), it's
- * cached onto the execution's own metadata (`writeExecutionStreamId`) so a
+ * cached onto the execution's own metadata (`writeExecutionStreamId`) before a
  * later call for the same executionId can skip straight to a single cheap
  * read instead of re-scanning every persisted stream. A multi-candidate
  * resolution is deliberately NOT cached: `pickBestMetaMatch`'s ranking
@@ -162,7 +162,7 @@ export async function resolvePersistedStreamIdForExecution(
       options.streamLogStore,
     );
     if (metaCandidates.length === 1) {
-      void writeExecutionStreamId(executionId, streamId);
+      await writeExecutionStreamId(executionId, streamId);
     }
     return { streamId, source: 'streamDataMeta' };
   }


### PR DESCRIPTION
## Summary

`resolvePersistedStreamIdForExecution()` now awaits the single-candidate
`writeExecutionStreamId()` cache write-through it starts before returning. This
keeps callers from racing storage teardown or follow-up reads against an
in-flight execution metadata write.

## Issue acceptance gates

Addresses #7553:

- The single-candidate `streamDataMeta` cache write is awaited before the
  resolver returns.
- Multi-candidate, suffix, and fallback resolutions remain uncached.
- `completedRunArchive.vitest.ts` and `executionStreamResolver.vitest.ts` pass
  together.

## Single source of truth

`resolvePersistedStreamIdForExecution()` remains the owner of the
execution-id-to-stream resolution and its cache write-through timing.

## Duplication and abstraction budget

No new abstraction. This removes a race from the existing write-through path by
making its async side effect part of the resolver's completion contract.

## Host impact

Extension: Completed-run archive reads no longer return while the resolver's
stream-id cache write is still pending.

Desktop: Same runtime behavior as extension; no desktop-specific surface change.

CLI: History/chat-export paths that read completed-run archives get the same
deterministic write-through behavior.

## Scheduled refactoring

None; this PR introduces no shim, projection, dual-write, alias, fallback, or
migration path.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/transcript/completedRunArchive.vitest.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts`
- `npm run typecheck`
- `corepack pnpm exec prettier --check src/transcript/executionStreamResolver.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts`
- `corepack pnpm exec eslint src/transcript/executionStreamResolver.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts`
- `npm test`

Closes #7553

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing fix on an existing cache path; behavior for uncached resolution paths is unchanged.
> 
> **Overview**
> When `resolvePersistedStreamIdForExecution()` finds exactly one `streamDataMeta` match, it now **awaits** `writeExecutionStreamId()` before returning instead of firing that write with `void` and returning immediately.
> 
> That makes the single-candidate cache write part of the resolver’s completion contract, so follow-up reads (e.g. completed-run archive) and storage teardown no longer race an in-flight execution metadata update. Multi-candidate, suffix, and fallback resolutions are unchanged and still not cached.
> 
> Test comments were updated to describe the cache as written by a completed write-through rather than an async settle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c2f9d69855f3ac02e26c7418bb5cc6e4463049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->