### PR TITLE
refactor: emit host activations as session facts

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -255,6 +255,7 @@ export class DesktopProgressBridge {
     this.detachHostInteractions = this.session.useHostInteractions(
       createDesktopHostInteractions({
         runtimeHost: this.runtimeHost,
+        session: this.session,
         getApprovalHandlers: () => this.approvalHandlers,
         getToolEditApprovals: () => this.toolEditApprovals,
       }),

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   matchesCancelSelector,
   type HostBashApprovalRequest,
@@ -20,6 +21,7 @@ import {
   toProposalResult,
   toUserQuestionResult,
 } from '@agent/runtime/hostInteractionResultMappers';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
 import type {
@@ -53,6 +55,7 @@ type PendingDesktopInteraction =
 
 export interface DesktopHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
+  session?: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
   getToolEditApprovals(): DesktopToolEditApprovalController;
 }
@@ -235,7 +238,8 @@ class DesktopHostInteractions implements HostInteractions {
 
   private activateStream(streamId: StreamTabId | undefined): void {
     this.options.runtimeHost.emit('requestEnsureProgressView', {});
-    if (streamId)
-      this.options.runtimeHost.emit('setActiveStream', { streamId });
+    if (streamId) {
+      emitRuntimeEvent('setActiveStream', { streamId }, this.options.session);
+    }
   }
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -173,6 +173,7 @@ export class ProgressViewProvider
     this.detachHostInteractions = defaultSession().useHostInteractions(
       createExtensionHostInteractions({
         runtimeHost: extensionAgentRuntimeHost,
+        session: defaultSession(),
         getApprovalHandlers: () => this.approvalHandlers,
       }),
     );

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   matchesCancelSelector,
   type HostBashApprovalRequest,
@@ -23,6 +24,7 @@ import {
   toRetryResult,
   toUserQuestionResult,
 } from '@agent/runtime/hostInteractionResultMappers';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
@@ -33,6 +35,7 @@ import type {
 
 export interface ExtensionHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
+  session?: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
 }
 
@@ -68,7 +71,7 @@ export function createExtensionHostInteractions(
   const activateStream = (streamId?: StreamTabId | null) => {
     options.runtimeHost.emit('requestEnsureProgressView', {});
     if (streamId) {
-      options.runtimeHost.emit('setActiveStream', { streamId });
+      emitRuntimeEvent('setActiveStream', { streamId }, options.session);
     }
   };
 

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
 import type { HostInteractionResolution } from '@agent/runtime/HostInteractions';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
@@ -34,6 +36,7 @@ interface DesktopHostInteractions {
 interface DesktopHostInteractionsModule {
   createDesktopHostInteractions(options: {
     runtimeHost: { emit: (event: string, payload: unknown) => void };
+    session?: SessionHandle;
     getApprovalHandlers(): unknown;
     getToolEditApprovals(): unknown;
   }): DesktopHostInteractions;
@@ -73,21 +76,31 @@ async function createInteractions(handlers = createHandlers()) {
   const { createDesktopHostInteractions } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopHostInteractions.ts'))
   )) as DesktopHostInteractionsModule;
+  const runtimeHost = { emit: vi.fn() };
+  const session = new SessionHandle();
+  const sessionEvents: SessionEvent[] = [];
+  session.events.subscribe((event) => sessionEvents.push(event), {
+    scope: 'session',
+  });
 
   return {
     interactions: createDesktopHostInteractions({
-      runtimeHost: { emit: vi.fn() },
+      runtimeHost,
+      session,
       getApprovalHandlers: () => handlers,
       getToolEditApprovals: () => ({}),
     }),
     handlers,
+    runtimeHost,
+    sessionEvents,
   };
 }
 
 describe('createDesktopHostInteractions', () => {
   it('rejects a resolution whose kind does not match the pending request', async () => {
     const handlers = createHandlers();
-    const { interactions } = await createInteractions(handlers);
+    const { interactions, runtimeHost, sessionEvents } =
+      await createInteractions(handlers);
 
     const resultPromise = interactions.requestBashApproval({
       command: 'echo hi',
@@ -106,6 +119,18 @@ describe('createDesktopHostInteractions', () => {
       interactions.resolve(requestId, { kind: 'bash', action: 'approve' }),
     ).toBe(true);
     await expect(resultPromise).resolves.toEqual({ accepted: true });
+    expect(runtimeHost.emit).toHaveBeenCalledWith(
+      'requestEnsureProgressView',
+      {},
+    );
+    expect(runtimeHost.emit).not.toHaveBeenCalledWith(
+      'setActiveStream',
+      expect.anything(),
+    );
+    expect(sessionEvents).toContainEqual({
+      scope: 'session',
+      event: { type: 'setActiveStream', payload: { streamId: 'stream-a' } },
+    });
   });
 
   it('forwards a cancellation cause as bash reject feedback', async () => {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
 import type { StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@shared/progressView/backend/progressBackendUiConfig';
@@ -66,20 +68,33 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
 function createInteractions(options?: {
   runtimeHost?: ReturnType<typeof createRuntimeHost>;
   handlers?: ApprovalRequestHandlerSet;
+  session?: SessionHandle;
 }) {
   return createExtensionHostInteractions({
     runtimeHost: options?.runtimeHost ?? createRuntimeHost(),
+    session: options?.session,
     getApprovalHandlers: () => options?.handlers ?? createHandlers(),
   });
+}
+
+function recordSessionEvents(session: SessionHandle): SessionEvent[] {
+  const events: SessionEvent[] = [];
+  session.events.subscribe((event) => events.push(event), {
+    scope: 'session',
+  });
+  return events;
 }
 
 describe('createExtensionHostInteractions', () => {
   it('shows and resolves plan approvals through existing handlers', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
+    const session = new SessionHandle();
+    const sessionEvents = recordSessionEvents(session);
     const interactions = createInteractions({
       runtimeHost,
       handlers,
+      session,
     });
 
     const resultPromise = interactions.requestPlanApproval?.({
@@ -94,8 +109,13 @@ describe('createExtensionHostInteractions', () => {
       'requestEnsureProgressView',
       {},
     );
-    expect(runtimeHost.emit).toHaveBeenCalledWith('setActiveStream', {
-      streamId: 'stream-a',
+    expect(runtimeHost.emit).not.toHaveBeenCalledWith(
+      'setActiveStream',
+      expect.anything(),
+    );
+    expect(sessionEvents).toContainEqual({
+      scope: 'session',
+      event: { type: 'setActiveStream', payload: { streamId: 'stream-a' } },
     });
     expect(handlers.planApproval.show).toHaveBeenCalledWith({
       approvalId: 'plan-a',


### PR DESCRIPTION
Part of #6968 and #6951. Follows #7604.

## Summary
- Route extension and desktop host-interaction stream activation through session facts instead of the legacy host-progress `setActiveStream` event.
- Keep `requestEnsureProgressView` on the runtime host as a presentation event.
- Thread the owning `SessionHandle` into extension and desktop host-interactions composition roots.
- Update host-interaction tests to assert session-fact activation and absence of legacy `setActiveStream` host emissions.

## Validation
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test -- --run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts` (4 files passed, 103 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the progress UI learns which stream is active during approvals; behavior should be equivalent but depends on session-fact consumers handling `setActiveStream` correctly.
> 
> **Overview**
> When desktop and VS Code host interactions need to focus a stream (approvals, questions, etc.), **stream activation no longer goes through the legacy progress host `setActiveStream` emit**. It now uses **`emitRuntimeEvent('setActiveStream', …, session)`**, so activation is recorded as a **session fact** on the owning `SessionHandle`.
> 
> **`requestEnsureProgressView`** is unchanged and still uses **`runtimeHost.emit`** as a presentation signal. Composition roots pass **`session`** into `createDesktopHostInteractions` / `createExtensionHostInteractions` (desktop bridge and extension `ProgressViewProvider`).
> 
> Tests assert **`requestEnsureProgressView`** on the mock host, **no** `setActiveStream` on `runtimeHost.emit`, and a **session-scoped** `setActiveStream` event when a `streamId` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0fb905fae67a7446dd1e4f65a22a01dd0fd4e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->