### PR TITLE
refactor: route CLI live progress from session facts

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -166,6 +166,9 @@ export async function executeCliRequest(
   const detachSnapshotEvents = snapshotStore.attachSessionEvents(
     defaultSession().events,
   );
+  const detachRunProgressRenderer = runtimeHost.attachRunProgressRenderer(
+    defaultSession().events,
+  );
   const detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
@@ -245,6 +248,7 @@ export async function executeCliRequest(
       await writeTerminalStatus(ownedExecutionId, EXECUTION_STATUS.INTERRUPTED);
     }
     detachResultToast();
+    detachRunProgressRenderer();
     detachSessionProgressProjection();
     detachHostInteractions();
     uninstallApprovalHandlers();

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -1,11 +1,26 @@
 import path from 'node:path';
 
-// Local imports - agent metadata
+// Local imports - agent runtime and trace
 import { getAgent } from '@agent/index';
+import type { AgentEvent } from '@agent/trace';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type {
+  SessionEvent,
+  SessionEventHub,
+  SessionFact,
+} from '@agent/runtime/SessionEventHub';
 
 // Local imports - shared schemas
-import { STREAM_PHASE, STREAM_STATUS, type StreamPhase } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type ActiveChildInfo,
+  type ConversationProgress,
+  type RoundStage,
+  type StreamPhase,
+  type StreamTabId,
+} from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -35,6 +50,14 @@ export function isRunProgressEvent(event: string): event is RunProgressEvent {
   return RunProgressEventSet.has(event);
 }
 
+const RUN_PROGRESS_RUN_FACT_TYPES = [
+  'conversation.progress',
+  'run.config',
+  'status',
+  'stage.start',
+  'child.activity',
+] as const satisfies readonly AgentEvent['type'][];
+
 // Carriage return + erase-line (CSI 2K): rewind to column 0 and clear the row
 // so the single live status line can be repainted in place.
 const CLEAR_LINE = '\r\x1b[2K';
@@ -51,6 +74,7 @@ interface RenderState {
 }
 
 export interface RunProgressRenderer {
+  handleSessionEvent(event: SessionEvent): boolean;
   handle(event: RunProgressEvent, payload: unknown): boolean;
   clear(): void;
   preserve(): void;
@@ -80,6 +104,31 @@ export function createRunProgressRenderer(
   return new DefaultRunProgressRenderer(init);
 }
 
+export function attachRunProgressRenderer(
+  events: SessionEventHub,
+  renderer: RunProgressRenderer | undefined,
+): () => void {
+  if (!renderer) return () => undefined;
+
+  const detachSessionFacts = events.subscribe(
+    (event) => {
+      renderer.handleSessionEvent(event);
+    },
+    { scope: 'session' },
+  );
+  const detachRunFacts = events.subscribe(
+    (event) => {
+      renderer.handleSessionEvent(event);
+    },
+    { scope: 'run', types: RUN_PROGRESS_RUN_FACT_TYPES },
+  );
+
+  return () => {
+    detachRunFacts();
+    detachSessionFacts();
+  };
+}
+
 class DefaultRunProgressRenderer implements RunProgressRenderer {
   private readonly state: RenderState = {};
   private readonly startedAt: number;
@@ -93,7 +142,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private lastRenderAt = 0;
   private lastLine = '';
   private liveLine = false;
-  private rootStreamId: string | undefined;
+  private rootStreamId: StreamTabId | undefined;
   private rootStreamTerminal = false;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -106,6 +155,13 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     this.clearInterval = init.clearInterval ?? clearInterval;
     this.ansi = init.colorEnabled;
     this.startedAt = this.nowMs();
+  }
+
+  handleSessionEvent(event: SessionEvent): boolean {
+    if (event.scope === 'session') {
+      return this.handleSessionFact(event.event);
+    }
+    return this.handleRunFact(event.streamId, event.event);
   }
 
   handle(event: RunProgressEvent, payload: unknown): boolean {
@@ -122,22 +178,23 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         return true;
       case 'updateConversationProgress':
         if (this.rootStreamTerminal) return true;
-        if (
-          this.applyConversationProgress(
-            payload as RunProgressEventPayloads['updateConversationProgress'],
-          )
-        ) {
+        {
+          const data =
+            payload as RunProgressEventPayloads['updateConversationProgress'];
+          if (!this.applyConversationProgress(data.streamId, data.progress)) {
+            return true;
+          }
           this.updateHeartbeat();
           this.render();
         }
         return true;
       case 'updateRoundStage':
         if (this.rootStreamTerminal) return true;
-        if (
-          this.applyRoundStage(
-            payload as RunProgressEventPayloads['updateRoundStage'],
-          )
-        ) {
+        {
+          const data = payload as RunProgressEventPayloads['updateRoundStage'];
+          if (!this.applyRoundStage(data.streamId, data.roundStage)) {
+            return true;
+          }
           this.updateHeartbeat();
           this.render();
         }
@@ -146,13 +203,13 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       case 'updateActiveSubagents':
         if (this.rootStreamTerminal) return true;
         if (event === 'updateActiveProcesses') {
-          this.applyActiveProcesses(
-            payload as RunProgressEventPayloads['updateActiveProcesses'],
-          );
+          const data =
+            payload as RunProgressEventPayloads['updateActiveProcesses'];
+          this.applyActiveProcesses(data.parentStreamId, data.processes);
         } else {
-          this.applyActiveSubagents(
-            payload as RunProgressEventPayloads['updateActiveSubagents'],
-          );
+          const data =
+            payload as RunProgressEventPayloads['updateActiveSubagents'];
+          this.applyActiveSubagents(data.parentStreamId, data.children);
         }
         this.updateHeartbeat();
         this.render(true);
@@ -161,27 +218,14 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
         {
           const data =
             payload as RunProgressEventPayloads['updateStreamStatus'];
-          if (!this.isRootStream(data.streamId)) return true;
-          const { status } = data;
-          this.state.phase = formatRunProgressStatus(status);
-          this.rootStreamTerminal = isTerminalStreamStatus(status);
-          if (this.rootStreamTerminal) {
-            this.state.activeProcesses = undefined;
-            this.state.activeSubagents = undefined;
-          }
-          this.updateHeartbeat();
-          this.render(true);
+          this.applyStatus(data.streamId, data.status);
         }
         return true;
       case 'updateStreamDescription': {
         if (this.rootStreamTerminal) return true;
         const data =
           payload as RunProgressEventPayloads['updateStreamDescription'];
-        if (this.isRootStream(data.streamId)) {
-          this.state.phase = data.description;
-          this.updateHeartbeat();
-          this.render(true);
-        }
+        this.applyStreamDescription(data.streamId, data.description);
         return true;
       }
       default:
@@ -208,9 +252,79 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private applyTaskState(
     payload: RunProgressEventPayloads['setTaskState'],
   ): boolean {
-    if (!this.claimRootStream(payload.streamId)) return false;
+    return this.applyRunConfig(payload.streamId, payload.taskState.agentConfig);
+  }
 
-    const config = payload.taskState.agentConfig;
+  private handleSessionFact(event: SessionFact): boolean {
+    switch (event.type) {
+      case 'updateStreamStatus': {
+        const { status, streamId } = event.payload;
+        this.applyStatus(streamId, status);
+        return true;
+      }
+      case 'updateStreamDescription':
+        if (!this.rootStreamTerminal) {
+          this.applyStreamDescription(
+            event.payload.streamId,
+            event.payload.description,
+          );
+        }
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private handleRunFact(streamId: StreamTabId, event: AgentEvent): boolean {
+    switch (event.type) {
+      case 'run.config':
+        if (this.applyRunConfig(event.streamId, event.config)) {
+          this.updateHeartbeat();
+          this.render(true);
+        }
+        return true;
+      case 'status':
+        this.applyStatus(event.streamId, event.phase);
+        return true;
+      case 'conversation.progress':
+        if (this.rootStreamTerminal) return true;
+        if (this.applyConversationProgress(streamId, event.progress)) {
+          this.updateHeartbeat();
+          this.render();
+        }
+        return true;
+      case 'stage.start':
+        if (this.rootStreamTerminal || event.kind !== 'round') return true;
+        if (
+          this.applyRoundStage(streamId, {
+            index: event.index ?? 0,
+            ...(event.total !== undefined && event.total > 0
+              ? { total: event.total }
+              : {}),
+          })
+        ) {
+          this.updateHeartbeat();
+          this.render();
+        }
+        return true;
+      case 'child.activity':
+        if (this.rootStreamTerminal) return true;
+        if (event.kind === 'processes') {
+          this.applyActiveProcesses(event.parentStreamId, event.processes);
+        } else {
+          this.applyActiveSubagents(event.parentStreamId, event.children);
+        }
+        this.updateHeartbeat();
+        this.render(true);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private applyRunConfig(streamId: StreamTabId, config: AgentConfig): boolean {
+    if (!this.claimRootStream(streamId)) return false;
+
     this.state.agent = config.agent;
     this.state.inputLabel = formatInputLabel(config.inputFiles);
     this.state.plannedRounds =
@@ -222,58 +336,86 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   }
 
   private applyConversationProgress(
-    payload: RunProgressEventPayloads['updateConversationProgress'],
+    streamId: StreamTabId,
+    progress: ConversationProgress,
   ): boolean {
-    if (!this.claimRootStream(payload.streamId)) return false;
+    if (!this.claimRootStream(streamId)) return false;
 
-    this.state.toolCallCount = payload.progress.toolCallCount || undefined;
+    this.state.toolCallCount = progress.toolCallCount || undefined;
     this.state.phase ??= 'running';
     return true;
   }
 
   private applyRoundStage(
-    payload: RunProgressEventPayloads['updateRoundStage'],
+    streamId: StreamTabId,
+    roundStage: RoundStage,
   ): boolean {
-    if (!this.claimRootStream(payload.streamId)) return false;
+    if (!this.claimRootStream(streamId)) return false;
 
-    this.state.round = payload.roundStage.index + 1;
-    if (payload.roundStage.total !== undefined) {
-      this.state.plannedRounds = payload.roundStage.total;
+    this.state.round = roundStage.index + 1;
+    if (roundStage.total !== undefined) {
+      this.state.plannedRounds = roundStage.total;
     }
     this.state.phase ??= 'running';
     return true;
   }
 
   private applyActiveProcesses(
-    payload: RunProgressEventPayloads['updateActiveProcesses'],
+    parentStreamId: StreamTabId,
+    processes: readonly ActiveChildInfo[],
   ): void {
-    if (!this.claimRootStream(payload.parentStreamId)) return;
+    if (!this.claimRootStream(parentStreamId)) return;
 
     this.state.activeProcesses = formatActiveChildren(
       'tool',
-      payload.processes.map(
+      processes.map(
         (activeProcess) => activeProcess.toolName ?? activeProcess.agentName,
       ),
     );
   }
 
   private applyActiveSubagents(
-    payload: RunProgressEventPayloads['updateActiveSubagents'],
+    parentStreamId: StreamTabId,
+    children: readonly ActiveChildInfo[],
   ): void {
-    if (!this.claimRootStream(payload.parentStreamId)) return;
+    if (!this.claimRootStream(parentStreamId)) return;
 
     this.state.activeSubagents = formatActiveChildren(
       'subagent',
-      payload.children.map((child) => child.agentName),
+      children.map((child) => child.agentName),
     );
   }
 
-  private claimRootStream(streamId: string): boolean {
+  private applyStatus(streamId: StreamTabId, status: StreamPhase): void {
+    if (!this.isRootStream(streamId)) return;
+
+    this.state.phase = formatRunProgressStatus(status);
+    this.rootStreamTerminal = isTerminalStreamStatus(status);
+    if (this.rootStreamTerminal) {
+      this.state.activeProcesses = undefined;
+      this.state.activeSubagents = undefined;
+    }
+    this.updateHeartbeat();
+    this.render(true);
+  }
+
+  private applyStreamDescription(
+    streamId: StreamTabId,
+    description: string,
+  ): void {
+    if (!this.isRootStream(streamId)) return;
+
+    this.state.phase = description;
+    this.updateHeartbeat();
+    this.render(true);
+  }
+
+  private claimRootStream(streamId: StreamTabId): boolean {
     this.rootStreamId ??= streamId;
     return this.rootStreamId === streamId;
   }
 
-  private isRootStream(streamId: string): boolean {
+  private isRootStream(streamId: StreamTabId): boolean {
     return this.rootStreamId === streamId;
   }
 

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -14,6 +14,7 @@ import {
   isRuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
+import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
 // Local imports - CLI runtime
@@ -26,6 +27,7 @@ import {
   type LogSink,
 } from './logSinks';
 import {
+  attachRunProgressRenderer,
   createRunProgressRenderer,
   isRunProgressEvent,
 } from './runProgressRenderer';
@@ -42,6 +44,7 @@ export type CliRuntimeEvent = AgentRuntimeEvent | CliProgressEvent;
 
 export type CliRuntimeHost = AgentRuntimeHost &
   CliProgressSink & {
+    attachRunProgressRenderer(events: SessionEventHub): () => void;
     prepareInteractivePrompt?: () => void;
     close(): Promise<void>;
   };
@@ -62,7 +65,12 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
     runProgress?.preserve();
   }
 
+  function attachProgressRenderer(events: SessionEventHub): () => void {
+    return attachRunProgressRenderer(events, runProgress);
+  }
+
   return {
+    attachRunProgressRenderer: attachProgressRenderer,
     prepareInteractivePrompt,
     emit<K extends CliRuntimeEvent>(
       event: K,
@@ -108,7 +116,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         !isRuntimePresentationEvent(event) &&
         !isRuntimeInteractionEvent(event) &&
         isRunProgressEvent(event) &&
-        runProgress?.handle(event, payload)
+        runProgress
       ) {
         return;
       }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -23,6 +23,7 @@ import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCap
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
+  detachRunProgressRenderer: vi.fn(),
   createHeadlessCliHostInteractions: vi.fn(),
   createCliRuntimeHost: vi.fn(),
   installCliApprovalHandlers: vi.fn(),
@@ -120,6 +121,7 @@ function toolUseConfig() {
 function stubRunExecutionDeps(): void {
   vi.clearAllMocks();
   mocks.close.mockResolvedValue(undefined);
+  mocks.detachRunProgressRenderer.mockReturnValue(undefined);
   mocks.createHeadlessCliHostInteractions.mockReturnValue({
     pending: vi.fn(() => []),
     resolve: vi.fn(() => false),
@@ -128,6 +130,7 @@ function stubRunExecutionDeps(): void {
   mocks.installCliApprovalHandlers.mockReturnValue(vi.fn());
   mocks.createCliRuntimeHost.mockReturnValue({
     emit: vi.fn(),
+    attachRunProgressRenderer: vi.fn(() => mocks.detachRunProgressRenderer),
     prepareInteractivePrompt: mocks.prepareInteractivePrompt,
     close: mocks.close,
   });

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
   createRunProgressRenderer,
@@ -8,7 +9,13 @@ import {
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { CliContext } from '@cli/runtime/cliContext';
-import { STREAM_PHASE, STREAM_STATUS } from '@shared/schemas';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
+import {
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   getAgent: vi.fn(),
@@ -110,6 +117,23 @@ function toolUseTaskState(
       },
     },
   };
+}
+
+function emitWorkflowRunConfig(
+  events: SessionEventHub,
+  taskState = workflowTaskState(),
+): void {
+  const streamId = taskState.streamId as StreamTabId;
+  events.emit({
+    scope: 'run',
+    streamId,
+    event: {
+      type: 'run.config',
+      streamId,
+      executionId: 'execution-1' as ExecutionId,
+      config: taskState.taskState.agentConfig,
+    },
+  });
 }
 
 function outputBuffer(): { write: (chunk: string) => void; text: string } {
@@ -347,6 +371,97 @@ describe('CLI run progress renderer', () => {
       'polish paper.tex · 0s\n' +
         'polish paper.tex · drafting · 0s\n' +
         'polish paper.tex · drafting · tool: Bash · 0s\n',
+    );
+  });
+
+  it('renders the live line from direct session and run facts', () => {
+    const output = outputBuffer();
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: output.write,
+        minIntervalMs: 0,
+        nowMs: () => 0,
+      },
+    );
+    const streamId = 'stream-1' as StreamTabId;
+    const taskState = workflowTaskState();
+
+    renderer?.handleSessionEvent({
+      scope: 'run',
+      streamId,
+      event: {
+        type: 'run.config',
+        streamId,
+        executionId: 'execution-1' as ExecutionId,
+        config: taskState.taskState.agentConfig,
+      },
+    });
+    renderer?.handleSessionEvent({
+      scope: 'run',
+      streamId,
+      event: {
+        type: 'conversation.progress',
+        progress: { toolCallCount: 3 },
+      },
+    });
+    renderer?.handleSessionEvent({
+      scope: 'run',
+      streamId,
+      event: {
+        type: 'stage.start',
+        id: 'round-1',
+        label: 'Round 1',
+        kind: 'round',
+        index: 0,
+        total: 2,
+      },
+    });
+    renderer?.handleSessionEvent({
+      scope: 'session',
+      event: {
+        type: 'updateStreamDescription',
+        payload: { streamId, description: 'drafting' },
+      },
+    });
+    renderer?.handleSessionEvent({
+      scope: 'run',
+      streamId,
+      event: {
+        type: 'child.activity',
+        kind: 'subagents',
+        parentStreamId: streamId,
+        children: [
+          {
+            kind: 'subagent',
+            executionId: 'child-1',
+            childStreamId: 'child-stream',
+            agentName: 'review',
+            status: 'running',
+          },
+        ],
+      },
+    });
+    renderer?.handleSessionEvent({
+      scope: 'run',
+      streamId,
+      event: {
+        type: 'status',
+        streamId,
+        phase: STREAM_PHASE.COMPLETED,
+        previousPhase: STREAM_PHASE.RUNNING,
+        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      },
+    });
+
+    expect(output.text).toBe(
+      'polish paper.tex · 0s\n' +
+        'polish paper.tex · tools: 3 · 0s\n' +
+        '[r1/2] · polish paper.tex · tools: 3 · 0s\n' +
+        '[r1/2] · polish paper.tex · drafting · tools: 3 · 0s\n' +
+        '[r1/2] · polish paper.tex · drafting · subagent: review · 0s\n' +
+        '[r1/2] · polish paper.tex · done · tools: 3 · 0s\n',
     );
   });
 
@@ -747,10 +862,13 @@ describe('CLI run progress renderer', () => {
 
   it('routes progress events even when ordinary CLI logs are quiet', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
+      const events = new SessionEventHub();
       const host = createCliRuntimeHost(
         context({ quietLogs: true, renderRunProgress: true }),
       );
-      host.emit('setTaskState', workflowTaskState());
+      const detach = host.attachRunProgressRenderer(events);
+      emitWorkflowRunConfig(events);
+      detach();
       await host.close();
     });
 
@@ -759,6 +877,7 @@ describe('CLI run progress renderer', () => {
 
   it('preserves the live progress line before interactive prompts', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
+      const events = new SessionEventHub();
       const host = createCliRuntimeHost(
         context({
           approvalPolicy: 'ask',
@@ -766,9 +885,11 @@ describe('CLI run progress renderer', () => {
         }),
       );
 
-      host.emit('setTaskState', workflowTaskState());
+      const detach = host.attachRunProgressRenderer(events);
+      emitWorkflowRunConfig(events);
       host.prepareInteractivePrompt?.();
       await Promise.resolve();
+      detach();
       await host.close();
     });
 
@@ -779,6 +900,7 @@ describe('CLI run progress renderer', () => {
     let stderr = '';
     const stdout = await captureStreamWrites(process.stdout, async () => {
       stderr = await captureStreamWrites(process.stderr, async () => {
+        const events = new SessionEventHub();
         const host = createCliRuntimeHost(
           context({
             outputFormat: 'json',
@@ -786,7 +908,9 @@ describe('CLI run progress renderer', () => {
             renderRunProgress: true,
           }),
         );
-        host.emit('setTaskState', workflowTaskState());
+        const detach = host.attachRunProgressRenderer(events);
+        emitWorkflowRunConfig(events);
+        detach();
         await host.close();
       });
     });


### PR DESCRIPTION
## Summary
- attach the headless CLI live progress renderer directly to `SessionEventHub` facts
- render from typed run/session events (`run.config`, `status`, `stage.start`, `child.activity`, `conversation.progress`, and stream descriptions) instead of projected `CliProgressEvent` records
- keep `attachCliSessionProgressProjection` and NDJSON/public CLI progress output unchanged

## Validation
- npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
- npm run typecheck
- npm run format
- git diff --check
- npm run compile:fast
- npm run lint
- npm test

Part of #6968 and #6951.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation refactor with lifecycle wiring and tests; NDJSON/public progress projection is unchanged and auth/data paths are untouched.
> 
> **Overview**
> **Headless CLI live progress** now subscribes to `SessionEventHub` instead of relying on `runtimeHost.emit` for `CliProgressEvent` payloads.
> 
> `executeCliRequest` calls `attachRunProgressRenderer` on the default session hub and detaches it in `finally`. `CliRuntimeHost` exposes that hook; when run-progress events still hit `emit`, they are no longer passed into the stderr renderer (NDJSON and the existing `attachCliSessionProgressProjection` path stay as-is).
> 
> The renderer adds `handleSessionEvent` and shared `apply*` helpers so the same line is driven by typed **run** facts (`run.config`, `status`, `conversation.progress`, `stage.start`, `child.activity`) and **session** facts (`updateStreamStatus`, `updateStreamDescription`). Legacy `handle()` for projected progress events remains for compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36ad13ffa97fcef174de8885ed9e2314a4b80f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->