### PR TITLE
refactor: read flow identity from run scope

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -12,6 +12,7 @@ import type {
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { RunScope } from '@agent/runtime/RunScope';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -51,8 +52,13 @@ export interface AgentCore<C = unknown> {
 }
 
 export interface AgentRunIdentity {
+  /** Canonical identity and session owner for this launched run. */
+  readonly runScope: RunScope;
+  /** Compatibility field; prefer `runScope.runtimeHost` for new code. */
   readonly runtimeHost: AgentRuntimeHost;
+  /** Compatibility field; prefer `runScope.streamId` for new code. */
   readonly streamId: StreamTabId;
+  /** Compatibility field; prefer `runScope.executionId` for new code. */
   readonly executionId: ExecutionId;
 }
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -10,7 +10,6 @@ import {
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
-import { currentSession } from '@agent/runtime/SessionHandle';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { activeModelHandlerCompatibilityKey } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
@@ -105,10 +104,10 @@ export async function runReflectionFlow<C = unknown>(
     checkInterruption,
     onRoundFinalized = async () => {},
   } = input;
-  const { runtimeHost, streamId, executionId } = useLaunchRunContext();
-  // Capture the run's session at setup (inside the run's ALS); the interrupt
-  // closure below fires from the host thread outside the ALS.
-  const runSession = currentSession();
+  const { runScope } = useLaunchRunContext();
+  const { runtimeHost, streamId, executionId, session: runSession } = runScope;
+  // Capture the run's scope at setup; the interrupt closure below fires from
+  // the host thread outside the ALS.
 
   let outcome: RunOutcome = RUN_OUTCOME.CANCELLED;
   let shared: ReflectionFlowShared | undefined;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -9,10 +9,7 @@ import {
   modelHandlerCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
-import {
-  currentSession,
-  type SessionHandle,
-} from '@agent/runtime/SessionHandle';
+import { type SessionHandle } from '@agent/runtime/SessionHandle';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
@@ -151,11 +148,11 @@ export async function runToolUseFlow<C = unknown>(
   onSetup?: ToolUseFlowSetupCallback,
 ): Promise<RunToolUseFlowResult> {
   const { logger, setting, onInterrupt } = input;
-  const { runtimeHost, streamId, executionId } = useLaunchRunContext();
-  // Capture the run's session at setup (inside the run's ALS). The interrupt
-  // closure below fires from the host thread outside the ALS, so it must use
-  // this captured handle, not a fresh currentSession() lookup.
-  const runSession = currentSession();
+  const { runScope } = useLaunchRunContext();
+  const { runtimeHost, streamId, executionId, session: runSession } = runScope;
+  // Capture the run's scope at setup. The interrupt closure below fires from
+  // the host thread outside the ALS, so it must use this captured session
+  // handle instead of asking for an ambient current session later.
   const sessionLifecycle = new ToolUseSessionLifecycle(
     streamId,
     runSession.followUps,


### PR DESCRIPTION
## Summary

- make `RunScope` part of `AgentRunIdentity`, while keeping flat identity fields as compatibility accessors for existing callers
- update tool-use and reflection flow entry points to read runtime host, stream id, execution id, and owner session from `useLaunchRunContext().runScope`
- remove the extra ambient `currentSession()` lookup from those flow setup paths

## Verification

- `npm test -- --run src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts`
- `npm run typecheck`
- `npm test -- --run src/test-kernel/agent/runtime src/test-kernel/agent/followUp`
- `npm test`
- `npm run compile:fast`
- `npm run lint` (passes with existing import-order warnings outside this patch)
- `git diff --check`

Refs #6968
Refs #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session/identity wiring used when interrupts and run teardown fire outside ALS; behavior should be equivalent but mistakes could break cancellation or session isolation.
> 
> **Overview**
> **Run identity is centralized on `RunScope`.** `AgentRunIdentity` now exposes `runScope` as the canonical source for runtime host, stream/execution ids, and the owning session; the existing flat fields remain as documented compatibility accessors.
> 
> **Tool-use and reflection flow entry points** destructure `runtimeHost`, `streamId`, `executionId`, and `session` from `useLaunchRunContext().runScope` instead of mixing launch-context fields with a separate `currentSession()` lookup at setup. That keeps the session handle captured for interrupt/teardown paths that run outside the run’s ALS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d76074d05c656d3e5f4b6987827ad2d995abfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->