### PR TITLE
refactor: modern-TS simplification sweep over recently-merged code (net -50)

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -712,13 +712,6 @@ function stoppedChild(child: ActiveChildInfo): ActiveChildInfo {
   };
 }
 
-function stopMatchingChild(
-  child: ActiveChildInfo,
-  executionId: string,
-): ActiveChildInfo {
-  return child.executionId === executionId ? stoppedChild(child) : child;
-}
-
 function isDifferentExecution(
   child: ActiveChildInfo,
   executionId: string,
@@ -1447,7 +1440,7 @@ function markHarnessExecutionStopped(executionId: string): void {
       isDifferentExecution(child, executionId),
     ),
     childStreams: slice.childStreams.map((child) =>
-      stopMatchingChild(child, executionId),
+      child.executionId === executionId ? stoppedChild(child) : child,
     ),
     entries: [
       ...slice.entries,

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -58,13 +58,11 @@ function wrappedUserQuestionPromptLines({
   readonly text: string;
   readonly width: number;
 }): UserQuestionPromptLine[] {
-  const lines: UserQuestionPromptLine[] = [];
-  for (const line of text.split('\n')) {
-    for (const wrapped of wrapAnsiToWidth(line, width).split('\n')) {
-      lines.push({ kind, text: wrapped });
-    }
-  }
-  return lines;
+  return text.split('\n').flatMap((line) =>
+    wrapAnsiToWidth(line, width)
+      .split('\n')
+      .map((wrapped): UserQuestionPromptLine => ({ kind, text: wrapped })),
+  );
 }
 
 function userQuestionInlineClipIndicator({

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -212,7 +212,7 @@ function overflowMarkerText(
   return (
     candidates.find(
       (candidate) => textDisplayWidth(candidate) <= markerWidth,
-    ) ?? clipToWidth(candidates.at(-1) ?? '', markerWidth)
+    ) ?? clipToWidth(candidates[1], markerWidth)
   );
 }
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -41,7 +41,6 @@ import {
   wakeQueuedFollowUpStream,
 } from '@agent/followUp/ToolUseFollowUp';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
-import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
 import {
   getFileListConfig,
@@ -1036,14 +1035,10 @@ export class DesktopProgressBridge {
     }
   }
 
-  private streamStateSnapshot(): Map<StreamTabId, StreamPhaseState> {
-    return this.session.status.getAllStreamStates();
-  }
-
   private updateStreamMetadata(): StreamTabId | '' {
     return this.backend.webviewUpdater.sendStreamMetadata(
       this.state,
-      this.streamStateSnapshot(),
+      this.session.status.getAllStreamStates(),
     );
   }
 

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -38,13 +38,11 @@ export interface FollowUpSendDetail {
   readonly images: readonly ExtractedClipboardImage[];
 }
 
-interface WorkflowFollowupFormData {
+export interface FollowupCommandDetail {
   agent: string;
   model: string;
   initialQuestion: string;
 }
-
-export type FollowupCommandDetail = WorkflowFollowupFormData;
 
 /**
  * Frontend-only panel action emitted by the inline "Yolo (this session)"

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -12,7 +12,6 @@ import type { LogMessageData } from '@shared/schemas';
 import {
   html,
   unsafeHTML,
-  classMap,
   ifDefined,
   type FormatResult,
 } from '../litTemplates';
@@ -105,20 +104,8 @@ export function formatModelResponseTemplate(
   // banner-content--streaming whitespace note).
   // prettier-ignore
   const contentTemplate = options?.isRunning
-    ? html`<div class=${classMap({
-        'banner-content': true,
-        'banner-content--streaming': true,
-        'log-entry-content': true,
-        'banner-content--model': true,
-        [`message-${level}`]: true,
-      })}>${trimmedContent}</div>`
-    : html`<div class=${classMap({
-        'banner-content': true,
-        'markdown-content': true,
-        'log-entry-content': true,
-        'banner-content--model': true,
-        [`message-${level}`]: true,
-      })}>${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
+    ? html`<div class="banner-content banner-content--streaming log-entry-content banner-content--model message-${level}">${trimmedContent}</div>`
+    : html`<div class="banner-content markdown-content log-entry-content banner-content--model message-${level}">${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
 
   // prettier-ignore
   return html`<details class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -155,7 +155,6 @@ export class PersistedFlow<
     await this.ensureRecord(shared);
     let step = await this.stepWithResult();
     while (step.hasMore) {
-      // step loop
       step = await this.stepWithResult();
     }
     return (step.action ??

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -53,8 +53,7 @@ function normalizeWorkspaceRelativeDirectory(candidate: string): string {
   return candidate
     .trim()
     .replaceAll(path.sep, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
+    .replaceAll(/^\/+|\/+$/g, '');
 }
 
 export function resolveArxivPaperDirectoryRelative(

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -22,12 +22,10 @@ const convertFencedLatexBlock: ReplacementFunction = (
   const safeEnvironment = environment ?? '';
   const safeBody = multilineBody || inlineBody || '';
 
-  let bodyWithTrailingBreak = '';
-  if (safeBody !== '') {
-    bodyWithTrailingBreak = safeBody.endsWith(newline)
+  const bodyWithTrailingBreak =
+    safeBody === '' || safeBody.endsWith(newline)
       ? safeBody
       : `${safeBody}${newline}`;
-  }
   const emptyBodyPadding = safeBody === '' ? newline : '';
 
   return `${safeLeadingBreak}${safeIndent}\\begin{${safeEnvironment}}${newline}${emptyBodyPadding}${bodyWithTrailingBreak}${safeIndent}\\end{${safeEnvironment}}`;

--- a/src/shared/hostBridge.ts
+++ b/src/shared/hostBridge.ts
@@ -15,9 +15,8 @@ function resolveHostBridgeApi(): HostBridgeApi {
     [HOST_BRIDGE_API_KEY]?: HostBridgeApi;
   };
 
-  if (globalScope[HOST_BRIDGE_API_KEY]) {
-    return globalScope[HOST_BRIDGE_API_KEY] as HostBridgeApi;
-  }
+  const existing = globalScope[HOST_BRIDGE_API_KEY];
+  if (existing) return existing;
 
   if (typeof acquireVsCodeApi === 'function') {
     const api = acquireVsCodeApi();

--- a/src/shared/schemas/fileFields.ts
+++ b/src/shared/schemas/fileFields.ts
@@ -32,7 +32,7 @@ export function migrateLegacyContextFileFields(input: unknown): unknown {
   const obj = { ...source };
 
   // Step 1: rename reference/auxiliary → context.
-  if (obj.contextFile === undefined || obj.contextFile === null) {
+  if (obj.contextFile == null) {
     if (isNonEmptyString(obj.referenceFile)) {
       obj.contextFile = obj.referenceFile;
     } else if (isNonEmptyString(obj.auxiliaryFile)) {

--- a/src/shared/schemas/runDescriptor.ts
+++ b/src/shared/schemas/runDescriptor.ts
@@ -5,10 +5,6 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 
 export const RUN_DESCRIPTOR_SCHEMA_VERSION = 1;
 
-function executionConfigReferencePath(executionId: string): string {
-  return `executions/${executionId}/config.json`;
-}
-
 export const RunConfigReferenceSchema = z.strictObject({
   kind: z.literal('executionConfig'),
   executionId: ExecutionIdSchema,
@@ -41,7 +37,7 @@ export function buildRunDescriptor(input: {
     configRef: {
       kind: 'executionConfig',
       executionId: input.executionId,
-      path: executionConfigReferencePath(input.executionId),
+      path: `executions/${input.executionId}/config.json`,
     },
   });
 }

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -13,14 +13,8 @@ import {
 export type StreamStatusDisplayKey = StreamPhase | StreamSubstate | 'ready';
 
 interface StreamStatusDisplayState {
-  readonly phase?: StreamPhase;
-  readonly substate?: StreamSubstate;
   readonly key?: StreamStatusDisplayKey;
   readonly legacyStatus?: string;
-}
-
-function phaseDisplayKey(phase: StreamPhase): StreamStatusDisplayKey {
-  return phase;
 }
 
 function streamStatusDisplayState(
@@ -34,11 +28,7 @@ function streamStatusDisplayState(
 
   const phase = StreamPhaseSchema.safeParse(status);
   if (phase.success) {
-    return {
-      phase: phase.data,
-      ...(substate ? { substate } : {}),
-      key: substate ?? phaseDisplayKey(phase.data),
-    };
+    return { key: substate ?? phase.data };
   }
 
   const legacyStatus = StreamStatusSchema.safeParse(status);
@@ -47,10 +37,8 @@ function streamStatusDisplayState(
   const legacyPhase = streamStatusToPhase(legacyStatus.data);
   const legacySubstate = streamStatusToSubstate(legacyStatus.data);
   return {
-    phase: legacyPhase,
-    ...(legacySubstate ? { substate: legacySubstate } : {}),
     legacyStatus: legacyStatus.data,
-    key: legacySubstate ?? phaseDisplayKey(legacyPhase),
+    key: legacySubstate ?? legacyPhase,
   };
 }
 

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -86,7 +86,9 @@ function formatEmail(
   // -- Body -----------------------------------------------------------------
   // Falls back to a Markdown conversion of the HTML body (preserving lists,
   // links, and emphasis) when no text/plain part exists.
-  const body = (email.text ?? turndownService.turndown(email.html ?? '')).trim();
+  const body = (
+    email.text ?? turndownService.turndown(email.html ?? '')
+  ).trim();
   if (body) {
     sections.push(body);
   }

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -86,9 +86,9 @@ function formatEmail(
   // -- Body -----------------------------------------------------------------
   // Falls back to a Markdown conversion of the HTML body (preserving lists,
   // links, and emphasis) when no text/plain part exists.
-  const body = email.text ?? turndownService.turndown(email.html ?? '').trim();
-  if (body.trim()) {
-    sections.push(body.trim());
+  const body = (email.text ?? turndownService.turndown(email.html ?? '')).trim();
+  if (body) {
+    sections.push(body);
   }
 
   // -- Image attachments (returned as binary, noted in text) ----------------

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -75,7 +75,7 @@ export function extractTextFromTag(
  */
 function extractLatexFromMarkdown(content: string): string | null {
   const match = content.match(/```(?:latex|tex)\n([\s\S]*?)\n```/i);
-  return match ? match[1] : null;
+  return match?.[1] ?? null;
 }
 
 /**
@@ -123,7 +123,7 @@ export function extractMultipleTextFromTag(
     );
     const containerMatch = inputContent.match(containerRegex);
 
-    if (containerMatch && containerMatch[1]) {
+    if (containerMatch?.[1]) {
       const documents = extractNamedDocuments(containerMatch[1]);
       if (documents.length > 0) {
         return documents;


### PR DESCRIPTION
## What

Third simplification pass (after #7540 and #7581), targeting code **merged in the last ~60 commits** — the "periodic pass over recently-merged code" pattern (cf. #7485). **Net −50 LOC across 15 files**, same mechanical modern-TS/dead-code/pass-through style, **no new abstractions**.

Produced by a 13-partition finder fan-out (each finder read only its recently-changed file list) → **adversarial verify** (default-reject) → eyeball → full local gate.

## Deliberately excluded

- The **in-flight session-scoped-runtime migration** files (`agent/runtime/*` events, `cli/runtime/*`, `subscribeRuntimeHost`, `StreamLog*`, `ProgressInteractionHandler`) — they churn per stage-slice; sweeping them mid-migration is high-conflict and gets rewritten anyway.
- All **5 open PRs'** files (exact-path check, re-verified at commit).

## Changes

- **Dead code**: remove write-only `.phase`/`.substate` fields + an identity helper in `streamStatusDisplay`; drop a dead `classMap` import and a dead type-alias indirection (`events.ts`); a dead comment (`persistedFlow`).
- **`classMap({allTrue})` → static class string** in `bannerFormatters` (identical class list & order; −12).
- **Pass-through / single-caller inlines**: `executionConfigReferencePath` (`runDescriptor`), `streamStateSnapshot` (`desktopAgentExecution`), `stopMatchingChild` (`tui-harness`) — each deletes the wrapper + any now-dead import.
- **Modern idioms**: `== null`; `flatMap` over nested push-loops (`UserQuestion`); `candidates[1]` over `.at(-1) ?? ''` on a typed 2-tuple (`DiffView`); const-narrowing over a redundant `as` (`hostBridge`); one combined anchored `replaceAll` (`arxivProcessor`); ternary / optional-chaining collapses.

## Verification

- `tsc --noEmit` (root) ✅ · test-kernel ✅ · extension ✅ · cli ✅
- eslint on changed files — **0 warnings, 0 errors** ✅ (fixed a `prefer-string-replace-all` warning my own combine introduced)
- full `vitest run` — **5253 passed / 4 skipped** ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only changes with no new behavior; the largest touch is stream status display state shape, but removed fields were unused by consumers.
> 
> **Overview**
> Third periodic simplification pass over recently merged code: **net −50 LOC across 15 files**, same style as prior sweeps—no new abstractions.
> 
> **Dead code & indirection:** Drops unused `phase`/`substate` fields and an identity helper in `streamStatusDisplay`; removes a dead `classMap` import and collapses `WorkflowFollowupFormData` → exported `FollowupCommandDetail` in extension events; deletes a stale comment in `persistedFlow`. Banner formatters replace dynamic `classMap({ all true })` with **static class strings** (same classes, less Lit overhead).
> 
> **Inlined pass-throughs:** `stopMatchingChild` in the TUI harness, `streamStateSnapshot` in desktop agent execution, and `executionConfigReferencePath` in `runDescriptor` are folded into their single call sites (and related imports cleaned up).
> 
> **Idiomatic cleanups:** `flatMap` for user-question line wrapping; `== null` in legacy file-field migration; optional chaining in XML extraction and host-bridge lookup; combined `replaceAll` for arXiv path trimming; ternary body newline handling in fenced-LaTeX regex rules; single trim path in EML parsing; `candidates[1]` for diff overflow markers on a typed two-element tuple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce331882bd42c11cd653f996bdfaef7a1e84ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->