### PR TITLE
[codex] narrow progress backend host adapter

### DIFF
--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -36,7 +36,7 @@ import {
 } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
 import { ProgressBackend } from '@shared/progressView/backend/ProgressBackend';
-import type { ProgressBackendEventPayloads } from '@shared/progressView/backend/events/ProgressEventHandler';
+import type { ProgressBackendInteractionPayloads } from '@shared/progressView/backend/events/ProgressEventHandler';
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
@@ -179,7 +179,7 @@ export class ProgressViewProvider
       (event, payload) => {
         this.backend.handleProgressEvent(
           event,
-          payload as ProgressBackendEventPayloads[typeof event],
+          payload as ProgressBackendInteractionPayloads[typeof event],
         );
       },
     );

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -10,8 +10,8 @@ import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import {
   PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES,
   ProgressEventHandler,
-  type ProgressBackendEvent,
-  type ProgressBackendEventPayloads,
+  type ProgressBackendInteractionEvent,
+  type ProgressBackendInteractionPayloads,
   type GetProgressStreamControls,
   type ProgressEventSubscription,
   type UICallbacks,
@@ -142,9 +142,9 @@ export class ProgressBackend {
     };
   }
 
-  handleProgressEvent<K extends ProgressBackendEvent>(
+  handleProgressEvent<K extends ProgressBackendInteractionEvent>(
     event: K,
-    payload: ProgressBackendEventPayloads[K],
+    payload: ProgressBackendInteractionPayloads[K],
   ): void {
     // A run may still hold the host-channel emit closure that routes here after
     // this backend is disposed (e.g. a desktop window closed while the run keeps

--- a/src/shared/progressView/backend/events/ProgressEventHandler.ts
+++ b/src/shared/progressView/backend/events/ProgressEventHandler.ts
@@ -1,6 +1,5 @@
 import type { AgentEvent } from '@agent/trace';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import type { StreamTabId } from '@shared/schemas';
 import type { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
@@ -69,26 +68,21 @@ export function isProgressBackendInteractionEvent(
   return ProgressBackendInteractionEventSet.has(event);
 }
 
-export type ProgressBackendEventPayloads = ProgressEventPayloads &
-  ProgressBackendInteractionPayloads;
-
-export type ProgressBackendEvent = keyof ProgressBackendEventPayloads;
-
-type ProgressEventRegistration<K extends ProgressBackendEvent> = {
+type ProgressEventRegistration<K extends ProgressBackendInteractionEvent> = {
   /** Defaults to 'ProgressEvents' when omitted. */
   readonly module?: string;
   /** Defaults to `failed to handle ${event}` when omitted. */
   readonly context?: string;
   readonly handle: (
-    payload: ProgressBackendEventPayloads[K],
+    payload: ProgressBackendInteractionPayloads[K],
   ) => void | Promise<void>;
 };
 
 type ProgressEventRegistrationMap = {
-  [K in ProgressBackendEvent]?: ProgressEventRegistration<K>;
+  [K in ProgressBackendInteractionEvent]?: ProgressEventRegistration<K>;
 };
 
-/** Compatibility adapter for legacy host progress events. */
+/** Host adapter for progress-view interaction callbacks. */
 export class ProgressEventHandler {
   readonly factApplier: ProgressFactApplier;
   private readonly eventRegistrations: ProgressEventRegistrationMap;
@@ -113,90 +107,6 @@ export class ProgressEventHandler {
 
   private createEventRegistrations(): ProgressEventRegistrationMap {
     return {
-      setActiveStream: {
-        handle: (payload) => this.factApplier.handleSetActiveStream(payload),
-      },
-      updateStreamStatus: {
-        handle: ({ streamId, status, previousStatus, substate }) =>
-          this.factApplier.setStreamStatus(
-            streamId,
-            status,
-            previousStatus,
-            substate,
-          ),
-      },
-      setTaskState: {
-        handle: (data) => this.factApplier.handleSetTaskState(data),
-      },
-      updateConversationProgress: {
-        handle: (data) =>
-          this.factApplier.handleUpdateConversationProgress(data),
-      },
-      updateRoundStage: {
-        handle: (data) => this.factApplier.handleUpdateRoundStage(data),
-      },
-      updateActiveSubagents: {
-        handle: (data) =>
-          this.factApplier.updateActiveChildren(data.parentStreamId, {
-            activeField: 'activeSubagents',
-            countField: 'finishedSubagentCount',
-            next: data.children,
-          }),
-      },
-      updateActiveProcesses: {
-        handle: (data) =>
-          this.factApplier.updateActiveChildren(data.parentStreamId, {
-            activeField: 'activeProcesses',
-            countField: 'finishedProcessCount',
-            next: data.processes,
-          }),
-      },
-      updateProcessOutput: {
-        handle: (data) => this.factApplier.handleUpdateProcessOutput(data),
-      },
-      inquiryThreadUpdated: {
-        handle: (thread) => this.factApplier.handleInquiryThreadUpdated(thread),
-      },
-      updateStreamDescription: {
-        handle: (payload) =>
-          this.factApplier.handleUpdateStreamDescription(payload),
-      },
-      setParentStream: {
-        handle: (payload) => this.factApplier.handleSetParentStream(payload),
-      },
-      // Output events: workflow tabs hold one run; ignore the storageKey dim.
-      addOutputFiles: {
-        handle: (payload) => this.factApplier.handleAddOutputFiles(payload),
-      },
-      updateMissingOutputs: {
-        handle: (payload) =>
-          this.factApplier.handleUpdateMissingOutputs(payload),
-      },
-      updateCompileFailures: {
-        handle: (payload) =>
-          this.factApplier.handleUpdateCompileFailures(payload),
-      },
-      clearMissingOutputs: {
-        handle: (payload) =>
-          this.factApplier.handleClearMissingOutputs(payload),
-      },
-      // Usage events: workflow tabs collapse to a single accumulated value;
-      // tool-use tabs keep per-run accumulation (resume produces multiple runs).
-      updateStreamUsage: {
-        handle: (payload) => this.factApplier.handleUpdateStreamUsage(payload),
-      },
-      updateTodos: {
-        handle: (payload) => this.factApplier.handleUpdateTodos(payload),
-      },
-      // Plan events are rare and critical for the approval UX, so send them
-      // whenever the webview is available rather than only for the active tab.
-      updatePlan: {
-        handle: (payload) => this.factApplier.handleUpdatePlan(payload),
-      },
-      updateQueuedFollowUps: {
-        handle: (payload) =>
-          this.factApplier.handleUpdateQueuedFollowUps(payload),
-      },
       showToolEditPermission: {
         module: 'ProgressEventHandler',
         context: 'failed to show approval prompt',
@@ -233,9 +143,9 @@ export class ProgressEventHandler {
     return this.factApplier.createLocalSubscription();
   }
 
-  handleProgressEvent<K extends ProgressBackendEvent>(
+  handleProgressEvent<K extends ProgressBackendInteractionEvent>(
     event: K,
-    payload: ProgressBackendEventPayloads[K],
+    payload: ProgressBackendInteractionPayloads[K],
   ): void {
     const registration = this.eventRegistrations[event] as
       ProgressEventRegistration<K> | undefined;

--- a/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
+++ b/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
@@ -1,0 +1,153 @@
+// Node imports
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+const TARGET_MODULE = 'packages/cli/src/runtime/sessionProgressSubscription.ts';
+const TARGET_MODULE_STEM = TARGET_MODULE.replace(/\.(?:ts|tsx|mts|cts)$/, '');
+const TARGET_ALIAS = '@cli/runtime/sessionProgressSubscription';
+
+const ALLOWED_IMPORTERS = [
+  'packages/cli/src/runtime/runExecution.ts',
+  'src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts',
+] as const;
+
+const SCAN_ROOTS = [
+  'packages/cli/src',
+  'packages/desktop/src',
+  'packages/extension/src',
+  'src',
+] as const;
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
+const SOURCE_OR_OUTPUT_EXTENSION = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+
+function toRepoPath(path: string): string {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replaceAll('\\', '/');
+}
+
+function sourceFilesUnder(root: string): string[] {
+  const absoluteRoot = resolve(REPO_ROOT, root);
+  let entries: string[];
+  try {
+    entries = readdirSync(absoluteRoot, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => SOURCE_FILE.test(entry) && !entry.endsWith('.d.ts'))
+    .map((entry) => toRepoPath(join(absoluteRoot, entry)));
+}
+
+function literalText(node: ts.Expression | undefined): string | null {
+  return node != null && ts.isStringLiteralLike(node) ? node.text : null;
+}
+
+function moduleSpecifierFromImportEquals(
+  node: ts.ImportEqualsDeclaration,
+): string | null {
+  const reference = node.moduleReference;
+  if (!ts.isExternalModuleReference(reference)) return null;
+  return literalText(reference.expression);
+}
+
+function moduleSpecifierFromCall(node: ts.CallExpression): string | null {
+  const [firstArg] = node.arguments;
+  if (
+    node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+    (ts.isIdentifier(node.expression) && node.expression.text === 'require')
+  ) {
+    return literalText(firstArg);
+  }
+  return null;
+}
+
+function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = literalText(node.moduleSpecifier);
+      if (specifier != null) specifiers.push(specifier);
+    } else if (ts.isImportEqualsDeclaration(node)) {
+      const specifier = moduleSpecifierFromImportEquals(node);
+      if (specifier != null) specifiers.push(specifier);
+    } else if (ts.isCallExpression(node)) {
+      const specifier = moduleSpecifierFromCall(node);
+      if (specifier != null) specifiers.push(specifier);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+function resolveCliAlias(specifier: string): string | null {
+  if (specifier === TARGET_ALIAS) return TARGET_MODULE;
+  if (!specifier.startsWith('@cli/')) return null;
+  return `packages/cli/src/${specifier.slice('@cli/'.length)}`;
+}
+
+function resolveRepoRelativeImport(
+  importer: string,
+  specifier: string,
+): string | null {
+  if (specifier.startsWith('@cli/')) return resolveCliAlias(specifier);
+  if (!specifier.startsWith('.')) return null;
+  return toRepoPath(join(dirname(importer), specifier));
+}
+
+function resolvesToTarget(importer: string, specifier: string): boolean {
+  const resolved = resolveRepoRelativeImport(importer, specifier);
+  if (resolved == null) return false;
+
+  if (resolved === TARGET_MODULE) return true;
+
+  const resolvedStem = resolved.replace(SOURCE_OR_OUTPUT_EXTENSION, '');
+  return resolvedStem === TARGET_MODULE_STEM;
+}
+
+function importsTargetModule(file: string): boolean {
+  const sourceText = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  return collectModuleSpecifiers(sourceFile).some((specifier) =>
+    resolvesToTarget(file, specifier),
+  );
+}
+
+describe('CLI session progress projection boundary', () => {
+  it('keeps sessionProgressSubscription scoped to headless CLI output', () => {
+    expect(existsSync(resolve(REPO_ROOT, TARGET_MODULE))).toBe(true);
+
+    const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
+      .filter(importsTargetModule)
+      .toSorted();
+
+    expect(importers).toEqual([...ALLOWED_IMPORTERS].toSorted());
+  });
+
+  it('actually scans the repository source roots', () => {
+    const scanned = SCAN_ROOTS.reduce(
+      (total, root) => total + sourceFilesUnder(root).length,
+      0,
+    );
+    expect(scanned).toBeGreaterThan(100);
+  });
+});

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -10,12 +10,14 @@ import { streamDataDir, StreamSnapshotStore } from '@transcript';
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
-import type { TaskState } from '@agent/core/state/TaskState';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
-  type ProgressEvent,
-  type ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+  toRunFactDomainKey,
+  type RunFactEventName,
+  type RunFactPayloads,
+} from '@agent/runtime/runFactEvents';
+import type { TaskState } from '@agent/core/state/TaskState';
+import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -132,6 +134,67 @@ async function writeExecutionConfig(executionId: ExecutionId): Promise<void> {
   );
 }
 
+function emitActiveStream(
+  target: { session: SessionHandle },
+  payload: ProgressEventPayloads['setActiveStream'],
+): void {
+  target.session.events.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload,
+    },
+  });
+}
+
+function emitRunConfig(
+  target: { session: SessionHandle },
+  streamId: StreamTabId,
+  executionId: ExecutionId,
+  taskState: TaskState,
+): void {
+  target.session.events.emit({
+    scope: 'run',
+    streamId,
+    event: {
+      type: 'run.config',
+      streamId,
+      executionId,
+      config: taskState.agentConfig,
+    },
+  });
+}
+
+function emitStreamDescription(
+  target: { session: SessionHandle },
+  payload: ProgressEventPayloads['updateStreamDescription'],
+): void {
+  target.session.events.emit({
+    scope: 'session',
+    event: {
+      type: 'updateStreamDescription',
+      payload,
+    },
+  });
+}
+
+function emitRunDomainFact<K extends RunFactEventName>(
+  target: { session: SessionHandle },
+  streamId: StreamTabId,
+  factName: K,
+  payload: RunFactPayloads[K],
+): void {
+  target.session.events.emit({
+    scope: 'run',
+    streamId,
+    event: {
+      type: 'domain',
+      key: toRunFactDomainKey(factName),
+      data: payload,
+    },
+  });
+}
+
 describe('ProgressBackend', () => {
   it('constructs the shared progress backend service graph', () => {
     let servicesFromConfig: ProgressBackendServices | undefined;
@@ -156,13 +219,14 @@ describe('ProgressBackend', () => {
     backend.dispose();
   });
 
-  it('handles progress events through its local subscription', () => {
-    const { backend } = createIsolatedRecordingBackend();
+  it('handles session facts through its local subscription', () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, session } = target;
     const subscription = backend.setupEventListeners();
     const streamId = 'desktop-local-stream' as StreamTabId;
 
     try {
-      backend.handleProgressEvent('setActiveStream', {
+      emitActiveStream(target, {
         streamId,
         agentCategory: AgentCategory.Workflow,
       });
@@ -172,6 +236,7 @@ describe('ProgressBackend', () => {
     } finally {
       subscription.dispose();
       backend.dispose();
+      session.dispose();
     }
   });
 
@@ -264,7 +329,8 @@ describe('ProgressBackend', () => {
   });
 
   it('patches one stream for subagent registration and run-start metadata', async () => {
-    const { backend, messages } = createRecordingBackend();
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages, session } = target;
     const subscription = backend.setupEventListeners();
 
     try {
@@ -272,7 +338,7 @@ describe('ProgressBackend', () => {
         backend.state.streamLogs.ensureStream(`history-${i}`);
       }
 
-      backend.handleProgressEvent('setActiveStream', {
+      emitActiveStream(target, {
         streamId: 'root',
         agentCategory: AgentCategory.Workflow,
       });
@@ -286,7 +352,7 @@ describe('ProgressBackend', () => {
       );
       messages.length = 0;
 
-      backend.handleProgressEvent('setActiveStream', {
+      emitActiveStream(target, {
         streamId: 'child',
         agentCategory: AgentCategory.ToolUse,
         suppressViewSwitch: true,
@@ -309,11 +375,12 @@ describe('ProgressBackend', () => {
       ).toBe(false);
       messages.length = 0;
 
-      backend.handleProgressEvent('setTaskState', {
-        streamId: 'child',
-        executionId: 'c41111',
-        taskState: toolUseTaskState('search', 'deepseekproT'),
-      });
+      emitRunConfig(
+        target,
+        'child' as StreamTabId,
+        'c41111' as ExecutionId,
+        toolUseTaskState('search', 'deepseekproT'),
+      );
 
       await vi.waitFor(() =>
         expect(
@@ -366,6 +433,7 @@ describe('ProgressBackend', () => {
     } finally {
       subscription.dispose();
       backend.dispose();
+      session.dispose();
     }
   });
 
@@ -562,16 +630,18 @@ describe('ProgressBackend', () => {
         },
       });
 
-      first.backend.handleProgressEvent('setTaskState', {
-        streamId: firstStream,
-        executionId: firstExecution,
-        taskState: toolUseTaskState('search', 'deepseekproT'),
-      });
-      second.backend.handleProgressEvent('setTaskState', {
-        streamId: secondStream,
-        executionId: secondExecution,
-        taskState: toolUseTaskState('revise', 'gpt-4o'),
-      });
+      emitRunConfig(
+        first,
+        firstStream,
+        firstExecution,
+        toolUseTaskState('search', 'deepseekproT'),
+      );
+      emitRunConfig(
+        second,
+        secondStream,
+        secondExecution,
+        toolUseTaskState('revise', 'gpt-4o'),
+      );
       first.session.status.transition(
         firstStream,
         STREAM_PHASE.RUNNING,
@@ -583,11 +653,11 @@ describe('ProgressBackend', () => {
         'lifecycle',
       );
       second.session.status.transitionToWaiting(secondStream, 'wait');
-      first.backend.handleProgressEvent('updateStreamDescription', {
+      emitStreamDescription(first, {
         streamId: firstStream,
         description: 'first window run',
       });
-      second.backend.handleProgressEvent('updateStreamDescription', {
+      emitStreamDescription(second, {
         streamId: secondStream,
         description: 'second window run',
       });
@@ -697,7 +767,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('no-ops the direct applier after dispose', () => {
+  it('no-ops direct interaction events after dispose', () => {
     const { backend } = createIsolatedRecordingBackend();
     const applier = vi.spyOn(backend.eventHandler, 'handleProgressEvent');
     const streamId = 'desktop-post-close-stream' as StreamTabId;
@@ -707,9 +777,9 @@ describe('ProgressBackend', () => {
     // A run that kept executing headless after a desktop window closed still
     // holds the host-channel emit closure that routes to handleProgressEvent.
     expect(() =>
-      backend.handleProgressEvent('setActiveStream', {
+      backend.handleProgressEvent('updateToolEditApprovalBypassState', {
         streamId,
-        agentCategory: AgentCategory.Workflow,
+        bypassActive: true,
       }),
     ).not.toThrow();
 
@@ -779,10 +849,13 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      backend.handleProgressEvent('setActiveStream', {
-        streamId,
-        agentCategory: AgentCategory.Workflow,
-      });
+      emitActiveStream(
+        { session },
+        {
+          streamId,
+          agentCategory: AgentCategory.Workflow,
+        },
+      );
       handleRunFact.mockClear();
       handleProgressEvent.mockClear();
       updateFiles.mockClear();
@@ -950,10 +1023,13 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      backend.handleProgressEvent('setActiveStream', {
-        streamId,
-        agentCategory: AgentCategory.Workflow,
-      });
+      emitActiveStream(
+        { session },
+        {
+          streamId,
+          agentCategory: AgentCategory.Workflow,
+        },
+      );
       handleProgressEvent.mockClear();
       updateTodos.mockClear();
       updatePlan.mockClear();
@@ -1013,10 +1089,13 @@ describe('ProgressBackend', () => {
 
     try {
       await backend.state.snapshots.load([]);
-      backend.handleProgressEvent('setActiveStream', {
-        streamId,
-        agentCategory: AgentCategory.Workflow,
-      });
+      emitActiveStream(
+        { session },
+        {
+          streamId,
+          agentCategory: AgentCategory.Workflow,
+        },
+      );
       handleRunFact.mockClear();
       handleProgressEvent.mockClear();
       updateFiles.mockClear();
@@ -1047,11 +1126,13 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('handles session facts with the same backend effects as host progress events', async () => {
-    const direct = createIsolatedRecordingBackend();
-    const legacyEquivalent = createIsolatedRecordingBackend();
-    const directSubscription = direct.backend.setupEventListeners();
-    const legacySubscription = legacyEquivalent.backend.setupEventListeners();
+  it('handles session facts without the host progress-event adapter', async () => {
+    const target = createIsolatedRecordingBackend();
+    const subscription = target.backend.setupEventListeners();
+    const handleProgressEvent = vi.spyOn(
+      target.backend.eventHandler,
+      'handleProgressEvent',
+    );
     const parentStreamId = 'session:parent' as StreamTabId;
     const childStreamId = 'session:child' as StreamTabId;
     const executionId = 'exec:direct-session' as ExecutionId;
@@ -1084,34 +1165,38 @@ describe('ProgressBackend', () => {
     } satisfies ProgressEventPayloads['inquiryThreadUpdated'];
 
     try {
-      for (const target of [direct, legacyEquivalent]) {
-        await target.backend.state.snapshots.load([]);
-        target.backend.handleProgressEvent('setActiveStream', {
+      await target.backend.state.snapshots.load([]);
+      emitActiveStream(target, {
+        streamId: parentStreamId,
+        agentCategory: AgentCategory.ToolUse,
+      });
+      target.session.events.emit({
+        scope: 'run',
+        streamId: parentStreamId,
+        event: {
+          type: 'status',
           streamId: parentStreamId,
-          agentCategory: AgentCategory.ToolUse,
-        });
-        target.session.followUps.enqueue(
-          parentStreamId,
-          { text: 'continue with the local calculation' },
-          { force: true },
-        );
-        target.backend.handleProgressEvent('updateMissingOutputs', {
-          streamId: parentStreamId,
-          filesByRound: { 0: ['missing-output.tex'] },
-        });
-      }
-      await vi.waitFor(() =>
-        expect(direct.backend.state.activeStream).toBe(parentStreamId),
+          phase: STREAM_PHASE.RUNNING,
+          cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+        },
+      });
+      target.session.followUps.enqueue(
+        parentStreamId,
+        { text: 'continue with the local calculation' },
+        { force: true },
       );
-      await vi.waitFor(() =>
-        expect(legacyEquivalent.backend.state.activeStream).toBe(
-          parentStreamId,
-        ),
-      );
-      direct.messages.length = 0;
-      legacyEquivalent.messages.length = 0;
+      emitRunDomainFact(target, parentStreamId, 'updateMissingOutputs', {
+        streamId: parentStreamId,
+        filesByRound: { 0: ['missing-output.tex'] },
+      });
 
-      direct.session.events.emit({
+      await vi.waitFor(() =>
+        expect(target.backend.state.activeStream).toBe(parentStreamId),
+      );
+      target.messages.length = 0;
+      handleProgressEvent.mockClear();
+
+      target.session.events.emit({
         scope: 'run',
         streamId: parentStreamId,
         event: {
@@ -1123,12 +1208,8 @@ describe('ProgressBackend', () => {
           total: 4,
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('updateRoundStage', {
-        streamId: parentStreamId,
-        roundStage: { index: 2, total: 4 },
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'run',
         streamId: parentStreamId,
         event: {
@@ -1138,12 +1219,8 @@ describe('ProgressBackend', () => {
           children: [child],
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('updateActiveSubagents', {
-        parentStreamId,
-        children: [child],
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'run',
         streamId: parentStreamId,
         event: {
@@ -1153,12 +1230,8 @@ describe('ProgressBackend', () => {
           processes: [process],
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('updateActiveProcesses', {
-        parentStreamId,
-        processes: [process],
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'session',
         event: {
           type: 'setParentStream',
@@ -1168,12 +1241,8 @@ describe('ProgressBackend', () => {
           },
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('setParentStream', {
-        childStreamId,
-        parentStreamId,
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'run',
         streamId: parentStreamId,
         event: {
@@ -1184,67 +1253,53 @@ describe('ProgressBackend', () => {
           stderr: '',
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('updateProcessOutput', {
-        parentStreamId,
-        executionId,
-        stdout: 'hello',
-        stderr: '',
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'session',
         event: {
           type: 'updateQueuedFollowUps',
           payload: { streamId: parentStreamId },
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('updateQueuedFollowUps', {
-        streamId: parentStreamId,
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'session',
         event: {
           type: 'clearMissingOutputs',
           payload: { streamId: parentStreamId },
         },
       });
-      legacyEquivalent.backend.handleProgressEvent('clearMissingOutputs', {
-        streamId: parentStreamId,
-      });
 
-      direct.session.events.emit({
+      target.session.events.emit({
         scope: 'session',
         event: {
           type: 'inquiryThreadUpdated',
           payload: inquiryThread,
         },
       });
-      legacyEquivalent.backend.handleProgressEvent(
-        'inquiryThreadUpdated',
-        inquiryThread,
-      );
 
-      expect(direct.backend.factApplier.getAllStreamStates()).toEqual(
-        legacyEquivalent.backend.factApplier.getAllStreamStates(),
+      expect(handleProgressEvent).not.toHaveBeenCalled();
+      expect(target.backend.state.getStreamState(parentStreamId)).toMatchObject(
+        {
+          roundStage: { index: 2, total: 4 },
+          activeSubagents: [child],
+          activeProcesses: [process],
+        },
       );
       expect(
-        direct.backend.state.snapshots.getMissingOutputs(parentStreamId),
-      ).toEqual(
-        legacyEquivalent.backend.state.snapshots.getMissingOutputs(
-          parentStreamId,
+        target.backend.state.snapshots.getMissingOutputs(parentStreamId),
+      ).toEqual({});
+      expect(
+        target.messages.some(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_INQUIRY_THREAD,
         ),
-      );
-      expect(direct.messages).toEqual(legacyEquivalent.messages);
+      ).toBe(true);
     } finally {
-      directSubscription.dispose();
-      legacySubscription.dispose();
-      await direct.backend.state.clearAll();
-      await legacyEquivalent.backend.state.clearAll();
-      direct.backend.dispose();
-      legacyEquivalent.backend.dispose();
-      direct.session.dispose();
-      legacyEquivalent.session.dispose();
+      subscription.dispose();
+      await target.backend.state.clearAll();
+      target.backend.dispose();
+      target.session.dispose();
     }
   });
 
@@ -1370,9 +1425,10 @@ describe('ProgressBackend', () => {
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
 
-      backend.handleProgressEvent('updateConversationProgress', {
-        streamId: stream,
-        progress: { toolCallCount: 7 },
+      backend.factApplier.handleRunFact(stream, {
+        type: 'domain',
+        key: 'conversationProgress',
+        data: { toolCallCount: 7 },
       });
 
       await backend.factApplier.setStreamStatus(


### PR DESCRIPTION
## Summary

This Stage 5 slice narrows the progress-view backend host adapter to the four interaction callbacks that still arrive through the host rail: tool-edit show/resolve and approval bypass-state pushes. Durable progress-view state no longer has registrations in `ProgressEventHandler.handleProgressEvent`; session and run facts enter through `ProgressBackend.setupEventListeners()` and `ProgressFactApplier.handleSessionFact` / `handleRunFact`.

The extension progress sink now carries `ProgressBackendInteractionPayloads` instead of a broader progress-event shape. Backend tests seed durable state through native session/run events, and a new architecture gate keeps `@cli/runtime/sessionProgressSubscription` scoped to the headless CLI public-output adapter and its dedicated test.

Part of #6968 and #6951.

## Issue acceptance gates

- #6968 Stage 5 slice: durable progress facts no longer register on `ProgressEventHandler.handleProgressEvent`; the host adapter handles only the explicit progress-view interaction callbacks.
- #6968 CLI compatibility: the retained headless CLI public-output projection remains intact; `corepack pnpm --filter @texra-ai/cli validate:run` passed.
- #6968 boundary guard: `cliSessionProgressProjectionBoundary.vitest.ts` asserts `sessionProgressSubscription` is imported only by `packages/cli/src/runtime/runExecution.ts` and its dedicated CLI test.
- Full Stage 5 acceptance remains open in #6968; this PR deliberately does not delete the frozen headless CLI projection or close the tracking issue.

## Single source of truth

`SessionHandle.events` plus `ProgressFactApplier` are the single source of truth for durable progress-view session/run facts. `ProgressEventHandler` now owns only the host interaction callback table for progress-view UI callbacks.

## Duplication and abstraction budget

Removed the duplicate durable-state registration path from `ProgressEventHandler.handleProgressEvent`. The remaining adapter is not a pass-through layer: it encodes the host-boundary invariant that only the four progress-view interaction callbacks may arrive through the extension/desktop host rail. The branch is net positive in lines because the architecture gate and fact-native tests replace broad legacy event coverage with explicit boundary coverage.

## Host impact

Extension: the extension progress-event sink is narrowed to `ProgressBackendInteractionPayloads`; durable progress state continues through the default session's fact subscriptions.

Desktop: shared backend behavior stays session/fact-native; desktop keeps the same interaction callback surface while avoiding durable state through the host adapter.

CLI: headless public-output projection is preserved and fenced to the CLI boundary; internal TUI/backend/transcript/desktop/extension paths are blocked from importing it.

## Scheduled refactoring

No new shim, projection, dual-write, alias, fallback, or migration path was added, so no new #6981 ledger row is required. Remaining Stage 5 deletion work continues under #6968, with existing frozen-projection retirement tracking in #6981/#6984.

## Validation

- `corepack pnpm exec prettier --write packages/extension/src/progressView/ProgressViewProvider.ts src/shared/progressView/backend/ProgressBackend.ts src/shared/progressView/backend/events/ProgressEventHandler.ts src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts` (unchanged)
- `git diff --check origin/main...HEAD`
- `corepack pnpm exec vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressEventBridge.vitest.mts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts`
- `npm run typecheck`
- `npm run lint` (58 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `CI=true corepack pnpm run test` (608 files passed, 1 skipped; 5244 tests passed, 4 skipped)
