### PR TITLE
refactor(tools): replace hand-rolled HTML stripping in emlParser with turndown

### DIFF
--- a/src/test-kernel/tools/EmlParser.vitest.ts
+++ b/src/test-kernel/tools/EmlParser.vitest.ts
@@ -1,0 +1,36 @@
+// Third-party imports
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+
+// Local imports
+import { parseEml } from '@tools/emlParser';
+
+const HTML_ONLY_EML = `From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+Subject: Test
+Content-Type: text/html; charset=utf-8
+
+<html><head><style>.x{color:red}</style></head><body>
+<p>Hello <b>world</b>,</p>
+<ul><li>Item one</li><li>Item two</li></ul>
+<p>See <a href="https://example.com">this link</a>.</p>
+<p>Curly quote: it&#8217;s here.</p>
+<script>alert('x')</script>
+</body></html>
+`;
+
+describe('parseEml', () => {
+  it('converts an HTML-only body to Markdown without leaking style/script content', async () => {
+    const { text } = await parseEml(HTML_ONLY_EML);
+
+    assert.match(text, /Hello \*\*world\*\*,/);
+    assert.match(text, /Item one/);
+    assert.match(text, /Item two/);
+    assert.match(text, /\[this link\]\(https:\/\/example\.com\)/);
+    // Numeric entity (&#8217;) decodes to a curly apostrophe.
+    assert.match(text, /it’s here/);
+
+    assert.doesNotMatch(text, /color:red/);
+    assert.doesNotMatch(text, /alert\(/);
+  });
+});

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -160,9 +160,9 @@ const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
 ]);
 
 /**
- * HTML-to-text conversion via turndown, used only when no text/plain part
- * exists in the email. Renders as Markdown rather than raw plain text, but
- * that's a feature here: it preserves lists, links, and emphasis instead of
+ * HTML-to-Markdown conversion via turndown, used only when no text/plain
+ * part exists in the email. Rendering as Markdown rather than raw plain text
+ * is a feature here: it preserves lists, links, and emphasis instead of
  * flattening them, and matches the html-to-Markdown fallback already used by
  * WebFetchTool for the same "readable representation" purpose.
  */

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -27,6 +27,11 @@ interface AttachmentPartition {
 
 const IMAGE_MIME_PREFIX = 'image/';
 
+const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
+  'style',
+  'script',
+]);
+
 /**
  * Parse an EML file's raw text content into a human-readable representation,
  * and extract any image attachments.
@@ -79,7 +84,9 @@ function formatEmail(
   }
 
   // -- Body -----------------------------------------------------------------
-  const body = email.text ?? htmlToMarkdown(email.html ?? '');
+  // Falls back to a Markdown conversion of the HTML body (preserving lists,
+  // links, and emphasis) when no text/plain part exists.
+  const body = email.text ?? turndownService.turndown(email.html ?? '').trim();
   if (body.trim()) {
     sections.push(body.trim());
   }
@@ -152,20 +159,4 @@ function formatAddress(addr: Address): string {
     return addr.name ? `${addr.name}: ${members}` : members;
   }
   return addr.name ? `${addr.name} <${addr.address}>` : (addr.address ?? '');
-}
-
-const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
-  'style',
-  'script',
-]);
-
-/**
- * HTML-to-Markdown conversion via turndown, used only when no text/plain
- * part exists in the email. Rendering as Markdown rather than raw plain text
- * is a feature here: it preserves lists, links, and emphasis instead of
- * flattening them, and matches the html-to-Markdown fallback already used by
- * WebFetchTool for the same "readable representation" purpose.
- */
-function htmlToMarkdown(html: string): string {
-  return turndownService.turndown(html).trim();
 }

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import PostalMime from 'postal-mime';
+import TurndownService from 'turndown';
 import type { Address, Attachment, Email } from 'postal-mime';
 
 /** An image extracted from the email (inline or attached). */
@@ -153,28 +154,18 @@ function formatAddress(addr: Address): string {
   return addr.name ? `${addr.name} <${addr.address}>` : (addr.address ?? '');
 }
 
+const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
+  'style',
+  'script',
+]);
+
 /**
- * Minimal HTML-to-text conversion: strip tags and decode common entities.
- * This is intentionally lightweight — we only hit this path when no text/plain
- * part exists in the email.
+ * HTML-to-text conversion via turndown, used only when no text/plain part
+ * exists in the email. Renders as Markdown rather than raw plain text, but
+ * that's a feature here: it preserves lists, links, and emphasis instead of
+ * flattening them, and matches the html-to-Markdown fallback already used by
+ * WebFetchTool for the same "readable representation" purpose.
  */
 function stripHtml(html: string): string {
-  return (
-    html
-      // Remove non-visible blocks before stripping tags so their text content
-      // (CSS rules, JS code) doesn't leak into the plain-text output.
-      .replaceAll(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replaceAll(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replaceAll(/<br\s*\/?>/gi, '\n')
-      .replaceAll(/<\/(?:p|div|tr|li|h[1-6])>/gi, '\n')
-      .replaceAll(/<[^>]+>/g, '')
-      .replaceAll(/&nbsp;/gi, ' ')
-      .replaceAll(/&lt;/gi, '<')
-      .replaceAll(/&gt;/gi, '>')
-      .replaceAll(/&quot;/gi, '"')
-      .replaceAll(/&#039;/gi, "'")
-      .replaceAll(/&amp;/gi, '&')
-      .replaceAll(/\n{3,}/g, '\n\n')
-      .trim()
-  );
+  return turndownService.turndown(html).trim();
 }

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -14,7 +14,7 @@ export interface EmlImageAttachment {
 }
 
 export interface EmlParseResult {
-  /** Human-readable plain-text representation of the email */
+  /** Human-readable representation of the email (plain text, or Markdown when falling back from an HTML-only body) */
   text: string;
   /** Image attachments extracted from the email */
   images: EmlImageAttachment[];
@@ -28,11 +28,11 @@ interface AttachmentPartition {
 const IMAGE_MIME_PREFIX = 'image/';
 
 /**
- * Parse an EML file's raw text content into a human-readable plain-text
- * representation, and extract any image attachments.
+ * Parse an EML file's raw text content into a human-readable representation,
+ * and extract any image attachments.
  *
  * Extracts key headers (From, To, CC, Subject, Date) and the text body.
- * When no plain-text part exists, falls back to a simplified version of the HTML body.
+ * When no plain-text part exists, falls back to a Markdown conversion of the HTML body.
  * Non-image attachment filenames are listed at the end of the text.
  */
 export async function parseEml(rawEml: string): Promise<EmlParseResult> {
@@ -79,7 +79,7 @@ function formatEmail(
   }
 
   // -- Body -----------------------------------------------------------------
-  const body = email.text ?? stripHtml(email.html ?? '');
+  const body = email.text ?? htmlToMarkdown(email.html ?? '');
   if (body.trim()) {
     sections.push(body.trim());
   }
@@ -166,6 +166,6 @@ const turndownService = new TurndownService({ headingStyle: 'atx' }).remove([
  * flattening them, and matches the html-to-Markdown fallback already used by
  * WebFetchTool for the same "readable representation" purpose.
  */
-function stripHtml(html: string): string {
+function htmlToMarkdown(html: string): string {
   return turndownService.turndown(html).trim();
 }


### PR DESCRIPTION
## Summary

`src/tools/emlParser.ts` fell back to a hand-rolled `stripHtml()` regex chain when parsing an EML file whose email has no `text/plain` part (only HTML). That function only decoded 5 named HTML entities, missed numeric entities (e.g. `&#8217;`), and mishandled tables/nested lists — a correctness gap surfaced during a broader scan for ad-hoc code that duplicates well-maintained npm packages. This PR replaces it with `turndown`, which is already a repo-root dependency used by `src/tools/web/WebFetchTool.ts` to solve the identical "HTML → readable text for an LLM" problem.

## Issue acceptance gates

No tracked issue — found via a repo scan for brute-force/ad-hoc code with npm-package alternatives. Acceptance gate: the EML HTML-body fallback path produces correct text (proper entity decoding, no leaked `<style>`/`<script>` content) using the same conversion library already relied on elsewhere in the codebase, with no new dependency added.

## Single source of truth

`turndown` (via a module-level `TurndownService` instance in `emlParser.ts`, configured with `.remove(['style', 'script'])` to match the prior explicit-removal behavior) now owns HTML→text conversion for the no-plain-text-part fallback, mirroring the pattern already used in `WebFetchTool.ts`.

## Duplication and abstraction budget

Removed ~20 lines of a fragile, incomplete regex-based HTML stripper. No new abstraction introduced — reused an existing dependency and existing call-site pattern (`turndownService.turndown(html)`), consistent with how `WebFetchTool.ts` already does HTML-to-Markdown conversion.

## Host impact

Extension: none directly — flows through the shared host-agnostic `src/tools/emlParser.ts` used wherever EML attachments are read.

Desktop: same as extension — no host-specific change.

CLI: same as extension — no host-specific change.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes across all workspace packages.
- `npx eslint src/tools/emlParser.ts` — no errors (import-order warning auto-fixed).
- `npx prettier --write src/tools/emlParser.ts` — no formatting changes needed.
- `npx vitest run` — 599/600 test files pass; the one failure (`SystemUtils.vitest.ts > aborts shell command process groups including children`) is a pre-existing, unrelated process-group-signal test that is flaky in this sandboxed environment and is untouched by this change.
- Manual sanity check: ran `turndown` against a sample HTML email body containing `<style>`, `<script>`, lists, links, and a numeric HTML entity (`&#8217;`) — confirmed style/script content is stripped and the entity decodes correctly (a case the old regex implementation missed).


---
_Generated by [Claude Code](https://claude.ai/code/session_011uvAEpLnQja2fAGPUWxj1Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the HTML-only email body fallback in shared tooling; behavior improves formatting/entities with no new dependency and is covered by a focused unit test.
> 
> **Overview**
> When an EML has no `text/plain` part, **`emlParser`** now uses a module-level **`TurndownService`** (with `style`/`script` removed) to produce **Markdown** from the HTML body, replacing the deleted **`stripHtml`** regex path. **`EmlParseResult.text`** docs and comments are updated to reflect that fallback.
> 
> A new **`EmlParser.vitest.ts`** case asserts Markdown output (bold, lists, links), numeric entity decoding (`&#8217;`), and that CSS/JS content does not appear in the parsed text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c261338fa909243afe983ccf1f28eacd6ffb9896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->