### PR TITLE
[codex] narrow cli progress ingestion

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -1,13 +1,13 @@
-// Wrap a runtime host's `emit` so progress payloads patch `cliState` while
-// still flowing through the original emitter. Approvals are intentionally
-// not handled here — `subscribeApprovals.ts` owns the typed-modal pipeline.
+// Wrap a runtime host's `emit` so host-local focus and approval-bypass updates
+// patch `cliState` while still flowing through the original emitter. Durable
+// progress facts enter through `attachTuiRunFactSubscription`.
 
 import type { AgentEvent } from '@agent/trace';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
@@ -17,8 +17,13 @@ import {
   UpdateTodosPayloadSchema,
   type ActiveChildInfo,
   type GoalPausedPayload,
+  type RemoveStreamPayload,
+  type SetActiveStreamPayload,
+  type StreamTabId,
   type UpdateActiveProcessesPayload,
   type UpdateProcessOutputPayload,
+  type UpdateQueuedFollowUpsPayload,
+  type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
@@ -43,8 +48,13 @@ import { appendLocalAssistantTranscript } from './transcript';
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
-type CliStateRuntimeEventPayloads = ProgressEventPayloads &
-  RuntimeInteractionEventPayloads;
+type CliStateRuntimeEventPayloads = {
+  setActiveStream: SetActiveStreamPayload;
+  removeStream: RemoveStreamPayload;
+  updateToolEditApprovalBypassState: RuntimeInteractionEventPayloads['updateToolEditApprovalBypassState'];
+  updateBashApprovalBypassState: RuntimeInteractionEventPayloads['updateBashApprovalBypassState'];
+  updateSuperYoloBypassState: RuntimeInteractionEventPayloads['updateSuperYoloBypassState'];
+};
 
 type CliStateRuntimeEvent = keyof CliStateRuntimeEventPayloads;
 
@@ -67,9 +77,7 @@ function applyUsageUpdate(payload: UpdateStreamUsagePayload): void {
   }));
 }
 
-function applySetActiveStream(
-  payload: ProgressEventPayloads['setActiveStream'],
-): void {
+function applySetActiveStream(payload: SetActiveStreamPayload): void {
   const next = payload.streamId;
   if (!next) {
     activeStreamId.set(undefined);
@@ -91,15 +99,7 @@ function applySetActiveStream(
   }
 }
 
-function applyTaskState(payload: ProgressEventPayloads['setTaskState']): void {
-  const config = payload.taskState.agentConfig;
-  applyRunConfig(payload.streamId, config);
-}
-
-function applyRunConfig(
-  streamId: ProgressEventPayloads['setTaskState']['streamId'],
-  config: ProgressEventPayloads['setTaskState']['taskState']['agentConfig'],
-): void {
+function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
   patchStream(streamId, (s) => {
     if (s.model === config.model && s.category === config.agentCategory) {
       return s;
@@ -122,9 +122,7 @@ function sameQueuedFollowUps(
   );
 }
 
-function applyRoundStage(
-  payload: ProgressEventPayloads['updateRoundStage'],
-): void {
+function applyRoundStage(payload: UpdateRoundStagePayload): void {
   patchStream(payload.streamId, (s) => {
     if (
       s.roundStage?.index === payload.roundStage.index &&
@@ -148,9 +146,10 @@ function sameActiveChildren(
   );
 }
 
-function applyActiveSubagents(
-  payload: ProgressEventPayloads['updateActiveSubagents'],
-): void {
+function applyActiveSubagents(payload: {
+  parentStreamId: StreamTabId;
+  children: readonly ActiveChildInfo[];
+}): void {
   registerChildStreams(payload.parentStreamId, payload.children);
   patchStream(payload.parentStreamId, (s) => {
     const childStreams = mergeChildStreams(s.childStreams, payload.children);
@@ -207,9 +206,10 @@ function applyProcessOutput(payload: UpdateProcessOutputPayload): void {
   }));
 }
 
-function applyParentStream(
-  payload: ProgressEventPayloads['setParentStream'],
-): void {
+function applyParentStream(payload: {
+  childStreamId: StreamTabId;
+  parentStreamId: StreamTabId | null;
+}): void {
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
@@ -224,7 +224,7 @@ function isGoalPausedPayload(value: unknown): value is GoalPausedPayload {
 
 function applyDirectTuiDomainEvent(
   event: Extract<AgentEvent, { type: 'domain' }>,
-  fallbackStreamId: ProgressEventPayloads['updateRoundStage']['streamId'],
+  fallbackStreamId: StreamTabId,
 ): boolean {
   if (event.key === 'conversationProgress') {
     const progress = ConversationProgressSchema.safeParse(event.data);
@@ -271,7 +271,7 @@ function applyDirectTuiDomainEvent(
 
 function applyDirectTuiRunEvent(
   event: AgentEvent,
-  fallbackStreamId: ProgressEventPayloads['updateRoundStage']['streamId'],
+  fallbackStreamId: StreamTabId,
 ): boolean {
   switch (event.type) {
     case 'run.config':
@@ -324,7 +324,7 @@ function applyDirectTuiRunEvent(
 }
 
 function refreshQueuedFollowUps(
-  streamId: ProgressEventPayloads['updateQueuedFollowUps']['streamId'],
+  streamId: UpdateQueuedFollowUpsPayload['streamId'],
 ): void {
   const messages = defaultSession().followUps.getAll(streamId);
   patchStream(streamId, (s) => {
@@ -452,83 +452,18 @@ function applyToState<K extends CliStateRuntimeEvent>(
 ): void {
   switch (event) {
     case 'setActiveStream': {
-      const p = payload as ProgressEventPayloads['setActiveStream'];
+      const p = payload as CliStateRuntimeEventPayloads['setActiveStream'];
       applySetActiveStream(p);
       return;
     }
-    case 'setTaskState': {
-      const p = payload as ProgressEventPayloads['setTaskState'];
-      applyTaskState(p);
-      return;
-    }
-    case 'setParentStream': {
-      const p = payload as ProgressEventPayloads['setParentStream'];
-      applyParentStream(p);
-      return;
-    }
     case 'removeStream':
-      removeStream((payload as ProgressEventPayloads['removeStream']).streamId);
+      removeStream(
+        (payload as CliStateRuntimeEventPayloads['removeStream']).streamId,
+      );
       return;
-    case 'updateStreamUsage': {
-      const p = payload as ProgressEventPayloads['updateStreamUsage'];
-      applyUsageUpdate(p);
-      return;
-    }
-    case 'updateConversationProgress': {
-      const p = payload as ProgressEventPayloads['updateConversationProgress'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        conversation: p.progress,
-      }));
-      return;
-    }
-    case 'updateRoundStage': {
-      const p = payload as ProgressEventPayloads['updateRoundStage'];
-      applyRoundStage(p);
-      return;
-    }
-    case 'updateStreamDescription': {
-      const p = payload as ProgressEventPayloads['updateStreamDescription'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        description: p.description,
-      }));
-      return;
-    }
-    case 'updateActiveSubagents': {
-      const p = payload as ProgressEventPayloads['updateActiveSubagents'];
-      applyActiveSubagents(p);
-      return;
-    }
-    case 'updateActiveProcesses': {
-      const p = payload as ProgressEventPayloads['updateActiveProcesses'];
-      applyActiveProcesses(p);
-      return;
-    }
-    case 'updateProcessOutput': {
-      const p = payload as ProgressEventPayloads['updateProcessOutput'];
-      applyProcessOutput(p);
-      return;
-    }
-    case 'updateTodos': {
-      const p = payload as ProgressEventPayloads['updateTodos'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        todos: p.todos,
-      }));
-      return;
-    }
-    case 'updatePlan': {
-      const p = payload as ProgressEventPayloads['updatePlan'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        plan: p.plan,
-      }));
-      return;
-    }
     case 'updateToolEditApprovalBypassState': {
       const p =
-        payload as RuntimeInteractionEventPayloads['updateToolEditApprovalBypassState'];
+        payload as CliStateRuntimeEventPayloads['updateToolEditApprovalBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, toolEdit: p.bypassActive },
@@ -537,7 +472,7 @@ function applyToState<K extends CliStateRuntimeEvent>(
     }
     case 'updateBashApprovalBypassState': {
       const p =
-        payload as RuntimeInteractionEventPayloads['updateBashApprovalBypassState'];
+        payload as CliStateRuntimeEventPayloads['updateBashApprovalBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, bash: p.bypassActive },
@@ -546,22 +481,11 @@ function applyToState<K extends CliStateRuntimeEvent>(
     }
     case 'updateSuperYoloBypassState': {
       const p =
-        payload as RuntimeInteractionEventPayloads['updateSuperYoloBypassState'];
+        payload as CliStateRuntimeEventPayloads['updateSuperYoloBypassState'];
       patchStream(p.streamId, (s) => ({
         ...s,
         bypass: { ...s.bypass, superYolo: p.bypassActive },
       }));
-      return;
-    }
-    case 'updateQueuedFollowUps': {
-      // The event itself has no delta payload, so re-read the queue directly.
-      const p = payload as ProgressEventPayloads['updateQueuedFollowUps'];
-      refreshQueuedFollowUps(p.streamId);
-      return;
-    }
-    case 'goalPaused': {
-      const p = payload as ProgressEventPayloads['goalPaused'];
-      appendGoalPausedTranscriptNotice(p);
       return;
     }
     default:

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -282,45 +282,53 @@ describe('cliState Phase 4 fields', () => {
   });
 
   it('registers subagent parent edges when active child rows arrive', () => {
-    const wrapped = wrapRuntimeHost({
-      emit: () => undefined,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
 
-    activeStreamId.set(root);
-    patchStream(child1, (s) => ({
-      ...s,
-      status: STREAM_STATUS.RUNNING,
-    }));
+    try {
+      activeStreamId.set(root);
+      patchStream(child1, (s) => ({
+        ...s,
+        status: STREAM_STATUS.RUNNING,
+      }));
 
-    wrapped.emit('updateActiveSubagents', {
-      parentStreamId: root,
-      children: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_STATUS.RUNNING,
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId: root,
+          children: [
+            {
+              kind: 'subagent',
+              executionId: 'agent-1',
+              agentName: 'critic',
+              childStreamId: child1,
+              status: STREAM_STATUS.RUNNING,
+            },
+          ],
         },
-      ],
-    });
+      });
 
-    expect(parentStream.get().get(child1)).toBe(root);
-    expect(nextFocusForward()).toBe(child1);
-    expect(
-      transcriptViewportKey({
-        activeStreamId: child1,
-        parentStream: parentStream.get(),
-      }),
-    ).toBe(`scoped:${child1}`);
-    expect(
-      transcriptViewportKey({
-        activeStreamId: root,
-        parentStream: parentStream.get(),
-        transcriptViewerStreamId: child1,
-      }),
-    ).toBe(`viewer:${child1}`);
+      expect(parentStream.get().get(child1)).toBe(root);
+      expect(nextFocusForward()).toBe(child1);
+      expect(
+        transcriptViewportKey({
+          activeStreamId: child1,
+          parentStream: parentStream.get(),
+        }),
+      ).toBe(`scoped:${child1}`);
+      expect(
+        transcriptViewportKey({
+          activeStreamId: root,
+          parentStream: parentStream.get(),
+          transcriptViewerStreamId: child1,
+        }),
+      ).toBe(`viewer:${child1}`);
+    } finally {
+      detach();
+    }
   });
 });
 
@@ -3197,47 +3205,66 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   });
 
   it('registers suppressed child streams without switching away from the parent page', () => {
-    const wrapped = wrapRuntimeHost(makeHost());
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
     activeStreamId.set(root);
 
-    wrapped.emit('setActiveStream', {
-      streamId: child1,
-      suppressViewSwitch: true,
-    });
+    try {
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId: child1,
+            suppressViewSwitch: true,
+          },
+        },
+      });
 
-    expect(activeStreamId.get()).toBe(root);
-    expect(streams.get().has(child1)).toBe(true);
+      expect(activeStreamId.get()).toBe(root);
+      expect(streams.get().has(child1)).toBe(true);
+    } finally {
+      detach();
+    }
   });
 
   it('captures per-stream model identity from task state', () => {
-    const wrapped = wrapRuntimeHost(makeHost());
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
 
-    wrapped.emit('setTaskState', {
-      streamId: child1,
-      executionId: 'exec-search',
-      taskState: {
-        agentConfig: {
-          agent: 'search',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'kimi26T',
-          instruction: 'Check the enumeration independently.',
-          inputFiles: [],
-          contextFiles: [],
-          mediaFiles: [],
-          outputFiles: [],
-          editedFile: null,
-          editedFiles: [],
-          toolConfig: DEFAULT_TOOL_CONFIG,
-          memories: [],
-          workingDirectory: undefined,
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: child1,
+        event: {
+          type: 'run.config',
+          streamId: child1,
+          executionId: 'exec-search' as ExecutionId,
+          config: {
+            agent: 'search',
+            agentCategory: AgentCategory.ToolUse,
+            model: 'kimi26T',
+            instruction: 'Check the enumeration independently.',
+            inputFiles: [],
+            contextFiles: [],
+            mediaFiles: [],
+            outputFiles: [],
+            editedFile: null,
+            editedFiles: [],
+            toolConfig: DEFAULT_TOOL_CONFIG,
+            memories: [],
+            workingDirectory: undefined,
+          },
         },
-      },
-    });
+      });
 
-    expect(streams.get().get(child1)).toMatchObject({
-      model: 'kimi26T',
-      category: AgentCategory.ToolUse,
-    });
+      expect(streams.get().get(child1)).toMatchObject({
+        model: 'kimi26T',
+        category: AgentCategory.ToolUse,
+      });
+    } finally {
+      detach();
+    }
   });
 
   it('refreshes queued follow-up display when an active follow-up is sent', () => {
@@ -3281,126 +3308,174 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   });
 
   it('keeps latest usage separate from cumulative resume usage', () => {
-    const wrapped = wrapRuntimeHost(makeHost());
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
     const storageKey = 'root-run' as StorageKey;
 
-    wrapped.emit('updateStreamUsage', {
-      streamId: root,
-      storageKey,
-      usage: {
-        inputTokens: 100,
-        outputTokens: 20,
-        cost: 1,
-        cacheReadInputTokens: 30,
-      },
-    });
-    wrapped.emit('updateStreamUsage', {
-      streamId: root,
-      storageKey,
-      usage: {
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: {},
+          data: {
+            streamId: root,
+            storageKey,
+            usage: {
+              inputTokens: 100,
+              outputTokens: 20,
+              cost: 1,
+              cacheReadInputTokens: 30,
+            },
+          },
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'usage',
+          stats: {},
+          data: {
+            streamId: root,
+            storageKey,
+            usage: {
+              inputTokens: 40,
+              outputTokens: 10,
+              cost: 2,
+              cacheReadInputTokens: 5,
+              cacheCreationInputTokens: 7,
+            },
+          },
+        },
+      });
+
+      expect(streams.get().get(root)?.usage).toEqual({
         inputTokens: 40,
         outputTokens: 10,
         cost: 2,
         cacheReadInputTokens: 5,
         cacheCreationInputTokens: 7,
-      },
-    });
-
-    expect(streams.get().get(root)?.usage).toEqual({
-      inputTokens: 40,
-      outputTokens: 10,
-      cost: 2,
-      cacheReadInputTokens: 5,
-      cacheCreationInputTokens: 7,
-    });
-    expect(streams.get().get(root)?.cumulativeUsage).toEqual({
-      inputTokens: 140,
-      outputTokens: 30,
-      cost: 3,
-      cacheReadInputTokens: 35,
-      cacheMissInputTokens: 0,
-      cacheCreationInputTokens: 7,
-    });
+      });
+      expect(streams.get().get(root)?.cumulativeUsage).toEqual({
+        inputTokens: 140,
+        outputTokens: 30,
+        cost: 3,
+        cacheReadInputTokens: 35,
+        cacheMissInputTokens: 0,
+        cacheCreationInputTokens: 7,
+      });
+    } finally {
+      detach();
+    }
   });
 
   it('persists a bounded completed-process transcript before pruning processOutput', () => {
-    const wrapped = wrapRuntimeHost(makeHost());
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
     const lines = Array.from(
       { length: COMPLETED_PROCESS_TAIL_LINES + 2 },
       (_, index) => `line ${index + 1}`,
     ).join('\n');
 
-    // Seed: two live processes with tail output.
-    wrapped.emit('updateActiveProcesses', {
-      parentStreamId: root,
-      processes: [
-        {
-          kind: 'process',
+    try {
+      // Seed: two live processes with tail output.
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId: root,
+          processes: [
+            {
+              kind: 'process',
+              executionId: 'exec-a',
+              agentName: 'latexmk',
+              toolName: 'bash',
+              status: 'exit 1',
+              elapsed: '2s',
+            },
+            { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
+          ],
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          parentStreamId: root,
           executionId: 'exec-a',
-          agentName: 'latexmk',
-          toolName: 'bash',
+          stdout: lines,
+          stderr: 'stderr tail',
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'process.output',
+          parentStreamId: root,
+          executionId: 'exec-b',
+          stdout: 'B',
+          stderr: '',
+        },
+      });
+      expect(streams.get().get(root)?.processOutput.size).toBe(2);
+
+      // exec-a finishes: its output buffer must be dropped on the next
+      // active-processes update, after a durable transcript entry is added.
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'child.activity',
+          kind: 'processes',
+          parentStreamId: root,
+          processes: [
+            { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
+          ],
+        },
+      });
+      const slice = streams.get().get(root);
+      const out = streams.get().get(root)?.processOutput;
+      expect(out?.size).toBe(1);
+      expect(out?.has('exec-a')).toBe(false);
+      expect(out?.has('exec-b')).toBe(true);
+
+      const processEntries =
+        slice?.entries.filter((entry) => entry.role === 'process') ?? [];
+      expect(processEntries).toHaveLength(1);
+      expect(processEntries[0]).toMatchObject({
+        role: 'process',
+        finalized: true,
+        synthetic: true,
+        syntheticKind: 'process',
+        process: {
+          executionId: 'exec-a',
+          title: 'latexmk',
           status: 'exit 1',
           elapsed: '2s',
+          isError: true,
         },
-        { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
-      ],
-    });
-    wrapped.emit('updateProcessOutput', {
-      parentStreamId: root,
-      executionId: 'exec-a',
-      stdout: lines,
-      stderr: 'stderr tail',
-    });
-    wrapped.emit('updateProcessOutput', {
-      parentStreamId: root,
-      executionId: 'exec-b',
-      stdout: 'B',
-      stderr: '',
-    });
-    expect(streams.get().get(root)?.processOutput.size).toBe(2);
+      });
+      expect(processEntries[0]?.process?.tailLines).toHaveLength(
+        COMPLETED_PROCESS_TAIL_LINES,
+      );
+      expect(processEntries[0]?.process?.tailLines.at(0)).toBe('line 4');
+      expect(processEntries[0]?.process?.tailLines.at(-1)).toBe('stderr tail');
 
-    // exec-a finishes: its output buffer must be dropped on the next
-    // active-processes update, after a durable transcript entry is added.
-    wrapped.emit('updateActiveProcesses', {
-      parentStreamId: root,
-      processes: [
-        { kind: 'process', executionId: 'exec-b', agentName: 'bash' },
-      ],
-    });
-    const slice = streams.get().get(root);
-    const out = streams.get().get(root)?.processOutput;
-    expect(out?.size).toBe(1);
-    expect(out?.has('exec-a')).toBe(false);
-    expect(out?.has('exec-b')).toBe(true);
-
-    const processEntries =
-      slice?.entries.filter((entry) => entry.role === 'process') ?? [];
-    expect(processEntries).toHaveLength(1);
-    expect(processEntries[0]).toMatchObject({
-      role: 'process',
-      finalized: true,
-      synthetic: true,
-      syntheticKind: 'process',
-      process: {
-        executionId: 'exec-a',
-        title: 'latexmk',
-        status: 'exit 1',
-        elapsed: '2s',
-        isError: true,
-      },
-    });
-    expect(processEntries[0]?.process?.tailLines).toHaveLength(
-      COMPLETED_PROCESS_TAIL_LINES,
-    );
-    expect(processEntries[0]?.process?.tailLines.at(0)).toBe('line 4');
-    expect(processEntries[0]?.process?.tailLines.at(-1)).toBe('stderr tail');
-
-    const split = splitTranscriptEntries(
-      slice?.entries ?? [],
-      STREAM_STATUS.WAITING,
-    );
-    expect(split.finalized).toContain(processEntries[0]);
-    expect(split.pending).not.toContain(processEntries[0]);
+      const split = splitTranscriptEntries(
+        slice?.entries ?? [],
+        STREAM_STATUS.WAITING,
+      );
+      expect(split.finalized).toContain(processEntries[0]);
+      expect(split.pending).not.toContain(processEntries[0]);
+    } finally {
+      detach();
+    }
   });
 
   it('formats completed-process transcript rows for terminal rendering', () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -130,25 +130,14 @@ describe('StreamSnapshotStore', () => {
     );
   });
 
-  it('persists todos/plan/usage from progress events and reassembles them on a fresh store', async () => {
+  it('persists todos/plan/usage from direct mutators and reassembles them on a fresh store', async () => {
     const writer = new StreamSnapshotStore();
 
-    writer.handleProgressEvent('updateTodos', {
-      streamId: STREAM,
-      todos: [TODO],
-    });
-    writer.handleProgressEvent('updatePlan', { streamId: STREAM, plan: PLAN });
+    writer.setTodos(STREAM, [TODO]);
+    writer.setPlan(STREAM, PLAN);
     // Two deltas for the same run must accumulate, not overwrite.
-    writer.handleProgressEvent('updateStreamUsage', {
-      streamId: STREAM,
-      storageKey: RUN,
-      usage: usage(100, 20, 0.5),
-    });
-    writer.handleProgressEvent('updateStreamUsage', {
-      streamId: STREAM,
-      storageKey: RUN,
-      usage: usage(50, 10, 0.25),
-    });
+    void writer.addUsage(STREAM, RUN, usage(100, 20, 0.5));
+    void writer.addUsage(STREAM, RUN, usage(50, 10, 0.25));
 
     await writer.flush();
 
@@ -352,7 +341,7 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
-  it('seeds existing disk data before an unloaded progress mutation, so it is not erased', async () => {
+  it('seeds existing disk data before an unloaded usage mutation, so it is not erased', async () => {
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);
     // A prior session persisted usage for run-1.
@@ -363,11 +352,7 @@ describe('StreamSnapshotStore', () => {
 
     // A fresh store (NOT load()ed) handles a delta for a NEW run.
     const store = new StreamSnapshotStore();
-    store.handleProgressEvent('updateStreamUsage', {
-      streamId: STREAM,
-      storageKey: 'run-2' as StorageKey,
-      usage: usage(50, 10, 0.25),
-    });
+    void store.addUsage(STREAM, 'run-2' as StorageKey, usage(50, 10, 0.25));
     await store.flush();
 
     // run-1 (prior) survives — the unseeded write did not clobber it.

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -137,10 +137,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       const store = new StreamSnapshotStore();
       store.setTaskState(parentStream, taskState('orchestrator'), executionId);
       store.setTaskState(childStream, taskState('bash'), executionId);
-      store.handleProgressEvent('updateTodos', {
-        streamId: childStream,
-        todos: [TODO],
-      });
+      store.setTodos(childStream, [TODO]);
       await store.flush();
 
       const resolved = await resolvePersistedStreamIdForExecution(executionId, {
@@ -221,10 +218,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
         taskState('bash'),
         executionId,
       );
-      snapshotWriter.handleProgressEvent('updateTodos', {
-        streamId: workPlanOnlyStream,
-        todos: [TODO],
-      });
+      snapshotWriter.setTodos(workPlanOnlyStream, [TODO]);
       await snapshotWriter.flush();
 
       const logStore = new StreamLogStore();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -3,10 +3,10 @@
  *
  * One store, shared by the CLI TUI, VS Code extension, and Electron desktop
  * app, that is the SINGLE writer of `streamData/{id}/*` and the reader that
- * reassembles a {@link StreamSnapshot} for resume. Runtime events are fed into
- * {@link handleProgressEvent}, which persists the same field-scoped files the
- * extension already writes (so all three hosts produce identical on-disk data),
- * plus the `workPlan.json` giving todos/plan a durable home.
+ * reassembles a {@link StreamSnapshot} for resume. Session/run facts are fed
+ * through {@link attachSessionEvents}, while host-owned callers use the public
+ * mutators below. Both paths persist the same field-scoped files, including the
+ * `workPlan.json` giving todos/plan a durable home.
  *
  * It consolidates the accumulation logic previously split across the extension's
  * `OutputFilesManager` / `UsageStatsManager` / `StreamMetaManager`, talking to
@@ -26,10 +26,6 @@ import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
@@ -258,74 +254,9 @@ export class StreamSnapshotStore {
     return false;
   }
 
-  // ==========================================================================
-  // Runtime event ingestion
-  // ==========================================================================
-
-  /**
-   * Persist durable state carried by a runtime progress event. Each mutation
-   * goes through the public store mutators used by the extension and desktop,
-   * so all hosts share the same seed-before-write policy.
-   */
-  handleProgressEvent<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void {
-    switch (event) {
-      case 'addOutputFiles': {
-        const p = payload as ProgressEventPayloads['addOutputFiles'];
-        this.addOutputFiles(p.streamId, p.filesByRound);
-        return;
-      }
-      case 'updateMissingOutputs': {
-        const p = payload as ProgressEventPayloads['updateMissingOutputs'];
-        this.updateMissingOutputs(p.streamId, p.filesByRound);
-        return;
-      }
-      case 'updateCompileFailures': {
-        const p = payload as ProgressEventPayloads['updateCompileFailures'];
-        this.updateCompileFailures(p.streamId, p.filesByRound);
-        return;
-      }
-      case 'updateStreamUsage': {
-        const p = payload as ProgressEventPayloads['updateStreamUsage'];
-        void this.addUsage(p.streamId, p.storageKey, p.usage);
-        return;
-      }
-      case 'updateTodos': {
-        const p = payload as ProgressEventPayloads['updateTodos'];
-        this.setTodos(p.streamId, p.todos);
-        return;
-      }
-      case 'updatePlan': {
-        const p = payload as ProgressEventPayloads['updatePlan'];
-        this.setPlan(p.streamId, p.plan);
-        return;
-      }
-      case 'setTaskState': {
-        const p = payload as ProgressEventPayloads['setTaskState'];
-        this.setTaskState(p.streamId, p.taskState, p.executionId);
-        return;
-      }
-      case 'updateStreamDescription': {
-        const p = payload as ProgressEventPayloads['updateStreamDescription'];
-        this.setDescription(p.streamId, p.description);
-        return;
-      }
-      case 'setParentStream': {
-        const p = payload as ProgressEventPayloads['setParentStream'];
-        this.setParentStream(p.childStreamId, p.parentStreamId);
-        return;
-      }
-      default:
-        return;
-    }
-  }
-
   /**
    * Persist already-migrated durable facts directly from the session event
-   * plane. The legacy progress-event entry point remains for extension/desktop
-   * consumers.
+   * plane.
    */
   attachSessionEvents(events: SessionEventHub): () => void {
     const detachRunEvents = events.subscribe(


### PR DESCRIPTION
## Summary

This PR narrows the remaining CLI and transcript progress ingress for the session-scoped runtime migration. The CLI TUI runtime-host wrapper now applies only host-local focus/removal and approval-bypass updates; durable run facts enter through `attachTuiRunFactSubscription`.

The transcript snapshot store also no longer exposes a legacy progress-event handler. Persistence now uses direct mutators and the session event attachment path for migrated facts. Tests that previously seeded migrated state through projected progress events now seed through session/run facts or direct store mutators.

This keeps the public progress-event vocabulary available where it is still deliberately used, while removing another internal route by which session facts could be applied twice.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test -- src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/transcript/executionStreamResolver.vitest.ts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts`

Part of #6968 and #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI state hydration and stream sidecar persistence paths; behavior should be equivalent but regressions could affect TUI focus, usage/todos display, and resume snapshots if any progress events still bypass the hub.
> 
> **Overview**
> This PR finishes narrowing **CLI TUI** and **transcript** progress ingestion for the session-scoped runtime migration.
> 
> **CLI (`subscribeRuntimeHost`)** — `wrapRuntimeHost` now patches `cliState` only for **host-local** events: active stream focus/removal and approval-bypass flags. Durable run progress (usage, todos/plan, child activity, process output, `run.config`, round stage, etc.) is **no longer** applied through the wrapped host’s progress-event `switch`; it goes through **`attachTuiRunFactSubscription`** on `SessionEventHub` (session + run fact handlers that reuse the existing apply helpers).
> 
> **Transcript (`StreamSnapshotStore`)** — The legacy **`handleProgressEvent`** entry point is **removed**. Persistence uses **direct mutators** (`setTodos`, `setPlan`, `addUsage`, …) and **`attachSessionEvents`** for migrated facts.
> 
> **Tests** — Kernel tests that previously drove migrated state via `wrapRuntimeHost.emit(...)` or `handleProgressEvent` now seed **`SessionEventHub`** events or call store mutators directly, matching the single ingress path and avoiding double-application of session facts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a569601ca4e2f9530b23d13f2b72ea083b89dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->