### PR TITLE
chore: remove dead exports flagged by knip (batch: shared-schemas-4)

### DIFF
--- a/src/shared/schemas/memoryViewMessages.ts
+++ b/src/shared/schemas/memoryViewMessages.ts
@@ -13,7 +13,7 @@ import { commandOnly } from './messageFactories';
 // Data schemas
 // ============================================================
 
-export const MemoryViewItemSchema = z.object({
+const MemoryViewItemSchema = z.object({
   displayPath: z.string(),
   storagePath: z.string(),
   size: z.number(),
@@ -28,7 +28,7 @@ export const MemoryViewItemSchema = z.object({
 });
 export type MemoryViewItem = z.infer<typeof MemoryViewItemSchema>;
 
-export const MemoryPreviewSchema = z.object({
+const MemoryPreviewSchema = z.object({
   storagePath: z.string(),
   lineCount: z.number().optional(),
   preview: z.string().optional(),
@@ -63,10 +63,9 @@ export const UpdateMemoryEnabledMessageSchema = z.object({
 export const MemoryPathMessageSchema = z.object({
   storagePath: z.string().min(1),
 });
-export type MemoryPathMessage = z.infer<typeof MemoryPathMessageSchema>;
 
 /** Memory item action detail for frontend events (open/delete) */
-export const MemoryItemActionDetailSchema = z.object({
+const MemoryItemActionDetailSchema = z.object({
   storagePath: z.string(),
   displayPath: z.string().optional(),
 });
@@ -78,13 +77,11 @@ export type MemoryItemActionDetail = z.infer<
 export const MemoryDeleteMessageSchema = MemoryPathMessageSchema.extend({
   displayPath: z.string().min(1),
 });
-export type MemoryDeleteMessage = z.infer<typeof MemoryDeleteMessageSchema>;
 
 /** Memory enabled toggle message (reusable field schema) */
 export const MemoryEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
-export type MemoryEnabledMessage = z.infer<typeof MemoryEnabledMessageSchema>;
 
 // Inbound messages with command literals
 export const GetMemoryDataMessageSchema = commandOnly(

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -12,18 +12,12 @@
 // re-exported here for consumers that expect it from the schema module.
 export { SETTINGS_VIEW_CMD } from '@shared/ipc';
 
-// Re-export the canonical LaTeX config field type so existing consumers that
-// import `LatexConfigField` from this module continue to compile.
-export type { LatexConfigField } from '@shared/constants/latex';
-
 // Re-export Goal metadata from its shared leaf module so this file (consumed by
 // webview frontends) does not pull in GoalTool/GoalStore runtime modules.
 export {
-  GoalSchema,
   formatGoalTime,
   isGoalInFlight,
   goalDurationMs,
-  goalElapsedMs,
   type Goal,
   type GoalStatus,
 } from './goal';
@@ -31,23 +25,15 @@ export {
 // Re-export data schemas from the individual view-message modules so the
 // historical settings surface (single import site) stays intact.
 export {
-  MemoryViewItemSchema,
-  MemoryPreviewSchema,
   type MemoryViewItem,
   type MemoryPreview,
   type MemoryItemActionDetail,
-  type MemoryPathMessage,
-  type MemoryDeleteMessage,
-  type MemoryEnabledMessage,
 } from './memoryViewMessages';
 
-export { HistoryItemSchema, type HistoryItem } from './historyViewMessages';
+export { type HistoryItem } from './historyViewMessages';
 
 export {
   API_ACCESS_MODE_OPTIONS,
-  NumberVscodeSettingSchema,
-  type RemoteAgent,
-  type ApiAccessMode,
   type ProviderKeyStatus,
   type ProviderVscodeSetting,
   type NumberVscodeSetting,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -22,8 +22,10 @@ export {
   type GoalStatus,
 } from './goal';
 
-// Re-export data schemas from the individual view-message modules so the
-// historical settings surface (single import site) stays intact.
+// Re-export types (and one constant) from the individual view-message
+// modules so the historical settings surface (single import site) stays
+// intact. The schemas themselves are no longer re-exported here — consumers
+// only ever needed the inferred types through this barrel.
 export {
   type MemoryViewItem,
   type MemoryPreview,

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { StreamTabIdSchema } from './identifiers';
 import { TaskGroupStatusSchema } from './stream';
 
 export const TaskGroupSchema = z.strictObject({
@@ -16,14 +15,3 @@ export const TaskGroupSchema = z.strictObject({
 });
 
 export type TaskGroup = z.infer<typeof TaskGroupSchema>;
-
-export const AddTaskGroupPayloadSchema = z.strictObject({
-  streamId: StreamTabIdSchema,
-  ...TaskGroupSchema.shape,
-});
-export const UpdateTaskGroupPayloadSchema = AddTaskGroupPayloadSchema.pick({
-  streamId: true,
-  id: true,
-  status: true,
-  endTime: true,
-});

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -115,7 +115,6 @@ export function sumUsageStats(
 /** Run-keyed usage map: `{ runId: TokenUsageStats }`. Single source of truth used by
  * stream state, snapshot, and IPC message schemas so all four sites stay in sync. */
 export const RunUsageMapSchema = z.record(z.string(), TokenUsageStatsSchema);
-export type RunUsageMap = z.infer<typeof RunUsageMapSchema>;
 
 /**
  * Extended token usage with per-round deltas. Note: percentageCached is


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep (batch: shared-schemas-4). All items were re-verified against current `main` before editing.

### Fully deleted (zero references anywhere)

| Name | File | Action |
|---|---|---|
| `MemoryPathMessage` (type) | `src/shared/schemas/memoryViewMessages.ts` | deleted |
| `MemoryDeleteMessage` (type) | `src/shared/schemas/memoryViewMessages.ts` | deleted |
| `MemoryEnabledMessage` (type) | `src/shared/schemas/memoryViewMessages.ts` | deleted |
| `AddTaskGroupPayloadSchema` | `src/shared/schemas/taskGroup.ts` | deleted (+ its now-unused `StreamTabIdSchema` import) |
| `UpdateTaskGroupPayloadSchema` | `src/shared/schemas/taskGroup.ts` | deleted |
| `RunUsageMap` (type) | `src/shared/schemas/usage.ts` | deleted (`RunUsageMapSchema` const kept — still heavily used) |

### De-exported (used only internally; `export` keyword dropped, declaration kept)

| Name | File | Action |
|---|---|---|
| `MemoryItemActionDetailSchema` | `src/shared/schemas/memoryViewMessages.ts` | de-exported — still backs the exported `MemoryItemActionDetail` type via `z.infer` |
| `MemoryViewItemSchema` | `src/shared/schemas/memoryViewMessages.ts` | de-exported — **not in the original item list**, discovered during the post-fix `knip` re-scan. Removing the dead barrel re-export (see below) left this with zero external consumers; the derived `MemoryViewItem` type stays exported and is used repo-wide (tools, controllers, webview components, CLI). |
| `MemoryPreviewSchema` | `src/shared/schemas/memoryViewMessages.ts` | de-exported — same discovery/rationale as `MemoryViewItemSchema`; derived `MemoryPreview` type stays exported and used repo-wide. |

### Barrel re-export lines removed from `src/shared/schemas/settingsViewMessages.ts`

Only the re-export statements were touched; the underlying declarations in `goal.ts` / `historyViewMessages.ts` / `profileViewMessages.ts` / `@shared/constants/latex.ts` are alive via other direct import paths and were **not modified**:

`GoalSchema`, `goalElapsedMs`, `MemoryViewItemSchema`, `MemoryPreviewSchema`, `HistoryItemSchema`, `ProfileUserSchema`, `RemoteAgentSchema`, `ApiAccessModeSchema`, `TierConstantsSchema`, `ProviderKeyStatusSchema`, `ProviderVscodeSettingSchema`, `NumberVscodeSettingSchema`, `LatexConfigField`, `MemoryPathMessage`, `MemoryDeleteMessage`, `MemoryEnabledMessage`, `HistoryIdMessage`, `ProfileUser`, `RemoteAgent`, `ApiAccessMode`, `TierConstants`, `SelectAgentMessage`, `SetApiAccessModeMessage`.

### Skipped

None — every item in the batch list was still accurate against current `main` and was executed.

### Note for the orchestrator

`knip` also flags `MemoryPathMessageSchema`, `MemoryDeleteMessageSchema`, `MemoryEnabledMessageSchema` (schema consts, not the types deleted above) as dead exports in `memoryViewMessages.ts`. These were **not** touched — they were never reachable via the barrel re-export (only their derived types were re-exported, never these consts), so their dead-export status predates this batch and isn't a consequence of this change. Leaving them for a separate pass since they weren't in this batch's item list.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — output identical to the pre-existing baseline (428 lines, all pre-existing `citty`/`ink`/`electron`/`react` module-resolution errors from this worktree's package layout, none referencing touched files)
- [x] `npx eslint` on all 4 touched files — clean
- [x] `npx prettier --check` on all 4 touched files — clean
- [x] Targeted vitest suites covering the touched files' directories (settings, desktop IPC, schemas, controllers, progressView task groups) — 20 files / 254 tests passed
- [x] `npx knip --include files,exports,types,duplicates` re-scan — all originally-flagged items in this batch no longer appear; no new flags introduced in the touched files beyond the pre-existing `*Schema` consts noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-surface-only changes with no runtime or validation logic edits; risk is limited to any external importers of removed symbols (verified unused in-repo).
> 
> **Overview**
> Removes **unused public exports** from shared Zod schema modules and trims the `settingsViewMessages` barrel so it only re-exports types (and a few constants) that callers still use.
> 
> In **`memoryViewMessages`**, several inferred types are dropped entirely; internal schemas like `MemoryViewItemSchema` / `MemoryPreviewSchema` / `MemoryItemActionDetailSchema` stay in the file but are no longer exported—exported **types** such as `MemoryViewItem` and `MemoryPreview` are unchanged.
> 
> In **`taskGroup`**, unused `AddTaskGroupPayloadSchema` and `UpdateTaskGroupPayloadSchema` are removed along with the unused `StreamTabIdSchema` import.
> 
> In **`usage`**, the redundant `RunUsageMap` type export is removed; **`RunUsageMapSchema`** remains.
> 
> **`settingsViewMessages`** stops re-exporting many schema consts and extra types (`GoalSchema`, profile/history/memory schema barrels, `LatexConfigField`, etc.); consumers are expected to import those from their source modules or use the surviving type-only re-exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf700dc78b587acdca3c88ba2efe91f4ec69c1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->