### PR TITLE
refactor(cli): handle TUI run facts directly

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -3,8 +3,9 @@
 // not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
 
 import type { AgentEvent } from '@agent/trace';
+import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { projectRunFactToProgressEvent } from '@agent/runtime/sessionProgressEventProjection';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/sessionProgressEventProjection';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type {
   ProgressEvent,
@@ -12,6 +13,9 @@ import type {
 } from '@agent/runtime/hostProgressEvents';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
+  ConversationProgressSchema,
+  UpdatePlanPayloadSchema,
+  UpdateTodosPayloadSchema,
   type ActiveChildInfo,
   type GoalPausedPayload,
   type UpdateActiveProcessesPayload,
@@ -90,7 +94,14 @@ function applySetActiveStream(
 
 function applyTaskState(payload: ProgressEventPayloads['setTaskState']): void {
   const config = payload.taskState.agentConfig;
-  patchStream(payload.streamId, (s) => {
+  applyRunConfig(payload.streamId, config);
+}
+
+function applyRunConfig(
+  streamId: ProgressEventPayloads['setTaskState']['streamId'],
+  config: ProgressEventPayloads['setTaskState']['taskState']['agentConfig'],
+): void {
+  patchStream(streamId, (s) => {
     if (s.model === config.model && s.category === config.agentCategory) {
       return s;
     }
@@ -203,52 +214,110 @@ function applyParentStream(
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
+function isGoalPausedPayload(value: unknown): value is GoalPausedPayload {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'streamId' in value &&
+    typeof value.streamId === 'string'
+  );
+}
+
+function applyDirectTuiDomainEvent(
+  event: Extract<AgentEvent, { type: 'domain' }>,
+  fallbackStreamId: ProgressEventPayloads['updateRoundStage']['streamId'],
+): boolean {
+  if (event.key === 'conversationProgress') {
+    const progress = ConversationProgressSchema.safeParse(event.data);
+    if (!progress.success) return false;
+    patchStream(fallbackStreamId, (s) => ({
+      ...s,
+      conversation: progress.data,
+    }));
+    return true;
+  }
+
+  const factName = fromRunFactDomainKey(event.key);
+  if (!factName) return false;
+
+  switch (factName) {
+    case 'updateTodos': {
+      const payload = UpdateTodosPayloadSchema.safeParse(event.data);
+      if (!payload.success) return false;
+      patchStream(payload.data.streamId, (s) => ({
+        ...s,
+        todos: payload.data.todos,
+      }));
+      return true;
+    }
+    case 'updatePlan': {
+      const payload = UpdatePlanPayloadSchema.safeParse(event.data);
+      if (!payload.success) return false;
+      patchStream(payload.data.streamId, (s) => ({
+        ...s,
+        plan: payload.data.plan,
+      }));
+      return true;
+    }
+    case 'goalPaused':
+      if (!isGoalPausedPayload(event.data)) return false;
+      appendGoalPausedTranscriptNotice(event.data);
+      return true;
+    case 'addOutputFiles':
+    case 'updateMissingOutputs':
+    case 'updateCompileFailures':
+      return false;
+  }
+}
+
 function applyDirectTuiRunEvent(
   event: AgentEvent,
   fallbackStreamId: ProgressEventPayloads['updateRoundStage']['streamId'],
 ): boolean {
-  const projected = projectRunFactToProgressEvent(fallbackStreamId, event);
-  if (!projected) return false;
-
-  switch (projected.event) {
-    case 'setTaskState':
-      applyTaskState(projected.payload);
+  switch (event.type) {
+    case 'run.config':
+      applyRunConfig(event.streamId, event.config);
       return true;
-    case 'updateStreamUsage':
-      applyUsageUpdate(projected.payload);
+    case 'usage': {
+      const payload = toUpdateStreamUsagePayload(event.data, fallbackStreamId);
+      if (!payload) return false;
+      applyUsageUpdate(payload);
       return true;
-    case 'updateTodos':
-      patchStream(projected.payload.streamId, (s) => ({
-        ...s,
-        todos: projected.payload.todos,
-      }));
+    }
+    case 'domain':
+      return applyDirectTuiDomainEvent(event, fallbackStreamId);
+    case 'stage.start':
+      if (event.kind !== 'round') return false;
+      applyRoundStage({
+        streamId: fallbackStreamId,
+        roundStage: {
+          index: event.index ?? 0,
+          ...(event.total !== undefined && event.total > 0
+            ? { total: event.total }
+            : {}),
+        },
+      });
       return true;
-    case 'updatePlan':
-      patchStream(projected.payload.streamId, (s) => ({
-        ...s,
-        plan: projected.payload.plan,
-      }));
+    case 'child.activity':
+      if (event.kind === 'subagents') {
+        applyActiveSubagents({
+          parentStreamId: event.parentStreamId,
+          children: [...event.children],
+        });
+        return true;
+      }
+      applyActiveProcesses({
+        parentStreamId: event.parentStreamId,
+        processes: [...event.processes],
+      });
       return true;
-    case 'updateConversationProgress':
-      patchStream(projected.payload.streamId, (s) => ({
-        ...s,
-        conversation: projected.payload.progress,
-      }));
-      return true;
-    case 'updateRoundStage':
-      applyRoundStage(projected.payload);
-      return true;
-    case 'updateActiveSubagents':
-      applyActiveSubagents(projected.payload);
-      return true;
-    case 'updateActiveProcesses':
-      applyActiveProcesses(projected.payload);
-      return true;
-    case 'updateProcessOutput':
-      applyProcessOutput(projected.payload);
-      return true;
-    case 'goalPaused':
-      appendGoalPausedTranscriptNotice(projected.payload);
+    case 'process.output':
+      applyProcessOutput({
+        parentStreamId: event.parentStreamId,
+        executionId: event.executionId,
+        stdout: event.stdout,
+        stderr: event.stderr,
+      });
       return true;
     default:
       return false;


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This removes the interactive CLI TUI from the legacy run-fact-to-progress-event projector. The TUI now applies the typed runtime event forms directly for run configuration, usage, conversation progress, todos, plans, goal-paused notices, round stages, child activity, and process output.

The headless CLI public-output path is unchanged: `packages/cli/src/runtime/sessionProgressSubscription.ts` remains the compatibility adapter for text/NDJSON progress output. The public host progress-event keys such as `setTaskState`, `updateRoundStage`, and `updateStreamUsage` remain supported for host-originated events.

A post-change grep shows no CLI file calls `projectRunFactToProgressEvent`; the remaining direct references are confined to `src/agent/runtime/sessionProgressEventProjection.ts` itself.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts`
- `git diff --check`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint` (passes with existing import-order warnings)
- `CI=true corepack pnpm test`

No #6981 compatibility-ledger row is added: this PR removes an internal compatibility dependency and does not add a new dual path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live TUI state subscription for many run event types; behavior should match the old projector but parsing and routing logic moved, so regressions in stream UI (usage, todos, child activity) are possible.
> 
> **Overview**
> The interactive TUI **stops projecting run facts through** `projectRunFactToProgressEvent` and instead patches `cliState` from **typed `AgentEvent` shapes** on the run subscription (`run.config`, `usage`, `stage.start`, `child.activity`, `process.output`, and selected `domain` keys).
> 
> **Domain facts** are parsed with shared Zod schemas (`ConversationProgressSchema`, `UpdateTodosPayloadSchema`, `UpdatePlanPayloadSchema`) and `fromRunFactDomainKey`; run config updates are shared via a new **`applyRunConfig`** helper used by both host `setTaskState` and `run.config` events. Some domain fact types are explicitly ignored in the TUI path (`addOutputFiles`, `updateMissingOutputs`, `updateCompileFailures`).
> 
> The **`wrapRuntimeHost` / `applyToState` progress-event pipeline is unchanged**, so host-originated keys like `setTaskState` and `updateStreamUsage` still work. Headless/public output adapters are out of scope for this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1e64a735666a8b2b7c40e13a2071c9934df491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->