### PR TITLE
refactor(runtime): normalize result metadata shapes

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -164,15 +164,18 @@ async function persistWorkflowResultMeta(
 ): Promise<void> {
   try {
     const resultMeta: ResultMeta = {
-      outputs: [...result.outputs],
-      compileFailures: [...result.compileFailures],
+      producer: 'cliWorkflow',
+      result: {
+        outputs: [...result.outputs],
+        compileFailures: [...result.compileFailures],
+        ...(result.copiedOutput && {
+          copiedOutput: result.copiedOutput,
+        }),
+        ...(result.copiedOutputs?.length && {
+          copiedOutputs: [...result.copiedOutputs],
+        }),
+      },
     };
-    if (result.copiedOutput) {
-      resultMeta.copiedOutput = result.copiedOutput;
-    }
-    if (result.copiedOutputs?.length) {
-      resultMeta.copiedOutputs = [...result.copiedOutputs];
-    }
     await getExecutionStore(executionId).writeResultMeta(resultMeta);
   } catch (error) {
     writeTextStderr(

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -8,7 +8,7 @@ import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState'
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import {
-  ProviderMessageSchema,
+  ProviderMessageArraySchema,
   type ProviderMessage,
 } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
@@ -20,7 +20,7 @@ import { formatPostCompactionContext } from '@tools/subagentResults';
 
 /** Base schema for fields common to all cycle flows. */
 export const BaseCycleFieldsSchema = z.object({
-  messages: z.array(ProviderMessageSchema),
+  messages: ProviderMessageArraySchema,
   shouldStop: z.boolean(),
   /** Distinguishes: completion (true) vs cancellation/failure (false) */
   endTurn: z.boolean(),

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -7,7 +7,7 @@ import {
   ConversationRoundStateSnapshotSchema,
 } from '@agent/core/state/AgentState';
 import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/state/AgentWorkspaceState';
-import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
+import { ProviderMessageArraySchema } from '@agent/modelHandlers/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import {
   AgentFileLocationSchema,
@@ -17,7 +17,7 @@ import {
 } from '@shared/schemas';
 
 const RoundContextSchema = z.object({
-  messages: z.array(ProviderMessageSchema),
+  messages: ProviderMessageArraySchema,
   stateRoundSnapshot: ConversationRoundStateSnapshotSchema,
 });
 
@@ -31,7 +31,7 @@ export const ReflectionFlowStateSchema = z.object({
   context: RoundContextSchema.nullable(),
   outputLocation: AgentFileLocationSchema.nullable(),
 
-  conversation: z.array(ProviderMessageSchema),
+  conversation: ProviderMessageArraySchema,
   runStateSnapshot: AgentRunStateSnapshotSchema,
 
   roundStateSnapshots: z.array(ConversationRoundStateSnapshotSchema),

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
@@ -4,7 +4,7 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/state/AgentWorkspaceState';
 import { UserVariableChannelsSchema } from '@agent/core/definition/AgentCycleOptions';
-import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
+import { ProviderMessageArraySchema } from '@agent/modelHandlers/types/ProviderMessage';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { ExecutionIdSchema, StreamTabIdSchema } from '@shared/schemas';
 
@@ -17,7 +17,7 @@ export const ToolUseSessionSnapshotSchema = z.strictObject({
   parentStreamId: StreamTabIdSchema.nullish(),
   agentConfig: AgentConfigSchema,
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
-  messages: z.array(ProviderMessageSchema),
+  messages: ProviderMessageArraySchema,
   run: AgentRunStateSnapshotSchema,
   workspace: AgentWorkspaceStateSnapshotSchema,
   user: UserVariableChannelsSchema,

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -12,7 +12,10 @@ import {
   UserVariableChannelsSchema,
   type UserVariableChannels,
 } from '@agent/core/definition/AgentCycleOptions';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import {
+  ProviderMessageArraySchema,
+  type ProviderMessage,
+} from '@agent/modelHandlers/types/ProviderMessage';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import type { RetryErrorInfo } from '@shared/schemas';
@@ -107,9 +110,9 @@ export function assertPreparedShared(
   }
 }
 
-const MessagesSchema = z.looseObject({ messages: z.array(z.unknown()) });
+const MessagesSchema = z.looseObject({ messages: ProviderMessageArraySchema });
 const LegacyConversationSchema = z.looseObject({
-  conversation: z.array(z.unknown()),
+  conversation: ProviderMessageArraySchema,
 });
 
 /**

--- a/src/agent/modelHandlers/types/ProviderMessage.ts
+++ b/src/agent/modelHandlers/types/ProviderMessage.ts
@@ -31,3 +31,22 @@ export const ProviderMessageSchema = z.custom<ProviderMessage>(
     error: 'messages must contain provider message objects',
   },
 );
+
+export const ProviderMessageArraySchema = z.array(ProviderMessageSchema);
+
+const ProviderMessageStorageSchema = z.union([
+  ProviderMessageArraySchema,
+  z
+    .looseObject({ messages: ProviderMessageArraySchema })
+    .transform(({ messages }) => messages),
+  z
+    .looseObject({ conversation: ProviderMessageArraySchema })
+    .transform(({ conversation }) => conversation),
+]);
+
+export function normalizeProviderMessages(
+  value: unknown,
+): ProviderMessage[] | null {
+  const result = ProviderMessageStorageSchema.safeParse(value);
+  return result.success ? result.data : null;
+}

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -20,7 +20,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
+import { ProviderMessageArraySchema } from '@agent/modelHandlers/types/ProviderMessage';
 import {
   migrateSharedState,
   StateSlicesSchema,
@@ -67,7 +67,7 @@ export interface SessionResumeRetrievalOptions {
 }
 
 const CurrentToolUseFlowRecordStateSchema = z.looseObject({
-  messages: z.array(ProviderMessageSchema),
+  messages: ProviderMessageArraySchema,
   modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
   stateSlices: StateSlicesSchema,
 });
@@ -94,12 +94,18 @@ function throwIfResumeStorageUnreadable(
  * Minimal schema for validating workflow flow record exists and has resumable state.
  * Full validation happens when the flow actually resumes.
  */
-const WorkflowFlowRecordStateSchema = z.object({
-  currentRound: z.int().nonnegative(),
-  totalRounds: z.int().nonnegative(),
-  conversation: z.array(ProviderMessageSchema).prefault([]),
-  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
-});
+const WorkflowFlowRecordStateSchema = z
+  .looseObject({
+    currentRound: z.int().nonnegative(),
+    totalRounds: z.int().nonnegative(),
+    conversation: ProviderMessageArraySchema.nullish(),
+    messages: ProviderMessageArraySchema.nullish(),
+    modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
+  })
+  .transform(({ messages, conversation, ...state }) => ({
+    ...state,
+    conversation: conversation ?? messages ?? [],
+  }));
 
 /**
  * Retrieve resume data for a WAITING session.

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -1,6 +1,9 @@
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import {
+  normalizeProviderMessages,
+  type ProviderMessage,
+} from '@agent/modelHandlers/types/ProviderMessage';
 import { isObject } from '@utils/core';
 import {
   ModelHandlerCompatibilityKeySchema,
@@ -61,10 +64,6 @@ export function inferPersistedModelHandlerCompatibilityKey(
     : undefined;
 }
 
-function arrayOfProviderMessages(value: unknown): ProviderMessage[] | null {
-  return Array.isArray(value) ? (value as ProviderMessage[]) : null;
-}
-
 function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
@@ -104,8 +103,9 @@ export function inferPersistedFlowModelHandlerCompatibilityKey(
   if (parsedKey.success && parsedKey.data) return parsedKey.data;
 
   const messages =
-    arrayOfProviderMessages(record.messages) ??
-    arrayOfProviderMessages(record.conversation);
+    normalizeProviderMessages(record.messages) ??
+    normalizeProviderMessages(record.conversation) ??
+    normalizeProviderMessages(record);
   if (!messages) return undefined;
 
   return inferPersistedModelHandlerCompatibilityKey(

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -263,8 +263,22 @@ const LegacySubagentResultMetaSchema = z
     diffsUnavailable: z.string().optional(),
   })
   .transform((meta) => {
+    // Legacy records from before `category` existed carry workflow/toolUse
+    // fields with no category tag at all — infer it from which fields are
+    // present rather than requiring it, or the payload silently disappears.
+    const category =
+      meta.category ??
+      (meta.outputs !== undefined ||
+      meta.compileFailures !== undefined ||
+      meta.diffs !== undefined ||
+      meta.diffsUnavailable !== undefined
+        ? 'workflow'
+        : meta.lastResponse !== undefined || meta.touchedFiles !== undefined
+          ? 'toolUse'
+          : undefined);
+
     const result =
-      meta.category === 'workflow'
+      category === 'workflow'
         ? {
             category: 'workflow' as const,
             outputs: meta.outputs ?? [],
@@ -276,7 +290,7 @@ const LegacySubagentResultMetaSchema = z
               diffsUnavailable: meta.diffsUnavailable,
             }),
           }
-        : meta.category === 'toolUse'
+        : category === 'toolUse'
           ? {
               category: 'toolUse' as const,
               ...(meta.lastResponse !== undefined && {
@@ -445,10 +459,17 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readConversation(): Promise<unknown[] | null> {
-    const messages = normalizeProviderMessages(
-      await this.read(KEYS.CONVERSATION),
-    );
-    return messages && messages.length > 0 ? messages : null;
+    const raw = await this.read(KEYS.CONVERSATION);
+    if (raw == null) return null;
+    const messages = normalizeProviderMessages(raw);
+    if (messages === null) {
+      logger.warn(
+        CHANNEL,
+        `Failed to parse execution ${this.executionId} ${KEYS.CONVERSATION}.json as provider messages`,
+      );
+      return null;
+    }
+    return messages.length > 0 ? messages : null;
   }
 
   async conversationModifiedAt(): Promise<number | undefined> {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -14,6 +14,10 @@ import {
   type AgentConfig,
   AgentConfigSchema,
 } from '@agent/core/definition/AgentConfig';
+import {
+  normalizeProviderMessages,
+  ProviderMessageArraySchema,
+} from '@agent/modelHandlers/types/ProviderMessage';
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import {
@@ -128,36 +132,17 @@ const ResultDiffSummarySchema = z.object({
   largeChange: z.boolean(),
 });
 
-/**
- * Structured result of a finished execution — the machine-readable
- * counterpart of the prose report. This is the chaining contract: a later
- * stage (orchestrator or workflow script) reads outputs/diffs/outcome as
- * data instead of parsing the XML delivery. Written by subagent completion,
- * background bash, and CLI workflow runs; all fields optional so each
- * writer contributes what it has.
- */
-export const ResultMetaSchema = z.object({
-  exitCode: z.int().optional(),
-  wallTimeMs: z.number().nonnegative().optional(),
-  success: z.boolean().optional(),
-  timedOut: z.boolean().optional(),
-  command: z.string().optional(),
+const WorkflowResultMetaPayloadSchema = z.object({
+  outputs: z.array(OutputFileSummarySchema),
+  compileFailures: z.array(CompileFailureSummarySchema),
   copiedOutput: z.string().optional(),
   copiedOutputs: z.array(z.string()).optional(),
-  outputs: z.array(OutputFileSummarySchema).optional(),
+});
+
+const SubagentWorkflowResultMetaPayloadSchema = z.object({
+  category: z.literal('workflow'),
+  outputs: z.array(OutputFileSummarySchema),
   compileFailures: z.array(CompileFailureSummarySchema).optional(),
-  /** Agent that produced this result (subagent completions). */
-  agentName: z.string().optional(),
-  // New agent categories must be added here, or their manifests fail
-  // validation on read and surface as null.
-  category: z.enum(['workflow', 'toolUse']).optional(),
-  outcome: RunOutcomeSchema.optional(),
-  /** Final assistant text (tool-use agents). */
-  lastResponse: z.string().optional(),
-  /** Workspace-relative paths touched by a tool-use run. */
-  touchedFiles: z.array(z.string()).optional(),
-  /** Total model cost (USD) including the run's own subagents. */
-  totalCostUsd: z.number().nonnegative().optional(),
   /** Line-diff files written for workflow outputs. */
   diffs: z.array(ResultDiffSummarySchema).optional(),
   /**
@@ -167,6 +152,174 @@ export const ResultMetaSchema = z.object({
    */
   diffsUnavailable: z.string().optional(),
 });
+
+const SubagentToolUseResultMetaPayloadSchema = z.object({
+  category: z.literal('toolUse'),
+  /** Final assistant text (tool-use agents). */
+  lastResponse: z.string().optional(),
+  /** Workspace-relative paths touched by a tool-use run. */
+  touchedFiles: z.array(z.string()).optional(),
+});
+
+const SubagentResultMetaPayloadSchema = z.discriminatedUnion('category', [
+  SubagentWorkflowResultMetaPayloadSchema,
+  SubagentToolUseResultMetaPayloadSchema,
+]);
+
+const BackgroundBashResultMetaSchema = z.object({
+  producer: z.literal('backgroundBash'),
+  exitCode: z.int().optional(),
+  wallTimeMs: z.number().nonnegative(),
+  success: z.boolean(),
+  timedOut: z.boolean().optional(),
+  command: z.string(),
+});
+
+const CliWorkflowResultMetaSchema = z.object({
+  producer: z.literal('cliWorkflow'),
+  result: WorkflowResultMetaPayloadSchema,
+});
+
+const SubagentResultMetaSchema = z.object({
+  producer: z.literal('subagent'),
+  /** Agent that produced this result (subagent completions). */
+  agentName: z.string(),
+  outcome: RunOutcomeSchema,
+  success: z.boolean(),
+  wallTimeMs: z.number().nonnegative(),
+  /** Total model cost (USD) including the run's own subagents. */
+  totalCostUsd: z.number().nonnegative().optional(),
+  result: SubagentResultMetaPayloadSchema.optional(),
+});
+
+const CanonicalResultMetaSchema = z.discriminatedUnion('producer', [
+  BackgroundBashResultMetaSchema,
+  CliWorkflowResultMetaSchema,
+  SubagentResultMetaSchema,
+]);
+
+const LegacyBackgroundBashResultMetaSchema = z
+  .object({
+    producer: z.undefined().optional(),
+    exitCode: z.int().optional(),
+    command: z.string(),
+    wallTimeMs: z.number().nonnegative(),
+    success: z.boolean(),
+    timedOut: z.boolean().optional(),
+  })
+  .transform((meta) => ({
+    producer: 'backgroundBash' as const,
+    command: meta.command,
+    wallTimeMs: meta.wallTimeMs,
+    success: meta.success,
+    ...(meta.exitCode !== undefined && { exitCode: meta.exitCode }),
+    ...(meta.timedOut !== undefined && { timedOut: meta.timedOut }),
+  }));
+
+const LegacyCliWorkflowResultMetaSchema = z
+  .object({
+    producer: z.undefined().optional(),
+    copiedOutput: z.string().optional(),
+    copiedOutputs: z.array(z.string()).optional(),
+    outputs: z.array(OutputFileSummarySchema).optional(),
+    compileFailures: z.array(CompileFailureSummarySchema).optional(),
+  })
+  .refine(
+    (meta) =>
+      meta.outputs !== undefined ||
+      meta.compileFailures !== undefined ||
+      meta.copiedOutput !== undefined ||
+      meta.copiedOutputs !== undefined,
+    { message: 'legacy CLI workflow result metadata has no workflow fields' },
+  )
+  .transform((meta) => ({
+    producer: 'cliWorkflow' as const,
+    result: {
+      outputs: meta.outputs ?? [],
+      compileFailures: meta.compileFailures ?? [],
+      ...(meta.copiedOutput !== undefined && {
+        copiedOutput: meta.copiedOutput,
+      }),
+      ...(meta.copiedOutputs !== undefined && {
+        copiedOutputs: meta.copiedOutputs,
+      }),
+    },
+  }));
+
+const LegacySubagentResultMetaSchema = z
+  .object({
+    producer: z.undefined().optional(),
+    agentName: z.string(),
+    category: z.enum(['workflow', 'toolUse']).optional(),
+    outcome: RunOutcomeSchema,
+    success: z.boolean(),
+    wallTimeMs: z.number().nonnegative(),
+    lastResponse: z.string().optional(),
+    touchedFiles: z.array(z.string()).optional(),
+    totalCostUsd: z.number().nonnegative().optional(),
+    outputs: z.array(OutputFileSummarySchema).optional(),
+    compileFailures: z.array(CompileFailureSummarySchema).optional(),
+    diffs: z.array(ResultDiffSummarySchema).optional(),
+    diffsUnavailable: z.string().optional(),
+  })
+  .transform((meta) => {
+    const result =
+      meta.category === 'workflow'
+        ? {
+            category: 'workflow' as const,
+            outputs: meta.outputs ?? [],
+            ...(meta.compileFailures !== undefined && {
+              compileFailures: meta.compileFailures,
+            }),
+            ...(meta.diffs !== undefined && { diffs: meta.diffs }),
+            ...(meta.diffsUnavailable !== undefined && {
+              diffsUnavailable: meta.diffsUnavailable,
+            }),
+          }
+        : meta.category === 'toolUse'
+          ? {
+              category: 'toolUse' as const,
+              ...(meta.lastResponse !== undefined && {
+                lastResponse: meta.lastResponse,
+              }),
+              ...(meta.touchedFiles !== undefined && {
+                touchedFiles: meta.touchedFiles,
+              }),
+            }
+          : undefined;
+
+    return {
+      producer: 'subagent' as const,
+      agentName: meta.agentName,
+      outcome: meta.outcome,
+      success: meta.success,
+      wallTimeMs: meta.wallTimeMs,
+      ...(meta.totalCostUsd !== undefined && {
+        totalCostUsd: meta.totalCostUsd,
+      }),
+      ...(result !== undefined && { result }),
+    };
+  });
+
+const LegacyFlatResultMetaSchema = z.union([
+  LegacyBackgroundBashResultMetaSchema,
+  LegacySubagentResultMetaSchema,
+  LegacyCliWorkflowResultMetaSchema,
+]);
+
+/**
+ * Structured result of a finished execution — the machine-readable
+ * counterpart of the prose report. This is the chaining contract: a later
+ * stage (orchestrator or workflow script) reads outputs/diffs/outcome as
+ * data instead of parsing the XML delivery.
+ *
+ * Canonical records are keyed by producer; legacy flat records are accepted
+ * and normalized on read so existing execution metadata remains readable.
+ */
+export const ResultMetaSchema = z.union([
+  CanonicalResultMetaSchema,
+  LegacyFlatResultMetaSchema,
+]);
 export type ResultMeta = z.infer<typeof ResultMetaSchema>;
 
 // ============================================================================
@@ -292,8 +445,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readConversation(): Promise<unknown[] | null> {
-    const raw = await this.read<unknown[]>(KEYS.CONVERSATION);
-    return Array.isArray(raw) && raw.length > 0 ? raw : null;
+    const messages = normalizeProviderMessages(
+      await this.read(KEYS.CONVERSATION),
+    );
+    return messages && messages.length > 0 ? messages : null;
   }
 
   async conversationModifiedAt(): Promise<number | undefined> {
@@ -349,7 +504,10 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async writeConversation(messages: unknown[]): Promise<void> {
-    await this.write(KEYS.CONVERSATION, messages);
+    await this.write(
+      KEYS.CONVERSATION,
+      ProviderMessageArraySchema.parse(messages),
+    );
   }
 
   async writeWorkspaceFiles(paths: readonly string[]): Promise<void> {
@@ -361,7 +519,7 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async writeResultMeta(data: ResultMeta): Promise<void> {
-    await this.write(KEYS.RESULT_META, data);
+    await this.write(KEYS.RESULT_META, CanonicalResultMetaSchema.parse(data));
   }
 }
 

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -305,4 +305,35 @@ describe('retrieveSessionResumeData', () => {
     if (resume?.type !== 'workflow') return;
     expect(resume.modelHandlerCompatibilityKey).toBe('ModelHandlerGoogleGenAI');
   });
+
+  it('normalizes legacy workflow messages shared state for resume routing', async () => {
+    const executionId = 'abc132' as ExecutionId;
+    const streamId = 'workflow@gemini35f#abc132' as StreamTabId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        currentRound: 1,
+        totalRounds: 2,
+        messages: [
+          {
+            role: 'user',
+            parts: [{ text: 'Continue the old workflow messages.' }],
+          },
+        ],
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(GOOGLE_WORKFLOW_CONFIG),
+    );
+
+    expect(resume?.type).toBe('workflow');
+    if (resume?.type !== 'workflow') return;
+    expect(resume.modelHandlerCompatibilityKey).toBe('ModelHandlerGoogleGenAI');
+  });
 });

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -75,6 +75,140 @@ describe('ExecutionKVStore meta read shims', () => {
     });
   });
 
+  it('normalizes legacy flat CLI workflow result metadata', async () => {
+    const id = 'legacy-result-workflow' as ExecutionId;
+    const output = {
+      round: 1,
+      relativePath: 'r1/output.tex',
+      absolutePath: '/workspace/.texra/runs/r1/output.tex',
+      location: 'runStorage' as const,
+      originalPath: '/workspace/output.tex',
+      added: 2,
+      removed: 1,
+    };
+    await getExecutionStore(id).write('result-meta', {
+      copiedOutput: '/workspace/output.tex',
+      outputs: [output],
+      compileFailures: [],
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      producer: 'cliWorkflow',
+      result: {
+        copiedOutput: '/workspace/output.tex',
+        outputs: [output],
+        compileFailures: [],
+      },
+    });
+  });
+
+  it('normalizes legacy flat subagent result metadata', async () => {
+    const id = 'legacy-result-subagent' as ExecutionId;
+    await getExecutionStore(id).write('result-meta', {
+      agentName: 'reviewer',
+      category: 'toolUse',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 25,
+      lastResponse: 'done',
+      touchedFiles: ['notes.md'],
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      producer: 'subagent',
+      agentName: 'reviewer',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 25,
+      result: {
+        category: 'toolUse',
+        lastResponse: 'done',
+        touchedFiles: ['notes.md'],
+      },
+    });
+  });
+
+  it('normalizes legacy flat background bash result metadata', async () => {
+    const id = 'legacy-result-bash' as ExecutionId;
+    await getExecutionStore(id).write('result-meta', {
+      command: 'echo hi',
+      exitCode: 0,
+      wallTimeMs: 10,
+      success: true,
+      timedOut: false,
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      producer: 'backgroundBash',
+      command: 'echo hi',
+      exitCode: 0,
+      wallTimeMs: 10,
+      success: true,
+      timedOut: false,
+    });
+  });
+
+  it('rejects empty result metadata instead of inventing a workflow result', async () => {
+    const id = 'bad-result-empty' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('result-meta', {});
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} result-meta.json`,
+      ),
+      { data: expect.any(Error) },
+    );
+  });
+
+  it('rejects unknown result metadata producers', async () => {
+    const id = 'bad-result-producer' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await getExecutionStore(id).write('result-meta', {
+      producer: 'unknown',
+      outputs: [],
+      compileFailures: [],
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} result-meta.json`,
+      ),
+      { data: expect.any(Error) },
+    );
+  });
+
+  it('reads legacy conversation wrappers as provider messages', async () => {
+    const id = 'legacy-conversation-wrapper' as ExecutionId;
+    const message = { role: 'user', content: 'Resume this.' };
+
+    await getExecutionStore(id).write('conversation', { messages: [message] });
+    await expect(getExecutionStore(id).readConversation()).resolves.toEqual([
+      message,
+    ]);
+
+    await getExecutionStore(id).write('conversation', {
+      conversation: [message],
+    });
+    await expect(getExecutionStore(id).readConversation()).resolves.toEqual([
+      message,
+    ]);
+  });
+
+  it('returns null for malformed conversation storage wrappers', async () => {
+    const id = 'bad-conversation-wrapper' as ExecutionId;
+
+    await getExecutionStore(id).write('conversation', { messages: ['text'] });
+
+    await expect(getExecutionStore(id).readConversation()).resolves.toBeNull();
+  });
+
   it('warns when execution meta is malformed instead of silently dropping it', async () => {
     const id = 'bad-meta' as ExecutionId;
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -128,6 +128,61 @@ describe('ExecutionKVStore meta read shims', () => {
     });
   });
 
+  it('infers category for legacy subagent result metadata with no category tag (workflow fields)', async () => {
+    const id = 'legacy-result-subagent-no-category' as ExecutionId;
+    const output = {
+      round: 1,
+      relativePath: 'r1/output.tex',
+      absolutePath: '/workspace/.texra/runs/r1/output.tex',
+      location: 'runStorage' as const,
+      originalPath: '/workspace/output.tex',
+      added: 2,
+      removed: 1,
+    };
+    await getExecutionStore(id).write('result-meta', {
+      agentName: 'writer',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 40,
+      outputs: [output],
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      producer: 'subagent',
+      agentName: 'writer',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 40,
+      result: {
+        category: 'workflow',
+        outputs: [output],
+      },
+    });
+  });
+
+  it('infers category for legacy subagent result metadata with no category tag (toolUse fields)', async () => {
+    const id = 'legacy-result-subagent-no-category-tooluse' as ExecutionId;
+    await getExecutionStore(id).write('result-meta', {
+      agentName: 'reviewer',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 25,
+      lastResponse: 'done',
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      producer: 'subagent',
+      agentName: 'reviewer',
+      outcome: RUN_OUTCOME.COMPLETED,
+      success: true,
+      wallTimeMs: 25,
+      result: {
+        category: 'toolUse',
+        lastResponse: 'done',
+      },
+    });
+  });
+
   it('normalizes legacy flat background bash result metadata', async () => {
     const id = 'legacy-result-bash' as ExecutionId;
     await getExecutionStore(id).write('result-meta', {
@@ -201,12 +256,19 @@ describe('ExecutionKVStore meta read shims', () => {
     ]);
   });
 
-  it('returns null for malformed conversation storage wrappers', async () => {
+  it('warns when conversation storage is malformed instead of silently dropping it', async () => {
     const id = 'bad-conversation-wrapper' as ExecutionId;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
     await getExecutionStore(id).write('conversation', { messages: ['text'] });
 
     await expect(getExecutionStore(id).readConversation()).resolves.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} conversation.json as provider messages`,
+      ),
+    );
   });
 
   it('warns when execution meta is malformed instead of silently dropping it', async () => {

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -393,18 +393,24 @@ describe('CLI history runtime', () => {
       logAbsolutePath: '/tmp/run/compile/r1_paper.tex.log',
     };
     mocks.readResultMeta.mockResolvedValue({
-      copiedOutput: '/tmp/annotated.tex',
-      outputs: [outputSummary],
-      compileFailures: [compileFailure],
+      producer: 'cliWorkflow',
+      result: {
+        copiedOutput: '/tmp/annotated.tex',
+        outputs: [outputSummary],
+        compileFailures: [compileFailure],
+      },
     });
 
     const details = await readCliHistoryDetails('a1' as ExecutionId);
     const text = formatCliHistoryDetailsText(details!);
 
     expect(details?.resultMeta).toEqual({
-      copiedOutput: '/tmp/annotated.tex',
-      outputs: [outputSummary],
-      compileFailures: [compileFailure],
+      producer: 'cliWorkflow',
+      result: {
+        copiedOutput: '/tmp/annotated.tex',
+        outputs: [outputSummary],
+        compileFailures: [compileFailure],
+      },
     });
     expect(text).toContain('"copiedOutput":"/tmp/annotated.tex"');
     expect(text).toContain('"compileFailures"');

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -377,9 +377,12 @@ describe('CLI workflow run command', () => {
         fs.readFile(path.join(root, 'polished.tex'), 'utf8'),
       ).resolves.toBe('polished');
       expect(mocks.writeResultMeta).toHaveBeenCalledWith({
-        copiedOutput: path.join(root, 'polished.tex'),
-        outputs: [outputSummary],
-        compileFailures: [compileFailure],
+        producer: 'cliWorkflow',
+        result: {
+          copiedOutput: path.join(root, 'polished.tex'),
+          outputs: [outputSummary],
+          compileFailures: [compileFailure],
+        },
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
@@ -430,9 +433,12 @@ describe('CLI workflow run command', () => {
         fs.readFile(path.join(root, 'out', 'paper.tex'), 'utf8'),
       ).resolves.toBe('polished');
       expect(mocks.writeResultMeta).toHaveBeenCalledWith({
-        copiedOutputs: [path.join(root, 'out', 'paper.tex')],
-        outputs: [outputSummary],
-        compileFailures: [],
+        producer: 'cliWorkflow',
+        result: {
+          copiedOutputs: [path.join(root, 'out', 'paper.tex')],
+          outputs: [outputSummary],
+          compileFailures: [],
+        },
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -56,6 +56,7 @@ describe('child run delivery', () => {
 
   it('persists result manifests through the execution store', async () => {
     const resultMeta = {
+      producer: 'subagent',
       agentName: 'review',
       outcome: 'completed',
       success: true,

--- a/src/test-kernel/tools/SubagentResultMeta.vitest.ts
+++ b/src/test-kernel/tools/SubagentResultMeta.vitest.ts
@@ -42,22 +42,30 @@ describe('buildSubagentResultMeta', () => {
 
     expect(ResultMetaSchema.parse(meta)).toEqual(meta);
     expect(meta).toMatchObject({
+      producer: 'subagent',
       agentName: 'merge',
-      category: 'workflow',
       outcome: 'completed',
       success: true,
       wallTimeMs: 1234,
       totalCostUsd: 0.42,
-      outputs: [OUTPUT],
-      diffs: [
-        {
-          path: OUTPUT.absolutePath,
-          diffRelPath: 'diffs/r0_output.tex.diff',
-          largeChange: false,
-        },
-      ],
+      result: {
+        category: 'workflow',
+        outputs: [OUTPUT],
+        diffs: [
+          {
+            path: OUTPUT.absolutePath,
+            diffRelPath: 'diffs/r0_output.tex.diff',
+            largeChange: false,
+          },
+        ],
+      },
     });
-    expect(meta.compileFailures).toBeUndefined();
+    expect(meta.result?.category).toBe('workflow');
+    expect(
+      meta.result?.category === 'workflow'
+        ? meta.result.compileFailures
+        : undefined,
+    ).toBeUndefined();
   });
 
   it('records diffsUnavailable in the manifest when diff generation failed', () => {
@@ -75,8 +83,15 @@ describe('buildSubagentResultMeta', () => {
     });
 
     expect(ResultMetaSchema.parse(meta)).toEqual(meta);
-    expect(meta.diffs).toBeUndefined();
-    expect(meta.diffsUnavailable).toBe('latexdiff crashed');
+    expect(meta.result?.category).toBe('workflow');
+    expect(
+      meta.result?.category === 'workflow' ? meta.result.diffs : undefined,
+    ).toBeUndefined();
+    expect(
+      meta.result?.category === 'workflow'
+        ? meta.result.diffsUnavailable
+        : undefined,
+    ).toBe('latexdiff crashed');
   });
 
   it('builds a schema-valid manifest for tool-use results', () => {
@@ -94,14 +109,16 @@ describe('buildSubagentResultMeta', () => {
 
     expect(ResultMetaSchema.parse(meta)).toEqual(meta);
     expect(meta).toMatchObject({
+      producer: 'subagent',
       agentName: 'reviewer',
-      category: 'toolUse',
       success: true,
-      lastResponse: 'All findings verified.',
-      touchedFiles: ['notes.md'],
+      result: {
+        category: 'toolUse',
+        lastResponse: 'All findings verified.',
+        touchedFiles: ['notes.md'],
+      },
     });
-    expect(meta.outputs).toBeUndefined();
-    expect(meta.diffs).toBeUndefined();
+    expect(meta.result?.category).toBe('toolUse');
   });
 
   it('failure manifest overwrites interim success and never claims success', () => {
@@ -130,6 +147,7 @@ describe('buildSubagentResultMeta', () => {
     const meta = buildSubagentFailureResultMeta('merge', undefined, 10);
     expect(ResultMetaSchema.parse(meta)).toEqual(meta);
     expect(meta).toEqual({
+      producer: 'subagent',
       agentName: 'merge',
       outcome: 'failed',
       success: false,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -428,10 +428,11 @@ export class BashTool extends defineTool({
         try {
           const store = getExecutionStore(executionId);
           await store.writeResultMeta({
-            exitCode: result.exitCode,
+            producer: 'backgroundBash',
+            exitCode: result.exitCode ?? (result.success ? 0 : 1),
             wallTimeMs,
             success: result.success,
-            timedOut: result.timedOut,
+            timedOut: result.timedOut ?? false,
             command,
           });
           await writeTerminalStatus(

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -32,6 +32,8 @@ import {
 } from './deliveryEnvelope';
 import type { DiffFileInfo } from './subagentDiffs';
 
+type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
+
 // ============================================================================
 // Formatting helpers
 // ============================================================================
@@ -532,10 +534,10 @@ export function buildSubagentResultMeta(
     diffsUnavailable?: string;
     wallTimeMs: number;
   },
-): ResultMeta {
-  const base: ResultMeta = {
+): SubagentResultMeta {
+  const base: SubagentResultMeta = {
+    producer: 'subagent',
     agentName,
-    category: result.category,
     outcome: result.outcome,
     success: result.outcome === 'completed',
     wallTimeMs: options.wallTimeMs,
@@ -546,35 +548,41 @@ export function buildSubagentResultMeta(
   if (result.category === 'workflow') {
     return {
       ...base,
-      outputs: result.outputs,
-      ...(result.compileFailures.length > 0 && {
-        compileFailures: result.compileFailures,
-      }),
-      ...(options.diffInfos &&
-        options.diffInfos.size > 0 && {
-          diffs: [...options.diffInfos.entries()].map(([path, info]) => ({
-            path,
-            diffRelPath: info.diffRelPath,
-            largeChange: info.largeChange,
-          })),
+      result: {
+        category: 'workflow',
+        outputs: result.outputs,
+        ...(result.compileFailures.length > 0 && {
+          compileFailures: result.compileFailures,
         }),
-      // Mirror the XML delivery's diffsUnavailable: a chaining consumer must
-      // distinguish "diff generation failed, read the outputs directly" from
-      // a clean no-diff result.
-      ...(options.diffsUnavailable !== undefined && {
-        diffsUnavailable: options.diffsUnavailable,
-      }),
+        ...(options.diffInfos &&
+          options.diffInfos.size > 0 && {
+            diffs: [...options.diffInfos.entries()].map(([path, info]) => ({
+              path,
+              diffRelPath: info.diffRelPath,
+              largeChange: info.largeChange,
+            })),
+          }),
+        // Mirror the XML delivery's diffsUnavailable: a chaining consumer must
+        // distinguish "diff generation failed, read the outputs directly" from
+        // a clean no-diff result.
+        ...(options.diffsUnavailable !== undefined && {
+          diffsUnavailable: options.diffsUnavailable,
+        }),
+      },
     };
   }
   return {
     ...base,
-    ...(result.lastResponse !== undefined && {
-      lastResponse: result.lastResponse,
-    }),
-    ...(result.touchedFiles !== undefined &&
-      result.touchedFiles.length > 0 && {
-        touchedFiles: [...result.touchedFiles],
+    result: {
+      category: 'toolUse',
+      ...(result.lastResponse !== undefined && {
+        lastResponse: result.lastResponse,
       }),
+      ...(result.touchedFiles !== undefined &&
+        result.touchedFiles.length > 0 && {
+          touchedFiles: [...result.touchedFiles],
+        }),
+    },
   };
 }
 
@@ -588,9 +596,15 @@ export function buildSubagentFailureResultMeta(
   agentName: string,
   result: AgentFlowResult | undefined,
   wallTimeMs: number,
-): ResultMeta {
+): SubagentResultMeta {
   if (!result) {
-    return { agentName, outcome: 'failed', success: false, wallTimeMs };
+    return {
+      producer: 'subagent',
+      agentName,
+      outcome: 'failed',
+      success: false,
+      wallTimeMs,
+    };
   }
   const meta = buildSubagentResultMeta(agentName, result, { wallTimeMs });
   return {


### PR DESCRIPTION
## Summary

Normalize execution result metadata and persisted provider-message shapes at
their storage boundaries.

- `ResultMeta` is now a producer-discriminated union for background bash, CLI
  workflow, and subagent records.
- Legacy flat result metadata is still accepted on read and normalized to the
  canonical producer-tagged shape.
- Provider-message persistence now has one storage normalizer for raw arrays and
  the legacy `{ messages }` / `{ conversation }` wrappers.

## Issue acceptance gates

Addresses #7427:

- Re-verified the cited `ResultMeta` evidence before implementation; the
  original `nativeSubagentStrategy.ts` citation had drifted and was documented
  on the issue.
- Modeled producer-specific `ResultMeta` fields as a discriminated union.
- Kept backward-compatible read shims for legacy flat metadata and legacy
  provider-message wrappers.
- Added focused storage, resume, subagent, CLI workflow, and history coverage.

## Single source of truth

`ResultMetaSchema` in `ExecutionKVStore.ts` owns the producer-tagged result
metadata contract. `ProviderMessageStorageSchema` in `ProviderMessage.ts` owns
provider-message storage normalization.

## Duplication and abstraction budget

This removes the glued all-optional `ResultMeta` shape and the repeated
messages/conversation array parsing. The added mass is schema/test coverage at
the persisted-storage boundary, where the compatibility logic has to live until
D3 retires the legacy records.

## Host impact

Extension: Existing completed-run metadata and conversation storage remain
readable through the read shims; new writes use canonical shapes.

Desktop: Same runtime/storage behavior as extension; no desktop-specific IPC or
UI contract change.

CLI: Workflow result metadata is persisted as `producer: "cliWorkflow"` with a
nested `result`; history/detail rendering continues to expose the metadata
content and legacy flat records remain readable.

## Scheduled refactoring

#6981 now tracks removal of the flat `ResultMeta` read shims and
provider-message wrapper normalizer under D3 persisted-run retention triggers.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts src/test-kernel/agent/SessionResumeRetrieval.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerCompatibilityInference.vitest.ts src/test-kernel/tools/SubagentResultMeta.vitest.ts src/test-kernel/tools/ChildRunDelivery.vitest.ts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/History.vitest.mts src/test-kernel/transcript/completedRunArchive.vitest.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts`
- `npm run typecheck`
- `corepack pnpm exec prettier --check` on touched files
- `corepack pnpm exec eslint` on touched files
- `npm run check:dead-code-ratchet`
- `CI=true corepack pnpm run test`

Closes #7427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted execution chaining data and session resume paths; backward-compatible read shims limit breakage, but any consumer still assuming flat `ResultMeta` or unwrapped conversations must follow the normalized shapes.
> 
> **Overview**
> **Result metadata** moves from a single flat optional-field blob to a **`producer`-tagged union** (`backgroundBash`, `cliWorkflow`, `subagent`). Writers (CLI workflow, background bash, subagent builders) persist the canonical shape; **`writeResultMeta`** validates against it. **Reads** still accept legacy flat records and normalize them (including inferring subagent `workflow` vs `toolUse` when `category` is missing). Empty or unknown producer records fail validation with warnings instead of being guessed.
> 
> **Provider messages** gain **`ProviderMessageArraySchema`**, **`normalizeProviderMessages`**, and a storage union for raw arrays plus `{ messages }` / `{ conversation }` wrappers. **`readConversation`** / **`writeConversation`** use this; flow/resume schemas and model-handler compatibility inference call the same helper. Workflow resume state now accepts **`messages`** as well as **`conversation`**.
> 
> Tests cover legacy result-meta and conversation wrappers, workflow resume with `messages`, and updated CLI/subagent persistence expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640bfb59d8348f4b8b360b7dc644055509811c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

