### PR TITLE
refactor: modern-TS simplification sweep over previously-unswept dirs (net -56)

### DIFF
--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -205,8 +205,7 @@ function configureAnsi(
 
   r.heading_open = (tokens, idx) => {
     headingDepth += 1;
-    const start = quoteDepth === 0 ? '\n' : quoteBlockStart(tokens, idx);
-    return start;
+    return quoteDepth === 0 ? '\n' : quoteBlockStart(tokens, idx);
   };
   r.heading_close = () => {
     headingDepth = Math.max(0, headingDepth - 1);

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -161,12 +161,11 @@ export async function executeCliRequest(
   runContext: CliContext,
   options: CliExecuteOptions = {},
 ): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
-  const baseRuntimeHost = createCliRuntimeHost(runContext);
+  const runtimeHost = createCliRuntimeHost(runContext);
   const snapshotStore = new StreamSnapshotStore();
   const detachSnapshotEvents = snapshotStore.attachSessionEvents(
     defaultSession().events,
   );
-  const runtimeHost = baseRuntimeHost;
   const detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -233,15 +233,10 @@ function refreshPersistedSystemMessage(
   // For system-role messages: preserve existing content block type (OpenAI Chat
   // uses 'text', OpenAI Responses uses 'input_text') so the resumed snapshot
   // stays valid across providers.
-  const prevContent = existing.content;
-  let firstBlockType: string | null = null;
-  if (Array.isArray(prevContent) && prevContent.length > 0) {
-    const firstBlock = prevContent[0];
-    if (typeof firstBlock === 'object' && firstBlock !== null) {
-      const type = (firstBlock as { type?: unknown }).type;
-      if (typeof type === 'string') firstBlockType = type;
-    }
-  }
+  const prevType = Array.isArray(existing.content)
+    ? (existing.content[0] as { type?: unknown } | undefined)?.type
+    : undefined;
+  const firstBlockType = typeof prevType === 'string' ? prevType : null;
   const systemContent = firstBlockType
     ? [{ type: firstBlockType, text: systemText }]
     : systemText;

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -206,9 +206,7 @@ export async function uploadGoogleMediaEntries<T>(
     }
 
     const canUseSourcePath =
-      entry.source_path &&
-      entry.source_path.length > 0 &&
-      entry.bytes_match_source !== false;
+      entry.source_path && entry.bytes_match_source !== false;
     if (!canUseSourcePath) {
       logger.error(
         `Skipping media entry ${fileName} due to missing upload source`,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -129,10 +129,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       return undefined;
     }
 
-    const isImage = mimeType.startsWith('image/');
-    const isPdf = mimeType === 'application/pdf';
-
-    if (isImage || isPdf) {
+    if (mimeType.startsWith('image/') || mimeType === 'application/pdf') {
       return PartMediaResolutionLevel.MEDIA_RESOLUTION_HIGH;
     }
     // Videos use default which is optimal
@@ -363,12 +360,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         `Sending message with ${lastMessageParts.length} parts.`,
       );
 
+      const messageParams: SendMessageParameters = {
+        message: [...lastMessageParts],
+        config: { ...generationConfig, abortSignal: signal },
+      };
       if (useStreaming) {
-        const streamParams: SendMessageParameters = {
-          message: [...lastMessageParts],
-          config: { ...generationConfig, abortSignal: signal },
-        };
-        const stream = await chat.sendMessageStream(streamParams);
+        const stream = await chat.sendMessageStream(messageParams);
 
         // Opened before the request; the deferred starts fire (if ever) at
         // the first thought/text part — the phase signal for this API.
@@ -465,22 +462,16 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         // Part.thought is a native property of the Google GenAI SDK Part interface
         const candidateContent = baseResponse.candidates?.[0]?.content;
         if (candidateContent?.parts) {
-          const filteredParts = candidateContent.parts.filter(
+          // Update the parts array; the SDK will compute the text property from it
+          candidateContent.parts = candidateContent.parts.filter(
             (part) => !part.thought,
           );
-          // Update the parts array; the SDK will compute the text property from it
-          candidateContent.parts = filteredParts;
         }
 
         return { response: baseResponse };
       }
 
-      const sendParams: SendMessageParameters = {
-        message: [...lastMessageParts],
-        config: { ...generationConfig, abortSignal: signal },
-      };
-
-      const response = await chat.sendMessage(sendParams);
+      const response = await chat.sendMessage(messageParams);
       return { response };
     } catch (error) {
       return handleStreamingFailure(error, {
@@ -689,7 +680,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       };
     }
 
-    if (!responseObject.candidates || responseObject.candidates.length === 0) {
+    if (!responseObject.candidates?.length) {
       if (responseObject?.promptFeedback?.blockReason) {
         const { blockReason, safetyRatings } = responseObject.promptFeedback;
         this.logger.error(`Request blocked: ${blockReason}`, {
@@ -967,7 +958,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         (part): part is FunctionResponsePart => part !== null,
       );
 
-      if (attachmentParts.length === 0 && attachments.length > 0) {
+      if (attachmentParts.length === 0) {
         this.logger.warn(
           `All attachments for Google function response '${call.name}' failed to encode.`,
         );

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -381,9 +381,7 @@ async function assembleAgentLaunchContext(
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
   const displayInstruction =
-    config.displayInstruction == null
-      ? config.instruction?.trim()
-      : config.displayInstruction.trim();
+    (config.displayInstruction ?? config.instruction)?.trim();
   const initialInstruction =
     displayInstruction && !input.streamTabIdOverride
       ? displayInstruction

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -380,8 +380,9 @@ async function assembleAgentLaunchContext(
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
-  const displayInstruction =
-    (config.displayInstruction ?? config.instruction)?.trim();
+  const displayInstruction = (
+    config.displayInstruction ?? config.instruction
+  )?.trim();
   const initialInstruction =
     displayInstruction && !input.streamTabIdOverride
       ? displayInstruction

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -133,10 +133,9 @@ class ExecutionSubscription implements Disposable {
       return;
     }
 
-    const transition =
-      this.last && statusChanged
-        ? `${this.last.status} → ${current.status}`
-        : current.status;
+    const transition = this.last
+      ? `${this.last.status} → ${current.status}`
+      : current.status;
     const elapsed = current.elapsed ? ` (${current.elapsed} elapsed)` : '';
     this.send(
       `${this.executionId} (${this.agentName}, ${this.category}) ${transition}${elapsed}`,

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -70,10 +70,10 @@ export class StreamStatusMachine {
     options: StreamStatusEmitOptions = {},
   ): boolean {
     if (this.reservations.has(stream)) return false;
-    if (!canAcquireStreamReservation(this.phases.get(stream)?.phase)) {
+    const previousPhase = this.phases.get(stream)?.phase;
+    if (!canAcquireStreamReservation(previousPhase)) {
       return false;
     }
-    const previousPhase = this.phases.get(stream)?.phase;
     this.reservations.add(stream);
     this.publishStatus(stream, STREAM_PHASE.RUNNING, {
       ...options,

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -196,10 +196,7 @@ function runtimeNarrowToolDefinition(
   tool: ToolDefinition,
   diagnosticsAddUnavailable: boolean,
 ): ToolDefinition {
-  if (diagnosticsAddUnavailable) {
-    return withoutDiagnosticsAddCommand(tool);
-  }
-  return tool;
+  return diagnosticsAddUnavailable ? withoutDiagnosticsAddCommand(tool) : tool;
 }
 
 /**

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -66,7 +66,9 @@ function buildUserPrompt(
 export function getSessionDescriptionInstruction(
   config: Pick<AgentConfig, 'displayInstruction' | 'instruction'>,
 ): string {
-  return (config.displayInstruction?.trim() || config.instruction?.trim()) ?? '';
+  return (
+    (config.displayInstruction?.trim() || config.instruction?.trim()) ?? ''
+  );
 }
 
 /**

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -66,9 +66,7 @@ function buildUserPrompt(
 export function getSessionDescriptionInstruction(
   config: Pick<AgentConfig, 'displayInstruction' | 'instruction'>,
 ): string {
-  const displayInstruction = config.displayInstruction?.trim();
-  if (displayInstruction) return displayInstruction;
-  return config.instruction?.trim() ?? '';
+  return (config.displayInstruction?.trim() || config.instruction?.trim()) ?? '';
 }
 
 /**

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -258,18 +258,12 @@ export class ProgressWorkflowFileActionsController {
     // Use the matched entry's own `round` and prefer the most recent match:
     // in-place workflows reuse the same workspace path across rounds, so the
     // Map key (and the first match) would mislabel the `r<round>` postfix.
-    let round: number | undefined;
-    for (const infos of Object.values(this.deps.state.getOutputFiles(stream))) {
-      for (const info of infos) {
-        if (
-          info.location.absolutePath === file &&
-          (round === undefined || info.round > round)
-        ) {
-          round = info.round;
-        }
-      }
-    }
-    if (round === undefined) return undefined;
+    const rounds = Object.values(this.deps.state.getOutputFiles(stream))
+      .flat()
+      .filter((info) => info.location.absolutePath === file)
+      .map((info) => info.round);
+    if (rounds.length === 0) return undefined;
+    const round = Math.max(...rounds);
 
     return { agent: config.agent, model: config.model, round };
   }
@@ -277,14 +271,12 @@ export class ProgressWorkflowFileActionsController {
   private findOutputDirectory(
     runOutputs: RoundIndexed<OutputFileInfo>,
   ): string | undefined {
-    for (const infos of Object.values(runOutputs)) {
-      for (const info of infos) {
-        const kind = info.location.kind;
-        if (kind === 'runStorage' || kind === 'workspace') {
-          return path.dirname(info.location.absolutePath);
-        }
-      }
-    }
-    return undefined;
+    const match = Object.values(runOutputs)
+      .flat()
+      .find(
+        ({ location }) =>
+          location.kind === 'runStorage' || location.kind === 'workspace',
+      );
+    return match ? path.dirname(match.location.absolutePath) : undefined;
   }
 }

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -263,7 +263,7 @@ export class ProgressWorkflowFileActionsController {
       .filter((info) => info.location.absolutePath === file)
       .map((info) => info.round);
     if (rounds.length === 0) return undefined;
-    const round = Math.max(...rounds);
+    const round = rounds.reduce((max, r) => Math.max(max, r));
 
     return { agent: config.agent, model: config.model, round };
   }

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -7,7 +7,7 @@ import { getConfig } from '@utils/config/configUtils';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // Local file imports
-import { DEFAULT_MATH_MARKUP, type MathMarkupOption } from './mathMarkup';
+import type { MathMarkupOption } from './mathMarkup';
 
 const DEFAULT_PICTURE_ENVS =
   '(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*';

--- a/src/shared/progressView/backend/WebviewUpdater.ts
+++ b/src/shared/progressView/backend/WebviewUpdater.ts
@@ -454,12 +454,11 @@ export class WebviewUpdater {
     // Send lightweight metadata — only backend-owned fields the frontend merges.
     const streamMetadata: Record<StreamTabId, StreamMetadata> = {};
     for (const streamInfo of streams) {
-      const metadata = this.buildStreamMetadataForStream(
+      streamMetadata[streamInfo.name] = this.buildStreamMetadataForStream(
         state,
         streamInfo,
         streamStates,
       );
-      streamMetadata[streamInfo.name] = metadata;
     }
 
     this.updateStreams(

--- a/src/shared/progressView/backend/events/errorHandling.ts
+++ b/src/shared/progressView/backend/events/errorHandling.ts
@@ -14,10 +14,7 @@ function toErrorData(error: unknown): Record<string, unknown> {
 
 /** Check if a value is a thenable (has .catch method). */
 function isThenable(value: unknown): value is PromiseLike<unknown> {
-  return (
-    value !== null &&
-    typeof (value as PromiseLike<unknown>)?.then === 'function'
-  );
+  return typeof (value as PromiseLike<unknown>)?.then === 'function';
 }
 
 /** Log an error with module context. */

--- a/src/tools/deliveryEnvelope.ts
+++ b/src/tools/deliveryEnvelope.ts
@@ -27,7 +27,7 @@ interface DeliveryEnvelopeParams {
 
 function formatDeliveryEnvelope(params: DeliveryEnvelopeParams): string {
   const attrs = params.attributes
-    .filter((attr) => attr.value !== null && attr.value !== undefined)
+    .filter((attr) => attr.value != null)
     .map((attr) => `${attr.name}="${escapeAttr(String(attr.value))}"`)
     .join(' ');
   const open = attrs ? `<${params.tag} ${attrs}>` : `<${params.tag}>`;

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -249,9 +249,7 @@ export abstract class PollingSourceBase<
    * `pollOne`.
    */
   protected detach(key: K): void {
-    const state = this.subscriptions.get(key);
-    if (!state) return;
-    this.subscriptions.delete(key);
+    if (!this.subscriptions.delete(key)) return;
     this.notifyKeysChanged();
   }
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -141,7 +141,7 @@ Best practices:
       return {
         status: 'executed',
         summary: 'Created plan (no active session)',
-        output: this.formatPlan(plan),
+        output: `Plan objective:\n${plan.objective}`,
         diagnostics: {
           warning: 'No active plan context — plan may not persist',
         },
@@ -435,9 +435,5 @@ Best practices:
         : 'Plan approved — proceed with implementation',
       output: `${prefix} Work toward the objective, tracking concrete steps with the todo tool.`,
     };
-  }
-
-  private formatPlan(plan: Plan): string {
-    return `Plan objective:\n${plan.objective}`;
   }
 }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -157,12 +157,10 @@ export function formatSubagentDelivery(
     workingDirectory?: string;
   },
 ): string {
-  const lines = [
-    ...formatDeliveryPreamble({
-      workingDirectory: options?.workingDirectory,
-      memoryMisses: result.memoryMisses,
-    }),
-  ];
+  const lines = formatDeliveryPreamble({
+    workingDirectory: options?.workingDirectory,
+    memoryMisses: result.memoryMisses,
+  });
 
   if (result.category === 'workflow') {
     if (options?.diffsUnavailable) {

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -31,12 +31,6 @@ const AskUserQuestionInputSchema = z.strictObject({
 
 export type AskUserQuestionInput = z.infer<typeof AskUserQuestionInputSchema>;
 
-interface UserQuestionResult {
-  submitted: boolean;
-  answers?: UserQuestionAnswers;
-  feedback?: string;
-}
-
 export async function handleUserQuestionAction(payload: {
   requestId: string;
   action: 'submit' | 'reject' | 'skip';

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -465,8 +465,7 @@ export class StreamSnapshotStore {
     version: number,
     apply: () => unknown,
   ): Promise<void> {
-    let next: Promise<void> = Promise.resolve();
-    next = this.ensureSeeded(stream, version)
+    const next: Promise<void> = this.ensureSeeded(stream, version)
       .then(() => {
         if (this.streamVersion(stream) !== version) return;
         if (!this.seeded.has(stream)) {
@@ -1297,9 +1296,6 @@ export class StreamSnapshotStore {
   ): Promise<HydratedRunState> {
     const executionId = executionIdFromMeta(meta);
     let descriptor = meta.runDescriptor;
-    if (meta.runDescriptor) {
-      descriptor = meta.runDescriptor;
-    }
 
     if (executionId) {
       let config: AgentConfig | null = null;


### PR DESCRIPTION
## What

Follow-up to #7540. That sweep covered the collision-free surface; this one targets the **previously-*excluded*** dirs — `tools`, `agent/modelHandlers`, `agent/runtime`, `transcript`, `latex/latexdiff`, `shared`/`controllers` progressView, `flows/tooluse`, and `cli` — which the earlier repo-wide sweeps skipped because they sat behind open PRs at the time. **Net −56 LOC across 20 files**, same proven mechanical style, **no new abstractions** (deliberately avoiding the #7271 "+726" anti-pattern).

Produced by a 14-partition finder fan-out over ~500 never-swept source files, each edit then **adversarially verified** (default-reject) and re-checked by eye.

## Changes (by category)

- **Loop → array-method collapse**: `filter`/`map`/`flat` over manual accumulator loops — `ProgressWorkflowFileActionsController` (max-round + first-match-dirname finders), Google GenAI thought-part filter, `PollingSourceBase`.
- **Pass-through / dead-code removal**: inline single-caller `PlanTool.formatPlan`; delete the dead `UserQuestionResult` interface; drop a dead import + a provable no-op `if` in latexdiff; remove a redundant spread-copy of a freshly-returned array (`subagentResults`).
- **Nullish / optional idioms**: `!= null`, `?.length`, redundant-guard collapses (`deliveryEnvelope`, Google GenAI candidate/parts checks, `ToolUsePrepareNode`, progressView `errorHandling`/`WebviewUpdater`, `StreamSnapshotStore`, cli `ansiMarkdown`/`runExecution`).
- **Hoist a duplicated literal**: identical `SendMessageParameters` object was built in both the streaming and non-streaming Google GenAI branches — built once now (only one branch runs per call, so no aliasing change).

## Collision-safety

Branched from `origin/main` (`0900cbe38`), and **excluded every file touched by all 12 current open PRs** via an exact-path check (re-verified at commit time; none of the 20 files moved on `origin/main`). Two candidate edits were dropped: one whose `oldString` was already-applied on the worktree, and one that only changed a mocked call's arity (runtime-identical but pinned by `toHaveBeenCalledWith`) — dropped rather than edit a test.

## Verification

- `tsc --noEmit` (root) ✅ · `tsc -p tsconfig.test-kernel.json` ✅ · extension typecheck ✅ · cli typecheck ✅
- eslint on changed files ✅
- full `vitest run` — **5216 passed / 4 skipped** ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly local refactors with equivalent control flow; watch for edge cases where `??` vs explicit empty-`displayInstruction` handling or Google attachment warnings when `attachments` is empty could differ slightly from before.
> 
> **Overview**
> Follow-up mechanical cleanup across CLI, agent runtime/model handlers, progress view, tools, and transcript—**net −56 LOC**, no new abstractions.
> 
> **Google GenAI handler** builds one shared `SendMessageParameters` for streaming and non-streaming sends, tightens optional checks (`candidates?.length`), in-place filters thought parts, and simplifies media-resolution branching.
> 
> **Runtime / launch** drops redundant variables (`runExecution` host, `StreamSnapshotStore` seed chain, duplicate `runDescriptor` assign), simplifies status-transition strings, stream acquire ordering, session description / display-instruction nullish handling, and tool-definition narrowing to ternaries.
> 
> **Progress & tools** replace nested loops with `flat`/`filter`/`reduce`/`find` in workflow file actions; inline `PlanTool` plan text and remove dead types/imports; use `Map.delete` guard in GitHub polling detach; drop redundant array spread in subagent delivery preamble.
> 
> Scattered **optional-chaining / `!= null`** idioms in markdown ANSI render, delivery envelopes, error thenable checks, tool-use resume system-block typing, and Google upload path checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b413f601c1a00f28c416f3536cf93840a0d7305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->