### PR TITLE
chore: remove dead exports flagged by knip (batch: shared-schemas-2)

### DIFF
--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -33,7 +33,6 @@ export {
   isWorkflowState,
   type StreamState,
   type ToolUseStreamState,
-  type ToolUseUIState,
   type WorkflowStreamState,
 } from '@shared/schemas';
 

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -17,9 +17,6 @@ const ExternalInquirySessionLinkSchema = z.string().trim().min(1);
 export const ExternalInquirySessionLinksSchema = z.array(
   ExternalInquirySessionLinkSchema,
 );
-export type ExternalInquirySessionLinks = z.infer<
-  typeof ExternalInquirySessionLinksSchema
->;
 
 export const ExternalInquiryThreadIdSchema = z
   .string()
@@ -33,14 +30,10 @@ export type ExternalInquiryThreadId = z.infer<
 // Status + summary
 // ============================================================================
 
-export const InquiryThreadStatusSchema = z.enum([
-  'open',
-  'answered',
-  'dropped',
-]);
+const InquiryThreadStatusSchema = z.enum(['open', 'answered', 'dropped']);
 export type InquiryThreadStatus = z.infer<typeof InquiryThreadStatusSchema>;
 
-export const ExternalInquiryThreadSummarySchema = z.object({
+const ExternalInquiryThreadSummarySchema = z.object({
   threadId: ExternalInquiryThreadIdSchema,
   parentStreamId: StreamTabIdSchema.nullable(),
   status: InquiryThreadStatusSchema,
@@ -56,7 +49,7 @@ export type ExternalInquiryThreadSummary = z.infer<
 // Resume outcome — UI badge metadata for inquiryThreadUpdated events
 // ============================================================================
 
-export const InquiryResumeOutcomeSchema = z.enum([
+const InquiryResumeOutcomeSchema = z.enum([
   'sent',
   'queued',
   'resumed',
@@ -76,7 +69,7 @@ export type InquiryThreadUpdatedEvent = z.infer<
 // Action payloads — sent from inquiry panel to the host (keyed by threadId)
 // ============================================================================
 
-export const InquiryActionMessageSchema = z.discriminatedUnion('action', [
+const InquiryActionMessageSchema = z.discriminatedUnion('action', [
   z.object({
     action: z.literal('submit'),
     threadId: ExternalInquiryThreadIdSchema,

--- a/src/shared/schemas/mainView/index.ts
+++ b/src/shared/schemas/mainView/index.ts
@@ -19,11 +19,8 @@
  */
 export {
   DocumentFileTypeSchema,
-  ExtendedDocumentFileTypeSchema,
   MULTIPLE_DOCUMENT_FILE_TYPES,
-  MultipleDocumentFileTypeSchema,
   type DocumentFileType,
-  type ExtendedDocumentFileType,
   type MultipleDocumentFileType,
 } from '../fileTypes';
 export * from './state';

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -34,12 +34,12 @@ export type SessionType = z.infer<typeof SessionTypeSchema>;
  * keeps the two field names in lockstep — historically a typo in either schema
  * would have silently broken option matching in only one picker.
  */
-export const PickerOptionBaseSchema = z.object({
+const PickerOptionBaseSchema = z.object({
   value: z.string(),
   label: z.string(),
 });
 
-export const ModelAvailabilityKindSchema = z.enum([
+const ModelAvailabilityKindSchema = z.enum([
   'included-access',
   'provider-key',
   'openrouter-key',
@@ -121,18 +121,18 @@ export type MainViewPersistedState = z.infer<
 // Banner State Schemas
 // ============================================================
 
-export const BannerStateSchema = z.object({
+const BannerStateSchema = z.object({
   visible: z.boolean(),
 });
 export type BannerState = z.infer<typeof BannerStateSchema>;
 
-export const ApiKeyBannerStateSchema = BannerStateSchema.extend({
+const ApiKeyBannerStateSchema = BannerStateSchema.extend({
   provider: z.string().nullish(),
   requiresKey: z.boolean().nullish(),
 });
 export type ApiKeyBannerState = z.infer<typeof ApiKeyBannerStateSchema>;
 
-export const AgentConfigBannerStateSchema = BannerStateSchema.extend({
+const AgentConfigBannerStateSchema = BannerStateSchema.extend({
   agentName: z.string().nullish(),
   customDirSet: z.boolean().nullish(),
 });
@@ -140,7 +140,7 @@ export type AgentConfigBannerState = z.infer<
   typeof AgentConfigBannerStateSchema
 >;
 
-export const DependencyBannerStateSchema = BannerStateSchema.extend({
+const DependencyBannerStateSchema = BannerStateSchema.extend({
   missingTools: z.array(z.string()).nullish(),
 });
 export type DependencyBannerState = z.infer<typeof DependencyBannerStateSchema>;
@@ -149,7 +149,7 @@ export type DependencyBannerState = z.infer<typeof DependencyBannerStateSchema>;
 // File State Schemas
 // ============================================================
 
-export const FileSelectConfigSchema = z.object({
+const FileSelectConfigSchema = z.object({
   type: DocumentFileTypeSchema,
   label: z.string(),
   icon: z.string(),
@@ -162,23 +162,23 @@ export const FileSelectConfigSchema = z.object({
 });
 export type FileSelectConfig = z.infer<typeof FileSelectConfigSchema>;
 
-export const CheckboxValuesSchema = WorkflowToolConfigFieldsSchema;
+const CheckboxValuesSchema = WorkflowToolConfigFieldsSchema;
 export type CheckboxValues = z.infer<typeof CheckboxValuesSchema>;
 
-export const SingleFilesSchema = z.object({
+const SingleFilesSchema = z.object({
   baseFile: z.string(),
   editedFile: z.string(),
 });
 export type SingleFiles = z.infer<typeof SingleFilesSchema>;
 
-export const FileOptionsSchema = z.object({
+const FileOptionsSchema = z.object({
   baseFile: z.array(z.string()),
   editedFile: z.array(z.string()),
   commit: z.array(z.string()).optional(),
 });
 export type FileOptions = z.infer<typeof FileOptionsSchema>;
 
-export const MultiFilesSchema = z.object({
+const MultiFilesSchema = z.object({
   inputFiles: z.array(z.string()),
   contextFiles: z.array(z.string()),
   mediaFiles: z.array(z.string()),
@@ -189,10 +189,9 @@ export type MultiFiles = z.infer<typeof MultiFilesSchema>;
 // Enumerates the four `MultiFiles` keys (`inputFiles` / `contextFiles` /
 // `mediaFiles` / `outputFiles`) so `listId` fields below are constrained to
 // valid `keyof MultiFiles` values instead of an unconstrained `z.string()`.
-export const MultiFilesKeySchema = MultiFilesSchema.keyof();
-export type MultiFilesKey = z.infer<typeof MultiFilesKeySchema>;
+const MultiFilesKeySchema = MultiFilesSchema.keyof();
 
-export const FileStateContextSchema = z.object({
+const FileStateContextSchema = z.object({
   sessionType: SessionTypeSchema,
   checkboxValues: CheckboxValuesSchema,
   singleFiles: SingleFilesSchema,
@@ -202,7 +201,7 @@ export const FileStateContextSchema = z.object({
 });
 export type FileStateContextValue = z.infer<typeof FileStateContextSchema>;
 
-export const SessionContextSchema = z.object({
+const SessionContextSchema = z.object({
   sessionType: SessionTypeSchema,
   instruction: z.string(),
   placeholder: z.string(),
@@ -218,7 +217,7 @@ export const SessionContextSchema = z.object({
 });
 export type SessionContextValue = z.infer<typeof SessionContextSchema>;
 
-export const StringValueDetailSchema = z.object({
+const StringValueDetailSchema = z.object({
   value: z.string(),
 });
 export type StringValueDetail = z.infer<typeof StringValueDetailSchema>;
@@ -229,44 +228,44 @@ export type ModelChangeDetail = StringValueDetail;
 export type InstructionChangeDetail = StringValueDetail;
 export type CommitChangeDetail = StringValueDetail;
 
-export const FileActionDetailSchema = z.object({
+const FileActionDetailSchema = z.object({
   type: z.union([DocumentFileTypeSchema, z.enum(['base', 'edited'])]),
 });
 export type FileActionDetail = z.infer<typeof FileActionDetailSchema>;
 
-export const MultipleFilesActionDetailSchema = z.object({
+const MultipleFilesActionDetailSchema = z.object({
   listId: MultiFilesKeySchema,
 });
 export type MultipleFilesActionDetail = z.infer<
   typeof MultipleFilesActionDetailSchema
 >;
 
-export const MultipleFilesTypeActionDetailSchema = z.object({
+const MultipleFilesTypeActionDetailSchema = z.object({
   type: MultipleDocumentFileTypeSchema,
 });
 export type MultipleFilesTypeActionDetail = z.infer<
   typeof MultipleFilesTypeActionDetailSchema
 >;
 
-export const RemoveFileDetailSchema = z.object({
+const RemoveFileDetailSchema = z.object({
   listId: MultiFilesKeySchema,
   file: z.string(),
 });
 export type RemoveFileDetail = z.infer<typeof RemoveFileDetailSchema>;
 
-export const ReorderFilesDetailSchema = z.object({
+const ReorderFilesDetailSchema = z.object({
   listId: MultiFilesKeySchema,
   files: z.array(z.string()),
 });
 export type ReorderFilesDetail = z.infer<typeof ReorderFilesDetailSchema>;
 
-export const CheckboxChangeDetailSchema = z.object({
+const CheckboxChangeDetailSchema = z.object({
   id: z.string(),
   checked: z.boolean(),
 });
 export type CheckboxChangeDetail = z.infer<typeof CheckboxChangeDetailSchema>;
 
-export const BannerActionDetailSchema = z.object({
+const BannerActionDetailSchema = z.object({
   action: z.string(),
   provider: z.string().nullish(),
   customDirSet: z.boolean().nullish(),
@@ -282,26 +281,26 @@ export const GettingStartedActionSchema = z.enum([
 ]);
 export type GettingStartedAction = z.infer<typeof GettingStartedActionSchema>;
 
-export const GettingStartedActionDetailSchema = z.object({
+const GettingStartedActionDetailSchema = z.object({
   action: GettingStartedActionSchema,
 });
 export type GettingStartedActionDetail = z.infer<
   typeof GettingStartedActionDetailSchema
 >;
 
-export const InstallGuideDetailSchema = z.object({
+const InstallGuideDetailSchema = z.object({
   tool: z.string(),
 });
 export type InstallGuideDetail = z.infer<typeof InstallGuideDetailSchema>;
 
-export const LatexDiffsToggleDetailSchema = z.object({
+const LatexDiffsToggleDetailSchema = z.object({
   visible: z.boolean(),
 });
 export type LatexDiffsToggleDetail = z.infer<
   typeof LatexDiffsToggleDetailSchema
 >;
 
-export const LatexDiffsActionDetailSchema = z.object({
+const LatexDiffsActionDetailSchema = z.object({
   action: z.enum([
     'latexdiff',
     'latexdiffvc',
@@ -316,7 +315,7 @@ export type LatexDiffsActionDetail = z.infer<
   typeof LatexDiffsActionDetailSchema
 >;
 
-export const FocusInstructionDetailSchema = z.object({
+const FocusInstructionDetailSchema = z.object({
   key: z.string(),
   text: z.string(),
 });
@@ -324,20 +323,20 @@ export type FocusInstructionDetail = z.infer<
   typeof FocusInstructionDetailSchema
 >;
 
-export const SessionTypeChangeDetailSchema = z.object({
+const SessionTypeChangeDetailSchema = z.object({
   value: SessionTypeSchema,
 });
 export type SessionTypeChangeDetail = z.infer<
   typeof SessionTypeChangeDetailSchema
 >;
 
-export const AgentChangeDetailSchema = z.object({
+const AgentChangeDetailSchema = z.object({
   sessionType: SessionTypeSchema,
   value: z.string(),
 });
 export type AgentChangeDetail = z.infer<typeof AgentChangeDetailSchema>;
 
-export const ActionDetailSchema = z.object({
+const ActionDetailSchema = z.object({
   action: z.string(),
 });
 export type ActionDetail = z.infer<typeof ActionDetailSchema>;

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -16,25 +16,24 @@ import { SpendingStatusSchema } from './spendingStatus';
 // Data schemas
 // ============================================================
 
-export const ProfileUserSchema = z.object({
+const ProfileUserSchema = z.object({
   email: z.string(),
   id: z.string(),
 });
-export type ProfileUser = z.infer<typeof ProfileUserSchema>;
 
 /**
  * Remote agent data for the profile view.
  * Extends AgentMetadataBaseSchema (name, category, description) with
  * profile-specific fields. Description is required (non-optional) here.
  */
-export const RemoteAgentSchema = AgentMetadataBaseSchema.extend({
+const RemoteAgentSchema = AgentMetadataBaseSchema.extend({
   description: z.string(), // override optional → required for display
   visibility: z.array(z.string()),
   supportsMultipleOutput: z.boolean(),
 });
 export type RemoteAgent = z.infer<typeof RemoteAgentSchema>;
 
-export const ApiAccessModeSchema = z.enum(['included', 'personal']);
+const ApiAccessModeSchema = z.enum(['included', 'personal']);
 export type ApiAccessMode = z.infer<typeof ApiAccessModeSchema>;
 export const API_ACCESS_MODE_OPTIONS: readonly {
   readonly value: ApiAccessMode;
@@ -55,20 +54,18 @@ export const API_ACCESS_MODE_OPTIONS: readonly {
   },
 ] as const;
 
-export const TierConstantsSchema = z.object({
+const TierConstantsSchema = z.object({
   ultra: z.string(),
   max: z.string(),
 });
-export type TierConstants = z.infer<typeof TierConstantsSchema>;
 
 /**
  * A VS Code configuration toggle surfaced in a provider's expanded settings.
  * Extends ProviderVscodeSettingDefSchema (single source of truth) with runtime `value`.
  */
-export const ProviderVscodeSettingSchema =
-  ProviderVscodeSettingDefSchema.extend({
-    value: z.boolean(),
-  });
+const ProviderVscodeSettingSchema = ProviderVscodeSettingDefSchema.extend({
+  value: z.boolean(),
+});
 export type ProviderVscodeSetting = z.infer<typeof ProviderVscodeSettingSchema>;
 
 /** A VS Code numeric configuration surfaced in a settings section. */
@@ -83,7 +80,7 @@ export const NumberVscodeSettingSchema = z.object({
 });
 export type NumberVscodeSetting = z.infer<typeof NumberVscodeSettingSchema>;
 
-export const ProviderKeyStatusSchema = z.object({
+const ProviderKeyStatusSchema = z.object({
   provider: z.string(),
   displayName: z.string(),
   status: z.enum(['set', 'env', 'not-set']),
@@ -121,18 +118,14 @@ export type UpdateProfileMessage = z.infer<typeof UpdateProfileMessageSchema>;
 // ============================================================
 
 /** Agent selection message (reusable field schema) */
-export const SelectAgentMessageSchema = z.object({
+const SelectAgentMessageSchema = z.object({
   agentName: z.string().min(1),
 });
-export type SelectAgentMessage = z.infer<typeof SelectAgentMessageSchema>;
 
 /** API access mode message (reusable field schema) */
-export const SetApiAccessModeMessageSchema = z.object({
+const SetApiAccessModeMessageSchema = z.object({
   mode: ApiAccessModeSchema,
 });
-export type SetApiAccessModeMessage = z.infer<
-  typeof SetApiAccessModeMessageSchema
->;
 
 // Inbound messages with command literals
 export const GetProfileDataMessageSchema = commandOnly(

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -107,7 +107,7 @@ export type NormalizedToolUse = z.infer<typeof NormalizedToolUseSchema>;
 /** URL field for tool payloads that will be rendered as live links. */
 const SafeUrlSchema = z.string().transform(sanitizeLiveLinkUrl);
 
-export const WebSearchResultItemSchema = z.object({
+const WebSearchResultItemSchema = z.object({
   url: SafeUrlSchema.optional(),
   title: z.string().optional(),
   domain: z.string().optional(),
@@ -119,7 +119,6 @@ export const WebSearchPayloadSchema = z.object({
   provider: z.string().optional(),
   status: z.string().optional(),
 });
-export type WebSearchPayload = z.infer<typeof WebSearchPayloadSchema>;
 
 export const WebFetchPayloadSchema = z.object({
   url: SafeUrlSchema.optional(),
@@ -130,4 +129,3 @@ export const WebFetchPayloadSchema = z.object({
   /** Fetched document text, size-capped at the source (#7508). */
   content: z.string().optional(),
 });
-export type WebFetchPayload = z.infer<typeof WebFetchPayloadSchema>;

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -16,10 +16,7 @@ import {
 } from './proposalFields';
 
 /** Optional stream ID - allows empty string when stream context is unavailable */
-export const OptionalStreamIdSchema = z.union([
-  StreamTabIdSchema,
-  z.literal(''),
-]);
+const OptionalStreamIdSchema = z.union([StreamTabIdSchema, z.literal('')]);
 
 /** Common permission request fields */
 const PermissionBaseSchema = z.strictObject({
@@ -80,13 +77,13 @@ const ProposalPermissionBaseSchema = z.object({
   streamId: StreamTabIdSchema,
 });
 
-export const WorkflowAgentProposalPermissionSchema =
+const WorkflowAgentProposalPermissionSchema =
   ProposalPermissionBaseSchema.extend(WorkflowAgentProposalSchema.shape);
 export type WorkflowAgentProposalPermission = z.infer<
   typeof WorkflowAgentProposalPermissionSchema
 >;
 
-export const ToolUseAgentProposalPermissionSchema =
+const ToolUseAgentProposalPermissionSchema =
   ProposalPermissionBaseSchema.extend(ToolUseAgentProposalSchema.shape);
 
 export const AgentProposalPermissionSchema = z.discriminatedUnion(
@@ -127,11 +124,11 @@ const ExternalInquiryPermissionBaseSchema = PermissionBaseSchema.extend(
  * First inquiry in a thread. Fresh dispatches have no prior transcript, draft,
  * or session links, but durable hydration may carry a saved open-turn draft.
  */
-export const NewExternalInquiryPermissionSchema =
+const NewExternalInquiryPermissionSchema =
   ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('new') });
 
 /** Follow-up inquiry — carries thread context from prior turns. */
-export const FollowUpExternalInquiryPermissionSchema =
+const FollowUpExternalInquiryPermissionSchema =
   ExternalInquiryPermissionBaseSchema.extend({ mode: z.literal('followUp') });
 
 export const ExternalInquiryPermissionSchema = z.discriminatedUnion('mode', [
@@ -148,11 +145,10 @@ export type ExternalInquiryPermission = z.infer<
 
 export const USER_QUESTION_ACTIONS = ['submit', 'reject'] as const;
 
-export const UserQuestionOptionSchema = z.strictObject({
+const UserQuestionOptionSchema = z.strictObject({
   label: z.string().min(1),
   description: z.string().nullish(),
 });
-export type UserQuestionOption = z.infer<typeof UserQuestionOptionSchema>;
 
 export const UserQuestionPromptSchema = z.strictObject({
   question: z.string().min(1),
@@ -177,7 +173,7 @@ export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
  * has a single source of truth. See docs/proposals/tui-extension-sharing.md
  * (Rung 1).
  */
-export const ApprovalDecisionSchema = z.object({
+const ApprovalDecisionSchema = z.object({
   accepted: z.boolean(),
   /**
    * Free-text payload carried with the decision. For rejections this is the
@@ -225,7 +221,6 @@ export type ToolEditApprovalAction =
   (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
 
 export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
-export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
 export const PlanApprovalPermissionSchema = z.strictObject({
   approvalId: z.string(),

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -48,23 +48,13 @@ export {
 } from './historyViewMessages';
 
 export {
-  ProfileUserSchema,
-  RemoteAgentSchema,
-  ApiAccessModeSchema,
   API_ACCESS_MODE_OPTIONS,
-  TierConstantsSchema,
-  ProviderKeyStatusSchema,
-  ProviderVscodeSettingSchema,
   NumberVscodeSettingSchema,
-  type ProfileUser,
   type RemoteAgent,
   type ApiAccessMode,
-  type TierConstants,
   type ProviderKeyStatus,
   type ProviderVscodeSetting,
   type NumberVscodeSetting,
-  type SelectAgentMessage,
-  type SetApiAccessModeMessage,
 } from './profileViewMessages';
 
 // Settings-specific data + outbound message schemas and the inbound schemas.

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -57,12 +57,12 @@ import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
  */
 
 /** Hosts that may consume a setting. */
-export type SettingHost = 'vscode' | 'cli' | 'desktop';
+type SettingHost = 'vscode' | 'cli' | 'desktop';
 
 /** Storage slot a setting is read from / written to. */
 export type SettingStore = 'config' | 'workspaceState' | 'globalState';
 
-export interface CliRuntimeReachability {
+interface CliRuntimeReachability {
   /**
    * Representative CLI command that reaches this setting after it has been set.
    * Placeholders are allowed when the command needs an installed agent/model.

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -69,7 +69,7 @@ export type StreamTabMeta = z.infer<typeof StreamTabMetaSchema>;
 // tracked in `docs/proposals/architecture-checkpoints-2026.md` / `#6981`.
 // ============================================================================
 
-export const LegacyInstructionEntrySchema = z.looseObject({
+const LegacyInstructionEntrySchema = z.looseObject({
   text: z.string(),
   timestamp: z.number().optional(),
 });

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -76,7 +76,6 @@ export const ActiveChildInfoSchema = z.preprocess(
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;
 export type SubagentChildInfo = Extract<ActiveChildInfo, { kind: 'subagent' }>;
-export type ProcessChildInfo = Extract<ActiveChildInfo, { kind: 'process' }>;
 
 // Round Stage (ephemeral round label from typed stage.start metadata)
 
@@ -142,7 +141,7 @@ const BaseStreamStateSchema = BackendOwnedFieldsSchema.extend({
 
 // Tool-Use UI State (frontend-only, preserved during backend updates)
 
-export const ToolUseUIStateSchema = z.object({
+const ToolUseUIStateSchema = z.object({
   followUpText: z.string().prefault(''),
   polishedText: z.string().nullable().prefault(null),
   polishRevision: z.int().prefault(0),
@@ -151,11 +150,9 @@ export const ToolUseUIStateSchema = z.object({
   shouldFocusFollowUp: z.boolean().prefault(false),
 });
 
-export type ToolUseUIState = z.infer<typeof ToolUseUIStateSchema>;
-
 // Tool-Use Stream State
 
-export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
+const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   kind: z.literal(AgentCategory.ToolUse),
   // Frontend-owned fields updated by targeted progress-view messages
   todos: z.array(TodoItemSchema).prefault([]),
@@ -178,7 +175,7 @@ export type ToolUseStreamState = z.infer<typeof ToolUseStreamStateSchema>;
 // Workflow Stream State
 // One run per tab — all run-scoped data is flat, not keyed by runId.
 
-export const WorkflowStreamStateSchema = BaseStreamStateSchema.extend({
+const WorkflowStreamStateSchema = BaseStreamStateSchema.extend({
   kind: z.literal(AgentCategory.Workflow),
   // Frontend-owned fields updated by targeted progress-view messages.
   // Per-run usage mirrors tool-use so resume correctly accumulates across
@@ -194,7 +191,7 @@ export type WorkflowStreamState = z.infer<typeof WorkflowStreamStateSchema>;
 
 // Discriminated Union
 
-export const StreamStateSchema = z.discriminatedUnion('kind', [
+const StreamStateSchema = z.discriminatedUnion('kind', [
   ToolUseStreamStateSchema,
   WorkflowStreamStateSchema,
 ]);
@@ -217,7 +214,7 @@ export function isWorkflowState(
 
 // Factory Functions
 
-export function createToolUseStreamState(
+function createToolUseStreamState(
   partial?: Partial<ToolUseStreamState>,
 ): ToolUseStreamState {
   return ToolUseStreamStateSchema.parse({


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Each item was independently verified (adversarial verification agent + orchestrator spot-checks), and re-verified with fresh repo-wide greps immediately before editing in this worktree.

All 73 items are in `src/shared/schemas/` (plus two barrel re-export fixups):

**De-exported** (kept the declaration + internal logic intact, only removed the `export` keyword since nothing outside the file uses it):

`src/shared/schemas/mainView/state.ts` (30): `PickerOptionBaseSchema`, `ModelAvailabilityKindSchema`, `BannerStateSchema`, `ApiKeyBannerStateSchema`, `AgentConfigBannerStateSchema`, `DependencyBannerStateSchema`, `FileSelectConfigSchema`, `CheckboxValuesSchema`, `SingleFilesSchema`, `FileOptionsSchema`, `MultiFilesSchema`, `MultiFilesKeySchema`, `FileStateContextSchema`, `SessionContextSchema`, `StringValueDetailSchema`, `FileActionDetailSchema`, `MultipleFilesActionDetailSchema`, `MultipleFilesTypeActionDetailSchema`, `RemoveFileDetailSchema`, `ReorderFilesDetailSchema`, `CheckboxChangeDetailSchema`, `BannerActionDetailSchema`, `GettingStartedActionDetailSchema`, `InstallGuideDetailSchema`, `LatexDiffsToggleDetailSchema`, `LatexDiffsActionDetailSchema`, `FocusInstructionDetailSchema`, `SessionTypeChangeDetailSchema`, `AgentChangeDetailSchema`, `ActionDetailSchema`

`src/shared/schemas/profileViewMessages.ts` (8): `ProfileUserSchema`, `RemoteAgentSchema`, `ApiAccessModeSchema`, `TierConstantsSchema`, `ProviderVscodeSettingSchema`, `ProviderKeyStatusSchema`, `SelectAgentMessageSchema`, `SetApiAccessModeMessageSchema`

`src/shared/schemas/prompts.ts` (7): `OptionalStreamIdSchema`, `WorkflowAgentProposalPermissionSchema`, `ToolUseAgentProposalPermissionSchema`, `NewExternalInquiryPermissionSchema`, `FollowUpExternalInquiryPermissionSchema`, `UserQuestionOptionSchema`, `ApprovalDecisionSchema`

`src/shared/schemas/streamState.ts` (5): `ToolUseUIStateSchema`, `ToolUseStreamStateSchema`, `WorkflowStreamStateSchema`, `StreamStateSchema`, `createToolUseStreamState` (function; still called internally by `createStreamState`)

`src/shared/schemas/inquiry.ts` (4): `InquiryThreadStatusSchema`, `ExternalInquiryThreadSummarySchema`, `InquiryResumeOutcomeSchema`, `InquiryActionMessageSchema`

`src/shared/schemas/progressView/data.ts` (1): `WebSearchResultItemSchema`

`src/shared/schemas/stateSettings.ts` (2): `SettingHost` (type), `CliRuntimeReachability` (interface)

`src/shared/schemas/streamData.ts` (1): `LegacyInstructionEntrySchema`

**Fully deleted** (zero references anywhere, even internally):

`src/shared/schemas/mainView/state.ts`: `MultiFilesKey` (type)

`src/shared/schemas/profileViewMessages.ts`: `ProfileUser`, `TierConstants`, `SelectAgentMessage`, `SetApiAccessModeMessage` (types)

`src/shared/schemas/prompts.ts`: `UserQuestionOption`, `BashApprovalAction` (types)

`src/shared/schemas/streamState.ts`: `ProcessChildInfo`, `ToolUseUIState` (types)

`src/shared/schemas/inquiry.ts`: `ExternalInquirySessionLinks` (type)

`src/shared/schemas/mainView/index.ts`: `ExtendedDocumentFileTypeSchema`, `MultipleDocumentFileTypeSchema`, `ExtendedDocumentFileType` — duplicate barrel re-export lines (real consumers already import these directly from `../fileTypes`, which the schemas/index.ts root barrel already wildcard re-exports separately)

`src/shared/schemas/progressView/data.ts`: `WebSearchPayload`, `WebFetchPayload` (types)

**Barrel-consistency fixups** (required because they named-re-exported symbols removed above; not separate knip findings):
- `src/shared/schemas/settingsViewMessages.ts` — dropped the now-nonexistent named re-exports (`ProfileUserSchema`, `RemoteAgentSchema`, `ApiAccessModeSchema`, `TierConstantsSchema`, `ProviderKeyStatusSchema`, `ProviderVscodeSettingSchema`, `type ProfileUser`, `type TierConstants`, `type SelectAgentMessage`, `type SetApiAccessModeMessage`) from its `profileViewMessages` re-export block.
- `packages/extension/src/progressView/frontend/store.ts` — dropped `type ToolUseUIState` from its `@shared/schemas` re-export block.

**Skipped:** none — all 73 items still checked out as dead on re-verification against current `main`.

**Note for a future batch (out of scope here):** after removing the duplicate `ExtendedDocumentFileType` barrel re-export, `npx knip` now also flags the *original* `export type ExtendedDocumentFileType` in `src/shared/schemas/fileTypes.ts` as unused (it was previously "anchored" by the now-removed duplicate barrel path). That export was not in this batch's list, so it's left untouched here.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `CI=true corepack pnpm --filter texra typecheck` — clean (covers the one touched `packages/extension` file)
- [x] `npx eslint` on all touched files — clean
- [x] `npx prettier --check` on all touched files — clean (prettier reformatted 3 files after the mechanical edits; committed)
- [x] Targeted vitest: `src/test-kernel/{schemas,shared,progressView,settings,transcript,controllers}/` — 107 test files / 746 tests pass (one file, `LogListKeyboard.vitest.mts`, hit a pre-existing JSDOM `beforeAll` hook-timeout under load — confirmed unrelated: it doesn't import any touched file, and passes cleanly with a longer hook timeout)
- [x] `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` — none of the 73 batch item names appear in the fresh report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical export visibility and barrel cleanup with no logic changes; risk is limited to any out-of-repo importers of removed symbols.
> 
> **Overview**
> Knip-driven cleanup in `src/shared/schemas/`: **dozens of Zod schemas and helper symbols are no longer exported** (many are now file-private `const` while inferred **types** and public APIs like `createStreamState` stay exported). A few **types with zero references were deleted** outright (e.g. `MultiFilesKey`, `ProfileUser`, `ToolUseUIState`, `ProcessChildInfo`, duplicate payload types).
> 
> **Barrels were tightened** so they do not re-export removed symbols: `mainView/index.ts` drops duplicate `ExtendedDocumentFileType*` re-exports (canonical path remains `fileTypes`), `settingsViewMessages.ts` stops forwarding profile schemas/types that are now internal, and the progress view store stops re-exporting `ToolUseUIState`.
> 
> No validation or IPC contract changes—only the public import surface shrinks to match actual consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8071dcd1bfd056fc3608b04d0919afbf14ba983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->