### PR TITLE
chore: remove dead exports flagged by knip (batch: agent)

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -21,7 +21,7 @@ export type RoundFinalizedCallback = (
 ) => void | Promise<void>;
 
 /** Delegation-scoped policy flags, grouped so they travel together on `AgentCore`. */
-export interface DelegationPolicy {
+interface DelegationPolicy {
   /**
    * Delegation depth: 0 for root (user-initiated), N for a subagent N levels deep.
    * Set by executeAgent from ExecuteAgentOptions.delegationDepth. Used by the

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -60,7 +60,7 @@ export async function withModelClient<C, T extends object>(
   };
 }
 
-export interface TextConnectionService {
+interface TextConnectionService {
   /**
    * Determines the best textual connector between two strings in a LaTeX
    * document context (empty string, space, or newline).

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -54,7 +54,7 @@ import type { ResponseCycleServices } from './CycleServices';
  * All fields here are natively serializable (structuredClone compatible).
  * Non-serializable fields (debug, responseObject) are in CycleTransientFields.
  */
-export const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
+const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
   /** Whether output file exists */
   outputExists: z.boolean(),
   /** Agent output location (nullable for native nesting compatibility) */
@@ -64,7 +64,7 @@ export const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
 });
 
 /** Serializable cycle fields derived from schema */
-export type CycleFields = z.infer<typeof CycleFieldsSchema>;
+type CycleFields = z.infer<typeof CycleFieldsSchema>;
 
 /**
  * Transient cycle fields that are NOT serialized.
@@ -76,7 +76,7 @@ export type CycleFields = z.infer<typeof CycleFieldsSchema>;
  * services/shared at each `maybeSaveDebugObject` call site. Nothing is
  * stored in shared state.
  */
-export interface CycleTransientFields {
+interface CycleTransientFields {
   /** System prompt for model (regenerated from agent prompt each cycle) */
   systemPrompt?: string;
   /** Raw response from model (type unknown, not serialized) */

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -29,11 +29,7 @@ import { ToolUseDispatchNode } from './toolUseRound/ToolUseDispatchNode';
 import type { ToolUseRoundServices } from './CycleServices';
 import type { ToolUseRoundShared } from './toolUseRound/roundShared';
 
-export {
-  ToolUseRoundFieldsSchema,
-  type ToolUseRoundFields,
-  type ToolUseRoundShared,
-} from './toolUseRound/roundShared';
+export { type ToolUseRoundShared } from './toolUseRound/roundShared';
 
 /**
  * Creates a tool-use round flow with services injected via params.

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -20,7 +20,7 @@ import { NormalizedUsageSchema } from '@agent/types/NormalizedUsage';
  * Tool-use specific fields:
  * - response, toolCalls, text, roundIndex, roundResponseTimeMs, roundNormalizedUsage
  */
-export const ToolUseRoundFieldsSchema = BaseCycleFieldsSchema.extend({
+const ToolUseRoundFieldsSchema = BaseCycleFieldsSchema.extend({
   /**
    * System prompt for providers that pass `system` per-call (Anthropic,
    * Google) rather than embedding it into `messages` at session init.
@@ -61,7 +61,7 @@ export const ToolUseRoundFieldsSchema = BaseCycleFieldsSchema.extend({
 });
 
 /** Tool-use round fields derived from schema */
-export type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
+type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
 
 /**
  * Shared state for tool-use round flows.

--- a/src/agent/core/usage/ResponseUsage.ts
+++ b/src/agent/core/usage/ResponseUsage.ts
@@ -36,7 +36,7 @@ export interface ExtendedCompletionUsage extends CompletionUsage {
  * - AnthropicUsage: Anthropic Messages API
  * - GenerateContentResponseUsageMetadata: Google Gemini API
  */
-export type NativeUsagePayload =
+type NativeUsagePayload =
   | ExtendedCompletionUsage
   | OpenAIResponseUsage
   | AnthropicUsage

--- a/src/agent/export/chatExport/formatSpec.ts
+++ b/src/agent/export/chatExport/formatSpec.ts
@@ -50,7 +50,7 @@ function collectFiles(config: ExportConfig): Array<[string, string]> {
   return files;
 }
 
-export function extractMeta(input: ChatExportInput): DocumentMeta {
+function extractMeta(input: ChatExportInput): DocumentMeta {
   return {
     date: formatLocaleTimestamp(input.timestamp),
     agent: input.config.agent,

--- a/src/agent/export/chatExportFormatter.ts
+++ b/src/agent/export/chatExportFormatter.ts
@@ -23,14 +23,7 @@ import { renderDocument } from './chatExport/formatSpec';
 import { createLatexSpec } from './chatExport/latexSpec';
 import { markdownSpec } from './chatExport/markdownSpec';
 
-export type {
-  ChatExportInput,
-  DocumentMeta,
-  ExportNode,
-} from '@agent/export/schemas';
-export type { FormatSpec } from './chatExport/formatSpec';
-export { extractMeta } from './chatExport/formatSpec';
-export { normalizeConversationForExport as normalizeMessages } from '@agent/export/normalizeConversation';
+export type { ChatExportInput } from '@agent/export/schemas';
 export { generateExportFilename } from './chatExport/filenames';
 
 export function formatChatAsMarkdown(input: ChatExportInput): string {

--- a/src/agent/export/schemas.ts
+++ b/src/agent/export/schemas.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 // Export configuration (caller-supplied)
 // ============================================================
 
-export const ExportConfigSchema = z.object({
+const ExportConfigSchema = z.object({
   agent: z.string().optional(),
   model: z.string().optional(),
   instruction: z.string().optional(),
@@ -27,7 +27,7 @@ export const ExportConfigSchema = z.object({
 });
 export type ExportConfig = z.infer<typeof ExportConfigSchema>;
 
-export const ChatExportInputSchema = z.object({
+const ChatExportInputSchema = z.object({
   timestamp: z.string(),
   description: z.string().optional(),
   config: ExportConfigSchema,
@@ -44,7 +44,7 @@ const WebSearchResultSchema = z.object({
   url: z.string(),
 });
 
-export const UserPartSchema = z.discriminatedUnion('type', [
+const UserPartSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('text'), text: z.string() }),
   z.object({
     type: z.literal('attachment'),

--- a/src/agent/followUp/FollowUpQueue.ts
+++ b/src/agent/followUp/FollowUpQueue.ts
@@ -7,9 +7,8 @@
 import pDefer, { type DeferredPromise } from 'p-defer';
 
 /** Preserves visible follow-up provenance across queueing and resume replay. */
-export type VisibleFollowUpQueueItemOrigin = 'user' | 'subagent_result';
-export type FollowUpQueueItemOrigin =
-  VisibleFollowUpQueueItemOrigin | 'synthetic';
+type VisibleFollowUpQueueItemOrigin = 'user' | 'subagent_result';
+type FollowUpQueueItemOrigin = VisibleFollowUpQueueItemOrigin | 'synthetic';
 
 export interface FollowUpQueueInput {
   readonly text: string;

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -27,7 +27,7 @@ const CHANNEL = 'AgentCreator';
 
 export type AgentCategory = 'workflow' | 'toolUse';
 
-export interface AgentPromptPair {
+interface AgentPromptPair {
   systemPrompt: string;
   userRequest: string;
 }
@@ -42,7 +42,7 @@ export interface CreatorConfig {
   };
 }
 
-export interface AgentBlueprint {
+interface AgentBlueprint {
   category: AgentCategory;
   agentName: string;
   filePath: string;

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -60,7 +60,7 @@ export const ReflectionFlowStateSchema = z.object({
   compileRepairRoundGranted: z.boolean().optional(),
 });
 
-export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;
+type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;
 
 /** Shared state type for reflection flow nodes. */
 export type ReflectionFlowShared = ReflectionFlowState;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -99,7 +99,7 @@ export interface RunToolUseFlowResult {
   totalCostUsd?: number;
 }
 
-export class ToolUseFlowError extends Error {
+class ToolUseFlowError extends Error {
   constructor(
     message: string,
     readonly result: RunToolUseFlowResult,
@@ -116,7 +116,7 @@ export function getToolUseFlowErrorResult(
   return error instanceof ToolUseFlowError ? error.result : undefined;
 }
 
-export interface ToolUseFlowContext {
+interface ToolUseFlowContext {
   readonly ownerSession: SessionHandle;
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: ToolUseServices['modelHandler'];

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -16,7 +16,7 @@ export interface AgentDirectoryPathStorage {
   fullPath(relativePath: string): string;
 }
 
-export interface CustomAgentDirectoryStore {
+interface CustomAgentDirectoryStore {
   get(): string | undefined;
 }
 
@@ -25,7 +25,7 @@ export interface AbsoluteDirectoryAccess {
   ensureDir(absolutePath: string): Promise<void>;
 }
 
-export type AgentDirectoryDocsId = 'custom-agents';
+type AgentDirectoryDocsId = 'custom-agents';
 
 /** A local agent directory paired with the source it represents. */
 export interface AgentDirectoryEntry {

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -53,7 +53,7 @@ export interface AgentDirectoryVersionStore {
   update(version: string | undefined): PromiseLike<void>;
 }
 
-export interface AgentDirectorySyncLogger {
+interface AgentDirectorySyncLogger {
   info(message: string, data?: unknown): void;
   warn(message: string, data?: unknown): void;
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -15,11 +15,9 @@ import type { SdkToolCall } from './ModelHandlerContracts';
 // to avoid — see the note on `IModelHandler` below.
 export type {
   TokenCountOptions,
-  TokenValidationResult,
   CreateResponseOptions,
   CreateResponseResult,
   ExtractResponseResult,
-  StopConditionsResult,
   OpenAIToolCall,
   DeepSeekToolCall,
   OpenAIResponseToolCall,

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -37,7 +37,7 @@ import type {
  * Schema for a single web search result entry.
  * Normalized across all providers.
  */
-export const WebSearchResultEntrySchema = z.object({
+const WebSearchResultEntrySchema = z.object({
   /** URL of the search result */
   url: z.string(),
   /** Title of the page */
@@ -56,7 +56,7 @@ export type WebSearchResultEntry = z.infer<typeof WebSearchResultEntrySchema>;
 /**
  * Schema for unified web search result across all providers.
  */
-export const WebSearchResultSchema = z.object({
+const WebSearchResultSchema = z.object({
   /** The search query that was executed */
   query: z.string(),
   /** Search result entries */
@@ -80,7 +80,7 @@ export type WebSearchResult = z.infer<typeof WebSearchResultSchema>;
  * Schema for unified web fetch result.
  * Represents a single URL fetch performed by the Anthropic server-side tool.
  */
-export const WebFetchResultSchema = z.object({
+const WebFetchResultSchema = z.object({
   /** The URL that was fetched */
   url: z.string(),
   /** Title of the fetched document (if available) */
@@ -503,7 +503,7 @@ export function extractOpenAIWebSearchResults(
 /**
  * Extract domain from URL.
  */
-export function extractDomain(url: string): string {
+function extractDomain(url: string): string {
   const parsed = tryParseUrl(url);
   if (parsed) return parsed.hostname;
   // Contract: return '' for unparseable URLs. Log so malformed source data

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -25,7 +25,7 @@ interface NodeRecord {
   nodeId?: string;
 }
 
-export interface FlowCursor {
+interface FlowCursor {
   /** The next graph-local node path, or null when the flow has reached a terminal edge. */
   nextNodeId: string | null;
   /** Last action emitted by the previous node, for diagnostics and legacy parity. */

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -36,7 +36,7 @@ export const EdgeFunctionResponseSchema = z.object({
 });
 
 /** Loaded remote agent configuration (settings + prompts). */
-export const RemoteAgentConfigSchema = z.strictObject({
+const RemoteAgentConfigSchema = z.strictObject({
   settings: AgentSettingSchema,
   prompts: AgentPromptSchema,
 });

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -54,7 +54,7 @@ export interface CollectReviewDiffOptions {
   baseBranch?: string;
 }
 
-export interface ReviewDiff {
+interface ReviewDiff {
   /** Absolute path of the repository root all paths are relative to. */
   repoRoot: string;
   /** Ref or commit the working tree was diffed against. */

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -27,7 +27,7 @@ const AgentFlowMetaSchema = z.object({
   totalCostUsd: z.number().nonnegative().optional(),
 });
 
-export const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
+const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('workflow'),
   outcome: RunOutcomeSchema,
   outputs: z.array(OutputFileSummarySchema),
@@ -36,7 +36,7 @@ export const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
 
 export type WorkflowFlowResult = z.infer<typeof WorkflowFlowResultSchema>;
 
-export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
+const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('toolUse'),
   outcome: RunOutcomeSchema,
   lastResponse: z.string().optional(),
@@ -46,14 +46,14 @@ export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
 
 export type ToolUseFlowResult = z.infer<typeof ToolUseFlowResultSchema>;
 
-export const AgentFlowResultSchema = z.discriminatedUnion('category', [
+const AgentFlowResultSchema = z.discriminatedUnion('category', [
   WorkflowFlowResultSchema,
   ToolUseFlowResultSchema,
 ]);
 
 export type AgentFlowResult = z.infer<typeof AgentFlowResultSchema>;
 
-export const WaitingToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
+const WaitingToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('toolUse'),
   outcome: z.literal(STREAM_PHASE.WAITING),
   lastResponse: z.string().optional(),

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -27,7 +27,7 @@ import { AbsoluteFS } from '@utils/files';
 const CHANNEL = 'agentLoad';
 logger.initialize(CHANNEL);
 
-export interface ValidAgentDefinition {
+interface ValidAgentDefinition {
   name: string;
   settings: AgentSettingInput;
 }
@@ -75,7 +75,7 @@ export async function loadYaml(absolutePath: string): Promise<object> {
   return yaml.parse(yamlContent);
 }
 
-export function ensureAgentCategoryForSource<
+function ensureAgentCategoryForSource<
   T extends { agentCategory?: AgentCategory },
 >(settings: T, source: AgentSource): T {
   if (source === 'builtInToolUse' && !settings.agentCategory) {

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -18,7 +18,7 @@ import { StreamStatusService } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
-export interface ResolvedResumeState {
+interface ResolvedResumeState {
   readonly runState: AgentConfig | TaskState;
   readonly executionId: ExecutionId;
   readonly parentStreamId?: StreamTabId;

--- a/src/agent/runtime/runFactEvents.ts
+++ b/src/agent/runtime/runFactEvents.ts
@@ -16,7 +16,7 @@ import type {
  * `updateTodos`/`updatePlan`/`goalPaused`, the extension filters on
  * `addOutputFiles`). Retiring it means typed `AgentEvent` arms per fact.
  */
-export const RUN_FACT_DOMAIN_PREFIX = 'runFact.';
+const RUN_FACT_DOMAIN_PREFIX = 'runFact.';
 
 export type RunFactPayloads = {
   updateTodos: UpdateTodosPayload;

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -115,7 +115,7 @@ const ChildRecordDataSchema = z.object({
   agent: z.string(),
   timestamp: z.string(),
 });
-export type ChildRecordData = z.infer<typeof ChildRecordDataSchema>;
+type ChildRecordData = z.infer<typeof ChildRecordDataSchema>;
 
 /** Full child record including the `id` derived from the KV key name. */
 export interface ChildRecord extends ChildRecordData {

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -133,7 +133,7 @@ function formatToolResultMarker(
  * Google's discriminator-less `{text}`/`{functionCall}`/`{functionResponse}`
  * parts, and falls back to a JSON dump for unrecognized shapes.
  */
-export function formatConversationBlock(
+function formatConversationBlock(
   block: unknown,
   options: ConversationFormatOptions = {},
 ): string {

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -8,7 +8,6 @@ export {
   EXECUTION_META_SCHEMA_VERSION,
   type ExecutionKVStore,
   type ExecutionMeta,
-  type ExecutionMetaInput,
   type TodoEntry,
   type ChildRecord,
   type ResultMeta,
@@ -34,14 +33,5 @@ export {
 export {
   RESUMABILITY_CAUSE,
   deriveResumability,
-  type ResumabilityCause,
   type ResumabilityDecision,
 } from './resumability';
-export {
-  HIDDEN_PROVIDER_REASONING_MARKER,
-  type ConversationFormatOptions,
-  formatConversationBlock,
-  formatConversationContent,
-  hasProviderReasoningBlock,
-  stringifyConversationValue,
-} from './conversationFormat';

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -40,7 +40,7 @@ export const RESUMABILITY_CAUSE = {
   UNREADABLE_META: 'unreadable-meta',
 } as const;
 
-export type ResumabilityCause =
+type ResumabilityCause =
   (typeof RESUMABILITY_CAUSE)[keyof typeof RESUMABILITY_CAUSE];
 type ResumableCause =
   | typeof RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -26,8 +26,6 @@ export const UsageProviderSchema = z.enum([
   'unknown',
 ]);
 
-export type UsageProvider = z.infer<typeof UsageProviderSchema>;
-
 /**
  * Normalized usage statistics from any model provider.
  *

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -7,7 +7,7 @@ import { WorkspaceFS, StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
-export interface DebugContext {
+interface DebugContext {
   logger: AgentTrace;
   modelName?: string;
   executionId?: ExecutionId;
@@ -15,14 +15,14 @@ export interface DebugContext {
   isRemote?: boolean;
 }
 
-export interface DebugSaveOptions {
+interface DebugSaveOptions {
   outputFile?: string;
   /** Base name for the file (e.g. 'messages', 'response'). */
   baseName?: string;
   continuationCount?: number;
 }
 
-export type DebugObjectType = 'messages' | 'response';
+type DebugObjectType = 'messages' | 'response';
 
 export interface SaveDebugParams {
   object: unknown;

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -42,7 +42,7 @@ export type UserVars = Record<string, unknown>;
  * Extends FileListEntry with required source and varName fields.
  * Compatible with FileListEntry (can be passed to AgentTrace.fileList).
  */
-export type LoadedFileEntry = FileListEntry & {
+type LoadedFileEntry = FileListEntry & {
   source: string;
   varName: string;
 };


### PR DESCRIPTION
## Summary

Part of the 2026-07-08 dead-export census sweep. All 63 items in this batch were independently verified (adversarial verification pass + orchestrator spot-checks) to have zero real usage outside their own declaring file. This PR re-verified each item against current `main` before touching it and executes the fix: either narrowing visibility (drop `export`, keep the declaration and its in-file logic intact) or deleting the dead declaration/re-export outright.

### De-exported (kept declaration, dropped `export` only — still used internally in-file)

| Name | File |
| --- | --- |
| `formatConversationBlock` | `src/agent/storage/conversationFormat.ts` |
| `ResumabilityCause` | `src/agent/storage/resumability.ts` |
| `CycleFieldsSchema`, `CycleFields`, `CycleTransientFields` | `src/agent/core/flows/ResponseCycleFlow.ts` |
| `RUN_FACT_DOMAIN_PREFIX` | `src/agent/runtime/runFactEvents.ts` |
| `WorkflowFlowResultSchema`, `ToolUseFlowResultSchema`, `AgentFlowResultSchema`, `WaitingToolUseFlowResultSchema` | `src/agent/runtime/AgentFlowResult.ts` |
| `WebSearchResultEntrySchema`, `WebSearchResultSchema`, `WebFetchResultSchema`, `extractDomain` | `src/agent/modelHandlers/types/ServerToolTypes.ts` |
| `ensureAgentCategoryForSource`, `ValidAgentDefinition` | `src/agent/runtime/agentLoad.ts` |
| `ExportConfigSchema`, `ChatExportInputSchema`, `UserPartSchema` | `src/agent/export/schemas.ts` |
| `ToolUseRoundFieldsSchema`, `ToolUseRoundFields` | `src/agent/core/flows/toolUseRound/roundShared.ts` |
| `RemoteAgentConfigSchema` | `src/agent/remote/types.ts` |
| `extractMeta` | `src/agent/export/chatExport/formatSpec.ts` |
| `ToolUseFlowError`, `ToolUseFlowContext` | `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` |
| `AgentDirectorySyncLogger` | `src/agent/index/AgentDirectorySync.ts` |
| `LoadedFileEntry` | `src/agent/utils/userVars.ts` |
| `FlowCursor` | `src/agent/node/persistedFlow.ts` |
| `ReflectionFlowState` | `src/agent/implementations/flows/reflection/ReflectionFlowState.ts` |
| `ChildRecordData` | `src/agent/storage/ExecutionKVStore.ts` |
| `TextConnectionService` | `src/agent/core/flows/CycleServices.ts` |
| `VisibleFollowUpQueueItemOrigin`, `FollowUpQueueItemOrigin` | `src/agent/followUp/FollowUpQueue.ts` |
| `ReviewDiff` | `src/agent/review/reviewDiff.ts` |
| `DebugContext`, `DebugSaveOptions`, `DebugObjectType` | `src/agent/utils/debugMessageSaver.ts` |
| `ResolvedResumeState` | `src/agent/runtime/resolveAndResumeStream.ts` |
| `CustomAgentDirectoryStore`, `AgentDirectoryDocsId` | `src/agent/index/AgentDirectoryService.ts` |
| `DelegationPolicy` | `src/agent/core/flows/BaseFlowServices.ts` |
| `NativeUsagePayload` | `src/agent/core/usage/ResponseUsage.ts` |
| `AgentPromptPair`, `AgentBlueprint` | `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` |

### Removed dead barrel/facade re-export lines (underlying declaration stays correctly exported from its own module)

| Name(s) | Barrel file |
| --- | --- |
| `HIDDEN_PROVIDER_REASONING_MARKER`, `formatConversationBlock`, `formatConversationContent`, `hasProviderReasoningBlock`, `stringifyConversationValue`, `ExecutionMetaInput`, `ResumabilityCause`, `ConversationFormatOptions` | `src/agent/storage/index.ts` |
| `ToolUseRoundFieldsSchema`, `ToolUseRoundFields` | `src/agent/core/flows/ToolUseRoundFlow.ts` |
| `extractMeta`, `normalizeMessages`, `DocumentMeta`, `ExportNode`, `FormatSpec` | `src/agent/export/chatExportFormatter.ts` |
| `TokenValidationResult`, `StopConditionsResult` | `src/agent/modelHandlers/types/IModelHandler.ts` |

### Fully deleted (zero usage anywhere, including in-file)

- `UsageProvider` — `src/agent/types/NormalizedUsage.ts`

### Skipped

- `emitProjectedProgressEvent` in `src/agent/runtime/sessionProgressEventProjection.ts` — the entire file was already deleted on `main` by PR #7590 ("refactor(runtime): delete test-only session projection") before this batch executed. No action needed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- [x] `npx eslint <touched files>` — clean
- [x] `npx prettier --check <touched files>` — clean
- [x] Targeted `vitest` run across all 79 test files that reference the touched modules/paths — 74 passed on first run; the 5 timeouts under parallel load were confirmed pre-existing flakiness (reproduced identically on a `git stash` back to unmodified `main`) and all 5 pass individually with my changes applied
- [x] `npx knip --no-progress --include files,exports,types,duplicates --reporter compact` re-run — none of the 62 fixed items still appear in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only refactor with no logic changes; risk is limited to missed external imports, which tsc and knip re-runs are meant to catch.
> 
> **Overview**
> **Dead-export cleanup** across `src/agent/` from the knip census: symbols that had no external consumers are either **module-private** (`export` dropped, in-file use unchanged) or **removed from barrel files** while the real definitions stay exported from their owning modules.
> 
> **Barrel trims** narrow the public surface of `storage/index.ts`, `chatExportFormatter.ts`, `IModelHandler.ts`, and `ToolUseRoundFlow.ts` (e.g. conversation-format helpers and `ExecutionMetaInput` no longer re-exported from storage; chat export types/helpers only via `@agent/export/schemas` and `./chatExport/`).
> 
> **Fully removed:** exported `UsageProvider` type alias in `NormalizedUsage.ts` (`UsageProviderSchema` remains for telemetry/usage code).
> 
> No intended behavior change—visibility and import paths only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917562fe371efdbb97e4b33b238e2b869f968c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->