### PR TITLE
chore: remove dead exports flagged by knip (batch: tools)

### DIFF
--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -3,7 +3,6 @@
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import {
   ClaudeAgentEffortSchema,
-  ClaudeAgentModelSchema,
   ClaudeAgentPermissionModeSchema,
 } from '@shared/schemas/agentCliSettings';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -48,14 +47,6 @@ export type ClaudeAgentPermissionMode =
  * adaptively how much thinking to do, scaled by this hint. Derived from
  * `ClaudeAgentEffortSchema` (the single source of truth in `@shared`). */
 export const CLAUDE_AGENT_EFFORT_LEVELS = ClaudeAgentEffortSchema.options;
-
-/** Canonical Claude model IDs surfaced by the settings dropdown.
- * The SDK accepts arbitrary model strings; this list is what we expose in the
- * UI. Derived from `ClaudeAgentModelSchema` (the single source of truth in
- * `@shared`). Sonnet, Fable, and Opus use the alias form; Haiku 4.5 ships with
- * a dated snapshot suffix (its only published identifier at time of writing). */
-export const CLAUDE_AGENT_MODELS = ClaudeAgentModelSchema.options;
-export type ClaudeAgentModel = (typeof CLAUDE_AGENT_MODELS)[number];
 
 /**
  * Adaptive thinking is only supported on Fable 5, Opus 4.6+, and Sonnet 4.6+

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -43,11 +43,6 @@ export type CodexCommandToolLogOptions = Pick<
   CommandExecutionItem,
   'command' | 'aggregated_output' | 'exit_code' | 'status'
 >;
-export type CodexTodoItem = TodoListItem['items'][number];
-export type CodexMcpContentBlock = NonNullable<
-  NonNullable<McpToolCallItem['result']>['content']
->[number];
-
 /** Normalize Codex command execution events for the native bash tool card. */
 export function buildCodexCommandToolLog(
   options: CodexCommandToolLogOptions,

--- a/src/tools/github/index.ts
+++ b/src/tools/github/index.ts
@@ -2,7 +2,6 @@ export { GitHubSubscriptionTool } from './githubSubscriptionTool';
 export { SharedPRPollingSource } from './PRPollingSource';
 export { SharedRepoPollingSource } from './RepoPollingSource';
 export { SharedIssuePollingSource } from './IssuePollingSource';
-export type { RepoKey } from './RepoPollingSource';
 export {
   listIssueSubscriptionBindings,
   listPRSubscriptionBindings,
@@ -11,4 +10,3 @@ export {
   unbindAllForPR,
   unbindAllForRepo,
 } from './subscriptionBindings';
-export type { Disposable } from '@platform/interfaces';

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -49,7 +49,7 @@ export const GhReviewCommentSchema = z.looseObject({
 });
 export type GhReviewComment = z.infer<typeof GhReviewCommentSchema>;
 
-export const GhReviewSchema = z.looseObject({
+const GhReviewSchema = z.looseObject({
   id: z.number(),
   body: z.string().nullable(),
   // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING — kept a
@@ -61,15 +61,14 @@ export const GhReviewSchema = z.looseObject({
 });
 export type GhReview = z.infer<typeof GhReviewSchema>;
 
-export const GhCheckRunOutputSchema = z.looseObject({
+const GhCheckRunOutputSchema = z.looseObject({
   title: z.string().nullish(),
   summary: z.string().nullish(),
   /** Treat undefined / null / 0 as "no annotations to fetch". */
   annotations_count: z.number().nullish(),
 });
-export type GhCheckRunOutput = z.infer<typeof GhCheckRunOutputSchema>;
 
-export const GhCheckRunSchema = z.looseObject({
+const GhCheckRunSchema = z.looseObject({
   id: z.number(),
   name: z.string(),
   status: z.string(), // queued, in_progress, completed

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -16,7 +16,7 @@ type ArxivEntry = Awaited<ReturnType<typeof arxivClient.execute>>[number];
 /**
  * Schema for base arXiv paper metadata shared between search and metadata tools.
  */
-export const ArxivPaperBaseSchema = z.object({
+const ArxivPaperBaseSchema = z.object({
   id: z.string().nullable(),
   doi: z.string().nullable(),
   title: z.string(),
@@ -33,7 +33,7 @@ export type ArxivPaperBase = z.infer<typeof ArxivPaperBaseSchema>;
  * Schema for arXiv paper metadata returned by search results.
  * Extends ArxivPaperBaseSchema with search-specific fields.
  */
-export const ArxivSearchResultSchema = ArxivPaperBaseSchema.extend({
+const ArxivSearchResultSchema = ArxivPaperBaseSchema.extend({
   abstract: z.string().nullable(),
   arxivUrl: z.string().nullable(),
 });
@@ -45,7 +45,7 @@ export type ArxivSearchResult = z.infer<typeof ArxivSearchResultSchema>;
  * Schema for detailed arXiv paper metadata with additional fields.
  * Extends ArxivPaperBaseSchema with metadata-specific fields.
  */
-export const ArxivPaperMetadataSchema = ArxivPaperBaseSchema.extend({
+const ArxivPaperMetadataSchema = ArxivPaperBaseSchema.extend({
   abstract: z.string().nullish(),
   journalReference: z.string().nullable(),
   comment: z.string().nullable(),

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -8,11 +8,7 @@
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
 
-import type {
-  TerminalRunRequest,
-  TerminalRunResult,
-  TerminalRunner,
-} from '@hosts/uiHosts';
+import type { TerminalRunResult, TerminalRunner } from '@hosts/uiHosts';
 import type { ApiProvider } from '@model/apiProviders';
 
 /** Per-provider API key surface. */
@@ -92,7 +88,7 @@ export interface SetupConfigAdapter {
  * actionable.
  */
 export type SetupTerminalAdapter = TerminalRunner;
-export type { TerminalRunRequest, TerminalRunResult };
+export type { TerminalRunResult };
 
 /** Aggregated setup platform. */
 export interface SetupPlatform {


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep (`src/tools/` batch). Every item was independently verified (adversarial verification pass + orchestrator spot-checks) to have zero real usage outside its own file, then re-checked here against current `main` before touching.

**De-exported** (schema kept — still needed internally to derive its `z.infer` type or as a base for `.extend()` — only the `export` keyword was dropped since nothing outside the file calls `.parse()`/`.safeParse()` on the schema value):
- `ArxivPaperBaseSchema`, `ArxivSearchResultSchema`, `ArxivPaperMetadataSchema` — `src/tools/latex/arxivShared.ts`
- `GhReviewSchema`, `GhCheckRunOutputSchema`, `GhCheckRunSchema` — `src/tools/github/prTypes.ts`

**Fully deleted** (zero references anywhere, including internally within their own file):
- `GhCheckRunOutput` type — `src/tools/github/prTypes.ts` (not even referenced via `GhCheckRun['output']` elsewhere)
- `CLAUDE_AGENT_MODELS` const + `ClaudeAgentModel` type — `src/tools/claudeAgentShared.ts` (a dead duplicate/shadow of the real SSOT in `@shared/schemas/agentCliSettings`; removed the now-unused `ClaudeAgentModelSchema` import alongside it)
- `TerminalRunRequest` — `src/tools/setup/platform.ts` (dead barrel re-export of the type defined in `@hosts/uiHosts`; both real consumers already import it directly from there. `TerminalRunResult` on the same line was left alone — it's still consumed through this barrel by test fixtures)
- `CodexTodoItem`, `CodexMcpContentBlock` types — `src/tools/codexShared.ts`
- `RepoKey`, `Disposable` barrel re-exports — `src/tools/github/index.ts` (both real consumers import the underlying types directly, bypassing the barrel)

No items were skipped — all 13 held up against a fresh grep of current `main`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` clean
- [x] `npx eslint` + `npx prettier --check` on all touched files — clean
- [x] `npx vitest run src/test-kernel/tools/` — 446/448 passing; the 2 failures (`LeanTools.vitest.ts` parallel-mutex timing, `SubagentExecutionChildStreamId.vitest.ts` timeout) are unrelated to any touched file and pass individually in isolation (pre-existing flakiness under full-suite parallel load)
- [x] `npx vitest run src/test-kernel/tools/setup/` — 44/44 passing
- [x] `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` — none of the fixed items still appear; remaining flags in touched files are pre-existing and out of this batch's scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only cleanup with no logic changes; risk is limited to any external importers of removed symbols, which the PR verified are absent.
> 
> **Overview**
> This PR trims **unused public surface** in `src/tools/` as part of a knip dead-export sweep. There is **no runtime or API behavior change** for callers that already import from the right modules.
> 
> **Removed entirely:** `CLAUDE_AGENT_MODELS` / `ClaudeAgentModel` from `claudeAgentShared.ts` (settings still use `@shared/schemas/agentCliSettings`); `CodexTodoItem` and `CodexMcpContentBlock` from `codexShared.ts`; `GhCheckRunOutput` from `prTypes.ts`; barrel re-exports `RepoKey`, `Disposable` from `github/index.ts`; and `TerminalRunRequest` from `setup/platform.ts` (consumers use `@hosts/uiHosts` directly).
> 
> **Made module-private:** several Zod schemas that only exist to derive exported types—arXiv paper schemas in `arxivShared.ts` and `GhReview` / check-run schemas in `prTypes.ts`—by dropping `export` on the schema constants while keeping the inferred types exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9f966b1f05f277167415ef081bbe8766245f90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->