### PR TITLE
chore: remove dead exports flagged by knip (shared-schemas batch 3)

### DIFF
--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -57,4 +57,3 @@ export const CommonViewMessageSchema = z.discriminatedUnion('command', [
 ]);
 
 export type StateRestoreMessage = z.infer<typeof StateRestoreMessageSchema>;
-export type SwitchViewMessage = z.infer<typeof SwitchViewMessageSchema>;

--- a/src/shared/schemas/fileFields.ts
+++ b/src/shared/schemas/fileFields.ts
@@ -100,8 +100,6 @@ export const NullableFileFieldsSchema = z.object({
   editedFile: z.string().nullable().prefault(null),
 });
 
-export type NullableFileFields = z.infer<typeof NullableFileFieldsSchema>;
-
 /** Schema that accepts string or null/undefined, outputs string (coerces nullish → ''). */
 const nullishString = z
   .string()
@@ -116,5 +114,3 @@ export const UIFileFieldsSchema = z.object({
   ...fileListFields,
   editedFile: nullishString,
 });
-
-export type UIFileFields = z.infer<typeof UIFileFieldsSchema>;

--- a/src/shared/schemas/fileTypes.ts
+++ b/src/shared/schemas/fileTypes.ts
@@ -18,6 +18,3 @@ export const ExtendedDocumentFileTypeSchema = z.enum([
   'edited',
   'output',
 ]);
-export type ExtendedDocumentFileType = z.infer<
-  typeof ExtendedDocumentFileTypeSchema
->;

--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -66,7 +66,6 @@ export type UpdateHistoryMessage = z.infer<typeof UpdateHistoryMessageSchema>;
 export const HistoryClearedMessageSchema = z.object({
   command: z.literal(HISTORY_VIEW_COMMANDS.HISTORY_CLEARED),
 });
-export type HistoryClearedMessage = z.infer<typeof HistoryClearedMessageSchema>;
 
 // ============================================================
 // Inbound message schemas (frontend → backend)
@@ -76,7 +75,6 @@ export type HistoryClearedMessage = z.infer<typeof HistoryClearedMessageSchema>;
 export const HistoryIdMessageSchema = z.object({
   historyId: z.string().min(1),
 });
-export type HistoryIdMessage = z.infer<typeof HistoryIdMessageSchema>;
 
 export const GetHistoryDataMessageSchema = commandOnly(
   HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA,

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -8,18 +8,6 @@ export * from './lineChanges';
 export * from './goal';
 export * from './proposalFields';
 export * from './toolConfig';
-export {
-  CoreSettingsSchema,
-  CoreSettingsShape,
-  DEFAULT_CORE_SETTINGS,
-  LATEXDIFF_TEMP_FILE_LOCATIONS,
-  NON_REGEX_REPLACEMENT_CATEGORIES,
-  REGEX_REPLACEMENT_CATEGORIES,
-  type CoreSettings,
-  type LatexdiffTempFileLocation,
-  type NonRegexReplacementCategory,
-  type RegexReplacementCategory,
-} from './coreSettings';
 export * from './errors';
 export * from './usage';
 export * from './contextManagement';
@@ -56,7 +44,6 @@ export * from './progressView';
 
 // Layer 6: Other view message schemas
 export * as commonViewMessages from './commonViewMessages';
-export { ThemeSchema, type Theme } from './commonViewMessages';
 // Memory/History/Profile view-message schemas have a single public home in
 // settingsViewMessages (the canonical settings entry point), which re-exports
 // the symbols consumers need. They are not re-exported directly here, so each

--- a/src/shared/schemas/mainView/executeMessage.ts
+++ b/src/shared/schemas/mainView/executeMessage.ts
@@ -54,6 +54,3 @@ export const MainViewExecuteInboundMessageSchema =
   MainViewExecuteMessageSchema.extend({
     command: z.literal(MAIN_VIEW_COMMANDS.EXECUTE),
   });
-export type MainViewExecuteInboundMessage = z.infer<
-  typeof MainViewExecuteInboundMessageSchema
->;

--- a/src/shared/schemas/mainView/index.ts
+++ b/src/shared/schemas/mainView/index.ts
@@ -23,7 +23,6 @@ export {
   MULTIPLE_DOCUMENT_FILE_TYPES,
   MultipleDocumentFileTypeSchema,
   type DocumentFileType,
-  type ExtendedDocumentFileType,
   type MultipleDocumentFileType,
 } from '../fileTypes';
 export * from './state';

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -41,11 +41,7 @@ export {
   type MemoryEnabledMessage,
 } from './memoryViewMessages';
 
-export {
-  HistoryItemSchema,
-  type HistoryItem,
-  type HistoryIdMessage,
-} from './historyViewMessages';
+export { HistoryItemSchema, type HistoryItem } from './historyViewMessages';
 
 export {
   ProfileUserSchema,

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -50,7 +50,6 @@ export const EditedFileRecordSchema = z.object({
   source: z.string(),
   sourceDisplay: z.string(),
 });
-export type EditedFileRecord = z.infer<typeof EditedFileRecordSchema>;
 
 /**
  * Schema for flattened edit records used in state snapshots.
@@ -64,7 +63,6 @@ export const FlattenedEditRecordSchema = z.object({
   added: LineCountSchema.prefault(0),
   removed: LineCountSchema.prefault(0),
 });
-export type FlattenedEditRecord = z.infer<typeof FlattenedEditRecordSchema>;
 
 // ============================================================================
 // Diagnostics Types (not Zod - these are complex unions with external types)
@@ -140,9 +138,6 @@ const ToolResultSharedFields = {
   attachmentSummary: z.string().optional(),
 };
 
-export const TOOL_RESULT_STATUSES = ['executed', 'error'] as const;
-export type ToolResultStatus = (typeof TOOL_RESULT_STATUSES)[number];
-
 export const ExecutedToolResultSchema = z
   .object({
     status: z.literal('executed'),
@@ -162,7 +157,6 @@ export const ExecutedToolResultSchema = z
     ...ToolResultSharedFields,
   })
   .catchall(z.unknown());
-export type ExecutedToolResult = z.infer<typeof ExecutedToolResultSchema>;
 
 export const ErrorToolResultSchema = z
   .object({
@@ -179,7 +173,6 @@ export const ErrorToolResultSchema = z
     ...ToolResultSharedFields,
   })
   .catchall(z.unknown());
-export type ErrorToolResult = z.infer<typeof ErrorToolResultSchema>;
 
 export const ToolResultSchema = z.discriminatedUnion('status', [
   ExecutedToolResultSchema,


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. All items were verified (two-pass: adversarial verification + orchestrator spot-checks) to have zero real usage outside their own file, then re-checked here against current `main` before editing.

Every item is a **barrel re-export line** or an **unused `z.infer` type alias**. In every case the underlying runtime schema value (`XxxSchema`) that the type is derived from is genuinely used elsewhere and was left completely untouched — only the dead re-export line or dead type-alias line was deleted.

### `src/shared/schemas/index.ts` (barrel re-export deletions — origin exports untouched)
- `CoreSettingsSchema` — de-export (barrel re-export line removed; `src/shared/schemas/coreSettings.ts` origin kept)
- `CoreSettingsShape` — de-export (barrel re-export line removed; origin kept)
- `DEFAULT_CORE_SETTINGS` — de-export (barrel re-export line removed; origin kept)
- `LATEXDIFF_TEMP_FILE_LOCATIONS` — de-export (barrel re-export line removed; origin kept)
- `NON_REGEX_REPLACEMENT_CATEGORIES` — de-export (barrel re-export line removed; origin kept)
- `REGEX_REPLACEMENT_CATEGORIES` — de-export (barrel re-export line removed; origin kept)
- `CoreSettings` (type) — de-export (barrel re-export line removed; origin kept)
- `LatexdiffTempFileLocation` (type) — de-export (barrel re-export line removed; origin kept)
- `NonRegexReplacementCategory` (type) — de-export (barrel re-export line removed; origin kept)
- `RegexReplacementCategory` (type) — de-export (barrel re-export line removed; origin kept)
- `ThemeSchema` — de-export (barrel re-export line removed; `src/shared/schemas/commonViewMessages.ts` origin kept)
- `Theme` (type) — de-export (barrel re-export line removed; origin kept)

The entire `export { ... } from './coreSettings'` block (every member was flagged dead) and the `export { ThemeSchema, type Theme } from './commonViewMessages'` line were removed outright since nothing survived in either.

### `src/shared/schemas/toolResult.ts` (fully orphaned type aliases — deleted)
- `TOOL_RESULT_STATUSES` + `ToolResultStatus` (type) — deleted together (type derived solely from the const, neither used anywhere)
- `EditedFileRecord` (type) — deleted (schema `EditedFileRecordSchema` stays, used externally)
- `FlattenedEditRecord` (type) — deleted (schema `FlattenedEditRecordSchema` stays, used externally)
- `ExecutedToolResult` (type) — deleted
- `ErrorToolResult` (type) — deleted

### `src/shared/schemas/commonViewMessages.ts`
- `SwitchViewMessage` (type) — deleted (zero references anywhere; unrelated same-named local type in `MainViewInteractionController.ts` is untouched)

### `src/shared/schemas/historyViewMessages.ts` + `settingsViewMessages.ts`
- `HistoryClearedMessage` (type) — deleted (schema `HistoryClearedMessageSchema` stays, used externally)
- `HistoryIdMessage` (type) — deleted, plus its now-dead re-export removed from `settingsViewMessages.ts`'s `historyViewMessages` re-export block

### `src/shared/schemas/mainView/executeMessage.ts`
- `MainViewExecuteInboundMessage` (type) — deleted (schema `MainViewExecuteInboundMessageSchema` stays, used externally in `mainView/inbound.ts` and a vitest suite)

### `src/shared/schemas/fileFields.ts`
- `NullableFileFields` (type) — deleted (schema stays, used externally)
- `UIFileFields` (type) — deleted (schema stays, used externally)

### `src/shared/schemas/fileTypes.ts` + `mainView/index.ts`
- `ExtendedDocumentFileType` (type) — deleted, plus its re-export removed from `mainView/index.ts`

## Skipped
None — every item in the batch was re-confirmed dead against current `main` and executed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] `npx tsc --noEmit` in `packages/trace-viewer` — clean
- [x] `npx tsc --noEmit -p packages/desktop/tsconfig.json` — clean
- [x] `npx eslint` on all touched files — clean
- [x] `npx prettier --check` on all touched files — clean
- [x] Targeted vitest suites covering every touched file's directory (schemas, mainView controllers, trace-viewer schema mirror, replacement rules, tool result usage, AgentSettingSchema, RemoteAgentLoaderSchemaFallback, stateSettings) — 228 tests passed
- [x] Re-ran `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` — none of the 24 batch items remain flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of unused exports and type aliases; schemas and runtime contracts are unchanged, with TypeScript checks reported clean in the PR.
> 
> **Overview**
> Removes **knip-flagged dead exports** across `src/shared/schemas` without changing any runtime Zod schemas or validation behavior.
> 
> The `@shared/schemas` barrel no longer re-exports the entire `coreSettings` surface or `ThemeSchema` / `Theme` from `commonViewMessages`; consumers that still need those must import from the origin modules (or `commonViewMessages` namespace). Settings history re-exports drop `HistoryIdMessage` while keeping `HistoryItemSchema` / `HistoryItem`. The mainView sub-barrel stops exporting `ExtendedDocumentFileType`.
> 
> Several files shed **unused `z.infer` type aliases** (`SwitchViewMessage`, history message types, `MainViewExecuteInboundMessage`, file-field types, tool-result variants, etc.) and `toolResult.ts` also removes the unused `TOOL_RESULT_STATUSES` const and its derived type. All corresponding `*Schema` values remain exported and in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556d8ab9fe52e691a9ff938b7995334a50dc5565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->