### PR TITLE
refactor(runtime): remove host progress interaction port

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -234,7 +234,6 @@ export function createTuiHostInteractions(
     openExternalInquiry(request) {
       return openExternalInquiryInteraction(request, context, host);
     },
-    handleProgressEvent: () => false,
     resolve: () => false,
     cancel(selector: HostInteractionCancelSelector = {}) {
       // Retry routes live outside the modal queue (the pre-queue auto-switch

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -288,7 +288,6 @@ export function createHeadlessCliHostInteractions(
       });
       return { threadId: request.threadId };
     },
-    handleProgressEvent: () => false,
     resolve: () => false,
     // Headless requests decide inline (policy or prompt hooks) — there is no
     // pending registry to cancel into.

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -189,15 +189,6 @@ function emitProjectedProgressEvent(
   runtimeHost: AgentRuntimeHost,
   projected: CliProjectedProgressEvent,
 ): void {
-  if (
-    projected.event === 'removeStream' &&
-    runtimeHost.interactions?.handleProgressEvent(
-      projected.event,
-      projected.payload,
-    )
-  ) {
-    return;
-  }
   runtimeHost.emit(projected.event, projected.payload);
 }
 

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -152,10 +152,6 @@ class DesktopHostInteractions implements HostInteractions {
     return Promise.resolve({ threadId: request.threadId });
   }
 
-  handleProgressEvent(): boolean {
-    return false;
-  }
-
   /**
    * `result.kind` must match the pending request's own recorded kind before
    * it's honored — the same discriminant check the extension host performs

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -6,6 +6,7 @@ import {
   type ExtensionPresentationEventPayloads,
   isExtensionPresentationEvent,
 } from '@frontend/events/extensionPresentationEvents';
+import { emitExtensionProgressEvent } from '@frontend/events/extensionProgressEvents';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
   interactions: defaultSession().interactions,
@@ -17,6 +18,6 @@ export const extensionAgentRuntimeHost: AgentRuntimeHost = {
       );
       return;
     }
-    defaultSession().interactions.handleProgressEvent(event, payload);
+    emitExtensionProgressEvent(event, payload);
   },
 };

--- a/packages/extension/src/frontend/events/extensionProgressEvents.ts
+++ b/packages/extension/src/frontend/events/extensionProgressEvents.ts
@@ -1,0 +1,31 @@
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@agent/runtime/hostProgressEvents';
+
+type ExtensionProgressEventSink = <K extends ProgressEvent>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+) => void;
+
+let activeSink: ExtensionProgressEventSink | undefined;
+
+export function setExtensionProgressEventSink(
+  sink: ExtensionProgressEventSink,
+): () => void {
+  const previous = activeSink;
+  activeSink = sink;
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    if (activeSink === sink) activeSink = previous;
+  };
+}
+
+export function emitExtensionProgressEvent<K extends ProgressEvent>(
+  event: K,
+  payload: ProgressEventPayloads[K],
+): void {
+  activeSink?.(event, payload);
+}

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -19,6 +19,7 @@ import {
 import { workspaceSM } from '@common/state';
 import { appSignals } from '@eventBus/AppSignals';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { setExtensionProgressEventSink } from '@frontend/events/extensionProgressEvents';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
 import {
@@ -59,6 +60,8 @@ import { attachProgressBackendAppSignals } from './progressBackendAppSignals';
 import type { MainViewProvider } from '../MainViewProvider';
 
 const MAX_INQUIRY_THREAD_HYDRATION = 100;
+const SESSION_FACT_OWNED_EXTENSION_PROGRESS_EVENTS: ReadonlySet<string> =
+  new Set(['addOutputFiles', 'removeStream']);
 
 export type ProgressStreamRevealResult = 'revealed' | 'missing';
 
@@ -171,13 +174,32 @@ export class ProgressViewProvider
       createExtensionHostInteractions({
         runtimeHost: extensionAgentRuntimeHost,
         getApprovalHandlers: () => this.approvalHandlers,
-        removeStream: (streamId) =>
-          this.messageHandler.removeStreamFromHost(streamId),
-        handleProgressEvent: (event, payload) =>
-          this.backend.handleProgressEvent(event, payload),
       }),
     );
-    this._disposables.push({ dispose: this.detachHostInteractions });
+    const detachExtensionProgressEvents = setExtensionProgressEventSink(
+      (event, payload) => {
+        if (SESSION_FACT_OWNED_EXTENSION_PROGRESS_EVENTS.has(event)) return;
+        this.backend.handleProgressEvent(event, payload);
+      },
+    );
+    const detachRemoveStreamCleanup = defaultSession().events.subscribe(
+      (sessionEvent) => {
+        if (
+          sessionEvent.scope === 'session' &&
+          sessionEvent.event.type === 'removeStream'
+        ) {
+          this.messageHandler.removeStreamFromHost(
+            sessionEvent.event.payload.streamId,
+          );
+        }
+      },
+      { scope: 'session' },
+    );
+    this._disposables.push(
+      { dispose: this.detachHostInteractions },
+      { dispose: detachExtensionProgressEvents },
+      { dispose: detachRemoveStreamCleanup },
+    );
 
     ProgressViewProvider._instance = this;
     setProgressViewBridge(this);

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -16,10 +16,6 @@ import {
   type ProposalResult,
   type RetryResult,
 } from '@agent/runtime/HostInteractions';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
 import {
   toBashApprovalResult,
   toPlanApprovalResult,
@@ -38,11 +34,6 @@ import type {
 export interface ExtensionHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
-  removeStream(streamId: StreamTabId): void;
-  handleProgressEvent<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void;
 }
 
 type PendingKind = Extract<
@@ -245,17 +236,6 @@ export function createExtensionHostInteractions(
       activateStream(request.streamId || undefined);
       handlers().externalInquiry.show(request);
       return { threadId: request.threadId };
-    },
-
-    handleProgressEvent(event, payload): boolean {
-      if (event === 'addOutputFiles') return true;
-      if (event === 'removeStream') {
-        const data = payload as ProgressEventPayloads['removeStream'];
-        options.removeStream(data.streamId);
-        return true;
-      }
-      options.handleProgressEvent(event, payload);
-      return true;
     },
 
     resolve(requestId: string, result: HostInteractionResolution): boolean {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -1,8 +1,4 @@
 import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
-import type {
   AgentProposal,
   Plan,
   ProviderErrorPartial,
@@ -180,10 +176,6 @@ export interface HostInteractions {
   openExternalInquiry?(
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined;
-  handleProgressEvent<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): boolean;
   resolve(requestId: string, result: HostInteractionResolution): boolean;
   /** Settle pending requests matching the selector with their reject/cancel defaults. */
   cancel(selector?: HostInteractionCancelSelector): void;
@@ -191,7 +183,6 @@ export interface HostInteractions {
 }
 
 const noopHostInteractions: HostInteractions = {
-  handleProgressEvent: () => false,
   resolve: () => false,
   cancel: () => {},
 };
@@ -215,13 +206,6 @@ export class SessionHostInteractions implements HostInteractions {
       if (this.active === interactions) this.active = previous;
       interactions.dispose?.();
     };
-  }
-
-  handleProgressEvent<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): boolean {
-    return this.active.handleProgressEvent(event, payload);
   }
 
   requestToolEditApproval(

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -39,7 +39,7 @@ import type {
 
 /**
  * **Frozen** legacy host progress-event view, spoken by
- * `AgentRuntimeHost.emit` and `HostInteractions.handleProgressEvent`.
+ * `AgentRuntimeHost.emit` and host-owned compatibility adapters.
  * Retained CLI public output now projects into this table inside the CLI
  * adapter boundary (D3 decision on #6984: frozen until v0.41).
  *

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -325,26 +325,12 @@ describe('child stream progress events', () => {
     }
   });
 
-  it('uses host interactions for child stream auto-close when available', async () => {
+  it('emits removeStream for child stream auto-close', async () => {
     const active = createRecordingHost();
-    const removedStreams: StreamTabId[] = [];
-    const host: AgentRuntimeHost = {
-      ...active.host,
-      interactions: {
-        handleProgressEvent: (event, payload) => {
-          if (event !== 'removeStream') return false;
-          const data = payload as ProgressEventPayloads['removeStream'];
-          removedStreams.push(data.streamId);
-          return true;
-        },
-        resolve: () => false,
-        cancel: () => {},
-      },
-    };
 
-    const childStream = withSessionProgressProjection(host, () =>
+    const childStream = withSessionProgressProjection(active.host, () =>
       createChildStream(executionId, parentStreamId, {
-        runtimeHost: host,
+        runtimeHost: active.host,
         streamPrefix: 'bash',
         streamCategory: AgentCategory.ToolUse,
         agentName: 'test-agent',
@@ -354,14 +340,14 @@ describe('child stream progress events', () => {
       }),
     );
 
-    await withSessionProgressProjection(host, () =>
+    await withSessionProgressProjection(active.host, () =>
       childStream.finalize({ autoClose: true }),
     );
 
-    expect(removedStreams).toEqual([childStreamId]);
-    expect(active.events.map((entry) => entry.event)).not.toContain(
-      'removeStream',
-    );
+    expect(active.events).toContainEqual({
+      event: 'removeStream',
+      payload: { streamId: childStreamId },
+    });
   });
 
   it('publishes child loop status changes through the child stream owner', async () => {

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -129,7 +129,6 @@ export function createRecordingHost(): {
         });
       });
     },
-    handleProgressEvent: () => false,
     resolve: (requestId, result) => {
       if (result.kind === 'bash') {
         const pending = pendingBashes.get(requestId);

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -96,7 +96,6 @@ async function withRetryRunContext<T>(
     agentName: 'retry-test',
     session: sessionWithInteractions({
       requestRetry,
-      handleProgressEvent: () => false,
       resolve: () => false,
       cancel: () => {},
     }),

--- a/src/test-kernel/agent/sessionProgressTestUtils.ts
+++ b/src/test-kernel/agent/sessionProgressTestUtils.ts
@@ -202,15 +202,6 @@ function emitProjectedProgressEventForTest(
   runtimeHost: AgentRuntimeHost,
   projected: ProjectedProgressEvent,
 ): void {
-  if (
-    projected.event === 'removeStream' &&
-    runtimeHost.interactions?.handleProgressEvent(
-      projected.event,
-      projected.payload,
-    )
-  ) {
-    return;
-  }
   runtimeHost.emit(projected.event, projected.payload);
 }
 

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -15,7 +15,6 @@ function hostWithInteractions(
   return {
     emit: vi.fn(),
     interactions: {
-      handleProgressEvent: () => false,
       resolve: () => false,
       cancel: () => {},
       ...interactions,
@@ -75,10 +74,9 @@ describe('attachCliSessionProgressProjection', () => {
     }
   });
 
-  it('offers removeStream to host interactions before legacy emission', () => {
+  it('re-emits removeStream through the headless CLI host rail', () => {
     const events = new SessionEventHub();
-    const handleProgressEvent = vi.fn(() => true);
-    const host = hostWithInteractions({ handleProgressEvent });
+    const host = hostWithInteractions();
     const detach = attachCliSessionProgressProjection(events, host);
 
     try {
@@ -90,10 +88,9 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(handleProgressEvent).toHaveBeenCalledWith('removeStream', {
+      expect(host.emit).toHaveBeenCalledWith('removeStream', {
         streamId,
       });
-      expect(host.emit).not.toHaveBeenCalled();
     } finally {
       detach();
     }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -121,7 +121,6 @@ function stubRunExecutionDeps(): void {
   vi.clearAllMocks();
   mocks.close.mockResolvedValue(undefined);
   mocks.createHeadlessCliHostInteractions.mockReturnValue({
-    handleProgressEvent: vi.fn(() => false),
     pending: vi.fn(() => []),
     resolve: vi.fn(() => false),
     cancel: vi.fn(),

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { extensionPresentationEvents } from '@frontend/events/extensionPresentationEvents';
+import { setExtensionProgressEventSink } from '@frontend/events/extensionProgressEvents';
 import type { StreamTabId } from '@shared/schemas';
 
 describe('extensionAgentRuntimeHost', () => {
@@ -27,43 +27,39 @@ describe('extensionAgentRuntimeHost', () => {
     }
   });
 
-  it('routes run progress events through extension host interactions', () => {
-    const interactionEvents: unknown[] = [];
-    const disposeInteractions = defaultSession().useHostInteractions({
-      handleProgressEvent: (event, payload) => {
-        interactionEvents.push({ event, payload });
-        return true;
+  it('routes run progress events through the extension progress sink', () => {
+    const progressEvents: unknown[] = [];
+    const disposeProgressSink = setExtensionProgressEventSink(
+      (event, payload) => {
+        progressEvents.push({ event, payload });
       },
-      resolve: () => false,
-      cancel: () => {},
-    });
+    );
 
     try {
       extensionAgentRuntimeHost.emit('setActiveStream', {
         streamId: 'extension:progress' as StreamTabId,
       });
 
-      expect(interactionEvents).toEqual([
+      expect(progressEvents).toEqual([
         {
           event: 'setActiveStream',
           payload: { streamId: 'extension:progress' as StreamTabId },
         },
       ]);
 
-      disposeInteractions();
+      disposeProgressSink();
       extensionAgentRuntimeHost.emit('setActiveStream', {
         streamId: 'extension:after-detach' as StreamTabId,
       });
 
-      // A detached host-interactions implementation no longer receives events.
-      expect(interactionEvents).toEqual([
+      expect(progressEvents).toEqual([
         {
           event: 'setActiveStream',
           payload: { streamId: 'extension:progress' as StreamTabId },
         },
       ]);
     } finally {
-      disposeInteractions();
+      disposeProgressSink();
     }
   });
 });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 
 const mocks = vi.hoisted(() => ({
@@ -66,16 +66,10 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
 function createInteractions(options?: {
   runtimeHost?: ReturnType<typeof createRuntimeHost>;
   handlers?: ApprovalRequestHandlerSet;
-  removeStream?: (streamId: StreamTabId) => void;
-  handleProgressEvent?: (event: unknown, payload: unknown) => void;
 }) {
-  const handleProgressEvent = options?.handleProgressEvent ?? (() => undefined);
   return createExtensionHostInteractions({
     runtimeHost: options?.runtimeHost ?? createRuntimeHost(),
     getApprovalHandlers: () => options?.handlers ?? createHandlers(),
-    removeStream: options?.removeStream ?? (() => {}),
-    handleProgressEvent: (event, payload) =>
-      handleProgressEvent(event, payload),
   });
 }
 
@@ -311,63 +305,5 @@ describe('createExtensionHostInteractions', () => {
       nativeResult,
     );
     expect(mocks.nativeRequestApproval).toHaveBeenCalledWith(request);
-  });
-
-  it('handles extension removeStream requests through the progress lifecycle callback', () => {
-    const removed: StreamTabId[] = [];
-    const interactions = createInteractions({
-      removeStream: (streamId) => removed.push(streamId),
-    });
-
-    expect(
-      interactions.handleProgressEvent('removeStream', {
-        streamId: 'child-a' as StreamTabId,
-      }),
-    ).toBe(true);
-    expect(removed).toEqual(['child-a']);
-  });
-
-  it('routes backend progress events through the supplied callback', () => {
-    const handleProgressEvent = vi.fn(
-      (_event: unknown, _payload: unknown) => undefined,
-    );
-    const interactions = createInteractions({ handleProgressEvent });
-
-    expect(
-      interactions.handleProgressEvent('setActiveStream', {
-        streamId: 'stream-a' as StreamTabId,
-      }),
-    ).toBe(true);
-
-    expect(handleProgressEvent).toHaveBeenCalledWith('setActiveStream', {
-      streamId: 'stream-a',
-    });
-  });
-
-  it('leaves addOutputFiles to the session run-fact path', () => {
-    const handleProgressEvent = vi.fn(
-      (_event: unknown, _payload: unknown) => undefined,
-    );
-    const interactions = createInteractions({ handleProgressEvent });
-    const outputFile: OutputFileInfo = {
-      source: 'paper.tex',
-      location: {
-        kind: 'workspace',
-        absolutePath: '/workspace/paper.tex',
-        relativePath: 'paper.tex',
-      },
-      round: 1,
-      lineage: null,
-      diff: null,
-    };
-
-    expect(
-      interactions.handleProgressEvent('addOutputFiles', {
-        streamId: 'stream-a' as StreamTabId,
-        filesByRound: { 1: [outputFile] },
-      }),
-    ).toBe(true);
-
-    expect(handleProgressEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -45,7 +45,6 @@ function createHostInteractions(
   overrides: Partial<HostInteractions> = {},
 ): HostInteractions {
   return {
-    handleProgressEvent: vi.fn(() => false),
     resolve: vi.fn(() => false),
     cancel: vi.fn(),
     ...overrides,

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -53,7 +53,6 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
     const session = new SessionHandle();
     const cancel = vi.fn();
     const detach = session.useHostInteractions({
-      handleProgressEvent: () => false,
       resolve: () => false,
       cancel,
     });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -60,7 +60,6 @@ function runtimeHost(): AgentRuntimeHost {
   return {
     emit: vi.fn(),
     interactions: {
-      handleProgressEvent: vi.fn(() => false),
       resolve: vi.fn(() => false),
       cancel: vi.fn(),
     } satisfies HostInteractions,

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -46,7 +46,6 @@ describe('handleExternalInquiryAction', () => {
       (requestId: string, result: HostInteractionResolution) => boolean
     >(() => true);
     const interactions: HostInteractions = {
-      handleProgressEvent: () => false,
       resolve,
       cancel: () => {},
     };

--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -14,7 +14,6 @@ function createRuntimeHostWithRejectingInteraction(
   return {
     emit: () => {},
     interactions: {
-      handleProgressEvent: () => false,
       resolve: () => false,
       cancel: () => {},
       openExternalInquiry: () => Promise.reject(reason),


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This removes the generic `HostInteractions.handleProgressEvent` port. Host interactions now contain only interaction requests, resolutions, cancellation, and disposal; progress events no longer tunnel through that interface.

The VS Code extension keeps its remaining host-progress compatibility path through an explicit extension-owned sink in `packages/extension/src/frontend/events/extensionProgressEvents.ts`. `extensionAgentRuntimeHost.emit()` now routes presentation events to `extensionPresentationEvents` and all other host-progress events to this progress sink. The progress view provider installs the sink for its lifetime and still drops `addOutputFiles` because those are owned by direct run facts.

`removeStream` cleanup no longer uses a host-interaction special case. The progress view provider subscribes directly to `defaultSession().events` for session-scoped `removeStream` facts and calls `removeStreamFromHost()` there; the backend still consumes the same fact through its existing session-fact path. CLI retained public-output projection now simply emits the frozen `removeStream` event instead of offering it to host interactions first.

## Issue acceptance gates

This satisfies the current Stage 5 slice: `HostInteractions` no longer carries host-progress events, `removeStream` cleanup is session-event-owned in the extension progress view, and the retained CLI public-output path no longer special-cases `removeStream` through interactions.

The full #6968 close-out remains incomplete until the remaining frozen host-progress surface and layer-budget checks are audited after this slice lands.

## Single source of truth

`HostInteractions` is now only the session-owned user interaction port. Extension host-progress compatibility delivery is owned by `packages/extension/src/frontend/events/extensionProgressEvents.ts`, while `SessionEventHub` remains the source for session facts such as `removeStream`.

## Duplication and abstraction budget

This deletes a generic progress pass-through from the interaction port and replaces it with an explicit extension boundary sink. The PR is net-negative in lines; the remaining sink owns a real host boundary instead of relaying through `HostInteractions`.

No #6981 ledger row is added: this removes an existing mixed-purpose path and does not introduce a new shim, dual-write, fallback, or migration path.

## Host impact

Extension: remaining frozen host-progress events route through an explicit extension progress sink; `removeStream` tab cleanup now subscribes directly to session facts.

Desktop: no behavior change; desktop keeps its window-local progress bridge path and loses no interaction capability.

CLI: headless public output keeps the same frozen progress-event vocabulary; `removeStream` is emitted on that rail like other projected events.

## Scheduled refactoring

Tracked by #6968: after this lands, continue the remaining frozen host-progress/layer-budget audit before closing Stage 5.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm exec prettier --check` on touched files
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `CI=true corepack pnpm run test`

Refs #6968

