### PR TITLE
Refactor scroll jump inputs and improve API status loading UX

### DIFF
--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from 'ink';
+import { Spinner } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
 import { type CliApiMode } from '@cli/runtime/apiAccessMode';
@@ -16,12 +17,13 @@ export interface ApiModeFormProps {
 }
 
 export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
-  const [statusLines, setStatusLines] = useState<readonly string[]>([
-    'loading API status...',
-  ]);
+  const [statusLines, setStatusLines] = useState<readonly string[] | null>(
+    null,
+  );
 
   useEffect(() => {
     let cancelled = false;
+    setStatusLines(null);
     void loadCliApiStatusLines({ apiMode: props.currentMode })
       .then((lines) => {
         if (!cancelled) setStatusLines(lines);
@@ -69,11 +71,15 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
         Choose which credentials model calls should use. Press 1 for API keys.
       </Text>
       <Box marginTop={1} flexDirection="column">
-        {statusLines.map((line, index) => (
-          <Text key={`${index}:${line}`} dimColor>
-            {line}
-          </Text>
-        ))}
+        {statusLines === null ? (
+          <Spinner label="loading API status..." />
+        ) : (
+          statusLines.map((line, index) => (
+            <Text key={`${index}:${line}`} dimColor>
+              {line}
+            </Text>
+          ))
+        )}
       </Box>
       <Box marginTop={1} flexDirection="column">
         <Select

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -47,6 +47,16 @@ export function isEscapeInput(
   return key.escape === true || input === '\u001B';
 }
 
+// Vim-style "jump to top/bottom" bindings, shared by every scrollable modal
+// (child-control picker task detail, transcript viewer).
+export function isJumpToTopInput(input: string): boolean {
+  return input === 'g';
+}
+
+export function isJumpToBottomInput(input: string): boolean {
+  return input === 'G';
+}
+
 export function isUnhandledControlInput(input: string): boolean {
   if (input.length !== 1) return false;
   const code = input.charCodeAt(0);

--- a/packages/cli/src/chat/tui/input/inputKeys.ts
+++ b/packages/cli/src/chat/tui/input/inputKeys.ts
@@ -47,8 +47,9 @@ export function isEscapeInput(
   return key.escape === true || input === '\u001B';
 }
 
-// Vim-style "jump to top/bottom" bindings, shared by every scrollable modal
-// (child-control picker task detail, transcript viewer).
+// Vim-style "jump to top/bottom" bindings, shared by the scrollable modals
+// that implement them (child-control picker task detail, transcript viewer —
+// not every scrollable modal wires these up, e.g. ExternalInquiry doesn't).
 export function isJumpToTopInput(input: string): boolean {
   return input === 'g';
 }

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -11,6 +11,7 @@ import type { StreamTabId } from '@shared/schemas';
 // Local imports - CLI state and UI
 import { clamp, clampIndex } from '@utils/core';
 
+import { isJumpToBottomInput, isJumpToTopInput } from '../input/inputKeys';
 import {
   CHILD_CONTROL_MODE_COPY,
   buildChildControlItems,
@@ -638,7 +639,7 @@ function TaskDetailView({
         ),
       );
     }
-    if (input === 'g') {
+    if (isJumpToTopInput(input)) {
       setScrollState((current) =>
         jumpTaskDetailScrollState(
           current,
@@ -649,7 +650,7 @@ function TaskDetailView({
         ),
       );
     }
-    if (input === 'G') {
+    if (isJumpToBottomInput(input)) {
       setScrollState((current) =>
         jumpTaskDetailScrollState(
           current,

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -9,7 +9,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Text, useInput } from 'ink';
 
-import { isEscapeInput } from '../input/inputKeys';
+import {
+  isEscapeInput,
+  isJumpToBottomInput,
+  isJumpToTopInput,
+} from '../input/inputKeys';
 import { KeyHints } from '../ui/KeyHints';
 import {
   initialTranscriptScrollState,
@@ -81,8 +85,8 @@ export function TranscriptViewer({
     else if (key.upArrow) scrollTo((current) => current - 1);
     else if (key.pageDown) scrollTo((current) => current + viewRows);
     else if (key.pageUp) scrollTo((current) => current - viewRows);
-    else if (input === 'g') scrollTo(0);
-    else if (input === 'G')
+    else if (isJumpToTopInput(input)) scrollTo(0);
+    else if (isJumpToBottomInput(input))
       scrollTo(
         maxTranscriptScrollOffset({ lineCount: lines.length, viewRows }),
       );

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -136,7 +136,12 @@ export class LatexdiffResults extends LitElement {
           aria-hidden="true"
         ></wa-icon>
         ${this.renderFileLink(baseFile, baseLabel)}
-        <span class="arrow">→</span>
+        <wa-icon
+          class="arrow"
+          library=${TEXRA_ICON_LIBRARY}
+          name="arrow-right"
+          aria-hidden="true"
+        ></wa-icon>
         ${this.renderFileLink(revisedFile, revisedLabel)}
         (${this.renderFileLink(diffFile, 'diff')})
       </li>

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
 import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons/faArrowRotateLeft';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons/faArrowsRotate';
 import { faArrowUp } from '@fortawesome/free-solid-svg-icons/faArrowUp';
@@ -143,6 +144,7 @@ function iconSvg(iconDefinition: FontAwesomeIconDefinition): string {
 const icons = {
   'arrow-down': faArrowDown,
   'arrow-left': faArrowLeft,
+  'arrow-right': faArrowRight,
   'arrow-rotate-left': faArrowRotateLeft,
   'arrow-up': faArrowUp,
   'arrow-up-right-from-square': faArrowUpRightFromSquare,


### PR DESCRIPTION
## Summary

This PR improves the CLI TUI and extension UI by:

1. **Extracting vim-style scroll bindings** (`g` for top, `G` for bottom) into reusable input helper functions in `inputKeys.ts`, eliminating duplication across `TranscriptViewer` and `ChildControlPicker`.
2. **Improving API status loading UX** in `ApiModeForm` by replacing a static "loading..." message with a proper `Spinner` component that displays only while loading.
3. **Replacing a text arrow** with an icon in `LatexdiffResults` for better visual consistency and accessibility.

## Issue acceptance gates

N/A — this is a refactoring and UX improvement with no associated issue.

## Single source of truth

Input key handling is now centralized in `packages/cli/src/chat/tui/input/inputKeys.ts`, which owns the vim-style navigation bindings used across scrollable modals.

## Duplication and abstraction budget

**Removed duplication:**
- Extracted `isJumpToTopInput()` and `isJumpToBottomInput()` helper functions to eliminate hardcoded `input === 'g'` and `input === 'G'` checks in `TranscriptViewer.tsx` and `ChildControlPicker.tsx`.

**New abstraction:**
- Added two input validation functions in `inputKeys.ts` that own the vim-style navigation contract, making it easier to adjust these bindings globally in the future.

## Host impact

**Extension:**
- `LatexdiffResults.ts`: Replaced plain text arrow (`→`) with `wa-icon` component using the new `arrow-right` icon from FontAwesome.
- Added `faArrowRight` import to `webAwesomeIcons.ts` and registered the `arrow-right` icon.

**Desktop:**
- No changes.

**CLI:**
- `ApiModeForm.tsx`: Replaced static "loading API status..." text with a `Spinner` component that only displays while `statusLines` is `null`.
- `TranscriptViewer.tsx` and `ChildControlPicker.tsx`: Refactored to use new `isJumpToTopInput()` and `isJumpToBottomInput()` helpers.
- `inputKeys.ts`: Added two new exported input validation functions.

## Scheduled refactoring

None.

## Validation

- Existing tests pass (no new test files added; changes are straightforward refactors and UX improvements).
- Input key extraction is a pure refactor with no behavioral change.
- Spinner component is from `@inkjs/ui`, a standard dependency already in use.
- Icon addition follows existing patterns in `webAwesomeIcons.ts`.

https://claude.ai/code/session_01GjxyPbqQTxi93gdf6sP8uR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactors and cosmetic UX with no auth, data, or API contract changes; scroll bindings and status loading behavior stay the same aside from the loading indicator.
> 
> **Overview**
> **CLI TUI:** Vim-style **g** / **G** jump-to-top/bottom handling moves into shared `isJumpToTopInput` / `isJumpToBottomInput` helpers in `inputKeys.ts`, and `TranscriptViewer` plus `ChildControlPicker` task detail use those instead of inline key checks (behavior unchanged).
> 
> The **`/api` mode form** treats API status as `null` while loading, resets that state when the mode changes, and shows an `@inkjs/ui` **Spinner** instead of a static “loading…” text line until `loadCliApiStatusLines` resolves.
> 
> **Extension:** Latexdiff result rows replace the plain **→** separator with a TeXRA **`wa-icon`** (`arrow-right`), backed by registering **`faArrowRight`** in `webAwesomeIcons.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b18d64394692622a1937fa14ec77a8fe8f58572a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->