### PR TITLE
refactor: split runtime interaction events

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -27,7 +27,7 @@ import {
   type ProposalResult,
   type RetryResult,
 } from '@agent/runtime/HostInteractions';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
@@ -86,7 +86,7 @@ async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
  * (no usable key stored, direct-key failure, or unknown provider).
  */
 async function maybeAutoSwitchRetry(
-  payload: ProgressEventPayloads['showRetryRequest'],
+  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
 ): Promise<ApprovalDecision | undefined> {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
 
@@ -391,7 +391,7 @@ async function decideWithPolicy<
     kind === 'retry'
       ? immediateDecisionForApproval(
           'showRetryRequest',
-          payload as ProgressEventPayloads['showRetryRequest'],
+          payload as RuntimeInteractionEventPayloads['showRetryRequest'],
           context,
         )
       : immediateDecision(context);
@@ -437,7 +437,7 @@ async function requestBashInteraction(
   host: CliRuntimeHost,
   requestId: string,
 ): Promise<HostBashApprovalResult> {
-  const payload: ProgressEventPayloads['showBashPermission'] = {
+  const payload: RuntimeInteractionEventPayloads['showBashPermission'] = {
     requestId,
     command: request.command,
     ...(request.cwd ? { cwd: request.cwd } : {}),
@@ -455,7 +455,7 @@ async function requestBashInteraction(
 }
 
 async function requestPlanInteraction(
-  request: ProgressEventPayloads['showPlanApproval'],
+  request: RuntimeInteractionEventPayloads['showPlanApproval'],
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<PlanApprovalResult> {
@@ -467,7 +467,7 @@ async function requestPlanInteraction(
 }
 
 async function requestProposalInteraction(
-  request: ProgressEventPayloads['showAgentProposal'],
+  request: RuntimeInteractionEventPayloads['showAgentProposal'],
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<ProposalResult> {
@@ -530,7 +530,7 @@ async function requestRetryInteraction(
 }
 
 async function requestUserQuestionInteraction(
-  payload: ProgressEventPayloads['showUserQuestion'],
+  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<{
@@ -562,7 +562,7 @@ async function requestUserQuestionInteraction(
 }
 
 async function openExternalInquiryInteraction(
-  payload: ProgressEventPayloads['showExternalInquiry'],
+  payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<{ threadId: string }> {
@@ -592,7 +592,10 @@ function markIfRejected(context: CliContext, decision: ApprovalDecision): void {
 }
 
 async function applyRetrySideEffects(
-  payload: Pick<ProgressEventPayloads['showRetryRequest'], 'streamId'>,
+  payload: Pick<
+    RuntimeInteractionEventPayloads['showRetryRequest'],
+    'streamId'
+  >,
   decision: ApprovalDecision,
   options: { isCurrent?: () => boolean } = {},
 ): Promise<void> {
@@ -610,7 +613,7 @@ async function applyRetrySideEffects(
 }
 
 function handleExternalInquiry(
-  payload: ProgressEventPayloads['showExternalInquiry'],
+  payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
   host: CliRuntimeHost,
 ): void {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -7,10 +7,8 @@ import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
@@ -44,6 +42,11 @@ import { appendLocalAssistantTranscript } from './transcript';
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
+
+type CliStateRuntimeEventPayloads = ProgressEventPayloads &
+  RuntimeInteractionEventPayloads;
+
+type CliStateRuntimeEvent = keyof CliStateRuntimeEventPayloads;
 
 function appendGoalPausedTranscriptNotice(payload: GoalPausedPayload): void {
   // Without a transcript line, an auto-paused goal is indistinguishable
@@ -368,7 +371,10 @@ export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
   const original = host.emit;
   const emit: CliRuntimeHost['emit'] = (event, payload) => {
     if (!isRuntimePresentationEvent(event)) {
-      applyToState(event, payload as ProgressEventPayloads[ProgressEvent]);
+      applyToState(
+        event as CliStateRuntimeEvent,
+        payload as CliStateRuntimeEventPayloads[CliStateRuntimeEvent],
+      );
     }
     return original(event, payload);
   };
@@ -440,9 +446,9 @@ export function attachTuiRunFactSubscription(
   };
 }
 
-function applyToState<K extends ProgressEvent>(
+function applyToState<K extends CliStateRuntimeEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: CliStateRuntimeEventPayloads[K],
 ): void {
   switch (event) {
     case 'setActiveStream': {
@@ -522,7 +528,7 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateToolEditApprovalBypassState': {
       const p =
-        payload as ProgressEventPayloads['updateToolEditApprovalBypassState'];
+        payload as RuntimeInteractionEventPayloads['updateToolEditApprovalBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, toolEdit: p.bypassActive },
@@ -531,7 +537,7 @@ function applyToState<K extends ProgressEvent>(
     }
     case 'updateBashApprovalBypassState': {
       const p =
-        payload as ProgressEventPayloads['updateBashApprovalBypassState'];
+        payload as RuntimeInteractionEventPayloads['updateBashApprovalBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, bash: p.bypassActive },
@@ -539,7 +545,8 @@ function applyToState<K extends ProgressEvent>(
       return;
     }
     case 'updateSuperYoloBypassState': {
-      const p = payload as ProgressEventPayloads['updateSuperYoloBypassState'];
+      const p =
+        payload as RuntimeInteractionEventPayloads['updateSuperYoloBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, superYolo: p.bypassActive },

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,4 +1,4 @@
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
   isChatGptSubscriptionLimitError,
@@ -46,13 +46,13 @@ export function hasCliApprovalDenied(context: CliContext): boolean {
 /** Whether the failed retry was a ChatGPT-subscription (Codex) usage limit, so
  *  the switch turns off the subscription preference rather than relay access. */
 export function isCliChatGptSubscriptionRetry(
-  payload: ProgressEventPayloads['showRetryRequest'],
+  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
 ): boolean {
   return isChatGptSubscriptionLimitError(payload.errorDetails);
 }
 
 export function isCliApiSwitchableRetry(
-  payload: ProgressEventPayloads['showRetryRequest'],
+  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
 ): boolean {
   const details = payload.errorDetails;
   if (!details) return false;
@@ -162,11 +162,12 @@ export function immediateDecision(
  *  and auto-approval modes should not burn the retry budget. */
 function isUnretryableRetryRequest(
   event: CliDecisionApprovalEvent,
-  payload: ProgressEventPayloads[CliDecisionApprovalEvent],
+  payload: RuntimeInteractionEventPayloads[CliDecisionApprovalEvent],
 ): boolean {
   if (event !== 'showRetryRequest') return false;
-  const details = (payload as ProgressEventPayloads['showRetryRequest'])
-    .errorDetails;
+  const details = (
+    payload as RuntimeInteractionEventPayloads['showRetryRequest']
+  ).errorDetails;
   if (!details) return false;
   if (isCredentialExhausted(details)) return true;
   if (details.statusCode === 401 || details.statusCode === 403) return true;
@@ -175,7 +176,7 @@ function isUnretryableRetryRequest(
 
 export function immediateDecisionForApproval(
   event: CliDecisionApprovalEvent,
-  payload: ProgressEventPayloads[CliDecisionApprovalEvent],
+  payload: RuntimeInteractionEventPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
   if (isUnretryableRetryRequest(event, payload)) {

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -1,6 +1,6 @@
 import { structuredPatch } from 'diff';
 
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
   agentProposalCategoryLabel,
   getProposalFileGroups,
@@ -139,7 +139,7 @@ export function formatAgentProposalApprovalSummary(
 }
 
 export function formatRetryRequestMessage(
-  payload: ProgressEventPayloads['showRetryRequest'],
+  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
 ): string {
   const message = `Retry requested (${payload.operation}): ${payload.errorMessage ?? 'unknown error'}`;
   if (isCliChatGptSubscriptionRetry(payload)) {
@@ -209,7 +209,7 @@ export function formatToolEditApprovalSummary(
 }
 
 export function formatUserQuestionPrompt(
-  payload: ProgressEventPayloads['showUserQuestion'],
+  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
 ): string {
   return payload.questions
     .map((question, index) => {

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -1,4 +1,4 @@
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 
 import { type CliDecisionApprovalEvent } from '../approvalEvents';
 
@@ -6,24 +6,28 @@ import { formatAgentProposalApprovalSummary } from './approvalSummaries';
 
 export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: RuntimeInteractionEventPayloads[K],
 ): string {
   switch (event) {
     case 'showBashPermission': {
-      const data = payload as ProgressEventPayloads['showBashPermission'];
+      const data =
+        payload as RuntimeInteractionEventPayloads['showBashPermission'];
       const cwd = data.cwd ? `Directory: ${data.cwd}\n` : '';
       return `Bash command requested:\n${cwd}${data.command}`;
     }
     case 'showPlanApproval': {
-      const data = payload as ProgressEventPayloads['showPlanApproval'];
+      const data =
+        payload as RuntimeInteractionEventPayloads['showPlanApproval'];
       return `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`;
     }
     case 'showAgentProposal': {
-      const data = payload as ProgressEventPayloads['showAgentProposal'];
+      const data =
+        payload as RuntimeInteractionEventPayloads['showAgentProposal'];
       return formatAgentProposalApprovalSummary(data);
     }
     case 'showRetryRequest': {
-      const data = payload as ProgressEventPayloads['showRetryRequest'];
+      const data =
+        payload as RuntimeInteractionEventPayloads['showRetryRequest'];
       return `Retry requested for ${data.operation}: ${data.errorMessage ?? 'unknown error'}`;
     }
     default: {

--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -1,4 +1,4 @@
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
@@ -22,7 +22,7 @@ const NON_TUI_EXTERNAL_INQUIRY_FEEDBACK =
   'panel, or ask_user_question for synchronous CLI input.';
 
 export function handleExternalInquiry(
-  payload: ProgressEventPayloads['showExternalInquiry'],
+  payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
   _hooks: CliApprovalPromptHooks = {},
 ): void {
@@ -49,7 +49,7 @@ export function handleExternalInquiry(
 }
 
 export function handleUserQuestion(
-  payload: ProgressEventPayloads['showUserQuestion'],
+  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
   context: CliContext,
   hooks: CliApprovalPromptHooks = {},
 ): void {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -12,7 +12,7 @@ import type {
   ProposalResult,
   RetryResult,
 } from '@agent/runtime/HostInteractions';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import type { UserQuestionAnswers } from '@shared/schemas';
 
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
@@ -109,7 +109,7 @@ export function installCliApprovalHandlers(
 
 async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: RuntimeInteractionEventPayloads[K],
   context: CliContext,
   hooks: CliApprovalPromptHooks,
   options: { writeRejectionToStderr?: boolean } = {},
@@ -117,7 +117,7 @@ async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
   const immediate = immediateDecisionForApproval(event, payload, context);
 
   if (event === 'showRetryRequest') {
-    const data = payload as ProgressEventPayloads['showRetryRequest'];
+    const data = payload as RuntimeInteractionEventPayloads['showRetryRequest'];
     if (!immediate) hooks.beforePrompt?.();
     writeTextStderr(formatRetryRequestMessage(data));
   }
@@ -172,7 +172,7 @@ function toRetryResult(
 }
 
 async function askHeadlessUserQuestion(
-  payload: ProgressEventPayloads['showUserQuestion'],
+  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
   context: CliContext,
   hooks: CliApprovalPromptHooks,
 ): Promise<HostUserQuestionResult> {
@@ -226,7 +226,7 @@ export function createHeadlessCliHostInteractions(
       return decideToolEdit(request, context, hooks);
     },
     async requestBashApproval(request) {
-      const payload: ProgressEventPayloads['showBashPermission'] = {
+      const payload: RuntimeInteractionEventPayloads['showBashPermission'] = {
         requestId: 'headless-bash',
         command: request.command,
         ...(request.cwd ? { cwd: request.cwd } : {}),
@@ -260,7 +260,7 @@ export function createHeadlessCliHostInteractions(
       return toProposalResult(decision);
     },
     async requestRetry(request: HostRetryRequest) {
-      const payload: ProgressEventPayloads['showRetryRequest'] = {
+      const payload: RuntimeInteractionEventPayloads['showRetryRequest'] = {
         streamId: request.streamId,
         operation: request.operation,
         ...(request.model ? { model: request.model } : {}),
@@ -295,15 +295,17 @@ export function createHeadlessCliHostInteractions(
   };
 }
 
-export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
+export function handleCliApprovalEvent<
+  K extends keyof RuntimeInteractionEventPayloads,
+>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: RuntimeInteractionEventPayloads[K],
   context: CliContext,
   hooks: CliApprovalPromptHooks = {},
 ): boolean {
   if (event === 'showExternalInquiry') {
     handleExternalInquiry(
-      payload as ProgressEventPayloads['showExternalInquiry'],
+      payload as RuntimeInteractionEventPayloads['showExternalInquiry'],
       context,
       hooks,
     );
@@ -312,7 +314,7 @@ export function handleCliApprovalEvent<K extends keyof ProgressEventPayloads>(
 
   if (event === 'showUserQuestion') {
     handleUserQuestion(
-      payload as ProgressEventPayloads['showUserQuestion'],
+      payload as RuntimeInteractionEventPayloads['showUserQuestion'],
       context,
       hooks,
     );

--- a/packages/cli/src/runtime/approvalEvents.ts
+++ b/packages/cli/src/runtime/approvalEvents.ts
@@ -1,7 +1,4 @@
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 
 // CLI hosts share the same progress-event names, but not the same handling.
 // Decision approvals can be auto-approved or denied by policy; human-input
@@ -11,17 +8,17 @@ export const CLI_DECISION_APPROVAL_EVENTS = [
   'showPlanApproval',
   'showAgentProposal',
   'showRetryRequest',
-] as const satisfies readonly (keyof ProgressEventPayloads)[];
+] as const satisfies readonly (keyof RuntimeInteractionEventPayloads)[];
 
 export const CLI_HUMAN_INPUT_APPROVAL_EVENTS = [
   'showExternalInquiry',
   'showUserQuestion',
-] as const satisfies readonly (keyof ProgressEventPayloads)[];
+] as const satisfies readonly (keyof RuntimeInteractionEventPayloads)[];
 
 export const CLI_APPROVAL_EVENTS = [
   ...CLI_DECISION_APPROVAL_EVENTS,
   ...CLI_HUMAN_INPUT_APPROVAL_EVENTS,
-] as const satisfies readonly (keyof ProgressEventPayloads)[];
+] as const satisfies readonly (keyof RuntimeInteractionEventPayloads)[];
 
 export const CLI_APPROVAL_EVENT_KIND = {
   showBashPermission: 'bash',
@@ -40,22 +37,20 @@ export type CliApprovalEvent = (typeof CLI_APPROVAL_EVENTS)[number];
 export type CliApprovalEventKind =
   (typeof CLI_APPROVAL_EVENT_KIND)[CliApprovalEvent];
 
-const CLI_DECISION_APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(
+const CLI_DECISION_APPROVAL_EVENT_SET: ReadonlySet<string> = new Set(
   CLI_DECISION_APPROVAL_EVENTS,
 );
-const CLI_APPROVAL_EVENT_SET: ReadonlySet<ProgressEvent> = new Set(
+const CLI_APPROVAL_EVENT_SET: ReadonlySet<string> = new Set(
   CLI_APPROVAL_EVENTS,
 );
 
 export function isCliDecisionApprovalEvent(
-  event: ProgressEvent,
+  event: string,
 ): event is CliDecisionApprovalEvent {
   return CLI_DECISION_APPROVAL_EVENT_SET.has(event);
 }
 
-export function isCliApprovalEvent(
-  event: ProgressEvent,
-): event is CliApprovalEvent {
+export function isCliApprovalEvent(event: string): event is CliApprovalEvent {
   return CLI_APPROVAL_EVENT_SET.has(event);
 }
 

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -5,6 +5,11 @@ import type {
   ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
 import {
+  isRuntimeInteractionEvent,
+  type RuntimeInteractionEvent,
+  type RuntimeInteractionEventPayloads,
+} from '@agent/runtime/runtimeInteractionEvents';
+import {
   isRuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
@@ -49,10 +54,10 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (closed) return;
 
       if (
-        !isRuntimePresentationEvent(event) &&
+        isRuntimeInteractionEvent(event) &&
         handleCliApprovalEvent(
-          event as ProgressEvent,
-          payload as ProgressEventPayloads[ProgressEvent],
+          event as RuntimeInteractionEvent,
+          payload as RuntimeInteractionEventPayloads[RuntimeInteractionEvent],
           context,
           {
             beforePrompt: prepareInteractivePrompt,
@@ -84,7 +89,8 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
 
       if (
         !isRuntimePresentationEvent(event) &&
-        runProgress?.handle(event, payload)
+        !isRuntimeInteractionEvent(event) &&
+        runProgress?.handle(event as ProgressEvent, payload)
       ) {
         return;
       }

--- a/packages/cli/src/runtime/userQuestionAnswer.ts
+++ b/packages/cli/src/runtime/userQuestionAnswer.ts
@@ -1,8 +1,8 @@
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 
 export function parseUserQuestionAnswer(
   raw: string,
-  question: ProgressEventPayloads['showUserQuestion']['questions'][number],
+  question: RuntimeInteractionEventPayloads['showUserQuestion']['questions'][number],
 ): string | string[] | undefined {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -63,6 +63,10 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
+import type {
+  ProgressBackendEvent,
+  ProgressBackendEventPayloads,
+} from '@shared/progressView/backend/events/ProgressEventHandler';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
 import {
@@ -1010,7 +1014,10 @@ export class DesktopProgressBridge {
   ): void {
     if (!isRuntimePresentationEvent(event)) {
       if (event === 'addOutputFiles') return;
-      this.backend.handleProgressEvent(event, payload);
+      this.backend.handleProgressEvent(
+        event as ProgressBackendEvent,
+        payload as ProgressBackendEventPayloads[ProgressBackendEvent],
+      );
       return;
     }
 

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,8 +1,4 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   extensionPresentationEvents,
@@ -11,6 +7,10 @@ import {
   isExtensionPresentationEvent,
 } from '@frontend/events/extensionPresentationEvents';
 import { emitExtensionProgressEvent } from '@frontend/events/extensionProgressEvents';
+import type {
+  ProgressBackendEvent,
+  ProgressBackendEventPayloads,
+} from '@shared/progressView/backend/events/ProgressEventHandler';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
   interactions: defaultSession().interactions,
@@ -23,8 +23,8 @@ export const extensionAgentRuntimeHost: AgentRuntimeHost = {
       return;
     }
     emitExtensionProgressEvent(
-      event as ProgressEvent,
-      payload as ProgressEventPayloads[ProgressEvent],
+      event as ProgressBackendEvent,
+      payload as ProgressBackendEventPayloads[ProgressBackendEvent],
     );
   },
 };

--- a/packages/extension/src/frontend/events/extensionProgressEvents.ts
+++ b/packages/extension/src/frontend/events/extensionProgressEvents.ts
@@ -1,11 +1,11 @@
 import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+  ProgressBackendEvent,
+  ProgressBackendEventPayloads,
+} from '@shared/progressView/backend/events/ProgressEventHandler';
 
-type ExtensionProgressEventSink = <K extends ProgressEvent>(
+type ExtensionProgressEventSink = <K extends ProgressBackendEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: ProgressBackendEventPayloads[K],
 ) => void;
 
 let activeSink: ExtensionProgressEventSink | undefined;
@@ -23,9 +23,9 @@ export function setExtensionProgressEventSink(
   };
 }
 
-export function emitExtensionProgressEvent<K extends ProgressEvent>(
+export function emitExtensionProgressEvent<K extends ProgressBackendEvent>(
   event: K,
-  payload: ProgressEventPayloads[K],
+  payload: ProgressBackendEventPayloads[K],
 ): void {
   activeSink?.(event, payload);
 }

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,8 +1,10 @@
 import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import type { RuntimePresentationEventPayloads } from '@agent/runtime/runtimePresentationEvents';
 import type { HostInteractions } from './HostInteractions';
 
 export type AgentRuntimeEventPayloads = ProgressEventPayloads &
+  RuntimeInteractionEventPayloads &
   RuntimePresentationEventPayloads;
 
 export type AgentRuntimeEvent = keyof AgentRuntimeEventPayloads;
@@ -20,7 +22,7 @@ export type AgentRuntimeEvent = keyof AgentRuntimeEventPayloads;
  *   lifecycle (`setActiveStream`, `updateStreamStatus`, `updateStreamUsage`,
  *   `setTaskState`), output/compile tracking (`addOutputFiles`,
  *   `updateMissingOutputs`, `updateCompileFailures`, `clearMissingOutputs`),
- *   the `show*`/`resolve*` approval pairs, and conversation progress
+ *   interaction requests (`RuntimeInteractionEventPayloads`), and conversation progress
  *   (`updateTodos`/`updatePlan`/`updateConversationProgress`). See
  *   {@link ProgressEventPayloads} for the complete, authoritative enumeration.
  * - **Frontend-bound, ignorable** (`RuntimePresentationEventPayloads`):

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -1,22 +1,16 @@
 import type { TaskState } from '@agent/core/state/TaskState';
 import type {
   AddOutputFilesPayload,
-  AgentProposalPermission,
-  BashPermission,
   ClearMissingOutputsPayload,
   ConversationProgress,
   ExecutionId,
-  ExternalInquiryPermission,
   GoalPausedPayload,
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
-  PlanApprovalPermission,
   RemoveStreamPayload,
-  RetryPermission,
   SetActiveStreamPayload,
   SetParentStreamPayload,
   StreamTabId,
-  ToolEditPermission,
   UpdateActiveProcessesPayload,
   UpdateActiveSubagentsPayload,
   UpdateCompileFailuresPayload,
@@ -29,7 +23,6 @@ import type {
   UpdateStreamStatusPayload,
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
-  UserQuestionPermission,
 } from '@shared/schemas';
 
 /**
@@ -46,9 +39,8 @@ import type {
  * rails keep one shared key/payload table while they are migrated to typed
  * session/host surfaces.
  * Every fact-plane key below references its named vocabulary type — this map
- * projects the vocabulary, it does not define it. Keys still typed inline are
- * not facts: host-rail status/RPC keys plus the remaining Stage-5 residue
- * (`setTaskState`).
+ * projects the vocabulary, it does not define it. The remaining inline key is
+ * the Stage-5 `setTaskState` residue.
  */
 export interface ProgressEventPayloads {
   // ── Run/stream progress ──
@@ -64,32 +56,8 @@ export interface ProgressEventPayloads {
     taskState: TaskState;
   };
   updateStreamUsage: UpdateStreamUsagePayload;
-  // ── Approval / permission RPC ──
-  // The show* keys are synthesized by the CLI approval adapter from typed
-  // `HostInteractions` requests; only tool-edit show/resolve still flows on
-  // the host rail itself (src/tools/approval + native approval paths).
-  showRetryRequest: RetryPermission;
-  showToolEditPermission: ToolEditPermission;
-  resolveToolEditPermission: { requestId: string };
-  updateToolEditApprovalBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
-  updateBashApprovalBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
-  updateSuperYoloBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
-  showBashPermission: BashPermission;
-  showAgentProposal: AgentProposalPermission;
-  showPlanApproval: PlanApprovalPermission;
-  showExternalInquiry: ExternalInquiryPermission;
   /** Inquiry thread state changed (open, answered, dropped, or resume outcome). */
   inquiryThreadUpdated: InquiryThreadUpdatedEvent;
-  showUserQuestion: UserQuestionPermission;
   // ── Run/stream progress (part 2) ──
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;

--- a/src/agent/runtime/runtimeInteractionEvents.ts
+++ b/src/agent/runtime/runtimeInteractionEvents.ts
@@ -1,0 +1,66 @@
+import type {
+  AgentProposalPermission,
+  BashPermission,
+  ExternalInquiryPermission,
+  PlanApprovalPermission,
+  RetryPermission,
+  StreamTabId,
+  ToolEditPermission,
+  UserQuestionPermission,
+} from '@shared/schemas';
+
+/**
+ * Host interaction and approval UI requests emitted by runtime/tool code.
+ *
+ * These are not progress facts. Some hosts still route a subset of them through
+ * their progress-view UI adapter for compatibility, but the vocabulary is
+ * interaction-owned rather than part of the frozen progress fact map.
+ */
+export interface RuntimeInteractionEventPayloads {
+  showRetryRequest: RetryPermission;
+  showToolEditPermission: ToolEditPermission;
+  resolveToolEditPermission: { requestId: string };
+  updateToolEditApprovalBypassState: {
+    streamId: StreamTabId;
+    bypassActive: boolean;
+  };
+  updateBashApprovalBypassState: {
+    streamId: StreamTabId;
+    bypassActive: boolean;
+  };
+  updateSuperYoloBypassState: {
+    streamId: StreamTabId;
+    bypassActive: boolean;
+  };
+  showBashPermission: BashPermission;
+  showAgentProposal: AgentProposalPermission;
+  showPlanApproval: PlanApprovalPermission;
+  showExternalInquiry: ExternalInquiryPermission;
+  showUserQuestion: UserQuestionPermission;
+}
+
+export type RuntimeInteractionEvent = keyof RuntimeInteractionEventPayloads;
+
+const RUNTIME_INTERACTION_EVENTS = [
+  'showRetryRequest',
+  'showToolEditPermission',
+  'resolveToolEditPermission',
+  'updateToolEditApprovalBypassState',
+  'updateBashApprovalBypassState',
+  'updateSuperYoloBypassState',
+  'showBashPermission',
+  'showAgentProposal',
+  'showPlanApproval',
+  'showExternalInquiry',
+  'showUserQuestion',
+] as const satisfies readonly RuntimeInteractionEvent[];
+
+const RuntimeInteractionEventSet: ReadonlySet<string> = new Set(
+  RUNTIME_INTERACTION_EVENTS,
+);
+
+export function isRuntimeInteractionEvent(
+  event: string,
+): event is RuntimeInteractionEvent {
+  return RuntimeInteractionEventSet.has(event);
+}

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -2,10 +2,6 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
 import {
   WebviewBridge,
   type ProgressViewMessageSender,
@@ -14,6 +10,8 @@ import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import {
   PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES,
   ProgressEventHandler,
+  type ProgressBackendEvent,
+  type ProgressBackendEventPayloads,
   type GetProgressStreamControls,
   type ProgressEventSubscription,
   type UICallbacks,
@@ -142,9 +140,9 @@ export class ProgressBackend {
     };
   }
 
-  handleProgressEvent<K extends ProgressEvent>(
+  handleProgressEvent<K extends ProgressBackendEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: ProgressBackendEventPayloads[K],
   ): void {
     // A run may still hold the host-channel emit closure that routes here after
     // this backend is disposed (e.g. a desktop window closed while the run keeps

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -5,10 +5,8 @@ import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -49,7 +47,7 @@ import { withEventErrorHandling } from './errorHandling';
  */
 export interface UICallbacks {
   showToolEditPermission: (
-    payload: ProgressEventPayloads['showToolEditPermission'],
+    payload: RuntimeInteractionEventPayloads['showToolEditPermission'],
   ) => void;
   resolveToolEditPermission: (requestId: string) => void;
   updateToolEditApprovalBypassState: (
@@ -78,16 +76,23 @@ export type GetProgressStreamControls = (
   stream: StreamTabId,
 ) => ProgressStreamControls;
 
-type ProgressEventRegistration<K extends ProgressEvent> = {
+export type ProgressBackendEventPayloads = ProgressEventPayloads &
+  RuntimeInteractionEventPayloads;
+
+export type ProgressBackendEvent = keyof ProgressBackendEventPayloads;
+
+type ProgressEventRegistration<K extends ProgressBackendEvent> = {
   /** Defaults to 'ProgressEvents' when omitted. */
   readonly module?: string;
   /** Defaults to `failed to handle ${event}` when omitted. */
   readonly context?: string;
-  readonly handle: (payload: ProgressEventPayloads[K]) => void | Promise<void>;
+  readonly handle: (
+    payload: ProgressBackendEventPayloads[K],
+  ) => void | Promise<void>;
 };
 
 type ProgressEventRegistrationMap = {
-  [K in ProgressEvent]?: ProgressEventRegistration<K>;
+  [K in ProgressBackendEvent]?: ProgressEventRegistration<K>;
 };
 
 export const PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES: readonly AgentEvent['type'][] =
@@ -277,9 +282,9 @@ export class ProgressEventHandler {
     };
   }
 
-  handleProgressEvent<K extends ProgressEvent>(
+  handleProgressEvent<K extends ProgressBackendEvent>(
     event: K,
-    payload: ProgressEventPayloads[K],
+    payload: ProgressBackendEventPayloads[K],
   ): void {
     const registration = this.eventRegistrations[event] as
       ProgressEventRegistration<K> | undefined;

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -6,7 +6,7 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
 
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
 import {
   setActiveCliToolEditApprovalHandler,
@@ -49,17 +49,18 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
   };
 }
 
-const credentialExhaustedRetry: ProgressEventPayloads['showRetryRequest'] = {
-  streamId:
-    'test-stream' as ProgressEventPayloads['showRetryRequest']['streamId'],
-  operation: 'Tool-use call',
-  errorMessage: 'HTTP 429 Too Many Requests',
-  errorDetails: {
-    exhaustionReason: 'relay-limit',
-    isRelayError: true,
-    statusCode: 429,
-  },
-};
+const credentialExhaustedRetry: RuntimeInteractionEventPayloads['showRetryRequest'] =
+  {
+    streamId:
+      'test-stream' as RuntimeInteractionEventPayloads['showRetryRequest']['streamId'],
+    operation: 'Tool-use call',
+    errorMessage: 'HTTP 429 Too Many Requests',
+    errorDetails: {
+      exhaustionReason: 'relay-limit',
+      isRelayError: true,
+      statusCode: 429,
+    },
+  };
 
 beforeEach(async () => {
   // Wire the Platform with a delegating port that reads the CLI's active
@@ -146,7 +147,7 @@ describe('human input approval policy', () => {
 });
 
 describe('approval prompt hooks', () => {
-  const proposal: ProgressEventPayloads['showAgentProposal'] = {
+  const proposal: RuntimeInteractionEventPayloads['showAgentProposal'] = {
     proposalId: 'proposal-1',
     streamId: 'root@deepseekT#abc',
     agent: 'review',
@@ -528,7 +529,7 @@ describe('formatRetryRequestMessage', () => {
   });
 
   it('recognizes relay monthly-limit text when the relay body is absent', () => {
-    const retry: ProgressEventPayloads['showRetryRequest'] = {
+    const retry: RuntimeInteractionEventPayloads['showRetryRequest'] = {
       ...credentialExhaustedRetry,
       errorMessage:
         'HTTP 429 Too Many Requests – 429 Monthly spending limit reached ($300).',

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -86,7 +86,7 @@ vi.mock('@platform/platform', () => ({
 }));
 
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
   clearApprovals,
   currentApproval,
@@ -134,7 +134,7 @@ function relayRetry(params: {
   streamId: string;
   provider?: string;
   message?: string;
-}): ProgressEventPayloads['showRetryRequest'] {
+}): RuntimeInteractionEventPayloads['showRetryRequest'] {
   return {
     streamId: params.streamId,
     operation: 'model request',
@@ -145,12 +145,12 @@ function relayRetry(params: {
       isRelayError: true,
       ...(params.provider ? { provider: params.provider } : {}),
     },
-  } as ProgressEventPayloads['showRetryRequest'];
+  } as RuntimeInteractionEventPayloads['showRetryRequest'];
 }
 
 function chatGptSubscriptionRetry(
   streamId: string,
-): ProgressEventPayloads['showRetryRequest'] {
+): RuntimeInteractionEventPayloads['showRetryRequest'] {
   return {
     streamId,
     operation: 'model request',
@@ -160,7 +160,7 @@ function chatGptSubscriptionRetry(
       exhaustionReason: 'chatgpt-subscription',
       provider: 'openai',
     },
-  } as ProgressEventPayloads['showRetryRequest'];
+  } as RuntimeInteractionEventPayloads['showRetryRequest'];
 }
 
 afterEach(() => {
@@ -275,7 +275,7 @@ describe('TUI retry approvals', () => {
           isRelayError: false,
           provider: 'openai',
         },
-      } as ProgressEventPayloads['showRetryRequest']);
+      } as RuntimeInteractionEventPayloads['showRetryRequest']);
 
       await vi.waitFor(() => {
         expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import type {
   DiffOptions,
   DiffSession,
@@ -53,8 +53,8 @@ interface DesktopPlatformModule {
 }
 
 interface RecordingRuntimeHost extends AgentRuntimeHost {
-  shownToolEditPermissions: ProgressEventPayloads['showToolEditPermission'][];
-  resolvedToolEditPermissions: ProgressEventPayloads['resolveToolEditPermission'][];
+  shownToolEditPermissions: RuntimeInteractionEventPayloads['showToolEditPermission'][];
+  resolvedToolEditPermissions: RuntimeInteractionEventPayloads['resolveToolEditPermission'][];
 }
 
 let activeToolEditApproval:
@@ -70,27 +70,25 @@ function useControllerApproval(controller: {
 }
 
 function createRecordingRuntimeHost(): RecordingRuntimeHost {
-  const shownToolEditPermissions: ProgressEventPayloads['showToolEditPermission'][] =
+  const shownToolEditPermissions: RuntimeInteractionEventPayloads['showToolEditPermission'][] =
     [];
-  const resolvedToolEditPermissions: ProgressEventPayloads['resolveToolEditPermission'][] =
+  const resolvedToolEditPermissions: RuntimeInteractionEventPayloads['resolveToolEditPermission'][] =
     [];
-  const eventHandlers: Partial<{
-    [K in keyof ProgressEventPayloads]: (
-      payload: ProgressEventPayloads[K],
-    ) => void;
-  }> = {
-    showToolEditPermission: (payload) => {
-      shownToolEditPermissions.push(payload);
-    },
-    resolveToolEditPermission: (payload) => {
-      resolvedToolEditPermissions.push(payload);
-    },
-  };
   return {
     shownToolEditPermissions,
     resolvedToolEditPermissions,
     emit: (event, payload) => {
-      eventHandlers[event]?.(payload);
+      if (event === 'showToolEditPermission') {
+        shownToolEditPermissions.push(
+          payload as RuntimeInteractionEventPayloads['showToolEditPermission'],
+        );
+        return;
+      }
+      if (event === 'resolveToolEditPermission') {
+        resolvedToolEditPermissions.push(
+          payload as RuntimeInteractionEventPayloads['resolveToolEditPermission'],
+        );
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR moves runtime interaction and approval requests out of the frozen progress-event vocabulary.

It adds `RuntimeInteractionEventPayloads` in `src/agent/runtime/runtimeInteractionEvents.ts` for:

- retry, bash, plan, proposal, external-inquiry, and user-question requests
- tool-edit show/resolve requests
- tool-edit, bash, and super-yolo bypass-state pushes

`AgentRuntimeHost.emit` now accepts progress facts, runtime presentation events, and runtime interaction events as separate typed vocabularies. `ProgressEventPayloads` no longer owns the interaction keys.

## Design Notes

`inquiryThreadUpdated` deliberately remains in `ProgressEventPayloads`. It is a durable session/progress fact projected from `SessionEventHub`, not a host interaction request. Moving it with approval requests would mix session state with UI/RPC interactions and enlarge the migration boundary.

The progress backend still accepts a compatibility union of progress facts plus runtime interaction events, because tool-edit show/resolve and bypass-state pushes still route through the existing progress-view adapter. CLI/TUI state similarly accepts progress facts plus interaction bypass updates. Presentation events remain separate.

## Behavior

- Interactive CLI still diverts runtime approval/question events through the approval adapter.
- NDJSON/headless CLI still serializes unhandled runtime interaction events.
- TUI bypass updates still update local state.
- VS Code and desktop behavior for tool-edit approval and bypass state is preserved.
- No new VS Code/desktop behavior is added for bash bypass state.

## Validation

- `corepack pnpm exec tsc --noEmit --pretty false`
- `npm run format`
- `npm run lint` (58 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `git diff --check`
- Focused Vitest set:
  - `src/test-kernel/cli/ApprovalEvents.vitest.mts`
  - `src/test-kernel/cli/ApprovalAdapter.vitest.mts`
  - `src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
  - `src/test-kernel/agent/runtime/SessionInteractions.vitest.ts`
  - `src/test-kernel/progressView/ProgressBackend.vitest.ts`
  - `src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts`
  - `src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts`
  - `src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts`
  - `src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts`
- `npm test` (605 files passed, 1 skipped; 5237 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval routing across CLI, desktop, and extension with wide type renames; behavior is intended to be unchanged but mistakes in event classification could mis-route prompts or bypass updates.
> 
> **Overview**
> **Splits host approval/interaction traffic out of the frozen `ProgressEventPayloads` map** into a new `RuntimeInteractionEventPayloads` module (`show*` permissions, tool-edit show/resolve, bypass-state updates). `AgentRuntimeHost.emit` now unions progress facts, presentation events, and interaction events; `inquiryThreadUpdated` stays on the progress side as a session fact.
> 
> **CLI** approval/TUI code retargets types and routing: `isRuntimeInteractionEvent` drives the approval adapter before progress rendering/NDJSON, and TUI state still applies interaction bypass updates via a progress+interaction union. **Progress view** backends accept `ProgressBackendEvent` (progress ∪ interaction) so tool-edit and bypass events keep flowing through the existing adapter; extension and desktop hosts cast into that union when forwarding.
> 
> No intentional behavior change—same prompts, auto-switch retry, and tool-edit paths; mostly typing and vocabulary boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edb66c16e14f586db8aefb8cfb8636ef684d08b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->