### PR TITLE
fix(progress): validate updateTodos/updatePlan run facts before applying

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -14,6 +14,8 @@ import {
   STREAM_PHASE,
   ConversationProgressSchema,
   ExtendedTokenUsageStatsSchema,
+  UpdatePlanPayloadSchema,
+  UpdateTodosPayloadSchema,
   type ConversationProgress,
   type GoalStatus,
   type StorageKey,
@@ -456,10 +458,25 @@ export class ProgressEventHandler {
       }
 
       const factName = fromRunFactDomainKey(event.key);
+
+      if (factName === 'updateTodos') {
+        const payload = UpdateTodosPayloadSchema.safeParse(event.data);
+        return payload.success
+          ? this.handleProgressFact('updateTodos', payload.data)
+          : undefined;
+      }
+
+      if (factName === 'updatePlan') {
+        const payload = UpdatePlanPayloadSchema.safeParse(event.data);
+        return payload.success
+          ? this.handleProgressFact('updatePlan', payload.data)
+          : undefined;
+      }
+
       if (!factName || !isObject(event.data)) return undefined;
       return this.handleProgressFact(
         factName,
-        event.data as ProgressEventPayloads[typeof factName],
+        event.data as unknown as ProgressEventPayloads[typeof factName],
       );
     }
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -977,6 +977,57 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('drops malformed updateTodos/updatePlan run facts instead of forwarding them unchecked (#7562)', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const subscription = backend.setupEventListeners();
+    const handleProgressEvent = vi.spyOn(
+      backend.eventHandler,
+      'handleProgressEvent',
+    );
+    const updateTodos = vi.spyOn(backend.webviewUpdater, 'updateTodos');
+    const updatePlan = vi.spyOn(backend.webviewUpdater, 'updatePlan');
+    const streamId = 'session:malformed-todos-plan' as StreamTabId;
+
+    try {
+      await backend.state.snapshots.load([]);
+      backend.handleProgressEvent('setActiveStream', {
+        streamId,
+        agentCategory: AgentCategory.Workflow,
+      });
+      handleProgressEvent.mockClear();
+      updateTodos.mockClear();
+      updatePlan.mockClear();
+
+      session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('updateTodos'),
+          data: { streamId, todos: 'not-an-array' },
+        },
+      });
+      session.events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'domain',
+          key: toRunFactDomainKey('updatePlan'),
+          data: { streamId, plan: { steps: ['legacy shape'] } },
+        },
+      });
+
+      expect(handleProgressEvent).not.toHaveBeenCalled();
+      expect(updateTodos).not.toHaveBeenCalled();
+      expect(updatePlan).not.toHaveBeenCalled();
+    } finally {
+      subscription.dispose();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('no-ops session output-file run facts after dispose', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();


### PR DESCRIPTION
Closes #7562.

## Note on the issue's file attribution

The issue names `sessionProgressEventProjection.ts`'s `projectRunFactToProgressEvent` as the "legacy" validated path. I checked that function directly — it does **not** special-case `updateTodos`/`updatePlan` either (same generic fallback shape as `ProgressEventHandler.handleRunFact`). The actual pre-existing validated path is the CLI's own direct-TUI subscription, `packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts`'s `attachTuiRunFactSubscription` (lines ~454-474), which validates via `UpdateTodosPayloadSchema`/`UpdatePlanPayloadSchema.safeParse()` in its own dedicated switch after `applyDirectTuiRunEvent` (which wraps `projectRunFactToProgressEvent`) returns `false` for these two facts. The underlying concern the issue raises is real regardless — just attributed to the wrong file — and this PR fixes exactly what the issue's own "Details" section asks for: `ProgressEventHandler.ts`.

## Fix

`handleRunFact`'s `domain` branch special-cased `conversationProgress` (schema-validated) but fell through to the generic `fromRunFactDomainKey` + `isObject` + blind-cast path for every other fact, including `updateTodos`/`updatePlan`. This backend path drives extension/desktop UI state (`ProgressViewState`/webview), so a malformed payload would flow through to `handleProgressFact` and the webview updaters unchecked — previously silent-drop, now would at least be a logged error via `withEventErrorHandling`, but still worth closing at the source.

Added the same schema-validate-or-drop special-case for `updateTodos` and `updatePlan`, mirroring `conversationProgress`'s existing pattern. One implementation note: `event.key` is the prefixed `runFact.<name>` form (not the bare fact name `conversationProgress` uses, which isn't part of that prefixed family), so the fix derives `factName` via `fromRunFactDomainKey` once up front and branches on that, rather than comparing `event.key` directly — an approach I initially got wrong (compared `event.key === 'updateTodos'`, which never matches) and caught via the regression test failing before I found the actual key format.

The narrowed generic fallback's cast needed `as unknown as` since TypeScript's overlap check on the remaining fact-name union (after excluding the two now-validated cases) no longer accepts a direct `Record<string, unknown>` cast — same runtime risk the fallback already carried before this change, just made explicit by the narrower type.

## Verification

- `tsc --noEmit` (root) and `tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts` — 29/29 passing, including the existing `updateTodos`/`updatePlan` fact-native coverage (unaffected) and a new regression test verifying malformed payloads are dropped before reaching `handleProgressEvent`/the webview updaters. Verified the new test actually catches the bug: my first (incorrect, `event.key`-based) fix attempt failed it.
- `eslint` on both changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive input validation on progress UI state only; valid payloads behave as before and malformed data is silently dropped at the handler.
> 
> **Overview**
> **`ProgressEventHandler.handleRunFact`** now **schema-validates** `updateTodos` and `updatePlan` domain run facts (via `UpdateTodosPayloadSchema` / `UpdatePlanPayloadSchema`) before they reach progress handlers and webview updaters, matching the existing **`conversationProgress`** pattern. Malformed payloads are **dropped** instead of flowing through the generic `isObject` + cast path.
> 
> Fact names are resolved with **`fromRunFactDomainKey(event.key)`** so prefixed `runFact.*` keys are handled correctly. The remaining generic domain fallback uses an **`as unknown as`** cast after those branches narrow the union.
> 
> A **regression test** in `ProgressBackend.vitest.ts` asserts invalid todo/plan shapes never call `handleProgressEvent` or `updateTodos` / `updatePlan`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c54a746ee8cc6c0e44dcc500dc0304ad587ceab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->