### PR TITLE
refactor: seed run scope for launch contexts

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -61,6 +61,7 @@ import {
   withRunContext,
   type CreateRunContextOptions,
 } from './RunContext';
+import { createRunScope, type RunScope } from './RunScope';
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
@@ -75,6 +76,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 const logger = createChannelTrace('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore, AgentRunIdentity {
+  runScope: RunScope;
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;
@@ -153,18 +155,19 @@ function agentContextToRunContext(
   ctx: AgentLaunchContext,
 ): CreateRunContextOptions {
   return {
-    runtimeHost: ctx.runtimeHost,
-    streamId: ctx.streamId,
-    executionId: ctx.executionId,
+    runScope: ctx.runScope,
+    runtimeHost: ctx.runScope.runtimeHost,
+    streamId: ctx.runScope.streamId,
+    executionId: ctx.runScope.executionId,
     modelSource: 'live' as const,
     getModel: () => ctx.config.model,
-    agentName: ctx.config.agent,
-    workingDirectory: ctx.workingDirectory,
+    agentName: ctx.runScope.agentName,
+    workingDirectory: ctx.runScope.workingDirectory,
     delegationDepth: ctx.delegation?.delegationDepth,
     approvalPromptsUnavailable: ctx.delegation?.approvalPromptsUnavailable,
     runtimeUnavailableTools: ctx.runtimeUnavailableTools,
     stopAfterCycle: ctx.stopAfterCycle,
-    session: ctx.session,
+    session: ctx.runScope.session,
     toolEditApprovalHandler: ctx.toolEditApprovalHandler,
   };
 }
@@ -456,6 +459,15 @@ async function assembleAgentLaunchContext(
       agentCategory: setting.agentCategory,
     },
   );
+  const workingDirectory = configPayload.workingDirectory?.trim() || undefined;
+  const runScope = createRunScope({
+    runtimeHost,
+    streamId,
+    executionId,
+    agentName: config.agent,
+    workingDirectory,
+    session,
+  });
 
   return {
     config,
@@ -470,13 +482,14 @@ async function assembleAgentLaunchContext(
     userVarChannels,
     attachedMemoryMisses,
     usageMonitor,
-    runtimeHost,
+    runScope,
+    runtimeHost: runScope.runtimeHost,
     streamStatus,
-    workingDirectory: configPayload.workingDirectory?.trim() || undefined,
+    workingDirectory: runScope.workingDirectory,
     initialUserMessageForTranscript: initialMediaMayBeInserted
       ? initialInstruction
       : undefined,
-    session,
+    session: runScope.session,
     disposeTrace: runTrace.dispose,
   };
 }

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { createRunScope, type RunScope } from './RunScope';
 import type { ToolEditApprovalPort } from '@platform/interfaces';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -28,6 +29,7 @@ interface RunContextCommon {
 
 export interface LaunchRunContext extends RunContextCommon {
   readonly kind: 'launch';
+  readonly runScope: RunScope;
   readonly streamId: StreamTabId;
   readonly executionId: ExecutionId;
   /** Agent name (e.g. "orchestrator", "search-agent"). */
@@ -63,6 +65,7 @@ export type RunContext = LaunchRunContext | BareRunContext;
 
 interface CreateRunContextBase {
   runtimeHost: AgentRuntimeHost;
+  runScope?: RunScope;
   streamId?: StreamTabId;
   executionId?: ExecutionId;
   agentName?: string;
@@ -106,6 +109,7 @@ const runContextScope = new AsyncLocalStorage<RunContext>();
 
 type CommonRunContextFieldNames =
   | 'runtimeHost'
+  | 'runScope'
   | 'streamId'
   | 'executionId'
   | 'agentName'
@@ -129,6 +133,7 @@ function commonRunContextFields<T extends CreateRunContextBase>(
 ): Pick<T, CommonRunContextFieldNames> {
   return {
     runtimeHost: options.runtimeHost,
+    runScope: options.runScope,
     streamId: options.streamId,
     executionId: options.executionId,
     agentName: options.agentName,
@@ -157,9 +162,26 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
 
   if (options.modelSource === 'live') {
     const { getModel, model } = options;
+    const runScope =
+      options.runScope ??
+      createRunScope({
+        runtimeHost: options.runtimeHost,
+        streamId: options.streamId,
+        executionId: options.executionId,
+        agentName: options.agentName,
+        workingDirectory: options.workingDirectory,
+        session: options.session,
+      });
     return Object.freeze({
       kind: 'launch',
       ...commonRunContextFields(options),
+      runScope,
+      runtimeHost: runScope.runtimeHost,
+      streamId: runScope.streamId,
+      executionId: runScope.executionId,
+      agentName: runScope.agentName,
+      workingDirectory: runScope.workingDirectory,
+      session: runScope.session,
       get model() {
         return getModel() ?? model;
       },

--- a/src/agent/runtime/RunScope.ts
+++ b/src/agent/runtime/RunScope.ts
@@ -1,0 +1,27 @@
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type { SessionHandle } from './SessionHandle';
+
+/**
+ * Canonical identity and ownership scope for a launched agent run.
+ *
+ * This object is deliberately smaller than `AgentLaunchContext`: it contains
+ * only the facts that identify the run and the session that owns its runtime
+ * state. Older flat fields remain on launch contexts for compatibility, but
+ * new runtime code should prefer carrying this object when it needs the full
+ * run scope.
+ */
+export interface RunScope {
+  readonly runtimeHost: AgentRuntimeHost;
+  readonly streamId: StreamTabId;
+  readonly executionId: ExecutionId;
+  /** Agent name (e.g. "orchestrator", "search-agent"). */
+  readonly agentName: string;
+  readonly workingDirectory?: string;
+  readonly session: SessionHandle;
+}
+
+export function createRunScope(scope: RunScope): RunScope {
+  return Object.freeze({ ...scope });
+}

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -10,6 +10,7 @@ import {
 } from '@agent/runtime/AgentLaunchContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { useRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -37,21 +38,36 @@ describe('AgentLaunchContext', () => {
 
   it('projects model changes into the active run context', async () => {
     const explicit = createRecordingHost();
-    const ctx = {
+    const session = {} as AgentLaunchContext['session'];
+    const runScope = createRunScope({
       runtimeHost: explicit.host,
-      logger: noopTrace,
       streamId: 'launch-context-stream' as AgentLaunchContext['streamId'],
       executionId:
         'launch-context-execution' as AgentLaunchContext['executionId'],
+      agentName: 'chat',
+      session,
+    });
+    const ctx = {
+      runtimeHost: explicit.host,
+      runScope,
+      logger: noopTrace,
+      streamId: runScope.streamId,
+      executionId: runScope.executionId,
       config: {
-        agent: 'chat',
+        agent: runScope.agentName,
         model: 'deepseekT',
       },
-      session: {} as AgentLaunchContext['session'],
+      session,
     } as unknown as AgentLaunchContext;
 
     await withExecutionRunContext(ctx, async () => {
-      expect(useRunContext().model).toBe('deepseekT');
+      const context = useRunContext();
+      expect(context.model).toBe('deepseekT');
+      expect(context.kind).toBe('launch');
+      if (context.kind !== 'launch') {
+        throw new Error('expected launch context');
+      }
+      expect(context.runScope).toBe(runScope);
 
       ctx.config.model = 'sonnet46T';
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -24,6 +24,7 @@ import {
   AgentExecutionHandle,
   SharedExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
+import { createRunScope } from '@agent/runtime/RunScope';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   finalizeRunTerminal,
@@ -92,6 +93,14 @@ function createLifecycleContext({
   });
   const prompt = AgentPromptSchema.parse({});
   const storageKey = executionId as StorageKey;
+  const session = defaultSession();
+  const runScope = createRunScope({
+    runtimeHost: explicit.host,
+    streamId,
+    executionId,
+    agentName: config.agent,
+    session,
+  });
   const modelInfo = {
     capabilities: {
       supportsPromptCaching: false,
@@ -113,10 +122,11 @@ function createLifecycleContext({
     config,
     setting,
     prompt,
-    streamId,
-    executionId,
-    runtimeHost: explicit.host,
-    session: defaultSession(),
+    runScope,
+    streamId: runScope.streamId,
+    executionId: runScope.executionId,
+    runtimeHost: runScope.runtimeHost,
+    session: runScope.session,
     streamStatus,
     logger: noopTrace,
     parentStage: noopTrace.openStage('Run: test-agent'),

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -7,6 +7,7 @@ import {
   useRunContext,
   withRunContext,
 } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -72,6 +73,41 @@ describe('RunContext', () => {
     currentModel = undefined;
 
     expect(context.model).toBe('fallback-model');
+  });
+
+  it('preserves the exact run scope on launch contexts', () => {
+    const runtimeHost = createRuntimeHost();
+    const runScope = createRunScope({
+      runtimeHost,
+      streamId: 'scoped-stream' as StreamTabId,
+      executionId: 'scoped-execution' as ExecutionId,
+      agentName: 'scoped-agent',
+      workingDirectory: '/tmp/scoped-worktree',
+      session: {} as SessionHandle,
+    });
+    const context = createRunContext({
+      runtimeHost,
+      runScope,
+      streamId: runScope.streamId,
+      executionId: runScope.executionId,
+      modelSource: 'live',
+      getModel: () => 'deepseekT',
+      agentName: runScope.agentName,
+      session: runScope.session,
+    });
+
+    expect(Object.isFrozen(runScope)).toBe(true);
+    expect(context.kind).toBe('launch');
+    if (context.kind !== 'launch') {
+      throw new Error('expected launch context');
+    }
+    expect(context.runScope).toBe(runScope);
+    expect(context.runtimeHost).toBe(runScope.runtimeHost);
+    expect(context.streamId).toBe(runScope.streamId);
+    expect(context.executionId).toBe(runScope.executionId);
+    expect(context.agentName).toBe(runScope.agentName);
+    expect(context.workingDirectory).toBe(runScope.workingDirectory);
+    expect(context.session).toBe(runScope.session);
   });
 
   it('requires an active context for owned runtime state', () => {

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -13,6 +13,7 @@ import {
   AgentSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 import {
   SessionHandle,
   currentSession,
@@ -64,6 +65,14 @@ function createLifecycleContext(
   });
   const prompt = AgentPromptSchema.parse({});
   const storageKey = executionId as StorageKey;
+  const runtimeHost = explicit.host;
+  const runScope = createRunScope({
+    runtimeHost,
+    streamId,
+    executionId,
+    agentName: config.agent,
+    session,
+  });
   const modelInfo = {
     capabilities: {
       supportsPromptCaching: false,
@@ -85,9 +94,10 @@ function createLifecycleContext(
     config,
     setting,
     prompt,
-    streamId,
-    executionId,
-    runtimeHost: explicit.host,
+    runScope,
+    streamId: runScope.streamId,
+    executionId: runScope.executionId,
+    runtimeHost: runScope.runtimeHost,
     streamStatus,
     logger: noopTrace,
     parentStage: noopTrace.openStage('Run: assistant'),
@@ -98,7 +108,7 @@ function createLifecycleContext(
       modelInfo,
       {
         logger: noopTrace,
-        runtimeHost: explicit.host,
+        runtimeHost,
         storageKey,
         streamId,
       },

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -14,6 +14,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
+import { createRunScope } from '@agent/runtime/RunScope';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -61,6 +62,14 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
   const prompt = AgentPromptSchema.parse({});
   const storageKey = executionId as unknown as StorageKey;
   const logger = overrides?.logger ?? new TraceEmitter();
+  const session = defaultSession();
+  const runScope = createRunScope({
+    runtimeHost: explicit.host,
+    streamId,
+    executionId,
+    agentName: config.agent,
+    session,
+  });
   const modelInfo = {
     capabilities: {
       supportsPromptCaching: false,
@@ -82,10 +91,11 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
     config,
     setting,
     prompt,
-    streamId,
-    executionId,
-    runtimeHost: explicit.host,
-    session: defaultSession(),
+    runScope,
+    streamId: runScope.streamId,
+    executionId: runScope.executionId,
+    runtimeHost: runScope.runtimeHost,
+    session: runScope.session,
     streamStatus,
     logger,
     parentStage: logger.openStage('Run: assistant'),


### PR DESCRIPTION
## Summary

- add `RunScope` as the canonical launched-run identity and ownership object
- create a frozen scope when building `AgentLaunchContext`, while preserving the older flat compatibility fields
- project launch `RunContext` identity from the same scope instance and cover that object identity in tests

## Verification

- `npm test -- --run src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts`
- `npm run typecheck`
- `npm test -- --run src/test-kernel/agent/runtime src/test-kernel/agent/followUp`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `git diff --check`

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring with backward-compatible flat fields; behavior change risk is low aside from launch contexts now deriving identity from one frozen scope instance.
> 
> **Overview**
> Introduces **`RunScope`** as a frozen bundle of run identity (`runtimeHost`, `streamId`, `executionId`, `agentName`, `workingDirectory`, `session`) and wires it through launch and ambient context.
> 
> **`buildAgentLaunchContext`** now creates one `runScope` instance and sets the legacy flat fields on `AgentLaunchContext` from that same object. **`agentContextToRunContext`** and **`createRunContext`** (live/`launch` path) read identity from `runScope` when present, and launch contexts expose **`runScope`** on **`LaunchRunContext`** so callers can pass a single scope instead of duplicating fields.
> 
> Tests assert **object identity** (`context.runScope === runScope`) and that frozen scopes stay aligned with projected `streamId`, `session`, etc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd8aaa2d383111183c145f78fa5a6aeccb60067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->