### PR TITLE
[codex] refactor runtime child stream removal through session facts

### DIFF
--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -7,6 +7,7 @@ import type {
   FollowUpSentPayload,
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
+  RemoveStreamPayload,
   SetActiveStreamPayload,
   SetParentStreamPayload,
   StreamTabId,
@@ -59,6 +60,10 @@ export type SessionFact =
   | {
       readonly type: 'setParentStream';
       readonly payload: SetParentStreamPayload;
+    }
+  | {
+      readonly type: 'removeStream';
+      readonly payload: RemoveStreamPayload;
     };
 
 export type SessionEvent =

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -11,6 +11,7 @@ import type {
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
   PlanApprovalPermission,
+  RemoveStreamPayload,
   RequestEnsureProgressViewPayload,
   RequestOpenFilePayload,
   RequestShowErrorPayload,
@@ -113,7 +114,7 @@ export interface ProgressEventPayloads {
 
   /** Request the progress view to remove a stream tab (used by short-lived
    *  child streams that should auto-close once their work is done). */
-  removeStream: { streamId: StreamTabId };
+  removeStream: RemoveStreamPayload;
 
   goalStateChanged: GoalStateChangedPayload;
 

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -28,6 +28,15 @@ export function emitProjectedProgressEvent(
   runtimeHost: AgentRuntimeHost,
   projected: ProjectedProgressEvent,
 ): void {
+  if (
+    projected.event === 'removeStream' &&
+    runtimeHost.interactions?.handleProgressEvent(
+      projected.event,
+      projected.payload,
+    )
+  ) {
+    return;
+  }
   runtimeHost.emit(projected.event, projected.payload);
 }
 
@@ -111,6 +120,8 @@ export function projectSessionFactToProgressEvent(
       return { event: 'updateStreamStatus', payload: fact.payload };
     case 'setParentStream':
       return { event: 'setParentStream', payload: fact.payload };
+    case 'removeStream':
+      return { event: 'removeStream', payload: fact.payload };
   }
 }
 

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -45,6 +45,10 @@ export interface SetParentStreamPayload {
   parentStreamId: StreamTabId | null;
 }
 
+export interface RemoveStreamPayload {
+  streamId: StreamTabId;
+}
+
 export interface UpdateStreamStatusPayload {
   streamId: StreamTabId;
   status: StreamPhase;

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -37,6 +37,8 @@ const failedExecutionId = 'c11116' as ExecutionId;
 const failedChildStreamId = 'codex#c11116' as StreamTabId;
 const normalizedErrorExecutionId = 'c11117' as ExecutionId;
 const normalizedErrorChildStreamId = 'codex#c11117' as StreamTabId;
+const noProjectionAutoCloseExecutionId = 'c11118' as ExecutionId;
+const noProjectionAutoCloseChildStreamId = 'bash#c11118' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -68,9 +70,15 @@ function withSessionProgressProjection<T>(
     host,
   );
   try {
-    return run();
-  } finally {
+    const result = run();
+    if (result instanceof Promise) {
+      return result.finally(detach) as T;
+    }
     detach();
+    return result;
+  } catch (err) {
+    detach();
+    throw err;
   }
 }
 
@@ -84,6 +92,7 @@ describe('child stream progress events', () => {
       cancelledChildStreamId,
       failedChildStreamId,
       normalizedErrorChildStreamId,
+      noProjectionAutoCloseChildStreamId,
     ]) {
       clearStreamStatusForTest(StreamStatusService, streamId);
     }
@@ -272,6 +281,45 @@ describe('child stream progress events', () => {
       ]);
 
       await childStream.finalize();
+    } finally {
+      detachFacts();
+    }
+  });
+
+  it('publishes child stream auto-close as a session fact without direct host emission', async () => {
+    const active = createRecordingHost();
+    const facts: unknown[] = [];
+    const detachFacts = defaultSession().events.subscribe((event) => {
+      if (event.scope === 'session') {
+        facts.push(event);
+      }
+    });
+
+    try {
+      const childStream = createChildStream(
+        noProjectionAutoCloseExecutionId,
+        parentStreamId,
+        {
+          runtimeHost: active.host,
+          streamPrefix: 'bash',
+          streamCategory: AgentCategory.ToolUse,
+          agentName: 'test-agent',
+          description: 'Run a background bash command',
+          config,
+          toolName: 'bash',
+        },
+      );
+
+      await childStream.finalize({ autoClose: true });
+
+      expect(active.events).toEqual([]);
+      expect(facts).toContainEqual({
+        scope: 'session',
+        event: {
+          type: 'removeStream',
+          payload: { streamId: noProjectionAutoCloseChildStreamId },
+        },
+      });
     } finally {
       detachFacts();
     }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -263,14 +263,10 @@ async function finalizeChildStream(
   disposeTrace();
 
   if (options?.autoClose) {
-    const handled = handle.runtimeHost.interactions?.handleProgressEvent(
+    emitRuntimeEvent(
       'removeStream',
       { streamId: handle.childStreamId },
+      session,
     );
-    if (!handled) {
-      handle.runtimeHost.emit('removeStream', {
-        streamId: handle.childStreamId,
-      });
-    }
   }
 }


### PR DESCRIPTION
## Summary

This PR moves child-stream auto-close off the direct host-progress producer path. `removeStream` is now a session-scoped fact with a named `RemoveStreamPayload`, and `createChildStream(...).finalize({ autoClose: true })` publishes it through `emitRuntimeEvent` on the owning session.

The retained session-to-host projector still emits the legacy `removeStream` host event for CLI/public-output compatibility. For extension-style hosts, projected `removeStream` is offered to `HostInteractions.handleProgressEvent` before falling back to `runtimeHost.emit`, preserving the lifecycle-controller path that deletes the stream tab and forgets goal state.

This is a Stage 5 producer switchover slice; it does not delete the frozen host key yet.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (passes with existing import-order warnings)
- `corepack pnpm run compile:fast`
- `CI=true corepack pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view stream tab lifecycle and event ordering; behavior is preserved via projection and HostInteractions, but regressions could affect extension UI or CLI stream cleanup.
> 
> **Overview**
> Child-stream **auto-close** no longer calls `runtimeHost.emit('removeStream')` or `interactions.handleProgressEvent` from `finalizeChildStream`. It publishes a session-scoped **`removeStream`** fact via `emitRuntimeEvent`, backed by a new **`RemoveStreamPayload`** on `SessionFact` and the frozen host progress map.
> 
> The **session→host projector** now maps that fact to legacy `removeStream` progress events. For **`removeStream` only**, projected emission tries **`HostInteractions.handleProgressEvent`** first (extension tab teardown) and skips `runtimeHost.emit` when handled; otherwise behavior matches other facts for CLI/public output.
> 
> Tests cover fact-only publication without a projector and async-safe projection teardown in **`ChildStreamProgressEvents`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a59c4c8e26fbffd119ece1231e1611a58f48280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->