### PR TITLE
refactor: narrow launch run context

### DIFF
--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -8,10 +8,8 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { SessionHandle } from './SessionHandle';
 
 interface RunContextCommon {
-  readonly runtimeHost: AgentRuntimeHost;
   /** Current model short name for this run (e.g. "opus46T"). */
   readonly model?: string;
-  readonly workingDirectory?: string;
   readonly delegationDepth?: number;
   readonly approvalPromptsUnavailable?: boolean;
   readonly runtimeUnavailableTools?: readonly string[];
@@ -30,20 +28,16 @@ interface RunContextCommon {
 export interface LaunchRunContext extends RunContextCommon {
   readonly kind: 'launch';
   readonly runScope: RunScope;
-  readonly streamId: StreamTabId;
-  readonly executionId: ExecutionId;
-  /** Agent name (e.g. "orchestrator", "search-agent"). */
-  readonly agentName: string;
-  /** Session that owns this run's coordination state. */
-  readonly session: SessionHandle;
 }
 
 interface BareRunContext extends RunContextCommon {
   readonly kind: 'bare';
+  readonly runtimeHost: AgentRuntimeHost;
   readonly streamId?: StreamTabId;
   readonly executionId?: ExecutionId;
   /** Agent name (e.g. "orchestrator", "search-agent"). */
   readonly agentName?: string;
+  readonly workingDirectory?: string;
   /** Session that owns this run's coordination state. */
   readonly session?: SessionHandle;
 }
@@ -108,43 +102,50 @@ const runContextScope = new AsyncLocalStorage<RunContext>();
 // ---------------------------------------------------------------------------
 
 type CommonRunContextFieldNames =
-  | 'runtimeHost'
-  | 'runScope'
-  | 'streamId'
-  | 'executionId'
-  | 'agentName'
-  | 'workingDirectory'
   | 'delegationDepth'
   | 'approvalPromptsUnavailable'
   | 'runtimeUnavailableTools'
   | 'stopAfterCycle'
-  | 'session'
   | 'toolEditApprovalHandler';
+
+type BareRunContextFieldNames =
+  | CommonRunContextFieldNames
+  | 'runtimeHost'
+  | 'streamId'
+  | 'executionId'
+  | 'agentName'
+  | 'workingDirectory'
+  | 'session';
 
 /**
  * Fields shared by both `RunContext` kinds, forwarded as-is from the input
- * options. The return type is `Pick<T, ...>` (rather than inferred from the
- * function body) so the `live` branch's `CreateLaunchRunContextFields`
- * guarantees — e.g. a required `streamId` — survive the call instead of
- * widening back to the optional `bare` shape.
+ * options.
  */
 function commonRunContextFields<T extends CreateRunContextBase>(
   options: T,
 ): Pick<T, CommonRunContextFieldNames> {
   return {
-    runtimeHost: options.runtimeHost,
-    runScope: options.runScope,
-    streamId: options.streamId,
-    executionId: options.executionId,
-    agentName: options.agentName,
-    workingDirectory: options.workingDirectory,
     delegationDepth: options.delegationDepth,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
-    session: options.session,
     toolEditApprovalHandler: options.toolEditApprovalHandler,
   } as Pick<T, CommonRunContextFieldNames>;
+}
+
+/** Fields used only by the manually constructed `bare` context shape. */
+function bareRunContextFields<T extends CreateRunContextBase>(
+  options: T,
+): Pick<T, BareRunContextFieldNames> {
+  return {
+    ...commonRunContextFields(options),
+    runtimeHost: options.runtimeHost,
+    streamId: options.streamId,
+    executionId: options.executionId,
+    agentName: options.agentName,
+    workingDirectory: options.workingDirectory,
+    session: options.session,
+  } as Pick<T, BareRunContextFieldNames>;
 }
 
 /**
@@ -176,12 +177,6 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
       kind: 'launch',
       ...commonRunContextFields(options),
       runScope,
-      runtimeHost: runScope.runtimeHost,
-      streamId: runScope.streamId,
-      executionId: runScope.executionId,
-      agentName: runScope.agentName,
-      workingDirectory: runScope.workingDirectory,
-      session: runScope.session,
       get model() {
         return getModel() ?? model;
       },
@@ -191,7 +186,7 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
   const { model } = options;
   return Object.freeze({
     kind: 'bare',
-    ...commonRunContextFields(options),
+    ...bareRunContextFields(options),
     get model() {
       return model;
     },

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest';
 // Local imports - runtime
 import {
   createRunContext,
+  getRunContextAgentName,
+  getRunContextExecutionId,
+  getRunContextRuntimeHost,
+  getRunContextSession,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
   useRunContext,
   withRunContext,
 } from '@agent/runtime/RunContext';
@@ -41,7 +47,9 @@ describe('RunContext', () => {
     const runtimeHost = createRuntimeHost();
     const context = createRunContext({ runtimeHost });
 
-    const resolved = withRunContext(context, () => useRunContext().runtimeHost);
+    const resolved = withRunContext(context, () =>
+      getRunContextRuntimeHost(useRunContext()),
+    );
 
     expect(resolved).toBe(runtimeHost);
   });
@@ -102,12 +110,20 @@ describe('RunContext', () => {
       throw new Error('expected launch context');
     }
     expect(context.runScope).toBe(runScope);
-    expect(context.runtimeHost).toBe(runScope.runtimeHost);
-    expect(context.streamId).toBe(runScope.streamId);
-    expect(context.executionId).toBe(runScope.executionId);
-    expect(context.agentName).toBe(runScope.agentName);
-    expect(context.workingDirectory).toBe(runScope.workingDirectory);
-    expect(context.session).toBe(runScope.session);
+    expect('runtimeHost' in context).toBe(false);
+    expect('streamId' in context).toBe(false);
+    expect('executionId' in context).toBe(false);
+    expect('agentName' in context).toBe(false);
+    expect('workingDirectory' in context).toBe(false);
+    expect('session' in context).toBe(false);
+    expect(getRunContextRuntimeHost(context)).toBe(runScope.runtimeHost);
+    expect(getRunContextStreamId(context)).toBe(runScope.streamId);
+    expect(getRunContextExecutionId(context)).toBe(runScope.executionId);
+    expect(getRunContextAgentName(context)).toBe(runScope.agentName);
+    expect(getRunContextWorkingDirectory(context)).toBe(
+      runScope.workingDirectory,
+    );
+    expect(getRunContextSession(context)).toBe(runScope.session);
   });
 
   it('requires an active context for owned runtime state', () => {


### PR DESCRIPTION
Part of #6968 and #6951. Follows #7668.

## Summary

- Removes the flat `LaunchRunContext` compatibility fields that duplicate `runScope` (`runtimeHost`, `streamId`, `executionId`, `agentName`, `workingDirectory`, and `session`).
- Keeps those direct fields only on the `bare` run-context shape used by manually constructed tool contexts.
- Updates `RunContext` tests to use the accessor functions for launch contexts and to assert that launch contexts expose `runScope` rather than duplicate identity/session fields.

This keeps the public accessor functions as the compatibility boundary while making launched run identity single-sourced through `RunScope`.

## Validation

- `npm run typecheck`
- `npm test -- --run src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime`
- `npm run format`
- `git diff --check origin/main...HEAD`
- `npm run lint` (passes with existing unrelated import-order warnings)
- `npm run compile:fast`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Type-level narrowing can break any code that still reads identity fields off launch contexts instead of `runScope` or the existing getters, though accessors already centralize that path.
> 
> **Overview**
> **Launch** run contexts no longer duplicate run identity on the object itself: fields like `runtimeHost`, `streamId`, `executionId`, `agentName`, `workingDirectory`, and `session` are removed from `LaunchRunContext` and live only on `runScope`. The **bare** test/one-shot shape still carries those fields directly.
> 
> `createRunContext` is split so shared options use `commonRunContextFields`, while `bareRunContextFields` adds host/identity/session only for static contexts; the live/launch path freezes `kind`, common fields, and `runScope` without copying scope properties onto the context.
> 
> Tests now assert launch objects omit the duplicate keys and resolve identity via `getRunContext*` helpers instead of direct property reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105b240f36c901242f869bc8ceb245cc73130f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->