### PR TITLE
[codex] Narrow desktop host progress events

### DIFF
--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -80,11 +80,10 @@ export interface DesktopProgressEventBridge {
   hasRestoredStream(streamId: StreamTabId): boolean;
 
   /**
-   * Handle a progress event emitted through the runtime host.
+   * Handle a desktop presentation event emitted through the runtime host.
    *
-   * Applies the desktop-specific rail update (persist snapshot, remove ghost,
-   * route-to-progress, show root errors) for events delivered through the
-   * owning window's runtime host or session projection path.
+   * Session and run facts reach this bridge through `onSessionEvent`; this path
+   * is only for window-local host requests that have no durable session fact.
    */
   onProgressEvent<K extends keyof ProgressEventPayloads>(
     event: K,
@@ -216,37 +215,6 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     // this second route also no-ops once disposed.
     if (this.disposed) return;
     switch (event) {
-      case 'setActiveStream': {
-        const data = payload as ProgressEventPayloads['setActiveStream'];
-        this.handleSetActiveStream(data);
-        return;
-      }
-      case 'setTaskState': {
-        const data = payload as ProgressEventPayloads['setTaskState'];
-        this.handleRunConfigFact(data.streamId, data.executionId);
-        return;
-      }
-      case 'updateStreamStatus': {
-        const data = payload as ProgressEventPayloads['updateStreamStatus'];
-        this.handleStreamStatusFact(data.streamId, data.status);
-        return;
-      }
-      case 'updateStreamDescription': {
-        const data =
-          payload as ProgressEventPayloads['updateStreamDescription'];
-        this.persistStreamSnapshot(data.streamId);
-        return;
-      }
-      case 'setParentStream': {
-        const data = payload as ProgressEventPayloads['setParentStream'];
-        this.persistStreamSnapshot(data.childStreamId);
-        return;
-      }
-      case 'goalStateChanged': {
-        const data = payload as ProgressEventPayloads['goalStateChanged'];
-        this.handleGoalStateChanged(data.streamId);
-        return;
-      }
       case 'requestEnsureProgressView':
         this.opts.routeToProgress();
         return;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -686,7 +686,7 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
-  it('routes host-path runtime events through the desktop session host channel', async () => {
+  it('does not persist desktop snapshots from host-path stream facts', async () => {
     const messages: unknown[] = [];
     const streamSnapshotStore = createStreamSnapshotStore([]);
     const bridge = (await createBridge(messages, {
@@ -701,15 +701,9 @@ describe('DesktopProgressBridge', () => {
         executionId: 'de57e0',
         taskState: TaskStateSchema.parse(workflowTaskState()),
       });
+      await settleProgressEvents();
 
-      await vi.waitFor(() => {
-        expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(
-          expect.objectContaining({
-            streamId: 'desktop-host-stream',
-            executionId: 'de57e0',
-          }),
-        );
-      });
+      expect(streamSnapshotStore.upsert).not.toHaveBeenCalled();
     } finally {
       bridge.dispose();
     }
@@ -2139,17 +2133,27 @@ describe('DesktopProgressBridge', () => {
     });
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      (bridge as BridgeWithSession).session.events.emit({
+        scope: 'run',
         streamId: 'stream-1',
-        executionId: 'ec1001',
-        taskState,
+        event: {
+          type: 'run.config',
+          streamId: 'stream-1',
+          executionId: 'ec1001',
+          config: taskState.agentConfig,
+        } as any,
       });
 
       await bridge.deleteStream('stream-1');
-      bridge.handleProgressEvent('setTaskState', {
+      (bridge as BridgeWithSession).session.events.emit({
+        scope: 'run',
         streamId: 'stream-1',
-        executionId: 'ec1001',
-        taskState,
+        event: {
+          type: 'run.config',
+          streamId: 'stream-1',
+          executionId: 'ec1001',
+          config: taskState.agentConfig,
+        } as any,
       });
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
       expect(retrieveSessionResumeData).not.toHaveBeenCalled();

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -326,10 +326,16 @@ describe('DesktopProgressEventBridge', () => {
 
       try {
         expect(bridge.hasRestoredStream('live-stream')).toBe(true);
-        bridge.onProgressEvent('updateStreamStatus', {
+        bridge.onSessionEvent({
+          scope: 'run',
           streamId: 'live-stream',
-          status: STREAM_STATUS.RUNNING,
-          previousStatus: STREAM_PHASE.CANCELLED,
+          event: {
+            type: 'status',
+            streamId: 'live-stream',
+            phase: STREAM_PHASE.RUNNING,
+            previousPhase: STREAM_PHASE.CANCELLED,
+            cause: 'run-start',
+          } as any,
         });
         bridge.hydrateRestoredStreams();
 
@@ -378,16 +384,23 @@ describe('DesktopProgressEventBridge', () => {
   // ── Progress events ─────────────────────────────────────────────────────
 
   describe('onProgressEvent', () => {
-    it('removes ghost and persists snapshot on setTaskState', async () => {
+    it('ignores stream fact-shaped host events', async () => {
       const upsert = vi.fn(async () => {});
+      const onGoalStateChanged = vi.fn();
+      const streamStatus = {
+        get: vi.fn(() => STREAM_PHASE.WAITING),
+        transition: vi.fn(() => true),
+      };
 
       const bridge = createBridge({
+        onGoalStateChanged,
         state: makeMockState({
           streamLogs: createStreamLogs({
             has: () => true,
             getLastTimestamp: () => 3_000,
           }),
         }),
+        streamStatus,
         streamSnapshotStore: createSnapshotStore({
           hydrated: [createSnapshot({ streamId: 'task-stream' })],
           upsert,
@@ -401,51 +414,19 @@ describe('DesktopProgressEventBridge', () => {
           streamId: 'task-stream',
           taskState: undefined as any,
         });
-
-        expect(bridge.hasRestoredStream('task-stream')).toBe(false);
-        await settleMicrotasks();
-        expect(upsert).toHaveBeenCalled();
-      } finally {
-        bridge.dispose();
-      }
-    });
-
-    it('removes ghost and persists snapshot on updateStreamStatus', async () => {
-      const upsert = vi.fn(async () => {});
-      const streamStatus = {
-        get: vi.fn(() => STREAM_PHASE.WAITING),
-        transition: vi.fn(() => true),
-      };
-
-      const bridge = createBridge({
-        state: makeMockState({
-          streamLogs: createStreamLogs({
-            has: () => true,
-            getLastTimestamp: () => 3_000,
-          }),
-        }),
-        streamStatus,
-        streamSnapshotStore: createSnapshotStore({
-          hydrated: [createSnapshot({ streamId: 'status-stream' })],
-          upsert,
-        }),
-      });
-
-      try {
         bridge.onProgressEvent('updateStreamStatus', {
-          streamId: 'status-stream',
+          streamId: 'task-stream',
           status: STREAM_STATUS.RUNNING,
           previousStatus: STREAM_PHASE.CANCELLED,
         });
+        bridge.onProgressEvent('goalStateChanged', {
+          streamId: 'task-stream',
+        });
 
-        expect(bridge.hasRestoredStream('status-stream')).toBe(false);
         await settleMicrotasks();
-        expect(upsert).toHaveBeenCalledWith(
-          expect.objectContaining({
-            streamId: 'status-stream',
-            lastKnownStatus: STREAM_PHASE.RUNNING,
-          }),
-        );
+        expect(bridge.hasRestoredStream('task-stream')).toBe(true);
+        expect(upsert).not.toHaveBeenCalled();
+        expect(onGoalStateChanged).not.toHaveBeenCalled();
       } finally {
         bridge.dispose();
       }
@@ -460,51 +441,6 @@ describe('DesktopProgressEventBridge', () => {
             streamId: 'test',
           }),
         ).not.toThrow();
-      } finally {
-        bridge.dispose();
-      }
-    });
-
-    it('clears active stream when setActiveStream has empty streamId', () => {
-      const messages: unknown[] = [];
-      const mockState = makeMockState();
-      mockState.activeStream = 'previous-stream';
-
-      const bridge = createBridge({
-        state: mockState,
-        sendMessage: (msg) => messages.push(msg),
-        getActiveStream: () => mockState.activeStream,
-      });
-
-      try {
-        bridge.onProgressEvent('setActiveStream', {
-          streamId: '',
-          suppressViewSwitch: true,
-        });
-
-        expect(mockState.activeStream).toBe('');
-        expect(messages).toContainEqual({
-          command: 'setActiveStream',
-          activeStream: '',
-        });
-      } finally {
-        bridge.dispose();
-      }
-    });
-
-    it('updates goal badge state from the session progress path', () => {
-      const onGoalStateChanged = vi.fn();
-      const bridge = createBridge({ onGoalStateChanged });
-
-      try {
-        bridge.onProgressEvent('goalStateChanged', {
-          streamId: 'goal-stream',
-        });
-
-        expect(onGoalStateChanged).toHaveBeenCalledWith('goal-stream', false, {
-          status: undefined,
-          objective: undefined,
-        });
       } finally {
         bridge.dispose();
       }
@@ -875,9 +811,8 @@ describe('DesktopProgressEventBridge', () => {
       bridge.dispose();
 
       // These should not throw
-      bridge.onProgressEvent('setTaskState', {
-        streamId: 'test',
-        taskState: undefined as any,
+      bridge.onProgressEvent('requestShowError', {
+        message: 'test',
       });
       bridge.onStreamDeleted('test');
       bridge.sendRestoredDisplay('test');


### PR DESCRIPTION
## Summary

This Stage 5 slice narrows the desktop progress-event bridge so its host-event entry point handles only desktop presentation requests. Desktop stream, snapshot, and goal side effects now come from the direct `SessionEventHub` subscription rather than from host-event-shaped stream facts.

## Details

- Removed stream fact handling from `DesktopProgressEventBridge.onProgressEvent` for `setActiveStream`, `setTaskState`, `updateStreamStatus`, `updateStreamDescription`, `setParentStream`, and `goalStateChanged`.
- Kept `requestEnsureProgressView` and `requestShowError` on the desktop host-event path because they are window-local presentation requests without durable session facts.
- Updated desktop tests so host-path stream-shaped events do not persist desktop snapshots or mutate goal state.
- Kept positive desktop snapshot and goal coverage on direct session/run facts.

This leaves `DesktopProgressBridge.handleProgressEvent` free to keep forwarding compatibility events to the shared backend while the desktop-specific bridge no longer treats that host rail as a stream-fact projection.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with the existing import-order warnings)
- `npm run check:dead-code-ratchet`
- `npm test`
- Verified `DesktopProgressEventBridge.onProgressEvent` has no stream-fact cases for `setActiveStream`, `setTaskState`, `updateStreamStatus`, `updateStreamDescription`, `setParentStream`, or `goalStateChanged`.

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event routing for desktop rail persistence and ghost lifecycle; regressions would show as missing snapshots or stale ghosts if session facts are not delivered, though the session subscription path is already wired in production.
> 
> **Overview**
> **Narrows** `DesktopProgressEventBridge.onProgressEvent` so the runtime-host path handles only window-local presentation (`requestEnsureProgressView`, `requestShowError`). Stream-shaped host events (`setTaskState`, status/description/parent/active stream, `goalStateChanged`) no longer clear ghosts, persist snapshots, or update goal badges from that entry point.
> 
> Ghost streams, desktop snapshot persistence, and goal side effects are expected from **`onSessionEvent`** (session facts and `run.config` / `status` run facts), matching how `DesktopProgressBridge` already subscribes to `SessionEventHub`.
> 
> Tests now assert host-channel `setTaskState` does not call snapshot `upsert`, that stream-fact-shaped `onProgressEvent` calls are ignored, and that resume/delete scenarios drive **`session.events.emit`** instead of `handleProgressEvent` for run config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34c80295aa2a778445d6f12862d1c4c413816c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->