### PR TITLE
fix(transcript): emit finalized assistant text with a stable id, delete CLI synthetic-entry machinery

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -273,7 +273,6 @@ export function createChatSessionController(
     const { runtimeHost, approvalsUnavailable, finalize } =
       setupRunHost(sessionContext);
     const executionId = generateExecutionId();
-    let waitingTurn = 0;
     let executionRegistered = false;
     let agentSettled = false;
     session.executionId = executionId;
@@ -293,15 +292,9 @@ export function createChatSessionController(
             activeStreamId.set(resolvedStreamId);
             if (session.stopRequested) interruptActiveRun();
           },
-          onIdle: (lastResponse) => {
+          onIdle: () => {
             if (!session.streamId) return;
-            projectStreamTranscript(session.streamId, {
-              fallbackAssistant: {
-                text: lastResponse,
-                idPrefix: `waiting:${executionId}:${waitingTurn++}`,
-              },
-              finalize: true,
-            });
+            projectStreamTranscript(session.streamId, { finalize: true });
           },
         });
       })
@@ -312,17 +305,7 @@ export function createChatSessionController(
           sessionContext,
         );
         if (result.streamId) {
-          projectStreamTranscript(result.streamId, {
-            finalize: true,
-            ...(result.category === AgentCategory.ToolUse
-              ? {
-                  fallbackAssistant: {
-                    text: result.lastResponse,
-                    idPrefix: `final:${result.executionId}`,
-                  },
-                }
-              : {}),
-          });
+          projectStreamTranscript(result.streamId, { finalize: true });
         }
         notify({ kind: 'agentFinished' });
       })

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -46,7 +46,7 @@ interface ConversationEntryBase {
   /** Entry was synthesized by the CLI and is not present in StreamLogStore. */
   readonly synthetic?: boolean;
   /** Why the CLI synthesized this entry. */
-  readonly syntheticKind?: 'final' | 'local' | 'process';
+  readonly syntheticKind?: 'local' | 'process';
   /** StreamLog head at the moment a synthetic entry was appended. */
   readonly syntheticAfterSeq?: number;
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -398,22 +398,13 @@ export function syncStreamLog(streamId: StreamTabId): void {
       if (!rendered) continue;
       logCandidates.push({ rendered, sortSeq: entry.seqNo, tieBreak: 0 });
     }
-    // The synthetic loop's duplicate check scans `logCandidates`, so synthetics
-    // push into a copy; without synthetics the log list is used as-is.
+    // Synthetic (local/process) rows are positioned by `syntheticAfterSeq`
+    // alongside the ordered log entries; push into a copy so we don't mutate
+    // `logCandidates` itself.
     const candidates: TranscriptCandidate[] =
       syntheticEntries.length === 0 ? logCandidates : [...logCandidates];
 
     for (const [index, entry] of syntheticEntries.entries()) {
-      if (entry.syntheticKind !== 'local') {
-        const entryTextTrimmed = entry.text.trim();
-        const duplicate = logCandidates.some(
-          (candidate) =>
-            candidate.rendered.role === entry.role &&
-            candidate.rendered.text.trim() === entryTextTrimmed,
-        );
-        if (duplicate) continue;
-      }
-
       candidates.push({
         rendered: entry,
         sortSeq: entry.syntheticAfterSeq ?? Number.POSITIVE_INFINITY,

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -35,69 +35,6 @@ function normalizeTranscriptText(text: string): string {
   return text.trim();
 }
 
-function syntheticFallbackDedupeText(text: string): string {
-  return normalizeTranscriptText(text).replaceAll('\\checkmark', '✓');
-}
-
-function currentTurnStartIndex(entries: readonly ConversationEntry[]): number {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    if (entries[index]?.role === 'user') return index;
-  }
-  return 0;
-}
-
-export function appendAssistantTranscriptIfMissing(
-  streamId: StreamTabId,
-  text: string | undefined,
-  idPrefix = 'assistant',
-): void {
-  const normalized = normalizeTranscriptText(text ?? '');
-  if (!normalized) return;
-  const syntheticDedupeText = syntheticFallbackDedupeText(normalized);
-  const syntheticAfterSeq = getDefaultStreamLogStore().get(streamId)?.head ?? 0;
-
-  patchStream(streamId, (slice) => {
-    const entryId = `${idPrefix}:${streamId}`;
-    const turnStartIndex = currentTurnStartIndex(slice.entries);
-    const lastStreamEntryInTurn = slice.entries.findLast(
-      (entry, index) => index >= turnStartIndex && !entry.synthetic,
-    );
-    const streamLogOwnsFallback = lastStreamEntryInTurn?.role === 'assistant';
-    const streamLogAlreadyRenderedFallback = slice.entries.some(
-      (entry, index) =>
-        !entry.synthetic &&
-        index >= turnStartIndex &&
-        entry.role === 'assistant' &&
-        syntheticFallbackDedupeText(entry.text) === syntheticDedupeText,
-    );
-    const alreadyRendered =
-      streamLogOwnsFallback ||
-      streamLogAlreadyRenderedFallback ||
-      slice.entries.some((entry) => {
-        if (entry.id === entryId) return true;
-        return (
-          entry.synthetic === true &&
-          entry.syntheticKind === 'final' &&
-          entry.syntheticAfterSeq === syntheticAfterSeq &&
-          entry.role === 'assistant' &&
-          syntheticFallbackDedupeText(entry.text) === syntheticDedupeText
-        );
-      });
-    if (alreadyRendered) return slice;
-
-    const entry: ConversationEntry = {
-      id: entryId,
-      role: 'assistant',
-      text: normalized,
-      finalized: true,
-      synthetic: true,
-      syntheticKind: 'final',
-      syntheticAfterSeq,
-    };
-    return { ...slice, entries: [...slice.entries, entry] };
-  });
-}
-
 export function appendLocalAssistantTranscript(
   text: string,
   streamId?: StreamTabId,

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -2,22 +2,11 @@ import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
 
 import { syncStreamLog } from './subscribeStreamLog';
 import {
-  appendAssistantTranscriptIfMissing,
   finalizeAssistantTranscriptEntries,
   isFinalTranscriptStatus,
 } from './transcript';
 
-interface TranscriptFallbackAssistant {
-  readonly text: string | undefined;
-  readonly idPrefix: string;
-}
-
 export interface ProjectStreamTranscriptOptions {
-  /**
-   * Fallback text from the agent result when the stream log did not already
-   * materialize the final assistant block.
-   */
-  readonly fallbackAssistant?: TranscriptFallbackAssistant;
   /** Promote all deferred assistant/tool rows into static scrollback. */
   readonly finalize?: boolean;
 }
@@ -26,21 +15,14 @@ export interface ProjectStreamTranscriptOptions {
  * Single projection edge from StreamLogStore into the CLI state slices.
  *
  * Callers that know a stream reached a turn boundary should project through
- * this helper instead of open-coding sync + fallback + finalization. That keeps
- * transcript ordering and dedupe rules owned by one path.
+ * this helper instead of open-coding sync + finalization. That keeps
+ * transcript ordering owned by one path.
  */
 export function projectStreamTranscript(
   streamId: StreamTabId,
   options: ProjectStreamTranscriptOptions = {},
 ): void {
   syncStreamLog(streamId);
-  if (options.fallbackAssistant) {
-    appendAssistantTranscriptIfMissing(
-      streamId,
-      options.fallbackAssistant.text,
-      options.fallbackAssistant.idPrefix,
-    );
-  }
   if (options.finalize) {
     finalizeAssistantTranscriptEntries(streamId);
   }

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -70,6 +70,7 @@ type ToolUseProcessExecResult =
       serverToolContentBlocks?: ServerToolContentBlock[];
       lastAssistantContent?: unknown[];
       normalizedUsage?: NormalizedUsage;
+      useStreaming: boolean;
     };
 
 /** Prep result for ToolUseProcessNode - captures shared state snapshot for exec. */
@@ -159,6 +160,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
       serverToolContentBlocks: serverToolData.contentBlocks,
       lastAssistantContent,
       normalizedUsage,
+      useStreaming,
     };
   }
 
@@ -167,7 +169,8 @@ export class ToolUseProcessNode<C> extends BaseNode<
     prepRes: ToolUseProcessPrepResult,
     execRes: ToolUseProcessExecResult,
   ): Promise<string | undefined> {
-    const { run, workspace, onRoundFinalized, modelHandler } = this.services;
+    const { run, workspace, onRoundFinalized, modelHandler, logger } =
+      this.services;
 
     if (execRes.kind === 'skipped') {
       return FlowTransition.COMPLETE;
@@ -230,6 +233,17 @@ export class ToolUseProcessNode<C> extends BaseNode<
           ),
         );
         workspace.assembly.lastResponse = execRes.text;
+        // The round's own MODEL_RESPONSE stream (below, in `exec()`) writes
+        // raw provider chunks in real time, before replacement rules run —
+        // so its persisted transcript text can trivially differ from this
+        // authoritative post-replacement value (#7086). Reconcile the two
+        // here, once, at the turn boundary that both a mid-run WAITING pause
+        // and the terminal round go through. Non-streaming responses already
+        // log their own (formatted) MODEL_RESPONSE line directly in `exec()`,
+        // so this only fires for the streamed case it now finalizes.
+        if (execRes.useStreaming) {
+          logger.responseFinalized(execRes.text);
+        }
       }
       workspace.resetServerToolContent();
       workspace.resetReasoning();

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -17,6 +17,7 @@ import type {
   AgentEvent,
   ContextStateData,
   LogEvent,
+  ResponseFinalizedEvent,
   StreamKind,
   TokenUsageStats,
   ToolStatus,
@@ -180,6 +181,13 @@ export interface AgentTrace {
     options?: StagedEmitOptions,
   ): void;
   domain(input: DomainEventInput): void;
+  /**
+   * Authoritative final assistant text for the round that just ended the
+   * turn (see {@link ResponseFinalizedEvent}). Call once, at the flow
+   * boundary where the final text is decided, for both a mid-run turn
+   * boundary and the terminal round.
+   */
+  responseFinalized(text: string, options?: StagedEmitOptions): void;
 
   // ─── Stage + stream handles ─────────────────────────────────────────
   openStage(label: string, options?: StageOptions): StageHandle;

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -198,6 +198,14 @@ export class TraceEmitter implements AgentTrace {
     });
   }
 
+  responseFinalized(text: string, options: StagedEmitOptions = {}): void {
+    this.emit({
+      type: 'response.finalized',
+      text,
+      stageId: options.stageId,
+    });
+  }
+
   // ─── Stages ────────────────────────────────────────────────────────
 
   openStage(label: string, options: StageOptions = {}): StageHandle {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -253,6 +253,27 @@ export interface StreamEndEvent extends StageStamp {
 }
 
 /**
+ * Authoritative final assistant text for the round that just ended the
+ * turn — decided once at the flow boundary where `assembly.lastResponse` is
+ * set (after `extractResponse`'s replacement-rule cleanup runs), and carried
+ * as data from there rather than re-derived downstream. Fires at every
+ * mid-run turn boundary (the tool-use loop pausing to wait for the next user
+ * message), not only the terminal round, so a subscriber never has to guess
+ * whether the run is "really" done (#7086).
+ *
+ * The round's own MODEL_RESPONSE stream (when the response actually
+ * streamed) writes raw provider chunks in real time, before replacement
+ * rules run — so its persisted text can trivially differ from this event's
+ * text (e.g. a literal vs. a replaced LaTeX symbol). Subscribers reconcile by
+ * updating that stream's entry to this text instead of a caller having to
+ * prove the two already match.
+ */
+export interface ResponseFinalizedEvent extends StageStamp {
+  readonly type: 'response.finalized';
+  readonly text: string;
+}
+
+/**
  * Host-specific escape hatch. Hosts use this for events that aren't part
  * of the agent-general union (TeXRA: `latexdiff`, `scratchpad`,
  * `filesLoaded`, `missingOutputs`, `webSearch`, `webFetch`, …). Keeps the
@@ -355,5 +376,6 @@ export type AgentEvent =
   | StreamStartEvent
   | StreamChunkEvent
   | StreamEndEvent
+  | ResponseFinalizedEvent
   | DomainEvent
   | ResultEvent;

--- a/src/agent/trace/noopTrace.ts
+++ b/src/agent/trace/noopTrace.ts
@@ -54,6 +54,7 @@ export const noopTrace: AgentTrace = {
   toolStart: NOOP,
   toolEnd: NOOP,
   domain: NOOP,
+  responseFinalized: NOOP,
 
   openStage(_label, options) {
     return new NoopStageHandle(options?.id ?? nanoid());

--- a/src/test-kernel/agent/core/ToolUseProcessNodeResponseFinalized.vitest.ts
+++ b/src/test-kernel/agent/core/ToolUseProcessNodeResponseFinalized.vitest.ts
@@ -1,0 +1,119 @@
+// Regression coverage for issue #7086: `ToolUseProcessNode.post()` must emit
+// the authoritative `response.finalized` fact exactly when a round both ends
+// the turn AND actually streamed its output — never for non-streaming
+// rounds (which already log their own MODEL_RESPONSE line in `exec()`) and
+// never for a round that continues with tool calls.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ToolUseProcessNode } from '@agent/core/flows/toolUseRound/ToolUseProcessNode';
+import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
+import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
+function buildServices(
+  overrides: Partial<ToolUseRoundServices<unknown>> = {},
+): ToolUseRoundServices<unknown> {
+  return {
+    run: { totalResponseTimeMs: 0, usageAccumulator: {}, totalRounds: 0 },
+    workspace: {
+      assembly: { lastResponse: '', accumulatedOutput: '' },
+      serverToolContent: { contentBlocks: [], lastAssistantContent: [] },
+      resetServerToolContent: vi.fn(),
+      resetReasoning: vi.fn(),
+    },
+    onRoundFinalized: vi.fn(),
+    modelHandler: {
+      createAssistantMessageFromResponse: vi.fn(() => ({
+        role: 'assistant',
+        content: 'assistant message',
+      })),
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      responseFinalized: vi.fn(),
+    },
+    ...overrides,
+  } as unknown as ToolUseRoundServices<unknown>;
+}
+
+function buildShared(): ToolUseRoundShared {
+  return {
+    messages: [],
+    roundIndex: 0,
+    roundResponseTimeMs: 0,
+  } as unknown as ToolUseRoundShared;
+}
+
+describe('ToolUseProcessNode.post responseFinalized (#7086)', () => {
+  it('emits responseFinalized with the authoritative text on a streamed, turn-ending round', async () => {
+    const services = buildServices();
+    const node = new ToolUseProcessNode().setServices(services);
+    const shared = buildShared();
+
+    const transition = await node.post(
+      shared,
+      { shouldStop: false },
+      {
+        kind: 'success',
+        endTurn: true,
+        text: 'Done \\checkmark',
+        useStreaming: true,
+      },
+    );
+
+    expect(transition).toBe(FlowTransition.COMPLETE);
+    expect(services.logger.responseFinalized).toHaveBeenCalledOnce();
+    expect(services.logger.responseFinalized).toHaveBeenCalledWith(
+      'Done \\checkmark',
+    );
+    expect(services.workspace.assembly.lastResponse).toBe('Done \\checkmark');
+  });
+
+  it('does not emit responseFinalized for a non-streaming round (exec() already logged it)', async () => {
+    const services = buildServices();
+    const node = new ToolUseProcessNode().setServices(services);
+    const shared = buildShared();
+
+    await node.post(
+      shared,
+      { shouldStop: false },
+      {
+        kind: 'success',
+        endTurn: true,
+        text: 'The answer is 2.',
+        useStreaming: false,
+      },
+    );
+
+    expect(services.logger.responseFinalized).not.toHaveBeenCalled();
+    expect(services.workspace.assembly.lastResponse).toBe('The answer is 2.');
+  });
+
+  it('does not emit responseFinalized for a round that continues with tool calls', async () => {
+    const services = buildServices();
+    const node = new ToolUseProcessNode().setServices(services);
+    const shared = buildShared();
+
+    const transition = await node.post(
+      shared,
+      { shouldStop: false },
+      {
+        kind: 'success',
+        endTurn: false,
+        text: 'Let me check that.',
+        useStreaming: true,
+        toolCalls: [{} as never],
+      },
+    );
+
+    expect(transition).toBe(FlowTransition.DEFAULT);
+    expect(services.logger.responseFinalized).not.toHaveBeenCalled();
+    // Non-final rounds never update `assembly.lastResponse` — only the round
+    // that ends the turn does.
+    expect(services.workspace.assembly.lastResponse).toBe('');
+  });
+});

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -50,6 +50,41 @@ describe('TraceEmitter stage metadata', () => {
 });
 
 // ---------------------------------------------------------------------------
+// responseFinalized (issue #7086)
+// ---------------------------------------------------------------------------
+
+describe('TraceEmitter responseFinalized', () => {
+  it('emits a response.finalized event carrying the given text', () => {
+    const trace = new TraceEmitter();
+    const events: AgentEvent[] = [];
+    trace.subscribe((event) => events.push(event));
+
+    trace.responseFinalized('The answer is 2.');
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'response.finalized',
+        text: 'The answer is 2.',
+      }),
+    ]);
+  });
+
+  it('stamps the ambient stage id when no explicit stageId is given', () => {
+    const trace = new TraceEmitter();
+    const events: AgentEvent[] = [];
+    trace.subscribe((event) => events.push(event));
+
+    const stage = trace.openStage('r0', { kind: 'round' });
+    void stage.within(() => {
+      trace.responseFinalized('Final answer.');
+    });
+
+    const finalized = events.find((e) => e.type === 'response.finalized');
+    expect(finalized).toMatchObject({ stageId: stage.id });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // EmitToolUseCard
 // ---------------------------------------------------------------------------
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -84,7 +84,6 @@ import { chatTuiFocusedChildFollowUpRoute } from '@cli/chat/tui/runChatTui';
 import { installTuiStdoutListenerLimit } from '@cli/chat/tui/render/noColorOutput';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
-  appendAssistantTranscriptIfMissing,
   appendLocalAssistantTranscript,
   appendLocalErrorTranscript,
   appendLocalUserTranscript,
@@ -2014,222 +2013,84 @@ describe('CLI transcript state', () => {
     });
   });
 
-  it('adds a final assistant response only when the stream log did not render it', () => {
-    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
-    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+  // #7086: the transcript store — not a CLI-side synthetic fallback — is now
+  // the single source of the finalized assistant message. `responseFinalized`
+  // is what `ToolUseProcessNode` calls at the turn boundary once
+  // `assembly.lastResponse` is set (see TexraTranscriptRecorder.vitest.ts for
+  // the recorder-level upsert-vs-append unit coverage); these tests confirm
+  // the CLI's own state ends up with exactly one entry, never a synthetic one.
+  it('reconciles a streamed response to the authoritative post-replacement text', () => {
+    const logger = createRunTrace(root).trace;
+    const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    // Raw provider text, as it would arrive before replacement rules run.
+    output.append('Done ✓');
+    output.finalize();
+    // The flow boundary's authoritative (replacement-cleaned) text.
+    logger.responseFinalized('Done \\checkmark');
+
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'assistant',
+      text: 'Done \\checkmark',
+    });
+    expect(entries[0]?.synthetic).toBeUndefined();
+  });
+
+  it('appends the final response when the round produced no live stream', () => {
+    const logger = createRunTrace(root).trace;
+    logger.responseFinalized('The answer is 2.');
+
+    syncStreamLog(root);
 
     const entries = streams.get().get(root)?.entries ?? [];
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       role: 'assistant',
       text: 'The answer is 2.',
-      finalized: true,
     });
-  });
-
-  it('does not duplicate waiting and final fallback entries for the same response', () => {
-    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'waiting:1');
-    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final:1');
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.id)).toEqual(['waiting:1:root']);
-    expect(entries[0]).toMatchObject({
-      role: 'assistant',
-      text: 'The answer is 2.',
-      finalized: true,
-      synthetic: true,
-    });
-  });
-
-  it('dedupes synthetic checkmark aliases from the same stream anchor', () => {
-    appendAssistantTranscriptIfMissing(root, 'Done \\checkmark', 'waiting:1');
-    appendAssistantTranscriptIfMissing(root, 'Done ✓', 'final:1');
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual(['Done \\checkmark']);
-  });
-
-  it('keeps distinct synthetic fallback responses from the same stream anchor', () => {
-    appendAssistantTranscriptIfMissing(
-      root,
-      'The condition is x < y.',
-      'first',
-    );
-    appendAssistantTranscriptIfMissing(
-      root,
-      'The condition is x > y.',
-      'second',
-    );
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual([
-      'The condition is x < y.',
-      'The condition is x > y.',
-    ]);
-  });
-
-  it('keeps repeated final responses from distinct turns visible', () => {
-    const logger = createRunTrace(root).trace;
-    logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
-
-    logger.info('second prompt', {
-      messageType: MESSAGE_TYPES.USER_MESSAGE,
-    });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:second');
-
-    logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-    syncStreamLog(root);
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual([
-      'first prompt',
-      'Done.',
-      'second prompt',
-      'Done.',
-      'third prompt',
-    ]);
-  });
-
-  it('does not duplicate a final response already present in the stream log', () => {
-    const logger = createRunTrace(root).trace;
-    logger.info('Done.', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'Done.', 'final:first');
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual(['Done.']);
     expect(entries[0]?.synthetic).toBeUndefined();
   });
 
-  it('lets the stream-log assistant own final text even when fallback text differs', () => {
+  it('does not let an earlier round leak its stream id into a later round', () => {
     const logger = createRunTrace(root).trace;
-    logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
+    const round0 = logger.openStage('r0', { kind: 'round', index: 0 });
+    const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    output.append('Let me check that.');
+    output.finalize();
+    round0.end();
+
+    // A later round that never streams must append its own entry rather
+    // than reuse round 0's (now-closed) stream id.
+    const round1 = logger.openStage('r1', { kind: 'round', index: 1 });
+    logger.responseFinalized('Final answer.');
+    round1.end();
+
     syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(
-      root,
-      '| x | Check |\n|---|---|\n| 3 | 1 \\checkmark |',
-      'final:first',
-    );
 
     const entries = streams.get().get(root)?.entries ?? [];
     expect(entries.map((entry) => entry.text)).toEqual([
-      '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
+      'Let me check that.',
+      'Final answer.',
     ]);
-    expect(entries[0]?.synthetic).toBeUndefined();
+    expect(entries.every((entry) => !entry.synthetic)).toBe(true);
   });
 
-  it('does not let a pre-tool stream assistant suppress final fallback text', () => {
-    const logger = createRunTrace(root).trace;
-    logger.info('| x | Check |\n|---|---|\n| 3 | 1 ✓ |', {
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
-    logger.info('', {
-      messageType: MESSAGE_TYPES.TOOL_USE,
-      data: {
-        toolName: 'bash',
-        input: { command: 'true' },
-        output: { summary: 'Executed: true', output: 'ok' },
-        status: 'completed',
-      },
-    });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(
-      root,
-      'Final answer after the tool.',
-      'final:first',
-    );
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.role)).toEqual([
-      'assistant',
-      'tool',
-      'assistant',
-    ]);
-    expect(entries.map((entry) => entry.text)).toEqual([
-      '| x | Check |\n|---|---|\n| 3 | 1 ✓ |',
-      '',
-      'Final answer after the tool.',
-    ]);
-  });
-
-  it('dedupes fallback text that already appeared before a tool row', () => {
-    const logger = createRunTrace(root).trace;
-    logger.info('Intermediate result ✓', {
-      messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-    });
-    logger.info('', {
-      messageType: MESSAGE_TYPES.TOOL_USE,
-      data: {
-        toolName: 'bash',
-        input: { command: 'true' },
-        output: { summary: 'Executed: true', output: 'ok' },
-        status: 'completed',
-      },
-    });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(
-      root,
-      'Intermediate result \\checkmark',
-      'final:matching',
-    );
-    appendAssistantTranscriptIfMissing(
-      root,
-      'Final answer after the tool.',
-      'final:actual',
-    );
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual([
-      'Intermediate result ✓',
-      '',
-      'Final answer after the tool.',
-    ]);
-  });
-
-  it('does not let a prior-turn stream assistant suppress fallback text', () => {
-    const logger = createRunTrace(root).trace;
-    logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-    logger.info('Done ✓', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
-    syncStreamLog(root);
-
-    logger.info('second prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
-    syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'Done \\checkmark', 'final:2');
-
-    const entries = streams.get().get(root)?.entries ?? [];
-    expect(entries.map((entry) => entry.text)).toEqual([
-      'first prompt',
-      'Done ✓',
-      'second prompt',
-      'Done \\checkmark',
-    ]);
-    expect(entries.at(-1)).toMatchObject({
-      synthetic: true,
-      syntheticKind: 'final',
-    });
-  });
-
-  it('projects a turn boundary without duplicating fallback assistant text', () => {
+  it('projects a turn boundary from the store alone, with zero synthetic entries', () => {
     const logger = createRunTrace(root).trace;
     logger.info('What is 1 + 1?', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
     logger.info('2', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
 
-    projectStreamTranscript(root, {
-      fallbackAssistant: { text: '2', idPrefix: 'final:turn' },
-      finalize: true,
-    });
+    projectStreamTranscript(root, { finalize: true });
 
     const entries = streams.get().get(root)?.entries ?? [];
     expect(entries.map((entry) => entry.text)).toEqual(['What is 1 + 1?', '2']);
     expect(entries.map((entry) => entry.finalized)).toEqual([true, true]);
-    expect(entries.some((entry) => entry.id === 'final:turn:root')).toBe(false);
+    expect(entries.every((entry) => !entry.synthetic)).toBe(true);
   });
 
   it('keeps repeated local slash-command responses visible', () => {
@@ -2555,11 +2416,11 @@ describe('CLI transcript state', () => {
     expect(activeStreamId.get()).toBeUndefined();
   });
 
-  it('preserves synthetic final responses across later log syncs', () => {
+  it('preserves the finalized response across later log syncs', () => {
     const logger = createRunTrace(root).trace;
     logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'The answer is 2.', 'final');
+    logger.responseFinalized('The answer is 2.');
 
     logger.info('next prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
@@ -2572,17 +2433,17 @@ describe('CLI transcript state', () => {
     ]);
   });
 
-  it('orders multiple synthetic responses relative to their stream-log anchors', () => {
+  it('orders multiple finalized responses relative to the turns around them', () => {
     const logger = createRunTrace(root).trace;
     logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'first answer', 'final-1');
+    logger.responseFinalized('first answer');
 
     logger.info('second prompt', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
     syncStreamLog(root);
-    appendAssistantTranscriptIfMissing(root, 'second answer', 'final-2');
+    logger.responseFinalized('second answer');
 
     logger.info('third prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
@@ -2595,6 +2456,7 @@ describe('CLI transcript state', () => {
       'second answer',
       'third prompt',
     ]);
+    expect(entries.every((entry) => !entry.synthetic)).toBe(true);
   });
 });
 

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { StreamLogStore } from '@transcript/StreamLogStore';
 import { TraceEmitter } from '@agent/trace';
-import { STREAM_LOG_ENTRY_TYPES, type StreamTabId } from '@shared/schemas';
+import {
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamTabId,
+} from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
@@ -39,5 +43,93 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
 
     expect(runEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
     expect(isObject(runEntry?.data) && runEntry.data.kind).toBe('run');
+  });
+});
+
+describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
+  it('upserts the round MODEL_RESPONSE stream entry to the authoritative text', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:upsert' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    // The round's own stream writes raw provider text in real time...
+    const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    output.append('Done ✓');
+    output.finalize();
+    // ...then the flow boundary emits the authoritative, replacement-clean
+    // text once `assembly.lastResponse` is set.
+    trace.responseFinalized('Done \\checkmark');
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const modelResponseEntries = entries.filter(
+      (e) => e.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+    expect(modelResponseEntries).toHaveLength(1);
+    expect(modelResponseEntries[0]?.id).toBe(output.id);
+    expect(modelResponseEntries[0]?.text).toBe('Done \\checkmark');
+  });
+
+  it('appends a fresh MODEL_RESPONSE entry when the round never streamed', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:append' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    trace.responseFinalized('The answer is 2.');
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const modelResponseEntries = entries.filter(
+      (e) => e.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+    expect(modelResponseEntries).toHaveLength(1);
+    expect(modelResponseEntries[0]?.text).toBe('The answer is 2.');
+  });
+
+  it('does not let an earlier round leak its stream id into a later round', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:round-reset' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const round0 = trace.openStage('r0', { kind: 'round', index: 0 });
+    const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    output.append('Let me check that.');
+    output.finalize();
+    round0.end();
+
+    // Round 1 never opens its own stream (e.g. a non-streaming provider
+    // call) — its `response.finalized` must append a new entry, not
+    // overwrite round 0's already-closed stream entry.
+    const round1 = trace.openStage('r1', { kind: 'round', index: 1 });
+    trace.responseFinalized('Final answer.');
+    round1.end();
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const modelResponseEntries = entries.filter(
+      (e) => e.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+    expect(modelResponseEntries.map((e) => e.text)).toEqual([
+      'Let me check that.',
+      'Final answer.',
+    ]);
+    expect(modelResponseEntries[0]?.id).toBe(output.id);
+    expect(modelResponseEntries[1]?.id).not.toBe(output.id);
+  });
+
+  it('ignores an empty finalized response', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:empty' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    trace.responseFinalized('');
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    expect(entries).toHaveLength(0);
   });
 });

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -113,6 +113,13 @@ export function attachTranscriptRecorder(
   // rely on that distinction to tell a root run's terminal status apart from
   // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
   const stageKinds = new Map<string, 'run' | 'round' | 'phase' | 'session'>();
+  // Id of the round's own MODEL_RESPONSE stream entry, so a subsequent
+  // `response.finalized` event (#7086) can upsert that entry's text instead
+  // of appending a duplicate row. Set on `stream.start` for a MODEL_RESPONSE
+  // stream, consumed (and cleared) by `response.finalized`, and reset at
+  // every round boundary so a round that never streamed can't accidentally
+  // reuse an earlier round's stream id.
+  let pendingModelResponseId: string | undefined;
 
   const flushStream = (state: StreamSinkState, id: string): void => {
     if (state.updateTimer) {
@@ -213,6 +220,9 @@ export function attachTranscriptRecorder(
 
       case 'stage.start':
         if (event.kind) stageKinds.set(event.id, event.kind);
+        // A new round starts fresh: whatever MODEL_RESPONSE stream the
+        // previous round may have opened is no longer this round's to reuse.
+        if (event.kind === 'round') pendingModelResponseId = undefined;
         store.append(streamId, {
           id: event.id,
           type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
@@ -331,6 +341,9 @@ export function attachTranscriptRecorder(
           updateTimer: null,
         };
         streams.set(event.id, state);
+        if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE) {
+          pendingModelResponseId = event.id;
+        }
         // The start IS the signal consumers care about — it marks the moment
         // the phase began: a running THINKING entry drives the CLI's "model
         // is thinking" indicator, and a running MODEL_RESPONSE entry says
@@ -367,6 +380,29 @@ export function attachTranscriptRecorder(
         state.ended = true;
         flushStream(state, event.id);
         streams.delete(event.id);
+        return;
+      }
+
+      case 'response.finalized': {
+        if (!event.text) return;
+        // Upsert by id, not by text: if this round's own MODEL_RESPONSE
+        // stream already wrote a (possibly raw, pre-replacement) entry,
+        // reconcile it to the authoritative text; otherwise this round never
+        // streamed (e.g. a non-streaming provider call), so append it fresh.
+        const correlatorId = pendingModelResponseId;
+        pendingModelResponseId = undefined;
+        if (correlatorId) {
+          store.update(streamId, correlatorId, {
+            text: event.text,
+            data: { status: 'completed' },
+          });
+          return;
+        }
+        appendLog({
+          groupId: event.stageId,
+          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+          text: event.text,
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary

The CLI transcript worked around a gap in the transcript store by re-deriving the last assistant response from the run result and appending it as a synthetic entry whenever the store didn't already seem to show it — deduped by normalized text, including a hand-coded `\checkmark` <-> checkmark-glyph alias. That hack existed because the store's live `MODEL_RESPONSE` stream writes raw provider text in real time, while the run result's text has already gone through `extractResponse`'s replacement-rule cleanup, so the two copies of "the same" text could differ trivially and defeat exact-match dedup.

This fixes the root cause instead of continuing to compensate for it at the CLI edge, and deletes the compensating CLI machinery entirely (net-negative production LoC, per the issue).

## Details

- Added a new first-class trace fact, `response.finalized` (`ResponseFinalizedEvent` in `src/agent/trace/events.ts`, `AgentTrace.responseFinalized()`), decided once at the flow boundary where `assembly.lastResponse` is set.
- `ToolUseProcessNode.post()` (`src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts`) now calls `logger.responseFinalized(execRes.text)` at that exact point — which fires both at a mid-run WAITING turn boundary (the tool-use loop pausing for the next user message) and at the terminal round, since both go through the same `endTurn` branch. Gated on `useStreaming` so non-streaming rounds (which already log their own formatted `MODEL_RESPONSE` line in `exec()`) don't get a duplicate.
- `TexraTranscriptRecorder` tracks the id of the round's own `MODEL_RESPONSE` stream (if one was opened) and, on `response.finalized`, upserts that entry to the authoritative text; if the round never streamed, it appends a fresh entry instead. Correlation is by id, never by comparing text, and is reset at every round boundary so an earlier round's stream id can never leak into a later round's finalize.
- Deleted the CLI's compensating machinery entirely: `appendAssistantTranscriptIfMissing`, the checkmark-alias dedup helper, the `syntheticKind: 'final'` entry kind, and the associated splice/dedup branch in `subscribeStreamLog.syncStreamLog`. `projectStreamTranscript`'s `fallbackAssistant` option and both call sites in `chatSessionController.ts` (WAITING boundary + terminal result) are gone.
- Deliberately scoped to `ToolUseProcessNode` (the tool-use round flow that the CLI, extension, and desktop chat surfaces all share) and left `ResponseCycleFlow` (reflection/workflow) untouched — that flow always streams `phaseOnly` by design (output is surfaced via export/extraction, not the live transcript), so applying the same upsert there would leak content a workflow deliberately withholds.

## Validation

- `npx tsc --noEmit` (root), `npx tsc --noEmit -p tsconfig.test-kernel.json`, and `packages/cli`'s own `tsc --noEmit -p tsconfig.json` — all clean.
- `npx eslint` on every touched file — 0 errors (3 pre-existing import-order warnings, unrelated to this diff).
- `npx prettier --check` on every touched file — clean.
- `npm test` (full suite) — 5241 passed, 4 skipped (pre-existing skips).
- New/updated coverage:
  - `src/test-kernel/agent/trace/AgentTrace.vitest.ts` — `responseFinalized` emits the event and stamps the ambient stage id.
  - `src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts` — upserts the round's streamed entry to the authoritative text, appends fresh when the round never streamed, and does not let an earlier round's stream id leak into a later round.
  - `src/test-kernel/agent/core/ToolUseProcessNodeResponseFinalized.vitest.ts` — `responseFinalized` fires only for a streamed, turn-ending round; not for non-streaming or mid-turn (tool-continuing) rounds.
  - `src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — replaced the deleted synthetic-fallback tests with equivalents exercising the real mechanism (streamed-then-finalized reconciliation, no-stream append, round-boundary isolation, zero synthetic entries on projection).
- Production code net LoC: -18 (99 insertions, 117 deletions across CLI + trace/recorder files); test code grew (+108) to cover the new mechanism at three levels instead of just the deleted workaround.

Refs #7086

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared agent trace, transcript persistence, and CLI projection paths used on every chat turn; behavior is gated and well-tested but regressions could show as missing or duplicate assistant lines.
> 
> **Overview**
> Fixes **#7086** by making the transcript store own authoritative assistant text instead of the CLI guessing from run results.
> 
> Adds a **`response.finalized`** trace event and **`AgentTrace.responseFinalized()`**. **`ToolUseProcessNode.post()`** emits it when a round **ends the turn** and used **streaming** (non-streaming rounds already log `MODEL_RESPONSE` in `exec()`).
> 
> **`TexraTranscriptRecorder`** upserts the round’s `MODEL_RESPONSE` row by stream id when streaming happened, or appends a new row when it did not; round boundaries reset correlation so ids don’t leak across turns.
> 
> The CLI **removes** `appendAssistantTranscriptIfMissing`, `syntheticKind: 'final'`, text-based dedup in stream sync, and **`projectStreamTranscript`’s `fallbackAssistant`** (including **`chatSessionController`** idle/terminal projection). Turn boundaries now rely on **sync + finalize** from the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b173932d8fa3f34a2d784437bfcc68954e55c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->