### PR TITLE
refactor(desktop): consume session facts in progress bridge

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -261,9 +261,6 @@ export class DesktopProgressBridge {
       getStreamControls: getProgressStreamControls,
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
-      onSessionProgressEvent: (event, payload) => {
-        this.progressEvents.onProgressEvent(event, payload);
-      },
       configureUi: ({ webviewUpdater }) => {
         // The desktop renderer is always attached (no sidebar/editor re-target),
         // so every show/resolve reaches the webview.
@@ -319,6 +316,14 @@ export class DesktopProgressBridge {
       },
     });
     const backendSubscription = this.backend.setupEventListeners();
+    const detachSessionProgressFacts = this.session.events.subscribe(
+      (event) => this.progressEvents.onSessionEvent(event),
+      { scope: 'session' },
+    );
+    const detachRunProgressFacts = this.session.events.subscribe(
+      (event) => this.progressEvents.onSessionEvent(event),
+      { scope: 'run', types: ['run.config', 'status'] },
+    );
     this.restartRepair = this.repairOrphanedStreamsAfterRestart();
     // Onboarding funnel (PRD: agent-native onboarding): a completed run ends
     // State 1. `AgentRunLifecycle` persists `firstRunDone` BEFORE it emits the
@@ -332,6 +337,8 @@ export class DesktopProgressBridge {
       }
     });
     this.unsubscribe = () => {
+      detachRunProgressFacts();
+      detachSessionProgressFacts();
       backendSubscription.dispose();
       this.progressEvents.dispose();
       unsubscribeResult();

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -10,7 +10,8 @@
  * This is Slice 1 of the desktopAgentExecution.ts refactor (issue #6329).
  */
 
-import type { AgentTrace } from '@agent/trace';
+import type { AgentEvent, AgentTrace } from '@agent/trace';
+import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import {
@@ -90,6 +91,9 @@ export interface DesktopProgressEventBridge {
     payload: ProgressEventPayloads[K],
   ): void;
 
+  /** Handle session/run facts emitted by this window's SessionEventHub. */
+  onSessionEvent(event: SessionEvent): void;
+
   /**
    * Restore a ghost stream's persisted sidecar display (todos, plan, usage,
    * output files) if it hasn't been restored yet.  Public so `syncStreamContent`
@@ -123,6 +127,11 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   private readonly restoredDisplayInFlight = new Set<StreamTabId>();
   /** Streams that became live in this bridge and must not be restored as ghosts. */
   private readonly liveStreams = new Set<StreamTabId>();
+  /** Fact values known before the durable snapshot meta view catches up. */
+  private readonly liveSnapshotFacts = new Map<
+    StreamTabId,
+    Partial<Pick<RestoredStreamSnapshot, 'executionId' | 'lastKnownStatus'>>
+  >();
 
   /** True once `dispose()` has torn down this bridge. */
   private disposed = false;
@@ -188,6 +197,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       this.restoredStreams.delete(streamId);
       this.restoredDisplaySent.delete(streamId);
       this.restoredDisplayInFlight.delete(streamId);
+      this.liveSnapshotFacts.delete(streamId);
     }
   }
 
@@ -208,33 +218,17 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     switch (event) {
       case 'setActiveStream': {
         const data = payload as ProgressEventPayloads['setActiveStream'];
-        if (!data.streamId) {
-          this.opts.state.activeStream = '';
-          this.opts.sendMessage({
-            command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-            activeStream: '',
-          });
-          return;
-        }
-        if (data.suppressViewSwitch !== true) {
-          this.opts.routeToProgress();
-          this.sendRestoredDisplay(data.streamId);
-        }
+        this.handleSetActiveStream(data);
         return;
       }
       case 'setTaskState': {
         const data = payload as ProgressEventPayloads['setTaskState'];
-        this.liveStreams.add(data.streamId);
-        this.opts.state.streamLogs.ensureStream(data.streamId);
-        this.restoredStreams.delete(data.streamId);
-        this.persistStreamSnapshot(data.streamId);
+        this.handleRunConfigFact(data.streamId, data.executionId);
         return;
       }
       case 'updateStreamStatus': {
         const data = payload as ProgressEventPayloads['updateStreamStatus'];
-        this.liveStreams.add(data.streamId);
-        this.restoredStreams.delete(data.streamId);
-        this.persistStreamSnapshot(data.streamId);
+        this.handleStreamStatusFact(data.streamId, data.status);
         return;
       }
       case 'updateStreamDescription': {
@@ -250,11 +244,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       }
       case 'goalStateChanged': {
         const data = payload as ProgressEventPayloads['goalStateChanged'];
-        const goal = GoalStore.getForStream(data.streamId);
-        this.opts.onGoalStateChanged(data.streamId, isGoalInFlight(goal), {
-          status: goal?.status,
-          objective: goal?.objective,
-        });
+        this.handleGoalStateChanged(data.streamId);
         return;
       }
       case 'requestEnsureProgressView':
@@ -268,6 +258,15 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       default:
         return;
     }
+  }
+
+  onSessionEvent(event: SessionEvent): void {
+    if (this.disposed) return;
+    if (event.scope === 'session') {
+      this.handleSessionFact(event.event);
+      return;
+    }
+    this.handleRunEvent(event.event);
   }
 
   // ── Restored display ─────────────────────────────────────────────────────
@@ -360,6 +359,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.removePersistedStream(streamId);
     this.restoredDisplaySent.delete(streamId);
     this.restoredDisplayInFlight.delete(streamId);
+    this.liveSnapshotFacts.delete(streamId);
   }
 
   async onAllStreamsDeleted(): Promise<void> {
@@ -367,6 +367,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.restoredDisplaySent.clear();
     this.restoredDisplayInFlight.clear();
     this.liveStreams.clear();
+    this.liveSnapshotFacts.clear();
     if (this.opts.streamSnapshotStore) {
       try {
         await this.opts.streamSnapshotStore.replaceAll([]);
@@ -386,14 +387,28 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     this.restoredDisplaySent.clear();
     this.restoredDisplayInFlight.clear();
     this.liveStreams.clear();
+    this.liveSnapshotFacts.clear();
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────
 
-  private persistStreamSnapshot(streamId: StreamTabId): void {
+  private persistStreamSnapshot(
+    streamId: StreamTabId,
+    overrides: Partial<
+      Pick<RestoredStreamSnapshot, 'executionId' | 'lastKnownStatus'>
+    > = {},
+  ): void {
     const store = this.opts.streamSnapshotStore;
     if (!store) return;
 
+    const knownFacts = { ...this.liveSnapshotFacts.get(streamId) };
+    if (overrides.executionId !== undefined) {
+      knownFacts.executionId = overrides.executionId;
+    }
+    if (overrides.lastKnownStatus !== undefined) {
+      knownFacts.lastKnownStatus = overrides.lastKnownStatus;
+    }
+    this.liveSnapshotFacts.set(streamId, knownFacts);
     const taskState = this.opts.state.snapshots.getTaskState(streamId);
     const info = buildStreamInfo(this.opts.state, streamId, 'all');
     const restored = this.restoredStreams.get(streamId);
@@ -409,9 +424,13 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
       inputFile: info?.inputFile || restored?.inputFile,
       instruction: taskState?.agentConfig.instruction || restored?.instruction,
       lastKnownStatus:
-        currentStatus ?? restored?.lastKnownStatus ?? STREAM_PHASE.COMPLETED,
+        knownFacts.lastKnownStatus ??
+        currentStatus ??
+        restored?.lastKnownStatus ??
+        STREAM_PHASE.COMPLETED,
       description: info?.description ?? restored?.description,
-      executionId: info?.executionId ?? restored?.executionId,
+      executionId:
+        knownFacts.executionId ?? info?.executionId ?? restored?.executionId,
       parentStreamId: info?.parentStreamId ?? restored?.parentStreamId,
       creationTimestamp:
         info?.creationTimestamp ?? restored?.creationTimestamp ?? Date.now(),
@@ -429,12 +448,92 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 
   private removePersistedStream(streamId: StreamTabId): void {
     this.restoredStreams.delete(streamId);
+    this.liveSnapshotFacts.delete(streamId);
     const store = this.opts.streamSnapshotStore;
     if (!store) return;
     void store.remove(streamId).catch((error: unknown) => {
       this.opts.logger.warn('Failed to remove persisted stream snapshot', {
         data: error instanceof Error ? error : { error },
       });
+    });
+  }
+
+  private handleSessionFact(fact: SessionFact): void {
+    switch (fact.type) {
+      case 'setActiveStream':
+        this.handleSetActiveStream(fact.payload);
+        return;
+      case 'updateStreamStatus':
+        this.handleStreamStatusFact(fact.payload.streamId, fact.payload.status);
+        return;
+      case 'updateStreamDescription':
+        this.persistStreamSnapshot(fact.payload.streamId);
+        return;
+      case 'setParentStream':
+        this.persistStreamSnapshot(fact.payload.childStreamId);
+        return;
+      case 'goalStateChanged':
+        this.handleGoalStateChanged(fact.payload.streamId);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private handleRunEvent(event: AgentEvent): void {
+    switch (event.type) {
+      case 'run.config':
+        this.handleRunConfigFact(event.streamId, event.executionId);
+        return;
+      case 'status':
+        this.handleStreamStatusFact(event.streamId, event.phase);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private handleSetActiveStream(
+    payload: ProgressEventPayloads['setActiveStream'],
+  ): void {
+    if (!payload.streamId) {
+      this.opts.state.activeStream = '';
+      this.opts.sendMessage({
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        activeStream: '',
+      });
+      return;
+    }
+    if (payload.suppressViewSwitch !== true) {
+      this.opts.routeToProgress();
+      this.sendRestoredDisplay(payload.streamId);
+    }
+  }
+
+  private handleRunConfigFact(
+    streamId: StreamTabId,
+    executionId?: RestoredStreamSnapshot['executionId'],
+  ): void {
+    this.liveStreams.add(streamId);
+    this.opts.state.streamLogs.ensureStream(streamId);
+    this.restoredStreams.delete(streamId);
+    this.persistStreamSnapshot(streamId, { executionId });
+  }
+
+  private handleStreamStatusFact(
+    streamId: StreamTabId,
+    lastKnownStatus?: RestoredStreamSnapshot['lastKnownStatus'],
+  ): void {
+    this.liveStreams.add(streamId);
+    this.restoredStreams.delete(streamId);
+    this.persistStreamSnapshot(streamId, { lastKnownStatus });
+  }
+
+  private handleGoalStateChanged(streamId: StreamTabId): void {
+    const goal = GoalStore.getForStream(streamId);
+    this.opts.onGoalStateChanged(streamId, isGoalInFlight(goal), {
+      status: goal?.status,
+      objective: goal?.objective,
     });
   }
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -26,6 +26,7 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   type EndGroupStatus,
+  type ExecutionId,
   type RestoredStreamSnapshot,
   type RunOutcome,
   type StreamTabId,
@@ -104,6 +105,7 @@ type BridgeWithSession = TestableBridge & {
       cancel(selector?: { cause?: string }): void;
     };
     status: StreamStatusMachine;
+    events: SessionHandle['events'];
     followUps: {
       enqueue(
         streamId: StreamTabId,
@@ -705,6 +707,63 @@ describe('DesktopProgressBridge', () => {
           expect.objectContaining({
             streamId: 'desktop-host-stream',
             executionId: 'de57e0',
+          }),
+        );
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('persists desktop stream snapshots from direct session and run facts', async () => {
+    const messages: unknown[] = [];
+    const streamSnapshotStore = createStreamSnapshotStore([]);
+    const bridge = (await createBridge(messages, {
+      streamSnapshotStore,
+    })) as BridgeWithSession;
+    const streamId = 'desktop-session-fact-stream' as StreamTabId;
+    const executionId = 'desktop-session-fact-exec' as ExecutionId;
+
+    try {
+      bridge.session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'run.config',
+          streamId,
+          executionId,
+          config: TaskStateSchema.parse(workflowTaskState()).agentConfig,
+        },
+      });
+      bridge.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamDescription',
+          payload: {
+            streamId,
+            description: 'Direct session fact description',
+          },
+        },
+      });
+      bridge.session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'status',
+          streamId,
+          phase: STREAM_PHASE.RUNNING,
+          previousPhase: STREAM_PHASE.WAITING,
+          cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId,
+            executionId,
+            description: 'Direct session fact description',
+            lastKnownStatus: STREAM_PHASE.RUNNING,
           }),
         );
       });

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -443,7 +443,7 @@ describe('DesktopProgressEventBridge', () => {
         expect(upsert).toHaveBeenCalledWith(
           expect.objectContaining({
             streamId: 'status-stream',
-            lastKnownStatus: STREAM_PHASE.WAITING,
+            lastKnownStatus: STREAM_PHASE.RUNNING,
           }),
         );
       } finally {
@@ -533,6 +533,123 @@ describe('DesktopProgressEventBridge', () => {
         });
 
         expect(onShowError).toHaveBeenCalledWith('Root run failed');
+      } finally {
+        bridge.dispose();
+      }
+    });
+  });
+
+  describe('onSessionEvent', () => {
+    it('handles session stream facts without progress-event projection', async () => {
+      const upsert = vi.fn(async () => {});
+      const streamStatus = {
+        get: vi.fn(() => STREAM_PHASE.WAITING),
+        transition: vi.fn(() => true),
+      };
+      const bridge = createBridge({
+        streamStatus,
+        streamSnapshotStore: createSnapshotStore({
+          hydrated: [createSnapshot({ streamId: 'fact-stream' })],
+          upsert,
+        }),
+      });
+
+      try {
+        bridge.onSessionEvent({
+          scope: 'session',
+          event: {
+            type: 'updateStreamStatus',
+            payload: {
+              streamId: 'fact-stream',
+              status: STREAM_STATUS.RUNNING,
+              previousStatus: STREAM_PHASE.WAITING,
+            },
+          },
+        });
+
+        expect(bridge.hasRestoredStream('fact-stream')).toBe(false);
+        await settleMicrotasks();
+        expect(upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId: 'fact-stream',
+            lastKnownStatus: STREAM_PHASE.RUNNING,
+          }),
+        );
+      } finally {
+        bridge.dispose();
+      }
+    });
+
+    it('handles run config and status facts as live stream updates', async () => {
+      const ensureStream = vi.fn();
+      const upsert = vi.fn(async () => {});
+      const bridge = createBridge({
+        state: makeMockState({
+          streamLogs: createStreamLogs({ ensureStream }),
+        }),
+        streamSnapshotStore: createSnapshotStore({
+          hydrated: [createSnapshot({ streamId: 'run-fact-stream' })],
+          upsert,
+        }),
+      });
+
+      try {
+        bridge.onSessionEvent({
+          scope: 'run',
+          streamId: 'run-fact-stream',
+          event: {
+            type: 'run.config',
+            streamId: 'run-fact-stream',
+            executionId: 'exec-run-fact',
+            config: {
+              agent: 'proofreader',
+              model: 'deepseekproT',
+              agentCategory: AgentCategory.Workflow,
+            },
+          } as any,
+        });
+        bridge.onSessionEvent({
+          scope: 'run',
+          streamId: 'run-fact-stream',
+          event: {
+            type: 'status',
+            streamId: 'run-fact-stream',
+            phase: STREAM_PHASE.RUNNING,
+            previousPhase: STREAM_PHASE.WAITING,
+            cause: 'run-start',
+          } as any,
+        });
+
+        expect(ensureStream).toHaveBeenCalledWith('run-fact-stream');
+        expect(bridge.hasRestoredStream('run-fact-stream')).toBe(false);
+        await settleMicrotasks();
+        expect(upsert).toHaveBeenCalled();
+      } finally {
+        bridge.dispose();
+      }
+    });
+
+    it('keeps goal badge updates on direct session facts', () => {
+      const onGoalStateChanged = vi.fn();
+      const bridge = createBridge({ onGoalStateChanged });
+
+      try {
+        bridge.onSessionEvent({
+          scope: 'session',
+          event: {
+            type: 'goalStateChanged',
+            payload: { streamId: 'goal-fact-stream' },
+          },
+        });
+
+        expect(onGoalStateChanged).toHaveBeenCalledWith(
+          'goal-fact-stream',
+          false,
+          {
+            status: undefined,
+            objective: undefined,
+          },
+        );
       } finally {
         bridge.dispose();
       }


### PR DESCRIPTION
## Summary

This PR advances Stage 5 of the session-scoped runtime migration by moving the desktop progress bridge observer off the legacy session-progress event projection.

The desktop bridge now subscribes directly to `SessionEventHub` facts for the desktop-side stream-rail responsibilities it owns:

- session facts: `setActiveStream`, `updateStreamStatus`, `updateStreamDescription`, `setParentStream`, `goalStateChanged`
- run facts: `run.config`, `status`

The existing `onProgressEvent` path remains for direct host presentation requests, such as ensuring the progress view is visible and showing errors. This keeps host UI requests distinct from canonical session/run facts.

## Design Notes

The change keeps the desktop bridge responsible only for desktop side effects: ghost-stream removal, stream snapshot persistence, restored display routing, and goal badge updates. It does not route the desktop observer through `sessionProgressEventProjection`, which is now left for compatibility consumers that have not yet moved to direct facts.

A small live snapshot fact cache preserves values such as `executionId` and the last known phase when the fact stream reaches the bridge before the durable progress-view metadata snapshot has caught up.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm run check:dead-code-ratchet`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop progress rail persistence and event ordering during session-scoped runtime migration; dual `onProgressEvent` + hub paths could duplicate work until legacy projection is fully removed.
> 
> **Overview**
> Moves desktop stream-rail side effects off the legacy **session-progress event projection** onto direct **`SessionEventHub`** subscriptions in `DesktopProgressBridge`.
> 
> **`desktopAgentExecution`** wires two scoped listeners (session facts + run `run.config` / `status`) into `progressEvents.onSessionEvent`, and tears them down on dispose. It no longer forwards progress events through `onSessionProgressEvent`.
> 
> **`desktopProgressEventBridge`** adds `onSessionEvent` and shared handlers for active stream, status, run config, descriptions, parent stream, and goal badges. Stream snapshot **`upsert`** now prefers fact-driven **`executionId`** and **`lastKnownStatus`** via a small **`liveSnapshotFacts`** cache when facts arrive before durable progress-view metadata. **`onProgressEvent`** still handles host-only presentation (`requestEnsureProgressView`, `requestShowError`) and reuses the same helpers for overlapping event shapes.
> 
> Tests cover direct fact persistence, session/run fact handling without the projection path, and corrected snapshot status when status facts carry the new phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a480c9b9ffffe97bd00eb66fa4095f5a8136ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->