### PR TITLE
refactor(cli): derive run progress payloads

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -3,36 +3,14 @@ import path from 'node:path';
 // Local imports - agent metadata
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 
 // Local imports - shared schemas
-import {
-  STREAM_PHASE,
-  STREAM_STATUS,
-  type StreamPhase,
-  type UpdateActiveProcessesPayload,
-  type UpdateActiveSubagentsPayload,
-  type UpdateConversationProgressPayload,
-  type UpdateRoundStagePayload,
-  type UpdateStreamDescriptionPayload,
-  type UpdateStreamStatusPayload,
-} from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamPhase } from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
 import type { CliContext } from './cliContext';
-
-export type RunProgressEventPayloads = {
-  setTaskState: SetTaskStatePayload;
-  updateConversationProgress: UpdateConversationProgressPayload;
-  updateRoundStage: UpdateRoundStagePayload;
-  updateActiveProcesses: UpdateActiveProcessesPayload;
-  updateActiveSubagents: UpdateActiveSubagentsPayload;
-  updateStreamStatus: UpdateStreamStatusPayload;
-  updateStreamDescription: UpdateStreamDescriptionPayload;
-};
-
-export type RunProgressEvent = keyof RunProgressEventPayloads;
+import type { CliProgressEventPayloads } from './cliProgressEvents';
 
 const RUN_PROGRESS_EVENTS = [
   'setTaskState',
@@ -42,7 +20,14 @@ const RUN_PROGRESS_EVENTS = [
   'updateActiveSubagents',
   'updateStreamStatus',
   'updateStreamDescription',
-] as const satisfies readonly RunProgressEvent[];
+] as const satisfies readonly (keyof CliProgressEventPayloads)[];
+
+export type RunProgressEvent = (typeof RUN_PROGRESS_EVENTS)[number];
+
+type RunProgressEventPayloads = Pick<
+  CliProgressEventPayloads,
+  RunProgressEvent
+>;
 
 const RunProgressEventSet: ReadonlySet<string> = new Set(RUN_PROGRESS_EVENTS);
 
@@ -220,7 +205,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
   }
 
-  private applyTaskState(payload: SetTaskStatePayload): boolean {
+  private applyTaskState(
+    payload: RunProgressEventPayloads['setTaskState'],
+  ): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
     const config = payload.taskState.agentConfig;
@@ -235,7 +222,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   private applyConversationProgress(
-    payload: UpdateConversationProgressPayload,
+    payload: RunProgressEventPayloads['updateConversationProgress'],
   ): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
@@ -244,7 +231,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return true;
   }
 
-  private applyRoundStage(payload: UpdateRoundStagePayload): boolean {
+  private applyRoundStage(
+    payload: RunProgressEventPayloads['updateRoundStage'],
+  ): boolean {
     if (!this.claimRootStream(payload.streamId)) return false;
 
     this.state.round = payload.roundStage.index + 1;
@@ -255,7 +244,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     return true;
   }
 
-  private applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {
+  private applyActiveProcesses(
+    payload: RunProgressEventPayloads['updateActiveProcesses'],
+  ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
     this.state.activeProcesses = formatActiveChildren(
@@ -266,7 +257,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     );
   }
 
-  private applyActiveSubagents(payload: UpdateActiveSubagentsPayload): void {
+  private applyActiveSubagents(
+    payload: RunProgressEventPayloads['updateActiveSubagents'],
+  ): void {
     if (!this.claimRootStream(payload.parentStreamId)) return;
 
     this.state.activeSubagents = formatActiveChildren(

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -20,6 +20,7 @@ const OLD_AGENT_RUNTIME_ALIAS = '@agent/runtime/agentRuntimeProgressEvents';
 const CLI_ALIAS = '@cli/runtime/cliProgressEvents';
 
 const ALLOWED_PRODUCTION_IMPORTERS = [
+  'packages/cli/src/runtime/runProgressRenderer.ts',
   'packages/cli/src/runtime/runtimeHost.ts',
   'packages/cli/src/runtime/sessionProgressSubscription.ts',
 ] as const;


### PR DESCRIPTION
Part of #6968.

## Summary

- Derive `RunProgressEventPayloads` from the retained `CliProgressEventPayloads` table instead of maintaining a second local payload vocabulary in `runProgressRenderer.ts`.
- Keep `RUN_PROGRESS_EVENTS` as the renderer's explicit subset, so `isRunProgressEvent()` does not widen to every CLI public-output event.
- Update the architecture boundary guard to allow this CLI-local type-only importer of `cliProgressEvents.ts`.

## Single source of truth

The retained CLI public-output compatibility vocabulary remains owned by `packages/cli/src/runtime/cliProgressEvents.ts`. The run progress renderer now selects its subset from that table instead of restating payload types.

## Validation

- `CI=true corepack pnpm exec vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts --config vitest.config.mjs`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `CI=true corepack pnpm exec eslint packages/cli/src/runtime/runProgressRenderer.ts src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/runProgressRenderer.ts src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor and boundary-test update; no runtime behavior change intended.
> 
> **Overview**
> **`runProgressRenderer.ts`** stops defining its own progress payload types and shared-schema imports for those events. It now imports **`CliProgressEventPayloads`** from **`cliProgressEvents.ts`**, keeps **`RUN_PROGRESS_EVENTS`** as an explicit subset (still validated with `satisfies readonly (keyof CliProgressEventPayloads)[]`), and defines **`RunProgressEventPayloads`** as **`Pick<CliProgressEventPayloads, RunProgressEvent>`**. Handler/`apply*` methods use indexed payload types from that pick instead of standalone shared types.
> 
> The architecture boundary test **`agentRuntimeProgressEventsBoundary.vitest.ts`** adds **`runProgressRenderer.ts`** to **`ALLOWED_PRODUCTION_IMPORTERS`** so this type-only import of **`cliProgressEvents.ts`** is permitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e389fb87570772a1152260ee6e8c71fbda88b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->