### PR TITLE
refactor(runtime): extract run fact usage parser

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -4,8 +4,8 @@
 
 import type { AgentEvent } from '@agent/trace';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { toUpdateStreamUsagePayload } from '@agent/runtime/sessionProgressEventProjection';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type {
   ProgressEvent,

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -1,6 +1,6 @@
 // Local imports - runtime events
+import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { toUpdateStreamUsagePayload } from '@agent/runtime/sessionProgressEventProjection';
 
 // Local imports - status bar state
 import type { StatusBarUsageTracker } from './StatusBarUsageTracker';

--- a/src/agent/runtime/runFactUsage.ts
+++ b/src/agent/runtime/runFactUsage.ts
@@ -1,0 +1,36 @@
+import {
+  ExtendedTokenUsageStatsSchema,
+  type StorageKey,
+  type StreamTabId,
+  type UpdateStreamUsagePayload,
+} from '@shared/schemas';
+import { isObject } from '@utils/core';
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Parse a raw `usage` run-fact payload into the typed usage update form used by
+ * host-neutral consumers. Keep this parser outside the legacy projection
+ * module so fact-native UI paths do not depend on compatibility machinery.
+ */
+export function toUpdateStreamUsagePayload(
+  data: unknown,
+  fallbackStreamId: StreamTabId,
+): UpdateStreamUsagePayload | undefined {
+  if (!isObject(data)) return undefined;
+  const storageKey = asString(data.storageKey);
+  if (!storageKey) return undefined;
+  const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
+  if (!usage.success) return undefined;
+
+  const streamId = asString(data.streamId) ?? fallbackStreamId;
+  const executionId = asString(data.executionId);
+  return {
+    streamId: streamId as StreamTabId,
+    storageKey: storageKey as StorageKey,
+    ...(executionId ? { executionId } : {}),
+    usage: usage.data,
+  };
+}

--- a/src/agent/runtime/sessionProgressEventProjection.ts
+++ b/src/agent/runtime/sessionProgressEventProjection.ts
@@ -5,17 +5,15 @@ import type {
   ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
 import {
-  ExtendedTokenUsageStatsSchema,
   ConversationProgressSchema,
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
-  type StorageKey,
   type StreamTabId,
-  type UpdateStreamUsagePayload,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 import { fromRunFactDomainKey } from './runFactEvents';
+import { toUpdateStreamUsagePayload } from './runFactUsage';
 import type { SessionEventHub, SessionFact } from './SessionEventHub';
 
 export type ProjectedProgressEvent = {
@@ -55,36 +53,6 @@ export function projectSessionFactToProgressEvent(
     case 'removeStream':
       return { event: 'removeStream', payload: fact.payload };
   }
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-
-/**
- * Parse a raw `usage` session-event `data` payload into the typed
- * `updateStreamUsage` progress payload. CLI TUI, legacy host projection, and
- * ProgressBackend all consume this same parser so their accepted usage shapes
- * cannot silently diverge.
- */
-export function toUpdateStreamUsagePayload(
-  data: unknown,
-  fallbackStreamId: StreamTabId,
-): UpdateStreamUsagePayload | undefined {
-  if (!isObject(data)) return undefined;
-  const storageKey = asString(data.storageKey);
-  if (!storageKey) return undefined;
-  const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
-  if (!usage.success) return undefined;
-
-  const streamId = asString(data.streamId) ?? fallbackStreamId;
-  const executionId = asString(data.executionId);
-  return {
-    streamId: streamId as StreamTabId,
-    storageKey: storageKey as StorageKey,
-    ...(executionId ? { executionId } : {}),
-    usage: usage.data,
-  };
 }
 
 export function projectRunFactToProgressEvent(

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
@@ -13,12 +14,10 @@ import { createChannelTrace } from '@logger';
 import {
   STREAM_PHASE,
   ConversationProgressSchema,
-  ExtendedTokenUsageStatsSchema,
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
   type ConversationProgress,
   type GoalStatus,
-  type StorageKey,
   type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
@@ -107,10 +106,6 @@ function getDefaultProgressStreamControls(): ProgressStreamControls {
     superYoloBypass: false,
     goalActive: false,
   };
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
 }
 
 /** Applies host progress events to progress-view state and webview updates. */
@@ -421,7 +416,7 @@ export class ProgressEventHandler {
 
   handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
     if (event.type === 'usage') {
-      const payload = this.toUpdateStreamUsagePayload(event.data, streamId);
+      const payload = toUpdateStreamUsagePayload(event.data, streamId);
       if (payload) this.handleProgressFact('updateStreamUsage', payload);
       return;
     }
@@ -530,26 +525,6 @@ export class ProgressEventHandler {
     payload: ProgressEventPayloads[K],
   ): void {
     this.handleProgressEvent(event, payload);
-  }
-
-  private toUpdateStreamUsagePayload(
-    data: unknown,
-    fallbackStreamId: StreamTabId,
-  ): ProgressEventPayloads['updateStreamUsage'] | undefined {
-    if (!isObject(data)) return undefined;
-    const storageKey = asString(data.storageKey);
-    if (!storageKey) return undefined;
-    const usage = ExtendedTokenUsageStatsSchema.safeParse(data.usage);
-    if (!usage.success) return undefined;
-
-    const streamId = asString(data.streamId) ?? fallbackStreamId;
-    const executionId = asString(data.executionId);
-    return {
-      streamId: streamId as StreamTabId,
-      storageKey: storageKey as StorageKey,
-      ...(executionId ? { executionId } : {}),
-      usage: usage.data,
-    };
   }
 
   private handleAddOutputFiles({


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This moves `toUpdateStreamUsagePayload` out of the legacy `sessionProgressEventProjection.ts` compatibility module into `src/agent/runtime/runFactUsage.ts`. The parser is a neutral run-fact helper used by fact-native consumers, not a projection boundary.

After this change:
- CLI TUI direct run-fact handling imports the neutral parser.
- The extension status bar imports the neutral parser.
- The shared progress backend reuses the same parser instead of carrying a duplicate private implementation.
- `sessionProgressEventProjection.ts` remains focused on the retained headless CLI public-output adapter.

A production grep now leaves `sessionProgressEventProjection.ts` referenced only by `packages/cli/src/runtime/sessionProgressSubscription.ts` and the documentation note in `hostProgressEvents.ts`.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm run compile:fast`
- `corepack pnpm exec prettier --check src/agent/runtime/runFactUsage.ts src/agent/runtime/sessionProgressEventProjection.ts src/shared/progressView/backend/events/ProgressEventHandler.ts packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts`
- `git diff --check`
- `corepack pnpm run lint` (passes with existing import-order warnings)

No #6981 compatibility-ledger row is added: this PR moves a helper out of compatibility code and does not add a new dual path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical parsing logic consolidated in one place; no auth, security, or behavioral API changes beyond import paths.
> 
> **Overview**
> **`toUpdateStreamUsagePayload`** moves from the legacy **`sessionProgressEventProjection`** compatibility module into a new **`runFactUsage.ts`** helper so fact-native UI paths do not import projection machinery.
> 
> **CLI TUI** (`subscribeRuntimeHost`) and the **extension status bar** now import the neutral parser directly. **`ProgressEventHandler`** drops its duplicate private parser and calls the shared function. **`sessionProgressEventProjection`** keeps usage projection for the remaining headless CLI adapter but delegates parsing to **`runFactUsage`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b6155f832331422b234250c567e1c0ce62fc5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->