### PR TITLE
[codex] emit desktop follow-up queue updates via session

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -28,7 +28,6 @@ import type {
   AgentRuntimeEventPayloads,
   AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import {
@@ -1352,7 +1351,13 @@ export class DesktopProgressBridge {
       this.session,
     );
     if (result.status === 'sent' || result.status === 'queued') {
-      emitRuntimeEvent('updateQueuedFollowUps', { streamId }, this.session);
+      this.session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId },
+        },
+      });
       const wake = await wakeQueuedFollowUpStream(
         streamId,
         result,
@@ -1363,7 +1368,13 @@ export class DesktopProgressBridge {
         this.session,
       );
       if (wake.kind === 'dropped') {
-        emitRuntimeEvent('updateQueuedFollowUps', { streamId }, this.session);
+        this.session.events.emit({
+          scope: 'session',
+          event: {
+            type: 'updateQueuedFollowUps',
+            payload: { streamId },
+          },
+        });
         await this.options.showInfoMessage?.(
           'Message dropped because no session was available to receive it. Start a new agent task to continue.',
         );

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -12,7 +12,6 @@ const REPO_ROOT = resolve(
 );
 
 const ALLOWED_PRODUCTION_REFERENCES = [
-  'packages/desktop/src/main/desktopAgentExecution.ts',
   'packages/extension/src/commands/agent/followUpCommand.ts',
   'packages/extension/src/commands/housekeeping/streamEventUtils.ts',
   'src/agent/followUp/ToolUseFollowUp.ts',


### PR DESCRIPTION
## Summary

- remove `emitRuntimeEvent` from the desktop follow-up submission path
- emit `updateQueuedFollowUps` directly through the owning window session event hub at the two existing desktop invalidation sites

## Validation

- `corepack pnpm exec prettier --check packages/desktop/src/main/desktopAgentExecution.ts`
- `corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing unrelated import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to the same session-scoped event payload on an already-correct session handle; no auth, persistence, or shared-runtime fallback paths are altered beyond removing one helper call site.
> 
> **Overview**
> **Desktop follow-up queue invalidation** no longer goes through `emitRuntimeEvent`. After a follow-up is sent/queued (and again when a queued message is dropped), the desktop path emits `updateQueuedFollowUps` directly on **`this.session.events`**, matching the explicit window session already passed into `sendFollowUp` (that IPC path runs outside run ALS, so the helper’s default-session fallback was the wrong abstraction).
> 
> An **architecture guard** test drops `desktopAgentExecution.ts` from the allowlist of production files that may reference `emitRuntimeEvent`, keeping that helper’s surface bounded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00aa30abd5cee8ecfbd797893fdbfda02931b2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->