### PR TITLE
chore: remove dead exports flagged by knip (shared-schemas-1)

### DIFF
--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -18,7 +18,7 @@ export const END_GROUP_STATUS = {
   STOPPED: 'stopped',
 } as const;
 
-export const EndGroupStatusSchema = z.enum(END_GROUP_STATUS);
+const EndGroupStatusSchema = z.enum(END_GROUP_STATUS);
 export type EndGroupStatus = z.infer<typeof EndGroupStatusSchema>;
 
 type _AssertEndGroupStatusSubset = EndGroupStatus extends TaskGroupStatus
@@ -101,7 +101,7 @@ export const StreamLogTextDeltaSchema = z.strictObject({
 });
 export type StreamLogTextDelta = z.infer<typeof StreamLogTextDeltaSchema>;
 
-export const LogMessageDataSchema = z.strictObject({
+const LogMessageDataSchema = z.strictObject({
   id: z.string().min(1),
   text: z.string(),
   level: LogLevelSchema,
@@ -112,10 +112,6 @@ export const LogMessageDataSchema = z.strictObject({
   data: z.unknown().optional(),
 });
 export type LogMessageData = z.infer<typeof LogMessageDataSchema>;
-
-export const LogMessageUpdateSchema = LogMessageDataSchema.partial().required({
-  id: true,
-});
 
 /**
  * Legacy log message format (from STREAM_TABS era).

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -292,10 +292,10 @@ const CleanLatexdiffvcMessageSchema = z.object({
   ...latexdiffvcOperationFields,
 });
 
-export const LatexdiffvcOperationMessageSchema = z.discriminatedUnion(
-  'command',
-  [PackLatexdiffvcMessageSchema, CleanLatexdiffvcMessageSchema],
-);
+const LatexdiffvcOperationMessageSchema = z.discriminatedUnion('command', [
+  PackLatexdiffvcMessageSchema,
+  CleanLatexdiffvcMessageSchema,
+]);
 export type LatexdiffvcOperationMessage = z.infer<
   typeof LatexdiffvcOperationMessageSchema
 >;

--- a/src/shared/schemas/runDescriptor.ts
+++ b/src/shared/schemas/runDescriptor.ts
@@ -5,7 +5,7 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 
 export const RUN_DESCRIPTOR_SCHEMA_VERSION = 1;
 
-export function executionConfigReferencePath(executionId: string): string {
+function executionConfigReferencePath(executionId: string): string {
   return `executions/${executionId}/config.json`;
 }
 
@@ -14,8 +14,6 @@ export const RunConfigReferenceSchema = z.strictObject({
   executionId: ExecutionIdSchema,
   path: z.string(),
 });
-
-export type RunConfigReference = z.infer<typeof RunConfigReferenceSchema>;
 
 export const RunDescriptorSchema = z.strictObject({
   schemaVersion: z.literal(RUN_DESCRIPTOR_SCHEMA_VERSION),

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -49,14 +49,6 @@ import {
   CodexReasoningEffortSchema,
   CodexSandboxModeSchema,
 } from '../agentCliSettings';
-export {
-  ClaudeAgentEffortSchema,
-  ClaudeAgentModelSchema,
-  ClaudeAgentPermissionModeSchema,
-  CodexApprovalPolicySchema,
-  CodexReasoningEffortSchema,
-  CodexSandboxModeSchema,
-} from '../agentCliSettings';
 export type {
   ClaudeAgentEffort,
   ClaudeAgentModel,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -164,7 +164,7 @@ export const STREAM_SUBSTATE = {
 export const StreamSubstateSchema = z.enum(STREAM_SUBSTATE);
 export type StreamSubstate = z.infer<typeof StreamSubstateSchema>;
 
-export function isRunOutcome(value: string | undefined): value is RunOutcome {
+function isRunOutcome(value: string | undefined): value is RunOutcome {
   return RunOutcomeSchema.safeParse(value).success;
 }
 
@@ -215,20 +215,6 @@ export function streamStatusToSubstate(
   }
 }
 
-export function streamPhaseToStreamStatus(phase: StreamPhase): StreamStatus {
-  switch (phase) {
-    case STREAM_PHASE.RUNNING:
-      return STREAM_STATUS.RUNNING;
-    case STREAM_PHASE.WAITING:
-      return STREAM_STATUS.WAITING;
-    case STREAM_PHASE.FAILED:
-      return STREAM_STATUS.ERROR;
-    case STREAM_PHASE.COMPLETED:
-    case STREAM_PHASE.CANCELLED:
-      return STREAM_STATUS.STOPPED;
-  }
-}
-
 export type StreamLifecycleStatus = StreamPhase | typeof STREAM_STATUS.READY;
 
 export function streamStatusToLifecycleStatus(
@@ -274,7 +260,6 @@ export const WorktreePRInfoSchema = z.object({
   deletions: z.number().optional(),
   ciState: WorktreeCIStateSchema.optional(),
 });
-export type WorktreePRInfo = z.infer<typeof WorktreePRInfoSchema>;
 
 export const WorktreeInfoSchema = z.object({
   /** Absolute path of the worktree the agent is operating in. */


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Executes a verified batch of 15 dead-export/type findings across 5 files in `src/shared/schemas/`, all previously confirmed zero-usage-outside-own-file by an adversarial verification pass plus orchestrator spot-checks.

### De-exported (kept the declaration, dropped only the `export` keyword — each is still used internally in its own file)

| Name | File | Why |
|---|---|---|
| `ClaudeAgentEffortSchema` | `src/shared/schemas/settingsView/data.ts` | Redundant re-export block (lines 52-59) duplicating the direct `agentCliSettings.ts -> index.ts` barrel path; the import itself stays because the schema is used in-file at line ~325 |
| `ClaudeAgentModelSchema` | same | same redundant re-export block |
| `ClaudeAgentPermissionModeSchema` | same | same redundant re-export block |
| `CodexApprovalPolicySchema` | same | same redundant re-export block |
| `CodexReasoningEffortSchema` | same | same redundant re-export block |
| `CodexSandboxModeSchema` | same | same redundant re-export block |
| `LatexdiffvcOperationMessageSchema` | `src/shared/schemas/mainView/inbound.ts` | Only its inferred type (`LatexdiffvcOperationMessage`) is consumed externally (`DiffManager.ts`); schema itself has no external `.parse()`/`.safeParse()` call site |
| `isRunOutcome` | `src/shared/schemas/stream.ts` | Only used by `executionStatusToRunOutcome` in the same file |
| `EndGroupStatusSchema` | `src/shared/schemas/log.ts` | Only its inferred type `EndGroupStatus` is consumed externally (heavily, across `StreamLogStore.ts`, `TraceEmitter.ts`, `AgentTrace.ts`, etc.) |
| `LogMessageDataSchema` | `src/shared/schemas/log.ts` | Only its inferred type `LogMessageData` is consumed externally (extensively, across the progress-view frontend) |
| `executionConfigReferencePath` | `src/shared/schemas/runDescriptor.ts` | Only used by `buildRunDescriptor` in the same file |

### Fully deleted (zero references anywhere, including in-file)

| Name | File | Notes |
|---|---|---|
| `streamPhaseToStreamStatus` | `src/shared/schemas/stream.ts` | Fully orphaned function |
| `WorktreePRInfo` (type alias) | `src/shared/schemas/stream.ts` | `WorktreePRInfoSchema` itself is kept — it's used to build `WorktreeInfoSchema` |
| `LogMessageUpdateSchema` | `src/shared/schemas/log.ts` | No type was even derived from it; zero references |
| `RunConfigReference` (type alias) | `src/shared/schemas/runDescriptor.ts` | `RunConfigReferenceSchema` itself is kept — it's composed into `RunDescriptorSchema` |

### Skipped

None — all 15 items in the batch list were re-verified against current `main` and executed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — pre-existing 428 errors (missing `packages/cli`/`packages/desktop` node_modules symlinks in the isolated worktree — all `Cannot find module 'citty'/'ink'/'electron'/...`), zero of which touch any file in this PR; confirmed identical count on a clean pre-edit checkout
- [x] `npx eslint` on all 5 touched files — clean
- [x] `npx prettier --check` on all 5 touched files — clean (one file needed `--write` after the discriminated-union edit reformatted onto fewer lines)
- [x] `npx vitest run src/test-kernel/schemas/` — 7 files / 105 tests passed
- [x] `npx vitest run src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts` (only other test file referencing these schema files) — 4 tests passed
- [x] Re-ran `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` — none of the 15 touched names appear in the output anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only hygiene with verified zero external references; public types and composed schemas are unchanged.
> 
> **Overview**
> **Knip dead-export cleanup** in `src/shared/schemas/` — no runtime or public API behavior change for consumers that already used the retained exported types and schemas.
> 
> Several Zod schemas and helpers are now **module-private** (`EndGroupStatusSchema`, `LogMessageDataSchema`, `LatexdiffvcOperationMessageSchema`, `isRunOutcome`, `executionConfigReferencePath`) because only inferred types or same-file callers needed them externally.
> 
> **Removed entirely:** `LogMessageUpdateSchema`, `streamPhaseToStreamStatus`, and redundant type aliases `RunConfigReference` and `WorktreePRInfo` (their `*Schema` siblings stay for composition).
> 
> **settingsView/data.ts** drops a duplicate re-export block for six agent CLI Zod schemas; those schemas remain available via `agentCliSettings` / the settings barrel, and the file still imports them for `UpdateApprovalSettingsMessageSchema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a413acdb5fbbbbae98c1b80b223a106d32c35c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->