### PR TITLE
refactor(extension): rename interaction event adapter

### DIFF
--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -6,7 +6,7 @@ import {
   type ExtensionPresentationEventPayloads,
   isExtensionPresentationEvent,
 } from '@frontend/events/extensionPresentationEvents';
-import { emitExtensionProgressEvent } from '@frontend/events/extensionProgressEvents';
+import { emitExtensionInteractionEvent } from '@frontend/events/extensionInteractionEvents';
 import {
   isProgressBackendInteractionEvent,
   type ProgressBackendInteractionPayloads,
@@ -23,7 +23,7 @@ export const extensionAgentRuntimeHost: AgentRuntimeHost = {
       return;
     }
     if (isProgressBackendInteractionEvent(event)) {
-      emitExtensionProgressEvent(
+      emitExtensionInteractionEvent(
         event,
         payload as ProgressBackendInteractionPayloads[typeof event],
       );

--- a/packages/extension/src/frontend/events/extensionInteractionEvents.ts
+++ b/packages/extension/src/frontend/events/extensionInteractionEvents.ts
@@ -3,15 +3,17 @@ import type {
   ProgressBackendInteractionPayloads,
 } from '@shared/progressView/backend/events/ProgressInteractionHandler';
 
-type ExtensionProgressEventSink = <K extends ProgressBackendInteractionEvent>(
+type ExtensionInteractionEventSink = <
+  K extends ProgressBackendInteractionEvent,
+>(
   event: K,
   payload: ProgressBackendInteractionPayloads[K],
 ) => void;
 
-let activeSink: ExtensionProgressEventSink | undefined;
+let activeSink: ExtensionInteractionEventSink | undefined;
 
-export function setExtensionProgressEventSink(
-  sink: ExtensionProgressEventSink,
+export function setExtensionInteractionEventSink(
+  sink: ExtensionInteractionEventSink,
 ): () => void {
   const previous = activeSink;
   activeSink = sink;
@@ -23,7 +25,7 @@ export function setExtensionProgressEventSink(
   };
 }
 
-export function emitExtensionProgressEvent<
+export function emitExtensionInteractionEvent<
   K extends ProgressBackendInteractionEvent,
 >(event: K, payload: ProgressBackendInteractionPayloads[K]): void {
   activeSink?.(event, payload);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -19,7 +19,7 @@ import {
 import { workspaceSM } from '@common/state';
 import { appSignals } from '@eventBus/AppSignals';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
-import { setExtensionProgressEventSink } from '@frontend/events/extensionProgressEvents';
+import { setExtensionInteractionEventSink } from '@frontend/events/extensionInteractionEvents';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { createChannelTrace } from '@logger';
 import {
@@ -175,7 +175,7 @@ export class ProgressViewProvider
         getApprovalHandlers: () => this.approvalHandlers,
       }),
     );
-    const detachExtensionProgressEvents = setExtensionProgressEventSink(
+    const detachExtensionInteractionEvents = setExtensionInteractionEventSink(
       (event, payload) => {
         this.backend.handleInteractionEvent(
           event,
@@ -198,7 +198,7 @@ export class ProgressViewProvider
     );
     this._disposables.push(
       { dispose: this.detachHostInteractions },
-      { dispose: detachExtensionProgressEvents },
+      { dispose: detachExtensionInteractionEvents },
       { dispose: detachRemoveStreamCleanup },
     );
 

--- a/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
+++ b/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
@@ -13,6 +13,8 @@ const REPO_ROOT = resolve(
 
 const RETIRED_MODULE =
   'src/shared/progressView/backend/events/ProgressEventHandler.ts';
+const RETIRED_EXTENSION_PROGRESS_MODULE =
+  'packages/extension/src/frontend/events/extensionProgressEvents.ts';
 const RETIRED_SYMBOL = /\bProgressEventHandler\b/;
 
 const SCAN_ROOTS = [
@@ -62,6 +64,12 @@ function mentionsRetiredSymbol(file: string): boolean {
 describe('ProgressEventHandler retirement boundary', () => {
   it('removes the retired ProgressEventHandler module', () => {
     expect(existsSync(resolve(REPO_ROOT, RETIRED_MODULE))).toBe(false);
+  });
+
+  it('removes the retired extension progress-event adapter module', () => {
+    expect(
+      existsSync(resolve(REPO_ROOT, RETIRED_EXTENSION_PROGRESS_MODULE)),
+    ).toBe(false);
   });
 
   it('removes the ProgressEventHandler class name from production sources', () => {

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
+import { setExtensionInteractionEventSink } from '@frontend/events/extensionInteractionEvents';
 import { extensionPresentationEvents } from '@frontend/events/extensionPresentationEvents';
-import { setExtensionProgressEventSink } from '@frontend/events/extensionProgressEvents';
 import type { StreamTabId } from '@shared/schemas';
 
 describe('extensionAgentRuntimeHost', () => {
@@ -27,11 +27,11 @@ describe('extensionAgentRuntimeHost', () => {
     }
   });
 
-  it('routes backend interaction events through the extension progress sink', () => {
-    const progressEvents: unknown[] = [];
-    const disposeProgressSink = setExtensionProgressEventSink(
+  it('routes backend interaction events through the extension interaction sink', () => {
+    const interactionEvents: unknown[] = [];
+    const disposeInteractionSink = setExtensionInteractionEventSink(
       (event, payload) => {
-        progressEvents.push({ event, payload });
+        interactionEvents.push({ event, payload });
       },
     );
 
@@ -41,7 +41,7 @@ describe('extensionAgentRuntimeHost', () => {
         bypassActive: true,
       });
 
-      expect(progressEvents).toEqual([
+      expect(interactionEvents).toEqual([
         {
           event: 'updateToolEditApprovalBypassState',
           payload: {
@@ -51,13 +51,13 @@ describe('extensionAgentRuntimeHost', () => {
         },
       ]);
 
-      disposeProgressSink();
+      disposeInteractionSink();
       extensionAgentRuntimeHost.emit('updateToolEditApprovalBypassState', {
         streamId: 'extension:after-detach' as StreamTabId,
         bypassActive: false,
       });
 
-      expect(progressEvents).toEqual([
+      expect(interactionEvents).toEqual([
         {
           event: 'updateToolEditApprovalBypassState',
           payload: {
@@ -67,7 +67,7 @@ describe('extensionAgentRuntimeHost', () => {
         },
       ]);
     } finally {
-      disposeProgressSink();
+      disposeInteractionSink();
     }
   });
 });


### PR DESCRIPTION
## Summary
- rename the extension-local progress-event adapter to `extensionInteractionEvents`
- route backend interaction callbacks through `setExtensionInteractionEventSink` / `emitExtensionInteractionEvent`
- extend the retirement guard so the old extension progress-event adapter path cannot return

## Validation
- `CI=true corepack pnpm exec vitest run src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts --config vitest.config.mjs`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/extension/src/frontend/events/extensionInteractionEvents.ts packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts packages/extension/src/progressView/ProgressViewProvider.ts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts`
- `corepack pnpm exec eslint packages/extension/src/frontend/events/extensionInteractionEvents.ts packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts packages/extension/src/progressView/ProgressViewProvider.ts src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor with no logic changes; routing and disposal behavior are covered by existing tests.
> 
> **Overview**
> Renames the extension-local **progress-event** adapter to **`extensionInteractionEvents`**, aligning naming with backend **interaction** events rather than “progress” only.
> 
> **`extensionProgressEvents.ts`** is replaced by **`extensionInteractionEvents.ts`**: `setExtensionInteractionEventSink` / `emitExtensionInteractionEvent` (and related types) replace the old progress-named APIs. **`extensionAgentRuntimeHost`** and **`ProgressViewProvider`** import and wire the new sink; behavior is unchanged—backend interaction callbacks still forward to `ProgressBackend.handleInteractionEvent`.
> 
> Tests are updated to match. The **ProgressEventHandler retirement** architecture test now asserts **`extensionProgressEvents.ts`** cannot be reintroduced, alongside the existing guard for the retired shared handler module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f42a206b403347fef871d51ba9604dee0e131ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->