### PR TITLE
refactor: consolidate duplicated logic and native-method reimplementations

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -19,6 +19,7 @@ import {
 import { assertNever, clamp } from '@utils/core';
 import { SLASH_PALETTE_ROWS } from './commands/SlashPalette';
 import { REVERSE_SEARCH_ROWS } from './input/ReverseSearch';
+import { clampModalWidth } from './ui/theme';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ChildControlPicker } from './modals/ChildControlPicker';
 import { TranscriptViewer } from './modals/TranscriptViewer';
@@ -86,7 +87,6 @@ interface InputEventEmitterLike {
   off(event: 'input', listener: (data: string) => void): void;
 }
 
-const MIN_TRANSCRIPT_WIDTH = 20;
 const FOREGROUND_TRANSCRIPT_ROWS = 1;
 const MIN_FOREGROUND_ROWS_WITH_TRANSCRIPT = 6;
 const CHILD_CONTROL_FOREGROUND_MAX_ROWS = 12;
@@ -724,7 +724,7 @@ export function App(props: AppProps): React.JSX.Element {
     status: activeSlice?.status,
     todos: activeSlice?.todos ?? [],
   });
-  const transcriptWidth = Math.max(MIN_TRANSCRIPT_WIDTH, columns);
+  const transcriptWidth = clampModalWidth(columns);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
     childControlMode,

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -8,7 +8,11 @@ import {
 } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+  MIN_MODAL_CONTENT_WIDTH,
+} from '../ui/theme';
 import { confirmCardContentRowsBudget } from './confirmCardRowsBudget';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
@@ -29,7 +33,6 @@ export interface AgentProposalProps {
 }
 
 const FILE_LIMIT = 5;
-const MIN_AGENT_PROPOSAL_WIDTH = 20;
 const DEFAULT_AGENT_PROPOSAL_INSTRUCTION_ROWS = 12;
 const COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS = 3;
 const AGENT_PROPOSAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 7;
@@ -54,7 +57,7 @@ export function agentProposalInstructionRowsBudget({
     availableRows,
     columns,
     title,
-    minContentWidth: MIN_AGENT_PROPOSAL_WIDTH,
+    minContentWidth: MIN_MODAL_CONTENT_WIDTH,
     defaultRows: DEFAULT_AGENT_PROPOSAL_INSTRUCTION_ROWS,
     compactMaxRows: COMPACT_AGENT_PROPOSAL_INSTRUCTION_ROWS,
     spaciousFixedRows: AGENT_PROPOSAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE,
@@ -70,7 +73,7 @@ export function agentProposalInstructionDisplayLines({
   readonly instruction: string;
   readonly width: number;
 }): AgentProposalInstructionLine[] {
-  const instructionWidth = Math.max(MIN_AGENT_PROPOSAL_WIDTH, width);
+  const instructionWidth = clampModalWidth(width);
   return instruction.split('\n').flatMap((line) => {
     const wrapped =
       line.length === 0
@@ -95,9 +98,7 @@ export function maxAgentProposalInstructionScrollOffset(
 }
 
 function wrappedRows(text: string, width: number): number {
-  return wrapAnsiToWidth(text, Math.max(MIN_AGENT_PROPOSAL_WIDTH, width)).split(
-    '\n',
-  ).length;
+  return wrapAnsiToWidth(text, clampModalWidth(width)).split('\n').length;
 }
 
 function fileGroupText(label: string, files: readonly string[]): string {
@@ -175,8 +176,7 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const fileGroups = getProposalFileGroups(props.payload);
   const title = `Spawn ${props.payload.agent}?`;
-  const instructionWidth = Math.max(
-    MIN_AGENT_PROPOSAL_WIDTH,
+  const instructionWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const metadataRows = agentProposalMetadataRows({

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -4,7 +4,11 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { BashPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+  MIN_MODAL_CONTENT_WIDTH,
+} from '../ui/theme';
 import { confirmCardContentRowsBudget } from './confirmCardRowsBudget';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
@@ -27,7 +31,6 @@ export interface BashApprovalProps {
 export type BashCommandDisplayLine = ScrollableDisplayLine<'command'>;
 
 const BASH_APPROVAL_TITLE = 'Run bash command?';
-const MIN_BASH_COMMAND_WIDTH = 20;
 const DEFAULT_BASH_COMMAND_ROWS = 12;
 const COMPACT_BASH_COMMAND_ROWS = 3;
 const BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 7;
@@ -48,7 +51,7 @@ export function bashApprovalCommandRowsBudget({
     availableRows,
     columns,
     title,
-    minContentWidth: MIN_BASH_COMMAND_WIDTH,
+    minContentWidth: MIN_MODAL_CONTENT_WIDTH,
     defaultRows: DEFAULT_BASH_COMMAND_ROWS,
     compactMaxRows: COMPACT_BASH_COMMAND_ROWS,
     spaciousFixedRows: BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE,
@@ -64,7 +67,7 @@ export function bashCommandDisplayLines({
   readonly command: string;
   readonly width: number;
 }): BashCommandDisplayLine[] {
-  const commandWidth = Math.max(MIN_BASH_COMMAND_WIDTH, width);
+  const commandWidth = clampModalWidth(width);
   return command.split('\n').flatMap((line, index) =>
     wrapAnsiToWidth(`${index === 0 ? '$ ' : '  '}${line}`, commandWidth)
       .split('\n')
@@ -82,10 +85,7 @@ export function bashCwdDisplayLine({
   const trimmedCwd = cwd?.trim();
   if (!trimmedCwd) return undefined;
 
-  return truncateToWidth(
-    `Directory: ${trimmedCwd}`,
-    Math.max(MIN_BASH_COMMAND_WIDTH, width),
-  );
+  return truncateToWidth(`Directory: ${trimmedCwd}`, clampModalWidth(width));
 }
 
 export function maxBashCommandScrollOffset(
@@ -128,8 +128,7 @@ export function boundedBashCommandDisplayLines({
 
 export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   const { columns } = useWindowSize();
-  const commandWidth = Math.max(
-    MIN_BASH_COMMAND_WIDTH,
+  const commandWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const cwdLine = useMemo(

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -5,8 +5,10 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import { ConfirmCard } from './ConfirmCard';
 import {
+  clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
   EDIT_DIFF_PADDING,
+  MIN_MODAL_CONTENT_WIDTH,
 } from '../ui/theme';
 import { confirmCardContentRowsBudget } from './confirmCardRowsBudget';
 import {
@@ -27,7 +29,6 @@ const EDIT_APPROVAL_COMPACT_FIXED_ROWS_EXCLUDING_TITLE = 5;
 const EDIT_APPROVAL_FEEDBACK_MARGIN_ROWS = 1;
 const EDIT_APPROVAL_FEEDBACK_PREFIX_COLUMNS = 2;
 export const COMPACT_EDIT_APPROVAL_MAX_ROWS = 9;
-const MIN_EDIT_DIFF_WIDTH = 20;
 const DEFAULT_EDIT_DIFF_ROWS = 30;
 const EDIT_APPROVAL_FEEDBACK_PLACEHOLDER = 'Why reject?';
 
@@ -64,7 +65,7 @@ export function editApprovalDiffRowsBudget({
     availableRows,
     columns,
     title,
-    minContentWidth: MIN_EDIT_DIFF_WIDTH,
+    minContentWidth: MIN_MODAL_CONTENT_WIDTH,
     defaultRows: DEFAULT_EDIT_DIFF_ROWS,
     compactMaxRows: COMPACT_DIFF_DISPLAY_LINES,
     spaciousFixedRows: EDIT_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE,
@@ -104,7 +105,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedbackValue, setFeedbackValue] = useState('');
   const title = `Apply edit to ${props.request.path}?`;
-  const diffWidth = Math.max(MIN_EDIT_DIFF_WIDTH, columns - EDIT_DIFF_PADDING);
+  const diffWidth = clampModalWidth(columns - EDIT_DIFF_PADDING);
   const maxDiffLines = editApprovalDiffRowsBudget({
     availableRows: props.availableRows,
     columns,

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -5,7 +5,7 @@ import { writeClipboardText } from '@cli/runtime/clipboardText';
 import type { ExternalInquiryPermission } from '@shared/schemas';
 import { clamp } from '@utils/core';
 
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -45,7 +45,6 @@ function copyStatusLabel(status: Exclude<CopyStatus, 'idle'>): string {
   }
 }
 
-const MIN_EXTERNAL_INQUIRY_WIDTH = 20;
 const DEFAULT_EXTERNAL_INQUIRY_QUESTION_ROWS = 16;
 const COMPACT_EXTERNAL_INQUIRY_QUESTION_ROWS = 3;
 const EXTERNAL_INQUIRY_FIXED_ROWS = 6;
@@ -149,7 +148,7 @@ function externalInquiryQuestionLines({
   readonly question: string;
   readonly width: number;
 }): ExternalInquiryDisplayLine[] {
-  const questionWidth = Math.max(MIN_EXTERNAL_INQUIRY_WIDTH, width);
+  const questionWidth = clampModalWidth(width);
   return question.split('\n').flatMap((line) =>
     wrapAnsiToWidth(line, questionWidth)
       .split('\n')
@@ -232,8 +231,7 @@ export function ExternalInquiry(
   const [answer, setAnswer] = useState('');
   const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
   const [questionOffset, setQuestionOffset] = useState(0);
-  const contentWidth = Math.max(
-    MIN_EXTERNAL_INQUIRY_WIDTH,
+  const contentWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const answerRows = externalInquiryAnswerRowsBudget(props.availableRows);

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -5,7 +5,10 @@ import { writeClipboardText } from '@cli/runtime/clipboardText';
 import type { ExternalInquiryPermission } from '@shared/schemas';
 import { clamp } from '@utils/core';
 
-import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+} from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -4,7 +4,7 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { PlanApprovalPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
 import { confirmCardCompactChromeRows } from './ConfirmCardState';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
@@ -21,7 +21,6 @@ export interface PlanApprovalProps {
 }
 
 export const COMPACT_PLAN_APPROVAL_MAX_ROWS = 7;
-const MIN_PLAN_APPROVAL_CONTENT_WIDTH = 20;
 const PLAN_APPROVAL_TITLE = 'Approve plan?';
 export const PLAN_APPROVAL_GOAL_NOTICE =
   'Approve & run only auto-approves bash.';
@@ -169,7 +168,7 @@ export function planApprovalDisplayLines({
   readonly width: number;
   readonly padLines?: boolean;
 }): string[] {
-  const contentWidth = Math.max(MIN_PLAN_APPROVAL_CONTENT_WIDTH, width);
+  const contentWidth = clampModalWidth(width);
   return objective.split('\n').flatMap((line) => {
     if (line.length === 0) return [padLines ? fillRows('', contentWidth) : ''];
     const wrapped = wrapAnsiToWidth(line, contentWidth)

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -4,7 +4,10 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { PlanApprovalPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
-import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+} from '../ui/theme';
 import { confirmCardCompactChromeRows } from './ConfirmCardState';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -14,7 +14,10 @@ import {
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
-import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+} from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -14,7 +14,7 @@ import {
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -39,7 +39,6 @@ export interface UserQuestionPromptLine {
   readonly text: string;
 }
 
-const MIN_USER_QUESTION_CONTENT_WIDTH = 20;
 const DEFAULT_USER_QUESTION_PROMPT_ROWS = 12;
 const COMPACT_USER_QUESTION_MAX_ROWS = 10;
 const COMPACT_USER_QUESTION_CHROME_ROWS = 4;
@@ -194,7 +193,7 @@ export function boundedUserQuestionPromptLines({
   readonly width: number;
 }): readonly UserQuestionPromptLine[] {
   if (maxDisplayLines <= 0) return [];
-  const wrapWidth = Math.max(MIN_USER_QUESTION_CONTENT_WIDTH, width);
+  const wrapWidth = clampModalWidth(width);
   const contextLines = context
     ? wrappedUserQuestionPromptLines({
         kind: 'context',
@@ -264,8 +263,7 @@ interface QuestionShellProps {
 function QuestionShell(props: QuestionShellProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const compact = isCompactUserQuestionRows(props.availableRows);
-  const contentWidth = Math.max(
-    MIN_USER_QUESTION_CONTENT_WIDTH,
+  const contentWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const promptRows = userQuestionPromptRowsBudget({
@@ -452,8 +450,7 @@ interface FreeTextQuestionProps {
 function FreeTextQuestion(props: FreeTextQuestionProps): React.JSX.Element {
   const { columns } = useWindowSize();
   const [answer, setAnswer] = useState('');
-  const contentWidth = Math.max(
-    MIN_USER_QUESTION_CONTENT_WIDTH,
+  const contentWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
   );
   const optionRows = userQuestionFreeTextOptionRowsBudget({

--- a/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
+++ b/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
@@ -1,6 +1,6 @@
 import { clamp } from '@utils/core';
 
-import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 
 /**
@@ -44,9 +44,9 @@ export function confirmCardContentRowsBudget({
 }): number {
   if (availableRows === undefined) return defaultRows;
 
-  const titleWidth = Math.max(
-    minContentWidth,
+  const titleWidth = clampModalWidth(
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
+    minContentWidth,
   );
   const titleRows = wrapAnsiToWidth(title, titleWidth).split('\n').length;
   const fixedRows = titleRows + extraFixedRows;

--- a/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
+++ b/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
@@ -1,6 +1,9 @@
 import { clamp } from '@utils/core';
 
-import { clampModalWidth, CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
+import {
+  clampModalWidth,
+  CONFIRM_CARD_HORIZONTAL_DECORATION,
+} from '../ui/theme';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 
 /**

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -12,6 +12,7 @@ import { clamp, filterNotNullish, isObject } from '@utils/core';
 import { wrapAnsiToWidth } from './ansiWrap';
 import { maxScrollableRowOffset, scrollBoundedRows } from './scrollBounds';
 import { clipToWidth, fillRows, textDisplayWidth } from './terminalText';
+import { clampModalWidth } from '../ui/theme';
 
 type Hunk = StructuredPatchHunk;
 
@@ -32,7 +33,6 @@ interface DiffStats {
 }
 
 const NO_NEWLINE_MARKER = '\\';
-const MIN_DIFF_WIDTH = 20;
 const DEFAULT_DIFF_WIDTH = 74;
 export const COMPACT_DIFF_DISPLAY_LINES = 3;
 
@@ -151,7 +151,7 @@ export function wrappedDiffDisplayLines(
   width: number,
   maxHunkLines = 0,
 ): DiffDisplayLine[] {
-  const diffWidth = Math.max(MIN_DIFF_WIDTH, width);
+  const diffWidth = clampModalWidth(width);
   return diffDisplayLines(hunks, maxHunkLines).flatMap((line) =>
     wrapAnsiToWidth(line.text, diffWidth)
       .split('\n')
@@ -208,7 +208,7 @@ function overflowMarkerText(
   const candidates = overflowMarkerCandidates(kind, count);
   if (width === undefined) return candidates[0];
 
-  const markerWidth = Math.max(MIN_DIFF_WIDTH, width);
+  const markerWidth = clampModalWidth(width);
   return (
     candidates.find(
       (candidate) => textDisplayWidth(candidate) <= markerWidth,
@@ -309,7 +309,7 @@ interface DiffViewProps {
 export function DiffView(props: DiffViewProps): React.JSX.Element {
   const maxDisplayLines = props.maxDisplayLines ?? 0;
   const max = props.maxHunkLines ?? 0;
-  const width = Math.max(MIN_DIFF_WIDTH, props.width ?? DEFAULT_DIFF_WIDTH);
+  const width = clampModalWidth(props.width ?? DEFAULT_DIFF_WIDTH);
   const lines = scrollBoundedDiffDisplayLines(
     props.hunks,
     max,

--- a/packages/cli/src/chat/tui/ui/theme.ts
+++ b/packages/cli/src/chat/tui/ui/theme.ts
@@ -7,6 +7,16 @@ export const FORM_FRAME_MAX_WIDTH = 80;
 /** Combined columns consumed by ConfirmCard's left+right border and paddingX. */
 export const CONFIRM_CARD_HORIZONTAL_DECORATION = 4;
 
+/** Floor for modal/transcript content widths so wrapping never collapses to 0. */
+export const MIN_MODAL_CONTENT_WIDTH = 20;
+
+export function clampModalWidth(
+  width: number,
+  min: number = MIN_MODAL_CONTENT_WIDTH,
+): number {
+  return Math.max(min, width);
+}
+
 /** Columns consumed by the edit diff panel's side padding/gutter. */
 export const EDIT_DIFF_PADDING = 6;
 

--- a/packages/cli/src/commands/_helpers/fetchSilencer.ts
+++ b/packages/cli/src/commands/_helpers/fetchSilencer.ts
@@ -4,7 +4,7 @@ export function isCliFetchStackLog(args: readonly unknown[]): boolean {
   const [first] = args;
   if (!(first instanceof Error)) return false;
   const cause = first.cause;
-  const causeMessage = cause instanceof Error ? cause.message : '';
+  const causeMessage = cause instanceof Error ? toErrorMessage(cause) : '';
   return (
     /fetch failed/i.test(first.message) &&
     /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|getaddrinfo|remote\.texra\.ai/i.test(
@@ -31,7 +31,7 @@ export async function suppressCliFetchStackLogs<T>(
 export function formatCliModelListError(error: unknown): string {
   const message = toErrorMessage(error);
   const cause = error instanceof Error ? error.cause : undefined;
-  const causeMessage = cause instanceof Error ? cause.message : undefined;
+  const causeMessage = cause instanceof Error ? toErrorMessage(cause) : undefined;
   const detail = causeMessage ?? message;
   if (/ENOTFOUND|EAI_AGAIN|getaddrinfo|fetch failed/i.test(detail)) {
     return `texra: could not fetch model access metadata from remote.texra.ai: ${detail}`;

--- a/packages/cli/src/commands/_helpers/fetchSilencer.ts
+++ b/packages/cli/src/commands/_helpers/fetchSilencer.ts
@@ -31,7 +31,8 @@ export async function suppressCliFetchStackLogs<T>(
 export function formatCliModelListError(error: unknown): string {
   const message = toErrorMessage(error);
   const cause = error instanceof Error ? error.cause : undefined;
-  const causeMessage = cause instanceof Error ? toErrorMessage(cause) : undefined;
+  const causeMessage =
+    cause instanceof Error ? toErrorMessage(cause) : undefined;
   const detail = causeMessage ?? message;
   if (/ENOTFOUND|EAI_AGAIN|getaddrinfo|fetch failed/i.test(detail)) {
     return `texra: could not fetch model access metadata from remote.texra.ai: ${detail}`;

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -7,6 +7,7 @@ import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import { byStringProp, isObject } from '@utils/core';
+import { toPosixPath } from '@utils/core/pathCore';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';
 
@@ -58,7 +59,7 @@ async function walkStorageDirectory(
     const entryIsDirectory = isDirectory(type);
     const stat = await StorageFS.stat(childPath).catch(() => ({ size: 0 }));
     files.push({
-      path: rawRelative.replaceAll('\\', '/'),
+      path: toPosixPath(rawRelative),
       size: stat.size,
       isDirectory: entryIsDirectory,
     });

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -7,6 +7,9 @@ import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import { byStringProp, isObject } from '@utils/core';
+// toPosixPath also trims and resolves `.`/`..` segments beyond a bare slash
+// swap; safe here since the input is a workspace-relative path produced by
+// the storage directory walk below, not raw user input.
 import { toPosixPath } from '@utils/core/pathCore';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { findExistingRunStoragePath } from '@utils/files/taskRunStorage';

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -8,6 +8,7 @@ import { tryPlatform } from '@platform/platform';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { unique } from '@utils/core';
+import { toPosixPath } from '@utils/core/pathCore';
 import type { Disposable } from '@platform/interfaces';
 import type { Stats } from 'node:fs';
 
@@ -38,7 +39,7 @@ function normalizeCliInputPath(candidate: string, cwd: string): string {
   const absolutePath = resolveAgainstCwd(candidate, cwd);
   const relativePath = path.relative(cwd, absolutePath);
   return isContainedRelativePath(relativePath)
-    ? relativePath.replaceAll(path.sep, '/')
+    ? toPosixPath(relativePath)
     : absolutePath;
 }
 
@@ -99,7 +100,7 @@ export function hasMixedStdinWorkflowInputSpecs(
 export function isMaterializedStdinWorkflowInputPath(
   inputPath: string,
 ): boolean {
-  const normalized = inputPath.replaceAll('\\', '/');
+  const normalized = toPosixPath(inputPath);
   const parent = path.posix.basename(path.posix.dirname(normalized));
   return (
     path.posix.basename(normalized) === STDIN_WORKFLOW_INPUT_BASENAME &&

--- a/packages/cli/src/runtime/workflowInputs.ts
+++ b/packages/cli/src/runtime/workflowInputs.ts
@@ -8,6 +8,9 @@ import { tryPlatform } from '@platform/platform';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { unique } from '@utils/core';
+// toPosixPath also trims and resolves `.`/`..` segments beyond a bare slash
+// swap; safe at both call sites below since the input is always a relative
+// path already validated by isContainedRelativePath or path.relative.
 import { toPosixPath } from '@utils/core/pathCore';
 import type { Disposable } from '@platform/interfaces';
 import type { Stats } from 'node:fs';

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -8,8 +8,8 @@ import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
-import { toPosixPath } from '@utils/core/pathCore';
 import { getRunDir } from '@utils/files';
+import { toPosixPath } from '@utils/core/pathCore';
 
 import { CliUsageError, type CliContext } from './cliContext';
 import {

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -8,6 +8,7 @@ import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
+import { toPosixPath } from '@utils/core/pathCore';
 import { getRunDir } from '@utils/files';
 
 import { CliUsageError, type CliContext } from './cliContext';
@@ -94,14 +95,10 @@ interface WorkflowOutputResolutionOptions {
   readonly terminalStatus: ExecutionStatus;
 }
 
-function toPosix(p: string): string {
-  return p.replaceAll('\\', '/');
-}
-
 function outputCopyRelativePath(output: OutputFileSummary): string {
   const relativePath =
     output.relativePath || path.basename(output.absolutePath);
-  const parts = toPosix(relativePath).split('/');
+  const parts = toPosixPath(relativePath).split('/');
   const withoutRoundDir = /^r\d+$/.test(parts[0] ?? '')
     ? parts.slice(1)
     : parts;
@@ -115,14 +112,18 @@ function outputCopyRelativePathForExpectedOutput(
   const generatedRelativePath = outputCopyRelativePath(output);
   if (expectedRelativePaths.length === 0) return generatedRelativePath;
 
-  const generatedName = path.posix.basename(toPosix(generatedRelativePath));
+  const generatedName = path.posix.basename(
+    toPosixPath(generatedRelativePath),
+  );
   const normalizedOriginalPath =
-    output.originalPath == null ? undefined : toPosix(output.originalPath);
+    output.originalPath == null
+      ? undefined
+      : toPosixPath(output.originalPath);
   const matchingExpectedPaths =
     normalizedOriginalPath == null
       ? []
       : expectedRelativePaths.filter((expected) => {
-          const normalizedExpected = toPosix(expected);
+          const normalizedExpected = toPosixPath(expected);
           if (path.posix.basename(normalizedExpected) !== generatedName) {
             return false;
           }

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -112,13 +112,9 @@ function outputCopyRelativePathForExpectedOutput(
   const generatedRelativePath = outputCopyRelativePath(output);
   if (expectedRelativePaths.length === 0) return generatedRelativePath;
 
-  const generatedName = path.posix.basename(
-    toPosixPath(generatedRelativePath),
-  );
+  const generatedName = path.posix.basename(toPosixPath(generatedRelativePath));
   const normalizedOriginalPath =
-    output.originalPath == null
-      ? undefined
-      : toPosixPath(output.originalPath);
+    output.originalPath == null ? undefined : toPosixPath(output.originalPath);
   const matchingExpectedPaths =
     normalizedOriginalPath == null
       ? []

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -9,6 +9,9 @@ import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
 import { getRunDir } from '@utils/files';
+// toPosixPath also trims and resolves `.`/`..` segments beyond a bare slash
+// swap; safe here since these paths come from getSafeDocumentRelativePath /
+// path.relative on the workflow's own generated outputs, never user input.
 import { toPosixPath } from '@utils/core/pathCore';
 
 import { CliUsageError, type CliContext } from './cliContext';

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -91,6 +91,7 @@ import {
   type DesktopToolEditApprovalController,
 } from './desktopToolEditApproval.js';
 import { createDesktopHostInteractions } from './desktopHostInteractions.js';
+import { toLogData } from './desktopLogUtils.js';
 import {
   DesktopProgressFileActions,
   type DesktopLatexdiffRunContext,
@@ -445,7 +446,7 @@ export class DesktopProgressBridge {
           },
           logError: (message, error) => {
             this.logger.error(message, {
-              data: error instanceof Error ? error : { error },
+              data: toLogData(error),
             });
           },
         },
@@ -523,7 +524,7 @@ export class DesktopProgressBridge {
           reportImageSaveError: (image, error) => {
             this.logger.warn(
               `Failed to save pasted follow-up image ${image.fileName}`,
-              { data: error instanceof Error ? error : { error } },
+              { data: toLogData(error) },
             );
           },
         },
@@ -686,7 +687,7 @@ export class DesktopProgressBridge {
     this.workflowFileActions.clearAllBackups();
     void this.state.flush().catch((error: unknown) => {
       this.logger.warn('Failed to flush desktop progress state', {
-        data: error instanceof Error ? error : { error },
+        data: toLogData(error),
       });
     });
     // Tear down this window's session last. In-flight runs are allowed to keep
@@ -919,10 +920,7 @@ export class DesktopProgressBridge {
         this.logger.warn(
           'Failed to consult persisted flow records during desktop restart-repair fallback',
           {
-            data:
-              detectError instanceof Error
-                ? detectError
-                : { error: detectError },
+            data: toLogData(detectError),
           },
         );
         // detectRaceGuardedWaitingStreams() throwing only means the
@@ -979,15 +977,12 @@ export class DesktopProgressBridge {
         this.logger.warn(
           'Failed to apply desktop stream repair fallback writes',
           {
-            data:
-              repairError instanceof Error
-                ? repairError
-                : { error: repairError },
+            data: toLogData(repairError),
           },
         );
       }
       this.logger.warn('Failed to repair desktop streams after restart', {
-        data: error instanceof Error ? error : { error },
+        data: toLogData(error),
       });
     }
   }
@@ -1202,7 +1197,7 @@ export class DesktopProgressBridge {
     error: unknown,
   ): Promise<void> {
     this.logger.error(`Failed to resume desktop stream ${streamId}`, {
-      data: error instanceof Error ? error : { error },
+      data: toLogData(error),
     });
     await this.options.showErrorMessage?.(
       `Resume failed: ${toErrorMessage(error)}`,
@@ -1290,7 +1285,7 @@ export class DesktopProgressBridge {
       await this.state.snapshots.preload([streamId]);
     } catch (error) {
       this.logger.warn(`Failed to read persisted resume data for ${streamId}`, {
-        data: error instanceof Error ? error : { error },
+        data: toLogData(error),
       });
       return undefined;
     }

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { nanoid } from 'nanoid';
@@ -15,6 +14,7 @@ import {
   buildDesktopShowDiffMessage,
   monacoLanguageForFilePath,
 } from '../desktopDiffMessages.js';
+import { createTexraTempDir } from './desktopTempDir.js';
 
 export interface DesktopDiffHostOptions {
   /**
@@ -93,7 +93,7 @@ export function createDesktopDiffHost(
     const patch =
       computeUserPatch(originalContent, proposedContent) ??
       `No textual changes for ${path.basename(proposed.filePath)}.\n`;
-    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-desktop-diff-'));
+    const tempDir = await createTexraTempDir('texra-desktop-diff-');
     const diffPath = path.join(tempDir, `${nanoid()}.diff`);
 
     await writeFile(diffPath, patch, 'utf8');

--- a/packages/desktop/src/main/desktopLogUtils.ts
+++ b/packages/desktop/src/main/desktopLogUtils.ts
@@ -1,0 +1,4 @@
+/** Normalize a caught error into a logger `data` argument, preserving Error instances as-is. */
+export function toLogData(error: unknown): unknown {
+  return error instanceof Error ? error : { error };
+}

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -26,6 +26,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import { GoalStore } from '@tools/goal';
+import { toLogData } from './desktopLogUtils.js';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -373,7 +374,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         await this.opts.streamSnapshotStore.replaceAll([]);
       } catch (error: unknown) {
         this.opts.logger.warn('Failed to clear stream snapshot store', {
-          data: error instanceof Error ? error : { error },
+          data: toLogData(error),
         });
       }
     }
@@ -441,7 +442,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     };
     void store.upsert(snapshot).catch((error: unknown) => {
       this.opts.logger.warn('Failed to persist stream snapshot', {
-        data: error instanceof Error ? error : { error },
+        data: toLogData(error),
       });
     });
   }
@@ -453,7 +454,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     if (!store) return;
     void store.remove(streamId).catch((error: unknown) => {
       this.opts.logger.warn('Failed to remove persisted stream snapshot', {
-        data: error instanceof Error ? error : { error },
+        data: toLogData(error),
       });
     });
   }

--- a/packages/desktop/src/main/desktopTempDir.ts
+++ b/packages/desktop/src/main/desktopTempDir.ts
@@ -1,0 +1,11 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/** Create a fresh temp directory under `root` (default OS tmpdir) with `prefix`. */
+export async function createTexraTempDir(
+  prefix: string,
+  root?: string,
+): Promise<string> {
+  return mkdtemp(path.join(root ?? tmpdir(), prefix));
+}

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { nanoid } from 'nanoid';
@@ -27,6 +26,7 @@ import {
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
+import { createTexraTempDir } from './desktopTempDir.js';
 import { setDesktopToolEditApprovalHandler } from './platform/index.js';
 
 export interface DesktopToolEditApprovalOptions {
@@ -168,8 +168,10 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     requestId: string,
     request: ToolEditApprovalRequest,
   ): Promise<DesktopPendingToolEditApproval> {
-    const tempRoot = this.options.tempRoot ?? tmpdir();
-    const tempDir = await mkdtemp(path.join(tempRoot, 'texra-tool-edit-'));
+    const tempDir = await createTexraTempDir(
+      'texra-tool-edit-',
+      this.options.tempRoot,
+    );
     const { originalPath, proposedPath } = await writeApprovalTempFiles({
       directory: tempDir,
       targetPath: request.path,

--- a/packages/extension/src/frontend/comments/inlineComments.ts
+++ b/packages/extension/src/frontend/comments/inlineComments.ts
@@ -18,6 +18,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 // Local imports
+import { lineToRange } from '@frontend/vscode/vscodeEditor';
 import * as logger from '@logger/logUtils';
 import type {
   InlineCommentProvider,
@@ -97,18 +98,7 @@ const provider: InlineCommentProvider = {
   add: ({ absolutePath, line, endLine, body }) => {
     if (!controller) return null;
     const uri = vscode.Uri.file(absolutePath);
-    const startLine = Math.max(0, line - 1);
-    const lastLine = Math.max(startLine, endLine - 1);
-    // Span the whole range — from the start of the first line to the end of the
-    // last (MAX_SAFE_INTEGER is clamped to the line length by VS Code). A 0-end
-    // column would leave a single-line thread zero-width and exclude the last
-    // line's content, so the highlight would disagree with the reported lines.
-    const range = new vscode.Range(
-      startLine,
-      0,
-      lastLine,
-      Number.MAX_SAFE_INTEGER,
-    );
+    const range = lineToRange(line, endLine);
     const thread = controller.createCommentThread(uri, range, [
       makeComment(AGENT_AUTHOR, body),
     ]);

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -23,6 +23,7 @@ import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { globalSM, GlobalStateKey } from '@common/state';
 import { subscribeAddOutputFilesRunFact } from '@frontend/events/runFactSubscriptions';
+import { lineToRange } from '@frontend/vscode/vscodeEditor';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { AddOutputFilesPayload, OutputFileInfo } from '@shared/schemas';
@@ -167,13 +168,7 @@ export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
   if (!collection) return false;
 
   const uri = vscode.Uri.file(entry.absolutePath);
-  const lineIndex = Math.max(0, Math.floor(entry.line) - 1);
-  const range = new vscode.Range(
-    lineIndex,
-    0,
-    lineIndex,
-    Number.MAX_SAFE_INTEGER,
-  );
+  const range = lineToRange(entry.line);
   const diag = buildDiagnostic(
     range,
     entry.message,

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -37,6 +37,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
+import { lineToRange } from '@frontend/vscode/vscodeEditor';
 import * as logger from '@logger/logUtils';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
@@ -103,9 +104,7 @@ const SEVERITY_MAP: Record<ReviewSeverity, vscode.DiagnosticSeverity> = {
 
 /** Editor range for an issue (issue lines are 1-based). */
 export function issueRange(issue: ReviewIssue): vscode.Range {
-  const startLine = Math.max(0, issue.startLine - 1);
-  const endLine = Math.max(startLine, issue.endLine - 1);
-  return new vscode.Range(startLine, 0, endLine, Number.MAX_SAFE_INTEGER);
+  return lineToRange(issue.startLine, issue.endLine);
 }
 
 class AgentReviewServiceImpl {

--- a/packages/extension/src/frontend/vscode/vscodeEditor.ts
+++ b/packages/extension/src/frontend/vscode/vscodeEditor.ts
@@ -8,7 +8,11 @@ import * as vscode from 'vscode';
 
 import { WorkspaceFS } from '@utils/files';
 
-/** Clamp a 1-based line number to a 0-based VS Code line index. */
+/**
+ * Clamp a 1-based line number to a 0-based VS Code line index. Floors first
+ * so a fractional line number degrades gracefully instead of producing a
+ * fractional index; a no-op for the integer line numbers every caller passes.
+ */
 function toZeroBasedLine(line: number): number {
   return Math.max(0, Math.floor(line) - 1);
 }

--- a/packages/extension/src/frontend/vscode/vscodeEditor.ts
+++ b/packages/extension/src/frontend/vscode/vscodeEditor.ts
@@ -8,6 +8,25 @@ import * as vscode from 'vscode';
 
 import { WorkspaceFS } from '@utils/files';
 
+/** Clamp a 1-based line number to a 0-based VS Code line index. */
+function toZeroBasedLine(line: number): number {
+  return Math.max(0, Math.floor(line) - 1);
+}
+
+/**
+ * Build a VS Code range spanning 1-based `startLine` through `endLine`
+ * (inclusive, defaults to `startLine`). MAX_SAFE_INTEGER is clamped to the
+ * line length by VS Code, so this spans the full text of the last line.
+ */
+export function lineToRange(
+  startLine: number,
+  endLine: number = startLine,
+): vscode.Range {
+  const start = toZeroBasedLine(startLine);
+  const end = Math.max(start, toZeroBasedLine(endLine));
+  return new vscode.Range(start, 0, end, Number.MAX_SAFE_INTEGER);
+}
+
 /**
  * Open a file in VS Code editor, optionally positioning cursor at a line.
  * Reuses existing editor if file is already open.
@@ -39,7 +58,7 @@ export async function openFileInEditor(
 
     if (line !== undefined) {
       const position = new vscode.Position(
-        Math.max(0, line - 1),
+        toZeroBasedLine(line),
         column ? Math.max(0, column - 1) : 0,
       );
       editor.selection = new vscode.Selection(position, position);

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -35,6 +35,7 @@ import { formatLocaleTimestamp } from '@utils/text/stringUtils';
 
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
+import { hasSearchValue } from './historySearch';
 
 type ConfigValue = string | number | boolean | string[] | null | undefined;
 
@@ -219,11 +220,6 @@ export class HistoryItemElement extends LitElement {
     return html`${value ?? ''}`;
   }
 
-  private hasValue(value: ConfigValue): boolean {
-    if (value == null) return false;
-    return !Array.isArray(value) || value.length > 0;
-  }
-
   private renderInstructionBlock(
     instructionText: string | null,
     titleText: string,
@@ -259,7 +255,7 @@ export class HistoryItemElement extends LitElement {
     label: string | TemplateResult,
     entries: Array<[string, ConfigValue]>,
   ): TemplateResult | null {
-    const filtered = entries.filter(([, value]) => this.hasValue(value));
+    const filtered = entries.filter(([, value]) => hasSearchValue(value));
     if (!filtered.length) return null;
 
     return html`

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryList.ts
@@ -130,10 +130,7 @@ export class HistoryList extends LitElement {
 
     // Clamp page when items change (e.g. delete)
     if (changedProperties.has('items') && this.paginated) {
-      const totalPages = Math.max(
-        1,
-        Math.ceil(this.items.length / HISTORY_PAGE_SIZE),
-      );
+      const { totalPages } = paginate(this.items, this.page, HISTORY_PAGE_SIZE);
       if (this.page >= totalPages) {
         this.page = Math.max(0, totalPages - 1);
       }

--- a/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
@@ -11,7 +11,7 @@ function normalizeSearchText(text: string): string {
     .toLocaleLowerCase();
 }
 
-function hasSearchValue(value: unknown): boolean {
+export function hasSearchValue(value: unknown): boolean {
   if (value == null) return false;
   return !Array.isArray(value) || value.length > 0;
 }

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -142,13 +142,18 @@ export function stripFirstLastLineIfWrapped(
 export function stripSurroundingMarkdownFence(
   lines: readonly string[],
 ): string[] {
+  // `isClose` is always invoked with the same `openLine` (the wrapper's first
+  // content line) across a single stripFirstLastLineIfWrapped call, including
+  // once per line during the rejectInnerClose scan — parse it once and reuse.
+  let cachedOpeningFence: MarkdownFence | null | undefined;
   return stripFirstLastLineIfWrapped(
     lines,
     (line) => parseMarkdownFenceDelimiter(line) !== null,
     (openLine, line) => {
-      const openingFence = parseMarkdownFenceDelimiter(openLine);
+      cachedOpeningFence ??= parseMarkdownFenceDelimiter(openLine);
       return (
-        openingFence !== null && isClosingMarkdownFence(line, openingFence)
+        cachedOpeningFence !== null &&
+        isClosingMarkdownFence(line, cachedOpeningFence)
       );
     },
     { emptyOnNoContent: true, rejectInnerClose: true },

--- a/src/agent/output/extraction/contentSimilarity.ts
+++ b/src/agent/output/extraction/contentSimilarity.ts
@@ -93,32 +93,66 @@ export function isClosingMarkdownFence(
   );
 }
 
-export function stripSurroundingMarkdownFence(
+/**
+ * Strip a first/last wrapper line off `lines` when the first non-blank line
+ * opens a wrapper (per `isOpen`) and the last non-blank line closes it (per
+ * `isClose`, given the matched open line). Shared by
+ * {@link stripSurroundingMarkdownFence} (fence markers) and
+ * `stripDocumentsEnvelope` (XML-style tag wrapper) in `filenameHeaders.ts`.
+ *
+ * `options.emptyOnNoContent` controls the result when `lines` is entirely
+ * blank (fence stripping collapses to `[]`; the tag-envelope stripper leaves
+ * blank input untouched). `options.rejectInnerClose` additionally refuses to
+ * strip when some line strictly between the first and last also closes the
+ * wrapper (fence stripping must not treat a nested same-marker fence's close
+ * as the outer one; the tag envelope has no such nesting concern).
+ */
+export function stripFirstLastLineIfWrapped(
   lines: readonly string[],
+  isOpen: (line: string) => boolean,
+  isClose: (openLine: string, line: string) => boolean,
+  options: { emptyOnNoContent?: boolean; rejectInnerClose?: boolean } = {},
 ): string[] {
   const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
   if (firstContentIndex === -1) {
-    return [];
+    return options.emptyOnNoContent ? [] : [...lines];
   }
 
   const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
-  const openingFence = parseMarkdownFenceDelimiter(lines[firstContentIndex]);
-  if (
+  const firstLine = lines[firstContentIndex];
+  const wrapped =
     firstContentIndex < lastContentIndex &&
-    openingFence &&
-    isClosingMarkdownFence(lines[lastContentIndex], openingFence) &&
-    !lines
-      .slice(firstContentIndex + 1, lastContentIndex)
-      .some((line) => isClosingMarkdownFence(line, openingFence))
-  ) {
-    return [
-      ...lines.slice(0, firstContentIndex),
-      ...lines.slice(firstContentIndex + 1, lastContentIndex),
-      ...lines.slice(lastContentIndex + 1),
-    ];
-  }
+    isOpen(firstLine) &&
+    isClose(firstLine, lines[lastContentIndex]) &&
+    (!options.rejectInnerClose ||
+      !lines
+        .slice(firstContentIndex + 1, lastContentIndex)
+        .some((line) => isClose(firstLine, line)));
 
-  return [...lines];
+  if (!wrapped) {
+    return [...lines];
+  }
+  return [
+    ...lines.slice(0, firstContentIndex),
+    ...lines.slice(firstContentIndex + 1, lastContentIndex),
+    ...lines.slice(lastContentIndex + 1),
+  ];
+}
+
+export function stripSurroundingMarkdownFence(
+  lines: readonly string[],
+): string[] {
+  return stripFirstLastLineIfWrapped(
+    lines,
+    (line) => parseMarkdownFenceDelimiter(line) !== null,
+    (openLine, line) => {
+      const openingFence = parseMarkdownFenceDelimiter(openLine);
+      return (
+        openingFence !== null && isClosingMarkdownFence(line, openingFence)
+      );
+    },
+    { emptyOnNoContent: true, rejectInnerClose: true },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/output/extraction/filenameHeaders.ts
+++ b/src/agent/output/extraction/filenameHeaders.ts
@@ -23,6 +23,7 @@ import {
   type MarkdownFence,
   parseMarkdownFenceDelimiter,
   responseLines,
+  stripFirstLastLineIfWrapped,
   stripSurroundingMarkdownFence,
 } from './contentSimilarity';
 
@@ -248,22 +249,11 @@ function stripDocumentsEnvelope(
     'i',
   );
   const closeRegex = new RegExp(`^<\\/${escapeRegExp(trimmedTag)}>\\s*$`, 'i');
-  const firstContentIndex = lines.findIndex((line) => line.trim() !== '');
-  const lastContentIndex = lines.findLastIndex((line) => line.trim() !== '');
-  if (
-    firstContentIndex !== -1 &&
-    lastContentIndex !== -1 &&
-    firstContentIndex < lastContentIndex &&
-    openRegex.test(lines[firstContentIndex].trim()) &&
-    closeRegex.test(lines[lastContentIndex].trim())
-  ) {
-    return [
-      ...lines.slice(0, firstContentIndex),
-      ...lines.slice(firstContentIndex + 1, lastContentIndex),
-      ...lines.slice(lastContentIndex + 1),
-    ];
-  }
-  return [...lines];
+  return stripFirstLastLineIfWrapped(
+    lines,
+    (line) => openRegex.test(line.trim()),
+    (_openLine, line) => closeRegex.test(line.trim()),
+  );
 }
 
 function matchHeaderName(

--- a/src/shared/progressView/backend/state/SessionStores.ts
+++ b/src/shared/progressView/backend/state/SessionStores.ts
@@ -1,6 +1,9 @@
 // Local imports - agent
 import { deleteExecution as deleteStoredExecution } from '@agent/storage/executionListing';
 
+// Local imports - utils
+import { unique } from '@utils/core';
+
 // Local imports - logger
 import * as logger from '@logger/logUtils';
 
@@ -117,7 +120,7 @@ export class SessionStores {
     executionIds: Iterable<ExecutionId>,
   ): Promise<void> {
     await Promise.all(
-      [...new Set(executionIds)].map((executionId) =>
+      unique(executionIds).map((executionId) =>
         this.deleteExecution(executionId),
       ),
     );

--- a/src/shared/progressView/backend/state/SessionStores.ts
+++ b/src/shared/progressView/backend/state/SessionStores.ts
@@ -1,14 +1,14 @@
 // Local imports - agent
 import { deleteExecution as deleteStoredExecution } from '@agent/storage/executionListing';
 
-// Local imports - utils
-import { unique } from '@utils/core';
-
 // Local imports - logger
 import * as logger from '@logger/logUtils';
 
 // Local imports - shared
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+// Local imports - utils
+import { unique } from '@utils/core';
 
 // Local imports - transcript
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';

--- a/src/shared/schemas/fileFields.ts
+++ b/src/shared/schemas/fileFields.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { unique } from '@utils/core';
 import { isNonEmptyString } from '@utils/text/stringUtils';
 
 const LEGACY_KEYS = [
@@ -48,11 +49,9 @@ export function migrateLegacyContextFileFields(input: unknown): unknown {
       obj.contextFile !== obj.auxiliaryFile
         ? [obj.auxiliaryFile]
         : [];
-    const merged = [
-      ...new Set(
-        [...refList, ...auxList, ...auxFallback].filter(isNonEmptyString),
-      ),
-    ];
+    const merged = unique(
+      [...refList, ...auxList, ...auxFallback].filter(isNonEmptyString),
+    );
     if (merged.length > 0) obj.contextFiles = merged;
   }
   delete obj.referenceFile;
@@ -71,9 +70,9 @@ export function migrateLegacyContextFileFields(input: unknown): unknown {
       ? listValue.filter(isNonEmptyString)
       : [];
     if (isNonEmptyString(obj[single])) {
-      obj[multi] = [
-        ...new Set([obj[single] as string, ...list].filter(isNonEmptyString)),
-      ];
+      obj[multi] = unique(
+        [obj[single] as string, ...list].filter(isNonEmptyString),
+      );
     } else if (Array.isArray(listValue)) {
       obj[multi] = list;
     }

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -37,7 +37,7 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
-import { isNonEmptyString } from '@utils/core';
+import { formatWallTimeSeconds, isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -159,7 +159,7 @@ function formatClaudeDelivery(
       attributes: [{ name: 'session-id', value: turn.sessionId || null }],
     },
     {
-      wallTime: `${(wallTimeMs / 1000).toFixed(1)}s`,
+      wallTime: formatWallTimeSeconds(wallTimeMs),
       response: turn.finalResponse,
       usage: turn.usage
         ? {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -42,6 +42,7 @@ import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
+import { formatWallTimeSeconds } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -145,7 +146,7 @@ function formatCodexDelivery(
       attributes: [{ name: 'thread-id', value: threadId || null }],
     },
     {
-      wallTime: `${(wallTimeMs / 1000).toFixed(1)}s`,
+      wallTime: formatWallTimeSeconds(wallTimeMs),
       response: turn.finalResponse,
       usage: turn.usage
         ? { input: turn.usage.input_tokens, output: turn.usage.output_tokens }

--- a/src/tools/delegationModelAvailability.ts
+++ b/src/tools/delegationModelAvailability.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from '@model';
 import { decideRunModel } from '@model/runModelDecision';
 import type { ModelOptionData } from '@shared/schemas';
 import { replaceDelegationDescriptionBlock } from '@tools/delegationDescriptionBlock';
+import { unique } from '@utils/core';
 
 const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
 
@@ -35,11 +36,9 @@ export function selectDelegationModelFromAvailableNames(input: {
   readonly parentModel?: string | null;
   readonly availableModels: readonly string[];
 }): string {
-  const availableModels = [
-    ...new Set(
-      input.availableModels.map((model) => model.trim()).filter(Boolean),
-    ),
-  ];
+  const availableModels = unique(
+    input.availableModels.map((model) => model.trim()).filter(Boolean),
+  );
   if (availableModels.length === 0) {
     throw new Error(
       'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -20,7 +20,12 @@ import {
 } from '@shared/schemas';
 import { normalizeFilePath } from '@shared/utils/path';
 import { ToolError } from '@shared/schemas/toolResult';
-import { isObject, toNewestFirstByTimestamp, hexId12 } from '@utils/core';
+import {
+  isObject,
+  toNewestFirstByTimestamp,
+  unique,
+  hexId12,
+} from '@utils/core';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
@@ -476,11 +481,9 @@ async function mirrorThreadToExecution(params: {
 function normalizeSessionLinks(links?: string[] | null): string[] | undefined {
   if (!links?.length) return undefined;
 
-  const normalized = [
-    ...new Set(
-      links.map((link) => link.trim()).filter((link) => link.length > 0),
-    ),
-  ];
+  const normalized = unique(
+    links.map((link) => link.trim()).filter((link) => link.length > 0),
+  );
 
   return normalized.length ? normalized : undefined;
 }

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -20,6 +20,7 @@ export {
   formatCompactDuration,
   formatCompactTokenCount,
   formatDuration,
+  formatWallTimeSeconds,
   serializeError,
 } from '../text/stringUtils';
 

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -311,3 +311,14 @@ export function formatCostUsd(cost: number): string {
 export function formatLocaleTimestamp(ts: number | string): string {
   return new Date(ts).toLocaleString();
 }
+
+/**
+ * Format an elapsed wall-clock duration as seconds with one decimal digit
+ * (e.g. `12.3s`), regardless of magnitude. Unlike {@link formatDuration} /
+ * {@link formatCompactDuration}, this never switches to compound units
+ * (`2m 5s`) — agent-CLI turn timings are always shown as a single seconds
+ * figure.
+ */
+export function formatWallTimeSeconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}


### PR DESCRIPTION
## Summary

A codebase-wide sweep for two classes of cleanup: (1) copy-pasted logic that should be a single shared helper, and (2) hand-rolled code that reimplements something a native method or an already-imported utility already provides. Five parallel scans covered `src/agent`+`src/model`+`src/latex`, `src/utils`+`src/tools`+`src/common`+friends, `packages/cli`, `packages/extension`, and `packages/desktop`+`src/platform`+`src/hosts`. Most of the codebase turned out to already be well-consolidated (several files carry comments documenting past dedup work); the findings below are the concrete, mechanical opportunities that were left, each verified against the actual file before changing it.

**Implemented:**
- **CLI** (`packages/cli`): extracted `clampModalWidth()`/`MIN_MODAL_CONTENT_WIDTH` (`ui/theme.ts`) to replace 8 modals' identical local `MIN_*_WIDTH` constants + `Math.max` clamps; replaced 3 hand-rolled path-separator normalizations with the existing `toPosixPath()`; used the existing `toErrorMessage()` in `fetchSilencer.ts` instead of manual `.message` extraction.
- **Desktop** (`packages/desktop`): added `toLogData()` to replace 8 repeated `error instanceof Error ? error : { error }` log-data coercions across `desktopAgentExecution.ts`/`desktopProgressEventBridge.ts`; added `createTexraTempDir()` to replace duplicated `mkdtemp`-in-a-prefixed-dir logic in `desktopToolEditApproval.ts`/`desktopDiffHost.ts`.
- **Extension** (`packages/extension`): added `lineToRange()` (`frontend/vscode/vscodeEditor.ts`) to replace 4 near-identical 1-based-line-to-clamped-`Range` conversions; deduped `hasValue`/`hasSearchValue` into one exported `hasSearchValue()`; had `HistoryList.ts` reuse `paginate()` instead of recomputing `totalPages` inline.
- **Core** (`src/agent`, `src/tools`, `src/shared`): replaced 5 `[...new Set(...)]` call sites with the existing `unique()` helper; added `formatWallTimeSeconds()` and used it in `claudeAgent.ts`/`codex.ts` instead of both inlining `` `${(wallTimeMs/1000).toFixed(1)}s` ``; extracted `stripFirstLastLineIfWrapped()` so `stripSurroundingMarkdownFence()` and `filenameHeaders.ts`'s `stripDocumentsEnvelope()` share one find/slice implementation instead of two copies.

**Deliberately left out** (flagged during implementation as too risky for a mechanical pass, or as a display-format decision that needs a call, not just a refactor):
- `src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts`'s local `errorMessageOf()` vs. the shared `getSdkErrorMessage()` — the local version feeds anchored regex/substring matches used to classify specific Google API error conditions (stale interaction chain, unsupported background mode); swapping in the shared, more heavily-formatted helper risks changing those exact-text matches. Left as a follow-up requiring a human check of the actual error strings.
- `src/tools/memory/memoryUtils.ts`'s `formatSize()` vs. the existing `formatBytes()` — same scaling logic, but different display format (`"1.5K"` vs `"1.5 KiB"`); needs a UX decision, not just a mechanical swap.
- HTML/XML entity decoding duplicated across `src/shared/subagentFollowup.ts` and `src/tools/emlParser.ts` — same core unescape sequence, but with different case-sensitivity/`&nbsp;` handling; worth a shared low-level helper, but needs careful behavior-preserving parameterization rather than a blind merge.
- A handful of low-priority, single- or double-call-site items across all five scopes (documented in the scan transcripts): a couple of Zod-schema-shaped hand-rolled type guards in the desktop IPC/secrets code, minor `JSON.stringify(x, null, 2)` debug-dump repetition in the extension, small `string|string[]|undefined` normalization repeated 3x in the CLI, and a couple of near-identical SDK-error-tagging boilerplate files in `src/agent/modelHandlers` that are already about as consolidated as their differing SDK imports allow.

## Issue acceptance gates

No linked issue — this is a proactive consolidation sweep. Acceptance gate: every implemented item removes genuine duplication or a genuine reimplementation, preserves exact existing behavior (mechanical extraction, not a rewrite), and the full typecheck/test/lint suite passes.

## Single source of truth

- Modal minimum-content-width clamping: `clampModalWidth()`/`MIN_MODAL_CONTENT_WIDTH` in `packages/cli/src/chat/tui/ui/theme.ts`.
- Desktop log-data error coercion: `toLogData()` in `packages/desktop/src/main/desktopLogUtils.ts`.
- Desktop prefixed temp-dir creation: `createTexraTempDir()` in `packages/desktop/src/main/desktopTempDir.ts`.
- 1-based-line-to-VS-Code-`Range` conversion: `lineToRange()` in `packages/extension/src/frontend/vscode/vscodeEditor.ts`.
- History-field "has a value" predicate: `hasSearchValue()` in `packages/extension/src/settingsView/frontend/components/history/historySearch.ts`.
- First/last-line wrapper stripping (markdown fence and XML envelope): `stripFirstLastLineIfWrapped()` in `src/agent/output/extraction/contentSimilarity.ts`.
- Wall-clock-seconds formatting: `formatWallTimeSeconds()` in `src/utils/text/stringUtils.ts` (re-exported via `@utils/core`).

## Duplication and abstraction budget

Net change: +229/-172 lines across 37 files, all in the form of small, multi-caller helpers (2-8 call sites each) replacing copy-pasted logic — no new ports, facades, or single-caller abstractions. Every new helper was verified to have 2+ real call sites before extraction, per the repo's abstraction-cost guardrail.

## Host impact

Extension: 7 files — `lineToRange()`, `hasSearchValue()` dedup, `HistoryList.ts` pagination reuse.

Desktop: 6 files (+2 new: `desktopLogUtils.ts`, `desktopTempDir.ts`) — `toLogData()`, `createTexraTempDir()`.

CLI: 14 files — modal-width clamp, `toPosixPath()` reuse, `toErrorMessage()` reuse.

Core (shared by all three hosts): 9 files — `unique()` reuse, `formatWallTimeSeconds()`, `stripFirstLastLineIfWrapped()`.

## Scheduled refactoring

None filed — the deliberately-left-out items above are documented here for a maintainer to triage, not tracked as a follow-up issue.

## Validation

- `npm run typecheck` — full workspace (root, test-kernel, extension, CLI, trace-viewer): pass, 0 errors.
- `npm test` — 5211 passed, 1 skipped-irrelevant, 1 failed. The one failure (`SystemUtils.vitest.ts > executeCommand > aborts shell command process groups including children`) is in a file untouched by this PR (last touched by an unrelated commit) and fails on process-group/signal-abort timing, which is sensitive to this sandboxed execution environment — not caused by this change.
- `npm run lint` — 0 errors; pre-existing `import/order` warning backlog (65 warnings repo-wide, unrelated to this PR) plus 2 new warnings introduced by this PR's added imports, both fixed in a follow-up commit in this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RZDG8a59WzN5PDB7z9XJtv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extractions with no intended behavior changes; touches many files but not auth, payments, or critical runtime paths.
> 
> **Overview**
> This PR replaces copy-pasted patterns with small shared helpers across CLI, desktop, extension, and core—behavior-preserving refactors only.
> 
> **CLI TUI:** Adds `clampModalWidth()` / `MIN_MODAL_CONTENT_WIDTH` in `theme.ts` and routes approval modals, diff rendering, and transcript width through it instead of per-file `MIN_*_WIDTH` + `Math.max`. CLI runtime uses `toPosixPath()` for path normalization and `toErrorMessage()` for fetch error cause text.
> 
> **Desktop:** Adds `toLogData()` for logger `data` fields and `createTexraTempDir()` for prefixed temp dirs; desktop execution, progress bridge, diff host, and tool-edit approval call these instead of inline `instanceof Error` checks and `mkdtemp` boilerplate.
> 
> **Extension:** Adds `lineToRange()` for 1-based line → `vscode.Range` in comments, criticism, and agent review; exports `hasSearchValue()` for history UI; `HistoryList` reuses `paginate()` for page clamping.
> 
> **Core / shared:** Swaps `[...new Set(...)]` for `unique()` in several places; adds `formatWallTimeSeconds()` for Claude/Codex child-run timings; extracts `stripFirstLastLineIfWrapped()` so markdown fence and XML envelope stripping share one implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba02900f0e2ba081f14f76e481083e0116ac8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->