### PR TITLE
chore: remove dead exports flagged by knip (batch: other)

### DIFF
--- a/src/auth/SupabaseAuthCoordinator.ts
+++ b/src/auth/SupabaseAuthCoordinator.ts
@@ -16,7 +16,7 @@ import {
 
 export const DEFAULT_AUTH_EDGE_FUNCTION_TIMEOUT_MS = 30000;
 
-export interface SupabaseSecretStore {
+interface SupabaseSecretStore {
   get(key: string): Promise<string | undefined>;
   set(key: string, value: string): Promise<void>;
   delete(key: string): Promise<void>;

--- a/src/auth/core/authCallback.ts
+++ b/src/auth/core/authCallback.ts
@@ -9,18 +9,18 @@ export interface AuthCallbackUriParts {
   fragment?: string;
 }
 
-export interface AuthCallbackTokens {
+interface AuthCallbackTokens {
   accessToken: string;
   refreshToken: string;
   expiresIn: string | null;
 }
 
-export interface AuthCallbackTokenParseSuccess {
+interface AuthCallbackTokenParseSuccess {
   success: true;
   tokens: AuthCallbackTokens;
 }
 
-export interface AuthCallbackTokenParseError {
+interface AuthCallbackTokenParseError {
   success: false;
   error: string;
   isAuthError?: boolean;
@@ -114,7 +114,7 @@ export function parseAuthCallbackTokens(
   };
 }
 
-export interface AuthCallbackCodeParseSuccess {
+interface AuthCallbackCodeParseSuccess {
   success: true;
   code: string;
 }

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -44,7 +44,7 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
 };
 
 /** Global state key for the "use included model access" preference. */
-export const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
+const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
 const SERVICE_EVENT = 'event';
 

--- a/src/auth/supabaseSessionTypes.ts
+++ b/src/auth/supabaseSessionTypes.ts
@@ -4,7 +4,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export const DEFAULT_SUPABASE_SESSION_EXPIRY_MS = 60 * 60 * 1000;
 
-export const SupabaseSessionSchema = z.object({
+const SupabaseSessionSchema = z.object({
   id: z.string(),
   accessToken: z.string(),
   refreshToken: z.string(),
@@ -18,7 +18,7 @@ export const SupabaseSessionSchema = z.object({
 export type SupabaseSession = z.infer<typeof SupabaseSessionSchema>;
 
 /** Response schema for GitHub token exchange and refresh Edge Functions. */
-export const GitHubTokenExchangeSchema = z.object({
+const GitHubTokenExchangeSchema = z.object({
   access_token: z.string(),
   refresh_token: z.string(),
   expires_at: z.number().optional(),
@@ -59,12 +59,12 @@ export interface SupabaseSessionLog {
 }
 
 /** Result of converting an auth callback into a stored session. */
-export interface SupabaseCallbackParseResult {
+interface SupabaseCallbackParseResult {
   success: true;
   session: SupabaseSession;
 }
 
-export interface SupabaseCallbackParseError {
+interface SupabaseCallbackParseError {
   success: false;
   error: string;
   isAuthError?: boolean;

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -40,7 +40,7 @@ export type UserAccessStatus = z.infer<typeof UserAccessStatusSchema>;
  * Schema for a single tier's model access configuration.
  * - models: Either "*" for all models, or an array of specific model names
  */
-export const TierModelsConfigSchema = z.object({
+const TierModelsConfigSchema = z.object({
   /** Model access: "*" for all models, or array of specific model names */
   models: z.union([z.literal('*'), z.array(z.string())]),
 });

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -135,7 +135,7 @@ export function isInFlightPhase(phase: StreamPhase | undefined): boolean {
   return phase === STREAM_PHASE.RUNNING || phase === STREAM_PHASE.WAITING;
 }
 
-export function isTerminalPhase(phase: StreamPhase | undefined): boolean {
+function isTerminalPhase(phase: StreamPhase | undefined): boolean {
   return phase === STREAM_PHASE.WAITING || isTerminalOutcomePhase(phase);
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -7,7 +7,6 @@
  */
 export {
   type SdkErrorKind,
-  type SdkErrorMetadata,
   sdkErrorKindFromStatusCode,
   isRetryableStatusCode,
 } from './sdkError/sdkErrorKinds';
@@ -25,7 +24,6 @@ export {
 export {
   type ConnectTrackableStream,
   type StreamConnectTracker,
-  type StreamingFailureHooks,
   annotateStreamFailure,
   handleStreamingFailure,
   trackStreamConnect,
@@ -55,5 +53,4 @@ export { isRelayMonthlyLimitMessage } from './sdkError/relayDetection';
 export {
   parseChatGptSubscriptionLimit,
   describeChatGptSubscriptionLimit,
-  type ChatGptSubscriptionLimit,
 } from './sdkError/chatgptSubscriptionDetection';

--- a/src/common/files/workspaceFileListing.ts
+++ b/src/common/files/workspaceFileListing.ts
@@ -10,7 +10,7 @@ import {
   type FileListConfig,
 } from './fileListingRules';
 
-export interface WorkspaceTreeNode {
+interface WorkspaceTreeNode {
   name: string;
   path: string;
   type: 'directory' | 'file';

--- a/src/controllers/mainView/MainViewDroppedFilesController.ts
+++ b/src/controllers/mainView/MainViewDroppedFilesController.ts
@@ -10,7 +10,7 @@ export const MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES = [
   'media',
 ] as const satisfies readonly MultipleDocumentFileType[];
 
-export type MainViewAttachableDropCategory =
+type MainViewAttachableDropCategory =
   (typeof MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES)[number];
 
 export type MainViewAllowedDropExtensions = Readonly<

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -33,7 +33,7 @@ export interface ProgressFollowUpModelOption {
   disabled?: boolean;
 }
 
-export interface ProgressFollowUpWorkspace {
+interface ProgressFollowUpWorkspace {
   locatePath(path: string):
     | { kind: 'workspace'; relativePath: string }
     | {

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -22,13 +22,13 @@ export interface ProgressFollowUpPolishInput {
   readonly taskState: TaskState | undefined;
 }
 
-export interface ProgressFollowUpPolishTextResult {
+interface ProgressFollowUpPolishTextResult {
   readonly success: boolean;
   readonly text: string;
   readonly error?: string;
 }
 
-export type ProgressFollowUpPolishText = (
+type ProgressFollowUpPolishText = (
   text: string,
   fileContext?: FileContext,
 ) => Promise<ProgressFollowUpPolishTextResult>;

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -34,7 +34,7 @@ export type ProgressViewFollowUpImage = NonNullable<
   SendFollowUpMessage['images']
 >[number];
 
-export interface ProgressViewFollowUpSubmission {
+interface ProgressViewFollowUpSubmission {
   stream: StreamTabId;
   text: string;
   mediaFiles?: readonly string[];

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -37,7 +37,7 @@ export interface WorkflowFileOperationRequest {
   skipProgressViewClear: boolean;
 }
 
-export interface ProgressWorkflowActionsState {
+interface ProgressWorkflowActionsState {
   getTaskState(stream: StreamTabId): TaskState | undefined;
   getExecutionId(stream: StreamTabId): string | undefined;
   getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -22,7 +22,7 @@ export interface AcceptCopyMeta {
   round: number;
 }
 
-export interface ProgressWorkflowFileActionsState {
+interface ProgressWorkflowFileActionsState {
   getActiveStream(): StreamTabId | '';
   getExecutionId(stream: StreamTabId): string | undefined;
   getOutputFiles(stream: StreamTabId): RoundIndexed<OutputFileInfo>;
@@ -31,7 +31,7 @@ export interface ProgressWorkflowFileActionsState {
   ): { agent: string; model: string } | undefined;
 }
 
-export interface ProgressWorkflowFileActionsHost {
+interface ProgressWorkflowFileActionsHost {
   compareFiles(baseFile: string, editedFile: string): Promise<void>;
   acceptEditedFile(
     baseFile: string,

--- a/src/controllers/settingsView/LatexRecommendedSettingsController.ts
+++ b/src/controllers/settingsView/LatexRecommendedSettingsController.ts
@@ -5,7 +5,7 @@ export interface LatexRecommendedSettingUpdate {
   value: unknown;
 }
 
-export interface LatexRecommendedSettingsConfig {
+interface LatexRecommendedSettingsConfig {
   getConfig(key: string): unknown;
   getGlobalValue(key: string): unknown;
   isExplicitlySet(key: string): boolean;

--- a/src/controllers/settingsView/LatexToolingController.ts
+++ b/src/controllers/settingsView/LatexToolingController.ts
@@ -26,7 +26,7 @@ export type LatexProbeTool = (typeof LATEX_PROBE_TOOLS)[number];
 
 export type LatexPathTool = Exclude<LatexProbeTool, 'perl'>;
 
-export type LatexRecommendedStatus = Pick<
+type LatexRecommendedStatus = Pick<
   LatexSettingsStatus,
   'outDir' | 'autoRevealExclude'
 >;

--- a/src/controllers/settingsView/SettingsAgentDirectoryController.ts
+++ b/src/controllers/settingsView/SettingsAgentDirectoryController.ts
@@ -5,7 +5,7 @@ export interface SettingsAgentDirectoryEntry {
   path?: string;
 }
 
-export interface SettingsAgentDirectoryState {
+interface SettingsAgentDirectoryState {
   getConfiguredCustomDir(): string | undefined;
   setConfiguredCustomDir(path: string): Promise<void>;
   getCustomDir(): Promise<string>;

--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -8,7 +8,7 @@ export interface SettingsAgentFileEntry {
   path: string;
 }
 
-export interface SettingsAgentCustomizePlan {
+interface SettingsAgentCustomizePlan {
   targetPath: string;
 }
 
@@ -22,7 +22,7 @@ export type SettingsAgentCustomizeResult =
       reason: 'targetEscapesCustomDir';
     };
 
-export interface SettingsAgentDeletePlan {
+interface SettingsAgentDeletePlan {
   path: string;
 }
 

--- a/src/controllers/settingsView/SettingsAgentVisibilityController.ts
+++ b/src/controllers/settingsView/SettingsAgentVisibilityController.ts
@@ -10,7 +10,7 @@ export interface SettingsAgentVisibilityEntry {
   name: string;
 }
 
-export interface SettingsAgentVisibilityState {
+interface SettingsAgentVisibilityState {
   getEnabledAgentKeys(category: AgentCategory): string[] | undefined;
   setEnabledAgentKeys(
     category: AgentCategory,

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -84,7 +84,7 @@ export interface PromptHost {
   input(options: PromptInputOptions): Promise<string | undefined>;
 }
 
-export interface TerminalOptions {
+interface TerminalOptions {
   name: string;
   cwd?: string;
   env?: Record<string, string | undefined>;

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -64,7 +64,7 @@ function getAcceptAction(isNewFile: boolean, targetExists: boolean): string {
  * workspace. Shared by the VS Code command and the desktop bridge so both
  * hosts surface identical wording.
  */
-export function buildAcceptConfirmMessage(
+function buildAcceptConfirmMessage(
   target: AcceptedFileTarget,
   basePath: string,
   editedPath: string,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -18,12 +18,12 @@ import { normaliseArxivIdentifier } from './arxivIdentifier';
 import { indentLatexFilesInDirectory } from './formatter/indentDirectory';
 import type { ReadableStream as NodeWebReadableStream } from 'node:stream/web';
 
-export interface ExtractResult {
+interface ExtractResult {
   success: boolean;
   error?: string;
 }
 
-export interface ExtractOptions {
+interface ExtractOptions {
   timeout?: number;
   channel?: string;
 }

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -1,6 +1,6 @@
 import { checkToolInstalled } from '@utils/system/toolUtils';
 
-export type LatexToolName =
+type LatexToolName =
   | 'latexmk'
   | 'pdflatex'
   | 'xelatex'
@@ -10,7 +10,7 @@ export type LatexToolName =
   | 'latexdiff'
   | 'latexindent';
 
-export interface LatexToolStatus {
+interface LatexToolStatus {
   readonly name: LatexToolName;
   readonly installed: boolean;
   readonly required: boolean;

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -20,7 +20,7 @@ import type { MathMarkupOption } from './latexdiff/mathMarkup';
 // LaTeXdiff Result Schemas
 // ============================================================================
 
-export const LaTeXdiffResultSchema = z.object({
+const LaTeXdiffResultSchema = z.object({
   success: z.boolean(),
   diffFileName: z.string().optional(),
   message: z.string().optional(),

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -6,7 +6,7 @@ import {
   extractLastRoundModelMatch,
 } from '@agent/utils/mergeFileUtils';
 
-export type GeneratedLatexdiffArtifactKind =
+type GeneratedLatexdiffArtifactKind =
   'workspaceDiff' | 'versionControlDiff' | 'betweenRoundDiff';
 
 export interface GeneratedLatexdiffArtifact {

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -42,7 +42,7 @@ function getFileLabel(info: OutputFileInfo): string {
   return info.source ?? path.basename(getComparablePath(info.location));
 }
 
-export async function executeDiffOperations(
+async function executeDiffOperations(
   operations: DiffOperation[],
   mathMarkup: MathMarkupOption | undefined,
   progress: DiffProgressReporter,

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -40,10 +40,7 @@ import { CHANNEL } from './service';
  * Recursively collect all `.tex` file paths under `dir`, returned as paths
  * relative to `dir` using forward slashes (e.g. `"chapters/main.tex"`).
  */
-export async function collectTexFiles(
-  dir: string,
-  prefix = '',
-): Promise<string[]> {
+async function collectTexFiles(dir: string, prefix = ''): Promise<string[]> {
   const fs = platform().fs;
   let entries: [string, number][];
   try {

--- a/src/latex/latexdiff/runLatexdiff.ts
+++ b/src/latex/latexdiff/runLatexdiff.ts
@@ -52,8 +52,7 @@ export function normalizeRunLatexdiffOutputsByRound(
 }
 
 /** How the round outputs fed to the diff engine were resolved. */
-export type LatexdiffOutputsSource =
-  'metadata' | 'run-dir-scan' | 'workspace-scan';
+type LatexdiffOutputsSource = 'metadata' | 'run-dir-scan' | 'workspace-scan';
 
 export interface RunLatexdiffForExecutionParams {
   readonly agent: string;

--- a/src/latex/latexdiff/types.ts
+++ b/src/latex/latexdiff/types.ts
@@ -37,8 +37,6 @@ export interface DiffRunOutcome {
   totalOperations: number;
 }
 
-export type DiffOperationType = 'round' | 'between-rounds';
-
 interface DiffOperationBase {
   base: FileLocation;
   revised: FileLocation;
@@ -46,12 +44,12 @@ interface DiffOperationBase {
   cwd: string;
 }
 
-export interface RoundDiffOperation extends DiffOperationBase {
+interface RoundDiffOperation extends DiffOperationBase {
   type: 'round';
   round: number;
 }
 
-export interface BetweenRoundsDiffOperation extends DiffOperationBase {
+interface BetweenRoundsDiffOperation extends DiffOperationBase {
   type: 'between-rounds';
   fromRound: number;
   toRound: number;

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -2,7 +2,7 @@ import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
 
 import type { UsageRoute } from '@shared/schemas';
 
-export type ProviderAuthMode = 'chatgpt-subscription';
+type ProviderAuthMode = 'chatgpt-subscription';
 
 export interface OpenAIResponseProviderCapabilities {
   readonly backgroundMode: 'base' | 'disabled';

--- a/src/replacement/constants.ts
+++ b/src/replacement/constants.ts
@@ -50,7 +50,7 @@ export const MATH_OPERATORS = [
   'liminf',
 ];
 
-export const FENCED_LATEX_ENVIRONMENTS = [
+const FENCED_LATEX_ENVIRONMENTS = [
   'align',
   'align*',
   'aligned',
@@ -73,7 +73,7 @@ export const FENCED_LATEX_ENVIRONMENTS = [
   'smallmatrix',
 ];
 
-export const FENCED_LATEX_ENVIRONMENT_PATTERN =
+const FENCED_LATEX_ENVIRONMENT_PATTERN =
   FENCED_LATEX_ENVIRONMENTS.map(escapeRegExp).join('|');
 
 const LINE_BREAK_PATTERN = String.raw`\r?\n`;

--- a/src/skills/SkillSchema.ts
+++ b/src/skills/SkillSchema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Local imports - utilities
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
-export const SKILL_NAME_MAX_LENGTH = 64;
+const SKILL_NAME_MAX_LENGTH = 64;
 export const SKILL_DESCRIPTION_MAX_LENGTH = 1024;
 
 export const SkillNameSchema = z
@@ -36,7 +36,7 @@ const SkillDescriptionSchema = z
     `Skill description must be at most ${SKILL_DESCRIPTION_MAX_LENGTH} characters`,
   );
 
-export const SkillFrontmatterSchema = z.looseObject({
+const SkillFrontmatterSchema = z.looseObject({
   name: SkillNameSchema,
   description: SkillDescriptionSchema,
 });
@@ -51,4 +51,3 @@ export const SkillSchema = z.strictObject({
 });
 
 export type Skill = z.infer<typeof SkillSchema>;
-export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;

--- a/src/skills/loadSkills.ts
+++ b/src/skills/loadSkills.ts
@@ -14,19 +14,14 @@ import type { Skill } from './SkillSchema';
 // Local imports - utilities
 import type { Dirent } from 'node:fs';
 
-export {
-  type SkillIssueCode,
-  type SkillIssueSeverity,
-  type SkillLoadIssue,
-} from './skillLoader';
+export { type SkillLoadIssue } from './skillLoader';
 
 export interface DiscoverSkillsResult {
   skills: Skill[];
   errors: SkillLoadIssue[];
 }
 
-export type SkillSourceScope =
-  'bundled' | 'user' | 'project' | 'interop' | 'custom';
+type SkillSourceScope = 'bundled' | 'user' | 'project' | 'interop' | 'custom';
 
 export interface SkillSource {
   scope: SkillSourceScope;

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -15,7 +15,7 @@ const UsageLogMetadataSchema = z.object({
   streamId: z.string().optional(),
 });
 
-export const UsageLogStatsSchema = z.object({
+const UsageLogStatsSchema = z.object({
   inputTokens: z.int().nonnegative(),
   outputTokens: z.int().nonnegative(),
   cost: z.number().nonnegative(),
@@ -36,7 +36,7 @@ export const UsageLogStatsSchema = z.object({
  */
 export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
 
-export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
+const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
   UsageLogStatsSchema.shape,
 ).extend({
   timestamp: z.iso.datetime(),
@@ -46,7 +46,7 @@ export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
 
 export type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;
 
-export const UsageLogBatchSchema = z.object({
+const UsageLogBatchSchema = z.object({
   entries: z.array(UsageLogEntrySchema),
   batchId: z.uuid(),
 });

--- a/src/test-kernel/support/FakeHosts.ts
+++ b/src/test-kernel/support/FakeHosts.ts
@@ -28,14 +28,14 @@ export interface PromptInputEvent {
   options: PromptInputOptions;
 }
 
-export interface DiffOpenEvent {
+interface DiffOpenEvent {
   original: DiffSource;
   proposed: DiffSource;
   title: string;
   options?: DiffOptions;
 }
 
-export interface DiffRevealEvent {
+interface DiffRevealEvent {
   session: DiffSession;
   line: number;
 }
@@ -121,7 +121,7 @@ export class FakePromptHost implements PromptHost {
   }
 }
 
-export class FakeExternalOpener implements ExternalOpener {
+class FakeExternalOpener implements ExternalOpener {
   readonly externalUrls: string[] = [];
 
   readonly paths: string[] = [];
@@ -135,7 +135,7 @@ export class FakeExternalOpener implements ExternalOpener {
   }
 }
 
-export class FakeDiffViewHost implements DiffViewHost {
+class FakeDiffViewHost implements DiffViewHost {
   readonly opened: DiffOpenEvent[] = [];
 
   readonly closed: DiffSession[] = [];
@@ -187,7 +187,7 @@ export class FakeDiffViewHost implements DiffViewHost {
  * desktop) inject each port individually; this aggregate exists only so
  * test support can assemble and pass them as a single bundle.
  */
-export interface UIHosts {
+interface UIHosts {
   readonly prompt: PromptHost;
   readonly externalOpener: ExternalOpener;
   readonly diff: DiffViewHost;

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -23,13 +23,6 @@ import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import type { Platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
-export type RecordingLogLevel = 'debug' | 'info' | 'warn' | 'error';
-
-export interface RecordingLogEntry {
-  level: RecordingLogLevel;
-  message: string;
-}
-
 function fakeFsError(code: string, message: string): Error {
   return Object.assign(new Error(message), { code });
 }
@@ -424,7 +417,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   }
 }
 
-export class FakeWorkspaceProvider implements WorkspaceProvider {
+class FakeWorkspaceProvider implements WorkspaceProvider {
   constructor(private readonly workspacePath: string | undefined) {}
 
   getWorkspacePath(): string | undefined {
@@ -445,7 +438,7 @@ export class FakeWorkspaceProvider implements WorkspaceProvider {
   }
 }
 
-export class FakeStorageProvider implements StorageProvider {
+class FakeStorageProvider implements StorageProvider {
   constructor(
     private readonly storagePath = '/workspace/.texra/storage',
     private readonly globalStoragePath = '/global/.texra/storage',

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -27,7 +27,7 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 
-export class ControllerCallRecorder<T = unknown> {
+class ControllerCallRecorder<T = unknown> {
   readonly calls = new Map<string, T[]>();
 
   record(name: string, payload: T): void {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -35,7 +35,7 @@ import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
 import { StreamLogStore, STREAM_LOGS_DIR } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 
-export type CompletedRunTodosSource = 'streamData' | 'legacyKV' | 'none';
+type CompletedRunTodosSource = 'streamData' | 'legacyKV' | 'none';
 
 export interface CompletedRunTodosReadResult {
   readonly todos: TodoEntry[];
@@ -127,7 +127,7 @@ export async function readCompletedRunTodos(
 // Conversation
 // ============================================================================
 
-export type CompletedRunConversationSource = 'streamLog' | 'legacyKV' | 'none';
+type CompletedRunConversationSource = 'streamLog' | 'legacyKV' | 'none';
 
 export interface CompletedRunConversationReadResult {
   /** Provider-agnostic `{role, content}` messages, or `null` when neither
@@ -345,7 +345,7 @@ function conversationMessagesForEntry(entry: StreamLogEntry): unknown[] {
  * chat-export normalizer, the CLI workspace-file extractor) already
  * recognizes, so downstream rendering code needs no new shape.
  */
-export function streamLogEntriesToConversation(
+function streamLogEntriesToConversation(
   entries: readonly StreamLogEntry[],
 ): unknown[] {
   return entries.flatMap((entry) =>

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -7,7 +7,7 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 import type { StreamLogStore } from './StreamLogStore';
 
-export type PersistedStreamIdResolutionSource =
+type PersistedStreamIdResolutionSource =
   | 'executionMeta'
   | 'streamDataMeta'
   | 'streamDataSuffix'

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -34,15 +34,6 @@ export {
 export {
   readCompletedRunConversation,
   readCompletedRunTodos,
-  streamLogEntriesToConversation,
-  type CompletedRunConversationReadResult,
-  type CompletedRunConversationSource,
-  type CompletedRunTodosReadResult,
-  type CompletedRunTodosSource,
 } from './completedRunArchive';
-export {
-  resolvePersistedStreamIdForExecution,
-  type PersistedStreamIdResolution,
-  type PersistedStreamIdResolutionSource,
-} from './executionStreamResolver';
+export { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
 export { injectStandaloneTrace } from './standaloneTraceHtml';

--- a/src/transcript/streamDataPaths.ts
+++ b/src/transcript/streamDataPaths.ts
@@ -45,14 +45,11 @@ export const STREAM_DATA_KEYS = {
   LEGACY_RUN_INSTRUCTIONS: 'runInstructions',
 } as const;
 
-export type StreamDataKey =
-  (typeof STREAM_DATA_KEYS)[keyof typeof STREAM_DATA_KEYS];
-
 /**
  * Encode a stream tab id for safe use as a filesystem directory name.
  * Stream ids can contain `:`, `/`, `#`, and other unsafe characters.
  */
-export function encodeStreamId(id: string): string {
+function encodeStreamId(id: string): string {
   return encodeURIComponent(id);
 }
 

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -1,7 +1,7 @@
 import prettyMilliseconds from 'pretty-ms';
 import pluralizeWord from 'pluralize';
 import safeStringify from 'safe-stable-stringify';
-import { serializeError, type ErrorObject } from 'serialize-error';
+import { serializeError } from 'serialize-error';
 
 const graphemeSegmenter = new Intl.Segmenter(undefined, {
   granularity: 'grapheme',
@@ -22,9 +22,6 @@ export function toGraphemes(text: string): string[] {
  * `requestId`), and handles circular references.
  */
 export { serializeError };
-
-/** Plain-object shape produced by {@link serializeError}. */
-export type SerializedError = ErrorObject;
 
 /** Check if value is a non-empty string after trimming. */
 export function isNonEmptyString(value: unknown): value is string {

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -197,7 +197,7 @@ export async function extractScratchpad(
 // Extraction Result Schemas
 // ============================================================================
 
-export interface ExtractionResult {
+interface ExtractionResult {
   content: string | null;
   method: 'simple' | 'markdown' | 'latex' | 'none';
 }

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -27,6 +27,4 @@ export {
   extractContentFromXMLbyTagMultiple,
   extractScratchpad,
   extractDocuments,
-  type ExtractionResult,
-  type MultipleExtractionResult,
 } from './xmlExtraction';


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. Executes the `other` batch of knip-flagged dead exports/types, each independently verified twice (adversarial verification agent + orchestrator spot-checks) before this pass, with a final re-check against current `main` before touching each file.

De-export = drop the `export` keyword only, keep the declaration and its internal logic (still used in-file). Delete = the declaration had zero references anywhere, including in-file.

### De-exported (kept, visibility narrowed only)

| Name | File |
|---|---|
| `FakeWorkspaceProvider` | `src/test-kernel/support/FakePlatform.ts` |
| `FakeStorageProvider` | `src/test-kernel/support/FakePlatform.ts` |
| `USE_INCLUDED_ACCESS_KEY` | `src/auth/serverKeys/ServerSideKeyService.ts` |
| `isTerminalPhase` | `src/common/constants/streamStatus.ts` |
| `ControllerCallRecorder` | `src/test-kernel/support/ProgressControllerHarnesses.ts` |
| `FakeExternalOpener`, `FakeDiffViewHost`, `DiffOpenEvent`, `DiffRevealEvent`, `UIHosts` | `src/test-kernel/support/FakeHosts.ts` |
| `LaTeXdiffResultSchema` | `src/latex/latexdiff.ts` |
| `collectTexFiles` | `src/latex/latexdiff/outputDiscovery.ts` |
| `encodeStreamId` | `src/transcript/streamDataPaths.ts` |
| `streamLogEntriesToConversation`, `CompletedRunTodosSource`, `CompletedRunConversationSource` | `src/transcript/completedRunArchive.ts` (origin) |
| `PersistedStreamIdResolutionSource` | `src/transcript/executionStreamResolver.ts` (origin) |
| `SupabaseSessionSchema`, `GitHubTokenExchangeSchema`, `SupabaseCallbackParseResult`, `SupabaseCallbackParseError` | `src/auth/supabaseSessionTypes.ts` |
| `TierModelsConfigSchema` | `src/auth/tier/types.ts` |
| `executeDiffOperations` | `src/latex/latexdiff/diffOperations.ts` |
| `UsageLogStatsSchema`, `UsageLogEntrySchema`, `UsageLogBatchSchema` | `src/telemetry/UsageLogTypes.ts` |
| `SKILL_NAME_MAX_LENGTH`, `SkillFrontmatterSchema` | `src/skills/SkillSchema.ts` |
| `FENCED_LATEX_ENVIRONMENTS`, `FENCED_LATEX_ENVIRONMENT_PATTERN` | `src/replacement/constants.ts` |
| `buildAcceptConfirmMessage` | `src/latex/acceptedFileTarget.ts` |
| `ProviderAuthMode` | `src/model/providerCapabilities.ts` |
| `AuthCallbackTokens`, `AuthCallbackTokenParseSuccess`, `AuthCallbackTokenParseError`, `AuthCallbackCodeParseSuccess` | `src/auth/core/authCallback.ts` |
| `LatexRecommendedSettingsConfig` | `src/controllers/settingsView/LatexRecommendedSettingsController.ts` |
| `LatexRecommendedStatus` | `src/controllers/settingsView/LatexToolingController.ts` |
| `MainViewAttachableDropCategory` | `src/controllers/mainView/MainViewDroppedFilesController.ts` |
| `ProgressFollowUpWorkspace` | `src/controllers/progressView/ProgressFollowUpController.ts` |
| `ProgressFollowUpPolishTextResult`, `ProgressFollowUpPolishText` | `src/controllers/progressView/ProgressFollowUpPolishController.ts` |
| `ProgressViewFollowUpSubmission` | `src/controllers/progressView/ProgressViewCommandHandlers.ts` |
| `ProgressWorkflowFileActionsState`, `ProgressWorkflowFileActionsHost` | `src/controllers/progressView/ProgressWorkflowFileActionsController.ts` |
| `ProgressWorkflowActionsState` | `src/controllers/progressView/ProgressWorkflowActionsController.ts` |
| `SettingsAgentDirectoryState` | `src/controllers/settingsView/SettingsAgentDirectoryController.ts` |
| `SettingsAgentCustomizePlan`, `SettingsAgentDeletePlan` | `src/controllers/settingsView/SettingsAgentFileController.ts` |
| `SettingsAgentVisibilityState` | `src/controllers/settingsView/SettingsAgentVisibilityController.ts` |
| `TerminalOptions` | `src/hosts/uiHosts.ts` |
| `ExtractResult`, `ExtractOptions` | `src/latex/arxivProcessor.ts` |
| `GeneratedLatexdiffArtifactKind` | `src/latex/latexdiff/diffFileNameManager.ts` |
| `LatexdiffOutputsSource` | `src/latex/latexdiff/runLatexdiff.ts` |
| `SkillSourceScope` | `src/skills/loadSkills.ts` |
| `ExtractionResult` | `src/utils/text/xmlExtraction.ts` (origin) |
| `SupabaseSecretStore` | `src/auth/SupabaseAuthCoordinator.ts` |
| `RoundDiffOperation`, `BetweenRoundsDiffOperation` | `src/latex/latexdiff/types.ts` |
| `LatexToolName`, `LatexToolStatus` | `src/latex/latexToolchain.ts` |
| `WorkspaceTreeNode` | `src/common/files/workspaceFileListing.ts` |

### Deleted (fully orphaned)

| Name | File |
|---|---|
| `RecordingLogLevel`, `RecordingLogEntry` | `src/test-kernel/support/FakePlatform.ts` |
| `StreamDataKey` | `src/transcript/streamDataPaths.ts` |
| `SkillFrontmatter` | `src/skills/SkillSchema.ts` |
| `SerializedError` (+ now-unused `ErrorObject` import) | `src/utils/text/stringUtils.ts` |
| `DiffOperationType` | `src/latex/latexdiff/types.ts` |

### Barrel re-export lines removed (origin declaration untouched or de-exported separately)

- `src/transcript/index.ts`: dropped re-exports of `streamLogEntriesToConversation`, `CompletedRunConversationReadResult`, `CompletedRunConversationSource`, `CompletedRunTodosReadResult`, `CompletedRunTodosSource`, `PersistedStreamIdResolution`, `PersistedStreamIdResolutionSource`.
- `src/common/errors/sdkErrorUtils.ts`: dropped re-exports of `SdkErrorMetadata`, `StreamingFailureHooks`, `ChatGptSubscriptionLimit` (origin types untouched — still consumed directly elsewhere or in-file).
- `src/skills/loadSkills.ts`: dropped re-exports of `SkillIssueCode`, `SkillIssueSeverity` (origin in `skillLoader.ts` untouched).
- `src/utils/text/xmlUtils.ts`: dropped re-exports of `ExtractionResult`, `MultipleExtractionResult`.

### Skipped (6 items — main moved since verification)

`ProgressViewLifecycleCommandActions`, `ProgressViewRunCommandActions`, `ProgressViewFileCommandActions`, `ProgressViewBypassCommandOptions`, `ProgressViewApprovalCommandActions`, `ProgressViewExternalInquiryCommandActions` in `src/controllers/progressView/ProgressViewCommandHandlers.ts` — a same-day commit (`36affaf5d`, "refactor(progress): share progress view host wiring") landed a new file `src/controllers/progressView/ProgressViewHost.ts` that now imports all six of these types directly by name. Re-verified via repo-wide grep and confirmed a post-fix `knip` run no longer flags them (because they now have a real external consumer), so de-exporting would have broken the build. Left untouched.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `npx eslint <touched files>` — clean
- [x] `npx prettier --check <touched files>` — clean (2 files needed `--write` for a reflowed line, applied)
- [x] Targeted `vitest run` across every touched directory (`auth`, `common`, `controllers`, `hosts`, `latex`, `model`, `replacement`, `skills`, `telemetry`, `transcript`, `utils/text`, `test-kernel/support`) — 97 files / 803 tests passed
- [x] Post-fix `knip --include files,exports,types,duplicates` re-run — none of the touched items reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only cleanup with no logic edits; risk is limited to downstream packages that imported now-private symbols from barrels.
> 
> **Overview**
> This PR shrinks the **published TypeScript surface** after a knip dead-export sweep: mostly `export` → module-local on types, Zod schemas, constants, and helpers that are only referenced inside their own files, with **no intended runtime behavior change**.
> 
> **Barrel trims** drop re-exports consumers were not supposed to rely on: `src/transcript/index.ts` no longer forwards several completed-run archive types/helpers and resolution-source types; `sdkErrorUtils`, `loadSkills`, and `xmlUtils` shed a few type re-exports while direct imports elsewhere stay valid.
> 
> **Fully removed symbols** include orphaned test-kernel logging types, `StreamDataKey`, `SkillFrontmatter`, `SerializedError`, and `DiffOperationType`.
> 
> Across auth, controllers, latex/latexdiff, skills, telemetry, and test-kernel support, the pattern is the same—**tighten encapsulation** so the supported import graph matches real external usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f0a809c07d3dca88bcc0c8a546e000eb6245b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->