### PR TITLE
refactor(progressView): single-owner the config/hints agentCategory fallback

### DIFF
--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -29,6 +29,7 @@ import {
   type LogContentExtras,
 } from '@shared/progressView/backend/WebviewUpdater';
 import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
+import { pickAgentCategory } from '@shared/progressView/backend/streamTabInfo';
 import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
 import {
   ProgressViewState,
@@ -1005,9 +1006,7 @@ export class ProgressEventHandler {
 
   private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {
     const config = this.state.snapshots.getRunConfig(streamId);
-    return (
-      config?.agentCategory ?? this.state.getStreamHints(streamId).agentCategory
-    );
+    return pickAgentCategory(config, this.state.getStreamHints(streamId));
   }
 
   getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {

--- a/src/shared/progressView/backend/streamInfoUtils.ts
+++ b/src/shared/progressView/backend/streamInfoUtils.ts
@@ -2,7 +2,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
 import { filterNotNull } from '@utils/core';
 import { peekWorktreeInfo, resolveWorktreeInfo } from '@utils/git/worktreeInfo';
-import { buildStreamTabInfo } from './streamTabInfo';
+import { buildStreamTabInfo, pickAgentCategory } from './streamTabInfo';
 import { compareByNewestCreationTime } from './streamOrdering';
 import type { ProgressViewState } from './state/ProgressViewState';
 
@@ -47,7 +47,7 @@ export function buildStreamInfo(
   const config = state.snapshots.getRunConfig(id);
 
   // Determine category and check filter
-  const rawCategory = config?.agentCategory ?? hints.agentCategory;
+  const rawCategory = pickAgentCategory(config, hints);
   const category = matchesFilter(rawCategory, filter);
   if (category === null) return null;
 

--- a/src/shared/progressView/backend/streamTabInfo.ts
+++ b/src/shared/progressView/backend/streamTabInfo.ts
@@ -31,7 +31,7 @@ export interface StreamTabInfoInputs {
 
 /**
  * Single owner of the two-source `config`/`hints` agentCategory lookup shared
- * by `buildStreamTabInfo`, `matchesFilter` (streamInfoUtils.ts), and
+ * by `buildStreamTabInfo`, `buildStreamInfo` (streamInfoUtils.ts), and
  * `getStreamCategory` (ProgressEventHandler.ts). Live `config` wins over the
  * fallback `hints`. Deliberately undefined-preserving (no default baked in)
  * — `getStreamCategory` needs that variant; callers that want a concrete

--- a/src/shared/progressView/backend/streamTabInfo.ts
+++ b/src/shared/progressView/backend/streamTabInfo.ts
@@ -30,6 +30,21 @@ export interface StreamTabInfoInputs {
 }
 
 /**
+ * Single owner of the two-source `config`/`hints` agentCategory lookup shared
+ * by `buildStreamTabInfo`, `matchesFilter` (streamInfoUtils.ts), and
+ * `getStreamCategory` (ProgressEventHandler.ts). Live `config` wins over the
+ * fallback `hints`. Deliberately undefined-preserving (no default baked in)
+ * — `getStreamCategory` needs that variant; callers that want a concrete
+ * category layer `?? AgentCategory.Workflow` on top.
+ */
+export function pickAgentCategory(
+  config: Pick<AgentConfig, 'agentCategory'> | undefined,
+  hints: { agentCategory?: AgentCategory } | undefined,
+): AgentCategory | undefined {
+  return config?.agentCategory ?? hints?.agentCategory;
+}
+
+/**
  * Build a StreamTabInfo from already-resolved primitives. Host-neutral so
  * both the extension's progress view and the Electron desktop main can
  * emit identical metadata to the shared <stream-tab> renderer.
@@ -41,8 +56,7 @@ export interface StreamTabInfoInputs {
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, config, hints, creationTimestamp } = inputs;
 
-  const category =
-    config?.agentCategory ?? hints?.agentCategory ?? AgentCategory.Workflow;
+  const category = pickAgentCategory(config, hints) ?? AgentCategory.Workflow;
 
   const inputFile = config?.inputFiles?.[0] ?? hints?.inputFile ?? '';
   const rawAgentName = config?.agent ?? hints?.agent ?? streamId.split('@')[0];

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -44,6 +44,7 @@ import {
   type ProgressBackendServices,
   type ProgressBackendUiConfig,
 } from '@shared/progressView/backend/ProgressBackend';
+import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { StorageFS } from '@utils/files';
 
@@ -1507,6 +1508,53 @@ describe('ProgressBackend', () => {
       ).toMatchObject({
         stream: 'workflow-existing',
         action: 'render',
+      });
+    } finally {
+      backend.dispose();
+    }
+  });
+
+  it('agrees on the resolved agentCategory across the filter, tab-render, and sync-content paths (#7583)', async () => {
+    // Regression test for the config/hints agentCategory single-owner fix:
+    // buildStreamInfos (matchesFilter + buildStreamTabInfo, streamInfoUtils.ts
+    // / streamTabInfo.ts) and syncStreamContent (getStreamCategory,
+    // ProgressEventHandler.ts) must resolve the same category from the same
+    // config/hints inputs, even when hints deliberately disagree with the
+    // live config.
+    const { backend, messages } = createRecordingBackend();
+    const stream = 'search@deepseek#de5711c' as StreamTabId;
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.snapshots.setTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        'de5711c' as ExecutionId,
+      );
+      // Stale hint disagrees with the live config on purpose — config must
+      // win consistently everywhere the category is resolved.
+      backend.state.updateStreamHints(stream, {
+        agentCategory: AgentCategory.Workflow,
+      });
+
+      const toolUseInfos = buildStreamInfos(backend.state, 'toolUse');
+      expect(toolUseInfos.map((info) => info.name)).toContain(stream);
+      expect(
+        toolUseInfos.find((info) => info.name === stream)?.agentCategory,
+      ).toBe(AgentCategory.ToolUse);
+
+      const workflowInfos = buildStreamInfos(backend.state, 'workflow');
+      expect(workflowInfos.map((info) => info.name)).not.toContain(stream);
+
+      backend.eventHandler.syncStreamContent(stream);
+      const sync = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+      );
+      expect(sync).toMatchObject({
+        stream,
+        action: 'render',
+        agentCategory: AgentCategory.ToolUse,
       });
     } finally {
       backend.dispose();

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -89,15 +89,9 @@ describe('pickAgentCategory', () => {
     ).toBe(AgentCategory.ToolUse);
   });
 
-  it('falls back to hints when config has no category', () => {
-    expect(
-      pickAgentCategory({}, { agentCategory: AgentCategory.ToolUse }),
-    ).toBe(AgentCategory.ToolUse);
-  });
-
   it('returns undefined (no default) when both sources are empty', () => {
     expect(pickAgentCategory(undefined, undefined)).toBeUndefined();
-    expect(pickAgentCategory({}, {})).toBeUndefined();
+    expect(pickAgentCategory(undefined, {})).toBeUndefined();
   });
 
   it('agrees with buildStreamTabInfo, which layers the Workflow default on top', () => {

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -3,9 +3,13 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, expect, it } from 'vitest';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
 import { compareByNewestCreationTime } from '@shared/progressView/backend/streamOrdering';
-import { buildStreamTabInfo } from '@shared/progressView/backend/streamTabInfo';
+import {
+  buildStreamTabInfo,
+  pickAgentCategory,
+} from '@shared/progressView/backend/streamTabInfo';
 
 // ---------------------------------------------------------------------------
 // streamInfoUtils
@@ -58,5 +62,56 @@ describe('buildStreamTabInfo', () => {
     expect(info.label).toBe('bash');
     expect(info.agent).toBe('bash');
     expect(info.kind).toBe('process');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickAgentCategory — single owner of the config/hints agentCategory
+// precedence (issue #7583). Regression coverage for the desync scenario:
+// `matchesFilter`/`buildStreamInfo` (streamInfoUtils.ts), `buildStreamTabInfo`
+// (streamTabInfo.ts), and `getStreamCategory` (ProgressEventHandler.ts) must
+// all resolve the same category for the same config/hints inputs.
+// ---------------------------------------------------------------------------
+
+describe('pickAgentCategory', () => {
+  it('prefers a live config category over the hint fallback', () => {
+    expect(
+      pickAgentCategory(
+        { agentCategory: AgentCategory.ToolUse },
+        { agentCategory: AgentCategory.Workflow },
+      ),
+    ).toBe(AgentCategory.ToolUse);
+  });
+
+  it('falls back to hints when config is absent', () => {
+    expect(
+      pickAgentCategory(undefined, { agentCategory: AgentCategory.ToolUse }),
+    ).toBe(AgentCategory.ToolUse);
+  });
+
+  it('falls back to hints when config has no category', () => {
+    expect(
+      pickAgentCategory({}, { agentCategory: AgentCategory.ToolUse }),
+    ).toBe(AgentCategory.ToolUse);
+  });
+
+  it('returns undefined (no default) when both sources are empty', () => {
+    expect(pickAgentCategory(undefined, undefined)).toBeUndefined();
+    expect(pickAgentCategory({}, {})).toBeUndefined();
+  });
+
+  it('agrees with buildStreamTabInfo, which layers the Workflow default on top', () => {
+    const config = { agentCategory: AgentCategory.ToolUse } as AgentConfig;
+    const hints = { agentCategory: AgentCategory.Workflow };
+
+    const info = buildStreamTabInfo({
+      streamId: 'search@deepseek#exec',
+      config,
+      hints,
+      creationTimestamp: 1,
+    });
+
+    expect(pickAgentCategory(config, hints)).toBe(AgentCategory.ToolUse);
+    expect(info.agentCategory).toBe(pickAgentCategory(config, hints));
   });
 });


### PR DESCRIPTION
## Bug

The precedence `config?.agentCategory ?? hints?.agentCategory ?? AgentCategory.Workflow` for a stream's effective `agentCategory` was written out independently in three places with no single owner:

1. `src/shared/progressView/backend/streamInfoUtils.ts` — `matchesFilter`/`buildStreamInfo` computed `rawCategory = config?.agentCategory ?? hints.agentCategory` purely to decide filter pass/fail; the resolved value was discarded after the null-check.
2. `src/shared/progressView/backend/streamTabInfo.ts` — `buildStreamTabInfo` independently recomputed the byte-identical chain over the *same* `config`/`hints` inputs to build the actually-rendered `StreamTabInfo.agentCategory`.
3. `src/shared/progressView/backend/events/ProgressEventHandler.ts` — `getStreamCategory` shared the same two-source sub-chain but deliberately omitted the `?? AgentCategory.Workflow` default (its callers apply their own default or branch on truthiness).

Because the filter decision and the rendered category were computed by separate code paths reading the same underlying state, a future change to one chain's precedence/default could silently desync which tabs pass a filter from what category they actually render as.

## Fix

Added `pickAgentCategory(config, hints): AgentCategory | undefined` in `streamTabInfo.ts` as the single owner of the two-source lookup (no default baked in, since `getStreamCategory` legitimately needs the undefined-preserving variant). Call sites that want the `AgentCategory.Workflow` default layer it on top: `pickAgentCategory(config, hints) ?? AgentCategory.Workflow`.

- `buildStreamTabInfo` (streamTabInfo.ts) now calls `pickAgentCategory`.
- `matchesFilter`/`buildStreamInfo` (streamInfoUtils.ts) now call `pickAgentCategory` instead of re-deriving inline.
- `getStreamCategory` (ProgressEventHandler.ts) now calls `pickAgentCategory`, preserving its existing undefined-preserving behavior for all 3 existing callers.

`pickAgentCategory` lives in `streamTabInfo.ts` since `streamInfoUtils.ts` already imports `buildStreamTabInfo` from it, and `ProgressEventHandler.ts` already imports from `streamInfoUtils.ts` — putting the shared owner in `streamTabInfo.ts` keeps the existing dependency direction with no new cycle.

This is a pure dedup: behavior is identical for all existing callers.

## Tests

- Extended `src/test-kernel/progressView/streamInfoUtils.vitest.ts` with unit tests for `pickAgentCategory` (config wins, hints fallback, no-default-undefined) and a test proving `buildStreamTabInfo` agrees with it.
- Extended `src/test-kernel/progressView/ProgressBackend.vitest.ts` with a regression test for the exact desync scenario: a stream whose `hints.agentCategory` disagrees with its live `config.agentCategory` must resolve to the *config* value consistently across `buildStreamInfos` (filter + tab-render path) and `syncStreamContent` (`getStreamCategory` path).

Closes #7583

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/test-kernel/progressView/` — 180/180 passed
- [x] `npx eslint` / `npx prettier --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving deduplication in progress-view metadata only; no auth, persistence, or runtime execution changes.
> 
> **Overview**
> Introduces **`pickAgentCategory(config, hints)`** in `streamTabInfo.ts` as the single place that resolves a stream’s `agentCategory` from live run config vs. stream hints (config wins; no `Workflow` default inside the helper).
> 
> **`buildStreamTabInfo`**, **`buildStreamInfo`** / filtering in `streamInfoUtils.ts`, and **`getStreamCategory`** in `ProgressEventHandler.ts` now call that helper instead of duplicating `config?.agentCategory ?? hints?.agentCategory`. Callers that need a concrete category still apply `?? AgentCategory.Workflow` locally.
> 
> Adds unit tests for `pickAgentCategory` and a **`ProgressBackend`** regression test (#7583) so tab filtering, rendered tab metadata, and `syncStreamContent` all agree when stale hints disagree with live config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb023d1d037ec77c0f7ae771703b068c71b7dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->