### PR TITLE
refactor: read flow node run fields from run scope

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -100,7 +100,8 @@ export async function saveCycleDebug(
   services: AgentCore,
   fileOptions: CycleDebugFileOptions,
 ): Promise<void> {
-  const { executionId } = useLaunchRunContext();
+  const { runScope } = useLaunchRunContext();
+  const { executionId } = runScope;
   await maybeSaveDebugObject({
     object,
     objectType,
@@ -117,7 +118,8 @@ export async function saveCycleDebug(
 export function defaultPostCompactionContext(
   services: WorkspaceScopedCore,
 ): string | null {
-  const { session, streamId } = useLaunchRunContext();
+  const { runScope } = useLaunchRunContext();
+  const { session, streamId } = runScope;
   const { subagents, processes } =
     session.executions.getActiveChildren(streamId);
   return formatPostCompactionContext(

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -254,7 +254,8 @@ export abstract class RetryableInvocationNode<
     error: Error,
   ): Promise<ManualRetryPromptResult> {
     const { logger, streamStatus } = this.services;
-    const { session, streamId } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
+    const { session, streamId } = runScope;
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -63,7 +63,8 @@ export class OutputNode<C = unknown> extends Node<
   ReflectionServices<C>
 > {
   private outputDependencies(): OutputDependencies {
-    const { executionId, runtimeHost, streamId } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
+    const { executionId, runtimeHost, streamId } = runScope;
     const { baseFiles, config, fileService, logger, setting } = this.services;
 
     return {
@@ -100,9 +101,10 @@ export class OutputNode<C = unknown> extends Node<
 
     // Resolve to pre-run snapshots once so mapping, latexdiff, and diff
     // stats all see the same base locations (see snapshotResolution).
+    const { runScope } = useLaunchRunContext();
     const diffBaseFiles = await resolveBaseFilesForDiff(
       baseFiles,
-      useLaunchRunContext().executionId,
+      runScope.executionId,
     );
 
     let mapping: RoundFileMapping | undefined;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -54,7 +54,8 @@ export class ToolUseCycleNode<C> extends Node<
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
     const { setting, resolvedTools, modelHandler } = this.services;
-    const { streamId } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
+    const { streamId } = runScope;
 
     if (prepRes.shouldSkipCycle) {
       const { todos, plan } = prepRes.workspaceState.workPlan;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -55,7 +55,8 @@ export class ToolUseWaitNode<C> extends Node<
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
     const { checkInterruption, session, streamStatus, isSubagent } =
       this.services;
-    const { streamId, runtimeHost } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
+    const { streamId, runtimeHost } = runScope;
 
     if (checkInterruption()) {
       return { kind: 'stop' };
@@ -157,7 +158,8 @@ export class ToolUseWaitNode<C> extends Node<
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
     const { onFollowUpConsumed, logger, streamStatus } = this.services;
-    const { streamId, runtimeHost } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
+    const { streamId, runtimeHost } = runScope;
 
     if (execRes.kind === 'waiting') {
       return FlowTransition.WAITING;


### PR DESCRIPTION
## Summary

This Stage 5 runtime migration increment moves the remaining production flow-node reads of launch identity and session state from flat `useLaunchRunContext()` fields to `useLaunchRunContext().runScope`.

The changed call sites are mechanical and preserve behavior: cycle debug storage, post-compaction context, manual retry prompts, output dependency construction, reflection diff base resolution, tool-use cycle progress updates, and tool-use wait/resume transitions now read stream, execution, runtime-host, and session facts from the canonical run-scoped object.

This intentionally leaves test fixture cleanup and the flat compatibility fields themselves for later migration slices.

## Validation

- `npm test -- --run src/test-kernel/agent/runtime/RetryState.vitest.ts src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts`
- `npm test -- --run src/test-kernel/agent/runtime src/test-kernel/agent/followup`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `npm run compile:fast`
- `npm run lint` (passes with existing unrelated import-order warnings)

Refs #6968.
Refs #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical destructuring-only change with no new logic; flat context fields remain, so risk is mainly a missed call-site during future removal.
> 
> **Overview**
> Continues the launch run-context migration by having production flow nodes read **stream, execution, session, and runtime-host** facts from `useLaunchRunContext().runScope` instead of the flat context fields.
> 
> Touched paths include cycle debug persistence, post-compaction context, manual retry prompts (`RetryState`), reflection output dependencies and diff base resolution (`OutputNode`), and tool-use cycle progress plus wait/resume transitions (`ToolUseCycleNode`, `ToolUseWaitNode`). Behavior is intended to stay the same; flat compatibility fields on the context are left for later slices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a63751252cc923aebfa4ac76050a6221053a57e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->