### PR TITLE
refactor(runtime): dedupe ExecutionRegistry cancel + child-activity emission

### DIFF
--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -45,6 +45,13 @@ export function getAnthropicMaxPdfPages(contextWindow: number): number {
 export const CLIENT_COMPACTION_SUMMARY_MAX_TOKENS = 2000;
 
 /**
+ * Prefix prepended to a client-side compaction summary when it is folded back
+ * into the conversation as a synthetic user message. Shared across every
+ * provider handler so the resumed-conversation marker stays identical.
+ */
+export const COMPACTION_SUMMARY_PREFIX = '[Previous conversation summary]\n\n';
+
+/**
  * Rough chars-per-token ratio for estimating token counts without a tokenizer.
  * ~4 chars/token is the standard approximation for GPT-family models on English
  * and code. Used only where exact counting is unavailable — e.g. the

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1844,9 +1844,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       },
       (summary): Step => ({
         type: 'user_input',
-        content: [
-          this.textContent(`${COMPACTION_SUMMARY_PREFIX}${summary}`),
-        ],
+        content: [this.textContent(`${COMPACTION_SUMMARY_PREFIX}${summary}`)],
       }),
     );
   }

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -61,6 +61,7 @@ import {
 } from '../support/BackgroundPoller';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+  COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
 } from '../contextManagementConstants';
 import { tagGoogleSdkError } from './googleSdkError';
@@ -1844,7 +1845,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       (summary): Step => ({
         type: 'user_input',
         content: [
-          this.textContent(`[Previous conversation summary]\n\n${summary}`),
+          this.textContent(`${COMPACTION_SUMMARY_PREFIX}${summary}`),
         ],
       }),
     );

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -61,6 +61,7 @@ import {
 } from './BaseReasoningStreamAggregator';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+  COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
 } from '../contextManagementConstants';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
@@ -194,7 +195,7 @@ export class ModelHandlerOpenAI<
       },
       (summary) => ({
         role: 'user',
-        content: `[Previous conversation summary]\n\n${summary}`,
+        content: `${COMPACTION_SUMMARY_PREFIX}${summary}`,
       }),
     );
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -978,9 +978,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       (summary): ResponseInputItem => ({
         type: 'message',
         role: 'user',
-        content: [
-          createInputText(`${COMPACTION_SUMMARY_PREFIX}${summary}`),
-        ],
+        content: [createInputText(`${COMPACTION_SUMMARY_PREFIX}${summary}`)],
       }),
     );
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -63,6 +63,7 @@ import {
   CHAINED_RESPONSE_MAX_OUTPUT_FACTOR,
   CHAINED_RESPONSE_SAFETY_MARGIN_PERCENT,
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+  COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
   estimateTokensFromText,
   TOKEN_SAFETY_BUFFER,
@@ -978,7 +979,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         type: 'message',
         role: 'user',
         content: [
-          createInputText(`[Previous conversation summary]\n\n${summary}`),
+          createInputText(`${COMPACTION_SUMMARY_PREFIX}${summary}`),
         ],
       }),
     );

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -54,6 +54,7 @@ import {
 import { ModelHandler } from '../ModelHandler';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+  COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
 } from '../contextManagementConstants';
 import type {
@@ -349,7 +350,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       },
       (summary) => ({
         role: 'user',
-        content: `[Previous conversation summary]\n\n${summary}`,
+        content: `${COMPACTION_SUMMARY_PREFIX}${summary}`,
       }),
     );
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -190,7 +190,7 @@ export class ExecutionRegistry {
           ) {
             this.notifyWaiters(executionId);
             if (handle.isChildExecution) {
-              this.emitActiveSubagentsUpdate(handle.parentStreamId);
+              this.emitChildActivity(handle.parentStreamId, 'subagents');
             }
             break;
           }
@@ -237,7 +237,7 @@ export class ExecutionRegistry {
     this.handles.set(handle.executionId, handle);
     if (handle instanceof AgentExecutionHandle) {
       if (handle.isChildExecution) {
-        this.emitActiveSubagentsUpdate(handle.parentStreamId);
+        this.emitChildActivity(handle.parentStreamId, 'subagents');
         this.emitParentStreamUpdate({
           childStreamId: handle.childStreamId,
           parentStreamId: handle.parentStreamId,
@@ -245,7 +245,7 @@ export class ExecutionRegistry {
       }
     } else if (handle instanceof ProcessExecutionHandle) {
       this.processOutput.register(handle);
-      this.emitActiveProcessesUpdate(handle.parentStreamId);
+      this.emitChildActivity(handle.parentStreamId, 'processes');
     }
   }
 
@@ -308,7 +308,7 @@ export class ExecutionRegistry {
     this.handles.delete(handle.executionId);
     this.notifyWaiters(handle.executionId);
     if (handle instanceof AgentExecutionHandle && handle.isChildExecution) {
-      this.emitActiveSubagentsUpdate(handle.parentStreamId);
+      this.emitChildActivity(handle.parentStreamId, 'subagents');
       return;
     }
 
@@ -317,7 +317,7 @@ export class ExecutionRegistry {
       // badge handler prunes output entries for processes no longer active.
       const finalize = (): void => {
         this.processOutput.unregister(handle.executionId);
-        this.emitActiveProcessesUpdate(handle.parentStreamId);
+        this.emitChildActivity(handle.parentStreamId, 'processes');
       };
       if (handle.outputPaths) {
         void this.processOutput.flush(handle).finally(finalize);
@@ -570,7 +570,7 @@ export class ExecutionRegistry {
         this.terminate(handle, visited, { cascadeChildren: false });
       }
     }
-    this.emitActiveSubagentsUpdate(parentStreamId);
+    this.emitChildActivity(parentStreamId, 'subagents');
   }
 
   /**
@@ -617,14 +617,7 @@ export class ExecutionRegistry {
     if (!runtimeHost) {
       return { kind: 'no_target', streamId, childPolicy };
     }
-    this.streamStatus.transition(
-      streamId,
-      STREAM_PHASE.CANCELLED,
-      'user-stop',
-      {
-        ...(this.events ? { events: this.events } : {}),
-      },
-    );
+    this.cancelStreamStatus(streamId);
     return { kind: 'marked_stopped', streamId, childPolicy };
   }
 
@@ -667,37 +660,31 @@ export class ExecutionRegistry {
     };
   }
 
-  private emitActiveSubagentsUpdate(parentStreamId: StreamTabId): void {
-    const children = this.collectChildSummary(
+  private emitChildActivity(
+    parentStreamId: StreamTabId,
+    kind: 'subagents' | 'processes',
+  ): void {
+    const items = this.collectChildSummary(
       parentStreamId,
-      AgentExecutionHandle,
+      kind === 'subagents' ? AgentExecutionHandle : ProcessExecutionHandle,
     );
     this.requireSessionEvents().emit({
       scope: 'run',
       streamId: parentStreamId,
-      event: {
-        type: 'child.activity',
-        kind: 'subagents',
-        parentStreamId,
-        children,
-      },
-    });
-  }
-
-  private emitActiveProcessesUpdate(parentStreamId: StreamTabId): void {
-    const processes = this.collectChildSummary(
-      parentStreamId,
-      ProcessExecutionHandle,
-    );
-    this.requireSessionEvents().emit({
-      scope: 'run',
-      streamId: parentStreamId,
-      event: {
-        type: 'child.activity',
-        kind: 'processes',
-        parentStreamId,
-        processes,
-      },
+      event:
+        kind === 'subagents'
+          ? {
+              type: 'child.activity',
+              kind: 'subagents',
+              parentStreamId,
+              children: items,
+            }
+          : {
+              type: 'child.activity',
+              kind: 'processes',
+              parentStreamId,
+              processes: items,
+            },
     });
   }
 
@@ -779,12 +766,7 @@ export class ExecutionRegistry {
       const interruptible = this.interrupts.get(handle.childStreamId);
       if (interruptible) {
         interruptible.interrupt();
-        this.streamStatus.transition(
-          handle.childStreamId,
-          STREAM_PHASE.CANCELLED,
-          'user-stop',
-          this.streamStatusEmitOptions(handle),
-        );
+        this.cancelStreamStatus(handle.childStreamId, handle);
         return true;
       }
       // No live interrupt context: a native subagent suspended at WAITING has
@@ -881,20 +863,32 @@ export class ExecutionRegistry {
       projectRunOutcome(RUN_OUTCOME.CANCELLED).executionStatus,
     ).catch(() => {});
     this.untrackHandle(handle);
-    this.streamStatus.transition(
-      handle.childStreamId,
-      STREAM_PHASE.CANCELLED,
-      'user-stop',
-      this.streamStatusEmitOptions(handle),
-    );
+    this.cancelStreamStatus(handle.childStreamId, handle);
     return true;
   }
 
   private streamStatusEmitOptions(
-    handle: AgentExecutionHandle,
+    handle?: AgentExecutionHandle,
   ): StreamStatusEmitOptions {
-    if (handle.trace) return { trace: handle.trace };
+    if (handle?.trace) return { trace: handle.trace };
     return this.events ? { events: this.events } : {};
+  }
+
+  /**
+   * Mark a stream CANCELLED from a user stop. Routes the status emission through
+   * the handle's trace when one is available and falls back to the registry's
+   * SessionEventHub otherwise (see {@link streamStatusEmitOptions}).
+   */
+  private cancelStreamStatus(
+    streamId: StreamTabId,
+    handle?: AgentExecutionHandle,
+  ): void {
+    this.streamStatus.transition(
+      streamId,
+      STREAM_PHASE.CANCELLED,
+      'user-stop',
+      this.streamStatusEmitOptions(handle),
+    );
   }
 
   private interruptRegisteredStream(
@@ -905,14 +899,7 @@ export class ExecutionRegistry {
     if (!interruptible) return false;
     interruptible.interrupt();
     if (runtimeHost) {
-      this.streamStatus.transition(
-        streamId,
-        STREAM_PHASE.CANCELLED,
-        'user-stop',
-        {
-          ...(this.events ? { events: this.events } : {}),
-        },
-      );
+      this.cancelStreamStatus(streamId);
     }
     return true;
   }


### PR DESCRIPTION
Collapse four open-coded `streamStatus.transition(..., CANCELLED, 'user-stop', ...)`
call sites into a single `cancelStreamStatus(streamId, handle?)` helper, and
generalize `streamStatusEmitOptions` to accept an optional handle so the
no-handle (SessionEventHub-only) and handle-backed (trace) emission paths share
one implementation.

Merge the near-identical `emitActiveSubagentsUpdate` / `emitActiveProcessesUpdate`
twins into one `emitChildActivity(parentStreamId, kind)` (6 call sites), keeping
the discriminated `child.activity` event shape intact.

Behavior-preserving; ExecutionRegistry vitest suite unchanged and green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LmzDA6XAt3SW55HCvdERap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with identical strings and event payloads; risk is limited to accidental divergence in stop/cancel or UI child-activity updates, which the existing ExecutionRegistry tests are meant to guard.
> 
> **Overview**
> Introduces shared **`COMPACTION_SUMMARY_PREFIX`** in `contextManagementConstants` and wires Google Interactions, OpenAI chat, OpenAI Responses, and OpenRouter native handlers to use it when folding client-side compaction summaries into synthetic user messages, so the resumed-conversation marker stays identical across providers.
> 
> In **`ExecutionRegistry`**, collapses repeated user-stop **`CANCELLED`** transitions into **`cancelStreamStatus(streamId, handle?)`**, with **`streamStatusEmitOptions`** now accepting an optional handle for trace vs SessionEventHub emission. Merges **`emitActiveSubagentsUpdate`** / **`emitActiveProcessesUpdate`** into **`emitChildActivity(parentStreamId, kind)`** while preserving the discriminated **`child.activity`** event shape.
> 
> Behavior-preserving refactor only; no intentional runtime semantics change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7334993a3f5c77b1d3e087664f1925de8b183866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->