### PR TITLE
Unify setup model resolution and git commit formatting across hosts

### DIFF
--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -20,7 +20,10 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { clamp } from '@utils/core';
-import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
+import {
+  COMMIT_LABEL_FORMAT,
+  splitCommitLines,
+} from '@utils/git/commitLogFormat';
 import { isGitRepository } from '@utils/system/isGitRepository';
 
 const execFileAsync = promisify(execFile);
@@ -121,7 +124,7 @@ export function createDesktopGitHost(
           },
         );
         return {
-          commits: stdout.split('\n').map((line) => line.trim()),
+          commits: splitCommitLines(stdout),
           isGitRepo: true,
         };
       } catch (error) {

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -3,19 +3,14 @@
  * `docs/dev/standalone-trajectory-audit.md` (trajectory #16).
  *
  * The VS Code extension surfaces "recent commits" via `texra.getRecentCommits`,
- * which shells out to `git log` with `--pretty=format:'%h: %s (%cr)'` and
+ * which shells out to `git log` with the shared `COMMIT_LABEL_FORMAT` and
  * returns the lines verbatim. The desktop shell historically replied to
  * `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS` with an empty list because no
  * `vscode.git`-equivalent host port existed. This module fills that gap by
  * spawning `git log` directly via Node's `child_process.execFile` (no shell,
- * no string interpolation — the workspace path travels via `cwd`).
- *
- * The renderer's `SetRecentCommitsMessageSchema` consumes a `string[]` of
- * pre-formatted labels, so we parse a richer tab-separated `--pretty=format`
- * payload (`%h%x09%s%x09%cr`) and rebuild the same `<short>: <subject>
- * (<relative>)` shape the extension produces. Splitting the format keeps the
- * parser robust against subjects that contain `: ` literally — those would
- * have been ambiguous if we'd echoed the human-readable label directly.
+ * no string interpolation — the workspace path travels via `cwd`), reusing
+ * the same host-neutral `isGitRepository` probe and label format the
+ * extension uses so the two hosts can't drift apart.
  */
 
 // Not routed through executeCommand: it doesn't expose a `maxBuffer` option,
@@ -25,6 +20,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { clamp } from '@utils/core';
+import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
+import { isGitRepository } from '@utils/system/isGitRepository';
 
 const execFileAsync = promisify(execFile);
 
@@ -36,15 +33,6 @@ const execFileAsync = promisify(execFile);
  */
 const DEFAULT_COMMIT_LIMIT = 20;
 const MAX_COMMIT_LIMIT = 1000;
-
-/** Field separator used inside `git log --pretty=format` (literal TAB). */
-const FIELD_SEPARATOR = '\t';
-
-/**
- * `%h` short hash, `%s` subject, `%cr` committer date relative. Tabs separate
- * fields so subjects with literal `: ` survive the round-trip.
- */
-const COMMIT_PRETTY_FORMAT = `%h${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%cr`;
 
 /**
  * Hard upper bound on git output bytes (8 MiB). 20 commits with subjects
@@ -105,19 +93,11 @@ export function createDesktopGitHost(
       if (!workspace) {
         return { commits: [], isGitRepo: false };
       }
-      // Use `git rev-parse --is-inside-work-tree` instead of `existsSync('.git')`
-      // — the latter wrongly reports `false` from subdirectories and misses
-      // worktrees/submodules where `.git` is a pointer file (bot review #3817).
-      try {
-        const { stdout } = await execFileAsync(
-          'git',
-          ['rev-parse', '--is-inside-work-tree'],
-          { cwd: workspace, timeout: GIT_TIMEOUT_MS },
-        );
-        if (stdout.trim() !== 'true') {
-          return { commits: [], isGitRepo: false };
-        }
-      } catch {
+      // Uses `git rev-parse --is-inside-work-tree` instead of
+      // `existsSync('.git')` — the latter wrongly reports `false` from
+      // subdirectories and misses worktrees/submodules where `.git` is a
+      // pointer file (bot review #3817).
+      if (!(await isGitRepository(workspace))) {
         // Missing git, not a repo, etc. Don't surface via `onError` — this
         // is the steady-state for any non-git workspace.
         return { commits: [], isGitRepo: false };
@@ -132,7 +112,7 @@ export function createDesktopGitHost(
             'log',
             '-n',
             String(limit),
-            `--pretty=format:${COMMIT_PRETTY_FORMAT}`,
+            `--pretty=format:${COMMIT_LABEL_FORMAT}`,
           ],
           {
             cwd: workspace,
@@ -140,7 +120,10 @@ export function createDesktopGitHost(
             maxBuffer: MAX_BUFFER_BYTES,
           },
         );
-        return { commits: parseCommitLog(stdout), isGitRepo: true };
+        return {
+          commits: stdout.split('\n').map((line) => line.trim()),
+          isGitRepo: true,
+        };
       } catch (error) {
         // rev-parse already passed, so we know it's a repo — report
         // isGitRepo:true with an empty list so empty-repo states stay honest.
@@ -149,35 +132,6 @@ export function createDesktopGitHost(
       }
     },
   };
-}
-
-/**
- * Convert tab-separated `git log` output into the `<hash>: <subject>
- * (<relative>)` label shape the renderer expects.
- *
- * Exported for unit tests so we can pin the behaviour against fixtures that
- * include awkward subjects (literal `: `, embedded tabs, blank lines).
- */
-export function parseCommitLog(stdout: string): string[] {
-  if (!stdout) return [];
-  const lines = stdout.split('\n');
-  const commits: string[] = [];
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, '');
-    if (!line) continue;
-    // Split on the first two TABs only so subjects containing tabs
-    // (rare but legal) round-trip correctly.
-    const firstTab = line.indexOf(FIELD_SEPARATOR);
-    if (firstTab < 0) continue;
-    const lastTab = line.lastIndexOf(FIELD_SEPARATOR);
-    if (lastTab <= firstTab) continue;
-    const hash = line.slice(0, firstTab);
-    const subject = line.slice(firstTab + 1, lastTab);
-    const relative = line.slice(lastTab + 1);
-    if (!hash || !subject || !relative) continue;
-    commits.push(`${hash}: ${subject} (${relative})`);
-  }
-  return commits;
 }
 
 function clampCommitLimit(value: number): number {

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -99,7 +99,11 @@ export function createDesktopGitHost(
       // Uses `git rev-parse --is-inside-work-tree` instead of
       // `existsSync('.git')` — the latter wrongly reports `false` from
       // subdirectories and misses worktrees/submodules where `.git` is a
-      // pointer file (bot review #3817).
+      // pointer file (bot review #3817). This shared probe times out at 5s
+      // (this file previously inlined its own 10s timeout) — intentional:
+      // 5s is still generous for a `rev-parse` round-trip, and using the
+      // same probe as every other host caller matters more than the extra
+      // slack.
       if (!(await isGitRepository(workspace))) {
         // Missing git, not a repo, etc. Don't surface via `onError` — this
         // is the steady-state for any non-git workspace.

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -193,6 +193,14 @@ function buildVSCodeUI(): AgentCreatorUI {
   };
 }
 
+/**
+ * Runs the agent-creator wizard directly rather than via `executeAgent`.
+ * `executeAgent` launches YAML-defined `AgentConfig` runs (`workflow` /
+ * `toolUse`) and tracks them as sessions with resume/history semantics; this
+ * flow authors a *new* agent YAML and never itself becomes a trackable
+ * session, so there is no `AgentConfig` to hand it and no resume state to
+ * keep coherent.
+ */
 export async function handleCreateAgentWithAI(
   context: vscode.ExtensionContext,
   category: AgentCategory,

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -17,12 +17,12 @@ import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'gitCommands';
 logger.initialize(CHANNEL);
 
-const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
 const COMMIT_HASH_PATTERN = /^[0-9a-fA-F]{4,40}$/;
 const OVERLEAF_GIT_TOKEN_URL = 'https://www.overleaf.com/user/settings';
 const OVERLEAF_TOKEN_DOCS_URL =

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -17,7 +17,10 @@ import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { COMMIT_LABEL_FORMAT } from '@utils/git/commitLogFormat';
+import {
+  COMMIT_LABEL_FORMAT,
+  splitCommitLines,
+} from '@utils/git/commitLogFormat';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'gitCommands';
@@ -98,7 +101,7 @@ function getRecentCommits(rootPath?: string): string[] | null {
   if (result.exitCode !== 0) {
     return [];
   }
-  return result.stdout.split('\n').map((line) => line.trim());
+  return splitCommitLines(result.stdout);
 }
 
 function findCommitInHistory(

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import {
-  resolveSetupModel,
+  resolveSetupLaunchModel,
   SETUP_INSTRUCTION,
 } from '@controllers/onboarding/setupLaunch';
 import { platform } from '@platform/platform';
@@ -48,7 +48,7 @@ interface LaunchModelResolution {
  * fallback's flag flip is expected, unlike desktop's silent-launch path).
  */
 async function selectLaunchModel(): Promise<LaunchModelResolution | null> {
-  const resolution = await resolveSetupModel(platform().secrets, true);
+  const resolution = await resolveSetupLaunchModel(platform().secrets, true);
   if (!resolution) return null;
   return {
     model: resolution.model,

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { selectSetupCredentialModelExcludingOpenRouter } from '@controllers/onboarding/setupLaunch';
+import {
+  resolveSetupModel,
+  SETUP_INSTRUCTION,
+} from '@controllers/onboarding/setupLaunch';
 import { platform } from '@platform/platform';
 import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
@@ -19,11 +22,7 @@ import { SecretManager } from '@frontend/secretManager';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionSignIn';
 import * as logger from '@logger/logUtils';
-import {
-  CHATGPT_SETUP_MODEL,
-  SETUP_MODEL_BY_PROVIDER,
-} from '@model/setupModelDefaults';
-import { decideRunModel } from '@model/runModelDecision';
+import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 import {
   ONBOARDING_CHOICE_API_KEY,
   ONBOARDING_CHOICE_CHATGPT,
@@ -31,15 +30,12 @@ import {
 } from '@shared/copy/onboarding';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { agentName } from '@shared/schemas/agent';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 const CHANNEL = 'SetupAssistant';
 logger.initialize(CHANNEL);
-
-const SETUP_INSTRUCTION =
-  'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
 
 interface LaunchModelResolution {
   model: string;
@@ -47,40 +43,18 @@ interface LaunchModelResolution {
 }
 
 /**
- * Pure model selection. The caller already validated that a globally-enabled
- * OpenRouter route has a key; the OR-only fallback still needs a scoped flag
- * flip before launch.
+ * The extension additionally offers the OpenRouter access-list model as a
+ * last resort (`ensureRoutingConfigured` already prompted the user, so the
+ * fallback's flag flip is expected, unlike desktop's silent-launch path).
  */
 async function selectLaunchModel(): Promise<LaunchModelResolution | null> {
-  const useOpenRouter = getUseOpenRouter();
-  const openRouterModel = useOpenRouter
-    ? SETUP_MODEL_BY_PROVIDER.openRouter
-    : (await SecretManager.hasUsableApiKey('openRouter'))
-      ? SETUP_MODEL_BY_PROVIDER.openRouter
-      : undefined;
-  const credentialModel = useOpenRouter
-    ? undefined
-    : await selectSetupCredentialModelExcludingOpenRouter(platform().secrets);
-  const decision = decideRunModel([
-    {
-      model: useOpenRouter ? openRouterModel : undefined,
-      reason: 'router-config',
-    },
-    {
-      model: credentialModel,
-      reason: 'credential',
-    },
-    {
-      model: useOpenRouter ? undefined : openRouterModel,
-      reason: 'access-list-default',
-    },
-  ]);
-  if (!decision) return null;
+  const resolution = await resolveSetupModel(platform().secrets, true);
+  if (!resolution) return null;
   return {
-    model: decision.model,
+    model: resolution.model,
     requiresOpenRouter:
-      decision.reason === 'router-config' ||
-      decision.reason === 'access-list-default',
+      resolution.reason === 'router-config' ||
+      resolution.reason === 'access-list-default',
   };
 }
 

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -70,7 +70,7 @@ export interface SetupModelResolution {
  * extension prompts the user first (`ensureRoutingConfigured`) and can offer
  * it.
  */
-export async function resolveSetupModel(
+export async function resolveSetupLaunchModel(
   secrets: PlatformSecrets,
   includeAccessListFallback: boolean,
 ): Promise<SetupModelResolution | null> {
@@ -109,7 +109,7 @@ export async function resolveSetupModel(
  * already on and an OpenRouter key exists.
  */
 export async function selectDesktopSetupModel(): Promise<string | null> {
-  const resolution = await resolveSetupModel(platform().secrets, false);
+  const resolution = await resolveSetupLaunchModel(platform().secrets, false);
   return resolution?.model ?? null;
 }
 

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -2,7 +2,11 @@ import { platform } from '@platform/platform';
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { lookupApiKey, API_PROVIDERS } from '@model/apiProviders';
-import { decideRunModel } from '@model/runModelDecision';
+import {
+  decideRunModel,
+  type RunModelCandidate,
+  type RunModelDecisionReason,
+} from '@model/runModelDecision';
 import {
   CHATGPT_SETUP_MODEL,
   SETUP_MODEL_BY_PROVIDER,
@@ -14,7 +18,7 @@ import { isNonEmptyString } from '@utils/core';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 import type { PlatformSecrets } from '@platform/secrets';
 
-/** Instruction handed to the setup agent when launched (mirrors the extension). */
+/** Instruction handed to the setup agent when launched. Shared by every host. */
 export const SETUP_INSTRUCTION =
   'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.';
 
@@ -53,36 +57,60 @@ export async function selectSetupCredentialModelExcludingOpenRouter(
   return null;
 }
 
+export interface SetupModelResolution {
+  model: string;
+  reason: RunModelDecisionReason;
+}
+
+/**
+ * Resolve a launch model for the setup agent from router config, direct
+ * credential, and (only when a host asks for it) an OpenRouter access-list
+ * fallback used as a last resort when routing is off. Desktop has no prompt
+ * to explain the resulting flag flip, so it opts out of the fallback; the
+ * extension prompts the user first (`ensureRoutingConfigured`) and can offer
+ * it.
+ */
+export async function resolveSetupModel(
+  secrets: PlatformSecrets,
+  includeAccessListFallback: boolean,
+): Promise<SetupModelResolution | null> {
+  const useOpenRouter = getUseOpenRouter();
+  const openRouterModel = isNonEmptyString(
+    await lookupApiKey(secrets, 'openRouter'),
+  )
+    ? SETUP_MODEL_BY_PROVIDER.openRouter
+    : null;
+
+  const candidates: RunModelCandidate[] = [
+    {
+      model: useOpenRouter ? openRouterModel : null,
+      reason: 'router-config',
+    },
+    {
+      model: useOpenRouter
+        ? null
+        : await selectSetupCredentialModelExcludingOpenRouter(secrets),
+      reason: 'credential',
+    },
+  ];
+  if (includeAccessListFallback) {
+    candidates.push({
+      model: useOpenRouter ? null : openRouterModel,
+      reason: 'access-list-default',
+    });
+  }
+
+  const decision = decideRunModel(candidates);
+  return decision ? { model: decision.model, reason: decision.reason } : null;
+}
+
 /**
  * Desktop has no routing prompt, so OpenRouter is chosen only when the flag is
  * already on and an OpenRouter key exists.
  */
 export async function selectDesktopSetupModel(): Promise<string | null> {
-  const secrets = platform().secrets;
-  const useOpenRouter = getUseOpenRouter();
-
-  const routerModel =
-    useOpenRouter && isNonEmptyString(await lookupApiKey(secrets, 'openRouter'))
-      ? SETUP_MODEL_BY_PROVIDER.openRouter
-      : null;
-  if (useOpenRouter && !routerModel) {
-    return null;
-  }
-
-  return (
-    decideRunModel([
-      {
-        model: routerModel,
-        reason: 'router-config',
-      },
-      {
-        model: useOpenRouter
-          ? null
-          : await selectSetupCredentialModelExcludingOpenRouter(secrets),
-        reason: 'credential',
-      },
-    ])?.model ?? null
-  );
+  const resolution = await resolveSetupModel(platform().secrets, false);
+  return resolution?.model ?? null;
 }
 
 /**

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -24,6 +24,43 @@ const mocks = vi.hoisted(() => ({
   logError: vi.fn(),
 }));
 
+/**
+ * Mirrors `resolveSetupModel`'s real router-config / credential /
+ * access-list-fallback precedence using the same mocked primitives this
+ * suite already drives (`getUseOpenRouter`, `hasUsableApiKey`,
+ * `selectSetupCredentialModelExcludingOpenRouter`) — the real function lives
+ * in the mocked `@controllers/onboarding/setupLaunch` module, so this suite
+ * (which is about `launchSetupAssistant`'s routing/credential ordering, not
+ * model-precedence itself) needs a faithful stand-in to keep exercising that
+ * ordering past the model-selection step.
+ */
+const OPENROUTER_MODEL = 'openrouter/mock-model';
+
+async function resolveSetupModelMock(
+  includeAccessListFallback: boolean,
+): Promise<{ model: string; reason: string } | null> {
+  const useOpenRouter = mocks.getUseOpenRouter();
+  const openRouterModel = (await mocks.hasUsableApiKey('openRouter'))
+    ? OPENROUTER_MODEL
+    : null;
+
+  if (useOpenRouter) {
+    return openRouterModel
+      ? { model: openRouterModel, reason: 'router-config' }
+      : null;
+  }
+
+  const credentialModel =
+    await mocks.selectSetupCredentialModelExcludingOpenRouter();
+  if (credentialModel) {
+    return { model: credentialModel, reason: 'credential' };
+  }
+  if (includeAccessListFallback && openRouterModel) {
+    return { model: openRouterModel, reason: 'access-list-default' };
+  }
+  return null;
+}
+
 vi.mock('@utils/config/providerConfig', () => ({
   getUseOpenRouter: mocks.getUseOpenRouter,
 }));
@@ -43,8 +80,12 @@ vi.mock('@agent/runtime/executionRegistry', () => ({
 }));
 
 vi.mock('@controllers/onboarding/setupLaunch', () => ({
+  SETUP_INSTRUCTION:
+    'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.',
   selectSetupCredentialModelExcludingOpenRouter:
     mocks.selectSetupCredentialModelExcludingOpenRouter,
+  resolveSetupModel: (_secrets: unknown, includeAccessListFallback: boolean) =>
+    resolveSetupModelMock(includeAccessListFallback),
 }));
 
 vi.mock('@auth/codex', () => ({

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 /**
- * Mirrors `resolveSetupModel`'s real router-config / credential /
+ * Mirrors `resolveSetupLaunchModel`'s real router-config / credential /
  * access-list-fallback precedence using the same mocked primitives this
  * suite already drives (`getUseOpenRouter`, `hasUsableApiKey`,
  * `selectSetupCredentialModelExcludingOpenRouter`) — the real function lives
@@ -84,8 +84,10 @@ vi.mock('@controllers/onboarding/setupLaunch', () => ({
     'Please help me finish installing TeXRA. Probe my environment, install anything missing, and get me a working credential.',
   selectSetupCredentialModelExcludingOpenRouter:
     mocks.selectSetupCredentialModelExcludingOpenRouter,
-  resolveSetupModel: (_secrets: unknown, includeAccessListFallback: boolean) =>
-    resolveSetupModelMock(includeAccessListFallback),
+  resolveSetupLaunchModel: (
+    _secrets: unknown,
+    includeAccessListFallback: boolean,
+  ) => resolveSetupModelMock(includeAccessListFallback),
 }));
 
 vi.mock('@auth/codex', () => ({

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -194,9 +194,7 @@ describe('resolveSetupLaunchModel', () => {
       provider === 'openRouter' ? 'or-test' : undefined,
     );
 
-    await expect(
-      resolveSetupLaunchModel({} as never, true),
-    ).resolves.toEqual({
+    await expect(resolveSetupLaunchModel({} as never, true)).resolves.toEqual({
       model: SETUP_MODEL_BY_PROVIDER.openRouter,
       reason: 'access-list-default',
     });

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -55,6 +55,7 @@ vi.mock('@utils/config/providerConfig', () => ({
 const {
   selectSetupCredentialModelExcludingOpenRouter,
   selectDesktopSetupModel,
+  resolveSetupLaunchModel,
 } = await import('@controllers/onboarding/setupLaunch');
 
 describe('selectSetupCredentialModelExcludingOpenRouter', () => {
@@ -167,5 +168,47 @@ describe('selectDesktopSetupModel', () => {
     mocks.isCodexSubscriptionActive.mockResolvedValue(true);
 
     await expect(selectDesktopSetupModel()).resolves.toBe(CHATGPT_SETUP_MODEL);
+  });
+});
+
+/**
+ * `selectDesktopSetupModel` above always calls `resolveSetupLaunchModel`
+ * with `includeAccessListFallback: false`, so it never exercises the
+ * access-list-default branch the extension opts into. These cases drive
+ * `resolveSetupLaunchModel` directly (against the real `decideRunModel`,
+ * not a mock) to cover that branch and prove the two hosts' policies
+ * actually diverge where intended.
+ */
+describe('resolveSetupLaunchModel', () => {
+  beforeEach(() => {
+    mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeys.mockReset().mockResolvedValue(false);
+    mocks.canUseServerSideKeysForModel.mockReset().mockResolvedValue(false);
+    mocks.canUseModelSync.mockReset().mockReturnValue(false);
+    mocks.lookupApiKey.mockReset().mockResolvedValue(undefined);
+    mocks.getUseOpenRouter.mockReset().mockReturnValue(false);
+  });
+
+  it('falls back to the OpenRouter access-list model when no credential is available and the caller opts in', async () => {
+    mocks.lookupApiKey.mockImplementation(async (_secrets, provider) =>
+      provider === 'openRouter' ? 'or-test' : undefined,
+    );
+
+    await expect(
+      resolveSetupLaunchModel({} as never, true),
+    ).resolves.toEqual({
+      model: SETUP_MODEL_BY_PROVIDER.openRouter,
+      reason: 'access-list-default',
+    });
+  });
+
+  it('returns null instead of the access-list fallback when the caller opts out', async () => {
+    mocks.lookupApiKey.mockImplementation(async (_secrets, provider) =>
+      provider === 'openRouter' ? 'or-test' : undefined,
+    );
+
+    await expect(resolveSetupLaunchModel({} as never, false)).resolves.toBe(
+      null,
+    );
   });
 });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -356,30 +356,6 @@ describe('desktop IPC adapters', () => {
     });
   });
 
-  it('parses tab-separated git log output into renderer-shaped labels', async () => {
-    // The git host parser shapes lines into `<hash>: <subject>
-    // (<relative>)` so the renderer can keep its existing string[] schema.
-    const { parseCommitLog } = (await import(
-      moduleFileUrl(desktopSourcePath('main', 'desktopGitHost.ts'))
-    )) as { parseCommitLog: (stdout: string) => string[] };
-
-    const stdout = [
-      'abc1234\tAdd feature\t2 days ago',
-      'def5678\tFix: handle edge case\t3 days ago',
-      // Blank lines are silently skipped.
-      '',
-      // Lines missing a relative date are skipped (defensive — should not
-      // happen with our format but proves the parser doesn't crash).
-      'badrow',
-    ].join('\n');
-
-    expect(parseCommitLog(stdout)).toEqual([
-      'abc1234: Add feature (2 days ago)',
-      'def5678: Fix: handle edge case (3 days ago)',
-    ]);
-    expect(parseCommitLog('')).toEqual([]);
-  });
-
   it('wires the main login banner to desktop sign-in', async () => {
     const { createDesktopShellIpc } = await loadDesktopShellIpc();
     const postToRenderer = vi.fn();

--- a/src/test-kernel/utils/git/CommitLogFormat.vitest.ts
+++ b/src/test-kernel/utils/git/CommitLogFormat.vitest.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitCommitLines } from '@utils/git/commitLogFormat';
+
+describe('splitCommitLines', () => {
+  it('splits multiple commit labels on their own lines', () => {
+    const stdout = [
+      'abc1234: Add feature (2 days ago)',
+      'def5678: Fix: handle edge case (3 days ago)',
+    ].join('\n');
+
+    expect(splitCommitLines(stdout)).toEqual([
+      'abc1234: Add feature (2 days ago)',
+      'def5678: Fix: handle edge case (3 days ago)',
+    ]);
+  });
+
+  it('drops a trailing blank line instead of returning an empty commit label', () => {
+    const stdout = 'abc1234: Add feature (2 days ago)\n';
+
+    expect(splitCommitLines(stdout)).toEqual([
+      'abc1234: Add feature (2 days ago)',
+    ]);
+  });
+
+  it('returns an empty array for a zero-commit repo (empty stdout)', () => {
+    expect(splitCommitLines('')).toEqual([]);
+  });
+
+  it('drops interior blank lines', () => {
+    const stdout = ['abc1234: Add feature (2 days ago)', '', 'badrow'].join(
+      '\n',
+    );
+
+    expect(splitCommitLines(stdout)).toEqual([
+      'abc1234: Add feature (2 days ago)',
+      'badrow',
+    ]);
+  });
+});

--- a/src/utils/git/commitLogFormat.ts
+++ b/src/utils/git/commitLogFormat.ts
@@ -5,3 +5,15 @@
  * process produce byte-identical labels from one definition.
  */
 export const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
+
+/**
+ * Split `git log --pretty=format:<COMMIT_LABEL_FORMAT>` stdout into per-commit
+ * label lines. Filters blank lines so a zero-commit repo (empty stdout) or a
+ * trailing newline can't surface as an empty option in the commit dropdown.
+ */
+export function splitCommitLines(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/src/utils/git/commitLogFormat.ts
+++ b/src/utils/git/commitLogFormat.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared `git log --pretty=format` string for the "recent commits" label
+ * every host renders the same way: `<shortHash>: <subject> (<relativeDate>)`.
+ * Host-neutral so the VS Code extension and the Electron desktop main
+ * process produce byte-identical labels from one definition.
+ */
+export const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';


### PR DESCRIPTION
## Summary

This PR consolidates setup model selection logic and git commit label formatting into shared, host-neutral modules to prevent drift between the VS Code extension and Electron desktop implementations.

**Setup model resolution:** Extracted `resolveSetupModel()` as a new public function in `setupLaunch.ts` that encapsulates the router-config → credential → access-list-fallback precedence. Both extension and desktop now call this single function instead of duplicating the decision logic. The extension additionally passes `includeAccessListFallback: true` to offer OpenRouter as a last resort (after prompting the user), while desktop passes `false` to avoid silent flag flips.

**Git commit formatting:** Created `src/utils/git/commitLogFormat.ts` with a shared `COMMIT_LABEL_FORMAT` constant (`'%h: %s (%cr)'`) that both hosts use when invoking `git log`. Removed the desktop's custom `parseCommitLog()` parser and tab-separated format—the extension already renders labels directly from git output, so both hosts now produce identical output from one definition.

**Instruction constant:** Moved `SETUP_INSTRUCTION` to `setupLaunch.ts` so it's defined once and imported by both hosts.

## Issue acceptance gates

N/A (refactoring for consistency and maintainability)

## Single source of truth

- **Setup model resolution:** `resolveSetupModel()` in `src/controllers/onboarding/setupLaunch.ts` owns the router-config / credential / access-list-fallback precedence decision.
- **Git commit labels:** `COMMIT_LABEL_FORMAT` in `src/utils/git/commitLogFormat.ts` owns the format string both hosts use.
- **Setup instruction:** `SETUP_INSTRUCTION` in `src/controllers/onboarding/setupLaunch.ts` is the canonical prompt text.

## Duplication and abstraction budget

**Removed duplication:**
- Eliminated duplicate setup model selection logic in `setupAssistantCommand.ts` (extension) and `selectDesktopSetupModel()` (desktop).
- Removed the desktop's custom `parseCommitLog()` parser and tab-separated git format; both hosts now use the same `COMMIT_LABEL_FORMAT` and the extension's simpler line-splitting approach.
- Consolidated `SETUP_INSTRUCTION` from two definitions into one.

**New abstraction:**
- `resolveSetupModel(secrets, includeAccessListFallback)` abstracts the model precedence decision, parameterized by whether the caller (extension vs. desktop) wants the access-list fallback. This owns the invariant that router-config takes precedence when enabled, credential is the primary fallback, and access-list is only considered as a last resort when explicitly requested.

## Host impact

**Extension:**
- Now imports `resolveSetupModel` and `SETUP_INSTRUCTION` from `setupLaunch.ts` instead of duplicating logic.
- Passes `includeAccessListFallback: true` to offer OpenRouter as a fallback after user confirmation.
- Simplified `selectLaunchModel()` to call the shared function and map the result.

**Desktop:**
- Calls the shared `resolveSetupModel(platform().secrets, false)` instead of custom logic.
- Removed `parseCommitLog()` and now uses `COMMIT_LABEL_FORMAT` directly with `git log`.
- Git output is split and trimmed directly (no custom parsing) since the format is now human-readable.

**CLI:**
- No changes in this diff.

## Scheduled refactoring

None.

## Validation

- Existing unit tests in `SetupAssistantRouting.vitest.ts` updated to mock `resolveSetupModel` and verify routing/credential ordering still works.
- Removed test for `parseCommitLog()` in `DesktopIpcAdapters.vitest.mts` (function no longer exists).
- Added JSDoc comments to clarify the new `resolveSetupModel()` contract and its `includeAccessListFallback` parameter.
- No new test files added; existing test coverage for setup model selection and git operations remains intact.

https://claude.ai/code/session_014QBonbub52TSj6aSKPaET9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with bounded behavior changes: desktop commit labels match the extension format, and git repo probing uses the shared 5s timeout instead of 10s.
> 
> **Overview**
> Centralizes **setup assistant** model picking and **recent commits** formatting so the VS Code extension and Electron desktop stay aligned.
> 
> **Setup launch:** Adds `resolveSetupLaunchModel` in `setupLaunch.ts` (router → credential → optional OpenRouter access-list fallback) and moves `SETUP_INSTRUCTION` there. The extension calls it with `includeAccessListFallback: true`; desktop uses `false` so it won’t silently flip routing. `setupAssistantCommand` drops its duplicated `decideRunModel` wiring.
> 
> **Git commits:** New `@utils/git/commitLogFormat` exports `COMMIT_LABEL_FORMAT` (`%h: %s (%cr)`) and `splitCommitLines`. Extension and desktop both use them; desktop removes the tab-separated `parseCommitLog` path and uses shared `isGitRepository` (5s probe timeout vs the previous inlined 10s).
> 
> Tests cover `resolveSetupLaunchModel` fallback policy and `splitCommitLines`; routing tests mock the shared resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ee5e7f5fe5551bb1122c15c0d4bcf8a7abad40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->