### PR TITLE
fix: route tool edit approval activation via session

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -361,6 +361,7 @@ export class DesktopProgressBridge {
     );
     this.toolEditApprovals = createDesktopToolEditApprovalController({
       runtimeHost: this.runtimeHost,
+      session: this.session,
       openPath: options.openPath,
       openBuildDisplay: options.openBuildDisplay,
       openDiff: options.openDiff,
@@ -1200,7 +1201,10 @@ export class DesktopProgressBridge {
           session: this.session,
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
           toolEditApprovalHandler: (approvalRequest) =>
-            this.toolEditApprovals.requestApproval(approvalRequest),
+            this.toolEditApprovals.requestApproval(
+              approvalRequest,
+              this.session,
+            ),
           reportFailure: (error) => this.reportResumeFailure(streamId, error),
         }),
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
@@ -1410,7 +1414,7 @@ export class DesktopProgressBridge {
       session: this.session,
       runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
       toolEditApprovalHandler: (approvalRequest) =>
-        this.toolEditApprovals.requestApproval(approvalRequest),
+        this.toolEditApprovals.requestApproval(approvalRequest, this.session),
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       openWorkflowOutput: async (result) => {
         // Gate, outcome check, and final-output selection are shared policy

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -76,7 +76,9 @@ class DesktopHostInteractions implements HostInteractions {
   requestToolEditApproval(
     request: ToolEditApprovalRequest,
   ): Promise<ToolEditApprovalResult> {
-    return this.options.getToolEditApprovals().requestApproval(request);
+    return this.options
+      .getToolEditApprovals()
+      .requestApproval(request, this.options.session);
   }
 
   requestBashApproval(

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { DiffViewHost } from '@hosts/uiHosts';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
@@ -31,6 +32,7 @@ import { setDesktopToolEditApprovalHandler } from './platform/index.js';
 
 export interface DesktopToolEditApprovalOptions {
   runtimeHost: AgentRuntimeHost;
+  session: SessionHandle;
   openPath?: (filePath: string) => Promise<void>;
   openBuildDisplay?: BuildDisplayFn;
   openDiff?: DiffViewHost['openDiff'];
@@ -52,6 +54,7 @@ export interface DesktopToolEditApprovalController {
    */
   requestApproval(
     request: ToolEditApprovalRequest,
+    session?: SessionHandle,
   ): Promise<ToolEditApprovalResult>;
   dispose(): void;
 }
@@ -79,6 +82,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
 
   async requestApproval(
     request: ToolEditApprovalRequest,
+    session: SessionHandle = this.options.session,
   ): Promise<ToolEditApprovalResult> {
     if (this.disposed) {
       throw new Error('Desktop tool edit approval controller is disposed.');
@@ -109,7 +113,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
         isSettled: () => settled,
         settle: (value) => this.settle(requestId, value),
       });
-      this.showProgressPermission(requestId, request, lineChanges);
+      this.showProgressPermission(session, requestId, request, lineChanges);
     });
 
     if (result.accepted && result.appliedContent != null) return result;
@@ -196,6 +200,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   }
 
   private showProgressPermission(
+    session: SessionHandle,
     requestId: string,
     request: ToolEditApprovalRequest,
     lineChanges: { added: number; removed: number },
@@ -203,7 +208,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     // Activate the stream that needs approval and post the prompt (shared with
     // the VS Code host); the desktop host has no workspace API, so it falls
     // back to a basename when computing the relative display path.
-    emitToolEditApprovalPrompt(this.options.runtimeHost, {
+    emitToolEditApprovalPrompt(this.options.runtimeHost, session, {
       requestId,
       request,
       relativePath: this.relativeDisplayPath(request.path),

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -262,7 +262,8 @@ export async function activate(context: vscode.ExtensionContext) {
         void vscode.window.showInformationMessage(message);
       }
     },
-    toolEditApproval: nativeRequestApproval,
+    toolEditApproval: (request) =>
+      nativeRequestApproval(request, { session: defaultSession() }),
   });
   registerAgentFeatures();
   // `disposeStatusListener` and `statusBarItem` are owned solely by

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -15,6 +15,7 @@ import { nanoid } from 'nanoid';
 import * as vscode from 'vscode';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
 import {
@@ -102,6 +103,7 @@ async function revealFirstChangedLine(
 }
 
 async function showProgressViewApprovalPrompt(
+  session: SessionHandle,
   requestId: string,
   request: ToolEditApprovalRequest,
   relativePath: string,
@@ -114,7 +116,7 @@ async function showProgressViewApprovalPrompt(
 
   // Activate the stream that needs approval and post the prompt (shared with
   // the desktop host); VS Code computes the relative path via the workspace.
-  emitToolEditApprovalPrompt(getRuntimeHost(), {
+  emitToolEditApprovalPrompt(getRuntimeHost(), session, {
     requestId,
     request,
     relativePath,
@@ -128,6 +130,7 @@ function resolveProgressViewApprovalPrompt(requestId: string): void {
 
 export async function nativeRequestApproval(
   request: ToolEditApprovalRequest,
+  options: { session: SessionHandle },
 ): Promise<ToolEditApprovalResult> {
   getStorageDir(); // Validates initialization
 
@@ -271,6 +274,7 @@ export async function nativeRequestApproval(
 
     if (!approvalSettled) {
       void showProgressViewApprovalPrompt(
+        options.session,
         requestId,
         request,
         description,

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -161,7 +161,7 @@ export function createExtensionHostInteractions(
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
     ): Promise<ToolEditApprovalResult> {
-      return nativeRequestApproval(request);
+      return nativeRequestApproval(request, { session: options.session });
     },
 
     requestBashApproval(

--- a/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
+++ b/src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts
@@ -13,7 +13,6 @@ const REPO_ROOT = resolve(
 
 const ALLOWED_PRODUCTION_REFERENCES = [
   'src/agent/runtime/emitRuntimeEvent.ts',
-  'src/tools/approval/toolEditApproval.ts',
 ] as const;
 
 const SCAN_ROOTS = [

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -13,6 +13,13 @@ import type { StreamTabId } from '@shared/schemas';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 interface DesktopHostInteractions {
+  requestToolEditApproval(request: {
+    path: string;
+    originalContent: string;
+    proposedContent: string;
+    sourceTool: string;
+    streamId?: StreamTabId;
+  }): Promise<{ accepted: boolean }>;
   requestBashApproval(request: {
     command: string;
     streamId?: StreamTabId;
@@ -38,7 +45,9 @@ interface DesktopHostInteractionsModule {
     runtimeHost: { emit: (event: string, payload: unknown) => void };
     session: SessionHandle;
     getApprovalHandlers(): unknown;
-    getToolEditApprovals(): unknown;
+    getToolEditApprovals(): {
+      requestApproval: ReturnType<typeof vi.fn>;
+    };
   }): DesktopHostInteractions;
 }
 
@@ -78,6 +87,9 @@ async function createInteractions(handlers = createHandlers()) {
   )) as DesktopHostInteractionsModule;
   const runtimeHost = { emit: vi.fn() };
   const session = new SessionHandle();
+  const toolEditApprovals = {
+    requestApproval: vi.fn(async () => ({ accepted: true })),
+  };
   const sessionEvents: SessionEvent[] = [];
   session.events.subscribe((event) => sessionEvents.push(event), {
     scope: 'session',
@@ -88,15 +100,37 @@ async function createInteractions(handlers = createHandlers()) {
       runtimeHost,
       session,
       getApprovalHandlers: () => handlers,
-      getToolEditApprovals: () => ({}),
+      getToolEditApprovals: () => toolEditApprovals,
     }),
     handlers,
     runtimeHost,
     sessionEvents,
+    session,
+    toolEditApprovals,
   };
 }
 
 describe('createDesktopHostInteractions', () => {
+  it('delegates tool edit approvals with this window session', async () => {
+    const { interactions, session, toolEditApprovals } =
+      await createInteractions();
+    const request = {
+      path: '/workspace/paper.tex',
+      originalContent: 'old',
+      proposedContent: 'new',
+      sourceTool: 'edit',
+      streamId: 'stream-a' as StreamTabId,
+    };
+
+    await expect(
+      interactions.requestToolEditApproval(request),
+    ).resolves.toEqual({ accepted: true });
+    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(
+      request,
+      session,
+    );
+  });
+
   it('rejects a resolution whose kind does not match the pending request', async () => {
     const handlers = createHandlers();
     const { interactions, runtimeHost, sessionEvents } =

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type {
   DiffOptions,
   DiffSession,
@@ -27,6 +29,7 @@ const approvalTest = (name: string, fn: () => Promise<void>): void => {
 interface DesktopToolEditApprovalModule {
   createDesktopToolEditApprovalController(options: {
     runtimeHost: AgentRuntimeHost;
+    session: SessionHandle;
     openPath?: (filePath: string) => Promise<void>;
     openBuildDisplay?: (
       location: { absolutePath: string },
@@ -43,6 +46,7 @@ interface DesktopToolEditApprovalModule {
     }): boolean;
     requestApproval(
       request: ToolEditApprovalRequest,
+      session?: SessionHandle,
     ): Promise<ToolEditApprovalResult>;
     dispose(): void;
   };
@@ -60,6 +64,21 @@ interface RecordingRuntimeHost extends AgentRuntimeHost {
 let activeToolEditApproval:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
+const testSessions: SessionHandle[] = [];
+
+function createTestSession(): SessionHandle {
+  const session = new SessionHandle();
+  testSessions.push(session);
+  return session;
+}
+
+function recordSessionEvents(session: SessionHandle): SessionEvent[] {
+  const events: SessionEvent[] = [];
+  session.events.subscribe((event) => events.push(event), {
+    scope: 'session',
+  });
+  return events;
+}
 
 function useControllerApproval(controller: {
   requestApproval(
@@ -226,6 +245,7 @@ async function loadApprovalModules(workspacePath = '/workspace') {
 describe('desktop tool edit approval', () => {
   afterEach(() => {
     activeToolEditApproval = undefined;
+    for (const session of testSessions.splice(0)) session.dispose();
     vi.doUnmock('@utils/config/configUtils');
     vi.doUnmock('@agent/runtime/RunContext');
     vi.doUnmock('@utils/files');
@@ -239,9 +259,12 @@ describe('desktop tool edit approval', () => {
       const { requestToolEditApproval, desktopModule } =
         await loadApprovalModules();
       const runtimeHost = createRecordingRuntimeHost();
+      const session = createTestSession();
+      const sessionEvents = recordSessionEvents(session);
       const opened: string[] = [];
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
+        session,
         tempRoot,
         openPath: async (filePath) => {
           opened.push(filePath);
@@ -259,6 +282,19 @@ describe('desktop tool edit approval', () => {
           streamId: 'stream-2',
         });
         await vi.waitFor(() => expect(shown).toHaveLength(1));
+        expect(sessionEvents).toContainEqual({
+          scope: 'session',
+          event: {
+            type: 'setActiveStream',
+            payload: { streamId: 'stream-2' },
+          },
+        });
+        expect(shown[0]).toMatchObject({
+          path: '/workspace/notes.txt',
+          relativePath: 'notes.txt',
+          sourceTool: 'write_file',
+          streamId: 'stream-2',
+        });
 
         controller.handleAction({
           requestId: shown[0].requestId,
@@ -314,6 +350,7 @@ describe('desktop tool edit approval', () => {
       );
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
+        session: createTestSession(),
         tempRoot,
         openPath,
         openDiff,
@@ -365,6 +402,7 @@ describe('desktop tool edit approval', () => {
       const opened: string[] = [];
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
+        session: createTestSession(),
         tempRoot,
         openPath: async (filePath) => {
           opened.push(filePath);
@@ -429,6 +467,7 @@ describe('desktop tool edit approval', () => {
       const messages: string[] = [];
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
+        session: createTestSession(),
         tempRoot,
         openBuildDisplay: async (location, options) => {
           displayed.push({ absolutePath: location.absolutePath, options });
@@ -493,6 +532,7 @@ describe('desktop tool edit approval', () => {
       const runtimeHost = createRecordingRuntimeHost();
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
+        session: createTestSession(),
         tempRoot,
       });
       useControllerApproval(controller);
@@ -529,6 +569,7 @@ describe('desktop tool edit approval', () => {
     const runtimeHost = createRecordingRuntimeHost();
     const controller = desktopModule.createDesktopToolEditApprovalController({
       runtimeHost,
+      session: createTestSession(),
       tempRoot,
     });
     useControllerApproval(controller);

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -336,7 +336,8 @@ describe('createExtensionHostInteractions', () => {
   it('delegates tool edit approval to the native VS Code port', async () => {
     const nativeResult = { accepted: true };
     mocks.nativeRequestApproval.mockResolvedValue(nativeResult);
-    const interactions = createInteractions({ session: createTestSession() });
+    const session = createTestSession();
+    const interactions = createInteractions({ session });
     const request = {
       path: 'paper.tex',
       originalContent: 'A',
@@ -348,6 +349,8 @@ describe('createExtensionHostInteractions', () => {
     await expect(interactions.requestToolEditApproval?.(request)).resolves.toBe(
       nativeResult,
     );
-    expect(mocks.nativeRequestApproval).toHaveBeenCalledWith(request);
+    expect(mocks.nativeRequestApproval).toHaveBeenCalledWith(request, {
+      session,
+    });
   });
 });

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,7 +1,7 @@
 import { platform } from '@platform/platform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { emitRuntimeEvent } from '@agent/runtime/emitRuntimeEvent';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { StreamTabId } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
@@ -102,6 +102,7 @@ export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
  */
 export function emitToolEditApprovalPrompt(
   runtimeHost: AgentRuntimeHost,
+  session: SessionHandle,
   params: {
     requestId: string;
     request: ToolEditApprovalRequest;
@@ -112,7 +113,10 @@ export function emitToolEditApprovalPrompt(
   const { requestId, request, relativePath, lineChanges } = params;
   const { streamId } = request;
   if (streamId) {
-    emitRuntimeEvent('setActiveStream', { streamId });
+    session.events.emit({
+      scope: 'session',
+      event: { type: 'setActiveStream', payload: { streamId } },
+    });
   }
   const isBypassed = streamId ? isApprovalBypassedForStream(streamId) : false;
   runtimeHost.emit('showToolEditPermission', {


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary
- Removed the production `emitRuntimeEvent` use from `toolEditApproval.ts`.
- Made `emitToolEditApprovalPrompt` receive an explicit `SessionHandle` and emit `setActiveStream` through that session's event hub.
- Wired VS Code and desktop approval presenters to pass the owning session from their host-interaction/controller paths, while keeping `showToolEditPermission` on the runtime-host interaction rail.
- Added regression coverage for extension and desktop session routing.
- Removed `src/tools/approval/toolEditApproval.ts` from the `emitRuntimeEvent` architecture allowlist. After this PR, grep shows no real production caller of `emitRuntimeEvent` outside the helper itself; the remaining non-test match is a goal-store comment.

## Validation
- `npx vitest run src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts src/test-kernel/architecture/emitRuntimeEventBoundary.vitest.ts --config vitest.config.mjs`
- `npx vitest run src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts --config vitest.config.mjs`
- `npm run typecheck`
- `npx prettier --check ...touched files...`
- `npx eslint ...touched files...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multi-window desktop and progress-view routing pick the active stream during edit approval; wrong session wiring could focus the wrong window/stream, but behavior is covered by new regression tests.
> 
> **Overview**
> **Tool-edit approval stream activation** no longer goes through the ambient `emitRuntimeEvent` helper. `emitToolEditApprovalPrompt` now takes an explicit `SessionHandle` and emits `setActiveStream` on that session's event hub; `showToolEditPermission` still uses the runtime host interaction rail.
> 
> **Host wiring** passes the correct session end-to-end: desktop injects `session` into the tool-edit controller and forwards it from `runAgent` / `resumeToolUseSnapshot` and `desktopHostInteractions`; VS Code passes `{ session }` from `extensionHostInteractions`, `nativeRequestApproval`, and the platform fallback (`defaultSession()`).
> 
> **Guardrails:** `toolEditApproval.ts` was removed from the `emitRuntimeEvent` production allowlist, and tests assert desktop/extension delegation and session-scoped `setActiveStream` during tool-edit prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943efbe61bf7f338f736f8c9c0569582f887d2d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->