### PR TITLE
chore: remove dead exports flagged by knip (batch: extension)

### DIFF
--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -26,7 +26,7 @@ const openFileCommands = {
   openLabel: 'texra.openLabel',
 };
 
-export interface OpenLabelOptions {
+interface OpenLabelOptions {
   notifyNotFound?: boolean;
 }
 

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -5,12 +5,12 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { buildWebviewHtml } from './html';
 
-export interface ModuleDescriptor {
+interface ModuleDescriptor {
   key: string;
   path: string;
 }
 
-export abstract class BaseViewContentProvider {
+abstract class BaseViewContentProvider {
   protected readonly logger: typeof logger;
   protected readonly channel: string;
   private readonly viewPath: string;

--- a/packages/extension/src/common/webview/index.ts
+++ b/packages/extension/src/common/webview/index.ts
@@ -1,16 +1,11 @@
 // Barrel export for common webview components
-export {
-  BaseViewContentProvider,
-  BundledViewContentProvider,
-  type ViewBundle,
-} from './BaseViewContentProvider';
+export { BundledViewContentProvider } from './BaseViewContentProvider';
 export { BaseViewMessageHandler } from './BaseViewMessageHandler';
 export { BaseWebviewProvider } from './BaseWebviewProvider';
 export {
   SIDEBAR_VIEWS,
   getActiveSidebarView,
   setActiveSidebarView,
-  type SidebarView,
 } from './viewState';
 export {
   getSharedLocalResourceRoots,

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -26,13 +26,13 @@ logger.initialize(CHANNEL);
 
 type AgentDirectoryEventType = 'create' | 'change' | 'delete';
 
-export interface AgentDirectoryWatcherEvent extends AgentDirectoryEntry {
+interface AgentDirectoryWatcherEvent extends AgentDirectoryEntry {
   type: AgentDirectoryEventType;
   uri: vscode.Uri;
   relativePath: string;
 }
 
-export interface AgentDirectoryWatcherOptions {
+interface AgentDirectoryWatcherOptions {
   pattern?: string;
   onEvent: (event: AgentDirectoryWatcherEvent) => void;
 }
@@ -42,7 +42,7 @@ interface AgentDirectoryWatcherSubscription {
   handleEvent: (event: AgentDirectoryWatcherEvent) => void;
 }
 
-export class AgentDirectoryManager {
+class AgentDirectoryManager {
   private context: vscode.ExtensionContext | undefined;
   private directoryService: AgentDirectoryService | undefined;
   private watcherDisposables: vscode.Disposable[] = [];

--- a/packages/extension/src/frontend/agents/index.ts
+++ b/packages/extension/src/frontend/agents/index.ts
@@ -1,10 +1,6 @@
 // Barrel export for frontend agent utilities
+export { agentDirectories } from './AgentDirectoryManager';
 export {
-  AgentDirectoryManager,
-  agentDirectories,
-} from './AgentDirectoryManager';
-export {
-  AgentRegistrationSkipReason,
   getAgentRegistrationSkipReason,
   promptToAddAgentToConfig,
 } from './register';

--- a/packages/extension/src/frontend/files/fileSelectionRegistry.ts
+++ b/packages/extension/src/frontend/files/fileSelectionRegistry.ts
@@ -13,14 +13,6 @@ export const FILE_SELECTION_COMMAND_IDS = {
   getCurrentFile: 'texra.getCurrentFile',
 } as const;
 
-export type FileSelectionCommandId =
-  (typeof FILE_SELECTION_COMMAND_IDS)[keyof typeof FILE_SELECTION_COMMAND_IDS];
-
-// Only `editedFile` still uses single-file selection; input/context/media
-// route through SET_*_FILES.
-export type FileSelectionResponseCommand =
-  typeof MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED;
-
 /** File categories that support multiple file selection */
 export type MultiFileCategory = 'input' | 'context' | 'media' | 'output';
 

--- a/packages/extension/src/frontend/files/index.ts
+++ b/packages/extension/src/frontend/files/index.ts
@@ -1,11 +1,7 @@
 // Barrel export for frontend file utilities
 export { FileLister, getFileLister } from './fileLister';
-export type { ListableFileType } from '@common/files/fileListingRules';
-export { getFilesRecursively } from './listing';
 export {
   FILE_SELECTION_COMMAND_IDS,
   MULTIPLE_FILE_COMMANDS,
-  type FileSelectionCommandId,
-  type FileSelectionResponseCommand,
   type MultiFileCategory,
 } from './fileSelectionRegistry';

--- a/packages/extension/src/frontend/git/gitExtensionTypes.ts
+++ b/packages/extension/src/frontend/git/gitExtensionTypes.ts
@@ -7,12 +7,12 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-export interface GitBranchInfo {
+interface GitBranchInfo {
   readonly name?: string;
   readonly commit?: string;
 }
 
-export interface GitRepositoryState {
+interface GitRepositoryState {
   readonly HEAD: GitBranchInfo | undefined;
   readonly onDidChange: vscode.Event<void>;
 }
@@ -28,7 +28,7 @@ export interface GitAPI {
   getRepository(uri: vscode.Uri): GitRepository | null;
 }
 
-export interface GitExtension {
+interface GitExtension {
   getAPI(version: 1): GitAPI;
 }
 

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -38,7 +38,7 @@ export interface FollowUpSendDetail {
   readonly images: readonly ExtractedClipboardImage[];
 }
 
-export interface WorkflowFollowupFormData {
+interface WorkflowFollowupFormData {
   agent: string;
   model: string;
   initialQuestion: string;

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -98,14 +98,11 @@ export const unsupportedProgressCommands$ = signal<ReadonlySet<string> | null>(
 export const streamById$ = select(appState, (s) => s.streamById);
 export const streamFilter$ = select(appState, (s) => s.streamFilter);
 export const streamStates$ = select(appState, (s) => s.streamStates);
-export const streamLogs$ = select(appState, (s) => s.streamLogs);
+const streamLogs$ = select(appState, (s) => s.streamLogs);
 export const activeStreamId$ = select(appState, (s) => s.activeStreamId);
-export const processOutputs$ = select(appState, (s) => s.processOutputs);
-export const inquiries$ = select(appState, (s) => s.inquiries);
-export const followupOptions$ = select(
-  appState,
-  (s) => s.followupOptionsByStream,
-);
+const processOutputs$ = select(appState, (s) => s.processOutputs);
+const inquiries$ = select(appState, (s) => s.inquiries);
+const followupOptions$ = select(appState, (s) => s.followupOptionsByStream);
 
 // ---------------------------------------------------------------------------
 // Derived computeds: only re-evaluate when selector inputs propagate.
@@ -192,7 +189,7 @@ export function resetProgressState(): void {
 // ---------------------------------------------------------------------------
 
 /** Only changes when active stream switches or stream list changes. */
-export const activeStreamInfo$ = new Signal.Computed(() => {
+const activeStreamInfo$ = new Signal.Computed(() => {
   const id = activeStreamId$.get();
   return id ? (streamById$.get().get(id) ?? null) : null;
 });
@@ -203,9 +200,7 @@ export const activeStreamInfo$ = new Signal.Computed(() => {
  * unfiltered, so `streamById.size` alone can't distinguish "nothing
  * visible" from "everything hidden by filter".
  */
-export const hasStreams$ = new Signal.Computed(
-  () => tabStreams$.get().length > 0,
-);
+const hasStreams$ = new Signal.Computed(() => tabStreams$.get().length > 0);
 
 /** True only when the backend knows no streams at all, independent of filter. */
 export const hasAnyStreams$ = new Signal.Computed(
@@ -213,7 +208,7 @@ export const hasAnyStreams$ = new Signal.Computed(
 );
 
 /** Only changes when the ACTIVE stream's state changes, not any stream. */
-export const activeStreamState$ = new Signal.Computed(() => {
+const activeStreamState$ = new Signal.Computed(() => {
   const info = activeStreamInfo$.get();
   if (!info) return null;
   return (
@@ -222,7 +217,7 @@ export const activeStreamState$ = new Signal.Computed(() => {
 });
 
 /** Only changes when the ACTIVE stream's logs change, not any stream. */
-export const activeStreamLogs$ = new Signal.Computed(() => {
+const activeStreamLogs$ = new Signal.Computed(() => {
   const info = activeStreamInfo$.get();
   if (!info) return EMPTY_STREAM_LOGS;
   return streamLogs$.get().get(info.name) ?? EMPTY_STREAM_LOGS;
@@ -246,7 +241,7 @@ export const activeProcessOutputs$ = new Signal.Computed(
 // LogList doesn't re-render.
 // ---------------------------------------------------------------------------
 
-export const activeTaskGroups$ = new Signal.Computed(
+const activeTaskGroups$ = new Signal.Computed(
   () => activeStreamState$.get()?.taskGroups ?? EMPTY_TASK_GROUPS,
 );
 
@@ -263,7 +258,7 @@ export const activeInquiries$ = new Signal.Computed(() => {
   return threads.length > 0 ? threads : EMPTY_INQUIRIES;
 });
 
-export const activeIsToolUse$ = new Signal.Computed(() => {
+const activeIsToolUse$ = new Signal.Computed(() => {
   const state = activeStreamState$.get();
   return state ? isToolUseState(state) : false;
 });

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -18,7 +18,7 @@ import {
  * Defined here (not in contexts/streamContexts) so the store stays the single
  * home for state data shapes; the context object lives with the other contexts.
  */
-export interface ProcessOutputEntry {
+interface ProcessOutputEntry {
   stdout: string;
   stderr: string;
 }
@@ -33,7 +33,6 @@ export {
   isWorkflowState,
   type StreamState,
   type ToolUseStreamState,
-  type ToolUseUIState,
   type WorkflowStreamState,
 } from '@shared/schemas';
 

--- a/packages/extension/src/progressView/frontend/utils.ts
+++ b/packages/extension/src/progressView/frontend/utils.ts
@@ -4,7 +4,7 @@
  * Type for radio-group-like components that expose a value property.
  * Used for wa-radio-group / vscode-radio-group.
  */
-export type VSCodeValueElement = HTMLElement & { value?: string };
+type VSCodeValueElement = HTMLElement & { value?: string };
 
 /**
  * Extract value from a radio-group change event. Prefers the clicked

--- a/packages/extension/src/schemas/texraSettings.ts
+++ b/packages/extension/src/schemas/texraSettings.ts
@@ -50,7 +50,7 @@ export const TexraSettingsSchema = z
   })
   .prefault(DEFAULT_TEXRA_SETTINGS);
 
-export type TexraSettings = z.infer<typeof TexraSettingsSchema>;
+type TexraSettings = z.infer<typeof TexraSettingsSchema>;
 
 export const TEXRA_SETTING_PATHS = [
   ...CORE_SETTING_PATHS,
@@ -66,7 +66,7 @@ export const TEXRA_SETTING_KEYS = TEXRA_SETTING_PATHS.map(
 );
 const TEXRA_SETTING_KEY_SET = new Set<TexraSettingKey>(TEXRA_SETTING_KEYS);
 
-export interface TexraPackageConfigurationProperty {
+interface TexraPackageConfigurationProperty {
   type?: string;
   items?: unknown;
   additionalProperties?: unknown;

--- a/packages/extension/src/schemas/vscodeSettings.ts
+++ b/packages/extension/src/schemas/vscodeSettings.ts
@@ -54,5 +54,3 @@ export const VSCODE_SETTING_PATHS = [
   'apiKeys.set',
   'apiKeys.remove',
 ] as const;
-
-export type VscodeSettingPath = (typeof VSCODE_SETTING_PATHS)[number];

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -120,7 +120,7 @@ export const fileSelectLayoutStyles = css`
 `;
 
 /** Multiple files list styles. */
-export const multiFilesStyles = css`
+const multiFilesStyles = css`
   .multiple-files-container {
     display: flex;
     justify-content: space-between;
@@ -205,7 +205,7 @@ export const multiFilesStyles = css`
 
 /** Outline cue for the file-select button when document options are active.
  *  (The dropdown itself is a native <wa-dropdown>.) */
-export const dropdownStyles = css`
+const dropdownStyles = css`
   wa-button.has-options::part(base) {
     outline: var(--border-thin) solid
       var(--wa-color-brand-border-quiet, var(--wa-color-focus));


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Every item below was pre-verified (two review passes) to have zero real usage outside its own file; this PR executes the fixes. Two visibility patterns:

- **De-export**: symbol is still doing real work internally in its file, just narrowed from `export` to file-private.
- **Delete**: symbol had zero references anywhere, including internally (dead barrel re-export or fully orphaned declaration).

### De-exported (declaration kept, `export` dropped)

| Name | File |
| --- | --- |
| `AgentDirectoryManager` (class) | `packages/extension/src/frontend/agents/AgentDirectoryManager.ts` |
| `AgentDirectoryWatcherEvent` | same file |
| `AgentDirectoryWatcherOptions` | same file |
| `BaseViewContentProvider` (class) | `packages/extension/src/common/webview/BaseViewContentProvider.ts` |
| `ModuleDescriptor` | same file |
| `streamLogs$` | `packages/extension/src/progressView/frontend/progressState.ts` |
| `processOutputs$` | same file |
| `inquiries$` | same file |
| `followupOptions$` | same file |
| `activeStreamInfo$` | same file |
| `hasStreams$` | same file |
| `activeStreamState$` | same file |
| `activeStreamLogs$` | same file |
| `activeTaskGroups$` | same file |
| `activeIsToolUse$` | same file |
| `multiFilesStyles` | `packages/extension/src/webview/frontend/styles/fileSelectStyles.ts` |
| `dropdownStyles` | same file |
| `WorkflowFollowupFormData` | `packages/extension/src/progressView/frontend/events.ts` |
| `ProcessOutputEntry` | `packages/extension/src/progressView/frontend/store.ts` |
| `VSCodeValueElement` | `packages/extension/src/progressView/frontend/utils.ts` |
| `TexraSettings` (z.infer type) | `packages/extension/src/schemas/texraSettings.ts` |
| `TexraPackageConfigurationProperty` | same file |
| `GitBranchInfo` | `packages/extension/src/frontend/git/gitExtensionTypes.ts` |
| `GitRepositoryState` | same file |
| `GitExtension` | same file |
| `OpenLabelOptions` | `packages/extension/src/commands/files/openFileCommands.ts` |

### Deleted (dead barrel re-exports / fully orphaned declarations)

| Name | File |
| --- | --- |
| `AgentDirectoryManager` (barrel re-export) | `packages/extension/src/frontend/agents/index.ts` |
| `AgentRegistrationSkipReason` (barrel re-export) | same file |
| `BaseViewContentProvider` (barrel re-export) | `packages/extension/src/common/webview/index.ts` |
| `ViewBundle` (barrel type re-export) | same file |
| `SidebarView` (barrel type re-export) | same file |
| `getFilesRecursively` (barrel re-export) | `packages/extension/src/frontend/files/index.ts` |
| `ListableFileType` (barrel type re-export) | same file |
| `FileSelectionCommandId` (barrel type re-export) | same file |
| `FileSelectionResponseCommand` (barrel type re-export) | same file |
| `FileSelectionCommandId` (original type) | `packages/extension/src/frontend/files/fileSelectionRegistry.ts` |
| `FileSelectionResponseCommand` (original type) | same file |
| `ToolUseUIState` (re-export from `@shared/schemas`) | `packages/extension/src/progressView/frontend/store.ts` |
| `VscodeSettingPath` | `packages/extension/src/schemas/vscodeSettings.ts` |

### Skipped

None — every listed item was still accurate against current `main` and was applied.

### Follow-on (out of scope, noted not fixed)

Deleting the `ToolUseUIState` re-export in `store.ts` surfaces its origin export (`export type ToolUseUIState` in `src/shared/schemas/streamState.ts`) as now-unused per a fresh `knip` pass. That file isn't in this batch's item list, so it's left untouched here — flagging for a future batch/PR.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `npx eslint <touched files>` — clean
- [x] `npx prettier --check <touched files>` — clean
- [x] Targeted `vitest` suites covering every touched file's directory (progressView, frontend/agents/register, AgentDirectorySync, AgentDirectoryService, SettingsAgentDirectoryController, traceViewer/replayTrace) — 37 files / 209 tests passed
- [x] Re-ran `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` — none of the fixed items appear at their fixed locations anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only hygiene with no logic changes; risk is limited to accidental breakage if an external consumer imported removed symbols (unlikely for extension internals).
> 
> **Overview**
> This PR **narrows the extension package’s public surface** after a knip dead-export pass. Nothing changes at runtime—only what is `export`ed and what barrels re-export.
> 
> **De-exports:** Many symbols stay in their files but lose `export` (e.g. `AgentDirectoryManager`, `BaseViewContentProvider`, progress-view signals like `streamLogs$` / `activeStreamState$`, git helper types, `OpenLabelOptions`, settings/types helpers). They remain used **inside** the same module.
> 
> **Barrel cleanup:** `index.ts` files under agents, webview, and files drop re-exports that had no consumers (`AgentDirectoryManager`, `BaseViewContentProvider`, `ViewBundle`, `SidebarView`, `getFilesRecursively`, file-selection types, etc.).
> 
> **Removals:** Fully unused types are deleted where they only existed for export (`FileSelectionCommandId`, `FileSelectionResponseCommand`, `VscodeSettingPath`, `ToolUseUIState` re-export from progress `store.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45cab7b355a71d119ae156156e56bf295882a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->