### PR TITLE
fix(agent): log follow-up transcript rows even when media insertion throws

### DIFF
--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -78,13 +78,15 @@ export class ToolUseRoundPrepNode<C> extends BaseNode<
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUps?.length) {
       for (const followUp of prepRes.queuedFollowUps) {
-        // This follow-up's transcript row must be logged whether
+        // A non-synthetic follow-up's transcript row must be logged whether
         // appendFollowUpAsUserMessage succeeds or throws (e.g. a corrupt/
         // oversized media file) -- otherwise a failed follow-up round leaves
         // no record of what the user asked for. `finally` preserves the
         // throw so the round still fails as before; a throw before any
         // attachment was inserted just yields an empty attachments list,
-        // which is accurate (nothing was actually inserted).
+        // which is accurate (nothing was actually inserted). Synthetic
+        // follow-ups are still never logged, throw or not -- unchanged from
+        // before this fix.
         let result: AppendFollowUpResult | undefined;
         try {
           result = await appendFollowUpAsUserMessage(

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -9,6 +9,7 @@ import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
+  type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 
@@ -77,18 +78,29 @@ export class ToolUseRoundPrepNode<C> extends BaseNode<
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUps?.length) {
       for (const followUp of prepRes.queuedFollowUps) {
-        const result = await appendFollowUpAsUserMessage(
-          shared.messages,
-          followUp,
-          this.services,
-        );
-        shared.messages = result.messages;
-        if (!prepRes.synthetic) {
-          logUserMessage(
-            this.services.logger,
-            followUpDisplayText(followUp),
-            result.attachmentKinds,
+        // This follow-up's transcript row must be logged whether
+        // appendFollowUpAsUserMessage succeeds or throws (e.g. a corrupt/
+        // oversized media file) -- otherwise a failed follow-up round leaves
+        // no record of what the user asked for. `finally` preserves the
+        // throw so the round still fails as before; a throw before any
+        // attachment was inserted just yields an empty attachments list,
+        // which is accurate (nothing was actually inserted).
+        let result: AppendFollowUpResult | undefined;
+        try {
+          result = await appendFollowUpAsUserMessage(
+            shared.messages,
+            followUp,
+            this.services,
           );
+          shared.messages = result.messages;
+        } finally {
+          if (!prepRes.synthetic) {
+            logUserMessage(
+              this.services.logger,
+              followUpDisplayText(followUp),
+              result?.attachmentKinds ?? [],
+            );
+          }
         }
       }
       if (!prepRes.synthetic) {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -186,13 +186,14 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     for (const followUp of execRes.followUps) {
-      // This follow-up's transcript row must be logged whether
+      // A non-synthetic follow-up's transcript row must be logged whether
       // appendFollowUpAsUserMessage succeeds or throws (e.g. a corrupt/
       // oversized media file) -- otherwise a failed resume leaves no record
       // of what the user asked for. `finally` preserves the throw so the
       // resume still fails as before; a throw before any attachment was
       // inserted just yields an empty attachments list, which is accurate
-      // (nothing was actually inserted).
+      // (nothing was actually inserted). Synthetic follow-ups are still
+      // never logged, throw or not -- unchanged from before this fix.
       let result: AppendFollowUpResult | undefined;
       try {
         result = await appendFollowUpAsUserMessage(

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -7,6 +7,7 @@ import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
+  type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
 import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { STREAM_PHASE } from '@shared/schemas';
@@ -185,18 +186,29 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     for (const followUp of execRes.followUps) {
-      const result = await appendFollowUpAsUserMessage(
-        shared.messages,
-        followUp,
-        this.services,
-      );
-      shared.messages = result.messages;
-      if (!execRes.synthetic) {
-        logUserMessage(
-          logger,
-          followUpDisplayText(followUp),
-          result.attachmentKinds,
+      // This follow-up's transcript row must be logged whether
+      // appendFollowUpAsUserMessage succeeds or throws (e.g. a corrupt/
+      // oversized media file) -- otherwise a failed resume leaves no record
+      // of what the user asked for. `finally` preserves the throw so the
+      // resume still fails as before; a throw before any attachment was
+      // inserted just yields an empty attachments list, which is accurate
+      // (nothing was actually inserted).
+      let result: AppendFollowUpResult | undefined;
+      try {
+        result = await appendFollowUpAsUserMessage(
+          shared.messages,
+          followUp,
+          this.services,
         );
+        shared.messages = result.messages;
+      } finally {
+        if (!execRes.synthetic) {
+          logUserMessage(
+            logger,
+            followUpDisplayText(followUp),
+            result?.attachmentKinds ?? [],
+          );
+        }
       }
     }
 

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -1,0 +1,111 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { ToolUseRoundPrepNode } from '@agent/core/flows/toolUseRound/ToolUseRoundPrepNode';
+import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
+import { withTestRunContext } from '../progressTestUtils';
+
+function buildServices(
+  overrides: Partial<ToolUseRoundServices<unknown>> = {},
+): ToolUseRoundServices<unknown> {
+  return {
+    checkInterruption: () => false,
+    config: { model: 'deepseekT', agent: 'chat' } as never,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    modelHandler: {
+      createUserFollowUpMessages: vi.fn(async (messages) => messages),
+      addMediaToUserMessage: vi.fn(async () => []),
+      capabilities: {},
+    } as never,
+    fileService: { createLocation: vi.fn() } as never,
+    toolRegistry: {} as never,
+    ...overrides,
+  } as ToolUseRoundServices<unknown>;
+}
+
+function buildShared(): ToolUseRoundShared {
+  return {
+    messages: [],
+    shouldStop: false,
+    endTurn: false,
+  } as unknown as ToolUseRoundShared;
+}
+
+describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 pattern on a round)', () => {
+  it('logs a follow-up transcript row even when appendFollowUpAsUserMessage throws', async () => {
+    // A failed follow-up append mid-round (corrupt/oversized media, provider
+    // validation error, ...) must still leave a record of what the user
+    // asked for — otherwise that turn's transcript row silently vanishes.
+    const services = buildServices();
+    (
+      services.modelHandler.createUserFollowUpMessages as ReturnType<
+        typeof vi.fn
+      >
+    ).mockRejectedValue(new Error('follow-up append failed'));
+    const node = new ToolUseRoundPrepNode().setServices(services);
+    const shared = buildShared();
+    const runtimeHost = { emit: vi.fn() };
+
+    await expect(
+      withTestRunContext(runtimeHost, 'test-stream', () =>
+        node.post(shared, {
+          interrupted: false,
+          queuedFollowUps: [{ text: 'Do the thing.', origin: 'user' }],
+          synthetic: false,
+        }),
+      ),
+    ).rejects.toThrow('follow-up append failed');
+
+    expect(services.logger.info).toHaveBeenCalledWith(
+      'Do the thing.',
+      expect.objectContaining({ messageType: expect.any(String) }),
+    );
+  });
+
+  it('still logs exactly once per queued follow-up on the success path', async () => {
+    const services = buildServices();
+    const node = new ToolUseRoundPrepNode().setServices(services);
+    const shared = buildShared();
+    const runtimeHost = { emit: vi.fn() };
+
+    const transition = await withTestRunContext(
+      runtimeHost,
+      'test-stream',
+      () =>
+        node.post(shared, {
+          interrupted: false,
+          queuedFollowUps: [{ text: 'Do the thing.', origin: 'user' }],
+          synthetic: false,
+        }),
+    );
+
+    expect(transition).toBeDefined();
+    expect(services.logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log synthetic follow-ups', async () => {
+    const services = buildServices();
+    (
+      services.modelHandler.createUserFollowUpMessages as ReturnType<
+        typeof vi.fn
+      >
+    ).mockRejectedValue(new Error('boom'));
+    const node = new ToolUseRoundPrepNode().setServices(services);
+    const shared = buildShared();
+    const runtimeHost = { emit: vi.fn() };
+
+    await expect(
+      withTestRunContext(runtimeHost, 'test-stream', () =>
+        node.post(shared, {
+          interrupted: false,
+          queuedFollowUps: [{ text: 'synthesized', origin: 'user' }],
+          synthetic: true,
+        }),
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(services.logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -1,0 +1,121 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
+import type {
+  ToolUseRunShared,
+  WaitExecResult,
+} from '@agent/implementations/flows/tooluse/nodes/types';
+import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
+import { withTestRunContext } from '../progressTestUtils';
+
+function buildServices(
+  overrides: Partial<ToolUseServices<unknown>> = {},
+): ToolUseServices<unknown> {
+  return {
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    modelHandler: {
+      createUserFollowUpMessages: vi.fn(async (messages) => messages),
+      addMediaToUserMessage: vi.fn(async () => []),
+      capabilities: {},
+    } as never,
+    fileService: { createLocation: vi.fn() } as never,
+    streamStatus: { transition: vi.fn() } as never,
+    ...overrides,
+  } as ToolUseServices<unknown>;
+}
+
+// WaitPrepResult isn't exported by ToolUseWaitNode.ts; this structurally
+// satisfies it (checked at each node.post() call site below).
+const PREP_RES = {
+  lastResponse: undefined,
+  touchedFiles: [] as string[],
+  afterError: false,
+};
+
+describe('ToolUseWaitNode follow-up transcript logging (regression: #7508 pattern on resume)', () => {
+  it('logs a follow-up transcript row even when appendFollowUpAsUserMessage throws', async () => {
+    // A failed follow-up append on resume (corrupt/oversized media, provider
+    // validation error, ...) must still leave a record of what the user
+    // asked for — otherwise that turn's transcript row silently vanishes.
+    const services = buildServices();
+    (
+      services.modelHandler.createUserFollowUpMessages as ReturnType<
+        typeof vi.fn
+      >
+    ).mockRejectedValue(new Error('follow-up append failed'));
+    const node = new ToolUseWaitNode().setServices(services);
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const runtimeHost = { emit: vi.fn() };
+    const execRes: WaitExecResult = {
+      kind: 'continue',
+      followUps: [{ text: 'Do the thing.', origin: 'user' }],
+    };
+
+    await expect(
+      withTestRunContext(runtimeHost, 'test-stream', () =>
+        node.post(shared, PREP_RES, execRes),
+      ),
+    ).rejects.toThrow('follow-up append failed');
+
+    expect(services.logger.info).toHaveBeenCalledWith(
+      'Do the thing.',
+      expect.objectContaining({ messageType: expect.any(String) }),
+    );
+  });
+
+  it('still logs exactly once per follow-up on the success path', async () => {
+    const services = buildServices();
+    const node = new ToolUseWaitNode().setServices(services);
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const runtimeHost = { emit: vi.fn() };
+    const execRes: WaitExecResult = {
+      kind: 'continue',
+      followUps: [{ text: 'Do the thing.', origin: 'user' }],
+    };
+
+    await withTestRunContext(runtimeHost, 'test-stream', () =>
+      node.post(shared, PREP_RES, execRes),
+    );
+
+    expect(services.logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log synthetic (idle-continuation) follow-ups', async () => {
+    const services = buildServices();
+    (
+      services.modelHandler.createUserFollowUpMessages as ReturnType<
+        typeof vi.fn
+      >
+    ).mockRejectedValue(new Error('boom'));
+    const node = new ToolUseWaitNode().setServices(services);
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const runtimeHost = { emit: vi.fn() };
+    const execRes: WaitExecResult = {
+      kind: 'continue',
+      followUps: [{ text: 'synthesized', origin: 'user' }],
+      synthetic: true,
+    };
+
+    await expect(
+      withTestRunContext(runtimeHost, 'test-stream', () =>
+        node.post(shared, PREP_RES, execRes),
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(services.logger.info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #7508/#7524. Those fixed `ToolUsePrepareNode.ts` and `MediaExtractionNode.ts` (both session-init, round-0-only call sites) by wrapping their media/message-init call in `try`/`finally` so the transcript's opening row is always logged, success or throw.

A `/simplify` altitude review of that fix found the identical bug shape at **two more, real call sites** that handle every *follow-up* round (not just the first) — see #7575's PR body for the review that surfaced this.

## Root cause

- `src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts` (`post()`, the inner per-round prep node): injects a queued follow-up before each model call.
- `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts` (`post()`): injects a queued follow-up on resume from WAITING.

Both loop over queued follow-ups, calling `appendFollowUpAsUserMessage` then `logUserMessage` per item, with no `try`/`finally` around either. If `appendFollowUpAsUserMessage` throws partway through the loop (corrupt/oversized media file, provider validation error), the throwing item's own transcript row was silently dropped — the exact #7508 bug class, just on a follow-up round instead of round 0. Earlier items in the same batch already got their rows logged before the throw; only the failing item's own row was lost, and the throw still correctly aborts the remaining batch (unprocessed items were never attempted, so nothing to log for them).

## Fix

Wrap each loop iteration's `appendFollowUpAsUserMessage` call in `try`/`finally`, matching the exact idiom already used by `ToolUsePrepareNode.ts`/`MediaExtractionNode.ts` — **not** a shared abstraction. I considered extracting a helper, but the four real call sites' "what attachments to log" and "should we log at all" logic differ enough (`initialUserMessageForTranscript`-gated vs `synthetic`-gated, `consumeInsertedAttachmentKinds` side-channel vs direct return value) that forcing them through one signature would be a worse fit than repeating a five-line idiom already established at the first two sites.

The throw still propagates after the `finally` block (the round/resume still fails exactly as before); a throw before any attachment was inserted just yields an empty attachments list on that item's log call, which is accurate (nothing was actually inserted).

## Verification

- `npx tsc --noEmit` (root + test-kernel) — clean
- `npx eslint` on all 4 changed files — clean
- `npx prettier --check` — clean
- New regression tests for both nodes (3 each: throws-still-logs, success-logs-once, synthetic-never-logs) — confirmed to **fail against the pre-fix code** via `git stash` before re-verifying they pass against the fix
- Existing `ToolUseWaitNode.vitest.ts` and `ToolUseDispatchInterruption.vitest.ts` (18 tests) still pass
- Full `src/test-kernel/agent/` sweep — 1164 passed, 4 pre-existing skips, 0 failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized observability fix in agent flow nodes; failure behavior unchanged aside from ensuring transcript rows are recorded before rethrow.
> 
> **Overview**
> Extends the #7508 transcript-logging fix to **follow-up rounds**, not just session init. In `ToolUseRoundPrepNode` and `ToolUseWaitNode`, each queued follow-up used to call `appendFollowUpAsUserMessage` and only then `logUserMessage`; if append threw (bad media, provider validation, etc.), that user message never appeared in the transcript even though the round/resume still failed.
> 
> Each loop iteration now uses **`try`/`finally`** so non-synthetic follow-ups are still logged via `logUserMessage` (with `result?.attachmentKinds ?? []` when append failed early). Throws still propagate; synthetic follow-ups are still never logged.
> 
> Adds **regression tests** for both nodes: throw-still-logs, success logs once, synthetic never logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fc1cb78b5c459b3d03d91b67ef25723f3d7971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->