### PR TITLE
refactor: narrow host progress ingress

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -63,9 +63,9 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
-import type {
-  ProgressBackendEvent,
-  ProgressBackendEventPayloads,
+import {
+  isProgressBackendInteractionEvent,
+  type ProgressBackendInteractionPayloads,
 } from '@shared/progressView/backend/events/ProgressEventHandler';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
@@ -1008,14 +1008,15 @@ export class DesktopProgressBridge {
     event: K,
     payload: AgentRuntimeEventPayloads[K],
   ): void {
-    if (!isRuntimePresentationEvent(event)) {
-      if (event === 'addOutputFiles') return;
+    if (isProgressBackendInteractionEvent(event)) {
       this.backend.handleProgressEvent(
-        event as ProgressBackendEvent,
-        payload as ProgressBackendEventPayloads[ProgressBackendEvent],
+        event,
+        payload as ProgressBackendInteractionPayloads[typeof event],
       );
       return;
     }
+
+    if (!isRuntimePresentationEvent(event)) return;
 
     switch (event) {
       case 'requestEnsureProgressView':

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -7,9 +7,9 @@ import {
   isExtensionPresentationEvent,
 } from '@frontend/events/extensionPresentationEvents';
 import { emitExtensionProgressEvent } from '@frontend/events/extensionProgressEvents';
-import type {
-  ProgressBackendEvent,
-  ProgressBackendEventPayloads,
+import {
+  isProgressBackendInteractionEvent,
+  type ProgressBackendInteractionPayloads,
 } from '@shared/progressView/backend/events/ProgressEventHandler';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
@@ -22,9 +22,11 @@ export const extensionAgentRuntimeHost: AgentRuntimeHost = {
       );
       return;
     }
-    emitExtensionProgressEvent(
-      event as ProgressBackendEvent,
-      payload as ProgressBackendEventPayloads[ProgressBackendEvent],
-    );
+    if (isProgressBackendInteractionEvent(event)) {
+      emitExtensionProgressEvent(
+        event,
+        payload as ProgressBackendInteractionPayloads[typeof event],
+      );
+    }
   },
 };

--- a/packages/extension/src/frontend/events/extensionProgressEvents.ts
+++ b/packages/extension/src/frontend/events/extensionProgressEvents.ts
@@ -1,11 +1,11 @@
 import type {
-  ProgressBackendEvent,
-  ProgressBackendEventPayloads,
+  ProgressBackendInteractionEvent,
+  ProgressBackendInteractionPayloads,
 } from '@shared/progressView/backend/events/ProgressEventHandler';
 
-type ExtensionProgressEventSink = <K extends ProgressBackendEvent>(
+type ExtensionProgressEventSink = <K extends ProgressBackendInteractionEvent>(
   event: K,
-  payload: ProgressBackendEventPayloads[K],
+  payload: ProgressBackendInteractionPayloads[K],
 ) => void;
 
 let activeSink: ExtensionProgressEventSink | undefined;
@@ -23,9 +23,8 @@ export function setExtensionProgressEventSink(
   };
 }
 
-export function emitExtensionProgressEvent<K extends ProgressBackendEvent>(
-  event: K,
-  payload: ProgressBackendEventPayloads[K],
-): void {
+export function emitExtensionProgressEvent<
+  K extends ProgressBackendInteractionEvent,
+>(event: K, payload: ProgressBackendInteractionPayloads[K]): void {
   activeSink?.(event, payload);
 }

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -36,6 +36,7 @@ import {
 } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
+import type { ProgressBackendEventPayloads } from '@shared/progressView/backend/events/ProgressEventHandler';
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
@@ -60,9 +61,6 @@ import { attachProgressBackendAppSignals } from './progressBackendAppSignals';
 import type { MainViewProvider } from '../MainViewProvider';
 
 const MAX_INQUIRY_THREAD_HYDRATION = 100;
-const SESSION_FACT_OWNED_EXTENSION_PROGRESS_EVENTS: ReadonlySet<string> =
-  new Set(['addOutputFiles', 'removeStream']);
-
 export type ProgressStreamRevealResult = 'revealed' | 'missing';
 
 /**
@@ -179,8 +177,10 @@ export class ProgressViewProvider
     );
     const detachExtensionProgressEvents = setExtensionProgressEventSink(
       (event, payload) => {
-        if (SESSION_FACT_OWNED_EXTENSION_PROGRESS_EVENTS.has(event)) return;
-        this.backend.handleProgressEvent(event, payload);
+        this.backend.handleProgressEvent(
+          event,
+          payload as ProgressBackendEventPayloads[typeof event],
+        );
       },
     );
     const detachRemoveStreamCleanup = defaultSession().events.subscribe(

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -41,8 +41,36 @@ export interface UICallbacks {
   updateSuperYoloBypassState: (streamId: string, bypassActive: boolean) => void;
 }
 
+export type ProgressBackendInteractionPayloads = Pick<
+  RuntimeInteractionEventPayloads,
+  | 'showToolEditPermission'
+  | 'resolveToolEditPermission'
+  | 'updateToolEditApprovalBypassState'
+  | 'updateSuperYoloBypassState'
+>;
+
+export type ProgressBackendInteractionEvent =
+  keyof ProgressBackendInteractionPayloads;
+
+const PROGRESS_BACKEND_INTERACTION_EVENTS = [
+  'showToolEditPermission',
+  'resolveToolEditPermission',
+  'updateToolEditApprovalBypassState',
+  'updateSuperYoloBypassState',
+] as const satisfies readonly ProgressBackendInteractionEvent[];
+
+const ProgressBackendInteractionEventSet: ReadonlySet<string> = new Set(
+  PROGRESS_BACKEND_INTERACTION_EVENTS,
+);
+
+export function isProgressBackendInteractionEvent(
+  event: string,
+): event is ProgressBackendInteractionEvent {
+  return ProgressBackendInteractionEventSet.has(event);
+}
+
 export type ProgressBackendEventPayloads = ProgressEventPayloads &
-  RuntimeInteractionEventPayloads;
+  ProgressBackendInteractionPayloads;
 
 export type ProgressBackendEvent = keyof ProgressBackendEventPayloads;
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -9,9 +9,11 @@ import {
 
 // Local imports - agent state
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import type { AgentEvent } from '@agent/trace';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { TaskStateSchema } from '@agent/core/state/TaskState';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import type { SessionEvent } from '@agent/runtime/SessionEventHub';
+import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 
@@ -29,6 +31,7 @@ import {
   type ExecutionId,
   type RestoredStreamSnapshot,
   type RunOutcome,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -588,6 +591,62 @@ async function settleProgressEvents(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
+function emitSessionFact<K extends SessionFact['type']>(
+  bridge: TestableBridge,
+  type: K,
+  payload: Extract<SessionFact, { type: K }>['payload'],
+): void {
+  (bridge as BridgeWithSession).session.events.emit({
+    scope: 'session',
+    event: { type, payload } as Extract<SessionFact, { type: K }>,
+  });
+}
+
+function emitRunEvent(
+  bridge: TestableBridge,
+  streamId: StreamTabId,
+  event: AgentEvent,
+): void {
+  (bridge as BridgeWithSession).session.events.emit({
+    scope: 'run',
+    streamId,
+    event,
+  });
+}
+
+function emitRunConfigFact(
+  bridge: TestableBridge,
+  payload: {
+    streamId: StreamTabId;
+    executionId: ExecutionId;
+    taskState: { agentConfig: unknown };
+  },
+): void {
+  emitRunEvent(bridge, payload.streamId, {
+    type: 'run.config',
+    streamId: payload.streamId,
+    executionId: payload.executionId,
+    config: payload.taskState.agentConfig as AgentConfig,
+  });
+}
+
+function emitStatusFact(
+  bridge: TestableBridge,
+  payload: {
+    streamId: StreamTabId;
+    status: StreamPhase;
+    previousStatus?: StreamPhase;
+  },
+): void {
+  emitRunEvent(bridge, payload.streamId, {
+    type: 'status',
+    streamId: payload.streamId,
+    phase: payload.status,
+    previousPhase: payload.previousStatus,
+    cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  });
+}
+
 describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/ProgressViewBridge');
@@ -602,12 +661,12 @@ describe('DesktopProgressBridge', () => {
     vi.restoreAllMocks();
   });
 
-  it('routes runtime events to the window-local desktop backend', async () => {
+  it('routes session facts to the window-local desktop backend', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'parent',
         agentCategory: AgentCategory.Workflow,
       });
@@ -931,27 +990,44 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'parent',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('updateConversationProgress', {
-        streamId: 'parent',
-        progress: { toolCallCount: 5 },
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'domain',
+        key: 'conversationProgress',
+        data: { toolCallCount: 5 },
       });
-      bridge.handleProgressEvent('updateRoundStage', {
-        streamId: 'parent',
-        roundStage: { index: 2 },
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'stage.start',
+        id: 'round-2',
+        label: 'Round 2',
+        kind: 'round',
+        index: 2,
       });
-      bridge.handleProgressEvent('updateActiveProcesses', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'processes',
         parentStreamId: 'parent',
-        processes: [{ executionId: 'process-1', agentName: 'bash' }],
+        processes: [
+          { kind: 'process', executionId: 'process-1', agentName: 'bash' },
+        ],
       });
 
       vi.spyOn(Date, 'now').mockReturnValue(2_000);
-      bridge.handleProgressEvent('updateActiveSubagents', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'subagents',
         parentStreamId: 'parent',
-        children: [{ executionId: 'agent-1', agentName: 'reviewer' }],
+        children: [
+          {
+            kind: 'subagent',
+            childStreamId: 'agent-1',
+            executionId: 'agent-1',
+            agentName: 'reviewer',
+          },
+        ],
       });
       await settleProgressEvents();
       messages.length = 0;
@@ -985,23 +1061,40 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'parent',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('updateActiveProcesses', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'processes',
         parentStreamId: 'parent',
-        processes: [{ executionId: 'process-1', agentName: 'bash' }],
+        processes: [
+          { kind: 'process', executionId: 'process-1', agentName: 'bash' },
+        ],
       });
-      bridge.handleProgressEvent('updateActiveSubagents', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'subagents',
         parentStreamId: 'parent',
-        children: [{ executionId: 'agent-1', agentName: 'reviewer' }],
+        children: [
+          {
+            kind: 'subagent',
+            childStreamId: 'agent-1',
+            executionId: 'agent-1',
+            agentName: 'reviewer',
+          },
+        ],
       });
-      bridge.handleProgressEvent('updateActiveProcesses', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'processes',
         parentStreamId: 'parent',
         processes: [],
       });
-      bridge.handleProgressEvent('updateActiveSubagents', {
+      emitRunEvent(bridge, 'parent' as StreamTabId, {
+        type: 'child.activity',
+        kind: 'subagents',
         parentStreamId: 'parent',
         children: [],
       });
@@ -1027,10 +1120,9 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('updateStreamStatus', {
+      emitStatusFact(bridge, {
         streamId: 'new-stream',
         status: STREAM_STATUS.RUNNING,
-        previousStatus: STREAM_STATUS.READY,
       });
 
       expect(
@@ -1118,7 +1210,7 @@ describe('DesktopProgressBridge', () => {
     const taskState = workflowTaskState();
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      emitRunConfigFact(bridge, {
         streamId: 'stream-new',
         executionId: 'abc123',
         taskState,
@@ -1984,7 +2076,7 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'child-stream',
         agentCategory: AgentCategory.ToolUse,
         suppressViewSwitch: true,
@@ -2010,11 +2102,11 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'first',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'second',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2064,7 +2156,7 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'plan-delete-stream',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2170,7 +2262,7 @@ describe('DesktopProgressBridge', () => {
     await bridgeGoalStore.start(stream, 'finish the cleanup');
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: stream,
         agentCategory: AgentCategory.Workflow,
       });
@@ -2189,15 +2281,15 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'first',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'second',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'third',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2234,11 +2326,11 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'first',
         agentCategory: AgentCategory.Workflow,
       });
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'second',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2247,7 +2339,7 @@ describe('DesktopProgressBridge', () => {
       messages.length = 0;
 
       const deletePromise = bridge.deleteStream('second');
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'second',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2283,7 +2375,7 @@ describe('DesktopProgressBridge', () => {
     );
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'active',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2315,7 +2407,7 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.handleProgressEvent('setActiveStream', {
+      emitSessionFact(bridge, 'setActiveStream', {
         streamId: 'bash-delete-all-stream',
         agentCategory: AgentCategory.Workflow,
       });
@@ -2682,7 +2774,7 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge([], { runAgent });
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      emitRunConfigFact(bridge, {
         streamId: 'stream-new',
         executionId: 'exec-new',
         taskState,
@@ -2783,12 +2875,12 @@ describe('DesktopProgressBridge', () => {
     const taskState = { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG };
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      emitRunConfigFact(bridge, {
         streamId: 'stream-1',
-        executionId: 'ec1001',
+        executionId: 'ec1001' as ExecutionId,
         taskState,
       });
-      bridge.handleProgressEvent('setParentStream', {
+      emitSessionFact(bridge, 'setParentStream', {
         childStreamId: 'stream-1',
         parentStreamId,
       });
@@ -2860,9 +2952,9 @@ describe('DesktopProgressBridge', () => {
     });
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      emitRunConfigFact(bridge, {
         streamId: 'stream-1',
-        executionId: 'ec1001',
+        executionId: 'ec1001' as ExecutionId,
         taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
       bridgeFollowUps(bridge).enqueue(
@@ -2926,9 +3018,9 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge([], { retrieveSessionResumeData });
 
     try {
-      bridge.handleProgressEvent('setTaskState', {
+      emitRunConfigFact(bridge, {
         streamId: 'stream-1',
-        executionId: 'ec1001',
+        executionId: 'ec1001' as ExecutionId,
         taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
 

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -27,7 +27,7 @@ describe('extensionAgentRuntimeHost', () => {
     }
   });
 
-  it('routes run progress events through the extension progress sink', () => {
+  it('routes backend interaction events through the extension progress sink', () => {
     const progressEvents: unknown[] = [];
     const disposeProgressSink = setExtensionProgressEventSink(
       (event, payload) => {
@@ -39,23 +39,34 @@ describe('extensionAgentRuntimeHost', () => {
       extensionAgentRuntimeHost.emit('setActiveStream', {
         streamId: 'extension:progress' as StreamTabId,
       });
-
-      expect(progressEvents).toEqual([
-        {
-          event: 'setActiveStream',
-          payload: { streamId: 'extension:progress' as StreamTabId },
-        },
-      ]);
-
-      disposeProgressSink();
-      extensionAgentRuntimeHost.emit('setActiveStream', {
-        streamId: 'extension:after-detach' as StreamTabId,
+      extensionAgentRuntimeHost.emit('updateToolEditApprovalBypassState', {
+        streamId: 'extension:progress' as StreamTabId,
+        bypassActive: true,
       });
 
       expect(progressEvents).toEqual([
         {
-          event: 'setActiveStream',
-          payload: { streamId: 'extension:progress' as StreamTabId },
+          event: 'updateToolEditApprovalBypassState',
+          payload: {
+            streamId: 'extension:progress' as StreamTabId,
+            bypassActive: true,
+          },
+        },
+      ]);
+
+      disposeProgressSink();
+      extensionAgentRuntimeHost.emit('updateToolEditApprovalBypassState', {
+        streamId: 'extension:after-detach' as StreamTabId,
+        bypassActive: false,
+      });
+
+      expect(progressEvents).toEqual([
+        {
+          event: 'updateToolEditApprovalBypassState',
+          payload: {
+            streamId: 'extension:progress' as StreamTabId,
+            bypassActive: true,
+          },
         },
       ]);
     } finally {


### PR DESCRIPTION
## Summary

Part of #6968 and #6951.

This Stage 5 slice removes the broad runtime-host progress fallback from desktop and extension host ingress. Runtime-host progress ingress now accepts only the explicit progress-backend interaction subset that still belongs on the host rail: tool-edit show/resolve plus tool-edit and super-yolo bypass-state pushes.

Desktop and extension stream/progress facts now enter the progress view through their session/run fact subscriptions instead of being offered broadly through runtime-host progress events. Presentation events remain on their presentation rail.

## Issue acceptance gates

This advances the Stage 5 layer-budget gate by narrowing one remaining host-progress ingress path. It does not delete the frozen host-progress compatibility vocabulary yet; `ProgressBackend.handleProgressEvent()` remains the compatibility adapter for retained host events and tests, while desktop/extension runtime-host entry points stop treating it as a catch-all fact rail.

## Single source of truth

`ProgressBackendInteractionPayloads` in `ProgressEventHandler.ts` is now the single typed list of progress-backend UI interaction callbacks that still use the host progress sink. Session/run facts stay owned by `SessionEventHub` and `ProgressFactApplier`.

## Duplication and abstraction budget

This removes duplicate desktop/extension fact ingress through runtime-host progress events. The PR is not net-negative in lines because the added mass is mostly tests plus the typed boundary guard that prevents future broad re-expansion of the host rail; it does not add a pass-through layer.

No #6981 ledger row is added: this narrows an existing compatibility boundary and introduces no shim, projection, dual-write, fallback, or migration path.

## Host impact

Extension: runtime-host progress emission now reaches the progress backend only for the retained backend interaction subset. Stream facts continue through session/run fact subscriptions.

Desktop: runtime-host handling now forwards backend interaction events and desktop presentation events only. Stream/snapshot/goal facts continue through the session-owned path.

CLI: no behavior change; headless public-output compatibility remains on the existing CLI boundary.

## Scheduled refactoring

Tracked by #6968: continue Stage 5 by deleting or narrowing the remaining frozen host-progress compatibility surface once each consumer has a direct owner.

## Validation

- `corepack pnpm exec prettier --write` on touched files
- `npm run typecheck`
- `CI=true corepack pnpm exec vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `corepack pnpm run check:dead-code-ratchet`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `CI=true corepack pnpm run test`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /tmp/texra-tui-stage5-ingress-20260708`
- `corepack pnpm exec prettier --check` on touched files
- `git diff --check`

Refs #6968
