### PR TITLE
refactor(goal): emit state changes through sessions

### DIFF
--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -20,7 +20,6 @@ const ALLOWED_PRODUCTION_REFERENCES = [
   'src/agent/runtime/emitRuntimeEvent.ts',
   'src/agent/runtime/executeAgent.ts',
   'src/tools/approval/toolEditApproval.ts',
-  'src/tools/goal/goalStore.ts',
   'src/tools/inquiry/inquiryContinuation.ts',
 ] as const;
 

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createRecordingHost } from '@test/agent/progressTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import { GoalStore } from '@tools/goal';
+import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 
 const STREAM_A = 'stream:forget-a' as StreamTabId;
 const STREAM_B = 'stream:forget-b' as StreamTabId;
@@ -40,6 +43,64 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
     const next = await GoalStore.start(STREAM_A, 'objective two');
     expect(next.objective).toBe('objective two');
     expect(next.status).toBe('active');
+  });
+
+  it('routes explicit-session forget notifications only to the passed session', async () => {
+    const runSession = new SessionHandle();
+    const explicitSession = new SessionHandle();
+    const seenRun: unknown[] = [];
+    const seenExplicit: unknown[] = [];
+    const seenDefault: unknown[] = [];
+    const detachRun = subscribeGoalStateChanges(runSession, (change) => {
+      seenRun.push(change);
+    });
+    const detachExplicit = subscribeGoalStateChanges(
+      explicitSession,
+      (change) => {
+        seenExplicit.push(change);
+      },
+    );
+    const detachDefault = subscribeGoalStateChanges(
+      defaultSession(),
+      (change) => {
+        seenDefault.push(change);
+      },
+    );
+
+    try {
+      await withRunContext(
+        createRunContext({
+          runtimeHost: createRecordingHost().host,
+          session: runSession,
+        }),
+        async () => {
+          await GoalStore.start(STREAM_A, 'objective one');
+        },
+      );
+      seenRun.length = 0;
+      seenExplicit.length = 0;
+      seenDefault.length = 0;
+
+      await withRunContext(
+        createRunContext({
+          runtimeHost: createRecordingHost().host,
+          session: runSession,
+        }),
+        async () => {
+          await GoalStore.forget(STREAM_A, explicitSession);
+        },
+      );
+
+      expect(seenRun).toEqual([]);
+      expect(seenExplicit).toEqual([{ streamId: STREAM_A }]);
+      expect(seenDefault).toEqual([]);
+    } finally {
+      detachRun();
+      detachExplicit();
+      detachDefault();
+      runSession.dispose();
+      explicitSession.dispose();
+    }
   });
 
   it('cleans up an unparseable blob (raw key presence, not parse success)', async () => {

--- a/src/test-kernel/tools/GoalStateSubscription.vitest.ts
+++ b/src/test-kernel/tools/GoalStateSubscription.vitest.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createRecordingHost } from '@test/agent/progressTestUtils';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
-import { subscribeGoalStateChanges } from '@tools/goal';
+import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+
+const STREAM_ID = 'stream:goal-state-subscription' as StreamTabId;
 
 describe('subscribeGoalStateChanges', () => {
+  setupPlatform();
+
   it('delivers only goal changes from the supplied session', () => {
     const sessionA = new SessionHandle();
     const sessionB = new SessionHandle();
@@ -41,6 +48,54 @@ describe('subscribeGoalStateChanges', () => {
       detach();
       sessionA.dispose();
       sessionB.dispose();
+    }
+  });
+
+  it('routes start, status, and edit notifications through the current run session only', async () => {
+    const runSession = new SessionHandle();
+    const otherSession = new SessionHandle();
+    const seenRun: unknown[] = [];
+    const seenOther: unknown[] = [];
+    const seenDefault: unknown[] = [];
+    const detachRun = subscribeGoalStateChanges(runSession, (change) => {
+      seenRun.push(change);
+    });
+    const detachOther = subscribeGoalStateChanges(otherSession, (change) => {
+      seenOther.push(change);
+    });
+    const detachDefault = subscribeGoalStateChanges(
+      defaultSession(),
+      (change) => {
+        seenDefault.push(change);
+      },
+    );
+
+    try {
+      await withRunContext(
+        createRunContext({
+          runtimeHost: createRecordingHost().host,
+          session: runSession,
+        }),
+        async () => {
+          await GoalStore.start(STREAM_ID, 'prove the estimate');
+          await GoalStore.setStatus(STREAM_ID, 'paused');
+          await GoalStore.editObjective(STREAM_ID, 'prove the sharp estimate');
+        },
+      );
+
+      expect(seenRun).toEqual([
+        { streamId: STREAM_ID },
+        { streamId: STREAM_ID },
+        { streamId: STREAM_ID },
+      ]);
+      expect(seenOther).toEqual([]);
+      expect(seenDefault).toEqual([]);
+    } finally {
+      detachRun();
+      detachOther();
+      detachDefault();
+      runSession.dispose();
+      otherSession.dispose();
     }
   });
 });

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -1,8 +1,11 @@
 import { Mutex } from 'async-mutex';
 
 import { platform, tryWorkspaceState } from '@platform/platform';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas/identifiers';
 import {
   GoalSchema,
@@ -35,6 +38,23 @@ function nowIso(): string {
 
 function generateGoalId(): string {
   return `goal_${hexId12()}`;
+}
+
+function emitGoalStateChanged(
+  streamId: StreamTabId,
+  session?: SessionHandle,
+): void {
+  // Preserve emitRuntimeEvent's compatibility rule while deleting the bus
+  // dependency: older direct-node tests may carry a partial run session.
+  const owner = session ?? tryUseRunContext()?.session;
+  const target = owner?.events ? owner : defaultSession();
+  target.events.emit({
+    scope: 'session',
+    event: {
+      type: 'goalStateChanged',
+      payload: { streamId },
+    },
+  });
 }
 
 function normalizeGoalRecord(raw: unknown): Goal | null {
@@ -120,7 +140,7 @@ async function update(
   const final: Goal = { ...mutate(goal), updatedAt: nowIso() };
   await writeRaw(final);
   // In-run: the active run's session (ALS), falling back to the default session.
-  emitRuntimeEvent('goalStateChanged', { streamId });
+  emitGoalStateChanged(streamId);
   return final;
 }
 
@@ -200,7 +220,7 @@ export const GoalStore = {
       updatedAt: now,
     };
     await Promise.all([writeRaw(goal), addToIndex(streamId)]);
-    emitRuntimeEvent('goalStateChanged', { streamId });
+    emitGoalStateChanged(streamId);
     return goal;
   },
 
@@ -266,7 +286,7 @@ export const GoalStore = {
     ]);
     // Dual-context: PlanTool forgets in-run (→ run session via ALS); hosts
     // pass their owning session for non-default windows.
-    emitRuntimeEvent('goalStateChanged', { streamId }, session);
+    emitGoalStateChanged(streamId, session);
   },
 
   /**
@@ -294,8 +314,7 @@ export const GoalStore = {
         return next.length === index.length ? index : next;
       }),
     ]);
-    for (const id of toRemove)
-      emitRuntimeEvent('goalStateChanged', { streamId: id }, session);
+    for (const id of toRemove) emitGoalStateChanged(id, session);
   },
 
   /**


### PR DESCRIPTION
## Summary
- replace `GoalStore` uses of `emitRuntimeEvent` with a local session-event helper
- preserve routing semantics: explicit session first, otherwise `currentSession()` for active run session with default-session fallback
- remove `src/tools/goal/goalStore.ts` from the `emitRuntimeEvent` architecture allowlist
- add tests for current-run goal notifications and explicit-session forget notifications

## Validation
- `CI=true corepack pnpm exec vitest run src/test-kernel/tools/GoalStateSubscription.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts --config vitest.config.mjs`
- `corepack pnpm exec prettier --check src/tools/goal/goalStore.ts src/test-kernel/tools/GoalStateSubscription.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `corepack pnpm exec eslint src/tools/goal/goalStore.ts src/test-kernel/tools/GoalStateSubscription.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings)
- `git diff --check`

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is intended to be equivalent to the previous `emitRuntimeEvent` path; risk is mainly mis-routed UI updates if session selection diverges from the old helper.
> 
> **Overview**
> **Goal state notifications** no longer go through `emitRuntimeEvent`. `GoalStore` uses a local `emitGoalStateChanged` that emits `goalStateChanged` on a session’s event hub with the same routing as before: optional explicit `SessionHandle`, else the active run session from `RunContext`, else `defaultSession()` (including partial run sessions without an event hub).
> 
> `goalStore.ts` is **removed** from the `emitRuntimeEvent` architecture allowlist so goal tooling stays off the bounded ambient emit surface.
> 
> **Tests** add integration coverage: `subscribeGoalStateChanges` only sees `start` / `setStatus` / `editObjective` on the run session, and `forget(streamId, explicitSession)` notifies only that explicit session—not the run or default session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23eac33fd9995192941d7354c3b369a1754a5d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->