### PR TITLE
refactor: consolidate duplicated chat-message and file-op merge logic

### DIFF
--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -14,7 +14,11 @@ import {
   runCleanRunDir,
 } from '@housekeeping';
 import * as logger from '@logger/logUtils';
-import { FileOpParamsSchema, fileOpConfigFields } from './fileOpSchemas';
+import {
+  FileOpParamsSchema,
+  fileOpConfigFields,
+  mergeRunDirAndWorkspaceResult,
+} from './fileOpSchemas';
 import { emitClearMissingOutputs } from './streamEventUtils';
 
 const CHANNEL = 'cleanCommands';
@@ -159,18 +163,7 @@ async function handleClean(config: unknown): Promise<void> {
   if (executionId) {
     const runDirResult = await runCleanRunDir(executionId);
     const workspaceResult = await runWorkspaceClean();
-    // Surface errors from either leg — a failed runDir removal (e.g.
-    // permission-denied) must not be masked by a successful workspace
-    // sweep, or the user sees "Cleanup complete" while `executions/{id}`
-    // remains on disk.
-    if (runDirResult.status === 'error') {
-      result = runDirResult;
-    } else if (workspaceResult.status === 'error') {
-      result = workspaceResult;
-    } else {
-      result =
-        workspaceResult.status !== 'noFiles' ? workspaceResult : runDirResult;
-    }
+    result = mergeRunDirAndWorkspaceResult(runDirResult, workspaceResult);
   } else {
     result = await runWorkspaceClean();
   }

--- a/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
+++ b/packages/extension/src/commands/housekeeping/fileOpSchemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { ExecutionIdSchema } from '@shared/schemas';
+import type { FileOpResult } from '@shared/schemas/opResults';
 
 /** Non-empty string for the required file-operation identity fields. */
 const RequiredString = z.string().min(1);
@@ -31,3 +32,20 @@ export const fileOpConfigFields = {
   executionId: ExecutionIdSchema.optional(),
   skipProgressViewClear: z.boolean().optional(),
 };
+
+/**
+ * Merges the runDir and workspace legs of an executionId-driven pack/clean
+ * operation. Surfaces an error from either leg — a failed runDir
+ * removal/snapshot must not be masked by a successful workspace sweep/pack —
+ * and otherwise prefers the workspace result, falling back to the runDir
+ * result only when the workspace leg found nothing (legacy runs whose
+ * outputs still sit beside the source rather than inside the runDir).
+ */
+export function mergeRunDirAndWorkspaceResult(
+  runDirResult: FileOpResult,
+  workspaceResult: FileOpResult,
+): FileOpResult {
+  if (runDirResult.status === 'error') return runDirResult;
+  if (workspaceResult.status === 'error') return workspaceResult;
+  return workspaceResult.status !== 'noFiles' ? workspaceResult : runDirResult;
+}

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -20,6 +20,7 @@ import { WorkspaceFS } from '@utils/files';
 import {
   FileOpParamsSchema,
   fileOpConfigFields,
+  mergeRunDirAndWorkspaceResult,
   type FileOpParams,
 } from './fileOpSchemas';
 import {
@@ -119,15 +120,7 @@ async function handlePack(config: unknown): Promise<void> {
           data.inputFile,
         );
         const workspaceResult = await runWorkspacePack();
-        // Surface errors from either leg — a failed runDir snapshot
-        // (permission denied, disk full) must not be masked by a
-        // successful workspace pack, or the user sees "Pack complete"
-        // while no primary run-dir snapshot was created.
-        if (runDirResult.status === 'error') return runDirResult;
-        if (workspaceResult.status === 'error') return workspaceResult;
-        return workspaceResult.status !== 'noFiles'
-          ? workspaceResult
-          : runDirResult;
+        return mergeRunDirAndWorkspaceResult(runDirResult, workspaceResult);
       }
       return runWorkspacePack();
     },

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -32,7 +32,7 @@ import type {
 } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
-import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
+import { extractMimeSubtype } from '@utils/text/stringUtils';
 import { computeUtilizationPercent } from '../support/contextUtilization';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { tagOpenAISdkError } from './openAISdkError';
@@ -41,6 +41,11 @@ import { tagOpenAISdkError } from './openAISdkError';
 import { computeOpenAIPrice, normalizeOpenAIUsage } from './openAIUsage';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import {
+  appendUserTextToChatMessages,
+  createChatRoundMessages,
+  createChatUserFollowUpMessages,
+  extractChatAssistantText,
+  initializeChatMessages,
   insertMediaIntoChatUserMessage,
   normalizeOpenAIMessageContent,
   prependTextToChatUserMessage,
@@ -712,67 +717,14 @@ export class ModelHandlerOpenAI<
     mediaFiles?: FileLocation[],
     systemPrompt?: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    const messages: ChatCompletionMessageParam[] = [];
-
-    // Handle system prompt differently for O1 models
-    // O1 mini and O1 preview models do not support system prompt; use 'user' role instead.
-    // For openai native o1 full or above reasoning models, "developer" is the new name but "system" still works.
-    if (systemPrompt) {
-      const role = this.capabilities.supportsSystemPrompt ? 'system' : 'user';
-      messages.push({
-        role,
-        content: [{ type: 'text', text: systemPrompt }],
-      });
-    }
-
-    // Create content list for the user message (only add non-empty prefix)
-    const userMessageContent: ChatCompletionContentPart[] = [];
-    if (userPrefix) {
-      userMessageContent.push({ type: 'text', text: userPrefix });
-    }
-
-    // Add media if provided
-    if (
-      mediaFiles?.length &&
-      (this.capabilities.supportsVision ||
-        this.capabilities.supportsNativeAudio)
-    ) {
-      // createMediaMessage returns an array of objects formatted by createMediaContent
-      const formattedMediaContent = await this.createMediaForRound(
-        mediaFiles,
-        'initial',
-      );
-      userMessageContent.push(...formattedMediaContent);
-    }
-
-    // Append content to last user message, or create new user message
-    const lastMsg = messages.at(-1);
-    if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
-      lastMsg.content.push(...userMessageContent);
-    } else {
-      messages.push({ role: 'user', content: userMessageContent });
-    }
-
-    // Add final user request
-    const requestRole = this.capabilities.supportsIntermDevMsgs
-      ? 'system'
-      : 'user';
-    const lastMessage = messages.at(-1);
-
-    if (
-      requestRole === 'user' &&
-      lastMessage?.role === 'user' &&
-      Array.isArray(lastMessage.content)
-    ) {
-      lastMessage.content.push({ type: 'text', text: userRequest });
-    } else {
-      messages.push({
-        role: requestRole,
-        content: [{ type: 'text', text: userRequest }],
-      });
-    }
-
-    return messages;
+    return initializeChatMessages(
+      userPrefix,
+      userRequest,
+      mediaFiles,
+      systemPrompt,
+      this.capabilities,
+      (files, context) => this.createMediaForRound(files, context),
+    );
   }
 
   /** Adds user message content for subsequent rounds. */
@@ -781,40 +733,20 @@ export class ModelHandlerOpenAI<
     userMessage: string,
     mediaFiles?: FileLocation[],
   ): Promise<ChatCompletionMessageParam[]> {
-    const roundContent: ChatCompletionContentPart[] = [];
-
-    if (
-      mediaFiles?.length &&
-      (this.capabilities.supportsVision ||
-        this.capabilities.supportsNativeAudio)
-    ) {
-      const formattedMediaContent = await this.createMediaForRound(
-        mediaFiles,
-        'followUp',
-      );
-      roundContent.push(...formattedMediaContent);
-    }
-    // Only add text content if non-empty to avoid API "text content is empty" errors
-    if (userMessage) {
-      roundContent.push({ type: 'text', text: userMessage });
-    }
-
-    // Only push message if there's content (media or text)
-    if (roundContent.length > 0) {
-      messages.push({ role: 'user', content: roundContent });
-    }
-    return messages;
+    return createChatRoundMessages(
+      messages,
+      userMessage,
+      mediaFiles,
+      this.capabilities,
+      (files, context) => this.createMediaForRound(files, context),
+    );
   }
 
   async createUserFollowUpMessages(
     messages: ChatCompletionMessageParam[],
     userMessage: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    messages.push({
-      role: 'user',
-      content: [{ type: 'text', text: userMessage }],
-    });
-    return messages;
+    return createChatUserFollowUpMessages(messages, userMessage);
   }
 
   createAssistantMessage(text: string): ChatCompletionMessageParam {
@@ -842,15 +774,7 @@ export class ModelHandlerOpenAI<
   override extractAssistantText(
     message: ChatCompletionMessageParam,
   ): string | undefined {
-    if (message.role !== 'assistant') return undefined;
-    const { content } = message;
-    if (typeof content === 'string') return content;
-    if (!Array.isArray(content)) return undefined;
-    return joinNonEmpty(
-      content
-        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text),
-    );
+    return extractChatAssistantText(message);
   }
 
   /** Builds the default content parts for inline vision requests. */
@@ -1025,25 +949,12 @@ export class ModelHandlerOpenAI<
     text: string,
     placement: 'last-user' | 'continuation',
   ): void {
-    if (placement === 'continuation') {
-      const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-      messages.push({ role, content: [{ type: 'text', text }] });
-      return;
-    }
-
-    const lastMessage = messages.at(-1);
-    if (lastMessage && Array.isArray(lastMessage.content)) {
-      lastMessage.content.push({ type: 'text', text });
-      return;
-    }
-    if (lastMessage && typeof lastMessage.content === 'string') {
-      lastMessage.content = [
-        { type: 'text', text: lastMessage.content },
-        { type: 'text', text },
-      ];
-      return;
-    }
-    messages.push({ role: 'user', content: [{ type: 'text', text }] });
+    appendUserTextToChatMessages(
+      messages,
+      text,
+      placement,
+      this.capabilities.supportsIntermDevMsgs,
+    );
   }
 
   protected appendTextToLastAssistantMessage(

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -1,3 +1,8 @@
+// Local imports
+import type { FileLocation } from '@shared/schemas';
+import { joinNonEmpty } from '@utils/text/stringUtils';
+import type { MediaAttachmentContext } from '../support/mediaAttachmentPolicy';
+
 /** Options for normalizing OpenAI-style chat messages. */
 export interface NormalizeOpenAIMessageContentOptions {
   /** Merge consecutive messages that share the same role. */
@@ -185,7 +190,7 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
 }
 
 /** Minimal structural view of a chat content part (text or media). */
-type ChatContentPart = { type: string };
+type ChatContentPart = { type: string; text?: string };
 
 /**
  * Prepend `text` to the last user message in a chat-shaped conversation.
@@ -239,4 +244,191 @@ export function insertMediaIntoChatUserMessage(
   } else if (Array.isArray(content)) {
     content.unshift(...formattedMedia);
   }
+}
+
+/** Capability flags `initializeChatMessages`/`createChatRoundMessages` need from the handler. */
+export interface ChatMessageRoutingCapabilities {
+  supportsSystemPrompt: boolean;
+  supportsIntermDevMsgs: boolean;
+  supportsVision: boolean;
+  supportsNativeAudio: boolean;
+}
+
+/** Formats a round's media files into the provider's own content-part shape. */
+type CreateMediaForRound = (
+  mediaFiles: FileLocation[],
+  context: MediaAttachmentContext,
+) => Promise<readonly ChatContentPart[]>;
+
+/**
+ * Builds the initial message array for a chat-shaped provider (OpenAI,
+ * OpenRouter): an optional system/developer-role prompt, then a user turn
+ * carrying the prefix and any media, then the user request — routed to the
+ * "system" role instead of "user" when the model requires intermediate
+ * messages in that role (`supportsIntermDevMsgs`).
+ */
+export async function initializeChatMessages<T extends MessageLike>(
+  userPrefix: string,
+  userRequest: string,
+  mediaFiles: FileLocation[] | undefined,
+  systemPrompt: string | undefined,
+  capabilities: ChatMessageRoutingCapabilities,
+  createMediaForRound: CreateMediaForRound,
+): Promise<T[]> {
+  const messages: T[] = [];
+
+  // Handle system prompt differently for O1 models
+  // O1 mini and O1 preview models do not support system prompt; use 'user' role instead.
+  // For openai native o1 full or above reasoning models, "developer" is the new name but "system" still works.
+  if (systemPrompt) {
+    const role = capabilities.supportsSystemPrompt ? 'system' : 'user';
+    messages.push({
+      role,
+      content: [{ type: 'text', text: systemPrompt }],
+    } as T);
+  }
+
+  // Create content list for the user message (only add non-empty prefix)
+  const userMessageContent: ChatContentPart[] = [];
+  if (userPrefix) {
+    userMessageContent.push({ type: 'text', text: userPrefix });
+  }
+
+  // Add media if provided
+  if (
+    mediaFiles?.length &&
+    (capabilities.supportsVision || capabilities.supportsNativeAudio)
+  ) {
+    const formattedMediaContent = await createMediaForRound(
+      mediaFiles,
+      'initial',
+    );
+    userMessageContent.push(...formattedMediaContent);
+  }
+
+  // Append content to last user message, or create new user message
+  const lastMsg = messages.at(-1);
+  if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
+    (lastMsg.content as ChatContentPart[]).push(...userMessageContent);
+  } else {
+    messages.push({ role: 'user', content: userMessageContent } as T);
+  }
+
+  // Add final user request
+  const requestRole = capabilities.supportsIntermDevMsgs ? 'system' : 'user';
+  const lastMessage = messages.at(-1);
+
+  if (
+    requestRole === 'user' &&
+    lastMessage?.role === 'user' &&
+    Array.isArray(lastMessage.content)
+  ) {
+    (lastMessage.content as ChatContentPart[]).push({
+      type: 'text',
+      text: userRequest,
+    });
+  } else {
+    messages.push({
+      role: requestRole,
+      content: [{ type: 'text', text: userRequest }],
+    } as T);
+  }
+
+  return messages;
+}
+
+/** Adds user message content for subsequent rounds. */
+export async function createChatRoundMessages<T extends MessageLike>(
+  messages: T[],
+  userMessage: string,
+  mediaFiles: FileLocation[] | undefined,
+  capabilities: Pick<
+    ChatMessageRoutingCapabilities,
+    'supportsVision' | 'supportsNativeAudio'
+  >,
+  createMediaForRound: CreateMediaForRound,
+): Promise<T[]> {
+  const roundContent: ChatContentPart[] = [];
+
+  if (
+    mediaFiles?.length &&
+    (capabilities.supportsVision || capabilities.supportsNativeAudio)
+  ) {
+    const formattedMedia = await createMediaForRound(mediaFiles, 'followUp');
+    roundContent.push(...formattedMedia);
+  }
+  // Only add text content if non-empty to avoid API "text content is empty" errors
+  if (userMessage) {
+    roundContent.push({ type: 'text', text: userMessage });
+  }
+
+  // Only push message if there's content (media or text)
+  if (roundContent.length > 0) {
+    messages.push({ role: 'user', content: roundContent } as T);
+  }
+  return messages;
+}
+
+/** Appends a plain user-turn message; used for user follow-up rounds. */
+export function createChatUserFollowUpMessages<T extends MessageLike>(
+  messages: T[],
+  userMessage: string,
+): T[] {
+  messages.push({
+    role: 'user',
+    content: [{ type: 'text', text: userMessage }],
+  } as T);
+  return messages;
+}
+
+/** Extracts the joined text content of a chat-shaped assistant message. */
+export function extractChatAssistantText<T extends MessageLike>(
+  message: T,
+): string | undefined {
+  if (message.role !== 'assistant') return undefined;
+  const { content } = message;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return undefined;
+  return joinNonEmpty(
+    (content as ChatContentPart[])
+      .filter(
+        (p): p is { type: 'text'; text: string } =>
+          p.type === 'text' &&
+          typeof (p as { text?: unknown }).text === 'string',
+      )
+      .map((p) => p.text),
+  );
+}
+
+/**
+ * Appends `text` to the conversation as a user turn: for a continuation
+ * prompt, a fresh message (routed to "system" when the model requires
+ * intermediate messages in that role); otherwise merged into the trailing
+ * message's content.
+ */
+export function appendUserTextToChatMessages<T extends MessageLike>(
+  messages: T[],
+  text: string,
+  placement: 'last-user' | 'continuation',
+  supportsIntermDevMsgs: boolean,
+): void {
+  if (placement === 'continuation') {
+    const role = supportsIntermDevMsgs ? 'system' : 'user';
+    messages.push({ role, content: [{ type: 'text', text }] } as T);
+    return;
+  }
+
+  const lastMessage = messages.at(-1);
+  if (lastMessage && Array.isArray(lastMessage.content)) {
+    (lastMessage.content as ChatContentPart[]).push({ type: 'text', text });
+    return;
+  }
+  if (lastMessage && typeof lastMessage.content === 'string') {
+    lastMessage.content = [
+      { type: 'text', text: lastMessage.content },
+      { type: 'text', text },
+    ];
+    return;
+  }
+  messages.push({ role: 'user', content: [{ type: 'text', text }] } as T);
 }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -28,7 +28,7 @@ import type {
   ToolResult,
 } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
-import { extractMimeSubtype, joinNonEmpty } from '@utils/text/stringUtils';
+import { extractMimeSubtype } from '@utils/text/stringUtils';
 import {
   computeOpenRouterPrice,
   normalizeOpenRouterUsage,
@@ -39,6 +39,11 @@ import { tagOpenRouterSdkError } from './openRouterSdkError';
 import { OPENAI_CHAT_FINISH } from '../types/StopReasonTypes';
 import { toOpenAITools } from '../toolConversion';
 import {
+  appendUserTextToChatMessages,
+  createChatRoundMessages,
+  createChatUserFollowUpMessages,
+  extractChatAssistantText,
+  initializeChatMessages,
   insertMediaIntoChatUserMessage,
   prependTextToChatUserMessage,
 } from '../openai/openAIMessageUtils';
@@ -62,7 +67,6 @@ import type {
   ChatUsage,
   ChatMessages,
   ChatAssistantMessage,
-  ChatUserMessage,
   ChatToolCall,
   ChatContentItems,
   ChatContentText,
@@ -365,64 +369,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     mediaFiles?: FileLocation[],
     systemPrompt?: string,
   ): Promise<ChatMessages[]> {
-    const messages: ChatMessages[] = [];
-
-    if (systemPrompt) {
-      const role = this.capabilities.supportsSystemPrompt ? 'system' : 'user';
-      messages.push({
-        role,
-        content: [{ type: 'text', text: systemPrompt }],
-      });
-    }
-
-    const userContent: ChatContentItems[] = [];
-    if (userPrefix) {
-      userContent.push({ type: 'text', text: userPrefix });
-    }
-
-    if (
-      mediaFiles?.length &&
-      (this.capabilities.supportsVision ||
-        this.capabilities.supportsNativeAudio)
-    ) {
-      const formattedMedia = await this.createMediaForRound(
-        mediaFiles,
-        'initial',
-      );
-      userContent.push(...formattedMedia);
-    }
-
-    // Append to existing user message or create new
-    const lastMsg = messages.at(-1);
-    if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
-      (lastMsg.content as ChatContentItems[]).push(...userContent);
-    } else {
-      messages.push({ role: 'user', content: userContent });
-    }
-
-    // Add user request
-    const requestRole = this.capabilities.supportsIntermDevMsgs
-      ? 'system'
-      : 'user';
-    const lastMessage = messages.at(-1);
-
-    if (
-      requestRole === 'user' &&
-      lastMessage?.role === 'user' &&
-      Array.isArray(lastMessage.content)
-    ) {
-      (lastMessage.content as ChatContentItems[]).push({
-        type: 'text',
-        text: userRequest,
-      });
-    } else {
-      messages.push({
-        role: requestRole,
-        content: [{ type: 'text', text: userRequest }],
-      });
-    }
-
-    return messages;
+    return initializeChatMessages(
+      userPrefix,
+      userRequest,
+      mediaFiles,
+      systemPrompt,
+      this.capabilities,
+      (files, context) => this.createMediaForRound(files, context),
+    );
   }
 
   async createRoundMessages(
@@ -430,39 +384,20 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     userMessage: string,
     mediaFiles?: FileLocation[],
   ): Promise<ChatMessages[]> {
-    const roundContent: ChatContentItems[] = [];
-
-    if (
-      mediaFiles?.length &&
-      (this.capabilities.supportsVision ||
-        this.capabilities.supportsNativeAudio)
-    ) {
-      const formattedMedia = await this.createMediaForRound(
-        mediaFiles,
-        'followUp',
-      );
-      roundContent.push(...formattedMedia);
-    }
-
-    if (userMessage) {
-      roundContent.push({ type: 'text', text: userMessage });
-    }
-
-    if (roundContent.length > 0) {
-      messages.push({ role: 'user', content: roundContent });
-    }
-    return messages;
+    return createChatRoundMessages(
+      messages,
+      userMessage,
+      mediaFiles,
+      this.capabilities,
+      (files, context) => this.createMediaForRound(files, context),
+    );
   }
 
   async createUserFollowUpMessages(
     messages: ChatMessages[],
     userMessage: string,
   ): Promise<ChatMessages[]> {
-    messages.push({
-      role: 'user',
-      content: [{ type: 'text', text: userMessage }],
-    });
-    return messages;
+    return createChatUserFollowUpMessages(messages, userMessage);
   }
 
   createAssistantMessage(text: string): ChatMessages {
@@ -470,15 +405,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   }
 
   extractAssistantText(message: ChatMessages): string | undefined {
-    if (message.role !== 'assistant') return undefined;
-    const msg = message as ChatAssistantMessage;
-    if (typeof msg.content === 'string') return msg.content;
-    if (!Array.isArray(msg.content)) return undefined;
-    return joinNonEmpty(
-      (msg.content as ChatContentItems[])
-        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text),
-    );
+    return extractChatAssistantText(message);
   }
 
   // ---------------------------------------------------------------------------
@@ -727,31 +654,12 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     text: string,
     placement: 'last-user' | 'continuation',
   ): void {
-    if (placement === 'continuation') {
-      const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-      messages.push({
-        role,
-        content: [{ type: 'text', text }],
-      } as ChatMessages);
-      return;
-    }
-
-    const lastMessage = messages.at(-1);
-    if (lastMessage && Array.isArray(lastMessage.content)) {
-      (lastMessage.content as ChatContentItems[]).push({ type: 'text', text });
-      return;
-    }
-    if (lastMessage && typeof lastMessage.content === 'string') {
-      (lastMessage as ChatUserMessage).content = [
-        { type: 'text', text: lastMessage.content },
-        { type: 'text', text },
-      ];
-      return;
-    }
-    messages.push({
-      role: 'user',
-      content: [{ type: 'text', text }],
-    } as ChatMessages);
+    appendUserTextToChatMessages(
+      messages,
+      text,
+      placement,
+      this.capabilities.supportsIntermDevMsgs,
+    );
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Scanned the codebase for duplicate logic and reinvented native/stdlib methods (per a scheduled audit). Most of the codebase was already well-factored — `structuredClone`, `p-retry`, `p-queue`, `perfect-debounce`, etc. are already centralized and used consistently, and no genuine hand-rolled native-method reimplementations were found. Two genuine, verified duplications survived the scan and are fixed here:

1. **`ModelHandlerOpenAI` and `ModelHandlerOpenRouterNative`** each independently implemented `initializeMessages`, `createRoundMessages`, `createUserFollowUpMessages`, `extractAssistantText`, and `appendUserText` — ~170 near-identical lines (both build OpenAI-wire-compatible chat messages, differing only in the concrete SDK message type). These now delegate to shared generic helpers in `openAIMessageUtils.ts`, following the same `T extends MessageLike` generic pattern that file already uses for `normalizeOpenAIMessageContent`, `prependTextToChatUserMessage`, and `insertMediaIntoChatUserMessage`.
2. **`cleanCommands.ts`/`packCommands.ts`** duplicated the exact runDir/workspace result-merge algorithm (down to near-identical comments) for `executionId`-driven clean/pack operations. Factored into `mergeRunDirAndWorkspaceResult` in `fileOpSchemas.ts`.

`appendTextToLastAssistantMessage` was deliberately left un-merged: OpenRouter's implementation has genuine extra branching for Anthropic-routed-through-OpenRouter models, so consolidating it would need speculative hook parameters rather than a straightforward extraction.

## Issue acceptance gates

No linked issue — this is a proactive consolidation pass. Acceptance gate: behavior is unchanged (verified by full test suite + typecheck), duplicate logic is removed.

## Single source of truth

- `src/agent/modelHandlers/openai/openAIMessageUtils.ts` now owns the shared chat-message construction/mutation logic for any OpenAI-wire-compatible provider (currently OpenAI and OpenRouter).
- `packages/extension/src/commands/housekeeping/fileOpSchemas.ts` now owns the runDir/workspace result-merge decision for pack/clean operations.

## Duplication and abstraction budget

Removed ~170 duplicated lines across the two model handlers and ~35×2 duplicated lines across the two housekeeping commands. No new abstraction layer was introduced beyond plain functions added to files that already own this exact class of shared logic (`openAIMessageUtils.ts`, `fileOpSchemas.ts`) — both already host-agnostic, no `vscode` imports.

## Host impact

Extension: `packages/extension/src/commands/housekeeping/*` — clean/pack command result handling is behaviorally identical, just deduplicated.

Desktop: none (no desktop-specific code touched).

CLI: none (no CLI-specific code touched); the model-handler changes are host-agnostic and shared across all hosts that route through OpenAI/OpenRouter.

## Scheduled refactoring

None — `appendTextToLastAssistantMessage` is intentionally left separate per-provider; no further consolidation planned.

## Validation

- `npm run typecheck` — passes (all workspace packages).
- `npm run lint` — no new warnings/errors (fixed an import-order warning in the new code).
- `npx prettier --check` — clean.
- `npx vitest run src/test-kernel/agent/modelHandlers/` — 426 passed, 4 skipped.
- `npm test` (full suite) — 5269 passed, 1 unrelated pre-existing flake (`SystemUtils.vitest.ts` process-group-abort timing, unrelated to any file touched here), 7 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GWvoQK4YEhGFv5isMTxjeY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction with tests/typecheck passing; no new user-facing paths, though shared message/result logic means future edits affect both OpenAI and OpenRouter or both pack and clean.
> 
> **Overview**
> Deduplicates two areas of copy-pasted logic without changing behavior.
> 
> **OpenAI / OpenRouter chat messages:** Shared helpers in `openAIMessageUtils.ts` (`initializeChatMessages`, `createChatRoundMessages`, `createChatUserFollowUpMessages`, `extractChatAssistantText`, `appendUserTextToChatMessages`) now own message construction and mutation. `ModelHandlerOpenAI` and `ModelHandlerOpenRouterNative` delegate to them via capability flags and a `createMediaForRound` callback instead of maintaining ~170 parallel lines each.
> 
> **Pack / clean with `executionId`:** The runDir vs workspace `FileOpResult` merge (errors from either leg win; otherwise prefer workspace unless `noFiles`) lives in `mergeRunDirAndWorkspaceResult` in `fileOpSchemas.ts`, used by both `cleanCommands.ts` and `packCommands.ts`.
> 
> `appendTextToLastAssistantMessage` stays per-handler because OpenRouter’s Anthropic-routed path has extra branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3be2fab649342dc112161dd9ae00013bb5820c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->