### PR TITLE
refactor: table-drive ProgressFactApplier domain-fact dispatch

### DIFF
--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -322,14 +322,17 @@ export class ProgressFactApplier {
   }
 
   /**
-   * `domain` run facts (keyed `runFact.<name>`) dispatch through this table:
-   * one entry per handled {@link RunFactEventName}. Adding a new projected fact
-   * is a single row here. `goalPaused` is intentionally absent — the progress
-   * backend does not project it (see `runFactEvents.ts`) — so an unlisted fact
-   * is silently ignored, matching the prior if-ladder's fall-through.
+   * `domain` run facts (keyed `runFact.<name>`) dispatch through this table.
+   * It is typed as an *exhaustive* `Record<RunFactEventName, …>`, so adding a
+   * run fact is a COMPILE error here until it is given an arm — turning the old
+   * silent fall-through into compile-loudness (issue #7689; the silent-`default`
+   * class behind #7639/#7640). Facts the progress backend intentionally does not
+   * project map to `null` — an explicit, reviewable opt-out rather than an
+   * omission — currently only `goalPaused`.
    */
-  private readonly domainFactHandlers: Partial<
-    Record<RunFactEventName, (data: unknown) => void>
+  private readonly domainFactHandlers: Record<
+    RunFactEventName,
+    ((data: unknown) => void) | null
   > = {
     updateTodos: this.domainFact('updateTodos', UpdateTodosPayloadSchema, (p) =>
       this.handleUpdateTodos(p),
@@ -349,6 +352,8 @@ export class ProgressFactApplier {
       'updateCompileFailures',
       (p) => this.handleUpdateCompileFailures(p),
     ),
+    // Intentionally unprojected by the progress backend — explicit opt-out.
+    goalPaused: null,
   };
 
   /** Build a domain-fact handler that Zod-validates the payload before applying. */

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -1,4 +1,3 @@
-
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -1,9 +1,10 @@
-import { z } from 'zod';
 
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
-import type { RunFactEventName } from '@agent/runtime/runFactEvents';
+import {
+  fromRunFactDomainKey,
+  type RunFactEventName,
+} from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
@@ -55,6 +56,7 @@ import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
 import { isObject } from '@utils/core';
 
 import { withEventErrorHandling } from './errorHandling';
+import type { ZodType } from 'zod';
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
@@ -353,7 +355,7 @@ export class ProgressFactApplier {
   /** Build a domain-fact handler that Zod-validates the payload before applying. */
   private domainFact<T>(
     name: RunFactEventName,
-    schema: z.ZodType<T>,
+    schema: ZodType<T>,
     handle: (payload: T) => void,
   ): (data: unknown) => void {
     return (data) => {

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -1,6 +1,9 @@
+import { z } from 'zod';
+
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { fromRunFactDomainKey } from '@agent/runtime/runFactEvents';
+import type { RunFactEventName } from '@agent/runtime/runFactEvents';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
@@ -153,34 +156,34 @@ export class ProgressFactApplier {
       case 'goalStateChanged':
         return;
       case 'inquiryThreadUpdated':
-        this.applyFact('failed to handle inquiryThreadUpdated fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleInquiryThreadUpdated(fact.payload),
         );
         return;
       case 'clearMissingOutputs':
-        this.applyFact('failed to handle clearMissingOutputs fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleClearMissingOutputs(fact.payload),
         );
         return;
       case 'updateQueuedFollowUps':
-        this.applyFact('failed to handle updateQueuedFollowUps fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleUpdateQueuedFollowUps(fact.payload),
         );
         return;
       case 'followUpSent':
         return;
       case 'setActiveStream':
-        this.applyFact('failed to handle setActiveStream fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleSetActiveStream(fact.payload),
         );
         return;
       case 'updateStreamDescription':
-        this.applyFact('failed to handle updateStreamDescription fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleUpdateStreamDescription(fact.payload),
         );
         return;
       case 'updateStreamStatus':
-        this.applyFact('failed to handle updateStreamStatus fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.setStreamStatus(
             fact.payload.streamId,
             fact.payload.status,
@@ -190,7 +193,7 @@ export class ProgressFactApplier {
         );
         return;
       case 'setParentStream':
-        this.applyFact('failed to handle setParentStream fact', () =>
+        this.applyNamedFact(fact.type, () =>
           this.handleSetParentStream(fact.payload),
         );
         return;
@@ -203,7 +206,7 @@ export class ProgressFactApplier {
     if (event.type === 'usage') {
       const payload = toUpdateStreamUsagePayload(event.data, streamId);
       if (payload) {
-        this.applyFact('failed to handle usage fact', () =>
+        this.applyNamedFact(event.type, () =>
           this.handleUpdateStreamUsage(payload),
         );
       }
@@ -211,7 +214,7 @@ export class ProgressFactApplier {
     }
 
     if (event.type === 'run.config') {
-      this.applyFact('failed to handle run.config fact', () =>
+      this.applyNamedFact(event.type, () =>
         this.handleSetTaskState({
           streamId: event.streamId,
           executionId: event.executionId,
@@ -222,7 +225,7 @@ export class ProgressFactApplier {
     }
 
     if (event.type === 'status') {
-      this.applyFact('failed to handle status fact', () =>
+      this.applyNamedFact(event.type, () =>
         this.setStreamStatus(
           event.streamId,
           event.phase,
@@ -237,7 +240,7 @@ export class ProgressFactApplier {
       if (event.key === 'conversationProgress') {
         const progress = ConversationProgressSchema.safeParse(event.data);
         if (progress.success) {
-          this.applyFact('failed to handle conversationProgress fact', () =>
+          this.applyNamedFact('conversationProgress', () =>
             this.handleUpdateConversationProgress({
               streamId,
               progress: progress.data,
@@ -248,55 +251,13 @@ export class ProgressFactApplier {
       }
 
       const factName = fromRunFactDomainKey(event.key);
-      if (factName === 'updateTodos') {
-        const payload = UpdateTodosPayloadSchema.safeParse(event.data);
-        if (payload.success) {
-          this.applyFact('failed to handle updateTodos fact', () =>
-            this.handleUpdateTodos(payload.data),
-          );
-        }
-        return;
-      }
-
-      if (factName === 'updatePlan') {
-        const payload = UpdatePlanPayloadSchema.safeParse(event.data);
-        if (payload.success) {
-          this.applyFact('failed to handle updatePlan fact', () =>
-            this.handleUpdatePlan(payload.data),
-          );
-        }
-        return;
-      }
-
-      if (factName === 'addOutputFiles' && isObject(event.data)) {
-        this.applyFact('failed to handle addOutputFiles fact', () =>
-          this.handleAddOutputFiles(event.data as AddOutputFilesPayload),
-        );
-        return;
-      }
-
-      if (factName === 'updateMissingOutputs' && isObject(event.data)) {
-        this.applyFact('failed to handle updateMissingOutputs fact', () =>
-          this.handleUpdateMissingOutputs(
-            event.data as UpdateMissingOutputsPayload,
-          ),
-        );
-        return;
-      }
-
-      if (factName === 'updateCompileFailures' && isObject(event.data)) {
-        this.applyFact('failed to handle updateCompileFailures fact', () =>
-          this.handleUpdateCompileFailures(
-            event.data as UpdateCompileFailuresPayload,
-          ),
-        );
-      }
+      if (factName) this.domainFactHandlers[factName]?.(event.data);
       return;
     }
 
     if (event.type === 'stage.start') {
       if (event.kind !== 'round') return;
-      this.applyFact('failed to handle stage.start fact', () =>
+      this.applyNamedFact(event.type, () =>
         this.handleUpdateRoundStage({
           streamId,
           roundStage: {
@@ -312,7 +273,7 @@ export class ProgressFactApplier {
 
     if (event.type === 'child.activity') {
       if (event.kind === 'subagents') {
-        this.applyFact('failed to handle subagent activity fact', () =>
+        this.applyNamedFact('subagent activity', () =>
           this.updateActiveChildren(event.parentStreamId, {
             activeField: 'activeSubagents',
             countField: 'finishedSubagentCount',
@@ -322,7 +283,7 @@ export class ProgressFactApplier {
         return;
       }
       if (event.kind === 'processes') {
-        this.applyFact('failed to handle process activity fact', () =>
+        this.applyNamedFact('process activity', () =>
           this.updateActiveChildren(event.parentStreamId, {
             activeField: 'activeProcesses',
             countField: 'finishedProcessCount',
@@ -335,7 +296,7 @@ export class ProgressFactApplier {
     }
 
     if (event.type === 'process.output') {
-      this.applyFact('failed to handle process.output fact', () =>
+      this.applyNamedFact(event.type, () =>
         this.handleUpdateProcessOutput({
           parentStreamId: event.parentStreamId,
           executionId: event.executionId,
@@ -349,6 +310,68 @@ export class ProgressFactApplier {
 
   private applyFact(context: string, handle: () => void | Promise<void>): void {
     withEventErrorHandling('ProgressFacts', context, handle);
+  }
+
+  /** {@link applyFact} with the standard `failed to handle <name> fact` context. */
+  private applyNamedFact(
+    name: string,
+    handle: () => void | Promise<void>,
+  ): void {
+    this.applyFact(`failed to handle ${name} fact`, handle);
+  }
+
+  /**
+   * `domain` run facts (keyed `runFact.<name>`) dispatch through this table:
+   * one entry per handled {@link RunFactEventName}. Adding a new projected fact
+   * is a single row here. `goalPaused` is intentionally absent — the progress
+   * backend does not project it (see `runFactEvents.ts`) — so an unlisted fact
+   * is silently ignored, matching the prior if-ladder's fall-through.
+   */
+  private readonly domainFactHandlers: Partial<
+    Record<RunFactEventName, (data: unknown) => void>
+  > = {
+    updateTodos: this.domainFact('updateTodos', UpdateTodosPayloadSchema, (p) =>
+      this.handleUpdateTodos(p),
+    ),
+    updatePlan: this.domainFact('updatePlan', UpdatePlanPayloadSchema, (p) =>
+      this.handleUpdatePlan(p),
+    ),
+    addOutputFiles: this.domainFactObject<AddOutputFilesPayload>(
+      'addOutputFiles',
+      (p) => this.handleAddOutputFiles(p),
+    ),
+    updateMissingOutputs: this.domainFactObject<UpdateMissingOutputsPayload>(
+      'updateMissingOutputs',
+      (p) => this.handleUpdateMissingOutputs(p),
+    ),
+    updateCompileFailures: this.domainFactObject<UpdateCompileFailuresPayload>(
+      'updateCompileFailures',
+      (p) => this.handleUpdateCompileFailures(p),
+    ),
+  };
+
+  /** Build a domain-fact handler that Zod-validates the payload before applying. */
+  private domainFact<T>(
+    name: RunFactEventName,
+    schema: z.ZodType<T>,
+    handle: (payload: T) => void,
+  ): (data: unknown) => void {
+    return (data) => {
+      const parsed = schema.safeParse(data);
+      if (!parsed.success) return;
+      this.applyNamedFact(name, () => handle(parsed.data));
+    };
+  }
+
+  /** Build a domain-fact handler that requires an object payload (no schema). */
+  private domainFactObject<T>(
+    name: RunFactEventName,
+    handle: (payload: T) => void,
+  ): (data: unknown) => void {
+    return (data) => {
+      if (!isObject(data)) return;
+      this.applyNamedFact(name, () => handle(data as T));
+    };
   }
 
   public handleInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {


### PR DESCRIPTION
## Summary

`ProgressFactApplier` translates run/session facts into progress-view state and webview updates. Its `handleRunFact` `domain` branch had grown into a chain of near-identical `if (factName === '…') { Schema.safeParse(...); if (success) applyFact('failed to handle … fact', () => this.handleX(...)); return; }` blocks — one per projected fact — and the `failed to handle <name> fact` context string was hand-written at all 20 dispatch sites.

This PR replaces that ladder with a lookup table and centralizes the context-string phrasing, with **no behavior change**. It is the first cleanup landed from a broader read-only refactoring audit of the codebase.

- Introduce `domainFactHandlers`, a `Partial<Record<RunFactEventName, (data: unknown) => void>>` table built from two small typed helpers:
  - `domainFact(name, schema, handle)` — Zod-validates the payload, then applies.
  - `domainFactObject(name, handle)` — requires an object payload (the prior `isObject` cast path).
- The `domain` branch collapses to `this.domainFactHandlers[factName]?.(event.data)`. Adding a projected fact is now a single table row instead of a copy-pasted block.
- Add `applyNamedFact(name, handle)`, which owns the single `failed to handle <name> fact` phrasing, and route all session-fact and run-fact dispatch sites through it. Emitted error-context strings are byte-identical to before.

## Issue acceptance gates

No issue number. Addresses the "large switch/if-else fact appliers that could be table-driven" item flagged for this file in the internal runtime code-quality audit.

## Single source of truth

`ProgressFactApplier.domainFactHandlers` is now the single owner of the run-fact `domain` → handler mapping (keyed by `RunFactEventName` from `runFactEvents.ts`). `applyNamedFact` is the single owner of the progress-fact error-context phrasing. `goalPaused` remains intentionally unprojected by the progress backend — an unlisted fact silently falls through, matching the prior ladder.

## Duplication and abstraction budget

Removes five copy-pasted parse-then-`applyFact` blocks and 20 hand-written context-string literals. The two new builder helpers are multi-caller (2 and 3 call sites respectively) and each owns a real invariant (payload validation strategy), so they clear the abstraction-cost guardrail — no single-caller extractions, no pass-through layers.

## Host impact

Extension: none (shared core; behavior unchanged, same webview updates emitted).

Desktop: none (same shared `ProgressFactApplier`).

CLI: none (same shared `ProgressFactApplier`).

## Scheduled refactoring

None required for this change. The broader audit identified further independent areas (settings-view frontend boilerplate, model-handler response pipeline, transcript stores, desktop↔extension composition tier) that can be follow-up PRs.

## Validation

- `vitest run src/test-kernel/progressView/` — 181 tests pass (incl. the 27-test `ProgressBackend.vitest.ts` and run-fact progress-event suites).
- `tsc --noEmit` (root) — clean.
- `tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `eslint` on the changed file — clean.
- `prettier --check` on the changed file — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yHWk7JPgyTsQ31vw6WMRp

---
_Generated by [Claude Code](https://claude.ai/code/session_016yHWk7JPgyTsQ31vw6WMRp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only in progress-view fact projection with exhaustive typing; no new runtime paths and existing progress-view tests cover behavior.
> 
> **Overview**
> **`ProgressFactApplier`** no longer uses a long `if (factName === '…')` chain for `domain` run facts. Dispatch goes through an exhaustive **`domainFactHandlers`** table keyed by **`RunFactEventName`**, so a new run fact must get a table entry (or an explicit **`null`** opt-out like **`goalPaused`**) or TypeScript fails to compile.
> 
> Shared helpers **`domainFact`** (Zod **`safeParse`**) and **`domainFactObject`** (**`isObject`**) build the per-fact handlers; the branch is **`domainFactHandlers[factName]?.(event.data)`**. Session and run fact paths now call **`applyNamedFact`** so error context is always **`failed to handle <name> fact`** instead of hand-written strings at each site.
> 
> Intended as a no-behavior-change cleanup: same validation, handlers, and error wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17707db9e3056a1e34c96ba2857b0feea891e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->