### PR TITLE
refactor: split progress fact applier

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1132,13 +1132,13 @@ export class DesktopProgressBridge {
 
   private syncStreamContent(streamId: StreamTabId | ''): void {
     if (!streamId) {
-      this.backend.eventHandler.syncStreamContent('');
+      this.backend.factApplier.syncStreamContent('');
       return;
     }
 
     void this.streamLogs.ensureLoaded(streamId).then(() => {
       if (this.state.activeStream !== streamId) return;
-      this.backend.eventHandler.syncStreamContent(streamId, {
+      this.backend.factApplier.syncStreamContent(streamId, {
         includeActiveState: true,
       });
       this.progressEvents.sendRestoredDisplay(streamId);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -334,7 +334,7 @@ export class ProgressViewProvider
 
     const activeStream = this.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.eventHandler.getAllStreamStates(),
+      this.backend.factApplier.getAllStreamStates(),
       theme,
     );
 
@@ -348,10 +348,10 @@ export class ProgressViewProvider
       if (activeStream && !this.state.streamLogs.get(activeStream)) {
         void this.state.streamLogs.ensureLoaded(activeStream).then(() => {
           if (this.state.activeStream !== activeStream) return;
-          this.eventHandler.syncStreamContent(activeStream);
+          this.backend.factApplier.syncStreamContent(activeStream);
         });
       } else {
-        this.eventHandler.syncStreamContent(activeStream);
+        this.backend.factApplier.syncStreamContent(activeStream);
       }
     }
 
@@ -541,7 +541,9 @@ export class ProgressViewProvider
 
     this.webviewUpdater.setActiveStream(streamId);
     // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata
-    this.eventHandler.syncStreamContent(streamId, { includeActiveState: true });
+    this.backend.factApplier.syncStreamContent(streamId, {
+      includeActiveState: true,
+    });
   }
 
   public async revealStream(

--- a/packages/extension/src/progressView/progressBackendAppSignals.ts
+++ b/packages/extension/src/progressView/progressBackendAppSignals.ts
@@ -7,11 +7,11 @@ import type { ProgressEventSubscription } from '@shared/progressView/backend/eve
  * This adapter keeps app-scoped shutdown facts out of the progress event bus.
  */
 export function attachProgressBackendAppSignals(
-  backend: Pick<ProgressBackend, 'eventHandler'>,
+  backend: Pick<ProgressBackend, 'factApplier'>,
   signals: AppSignalsLike,
 ): ProgressEventSubscription {
   const dispose = signals.on('extensionDeactivating', () => {
-    backend.eventHandler.markAllRunningTasksAsCancelled();
+    backend.factApplier.markAllRunningTasksAsCancelled();
   });
 
   return { dispose };

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -16,6 +16,7 @@ import {
   type ProgressEventSubscription,
   type UICallbacks,
 } from '@shared/progressView/backend/events/ProgressEventHandler';
+import type { ProgressFactApplier } from '@shared/progressView/backend/events/ProgressFactApplier';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 import type { StreamSnapshotStore } from '@transcript';
@@ -61,6 +62,7 @@ export class ProgressBackend {
   readonly webviewUpdater: WebviewUpdater;
   readonly webviewBridge: WebviewBridge;
   readonly eventHandler: ProgressEventHandler;
+  readonly factApplier: ProgressFactApplier;
   private readonly session: SessionHandle;
   private disposed = false;
 
@@ -103,6 +105,7 @@ export class ProgressBackend {
       ui.hasPendingPermissions,
       options.getStreamControls,
     );
+    this.factApplier = this.eventHandler.factApplier;
   }
 
   async load(): Promise<void> {
@@ -110,13 +113,12 @@ export class ProgressBackend {
   }
 
   setupEventListeners(): ProgressEventSubscription {
-    const eventHandlerSubscription =
-      this.eventHandler.createLocalSubscription();
+    const factApplierSubscription = this.factApplier.createLocalSubscription();
     const detachSessionFacts = this.session.events.subscribe(
       (sessionEvent) => {
         if (this.disposed) return;
         if (sessionEvent.scope !== 'session') return;
-        this.eventHandler.handleSessionFact(sessionEvent.event);
+        this.factApplier.handleSessionFact(sessionEvent.event);
       },
       { scope: 'session' },
     );
@@ -124,7 +126,7 @@ export class ProgressBackend {
       (sessionEvent) => {
         if (this.disposed) return;
         if (sessionEvent.scope !== 'run') return;
-        this.eventHandler.handleRunFact(
+        this.factApplier.handleRunFact(
           sessionEvent.streamId,
           sessionEvent.event,
         );
@@ -135,7 +137,7 @@ export class ProgressBackend {
       dispose: () => {
         detachRunFacts();
         detachSessionFacts();
-        eventHandlerSubscription.dispose();
+        factApplierSubscription.dispose();
       },
     };
   }

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,43 +1,27 @@
-import type { AgentEvent, AgentTrace } from '@agent/trace';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
-import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
+import type { AgentEvent } from '@agent/trace';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
-import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import { isInFlightStatus } from '@common/constants/streamStatus';
-import { createChannelTrace } from '@logger';
-import {
-  STREAM_PHASE,
-  ConversationProgressSchema,
-  UpdatePlanPayloadSchema,
-  UpdateTodosPayloadSchema,
-  type ConversationProgress,
-  type GoalStatus,
-  type StreamPhase,
-  type StreamSubstate,
-  type StreamTabId,
-} from '@shared/schemas';
-import { diffActiveChildren } from '@shared/streams/childActivityReducer';
-import {
-  WebviewUpdater,
-  type LogContentExtras,
-} from '@shared/progressView/backend/WebviewUpdater';
-import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
-import { pickAgentCategory } from '@shared/progressView/backend/streamTabInfo';
-import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
-import {
-  ProgressViewState,
-  type ActiveStreamId,
-  type StreamBadgeSnapshot,
-  type StreamExecutionState,
-} from '@shared/progressView/backend/state/ProgressViewState';
-import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
-import { isObject } from '@utils/core';
+import type { StreamTabId } from '@shared/schemas';
+import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import type { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
+import type { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
 
+import {
+  ProgressFactApplier,
+  PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES,
+  type GetProgressStreamControls,
+  type ProgressEventSubscription,
+  type ProgressStreamControls,
+} from './ProgressFactApplier';
 import { withEventErrorHandling } from './errorHandling';
+
+export {
+  PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES,
+  type GetProgressStreamControls,
+  type ProgressEventSubscription,
+  type ProgressStreamControls,
+};
 
 /**
  * UI callbacks for the approval events that still flow on the host progress
@@ -56,25 +40,6 @@ export interface UICallbacks {
   ) => void;
   updateSuperYoloBypassState: (streamId: string, bypassActive: boolean) => void;
 }
-
-/** Throttle interval for conversation progress webview pushes (ms). */
-const PROGRESS_THROTTLE_MS = 500;
-
-export type ProgressEventSubscription = {
-  dispose(): void;
-};
-
-export interface ProgressStreamControls {
-  toolEditBypass: boolean;
-  superYoloBypass: boolean;
-  goalActive: boolean;
-  goalStatus?: GoalStatus;
-  goalObjective?: string;
-}
-
-export type GetProgressStreamControls = (
-  stream: StreamTabId,
-) => ProgressStreamControls;
 
 export type ProgressBackendEventPayloads = ProgressEventPayloads &
   RuntimeInteractionEventPayloads;
@@ -95,94 +60,56 @@ type ProgressEventRegistrationMap = {
   [K in ProgressBackendEvent]?: ProgressEventRegistration<K>;
 };
 
-export const PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES: readonly AgentEvent['type'][] =
-  [
-    'domain',
-    'run.config',
-    'usage',
-    'status',
-    'stage.start',
-    'child.activity',
-    'process.output',
-  ];
-
-function getDefaultProgressStreamControls(): ProgressStreamControls {
-  return {
-    toolEditBypass: false,
-    superYoloBypass: false,
-    goalActive: false,
-  };
-}
-
-/** Applies host progress events to progress-view state and webview updates. */
+/** Compatibility adapter for legacy host progress events. */
 export class ProgressEventHandler {
-  private readonly logger: AgentTrace;
+  readonly factApplier: ProgressFactApplier;
   private readonly eventRegistrations: ProgressEventRegistrationMap;
-  private progressThrottleTimer: ReturnType<typeof setTimeout> | null = null;
-  private pendingProgressUpdates = new Map<StreamTabId, ConversationProgress>();
 
   constructor(
-    private state: ProgressViewState,
-    private webviewUpdater: WebviewUpdater,
-    private webviewBridge: WebviewBridge,
+    state: ProgressViewState,
+    webviewUpdater: WebviewUpdater,
+    webviewBridge: WebviewBridge,
     private readonly uiCallbacks: UICallbacks,
-    private readonly hasPendingPermissions: (streamId: string) => boolean,
-    private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+    hasPendingPermissions: (streamId: string) => boolean,
+    getStreamControls?: GetProgressStreamControls,
   ) {
-    this.logger = createChannelTrace('ProgressEventHandler');
+    this.factApplier = new ProgressFactApplier(
+      state,
+      webviewUpdater,
+      webviewBridge,
+      hasPendingPermissions,
+      getStreamControls,
+    );
     this.eventRegistrations = this.createEventRegistrations();
-  }
-
-  private maybeUpdateFilterForCategory(
-    category: AgentCategory | undefined,
-  ): void {
-    if (
-      category &&
-      this.state.agentCategoryFilter !== 'all' &&
-      this.state.agentCategoryFilter !== category
-    ) {
-      this.state.agentCategoryFilter = category;
-    }
-  }
-
-  private handleRunningTransition(
-    streamId: StreamTabId,
-  ): AgentCategory | undefined {
-    const knownCategory = this.getStreamCategory(streamId);
-    const category = knownCategory ?? AgentCategory.Workflow;
-    this.state.clearStreamHints(streamId);
-    this.state.getOrCreateStreamState(streamId, category);
-    this.state.resetFinishedChildCounters(streamId);
-    this.pendingProgressUpdates.delete(streamId);
-    this.state.pruneInterruptHandles();
-
-    if (this.state.activeStream === streamId) {
-      this.maybeUpdateFilterForCategory(knownCategory);
-    }
-    return knownCategory;
   }
 
   private createEventRegistrations(): ProgressEventRegistrationMap {
     return {
       setActiveStream: {
-        handle: (payload) => this.handleSetActiveStream(payload),
+        handle: (payload) => this.factApplier.handleSetActiveStream(payload),
       },
       updateStreamStatus: {
         handle: ({ streamId, status, previousStatus, substate }) =>
-          this.setStreamStatus(streamId, status, previousStatus, substate),
+          this.factApplier.setStreamStatus(
+            streamId,
+            status,
+            previousStatus,
+            substate,
+          ),
       },
       setTaskState: {
-        handle: (data) => this.handleSetTaskState(data),
+        handle: (data) => this.factApplier.handleSetTaskState(data),
       },
       updateConversationProgress: {
-        handle: (data) => this.handleUpdateConversationProgress(data),
+        handle: (data) =>
+          this.factApplier.handleUpdateConversationProgress(data),
       },
       updateRoundStage: {
-        handle: (data) => this.handleUpdateRoundStage(data),
+        handle: (data) => this.factApplier.handleUpdateRoundStage(data),
       },
       updateActiveSubagents: {
         handle: (data) =>
-          this.updateActiveChildren(data.parentStreamId, {
+          this.factApplier.updateActiveChildren(data.parentStreamId, {
             activeField: 'activeSubagents',
             countField: 'finishedSubagentCount',
             next: data.children,
@@ -190,52 +117,57 @@ export class ProgressEventHandler {
       },
       updateActiveProcesses: {
         handle: (data) =>
-          this.updateActiveChildren(data.parentStreamId, {
+          this.factApplier.updateActiveChildren(data.parentStreamId, {
             activeField: 'activeProcesses',
             countField: 'finishedProcessCount',
             next: data.processes,
           }),
       },
       updateProcessOutput: {
-        handle: (data) => this.handleUpdateProcessOutput(data),
+        handle: (data) => this.factApplier.handleUpdateProcessOutput(data),
       },
       inquiryThreadUpdated: {
-        handle: (thread) => this.handleInquiryThreadUpdated(thread),
+        handle: (thread) => this.factApplier.handleInquiryThreadUpdated(thread),
       },
       updateStreamDescription: {
-        handle: (payload) => this.handleUpdateStreamDescription(payload),
+        handle: (payload) =>
+          this.factApplier.handleUpdateStreamDescription(payload),
       },
       setParentStream: {
-        handle: (payload) => this.handleSetParentStream(payload),
+        handle: (payload) => this.factApplier.handleSetParentStream(payload),
       },
-      // Output events — workflow tabs hold one run; ignore the storageKey dim.
+      // Output events: workflow tabs hold one run; ignore the storageKey dim.
       addOutputFiles: {
-        handle: (payload) => this.handleAddOutputFiles(payload),
+        handle: (payload) => this.factApplier.handleAddOutputFiles(payload),
       },
       updateMissingOutputs: {
-        handle: (payload) => this.handleUpdateMissingOutputs(payload),
+        handle: (payload) =>
+          this.factApplier.handleUpdateMissingOutputs(payload),
       },
       updateCompileFailures: {
-        handle: (payload) => this.handleUpdateCompileFailures(payload),
+        handle: (payload) =>
+          this.factApplier.handleUpdateCompileFailures(payload),
       },
       clearMissingOutputs: {
-        handle: (payload) => this.handleClearMissingOutputs(payload),
+        handle: (payload) =>
+          this.factApplier.handleClearMissingOutputs(payload),
       },
-      // Usage events — workflow tabs collapse to a single accumulated value;
+      // Usage events: workflow tabs collapse to a single accumulated value;
       // tool-use tabs keep per-run accumulation (resume produces multiple runs).
       updateStreamUsage: {
-        handle: (payload) => this.handleUpdateStreamUsage(payload),
+        handle: (payload) => this.factApplier.handleUpdateStreamUsage(payload),
       },
       updateTodos: {
-        handle: (payload) => this.handleUpdateTodos(payload),
+        handle: (payload) => this.factApplier.handleUpdateTodos(payload),
       },
       // Plan events are rare and critical for the approval UX, so send them
       // whenever the webview is available rather than only for the active tab.
       updatePlan: {
-        handle: (payload) => this.handleUpdatePlan(payload),
+        handle: (payload) => this.factApplier.handleUpdatePlan(payload),
       },
       updateQueuedFollowUps: {
-        handle: (payload) => this.handleUpdateQueuedFollowUps(payload),
+        handle: (payload) =>
+          this.factApplier.handleUpdateQueuedFollowUps(payload),
       },
       showToolEditPermission: {
         module: 'ProgressEventHandler',
@@ -270,16 +202,7 @@ export class ProgressEventHandler {
   }
 
   createLocalSubscription(): ProgressEventSubscription {
-    return {
-      dispose: () => {
-        if (this.progressThrottleTimer) {
-          clearTimeout(this.progressThrottleTimer);
-          this.progressThrottleTimer = null;
-        }
-        this.pendingProgressUpdates.clear();
-        this.webviewBridge.clearAll();
-      },
-    };
+    return this.factApplier.createLocalSubscription();
   }
 
   handleProgressEvent<K extends ProgressBackendEvent>(
@@ -298,824 +221,31 @@ export class ProgressEventHandler {
   }
 
   handleSessionFact(fact: SessionFact): void {
-    switch (fact.type) {
-      case 'goalStateChanged':
-        return;
-      case 'inquiryThreadUpdated':
-        this.applyFact('failed to handle inquiryThreadUpdated fact', () =>
-          this.handleInquiryThreadUpdated(fact.payload),
-        );
-        return;
-      case 'clearMissingOutputs':
-        this.applyFact('failed to handle clearMissingOutputs fact', () =>
-          this.handleClearMissingOutputs(fact.payload),
-        );
-        return;
-      case 'updateQueuedFollowUps':
-        this.applyFact('failed to handle updateQueuedFollowUps fact', () =>
-          this.handleUpdateQueuedFollowUps(fact.payload),
-        );
-        return;
-      case 'followUpSent':
-        return;
-      case 'setActiveStream':
-        this.applyFact('failed to handle setActiveStream fact', () =>
-          this.handleSetActiveStream(fact.payload),
-        );
-        return;
-      case 'updateStreamDescription':
-        this.applyFact('failed to handle updateStreamDescription fact', () =>
-          this.handleUpdateStreamDescription(fact.payload),
-        );
-        return;
-      case 'updateStreamStatus':
-        this.applyFact('failed to handle updateStreamStatus fact', () =>
-          this.setStreamStatus(
-            fact.payload.streamId,
-            fact.payload.status,
-            fact.payload.previousStatus,
-            fact.payload.substate,
-          ),
-        );
-        return;
-      case 'setParentStream':
-        this.applyFact('failed to handle setParentStream fact', () =>
-          this.handleSetParentStream(fact.payload),
-        );
-        return;
-      case 'removeStream':
-        return;
-    }
+    this.factApplier.handleSessionFact(fact);
   }
 
   handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
-    if (event.type === 'usage') {
-      const payload = toUpdateStreamUsagePayload(event.data, streamId);
-      if (payload) {
-        this.applyFact('failed to handle usage fact', () =>
-          this.handleUpdateStreamUsage(payload),
-        );
-      }
-      return;
-    }
-
-    if (event.type === 'run.config') {
-      this.applyFact('failed to handle run.config fact', () =>
-        this.handleSetTaskState({
-          streamId: event.streamId,
-          executionId: event.executionId,
-          taskState: agentConfigToTaskState(event.config),
-        }),
-      );
-      return;
-    }
-
-    if (event.type === 'status') {
-      this.applyFact('failed to handle status fact', () =>
-        this.setStreamStatus(
-          event.streamId,
-          event.phase,
-          event.previousPhase,
-          event.substate,
-        ),
-      );
-      return;
-    }
-
-    if (event.type === 'domain') {
-      if (event.key === 'conversationProgress') {
-        const progress = ConversationProgressSchema.safeParse(event.data);
-        if (progress.success) {
-          this.applyFact('failed to handle conversationProgress fact', () =>
-            this.handleUpdateConversationProgress({
-              streamId,
-              progress: progress.data,
-            }),
-          );
-        }
-        return;
-      }
-
-      const factName = fromRunFactDomainKey(event.key);
-      if (factName === 'updateTodos') {
-        const payload = UpdateTodosPayloadSchema.safeParse(event.data);
-        if (payload.success) {
-          this.applyFact('failed to handle updateTodos fact', () =>
-            this.handleUpdateTodos(payload.data),
-          );
-        }
-        return;
-      }
-
-      if (factName === 'updatePlan') {
-        const payload = UpdatePlanPayloadSchema.safeParse(event.data);
-        if (payload.success) {
-          this.applyFact('failed to handle updatePlan fact', () =>
-            this.handleUpdatePlan(payload.data),
-          );
-        }
-        return;
-      }
-
-      if (factName === 'addOutputFiles' && isObject(event.data)) {
-        this.applyFact('failed to handle addOutputFiles fact', () =>
-          this.handleAddOutputFiles(
-            event.data as ProgressEventPayloads['addOutputFiles'],
-          ),
-        );
-        return;
-      }
-
-      if (factName === 'updateMissingOutputs' && isObject(event.data)) {
-        this.applyFact('failed to handle updateMissingOutputs fact', () =>
-          this.handleUpdateMissingOutputs(
-            event.data as ProgressEventPayloads['updateMissingOutputs'],
-          ),
-        );
-        return;
-      }
-
-      if (factName === 'updateCompileFailures' && isObject(event.data)) {
-        this.applyFact('failed to handle updateCompileFailures fact', () =>
-          this.handleUpdateCompileFailures(
-            event.data as ProgressEventPayloads['updateCompileFailures'],
-          ),
-        );
-      }
-      return;
-    }
-
-    if (event.type === 'stage.start') {
-      if (event.kind !== 'round') return;
-      this.applyFact('failed to handle stage.start fact', () =>
-        this.handleUpdateRoundStage({
-          streamId,
-          roundStage: {
-            index: event.index ?? 0,
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
-        }),
-      );
-      return;
-    }
-
-    if (event.type === 'child.activity') {
-      if (event.kind === 'subagents') {
-        this.applyFact('failed to handle subagent activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeSubagents',
-            countField: 'finishedSubagentCount',
-            next: [...event.children],
-          }),
-        );
-        return;
-      }
-      if (event.kind === 'processes') {
-        this.applyFact('failed to handle process activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeProcesses',
-            countField: 'finishedProcessCount',
-            next: [...event.processes],
-          }),
-        );
-        return;
-      }
-      return;
-    }
-
-    if (event.type === 'process.output') {
-      this.applyFact('failed to handle process.output fact', () =>
-        this.handleUpdateProcessOutput({
-          parentStreamId: event.parentStreamId,
-          executionId: event.executionId,
-          stdout: event.stdout,
-          stderr: event.stderr,
-        }),
-      );
-      return;
-    }
+    this.factApplier.handleRunFact(streamId, event);
   }
 
-  private applyFact(context: string, handle: () => void | Promise<void>): void {
-    withEventErrorHandling('ProgressFacts', context, handle);
+  markAllRunningTasksAsCancelled(): void {
+    this.factApplier.markAllRunningTasksAsCancelled();
   }
 
-  private handleInquiryThreadUpdated(
-    thread: ProgressEventPayloads['inquiryThreadUpdated'],
+  syncStreamContent(
+    stream: Parameters<ProgressFactApplier['syncStreamContent']>[0],
+    options?: Parameters<ProgressFactApplier['syncStreamContent']>[1],
   ): void {
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateInquiryThread(thread);
-    }
+    this.factApplier.syncStreamContent(stream, options);
   }
 
-  private handleUpdateStreamDescription({
-    streamId,
-    description,
-  }: ProgressEventPayloads['updateStreamDescription']): void {
-    this.state.snapshots.setDescription(streamId, description);
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateStreamDescription(streamId, description);
-    }
+  setStreamStatus(
+    ...args: Parameters<ProgressFactApplier['setStreamStatus']>
+  ): ReturnType<ProgressFactApplier['setStreamStatus']> {
+    return this.factApplier.setStreamStatus(...args);
   }
 
-  private handleSetParentStream({
-    childStreamId,
-    parentStreamId,
-  }: ProgressEventPayloads['setParentStream']): void {
-    this.state.snapshots.setParentStream(childStreamId, parentStreamId);
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateParentStream(
-        childStreamId,
-        parentStreamId ?? undefined,
-      );
-    }
-  }
-
-  private handleUpdateProcessOutput({
-    parentStreamId,
-    executionId,
-    stdout,
-    stderr,
-  }: ProgressEventPayloads['updateProcessOutput']): void {
-    // Always send — output accumulates in frontend state per-stream,
-    // so it must not be dropped when the stream is inactive.
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateProcessOutput(
-        parentStreamId,
-        executionId,
-        stdout,
-        stderr,
-      );
-    }
-  }
-
-  private handleAddOutputFiles({
-    streamId,
-    filesByRound,
-  }: ProgressEventPayloads['addOutputFiles']): void {
-    this.state.snapshots.addOutputFiles(streamId, filesByRound);
-    this.sendIfActive(streamId, () => {
-      const rounds = this.state.snapshots.getOutputFiles(streamId);
-      this.webviewUpdater.updateFiles(streamId, {
-        rounds: Object.keys(rounds).length ? rounds : undefined,
-      });
-    });
-  }
-
-  private handleUpdateMissingOutputs({
-    streamId,
-    filesByRound,
-  }: ProgressEventPayloads['updateMissingOutputs']): void {
-    this.state.snapshots.updateMissingOutputs(streamId, filesByRound);
-    this.sendIfActive(streamId, () => {
-      const rounds = this.state.snapshots.getMissingOutputs(streamId);
-      this.webviewUpdater.updateMissingOutputs(streamId, {
-        rounds: Object.keys(rounds).length ? rounds : undefined,
-      });
-    });
-  }
-
-  private handleUpdateCompileFailures({
-    streamId,
-    filesByRound,
-  }: ProgressEventPayloads['updateCompileFailures']): void {
-    this.state.snapshots.updateCompileFailures(streamId, filesByRound);
-    this.sendIfActive(streamId, () => {
-      const rounds = this.state.snapshots.getCompileFailures(streamId);
-      this.webviewUpdater.updateCompileFailures(streamId, {
-        rounds: Object.keys(rounds).length ? rounds : undefined,
-        reset: true,
-      });
-    });
-  }
-
-  private handleClearMissingOutputs(
-    payload: ProgressEventPayloads['clearMissingOutputs'],
-  ): void {
-    const targets: StreamTabId[] = payload.streamId
-      ? [payload.streamId]
-      : payload.streamConfig
-        ? this.state.snapshots.findWorkflowStreamsMatching(payload.streamConfig)
-        : [];
-    for (const streamId of targets) {
-      this.state.snapshots.clearMissingOutputs(streamId);
-      this.sendIfActive(streamId, () =>
-        this.webviewUpdater.updateMissingOutputs(streamId, {
-          reset: true,
-        }),
-      );
-    }
-  }
-
-  private handleUpdateStreamUsage({
-    streamId,
-    usage,
-    storageKey,
-  }: ProgressEventPayloads['updateStreamUsage']): void {
-    void Promise.resolve(
-      this.state.snapshots.addUsage(streamId, storageKey, usage),
-    ).then((accumulated) => {
-      if (!accumulated) return;
-      this.sendIfActive(streamId, () =>
-        this.webviewUpdater.updateRunUsage(streamId, storageKey, accumulated),
-      );
-    });
-  }
-
-  private handleUpdateTodos({
-    streamId,
-    todos,
-  }: ProgressEventPayloads['updateTodos']): void {
-    this.state.snapshots.setTodos(streamId, todos);
-    this.sendIfActive(streamId, () =>
-      this.webviewUpdater.updateTodos(streamId, todos),
-    );
-  }
-
-  private handleUpdatePlan({
-    streamId,
-    plan,
-  }: ProgressEventPayloads['updatePlan']): void {
-    this.state.snapshots.setPlan(streamId, plan);
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updatePlan(streamId, plan);
-    }
-  }
-
-  private handleUpdateQueuedFollowUps({
-    streamId,
-  }: ProgressEventPayloads['updateQueuedFollowUps']): void {
-    this.sendIfActive(streamId, () => {
-      const messages = this.state.followUps.getAll(streamId);
-      this.webviewUpdater.updateQueuedFollowUps(streamId, messages);
-    });
-  }
-
-  /** Send to webview only if streamId is the active stream. */
-  private sendIfActive(streamId: string, send: () => void): void {
-    if (
-      streamId === this.state.activeStream &&
-      this.webviewUpdater.isAvailable()
-    ) {
-      send();
-    }
-  }
-
-  private async handleSetActiveStream(
-    payload: ProgressEventPayloads['setActiveStream'],
-  ): Promise<void> {
-    const { streamId, isRemote } = payload;
-    if (!streamId) return;
-
-    const wasKnownStream = this.state.streamLogs.has(streamId);
-    const previousFilter = this.state.agentCategoryFilter;
-    this.state.streamLogs.ensureStream(streamId);
-    // Only pass defined hint fields — spreading {key: undefined} over existing
-    // hints would clear previously-set values (isRemote).
-    const hints = {
-      ...(payload.agentCategory !== undefined && {
-        agentCategory: payload.agentCategory,
-      }),
-      ...(isRemote !== undefined && { isRemote }),
-    };
-    if (Object.keys(hints).length > 0) {
-      this.state.updateStreamHints(streamId, hints);
-    }
-    // Resolve category: use payload hint, fall back to existing stream state.
-    // Approval flows (proposal, tool-edit, bash) emit without agentCategory;
-    // the stream already exists by then so getStreamCategory() finds it.
-    const agentCategory =
-      payload.agentCategory ?? this.getStreamCategory(streamId);
-    // Ensure stream state exists so it's included in getAllStreamStates()
-    if (agentCategory) {
-      this.state.getOrCreateStreamState(streamId, agentCategory);
-    }
-    // Don't switch away from the current stream if it has pending permissions
-    // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
-    // interact with the approval panel before losing sight of it.
-    // Background child streams (bash, codex) pass `suppressViewSwitch` so the
-    // tab appears without auto-switching the active view.
-    const currentStream = this.state.activeStream;
-    const shouldSwitch =
-      payload.suppressViewSwitch !== true &&
-      (!currentStream || !this.hasPendingPermissions(currentStream));
-    if (shouldSwitch) {
-      // Update the category filter only when actually switching. If we change
-      // the filter while suppressing the switch, sendStreamMetadata →
-      // pickValidActiveStream rebuilds the stream list with the new filter,
-      // which may exclude the current stream and override state.activeStream —
-      // completely bypassing the pending-permissions guard.
-      this.maybeUpdateFilterForCategory(agentCategory);
-      const previous = this.state.activeStream;
-      this.state.activeStream = streamId;
-      // Release the previously-active stream if it reached a terminal
-      // status while visible — setStreamStatus skips release for the
-      // active stream, so this switch is our only chance.
-      if (previous && previous !== streamId) {
-        this.state.releasePreviousActive(previous);
-      }
-    }
-
-    if (!this.webviewUpdater.isAvailable()) return;
-
-    // Rehydrate a potentially-evicted stream before syncing content, so the
-    // webview doesn't get an empty log. All synchronous state mutations are
-    // already done above; the await here only gates webview delivery.
-    await this.state.streamLogs.ensureLoaded(streamId);
-
-    // A newer handleSetActiveStream may have resolved during our await and
-    // already taken over the active tab; skip webview sync so we don't
-    // overwrite its content with stale data.
-    if (shouldSwitch && this.state.activeStream !== streamId) return;
-
-    const filterChanged = this.state.agentCategoryFilter !== previousFilter;
-    if (!wasKnownStream || filterChanged) {
-      this.webviewUpdater.updateStreamMetadata(
-        this.state,
-        streamId,
-        this.state.streamStatus.getAllStreamStates(),
-        {
-          activeStream: shouldSwitch ? this.state.activeStream : undefined,
-          agentFilter: filterChanged
-            ? this.state.agentCategoryFilter
-            : undefined,
-        },
-      );
-    } else if (shouldSwitch) {
-      this.webviewUpdater.setActiveStream(streamId);
-    }
-    // Always sync content for the new stream so badges/parent info reaches
-    // the webview — even when we suppress the view switch. includeActiveState
-    // is only relevant when this IS the active stream.
-    this.syncStreamContent(streamId, {
-      includeActiveState: shouldSwitch && wasKnownStream && !filterChanged,
-    });
-  }
-
-  private handleSetTaskState(
-    data: ProgressEventPayloads['setTaskState'],
-  ): void {
-    const { streamId, executionId, taskState } = data;
-    const isActiveStream = this.state.activeStream === streamId;
-    const category = taskState.agentConfig.agentCategory;
-
-    // Legacy compatibility payload. The snapshot store derives the current
-    // config and run descriptor from this but no longer writes meta.taskState.
-    this.state.snapshots.setTaskState(streamId, taskState, executionId);
-
-    if (isActiveStream) {
-      this.maybeUpdateFilterForCategory(category);
-    }
-
-    if (this.webviewUpdater.isAvailable()) {
-      // setTaskState may change agentConfig (agent name, model, label), which
-      // the frontend tabs display even for background subagents. Patch only
-      // the affected stream instead of rebuilding all historical stream tabs.
-      this.webviewUpdater.updateStreamMetadata(
-        this.state,
-        streamId,
-        this.state.streamStatus.getAllStreamStates(),
-        {
-          agentFilter: isActiveStream
-            ? this.state.agentCategoryFilter
-            : undefined,
-        },
-      );
-    }
-  }
-
-  private handleUpdateConversationProgress(
-    data: ProgressEventPayloads['updateConversationProgress'],
-  ): void {
-    const { streamId, progress } = data;
-
-    // Always update state immediately so full metadata rebuilds include
-    // the latest values when structural refreshes happen.
-    this.state.updateStreamState(streamId, (prev) => ({
-      ...prev,
-      conversationProgress: progress,
-    }));
-
-    // Throttle webview pushes: buffer per-stream, flush on timer
-    this.pendingProgressUpdates.set(streamId, progress);
-    if (!this.progressThrottleTimer) {
-      this.progressThrottleTimer = setTimeout(
-        () => this.flushProgressUpdates(),
-        PROGRESS_THROTTLE_MS,
-      );
-    }
-  }
-
-  private handleUpdateRoundStage(
-    data: ProgressEventPayloads['updateRoundStage'],
-  ): void {
-    const { streamId, roundStage } = data;
-    this.state.updateStreamState(streamId, (prev) => ({
-      ...prev,
-      roundStage,
-    }));
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      this.state.activeStream === streamId
-    ) {
-      this.webviewUpdater.updateRoundStage(streamId, roundStage);
-    }
-  }
-
-  private flushProgressUpdates(): void {
-    this.progressThrottleTimer = null;
-
-    const { activeStream } = this.state;
-    const progress = activeStream
-      ? this.pendingProgressUpdates.get(activeStream)
-      : undefined;
-    if (progress && this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateConversationProgress(activeStream, progress);
-    }
-    this.pendingProgressUpdates.clear();
-  }
-
-  private updateActiveChildren(
-    parentStreamId: StreamTabId,
-    opts: {
-      activeField: 'activeSubagents' | 'activeProcesses';
-      countField: 'finishedSubagentCount' | 'finishedProcessCount';
-      next: StreamExecutionState['activeSubagents'];
-    },
-  ): void {
-    let nextBadges: StreamBadgeSnapshot | null = null;
-
-    this.state.updateStreamState(parentStreamId, (prev) => {
-      const vanishedIds = diffActiveChildren(prev[opts.activeField], opts.next);
-      const updatedState = {
-        ...prev,
-        [opts.activeField]: opts.next,
-        [opts.countField]: (prev[opts.countField] ?? 0) + vanishedIds.size,
-      };
-      nextBadges = this.toBadgeSnapshot(updatedState);
-      return updatedState;
-    });
-
-    if (
-      this.webviewUpdater.isAvailable() &&
-      parentStreamId === this.state.activeStream &&
-      nextBadges
-    ) {
-      this.webviewUpdater.updateStreamBadges(parentStreamId, nextBadges);
-    }
-  }
-
-  private toBadgeSnapshot(state: StreamExecutionState): StreamBadgeSnapshot {
-    return {
-      activeSubagents: state.activeSubagents,
-      finishedSubagentCount: state.finishedSubagentCount,
-      activeProcesses: state.activeProcesses,
-      finishedProcessCount: state.finishedProcessCount,
-    };
-  }
-
-  public markAllRunningTasksAsCancelled(): void {
-    for (const [stream, status] of this.state.streamStatus.entries()) {
-      if (status === STREAM_PHASE.RUNNING) {
-        this.state.streamStatus.transition(
-          stream,
-          STREAM_PHASE.CANCELLED,
-          'restart-repair',
-          { trace: this.logger },
-        );
-      }
-    }
-  }
-
-  public syncStreamContent(
-    stream: ActiveStreamId,
-    options: {
-      /** Include conversation progress, badges, and parent stream in the batch. */
-      includeActiveState?: boolean;
-    } = {},
-  ): void {
-    if (!this.webviewUpdater.isAvailable()) return;
-
-    const { includeActiveState = false } = options;
-
-    if (!stream) {
-      // Clear the stream surface when no stream is active.
-      this.webviewUpdater.sendSyncStreamContent({
-        stream: '',
-        action: 'clear',
-        todos: [],
-        plan: null,
-        queuedFollowUps: [],
-      });
-      return;
-    }
-
-    this.webviewBridge.syncStream(stream);
-
-    const extras = this.buildStreamSyncExtras(stream);
-    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
-    const queuedFollowUps = this.state.followUps.getAll(stream);
-    const agentCategory = this.getStreamCategory(stream);
-
-    // Optionally include active-stream state (replaces syncActiveStreamState).
-    let conversationProgress: ConversationProgress | undefined;
-    let roundStage: StreamExecutionState['roundStage'] | undefined;
-    let badges: StreamBadgeSnapshot | undefined;
-    let parentStreamId: StreamTabId | undefined;
-    if (includeActiveState) {
-      const streamState = this.state.getStreamState(stream);
-      if (streamState) {
-        conversationProgress = streamState.conversationProgress;
-        roundStage = streamState.roundStage;
-        badges = this.toBadgeSnapshot(streamState);
-      }
-      parentStreamId = this.state.snapshots.getParentStreamId(stream);
-    }
-
-    // Always include toggle/goal state so buttons render correctly on tab switch.
-    const streamControls = this.getStreamControls(stream);
-
-    this.webviewUpdater.sendSyncStreamContent({
-      stream,
-      action: 'render',
-      ...extras,
-      todos,
-      plan,
-      queuedFollowUps,
-      agentCategory,
-      conversationProgress,
-      roundStage: includeActiveState ? (roundStage ?? null) : undefined,
-      badges,
-      parentStreamId,
-      ...streamControls,
-    });
-  }
-
-  private buildStreamSyncExtras(stream: StreamTabId): LogContentExtras {
-    return {
-      // Workflow files/missing outputs are flat (one run per tab), already in
-      // the canonical round-indexed record shape the webview consumes.
-      workflowFiles: this.state.snapshots.getOutputFiles(stream),
-      workflowMissingOutputs: this.state.snapshots.getMissingOutputs(stream),
-      workflowCompileFailures: this.state.snapshots.getCompileFailures(stream),
-      // Per-run usage map — shared by workflow and tool-use. Frontend derives
-      // sessionUsage as the sum so cumulative totals survive resume.
-      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
-      contextState: this.state.getContextState(stream),
-    };
-  }
-
-  async setStreamStatus(
-    streamId: StreamTabId,
-    status: StreamPhase,
-    // Kept until Stage 5 removes the legacy bus projection; the status machine
-    // now owns repair writes, so this projection no longer consumes it.
-    _previousStatus?: StreamPhase,
-    substate?: StreamSubstate,
-  ): Promise<void> {
-    // Keep memory bounded by stream status:
-    //  - returning to in-flight (e.g., background resume) eagerly rehydrates
-    //    previously-released entries so pending appends from the agent
-    //    runtime land on the full on-disk log instead of clobbering it via
-    //    an empty getOrCreate.
-    //  - leaving the in-flight set drops heavy entries; disk stays
-    //    authoritative and `setActiveStream` re-reads on demand.
-    if (isInFlightStatus(status)) {
-      void this.state.streamLogs.ensureLoaded(streamId);
-    } else if (streamId !== this.state.activeStream) {
-      this.state.streamLogs.releaseEntries(streamId);
-    }
-
-    const isNewRunningTransition =
-      status === STREAM_PHASE.RUNNING && _previousStatus !== status;
-    const runningCategory = isNewRunningTransition
-      ? this.handleRunningTransition(streamId)
-      : undefined;
-
-    if (!this.webviewUpdater.isAvailable()) return;
-
-    const isNewStream = !this.state.streamLogs.has(streamId);
-    this.state.streamLogs.ensureStream(streamId);
-    // Persisted streams may be in stream logs but missing from _streamStates.
-    // The first RUNNING transition already created/reset the state above.
-    const streamCategory = runningCategory ?? this.getStreamCategory(streamId);
-    const category = streamCategory ?? AgentCategory.Workflow;
-    if (!isNewRunningTransition) {
-      this.state.getOrCreateStreamState(streamId, category);
-    }
-
-    if (isNewStream) {
-      const previousFilter = this.state.agentCategoryFilter;
-      this.maybeUpdateFilterForCategory(streamCategory);
-      const filterChanged = this.state.agentCategoryFilter !== previousFilter;
-      const matchesFilter =
-        this.state.agentCategoryFilter === 'all' ||
-        this.state.agentCategoryFilter === category;
-      if (!this.state.activeStream && matchesFilter) {
-        this.state.activeStream = streamId;
-      }
-      let activeStream: ActiveStreamId | undefined =
-        !this.state.activeStream || this.state.activeStream === streamId
-          ? this.state.activeStream
-          : undefined;
-      let activeStreamToSync: ActiveStreamId | undefined;
-      if (filterChanged) {
-        const selectableStreams = buildStreamInfos(
-          this.state,
-          this.state.agentCategoryFilter,
-        ).map((stream) => stream.name);
-        const nextActiveStream =
-          selectableStreams.length === 0
-            ? ''
-            : this.state.pickValidActiveStream(selectableStreams);
-        const previousActiveStream = this.state.activeStream;
-        if (nextActiveStream !== previousActiveStream) {
-          this.state.activeStream = nextActiveStream;
-          activeStreamToSync = nextActiveStream;
-          if (
-            previousActiveStream &&
-            previousActiveStream !== nextActiveStream
-          ) {
-            this.state.releasePreviousActive(previousActiveStream);
-          }
-        }
-        activeStream = nextActiveStream;
-      }
-      this.webviewUpdater.updateStreamMetadata(
-        this.state,
-        streamId,
-        this.buildStreamStatesForRefresh(streamId, status, substate),
-        {
-          activeStream,
-          agentFilter: this.state.agentCategoryFilter,
-        },
-      );
-      if (activeStreamToSync !== undefined) {
-        await this.syncFilterDrivenActiveStreamContent(activeStreamToSync);
-      }
-    } else if (isNewRunningTransition) {
-      this.webviewUpdater.updateStreamMetadata(
-        this.state,
-        streamId,
-        this.buildStreamStatesForRefresh(streamId, status, substate),
-      );
-    } else {
-      const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
-      this.webviewUpdater.updateStreamStatus(
-        streamId,
-        status,
-        lastTimestamp,
-        substate,
-      );
-    }
-  }
-
-  private async syncFilterDrivenActiveStreamContent(
-    stream: ActiveStreamId,
-  ): Promise<void> {
-    if (!stream) {
-      if (this.state.activeStream === '') {
-        this.syncStreamContent('');
-      }
-      return;
-    }
-
-    await this.state.streamLogs.ensureLoaded(stream);
-
-    // A newer tab switch may have happened while the released log was loading.
-    if (this.state.activeStream !== stream) return;
-
-    this.syncStreamContent(stream, { includeActiveState: true });
-  }
-
-  private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {
-    const config = this.state.snapshots.getRunConfig(streamId);
-    return pickAgentCategory(config, this.state.getStreamHints(streamId));
-  }
-
-  getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {
-    return this.state.streamStatus.getAllStreamStates();
-  }
-
-  /**
-   * Snapshot the status machine and splice in `streamId`'s about-to-be-applied
-   * status/substate, which hasn't been written to the machine yet when this
-   * is called during `setStreamStatus`. Combined into one map so the phase
-   * and substate views can't diverge on which streams they cover.
-   */
-  private buildStreamStatesForRefresh(
-    streamId: StreamTabId,
-    status: StreamPhase,
-    substate?: StreamSubstate,
-  ): Map<StreamTabId, StreamPhaseState> {
-    const statesForRefresh = this.state.streamStatus.getAllStreamStates();
-    statesForRefresh.set(
-      streamId,
-      substate ? { phase: status, substate } : { phase: status },
-    );
-    return statesForRefresh;
+  getAllStreamStates(): ReturnType<ProgressFactApplier['getAllStreamStates']> {
+    return this.factApplier.getAllStreamStates();
   }
 }

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -1,0 +1,956 @@
+import type { AgentEvent, AgentTrace } from '@agent/trace';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
+import type { SessionFact } from '@agent/runtime/SessionEventHub';
+import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import { isInFlightStatus } from '@common/constants/streamStatus';
+import { createChannelTrace } from '@logger';
+import {
+  STREAM_PHASE,
+  ConversationProgressSchema,
+  UpdatePlanPayloadSchema,
+  UpdateTodosPayloadSchema,
+  type ConversationProgress,
+  type GoalStatus,
+  type StreamPhase,
+  type StreamSubstate,
+  type StreamTabId,
+} from '@shared/schemas';
+import { diffActiveChildren } from '@shared/streams/childActivityReducer';
+import {
+  WebviewUpdater,
+  type LogContentExtras,
+} from '@shared/progressView/backend/WebviewUpdater';
+import { buildStreamInfos } from '@shared/progressView/backend/streamInfoUtils';
+import { pickAgentCategory } from '@shared/progressView/backend/streamTabInfo';
+import { mapToRecord } from '@shared/progressView/backend/persistence/serializationUtils';
+import {
+  ProgressViewState,
+  type ActiveStreamId,
+  type StreamBadgeSnapshot,
+  type StreamExecutionState,
+} from '@shared/progressView/backend/state/ProgressViewState';
+import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import { isObject } from '@utils/core';
+
+import { withEventErrorHandling } from './errorHandling';
+
+/** Throttle interval for conversation progress webview pushes (ms). */
+const PROGRESS_THROTTLE_MS = 500;
+
+export type ProgressEventSubscription = {
+  dispose(): void;
+};
+
+export interface ProgressStreamControls {
+  toolEditBypass: boolean;
+  superYoloBypass: boolean;
+  goalActive: boolean;
+  goalStatus?: GoalStatus;
+  goalObjective?: string;
+}
+
+export type GetProgressStreamControls = (
+  stream: StreamTabId,
+) => ProgressStreamControls;
+
+export const PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES: readonly AgentEvent['type'][] =
+  [
+    'domain',
+    'run.config',
+    'usage',
+    'status',
+    'stage.start',
+    'child.activity',
+    'process.output',
+  ];
+
+function getDefaultProgressStreamControls(): ProgressStreamControls {
+  return {
+    toolEditBypass: false,
+    superYoloBypass: false,
+    goalActive: false,
+  };
+}
+
+/** Applies session and run facts to progress-view state and webview updates. */
+export class ProgressFactApplier {
+  private readonly logger: AgentTrace;
+  private progressThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingProgressUpdates = new Map<StreamTabId, ConversationProgress>();
+
+  constructor(
+    private state: ProgressViewState,
+    private webviewUpdater: WebviewUpdater,
+    private webviewBridge: WebviewBridge,
+    private readonly hasPendingPermissions: (streamId: string) => boolean,
+    private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+  ) {
+    this.logger = createChannelTrace('ProgressFactApplier');
+  }
+
+  private maybeUpdateFilterForCategory(
+    category: AgentCategory | undefined,
+  ): void {
+    if (
+      category &&
+      this.state.agentCategoryFilter !== 'all' &&
+      this.state.agentCategoryFilter !== category
+    ) {
+      this.state.agentCategoryFilter = category;
+    }
+  }
+
+  private handleRunningTransition(
+    streamId: StreamTabId,
+  ): AgentCategory | undefined {
+    const knownCategory = this.getStreamCategory(streamId);
+    const category = knownCategory ?? AgentCategory.Workflow;
+    this.state.clearStreamHints(streamId);
+    this.state.getOrCreateStreamState(streamId, category);
+    this.state.resetFinishedChildCounters(streamId);
+    this.pendingProgressUpdates.delete(streamId);
+    this.state.pruneInterruptHandles();
+
+    if (this.state.activeStream === streamId) {
+      this.maybeUpdateFilterForCategory(knownCategory);
+    }
+    return knownCategory;
+  }
+
+  createLocalSubscription(): ProgressEventSubscription {
+    return {
+      dispose: () => {
+        if (this.progressThrottleTimer) {
+          clearTimeout(this.progressThrottleTimer);
+          this.progressThrottleTimer = null;
+        }
+        this.pendingProgressUpdates.clear();
+        this.webviewBridge.clearAll();
+      },
+    };
+  }
+
+  handleSessionFact(fact: SessionFact): void {
+    switch (fact.type) {
+      case 'goalStateChanged':
+        return;
+      case 'inquiryThreadUpdated':
+        this.applyFact('failed to handle inquiryThreadUpdated fact', () =>
+          this.handleInquiryThreadUpdated(fact.payload),
+        );
+        return;
+      case 'clearMissingOutputs':
+        this.applyFact('failed to handle clearMissingOutputs fact', () =>
+          this.handleClearMissingOutputs(fact.payload),
+        );
+        return;
+      case 'updateQueuedFollowUps':
+        this.applyFact('failed to handle updateQueuedFollowUps fact', () =>
+          this.handleUpdateQueuedFollowUps(fact.payload),
+        );
+        return;
+      case 'followUpSent':
+        return;
+      case 'setActiveStream':
+        this.applyFact('failed to handle setActiveStream fact', () =>
+          this.handleSetActiveStream(fact.payload),
+        );
+        return;
+      case 'updateStreamDescription':
+        this.applyFact('failed to handle updateStreamDescription fact', () =>
+          this.handleUpdateStreamDescription(fact.payload),
+        );
+        return;
+      case 'updateStreamStatus':
+        this.applyFact('failed to handle updateStreamStatus fact', () =>
+          this.setStreamStatus(
+            fact.payload.streamId,
+            fact.payload.status,
+            fact.payload.previousStatus,
+            fact.payload.substate,
+          ),
+        );
+        return;
+      case 'setParentStream':
+        this.applyFact('failed to handle setParentStream fact', () =>
+          this.handleSetParentStream(fact.payload),
+        );
+        return;
+      case 'removeStream':
+        return;
+    }
+  }
+
+  handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
+    if (event.type === 'usage') {
+      const payload = toUpdateStreamUsagePayload(event.data, streamId);
+      if (payload) {
+        this.applyFact('failed to handle usage fact', () =>
+          this.handleUpdateStreamUsage(payload),
+        );
+      }
+      return;
+    }
+
+    if (event.type === 'run.config') {
+      this.applyFact('failed to handle run.config fact', () =>
+        this.handleSetTaskState({
+          streamId: event.streamId,
+          executionId: event.executionId,
+          taskState: agentConfigToTaskState(event.config),
+        }),
+      );
+      return;
+    }
+
+    if (event.type === 'status') {
+      this.applyFact('failed to handle status fact', () =>
+        this.setStreamStatus(
+          event.streamId,
+          event.phase,
+          event.previousPhase,
+          event.substate,
+        ),
+      );
+      return;
+    }
+
+    if (event.type === 'domain') {
+      if (event.key === 'conversationProgress') {
+        const progress = ConversationProgressSchema.safeParse(event.data);
+        if (progress.success) {
+          this.applyFact('failed to handle conversationProgress fact', () =>
+            this.handleUpdateConversationProgress({
+              streamId,
+              progress: progress.data,
+            }),
+          );
+        }
+        return;
+      }
+
+      const factName = fromRunFactDomainKey(event.key);
+      if (factName === 'updateTodos') {
+        const payload = UpdateTodosPayloadSchema.safeParse(event.data);
+        if (payload.success) {
+          this.applyFact('failed to handle updateTodos fact', () =>
+            this.handleUpdateTodos(payload.data),
+          );
+        }
+        return;
+      }
+
+      if (factName === 'updatePlan') {
+        const payload = UpdatePlanPayloadSchema.safeParse(event.data);
+        if (payload.success) {
+          this.applyFact('failed to handle updatePlan fact', () =>
+            this.handleUpdatePlan(payload.data),
+          );
+        }
+        return;
+      }
+
+      if (factName === 'addOutputFiles' && isObject(event.data)) {
+        this.applyFact('failed to handle addOutputFiles fact', () =>
+          this.handleAddOutputFiles(
+            event.data as ProgressEventPayloads['addOutputFiles'],
+          ),
+        );
+        return;
+      }
+
+      if (factName === 'updateMissingOutputs' && isObject(event.data)) {
+        this.applyFact('failed to handle updateMissingOutputs fact', () =>
+          this.handleUpdateMissingOutputs(
+            event.data as ProgressEventPayloads['updateMissingOutputs'],
+          ),
+        );
+        return;
+      }
+
+      if (factName === 'updateCompileFailures' && isObject(event.data)) {
+        this.applyFact('failed to handle updateCompileFailures fact', () =>
+          this.handleUpdateCompileFailures(
+            event.data as ProgressEventPayloads['updateCompileFailures'],
+          ),
+        );
+      }
+      return;
+    }
+
+    if (event.type === 'stage.start') {
+      if (event.kind !== 'round') return;
+      this.applyFact('failed to handle stage.start fact', () =>
+        this.handleUpdateRoundStage({
+          streamId,
+          roundStage: {
+            index: event.index ?? 0,
+            ...(event.total !== undefined && event.total > 0
+              ? { total: event.total }
+              : {}),
+          },
+        }),
+      );
+      return;
+    }
+
+    if (event.type === 'child.activity') {
+      if (event.kind === 'subagents') {
+        this.applyFact('failed to handle subagent activity fact', () =>
+          this.updateActiveChildren(event.parentStreamId, {
+            activeField: 'activeSubagents',
+            countField: 'finishedSubagentCount',
+            next: [...event.children],
+          }),
+        );
+        return;
+      }
+      if (event.kind === 'processes') {
+        this.applyFact('failed to handle process activity fact', () =>
+          this.updateActiveChildren(event.parentStreamId, {
+            activeField: 'activeProcesses',
+            countField: 'finishedProcessCount',
+            next: [...event.processes],
+          }),
+        );
+        return;
+      }
+      return;
+    }
+
+    if (event.type === 'process.output') {
+      this.applyFact('failed to handle process.output fact', () =>
+        this.handleUpdateProcessOutput({
+          parentStreamId: event.parentStreamId,
+          executionId: event.executionId,
+          stdout: event.stdout,
+          stderr: event.stderr,
+        }),
+      );
+      return;
+    }
+  }
+
+  private applyFact(context: string, handle: () => void | Promise<void>): void {
+    withEventErrorHandling('ProgressFacts', context, handle);
+  }
+
+  public handleInquiryThreadUpdated(
+    thread: ProgressEventPayloads['inquiryThreadUpdated'],
+  ): void {
+    if (this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updateInquiryThread(thread);
+    }
+  }
+
+  public handleUpdateStreamDescription({
+    streamId,
+    description,
+  }: ProgressEventPayloads['updateStreamDescription']): void {
+    this.state.snapshots.setDescription(streamId, description);
+    if (this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updateStreamDescription(streamId, description);
+    }
+  }
+
+  public handleSetParentStream({
+    childStreamId,
+    parentStreamId,
+  }: ProgressEventPayloads['setParentStream']): void {
+    this.state.snapshots.setParentStream(childStreamId, parentStreamId);
+    if (this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updateParentStream(
+        childStreamId,
+        parentStreamId ?? undefined,
+      );
+    }
+  }
+
+  public handleUpdateProcessOutput({
+    parentStreamId,
+    executionId,
+    stdout,
+    stderr,
+  }: ProgressEventPayloads['updateProcessOutput']): void {
+    // Always send — output accumulates in frontend state per-stream,
+    // so it must not be dropped when the stream is inactive.
+    if (this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updateProcessOutput(
+        parentStreamId,
+        executionId,
+        stdout,
+        stderr,
+      );
+    }
+  }
+
+  public handleAddOutputFiles({
+    streamId,
+    filesByRound,
+  }: ProgressEventPayloads['addOutputFiles']): void {
+    this.state.snapshots.addOutputFiles(streamId, filesByRound);
+    this.sendIfActive(streamId, () => {
+      const rounds = this.state.snapshots.getOutputFiles(streamId);
+      this.webviewUpdater.updateFiles(streamId, {
+        rounds: Object.keys(rounds).length ? rounds : undefined,
+      });
+    });
+  }
+
+  public handleUpdateMissingOutputs({
+    streamId,
+    filesByRound,
+  }: ProgressEventPayloads['updateMissingOutputs']): void {
+    this.state.snapshots.updateMissingOutputs(streamId, filesByRound);
+    this.sendIfActive(streamId, () => {
+      const rounds = this.state.snapshots.getMissingOutputs(streamId);
+      this.webviewUpdater.updateMissingOutputs(streamId, {
+        rounds: Object.keys(rounds).length ? rounds : undefined,
+      });
+    });
+  }
+
+  public handleUpdateCompileFailures({
+    streamId,
+    filesByRound,
+  }: ProgressEventPayloads['updateCompileFailures']): void {
+    this.state.snapshots.updateCompileFailures(streamId, filesByRound);
+    this.sendIfActive(streamId, () => {
+      const rounds = this.state.snapshots.getCompileFailures(streamId);
+      this.webviewUpdater.updateCompileFailures(streamId, {
+        rounds: Object.keys(rounds).length ? rounds : undefined,
+        reset: true,
+      });
+    });
+  }
+
+  public handleClearMissingOutputs(
+    payload: ProgressEventPayloads['clearMissingOutputs'],
+  ): void {
+    const targets: StreamTabId[] = payload.streamId
+      ? [payload.streamId]
+      : payload.streamConfig
+        ? this.state.snapshots.findWorkflowStreamsMatching(payload.streamConfig)
+        : [];
+    for (const streamId of targets) {
+      this.state.snapshots.clearMissingOutputs(streamId);
+      this.sendIfActive(streamId, () =>
+        this.webviewUpdater.updateMissingOutputs(streamId, {
+          reset: true,
+        }),
+      );
+    }
+  }
+
+  public handleUpdateStreamUsage({
+    streamId,
+    usage,
+    storageKey,
+  }: ProgressEventPayloads['updateStreamUsage']): void {
+    void Promise.resolve(
+      this.state.snapshots.addUsage(streamId, storageKey, usage),
+    ).then((accumulated) => {
+      if (!accumulated) return;
+      this.sendIfActive(streamId, () =>
+        this.webviewUpdater.updateRunUsage(streamId, storageKey, accumulated),
+      );
+    });
+  }
+
+  public handleUpdateTodos({
+    streamId,
+    todos,
+  }: ProgressEventPayloads['updateTodos']): void {
+    this.state.snapshots.setTodos(streamId, todos);
+    this.sendIfActive(streamId, () =>
+      this.webviewUpdater.updateTodos(streamId, todos),
+    );
+  }
+
+  public handleUpdatePlan({
+    streamId,
+    plan,
+  }: ProgressEventPayloads['updatePlan']): void {
+    this.state.snapshots.setPlan(streamId, plan);
+    if (this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updatePlan(streamId, plan);
+    }
+  }
+
+  public handleUpdateQueuedFollowUps({
+    streamId,
+  }: ProgressEventPayloads['updateQueuedFollowUps']): void {
+    this.sendIfActive(streamId, () => {
+      const messages = this.state.followUps.getAll(streamId);
+      this.webviewUpdater.updateQueuedFollowUps(streamId, messages);
+    });
+  }
+
+  /** Send to webview only if streamId is the active stream. */
+  private sendIfActive(streamId: string, send: () => void): void {
+    if (
+      streamId === this.state.activeStream &&
+      this.webviewUpdater.isAvailable()
+    ) {
+      send();
+    }
+  }
+
+  public async handleSetActiveStream(
+    payload: ProgressEventPayloads['setActiveStream'],
+  ): Promise<void> {
+    const { streamId, isRemote } = payload;
+    if (!streamId) return;
+
+    const wasKnownStream = this.state.streamLogs.has(streamId);
+    const previousFilter = this.state.agentCategoryFilter;
+    this.state.streamLogs.ensureStream(streamId);
+    // Only pass defined hint fields — spreading {key: undefined} over existing
+    // hints would clear previously-set values (isRemote).
+    const hints = {
+      ...(payload.agentCategory !== undefined && {
+        agentCategory: payload.agentCategory,
+      }),
+      ...(isRemote !== undefined && { isRemote }),
+    };
+    if (Object.keys(hints).length > 0) {
+      this.state.updateStreamHints(streamId, hints);
+    }
+    // Resolve category: use payload hint, fall back to existing stream state.
+    // Approval flows (proposal, tool-edit, bash) emit without agentCategory;
+    // the stream already exists by then so getStreamCategory() finds it.
+    const agentCategory =
+      payload.agentCategory ?? this.getStreamCategory(streamId);
+    // Ensure stream state exists so it's included in getAllStreamStates()
+    if (agentCategory) {
+      this.state.getOrCreateStreamState(streamId, agentCategory);
+    }
+    // Don't switch away from the current stream if it has pending permissions
+    // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
+    // interact with the approval panel before losing sight of it.
+    // Background child streams (bash, codex) pass `suppressViewSwitch` so the
+    // tab appears without auto-switching the active view.
+    const currentStream = this.state.activeStream;
+    const shouldSwitch =
+      payload.suppressViewSwitch !== true &&
+      (!currentStream || !this.hasPendingPermissions(currentStream));
+    if (shouldSwitch) {
+      // Update the category filter only when actually switching. If we change
+      // the filter while suppressing the switch, sendStreamMetadata →
+      // pickValidActiveStream rebuilds the stream list with the new filter,
+      // which may exclude the current stream and override state.activeStream —
+      // completely bypassing the pending-permissions guard.
+      this.maybeUpdateFilterForCategory(agentCategory);
+      const previous = this.state.activeStream;
+      this.state.activeStream = streamId;
+      // Release the previously-active stream if it reached a terminal
+      // status while visible — setStreamStatus skips release for the
+      // active stream, so this switch is our only chance.
+      if (previous && previous !== streamId) {
+        this.state.releasePreviousActive(previous);
+      }
+    }
+
+    if (!this.webviewUpdater.isAvailable()) return;
+
+    // Rehydrate a potentially-evicted stream before syncing content, so the
+    // webview doesn't get an empty log. All synchronous state mutations are
+    // already done above; the await here only gates webview delivery.
+    await this.state.streamLogs.ensureLoaded(streamId);
+
+    // A newer handleSetActiveStream may have resolved during our await and
+    // already taken over the active tab; skip webview sync so we don't
+    // overwrite its content with stale data.
+    if (shouldSwitch && this.state.activeStream !== streamId) return;
+
+    const filterChanged = this.state.agentCategoryFilter !== previousFilter;
+    if (!wasKnownStream || filterChanged) {
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        this.state.streamStatus.getAllStreamStates(),
+        {
+          activeStream: shouldSwitch ? this.state.activeStream : undefined,
+          agentFilter: filterChanged
+            ? this.state.agentCategoryFilter
+            : undefined,
+        },
+      );
+    } else if (shouldSwitch) {
+      this.webviewUpdater.setActiveStream(streamId);
+    }
+    // Always sync content for the new stream so badges/parent info reaches
+    // the webview — even when we suppress the view switch. includeActiveState
+    // is only relevant when this IS the active stream.
+    this.syncStreamContent(streamId, {
+      includeActiveState: shouldSwitch && wasKnownStream && !filterChanged,
+    });
+  }
+
+  public handleSetTaskState(data: ProgressEventPayloads['setTaskState']): void {
+    const { streamId, executionId, taskState } = data;
+    const isActiveStream = this.state.activeStream === streamId;
+    const category = taskState.agentConfig.agentCategory;
+
+    // Legacy compatibility payload. The snapshot store derives the current
+    // config and run descriptor from this but no longer writes meta.taskState.
+    this.state.snapshots.setTaskState(streamId, taskState, executionId);
+
+    if (isActiveStream) {
+      this.maybeUpdateFilterForCategory(category);
+    }
+
+    if (this.webviewUpdater.isAvailable()) {
+      // setTaskState may change agentConfig (agent name, model, label), which
+      // the frontend tabs display even for background subagents. Patch only
+      // the affected stream instead of rebuilding all historical stream tabs.
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        this.state.streamStatus.getAllStreamStates(),
+        {
+          agentFilter: isActiveStream
+            ? this.state.agentCategoryFilter
+            : undefined,
+        },
+      );
+    }
+  }
+
+  public handleUpdateConversationProgress(
+    data: ProgressEventPayloads['updateConversationProgress'],
+  ): void {
+    const { streamId, progress } = data;
+
+    // Always update state immediately so full metadata rebuilds include
+    // the latest values when structural refreshes happen.
+    this.state.updateStreamState(streamId, (prev) => ({
+      ...prev,
+      conversationProgress: progress,
+    }));
+
+    // Throttle webview pushes: buffer per-stream, flush on timer
+    this.pendingProgressUpdates.set(streamId, progress);
+    if (!this.progressThrottleTimer) {
+      this.progressThrottleTimer = setTimeout(
+        () => this.flushProgressUpdates(),
+        PROGRESS_THROTTLE_MS,
+      );
+    }
+  }
+
+  public handleUpdateRoundStage(
+    data: ProgressEventPayloads['updateRoundStage'],
+  ): void {
+    const { streamId, roundStage } = data;
+    this.state.updateStreamState(streamId, (prev) => ({
+      ...prev,
+      roundStage,
+    }));
+
+    if (
+      this.webviewUpdater.isAvailable() &&
+      this.state.activeStream === streamId
+    ) {
+      this.webviewUpdater.updateRoundStage(streamId, roundStage);
+    }
+  }
+
+  private flushProgressUpdates(): void {
+    this.progressThrottleTimer = null;
+
+    const { activeStream } = this.state;
+    const progress = activeStream
+      ? this.pendingProgressUpdates.get(activeStream)
+      : undefined;
+    if (progress && this.webviewUpdater.isAvailable()) {
+      this.webviewUpdater.updateConversationProgress(activeStream, progress);
+    }
+    this.pendingProgressUpdates.clear();
+  }
+
+  public updateActiveChildren(
+    parentStreamId: StreamTabId,
+    opts: {
+      activeField: 'activeSubagents' | 'activeProcesses';
+      countField: 'finishedSubagentCount' | 'finishedProcessCount';
+      next: StreamExecutionState['activeSubagents'];
+    },
+  ): void {
+    let nextBadges: StreamBadgeSnapshot | null = null;
+
+    this.state.updateStreamState(parentStreamId, (prev) => {
+      const vanishedIds = diffActiveChildren(prev[opts.activeField], opts.next);
+      const updatedState = {
+        ...prev,
+        [opts.activeField]: opts.next,
+        [opts.countField]: (prev[opts.countField] ?? 0) + vanishedIds.size,
+      };
+      nextBadges = this.toBadgeSnapshot(updatedState);
+      return updatedState;
+    });
+
+    if (
+      this.webviewUpdater.isAvailable() &&
+      parentStreamId === this.state.activeStream &&
+      nextBadges
+    ) {
+      this.webviewUpdater.updateStreamBadges(parentStreamId, nextBadges);
+    }
+  }
+
+  private toBadgeSnapshot(state: StreamExecutionState): StreamBadgeSnapshot {
+    return {
+      activeSubagents: state.activeSubagents,
+      finishedSubagentCount: state.finishedSubagentCount,
+      activeProcesses: state.activeProcesses,
+      finishedProcessCount: state.finishedProcessCount,
+    };
+  }
+
+  public markAllRunningTasksAsCancelled(): void {
+    for (const [stream, status] of this.state.streamStatus.entries()) {
+      if (status === STREAM_PHASE.RUNNING) {
+        this.state.streamStatus.transition(
+          stream,
+          STREAM_PHASE.CANCELLED,
+          'restart-repair',
+          { trace: this.logger },
+        );
+      }
+    }
+  }
+
+  public syncStreamContent(
+    stream: ActiveStreamId,
+    options: {
+      /** Include conversation progress, badges, and parent stream in the batch. */
+      includeActiveState?: boolean;
+    } = {},
+  ): void {
+    if (!this.webviewUpdater.isAvailable()) return;
+
+    const { includeActiveState = false } = options;
+
+    if (!stream) {
+      // Clear the stream surface when no stream is active.
+      this.webviewUpdater.sendSyncStreamContent({
+        stream: '',
+        action: 'clear',
+        todos: [],
+        plan: null,
+        queuedFollowUps: [],
+      });
+      return;
+    }
+
+    this.webviewBridge.syncStream(stream);
+
+    const extras = this.buildStreamSyncExtras(stream);
+    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
+    const queuedFollowUps = this.state.followUps.getAll(stream);
+    const agentCategory = this.getStreamCategory(stream);
+
+    // Optionally include active-stream state (replaces syncActiveStreamState).
+    let conversationProgress: ConversationProgress | undefined;
+    let roundStage: StreamExecutionState['roundStage'] | undefined;
+    let badges: StreamBadgeSnapshot | undefined;
+    let parentStreamId: StreamTabId | undefined;
+    if (includeActiveState) {
+      const streamState = this.state.getStreamState(stream);
+      if (streamState) {
+        conversationProgress = streamState.conversationProgress;
+        roundStage = streamState.roundStage;
+        badges = this.toBadgeSnapshot(streamState);
+      }
+      parentStreamId = this.state.snapshots.getParentStreamId(stream);
+    }
+
+    // Always include toggle/goal state so buttons render correctly on tab switch.
+    const streamControls = this.getStreamControls(stream);
+
+    this.webviewUpdater.sendSyncStreamContent({
+      stream,
+      action: 'render',
+      ...extras,
+      todos,
+      plan,
+      queuedFollowUps,
+      agentCategory,
+      conversationProgress,
+      roundStage: includeActiveState ? (roundStage ?? null) : undefined,
+      badges,
+      parentStreamId,
+      ...streamControls,
+    });
+  }
+
+  private buildStreamSyncExtras(stream: StreamTabId): LogContentExtras {
+    return {
+      // Workflow files/missing outputs are flat (one run per tab), already in
+      // the canonical round-indexed record shape the webview consumes.
+      workflowFiles: this.state.snapshots.getOutputFiles(stream),
+      workflowMissingOutputs: this.state.snapshots.getMissingOutputs(stream),
+      workflowCompileFailures: this.state.snapshots.getCompileFailures(stream),
+      // Per-run usage map — shared by workflow and tool-use. Frontend derives
+      // sessionUsage as the sum so cumulative totals survive resume.
+      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
+      contextState: this.state.getContextState(stream),
+    };
+  }
+
+  async setStreamStatus(
+    streamId: StreamTabId,
+    status: StreamPhase,
+    // Kept until Stage 5 removes the legacy bus projection; the status machine
+    // now owns repair writes, so this projection no longer consumes it.
+    _previousStatus?: StreamPhase,
+    substate?: StreamSubstate,
+  ): Promise<void> {
+    // Keep memory bounded by stream status:
+    //  - returning to in-flight (e.g., background resume) eagerly rehydrates
+    //    previously-released entries so pending appends from the agent
+    //    runtime land on the full on-disk log instead of clobbering it via
+    //    an empty getOrCreate.
+    //  - leaving the in-flight set drops heavy entries; disk stays
+    //    authoritative and `setActiveStream` re-reads on demand.
+    if (isInFlightStatus(status)) {
+      void this.state.streamLogs.ensureLoaded(streamId);
+    } else if (streamId !== this.state.activeStream) {
+      this.state.streamLogs.releaseEntries(streamId);
+    }
+
+    const isNewRunningTransition =
+      status === STREAM_PHASE.RUNNING && _previousStatus !== status;
+    const runningCategory = isNewRunningTransition
+      ? this.handleRunningTransition(streamId)
+      : undefined;
+
+    if (!this.webviewUpdater.isAvailable()) return;
+
+    const isNewStream = !this.state.streamLogs.has(streamId);
+    this.state.streamLogs.ensureStream(streamId);
+    // Persisted streams may be in stream logs but missing from _streamStates.
+    // The first RUNNING transition already created/reset the state above.
+    const streamCategory = runningCategory ?? this.getStreamCategory(streamId);
+    const category = streamCategory ?? AgentCategory.Workflow;
+    if (!isNewRunningTransition) {
+      this.state.getOrCreateStreamState(streamId, category);
+    }
+
+    if (isNewStream) {
+      const previousFilter = this.state.agentCategoryFilter;
+      this.maybeUpdateFilterForCategory(streamCategory);
+      const filterChanged = this.state.agentCategoryFilter !== previousFilter;
+      const matchesFilter =
+        this.state.agentCategoryFilter === 'all' ||
+        this.state.agentCategoryFilter === category;
+      if (!this.state.activeStream && matchesFilter) {
+        this.state.activeStream = streamId;
+      }
+      let activeStream: ActiveStreamId | undefined =
+        !this.state.activeStream || this.state.activeStream === streamId
+          ? this.state.activeStream
+          : undefined;
+      let activeStreamToSync: ActiveStreamId | undefined;
+      if (filterChanged) {
+        const selectableStreams = buildStreamInfos(
+          this.state,
+          this.state.agentCategoryFilter,
+        ).map((stream) => stream.name);
+        const nextActiveStream =
+          selectableStreams.length === 0
+            ? ''
+            : this.state.pickValidActiveStream(selectableStreams);
+        const previousActiveStream = this.state.activeStream;
+        if (nextActiveStream !== previousActiveStream) {
+          this.state.activeStream = nextActiveStream;
+          activeStreamToSync = nextActiveStream;
+          if (
+            previousActiveStream &&
+            previousActiveStream !== nextActiveStream
+          ) {
+            this.state.releasePreviousActive(previousActiveStream);
+          }
+        }
+        activeStream = nextActiveStream;
+      }
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        this.buildStreamStatesForRefresh(streamId, status, substate),
+        {
+          activeStream,
+          agentFilter: this.state.agentCategoryFilter,
+        },
+      );
+      if (activeStreamToSync !== undefined) {
+        await this.syncFilterDrivenActiveStreamContent(activeStreamToSync);
+      }
+    } else if (isNewRunningTransition) {
+      this.webviewUpdater.updateStreamMetadata(
+        this.state,
+        streamId,
+        this.buildStreamStatesForRefresh(streamId, status, substate),
+      );
+    } else {
+      const lastTimestamp = this.state.streamLogs.getLastTimestamp(streamId);
+      this.webviewUpdater.updateStreamStatus(
+        streamId,
+        status,
+        lastTimestamp,
+        substate,
+      );
+    }
+  }
+
+  private async syncFilterDrivenActiveStreamContent(
+    stream: ActiveStreamId,
+  ): Promise<void> {
+    if (!stream) {
+      if (this.state.activeStream === '') {
+        this.syncStreamContent('');
+      }
+      return;
+    }
+
+    await this.state.streamLogs.ensureLoaded(stream);
+
+    // A newer tab switch may have happened while the released log was loading.
+    if (this.state.activeStream !== stream) return;
+
+    this.syncStreamContent(stream, { includeActiveState: true });
+  }
+
+  private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {
+    const config = this.state.snapshots.getRunConfig(streamId);
+    return pickAgentCategory(config, this.state.getStreamHints(streamId));
+  }
+
+  getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {
+    return this.state.streamStatus.getAllStreamStates();
+  }
+
+  /**
+   * Snapshot the status machine and splice in `streamId`'s about-to-be-applied
+   * status/substate, which hasn't been written to the machine yet when this
+   * is called during `setStreamStatus`. Combined into one map so the phase
+   * and substate views can't diverge on which streams they cover.
+   */
+  private buildStreamStatesForRefresh(
+    streamId: StreamTabId,
+    status: StreamPhase,
+    substate?: StreamSubstate,
+  ): Map<StreamTabId, StreamPhaseState> {
+    const statesForRefresh = this.state.streamStatus.getAllStreamStates();
+    statesForRefresh.set(
+      streamId,
+      substate ? { phase: status, substate } : { phase: status },
+    );
+    return statesForRefresh;
+  }
+}

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -194,7 +194,7 @@ export class ProgressViewState {
 
   /**
    * Release a previously-active stream's entries if its status is not
-   * in-flight. `ProgressEventHandler.setStreamStatus` intentionally skips
+   * in-flight. `ProgressFactApplier.setStreamStatus` intentionally skips
    * eviction for the active tab, so every active-stream switch path must
    * call this on the stream being moved away from to close the loop.
    */

--- a/src/shared/progressView/backend/streamTabInfo.ts
+++ b/src/shared/progressView/backend/streamTabInfo.ts
@@ -32,7 +32,7 @@ export interface StreamTabInfoInputs {
 /**
  * Single owner of the two-source `config`/`hints` agentCategory lookup shared
  * by `buildStreamTabInfo`, `buildStreamInfo` (streamInfoUtils.ts), and
- * `getStreamCategory` (ProgressEventHandler.ts). Live `config` wins over the
+ * `getStreamCategory` (ProgressFactApplier.ts). Live `config` wins over the
  * fallback `hints`. Deliberately undefined-preserving (no default baked in)
  * — `getStreamCategory` needs that variant; callers that want a concrete
  * category layer `?? AgentCategory.Workflow` on top.

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -236,7 +236,7 @@ describe('ProgressBackend', () => {
 
     backend.webviewUpdater.sendStreamMetadata(
       backend.state,
-      backend.eventHandler.getAllStreamStates(),
+      backend.factApplier.getAllStreamStates(),
     );
 
     expect(
@@ -346,7 +346,7 @@ describe('ProgressBackend', () => {
 
       backend.webviewUpdater.sendStreamMetadata(
         backend.state,
-        backend.eventHandler.getAllStreamStates(),
+        backend.factApplier.getAllStreamStates(),
       );
       const fullSync = messages.find(
         (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
@@ -720,7 +720,7 @@ describe('ProgressBackend', () => {
   it('applies session run facts through the fact-native handler', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();
-    const handleRunFact = vi.spyOn(backend.eventHandler, 'handleRunFact');
+    const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const handleProgressEvent = vi.spyOn(
       backend.eventHandler,
       'handleProgressEvent',
@@ -991,7 +991,7 @@ describe('ProgressBackend', () => {
   it('no-ops session output-file run facts after dispose', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const subscription = backend.setupEventListeners();
-    const handleRunFact = vi.spyOn(backend.eventHandler, 'handleRunFact');
+    const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const handleProgressEvent = vi.spyOn(
       backend.eventHandler,
       'handleProgressEvent',
@@ -1225,8 +1225,8 @@ describe('ProgressBackend', () => {
         inquiryThread,
       );
 
-      expect(direct.backend.eventHandler.getAllStreamStates()).toEqual(
-        legacyEquivalent.backend.eventHandler.getAllStreamStates(),
+      expect(direct.backend.factApplier.getAllStreamStates()).toEqual(
+        legacyEquivalent.backend.factApplier.getAllStreamStates(),
       );
       expect(
         direct.backend.state.snapshots.getMissingOutputs(parentStreamId),
@@ -1263,7 +1263,7 @@ describe('ProgressBackend', () => {
       backend.state.activeStream = 'tool-stream';
       backend.state.agentCategoryFilter = 'toolUse';
 
-      await backend.eventHandler.setStreamStatus(
+      await backend.factApplier.setStreamStatus(
         'unknown-stream',
         STREAM_PHASE.RUNNING,
       );
@@ -1312,7 +1312,7 @@ describe('ProgressBackend', () => {
         finishedProcessCount: 2,
       }));
 
-      await backend.eventHandler.setStreamStatus(
+      await backend.factApplier.setStreamStatus(
         stream,
         STREAM_PHASE.RUNNING,
         STREAM_PHASE.COMPLETED,
@@ -1375,7 +1375,7 @@ describe('ProgressBackend', () => {
         progress: { toolCallCount: 7 },
       });
 
-      await backend.eventHandler.setStreamStatus(
+      await backend.factApplier.setStreamStatus(
         stream,
         STREAM_PHASE.RUNNING,
         STREAM_PHASE.COMPLETED,
@@ -1439,7 +1439,7 @@ describe('ProgressBackend', () => {
         'workflow-existing',
       );
 
-      await backend.eventHandler.setStreamStatus(
+      await backend.factApplier.setStreamStatus(
         'workflow-stream',
         STREAM_PHASE.RUNNING,
       );
@@ -1477,7 +1477,7 @@ describe('ProgressBackend', () => {
     // Regression test for the config/hints agentCategory single-owner fix:
     // buildStreamInfos (matchesFilter + buildStreamTabInfo, streamInfoUtils.ts
     // / streamTabInfo.ts) and syncStreamContent (getStreamCategory,
-    // ProgressEventHandler.ts) must resolve the same category from the same
+    // ProgressFactApplier.ts) must resolve the same category from the same
     // config/hints inputs, even when hints deliberately disagree with the
     // live config.
     const { backend, messages } = createRecordingBackend();
@@ -1505,7 +1505,7 @@ describe('ProgressBackend', () => {
       const workflowInfos = buildStreamInfos(backend.state, 'workflow');
       expect(workflowInfos.map((info) => info.name)).not.toContain(stream);
 
-      backend.eventHandler.syncStreamContent(stream);
+      backend.factApplier.syncStreamContent(stream);
       const sync = messages.find(
         (message) =>
           message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -15,7 +15,7 @@ import type {
   TodoItem,
   TokenUsageStats,
 } from '@shared/schemas';
-import { ProgressEventHandler } from '@shared/progressView/backend/events/ProgressEventHandler';
+import { ProgressFactApplier } from '@shared/progressView/backend/events/ProgressFactApplier';
 import type { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import type { MementoStorage } from '@shared/progressView/backend/persistence/PersistentMapManager';
 import { ProgressViewState } from '@shared/progressView/backend/state/ProgressViewState';
@@ -121,11 +121,10 @@ describe('progress view snapshot hydration', () => {
   it('syncs the durable display snapshot from the shared progress-view backend', async () => {
     const state = await createLoadedState();
     const { messages, updater, bridge } = createSyncCapture();
-    const handler = new ProgressEventHandler(
+    const handler = new ProgressFactApplier(
       state,
       updater,
       bridge,
-      {} as never,
       () => false,
     );
 
@@ -189,11 +188,10 @@ describe('progress view snapshot hydration', () => {
     const state = await createLoadedState();
     const { messages, updater, bridge } = createSyncCapture();
     const controlledStream = 'stream:controls' as StreamTabId;
-    const handler = new ProgressEventHandler(
+    const handler = new ProgressFactApplier(
       state,
       updater,
       bridge,
-      {} as never,
       () => false,
       (streamId) => {
         expect(streamId).toBe(controlledStream);

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -69,7 +69,7 @@ describe('buildStreamTabInfo', () => {
 // pickAgentCategory — single owner of the config/hints agentCategory
 // precedence (issue #7583). Regression coverage for the desync scenario:
 // `matchesFilter`/`buildStreamInfo` (streamInfoUtils.ts), `buildStreamTabInfo`
-// (streamTabInfo.ts), and `getStreamCategory` (ProgressEventHandler.ts) must
+// (streamTabInfo.ts), and `getStreamCategory` (ProgressFactApplier.ts) must
 // all resolve the same category for the same config/hints inputs.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary
- Split `ProgressFactApplier` out of the legacy `ProgressEventHandler` adapter.
- Route session/run facts and direct progress-view state projection through `ProgressBackend.factApplier`.
- Keep `ProgressEventHandler.handleProgressEvent` as the host-progress compatibility adapter for the remaining legacy rail.

## Validation
- `npm run format`
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test -- --run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts`
- `npm test` (607 files passed, 1 skipped; 5243 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f4a04e6e3dbac826e615a648ce8640cd9a09724a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->