### PR TITLE
[codex] Split runtime presentation events from progress events

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -11,6 +11,7 @@ import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
+import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
   ConversationProgressSchema,
@@ -40,11 +41,6 @@ import { mergeChildStreams } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';
-
-type Emit = <K extends ProgressEvent>(
-  event: K,
-  payload: ProgressEventPayloads[K],
-) => void;
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
@@ -370,8 +366,10 @@ function applyStreamMeta(
 
 export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
-  const emit: Emit = (event, payload) => {
-    applyToState(event, payload);
+  const emit: CliRuntimeHost['emit'] = (event, payload) => {
+    if (!isRuntimePresentationEvent(event)) {
+      applyToState(event, payload as ProgressEventPayloads[ProgressEvent]);
+    }
     return original(event, payload);
   };
   return { ...host, emit };

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -1,6 +1,13 @@
 // Local imports - runtime
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@agent/runtime/hostProgressEvents';
+import {
+  isRuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
+} from '@agent/runtime/runtimePresentationEvents';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
 // Local imports - CLI runtime
@@ -42,9 +49,15 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (closed) return;
 
       if (
-        handleCliApprovalEvent(event, payload, context, {
-          beforePrompt: prepareInteractivePrompt,
-        })
+        !isRuntimePresentationEvent(event) &&
+        handleCliApprovalEvent(
+          event as ProgressEvent,
+          payload as ProgressEventPayloads[ProgressEvent],
+          context,
+          {
+            beforePrompt: prepareInteractivePrompt,
+          },
+        )
       ) {
         return;
       }
@@ -63,12 +76,18 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (event === 'requestShowError') {
         runProgress?.preserve();
         ensureLogger().error(
-          (payload as ProgressEventPayloads['requestShowError']).message,
+          (payload as RuntimePresentationEventPayloads['requestShowError'])
+            .message,
         );
         return;
       }
 
-      if (runProgress?.handle(event, payload)) return;
+      if (
+        !isRuntimePresentationEvent(event) &&
+        runProgress?.handle(event, payload)
+      ) {
+        return;
+      }
 
       if (context.quietLogs) return;
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -23,7 +23,11 @@ import {
   resolveAndResumeStream,
 } from '@agent/runtime/resolveAndResumeStream';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  AgentRuntimeEvent,
+  AgentRuntimeEventPayloads,
+  AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
@@ -38,7 +42,7 @@ import {
 } from '@agent/followUp/ToolUseFollowUp';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
 import {
   getFileListConfig,
   loadFileListSettings,
@@ -1000,12 +1004,16 @@ export class DesktopProgressBridge {
     });
   }
 
-  private handleProgressEvent<K extends keyof ProgressEventPayloads>(
+  private handleProgressEvent<K extends AgentRuntimeEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: AgentRuntimeEventPayloads[K],
   ): void {
-    if (event === 'addOutputFiles') return;
-    this.backend.handleProgressEvent(event, payload);
+    if (!isRuntimePresentationEvent(event)) {
+      if (event === 'addOutputFiles') return;
+      this.backend.handleProgressEvent(event, payload);
+      return;
+    }
+
     switch (event) {
       case 'requestEnsureProgressView':
         this.progressEvents.onProgressEvent(

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,4 +1,8 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type {
+  ProgressEvent,
+  ProgressEventPayloads,
+} from '@agent/runtime/hostProgressEvents';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   extensionPresentationEvents,
@@ -18,6 +22,9 @@ export const extensionAgentRuntimeHost: AgentRuntimeHost = {
       );
       return;
     }
-    emitExtensionProgressEvent(event, payload);
+    emitExtensionProgressEvent(
+      event as ProgressEvent,
+      payload as ProgressEventPayloads[ProgressEvent],
+    );
   },
 };

--- a/packages/extension/src/frontend/events/extensionPresentationEvents.ts
+++ b/packages/extension/src/frontend/events/extensionPresentationEvents.ts
@@ -1,12 +1,10 @@
 import { EventEmitter } from 'node:events';
 
-import type {
-  RequestEnsureProgressViewPayload,
-  RequestOpenFilePayload,
-  RequestShowErrorPayload,
-  RequestShowInstructionPayload,
-  ShowAgentConfigBannerPayload,
-} from '@shared/schemas';
+import {
+  isRuntimePresentationEvent,
+  type RuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
+} from '@agent/runtime/runtimePresentationEvents';
 
 /**
  * Extension host-presentation channel: the five UI requests the agent core
@@ -14,31 +12,17 @@ import type {
  * banners, errors, progress-view reveals). Payloads are the fact-native
  * presentation types from `@shared/schemas`.
  */
-export interface ExtensionPresentationEventPayloads {
-  requestOpenFile: RequestOpenFilePayload;
-  requestShowInstruction: RequestShowInstructionPayload;
-  showAgentConfigBanner: ShowAgentConfigBannerPayload;
-  requestShowError: RequestShowErrorPayload;
-  requestEnsureProgressView: RequestEnsureProgressViewPayload;
-}
+export type ExtensionPresentationEventPayloads =
+  RuntimePresentationEventPayloads;
 
-export type ExtensionPresentationEvent =
-  keyof ExtensionPresentationEventPayloads;
-
-const EVENT_SET: ReadonlySet<string> = new Set([
-  'requestOpenFile',
-  'requestShowInstruction',
-  'showAgentConfigBanner',
-  'requestShowError',
-  'requestEnsureProgressView',
-] satisfies ExtensionPresentationEvent[]);
+export type ExtensionPresentationEvent = RuntimePresentationEvent;
 
 const MAX_BUFFER_SIZE = 1000;
 
 export function isExtensionPresentationEvent(
   event: string,
 ): event is ExtensionPresentationEvent {
-  return EVENT_SET.has(event);
+  return isRuntimePresentationEvent(event);
 }
 
 class ExtensionPresentationEventBus {

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,5 +1,11 @@
 import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimePresentationEventPayloads } from '@agent/runtime/runtimePresentationEvents';
 import type { HostInteractions } from './HostInteractions';
+
+export type AgentRuntimeEventPayloads = ProgressEventPayloads &
+  RuntimePresentationEventPayloads;
+
+export type AgentRuntimeEvent = keyof AgentRuntimeEventPayloads;
 
 /**
  * The single progress sink the agent core emits through during a run. Hosts
@@ -17,10 +23,10 @@ import type { HostInteractions } from './HostInteractions';
  *   the `show*`/`resolve*` approval pairs, and conversation progress
  *   (`updateTodos`/`updatePlan`/`updateConversationProgress`). See
  *   {@link ProgressEventPayloads} for the complete, authoritative enumeration.
- * - **Frontend-bound, ignorable** (the `── Frontend-bound events ──` group in
- *   {@link ProgressEventPayloads}: `requestOpenFile`, `requestShowInstruction`,
- *   `showAgentConfigBanner`, `requestShowError`, `requestEnsureProgressView`,
- *   pure host-UI requests with no effect on the agent loop.
+ * - **Frontend-bound, ignorable** (`RuntimePresentationEventPayloads`):
+ *   `requestOpenFile`, `requestShowInstruction`, `showAgentConfigBanner`,
+ *   `requestShowError`, `requestEnsureProgressView`, pure host-UI requests
+ *   with no effect on the agent loop.
  *
  * {@link noopAgentRuntimeHost} (drop everything) is a valid host — it is used
  * by tests and non-interactive paths.
@@ -28,9 +34,9 @@ import type { HostInteractions } from './HostInteractions';
 export interface AgentRuntimeHost {
   readonly interactions?: HostInteractions;
 
-  emit<K extends keyof ProgressEventPayloads>(
+  emit<K extends AgentRuntimeEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: AgentRuntimeEventPayloads[K],
   ): void;
 }
 

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -12,14 +12,9 @@ import type {
   InquiryThreadUpdatedEvent,
   PlanApprovalPermission,
   RemoveStreamPayload,
-  RequestEnsureProgressViewPayload,
-  RequestOpenFilePayload,
-  RequestShowErrorPayload,
-  RequestShowInstructionPayload,
   RetryPermission,
   SetActiveStreamPayload,
   SetParentStreamPayload,
-  ShowAgentConfigBannerPayload,
   StreamTabId,
   ToolEditPermission,
   UpdateActiveProcessesPayload,
@@ -38,8 +33,8 @@ import type {
 } from '@shared/schemas';
 
 /**
- * **Frozen** legacy host progress-event view, spoken by
- * `AgentRuntimeHost.emit` and host-owned compatibility adapters.
+ * **Frozen** legacy host progress-event view, spoken by retained
+ * progress-output adapters and host-owned compatibility adapters.
  * Retained CLI public output now projects into this table inside the CLI
  * adapter boundary (D3 decision on #6984: frozen until v0.41).
  *
@@ -116,15 +111,6 @@ export interface ProgressEventPayloads {
   removeStream: RemoveStreamPayload;
 
   goalStateChanged: GoalStateChangedPayload;
-
-  // ── Frontend-bound presentation requests ──
-  // Emitted by agent core/runtime; consumed by host presentation listeners
-  // (the extension routes these through `extensionPresentationEvents`).
-  requestOpenFile: RequestOpenFilePayload;
-  requestShowInstruction: RequestShowInstructionPayload;
-  showAgentConfigBanner: ShowAgentConfigBannerPayload;
-  requestShowError: RequestShowErrorPayload;
-  requestEnsureProgressView: RequestEnsureProgressViewPayload;
 }
 
 export type ProgressEvent = keyof ProgressEventPayloads;

--- a/src/agent/runtime/runtimePresentationEvents.ts
+++ b/src/agent/runtime/runtimePresentationEvents.ts
@@ -1,0 +1,42 @@
+import type {
+  RequestEnsureProgressViewPayload,
+  RequestOpenFilePayload,
+  RequestShowErrorPayload,
+  RequestShowInstructionPayload,
+  ShowAgentConfigBannerPayload,
+} from '@shared/schemas';
+
+/**
+ * Host-presentation requests emitted by agent/runtime code.
+ *
+ * These are not progress facts and do not belong to the frozen host progress
+ * compatibility vocabulary. Hosts may render them, ignore them, or route them
+ * to their own presentation channel without changing the agent loop.
+ */
+export interface RuntimePresentationEventPayloads {
+  requestOpenFile: RequestOpenFilePayload;
+  requestShowInstruction: RequestShowInstructionPayload;
+  showAgentConfigBanner: ShowAgentConfigBannerPayload;
+  requestShowError: RequestShowErrorPayload;
+  requestEnsureProgressView: RequestEnsureProgressViewPayload;
+}
+
+export type RuntimePresentationEvent = keyof RuntimePresentationEventPayloads;
+
+export const RUNTIME_PRESENTATION_EVENTS = [
+  'requestOpenFile',
+  'requestShowInstruction',
+  'showAgentConfigBanner',
+  'requestShowError',
+  'requestEnsureProgressView',
+] as const satisfies readonly RuntimePresentationEvent[];
+
+const RuntimePresentationEventSet: ReadonlySet<string> = new Set(
+  RUNTIME_PRESENTATION_EVENTS,
+);
+
+export function isRuntimePresentationEvent(
+  event: string,
+): event is RuntimePresentationEvent {
+  return RuntimePresentationEventSet.has(event);
+}


### PR DESCRIPTION
## Summary

This Stage 5 follow-up removes the five frontend-bound presentation requests from the frozen `ProgressEventPayloads` map:

- `requestOpenFile`
- `requestShowInstruction`
- `showAgentConfigBanner`
- `requestShowError`
- `requestEnsureProgressView`

Those requests now live in a separate `RuntimePresentationEventPayloads` table. `AgentRuntimeHost.emit` remains the single runtime host emission method, but its type is now the union of the retained frozen progress-event vocabulary and the explicit presentation vocabulary.

This keeps existing host behavior intact:

- the extension still routes presentation requests through `extensionPresentationEvents`;
- desktop still forwards only `requestEnsureProgressView` and `requestShowError` to its presentation bridge;
- CLI still writes all runtime host events to NDJSON in structured-output mode and still renders `requestShowError` as a human error in text mode;
- progress sinks no longer have to carry presentation keys in `ProgressEventPayloads`.

Part of #6968 and #6951.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain outside this slice)
- `npm run check:dead-code-ratchet`
- `npm test`
- Structural greps:
  - no presentation keys remain in `src/agent/runtime/hostProgressEvents.ts`
  - no `ProgressEventPayloads['request*']` or `ProgressEventPayloads['showAgentConfigBanner']` references remain in production TypeScript

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared runtime host contract and every host’s `emit` routing; behavior is intended to stay the same but mis-branching could drop errors or double-handle progress.
> 
> **Overview**
> Moves the five frontend-bound UI requests (`requestOpenFile`, `requestShowInstruction`, `showAgentConfigBanner`, `requestShowError`, `requestEnsureProgressView`) out of the frozen **`ProgressEventPayloads`** map into a new **`RuntimePresentationEventPayloads`** module with **`isRuntimePresentationEvent`**.
> 
> **`AgentRuntimeHost.emit`** is still the single emission API, but its event type is now **`AgentRuntimeEvent`** — progress keys plus presentation keys. Host adapters branch on presentation vs progress: CLI TUI state skips patching on presentation events; CLI text/NDJSON still handles **`requestShowError`** and writes all events to NDJSON; desktop forwards only **`requestEnsureProgressView`** / **`requestShowError`** to its presentation bridge while **`ProgressBackend`** sees progress only; the extension **`extensionPresentationEvents`** types alias the shared runtime presentation table instead of duplicating the five-key set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f7844ca71237f53a4f026225f5b9d1a7a9e606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->