### PR TITLE
test(progress): dispose extension host sessions

### DIFF
--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
@@ -56,6 +56,18 @@ function createRuntimeHost() {
   return { emit: vi.fn() };
 }
 
+const testSessions: SessionHandle[] = [];
+
+afterEach(() => {
+  for (const session of testSessions.splice(0)) session.dispose();
+});
+
+function createTestSession(): SessionHandle {
+  const session = new SessionHandle();
+  testSessions.push(session);
+  return session;
+}
+
 /** Reads the `requestId` passed to a handler's first `.show()` call. */
 function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
   const requestId = (
@@ -65,15 +77,15 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
   return requestId;
 }
 
-function createInteractions(options?: {
+function createInteractions(options: {
   runtimeHost?: ReturnType<typeof createRuntimeHost>;
   handlers?: ApprovalRequestHandlerSet;
-  session?: SessionHandle;
+  session: SessionHandle;
 }) {
   return createExtensionHostInteractions({
-    runtimeHost: options?.runtimeHost ?? createRuntimeHost(),
-    session: options?.session ?? new SessionHandle(),
-    getApprovalHandlers: () => options?.handlers ?? createHandlers(),
+    runtimeHost: options.runtimeHost ?? createRuntimeHost(),
+    session: options.session,
+    getApprovalHandlers: () => options.handlers ?? createHandlers(),
   });
 }
 
@@ -89,7 +101,7 @@ describe('createExtensionHostInteractions', () => {
   it('shows and resolves plan approvals through existing handlers', async () => {
     const runtimeHost = createRuntimeHost();
     const handlers = createHandlers();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const sessionEvents = recordSessionEvents(session);
     const interactions = createInteractions({
       runtimeHost,
@@ -146,6 +158,7 @@ describe('createExtensionHostInteractions', () => {
     const interactions = createInteractions({
       runtimeHost,
       handlers,
+      session: createTestSession(),
     });
 
     const resultPromise = interactions.requestRetry?.({
@@ -161,7 +174,10 @@ describe('createExtensionHostInteractions', () => {
 
   it('forwards a cancellation cause as bash reject feedback', async () => {
     const handlers = createHandlers();
-    const interactions = createInteractions({ handlers });
+    const interactions = createInteractions({
+      handlers,
+      session: createTestSession(),
+    });
 
     const resultPromise = interactions.requestBashApproval?.({
       command: 'rm -rf build',
@@ -182,7 +198,10 @@ describe('createExtensionHostInteractions', () => {
 
   it('rejects a resolution whose kind does not match the pending request', async () => {
     const handlers = createHandlers();
-    const interactions = createInteractions({ handlers });
+    const interactions = createInteractions({
+      handlers,
+      session: createTestSession(),
+    });
 
     const resultPromise = interactions.requestBashApproval?.({
       command: 'echo hi',
@@ -208,7 +227,10 @@ describe('createExtensionHostInteractions', () => {
 
   it('a retry-kind cancel clears only the retry, leaving the plan approval pending', async () => {
     const handlers = createHandlers();
-    const interactions = createInteractions({ handlers });
+    const interactions = createInteractions({
+      handlers,
+      session: createTestSession(),
+    });
 
     const retryPromise = interactions.requestRetry?.({
       streamId: 'stream-a' as StreamTabId,
@@ -247,6 +269,7 @@ describe('createExtensionHostInteractions', () => {
     const interactions = createInteractions({
       runtimeHost,
       handlers,
+      session: createTestSession(),
     });
 
     await expect(
@@ -274,6 +297,7 @@ describe('createExtensionHostInteractions', () => {
     const handlers = createHandlers();
     const interactions = createInteractions({
       handlers,
+      session: createTestSession(),
     });
 
     const resultPromise = interactions.askUserQuestion?.({
@@ -312,7 +336,7 @@ describe('createExtensionHostInteractions', () => {
   it('delegates tool edit approval to the native VS Code port', async () => {
     const nativeResult = { accepted: true };
     mocks.nativeRequestApproval.mockResolvedValue(nativeResult);
-    const interactions = createInteractions();
+    const interactions = createInteractions({ session: createTestSession() });
     const request = {
       path: 'paper.tex',
       originalContent: 'A',


### PR DESCRIPTION
## Summary

Fixes the #7634 test leak by making `createInteractions()` require a caller-owned `SessionHandle` and tracking each test-created session for disposal in `afterEach`. This removes the helper's hidden `new SessionHandle()` fallback while keeping the existing extension interaction behavior tests intact.

## Issue acceptance gates

- Addresses the `ExtensionHostInteractions.vitest.mts` fallback cited in #7634.
- `createInteractions()` no longer synthesizes an unowned session when `session` is omitted.
- The sibling `SessionInteractions.vitest.ts` path was checked; it already disposes its created sessions in `finally`.

Refs #6968

## Single source of truth

Each extension-host interaction test now owns the `SessionHandle` it passes into `createExtensionHostInteractions`; the helper no longer creates hidden session ownership.

## Duplication and abstraction budget

No production abstraction was added. The test helper keeps one tiny session tracker for cleanup and avoids a second implicit ownership path. No shim, fallback, alias, projection, migration path, or dual-write was introduced, so no #6981 ledger row is needed.

## Host impact

Extension: none at runtime; extension interaction tests now dispose their session handles.

Desktop: none; sibling desktop/session interaction tests were checked for the same pattern.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts`
- `CI=true corepack pnpm exec vitest run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/agent/runtime/SessionInteractions.vitest.ts --config vitest.config.mjs`
- `npm run typecheck`
- `CI=true corepack pnpm run test`
- `npm run lint` (57 existing warnings, 0 errors)
- `npm run compile:fast`
- `git diff --check`

Closes #7634

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to session lifecycle in one vitest file; no production code paths affected.
> 
> **Overview**
> Fixes **#7634** test leaks in `ExtensionHostInteractions.vitest.mts` by making session ownership explicit and tearing down handles after each test.
> 
> `createInteractions()` now **requires** a `session` argument instead of silently creating a `SessionHandle` when omitted. A small `createTestSession()` helper registers each handle in a module-level list, and **`afterEach`** disposes every tracked session. All cases that previously relied on the default session now pass `session: createTestSession()` (or a named session where event recording is needed).
> 
> No production or runtime behavior changes—only test cleanup and stricter helper typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29539d426e84caf39b0e6f86af55f1f4decc3e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->