### PR TITLE
[codex] Type desktop presentation progress events narrowly

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -98,6 +98,7 @@ import {
 } from './desktopProgressFileActions.js';
 import {
   createDesktopProgressEventBridge,
+  type DesktopPresentationPayloads,
   type DesktopProgressEventBridge,
 } from './desktopProgressEventBridge.js';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
@@ -1005,7 +1006,22 @@ export class DesktopProgressBridge {
   ): void {
     if (event === 'addOutputFiles') return;
     this.backend.handleProgressEvent(event, payload);
-    this.progressEvents.onProgressEvent(event, payload);
+    switch (event) {
+      case 'requestEnsureProgressView':
+        this.progressEvents.onProgressEvent(
+          event,
+          payload as DesktopPresentationPayloads[typeof event],
+        );
+        return;
+      case 'requestShowError':
+        this.progressEvents.onProgressEvent(
+          event,
+          payload as DesktopPresentationPayloads[typeof event],
+        );
+        return;
+      default:
+        return;
+    }
   }
 
   private streamStateSnapshot(): Map<StreamTabId, StreamPhaseState> {

--- a/packages/desktop/src/main/desktopProgressEventBridge.ts
+++ b/packages/desktop/src/main/desktopProgressEventBridge.ts
@@ -2,8 +2,8 @@
  * Desktop progress-event bridge.
  *
  * Extracted from DesktopProgressBridge to own the ghost-stream hydration,
- * stream-snapshot persistence, restored-display sending, and progress-event →
- * rail-update translation.  The parent bridge composes this as a focused
+ * stream-snapshot persistence, restored-display sending, and desktop-local
+ * presentation events. The parent bridge composes this as a focused
  * collaborator and keeps runtime-host, approval, resume, and stream-lifecycle
  * wiring.
  *
@@ -13,18 +13,20 @@
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   STREAM_PHASE,
   type ProgressViewOutboundMessage,
+  type RequestEnsureProgressViewPayload,
+  type RequestShowErrorPayload,
   type RestoredStreamSnapshot,
+  type SetActiveStreamPayload,
   type StreamTabId,
 } from '@shared/schemas';
-import { AgentCategory } from '@shared/schemas/agent';
-import { isGoalInFlight, type GoalStatus } from '@shared/schemas/goal';
-import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { buildStreamInfo } from '@shared/progressView/backend/streamInfoUtils';
 import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
+import { AgentCategory } from '@shared/schemas/agent';
+import { isGoalInFlight, type GoalStatus } from '@shared/schemas/goal';
 import { GoalStore } from '@tools/goal';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
@@ -58,6 +60,14 @@ export interface DesktopProgressEventBridgeOptions {
   onShowError: (message: string) => void;
 }
 
+export interface DesktopPresentationPayloads {
+  requestEnsureProgressView: RequestEnsureProgressViewPayload;
+  requestShowError: RequestShowErrorPayload;
+}
+
+export type DesktopPresentationProgressEvent =
+  keyof DesktopPresentationPayloads;
+
 // ── Public interface ────────────────────────────────────────────────────────
 
 export interface DesktopProgressEventBridge {
@@ -85,9 +95,9 @@ export interface DesktopProgressEventBridge {
    * Session and run facts reach this bridge through `onSessionEvent`; this path
    * is only for window-local host requests that have no durable session fact.
    */
-  onProgressEvent<K extends keyof ProgressEventPayloads>(
+  onProgressEvent<K extends DesktopPresentationProgressEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: DesktopPresentationPayloads[K],
   ): void;
 
   /** Handle session/run facts emitted by this window's SessionEventHub. */
@@ -202,9 +212,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 
   // ── Progress events ──────────────────────────────────────────────────────
 
-  onProgressEvent<K extends keyof ProgressEventPayloads>(
+  onProgressEvent<K extends DesktopPresentationProgressEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: DesktopPresentationPayloads[K],
   ): void {
     // A headless run may still hold the owning bridge's `hostChannel.emit`
     // closure that routes here after the desktop window closed and this bridge
@@ -219,12 +229,10 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
         this.opts.routeToProgress();
         return;
       case 'requestShowError': {
-        const data = payload as ProgressEventPayloads['requestShowError'];
+        const data = payload as RequestShowErrorPayload;
         this.opts.onShowError(data.message);
         return;
       }
-      default:
-        return;
     }
   }
 
@@ -461,9 +469,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     }
   }
 
-  private handleSetActiveStream(
-    payload: ProgressEventPayloads['setActiveStream'],
-  ): void {
+  private handleSetActiveStream(payload: SetActiveStreamPayload): void {
     if (!payload.streamId) {
       this.opts.state.activeStream = '';
       this.opts.sendMessage({

--- a/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts
@@ -1,7 +1,13 @@
 // Suites for packages/desktop DesktopProgressEventBridge (stream routing,
 // snapshot hydration, dispose guard).
 
+import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentTrace } from '@agent/trace';
+import {
+  createDesktopProgressEventBridge,
+  type DesktopProgressEventBridgeOptions,
+} from '@desktop/main/desktopProgressEventBridge';
 import {
   AgentCategory,
   type RestoredStreamSnapshot,
@@ -9,14 +15,8 @@ import {
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
-import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import { strict as assert } from 'node:assert';
-import type { AgentTrace } from '@agent/trace';
 import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
-import {
-  createDesktopProgressEventBridge,
-  type DesktopProgressEventBridgeOptions,
-} from '@desktop/main/desktopProgressEventBridge';
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 // ---------------------------------------------------------------------------
 // DesktopProgressEventBridge
@@ -384,68 +384,6 @@ describe('DesktopProgressEventBridge', () => {
   // ── Progress events ─────────────────────────────────────────────────────
 
   describe('onProgressEvent', () => {
-    it('ignores stream fact-shaped host events', async () => {
-      const upsert = vi.fn(async () => {});
-      const onGoalStateChanged = vi.fn();
-      const streamStatus = {
-        get: vi.fn(() => STREAM_PHASE.WAITING),
-        transition: vi.fn(() => true),
-      };
-
-      const bridge = createBridge({
-        onGoalStateChanged,
-        state: makeMockState({
-          streamLogs: createStreamLogs({
-            has: () => true,
-            getLastTimestamp: () => 3_000,
-          }),
-        }),
-        streamStatus,
-        streamSnapshotStore: createSnapshotStore({
-          hydrated: [createSnapshot({ streamId: 'task-stream' })],
-          upsert,
-        }),
-      });
-
-      try {
-        expect(bridge.hasRestoredStream('task-stream')).toBe(true);
-
-        bridge.onProgressEvent('setTaskState', {
-          streamId: 'task-stream',
-          taskState: undefined as any,
-        });
-        bridge.onProgressEvent('updateStreamStatus', {
-          streamId: 'task-stream',
-          status: STREAM_STATUS.RUNNING,
-          previousStatus: STREAM_PHASE.CANCELLED,
-        });
-        bridge.onProgressEvent('goalStateChanged', {
-          streamId: 'task-stream',
-        });
-
-        await settleMicrotasks();
-        expect(bridge.hasRestoredStream('task-stream')).toBe(true);
-        expect(upsert).not.toHaveBeenCalled();
-        expect(onGoalStateChanged).not.toHaveBeenCalled();
-      } finally {
-        bridge.dispose();
-      }
-    });
-
-    it('does not throw for unknown event types', () => {
-      const bridge = createBridge();
-
-      try {
-        expect(() =>
-          bridge.onProgressEvent('unknownEvent' as any, {
-            streamId: 'test',
-          }),
-        ).not.toThrow();
-      } finally {
-        bridge.dispose();
-      }
-    });
-
     it('routes window-local ensure-progress requests from runtime-host events', () => {
       const routeToProgress = vi.fn();
       const bridge = createBridge({ routeToProgress });


### PR DESCRIPTION
## Summary

This follow-up to #7598 makes the desktop progress presentation boundary structural instead of only behaviorally narrowed.

`DesktopProgressEventBridge.onProgressEvent` now accepts only the two desktop presentation requests that still legitimately travel on the desktop host-event path:

- `requestEnsureProgressView`
- `requestShowError`

The full frozen host progress rail is still forwarded from `DesktopProgressBridge` into `ProgressBackend`, except for the existing `addOutputFiles` early return. Only the two presentation requests are then forwarded into `DesktopProgressEventBridge`.

This removes the desktop event bridge's dependency on `ProgressEventPayloads`, so stream facts such as `setTaskState`, `updateStreamStatus`, `setParentStream`, and `goalStateChanged` are no longer part of that API. Their desktop effects remain owned by `SessionEventHub`, as established in #7598.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings outside this slice remain)
- `npm run check:dead-code-ratchet`
- `npm test`
- Structural greps:
  - no `ProgressEventPayloads` reference in `packages/desktop/src/main/desktopProgressEventBridge.ts`
  - no direct `progressEvents.onProgressEvent(event, payload)` forwarding in `DesktopProgressBridge`
  - no desktop bridge tests invoking stream-fact events through `onProgressEvent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral split was established in #7598; this PR is mainly typing and explicit forwarding, with stream facts unchanged on the session path.
> 
> **Overview**
> This follow-up tightens the desktop progress **presentation** boundary so the event bridge no longer depends on the full frozen `ProgressEventPayloads` map.
> 
> **`DesktopProgressEventBridge.onProgressEvent`** now accepts only **`requestEnsureProgressView`** and **`requestShowError`**, with a dedicated **`DesktopPresentationPayloads`** type. Stream-shaped host events (`setTaskState`, `updateStreamStatus`, `goalStateChanged`, etc.) are no longer part of that API; their desktop effects remain on **`onSessionEvent`** / **`SessionEventHub`**, as in #7598.
> 
> **`DesktopProgressBridge.handleProgressEvent`** still sends the full host progress rail to **`ProgressBackend`** (except the existing **`addOutputFiles`** early return), but forwards **only** those two presentation events into the event bridge via an explicit **`switch`** instead of blind fan-out.
> 
> Tests drop cases that drove stream facts or unknown events through **`onProgressEvent`**, matching the narrower public surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1baf7c9be8af6d024888331d44f9e86487db2cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->