### PR TITLE
refactor: isolate host progress vocabulary

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -3,18 +3,52 @@ import path from 'node:path';
 // Local imports - agent metadata
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-
-// Local imports - progress events
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 
 // Local imports - shared schemas
-import { STREAM_PHASE, STREAM_STATUS, type StreamPhase } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type StreamPhase,
+  type UpdateActiveProcessesPayload,
+  type UpdateActiveSubagentsPayload,
+  type UpdateConversationProgressPayload,
+  type UpdateRoundStagePayload,
+  type UpdateStreamDescriptionPayload,
+  type UpdateStreamStatusPayload,
+} from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
 import type { CliContext } from './cliContext';
 
-type ProgressEvent = keyof ProgressEventPayloads;
+export type RunProgressEventPayloads = {
+  setTaskState: SetTaskStatePayload;
+  updateConversationProgress: UpdateConversationProgressPayload;
+  updateRoundStage: UpdateRoundStagePayload;
+  updateActiveProcesses: UpdateActiveProcessesPayload;
+  updateActiveSubagents: UpdateActiveSubagentsPayload;
+  updateStreamStatus: UpdateStreamStatusPayload;
+  updateStreamDescription: UpdateStreamDescriptionPayload;
+};
+
+export type RunProgressEvent = keyof RunProgressEventPayloads;
+
+const RUN_PROGRESS_EVENTS = [
+  'setTaskState',
+  'updateConversationProgress',
+  'updateRoundStage',
+  'updateActiveProcesses',
+  'updateActiveSubagents',
+  'updateStreamStatus',
+  'updateStreamDescription',
+] as const satisfies readonly RunProgressEvent[];
+
+const RunProgressEventSet: ReadonlySet<string> = new Set(RUN_PROGRESS_EVENTS);
+
+export function isRunProgressEvent(event: string): event is RunProgressEvent {
+  return RunProgressEventSet.has(event);
+}
 
 // Carriage return + erase-line (CSI 2K): rewind to column 0 and clear the row
 // so the single live status line can be repainted in place.
@@ -32,7 +66,7 @@ interface RenderState {
 }
 
 export interface RunProgressRenderer {
-  handle(event: ProgressEvent, payload: unknown): boolean;
+  handle(event: RunProgressEvent, payload: unknown): boolean;
   clear(): void;
   preserve(): void;
 }
@@ -89,11 +123,13 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     this.startedAt = this.nowMs();
   }
 
-  handle(event: ProgressEvent, payload: unknown): boolean {
+  handle(event: RunProgressEvent, payload: unknown): boolean {
     switch (event) {
       case 'setTaskState':
         if (
-          this.applyTaskState(payload as ProgressEventPayloads['setTaskState'])
+          this.applyTaskState(
+            payload as RunProgressEventPayloads['setTaskState'],
+          )
         ) {
           this.updateHeartbeat();
           this.render(true);
@@ -103,7 +139,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         if (this.rootStreamTerminal) return true;
         if (
           this.applyConversationProgress(
-            payload as ProgressEventPayloads['updateConversationProgress'],
+            payload as RunProgressEventPayloads['updateConversationProgress'],
           )
         ) {
           this.updateHeartbeat();
@@ -114,7 +150,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         if (this.rootStreamTerminal) return true;
         if (
           this.applyRoundStage(
-            payload as ProgressEventPayloads['updateRoundStage'],
+            payload as RunProgressEventPayloads['updateRoundStage'],
           )
         ) {
           this.updateHeartbeat();
@@ -126,11 +162,11 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         if (this.rootStreamTerminal) return true;
         if (event === 'updateActiveProcesses') {
           this.applyActiveProcesses(
-            payload as ProgressEventPayloads['updateActiveProcesses'],
+            payload as RunProgressEventPayloads['updateActiveProcesses'],
           );
         } else {
           this.applyActiveSubagents(
-            payload as ProgressEventPayloads['updateActiveSubagents'],
+            payload as RunProgressEventPayloads['updateActiveSubagents'],
           );
         }
         this.updateHeartbeat();
@@ -138,7 +174,8 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         return true;
       case 'updateStreamStatus':
         {
-          const data = payload as ProgressEventPayloads['updateStreamStatus'];
+          const data =
+            payload as RunProgressEventPayloads['updateStreamStatus'];
           if (!this.isRootStream(data.streamId)) return true;
           const { status } = data;
           this.state.phase = formatRunProgressStatus(status);
@@ -154,7 +191,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       case 'updateStreamDescription': {
         if (this.rootStreamTerminal) return true;
         const data =
-          payload as ProgressEventPayloads['updateStreamDescription'];
+          payload as RunProgressEventPayloads['updateStreamDescription'];
         if (this.isRootStream(data.streamId)) {
           this.state.phase = data.description;
           this.updateHeartbeat();
@@ -183,9 +220,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
   }
 
-  private applyTaskState(
-    payload: ProgressEventPayloads['setTaskState'],
-  ): boolean {
+  private applyTaskState(payload: SetTaskStatePayload): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
     const config = payload.taskState.agentConfig;
@@ -200,7 +235,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   private applyConversationProgress(
-    payload: ProgressEventPayloads['updateConversationProgress'],
+    payload: UpdateConversationProgressPayload,
   ): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
@@ -209,9 +244,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return true;
   }
 
-  private applyRoundStage(
-    payload: ProgressEventPayloads['updateRoundStage'],
-  ): boolean {
+  private applyRoundStage(payload: UpdateRoundStagePayload): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
     this.state.round = payload.roundStage.index + 1;
@@ -222,9 +255,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return true;
   }
 
-  private applyActiveProcesses(
-    payload: ProgressEventPayloads['updateActiveProcesses'],
-  ): void {
+  private applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
     this.state.activeProcesses = formatActiveChildren(
@@ -235,9 +266,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     );
   }
 
-  private applyActiveSubagents(
-    payload: ProgressEventPayloads['updateActiveSubagents'],
-  ): void {
+  private applyActiveSubagents(payload: UpdateActiveSubagentsPayload): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
     this.state.activeSubagents = formatActiveChildren(

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -1,9 +1,6 @@
 // Local imports - runtime
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@agent/runtime/hostProgressEvents';
+import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 import {
   isRuntimeInteractionEvent,
   type RuntimeInteractionEvent,
@@ -24,7 +21,10 @@ import {
   type Logger,
   type LogSink,
 } from './logSinks';
-import { createRunProgressRenderer } from './runProgressRenderer';
+import {
+  createRunProgressRenderer,
+  isRunProgressEvent,
+} from './runProgressRenderer';
 import type { CliContext } from './cliContext';
 
 export type CliRuntimeHost = AgentRuntimeHost & {
@@ -90,7 +90,8 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (
         !isRuntimePresentationEvent(event) &&
         !isRuntimeInteractionEvent(event) &&
-        runProgress?.handle(event as ProgressEvent, payload)
+        isRunProgressEvent(event) &&
+        runProgress?.handle(event, payload)
       ) {
         return;
       }
@@ -98,7 +99,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (context.quietLogs) return;
 
       if (event === 'setTaskState') {
-        const data = payload as ProgressEventPayloads['setTaskState'];
+        const data = payload as SetTaskStatePayload;
         ensureLogger().info('Task state registered', {
           streamId: data.streamId,
         });

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -1,8 +1,8 @@
 import type { AgentEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import {
+import type {
   ProgressEvent,
-  type ProgressEventPayloads,
+  ProgressEventPayloads,
 } from '@agent/runtime/hostProgressEvents';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
@@ -38,7 +38,7 @@ const CLI_RUN_FACT_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
 
 /**
  * Project session facts onto the frozen host-progress vocabulary for headless
- * CLI output. `followUpSent` is intentionally session-local.
+ * CLI public output. `followUpSent` is intentionally session-local.
  */
 function projectCliSessionFact(
   fact: SessionFact,

--- a/src/agent/runtime/hostProgressEvents.ts
+++ b/src/agent/runtime/hostProgressEvents.ts
@@ -1,16 +1,14 @@
-import type { TaskState } from '@agent/core/state/TaskState';
+import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 import type {
   AddOutputFilesPayload,
   ClearMissingOutputsPayload,
-  ConversationProgress,
-  ExecutionId,
   GoalPausedPayload,
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
   RemoveStreamPayload,
   SetActiveStreamPayload,
   SetParentStreamPayload,
-  StreamTabId,
+  UpdateConversationProgressPayload,
   UpdateActiveProcessesPayload,
   UpdateActiveSubagentsPayload,
   UpdateCompileFailuresPayload,
@@ -39,8 +37,7 @@ import type {
  * rails keep one shared key/payload table while they are migrated to typed
  * session/host surfaces.
  * Every fact-plane key below references its named vocabulary type — this map
- * projects the vocabulary, it does not define it. The remaining inline key is
- * the Stage-5 `setTaskState` residue.
+ * projects the vocabulary, it does not define it.
  */
 export interface ProgressEventPayloads {
   // ── Run/stream progress ──
@@ -50,21 +47,14 @@ export interface ProgressEventPayloads {
   updateMissingOutputs: UpdateMissingOutputsPayload;
   updateCompileFailures: UpdateCompileFailuresPayload;
   clearMissingOutputs: ClearMissingOutputsPayload;
-  setTaskState: {
-    streamId: StreamTabId;
-    executionId?: ExecutionId;
-    taskState: TaskState;
-  };
+  setTaskState: SetTaskStatePayload;
   updateStreamUsage: UpdateStreamUsagePayload;
   /** Inquiry thread state changed (open, answered, dropped, or resume outcome). */
   inquiryThreadUpdated: InquiryThreadUpdatedEvent;
   // ── Run/stream progress (part 2) ──
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
-  updateConversationProgress: {
-    streamId: StreamTabId;
-    progress: ConversationProgress;
-  };
+  updateConversationProgress: UpdateConversationProgressPayload;
   updateRoundStage: UpdateRoundStagePayload;
   updateQueuedFollowUps: UpdateQueuedFollowUpsPayload;
   goalPaused: GoalPausedPayload;

--- a/src/agent/runtime/taskStateProgressPayload.ts
+++ b/src/agent/runtime/taskStateProgressPayload.ts
@@ -1,0 +1,8 @@
+import type { TaskState } from '@agent/core/state/TaskState';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+export interface SetTaskStatePayload {
+  streamId: StreamTabId;
+  executionId?: ExecutionId;
+  taskState: TaskState;
+}

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -4,8 +4,8 @@ import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
+import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
@@ -13,11 +13,26 @@ import {
   ConversationProgressSchema,
   UpdatePlanPayloadSchema,
   UpdateTodosPayloadSchema,
+  type AddOutputFilesPayload,
+  type ClearMissingOutputsPayload,
   type ConversationProgress,
   type GoalStatus,
+  type InquiryThreadUpdatedEvent,
+  type SetActiveStreamPayload,
+  type SetParentStreamPayload,
   type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
+  type UpdateCompileFailuresPayload,
+  type UpdateConversationProgressPayload,
+  type UpdateMissingOutputsPayload,
+  type UpdatePlanPayload,
+  type UpdateProcessOutputPayload,
+  type UpdateQueuedFollowUpsPayload,
+  type UpdateRoundStagePayload,
+  type UpdateStreamDescriptionPayload,
+  type UpdateStreamUsagePayload,
+  type UpdateTodosPayload,
 } from '@shared/schemas';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
@@ -255,9 +270,7 @@ export class ProgressFactApplier {
 
       if (factName === 'addOutputFiles' && isObject(event.data)) {
         this.applyFact('failed to handle addOutputFiles fact', () =>
-          this.handleAddOutputFiles(
-            event.data as ProgressEventPayloads['addOutputFiles'],
-          ),
+          this.handleAddOutputFiles(event.data as AddOutputFilesPayload),
         );
         return;
       }
@@ -265,7 +278,7 @@ export class ProgressFactApplier {
       if (factName === 'updateMissingOutputs' && isObject(event.data)) {
         this.applyFact('failed to handle updateMissingOutputs fact', () =>
           this.handleUpdateMissingOutputs(
-            event.data as ProgressEventPayloads['updateMissingOutputs'],
+            event.data as UpdateMissingOutputsPayload,
           ),
         );
         return;
@@ -274,7 +287,7 @@ export class ProgressFactApplier {
       if (factName === 'updateCompileFailures' && isObject(event.data)) {
         this.applyFact('failed to handle updateCompileFailures fact', () =>
           this.handleUpdateCompileFailures(
-            event.data as ProgressEventPayloads['updateCompileFailures'],
+            event.data as UpdateCompileFailuresPayload,
           ),
         );
       }
@@ -338,9 +351,7 @@ export class ProgressFactApplier {
     withEventErrorHandling('ProgressFacts', context, handle);
   }
 
-  public handleInquiryThreadUpdated(
-    thread: ProgressEventPayloads['inquiryThreadUpdated'],
-  ): void {
+  public handleInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateInquiryThread(thread);
     }
@@ -349,7 +360,7 @@ export class ProgressFactApplier {
   public handleUpdateStreamDescription({
     streamId,
     description,
-  }: ProgressEventPayloads['updateStreamDescription']): void {
+  }: UpdateStreamDescriptionPayload): void {
     this.state.snapshots.setDescription(streamId, description);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateStreamDescription(streamId, description);
@@ -359,7 +370,7 @@ export class ProgressFactApplier {
   public handleSetParentStream({
     childStreamId,
     parentStreamId,
-  }: ProgressEventPayloads['setParentStream']): void {
+  }: SetParentStreamPayload): void {
     this.state.snapshots.setParentStream(childStreamId, parentStreamId);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateParentStream(
@@ -374,7 +385,7 @@ export class ProgressFactApplier {
     executionId,
     stdout,
     stderr,
-  }: ProgressEventPayloads['updateProcessOutput']): void {
+  }: UpdateProcessOutputPayload): void {
     // Always send — output accumulates in frontend state per-stream,
     // so it must not be dropped when the stream is inactive.
     if (this.webviewUpdater.isAvailable()) {
@@ -390,7 +401,7 @@ export class ProgressFactApplier {
   public handleAddOutputFiles({
     streamId,
     filesByRound,
-  }: ProgressEventPayloads['addOutputFiles']): void {
+  }: AddOutputFilesPayload): void {
     this.state.snapshots.addOutputFiles(streamId, filesByRound);
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getOutputFiles(streamId);
@@ -403,7 +414,7 @@ export class ProgressFactApplier {
   public handleUpdateMissingOutputs({
     streamId,
     filesByRound,
-  }: ProgressEventPayloads['updateMissingOutputs']): void {
+  }: UpdateMissingOutputsPayload): void {
     this.state.snapshots.updateMissingOutputs(streamId, filesByRound);
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getMissingOutputs(streamId);
@@ -416,7 +427,7 @@ export class ProgressFactApplier {
   public handleUpdateCompileFailures({
     streamId,
     filesByRound,
-  }: ProgressEventPayloads['updateCompileFailures']): void {
+  }: UpdateCompileFailuresPayload): void {
     this.state.snapshots.updateCompileFailures(streamId, filesByRound);
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getCompileFailures(streamId);
@@ -427,9 +438,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleClearMissingOutputs(
-    payload: ProgressEventPayloads['clearMissingOutputs'],
-  ): void {
+  public handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
     const targets: StreamTabId[] = payload.streamId
       ? [payload.streamId]
       : payload.streamConfig
@@ -449,7 +458,7 @@ export class ProgressFactApplier {
     streamId,
     usage,
     storageKey,
-  }: ProgressEventPayloads['updateStreamUsage']): void {
+  }: UpdateStreamUsagePayload): void {
     void Promise.resolve(
       this.state.snapshots.addUsage(streamId, storageKey, usage),
     ).then((accumulated) => {
@@ -460,20 +469,14 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleUpdateTodos({
-    streamId,
-    todos,
-  }: ProgressEventPayloads['updateTodos']): void {
+  public handleUpdateTodos({ streamId, todos }: UpdateTodosPayload): void {
     this.state.snapshots.setTodos(streamId, todos);
     this.sendIfActive(streamId, () =>
       this.webviewUpdater.updateTodos(streamId, todos),
     );
   }
 
-  public handleUpdatePlan({
-    streamId,
-    plan,
-  }: ProgressEventPayloads['updatePlan']): void {
+  public handleUpdatePlan({ streamId, plan }: UpdatePlanPayload): void {
     this.state.snapshots.setPlan(streamId, plan);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updatePlan(streamId, plan);
@@ -482,7 +485,7 @@ export class ProgressFactApplier {
 
   public handleUpdateQueuedFollowUps({
     streamId,
-  }: ProgressEventPayloads['updateQueuedFollowUps']): void {
+  }: UpdateQueuedFollowUpsPayload): void {
     this.sendIfActive(streamId, () => {
       const messages = this.state.followUps.getAll(streamId);
       this.webviewUpdater.updateQueuedFollowUps(streamId, messages);
@@ -500,7 +503,7 @@ export class ProgressFactApplier {
   }
 
   public async handleSetActiveStream(
-    payload: ProgressEventPayloads['setActiveStream'],
+    payload: SetActiveStreamPayload,
   ): Promise<void> {
     const { streamId, isRemote } = payload;
     if (!streamId) return;
@@ -590,7 +593,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleSetTaskState(data: ProgressEventPayloads['setTaskState']): void {
+  public handleSetTaskState(data: SetTaskStatePayload): void {
     const { streamId, executionId, taskState } = data;
     const isActiveStream = this.state.activeStream === streamId;
     const category = taskState.agentConfig.agentCategory;
@@ -621,7 +624,7 @@ export class ProgressFactApplier {
   }
 
   public handleUpdateConversationProgress(
-    data: ProgressEventPayloads['updateConversationProgress'],
+    data: UpdateConversationProgressPayload,
   ): void {
     const { streamId, progress } = data;
 
@@ -642,9 +645,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public handleUpdateRoundStage(
-    data: ProgressEventPayloads['updateRoundStage'],
-  ): void {
+  public handleUpdateRoundStage(data: UpdateRoundStagePayload): void {
     const { streamId, roundStage } = data;
     this.state.updateStreamState(streamId, (prev) => ({
       ...prev,

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -2,7 +2,11 @@ import type { AgentCategory } from './agent';
 import type { ExecutionId, StorageKey, StreamTabId } from './identifiers';
 import type { CompileFailure, FileLocation, OutputFileInfo } from './output';
 import type { RoundIndexed } from './roundIndexed';
-import type { ActiveChildInfo, RoundStage } from './streamState';
+import type {
+  ActiveChildInfo,
+  ConversationProgress,
+  RoundStage,
+} from './streamState';
 import type { StreamPhase, StreamSubstate } from './stream';
 import type { TokenUsageStats } from './usage';
 
@@ -96,6 +100,11 @@ export interface UpdateStreamUsagePayload {
   storageKey: StorageKey;
   executionId?: ExecutionId;
   usage: TokenUsageStats;
+}
+
+export interface UpdateConversationProgressPayload {
+  streamId: StreamTabId;
+  progress: ConversationProgress;
 }
 
 /** Round advance within a run, projected from `stage.start` (kind 'round'). */

--- a/src/test-kernel/architecture/hostProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/hostProgressEventsBoundary.vitest.ts
@@ -1,0 +1,154 @@
+// Node imports
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+const TARGET_MODULE = 'src/agent/runtime/hostProgressEvents.ts';
+const TARGET_MODULE_STEM = TARGET_MODULE.replace(/\.(?:ts|tsx|mts|cts)$/, '');
+const TARGET_ALIAS = '@agent/runtime/hostProgressEvents';
+
+const ALLOWED_PRODUCTION_IMPORTERS = [
+  'src/agent/runtime/AgentRuntimeHost.ts',
+  'packages/cli/src/runtime/sessionProgressSubscription.ts',
+] as const;
+
+const SCAN_ROOTS = [
+  'packages/cli/src',
+  'packages/desktop/src',
+  'packages/extension/src',
+  'src',
+] as const;
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
+const SOURCE_OR_OUTPUT_EXTENSION = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+
+function toRepoPath(path: string): string {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replaceAll('\\', '/');
+}
+
+function sourceFilesUnder(root: string): string[] {
+  const absoluteRoot = resolve(REPO_ROOT, root);
+  let entries: string[];
+  try {
+    entries = readdirSync(absoluteRoot, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => SOURCE_FILE.test(entry) && !entry.endsWith('.d.ts'))
+    .map((entry) => toRepoPath(join(absoluteRoot, entry)))
+    .filter((file) => !file.startsWith('src/test-kernel/'));
+}
+
+function literalText(node: ts.Expression | undefined): string | null {
+  return node != null && ts.isStringLiteralLike(node) ? node.text : null;
+}
+
+function moduleSpecifierFromImportEquals(
+  node: ts.ImportEqualsDeclaration,
+): string | null {
+  const reference = node.moduleReference;
+  if (!ts.isExternalModuleReference(reference)) return null;
+  return literalText(reference.expression);
+}
+
+function moduleSpecifierFromCall(node: ts.CallExpression): string | null {
+  const [firstArg] = node.arguments;
+  if (
+    node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+    (ts.isIdentifier(node.expression) && node.expression.text === 'require')
+  ) {
+    return literalText(firstArg);
+  }
+  return null;
+}
+
+function collectModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = literalText(node.moduleSpecifier);
+      if (specifier != null) specifiers.push(specifier);
+    } else if (ts.isImportEqualsDeclaration(node)) {
+      const specifier = moduleSpecifierFromImportEquals(node);
+      if (specifier != null) specifiers.push(specifier);
+    } else if (ts.isCallExpression(node)) {
+      const specifier = moduleSpecifierFromCall(node);
+      if (specifier != null) specifiers.push(specifier);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+function resolveAgentAlias(specifier: string): string | null {
+  if (specifier === TARGET_ALIAS) return TARGET_MODULE;
+  if (!specifier.startsWith('@agent/')) return null;
+  return `src/agent/${specifier.slice('@agent/'.length)}`;
+}
+
+function resolveRepoRelativeImport(
+  importer: string,
+  specifier: string,
+): string | null {
+  if (specifier.startsWith('@agent/')) return resolveAgentAlias(specifier);
+  if (!specifier.startsWith('.')) return null;
+  return toRepoPath(join(dirname(importer), specifier));
+}
+
+function resolvesToTarget(importer: string, specifier: string): boolean {
+  const resolved = resolveRepoRelativeImport(importer, specifier);
+  if (resolved == null) return false;
+
+  if (resolved === TARGET_MODULE) return true;
+
+  const resolvedStem = resolved.replace(SOURCE_OR_OUTPUT_EXTENSION, '');
+  return resolvedStem === TARGET_MODULE_STEM;
+}
+
+function importsTargetModule(file: string): boolean {
+  const sourceText = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  return collectModuleSpecifiers(sourceFile).some((specifier) =>
+    resolvesToTarget(file, specifier),
+  );
+}
+
+describe('host progress-event vocabulary boundary', () => {
+  it('keeps hostProgressEvents scoped to the runtime host contract and public CLI projection', () => {
+    expect(existsSync(resolve(REPO_ROOT, TARGET_MODULE))).toBe(true);
+
+    const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
+      .filter(importsTargetModule)
+      .toSorted();
+
+    expect(importers).toEqual([...ALLOWED_PRODUCTION_IMPORTERS].toSorted());
+  });
+
+  it('actually scans the production source roots', () => {
+    const scanned = SCAN_ROOTS.reduce(
+      (total, root) => total + sourceFilesUnder(root).length,
+      0,
+    );
+    expect(scanned).toBeGreaterThan(100);
+  });
+});

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -1,13 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { toRunFactDomainKey } from '@agent/runtime/runFactEvents';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { attachCliSessionProgressProjection } from '@cli/runtime/sessionProgressSubscription';
-import type { StreamTabId } from '@shared/schemas';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
+import {
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const streamId = 'stream:cli-session-projection' as StreamTabId;
+const executionId = 'execution:cli-session-projection' as ExecutionId;
+
+function workflowConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    agent: 'polish',
+    agentCategory: AgentCategory.Workflow,
+    model: 'deepseek-chat',
+    inputFiles: ['paper.tex'],
+    contextFiles: [],
+    mediaFiles: [],
+    outputFiles: [],
+    editedFile: null,
+    editedFiles: [],
+    instruction: '',
+    toolConfig: DEFAULT_TOOL_CONFIG,
+    memories: [],
+    workingDirectory: '/tmp/project',
+    ...overrides,
+  };
+}
 
 function hostWithInteractions(
   interactions?: Partial<HostInteractions>,
@@ -120,6 +149,76 @@ describe('attachCliSessionProgressProjection', () => {
         streamId,
         storageKey: 'run-a',
         usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+      });
+    } finally {
+      detach();
+    }
+  });
+
+  it('projects run config facts to the public setTaskState event', () => {
+    const events = new SessionEventHub();
+    const host = hostWithInteractions();
+    const detach = attachCliSessionProgressProjection(events, host);
+    const config = workflowConfig({
+      inputFiles: ['paper.tex', 'appendix.tex'],
+      contextFiles: ['notes.md'],
+    });
+
+    try {
+      events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'run.config',
+          streamId,
+          executionId,
+          config,
+        },
+      });
+
+      expect(host.emit).toHaveBeenCalledWith('setTaskState', {
+        streamId,
+        executionId,
+        taskState: {
+          agentConfig: config,
+          activeFiles: {
+            input: true,
+            context: true,
+            media: false,
+            output: false,
+          },
+        },
+      });
+    } finally {
+      detach();
+    }
+  });
+
+  it('projects status facts to the public stream-status event', () => {
+    const events = new SessionEventHub();
+    const host = hostWithInteractions();
+    const detach = attachCliSessionProgressProjection(events, host);
+
+    try {
+      events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'status',
+          streamId,
+          phase: STREAM_PHASE.RUNNING,
+          previousPhase: STREAM_PHASE.WAITING,
+          cause: STREAM_TRANSITION_CAUSE.RESUME,
+          substate: STREAM_SUBSTATE.RESUMING,
+        },
+      });
+
+      expect(host.emit).toHaveBeenCalledWith('updateStreamStatus', {
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+        previousStatus: STREAM_PHASE.WAITING,
+        cause: STREAM_TRANSITION_CAUSE.RESUME,
+        substate: STREAM_SUBSTATE.RESUMING,
       });
     } finally {
       detach();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -10,14 +10,13 @@ import { streamDataDir, StreamSnapshotStore } from '@transcript';
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
   toRunFactDomainKey,
   type RunFactEventName,
   type RunFactPayloads,
 } from '@agent/runtime/runFactEvents';
 import type { TaskState } from '@agent/core/state/TaskState';
-import type { ProgressEventPayloads } from '@agent/runtime/hostProgressEvents';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -27,7 +26,10 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
   type ActiveChildInfo,
+  type AddOutputFilesPayload,
   type CompileFailure,
+  type GoalPausedPayload,
+  type InquiryThreadUpdatedEvent,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -37,9 +39,15 @@ import {
   type OutputFileInfo,
   type Plan,
   type ProgressViewOutboundMessage,
+  type SetActiveStreamPayload,
   type StorageKey,
   type StreamTabId,
   type TodoItem,
+  type UpdateCompileFailuresPayload,
+  type UpdateMissingOutputsPayload,
+  type UpdatePlanPayload,
+  type UpdateStreamDescriptionPayload,
+  type UpdateTodosPayload,
 } from '@shared/schemas';
 import {
   ProgressBackend,
@@ -136,7 +144,7 @@ async function writeExecutionConfig(executionId: ExecutionId): Promise<void> {
 
 function emitActiveStream(
   target: { session: SessionHandle },
-  payload: ProgressEventPayloads['setActiveStream'],
+  payload: SetActiveStreamPayload,
 ): void {
   target.session.events.emit({
     scope: 'session',
@@ -167,7 +175,7 @@ function emitRunConfig(
 
 function emitStreamDescription(
   target: { session: SessionHandle },
-  payload: ProgressEventPayloads['updateStreamDescription'],
+  payload: UpdateStreamDescriptionPayload,
 ): void {
   target.session.events.emit({
     scope: 'session',
@@ -530,7 +538,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             todos: [firstTodo],
-          } satisfies ProgressEventPayloads['updateTodos'],
+          } satisfies UpdateTodosPayload,
         },
       });
       first.session.events.emit({
@@ -542,7 +550,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             filesByRound: { 1: [firstOutput] },
-          } satisfies ProgressEventPayloads['addOutputFiles'],
+          } satisfies AddOutputFilesPayload,
         },
       });
 
@@ -572,7 +580,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             todos: [secondTodo],
-          } satisfies ProgressEventPayloads['updateTodos'],
+          } satisfies UpdateTodosPayload,
         },
       });
 
@@ -744,7 +752,7 @@ describe('ProgressBackend', () => {
     const subscription = backend.setupEventListeners();
     const applier = vi.spyOn(backend.eventHandler, 'handleProgressEvent');
     const streamId = 'session:single-applier' as StreamTabId;
-    const payload: ProgressEventPayloads['setActiveStream'] = {
+    const payload: SetActiveStreamPayload = {
       streamId,
       agentCategory: AgentCategory.Workflow,
     };
@@ -874,7 +882,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             filesByRound: { 1: [outputFile] },
-          } satisfies ProgressEventPayloads['addOutputFiles'],
+          } satisfies AddOutputFilesPayload,
         },
       });
       session.events.emit({
@@ -886,7 +894,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             filesByRound: { 1: ['paper.pdf'] },
-          } satisfies ProgressEventPayloads['updateMissingOutputs'],
+          } satisfies UpdateMissingOutputsPayload,
         },
       });
       session.events.emit({
@@ -898,7 +906,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             filesByRound: { 1: [compileFailure] },
-          } satisfies ProgressEventPayloads['updateCompileFailures'],
+          } satisfies UpdateCompileFailuresPayload,
         },
       });
       session.events.emit({
@@ -910,7 +918,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             todos,
-          } satisfies ProgressEventPayloads['updateTodos'],
+          } satisfies UpdateTodosPayload,
         },
       });
       session.events.emit({
@@ -922,7 +930,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             plan,
-          } satisfies ProgressEventPayloads['updatePlan'],
+          } satisfies UpdatePlanPayload,
         },
       });
       session.events.emit({
@@ -945,7 +953,7 @@ describe('ProgressBackend', () => {
         event: {
           type: 'domain',
           key: toRunFactDomainKey('goalPaused'),
-          data: { streamId } satisfies ProgressEventPayloads['goalPaused'],
+          data: { streamId } satisfies GoalPausedPayload,
         },
       });
 
@@ -1110,7 +1118,7 @@ describe('ProgressBackend', () => {
           data: {
             streamId,
             filesByRound: { 1: [outputFile] },
-          } satisfies ProgressEventPayloads['addOutputFiles'],
+          } satisfies AddOutputFilesPayload,
         },
       });
 
@@ -1162,7 +1170,7 @@ describe('ProgressBackend', () => {
       lastActivityIso: '2026-07-06T12:00:00.000Z',
       turnCount: 1,
       resumeOutcome: null,
-    } satisfies ProgressEventPayloads['inquiryThreadUpdated'];
+    } satisfies InquiryThreadUpdatedEvent;
 
     try {
       await target.backend.state.snapshots.load([]);


### PR DESCRIPTION
## Summary

This Stage 5 slice isolates the frozen host-progress vocabulary to the two places that still need it: the `AgentRuntimeHost` contract and the headless CLI public-output projection adapter. Internal CLI live rendering now owns a narrow `RunProgressEvent` surface, and `ProgressFactApplier` consumes named fact-native payload types instead of depending on `ProgressEventPayloads`.

The retained `hostProgressEvents` table remains frozen for runtime-host/public CLI compatibility, but its `setTaskState` and `updateConversationProgress` entries now reference named payload types. A new architecture gate prevents production imports of `@agent/runtime/hostProgressEvents` outside `AgentRuntimeHost` and `packages/cli/src/runtime/sessionProgressSubscription.ts`.

Part of #6968 and #6951.

## Issue acceptance gates

- #6968 Stage 5 slice: internal CLI rendering and progress-backend fact application no longer depend on the frozen host-progress event map.
- #6968 compatibility: headless CLI public output still projects through the retained CLI boundary; `corepack pnpm --filter @texra-ai/cli validate:run` passed.
- #6968 boundary guard: `hostProgressEventsBoundary.vitest.ts` asserts production imports of `hostProgressEvents` are limited to `AgentRuntimeHost` and the CLI public projection adapter.
- #6968 projection coverage: `CliSessionProgressSubscription.vitest.mts` asserts `run.config` and `status` facts preserve task state, execution id, transition cause, previous phase, and substate in public progress output.
- Full Stage 5 acceptance remains open in #6968; this PR deliberately keeps the frozen host/public table for the next deletion/rename slice.

## Single source of truth

Named fact payload types are now the vocabulary source for internal progress facts: `SetTaskStatePayload` and `UpdateConversationProgressPayload` are consumed directly by internal renderers/appliers, while `hostProgressEvents` only projects those named types for retained host/public compatibility.

## Duplication and abstraction budget

Removed the duplicate dependency on the broad `ProgressEventPayloads` map from internal CLI rendering and progress backend fact application. The new `RunProgressEvent` table is intentionally local to CLI live rendering: it owns the display-specific subset that the CLI renderer can paint, while the architecture test owns the import-boundary invariant. The branch is net positive in lines because it adds boundary/projection coverage while deleting broad internal coupling.

## Host impact

Extension: no behavior change; progress-view fact application continues through session/run fact subscriptions.

Desktop: no behavior change; desktop continues using the session/fact-native progress backend path established by earlier Stage 5 slices.

CLI: headless `texra run`, `--print`, and `--output-format json` compatibility is preserved; interactive live run rendering now uses the CLI-owned `RunProgressEvent` subset instead of the frozen host-progress table.

## Scheduled refactoring

No new shim, projection, dual-write, alias, fallback, or migration path was added, so no new #6981 ledger row is required. The retained frozen host/public table remains scheduled under #6968 and the existing #6981/#6984 retirement plan.

## Validation

- `corepack pnpm exec prettier --write packages/cli/src/runtime/runProgressRenderer.ts packages/cli/src/runtime/runtimeHost.ts packages/cli/src/runtime/sessionProgressSubscription.ts src/agent/runtime/hostProgressEvents.ts src/agent/runtime/taskStateProgressPayload.ts src/shared/progressView/backend/events/ProgressFactApplier.ts src/shared/schemas/progressEvents.ts src/test-kernel/architecture/hostProgressEventsBoundary.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts` (unchanged)
- `git diff --check origin/main...HEAD`
- `corepack pnpm exec vitest run src/test-kernel/architecture/hostProgressEventsBoundary.vitest.ts src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `CI=true corepack pnpm run test` (609 files passed, 1 skipped; 5248 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI public progress output and progress-view fact handling along a migration boundary; behavior is largely type-level with new tests, but regressions in projection or rendering would affect user-visible status.
> 
> **Overview**
> This PR **narrows who depends on the frozen `hostProgressEvents` map** and routes internal consumers through **fact-native payload types** in `@shared/schemas` instead.
> 
> The CLI **live stderr progress line** now owns a small `RunProgressEventPayloads` / `isRunProgressEvent` surface and types handlers with `SetTaskStatePayload` plus shared update payloads; `runtimeHost` only forwards events the renderer recognizes. **`ProgressFactApplier`** drops `ProgressEventPayloads` in favor of the same named schema types.
> 
> **`SetTaskStatePayload`** moves to `taskStateProgressPayload.ts`, **`UpdateConversationProgressPayload`** is added to `progressEvents.ts`, and the legacy `ProgressEventPayloads` table **references those types** instead of inline shapes.
> 
> An **architecture test** locks production imports of `hostProgressEvents` to `AgentRuntimeHost` and the headless CLI session projection adapter. **CLI projection tests** assert `run.config` → `setTaskState` and `status` → `updateStreamStatus` (including execution id, cause, previous phase, and substate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbfff58b0d64d0c890710fb9e4b9b231b9eae52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->