### PR TITLE
refactor: simplify data structures flagged by code-review audit

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -1,4 +1,4 @@
-import { create } from 'mutative';
+import { create, type Draft } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { sumUsageStats } from '@shared/schemas';
@@ -6,11 +6,32 @@ import { sumUsageStats } from '@shared/schemas';
 import {
   isToolUseState,
   isWorkflowState,
+  type StreamState,
   type ToolUseStreamState,
   type WorkflowStreamState,
 } from '../store';
 import { updateParentStreamId } from '../stateUtils';
 import type { HandlerRegistry } from '../messageHandlerTypes';
+
+const isRunUsageOwner = (
+  state: StreamState,
+): state is ToolUseStreamState | WorkflowStreamState =>
+  isToolUseState(state) || isWorkflowState(state);
+
+/**
+ * Apply `mutate` to `draft` only when `prev` (the pre-mutation snapshot the
+ * union was narrowed from) satisfies `guard`. Centralizes the single
+ * necessarily-unsafe cast — `mutative`'s `Draft<T>` can't be narrowed from a
+ * guard on the un-drafted `prev` — instead of repeating it at every call site.
+ */
+function withDraftKind<S extends StreamState>(
+  draft: Draft<StreamState>,
+  prev: StreamState,
+  guard: (state: StreamState) => state is S,
+  mutate: (typedDraft: Draft<S>) => void,
+): void {
+  if (guard(prev)) mutate(draft as Draft<S>);
+}
 
 // `HandlerRegistry` is now exhaustive (every ProgressView outbound command
 // needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
@@ -51,18 +72,19 @@ export const syncHandlers = {
             draft.contextState = data.contextState;
           }
 
-          if (hasWorkflowFiles && isWorkflowState(prev)) {
-            const d = draft as WorkflowStreamState;
-            // Replace (not merge) so a clean operation that shrinks the
-            // backend's set is reflected after a tab switch — Object.assign
-            // would leak stale rounds.
-            if (data.workflowFiles) d.files = { ...data.workflowFiles };
-            if (data.workflowMissingOutputs) {
-              d.missingOutputs = { ...data.workflowMissingOutputs };
-            }
-            if (data.workflowCompileFailures) {
-              d.compileFailures = { ...data.workflowCompileFailures };
-            }
+          if (hasWorkflowFiles) {
+            withDraftKind(draft, prev, isWorkflowState, (d) => {
+              // Replace (not merge) so a clean operation that shrinks the
+              // backend's set is reflected after a tab switch — Object.assign
+              // would leak stale rounds.
+              if (data.workflowFiles) d.files = { ...data.workflowFiles };
+              if (data.workflowMissingOutputs) {
+                d.missingOutputs = { ...data.workflowMissingOutputs };
+              }
+              if (data.workflowCompileFailures) {
+                d.compileFailures = { ...data.workflowCompileFailures };
+              }
+            });
           }
 
           // runUsage is per-run for both workflow and tool-use; derive the
@@ -70,26 +92,24 @@ export const syncHandlers = {
           // Replace (not merge) so a clean operation that shrinks the backend's
           // run set is reflected — Object.assign would leak stale entries and
           // over-count sessionUsage.
-          if (
-            hasRunUsage &&
-            data.runUsage &&
-            (isToolUseState(prev) || isWorkflowState(prev))
-          ) {
-            const d = draft as ToolUseStreamState | WorkflowStreamState;
-            d.runUsage = { ...data.runUsage };
-            d.sessionUsage = sumUsageStats(Object.values(d.runUsage));
+          if (hasRunUsage && data.runUsage) {
+            withDraftKind(draft, prev, isRunUsageOwner, (d) => {
+              d.runUsage = { ...data.runUsage };
+              d.sessionUsage = sumUsageStats(Object.values(d.runUsage));
+            });
           }
 
-          if (isToolUseState(prev) && hasTaskData) {
-            const d = draft as ToolUseStreamState;
-            if (data.todos) d.todos = data.todos;
-            if (data.plan !== undefined) d.plan = data.plan;
-            if (data.queuedFollowUps) d.queuedFollowUps = data.queuedFollowUps;
+          if (hasTaskData) {
+            withDraftKind(draft, prev, isToolUseState, (d) => {
+              if (data.todos) d.todos = data.todos;
+              if (data.plan !== undefined) d.plan = data.plan;
+              if (data.queuedFollowUps)
+                d.queuedFollowUps = data.queuedFollowUps;
+            });
           }
 
           // Hydrate toggle bypass state on tab switch
-          if (isToolUseState(prev)) {
-            const d = draft as ToolUseStreamState;
+          withDraftKind(draft, prev, isToolUseState, (d) => {
             if (data.toolEditBypass !== undefined)
               d.toolEditBypass = data.toolEditBypass;
             if (data.superYoloBypass !== undefined)
@@ -103,7 +123,7 @@ export const syncHandlers = {
               d.goalStatus = data.goalStatus;
               d.goalObjective = data.goalObjective;
             }
-          }
+          });
 
           if (data.conversationProgress) {
             draft.conversationProgress = data.conversationProgress;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -259,37 +259,20 @@ function buildFallbackNotification(config: AgentConfig): FallbackNotification {
   };
 }
 
-/** Options for executeAgent. */
-export interface ExecuteAgentOptions {
-  /** Host services used by the runtime to report progress/UI events. */
-  runtimeHost: AgentRuntimeHost;
-  /** When true, proposal tools are filtered out to prevent nesting. */
-  isSubagent?: boolean;
-  /**
-   * When true, enforce that configPayload.agentCategory matches the agent's
-   * YAML-defined category. Callers that explicitly set a category (e.g.
-   * DelegationTools) should opt in; callers that pass pre-parsed configs with
-   * prefaulted defaults (e.g. runExecuteCommand) should leave this off.
-   */
-  enforceCategory?: boolean;
+/**
+ * Callback and host-context fields shared by every entry point that drives one
+ * subagent run (`executeAgent`, `resumeToolUseFromSnapshot`, and
+ * `resumeQueuedToolUseSnapshot`). Extracted so the three option bags describing
+ * the same run can't silently drift out of sync or re-declare the same field
+ * under a different name.
+ */
+export interface SubagentRunOptions {
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
-  /**
-   * Depth of this execution in the delegation chain. Root (user-initiated) is 0;
-   * each delegate_agent / delegate_workflow call increments it. Used to gate
-   * nested delegation based on the Multi-Agent settings. Defaults to 0.
-   */
-  delegationDepth?: number;
-  /** Fires with the real streamId before the stream is activated (before UI sync). */
-  onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires when a tool-use session consumes queued follow-up instructions. */
   onFollowUpConsumed?: () => void;
   /** Fires on meaningful progress: todo changes and tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
-  /** Root-run-only: fires with the latest response at every cycle boundary — see `ToolUseServices.onIdle`. */
-  onIdle?: (lastResponse: string | undefined) => void;
-  /** Stop a tool-use execution after one model/tool cycle instead of waiting for follow-up input. */
-  stopAfterCycle?: boolean;
   /**
    * Allow the promise to resolve with the non-terminal WAITING result. This is
    * reserved for native subagent drivers that keep the execution handle and
@@ -309,12 +292,47 @@ export interface ExecuteAgentOptions {
    * frozen, process-wide `platform().toolEditApproval` port.
    */
   toolEditApprovalHandler?: ToolEditApprovalPort;
-  /** Resume using this persisted provider-message format instead of today's default route. */
-  modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
-  /** Fires when a subagent fails and should report the failure to its orchestrator. */
-  onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
+  /**
+   * Fires when the subagent run itself fails, so a caller can report the
+   * failure up the delegation chain. Distinct from a host-level failure
+   * surface such as `ResumeQueuedToolUseOptions.onError` (log + toast for a
+   * failed resume-plumbing step) — this callback is about the run's outcome.
+   */
+  onRunError?: (
+    error: unknown,
+    result: AgentFlowResult,
+  ) => void | Promise<void>;
   /** Fires once with the live per-run handle right after it is tracked (F-2). */
   onRun?: (handle: AgentRunHandle) => void | Promise<void>;
+}
+
+/** Options for executeAgent. */
+export interface ExecuteAgentOptions extends SubagentRunOptions {
+  /** Host services used by the runtime to report progress/UI events. */
+  runtimeHost: AgentRuntimeHost;
+  /** When true, proposal tools are filtered out to prevent nesting. */
+  isSubagent?: boolean;
+  /**
+   * When true, enforce that configPayload.agentCategory matches the agent's
+   * YAML-defined category. Callers that explicitly set a category (e.g.
+   * DelegationTools) should opt in; callers that pass pre-parsed configs with
+   * prefaulted defaults (e.g. runExecuteCommand) should leave this off.
+   */
+  enforceCategory?: boolean;
+  /**
+   * Depth of this execution in the delegation chain. Root (user-initiated) is 0;
+   * each delegate_agent / delegate_workflow call increments it. Used to gate
+   * nested delegation based on the Multi-Agent settings. Defaults to 0.
+   */
+  delegationDepth?: number;
+  /** Fires with the real streamId before the stream is activated (before UI sync). */
+  onStreamResolved?: (streamId: StreamTabId) => void;
+  /** Root-run-only: fires with the latest response at every cycle boundary — see `ToolUseServices.onIdle`. */
+  onIdle?: (lastResponse: string | undefined) => void;
+  /** Stop a tool-use execution after one model/tool cycle instead of waiting for follow-up input. */
+  stopAfterCycle?: boolean;
+  /** Resume using this persisted provider-message format instead of today's default route. */
+  modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
 }
 
 export function executeAgent(
@@ -405,7 +423,7 @@ export async function executeAgent(
       {
         isSubagent,
         parentStreamId: options.parentStreamId,
-        onError: options.onError,
+        onError: options.onRunError,
         onRun: options.onRun,
       },
     );
@@ -418,24 +436,7 @@ export async function executeAgent(
   });
 }
 
-export interface ResumeToolUseFromSnapshotOptions {
-  /** Hide tools whose approval prompts cannot be answered in this host mode. */
-  readonly approvalPromptsUnavailable?: boolean;
-  /** Hide tools unavailable because the current host/runtime cannot support them. */
-  readonly runtimeUnavailableTools?: readonly string[];
-  /** Session owning this run's coordination state. Defaults to the process session. */
-  readonly session?: SessionHandle;
-  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
-  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
-  readonly onFollowUpConsumed?: () => void;
-  readonly onProgress?: (update: SubagentProgressUpdate) => void;
-  readonly onError?: (
-    error: unknown,
-    result: AgentFlowResult,
-  ) => void | Promise<void>;
-  readonly parentStreamId?: StreamTabId;
-  readonly allowWaitingResult?: boolean;
+export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly setupSession?: (session: IToolUseSession) => void;
 }
 
@@ -520,7 +521,7 @@ export async function resumeToolUseFromSnapshot(
       {
         isSubagent,
         parentStreamId: options.parentStreamId,
-        onError: options.onError,
+        onError: options.onRunError,
         onRun: options.onRun,
       },
     );

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,43 +1,21 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
-import type {
-  AgentFlowResult,
-  AgentRuntimeFlowResult,
-} from '@agent/runtime/AgentFlowResult';
-import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
+import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
-  type SubagentProgressUpdate,
   type StreamTabId,
 } from '@shared/schemas';
-import { resumeToolUseFromSnapshot } from './executeAgent';
+import {
+  resumeToolUseFromSnapshot,
+  type SubagentRunOptions,
+} from './executeAgent';
 import { emitRuntimeEvent } from './emitRuntimeEvent';
-import { defaultSession, type SessionHandle } from './SessionHandle';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
+import { defaultSession } from './SessionHandle';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
-export interface ResumeQueuedToolUseOptions {
-  /** Session owning this run's coordination state. Defaults to the process session. */
-  readonly session?: SessionHandle;
-  /** Tools hidden because the current host/runtime cannot support them. */
-  readonly runtimeUnavailableTools?: readonly string[];
-  /** Hide tools whose approval prompts cannot be answered in this host mode. */
-  readonly approvalPromptsUnavailable?: boolean;
-  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
-  /** Parent stream used when a native subagent resumes under its orchestrator. */
-  readonly parentStreamId?: StreamTabId;
-  /** Allow native subagent resume to halt at WAITING instead of terminalizing. */
-  readonly allowWaitingResult?: boolean;
-  readonly onFollowUpConsumed?: () => void;
-  readonly onProgress?: (update: SubagentProgressUpdate) => void;
-  readonly onRunError?: (
-    error: unknown,
-    result: AgentFlowResult,
-  ) => void | Promise<void>;
-  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
+export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
   /**
    * Fires with the resumed run's raw outcome — terminal or WAITING — right
    * after the call returns successfully. Additive to `onRunError`, which only
@@ -108,7 +86,7 @@ export async function resumeQueuedToolUseSnapshot(
       allowWaitingResult: options.allowWaitingResult,
       onFollowUpConsumed: options.onFollowUpConsumed,
       onProgress: options.onProgress,
-      onError: options.onRunError,
+      onRunError: options.onRunError,
       onRun: options.onRun,
       setupSession: (session) => {
         for (const item of followUps) {

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -63,7 +63,8 @@ export class LatexMediaManager {
     figures: string[],
     baseDir?: string,
   ): Promise<void> {
-    if (!this.fileService?.hasRunDirectory() || figures.length === 0) {
+    const fileService = this.fileService;
+    if (!fileService?.hasRunDirectory() || figures.length === 0) {
       return;
     }
 
@@ -91,7 +92,7 @@ export class LatexMediaManager {
       [...absolutePaths],
       async (absolutePath) => {
         try {
-          await this.fileService!.mirrorWorkspaceFile(
+          await fileService.mirrorWorkspaceFile(
             pathToLocation(absolutePath),
           );
         } catch (error) {
@@ -197,7 +198,8 @@ export class LatexMediaManager {
   private async mirrorLatexFileDependencies(
     files: FileLocation[],
   ): Promise<void> {
-    if (!this.fileService?.hasRunDirectory() || files.length === 0) {
+    const fileService = this.fileService;
+    if (!fileService?.hasRunDirectory() || files.length === 0) {
       return;
     }
 
@@ -245,7 +247,7 @@ export class LatexMediaManager {
           const depLocation = pathToLocation(absolutePath);
           const isTex = hasExtension(absolutePath, '.tex');
           try {
-            await this.fileService!.mirrorWorkspaceFile(depLocation, {
+            await fileService.mirrorWorkspaceFile(depLocation, {
               snapshot: isTex,
             });
             if (isTex) {
@@ -322,7 +324,8 @@ export class LatexMediaManager {
    * run storage so the compiled document can find its project-local style.
    */
   private async mirrorProjectSiblings(projectDir: string): Promise<void> {
-    if (!this.fileService) return;
+    const fileService = this.fileService;
+    if (!fileService) return;
 
     let entries: string[];
     try {
@@ -355,9 +358,7 @@ export class LatexMediaManager {
         try {
           const stats = await platform().fs.stat(absolutePath);
           if (!isFile(stats.type)) return;
-          await this.fileService!.mirrorWorkspaceFile(
-            pathToLocation(absolutePath),
-          );
+          await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
         } catch (error) {
           this.logger.debug('Unable to mirror project sibling', {
             data: { path: absolutePath, error },

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -92,9 +92,7 @@ export class LatexMediaManager {
       [...absolutePaths],
       async (absolutePath) => {
         try {
-          await fileService.mirrorWorkspaceFile(
-            pathToLocation(absolutePath),
-          );
+          await fileService.mirrorWorkspaceFile(pathToLocation(absolutePath));
         } catch (error) {
           this.logger.debug('Unable to mirror figure dependency', {
             data: { path: absolutePath, error },

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -231,6 +231,17 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     const roundOutputs: RoundOutput[] = [];
     const hasRound = (round: number): boolean =>
       roundOutputs.some((entry) => entry.round === round);
+    // Upsert so a round matched more than once (e.g. two legacy files
+    // matching the same round regex) keeps a single entry — the last match
+    // wins, same as the prior `Map<number, string>.set()` semantics.
+    const setRoundOutput = (round: number, filePath: string): void => {
+      const existing = roundOutputs.find((entry) => entry.round === round);
+      if (existing) {
+        existing.path = filePath;
+      } else {
+        roundOutputs.push({ round, path: filePath });
+      }
+    };
 
     // Legacy flat layout: files sit directly under outputDirPath as
     // `<base>_<chunk>_r{round}_<normalizedModel>.tex`.
@@ -255,10 +266,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       if (!match) continue;
       const round = RoundKeySchema.safeParse(match[1]);
       if (!round.success) continue;
-      roundOutputs.push({
-        round: round.data,
-        path: path.join(outputDirPath, fileName),
-      });
+      setRoundOutput(round.data, path.join(outputDirPath, fileName));
     }
 
     // Mid-era layout: outputs under `r{round}/<base>_<cleanAgent>_<model>.tex`.
@@ -295,10 +303,10 @@ export async function runLatexdiffViaWorkspaceScan(params: {
           fileName === midEraFilename,
       );
       if (!match) continue;
-      roundOutputs.push({
+      setRoundOutput(
         round,
-        path: path.join(outputDirPath, entryName, midEraFilename),
-      });
+        path.join(outputDirPath, entryName, midEraFilename),
+      );
     }
 
     // New-layout workflow outputs live inside task-run storage

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -344,14 +344,14 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       for (let index = 0; index < sorted.length - 1; index += 1) {
         const previous = sorted[index];
         const current = sorted[index + 1];
-        const resolvedCurrent = toAbsolute(previous.path);
+        const resolvedPrevious = toAbsolute(previous.path);
 
         operations.push({
           type: 'between-rounds',
-          base: pathToLocation(resolvedCurrent),
+          base: pathToLocation(resolvedPrevious),
           revised: pathToLocation(toAbsolute(current.path)),
           description: `${path.basename(previous.path)} (r${previous.round}→r${current.round})`,
-          cwd: path.dirname(resolvedCurrent),
+          cwd: path.dirname(resolvedPrevious),
           fromRound: previous.round,
           toRound: current.round,
         });

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -212,7 +212,11 @@ export async function runLatexdiffViaWorkspaceScan(params: {
 
   logger.debug(CHANNEL, `Input files: ${configuredInputFiles.join(', ')}`);
 
-  const inputToOutputsMap = new Map<string, Map<number, string>>();
+  interface RoundOutput {
+    round: number;
+    path: string;
+  }
+  const inputToOutputsMap = new Map<string, RoundOutput[]>();
 
   for (const candidateInput of configuredInputFiles) {
     const outputDirPath = path.dirname(candidateInput);
@@ -224,7 +228,9 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     const absoluteDir = path.join(workspacePath, outputDirPath);
     const dirEntries = await fs.readDirectory(absoluteDir);
 
-    const roundOutputsMap = new Map<number, string>();
+    const roundOutputs: RoundOutput[] = [];
+    const hasRound = (round: number): boolean =>
+      roundOutputs.some((entry) => entry.round === round);
 
     // Legacy flat layout: files sit directly under outputDirPath as
     // `<base>_<chunk>_r{round}_<normalizedModel>.tex`.
@@ -249,7 +255,10 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       if (!match) continue;
       const round = RoundKeySchema.safeParse(match[1]);
       if (!round.success) continue;
-      roundOutputsMap.set(round.data, path.join(outputDirPath, fileName));
+      roundOutputs.push({
+        round: round.data,
+        path: path.join(outputDirPath, fileName),
+      });
     }
 
     // Mid-era layout: outputs under `r{round}/<base>_<cleanAgent>_<model>.tex`.
@@ -264,7 +273,7 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       if (!isDirectory(entryType) || isSymlink(entryType)) continue;
       const round = parseWorkflowOutputRoundDir(entryName);
       if (round == null) continue;
-      if (roundOutputsMap.has(round)) continue;
+      if (hasRound(round)) continue;
 
       const roundAbsoluteDir = path.join(absoluteDir, entryName);
       let roundEntries: [string, number][];
@@ -286,10 +295,10 @@ export async function runLatexdiffViaWorkspaceScan(params: {
           fileName === midEraFilename,
       );
       if (!match) continue;
-      roundOutputsMap.set(
+      roundOutputs.push({
         round,
-        path.join(outputDirPath, entryName, midEraFilename),
-      );
+        path: path.join(outputDirPath, entryName, midEraFilename),
+      });
     }
 
     // New-layout workflow outputs live inside task-run storage
@@ -298,11 +307,11 @@ export async function runLatexdiffViaWorkspaceScan(params: {
     // via `runLatexdiffFromMetadata`; the workspace scan here only covers
     // pre-refactor files.
 
-    if (roundOutputsMap.size > 0) {
-      inputToOutputsMap.set(candidateInput, roundOutputsMap);
+    if (roundOutputs.length > 0) {
+      inputToOutputsMap.set(candidateInput, roundOutputs);
       logger.debug(
         CHANNEL,
-        `Found ${roundOutputsMap.size} matching outputs for ${candidateInput}`,
+        `Found ${roundOutputs.length} matching outputs for ${candidateInput}`,
       );
     } else {
       logger.debug(CHANNEL, `No matching outputs found for ${candidateInput}`);
@@ -316,10 +325,10 @@ export async function runLatexdiffViaWorkspaceScan(params: {
   const operations: DiffOperation[] = [];
 
   for (const [baseFile, roundOutputs] of inputToOutputsMap.entries()) {
-    const rounds = [...roundOutputs.keys()].sort((a, b) => a - b);
+    const sorted = [...roundOutputs].sort((a, b) => a.round - b.round);
 
-    for (const round of rounds) {
-      const resolvedOutput = toAbsolute(roundOutputs.get(round)!);
+    for (const { round, path: outputPath } of sorted) {
+      const resolvedOutput = toAbsolute(outputPath);
 
       operations.push({
         type: 'round',
@@ -331,22 +340,20 @@ export async function runLatexdiffViaWorkspaceScan(params: {
       });
     }
 
-    if (generateBetweenRoundDiffs && rounds.length > 1) {
-      for (let index = 0; index < rounds.length - 1; index += 1) {
-        const currentRound = rounds[index];
-        const nextRound = rounds[index + 1];
-        const currentFile = roundOutputs.get(currentRound)!;
-        const nextFile = roundOutputs.get(nextRound)!;
-        const resolvedCurrent = toAbsolute(currentFile);
+    if (generateBetweenRoundDiffs && sorted.length > 1) {
+      for (let index = 0; index < sorted.length - 1; index += 1) {
+        const previous = sorted[index];
+        const current = sorted[index + 1];
+        const resolvedCurrent = toAbsolute(previous.path);
 
         operations.push({
           type: 'between-rounds',
           base: pathToLocation(resolvedCurrent),
-          revised: pathToLocation(toAbsolute(nextFile)),
-          description: `${path.basename(currentFile)} (r${currentRound}→r${nextRound})`,
+          revised: pathToLocation(toAbsolute(current.path)),
+          description: `${path.basename(previous.path)} (r${previous.round}→r${current.round})`,
           cwd: path.dirname(resolvedCurrent),
-          fromRound: currentRound,
-          toRound: nextRound,
+          fromRound: previous.round,
+          toRound: current.round,
         });
       }
     }

--- a/src/latex/latexdiff/types.ts
+++ b/src/latex/latexdiff/types.ts
@@ -20,8 +20,6 @@ export interface RunLatexdiffCommandConfig {
   model: string;
   inputFile: string;
   outputFiles?: string[];
-  outputFilesActive?: string[];
-  streamId?: string;
   runId?: string | null;
   outputsByRound?: RoundIndexed<OutputFileInfo>;
 }

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -9,7 +9,12 @@ import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 
-import { ReplacementCategory, ReplacementValue } from './types';
+import {
+  ReplacementCategory,
+  NonRegexReplacementCategory,
+  RegexReplacementCategory,
+  ReplacementValue,
+} from './types';
 import {
   applyLatexQuotesFormatting,
   replaceMathUnicode,
@@ -85,7 +90,7 @@ const replacementEngine = {
 };
 
 // Non-regex categories, applied in this order.
-const NON_REGEX_CATEGORIES: ReplacementCategory[] = [
+const NON_REGEX_CATEGORIES: NonRegexReplacementCategory[] = [
   // LaTeX content formatting
   EQUATION_REPLACEMENTS,
   SECTION_REPLACEMENTS,
@@ -106,7 +111,7 @@ const NON_REGEX_CATEGORIES: ReplacementCategory[] = [
 ];
 
 // Regex categories, applied in this order.
-const REGEX_CATEGORIES: ReplacementCategory[] = [
+const REGEX_CATEGORIES: RegexReplacementCategory[] = [
   EQUATION_MACRO_REPLACEMENTS,
   FENCED_LATEX_BLOCK_REPLACEMENTS,
   INLINE_MATH_REPLACEMENTS,
@@ -121,10 +126,10 @@ function shouldWrapCritiqueInAlign(): boolean {
   return getConfig('texra.latex.wrapCritiqueInAlign', true);
 }
 
-function selectEnabledCategories(
-  categories: ReplacementCategory[],
+function selectEnabledCategories<T extends ReplacementCategory>(
+  categories: T[],
   enabledNames: string[],
-): ReplacementCategory[] {
+): T[] {
   const enabled = new Set(enabledNames);
   return categories.filter((category) => enabled.has(category.name));
 }
@@ -133,12 +138,12 @@ function selectEnabledCategories(
  * Combine every enabled non-regex category into a single category. Custom
  * replacements from user settings take precedence over predefined rules.
  */
-function getAllReplacements(): ReplacementCategory {
+function getAllReplacements(): NonRegexReplacementCategory {
   const enabledNames = getConfig<string[]>(
     'texra.latex.enabledReplacements',
     DEFAULT_CORE_SETTINGS.latex.enabledReplacements,
   );
-  const customReplacements = getConfig<Record<string, ReplacementValue>>(
+  const customReplacements = getConfig<Record<string, string>>(
     'texra.latex.customReplacements',
     {},
   );
@@ -147,7 +152,7 @@ function getAllReplacements(): ReplacementCategory {
     NON_REGEX_CATEGORIES,
     enabledNames,
   );
-  const patterns: Record<string, ReplacementValue> = Object.assign(
+  const patterns: Record<string, string> = Object.assign(
     {},
     ...enabledCategories.map((c) => c.patterns),
     customReplacements,
@@ -165,7 +170,7 @@ function getAllReplacements(): ReplacementCategory {
  * Return every enabled regex category in application order, appending a custom
  * category built from user settings whenever custom regex replacements exist.
  */
-function getAllReplacementsRegex(): ReplacementCategory[] {
+function getAllReplacementsRegex(): RegexReplacementCategory[] {
   const enabledNames = getConfig<string[]>(
     'texra.latex.enabledReplacementsRegex',
     DEFAULT_CORE_SETTINGS.latex.enabledReplacementsRegex,
@@ -251,7 +256,10 @@ export function applyReplacements(
       for (const [pattern, repl] of Object.entries(category.patterns)) {
         try {
           const regex = getCompiledRegex(pattern, category.flags);
-          result = result.replace(regex, repl as string);
+          result =
+            typeof repl === 'string'
+              ? result.replace(regex, repl)
+              : result.replace(regex, repl);
         } catch (regexErr) {
           logger.error(
             CHANNEL,
@@ -261,14 +269,7 @@ export function applyReplacements(
       }
     } else {
       for (const [old, newText] of Object.entries(category.patterns)) {
-        if (typeof newText === 'string') {
-          result = result.replaceAll(old, newText);
-        } else {
-          logger.debug(
-            CHANNEL,
-            `Skipping function pattern "${old}" in non-regex category "${category.name}"`,
-          );
-        }
+        result = result.replaceAll(old, newText);
       }
     }
   }

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -256,6 +256,10 @@ export function applyReplacements(
       for (const [pattern, repl] of Object.entries(category.patterns)) {
         try {
           const regex = getCompiledRegex(pattern, category.flags);
+          // Both arms call the same `replace` overload with the same
+          // arguments — the runtime behavior doesn't depend on the branch.
+          // The `typeof` check exists only so TS can select a `replace`
+          // overload; it can't choose one from `repl`'s union type directly.
           result =
             typeof repl === 'string'
               ? result.replace(regex, repl)

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -1,5 +1,5 @@
 // Local imports
-import { ReplacementCategory } from './types';
+import { NonRegexReplacementCategory, RegexReplacementCategory } from './types';
 import {
   generateMathCommandShortcuts,
   generateDecoratedMathShortcuts,
@@ -41,7 +41,7 @@ const GREEK_LETTER_SHORTCUTS: { [key: string]: string } = {
 };
 
 // Automatically generated replacement patterns
-const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
+const MAX_AUTO_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'max_auto',
   description: 'Automatically generated maximum style replacements for LaTeX',
   isRegex: false,
@@ -311,7 +311,7 @@ const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 };
 
 // Manually specified replacement patterns
-const MAX_MANUAL_REPLACEMENTS: ReplacementCategory = {
+const MAX_MANUAL_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'max_manual',
   description: 'Manually specified maximum style replacements for LaTeX',
   isRegex: false,
@@ -444,7 +444,7 @@ const MAX_MANUAL_REPLACEMENTS: ReplacementCategory = {
 };
 
 // Combined replacements for backward compatibility
-export const MAX_STYLE_REPLACEMENTS: ReplacementCategory = {
+export const MAX_STYLE_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'max_style',
   description: 'Maximum style replacements for LaTeX commands and symbols',
   isRegex: false,
@@ -554,7 +554,7 @@ const GEP_WORDS_PAREN_CREF_EQN_PATTERN = `(${GEP_WORDS_REGEX_PART_INTERNAL})(?:,
 const GEP_WORDS_PAREN_EQREF_EQN_PATTERN = `(${GEP_WORDS_REGEX_PART_INTERNAL})(?:,)?\\s+\\(\\\\eqref\\{(eqn:[^,}]+)\\}\\)`;
 const FULL_WORDS_CREF_FIG_PATTERN = `(${FULL_WORDS_REGEX_PART_INTERNAL})(?:,)?\\s+\\\\cref\\{(fig:[^,}]+)\\}`;
 
-export const MAX_REGEX_REPLACEMENTS: ReplacementCategory = {
+export const MAX_REGEX_REPLACEMENTS: RegexReplacementCategory = {
   name: 'max_style_regex',
   description:
     'Maximum style regex replacements for LaTeX commands and symbols',

--- a/src/replacement/rules/characters.ts
+++ b/src/replacement/rules/characters.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const CHARACTER_REPLACEMENTS: ReplacementCategory = {
+export const CHARACTER_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'characters',
   description: 'Fixes for special characters and diacritics',
   isRegex: false,

--- a/src/replacement/rules/equationMacros.ts
+++ b/src/replacement/rules/equationMacros.ts
@@ -1,5 +1,8 @@
 // Local imports - replacement
-import { RegexReplacementCategory, ReplacementFunction } from '@replacement/types';
+import {
+  RegexReplacementCategory,
+  ReplacementFunction,
+} from '@replacement/types';
 
 const MACRO_TO_ENVIRONMENT: Record<string, string> = {
   be: '\\begin{equation}',

--- a/src/replacement/rules/equationMacros.ts
+++ b/src/replacement/rules/equationMacros.ts
@@ -1,5 +1,5 @@
 // Local imports - replacement
-import { ReplacementCategory, ReplacementFunction } from '@replacement/types';
+import { RegexReplacementCategory, ReplacementFunction } from '@replacement/types';
 
 const MACRO_TO_ENVIRONMENT: Record<string, string> = {
   be: '\\begin{equation}',
@@ -20,7 +20,7 @@ const expandEquationMacro: ReplacementFunction = (
   return replacement ? `${leading}${replacement}${trailing}` : match;
 };
 
-export const EQUATION_MACRO_REPLACEMENTS: ReplacementCategory = {
+export const EQUATION_MACRO_REPLACEMENTS: RegexReplacementCategory = {
   name: 'equation_macros',
   description:
     'Expands short equation helpers like \\be into full environments',

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -7,10 +7,10 @@ import {
   GREEK_LETTERS,
   MATH_OPERATORS,
 } from '@replacement/helpers';
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
 // Common LaTeX equation spacing fixes
-export const EQUATION_REPLACEMENTS: ReplacementCategory = {
+export const EQUATION_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'equations',
   description: 'Fixes for LaTeX equation spacing and formatting',
   isRegex: false,

--- a/src/replacement/rules/fontCommands.ts
+++ b/src/replacement/rules/fontCommands.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
+export const FONT_COMMAND_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'font_commands',
   description: 'Normalize deprecated font commands to modern equivalents',
   isRegex: false,

--- a/src/replacement/rules/forbiddenCommands.ts
+++ b/src/replacement/rules/forbiddenCommands.ts
@@ -3,9 +3,9 @@ import {
   generateInvalidSectionEndingFixes,
   SECTION_TYPES,
 } from '@replacement/helpers';
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const LATEX_FORBIDDEN_REPLACEMENTS: ReplacementCategory = {
+export const LATEX_FORBIDDEN_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'latex_forbidden_commands',
   description:
     'Removes LaTeX commands that should never appear, such as section endings',

--- a/src/replacement/rules/gptness.ts
+++ b/src/replacement/rules/gptness.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const GPTNESS_REPLACEMENTS: ReplacementCategory = {
+export const GPTNESS_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'gptness',
   description: 'GPTness improvements',
   isRegex: false,

--- a/src/replacement/rules/htmlEntities.ts
+++ b/src/replacement/rules/htmlEntities.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const HTML_ENTITY_REPLACEMENTS: ReplacementCategory = {
+export const HTML_ENTITY_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'html_entities',
   description: 'Converts common HTML entities into LaTeX-safe equivalents',
   isRegex: false,

--- a/src/replacement/rules/latexXml.ts
+++ b/src/replacement/rules/latexXml.ts
@@ -4,9 +4,9 @@ import {
   generateLatexToXmlConversions,
   LATEX_ENVIRONMENTS,
 } from '@replacement/helpers';
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const LATEX_XML_REPLACEMENTS: ReplacementCategory = {
+export const LATEX_XML_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'latex_xml',
   description: 'Fixes specific to XML output processing',
   isRegex: false,

--- a/src/replacement/rules/latexdiff.ts
+++ b/src/replacement/rules/latexdiff.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const LATEXDIFF_REPLACEMENTS: ReplacementCategory = {
+export const LATEXDIFF_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'latexdiff',
   description: 'Fixes for LaTeXdiff markup and compatibility issues',
   isRegex: false,

--- a/src/replacement/rules/personalStyle.ts
+++ b/src/replacement/rules/personalStyle.ts
@@ -1,8 +1,8 @@
 // Local imports - replacement
 import { generateReferenceSpacing } from '@replacement/helpers';
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const PERSONAL_STYLE_REPLACEMENTS: ReplacementCategory = {
+export const PERSONAL_STYLE_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'personal_style',
   description:
     'Personal writing style preferences for specific LaTeX commands and spacing',

--- a/src/replacement/rules/sections.ts
+++ b/src/replacement/rules/sections.ts
@@ -3,9 +3,9 @@ import {
   generateSectionSpacingFixes,
   SECTION_TYPES,
 } from '@replacement/helpers';
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const SECTION_REPLACEMENTS: ReplacementCategory = {
+export const SECTION_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'sections',
   description: 'Fixes for section spacing in LaTeX documents',
   isRegex: false,

--- a/src/replacement/rules/spacing.ts
+++ b/src/replacement/rules/spacing.ts
@@ -1,8 +1,8 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
 // LaTeX spacing and punctuation fixes
-export const LATEX_SPACING_REPLACEMENTS: ReplacementCategory = {
+export const LATEX_SPACING_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'latex_spacing',
   description:
     'Fixes for LaTeX spacing, punctuation, and formatting [for O1 model]',

--- a/src/replacement/rules/unicode.ts
+++ b/src/replacement/rules/unicode.ts
@@ -1,7 +1,7 @@
 // Local imports - replacement
-import { ReplacementCategory } from '@replacement/types';
+import { NonRegexReplacementCategory } from '@replacement/types';
 
-export const UNICODE_REPLACEMENTS: ReplacementCategory = {
+export const UNICODE_REPLACEMENTS: NonRegexReplacementCategory = {
   name: 'unicode',
   description:
     'Fixes for common non-math Unicode characters to LaTeX equivalents or for general cleanup (e.g., removing zero-width spaces). Math-specific Unicode is handled by a separate function within math environments.',

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -140,27 +140,28 @@ export const INLINE_MATH_REPLACEMENTS: RegexReplacementCategory = {
 };
 
 // Context-aware personal style conversions
-export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: RegexReplacementCategory = {
-  name: 'personal_style_contextual',
-  description:
-    'Context-aware replacements for personal style rules that avoid macro definitions',
-  isRegex: true,
-  flags: 'g',
-  patterns: {
-    // Temporarily protect \mathrm{Tr} inside command definitions
-    '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\*?)\\{[^}]+\\}(?:\\[[^\\]]*\\])?\\{)\\\\mathrm\\{Tr\\}':
-      '$1__TEXRA_PRESERVE_TR__',
-    // Temporarily protect \mathrm{tr} inside command definitions
-    '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\*?)\\{[^}]+\\}(?:\\[[^\\]]*\\])?\\{)\\\\mathrm\\{tr\\}':
-      '$1__TEXRA_PRESERVE_tr__',
-    // Apply preferred operator command forms
-    '\\\\mathrm\\{Tr\\}': '\\Tr',
-    '\\\\mathrm\\{tr\\}': '\\tr',
-    // Restore protected command definitions
-    __TEXRA_PRESERVE_TR__: '\\mathrm{Tr}',
-    __TEXRA_PRESERVE_tr__: '\\mathrm{tr}',
-  },
-};
+export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: RegexReplacementCategory =
+  {
+    name: 'personal_style_contextual',
+    description:
+      'Context-aware replacements for personal style rules that avoid macro definitions',
+    isRegex: true,
+    flags: 'g',
+    patterns: {
+      // Temporarily protect \mathrm{Tr} inside command definitions
+      '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\*?)\\{[^}]+\\}(?:\\[[^\\]]*\\])?\\{)\\\\mathrm\\{Tr\\}':
+        '$1__TEXRA_PRESERVE_TR__',
+      // Temporarily protect \mathrm{tr} inside command definitions
+      '((?:\\\\(?:re)?newcommand|\\\\providecommand|\\\\DeclareMathOperator\\*?)\\{[^}]+\\}(?:\\[[^\\]]*\\])?\\{)\\\\mathrm\\{tr\\}':
+        '$1__TEXRA_PRESERVE_tr__',
+      // Apply preferred operator command forms
+      '\\\\mathrm\\{Tr\\}': '\\Tr',
+      '\\\\mathrm\\{tr\\}': '\\tr',
+      // Restore protected command definitions
+      __TEXRA_PRESERVE_TR__: '\\mathrm{Tr}',
+      __TEXRA_PRESERVE_tr__: '\\mathrm{tr}',
+    },
+  };
 
 /**
  * LATEXDIFF USAGE NOTE:

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -1,5 +1,5 @@
 // Local imports
-import { ReplacementCategory, ReplacementFunction } from './types';
+import { RegexReplacementCategory, ReplacementFunction } from './types';
 import {
   FENCED_LATEX_BLOCK_PATTERN_INLINE,
   FENCED_LATEX_BLOCK_PATTERN_MULTILINE,
@@ -60,7 +60,7 @@ function createCaptionTrimmer(
 
 // ===== Regex replacements =====
 
-export const FENCED_LATEX_BLOCK_REPLACEMENTS: ReplacementCategory = {
+export const FENCED_LATEX_BLOCK_REPLACEMENTS: RegexReplacementCategory = {
   name: 'fenced_latex_blocks',
   description:
     'Convert Markdown-style fenced math blocks into proper LaTeX environments',
@@ -73,7 +73,7 @@ export const FENCED_LATEX_BLOCK_REPLACEMENTS: ReplacementCategory = {
 };
 
 // Parentheses sizing standardization
-export const PARENTHESES_REPLACEMENTS: ReplacementCategory = {
+export const PARENTHESES_REPLACEMENTS: RegexReplacementCategory = {
   name: 'parentheses',
   description: 'Standardize parentheses sizing using regex patterns',
   isRegex: true,
@@ -113,7 +113,7 @@ export const PARENTHESES_REPLACEMENTS: ReplacementCategory = {
 };
 
 // LaTeX inline math formatting fixes
-export const INLINE_MATH_REPLACEMENTS: ReplacementCategory = {
+export const INLINE_MATH_REPLACEMENTS: RegexReplacementCategory = {
   name: 'inline_math',
   description: 'Fixes for LaTeX inline math formatting',
   isRegex: true,
@@ -140,7 +140,7 @@ export const INLINE_MATH_REPLACEMENTS: ReplacementCategory = {
 };
 
 // Context-aware personal style conversions
-export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: ReplacementCategory = {
+export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: RegexReplacementCategory = {
   name: 'personal_style_contextual',
   description:
     'Context-aware replacements for personal style rules that avoid macro definitions',
@@ -180,7 +180,7 @@ export const PERSONAL_STYLE_CONTEXTUAL_REPLACEMENTS: ReplacementCategory = {
  */
 
 // Latexdiff markup fixes using regex
-export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
+export const LATEXDIFF_MARKUP_REPLACEMENTS: RegexReplacementCategory = {
   name: 'latexdiff_markup',
   description: 'Fixes for redundant braces and whitespace in latexdiff markup',
   isRegex: true,
@@ -298,7 +298,7 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
   },
 };
 
-export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
+export const EQUATION_STYLE_REPLACEMENTS: RegexReplacementCategory = {
   name: 'equation_style',
   description: 'Fixes for equation style formatting',
   isRegex: true,

--- a/src/replacement/types.ts
+++ b/src/replacement/types.ts
@@ -9,11 +9,24 @@ export type ReplacementFunction = (
 
 export type ReplacementValue = string | ReplacementFunction;
 
-export interface ReplacementCategory {
+/** Plain string substitution, applied via `String.prototype.replaceAll`. */
+export interface NonRegexReplacementCategory {
+  name: string;
+  description: string;
+  patterns: Record<string, string>;
+  isRegex?: false;
+}
+
+/** Regex-based substitution; patterns may be a replacement string or callback. */
+export interface RegexReplacementCategory {
   name: string;
   description: string;
   patterns: Record<string, ReplacementValue>;
-  isRegex?: boolean;
-  /** Regex flags such as 'g'; only consulted when isRegex is true. */
+  isRegex: true;
+  /** Regex flags such as 'g'. */
   flags?: string;
 }
+
+export type ReplacementCategory =
+  | NonRegexReplacementCategory
+  | RegexReplacementCategory;

--- a/src/replacement/types.ts
+++ b/src/replacement/types.ts
@@ -28,5 +28,4 @@ export interface RegexReplacementCategory {
 }
 
 export type ReplacementCategory =
-  | NonRegexReplacementCategory
-  | RegexReplacementCategory;
+  NonRegexReplacementCategory | RegexReplacementCategory;

--- a/src/shared/schemas/streamSnapshot.ts
+++ b/src/shared/schemas/streamSnapshot.ts
@@ -28,12 +28,22 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 import { OutputFileInfoSchema, CompileFailureSchema } from './output';
 import { roundIndexedRecord } from './roundIndexed';
 import { StreamStatusSchema } from './stream';
-import {
-  ActiveChildInfoSchema,
-  ConversationProgressSchema,
-} from './streamState';
+import { BackendOwnedFieldsSchema } from './streamState';
 import { RunUsageMapSchema } from './usage';
 import { WorkPlanSnapshotShape } from './workPlan';
+
+/**
+ * The liveness/log-derived fields this snapshot shares with the backend-owned
+ * stream-state metadata (`@shared/schemas/streamState`), picked from that one
+ * definition so the two can't drift apart field-by-field.
+ */
+const SharedBackendOwnedFieldsSchema = BackendOwnedFieldsSchema.pick({
+  conversationProgress: true,
+  finishedSubagentCount: true,
+  finishedProcessCount: true,
+  activeSubagents: true,
+  activeProcesses: true,
+});
 
 /**
  * Bump when the persisted shape changes. A reader enforces this as a
@@ -83,7 +93,7 @@ export const PersistedWorkPlanSchema = z.object({
 // StreamSnapshot — the assembled logical view (durable + log-derived + liveness)
 // ============================================================================
 
-export const StreamSnapshotSchema = z.object({
+export const StreamSnapshotSchema = SharedBackendOwnedFieldsSchema.extend({
   schemaVersion: z
     .literal(STREAM_SNAPSHOT_SCHEMA_VERSION)
     .catch(STREAM_SNAPSHOT_SCHEMA_VERSION),
@@ -105,13 +115,11 @@ export const StreamSnapshotSchema = z.object({
 
   // -- Log-derived (recomputed from the StreamLog on load) ------------------
   status: StreamStatusSchema.optional(),
-  conversationProgress: ConversationProgressSchema.prefault({}),
-  finishedSubagentCount: z.number().prefault(0),
-  finishedProcessCount: z.number().prefault(0),
+  // conversationProgress, finishedSubagentCount, finishedProcessCount come
+  // from SharedBackendOwnedFieldsSchema above.
 
   // -- Liveness (NEVER restored as live — clamp on hydrate) -----------------
-  activeSubagents: z.array(ActiveChildInfoSchema).prefault([]),
-  activeProcesses: z.array(ActiveChildInfoSchema).prefault([]),
+  // activeSubagents, activeProcesses come from SharedBackendOwnedFieldsSchema.
 });
 
 export type StreamSnapshot = z.infer<typeof StreamSnapshotSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -108,7 +108,7 @@ export const DEFAULT_FINISHED_CHILD_COUNT = 0;
 // Stream Metadata — the lightweight subset sent over postMessage in UPDATE_STREAMS.
 // Contains only backend-owned fields that mergeBackendOwnedState() actually reads.
 
-const BackendOwnedFieldsSchema = z.object({
+export const BackendOwnedFieldsSchema = z.object({
   status: StreamLifecycleStatusSchema.prefault(DEFAULT_STREAM_METADATA_STATUS),
   substate: StreamSubstateSchema.optional(),
   lastTimestamp: z.number().optional(),

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -87,7 +87,7 @@ function callDelegateReview(agent = 'review') {
 }
 
 /**
- * One-shot executeAgent mock that reports a failed child via onError and
+ * One-shot executeAgent mock that reports a failed child via onRunError and
  * returns the same failed result, carrying the given subagent cost.
  */
 function mockExecuteAgentErrorOnce(totalCostUsd: number): void {
@@ -99,7 +99,7 @@ function mockExecuteAgentErrorOnce(totalCostUsd: number): void {
       streamId: 'child-stream',
       totalCostUsd,
     };
-    await options.onError?.(new Error('review model failed'), failed);
+    await options.onRunError?.(new Error('review model failed'), failed);
     return failed;
   });
 }

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -133,13 +133,13 @@ describe('NativeToolUseStrategy', () => {
     expect(msg).toContain('status="completed"');
   });
 
-  it('reports a non-throwing subagent failure via isTurnError, captured from onError', async () => {
+  it('reports a non-throwing subagent failure via isTurnError, captured from onRunError', async () => {
     const params = baseParams();
     const strategy = createNativeToolUseStrategy(params);
     const failure = new Error('model overloaded');
 
     mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
-      options.onError?.(failure);
+      options.onRunError?.(failure);
       return {
         category: 'toolUse',
         outcome: 'failed',

--- a/src/tools/delegation/nativeToolUseStrategy.ts
+++ b/src/tools/delegation/nativeToolUseStrategy.ts
@@ -149,7 +149,7 @@ export function createNativeToolUseStrategy(
           allowWaitingResult: true,
           onStreamResolved: params.onStreamResolved,
           onProgress: (update) => ports.notify(update),
-          onError: (err) => {
+          onRunError: (err) => {
             lastErr = err;
           },
           onRun: (handle) => {

--- a/src/tools/delegation/nativeWorkflowStrategy.ts
+++ b/src/tools/delegation/nativeWorkflowStrategy.ts
@@ -82,7 +82,7 @@ export function createNativeWorkflowStrategy(
           toolEditApprovalHandler: params.toolEditApprovalHandler,
           onStreamResolved: params.onStreamResolved,
           onProgress: (update) => ports.notify(update),
-          onError: (err) => {
+          onRunError: (err) => {
             lastErr = err;
           },
           onRun: (handle) => {

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -207,7 +207,7 @@ export async function executeSubagent(
         toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
         stopAfterCycle: true,
         onStreamResolved: inheritChildStreamApprovals,
-        onError: (err) => {
+        onRunError: (err) => {
           subagentError = err;
         },
       });


### PR DESCRIPTION
## Summary

A prior audit of the codebase's data-structure designs (maps-of-maps, overly generic collections, structures needing repeated null-checks/casts) surfaced several concrete issues. This PR fixes the highest-value, lowest-risk ones:

- **`src/replacement`**: `ReplacementCategory` was one interface shared by regex and non-regex categories, discriminated only by a runtime `isRegex` flag, so a non-regex category could type-accept a function pattern it could never actually use. `engine.ts` silently detected and skipped that "impossible" case, and cast `repl as string` on the regex path even though `repl` could legitimately be a callback. Split into `NonRegexReplacementCategory` / `RegexReplacementCategory`, a discriminated union — the dead skip-and-log path and the unsafe cast are both gone; `typeof repl === 'string'` now narrows correctly.
- **`src/agent/runtime`**: `ExecuteAgentOptions`, `ResumeToolUseFromSnapshotOptions`, and `ResumeQueuedToolUseOptions` each independently re-declared the same ~8 fields (`session`, `toolEditApprovalHandler`, `approvalPromptsUnavailable`, `runtimeUnavailableTools`, `parentStreamId`, `allowWaitingResult`, `onRun`, `onProgress`, `onFollowUpConsumed`). Worse, the run-failure callback was named `onError` in two of the three but `onRunError` in the third — colliding in meaning with a *different*, host-level `onError` in that same file, requiring a manual `onError: options.onRunError` bridge. Extracted a shared `SubagentRunOptions` type all three now extend, and renamed the run-failure callback to `onRunError` everywhere so it's unambiguous next to any host-level `onError`.
- **`src/latex/latexdiff/diffOperations.ts`**: replaced an ad hoc `Map<string, Map<number, string>>` with a plain sorted `{round, path}[]`, matching the canonical shape the sibling function in the same file already uses — removes three `!` non-null assertions.
- **`src/shared/schemas/streamSnapshot.ts`**: `StreamSnapshotSchema` re-declared 5 fields already defined once in `BackendOwnedFieldsSchema` (`streamState.ts`), with nothing keeping them in sync. Now derives them via `BackendOwnedFieldsSchema.pick(...)`.
- **`src/latex/latexdiff/types.ts`**: dropped 2 of 5 optional fields on `RunLatexdiffCommandConfig` that its only consumer never reads.
- **`src/latex/LatexMediaManager.ts`**: replaced repeated `this.fileService!` re-assertions inside `pMap` closures (3 occurrences) with a single `const fileService = this.fileService` captured right after the guard.
- **`syncSlice.ts`**: added a small `withDraftKind` helper to centralize the one necessarily-unsafe `mutative` `Draft<union>` cast instead of repeating it at 4 call sites.

Deliberately **not** touched (called out in the original audit as intentional or too broad-blast-radius for a mechanical pass): the fragmented per-stream `Map`s in the progress-view webview store, the legacy/canonical event-vocabulary bridge in `hostProgressEvents.ts` (frozen until v0.41 per its own comments), the 3x-reimplemented legacy provider-message migration, and the `goalActive`/`goalStatus`/`goalObjective` triple-optional-field pattern (touches persisted state shape).

## Issue acceptance gates

No tracked issue — this follows directly from a data-structure design review conducted in this session. Acceptance gate: each fix above compiles, typechecks, and its existing test coverage still passes with no behavior change.

## Single source of truth

- `SubagentRunOptions` (`src/agent/runtime/executeAgent.ts`) is now the one definition of subagent-run callback/host-context fields.
- `BackendOwnedFieldsSchema` (`src/shared/schemas/streamState.ts`) is now the one definition of the liveness/log-derived fields shared with `StreamSnapshotSchema`.
- `NonRegexReplacementCategory` / `RegexReplacementCategory` (`src/replacement/types.ts`) each now own exactly the pattern shape they can safely hold.

## Duplication and abstraction budget

Removed: 3 duplicated option-bag declarations → 1 shared type; 5 duplicated schema fields → 1 `.pick()`; 1 duplicated Map-based round-index shape → the codebase's existing array-of-`{round, ...}` convention. No new abstraction layers added — `SubagentRunOptions` and `withDraftKind` are each consumed by 3+ call sites (not single-caller extractions).

## Host impact

Extension: `packages/extension/src/progressView/frontend/slices/syncSlice.ts` (internal refactor only, no behavior change).

Desktop: none (shares the same `src/agent/runtime` and `src/shared/schemas` code paths; no desktop-specific file touched).

CLI: none (shares the same `src/agent/runtime` code paths; no CLI-specific file touched).

## Scheduled refactoring

None — the deliberately-deferred items above already have their own tracked context (frozen-migration comments in `hostProgressEvents.ts`, D3 ledger in `roundIndexed.ts`).

## Validation

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `corepack pnpm --filter texra typecheck` (extension) — clean
- `corepack pnpm --filter @texra-ai/cli typecheck` (CLI) — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npx vitest run src/test-kernel` — 5211 passed, 7 skipped, 1 failed. The 1 failure (`SystemUtils.vitest.ts > executeCommand > aborts shell command process groups including children`) is unrelated to any file this PR touches and reproduces identically on `main` in this sandboxed environment (confirmed by re-running it in isolation) — a process-group-signal timing flake specific to this container, not a regression.
- Updated two existing tests (`NativeToolUseStrategy.vitest.ts`, `DelegationHeadless.vitest.mts`) whose mocks referenced the renamed `onError` → `onRunError` field.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8wz4TJQj6VGERxYubZSrm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors and renames across replacement, runtime options, and schemas; delegation wiring changes only callback names and shared types, with tests updated accordingly.
> 
> **Overview**
> Mechanical refactors from a data-structure audit: **no intended runtime behavior change**, mostly typing and DRY.
> 
> **`src/replacement`:** `ReplacementCategory` is now a discriminated union (`NonRegexReplacementCategory` / `RegexReplacementCategory`) so string-only vs regex+callback patterns are enforced at compile time; the engine drops the old skip-and-log path for function patterns in non-regex categories and unsafe `repl as string` casts.
> 
> **`src/agent/runtime`:** Shared **`SubagentRunOptions`** backs `ExecuteAgentOptions`, `ResumeToolUseFromSnapshotOptions`, and `ResumeQueuedToolUseOptions`. The subagent failure callback is **`onRunError`** everywhere (was `onError` in two places), distinct from host-level `onError` on queued resume.
> 
> **Schemas:** `StreamSnapshotSchema` pulls liveness/log-derived fields from **`BackendOwnedFieldsSchema.pick(...)`** instead of duplicating five fields.
> 
> **LaTeX:** Workspace scan in `diffOperations` uses sorted `{round, path}[]` instead of nested `Map`s; `LatexMediaManager` captures `fileService` after guards; unused optional fields removed from `RunLatexdiffCommandConfig`.
> 
> **Extension:** `syncSlice` adds **`withDraftKind`** to centralize one `mutative` `Draft` cast for stream-kind guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cacdb13de3c1065f0c3e67f387060ddcdd5ad7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->