### PR TITLE
test(cli): pin model picker harness models

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -13,7 +13,7 @@ import { getAgentsByCategory, loadAgents } from '@agent/index';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { platform, tryPlatform } from '@platform/platform';
 import {
   AgentCategory,
@@ -277,6 +277,7 @@ const HARNESS_VISIBLE_TOOL_USE_AGENTS = parseList(
 const HARNESS_VISIBLE_WORKFLOW_AGENTS = parseList(
   process.env.HARNESS_VISIBLE_WORKFLOW_AGENTS,
 );
+const HARNESS_VISIBLE_MODELS = parseList(process.env.HARNESS_VISIBLE_MODELS);
 
 if (SHOW_PROJECT_SKILL) {
   seedHarnessProjectSkill();
@@ -300,6 +301,12 @@ if (process.env.HARNESS_VISIBLE_WORKFLOW_AGENTS !== undefined) {
   await platform().workspaceState.update(
     WorkspaceStateKey.ENABLED_AGENTS,
     HARNESS_VISIBLE_WORKFLOW_AGENTS,
+  );
+}
+if (process.env.HARNESS_VISIBLE_MODELS !== undefined) {
+  await platform().globalState.update(
+    GlobalStateKey.ENABLED_MODELS,
+    HARNESS_VISIBLE_MODELS,
   );
 }
 await loadAgents({ includeRemote: false });

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -95,6 +95,7 @@ const PHYSICIST_LOCAL_TOOL_USE_AGENTS = [
   'presenter',
 ].join('||');
 const PHYSICIST_WORKFLOW_AGENTS = ['correct', 'polish'].join('||');
+const TWO_OPENAI_MODELS = ['gpt55', 'gpt55pro'].join('||');
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -822,6 +823,7 @@ const SCENARIOS = [
     env: {
       HARNESS_CAN_SELECT_MODEL: '1',
       HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_MODELS: TWO_OPENAI_MODELS,
       OPENAI_API_KEY: 'harness-openai-key',
     },
     keys: ['/model', '\r'],
@@ -870,6 +872,7 @@ const SCENARIOS = [
     env: {
       HARNESS_CAN_SELECT_MODEL: '1',
       HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_MODELS: TWO_OPENAI_MODELS,
       OPENAI_API_KEY: 'harness-openai-key',
     },
     keys: ['/model', '\r', '\r'],
@@ -886,6 +889,7 @@ const SCENARIOS = [
     env: {
       HARNESS_CAN_SELECT_MODEL: '1',
       HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_MODELS: TWO_OPENAI_MODELS,
       OPENAI_API_KEY: 'harness-openai-key',
     },
     keys: ['/model', '\r', '21'],
@@ -1074,6 +1078,7 @@ const SCENARIOS = [
     cols: 80,
     env: {
       HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_MODELS: TWO_OPENAI_MODELS,
       OPENAI_API_KEY: 'harness-openai-key',
     },
     keys: ['/model', '\r'],


### PR DESCRIPTION
## Summary

Fixes the CLI PTY validator drift found while dogfooding recent TUI/runtime refactors. The `/model` scenarios that require more than one visible OpenAI model now seed the harness with active OpenAI models instead of relying on the live default model list, where `gpt54` is now deprecated and filtered out.

## Issue acceptance gates

Addresses #7577.

- Reproduced the failing TUI validator on current main: `model-form-buffered-hotkey` and `compact-model-form` failed because only `GPT-5.5` was visible.
- Added a harness-only visible-model override.
- Pinned the affected model-picker scenarios to two active OpenAI models: `gpt55` and `gpt55pro`.
- Re-ran the focused scenarios and the full PTY validator successfully.

## Single source of truth

Production model availability remains owned by `computeModelOptionsData` / the model registry path. Test fixture model visibility for the PTY harness is now owned by `HARNESS_VISIBLE_MODELS` in `packages/cli/scripts/tui-harness.tsx`, matching the existing harness-owned visible-agent knobs.

## Duplication and abstraction budget

No production abstraction was added. The new harness knob avoids duplicating or weakening model-picker assertions while keeping registry-driven production defaults untouched. No #6981 ledger row is needed because this is test harness fixture control, not a production shim, projection, dual-write, alias, fallback, or migration path.

## Host impact

Extension: none.

Desktop: none.

CLI: PTY validation is deterministic again for model-picker multi-item scenarios; runtime CLI behavior is unchanged.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /tmp/texra-tui-frames-model-fix-active-20260708-115532 model-form-buffered-hotkey compact-model-form`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-frames-model-fix-full-20260708-115639`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-frames-model-fix-rebased-20260708-120423 model-form-buffered-hotkey compact-model-form`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-tui.mjs packages/cli/scripts/tui-harness.tsx`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (passes with existing import-order warnings)
- `npm run compile:fast`
- `CI=true corepack pnpm run test`

Closes #7577
