### PR TITLE
feat(platform): add editor language model port

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -70,6 +70,7 @@ import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolE
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { registerAgentEventListeners } from '@frontend/events/agentEventListeners';
+import { createLanguageModelPort } from '@frontend/lm/createLanguageModelPort';
 import { registerLanguageModelTools } from '@frontend/lm/registerLanguageModelTools';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
@@ -225,6 +226,7 @@ export async function activate(context: vscode.ExtensionContext) {
       isVscodeExtensionInstalled: (id) =>
         vscode.extensions.getExtension(id) !== undefined,
     },
+    languageModel: createLanguageModelPort(context),
     linter: getLinterMessages,
     addCriticismSink: (payload) => {
       const accepted = pushManualCriticism({

--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -1,0 +1,174 @@
+import * as vscode from 'vscode';
+
+import {
+  UNAVAILABLE_LANGUAGE_MODEL_PORT,
+  type LanguageModelInfo,
+  type LanguageModelMessage,
+  type LanguageModelPort,
+  type LanguageModelRequestOptions,
+  type LanguageModelResponsePart,
+} from '@platform/languageModel';
+
+function toModelInfo(model: vscode.LanguageModelChat): LanguageModelInfo {
+  return {
+    id: model.id,
+    name: model.name,
+    family: model.family,
+    vendor: model.vendor,
+    version: model.version,
+    maxInputTokens: model.maxInputTokens,
+  };
+}
+
+function toVscodeMessage(
+  message: LanguageModelMessage,
+): vscode.LanguageModelChatMessage {
+  if (message.role === 'assistant') {
+    return vscode.LanguageModelChatMessage.Assistant(
+      message.content.map((part) =>
+        part.kind === 'text'
+          ? new vscode.LanguageModelTextPart(part.text)
+          : new vscode.LanguageModelToolCallPart(
+              part.callId,
+              part.name,
+              part.input,
+            ),
+      ),
+    );
+  }
+
+  return vscode.LanguageModelChatMessage.User(
+    message.content.map((part) =>
+      part.kind === 'text'
+        ? new vscode.LanguageModelTextPart(part.text)
+        : new vscode.LanguageModelToolResultPart(part.callId, [
+            new vscode.LanguageModelTextPart(part.text),
+          ]),
+    ),
+  );
+}
+
+function toVscodeOptions(
+  options: LanguageModelRequestOptions,
+): vscode.LanguageModelChatRequestOptions {
+  return {
+    justification: options.justification,
+    tools: options.tools?.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    })),
+    toolMode:
+      options.toolMode === undefined
+        ? undefined
+        : options.toolMode === 'required'
+          ? vscode.LanguageModelChatToolMode.Required
+          : vscode.LanguageModelChatToolMode.Auto,
+  };
+}
+
+async function findModel(
+  selectChatModels: typeof vscode.lm.selectChatModels,
+  modelId: string,
+): Promise<vscode.LanguageModelChat | undefined> {
+  const models = await selectChatModels({ id: modelId });
+  return models.find((model) => model.id === modelId);
+}
+
+async function requireModel(
+  selectChatModels: typeof vscode.lm.selectChatModels,
+  modelId: string,
+): Promise<vscode.LanguageModelChat> {
+  const model = await findModel(selectChatModels, modelId);
+  if (!model) {
+    throw new Error(`Language model "${modelId}" is unavailable.`);
+  }
+  return model;
+}
+
+async function* streamResponse(
+  selectChatModels: typeof vscode.lm.selectChatModels,
+  modelId: string,
+  messages: readonly LanguageModelMessage[],
+  options: LanguageModelRequestOptions,
+  signal: AbortSignal,
+): AsyncIterable<LanguageModelResponsePart> {
+  const model = await requireModel(selectChatModels, modelId);
+  const cancellation = new vscode.CancellationTokenSource();
+  const cancel = () => cancellation.cancel();
+  if (signal.aborted) cancel();
+  signal.addEventListener('abort', cancel, { once: true });
+
+  try {
+    const response = await model.sendRequest(
+      messages.map(toVscodeMessage),
+      toVscodeOptions(options),
+      cancellation.token,
+    );
+    for await (const part of response.stream) {
+      if (part instanceof vscode.LanguageModelTextPart) {
+        yield { kind: 'text', text: part.value };
+      } else if (part instanceof vscode.LanguageModelToolCallPart) {
+        yield {
+          kind: 'toolCall',
+          callId: part.callId,
+          name: part.name,
+          input: part.input,
+        };
+      }
+    }
+  } finally {
+    signal.removeEventListener('abort', cancel);
+    cancellation.dispose();
+  }
+}
+
+/** Create the VS Code implementation, or the shared unavailable port. */
+export function createLanguageModelPort(
+  context: vscode.ExtensionContext,
+): LanguageModelPort {
+  const lm = (vscode as { lm?: Partial<typeof vscode.lm> }).lm;
+  if (typeof lm?.selectChatModels !== 'function') {
+    return UNAVAILABLE_LANGUAGE_MODEL_PORT;
+  }
+  const selectChatModels = lm.selectChatModels;
+
+  return {
+    isAvailable: () => true,
+
+    async selectModels(selector) {
+      return (await selectChatModels(selector)).map(toModelInfo);
+    },
+
+    onDidChangeModels(listener) {
+      return typeof lm.onDidChangeChatModels === 'function'
+        ? lm.onDidChangeChatModels(listener)
+        : { dispose() {} };
+    },
+
+    sendRequest(modelId, messages, options, signal) {
+      return streamResponse(
+        selectChatModels,
+        modelId,
+        messages,
+        options,
+        signal,
+      );
+    },
+
+    async countTokens(modelId, text) {
+      return (await requireModel(selectChatModels, modelId)).countTokens(text);
+    },
+
+    async canSendRequest(modelId) {
+      const model = await findModel(selectChatModels, modelId);
+      return model === undefined
+        ? undefined
+        : context.languageModelAccessInformation.canSendRequest(model);
+    },
+
+    onDidChangeAccess(listener) {
+      return context.languageModelAccessInformation.onDidChange(listener);
+    },
+  };
+}

--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -95,7 +95,12 @@ async function* streamResponse(
 ): AsyncIterable<LanguageModelResponsePart> {
   const model = await requireModel(selectChatModels, modelId);
   const cancellation = new vscode.CancellationTokenSource();
-  const cancel = () => cancellation.cancel();
+  let cancelled = false;
+  const cancel = () => {
+    if (cancelled) return;
+    cancelled = true;
+    cancellation.cancel();
+  };
   if (signal.aborted) cancel();
   signal.addEventListener('abort', cancel, { once: true });
 
@@ -119,6 +124,7 @@ async function* streamResponse(
     }
   } finally {
     signal.removeEventListener('abort', cancel);
+    cancel();
     cancellation.dispose();
   }
 }

--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - platform
 import {
   UNAVAILABLE_LANGUAGE_MODEL_PORT,
   type LanguageModelInfo,
@@ -8,6 +10,8 @@ import {
   type LanguageModelRequestOptions,
   type LanguageModelResponsePart,
 } from '@platform/languageModel';
+
+const NOOP_DISPOSABLE = Object.freeze({ dispose() {} });
 
 function toModelInfo(model: vscode.LanguageModelChat): LanguageModelInfo {
   return {
@@ -138,6 +142,11 @@ export function createLanguageModelPort(
     return UNAVAILABLE_LANGUAGE_MODEL_PORT;
   }
   const selectChatModels = lm.selectChatModels;
+  const accessInformation = (
+    context as {
+      languageModelAccessInformation?: Partial<vscode.LanguageModelAccessInformation>;
+    }
+  ).languageModelAccessInformation;
 
   return {
     isAvailable: () => true,
@@ -149,7 +158,7 @@ export function createLanguageModelPort(
     onDidChangeModels(listener) {
       return typeof lm.onDidChangeChatModels === 'function'
         ? lm.onDidChangeChatModels(listener)
-        : { dispose() {} };
+        : NOOP_DISPOSABLE;
     },
 
     sendRequest(modelId, messages, options, signal) {
@@ -167,14 +176,19 @@ export function createLanguageModelPort(
     },
 
     async canSendRequest(modelId) {
+      if (typeof accessInformation?.canSendRequest !== 'function') {
+        return undefined;
+      }
       const model = await findModel(selectChatModels, modelId);
       return model === undefined
         ? undefined
-        : context.languageModelAccessInformation.canSendRequest(model);
+        : accessInformation.canSendRequest(model);
     },
 
     onDidChangeAccess(listener) {
-      return context.languageModelAccessInformation.onDidChange(listener);
+      return typeof accessInformation?.onDidChange === 'function'
+        ? accessInformation.onDidChange(listener)
+        : NOOP_DISPOSABLE;
     },
   };
 }

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -31,6 +31,7 @@ import { JsonConfigProvider } from './jsonConfigProvider';
 import { nodeFilesystem } from './nodeFilesystem';
 import { createNodeWorkspace } from './nodeWorkspace';
 import { NO_TOOL_AVAILABILITY_HOST } from '../interfaces';
+import { UNAVAILABLE_LANGUAGE_MODEL_PORT } from '../languageModel';
 import { platform } from '../platform';
 
 // Type imports
@@ -103,6 +104,7 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
     lifecycle: services.lifecycle,
     agentResume: services.agentResume,
     agentDirectories: services.agentDirectories,
+    languageModel: UNAVAILABLE_LANGUAGE_MODEL_PORT,
     toolAvailability: {
       ...NO_TOOL_AVAILABILITY_HOST,
       ...services.toolAvailability,

--- a/src/platform/languageModel.ts
+++ b/src/platform/languageModel.ts
@@ -1,0 +1,116 @@
+import type { Disposable } from './interfaces';
+
+export interface LanguageModelInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly family: string;
+  readonly vendor: string;
+  readonly version: string;
+  readonly maxInputTokens: number;
+}
+
+export interface LanguageModelSelector {
+  readonly vendor?: string;
+  readonly family?: string;
+  readonly version?: string;
+  readonly id?: string;
+}
+
+export interface LanguageModelTextPart {
+  readonly kind: 'text';
+  readonly text: string;
+}
+
+export interface LanguageModelToolCallPart {
+  readonly kind: 'toolCall';
+  readonly callId: string;
+  readonly name: string;
+  readonly input: object;
+}
+
+export interface LanguageModelToolResultPart {
+  readonly kind: 'toolResult';
+  readonly callId: string;
+  readonly text: string;
+}
+
+export type LanguageModelMessage =
+  | {
+      readonly role: 'user';
+      readonly content: readonly (
+        LanguageModelTextPart | LanguageModelToolResultPart
+      )[];
+    }
+  | {
+      readonly role: 'assistant';
+      readonly content: readonly (
+        LanguageModelTextPart | LanguageModelToolCallPart
+      )[];
+    };
+
+export interface LanguageModelToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema?: object;
+}
+
+export interface LanguageModelRequestOptions {
+  /** Shown in the host's first-use consent prompt. */
+  readonly justification?: string;
+  readonly tools?: readonly LanguageModelToolDefinition[];
+  readonly toolMode?: 'auto' | 'required';
+}
+
+export type LanguageModelResponsePart =
+  LanguageModelTextPart | LanguageModelToolCallPart;
+
+/**
+ * Host bridge for subscription-backed language models exposed by the editor.
+ * Hosts without such an API use {@link UNAVAILABLE_LANGUAGE_MODEL_PORT}.
+ */
+export interface LanguageModelPort {
+  isAvailable(): boolean;
+  selectModels(
+    selector?: LanguageModelSelector,
+  ): Promise<readonly LanguageModelInfo[]>;
+  onDidChangeModels(listener: () => void): Disposable;
+  sendRequest(
+    modelId: string,
+    messages: readonly LanguageModelMessage[],
+    options: LanguageModelRequestOptions,
+    signal: AbortSignal,
+  ): AsyncIterable<LanguageModelResponsePart>;
+  countTokens(modelId: string, text: string): Promise<number>;
+  canSendRequest(modelId: string): Promise<boolean | undefined>;
+  onDidChangeAccess(listener: () => void): Disposable;
+}
+
+const UNAVAILABLE_MESSAGE =
+  'Language models supplied by the editor are unavailable in this host.';
+
+function unavailableRequest(): AsyncIterable<LanguageModelResponsePart> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          throw new Error(UNAVAILABLE_MESSAGE);
+        },
+      };
+    },
+  };
+}
+
+/** Shared implementation for CLI, desktop, tests, and unsupported editors. */
+export const UNAVAILABLE_LANGUAGE_MODEL_PORT: LanguageModelPort = Object.freeze(
+  {
+    isAvailable: () => false,
+    selectModels: async () => [],
+    onDidChangeModels: () => ({ dispose() {} }),
+    sendRequest: unavailableRequest,
+    countTokens: async () => {
+      throw new Error(UNAVAILABLE_MESSAGE);
+    },
+    canSendRequest: async () => undefined,
+    onDidChangeAccess: () => ({ dispose() {} }),
+  },
+);

--- a/src/platform/languageModel.ts
+++ b/src/platform/languageModel.ts
@@ -1,3 +1,4 @@
+// Local imports - platform
 import type { Disposable } from './interfaces';
 
 export interface LanguageModelInfo {

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -23,6 +23,7 @@ import type {
   LifecycleHost,
   ToolAvailabilityHost,
 } from './interfaces';
+import type { LanguageModelPort } from './languageModel';
 import type { PlatformSecrets } from './secrets';
 
 /**
@@ -46,6 +47,8 @@ export interface Platform {
   readonly agentResume: AgentResumePort;
   readonly agentDirectories: AgentDirectoriesPort;
   readonly toolAvailability: ToolAvailabilityHost;
+  /** Subscription-backed models exposed by the active editor host. */
+  readonly languageModel: LanguageModelPort;
   /**
    * Linter diagnostics provider for the diagnostics tool's `list`/`count`
    * commands. Single-implementer (VS Code) — hosts without a linter

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - platform
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import { NO_TOOL_AVAILABILITY_HOST } from '@platform/interfaces';
+import { UNAVAILABLE_LANGUAGE_MODEL_PORT } from '@platform/languageModel';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
@@ -140,6 +141,7 @@ describe('desktop agent directory bootstrap', () => {
             globalStateStore.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR),
         },
       }),
+      languageModel: UNAVAILABLE_LANGUAGE_MODEL_PORT,
       toolAvailability: NO_TOOL_AVAILABILITY_HOST,
       linter: async () => [],
       addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -224,9 +224,10 @@ describe('createLanguageModelPort', () => {
   });
 
   it.each([
-    ['before iteration', true],
-    ['during streaming', false],
-  ])('cancels %s when the AbortSignal fires', async (_case, preAborted) => {
+    ['before iteration', 'pre-abort'],
+    ['during streaming', 'abort'],
+    ['when the consumer stops', 'return'],
+  ])('cancels %s', async (_case, mode) => {
     mocks.selectChatModels.mockResolvedValue([
       fakeModel({
         sendRequest: vi.fn(async () => ({
@@ -237,7 +238,7 @@ describe('createLanguageModelPort', () => {
       }),
     ]);
     const controller = new AbortController();
-    if (preAborted) controller.abort();
+    if (mode === 'pre-abort') controller.abort();
     const stream = createPort().sendRequest(
       'copilot-gpt-4o',
       [],
@@ -247,9 +248,10 @@ describe('createLanguageModelPort', () => {
     const iterator = stream[Symbol.asyncIterator]();
 
     await iterator.next();
-    if (!preAborted) controller.abort();
+    if (mode === 'abort') controller.abort();
+    if (mode === 'return') await iterator.return?.();
 
     expect(cancellationSources[0]?.cancel).toHaveBeenCalledOnce();
-    await iterator.return?.();
+    if (mode !== 'return') await iterator.return?.();
   });
 });

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 class LanguageModelTextPart {
@@ -83,12 +84,14 @@ vi.mock('vscode', () => ({
 const { createLanguageModelPort } =
   await import('@frontend/lm/createLanguageModelPort');
 
-function createPort() {
+function createPort(
+  accessInformation: object = {
+    canSendRequest: mocks.canSendRequest,
+    onDidChange: mocks.onDidChangeAccess,
+  },
+) {
   return createLanguageModelPort({
-    languageModelAccessInformation: {
-      canSendRequest: mocks.canSendRequest,
-      onDidChange: mocks.onDidChangeAccess,
-    },
+    languageModelAccessInformation: accessInformation,
   } as unknown as Parameters<typeof createLanguageModelPort>[0]);
 }
 
@@ -134,6 +137,14 @@ describe('createLanguageModelPort', () => {
     await expect(port.countTokens('missing', 'hello')).rejects.toThrow(
       'Language model "missing" is unavailable.',
     );
+    await expect(
+      createPort({}).canSendRequest('copilot-gpt-4o'),
+    ).resolves.toBeUndefined();
+    expect(() =>
+      createPort({})
+        .onDidChangeAccess(() => {})
+        .dispose(),
+    ).not.toThrow();
     expect(model.countTokens).toHaveBeenCalledWith('hello');
     expect(mocks.canSendRequest).toHaveBeenCalledWith(model);
   });

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class LanguageModelTextPart {
+  constructor(public readonly value: string) {}
+}
+
+class LanguageModelToolCallPart {
+  constructor(
+    public readonly callId: string,
+    public readonly name: string,
+    public readonly input: object,
+  ) {}
+}
+
+class LanguageModelToolResultPart {
+  constructor(
+    public readonly callId: string,
+    public readonly content: unknown[],
+  ) {}
+}
+
+class LanguageModelChatMessage {
+  private constructor(
+    public readonly role: 'user' | 'assistant',
+    public readonly content: unknown[],
+  ) {}
+
+  static User(content: unknown[]) {
+    return new LanguageModelChatMessage('user', content);
+  }
+
+  static Assistant(content: unknown[]) {
+    return new LanguageModelChatMessage('assistant', content);
+  }
+}
+
+const cancellationSources: CancellationTokenSource[] = [];
+
+class CancellationTokenSource {
+  readonly token = {};
+  readonly cancel = vi.fn();
+  readonly dispose = vi.fn();
+
+  constructor() {
+    cancellationSources.push(this);
+  }
+}
+
+function fakeModel(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'copilot-gpt-4o',
+    name: 'GPT-4o',
+    family: 'gpt-4o',
+    vendor: 'copilot',
+    version: '2026-07',
+    maxInputTokens: 128_000,
+    sendRequest: vi.fn(),
+    countTokens: vi.fn(async () => 42),
+    ...overrides,
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  selectChatModels: vi.fn(),
+  onDidChangeChatModels: vi.fn(() => ({ dispose: vi.fn() })),
+  canSendRequest: vi.fn(),
+  onDidChangeAccess: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock('vscode', () => ({
+  lm: {
+    selectChatModels: mocks.selectChatModels,
+    onDidChangeChatModels: mocks.onDidChangeChatModels,
+  },
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolResultPart,
+  LanguageModelChatMessage,
+  LanguageModelChatToolMode: { Auto: 1, Required: 2 },
+  CancellationTokenSource,
+}));
+
+const { createLanguageModelPort } =
+  await import('@frontend/lm/createLanguageModelPort');
+
+function createPort() {
+  return createLanguageModelPort({
+    languageModelAccessInformation: {
+      canSendRequest: mocks.canSendRequest,
+      onDidChange: mocks.onDidChangeAccess,
+    },
+  } as unknown as Parameters<typeof createLanguageModelPort>[0]);
+}
+
+describe('createLanguageModelPort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cancellationSources.length = 0;
+  });
+
+  it('maps model descriptors and forwards selectors', async () => {
+    mocks.selectChatModels.mockResolvedValue([fakeModel()]);
+    const port = createPort();
+
+    expect(port.isAvailable()).toBe(true);
+    await expect(
+      port.selectModels({ vendor: 'copilot', version: '2026-07' }),
+    ).resolves.toEqual([
+      {
+        id: 'copilot-gpt-4o',
+        name: 'GPT-4o',
+        family: 'gpt-4o',
+        vendor: 'copilot',
+        version: '2026-07',
+        maxInputTokens: 128_000,
+      },
+    ]);
+    expect(mocks.selectChatModels).toHaveBeenCalledWith({
+      vendor: 'copilot',
+      version: '2026-07',
+    });
+  });
+
+  it('resolves operations directly by model id', async () => {
+    const model = fakeModel();
+    mocks.selectChatModels.mockImplementation(async ({ id }) =>
+      id === 'missing' ? [] : [model],
+    );
+    mocks.canSendRequest.mockReturnValue(true);
+    const port = createPort();
+
+    await expect(port.countTokens('copilot-gpt-4o', 'hello')).resolves.toBe(42);
+    await expect(port.canSendRequest('copilot-gpt-4o')).resolves.toBe(true);
+    await expect(port.countTokens('missing', 'hello')).rejects.toThrow(
+      'Language model "missing" is unavailable.',
+    );
+    expect(model.countTokens).toHaveBeenCalledWith('hello');
+    expect(mocks.canSendRequest).toHaveBeenCalledWith(model);
+  });
+
+  it('translates messages, tools, and streamed parts', async () => {
+    const sendRequest = vi.fn(
+      async (_messages: unknown[], _options: unknown, _token: unknown) => ({
+        stream: (async function* () {
+          yield new LanguageModelTextPart('hello');
+          yield new LanguageModelToolCallPart('next', 'search', { query: 'x' });
+          yield { unsupported: true };
+        })(),
+      }),
+    );
+    mocks.selectChatModels.mockResolvedValue([fakeModel({ sendRequest })]);
+    const parts = [];
+
+    for await (const part of createPort().sendRequest(
+      'copilot-gpt-4o',
+      [
+        {
+          role: 'assistant',
+          content: [
+            { kind: 'text', text: 'prior' },
+            {
+              kind: 'toolCall',
+              callId: 'call-1',
+              name: 'search',
+              input: { query: 'input' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ kind: 'toolResult', callId: 'call-1', text: 'done' }],
+        },
+      ],
+      {
+        justification: 'Run TeXRA',
+        tools: [
+          {
+            name: 'search',
+            description: 'Search sources',
+            inputSchema: { type: 'object' },
+          },
+        ],
+        toolMode: 'required',
+      },
+      new AbortController().signal,
+    )) {
+      parts.push(part);
+    }
+
+    expect(parts).toEqual([
+      { kind: 'text', text: 'hello' },
+      {
+        kind: 'toolCall',
+        callId: 'next',
+        name: 'search',
+        input: { query: 'x' },
+      },
+    ]);
+    const call = sendRequest.mock.calls.at(0);
+    if (!call) throw new Error('Expected the adapter to send one request.');
+    const [messages, options] = call;
+    expect(messages).toEqual([
+      LanguageModelChatMessage.Assistant([
+        new LanguageModelTextPart('prior'),
+        new LanguageModelToolCallPart('call-1', 'search', { query: 'input' }),
+      ]),
+      LanguageModelChatMessage.User([
+        new LanguageModelToolResultPart('call-1', [
+          new LanguageModelTextPart('done'),
+        ]),
+      ]),
+    ]);
+    expect(options).toEqual({
+      justification: 'Run TeXRA',
+      tools: [
+        {
+          name: 'search',
+          description: 'Search sources',
+          inputSchema: { type: 'object' },
+        },
+      ],
+      toolMode: 2,
+    });
+  });
+
+  it.each([
+    ['before iteration', true],
+    ['during streaming', false],
+  ])('cancels %s when the AbortSignal fires', async (_case, preAborted) => {
+    mocks.selectChatModels.mockResolvedValue([
+      fakeModel({
+        sendRequest: vi.fn(async () => ({
+          stream: (async function* () {
+            yield new LanguageModelTextPart('hello');
+          })(),
+        })),
+      }),
+    ]);
+    const controller = new AbortController();
+    if (preAborted) controller.abort();
+    const stream = createPort().sendRequest(
+      'copilot-gpt-4o',
+      [],
+      {},
+      controller.signal,
+    );
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await iterator.next();
+    if (!preAborted) controller.abort();
+
+    expect(cancellationSources[0]?.cancel).toHaveBeenCalledOnce();
+    await iterator.return?.();
+  });
+});

--- a/src/test-kernel/frontend/createLanguageModelPortUnavailable.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPortUnavailable.vitest.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({ lm: undefined }));
+
+const { createLanguageModelPort } =
+  await import('@frontend/lm/createLanguageModelPort');
+
+describe('createLanguageModelPort without vscode.lm', () => {
+  it('uses the shared unavailable implementation', async () => {
+    const port = createLanguageModelPort(
+      {} as Parameters<typeof createLanguageModelPort>[0],
+    );
+
+    expect(port.isAvailable()).toBe(false);
+    await expect(port.selectModels()).resolves.toEqual([]);
+    await expect(port.countTokens('missing', 'text')).rejects.toThrow(
+      'unavailable in this host',
+    );
+  });
+});

--- a/src/test-kernel/frontend/createLanguageModelPortUnavailable.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPortUnavailable.vitest.ts
@@ -1,3 +1,4 @@
+// Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('vscode', () => ({ lm: undefined }));

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -20,6 +20,7 @@ import {
   type AgentDirectoriesPort,
 } from '@platform/interfaces';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
+import { UNAVAILABLE_LANGUAGE_MODEL_PORT } from '@platform/languageModel';
 import type { Platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
@@ -534,6 +535,7 @@ export function createFakePlatform(
     lifecycle: createLifecycleHost(),
     agentResume: { tryResumeStream: async () => false },
     agentDirectories: FAKE_AGENT_DIRECTORIES,
+    languageModel: UNAVAILABLE_LANGUAGE_MODEL_PORT,
     toolAvailability: NO_TOOL_AVAILABILITY_HOST,
     linter: async () => [],
     addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),


### PR DESCRIPTION
## Summary

- Add a host-neutral Language Model API port without importing `vscode` into core code.
- Wire the VS Code implementation at the extension composition root.
- Give CLI, desktop, and tests one shared unavailable implementation.
- Resolve models directly with `selectChatModels({ id })` instead of keeping mutable selection-order-dependent cache state.
- Use role-discriminated messages so assistant tool calls and user tool results are valid by construction.

## Design

`Platform.languageModel` is a required deep port: every host has one implementation, and unsupported hosts use `UNAVAILABLE_LANGUAGE_MODEL_PORT`. The VS Code adapter owns all translation between plain host-neutral DTOs and `vscode.LanguageModel*` classes, including messages, tools, streaming parts, consent checks, token counting, and cancellation.

Operations resolve the current model handle by ID on demand. This avoids stale handles, cross-consumer cache invalidation, and a prerequisite `selectModels()` call. Model and access-change events remain available to the future dynamic Copilot registry/handler work.

The consumer-side VS Code API does not expose capability profiles or numeric quota values, so this port does not fabricate them. Those concerns remain with the handler/registry tasks in #6725.

Closes #6726.

## Test Cleanup

- Consolidated the stale PR's ten adapter tests into seven behavior-focused tests.
- Removed tests that mirrored implementation details such as clearing a private model cache.
- Expanded the request-boundary test to cover both message roles, tool calls/results, tool definitions, tool mode, and streamed response mapping.

## Verification

- Focused adapter/platform/desktop suites: 23 tests passed.
- Full Vitest suite: 6,000 tests passed; 4 skipped.
- `npm run typecheck`.
- `npm run lint` (0 errors; existing warnings only).
- `npm run compile:fast`.
- Targeted Prettier and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New required platform surface and streaming/cancellation wiring; behavior is mostly additive behind the port with no core consumers shown in this diff, but mistakes in the VS Code adapter could affect future Copilot-backed flows.
> 
> **Overview**
> Introduces a **required** `Platform.languageModel` port so core code can use editor subscription models (e.g. Copilot) without importing `vscode`. The port defines host-neutral DTOs for model listing, streaming chat (text + tool calls), token counting, access checks, and **role-discriminated** messages (assistant tool calls vs user tool results).
> 
> The VS Code extension composes **`createLanguageModelPort(context)`**, which maps those DTOs to `vscode.lm` / `LanguageModelChat*` APIs, resolves models **on demand** via `selectChatModels({ id })` (no selection cache), bridges **AbortSignal** to cancellation tokens, and falls back to the shared stub when `vscode.lm` is missing.
> 
> CLI/desktop Node hosts, `FakePlatform`, and desktop harness tests wire **`UNAVAILABLE_LANGUAGE_MODEL_PORT`** (empty selects, throws on send/count). New Vitest coverage exercises the adapter mapping, access hooks, and cancellation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c4003116b191b8c30d23bc8e5a04c9741ac5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

