### PR TITLE
refactor(agent-core): widen CommonCycleTypes/ModelInvocationNode chokepoint to Pick-friendly types (#6945 step 1)

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -97,7 +97,7 @@ export type CycleDebugFileOptions = {
 export async function saveCycleDebug(
   object: unknown,
   objectType: 'messages' | 'response',
-  services: AgentCore,
+  services: Pick<AgentCore, 'logger' | 'config'>,
   fileOptions: CycleDebugFileOptions,
 ): Promise<void> {
   const { executionId } = useLaunchRunContext();
@@ -115,7 +115,7 @@ export async function saveCycleDebug(
 }
 
 export function defaultPostCompactionContext(
-  services: WorkspaceScopedCore,
+  services: Pick<WorkspaceScopedCore, 'workspace'>,
 ): string | null {
   const { session, streamId } = useLaunchRunContext();
   const { subagents, processes } =
@@ -150,7 +150,7 @@ export function extractModelResponse(
   response: unknown,
   responseTimeMs: number | undefined,
   endTag: string,
-  services: WorkspaceScopedCore,
+  services: Pick<WorkspaceScopedCore, 'modelHandler' | 'workspace' | 'logger'>,
   options: ExtractModelResponseOptions = {},
 ): ExtractedModelResponse {
   const { modelHandler, workspace, logger } = services;

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -7,7 +7,10 @@ import {
   replaceMessagesInPlace,
   saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
-import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
+import type {
+  AgentCore,
+  BaseFlowContextInit,
+} from '@agent/core/flows/BaseFlowServices';
 import { requiresFlowAutoRetry } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
 
@@ -41,10 +44,23 @@ export interface ModelInvocationConfig<TShared, TServices> {
   ) => CycleDebugFileOptions;
 }
 
-type InvocationServices = BaseFlowContextInit<unknown> & {
-  readonly client: unknown;
-  readonly refreshClient?: () => Promise<void>;
-};
+/**
+ * Only the services this node and its `RetryableInvocationNode` base class
+ * actually read: the model handler, logger, setting (temperature/tools),
+ * config (for `saveCycleDebug`'s log context), and the retry machinery's
+ * `streamStatus`/`setAbortController`, plus the live model client. Picking
+ * from `AgentCore`/`BaseFlowContextInit` instead of requiring the literal
+ * type keeps every existing caller, which passes the full services bag,
+ * satisfying this narrower shape structurally.
+ */
+type InvocationServices = Pick<
+  AgentCore,
+  'modelHandler' | 'logger' | 'setting' | 'config' | 'streamStatus'
+> &
+  Pick<BaseFlowContextInit, 'setAbortController'> & {
+    readonly client: unknown;
+    readonly refreshClient?: () => Promise<void>;
+  };
 
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,


### PR DESCRIPTION
## Summary

This is **step 1 of 4** from #6945 ("AgentDefinition: group config/setting/prompt/modelHandler/userVarChannels on AgentCore, ISP-narrow node interfaces"). It widens the read chokepoint before any grouping/ISP work happens elsewhere in the issue.

`saveCycleDebug`, `defaultPostCompactionContext`, and `extractModelResponse` in `src/agent/core/flows/CommonCycleTypes.ts` each required the literal `AgentCore`/`WorkspaceScopedCore` services bag as a parameter, even though each only reads a handful of its fields. Likewise `ModelInvocationNode`'s `InvocationServices` type (the default/bound for its `TServices` generic in `src/agent/core/flows/ModelInvocationNode.ts`) required the full `BaseFlowContextInit<unknown>` shape.

This PR narrows each to a `Pick` of exactly the fields it reads:

- `saveCycleDebug`: `Pick<AgentCore, 'logger' | 'config'>` (reads `services.logger` and `services.config.model` / `services.config.agent`).
- `defaultPostCompactionContext`: `Pick<WorkspaceScopedCore, 'workspace'>` (only reads `services.workspace`).
- `extractModelResponse`: `Pick<WorkspaceScopedCore, 'modelHandler' | 'workspace' | 'logger'>` (destructures exactly those three).
- `InvocationServices`: `Pick<AgentCore, 'modelHandler' | 'logger' | 'setting' | 'config' | 'streamStatus'> & Pick<BaseFlowContextInit, 'setAbortController'> & { client, refreshClient? }` — covers what `ModelInvocationNode` itself reads (`modelHandler`, `logger`, `setting.temperature`/`setting.tools`, `client`) plus what it must satisfy transitively as the generic bound for `RetryableInvocationNode`'s `RetryableNodeServices` (`streamStatus`, `setAbortController`).

This is a **pure type-signature widening with no behavior change**: every existing caller already passes the full services bag, which structurally satisfies these narrower `Pick` shapes, so nothing at any call site needed to change.

**Deferred to follow-up PRs** (steps 2-4 of #6945, not part of this PR):
- Introducing an `AgentDefinition` interface to group `config`/`setting`/`prompt`/`modelHandler`/`userVarChannels`.
- Opportunistic ISP-narrowing of individual nodes/readers.
- Fixing fragile test mocks.
- The two re-spread sites (`ToolUseCycleNode.ts`, `ResponseCycleFlow.ts`) and the 14 reader files are untouched.

## Test plan

- [x] `npx tsc --noEmit` (root) — passes
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — passes
- [x] `packages/extension`: `npx tsc --noEmit` — passes
- [x] `packages/cli`: `npx tsc --noEmit -p tsconfig.json` — passes
- [x] Targeted vitest suites touching these files/functions (`ResponseCycleTools`, `RetryState`, `ResponseCycleCancellation`, `ToolUseRoundFollowUpMedia`, `ToolUseRoundPrepNodeFollowUpTranscriptLog`, `ToolUseDispatchInterruption`, `BashTool`) — 36/36 passing
- [x] `npx eslint` on both touched files — clean
- [x] `npx prettier --check` on both touched files — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only signature widening with no logic changes; full services bags still satisfy the new Pick types at all call sites.
> 
> **Overview**
> **Step 1 of agent-core ISP work (#6945):** cycle helpers and `ModelInvocationNode` no longer require the full `AgentCore` / `WorkspaceScopedCore` bag—parameters are widened to `Pick` only the fields each path actually reads.
> 
> In `CommonCycleTypes.ts`, `saveCycleDebug`, `defaultPostCompactionContext`, and `extractModelResponse` now take `Pick<AgentCore, …>` or `Pick<WorkspaceScopedCore, …>` instead of the whole core type. In `ModelInvocationNode.ts`, the default `InvocationServices` bound is a `Pick` from `AgentCore` and `BaseFlowContextInit` (model handler, logger, setting, config, stream status, abort controller) plus `client` / optional `refreshClient`, replacing the previous full `BaseFlowContextInit<unknown>` requirement.
> 
> **No runtime or call-site edits**—existing callers still pass the full services object, which structurally satisfies the narrower types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102ed7192c2574260e2a000b17333ea05d75758b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->