### PR TITLE
fix: route execute follow-up refresh via session

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -7,7 +7,6 @@ import {
   runToolUseFlow,
   type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import {
   runReflectionFlow,
@@ -115,7 +114,13 @@ function wrapOnFollowUpConsumed(
   onFollowUpConsumed?: () => void,
 ): () => void {
   return () => {
-    emitRuntimeEvent('updateQueuedFollowUps', { streamId: ctx.streamId });
+    ctx.session.events.emit({
+      scope: 'session',
+      event: {
+        type: 'updateQueuedFollowUps',
+        payload: { streamId: ctx.streamId },
+      },
+    });
     onFollowUpConsumed?.();
   };
 }

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -13,7 +13,6 @@ const REPO_ROOT = resolve(
 
 const ALLOWED_PRODUCTION_REFERENCES = [
   'src/agent/runtime/emitRuntimeEvent.ts',
-  'src/agent/runtime/executeAgent.ts',
   'src/tools/approval/toolEditApproval.ts',
   'src/tools/inquiry/inquiryContinuation.ts',
 ] as const;


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary
- Removed the `emitRuntimeEvent` call from `executeAgent` follow-up consumption.
- Emitted `updateQueuedFollowUps` directly through the launch context's owning `SessionHandle.events` hub.
- Removed `src/agent/runtime/executeAgent.ts` from the `emitRuntimeEvent` architecture allowlist.

## Validation
- `CI=true corepack pnpm exec vitest run src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts --config vitest.config.mjs`
- `npm run typecheck`
- `npm test`
- `corepack pnpm exec prettier --check src/agent/runtime/executeAgent.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `corepack pnpm exec eslint src/agent/runtime/executeAgent.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same session event and payload as before; only the emit path changes with no auth or data-handling impact.
> 
> **Overview**
> When a tool-use run consumes a queued follow-up, **`wrapOnFollowUpConsumed`** in `executeAgent` no longer calls the ambient **`emitRuntimeEvent`** helper. It emits **`updateQueuedFollowUps`** on the launch context’s **`ctx.session.events`** hub instead, matching other session-scoped refresh paths (e.g. execution subscription binding).
> 
> The architecture test **`emitRuntimeEventBoundary`** was updated so **`executeAgent.ts`** is no longer on the small allowlist of production files that may reference **`emitRuntimeEvent`**—tightening the boundary around that helper as part of the broader session-event routing work (#6968 / #6951).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90244661f6296a1d36d699cd19f635706c0c0005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->