### PR TITLE
refactor: read tool run context through run scope

### DIFF
--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -17,7 +17,10 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextSession,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import type { FollowUpQueueInput } from './FollowUpQueue';
@@ -153,7 +156,7 @@ export function notifyFollowUpSent(
 }
 
 function followUpSentSession(session?: SessionHandle): SessionHandle {
-  const owner = session ?? tryUseRunContext()?.session;
+  const owner = session ?? getRunContextSession(tryUseRunContext());
   return owner?.events ? owner : defaultSession();
 }
 

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -230,6 +230,60 @@ export function tryUseRunContext(): RunContext | undefined {
   return runContextScope.getStore();
 }
 
+/** Return the runtime host for a context, reading launch contexts through RunScope. */
+export function getRunContextRuntimeHost(
+  context: RunContext | undefined = tryUseRunContext(),
+): AgentRuntimeHost | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.runtimeHost
+    : context?.runtimeHost;
+}
+
+/** Return the stream id for a context, reading launch contexts through RunScope. */
+export function getRunContextStreamId(
+  context: RunContext | undefined = tryUseRunContext(),
+): StreamTabId | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.streamId
+    : context?.streamId;
+}
+
+/** Return the execution id for a context, reading launch contexts through RunScope. */
+export function getRunContextExecutionId(
+  context: RunContext | undefined = tryUseRunContext(),
+): ExecutionId | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.executionId
+    : context?.executionId;
+}
+
+/** Return the agent name for a context, reading launch contexts through RunScope. */
+export function getRunContextAgentName(
+  context: RunContext | undefined = tryUseRunContext(),
+): string | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.agentName
+    : context?.agentName;
+}
+
+/** Return the working directory for a context, reading launch contexts through RunScope. */
+export function getRunContextWorkingDirectory(
+  context: RunContext | undefined = tryUseRunContext(),
+): string | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.workingDirectory
+    : context?.workingDirectory;
+}
+
+/** Return the owner session for a context, reading launch contexts through RunScope. */
+export function getRunContextSession(
+  context: RunContext | undefined = tryUseRunContext(),
+): SessionHandle | undefined {
+  return context?.kind === 'launch'
+    ? context.runScope.session
+    : context?.session;
+}
+
 /**
  * Return the active run context, asserting it is a `launch` context (i.e.
  * `streamId`/`executionId`/`runtimeHost` are guaranteed present).

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -38,7 +38,7 @@ import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManage
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
-import { tryUseRunContext } from './RunContext';
+import { getRunContextSession, tryUseRunContext } from './RunContext';
 import {
   ExecutionRegistry,
   SharedExecutionRegistry,
@@ -330,5 +330,5 @@ export function defaultSession(): SessionHandle {
  * inject an isolated session per run.
  */
 export function currentSession(): SessionHandle {
-  return tryUseRunContext()?.session ?? defaultSession();
+  return getRunContextSession(tryUseRunContext()) ?? defaultSession();
 }

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -16,9 +16,15 @@ const mocks = vi.hoisted(() => ({
   deliverChildRunFollowUp: vi.fn(),
 }));
 
-vi.mock('@agent/runtime/RunContext', () => ({
-  tryUseRunContext: mocks.tryUseRunContext,
-}));
+vi.mock('@agent/runtime/RunContext', () => {
+  const readRunContextField = (context: any, field: string) =>
+    context?.kind === 'launch' ? context.runScope[field] : context?.[field];
+  return {
+    tryUseRunContext: mocks.tryUseRunContext,
+    getRunContextStreamId: (context: any) =>
+      readRunContextField(context, 'streamId'),
+  };
+});
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -28,9 +28,17 @@ vi.mock('@agent/storage', () => ({
   registerExecution: mocks.registerExecution,
 }));
 
-vi.mock('@agent/runtime/RunContext', () => ({
-  tryUseRunContext: mocks.tryUseRunContext,
-}));
+vi.mock('@agent/runtime/RunContext', () => {
+  const readRunContextField = (context: any, field: string) =>
+    context?.kind === 'launch' ? context.runScope[field] : context?.[field];
+  return {
+    tryUseRunContext: mocks.tryUseRunContext,
+    getRunContextExecutionId: (context: any) =>
+      readRunContextField(context, 'executionId'),
+    getRunContextRuntimeHost: (context: any) =>
+      readRunContextField(context, 'runtimeHost'),
+  };
+});
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
   currentSession: mocks.currentSession,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -42,7 +42,7 @@ import {
   formatSubagentError,
 } from '@tools/subagentResults';
 import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
-import { requireRunStream } from '@tools/contextHelpers';
+import { getRunContextStreamId, requireRunStream } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utils
@@ -324,7 +324,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
         `Execution '${executionId}' was detached from its orchestrator and now runs top-level. Its results can no longer be delivered back to this session — start a new delegation instead.`,
       );
     }
-    const callerStreamId = parentContext?.streamId;
+    const callerStreamId = getRunContextStreamId(parentContext);
     if (callerStreamId && handle.parentStreamId !== callerStreamId) {
       throw new Error(
         `Execution '${executionId}' belongs to a different orchestrator session. Its results would be delivered there, not here — start a new delegation instead.`,

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -7,6 +7,7 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 import * as logger from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
+import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -117,7 +118,7 @@ export class DiagnosticsTool extends defineTool({
 
   /** Resolve an input path to an absolute path against the active working directory. */
   private resolveAbsolutePath(filePath: string): string {
-    const workingDirectory = tryUseRunContext()?.workingDirectory;
+    const workingDirectory = getRunContextWorkingDirectory(tryUseRunContext());
     return resolveWorkspaceRelativePath(filePath, workingDirectory).absolute;
   }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -42,7 +42,12 @@ import {
 } from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { requireRunStream } from '@tools/contextHelpers';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  requireRunStream,
+  requireStreamId,
+} from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { clamp, unique } from '@utils/core';
@@ -301,13 +306,13 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
 
   private resolveExecutionId(id: string): ExecutionId {
     if (id === 'current') {
-      const ctx = tryUseRunContext();
-      if (!ctx?.executionId) {
+      const executionId = getRunContextExecutionId();
+      if (!executionId) {
         throw new ToolError(
           'No active execution. Use a specific execution ID instead of "current".',
         );
       }
-      return ctx.executionId;
+      return executionId;
     }
     const result = ExecutionIdSchema.safeParse(id);
     if (!result.success) {
@@ -538,9 +543,9 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
 
   private handleKill(executionId: ExecutionId): ToolResult {
     const ctx = tryUseRunContext();
-    const callerStreamId = ctx?.streamId;
+    const callerStreamId = getRunContextStreamId(ctx);
 
-    if (ctx?.executionId === executionId) {
+    if (getRunContextExecutionId(ctx) === executionId) {
       return {
         status: 'error',
         error: `Cannot kill your own execution (${executionId}).`,
@@ -594,21 +599,21 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
   }
 
   private handleSubscribe(executionId: ExecutionId): ToolResult {
-    const { streamId, context: ctx } = requireRunStream('subscribe');
+    const {
+      streamId,
+      runtimeHost,
+      context: ctx,
+    } = requireRunStream('subscribe');
     // Subscribing to your own execution would feed every status transition
     // back into the same session, creating a self-sustaining loop of
     // <execution-activity> follow-ups.
-    if (ctx.executionId === executionId) {
+    if (getRunContextExecutionId(ctx) === executionId) {
       throw new ToolError(
         `Cannot subscribe to your own execution (${executionId}).`,
       );
     }
     try {
-      currentSession().subscriptions.bind(
-        streamId,
-        executionId,
-        ctx.runtimeHost,
-      );
+      currentSession().subscriptions.bind(streamId, executionId, runtimeHost);
     } catch (err) {
       throw new ToolError(toErrorMessage(err));
     }
@@ -620,12 +625,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
   }
 
   private handleUnsubscribe(executionId: ExecutionId): ToolResult {
-    const streamId = tryUseRunContext()?.streamId;
-    if (!streamId) {
-      throw new ToolError(
-        'unsubscribe must be called from within an agent stream.',
-      );
-    }
+    const streamId = requireStreamId('unsubscribe');
     const removed = currentSession().subscriptions.unbind(
       streamId,
       executionId,

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -7,6 +7,7 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 // Type imports
 import type { FileLocation } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { getRunContextExecutionId } from '@tools/contextHelpers';
 
 // Local imports - tools
 import {
@@ -93,7 +94,7 @@ function resolvePdfLocation(rawPath: string): FileLocation {
     throw new ToolError('path is required.');
   }
 
-  const executionId = tryUseRunContext()?.executionId;
+  const executionId = getRunContextExecutionId(tryUseRunContext());
   const runStorageLocation = executionId
     ? runStorageLocationFromAbsolutePath(trimmed, executionId)
     : undefined;

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -14,6 +14,7 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
+import { getRunContextExecutionId } from '@tools/contextHelpers';
 import {
   appendApprovalDiffNote,
   requestApprovedEditContent,
@@ -658,7 +659,7 @@ export class TextEditorTool extends defineTool({
    * (tests/manual) it collapses to the prior path-only behavior.
    */
   private historyKey(filePath: string): string {
-    return `${tryUseRunContext()?.executionId ?? ''}\u0000${filePath}`;
+    return `${getRunContextExecutionId(tryUseRunContext()) ?? ''}\u0000${filePath}`;
   }
 
   private addToHistory(filePath: string, content: string): void {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -5,7 +5,10 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
-import { requireRuntimeHost } from '@tools/contextHelpers';
+import {
+  getRunContextStreamId,
+  requireRuntimeHost,
+} from '@tools/contextHelpers';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -74,7 +77,7 @@ export async function requestBashApproval(
   const approvalsEnabled = getConfig<boolean>(BASH_APPROVAL_CONFIG_KEY, true);
 
   const context = tryUseRunContext();
-  const streamId = request.streamId ?? context?.streamId;
+  const streamId = request.streamId ?? getRunContextStreamId(context);
 
   if (
     !approvalsEnabled ||

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -8,6 +8,10 @@ import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { recordToolFileRead } from '@tools/fileInteractions';
+import {
+  getRunContextRuntimeHost,
+  getRunContextStreamId,
+} from '@tools/contextHelpers';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
@@ -221,10 +225,11 @@ export async function requestToolEditApproval(
   );
 
   const context = tryUseRunContext();
+  const contextStreamId = getRunContextStreamId(context);
   const preparedRequest =
-    request.streamId || !context?.streamId
+    request.streamId || !contextStreamId
       ? request
-      : { ...request, streamId: context.streamId };
+      : { ...request, streamId: contextStreamId };
 
   const streamId = preparedRequest.streamId;
   const isStreamBypassed =
@@ -234,7 +239,7 @@ export async function requestToolEditApproval(
   }
 
   const hostInteraction =
-    context?.runtimeHost.interactions?.requestToolEditApproval?.(
+    getRunContextRuntimeHost(context)?.interactions?.requestToolEditApproval?.(
       preparedRequest,
     );
   if (hostInteraction) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -30,7 +30,11 @@ import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
-import { requireRunStream } from '@tools/contextHelpers';
+import {
+  getRunContextExecutionId,
+  getRunContextWorkingDirectory,
+  requireRunStream,
+} from '@tools/contextHelpers';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -142,7 +146,7 @@ export class BashTool extends defineTool({
     const callContext = contexts?.callContext;
     const runContext = contexts?.runContext;
     const cwd =
-      parseWorkingDirectory(runContext?.workingDirectory) ??
+      parseWorkingDirectory(getRunContextWorkingDirectory(runContext)) ??
       tryPlatform()?.workspace.getWorkspacePath();
 
     // Request approval before executing the command.
@@ -170,7 +174,7 @@ export class BashTool extends defineTool({
         input.command,
         timeoutMs,
         streamId,
-        runContext?.executionId,
+        getRunContextExecutionId(runContext),
         runtimeHost,
         cwd,
       );

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -32,10 +32,21 @@ import {
   type ToolUseCardRef,
 } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  startChildRunLoop,
+  type ChildRunPorts,
+  type ChildRunStrategy,
+} from '@agent/runtime/childRunLoop';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { type ToolResult } from '@shared/schemas/toolResult';
-import { requireRunStream } from '@tools/contextHelpers';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
+  requireRunStream,
+} from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds, isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -59,12 +70,6 @@ import {
   formatChildRunDelivery,
   formatChildRunError,
 } from './deliveryEnvelope';
-import {
-  startChildRunLoop,
-  type ChildRunPorts,
-  type ChildRunStrategy,
-} from '@agent/runtime/childRunLoop';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   buildClaudeToolUseLog,
   buildClaudeUsageStats,
@@ -531,7 +536,7 @@ export class ClaudeAgentTool extends defineTool({
           return resumeAgentCliSession(ClaudeAgentSessions, {
             id: input.session_id,
             prompt: input.prompt,
-            callerStreamId: runContext?.streamId,
+            callerStreamId: getRunContextStreamId(runContext),
             labels: {
               notActiveLabel: 'Claude Code CLI session',
               idParamName: 'session_id',
@@ -550,8 +555,8 @@ export class ClaudeAgentTool extends defineTool({
           model,
           effort,
           streamId,
-          runContext?.executionId,
-          runContext?.workingDirectory,
+          getRunContextExecutionId(runContext),
+          getRunContextWorkingDirectory(runContext),
           runtimeHost,
         );
       },

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -31,6 +31,12 @@ import {
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  startChildRunLoop,
+  type ChildRunPorts,
+  type ChildRunStrategy,
+} from '@agent/runtime/childRunLoop';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import type {
   StreamTabId,
   ExecutionId,
@@ -40,7 +46,12 @@ import type {
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { requireRunStream } from '@tools/contextHelpers';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
+  requireRunStream,
+} from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -62,12 +73,6 @@ import {
   formatChildRunDelivery,
   formatChildRunError,
 } from './deliveryEnvelope';
-import {
-  startChildRunLoop,
-  type ChildRunPorts,
-  type ChildRunStrategy,
-} from '@agent/runtime/childRunLoop';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
@@ -515,7 +520,7 @@ export class CodexTool extends defineTool({
           return resumeAgentCliSession(CodexThreads, {
             id: input.thread_id,
             prompt: input.prompt,
-            callerStreamId: runContext?.streamId,
+            callerStreamId: getRunContextStreamId(runContext),
             labels: {
               notActiveLabel: 'Codex thread',
               idParamName: 'thread_id',
@@ -530,8 +535,8 @@ export class CodexTool extends defineTool({
         return launchCodexSession(
           input,
           streamId,
-          runContext?.executionId,
-          runContext?.workingDirectory,
+          getRunContextExecutionId(runContext),
+          getRunContextWorkingDirectory(runContext),
           runtimeHost,
         );
       },

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import * as logger from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -166,7 +167,8 @@ export class InlineCommentTool extends defineTool({
       throw new ToolError('endLine must be greater than or equal to line.');
     }
     try {
-      const workingDirectory = tryUseRunContext()?.workingDirectory;
+      const workingDirectory =
+        getRunContextWorkingDirectory(tryUseRunContext());
       const resolved = resolveWorkspaceRelativePath(path, workingDirectory);
       const result = provider.add({
         absolutePath: resolved.absolute,
@@ -224,7 +226,8 @@ export class InlineCommentTool extends defineTool({
   private list(input: InlineCommentInput): ToolResult {
     let absolutePath: string | undefined;
     if (input.path != null) {
-      const workingDirectory = tryUseRunContext()?.workingDirectory;
+      const workingDirectory =
+        getRunContextWorkingDirectory(tryUseRunContext());
       absolutePath = resolveWorkspaceRelativePath(
         input.path,
         workingDirectory,

--- a/src/tools/contextHelpers.ts
+++ b/src/tools/contextHelpers.ts
@@ -6,10 +6,24 @@
  * with slightly different error wording.
  */
 
-import { tryUseRunContext, type RunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextRuntimeHost,
+  getRunContextStreamId,
+  tryUseRunContext,
+  type RunContext,
+} from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 import { ToolError } from '@shared/schemas/toolResult';
+
+export {
+  getRunContextAgentName,
+  getRunContextExecutionId,
+  getRunContextRuntimeHost,
+  getRunContextSession,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
+} from '@agent/runtime/RunContext';
 
 /**
  * Return the active RunContext's runtime host, throwing a ToolError if no
@@ -20,7 +34,7 @@ export function requireRuntimeHost(
   toolName: string,
   context: RunContext | undefined = tryUseRunContext(),
 ): AgentRuntimeHost {
-  const host = context?.runtimeHost;
+  const host = getRunContextRuntimeHost(context);
   if (!host) {
     throw new ToolError(`${toolName} requires a tool runtime host.`);
   }
@@ -36,7 +50,7 @@ export function requireStreamId(
   toolName: string,
   context: RunContext | undefined = tryUseRunContext(),
 ): StreamTabId {
-  const streamId = context?.streamId;
+  const streamId = getRunContextStreamId(context);
   if (!streamId) {
     throw new ToolError(`${toolName} requires an active stream context.`);
   }
@@ -56,14 +70,16 @@ export function requireRunStream(
   runtimeHost: AgentRuntimeHost;
   context: RunContext;
 } {
-  if (!context?.streamId || !context.runtimeHost) {
+  const streamId = getRunContextStreamId(context);
+  const runtimeHost = getRunContextRuntimeHost(context);
+  if (!context || !streamId || !runtimeHost) {
     throw new ToolError(
       `${toolName} must be called from within an agent stream.`,
     );
   }
   return {
-    streamId: context.streamId,
-    runtimeHost: context.runtimeHost,
+    streamId,
+    runtimeHost,
     context,
   };
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -39,6 +39,10 @@ import {
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
 import {
+  getRunContextExecutionId,
+  getRunContextRuntimeHost,
+} from '@tools/contextHelpers';
+import {
   buildSubagentFailureResultMeta,
   formatSubagentError,
 } from '@tools/subagentResults';
@@ -46,10 +50,10 @@ import {
   persistChildRunReport,
   persistChildRunResultMeta,
 } from '@tools/childRunDelivery';
+import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - utils
-import { generateExecutionId } from '@utils/core';
 import { subagentDeliveryMessage } from './subagentDeliveryFormat';
 // `createNativeToolUseStrategy`/`createNativeWorkflowStrategy` are lazy-
 // imported below, alongside `executeAgent` — both strategy modules import
@@ -118,7 +122,8 @@ export async function executeSubagent(
   // dynamic RemoteAgentLoader import in agentRegistry.
   const { executeAgent } = await import('@agent/runtime/executeAgent');
   const parentContext = tryUseRunContext();
-  if (!parentContext?.runtimeHost) {
+  const runtimeHost = getRunContextRuntimeHost(parentContext);
+  if (!parentContext || !runtimeHost) {
     return {
       status: 'error',
       summary: 'Delegation tool runtime host unavailable',
@@ -130,9 +135,8 @@ export async function executeSubagent(
       },
     };
   }
-  const parentExecutionId = parentContext.executionId;
+  const parentExecutionId = getRunContextExecutionId(parentContext);
   const parentDelegationDepth = parentContext.delegationDepth ?? 0;
-  const runtimeHost = parentContext.runtimeHost;
   const parentSession = currentSession();
   // Captured now (while the launching tool call's ALS frame is live) so the
   // child-run loop can still roll the child's cost into the parent run after

--- a/src/tools/executions/summaryFormat.ts
+++ b/src/tools/executions/summaryFormat.ts
@@ -22,6 +22,7 @@ import {
   getAvailablePaths,
   getExecutionStatusInfo,
 } from '../executionFormatters';
+import { getRunContextStreamId } from '../contextHelpers';
 
 /** Options controlling how showSummary renders a result report. */
 export interface ExecutionSummaryOptions {
@@ -52,7 +53,10 @@ export function shouldSuppressAutoDeliveredSubagentReport(
   handle: unknown,
 ): boolean {
   if (!options.suppressAutoDeliveredSubagentReport) return false;
-  return isCallerParentOfToolUseSubagent(handle, tryUseRunContext()?.streamId);
+  return isCallerParentOfToolUseSubagent(
+    handle,
+    getRunContextStreamId(tryUseRunContext()),
+  );
 }
 
 /** Build the header line for the paginated /executions listing. */

--- a/src/tools/executions/waitCoordination.ts
+++ b/src/tools/executions/waitCoordination.ts
@@ -12,6 +12,7 @@ import {
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { onFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { STREAM_STATUS } from '@shared/schemas';
+import { getRunContextStreamId } from '@tools/contextHelpers';
 
 /**
  * Single-pass check: should the wait endpoint skip blocking on this execution?
@@ -59,10 +60,9 @@ export function shouldSkipWait(executionId: string): boolean {
  * Returns a cleanup function that removes the listener.
  */
 export function listenForFollowUp(ac: AbortController): () => void {
-  const ctx = tryUseRunContext();
-  if (!ctx?.streamId) return () => {};
+  const streamId = getRunContextStreamId(tryUseRunContext());
+  if (!streamId) return () => {};
 
-  const streamId = ctx.streamId;
   return onFollowUpSent((followUpStreamId) => {
     if (followUpStreamId === streamId) ac.abort();
   });

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -21,7 +21,10 @@ import { z } from 'zod';
 
 import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { requireRunStream } from '@tools/contextHelpers';
+import {
+  getRunContextWorkingDirectory,
+  requireRunStream,
+} from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
@@ -443,7 +446,7 @@ async function execFindCurrent(
   await requireToken();
   const cwd =
     parseWorkingDirectory(input.working_directory) ??
-    tryUseRunContext()?.workingDirectory;
+    getRunContextWorkingDirectory(tryUseRunContext());
   if (!cwd) {
     throw new ToolError(
       'No working_directory available. Provide one explicitly.',

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -13,6 +13,7 @@ import {
   type Goal,
   type GoalStatus,
 } from '@shared/schemas/goal';
+import { getRunContextSession } from '@tools/contextHelpers';
 import { filterNotNull, unique, hexId12 } from '@utils/core';
 
 const STREAM_KEY_PREFIX = 'goals:byStream:';
@@ -46,7 +47,7 @@ function emitGoalStateChanged(
 ): void {
   // Preserve the old fallback rule while deleting the bus dependency:
   // older direct-node tests may carry a partial run session.
-  const owner = session ?? tryUseRunContext()?.session;
+  const owner = session ?? getRunContextSession(tryUseRunContext());
   const target = owner?.events ? owner : defaultSession();
   target.events.emit({
     scope: 'session',

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -31,7 +31,12 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { requireRuntimeHost } from '@tools/contextHelpers';
+import {
+  getRunContextExecutionId,
+  getRunContextSession,
+  getRunContextStreamId,
+  requireRuntimeHost,
+} from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -321,8 +326,8 @@ export class ExternalInquiryTool extends defineTool({
 }) {
   protected async execute(input: InquiryInput): Promise<ToolResult> {
     const context = tryUseRunContext();
-    const streamId = context?.streamId;
-    const executionId = context?.executionId;
+    const streamId = getRunContextStreamId(context);
+    const executionId = getRunContextExecutionId(context);
 
     // Only `ask` emits events. `read` and `list` are pure storage reads
     // and stay usable in contexts without a wired runtime host.
@@ -334,7 +339,7 @@ export class ExternalInquiryTool extends defineTool({
           streamId,
           runtimeHost,
           executionId,
-          session: context?.session,
+          session: getRunContextSession(context),
         });
       }
       case 'read':

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -31,6 +31,7 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 import { formatRelativeTime } from '@shared/utils/string';
+import { getRunContextSession } from '@tools/contextHelpers';
 import { truncateSummary, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import {
@@ -48,7 +49,7 @@ const QUESTION_TRUNCATION = 400;
 const ANSWER_TRUNCATION = 2000;
 
 function inquiryThreadUpdateSession(session?: SessionHandle): SessionHandle {
-  const owner = session ?? tryUseRunContext()?.session;
+  const owner = session ?? getRunContextSession(tryUseRunContext());
   return owner?.events ? owner : defaultSession();
 }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -10,6 +10,10 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 import { debug } from '@logger/logUtils';
 import { formatRelativeTime } from '@shared/utils/string';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import {
+  getRunContextAgentName,
+  getRunContextExecutionId,
+} from '@tools/contextHelpers';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { splitContentLines } from '@utils/text/stringUtils';
@@ -194,7 +198,11 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     existingMeta?: MemoryFileMeta | null,
   ): Promise<void> {
     const ctx = tryUseRunContext();
-    const meta = createMeta(ctx?.agentName, ctx?.executionId, existingMeta);
+    const meta = createMeta(
+      getRunContextAgentName(ctx),
+      getRunContextExecutionId(ctx),
+      existingMeta,
+    );
     await StorageFS.write(resolvedPath, buildFile(content, meta));
   }
 

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -6,6 +6,7 @@ import { tryUseRunContext } from '@agent/runtime/RunContext';
 
 // Local imports - tools
 import { ToolError } from '@shared/schemas/toolResult';
+import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 
 // Local imports - core utilities
 import { WorkspaceFS } from '@utils/files';
@@ -51,11 +52,13 @@ export function parseWorkingDirectory(
  * or when no override was set on the launch — callers then fall back to the
  * workspace root via `WorkspaceFS.locatePath`.
  *
- * Centralizes the `parseWorkingDirectory(tryUseRunContext()?.workingDirectory)`
+ * Centralizes the active-context working-directory lookup and validation
  * pattern that every workspace-touching tool needs.
  */
 export function currentToolRoot(): string | undefined {
-  return parseWorkingDirectory(tryUseRunContext()?.workingDirectory);
+  return parseWorkingDirectory(
+    getRunContextWorkingDirectory(tryUseRunContext()),
+  );
 }
 
 /** Throw when a raw tool path contains a parent-directory segment. */

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -35,7 +35,11 @@ import {
 } from '@shared/schemas/goal';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { proposalApprovalState } from '@tools/approval';
-import { requireStreamId } from '@tools/contextHelpers';
+import {
+  getRunContextRuntimeHost,
+  getRunContextStreamId,
+  requireStreamId,
+} from '@tools/contextHelpers';
 import {
   GoalStore,
   isGoalEnabled,
@@ -153,19 +157,16 @@ Best practices:
     // Every update is a (re-)proposal: with no step statuses to record,
     // the only reason to call update is a new or changed objective, and
     // that decision belongs to the user.
-    if (!runContext?.streamId) {
+    const streamId = getRunContextStreamId(runContext);
+    if (!streamId) {
       logger.warn('Plan created without streamId — skipping approval gate');
       return this.buildApprovedResult({ autoApproved: false });
     }
-    if (proposalApprovalState.isBypassed(runContext.streamId)) {
+    if (proposalApprovalState.isBypassed(streamId)) {
       logger.info('Plan auto-approved via delegated-task auto-approval');
       return this.buildApprovedResult({ autoApproved: true });
     }
-    return this.requestApproval(
-      plan,
-      runContext.streamId,
-      callContext.workPlanState,
-    );
+    return this.requestApproval(plan, streamId, callContext.workPlanState);
   }
 
   private async executePause(
@@ -207,7 +208,9 @@ Best practices:
     streamId: string,
     enabled: boolean,
   ): Promise<void> {
-    const runtimeHost = getCurrentToolContexts()?.runContext?.runtimeHost;
+    const runtimeHost = getRunContextRuntimeHost(
+      getCurrentToolContexts()?.runContext,
+    );
     if (runtimeHost) {
       await setGoalSessionBashAutoApproval(streamId, enabled, runtimeHost);
     }

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -10,7 +10,10 @@ import {
   type UserQuestionAnswers,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import { requireRuntimeHost } from '@tools/contextHelpers';
+import {
+  getRunContextStreamId,
+  requireRuntimeHost,
+} from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 const logger = createChannelTrace('UserQuestionTool');
@@ -57,7 +60,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
   protected async execute(input: AskUserQuestionInput): Promise<ToolResult> {
     const context = tryUseRunContext();
     const runtimeHost = requireRuntimeHost('ask_user_question', context);
-    const streamId = context?.streamId;
+    const streamId = getRunContextStreamId(context);
     const requestId = `user-question-${nanoid()}`;
 
     logger.info('User question requested', {


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary

- Adds RunContext accessors that read launched-run identity and owner session from runScope, with the existing bare-context fallback for tests and one-shot tool contexts.
- Updates tool-side run-context consumers to use those accessors for stream id, execution id, runtime host, session, agent name, and working directory.
- Keeps @tools/contextHelpers as the tool-friendly error wrapper around the runtime accessors.
- Updates the two RunContext-mocking delegation tests to model the new accessor rule.

This is the next RunScope unification slice after #7665. It does not delete the CLI public-output projection.

## Validation

- npm run typecheck
- focused Vitest: 21 files, 128 tests
- failing-delegation rerun: 2 files, 9 tests
- full npm test: 609 files passed, 1 skipped; 5273 tests passed, 4 skipped
- npm run format
- git diff --check
- npm run compile:fast
- npm run lint passes with the repository existing unrelated import-order warnings only
- grep over src/tools, src/agent/followUp, and src/agent/runtime shows remaining direct flat run-context reads only inside the new RunContext accessors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many tool and approval paths that depend on correct stream/execution/session identity; behavior should be neutral when top-level fields match `runScope`, but launch-context mismatches would now surface differently.
> 
> **Overview**
> **RunScope unification slice:** new `getRunContext*` accessors in `RunContext` return stream id, execution id, runtime host, session, agent name, and working directory from `runScope` when `kind === 'launch'`, with the same flat fields on `bare` contexts for tests and one-shot tools.
> 
> **Call sites** stop reading `context?.streamId` (and siblings) directly. `currentSession`, follow-up session resolution, `contextHelpers` (`requireRunStream`, `requireStreamId`, `requireRuntimeHost`), and a wide set of tools (delegation, executions, bash, approvals, path resolution, agent CLIs, etc.) now go through those accessors. `ExecutionsTool` unsubscribe uses `requireStreamId` for consistent errors.
> 
> **Tests:** `DelegationTools` and `SubagentExecutionChildStreamId` mocks implement the launch-vs-bare accessor rule so delegation resume and subagent launch tests stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51ea5e17e00a5309d85618b412c89ce31ea6feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->