### PR TITLE
chore: simplify follow-up for the transcript-log and VSIX-exclusion fixes

### DIFF
--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -88,3 +88,12 @@ export function withoutCatalogDerivedContributes(packageJson) {
   for (const key of CATALOG_DERIVED_CONTRIBUTES) delete trimmedContributes[key];
   return { ...packageJson, contributes: trimmedContributes };
 }
+
+// packages/extension/resources/traceViewer is the multi-file, external-assets
+// trace-viewer build (shared-assets/site-hosting export mode) — CLI-only
+// (packages/cli/src/runtime/history.ts), never referenced by the extension
+// host, so packages/extension/.vscodeignore deliberately excludes it from the
+// packaged VSIX. One source of truth for the directory name so
+// verify-extension-package-invariants.mjs's required .vscodeignore line and
+// verify-vsix-contents.mjs's resource-hash exclusion can't drift apart.
+export const EXCLUDED_TRACE_VIEWER_DIR = 'traceViewer';

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
   withoutCatalogDerivedContributes,
@@ -61,22 +62,23 @@ const REQUIRED_PACKAGED_PATHS = [
 // VSIX includes them.
 const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 
+// See packages/extension/.vscodeignore for why resources/traceViewer is
+// excluded (and why there is deliberately no blanket `!resources/**` line).
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
-  // No blanket `!resources/**` line: it was dead weight (no earlier rule in
-  // .vscodeignore broadly excludes resources/ content — the only earlier
-  // match is the specific `resources/.DS_Store` line — so every
-  // resources/* entry is already included by default) and, if present,
-  // would silently
-  // override the plain resources/traceViewer/** exclusion below — vsce
-  // applies every `!`-negated line after all plain ignore lines regardless
-  // of position, so a later plain ignore line can never win against it.
-  'resources/traceViewer/**',
+  `resources/${EXCLUDED_TRACE_VIEWER_DIR}/**`,
   '!src/common/styles/*.css',
   '!src/progressView/*.html',
   '!src/settingsView/*.html',
   '!src/webview/*.html',
 ];
+
+// A blanket `!resources/**` (or an equivalent whitespace variant) would
+// silently re-include resources/traceViewer no matter where the required
+// line above sits in .vscodeignore, since vsce applies every `!`-negated
+// line after all plain ignore lines regardless of file position. Guard
+// against a future PR reintroducing it for an unrelated reason.
+const FORBIDDEN_VSCODEIGNORE_PATTERNS = [/^!\s*resources\/\*\*$/];
 
 function findExtensionPackagePath() {
   const splitPackagePath = path.join(
@@ -223,6 +225,15 @@ function verifyVscodeIgnore(snapshot, failures) {
     assert(
       lines.includes(line),
       `.vscodeignore must include ${line} so extension resources stay packaged after the workspace split.`,
+      failures,
+    );
+  }
+
+  for (const pattern of FORBIDDEN_VSCODEIGNORE_PATTERNS) {
+    const offendingLine = lines.find((line) => pattern.test(line));
+    assert(
+      !offendingLine,
+      `.vscodeignore must not include "${offendingLine}": a blanket resources/** unignore silently re-packages resources/${EXCLUDED_TRACE_VIEWER_DIR} regardless of where the exclusion line for it sits in the file.`,
       failures,
     );
   }

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   CATALOG_DERIVED_CONTRIBUTES,
+  EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
   withoutCatalogDerivedContributes,
@@ -129,16 +130,9 @@ function verifyRequiredPaths(entries, snapshot, failures) {
   }
 }
 
-// resources/traceViewer is the multi-file, external-assets trace-viewer
-// build (shared-assets/site-hosting export mode) — CLI-only
-// (packages/cli/src/runtime/history.ts), never referenced by the extension
-// host. It's built straight into the extension's resources/ as a staging
-// spot for packages/cli/scripts/copy-resources.mjs to copy from, and
-// .vscodeignore deliberately excludes it from the packaged VSIX (see
-// resources/traceViewer/** there) to avoid ~3.4MB of dead weight. Only
-// resources/traceViewerStandalone (the single-file build historyHandlers.ts
-// actually loads) ships.
-const RESOURCE_HASH_EXCLUDED_PREFIX = 'traceViewer/';
+// See packages/extension/.vscodeignore for why resources/traceViewer is
+// excluded from the packaged VSIX (~3.4MB of CLI-only dead weight).
+const RESOURCE_HASH_EXCLUDED_PREFIX = `${EXCLUDED_TRACE_VIEWER_DIR}/`;
 
 function verifyResourceHashes(vsixPath, entries, failures) {
   const resourcesDir = path.join(extensionDir, 'resources');

--- a/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/MediaExtractionNodeTranscriptLog.vitest.ts
@@ -35,9 +35,6 @@ function buildServices(
     modelHandler: {
       addMediaToUserMessage: vi.fn(async () => []),
     } as never,
-    onRoundFinalized: vi.fn(),
-    checkInterruption: () => false,
-    setAbortController: () => {},
     ...overrides,
   } as ReflectionServices<unknown>;
 }


### PR DESCRIPTION
## Context

A `/simplify` pass (4 parallel review agents: reuse, simplification, efficiency, altitude) over my own two recent PRs:
- #7524 — logs the transcript's opening row even when media insertion throws
- #7539 — excludes the CLI-only shared-assets trace-viewer build (~3.4MB) from the VS Code extension VSIX

## Findings applied

**Reuse** — `verify-vsix-contents.mjs`'s `RESOURCE_HASH_EXCLUDED_PREFIX` hardcoded the `traceViewer` directory name in a *third* independent string shape (`.vscodeignore`'s glob line and `REQUIRED_VSCODEIGNORE_LINES` already had it twice), instead of following this file's own established shared-constant pattern (`CATALOG_DERIVED_CONTRIBUTES` in `extension-package-utils.mjs`, imported by both verify scripts). Added `EXCLUDED_TRACE_VIEWER_DIR` there; both verify scripts now derive their own shape (a glob line, a path prefix) from one source of truth.

**Simplification** — the same 9–14 line WHY-comment explaining `vsce`'s negation-ordering quirk was spelled out in full three times (`.vscodeignore`, `verify-extension-package-invariants.mjs`, `verify-vsix-contents.mjs`). Kept the full explanation only in `.vscodeignore` (the canonical source of the rule); the other two are now one-line pointers — which also drops an orphaned line-break artifact in the invariants script's version.

**Simplification** — `MediaExtractionNodeTranscriptLog.vitest.ts`'s `buildServices` stubbed `checkInterruption`/`setAbortController`/`onRoundFinalized`, none of which `MediaExtractionNode` reads (verified by grep) — leftover from copy-pasting the sibling `ToolUsePrepareNode` test's helper, where those fields are genuinely required. Removed.

**Efficiency** — no findings.

**Altitude** — `verifyVscodeIgnore` only asserted *presence* of required `.vscodeignore` lines; nothing asserted *absence* of a re-introduced `!resources/**`-shaped line. A future PR could silently reintroduce the exact bug #7539 fixed, caught only much later by the expensive `check:vsix-contents` (needs a full VSIX build) instead of the cheap, buildless `check:extension-package-invariants` CI step. Added a `FORBIDDEN_VSCODEIGNORE_PATTERNS` check — manually verified it actually fires by temporarily reintroducing `!resources/**` and confirming the check fails with a clear message.

## Deliberately not fixed here

The altitude review also found that #7524's fix has **two more call sites with the identical bug shape**: `src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts` and `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts` both call `addMediaToUserMessage`-family functions before `logUserMessage` with no `try`/`finally` — so a **follow-up-round** media failure still silently drops that turn's transcript row (the exact #7508 bug class, just not on round 0). This is well outside this simplify pass's stated scope (neither original PR touched these files), so it's intentionally not fixed here. Flagging as a real, live gap worth a dedicated follow-up PR.

## Verification

- `npx tsc --noEmit` (root + test-kernel) — clean
- `npx eslint` on all 4 changed files — only the pre-existing `no-undef` on `console` (same count as unmodified main; `scripts/**` isn't lint-covered)
- `npx prettier --check` — clean
- The two directly affected vitest files (6 tests) plus a full `src/test-kernel/agent/` sweep — 1158 passed, 4 pre-existing skips, 0 failures
- `node scripts/verify-extension-package-invariants.mjs` passes; the new forbidden-pattern guard manually confirmed to catch a reintroduced `!resources/**`
- Full `npm run build:fast` production VSIX build + `npm run check:vsix-contents` both pass, built VSIX tree unchanged (`traceViewer/` absent, `traceViewerStandalone/` present)
- `node scripts/check-dead-code-ratchet.mjs` — at/below baseline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/verify script and test-only changes; no extension runtime or agent behavior changes.
> 
> **Overview**
> Follow-up cleanup after transcript-log and VSIX-exclusion fixes: **one shared constant** for the CLI-only `resources/traceViewer` directory and **earlier CI** if packaging rules regress.
> 
> Adds `EXCLUDED_TRACE_VIEWER_DIR` in `extension-package-utils.mjs` (same pattern as `CATALOG_DERIVED_CONTRIBUTES`) so `verify-extension-package-invariants.mjs` and `verify-vsix-contents.mjs` no longer hardcode `traceViewer` in separate string shapes. Long duplicate `vsce` negation-order comments are trimmed to pointers at `packages/extension/.vscodeignore`.
> 
> `verifyVscodeIgnore` now **fails** if `.vscodeignore` contains a blanket `!resources/**` line, which would silently re-package the excluded trace viewer without a full VSIX build.
> 
> `MediaExtractionNodeTranscriptLog.vitest.ts` drops unused `buildServices` stubs (`onRoundFinalized`, `checkInterruption`, `setAbortController`) that `MediaExtractionNode` does not use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c8ef89eaec9c8b76548af880309a2d8dac78e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->