### PR TITLE
chore: remove dead exports flagged by knip (batch: shared-other)

### DIFF
--- a/src/shared/constants/agents.ts
+++ b/src/shared/constants/agents.ts
@@ -15,7 +15,7 @@ export const REMOTE_ORCHESTRATOR_AGENT_NAMES = [
  * relay-served roots above, these ship in the extension/CLI and are available
  * offline without sign-in.
  */
-export const BUNDLED_ORCHESTRATOR_AGENT_NAMES = ['engineer'] as const;
+const BUNDLED_ORCHESTRATOR_AGENT_NAMES = ['engineer'] as const;
 
 /** Built-in delegating team roots, relay-served plus bundled. */
 export const BUILTIN_TEAM_ROOT_AGENT_NAMES = [

--- a/src/shared/constants/fastModels.ts
+++ b/src/shared/constants/fastModels.ts
@@ -12,7 +12,7 @@
  */
 
 /** Input-price ceiling (USD per million tokens) for the fast-model hint. */
-export const FAST_FIRST_RESPONSE_PRICE_CEILING = 1;
+const FAST_FIRST_RESPONSE_PRICE_CEILING = 1;
 
 /** Hint string prepended to the model tooltip when the model qualifies. */
 export const FAST_FIRST_RESPONSE_HINT =

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -24,7 +24,7 @@ interface ProviderDef {
   readonly region?: ProviderRegionSetting;
 }
 
-export interface ProviderRegionSetting {
+interface ProviderRegionSetting {
   readonly key: GlobalStateKey;
   readonly default: boolean;
   readonly displayName?: string;

--- a/src/shared/highlighting/hljs.ts
+++ b/src/shared/highlighting/hljs.ts
@@ -55,4 +55,3 @@ hljs.registerLanguage('xml', xml);
 hljs.registerLanguage('yaml', yaml);
 
 export { hljs };
-export default hljs;

--- a/src/shared/hostBridge.ts
+++ b/src/shared/hostBridge.ts
@@ -1,6 +1,6 @@
 import { HOST_BRIDGE_API_KEY, type HostBridgeApi } from './hostBridgeTypes';
 
-export { HOST_BRIDGE_API_KEY, type HostBridgeApi } from './hostBridgeTypes';
+export { type HostBridgeApi } from './hostBridgeTypes';
 
 declare const acquireVsCodeApi: (() => HostBridgeApi) | undefined;
 

--- a/src/shared/litControllers/CopyButtonController.ts
+++ b/src/shared/litControllers/CopyButtonController.ts
@@ -4,7 +4,7 @@ import {
 } from '@shared/utils/clipboard';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
-export interface CopyButtonConfig {
+interface CopyButtonConfig {
   /** Default button title/tooltip */
   defaultTitle?: string;
   /** Title shown after successful copy */
@@ -18,7 +18,7 @@ export interface CopyButtonConfig {
 /**
  * Computed state for copy button (used in templates).
  */
-export interface CopyButtonState {
+interface CopyButtonState {
   /** Current title/tooltip text */
   title: string;
   /** Current aria-label */

--- a/src/shared/litControllers/RecordingButtonController.ts
+++ b/src/shared/litControllers/RecordingButtonController.ts
@@ -2,7 +2,7 @@ import { postMessage } from '@shared/hostBridge';
 import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
-export interface RecordingButtonConfig {
+interface RecordingButtonConfig {
   startCommand: string;
   stopCommand: string;
   startTitle?: string;
@@ -15,7 +15,7 @@ export interface RecordingButtonConfig {
 /**
  * Computed state for recording button (used in templates).
  */
-export interface RecordingButtonState {
+interface RecordingButtonState {
   /** Current icon name */
   icon: TeXRAIconName;
   /** Current title/tooltip text */

--- a/src/shared/litControllers/SortableController.ts
+++ b/src/shared/litControllers/SortableController.ts
@@ -2,12 +2,12 @@
 import Sortable from 'sortablejs';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
-export interface SortableControllerConfig {
+interface SortableControllerConfig {
   /** Animation duration in ms (default: 150) */
   animation?: number;
 }
 
-export interface SortableReorderResult {
+interface SortableReorderResult {
   /** Original index before drag */
   oldIndex: number;
   /** New index after drop */
@@ -20,7 +20,7 @@ export interface SortableReorderResult {
  * Callback invoked when items are reordered via drag-and-drop.
  * @param result - Contains oldIndex, newIndex, and the reordered items array
  */
-export type SortableReorderCallback = (result: SortableReorderResult) => void;
+type SortableReorderCallback = (result: SortableReorderResult) => void;
 
 /**
  * Lit reactive controller for managing Sortable.js on a file list element.

--- a/src/shared/litControllers/index.ts
+++ b/src/shared/litControllers/index.ts
@@ -1,20 +1,7 @@
-export {
-  CopyButtonController,
-  type CopyButtonConfig,
-  type CopyButtonState,
-} from './CopyButtonController';
+export { CopyButtonController } from './CopyButtonController';
 
-export {
-  RecordingButtonController,
-  type RecordingButtonConfig,
-  type RecordingButtonState,
-} from './RecordingButtonController';
+export { RecordingButtonController } from './RecordingButtonController';
 
-export {
-  SortableController,
-  type SortableControllerConfig,
-  type SortableReorderCallback,
-  type SortableReorderResult,
-} from './SortableController';
+export { SortableController } from './SortableController';
 
 export { installToolbarTooltips } from './TooltipController';

--- a/src/shared/mainView/actionPlanner.ts
+++ b/src/shared/mainView/actionPlanner.ts
@@ -8,7 +8,7 @@ import { capitalize } from '@utils/text/stringUtils';
 // Common result types
 // ============================================================
 
-export interface ActionValidationError {
+interface ActionValidationError {
   readonly valid: false;
   readonly message: string;
 }
@@ -135,7 +135,7 @@ export interface CompareState {
   readonly editedFile: string;
 }
 
-export type ComparePayload = {
+type ComparePayload = {
   baseFile: string;
   editedFile: string;
 };

--- a/src/shared/mainView/executeMessage.ts
+++ b/src/shared/mainView/executeMessage.ts
@@ -1,9 +1,5 @@
 import { MULTIPLE_DOCUMENT_FILE_TYPES } from '../schemas/fileTypes';
-import type {
-  MainViewExecuteFiles,
-  MainViewExecuteMessage,
-  MainViewExecuteSession,
-} from '../schemas/mainView/executeMessage';
+import type { MainViewExecuteMessage } from '../schemas/mainView/executeMessage';
 import type {
   CheckboxValues,
   MultiFiles,
@@ -11,11 +7,7 @@ import type {
   SingleFiles,
 } from '../schemas/mainView/state';
 
-export type {
-  MainViewExecuteFiles,
-  MainViewExecuteMessage,
-  MainViewExecuteSession,
-};
+export type { MainViewExecuteMessage };
 
 export interface MainViewExecutionFormState {
   readonly sessionType: SessionType;

--- a/src/shared/markdown/createMarkdownProcessor.ts
+++ b/src/shared/markdown/createMarkdownProcessor.ts
@@ -24,7 +24,7 @@ export interface LatexReferenceFormatter {
   (refType: string, label: string): string;
 }
 
-export interface MarkdownProcessorConfig {
+interface MarkdownProcessorConfig {
   readonly renderer: MarkdownItInstance;
   /**
    * Formatter for `\ref{…}` / `\cref{…}` / `\eqref{…}` placeholders. Defaults
@@ -57,7 +57,7 @@ export interface MarkdownProcessorConfig {
  * renderer runs. Tests assert against these directly so the cache is
  * exercised as a behaviour, not as a string-equality coincidence.
  */
-export interface MarkdownProcessorStats {
+interface MarkdownProcessorStats {
   readonly hits: () => number;
   readonly misses: () => number;
 }

--- a/src/shared/markdown/createMarkdownRenderer.ts
+++ b/src/shared/markdown/createMarkdownRenderer.ts
@@ -15,7 +15,7 @@ import MarkdownIt from 'markdown-it/lib/index.mjs';
 /** Instance type for the markdown-it renderer (`new MarkdownIt(...)`). */
 export type MarkdownItInstance = InstanceType<typeof MarkdownIt>;
 
-export interface MarkdownRendererConfig {
+interface MarkdownRendererConfig {
   /**
    * Code-fence highlighter — same shape as markdown-it's `highlight` option.
    * The webview returns HTML; the CLI host returns an ANSI-coloured string.

--- a/src/shared/markdown/index.ts
+++ b/src/shared/markdown/index.ts
@@ -8,12 +8,9 @@
 export {
   createMarkdownRenderer,
   type MarkdownItInstance,
-  type MarkdownRendererConfig,
 } from './createMarkdownRenderer';
 export {
   createMarkdownProcessor,
-  type LatexReferenceFormatter,
   type MarkdownProcessor,
-  type MarkdownProcessorConfig,
   type MarkdownProcessorRenderEnv,
 } from './createMarkdownProcessor';

--- a/src/shared/progressView/backend/WebviewBridge.ts
+++ b/src/shared/progressView/backend/WebviewBridge.ts
@@ -15,7 +15,7 @@ export type ProgressViewMessageSender = (
   message: ProgressViewOutboundMessage,
 ) => boolean | PromiseLike<boolean>;
 
-export interface ProgressLogSource {
+interface ProgressLogSource {
   readonly head: number;
   getRange(fromSeq: number, toSeq: number): StreamLogEntry[];
   getDirtyUpdates(maxSeqInclusive: number): StreamLogEntry[];

--- a/src/shared/progressView/backend/progressBackendUiConfig.ts
+++ b/src/shared/progressView/backend/progressBackendUiConfig.ts
@@ -44,7 +44,7 @@ interface ApprovalHandlerTransport<T> {
   resolve: (id: string) => void;
 }
 
-export interface ApprovalRequestHandlerOverrides {
+interface ApprovalRequestHandlerOverrides {
   retry: ApprovalHandlerTransport<RetryPermission>;
   agentProposal: ApprovalHandlerTransport<AgentProposalPermission>;
 }

--- a/src/shared/progressView/backend/state/ProgressViewState.ts
+++ b/src/shared/progressView/backend/state/ProgressViewState.ts
@@ -42,7 +42,7 @@ import { SessionStores } from './SessionStores';
 const LEGACY_INSTRUCTION_BACKFILL_CONCURRENCY = 8;
 
 /** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
-export const StreamHintsSchema = StreamTabInfoBaseSchema.pick({
+const StreamHintsSchema = StreamTabInfoBaseSchema.pick({
   agent: true,
   agentCategory: true,
   inputFile: true,

--- a/src/shared/signals.ts
+++ b/src/shared/signals.ts
@@ -5,9 +5,9 @@
  * for extracting fields from monolithic signals.
  */
 
-import { SignalWatcher, signal, computed, Signal } from '@lit-labs/signals';
+import { SignalWatcher, signal, Signal } from '@lit-labs/signals';
 
-export { SignalWatcher, signal, computed, Signal };
+export { SignalWatcher, signal, Signal };
 
 /**
  * Selector: extracts a field from a monolithic signal.

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
  * Minimal storage interface for state persistence.
  * Works with both backend (Memento) and frontend (webview) storage.
  */
-export interface StateStorage {
+interface StateStorage {
   get(key: string): unknown;
   set(key: string, value: unknown): void;
 }

--- a/src/shared/state/index.ts
+++ b/src/shared/state/index.ts
@@ -1,5 +1,1 @@
-export {
-  PersistedState,
-  createWebviewStorage,
-  type StateStorage,
-} from './PersistedState';
+export { PersistedState, createWebviewStorage } from './PersistedState';

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -10,7 +10,7 @@ import type { ActiveChildInfo } from '@shared/schemas';
 import { appendTail } from '@utils/strings/appendTail';
 
 /** Per-execution captured stdout/stderr tail held in stream meta. */
-export interface StreamProcessOutput {
+interface StreamProcessOutput {
   readonly stdout: string;
   readonly stderr: string;
 }
@@ -40,7 +40,7 @@ export type StreamMetaCommand =
  * at the cap). The CLI uses an exact cut; the webview trims to a lower
  * `retainChars` so output can keep appending before the next reset.
  */
-export interface OutputCap {
+interface OutputCap {
   readonly maxChars: number;
   readonly retainChars?: number;
 }

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -12,7 +12,7 @@ import {
 
 export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
 
-export interface StreamStatusDisplayState {
+interface StreamStatusDisplayState {
   readonly phase?: StreamPhase;
   readonly substate?: StreamSubstate;
   readonly key?: StreamStatusDisplayKey;
@@ -23,7 +23,7 @@ function phaseDisplayKey(phase: StreamPhase): StreamStatusDisplayKey {
   return phase;
 }
 
-export function streamStatusDisplayState(
+function streamStatusDisplayState(
   status: string | undefined,
   substate?: StreamSubstate,
 ): StreamStatusDisplayState {

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -62,12 +62,6 @@ export function getModelProviderDecorator(provider: string): ProviderDecorator {
   );
 }
 
-export interface AgentDecorator {
-  icon: string;
-  label: string;
-  hint?: string;
-}
-
 export const AGENT_DECORATORS = {
   properties: {
     remote: {

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -9,7 +9,7 @@ import { html as staticHtml, literal } from 'lit/static-html.js';
 
 import { waIcon, type TeXRAIconName } from './webAwesomeIcons';
 
-export interface EmptyStateAction {
+interface EmptyStateAction {
   readonly label: string;
   readonly onClick: () => void;
   readonly appearance?: 'filled' | 'outlined';
@@ -23,7 +23,7 @@ export interface EmptyStateAction {
   readonly icon?: TeXRAIconName;
 }
 
-export type EmptyStateHeadingTag = 'h1' | 'h2' | 'h3';
+type EmptyStateHeadingTag = 'h1' | 'h2' | 'h3';
 
 export interface EmptyStateOptions {
   readonly icon: TeXRAIconName;

--- a/src/shared/wa/index.ts
+++ b/src/shared/wa/index.ts
@@ -7,7 +7,6 @@
 //
 // App entry points import registration from ./webAwesomeIcons directly because
 // icon registration is intentionally a one-time side effect at webview startup.
-// Child components import only TEXRA_ICON_LIBRARY from this barrel.
 // Component imports themselves (e.g. wa-button, wa-input) live alongside the
 // component family they belong to — added in subsequent migration PRs.
 
@@ -18,5 +17,3 @@ import { applyInitialWaColorScheme } from './waColorScheme';
 
 registerTeXRAWebAwesomeIcons();
 applyInitialWaColorScheme();
-
-export { TEXRA_ICON_LIBRARY } from './webAwesomeIcons';

--- a/src/shared/wa/statusIcons.ts
+++ b/src/shared/wa/statusIcons.ts
@@ -3,10 +3,9 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
 import { css, html, type CSSResult, type TemplateResult } from 'lit';
 
-export type WaTagVariant =
-  'brand' | 'neutral' | 'success' | 'warning' | 'danger';
+type WaTagVariant = 'brand' | 'neutral' | 'success' | 'warning' | 'danger';
 
-export interface SetStatusFallback {
+interface SetStatusFallback {
   readonly label: string;
   readonly variant?: WaTagVariant;
 }

--- a/src/shared/wa/walkthroughDialog.ts
+++ b/src/shared/wa/walkthroughDialog.ts
@@ -20,7 +20,7 @@ export interface WalkthroughStep {
   readonly body: string;
 }
 
-export interface WalkthroughAction {
+interface WalkthroughAction {
   readonly label: string;
   readonly onClick: () => void;
   // The "primary" action also serves as the initial focus target on show —
@@ -45,7 +45,7 @@ export interface WalkthroughDialogOptions {
   readonly classes?: WalkthroughDialogClassNames;
 }
 
-export interface WalkthroughDialogClassNames {
+interface WalkthroughDialogClassNames {
   readonly dialog?: string;
   readonly header?: string;
   readonly icon?: string;


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Executes a verified batch of 35 dead/orphaned export findings across `src/shared/`, all pre-checked by an adversarial verification pass plus spot-checks before this PR touched anything. Every item was re-verified against current `main` immediately before editing (repo-wide grep for the symbol name outside its own file). No behavior changes — this is visibility narrowing (`export` → file-private) or deletion of genuinely dead code/re-exports.

## Items touched (35)

**De-exported** (kept the declaration + its internal logic, just dropped `export` because nothing outside the file names it):
| Name | File | Notes |
|---|---|---|
| `StreamHintsSchema` | `src/shared/progressView/backend/state/ProgressViewState.ts` | Zod schema; only `.prefault()`/`.parse()` calls in-file |
| `FAST_FIRST_RESPONSE_PRICE_CEILING` | `src/shared/constants/fastModels.ts` | |
| `BUNDLED_ORCHESTRATOR_AGENT_NAMES` | `src/shared/constants/agents.ts` | only feeds `BUILTIN_TEAM_ROOT_AGENT_NAMES` in-file |
| `streamStatusDisplayState` | `src/shared/streams/streamStatusDisplay.ts` | |
| `StreamStatusDisplayState` | `src/shared/streams/streamStatusDisplay.ts` | |
| `ProviderRegionSetting` | `src/shared/constants/providers.ts` | consumed only structurally via `ProviderStateEntry.region` |
| `ApprovalRequestHandlerOverrides` | `src/shared/progressView/backend/progressBackendUiConfig.ts` | consumers pass matching object literal structurally |
| `ProgressLogSource` | `src/shared/progressView/backend/WebviewBridge.ts` | |
| `StreamProcessOutput` | `src/shared/streams/streamMetaReducer.ts` | |
| `OutputCap` | `src/shared/streams/streamMetaReducer.ts` | |
| `MarkdownRendererConfig` | `src/shared/markdown/createMarkdownRenderer.ts` | de-exported at source + dropped from `src/shared/markdown/index.ts` barrel |
| `MarkdownProcessorConfig` | `src/shared/markdown/createMarkdownProcessor.ts` | de-exported at source + dropped from barrel |
| `MarkdownProcessorStats` | `src/shared/markdown/createMarkdownProcessor.ts` | |
| `StateStorage` | `src/shared/state/PersistedState.ts` | de-exported at source + dropped from `src/shared/state/index.ts` barrel |
| `WaTagVariant` | `src/shared/wa/statusIcons.ts` | |
| `SetStatusFallback` | `src/shared/wa/statusIcons.ts` | |
| `ActionValidationError` | `src/shared/mainView/actionPlanner.ts` | `export *` barrel auto-drops it, no barrel edit needed |
| `ComparePayload` | `src/shared/mainView/actionPlanner.ts` | same |
| `EmptyStateAction` | `src/shared/wa/emptyState.ts` | |
| `EmptyStateHeadingTag` | `src/shared/wa/emptyState.ts` | |
| `WalkthroughAction` | `src/shared/wa/walkthroughDialog.ts` | |
| `WalkthroughDialogClassNames` | `src/shared/wa/walkthroughDialog.ts` | |
| `CopyButtonConfig` | `src/shared/litControllers/CopyButtonController.ts` | de-exported at source + dropped from `litControllers/index.ts` barrel |
| `CopyButtonState` | `src/shared/litControllers/CopyButtonController.ts` | same |
| `RecordingButtonConfig` | `src/shared/litControllers/RecordingButtonController.ts` | same |
| `RecordingButtonState` | `src/shared/litControllers/RecordingButtonController.ts` | same |
| `SortableControllerConfig` | `src/shared/litControllers/SortableController.ts` | same |
| `SortableReorderCallback` | `src/shared/litControllers/SortableController.ts` | same |
| `SortableReorderResult` | `src/shared/litControllers/SortableController.ts` | knip flagged this both at the barrel re-export and at the source declaration — same symbol, one fix |

**Removed dead re-export only** (underlying symbol stays alive and exported at its real definition site, just unreachable through this specific barrel path):
| Name | File |
|---|---|
| `TEXRA_ICON_LIBRARY` | `src/shared/wa/index.ts` (barrel) — all ~50 real consumers import from `@shared/wa/webAwesomeIcons` directly |
| `HOST_BRIDGE_API_KEY` | `src/shared/hostBridge.ts` — all real consumers import from `@shared/hostBridgeTypes` directly |
| `LatexReferenceFormatter` | `src/shared/markdown/index.ts` (barrel) — the one real consumer (`katexHtmlProcessor.ts`) imports directly from `./createMarkdownProcessor`, so the type stays exported there |
| `MainViewExecuteFiles`, `MainViewExecuteSession` | `src/shared/mainView/executeMessage.ts` — this file just imported-then-re-exported these from `schemas/mainView/executeMessage.ts` with zero consumers; dropped the pass-through import+export pair. The underlying `schemas/` file (out of scope for this batch) is untouched. |

**Fully deleted** (zero usage anywhere, including internally):
| Name | File |
|---|---|
| `AgentDecorator` | `src/shared/utils/icons.ts` — not even used to type `AGENT_DECORATORS` |
| `computed` | `src/shared/signals.ts` — re-exported from `@lit-labs/signals` but never imported by any consumer; removed from both the import and the re-export |
| `export default hljs` | `src/shared/highlighting/hljs.ts` — the one consumer uses the named `{ hljs }` export |

## Skipped

None — all 35 items re-verified as accurate against current `main` and executed.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `packages/cli`: `tsc --noEmit -p tsconfig.json` — clean
- `packages/extension`: `tsc --noEmit` — clean
- `packages/trace-viewer`: `tsc --noEmit` — clean
- `packages/desktop`: `tsc --noEmit` (main/preload/renderer) — clean except one **pre-existing, unrelated** error in `desktopAgentExecution.ts` (`StreamStatusEmitOptions`/`runtimeHost`) confirmed via `git diff origin/main` to be untouched by this PR
- `eslint` + `prettier --check` on all 27 touched files — clean
- Targeted `vitest` run covering every touched file's directory (30 files, 283 tests) — all passing
- Re-ran `knip --include files,exports,types,duplicates --reporter compact` — none of the 27 touched files appear in the output anymore (the two `MainViewExecuteFiles`/`MainViewExecuteSession` hits that remain are in `src/shared/schemas/mainView/executeMessage.ts`, explicitly out of scope for this batch)

## Test plan

- [x] Typecheck (root + test-kernel + per-package) all green
- [x] Lint/format clean on touched files
- [x] Targeted vitest suites green
- [x] knip sanity re-check confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only visibility and barrel trimming with no logic changes; risk is limited to any undetected deep imports of removed symbols, which the PR verified via grep and typecheck.
> 
> **Overview**
> Knip-driven cleanup across **`src/shared/`** with **no runtime behavior changes**: unused public surface is removed or made file-private so the module API matches real consumers.
> 
> **De-exported** symbols stay in place but lose `export` when nothing outside the defining file imports them (constants like `BUNDLED_ORCHESTRATOR_AGENT_NAMES`, internal config/types for Lit controllers, markdown, progress backend, streams, WA helpers, etc.). **`litControllers/index.ts`**, **`markdown/index.ts`**, and **`state/index.ts`** stop re-exporting those helper types.
> 
> **Barrel / pass-through cleanup** drops dead paths: `TEXRA_ICON_LIBRARY` from `wa/index.ts`, `HOST_BRIDGE_API_KEY` from `hostBridge.ts` (callers use `hostBridgeTypes`), unused markdown config types from the markdown barrel, `MainViewExecuteFiles` / `MainViewExecuteSession` re-exports from `executeMessage.ts`, and the unused `computed` re-export from `signals.ts`.
> 
> **Small deletions**: unused `AgentDecorator` type, default `hljs` export (named export remains), and `export default hljs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd9a99d2f926fd895f5871c121ba68905d34fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->