### PR TITLE
refactor(runtime): make host interactions session-owned

### DIFF
--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,6 +1,5 @@
 import { nanoid } from 'nanoid';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   matchesCancelSelector,
   type HostBashApprovalRequest,
@@ -55,7 +54,7 @@ type PendingDesktopInteraction =
 
 export interface DesktopHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
-  session?: SessionHandle;
+  session: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
   getToolEditApprovals(): DesktopToolEditApprovalController;
 }
@@ -239,7 +238,10 @@ class DesktopHostInteractions implements HostInteractions {
   private activateStream(streamId: StreamTabId | undefined): void {
     this.options.runtimeHost.emit('requestEnsureProgressView', {});
     if (streamId) {
-      emitRuntimeEvent('setActiveStream', { streamId }, this.options.session);
+      this.options.session.events.emit({
+        scope: 'session',
+        event: { type: 'setActiveStream', payload: { streamId } },
+      });
     }
   }
 }

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import {
   matchesCancelSelector,
   type HostBashApprovalRequest,
@@ -35,7 +34,7 @@ import type {
 
 export interface ExtensionHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
-  session?: SessionHandle;
+  session: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
 }
 
@@ -71,7 +70,10 @@ export function createExtensionHostInteractions(
   const activateStream = (streamId?: StreamTabId | null) => {
     options.runtimeHost.emit('requestEnsureProgressView', {});
     if (streamId) {
-      emitRuntimeEvent('setActiveStream', { streamId }, options.session);
+      options.session.events.emit({
+        scope: 'session',
+        event: { type: 'setActiveStream', payload: { streamId } },
+      });
     }
   };
 

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -94,14 +94,15 @@ function createPortSession(): {
     emit: (event) => emitted.push(event),
   };
   const handlers = createHandlerSet(uiEvents);
+  const session = new SessionHandle();
   const interactions = createDesktopHostInteractions({
     runtimeHost,
+    session,
     getApprovalHandlers: () => handlers,
     getToolEditApprovals: () => {
       throw new Error('tool-edit approvals are not exercised here');
     },
   });
-  const session = new SessionHandle();
   session.useHostInteractions(interactions);
   return { session, uiEvents, emitted, interactions };
 }

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -13,10 +13,8 @@ const REPO_ROOT = resolve(
 
 const ALLOWED_PRODUCTION_REFERENCES = [
   'packages/desktop/src/main/desktopAgentExecution.ts',
-  'packages/desktop/src/main/desktopHostInteractions.ts',
   'packages/extension/src/commands/agent/followUpCommand.ts',
   'packages/extension/src/commands/housekeeping/streamEventUtils.ts',
-  'packages/extension/src/progressView/extensionHostInteractions.ts',
   'src/agent/followUp/ToolUseFollowUp.ts',
   'src/agent/runtime/ExecutionSubscriptionBinder.ts',
   'src/agent/runtime/emitRuntimeEvent.ts',

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -36,7 +36,7 @@ interface DesktopHostInteractions {
 interface DesktopHostInteractionsModule {
   createDesktopHostInteractions(options: {
     runtimeHost: { emit: (event: string, payload: unknown) => void };
-    session?: SessionHandle;
+    session: SessionHandle;
     getApprovalHandlers(): unknown;
     getToolEditApprovals(): unknown;
   }): DesktopHostInteractions;

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -72,7 +72,7 @@ function createInteractions(options?: {
 }) {
   return createExtensionHostInteractions({
     runtimeHost: options?.runtimeHost ?? createRuntimeHost(),
-    session: options?.session,
+    session: options?.session ?? new SessionHandle(),
     getApprovalHandlers: () => options?.handlers ?? createHandlers(),
   });
 }


### PR DESCRIPTION
## Summary
- make extension and desktop host-interaction adapters require their owning `SessionHandle`
- emit `setActiveStream` directly through `session.events` in those host adapters
- remove the two host-interaction files from the `emitRuntimeEvent` architecture allowlist

## Why this is safe
Both production constructors already pass an owning session: the extension passes `defaultSession()`, and desktop passes the per-window session. These adapters are host-owned UI interaction ports, not ambient run code, so no active `RunContext` or default-session fallback behavior is removed.

## Validation
- `CI=true corepack pnpm exec vitest run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/agent/runtime/SessionInteractions.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts --config vitest.config.mjs`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec prettier --check packages/desktop/src/main/desktopHostInteractions.ts packages/extension/src/progressView/extensionHostInteractions.ts src/test-kernel/agent/runtime/SessionInteractions.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopHostInteractions.ts packages/extension/src/progressView/extensionHostInteractions.ts src/test-kernel/agent/runtime/SessionInteractions.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing change for UI stream focus; production callers already pass a session, and behavior is covered by updated kernel tests.
> 
> **Overview**
> Desktop and extension **host interaction** adapters now require an owning `SessionHandle` instead of an optional session, so stream activation is always tied to a concrete session.
> 
> When approval flows need to focus the progress UI, **`setActiveStream` is emitted through `session.events`** rather than the ambient `emitRuntimeEvent` helper; `requestEnsureProgressView` on the runtime host is unchanged. The architecture test’s **`emitRuntimeEvent` allowlist** no longer includes the two host-interaction modules. Tests construct or default a `SessionHandle` and assert session-scoped `setActiveStream` events instead of runtime-host `setActiveStream` emissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3250b45e23812828c48c26715c8e5543f75fb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->