### PR TITLE
refactor: promote conversation progress to trace event

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -15,7 +15,6 @@ import type {
   CliRuntimeHost,
 } from '@cli/runtime/runtimeHost';
 import {
-  ConversationProgressSchema,
   type ActiveChildInfo,
   type GoalPausedPayload,
   type RemoveStreamPayload,
@@ -214,22 +213,6 @@ function applyParentStream(payload: {
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
-function applyDirectTuiDomainEvent(
-  event: Extract<AgentEvent, { type: 'domain' }>,
-  fallbackStreamId: StreamTabId,
-): boolean {
-  if (event.key === 'conversationProgress') {
-    const progress = ConversationProgressSchema.safeParse(event.data);
-    if (!progress.success) return false;
-    patchStream(fallbackStreamId, (s) => ({
-      ...s,
-      conversation: progress.data,
-    }));
-    return true;
-  }
-  return false;
-}
-
 function applyDirectTuiRunEvent(
   event: AgentEvent,
   fallbackStreamId: StreamTabId,
@@ -244,8 +227,12 @@ function applyDirectTuiRunEvent(
       applyUsageUpdate(payload);
       return true;
     }
-    case 'domain':
-      return applyDirectTuiDomainEvent(event, fallbackStreamId);
+    case 'conversation.progress':
+      patchStream(fallbackStreamId, (s) => ({
+        ...s,
+        conversation: event.progress,
+      }));
+      return true;
     case 'updateTodos':
       patchStream(event.streamId, (s) => ({
         ...s,
@@ -419,7 +406,7 @@ export function attachTuiRunFactSubscription(
     {
       scope: 'run',
       types: [
-        'domain',
+        'conversation.progress',
         'updateTodos',
         'updatePlan',
         'addOutputFiles',

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -5,7 +5,7 @@ import type {
   SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import { ConversationProgressSchema, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type {
   CliProgressEvent,
   CliProgressEventPayloads,
@@ -19,8 +19,8 @@ type CliProjectedProgressEvent = {
   };
 }[CliProgressEvent];
 
-const CLI_RUN_FACT_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
-  'domain',
+const CLI_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
+  'conversation.progress',
   'updateTodos',
   'updatePlan',
   'addOutputFiles',
@@ -99,19 +99,14 @@ function projectCliRunFact(
     };
   }
 
-  if (event.type === 'domain') {
-    if (event.key === 'conversationProgress') {
-      const progress = ConversationProgressSchema.safeParse(event.data);
-      if (!progress.success) return undefined;
-      return {
-        event: 'updateConversationProgress',
-        payload: {
-          streamId,
-          progress: progress.data,
-        },
-      };
-    }
-    return undefined;
+  if (event.type === 'conversation.progress') {
+    return {
+      event: 'updateConversationProgress',
+      payload: {
+        streamId,
+        progress: event.progress,
+      },
+    };
   }
 
   if (event.type === 'updateTodos') {
@@ -250,7 +245,7 @@ export function attachCliSessionProgressProjection(
       );
       if (projected) emitProjectedProgressEvent(runtimeHost, projected);
     },
-    { scope: 'run', types: CLI_RUN_FACT_PROGRESS_EVENT_TYPES },
+    { scope: 'run', types: CLI_RUN_PROGRESS_EVENT_TYPES },
   );
 
   return () => {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -15,6 +15,7 @@ import type { StreamTransitionCause } from '@common/constants/streamStatus';
 import type {
   ActiveChildInfo,
   AddOutputFilesPayload,
+  ConversationProgress,
   GoalPausedPayload,
   EndGroupStatus,
   ExecutionId,
@@ -184,6 +185,12 @@ export interface ProcessOutputEvent extends StageStamp {
   readonly stderr: string;
 }
 
+/** UI progress counters for a run, projected by hosts but not transcript logs. */
+export interface ConversationProgressEvent extends StageStamp {
+  readonly type: 'conversation.progress';
+  readonly progress: ConversationProgress;
+}
+
 /** Durable TeXRA run facts carried by the run trace with fact-native names. */
 export type RunFactEvent =
   | (StageStamp &
@@ -342,6 +349,7 @@ export type AgentEvent =
   | StatusEvent
   | ChildActivityEvent
   | ProcessOutputEvent
+  | ConversationProgressEvent
   | RunFactEvent
   | ContextStateEvent
   | StreamStartEvent

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -2,7 +2,7 @@
  * TeXRA sugar over {@link AgentTrace}, as plain functions.
  *
  * Every helper takes the trace as its first argument and reduces to a
- * single primitive call (`info` / `warn` / `error` / `domain` /
+ * single primitive call (`info` / `warn` / `error` / `domain` / `emit` /
  * `contextState`). Agent code uses these instead of the bigger
  * `error(msg, { data: buildErrorLogData(...), messageType })` blocks so
  * call sites stay 1 line.
@@ -191,7 +191,7 @@ export function logConversationProgress(
   data: ConversationProgress,
   stageId?: string,
 ): void {
-  trace.domain({ key: 'conversationProgress', data, stageId });
+  trace.emit({ type: 'conversation.progress', progress: data, stageId });
 }
 
 /** Missing-outputs notification — counts `missing` entries for the label. */

--- a/src/shared/progressView/backend/ProgressBackend.ts
+++ b/src/shared/progressView/backend/ProgressBackend.ts
@@ -9,7 +9,7 @@ import {
 import { WebviewUpdater } from '@shared/progressView/backend/WebviewUpdater';
 import {
   ProgressFactApplier,
-  PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES,
+  PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES,
   type GetProgressStreamControls,
   type ProgressEventSubscription,
 } from '@shared/progressView/backend/events/ProgressFactApplier';
@@ -132,7 +132,7 @@ export class ProgressBackend {
           sessionEvent.event,
         );
       },
-      { scope: 'run', types: PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES },
+      { scope: 'run', types: PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES },
     );
     return {
       dispose: () => {

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -9,7 +9,6 @@ import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_PHASE,
-  ConversationProgressSchema,
   type AddOutputFilesPayload,
   type ClearMissingOutputsPayload,
   type ConversationProgress,
@@ -68,9 +67,9 @@ export type GetProgressStreamControls = (
   stream: StreamTabId,
 ) => ProgressStreamControls;
 
-export const PROGRESS_BACKEND_RUN_FACT_EVENT_TYPES: readonly AgentEvent['type'][] =
+export const PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] =
   [
-    'domain',
+    'conversation.progress',
     'updateTodos',
     'updatePlan',
     'addOutputFiles',
@@ -274,19 +273,13 @@ export class ProgressFactApplier {
       return;
     }
 
-    if (event.type === 'domain') {
-      if (event.key === 'conversationProgress') {
-        const progress = ConversationProgressSchema.safeParse(event.data);
-        if (progress.success) {
-          this.applyFact('failed to handle conversationProgress fact', () =>
-            this.handleUpdateConversationProgress({
-              streamId,
-              progress: progress.data,
-            }),
-          );
-        }
-        return;
-      }
+    if (event.type === 'conversation.progress') {
+      this.applyFact('failed to handle conversation.progress fact', () =>
+        this.handleUpdateConversationProgress({
+          streamId,
+          progress: event.progress,
+        }),
+      );
       return;
     }
 

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -280,7 +280,7 @@ describe('attachCliSessionProgressProjection', () => {
     }
   });
 
-  it('derives updateConversationProgress from a conversationProgress domain event', () => {
+  it('derives updateConversationProgress from a typed conversation progress event', () => {
     const { host, trace, detachAll } = setupTraceProjection();
 
     try {
@@ -308,7 +308,7 @@ describe('attachCliSessionProgressProjection', () => {
     expect(host.emit).not.toHaveBeenCalled();
   });
 
-  it('drops malformed conversationProgress domain payloads', () => {
+  it('ignores legacy conversationProgress domain payloads', () => {
     const { host, trace, detachAll } = setupTraceProjection();
 
     try {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3115,9 +3115,8 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         scope: 'run',
         streamId: root,
         event: {
-          type: 'domain',
-          key: 'conversationProgress',
-          data: { toolCallCount: 3 },
+          type: 'conversation.progress',
+          progress: { toolCallCount: 3 },
         },
       });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -995,9 +995,8 @@ describe('DesktopProgressBridge', () => {
         agentCategory: AgentCategory.Workflow,
       });
       emitRunEvent(bridge, 'parent' as StreamTabId, {
-        type: 'domain',
-        key: 'conversationProgress',
-        data: { toolCallCount: 5 },
+        type: 'conversation.progress',
+        progress: { toolCallCount: 5 },
       });
       emitRunEvent(bridge, 'parent' as StreamTabId, {
         type: 'stage.start',

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1402,9 +1402,8 @@ describe('ProgressBackend', () => {
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
 
       backend.factApplier.handleRunFact(stream, {
-        type: 'domain',
-        key: 'conversationProgress',
-        data: { toolCallCount: 7 },
+        type: 'conversation.progress',
+        progress: { toolCallCount: 7 },
       });
 
       await backend.factApplier.setStreamStatus(

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -372,10 +372,6 @@ export function attachTranscriptRecorder(
 
       case 'domain': {
         // Subscribers that care about specific keys can switch on event.key.
-        // conversationProgress is a UI-only signal projected to retained host
-        // progress events; it fires on every round/turn and would spam a
-        // transcript row per tick, so it adds none here.
-        if (event.key === 'conversationProgress') return;
         // filesLoaded has a richer payload shape; format the text accordingly.
         if (event.key === 'filesLoaded') {
           const payload = event.data as
@@ -400,6 +396,7 @@ export function attachTranscriptRecorder(
         return;
       }
 
+      case 'conversation.progress':
       case 'updateTodos':
       case 'updatePlan':
       case 'addOutputFiles':


### PR DESCRIPTION
## Summary
- add a typed `conversation.progress` trace event for UI progress counters
- project conversation progress directly in the CLI, TUI, and progress backend instead of parsing `domain` events
- remove the transcript suppression special case for `domain/conversationProgress` and ignore the typed UI event explicitly

## Validation
- npm run typecheck
- npm test -- --run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
- npm run format
- git diff --check
- npm run lint
- npm run compile:fast
- npm test

Part of #6968 and #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of UI-only progress signaling across trace and host subscribers; behavior should match prior projection when events use the new type, with intentional breakage for unmigrated legacy domain emissions.
> 
> **Overview**
> **Promotes run conversation counters (e.g. tool-call count) from the generic `domain` key `conversationProgress` to a first-class `conversation.progress` event on `AgentEvent`.**
> 
> `logConversationProgress` now calls `trace.emit({ type: 'conversation.progress', progress })` instead of `trace.domain`. CLI session projection, TUI run-fact subscription, and the progress backend subscribe to `conversation.progress` and patch state directly from `event.progress`, dropping `ConversationProgressSchema.safeParse` on domain payloads.
> 
> **Transcript behavior:** `TexraTranscriptRecorder` no longer special-cases `domain` + `conversationProgress`; the new event is ignored like other UI-only run facts. **Legacy `domain`/`conversationProgress` is no longer projected**—tests expect those payloads to be ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06ef30b59c20afd6d3bb780f0726e1e0dad649f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->