### PR TITLE
refactor(runtime): emit explicit session facts directly

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -36,7 +36,6 @@ import {
   createModelHandler,
   createModelHandlerForCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { inferPersistedFlowModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
@@ -367,15 +366,17 @@ async function assembleAgentLaunchContext(
   session.events.assertRunSubscribersAttachedBeforeActivation(streamId);
   input.onBeforeActivation?.(streamId);
 
-  emitRuntimeEvent(
-    'setActiveStream',
-    {
-      streamId,
-      agentCategory: setting.agentCategory,
-      isRemote: isRemoteAgent(fullConfig.agent),
+  session.events.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload: {
+        streamId,
+        agentCategory: setting.agentCategory,
+        isRemote: isRemoteAgent(fullConfig.agent),
+      },
     },
-    session,
-  );
+  });
   onActivated(streamId);
 
   // Log the initial instruction as a user message so both workflow and

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -10,7 +10,6 @@ import {
   resumeToolUseFromSnapshot,
   type SubagentRunOptions,
 } from './executeAgent';
-import { emitRuntimeEvent } from './emitRuntimeEvent';
 import { defaultSession } from './SessionHandle';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -74,7 +73,13 @@ export async function resumeQueuedToolUseSnapshot(
   let resumeError: { error: unknown } | undefined;
   try {
     followUps = [...seed, ...followUpsQueue.drainItems(streamId)];
-    emitRuntimeEvent('updateQueuedFollowUps', { streamId }, session);
+    session.events.emit({
+      scope: 'session',
+      event: {
+        type: 'updateQueuedFollowUps',
+        payload: { streamId },
+      },
+    });
 
     const result = await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       session: options.session,
@@ -103,7 +108,13 @@ export async function resumeQueuedToolUseSnapshot(
       followUpsQueue.enqueue(streamId, item, { force: true });
     }
     if (followUps.length > 0) {
-      emitRuntimeEvent('updateQueuedFollowUps', { streamId }, session);
+      session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId },
+        },
+      });
     }
   } finally {
     // Only the early-failure path leaves the stream RESUMING (a started run

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -11,7 +11,6 @@ import { getAgent } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   createHelperModelKit,
@@ -114,11 +113,13 @@ export async function generateSessionDescription(
       const description = cleanSessionDescription(text);
       if (!description) return;
       await writeSessionDescription(executionId, description);
-      emitRuntimeEvent(
-        'updateStreamDescription',
-        { streamId, description },
-        session,
-      );
+      session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamDescription',
+          payload: { streamId, description },
+        },
+      });
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }
   } catch (err) {

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -1,0 +1,90 @@
+// Node imports
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
+const ALLOWED_PRODUCTION_REFERENCES = [
+  'packages/desktop/src/main/desktopAgentExecution.ts',
+  'packages/desktop/src/main/desktopHostInteractions.ts',
+  'packages/extension/src/commands/agent/followUpCommand.ts',
+  'packages/extension/src/commands/housekeeping/streamEventUtils.ts',
+  'packages/extension/src/progressView/extensionHostInteractions.ts',
+  'src/agent/followUp/ToolUseFollowUp.ts',
+  'src/agent/runtime/ExecutionSubscriptionBinder.ts',
+  'src/agent/runtime/emitRuntimeEvent.ts',
+  'src/agent/runtime/executeAgent.ts',
+  'src/tools/approval/toolEditApproval.ts',
+  'src/tools/goal/goalStore.ts',
+  'src/tools/inquiry/inquiryContinuation.ts',
+] as const;
+
+const SCAN_ROOTS = [
+  'packages/cli/src',
+  'packages/desktop/src',
+  'packages/extension/src',
+  'src',
+] as const;
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
+const EMIT_RUNTIME_EVENT_SYMBOL = /\bemitRuntimeEvent\b/;
+
+function toRepoPath(path: string): string {
+  return relative(REPO_ROOT, resolve(REPO_ROOT, path)).replaceAll('\\', '/');
+}
+
+function sourceFilesUnder(root: string): string[] {
+  const absoluteRoot = resolve(REPO_ROOT, root);
+  let entries: string[];
+  try {
+    entries = readdirSync(absoluteRoot, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => SOURCE_FILE.test(entry) && !entry.endsWith('.d.ts'))
+    .map((entry) => toRepoPath(join(absoluteRoot, entry)))
+    .filter((file) => !file.startsWith('src/test-kernel/'));
+}
+
+function stripComments(source: string): string {
+  return source
+    .replaceAll(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => {
+      const commentStart = line.indexOf('//');
+      return commentStart === -1 ? line : line.slice(0, commentStart);
+    })
+    .join('\n');
+}
+
+function referencesEmitRuntimeEvent(file: string): boolean {
+  const source = stripComments(readFileSync(resolve(REPO_ROOT, file), 'utf8'));
+  return EMIT_RUNTIME_EVENT_SYMBOL.test(source);
+}
+
+describe('emitRuntimeEvent boundary', () => {
+  it('keeps the ambient session-fact helper surface explicitly bounded', () => {
+    const references = SCAN_ROOTS.flatMap(sourceFilesUnder)
+      .filter(referencesEmitRuntimeEvent)
+      .toSorted();
+
+    expect(references).toEqual([...ALLOWED_PRODUCTION_REFERENCES].toSorted());
+  });
+
+  it('actually scans the production source roots', () => {
+    const scanned = SCAN_ROOTS.reduce(
+      (total, root) => total + sourceFilesUnder(root).length,
+      0,
+    );
+    expect(scanned).toBeGreaterThan(100);
+  });
+});

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -5,7 +5,6 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { finalizeRunTerminal } from '@agent/runtime/AgentRunLifecycle';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   currentSession,
@@ -108,15 +107,17 @@ export function createChildStream(
   // Register the child stream (state, logs, hints) without switching the
   // active tab. Background child streams (bash, codex) shouldn't yank the
   // user away from whatever they're viewing — the tab simply appears.
-  emitRuntimeEvent(
-    'setActiveStream',
-    {
-      streamId: childStreamId,
-      agentCategory: options.streamCategory,
-      suppressViewSwitch: true,
+  session.events.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload: {
+        streamId: childStreamId,
+        agentCategory: options.streamCategory,
+        suppressViewSwitch: true,
+      },
     },
-    session,
-  );
+  });
   runTrace.trace.emit({
     type: 'run.start',
     descriptor: buildRunDescriptor({
@@ -132,14 +133,16 @@ export function createChildStream(
     executionId,
     config: options.config,
   });
-  emitRuntimeEvent(
-    'updateStreamDescription',
-    {
-      streamId: childStreamId,
-      description: truncateWithEllipsis(options.description, 80),
+  session.events.emit({
+    scope: 'session',
+    event: {
+      type: 'updateStreamDescription',
+      payload: {
+        streamId: childStreamId,
+        description: truncateWithEllipsis(options.description, 80),
+      },
     },
-    session,
-  );
+  });
 
   const handle = new AgentExecutionHandle(
     executionId,
@@ -263,10 +266,12 @@ async function finalizeChildStream(
   disposeTrace();
 
   if (options?.autoClose) {
-    emitRuntimeEvent(
-      'removeStream',
-      { streamId: handle.childStreamId },
-      session,
-    );
+    session.events.emit({
+      scope: 'session',
+      event: {
+        type: 'removeStream',
+        payload: { streamId: handle.childStreamId },
+      },
+    });
   }
 }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -14,7 +14,6 @@
 import type { AgentTrace } from '@agent/trace';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   currentSession,
   type SessionHandle,
@@ -121,11 +120,13 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       )
         .then((result) => {
           if (result.status === 'sent' || result.status === 'queued') {
-            emitRuntimeEvent(
-              'updateQueuedFollowUps',
-              { streamId },
-              subscription.session,
-            );
+            subscription.session.events.emit({
+              scope: 'session',
+              event: {
+                type: 'updateQueuedFollowUps',
+                payload: { streamId },
+              },
+            });
           }
         })
         .catch((err: unknown) => {

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -22,7 +22,6 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { createChannelTrace } from '@logger';
 import {
   ExternalInquiryThreadIdSchema,
@@ -358,6 +357,7 @@ export class ExternalInquiryTool extends defineTool({
         'inquiry { command: "ask" } requires an active stream context.',
       );
     }
+    const ownerSession = session ?? defaultSession();
 
     logger.info(`Inquiry dispatch [${input.thread_id ?? 'new'}]`, {
       data: input.question.slice(0, 100),
@@ -391,7 +391,13 @@ export class ExternalInquiryTool extends defineTool({
     }
 
     runtimeHost.emit('requestEnsureProgressView', {});
-    emitRuntimeEvent('setActiveStream', { streamId }, session);
+    ownerSession.events.emit({
+      scope: 'session',
+      event: {
+        type: 'setActiveStream',
+        payload: { streamId },
+      },
+    });
     const isFollowUp = !!input.thread_id;
     const basePermission = {
       requestId: persisted.threadId, // legacy field — panel addresses by threadId now
@@ -428,7 +434,13 @@ export class ExternalInquiryTool extends defineTool({
     // Background Tasks panel: announce the open thread.
     const summary = await getThreadSummary(persisted.threadId);
     if (summary) {
-      emitRuntimeEvent('inquiryThreadUpdated', summary, session);
+      ownerSession.events.emit({
+        scope: 'session',
+        event: {
+          type: 'inquiryThreadUpdated',
+          payload: summary,
+        },
+      });
     }
 
     const message =


### PR DESCRIPTION
## Summary

Moves concrete-session Stage 5 fact emissions off the ambient `emitRuntimeEvent` helper and onto their owning `SessionHandle.events` directly. This covers launch activation, child stream registration/description/autoclose, queued follow-up refresh during resume/subscription delivery, generated session descriptions, and external-inquiry open/update notifications.

Adds an architecture guard that keeps the remaining `emitRuntimeEvent` production surface as an explicit shrink-only allowlist.

## Issue acceptance gates

Addresses one Stage 5 slice of #6968.

- Reduces production `emitRuntimeEvent` call sites from 27 to 18; the remaining call-site files are now pinned by `emitRuntimeEventBoundary.vitest.ts`.
- Preserves the single session fact owner: the migrated paths emit exactly one `SessionFact` on the owning `SessionHandle.events` plane.
- Does not touch the retained headless CLI public-output projection or frozen CLI progress vocabulary.
- Does not complete the full #6968 acceptance gates; remaining Stage 5 deletion work stays open on #6968.

## Single source of truth

`SessionHandle.events` is the single owner for these session facts at migrated call sites. `emitRuntimeEvent` remains only for the still-unmigrated default-session / optional-session paths listed in the architecture guard.

## Duplication and abstraction budget

Removed an ambient helper hop from six concrete-session production files without adding a new runtime abstraction. The PR is net-positive because the new architecture guard records the remaining helper surface and prevents widening while later Stage 5 slices delete more entries.

## Host impact

Extension: Extension behavior is unchanged; migrated shared runtime/tool paths now publish through the session fact plane directly. Extension-only optional/default-session command paths are intentionally left for later slices.

Desktop: No desktop files changed. Desktop per-window sessions benefit when they use the migrated shared runtime/tool paths; contested `desktopAgentExecution.ts` remains untouched because #7628 is open.

CLI: Headless CLI public output remains on the retained compatibility projection. `texra run`, `--print`, and `--output-format json` byte-parity validation passed.

## Scheduled refactoring

Remaining Stage 5 helper/projection deletions stay tracked by #6968 and the active #6981 rows. No new shim, projection, dual-write, alias, fallback, or migration path was introduced, so no new #6981 ledger row is needed.

## Validation

- `corepack pnpm exec prettier --write src/agent/runtime/AgentLaunchContext.ts src/tools/childStream.ts src/agent/runtime/resumeQueuedToolUse.ts src/agent/runtime/sessionDescription.ts src/tools/github/StreamSubscriptionRegistry.ts src/tools/inquiry/ExternalInquiryTool.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `corepack pnpm exec vitest run src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts src/test-kernel/agent/runtime/EmitRuntimeEvent.vitest.ts src/test-kernel/agent/runtime/SessionEventHub.vitest.ts src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts src/test-kernel/tools/BashTool.vitest.ts` (6 files / 35 tests passed)
- `npm run typecheck`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `corepack pnpm --filter @texra-ai/cli validate:run` (rerun after rebase)
- `CI=true corepack pnpm run test` (rebased on `043c7df0`; 611 files passed, 1 skipped; 5257 tests passed, 4 skipped)

Refs #6968
