### PR TITLE
fix(runtime): resume guards read the owning session's status machine

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1169,6 +1169,10 @@ export class DesktopProgressBridge {
 
     return resolveAndResumeStream(streamId, {
       runtimeHost: this.runtimeHost,
+      // Desktop runs write status to this window's session machine, so the
+      // resume guards must read the same machine (the process-global default
+      // is never populated here).
+      streamStatus: this.session.status,
       resolveResumeState: async (id) => {
         const resumeState = await this.resolveResumeState(id);
         if (!resumeState) {

--- a/packages/extension/src/commands/agent/resumeFromSnapshot.ts
+++ b/packages/extension/src/commands/agent/resumeFromSnapshot.ts
@@ -14,6 +14,7 @@ import {
   isResumeInFlight,
   resolveAndResumeStream,
 } from '@agent/runtime/resolveAndResumeStream';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -29,6 +30,9 @@ export { isResumeInFlight };
 export function tryResumeFromSnapshot(streamId: StreamTabId): Promise<boolean> {
   return resolveAndResumeStream(streamId, {
     runtimeHost: extensionAgentRuntimeHost,
+    // The extension runs on the default session, whose machine IS the shared
+    // service instance (SessionHandle.defaultSession aliases it by identity).
+    streamStatus: StreamStatusService,
     resolveResumeState: async (id) => {
       const progressState = ProgressViewProvider.getInstance()?.state;
       if (!progressState) {

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -14,7 +14,7 @@ import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/toolus
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { retrieveSessionResumeData } from './SessionResumeRetrieval';
-import { StreamStatusService } from './StreamStatusService';
+import type { StreamStatusMachine } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
@@ -27,6 +27,14 @@ interface ResolvedResumeState {
 export interface ResumeStreamPorts {
   /** Runtime host receiving the RESUMING/WAITING status updates. */
   readonly runtimeHost: AgentRuntimeHost;
+  /**
+   * The status machine of the session that owns this stream — per-window on
+   * desktop, the default session's machine in the extension/CLI. The
+   * active/resuming guards must read the machine the run actually writes
+   * (`launchSession.status`); reading the process-global default here left
+   * both guards permanently false in multi-session hosts.
+   */
+  readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
   /**
    * Resolve the persisted run state + execution id for a stream, or `undefined`
    * when there is nothing to resume. The host owns any "no state" messaging it
@@ -79,7 +87,7 @@ export async function resolveAndResumeStream(
   ports: ResumeStreamPorts,
 ): Promise<boolean> {
   if (
-    StreamStatusService.isActiveOrResuming(streamId) ||
+    ports.streamStatus.isActiveOrResuming(streamId) ||
     resumeInFlight.has(streamId)
   ) {
     return false;
@@ -114,7 +122,7 @@ export async function resolveAndResumeStream(
     // that flips this stream active/resuming while we awaited retrieval. If that
     // happened, abandon the resume rather than clobbering the launched run's
     // status.
-    if (StreamStatusService.isActiveOrResuming(streamId)) {
+    if (ports.streamStatus.isActiveOrResuming(streamId)) {
       return false;
     }
 

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -15,7 +15,10 @@ import {
   resolveAndResumeStream,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  StreamStatusMachine,
+  StreamStatusService,
+} from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 const STREAM = 'stream:resume' as StreamTabId;
@@ -26,6 +29,7 @@ function basePorts(
 ): ResumeStreamPorts {
   return {
     runtimeHost,
+    streamStatus: StreamStatusService,
     resolveResumeState: vi.fn(async () => ({
       runState: { agent: 'a', model: 'm' } as never,
       executionId: 'exec-1' as never,
@@ -137,6 +141,34 @@ describe('resolveAndResumeStream', () => {
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.resolveResumeState).not.toHaveBeenCalled();
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
+  });
+
+  it('guards against the injected session machine, not the process default (#7640)', async () => {
+    // Desktop scenario: the window's own session machine has the stream
+    // active while the process-global default is empty. The guard must read
+    // the injected machine — before #7640 it read the global and never fired.
+    const windowStatus = new StreamStatusMachine();
+    seedStreamStatusForTest(windowStatus, STREAM, STREAM_STATUS.RUNNING);
+    const ports = basePorts({ streamStatus: windowStatus });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resolveResumeState).not.toHaveBeenCalled();
+
+    clearStreamStatusForTest(windowStatus, STREAM);
+  });
+
+  it('ignores activity recorded only on a different session machine', async () => {
+    // The inverse: activity on the process default must not block a resume in
+    // a session whose own machine says the stream is idle.
+    seedStreamStatusForTest(StreamStatusService, STREAM, STREAM_STATUS.RUNNING);
+    retrieveSessionResumeDataMock.mockResolvedValue({
+      type: 'toolUse',
+      snapshot: { streamId: STREAM, executionId: 'exec-1' },
+    });
+    const ports = basePorts({ streamStatus: new StreamStatusMachine() });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(true);
+    expect(ports.resumeToolUseSnapshot).toHaveBeenCalled();
   });
 
   it('returns false (host owns its messaging) when no state resolves', async () => {


### PR DESCRIPTION
Fixes #7640 (audit finding A4, PR #7636).

## Problem

`resolveAndResumeStream` imported the process-global `StreamStatusService` and read `isActiveOrResuming` at both guards — the pre-check and the post-retrieval race re-check. On **desktop**, every window run writes status to its own per-window `StreamStatusMachine` (`launchSession.status`), so the global is never populated and **both guards were permanently false**:

- a resume of an already-active stream fell through to `acquireStreamOrThrow` → spurious *"Resume failed: … is already running"* dialog;
- a tool-use resume could flip RESUMING over a concurrently-launched run's status.

The extension was correct only by identity (`defaultSession().status === StreamStatusService`).

## Fix

`ResumeStreamPorts` gains a **required** `streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>`; both guards read it; the singleton import is deleted. Extension passes `StreamStatusService` (its default session's machine); desktop passes `this.session.status`. Mirrors the injected-machine pattern `restartRepair.ts:26` already uses; `Pick<>` narrowing per the repo's established pattern; required-over-optional since both callers exist.

**Rejected trap** (from the audit's adversarial verification): `currentSession().status` would be wrong — this runs outside any run ALS (bridge/IPC entry), where `currentSession()` resolves to the empty process default. The machine must be injected by the owning host.

## Verification

- Extended the existing suite (R7: no new file) with the two previously-unrepresentable cases: guard fires from the injected machine while the global is empty (the desktop bug); activity on a foreign machine does not block another session's resume.
- `resolveAndResumeStream.vitest.ts` 13/13; adjacent `InquiryContinuationSession`/`ToolUseFollowUp`/`emitRuntimeEventBoundary` 19/19; `npm run typecheck` clean.

Net-element accounting (R6): +1 required port member, −1 singleton value-import, 0 new classes/files; +2 tests in the existing suite.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent resume/run guard logic in the agent runtime; scope is narrow and covered by new multi-session tests, but wrong injection would reintroduce duplicate resumes or spurious failures.
> 
> **Overview**
> Fixes **#7640**: stream resume no longer consults the process-global `StreamStatusService` for active/resuming checks. **`ResumeStreamPorts`** now requires an injected **`streamStatus`** machine, and both pre-check and post-retrieval guards use **`ports.streamStatus.isActiveOrResuming`**.
> 
> **Desktop** passes **`this.session.status`** (per-window runs write there, so the global machine was always empty and guards never blocked). **Extension** passes **`StreamStatusService`** (unchanged behavior via default-session identity). Tests cover the desktop bug and the inverse case where foreign-machine activity must not block resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b873b391f97a01ab3d614ac82274659629740d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->