### PR TITLE
chore: remove dead exports flagged by knip (batch: cli)

### DIFF
--- a/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts
@@ -7,7 +7,7 @@ import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { openCliSlashCommandForm } from '../slashForms';
 import { type SlashCommandContext } from './slashContext';
 
-export const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
+const YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 
 export function applyCliApprovalPolicySelection(
   input: string,

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -32,7 +32,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { setCliSessionApiMode } from './apiModeCommands';
 
-export const CHAT_LOGIN_USAGE = [
+const CHAT_LOGIN_USAGE = [
   'Usage: /login [texra [github | google]] [--no-browser] [--device] [--select-account] [--login-hint <account>]',
   '       /login chatgpt [--no-browser] [--device]',
 ].join('\n');

--- a/packages/cli/src/chat/tui/input/draftAttachments.ts
+++ b/packages/cli/src/chat/tui/input/draftAttachments.ts
@@ -15,7 +15,7 @@
 const PASTE_CHAR_THRESHOLD = 800;
 const PASTE_MAX_INLINE_LINES = 2;
 
-export interface PastedTextEntry {
+interface PastedTextEntry {
   readonly id: number;
   readonly kind: 'text';
   readonly content: string;

--- a/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
+++ b/packages/cli/src/chat/tui/notifications/terminalNotifier.ts
@@ -15,7 +15,7 @@
 import { writeRawStdout } from '@cli/runtime/logSinks';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 
-export type NotificationKind = 'agentFinished' | 'approvalNeeded';
+type NotificationKind = 'agentFinished' | 'approvalNeeded';
 
 export interface NotifyInit {
   readonly kind: NotificationKind;

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -7,7 +7,7 @@ import { truncateSummaryToWidth } from '../render/terminalText';
 
 const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
 
-export interface QueuedFollowUpPanelRow {
+interface QueuedFollowUpPanelRow {
   readonly kind: 'message' | 'overflow';
   readonly text: string;
 }

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -344,18 +344,17 @@ const DIFF_REMOVED_FG = '#4a171b';
  * foreground colors so text stays readable on both light and dark terminals.
  * Context lines stay un-banded and dim.
  */
-export const DIFF_LINE_STYLE: Partial<
-  Record<DiffDisplayLine['kind'], DiffLineStyle>
-> = {
-  added: {
-    backgroundColor: DIFF_ADDED_BG,
-    color: DIFF_ADDED_FG,
-  },
-  removed: {
-    backgroundColor: DIFF_REMOVED_BG,
-    color: DIFF_REMOVED_FG,
-  },
-};
+const DIFF_LINE_STYLE: Partial<Record<DiffDisplayLine['kind'], DiffLineStyle>> =
+  {
+    added: {
+      backgroundColor: DIFF_ADDED_BG,
+      color: DIFF_ADDED_FG,
+    },
+    removed: {
+      backgroundColor: DIFF_REMOVED_BG,
+      color: DIFF_REMOVED_FG,
+    },
+  };
 
 function DiffLine({
   line,

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -10,7 +10,7 @@ import type { BypassState } from './state/cliState';
 const QUEUED_FOLLOW_UP_STATUS_LENGTH = 160;
 const GOAL_OBJECTIVE_STATUS_LENGTH = 160;
 
-export interface CliSessionGoalStatus {
+interface CliSessionGoalStatus {
   readonly status: string;
   readonly objective: string;
 }

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -73,7 +73,7 @@ export interface ChildControlStreamTarget {
   readonly streamId: StreamTabId | undefined;
 }
 
-export interface ChildControlDisplayTarget extends ChildControlStreamTarget {
+interface ChildControlDisplayTarget extends ChildControlStreamTarget {
   readonly streamLabel: string | undefined;
   readonly streamScopeDetail: string | undefined;
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -492,7 +492,7 @@ export function registerChildStreams(
 /** Active inline slash form, or `undefined` when the chat input owns the
  *  screen. The form's `onDone` clears this slot. Kept opaque (the form
  *  carries its own state) so the registry stays declarative. */
-export interface ActiveSlashForm {
+interface ActiveSlashForm {
   /** The slash command that mounted the form (for the header strip). */
   readonly commandName: string;
   /** Status-bar verb for Escape while the form owns input. Defaults to close. */

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -7,7 +7,7 @@ import {
   isFinalTranscriptStatus,
 } from './transcript';
 
-export interface TranscriptFallbackAssistant {
+interface TranscriptFallbackAssistant {
   readonly text: string | undefined;
   readonly idPrefix: string;
 }

--- a/packages/cli/src/commands/relayTokens.ts
+++ b/packages/cli/src/commands/relayTokens.ts
@@ -37,8 +37,8 @@ import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import type { CliContext } from '../runtime/cliContext';
 
-export const SETUP_TOKEN_DEFAULT_EXPIRES_DAYS = 30;
-export const SETUP_TOKEN_MAX_EXPIRES_DAYS = 365;
+const SETUP_TOKEN_DEFAULT_EXPIRES_DAYS = 30;
+const SETUP_TOKEN_MAX_EXPIRES_DAYS = 365;
 
 /** Parse --expires; returns undefined (with the reason) for invalid input. */
 export function parseSetupTokenExpiresDays(

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -29,7 +29,7 @@ export interface CliApprovalPromptHooks {
 const deniedApprovalContexts = new WeakSet<CliContext>();
 const cliPromptQueues = new WeakMap<CliContext, Promise<unknown>>();
 
-export function denyMessage(policy: CliContext['approvalPolicy']): string {
+function denyMessage(policy: CliContext['approvalPolicy']): string {
   return policy === 'ask'
     ? 'Interactive approval requires a TTY; this CLI run is headless.'
     : 'Denied by CLI approval policy.';

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -50,11 +50,8 @@ import {
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
 
 export {
-  type ApprovalDecision,
   appendCliApiSwitchHint,
   approvalPromptAllowed,
-  CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT,
-  denyMessage,
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecision,
@@ -65,7 +62,6 @@ export {
 } from './approval/approvalPolicy';
 export {
   formatAgentProposalApprovalSummary,
-  formatUserQuestionPrompt,
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
 } from './approval/approvalSummaries';

--- a/packages/cli/src/runtime/approvalEvents.ts
+++ b/packages/cli/src/runtime/approvalEvents.ts
@@ -31,11 +31,7 @@ export const CLI_APPROVAL_EVENT_KIND = {
 
 export type CliDecisionApprovalEvent =
   (typeof CLI_DECISION_APPROVAL_EVENTS)[number];
-export type CliHumanInputApprovalEvent =
-  (typeof CLI_HUMAN_INPUT_APPROVAL_EVENTS)[number];
 export type CliApprovalEvent = (typeof CLI_APPROVAL_EVENTS)[number];
-export type CliApprovalEventKind =
-  (typeof CLI_APPROVAL_EVENT_KIND)[CliApprovalEvent];
 
 const CLI_DECISION_APPROVAL_EVENT_SET: ReadonlySet<string> = new Set(
   CLI_DECISION_APPROVAL_EVENTS,

--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -45,11 +45,10 @@ export interface ChatDefaults {
   readonly modelSource: ChatDefaultValueSource;
 }
 
-export type ChatDefaultSource =
-  'workspace' | 'user' | 'history' | 'builtin' | 'mixed';
+type ChatDefaultSource = 'workspace' | 'user' | 'history' | 'builtin' | 'mixed';
 
 /** Chat default value sources are the shared run-model decision reasons. */
-export type ChatDefaultValueSource = Extract<
+type ChatDefaultValueSource = Extract<
   RunModelDecisionReason,
   | 'explicit-override'
   | 'environment'

--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -21,7 +21,7 @@ import { KNOWN_TEXRA_KEYS } from '../schemas/knownKeys';
 
 export const CLI_BUILTIN_DEFAULT_MODEL = 'deepseekproT';
 
-export interface CliCommandConfig {
+interface CliCommandConfig {
   readonly agent?: string;
   readonly model?: string;
 }

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -25,7 +25,7 @@ import {
 import { resolveCliResourcesPath } from './resourcesPath';
 import type { SkillSourceOptions } from '@skills/skillSources';
 
-export type CliMode = 'headless' | 'interactive';
+type CliMode = 'headless' | 'interactive';
 
 export interface CliPromptRequest {
   readonly kind: 'approval' | 'externalInquiry';

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -33,9 +33,9 @@ import type { CliContext } from './cliContext';
 import type { CliStyle } from './style';
 import type { CliModelAccess } from './modelAccess';
 
-export type DoctorCheckStatus = 'pass' | 'warn' | 'fail' | 'skip';
+type DoctorCheckStatus = 'pass' | 'warn' | 'fail' | 'skip';
 
-export interface DoctorCheck {
+interface DoctorCheck {
   readonly id: string;
   readonly name: string;
   readonly status: DoctorCheckStatus;

--- a/packages/cli/src/runtime/loginOptions.ts
+++ b/packages/cli/src/runtime/loginOptions.ts
@@ -22,7 +22,7 @@ export interface CliTexraLoginSlashArgs {
   readonly loginHint?: string;
 }
 
-export interface CliChatGptLoginSlashArgs {
+interface CliChatGptLoginSlashArgs {
   readonly target: 'chatgpt';
   readonly noBrowser: boolean;
   readonly device: boolean;

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -15,7 +15,7 @@ import {
 } from '@shared/schemas/agentPresets';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
 
-export type CliMultiAgentPresetSource = 'built-in' | 'custom';
+type CliMultiAgentPresetSource = 'built-in' | 'custom';
 
 export interface CliMultiAgentPreset extends AgentModePreset {
   readonly source: CliMultiAgentPresetSource;
@@ -40,9 +40,9 @@ export interface CliMultiAgentTeamLaunchBlockMessageOptions {
   readonly followUpAdvice?: string;
 }
 
-export type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
+type CliMultiAgentPlanStatus = 'available' | 'degraded' | 'unavailable';
 
-export interface CliMultiAgentPresetAgentAvailability {
+interface CliMultiAgentPresetAgentAvailability {
   readonly available: number;
   readonly total: number;
   readonly missing: readonly string[];
@@ -81,7 +81,7 @@ const MULTI_AGENT_SHOW_HINT =
   'Hint: run `texra multi-agent show <team-id>` to see missing agents for degraded or unavailable presets.';
 const MULTI_AGENT_LOGIN_HINT =
   'Hint: Researcher Access sign-in may load additional remote team agents.';
-export const MULTI_AGENT_NO_TEAM_ROOT_REASON = 'no runnable team root';
+const MULTI_AGENT_NO_TEAM_ROOT_REASON = 'no runnable team root';
 const MULTI_AGENT_LAUNCHER_SHOW_HINT =
   'Team setup: run `texra multi-agent show <team-id>` using the team id shown in each row.';
 const MULTI_AGENT_LAUNCHER_LOGIN_HINT =


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep (CLI batch, 30 items — all verified via a two-pass adversarial verification before execution, then re-verified against current `main` before each edit landed here).

Two categories of fix per item:
- **De-export**: symbol is used only within its own file, so only the `export` keyword was removed; declaration and internal logic untouched.
- **Delete**: symbol was fully orphaned (zero references anywhere, including internally); the declaration was removed.

### De-exported (28 items — kept, visibility narrowed only)

| Name | File |
|---|---|
| `CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT` (barrel re-export) | `packages/cli/src/runtime/approvalAdapter.ts` |
| `denyMessage` (barrel re-export) | `packages/cli/src/runtime/approvalAdapter.ts` |
| `formatUserQuestionPrompt` (barrel re-export) | `packages/cli/src/runtime/approvalAdapter.ts` |
| `ApprovalDecision` (barrel re-export, type) | `packages/cli/src/runtime/approvalAdapter.ts` |
| `denyMessage` (original definition) | `packages/cli/src/runtime/approval/approvalPolicy.ts` |
| `DIFF_LINE_STYLE` | `packages/cli/src/chat/tui/render/DiffView.tsx` |
| `MULTI_AGENT_NO_TEAM_ROOT_REASON` | `packages/cli/src/runtime/multiAgentPresets.ts` |
| `CliMultiAgentPresetSource` (type) | `packages/cli/src/runtime/multiAgentPresets.ts` |
| `CliMultiAgentPlanStatus` (type) | `packages/cli/src/runtime/multiAgentPresets.ts` |
| `CliMultiAgentPresetAgentAvailability` (type) | `packages/cli/src/runtime/multiAgentPresets.ts` |
| `SETUP_TOKEN_DEFAULT_EXPIRES_DAYS` | `packages/cli/src/commands/relayTokens.ts` |
| `SETUP_TOKEN_MAX_EXPIRES_DAYS` | `packages/cli/src/commands/relayTokens.ts` |
| `CHAT_LOGIN_USAGE` | `packages/cli/src/chat/tui/commands/handlers/loginCommands.ts` |
| `YOLO_USAGE` | `packages/cli/src/chat/tui/commands/handlers/approvalCommand.ts` |
| `CliMode` (type) | `packages/cli/src/runtime/cliContext.ts` |
| `ChatDefaultSource` (type) | `packages/cli/src/runtime/chatDefaults.ts` |
| `ChatDefaultValueSource` (type) | `packages/cli/src/runtime/chatDefaults.ts` |
| `CliCommandConfig` (type) | `packages/cli/src/runtime/cliConfig.ts` |
| `ChildControlDisplayTarget` (type) | `packages/cli/src/chat/tui/state/childControls.ts` |
| `ActiveSlashForm` (type) | `packages/cli/src/chat/tui/state/cliState.ts` |
| `CliChatGptLoginSlashArgs` (type) | `packages/cli/src/runtime/loginOptions.ts` |
| `DoctorCheckStatus` (type) | `packages/cli/src/runtime/doctor.ts` |
| `DoctorCheck` (type) | `packages/cli/src/runtime/doctor.ts` |
| `PastedTextEntry` (type) | `packages/cli/src/chat/tui/input/draftAttachments.ts` |
| `QueuedFollowUpPanelRow` (type) | `packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx` |
| `CliSessionGoalStatus` (type) | `packages/cli/src/chat/tui/sessionStatus.ts` |
| `TranscriptFallbackAssistant` (type) | `packages/cli/src/chat/tui/state/transcriptProjection.ts` |
| `NotificationKind` (type) | `packages/cli/src/chat/tui/notifications/terminalNotifier.ts` |

### Deleted (2 items — fully orphaned)

| Name | File |
|---|---|
| `CliHumanInputApprovalEvent` (type) | `packages/cli/src/runtime/approvalEvents.ts` |
| `CliApprovalEventKind` (type) | `packages/cli/src/runtime/approvalEvents.ts` |

### Skipped

None — all 30 items in the batch list were verified accurate against current `main` and executed.

## Test plan

- [x] `npx tsc --noEmit` (root) — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `packages/cli` package-level `tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on all touched files — 0 errors (2 pre-existing `import/order` warnings unrelated to these edits, confirmed via diff)
- [x] `npx prettier --check` on all touched files — clean (reflowed 2 files after `export` removal shortened lines)
- [x] Full `src/test-kernel/cli` vitest suite (128 files) — 1604/1605 passed; the one failure (`InitPlatformSignalHandlers.vitest.mts`, a signal-handling timeout test unrelated to any touched file) passes cleanly in isolation, confirming it's a pre-existing load-sensitive flake, not a regression from this change
- [x] `npx knip --include files,exports,types,duplicates` re-run — none of the 30 processed items are flagged anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only cleanup with no logic changes; risk is limited to any undocumented deep imports of removed symbols, which knip reported as unused.
> 
> **Overview**
> This PR trims **dead public surface** in `packages/cli` after a knip census: symbols that were exported but only used inside their defining module stay in place; only `export` is removed (or barrel re-exports are dropped).
> 
> **Approval / runtime:** `approvalAdapter` no longer re-exports `denyMessage`, `CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT`, `formatUserQuestionPrompt`, or the `ApprovalDecision` type; `denyMessage` is file-private in `approval/approvalPolicy.ts`. **`approvalEvents.ts`** drops the unused types `CliHumanInputApprovalEvent` and `CliApprovalEventKind`.
> 
> **TUI / commands:** Usage strings and small types (`YOLO_USAGE`, `CHAT_LOGIN_USAGE`, `DIFF_LINE_STYLE`, `NotificationKind`, panel/status types, `ActiveSlashForm`, etc.) are module-local instead of package exports.
> 
> **Config / context:** Types like `CliMode`, `ChatDefaultSource`, `CliCommandConfig`, and relay token expiry constants are de-exported where nothing outside the file imported them.
> 
> No runtime or API behavior changes—only visibility and two orphaned type aliases removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020d5283f3f06fb9f420a55fe8131ee2e86d1b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->