### PR TITLE
[codex] Route subscription queue facts via sessions

### DIFF
--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -16,14 +16,13 @@ import {
   type ExecutionHandle,
   type ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
-import type { SessionHandle } from './SessionHandle';
+import { currentSession, type SessionHandle } from './SessionHandle';
 
 const logger = createChannelTrace('ExecutionSubscriptionBinder');
 
@@ -65,6 +64,17 @@ function snapshot(
     status: info.status,
     elapsed: info.elapsed,
   };
+}
+
+function emitQueuedFollowUpsChanged(
+  streamId: StreamTabId,
+  session?: SessionHandle,
+): void {
+  const target = session ?? currentSession();
+  target.events.emit({
+    scope: 'session',
+    event: { type: 'updateQueuedFollowUps', payload: { streamId } },
+  });
 }
 
 class ExecutionSubscription implements Disposable {
@@ -160,11 +170,7 @@ class ExecutionSubscription implements Disposable {
     )
       .then((result) => {
         if (result.status === 'sent' || result.status === 'queued') {
-          emitRuntimeEvent(
-            'updateQueuedFollowUps',
-            { streamId: this.streamId },
-            this.session,
-          );
+          emitQueuedFollowUpsChanged(this.streamId, this.session);
         }
       })
       .catch((err: unknown) => {

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -1,8 +1,15 @@
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type MockSendFollowUpResult =
+  | { status: 'sent' }
+  | { status: 'queued'; reason: 'waiting' }
+  | { status: 'no_session'; streamStatus: string | undefined };
+
 const sendFollowUpMock = vi.hoisted(() =>
-  vi.fn(async () => ({ status: 'sent' as const })),
+  vi.fn<(...args: unknown[]) => Promise<MockSendFollowUpResult>>(async () => ({
+    status: 'sent',
+  })),
 );
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
@@ -10,7 +17,8 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 }));
 
 // Local imports - runtime
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { ExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
 import {
   AgentExecutionHandle,
@@ -18,7 +26,7 @@ import {
 } from '@agent/runtime/executionRegistry';
 import type { StreamTabId } from '@shared/schemas';
 
-import { createRecordingHost } from '../progressTestUtils';
+import { createRecordingHost, recordSessionEvents } from '../progressTestUtils';
 
 const streamId = 'stream:subscription-session' as StreamTabId;
 const childStreamId = 'child:subscription-session' as StreamTabId;
@@ -38,6 +46,10 @@ function createLogger() {
   };
 }
 
+async function settleDelivery(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
 describe('ExecutionSubscriptionBinder session routing', () => {
   beforeEach(() => {
     sendFollowUpMock.mockReset();
@@ -46,7 +58,8 @@ describe('ExecutionSubscriptionBinder session routing', () => {
 
   it('passes the owning session to subscription follow-ups', async () => {
     const registry = new ExecutionRegistry();
-    const session = { tag: 'window-session' } as unknown as SessionHandle;
+    const session = new SessionHandle();
+    const recorded = recordSessionEvents(session.events, { scope: 'session' });
     const explicit = createRecordingHost();
     const binder = new ExecutionSubscriptionBinder({
       registry,
@@ -69,7 +82,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       binder.bind(streamId, executionId, explicit.host);
 
       registry.untrack(executionId);
-      await new Promise((resolve) => setImmediate(resolve));
+      await settleDelivery();
 
       expect(sendFollowUpMock).toHaveBeenCalledWith(
         streamId,
@@ -78,9 +91,130 @@ describe('ExecutionSubscriptionBinder session routing', () => {
         undefined,
         session,
       );
+      expect(recorded.events).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'updateQueuedFollowUps',
+            payload: { streamId },
+          },
+        },
+      ]);
     } finally {
+      recorded.detach();
       binder.dispose();
       registry.dispose();
+      session.dispose();
+    }
+  });
+
+  it.each([
+    [{ status: 'sent' as const }, true],
+    [{ status: 'queued' as const, reason: 'waiting' as const }, true],
+    [{ status: 'no_session' as const, streamStatus: undefined }, false],
+  ])(
+    'emits the queued-follow-up fact only for delivered follow-ups: %o',
+    async (sendResult, shouldEmit) => {
+      const registry = new ExecutionRegistry();
+      const session = new SessionHandle();
+      const recorded = recordSessionEvents(session.events, {
+        scope: 'session',
+      });
+      const explicit = createRecordingHost();
+      const binder = new ExecutionSubscriptionBinder({
+        registry,
+        releaseSource: createReleaseSource(),
+        logger: createLogger(),
+        session,
+      });
+      const executionId = `exec-subscription-${sendResult.status}-event-test`;
+      const handle = new AgentExecutionHandle(
+        executionId,
+        streamId,
+        childStreamId,
+        'search',
+        'toolUse',
+        explicit.host,
+      );
+      sendFollowUpMock.mockResolvedValueOnce(sendResult);
+
+      try {
+        registry.track(handle);
+        binder.bind(streamId, executionId, explicit.host);
+
+        registry.untrack(executionId);
+        await settleDelivery();
+
+        expect(recorded.events).toEqual(
+          shouldEmit
+            ? [
+                {
+                  scope: 'session',
+                  event: {
+                    type: 'updateQueuedFollowUps',
+                    payload: { streamId },
+                  },
+                },
+              ]
+            : [],
+        );
+      } finally {
+        recorded.detach();
+        binder.dispose();
+        registry.dispose();
+        session.dispose();
+      }
+    },
+  );
+
+  it('falls back to the current session when the binder has no explicit session', async () => {
+    const registry = new ExecutionRegistry();
+    const session = new SessionHandle();
+    const recorded = recordSessionEvents(session.events, { scope: 'session' });
+    const explicit = createRecordingHost();
+    const binder = new ExecutionSubscriptionBinder({
+      registry,
+      releaseSource: createReleaseSource(),
+      logger: createLogger(),
+    });
+    const executionId = 'exec-subscription-current-session-test';
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      childStreamId,
+      'search',
+      'toolUse',
+      explicit.host,
+    );
+
+    try {
+      registry.track(handle);
+      withRunContext(
+        createRunContext({
+          runtimeHost: explicit.host,
+          session,
+        }),
+        () => {
+          binder.bind(streamId, executionId, explicit.host);
+          registry.untrack(executionId);
+        },
+      );
+      await settleDelivery();
+
+      expect(recorded.events).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'updateQueuedFollowUps',
+            payload: { streamId },
+          },
+        },
+      ]);
+    } finally {
+      recorded.detach();
+      binder.dispose();
+      registry.dispose();
+      session.dispose();
     }
   });
 
@@ -88,10 +222,13 @@ describe('ExecutionSubscriptionBinder session routing', () => {
     const registry = new ExecutionRegistry();
     const explicit = createRecordingHost();
     const logger = createLogger();
+    const session = new SessionHandle();
+    const recorded = recordSessionEvents(session.events, { scope: 'session' });
     const binder = new ExecutionSubscriptionBinder({
       registry,
       releaseSource: createReleaseSource(),
       logger,
+      session,
     });
     const executionId = 'exec-subscription-rejection-test';
     const handle = new AgentExecutionHandle(
@@ -111,9 +248,10 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       binder.bind(streamId, executionId, explicit.host);
 
       registry.untrack(executionId);
-      await new Promise((resolve) => setImmediate(resolve));
+      await settleDelivery();
 
       expect(unhandledRejection).not.toHaveBeenCalled();
+      expect(recorded.events).toEqual([]);
       expect(logger.warn).toHaveBeenCalledWith(
         'Failed to deliver execution subscription follow-up',
         expect.objectContaining({
@@ -122,8 +260,10 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       );
     } finally {
       process.off('unhandledRejection', unhandledRejection);
+      recorded.detach();
       binder.dispose();
       registry.dispose();
+      session.dispose();
     }
   });
 });

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -15,7 +15,6 @@ const ALLOWED_PRODUCTION_REFERENCES = [
   'packages/extension/src/commands/agent/followUpCommand.ts',
   'packages/extension/src/commands/housekeeping/streamEventUtils.ts',
   'src/agent/followUp/ToolUseFollowUp.ts',
-  'src/agent/runtime/ExecutionSubscriptionBinder.ts',
   'src/agent/runtime/emitRuntimeEvent.ts',
   'src/agent/runtime/executeAgent.ts',
   'src/tools/approval/toolEditApproval.ts',


### PR DESCRIPTION
## Summary

- Route execution subscription queued-follow-up refreshes through direct session fact emission.
- Preserve explicit-session delivery and use currentSession() for shared/default binder instances.
- Keep emission after sendFollowUp reports sent or queued; no emission occurs for no_session results or delivery rejection.

## Validation

- corepack pnpm exec prettier --write src/agent/runtime/ExecutionSubscriptionBinder.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
- node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src/agent/runtime/ExecutionSubscriptionBinder.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow event-routing refactor with preserved gating and expanded tests; no auth or data-path changes.
> 
> **Overview**
> **Execution subscription follow-ups** now refresh the queued-follow-up UI by emitting `updateQueuedFollowUps` on the session event hub instead of going through `emitRuntimeEvent`.
> 
> After `sendFollowUp` reports **sent** or **queued**, `emitQueuedFollowUpsChanged` targets the binder’s explicit `SessionHandle` when set, otherwise **`currentSession()`** for shared binders. **No** session event is emitted for `no_session` results or when delivery rejects.
> 
> Tests assert session routing, conditional emission, run-context fallback, and no events on failure. The architecture boundary test no longer treats `ExecutionSubscriptionBinder` as an allowed `emitRuntimeEvent` caller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8721891acd8e4067301ec1d01f141680c2bc8b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->