### PR TITLE
chore: remove dead exports flagged by knip (batch: desktop)

### DIFF
--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -41,10 +41,6 @@ export const DesktopCloseDiffMessageSchema = z.object({
   command: z.literal(DESKTOP_DIFF_COMMANDS.CLOSE_DIFF),
 });
 
-export type DesktopCloseDiffMessage = z.infer<
-  typeof DesktopCloseDiffMessageSchema
->;
-
 export function buildDesktopShowDiffMessage(
   payload: Omit<DesktopShowDiffMessage, 'command'>,
 ): DesktopShowDiffMessage {

--- a/packages/desktop/src/desktopPdfMessages.ts
+++ b/packages/desktop/src/desktopPdfMessages.ts
@@ -42,10 +42,6 @@ export const DesktopClosePdfMessageSchema = z.object({
   command: z.literal(DESKTOP_PDF_COMMANDS.CLOSE_PDF),
 });
 
-export type DesktopClosePdfMessage = z.infer<
-  typeof DesktopClosePdfMessageSchema
->;
-
 export function buildDesktopShowPdfMessage(
   payload: Omit<DesktopShowPdfMessage, 'command'>,
 ): DesktopShowPdfMessage {

--- a/packages/desktop/src/desktopShellMessages.ts
+++ b/packages/desktop/src/desktopShellMessages.ts
@@ -16,7 +16,3 @@ export const DesktopSetRouteMessageSchema = z.object({
   command: z.literal(DESKTOP_SHELL_COMMANDS.SET_ROUTE),
   route: DesktopRouteSchema,
 });
-
-export type DesktopSetRouteMessage = z.infer<
-  typeof DesktopSetRouteMessageSchema
->;

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -5,7 +5,6 @@ import { app } from 'electron';
 
 import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
 import { getWorkspacePathInput } from '@desktop/workspacePath.js';
-export { hasWorkspacePath } from '@desktop/workspacePath.js';
 
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Batch: `desktop`. Every item was independently verified in two prior passes (adversarial verification agent + orchestrator spot-checks); this PR re-verified each with a fresh grep immediately before touching it.

## Items touched

| Name | File | Action |
|---|---|---|
| `DesktopSetRouteMessage` | `packages/desktop/src/desktopShellMessages.ts` | **Deleted** — unused `z.infer` type alias. The schema (`DesktopSetRouteMessageSchema`) stays exported and is still `.safeParse()`'d in `renderer/main.ts`. |
| `DesktopCloseDiffMessage` | `packages/desktop/src/desktopDiffMessages.ts` | **Deleted** — unused `z.infer` type alias. The schema (`DesktopCloseDiffMessageSchema`) stays exported and is still used externally. |
| `DesktopClosePdfMessage` | `packages/desktop/src/desktopPdfMessages.ts` | **Deleted** — unused `z.infer` type alias. The schema (`DesktopClosePdfMessageSchema`) stays exported and is still used externally. |
| `hasWorkspacePath` (re-export) | `packages/desktop/src/main/platform/paths.ts` | **Deleted** — dropped the pass-through `export { hasWorkspacePath } from '@desktop/workspacePath.js'` line. The real function and its only consumer (`src/test-kernel/desktop/desktopWorkspacePath.vitest.ts`) both go through `@desktop/workspacePath` directly, not through this re-export. |

## Skipped

- **`toElectronAccelerator` (re-export)**, `packages/desktop/src/desktopCommandSurface.ts` — the item's own evidence flagged it as a corrected false positive (superseded by discovery that `src/test-kernel/desktop/DesktopCommandSurface.vitest.mts` dynamic-imports it through this path). I re-verified independently: the re-export is consumed by that test file, and the underlying function is also called directly in the same file (`desktopCommandSurface.ts:241`). No change made.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `packages/desktop` package typecheck (`tsc -p tsconfig.json / tsconfig.main.json / tsconfig.preload.json / tsconfig.renderer.json`) — clean except one pre-existing, unrelated error in `desktopAgentExecution.ts` (`StreamStatusEmitOptions` / `runtimeHost`) that predates this change and touches none of the files in this PR
- `npx eslint` + `npx prettier --check` on all touched files — clean
- Targeted vitest: `DesktopPdfMessages.vitest.mts`, `DesktopDiffMessages.vitest.mts`, `desktopWorkspacePath.vitest.ts`, `DesktopCommandSurface.vitest.mts`, `DesktopAgentExecution.vitest.mts` — all passing (39 + 63 tests)
- `npx knip --include files,exports,types,duplicates` — the four fixed items no longer appear; `toElectronAccelerator` still appears (expected, confirms it's a real consumer knip's static analysis can't see through the dynamic import, matching the skip rationale above)

## Test plan

- [x] CI green on this branch
- [x] No functional behavior change — visibility/dead-code narrowing only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only dead code removal with no logic or API surface changes beyond narrowed public exports.
> 
> **Overview**
> Knip dead-export cleanup in `packages/desktop` with **no runtime or IPC behavior change**.
> 
> Removes three unused `z.infer` type aliases—`DesktopCloseDiffMessage`, `DesktopClosePdfMessage`, and `DesktopSetRouteMessage`—while keeping the corresponding Zod schemas and existing `.safeParse()` / message handling paths.
> 
> Drops the unused `hasWorkspacePath` re-export from `main/platform/paths.ts`; callers already import `hasWorkspacePath` from `@desktop/workspacePath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2e1e220456e5c319dfe4b8ee9e1cef988236c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->