### PR TITLE
fix: route extension host facts via sessions

### DIFF
--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -8,7 +8,6 @@ import {
   wakeQueuedFollowUpStream,
   type SendFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -22,6 +21,16 @@ import type { StreamTabId } from '@shared/schemas';
 const logger = createChannelTrace('followUpCommand');
 
 const inFlightDetections = new Set<StreamTabId>();
+
+function emitQueuedFollowUpsChanged(streamId: StreamTabId): void {
+  defaultSession().events.emit({
+    scope: 'session',
+    event: {
+      type: 'updateQueuedFollowUps',
+      payload: { streamId },
+    },
+  });
+}
 
 async function lazyDetectWaitingStatus(
   streamId: StreamTabId,
@@ -73,13 +82,13 @@ async function handleFollowUpResult(
 ): Promise<void> {
   switch (result.status) {
     case 'sent':
-      emitRuntimeEvent('updateQueuedFollowUps', { streamId });
+      emitQueuedFollowUpsChanged(streamId);
       break;
     case 'queued':
-      emitRuntimeEvent('updateQueuedFollowUps', { streamId });
+      emitQueuedFollowUpsChanged(streamId);
       switch ((await wakeQueuedFollowUpStream(streamId, result)).kind) {
         case 'dropped':
-          emitRuntimeEvent('updateQueuedFollowUps', { streamId });
+          emitQueuedFollowUpsChanged(streamId);
           await vscode.window.showWarningMessage(
             'Message dropped — no session available to receive it. Start a new agent task to continue.',
           );

--- a/packages/extension/src/commands/housekeeping/streamEventUtils.ts
+++ b/packages/extension/src/commands/housekeeping/streamEventUtils.ts
@@ -1,4 +1,4 @@
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 
 /**
  * How to identify the workflow tab(s) whose missing-outputs marker should be
@@ -23,12 +23,20 @@ export function emitClearMissingOutputs(
   options: ClearMissingOutputsOptions,
 ): void {
   if (options.streamIdOverride !== undefined) {
-    emitRuntimeEvent('clearMissingOutputs', {
-      streamId: options.streamIdOverride,
+    defaultSession().events.emit({
+      scope: 'session',
+      event: {
+        type: 'clearMissingOutputs',
+        payload: { streamId: options.streamIdOverride },
+      },
     });
     return;
   }
-  emitRuntimeEvent('clearMissingOutputs', {
-    streamConfig: options.streamConfig,
+  defaultSession().events.emit({
+    scope: 'session',
+    event: {
+      type: 'clearMissingOutputs',
+      payload: { streamConfig: options.streamConfig },
+    },
   });
 }

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -12,8 +12,6 @@ const REPO_ROOT = resolve(
 );
 
 const ALLOWED_PRODUCTION_REFERENCES = [
-  'packages/extension/src/commands/agent/followUpCommand.ts',
-  'packages/extension/src/commands/housekeeping/streamEventUtils.ts',
   'src/agent/runtime/emitRuntimeEvent.ts',
   'src/agent/runtime/executeAgent.ts',
   'src/tools/approval/toolEditApproval.ts',


### PR DESCRIPTION
## Summary
- emit extension follow-up queue refresh facts directly through the default session event hub
- emit clear-missing-outputs facts directly through the default session event hub
- remove the two extension host command files from the emitRuntimeEvent boundary allowlist

## Validation
- CI=true corepack pnpm exec vitest run src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts --config vitest.config.mjs
- corepack pnpm exec prettier --check packages/extension/src/commands/agent/followUpCommand.ts packages/extension/src/commands/housekeeping/streamEventUtils.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
- corepack pnpm exec eslint packages/extension/src/commands/agent/followUpCommand.ts packages/extension/src/commands/housekeeping/streamEventUtils.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
- npm run typecheck
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral parity refactor on UI/session notification wiring with no auth or data-path changes; risk is mainly missing a queue or missing-outputs refresh if emission shape diverges.
> 
> **Overview**
> Extension follow-up and housekeeping commands now publish **session facts** (`updateQueuedFollowUps`, `clearMissingOutputs`) through `defaultSession().events.emit` instead of the `emitRuntimeEvent` helper.
> 
> `followUpCommand` centralizes queue refresh notifications in `emitQueuedFollowUpsChanged`; `streamEventUtils` uses the same hub shape for both stream-id and stream-config clear paths. The **emitRuntimeEvent boundary** architecture test no longer allowlists those two command files, tightening who may reference the ambient helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73961a6cb4480449eb19f39c8780a2fb1c8df9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->