### PR TITLE
[codex] refactor runtime stream activation through session facts

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -36,6 +36,7 @@ import {
   createModelHandler,
   createModelHandlerForCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { inferPersistedFlowModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
@@ -366,11 +367,15 @@ async function assembleAgentLaunchContext(
   session.events.assertRunSubscribersAttachedBeforeActivation(streamId);
   input.onBeforeActivation?.(streamId);
 
-  runtimeHost.emit('setActiveStream', {
-    streamId,
-    agentCategory: setting.agentCategory,
-    isRemote: isRemoteAgent(fullConfig.agent),
-  });
+  emitRuntimeEvent(
+    'setActiveStream',
+    {
+      streamId,
+      agentCategory: setting.agentCategory,
+      isRemote: isRemoteAgent(fullConfig.agent),
+    },
+    session,
+  );
   onActivated(streamId);
 
   // Log the initial instruction as a user message so both workflow and

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -236,6 +236,47 @@ describe('child stream progress events', () => {
     });
   });
 
+  it('publishes child stream activation through the session fact hub', async () => {
+    const active = createRecordingHost();
+    const facts: unknown[] = [];
+    const detachFacts = defaultSession().events.subscribe((event) => {
+      if (event.scope === 'session' && event.event.type === 'setActiveStream') {
+        facts.push(event);
+      }
+    });
+
+    try {
+      const childStream = createChildStream(executionId, parentStreamId, {
+        runtimeHost: active.host,
+        streamPrefix: 'bash',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'test-agent',
+        description: 'Run a background bash command',
+        config,
+        toolName: 'bash',
+      });
+
+      expect(active.events).toEqual([]);
+      expect(facts).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'setActiveStream',
+            payload: {
+              streamId: childStreamId,
+              agentCategory: AgentCategory.ToolUse,
+              suppressViewSwitch: true,
+            },
+          },
+        },
+      ]);
+
+      await childStream.finalize();
+    } finally {
+      detachFacts();
+    }
+  });
+
   it('uses host interactions for child stream auto-close when available', async () => {
     const active = createRecordingHost();
     const removedStreams: StreamTabId[] = [];

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,5 +1,6 @@
 import { platform } from '@platform/platform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { StreamTabId } from '@shared/schemas';
@@ -111,7 +112,7 @@ export function emitToolEditApprovalPrompt(
   const { requestId, request, relativePath, lineChanges } = params;
   const { streamId } = request;
   if (streamId) {
-    runtimeHost.emit('setActiveStream', { streamId });
+    emitRuntimeEvent('setActiveStream', { streamId });
   }
   const isBypassed = streamId ? isApprovalBypassedForStream(streamId) : false;
   runtimeHost.emit('showToolEditPermission', {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -108,11 +108,15 @@ export function createChildStream(
   // Register the child stream (state, logs, hints) without switching the
   // active tab. Background child streams (bash, codex) shouldn't yank the
   // user away from whatever they're viewing — the tab simply appears.
-  runtimeHost.emit('setActiveStream', {
-    streamId: childStreamId,
-    agentCategory: options.streamCategory,
-    suppressViewSwitch: true,
-  });
+  emitRuntimeEvent(
+    'setActiveStream',
+    {
+      streamId: childStreamId,
+      agentCategory: options.streamCategory,
+      suppressViewSwitch: true,
+    },
+    session,
+  );
   runTrace.trace.emit({
     type: 'run.start',
     descriptor: buildRunDescriptor({

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -391,7 +391,7 @@ export class ExternalInquiryTool extends defineTool({
     }
 
     runtimeHost.emit('requestEnsureProgressView', {});
-    runtimeHost.emit('setActiveStream', { streamId });
+    emitRuntimeEvent('setActiveStream', { streamId }, session);
     const isFollowUp = !!input.thread_id;
     const basePermission = {
       requestId: persisted.threadId, // legacy field — panel addresses by threadId now

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -162,7 +162,7 @@ export async function resolvePersistedStreamIdForExecution(
       options.streamLogStore,
     );
     if (metaCandidates.length === 1) {
-      void writeExecutionStreamId(executionId, streamId);
+      await writeExecutionStreamId(executionId, streamId);
     }
     return { streamId, source: 'streamDataMeta' };
   }


### PR DESCRIPTION
## Summary

This PR moves the remaining core `setActiveStream` producers in the runtime/tool path onto the session event hub. Launch activation, child stream tab registration, tool-edit approval focus, and external inquiry focus now publish via `emitRuntimeEvent`, leaving host adapters to receive the projected event rather than serving as the core event bus.

It also fixes a verification race found while running the full suite: the completed-run stream resolver now awaits the confirmed execution-stream-id cache write. That write already handles persistence failures internally; awaiting it removes a detached storage writer that could race test teardown and recreate only `_workspace.json`.

Host-adapter activation emits remain intentionally unchanged for the later HostInteractions/Stage 5 slices.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/transcript/completedRunArchive.vitest.ts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts src/test-kernel/tools/InquiryReadBoundary.vitest.ts src/test-kernel/tools/ToolEditApprovalGate.vitest.ts src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing import-order warnings)
- `corepack pnpm run compile:fast`
- `CI=true corepack pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stream focus is signaled across launch and tool paths; behavior is covered by existing and new tests, with a small persistence-timing fix on a hot resolver path.
> 
> **Overview**
> Core **`setActiveStream`** producers in launch, child streams, tool-edit approval, and external inquiry now publish via **`emitRuntimeEvent`** into the session event hub (with an explicit **`session`** where the run owns one), instead of calling **`runtimeHost.emit`** directly. Host adapters still project those facts to the UI; other host-only events (e.g. **`showToolEditPermission`**, **`requestEnsureProgressView`**) are unchanged.
> 
> **`resolvePersistedStreamIdForExecution`** now **`await`s** **`writeExecutionStreamId`** when caching a single meta match, so the confirmed stream-id write finishes before callers return—avoiding a detached writer that could race test teardown.
> 
> A kernel test asserts child stream activation appears on the session fact hub while the recording host sees no direct **`setActiveStream`** emit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f283d6c4453ed346d6842ce7b4400d028a02f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->