### PR TITLE
fix(flow): stop spurious "Flow ends" warning on reflection-flow failure

### DIFF
--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -10,7 +10,13 @@ export type NonIterableObject = Partial<Record<string, unknown>> & {
 export type Action = string;
 
 const CHANNEL = 'PocketFlow';
-const TERMINAL_ACTIONS = new Set<Action>(['complete']);
+// Actions that deliberately end a flow when a node returns them with no
+// registered successor. `finalize` is the reflection flow's terminal action on
+// failure (ResponseCycleNode.post → FlowTransition.FINALIZE); without listing it
+// here, getNextNode logs a spurious "Flow ends: 'finalize' not found" warning on
+// every reflection-flow failure even though ending is the intended behavior.
+// (`waiting` is not terminal — ToolUseWaitNode wires it as a self-loop successor.)
+const TERMINAL_ACTIONS = new Set<Action>(['complete', 'finalize']);
 logger.initialize(CHANNEL);
 
 /**


### PR DESCRIPTION
## Problem

`ResponseCycleNode.post` returns `FlowTransition.FINALIZE` (`'finalize'`) on failure to terminate the reflection flow (deliberately skipping the output node — `ResponseCycleNode.ts:166-174`). But `'finalize'` was **not** in `TERMINAL_ACTIONS` (only `'complete'` was) and **no** node registers a `'finalize'` successor, so `BaseNode.getNextNode` (`node/index.ts:89-98`) fell through to:

```
logger.warn(CHANNEL, `Flow ends: '${action}' not found in [${...}]`)
```

→ a spurious `WARN` on **every reflection-flow failure**, even though ending the flow is exactly the intended behavior.

## Fix

Add `'finalize'` to `TERMINAL_ACTIONS` so the deliberate terminal action ends the flow silently, like `'complete'`. Termination behavior is otherwise unchanged (`getNextNode` still returns `undefined` → flow ends; the output node was already skipped).

`'waiting'` is intentionally **not** added — `ToolUseWaitNode` wires it as a self-loop successor (`runToolUseFlow.ts:384` `waitNode.on(FlowTransition.WAITING, waitNode)`), so it never reaches the warning branch.

## Verification

- `npm run typecheck` clean.
- No test pins the old warning / `FINALIZE` terminality (grep of `*.vitest.ts`).
- Pure routing-table addition; no behavioral change beyond removing the log line.

Found by the 2026-07 runtime/UI audit (finding **B6** / PocketFlow-engine **PF1**; see PR #7636, `tech-debt-audit-runtime-ui-2026-07.md`). Its original "delete a dead vocabulary member" framing was corrected during verification — `FINALIZE` is *used*, it was just missing from the terminal set.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-set membership and comment-only routing metadata; no change to successor resolution beyond suppressing an incorrect log line.
> 
> **Overview**
> Adds **`finalize`** to `TERMINAL_ACTIONS` in `BaseNode.getNextNode`, alongside **`complete`**, so when the reflection flow fails and `ResponseCycleNode` returns `FlowTransition.FINALIZE` with no wired successor, the engine ends the flow **without** logging `Flow ends: 'finalize' not found`.
> 
> Flow termination is unchanged (`undefined` next node); only the spurious **WARN** on intentional reflection-flow failure is removed. Inline comments document why **`waiting`** stays out of the terminal set (self-loop on `ToolUseWaitNode`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75f44fa88d7a01544dd0363d375d41aa6552f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->