### PR TITLE
fix(agent): suppress default legacy tag warnings

### DIFF
--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -21,7 +21,7 @@ Before creating a custom agent, it's highly recommended to understand the underl
 
 ## <wa-icon library="texra" name="library"></wa-icon> Reference Agents
 
-TeXRA includes ready-made reference agents you can use as starting points. Think of them as recipes: copy one into your custom agents directory, tweak it, and you have a new agent in minutes. Examples range from content-enhancement workflows to notation standardizers and multi-agent orchestrators. Each agent handles one input or several through a unified protocol: set `documentTag: documents` and your prompt emits one `<document name="...">` per input.
+TeXRA includes ready-made reference agents you can use as starting points. Think of them as recipes: copy one into your custom agents directory, tweak it, and you have a new agent in minutes. Examples range from content-enhancement workflows to notation standardizers and multi-agent orchestrators. Each agent handles one input or several through the fixed `<documents>` container and emits one `<document name="...">` per input.
 
 ## <wa-icon library="texra" name="new-file"></wa-icon> Creating a Custom Agent File
 
@@ -70,10 +70,6 @@ settings:
   isRewrite: true # Does the agent primarily rewrite existing content (true) or generate new content (false)?
   rounds: 2 # Maximum number of passes (Round 0 plus reflection rounds). The actual count is max(rounds, number of userRequest entries); a run can still stop early once the model signals it is finished.
 
-  # Output Handling
-  documentTag: documents # The main XML tag wrapping the agent's final output (defaults to `documents`).
-  endTag: '</documents>' # The closing tag that signals the agent has finished its main output.
-
   # File Handling (Optional - Advanced)
   # requiredFiles:
   #   TEMPLATE: path/to/template.tex # Map variable names to required file paths relative to workspace.
@@ -104,7 +100,7 @@ prompts:
   userRequest:
     - |
       # The prompt for the AI's first round of work (Round 0).
-      # Often includes guidance for thinking (<scratchpad>) and output structure (<documentTag>).
+      # Often includes guidance for thinking (<scratchpad>) and the fixed <documents> output structure.
       [Define the initial task prompt, potentially including scratchpad guidance]
     - |
       # Optional follow-up prompt for reflection rounds (Round 1+).
@@ -221,8 +217,6 @@ for a workflow agent that writes two generated output files:
 inherits: polish
 settings:
   agentCategory: workflow
-  documentTag: documents
-  endTag: </documents>
   defaultOutputFiles:
     - introduction.tex
     - conclusion.tex

--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -6,7 +6,10 @@ import {
   AgentCategorySchema,
   AgentNameSchema,
 } from '@shared/schemas/agent';
-import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
+import {
+  OUTPUT_DOCUMENTS_TAG,
+  OUTPUT_END_TAG,
+} from '@shared/constants/outputProtocol';
 
 export { AgentCategory };
 
@@ -50,10 +53,10 @@ export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
  * Drop obsolete settings accepted only for legacy YAML and persisted state.
  * `documentTag`/`endTag` used to configure the per-agent output container;
  * every bundled and custom agent has converged on the fixed
- * `<documents><document name="..."></documents>` protocol (see
- * `@shared/constants/outputProtocol`), so the fields are ignored — with a
- * warning, since a custom agent that relied on a bespoke tag silently gets
- * the standard container instead.
+ * `<documents><document name="...">...</document></documents>` protocol (see
+ * `@shared/constants/outputProtocol`). The fixed default legacy values are
+ * silently ignored so old bundled/persisted copies do not pollute CLI stderr;
+ * bespoke legacy tags still warn because they now get the standard container.
  */
 function stripLegacySettingFields(input: unknown): unknown {
   if (typeof input !== 'object' || input === null || Array.isArray(input)) {
@@ -66,7 +69,11 @@ function stripLegacySettingFields(input: unknown): unknown {
     endTag,
     ...rest
   } = input as Record<string, unknown>;
-  if (documentTag !== undefined || endTag !== undefined) {
+  const hasLegacyOutputTags = documentTag !== undefined || endTag !== undefined;
+  const usesDefaultOutputTags =
+    (documentTag === undefined || documentTag === OUTPUT_DOCUMENTS_TAG) &&
+    (endTag === undefined || endTag === OUTPUT_END_TAG);
+  if (hasLegacyOutputTags && !usesDefaultOutputTags) {
     // console.warn, not the structured trace logger: this module is a leaf
     // schema (`core/definition`, dependency-free by design — see
     // src/agent/core/README.md) and must not pull in the logger's transitive

--- a/src/test-kernel/agent/AgentSettingSchema.vitest.ts
+++ b/src/test-kernel/agent/AgentSettingSchema.vitest.ts
@@ -29,16 +29,46 @@ describe('AgentSettingSchema', () => {
     expect(Object.hasOwn(setting, 'outputExt')).toBe(false);
   });
 
-  it('ignores legacy documentTag/endTag without exposing them in settings', () => {
-    const setting = AgentSettingSchema.parse({
-      agentCategory: AgentCategory.Workflow,
-      documentTag: 'latex_document',
-      endTag: '</latex_document>',
-    });
+  it('ignores default legacy documentTag/endTag without warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let setting!: ReturnType<typeof AgentSettingSchema.parse>;
+    let warningCount = 0;
+    try {
+      setting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'documents',
+        endTag: '</documents>',
+      });
+      warningCount = warnSpy.mock.calls.length;
+    } finally {
+      warnSpy.mockRestore();
+    }
 
     expect(setting.agentCategory).toBe(AgentCategory.Workflow);
     expect(Object.hasOwn(setting, 'documentTag')).toBe(false);
     expect(Object.hasOwn(setting, 'endTag')).toBe(false);
+    expect(warningCount).toBe(0);
+  });
+
+  it('warns when stripping bespoke legacy documentTag/endTag values', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let setting!: ReturnType<typeof AgentSettingSchema.parse>;
+    let warningCount = 0;
+    try {
+      setting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'latex_document',
+        endTag: '</latex_document>',
+      });
+      warningCount = warnSpy.mock.calls.length;
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(setting.agentCategory).toBe(AgentCategory.Workflow);
+    expect(Object.hasOwn(setting, 'documentTag')).toBe(false);
+    expect(Object.hasOwn(setting, 'endTag')).toBe(false);
+    expect(warningCount).toBe(1);
   });
 
   it('regression #7497: shipped reference-agents YAML no longer carries documentTag/endTag', () => {


### PR DESCRIPTION
## Summary

Suppress the startup warning for legacy `settings.documentTag` / `settings.endTag` only when the values are the fixed defaults TeXRA already uses: `documents` and `</documents>`. Bespoke legacy tags still warn and are still stripped.

The custom-agent guide no longer tells users to configure those retired fields.

## Issue acceptance gates

Addresses #7497.

- Default legacy output-tag fields are stripped silently, so stale bundled/persisted copies do not print `AgentDataclass` warnings on CLI startup.
- Bespoke legacy tag values still warn before being stripped.
- Custom-agent documentation no longer advertises `documentTag` / `endTag` settings.

## Single source of truth

`src/shared/constants/outputProtocol.ts` remains the source of truth for the fixed output protocol tags. `AgentSettingSchema` owns the legacy-field stripping policy at the schema boundary.

## Duplication and abstraction budget

Removed documentation that duplicated retired per-agent tag configuration. No new abstraction or pass-through layer was added. The added lines are focused regression coverage for the silent-default and bespoke-warning branches.

## Host impact

Extension: custom agents that still carry default legacy tags load without a warning; bespoke legacy tags still warn and are stripped.

Desktop: persisted/copied default legacy agent YAML no longer pollutes startup stderr/logs; output protocol behavior is unchanged.

CLI: `texra agents list` and `texra multi-agent list --output-format ndjson` no longer emit `AgentDataclass` warnings for default legacy tag fields.

## Scheduled refactoring

None. This adjusts the existing legacy strip path from #7497; it does not introduce a new shim, projection, dual-write, alias, fallback, or migration path.

## Validation

- `corepack pnpm exec prettier --write docs/guide/custom-agents.md src/agent/core/definition/AgentDataclass.ts src/test-kernel/agent/AgentSettingSchema.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/agent/AgentSettingSchema.vitest.ts`
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run texra-local:build`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `TEXRA_NO_UPDATE_CHECK=1 texra-local agents list >/tmp/texra-agents-list-texra-local-fixed.out 2>/tmp/texra-agents-list-texra-local-fixed.err` (no `AgentDataclass` / `documentTag` / `endTag` warning; one expected hidden-agent notice remains)
- `TEXRA_NO_UPDATE_CHECK=1 texra-local multi-agent list --output-format ndjson >/tmp/texra-multi-agent-list-texra-local-fixed.out 2>/tmp/texra-multi-agent-list-texra-local-fixed.err` (stderr empty)
- `git diff --check`
- `CI=true corepack pnpm run test`

Closes #7497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-boundary deprecation policy and documentation only; fixed output protocol behavior is unchanged.
> 
> **Overview**
> **Legacy `documentTag` / `endTag` handling** in `AgentSettingSchema` now strips default values (`documents`, `</documents>`) **without** `console.warn`, while **non-default** legacy tags still warn before strip. This stops repeated startup noise from bundled or persisted YAML that still carries the old default keys (#7497).
> 
> The **custom agents guide** no longer documents or shows `documentTag` / `endTag` in templates; it describes the **fixed** `<documents>` / `<document name="...">` output protocol instead.
> 
> Tests split **silent default** vs **bespoke warning** behavior and keep the reference-agents bundle regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75a67199c376eeb07248370d48e724a7b2fd525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->