### PR TITLE
refactor(cli): isolate session progress compatibility adapter

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -14,7 +14,6 @@ import {
 } from '@agent/core/state/executionRequests';
 import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
@@ -24,6 +23,7 @@ import {
   createHeadlessCliHostInteractions,
   installCliApprovalHandlers,
 } from './approvalAdapter';
+import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
 import { CliExitCode } from './exitCodes';
 import { writeTextStderr } from './logSinks';
@@ -183,7 +183,7 @@ export async function executeCliRequest(
     defaultSession(),
     interactionHost,
   );
-  const detachSessionProgressProjection = attachSessionProgressEventProjection(
+  const detachSessionProgressProjection = attachCliSessionProgressProjection(
     defaultSession().events,
     interactionHost,
   );

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -6,7 +6,7 @@ import {
 } from '@agent/runtime/sessionProgressEventProjection';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 
-function emitProjectedProgressEventForTest(
+function emitProjectedProgressEvent(
   runtimeHost: AgentRuntimeHost,
   projected: ProjectedProgressEvent,
 ): void {
@@ -22,7 +22,12 @@ function emitProjectedProgressEventForTest(
   runtimeHost.emit(projected.event, projected.payload);
 }
 
-export function attachSessionProgressEventProjectionForTest(
+/**
+ * Headless CLI compatibility adapter. Public CLI output still speaks the
+ * frozen host progress-event vocabulary, so this boundary alone re-emits
+ * session facts through `runtimeHost.emit`.
+ */
+export function attachCliSessionProgressProjection(
   events: SessionEventHub,
   runtimeHost: AgentRuntimeHost,
 ): () => void {
@@ -30,15 +35,13 @@ export function attachSessionProgressEventProjectionForTest(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
       const projected = projectSessionFactToProgressEvent(sessionEvent.event);
-      if (projected) {
-        emitProjectedProgressEventForTest(runtimeHost, projected);
-      }
+      if (projected) emitProjectedProgressEvent(runtimeHost, projected);
     },
     { scope: 'session' },
   );
   const detachRunFacts = subscribeRunFactsAsProgressEvents(
     events,
-    (projected) => emitProjectedProgressEventForTest(runtimeHost, projected),
+    (projected) => emitProjectedProgressEvent(runtimeHost, projected),
   );
 
   return () => {

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -1,5 +1,4 @@
 import type { AgentEvent } from '@agent/trace';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type {
   ProgressEvent,
@@ -26,48 +25,36 @@ export type ProjectedProgressEvent = {
   };
 }[ProgressEvent];
 
-function emitProjectedProgressEvent(
-  runtimeHost: AgentRuntimeHost,
-  projected: ProjectedProgressEvent,
-): void {
-  if (
-    projected.event === 'removeStream' &&
-    runtimeHost.interactions?.handleProgressEvent(
-      projected.event,
-      projected.payload,
-    )
-  ) {
-    return;
-  }
-  runtimeHost.emit(projected.event, projected.payload);
-}
-
 /**
- * Subscribe a host-owned progress surface to the session fact plane and
- * re-emit the retained progress events that have not yet moved to a native
- * host/session projection.
+ * Project session facts onto the frozen host-progress vocabulary when a
+ * compatibility surface still needs that view. `followUpSent` is intentionally
+ * session-local and has no host-progress projection.
  */
-export function attachSessionProgressEventProjection(
-  events: SessionEventHub,
-  runtimeHost: AgentRuntimeHost,
-): () => void {
-  const detachSessionFacts = events.subscribe(
-    (sessionEvent) => {
-      if (sessionEvent.scope !== 'session') return;
-      const projected = projectSessionFactToProgressEvent(sessionEvent.event);
-      if (projected) emitProjectedProgressEvent(runtimeHost, projected);
-    },
-    { scope: 'session' },
-  );
-  const detachRunFacts = subscribeRunFactsAsProgressEvents(
-    events,
-    (projected) => emitProjectedProgressEvent(runtimeHost, projected),
-  );
-
-  return () => {
-    detachRunFacts();
-    detachSessionFacts();
-  };
+export function projectSessionFactToProgressEvent(
+  fact: SessionFact,
+): ProjectedProgressEvent | undefined {
+  switch (fact.type) {
+    case 'goalStateChanged':
+      return { event: 'goalStateChanged', payload: fact.payload };
+    case 'inquiryThreadUpdated':
+      return { event: 'inquiryThreadUpdated', payload: fact.payload };
+    case 'clearMissingOutputs':
+      return { event: 'clearMissingOutputs', payload: fact.payload };
+    case 'updateQueuedFollowUps':
+      return { event: 'updateQueuedFollowUps', payload: fact.payload };
+    case 'followUpSent':
+      return undefined;
+    case 'setActiveStream':
+      return { event: 'setActiveStream', payload: fact.payload };
+    case 'updateStreamDescription':
+      return { event: 'updateStreamDescription', payload: fact.payload };
+    case 'updateStreamStatus':
+      return { event: 'updateStreamStatus', payload: fact.payload };
+    case 'setParentStream':
+      return { event: 'setParentStream', payload: fact.payload };
+    case 'removeStream':
+      return { event: 'removeStream', payload: fact.payload };
+  }
 }
 
 function asString(value: unknown): string | undefined {
@@ -98,33 +85,6 @@ export function toUpdateStreamUsagePayload(
     ...(executionId ? { executionId } : {}),
     usage: usage.data,
   };
-}
-
-function projectSessionFactToProgressEvent(
-  fact: SessionFact,
-): ProjectedProgressEvent | undefined {
-  switch (fact.type) {
-    case 'goalStateChanged':
-      return { event: 'goalStateChanged', payload: fact.payload };
-    case 'inquiryThreadUpdated':
-      return { event: 'inquiryThreadUpdated', payload: fact.payload };
-    case 'clearMissingOutputs':
-      return { event: 'clearMissingOutputs', payload: fact.payload };
-    case 'updateQueuedFollowUps':
-      return { event: 'updateQueuedFollowUps', payload: fact.payload };
-    case 'followUpSent':
-      return undefined;
-    case 'setActiveStream':
-      return { event: 'setActiveStream', payload: fact.payload };
-    case 'updateStreamDescription':
-      return { event: 'updateStreamDescription', payload: fact.payload };
-    case 'updateStreamStatus':
-      return { event: 'updateStreamStatus', payload: fact.payload };
-    case 'setParentStream':
-      return { event: 'setParentStream', payload: fact.payload };
-    case 'removeStream':
-      return { event: 'removeStream', payload: fact.payload };
-  }
 }
 
 export function projectRunFactToProgressEvent(
@@ -261,7 +221,7 @@ const RUN_FACT_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
  * Kept for compatibility consumers that still need the legacy progress-event
  * surface, such as headless CLI output.
  */
-function subscribeRunFactsAsProgressEvents(
+export function subscribeRunFactsAsProgressEvents(
   events: SessionEventHub,
   onProjected: (projected: ProjectedProgressEvent) => void,
 ): () => void {

--- a/src/test-kernel/agent/runtime/ConversationProgressProjection.vitest.ts
+++ b/src/test-kernel/agent/runtime/ConversationProgressProjection.vitest.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { logConversationProgress, TraceEmitter } from '@agent/trace';
 import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
-import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
+import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
 
 function setupHub(streamId: StreamTabId) {
   const trace = new TraceEmitter();
@@ -15,7 +15,7 @@ function setupHub(streamId: StreamTabId) {
   const detachTrace = trace.subscribe((event) =>
     hub.emit({ scope: 'run', streamId, event }),
   );
-  const detach = attachSessionProgressEventProjection(hub, host);
+  const detach = attachSessionProgressEventProjectionForTest(hub, host);
   return {
     trace,
     events,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -12,7 +12,6 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { InterruptRegistry } from '@agent/runtime/InterruptRegistry';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
-import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
 import {
   SessionEventHub,
   type SessionEvent,
@@ -27,6 +26,7 @@ import {
 } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
+import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
 
 describe('executionRegistry', () => {
   it('owns process-output poller teardown', () => {
@@ -328,7 +328,7 @@ describe('executionRegistry', () => {
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
-    attachSessionProgressEventProjection(events, explicit.host);
+    attachSessionProgressEventProjectionForTest(events, explicit.host);
     const registry = new ExecutionRegistry({
       interrupts,
       streamStatus,
@@ -448,7 +448,7 @@ describe('executionRegistry', () => {
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
-    const detachProjection = attachSessionProgressEventProjection(
+    const detachProjection = attachSessionProgressEventProjectionForTest(
       events,
       explicit.host,
     );
@@ -522,7 +522,7 @@ describe('executionRegistry', () => {
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
-    const detachProjection = attachSessionProgressEventProjection(
+    const detachProjection = attachSessionProgressEventProjectionForTest(
       events,
       explicit.host,
     );
@@ -623,7 +623,7 @@ describe('executionRegistry', () => {
     const interrupts = new InterruptRegistry();
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
-    attachSessionProgressEventProjection(events, explicit.host);
+    attachSessionProgressEventProjectionForTest(events, explicit.host);
     const registry = new ExecutionRegistry({
       interrupts,
       streamStatus,
@@ -659,7 +659,7 @@ describe('executionRegistry', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
-    attachSessionProgressEventProjection(events, explicit.host);
+    attachSessionProgressEventProjectionForTest(events, explicit.host);
     const registry = new ExecutionRegistry({ streamStatus, events });
     const streamId = 'ownerless-stop-policy-test' as StreamTabId;
 
@@ -845,7 +845,7 @@ describe('executionRegistry', () => {
   it('projects handle updates from session events', () => {
     const explicit = createRecordingHost();
     const events = new SessionEventHub();
-    const detachProjection = attachSessionProgressEventProjection(
+    const detachProjection = attachSessionProgressEventProjectionForTest(
       events,
       explicit.host,
     );
@@ -1157,7 +1157,7 @@ describe('executionRegistry', () => {
   it('projects detach updates from session events', () => {
     const explicit = createRecordingHost();
     const events = new SessionEventHub();
-    const detachProjection = attachSessionProgressEventProjection(
+    const detachProjection = attachSessionProgressEventProjectionForTest(
       events,
       explicit.host,
     );

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { TraceEmitter, type StatusEvent } from '@agent/trace';
-import { attachSessionProgressEventProjection } from '@agent/runtime/sessionProgressEventProjection';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   StreamStatusMachine,
@@ -24,6 +23,7 @@ import {
 } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
+import { attachSessionProgressEventProjectionForTest } from '../sessionProgressTestUtils';
 
 /** Fresh registry + recording host, keyed to a per-test stream id. */
 function setupMachine(streamId: string): {
@@ -34,7 +34,7 @@ function setupMachine(streamId: string): {
 } {
   const events = new SessionEventHub();
   const explicit = createRecordingHost();
-  attachSessionProgressEventProjection(events, explicit.host);
+  attachSessionProgressEventProjectionForTest(events, explicit.host);
   return {
     machine: new StreamStatusMachine(),
     explicit,
@@ -65,7 +65,7 @@ describe('StreamStatusMachine', () => {
     const second = new StreamStatusMachine();
     const events = new SessionEventHub();
     const explicit = createRecordingHost();
-    attachSessionProgressEventProjection(events, explicit.host);
+    attachSessionProgressEventProjectionForTest(events, explicit.host);
     const streamId = 'stream-status-listener-test' as StreamTabId;
     const changes: string[] = [];
 
@@ -378,7 +378,7 @@ describe('StreamStatusMachine', () => {
     const machine = new StreamStatusMachine();
     const events = new SessionEventHub();
     const explicit = createRecordingHost();
-    attachSessionProgressEventProjection(events, explicit.host);
+    attachSessionProgressEventProjectionForTest(events, explicit.host);
     const trace = new TraceEmitter();
     const streamId = 'stream-status-projection-test' as StreamTabId;
     const statusEvents: StatusEvent[] = [];

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { HostInteractions } from '@agent/runtime/HostInteractions';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { attachCliSessionProgressProjection } from '@cli/runtime/sessionProgressSubscription';
+import type { StreamTabId } from '@shared/schemas';
+
+const streamId = 'stream:cli-session-projection' as StreamTabId;
+
+function hostWithInteractions(
+  interactions?: Partial<HostInteractions>,
+): AgentRuntimeHost {
+  return {
+    emit: vi.fn(),
+    interactions: {
+      handleProgressEvent: () => false,
+      resolve: () => false,
+      cancel: () => {},
+      ...interactions,
+    },
+  };
+}
+
+describe('attachCliSessionProgressProjection', () => {
+  it('re-emits retained session facts through the headless CLI host rail', () => {
+    const events = new SessionEventHub();
+    const host = hostWithInteractions();
+    const detach = attachCliSessionProgressProjection(events, host);
+
+    try {
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: { streamId },
+        },
+      });
+
+      expect(host.emit).toHaveBeenCalledWith('setActiveStream', { streamId });
+
+      detach();
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: { streamId: 'stream:after-detach' as StreamTabId },
+        },
+      });
+
+      expect(host.emit).toHaveBeenCalledTimes(1);
+    } finally {
+      detach();
+    }
+  });
+
+  it('keeps followUpSent session-local', () => {
+    const events = new SessionEventHub();
+    const host = hostWithInteractions();
+    const detach = attachCliSessionProgressProjection(events, host);
+
+    try {
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'followUpSent',
+          payload: { streamId },
+        },
+      });
+
+      expect(host.emit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+    }
+  });
+
+  it('offers removeStream to host interactions before legacy emission', () => {
+    const events = new SessionEventHub();
+    const handleProgressEvent = vi.fn(() => true);
+    const host = hostWithInteractions({ handleProgressEvent });
+    const detach = attachCliSessionProgressProjection(events, host);
+
+    try {
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'removeStream',
+          payload: { streamId },
+        },
+      });
+
+      expect(handleProgressEvent).toHaveBeenCalledWith('removeStream', {
+        streamId,
+      });
+      expect(host.emit).not.toHaveBeenCalled();
+    } finally {
+      detach();
+    }
+  });
+});


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary

This Stage 5 slice moves the remaining session-fact-to-host-progress subscription out of shared runtime code and into the headless CLI compatibility boundary. The shared `sessionProgressEventProjection` module now exposes only projection algebra and run-fact subscription helpers; it no longer imports `AgentRuntimeHost`, calls `runtimeHost.emit`, or owns the `removeStream` host-interaction short circuit.

Headless CLI output still receives the same retained host progress-event vocabulary through `packages/cli/src/runtime/sessionProgressSubscription.ts`. The adapter preserves the existing `removeStream` behavior: host interactions get the first chance to handle the tab-removal request before the event falls back to `runtimeHost.emit`.

Test code that still needs a legacy host projection now assembles it through `src/test-kernel/agent/sessionProgressTestUtils.ts`, so production runtime has no exported attach-to-host helper.

## Single source of truth

The canonical facts remain `SessionFact` and run-scoped `AgentEvent`. This PR does not add a second fact vocabulary and does not change any retained host event names or payloads. It only moves the compatibility re-emission owner to the CLI boundary that still needs public-output compatibility.

Grep evidence after the rebase onto `dde047956`:

```text
rg "attachSessionProgressEventProjection" src packages --glob "*.ts" --glob "*.mts" --glob "!src/test-kernel/**"
# no production matches

rg "AgentRuntimeHost|runtimeHost\.emit|handleProgressEvent" src/agent/runtime/sessionProgressEventProjection.ts
# no matches
```

No #6981 row is needed: this removes a compatibility owner from shared runtime and does not introduce a new shim, dual-write, or age-based exception.

## Validation

Rebased on current `origin/main` (`dde047956`) and then ran:

- `corepack pnpm exec vitest run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts src/test-kernel/agent/runtime/ConversationProgressProjection.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/StreamStatusService.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (passes with existing import-order warnings only)
- `corepack pnpm run check:dead-code-ratchet`
- touched-file `prettier --check`
- `git diff --check`

Before the final disjoint rebase, the same branch also passed full `CI=true corepack pnpm test` with 601 files passed, 1 skipped; 5218 tests passed, 4 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior-preserving boundary move; host event names/payloads and CLI output contract are explicitly unchanged, covered by targeted vitest.
> 
> **Overview**
> **Session progress re-emission** no longer lives in `sessionProgressEventProjection.ts`. That module now only exposes projection helpers (`projectSessionFactToProgressEvent`, `projectRunFactToProgressEvent`, `subscribeRunFactsAsProgressEvents`) and does not import `AgentRuntimeHost` or call `runtimeHost.emit`.
> 
> Headless CLI runs wire progress through new **`attachCliSessionProgressProjection`** in `packages/cli/src/runtime/sessionProgressSubscription.ts`, used from `executeCliRequest` instead of the old shared attach helper. Behavior is preserved: session and run facts still map to the same frozen host progress events, `followUpSent` stays unprojected, and **`removeStream`** still goes to `host.interactions.handleProgressEvent` before falling back to `emit`.
> 
> Tests that need a recording host use **`attachSessionProgressEventProjectionForTest`** in test-kernel; production code has no exported attach-to-host API. **`CliSessionProgressSubscription.vitest.mts`** covers detach, `followUpSent`, and `removeStream` routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91690d8970c08f11bfcdd6cae03bee4d4a780b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->