### PR TITLE
fix: route inquiry continuation updates via session

### DIFF
--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -14,7 +14,6 @@ const REPO_ROOT = resolve(
 const ALLOWED_PRODUCTION_REFERENCES = [
   'src/agent/runtime/emitRuntimeEvent.ts',
   'src/tools/approval/toolEditApproval.ts',
-  'src/tools/inquiry/inquiryContinuation.ts',
 ] as const;
 
 const SCAN_ROOTS = [

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -31,7 +31,9 @@ vi.mock('@tools/inquiry/externalInquiryStorage', () => ({
   readExternalInquiryThread: readExternalInquiryThreadMock,
 }));
 
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createRecordingHost } from '@test/agent/progressTestUtils';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ExternalInquiryThreadId, StreamTabId } from '@shared/schemas';
 import {
   injectContinuationForAnsweredThread,
@@ -110,6 +112,158 @@ describe('external inquiry continuation session routing', () => {
       undefined,
       session,
     );
+  });
+
+  it('emits inquiry thread updates through the explicit session hub', async () => {
+    const session = new SessionHandle();
+    const explicitFacts: unknown[] = [];
+    const defaultFacts: unknown[] = [];
+    const detachExplicitFacts = session.events.subscribe((event) => {
+      explicitFacts.push(event);
+    });
+    const detachDefaultFacts = defaultSession().events.subscribe((event) => {
+      defaultFacts.push(event);
+    });
+
+    try {
+      await injectContinuationForAnsweredThread(
+        THREAD,
+        answeredManifest(),
+        session,
+      );
+
+      expect(explicitFacts).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'inquiryThreadUpdated',
+            payload: {
+              threadId: THREAD,
+              parentStreamId: STREAM,
+              status: 'answered',
+              lastQuestionPreview: 'Check the boundary case.',
+              lastActivityIso: '2026-06-14T08:01:00.000Z',
+              turnCount: 1,
+              resumeOutcome: 'sent',
+            },
+          },
+        },
+      ]);
+      expect(defaultFacts).toEqual([]);
+    } finally {
+      detachExplicitFacts();
+      detachDefaultFacts();
+      session.dispose();
+    }
+  });
+
+  it("emits inquiry thread updates through the active run's session when no explicit session is provided", async () => {
+    const { host } = createRecordingHost();
+    const session = new SessionHandle();
+    const runFacts: unknown[] = [];
+    const defaultFacts: unknown[] = [];
+    const detachRunFacts = session.events.subscribe((event) => {
+      runFacts.push(event);
+    });
+    const detachDefaultFacts = defaultSession().events.subscribe((event) => {
+      defaultFacts.push(event);
+    });
+
+    try {
+      await withRunContext(
+        createRunContext({
+          runtimeHost: host,
+          session,
+        }),
+        () => injectContinuationForAnsweredThread(THREAD, answeredManifest()),
+      );
+
+      expect(runFacts).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'inquiryThreadUpdated',
+            payload: expect.objectContaining({
+              threadId: THREAD,
+              resumeOutcome: 'sent',
+            }),
+          },
+        },
+      ]);
+      expect(defaultFacts).toEqual([]);
+    } finally {
+      detachRunFacts();
+      detachDefaultFacts();
+      session.dispose();
+    }
+  });
+
+  it('falls back to the default session when the selected session has no event hub', async () => {
+    const { host } = createRecordingHost();
+    const runSession = new SessionHandle();
+    const runFacts: unknown[] = [];
+    const defaultFacts: unknown[] = [];
+    const detachRunFacts = runSession.events.subscribe((event) => {
+      runFacts.push(event);
+    });
+    const detachDefaultFacts = defaultSession().events.subscribe((event) => {
+      defaultFacts.push(event);
+    });
+
+    try {
+      await withRunContext(
+        createRunContext({
+          runtimeHost: host,
+          session: runSession,
+        }),
+        () =>
+          injectContinuationForAnsweredThread(
+            THREAD,
+            answeredManifest(),
+            {} as SessionHandle,
+          ),
+      );
+
+      expect(runFacts).toEqual([]);
+      expect(defaultFacts).toEqual([
+        {
+          scope: 'session',
+          event: {
+            type: 'inquiryThreadUpdated',
+            payload: expect.objectContaining({
+              threadId: THREAD,
+              resumeOutcome: 'sent',
+            }),
+          },
+        },
+      ]);
+    } finally {
+      detachRunFacts();
+      detachDefaultFacts();
+      runSession.dispose();
+    }
+  });
+
+  it('does not emit an inquiry thread update when no summary is returned', async () => {
+    const session = new SessionHandle();
+    const facts: unknown[] = [];
+    const detachFacts = session.events.subscribe((event) => {
+      facts.push(event);
+    });
+    getThreadSummaryMock.mockResolvedValueOnce(null);
+
+    try {
+      await injectContinuationForAnsweredThread(
+        THREAD,
+        answeredManifest(),
+        session,
+      );
+
+      expect(facts).toEqual([]);
+    } finally {
+      detachFacts();
+      session.dispose();
+    }
   });
 
   it('delegates queued wake decisions to the follow-up owner, threading the session', async () => {

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -17,12 +17,16 @@ import {
   wakeQueuedFollowUpStream,
   type FollowUpWakeResult,
 } from '@agent/followUp/ToolUseFollowUp';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
+import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { createChannelTrace } from '@logger';
 import type {
   ExternalInquiryThreadId,
   ExternalInquiryThreadSummary,
+  InquiryThreadUpdatedEvent,
   InquiryResumeOutcome,
   StreamTabId,
 } from '@shared/schemas';
@@ -42,6 +46,11 @@ export type InjectionOutcome = 'sent' | 'queued' | 'resumed' | 'archived';
 
 const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
+
+function inquiryThreadUpdateSession(session?: SessionHandle): SessionHandle {
+  const owner = session ?? tryUseRunContext()?.session;
+  return owner?.events ? owner : defaultSession();
+}
 
 function formatStillOpen(threads: ExternalInquiryThreadSummary[]): string[] {
   if (!threads.length) return [];
@@ -110,7 +119,11 @@ async function emitInquiryThreadUpdate(
 ): Promise<void> {
   const summary = await getThreadSummary(threadId);
   if (!summary) return;
-  emitRuntimeEvent('inquiryThreadUpdated', { ...summary, ...extra }, session);
+  const payload: InquiryThreadUpdatedEvent = { ...summary, ...extra };
+  inquiryThreadUpdateSession(session).events.emit({
+    scope: 'session',
+    event: { type: 'inquiryThreadUpdated', payload },
+  });
 }
 
 function mapWakeResultToInquiryOutcome(


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary
- Removed the production `emitRuntimeEvent` use from inquiry continuation updates.
- Emitted `inquiryThreadUpdated` directly through the resolved `SessionHandle.events` hub.
- Preserved the previous fallback order: explicit session, then active run-context session, then `defaultSession()` when the selected session has no event hub.
- Added regression tests for explicit-session routing, run-context routing, partial-session fallback, and no emission when no thread summary is available.
- Removed `src/tools/inquiry/inquiryContinuation.ts` from the `emitRuntimeEvent` architecture allowlist.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/InquiryContinuation.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `npm run typecheck`
- `corepack pnpm exec prettier --check src/tools/inquiry/inquiryContinuation.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `corepack pnpm exec eslint src/tools/inquiry/inquiryContinuation.ts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized event-routing change with preserved fallback semantics; no auth or data-path changes.
> 
> **Overview**
> **Inquiry continuation** no longer calls the bounded `emitRuntimeEvent` helper for `inquiryThreadUpdated`. Updates are emitted directly on `SessionHandle.events` after resolving the target session.
> 
> Session resolution keeps the prior contract: **explicit `SessionHandle`**, then the **active run-context session**, then **`defaultSession()`** when the chosen handle has no event hub. The architecture test allowlist drops `inquiryContinuation.ts` so only the remaining approved production callers may reference `emitRuntimeEvent`.
> 
> Regression tests cover explicit-session emission, run-context routing, default-session fallback for hub-less handles, and **no emission** when `getThreadSummary` returns null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf4936d2e1ee65cda87a6454dd644f8811fab17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->