### PR TITLE
refactor: delete TUI runtime host wrapper

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -65,10 +65,7 @@ import {
   type TuiSession,
 } from './tui/state/sessionRunState';
 import { createTuiHostInteractions } from './tui/state/subscribeApprovals';
-import {
-  attachTuiRunFactSubscription,
-  wrapRuntimeHost,
-} from './tui/state/subscribeRuntimeHost';
+import { attachTuiRunFactSubscription } from './tui/state/subscribeRuntimeHost';
 import { notify } from './tui/notifications/terminalNotifier';
 import {
   appendLocalErrorTranscript,
@@ -219,24 +216,23 @@ export function createChatSessionController(
       : CliExitCode.AgentError;
   };
 
-  // Build the wrapped runtime host shared by start and resume: attach the
+  // Build the runtime host shared by start and resume: attach the
   // terminal-result toast and the TUI approval pipeline, and return a
   // `finalize` teardown that both run promises invoke from their `.finally`.
   const setupRunHost = (
     sessionContext: CliContext,
   ): {
-    readonly wrapped: CliRuntimeHost;
+    readonly runtimeHost: CliRuntimeHost;
     readonly approvalsUnavailable: boolean;
     readonly finalize: () => void;
   } => {
     const runtimeHost = createCliRuntimeHost(sessionContext);
-    const wrapped = wrapRuntimeHost(runtimeHost);
     const detachHostInteractions = defaultSession().useHostInteractions(
-      createTuiHostInteractions(wrapped, sessionContext),
+      createTuiHostInteractions(runtimeHost, sessionContext),
     );
     disposers.push(detachHostInteractions);
     const interactiveHost: CliRuntimeHost = {
-      ...wrapped,
+      ...runtimeHost,
       interactions: defaultSession().interactions,
     };
     const detachResultToast = attachTerminalResultToast(
@@ -247,7 +243,7 @@ export function createChatSessionController(
       defaultSession().events,
     );
     return {
-      wrapped: interactiveHost,
+      runtimeHost: interactiveHost,
       approvalsUnavailable: approvalPromptsUnavailable(sessionContext),
       finalize: (): void => {
         detachResultToast();
@@ -274,7 +270,7 @@ export function createChatSessionController(
       model: config.model,
       canDelegate: chatAgentSupportsDelegation(config.agent),
     });
-    const { wrapped, approvalsUnavailable, finalize } =
+    const { runtimeHost, approvalsUnavailable, finalize } =
       setupRunHost(sessionContext);
     const executionId = generateExecutionId();
     let waitingTurn = 0;
@@ -286,7 +282,7 @@ export function createChatSessionController(
       .then((registeredConfig) => {
         executionRegistered = true;
         return executeAgent(registeredConfig, executionId, {
-          runtimeHost: wrapped,
+          runtimeHost,
           enforceCategory: true,
           approvalPromptsUnavailable: approvalsUnavailable,
           runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
@@ -338,7 +334,7 @@ export function createChatSessionController(
         reportRunFailure(error);
       })
       .finally(finalize);
-    markChatTuiRunPending(session, runPromise, wrapped);
+    markChatTuiRunPending(session, runPromise, runtimeHost);
   };
 
   // -----------------------------------------------------------------------
@@ -398,13 +394,13 @@ export function createChatSessionController(
     projectStreamTranscript(resolution.streamId);
     activeStreamId.set(resolution.streamId);
 
-    const { wrapped, approvalsUnavailable, finalize } =
+    const { runtimeHost, approvalsUnavailable, finalize } =
       setupRunHost(sessionContext);
-    session.runtimeHost = wrapped;
+    session.runtimeHost = runtimeHost;
 
     session.runPromise = setCliHelperModel(currentModel)
       .then(() =>
-        resumeToolUseFromSnapshot(resolution.snapshot, wrapped, {
+        resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {
           approvalPromptsUnavailable: approvalsUnavailable,
           runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
         }),

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -1,8 +1,8 @@
-// Approval-event interception per docs/prds/cli-tui-ink/10-architecture.md §9.
+// TUI implementation of the session-owned HostInteractions approval port.
 //
-// Wraps the runtime host so approval-kind events get diverted to the typed
-// queue (-> ApprovalModal -> user) instead of the legacy stderr prompt.
-// When the modal resolves, the *original* resolvers run unchanged.
+// Approval requests are routed through the typed queue (-> ApprovalModal ->
+// user) instead of the legacy stderr prompt. When the modal resolves, the
+// interaction promise resolves with the same host-facing result shape.
 //
 // Policy is honored *before* the modal is shown — `immediateDecision` runs
 // first so `--approval-policy yolo` auto-approves without a modal, and
@@ -15,6 +15,7 @@
 import { nanoid } from 'nanoid';
 
 import { platform } from '@platform/platform';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   matchesCancelSelector,
   type HostBashApprovalRequest,
@@ -48,15 +49,17 @@ import {
 } from '@model/apiProviders';
 import { isUpstreamCreditDepletedError } from '@shared/schemas';
 import {
+  proposalApprovalState,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { notify } from '../notifications/terminalNotifier';
-import { patchSessionMeta } from './cliState';
+import { patchSessionMeta, patchStream } from './cliState';
 import { setCliCodexSubscription } from './codexSubscription';
 import {
+  type ApprovalBypassKind,
   approvalPayloadStreamId,
   clearApprovalsWhere,
   clearRetryApprovalsForStream,
@@ -140,10 +143,10 @@ export function createTuiHostInteractions(
     async requestToolEditApproval(request) {
       let decision: ApprovalDecision | undefined = immediateDecision(context);
       if (!decision) {
-        decision = await enqueueTuiApproval(
-          { kind: 'toolEdit', payload: request },
-          host,
-        );
+        decision = await enqueueTuiApproval({
+          kind: 'toolEdit',
+          payload: request,
+        });
         markIfRejected(context, decision);
       }
       if (
@@ -152,6 +155,7 @@ export function createTuiHostInteractions(
         request.streamId
       ) {
         setToolEditApprovalSessionBypass(request.streamId, true, host);
+        setTuiApprovalBypassState(request.streamId, 'toolEdit', true);
       }
       return decision.accepted
         ? { accepted: true, appliedContent: request.proposedContent }
@@ -178,7 +182,7 @@ export function createTuiHostInteractions(
     },
     requestPlanApproval(request, options) {
       return withInteractionTimeout(
-        () => requestPlanInteraction(request, context, host),
+        () => requestPlanInteraction(request, context),
         options,
         { action: 'timeout' },
         () =>
@@ -206,7 +210,7 @@ export function createTuiHostInteractions(
     },
     requestRetry(request, options) {
       return withInteractionTimeout(
-        () => requestRetryInteraction(request, context, host, retryRoutes),
+        () => requestRetryInteraction(request, context, retryRoutes),
         options,
         { action: 'timeout' },
         () => {
@@ -219,7 +223,7 @@ export function createTuiHostInteractions(
     },
     askUserQuestion(request, options) {
       return withInteractionTimeout(
-        () => requestUserQuestionInteraction(request, context, host),
+        () => requestUserQuestionInteraction(request, context),
         options,
         { submitted: false, feedback: 'Approval request timed out.' },
         () =>
@@ -232,7 +236,7 @@ export function createTuiHostInteractions(
       );
     },
     openExternalInquiry(request) {
-      return openExternalInquiryInteraction(request, context, host);
+      return openExternalInquiryInteraction(request, context);
     },
     resolve: () => false,
     cancel(selector: HostInteractionCancelSelector = {}) {
@@ -382,7 +386,6 @@ async function decideWithPolicy<
   P,
 >(
   context: CliContext,
-  host: CliRuntimeHost,
   kind: K,
   payload: P,
   options: RouteWithPolicyOptions<P> = {},
@@ -415,7 +418,7 @@ async function decideWithPolicy<
       ApprovalPayload,
       { kind: K }
     >;
-    const decision = await enqueueTuiApproval(queuePayload, host);
+    const decision = await enqueueTuiApproval(queuePayload);
     if (options.isCurrent && !options.isCurrent()) {
       return { accepted: false, userMessage: 'Approval request was replaced.' };
     }
@@ -444,9 +447,10 @@ async function requestBashInteraction(
     allowBypass: true,
     streamId: request.streamId ?? '',
   };
-  const decision = await decideWithPolicy(context, host, 'bash', payload);
+  const decision = await decideWithPolicy(context, 'bash', payload);
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true, host);
+    setTuiApprovalBypassState(request.streamId, 'bash', true);
   }
   return {
     accepted: decision.accepted,
@@ -457,9 +461,8 @@ async function requestBashInteraction(
 async function requestPlanInteraction(
   request: RuntimeInteractionEventPayloads['showPlanApproval'],
   context: CliContext,
-  host: CliRuntimeHost,
 ): Promise<PlanApprovalResult> {
-  const decision = await decideWithPolicy(context, host, 'plan', request);
+  const decision = await decideWithPolicy(context, 'plan', request);
   const feedback = feedbackOnReject(decision);
   return decision.accepted
     ? { action: decision.planAction ?? 'approve' }
@@ -471,7 +474,15 @@ async function requestProposalInteraction(
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<ProposalResult> {
-  const decision = await decideWithPolicy(context, host, 'proposal', request);
+  const decision = await decideWithPolicy(context, 'proposal', request);
+  if (
+    decision.accepted &&
+    decision.bypass === 'superYolo' &&
+    request.streamId
+  ) {
+    proposalApprovalState.setBypass(request.streamId, true, host);
+    setTuiApprovalBypassState(request.streamId, 'superYolo', true);
+  }
   const feedback = feedbackOnReject(decision);
   return decision.accepted
     ? { action: 'approve' }
@@ -481,7 +492,6 @@ async function requestProposalInteraction(
 async function requestRetryInteraction(
   request: HostRetryRequest,
   context: CliContext,
-  host: CliRuntimeHost,
   retryRoutes: RetryRouteState,
 ): Promise<RetryResult> {
   cancelRetryRoute(retryRoutes, request.streamId);
@@ -500,7 +510,7 @@ async function requestRetryInteraction(
     };
 
     void (async () => {
-      const decision = await decideWithPolicy(context, host, 'retry', request, {
+      const decision = await decideWithPolicy(context, 'retry', request, {
         beforeQueue: maybeAutoSwitchRetry,
         isCurrent,
       });
@@ -532,7 +542,6 @@ async function requestRetryInteraction(
 async function requestUserQuestionInteraction(
   payload: RuntimeInteractionEventPayloads['showUserQuestion'],
   context: CliContext,
-  host: CliRuntimeHost,
 ): Promise<{
   submitted: boolean;
   answers?: ApprovalDecision['userQuestionAnswers'];
@@ -548,10 +557,7 @@ async function requestUserQuestionInteraction(
     };
   }
 
-  const decision = await enqueueTuiApproval(
-    { kind: 'userQuestion', payload },
-    host,
-  );
+  const decision = await enqueueTuiApproval({ kind: 'userQuestion', payload });
   markIfRejected(context, decision);
   return decision.accepted && decision.userQuestionAnswers
     ? { submitted: true, answers: decision.userQuestionAnswers }
@@ -564,20 +570,26 @@ async function requestUserQuestionInteraction(
 async function openExternalInquiryInteraction(
   payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
-  host: CliRuntimeHost,
 ): Promise<{ threadId: string }> {
-  handleExternalInquiry(payload, context, host);
+  handleExternalInquiry(payload, context);
   return { threadId: payload.threadId };
 }
 
 export function enqueueTuiApproval(
   payload: ApprovalPayload,
-  host: CliRuntimeHost,
 ): Promise<ApprovalDecision> {
   return enqueueApproval(payload, {
     onPresent: () => {
       const streamId = approvalPayloadStreamId(payload);
-      if (streamId) host.emit('setActiveStream', { streamId });
+      if (streamId) {
+        defaultSession().events.emit({
+          scope: 'session',
+          event: {
+            type: 'setActiveStream',
+            payload: { streamId },
+          },
+        });
+      }
       notify({ kind: 'approvalNeeded' });
     },
   });
@@ -589,6 +601,17 @@ function feedbackOnReject(decision: ApprovalDecision): string | undefined {
 
 function markIfRejected(context: CliContext, decision: ApprovalDecision): void {
   if (!decision.accepted) markApprovalDenied(context);
+}
+
+function setTuiApprovalBypassState(
+  streamId: string,
+  kind: ApprovalBypassKind,
+  bypassActive: boolean,
+): void {
+  patchStream(streamId, (s) => ({
+    ...s,
+    bypass: { ...s.bypass, [kind]: bypassActive },
+  }));
 }
 
 async function applyRetrySideEffects(
@@ -615,7 +638,6 @@ async function applyRetrySideEffects(
 function handleExternalInquiry(
   payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
-  host: CliRuntimeHost,
 ): void {
   const threadId = payload.threadId;
   if (!threadId) return;
@@ -628,7 +650,7 @@ function handleExternalInquiry(
     void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
     return;
   }
-  void enqueueTuiApproval({ kind: 'externalInquiry', payload }, host).then(
+  void enqueueTuiApproval({ kind: 'externalInquiry', payload }).then(
     (decision) => {
       markIfRejected(context, decision);
       // User-accept with text submits an answer; empty text, reject, and

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -1,23 +1,13 @@
-// Wrap a runtime host's `emit` so host-local focus and approval-bypass updates
-// patch `cliState` while still flowing through the original emitter. Durable
-// progress facts enter through `attachTuiRunFactSubscription`.
+// Project durable session and run facts into the local TUI state.
 
 import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import { isRuntimePresentationEvent } from '@agent/runtime/runtimePresentationEvents';
-import type {
-  CliRuntimeEvent,
-  CliRuntimeEventPayloads,
-  CliRuntimeHost,
-} from '@cli/runtime/runtimeHost';
 import {
   type ActiveChildInfo,
   type GoalPausedPayload,
-  type RemoveStreamPayload,
   type SetActiveStreamPayload,
   type StreamTabId,
   type UpdateActiveProcessesPayload,
@@ -47,16 +37,6 @@ import { appendLocalAssistantTranscript } from './transcript';
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
-
-type CliStateRuntimeEventPayloads = {
-  setActiveStream: SetActiveStreamPayload;
-  removeStream: RemoveStreamPayload;
-  updateToolEditApprovalBypassState: RuntimeInteractionEventPayloads['updateToolEditApprovalBypassState'];
-  updateBashApprovalBypassState: RuntimeInteractionEventPayloads['updateBashApprovalBypassState'];
-  updateSuperYoloBypassState: RuntimeInteractionEventPayloads['updateSuperYoloBypassState'];
-};
-
-type CliStateRuntimeEvent = keyof CliStateRuntimeEventPayloads;
 
 function appendGoalPausedTranscriptNotice(payload: GoalPausedPayload): void {
   // Without a transcript line, an auto-paused goal is indistinguishable
@@ -334,28 +314,6 @@ function applyStreamMeta(
   );
 }
 
-export function wrapRuntimeHost(host: CliRuntimeHost): CliRuntimeHost {
-  const original = host.emit;
-  const emit = <K extends CliRuntimeEvent>(
-    event: K,
-    payload: CliRuntimeEventPayloads[K],
-  ) => {
-    if (!isRuntimePresentationEvent(event)) {
-      applyToState(
-        event as CliStateRuntimeEvent,
-        payload as CliStateRuntimeEventPayloads[CliStateRuntimeEvent],
-      );
-    }
-    return (
-      original as (
-        event: CliRuntimeEvent,
-        payload: CliRuntimeEventPayloads[CliRuntimeEvent],
-      ) => void
-    )(event, payload);
-  };
-  return { ...host, emit };
-}
-
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
@@ -425,51 +383,4 @@ export function attachTuiRunFactSubscription(
     detachRunFacts();
     detachSessionFacts();
   };
-}
-
-function applyToState<K extends CliStateRuntimeEvent>(
-  event: K,
-  payload: CliStateRuntimeEventPayloads[K],
-): void {
-  switch (event) {
-    case 'setActiveStream': {
-      const p = payload as CliStateRuntimeEventPayloads['setActiveStream'];
-      applySetActiveStream(p);
-      return;
-    }
-    case 'removeStream':
-      removeStream(
-        (payload as CliStateRuntimeEventPayloads['removeStream']).streamId,
-      );
-      return;
-    case 'updateToolEditApprovalBypassState': {
-      const p =
-        payload as CliStateRuntimeEventPayloads['updateToolEditApprovalBypassState'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        bypass: { ...s.bypass, toolEdit: p.bypassActive },
-      }));
-      return;
-    }
-    case 'updateBashApprovalBypassState': {
-      const p =
-        payload as CliStateRuntimeEventPayloads['updateBashApprovalBypassState'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        bypass: { ...s.bypass, bash: p.bypassActive },
-      }));
-      return;
-    }
-    case 'updateSuperYoloBypassState': {
-      const p =
-        payload as CliStateRuntimeEventPayloads['updateSuperYoloBypassState'];
-      patchStream(p.streamId, (s) => ({
-        ...s,
-        bypass: { ...s.bypass, superYolo: p.bypassActive },
-      }));
-      return;
-    }
-    default:
-      return;
-  }
 }

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -6,6 +6,7 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: notifyMock,
 }));
 
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   approvalPayloadStreamId,
   approvalQueueStatus,
@@ -16,7 +17,6 @@ import {
   type ApprovalPayload,
 } from '@cli/chat/tui/state/approvalQueue';
 import { enqueueTuiApproval } from '@cli/chat/tui/state/subscribeApprovals';
-import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 
 function bashPayload(streamId: string): ApprovalPayload {
   return {
@@ -163,40 +163,52 @@ describe('CLI approval queue', () => {
   });
 
   it('notifies only when a TUI approval becomes the foreground modal', async () => {
-    const host = { emit: vi.fn() } as unknown as CliRuntimeHost;
+    const emit = vi.spyOn(defaultSession().events, 'emit');
     const first = bashPayload('child-1');
     const second = bashPayload('child-2');
 
-    const firstResult = enqueueTuiApproval(first, host);
-    await vi.waitFor(() => {
+    try {
+      const firstResult = enqueueTuiApproval(first);
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toBe(first);
+      });
+      expect(emit).toHaveBeenNthCalledWith(1, {
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: { streamId: 'child-1' },
+        },
+      });
+      expect(notifyMock).toHaveBeenNthCalledWith(1, {
+        kind: 'approvalNeeded',
+      });
+
+      const secondResult = enqueueTuiApproval(second);
+      await Promise.resolve();
       expect(currentApproval.get()?.payload).toBe(first);
-    });
-    expect(host.emit).toHaveBeenNthCalledWith(1, 'setActiveStream', {
-      streamId: 'child-1',
-    });
-    expect(notifyMock).toHaveBeenNthCalledWith(1, {
-      kind: 'approvalNeeded',
-    });
+      expect(notifyMock).toHaveBeenCalledTimes(1);
 
-    const secondResult = enqueueTuiApproval(second, host);
-    await Promise.resolve();
-    expect(currentApproval.get()?.payload).toBe(first);
-    expect(notifyMock).toHaveBeenCalledTimes(1);
+      currentApproval.get()?.decide({ accepted: true });
+      await expect(firstResult).resolves.toEqual({ accepted: true });
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toBe(second);
+      });
+      expect(emit).toHaveBeenNthCalledWith(2, {
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: { streamId: 'child-2' },
+        },
+      });
+      expect(notifyMock).toHaveBeenNthCalledWith(2, {
+        kind: 'approvalNeeded',
+      });
 
-    currentApproval.get()?.decide({ accepted: true });
-    await expect(firstResult).resolves.toEqual({ accepted: true });
-    await vi.waitFor(() => {
-      expect(currentApproval.get()?.payload).toBe(second);
-    });
-    expect(host.emit).toHaveBeenNthCalledWith(2, 'setActiveStream', {
-      streamId: 'child-2',
-    });
-    expect(notifyMock).toHaveBeenNthCalledWith(2, {
-      kind: 'approvalNeeded',
-    });
-
-    currentApproval.get()?.decide({ accepted: false });
-    await expect(secondResult).resolves.toEqual({ accepted: false });
+      currentApproval.get()?.decide({ accepted: false });
+      await expect(secondResult).resolves.toEqual({ accepted: false });
+    } finally {
+      emit.mockRestore();
+    }
   });
 
   it('extracts stream ids from every approval payload used by the TUI', () => {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -91,6 +91,7 @@ import {
   clearApprovals,
   currentApproval,
 } from '@cli/chat/tui/state/approvalQueue';
+import { resetCliState, streams } from '@cli/chat/tui/state/cliState';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
@@ -165,6 +166,7 @@ function chatGptSubscriptionRetry(
 
 afterEach(() => {
   clearApprovals();
+  resetCliState();
   mocks.lookupApiKey.mockReset();
   mocks.notify.mockReset();
   mocks.setCliApiMode.mockClear();
@@ -181,6 +183,116 @@ describe('TUI retry approvals', () => {
       expect(runtimeHost.emit).toBe(originalEmit);
     } finally {
       interactions.dispose?.();
+    }
+  });
+
+  it('updates TUI bash bypass state at the approval decision site', async () => {
+    const { runtimeHost, interactions, dispose } = tui();
+    try {
+      const result = interactions.requestBashApproval?.({
+        command: 'echo ok',
+        streamId: 'bash-bypass-stream',
+      });
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'bash',
+          payload: { streamId: 'bash-bypass-stream' },
+        });
+      });
+      currentApproval.get()?.decide({ accepted: true, bypass: 'bash' });
+
+      await expect(result).resolves.toEqual({
+        accepted: true,
+        userMessage: undefined,
+      });
+      expect(streams.get().get('bash-bypass-stream')?.bypass.bash).toBe(true);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateBashApprovalBypassState',
+        {
+          streamId: 'bash-bypass-stream',
+          bypassActive: true,
+        },
+      );
+    } finally {
+      dispose();
+    }
+  });
+
+  it('updates TUI edit bypass state at the approval decision site', async () => {
+    const { runtimeHost, interactions, dispose } = tui();
+    try {
+      const result = interactions.requestToolEditApproval?.({
+        path: '/work/main.tex',
+        originalContent: 'old',
+        proposedContent: 'new',
+        sourceTool: 'edit',
+        streamId: 'edit-bypass-stream',
+      });
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'toolEdit',
+          payload: { streamId: 'edit-bypass-stream' },
+        });
+      });
+      currentApproval.get()?.decide({ accepted: true, bypass: 'toolEdit' });
+
+      await expect(result).resolves.toEqual({
+        accepted: true,
+        appliedContent: 'new',
+      });
+      expect(streams.get().get('edit-bypass-stream')?.bypass.toolEdit).toBe(
+        true,
+      );
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateToolEditApprovalBypassState',
+        {
+          streamId: 'edit-bypass-stream',
+          bypassActive: true,
+        },
+      );
+    } finally {
+      dispose();
+    }
+  });
+
+  it('updates TUI super-yolo bypass state at the proposal decision site', async () => {
+    const { runtimeHost, interactions, dispose } = tui();
+    try {
+      const result = interactions.requestAgentProposal?.({
+        proposalId: 'proposal-bypass',
+        streamId: 'proposal-bypass-stream',
+        agent: 'critic',
+        agentSource: null,
+        model: 'kimi26T',
+        instruction: 'Check the local compactness claim.',
+        memories: [],
+        workingDirectory: null,
+        agentCategory: AgentCategory.ToolUse,
+      });
+
+      await vi.waitFor(() => {
+        expect(currentApproval.get()?.payload).toMatchObject({
+          kind: 'proposal',
+          payload: { streamId: 'proposal-bypass-stream' },
+        });
+      });
+      currentApproval.get()?.decide({ accepted: true, bypass: 'superYolo' });
+
+      await expect(result).resolves.toEqual({ action: 'approve' });
+      expect(
+        streams.get().get('proposal-bypass-stream')?.bypass.superYolo,
+      ).toBe(true);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateSuperYoloBypassState',
+        {
+          streamId: 'proposal-bypass-stream',
+          bypassActive: true,
+        },
+      );
+    } finally {
+      dispose();
     }
   });
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -57,10 +57,7 @@ import {
 import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
-import {
-  attachTuiRunFactSubscription,
-  wrapRuntimeHost,
-} from '@cli/chat/tui/state/subscribeRuntimeHost';
+import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
   COMPLETED_PROCESS_TAIL_LINES,
   buildCompletedProcessTranscript,
@@ -220,10 +217,6 @@ describe('cliState Phase 4 fields', () => {
   });
 
   it('updates retained child rows when a failed subagent leaves the active list', () => {
-    const wrapped = wrapRuntimeHost({
-      emit: () => undefined,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
     const dispose = subscribeStreamStatus();
     try {
       patchStream(root, (s) => ({
@@ -1594,10 +1587,6 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('mirrors running child status events into focused child routing', () => {
-    const wrapped = wrapRuntimeHost({
-      emit: () => undefined,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
     const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
@@ -1637,10 +1626,6 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('mirrors stopped child status events into focused child routing', () => {
-    const wrapped = wrapRuntimeHost({
-      emit: () => undefined,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
     const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
     patchStream(root, (s) => ({
@@ -2637,12 +2622,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 
   it('applies typed updateTodos run facts without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
     const todos: TodoItem[] = [
       {
@@ -2664,22 +2643,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       });
 
       expect(streams.get().get(root)?.todos).toEqual(todos);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies typed updatePlan run facts without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
     const plan: Plan = {
       objective: 'Prove the local estimate and record the stopping criterion.',
@@ -2697,22 +2667,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       });
 
       expect(streams.get().get(root)?.plan).toEqual(plan);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies typed goalPaused run facts without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -2731,22 +2692,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           .get(root)
           ?.entries.map((entry) => entry.text),
       ).toEqual([GOAL_PAUSED_TRANSCRIPT_NOTICE]);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct stage.start(kind: round) events without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -2767,22 +2719,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         index: 1,
         total: 3,
       });
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('ignores direct non-round stage.start events without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -2799,22 +2742,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       });
 
       expect(streams.get().get(root)?.roundStage).toBeUndefined();
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct child activity and parent-link facts without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
     const child: ActiveChildInfo = {
       kind: 'subagent',
@@ -2850,22 +2784,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       expect(streams.get().get(root)?.childStreams).toEqual([child]);
       expect(parentStream.get().get(child1)).toBe(root);
       expect(parentStream.get().get(child2)).toBe(root);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct process.output events without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -2885,22 +2810,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         stdout: 'stdout chunk',
         stderr: 'stderr chunk',
       });
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct child.activity(processes) completion and prunes output once', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -2957,22 +2873,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       expect(
         slice?.entries.filter((entry) => entry.role === 'process'),
       ).toHaveLength(1);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct usage events without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
     const storageKey = 'root-direct-run' as StorageKey;
     const usage = {
@@ -3011,22 +2918,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         cacheCreationInputTokens: 0,
         reasoningTokens: 7,
       });
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct session stream facts without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -3068,22 +2966,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       });
 
       expect(streams.get().has(child1)).toBe(false);
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 
   it('applies direct run config and conversation progress without host emission', () => {
     const hub = new SessionEventHub();
-    const hostEmit = vi.fn();
-    const wrapped = wrapRuntimeHost({
-      emit: hostEmit,
-      close: async () => {},
-    } as unknown as CliRuntimeHost);
-    const wrappedEmit = vi.spyOn(wrapped, 'emit');
     const detach = attachTuiRunFactSubscription(hub);
 
     try {
@@ -3125,11 +3014,8 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         category: AgentCategory.ToolUse,
         conversation: { toolCallCount: 3 },
       });
-      expect(wrappedEmit).not.toHaveBeenCalled();
-      expect(hostEmit).not.toHaveBeenCalled();
     } finally {
       detach();
-      wrappedEmit.mockRestore();
     }
   });
 


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary

This Stage 5 slice removes the interactive CLI TUI wrapper around `CliRuntimeHost.emit`. The TUI no longer patches local state by intercepting host progress emissions.

Changes:
- remove `wrapRuntimeHost`, `CliStateRuntimeEventPayloads`, `CliStateRuntimeEvent`, and `applyToState` from `subscribeRuntimeHost.ts`
- use the unwrapped CLI runtime host in `chatSessionController.ts`
- foreground approval streams by emitting `setActiveStream` directly on `defaultSession().events`
- update TUI approval-bypass badges directly at the bash, tool-edit, and proposal decision sites, while preserving the existing runtime-host bypass notifications for shared approval state
- update CLI TUI tests to assert the new direct session/state paths

This keeps the headless CLI public-output projection unchanged. `attachCliSessionProgressProjection` and `cliProgressEvents.ts` remain the explicit compatibility boundary for retained public CLI/NDJSON output.

## Verification

- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/TuiApprovalRetry.vitest.mts src/test-kernel/cli/ApprovalQueue.vitest.mts`
- `npx vitest run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts`
- combined focused run: 6 files, 204 tests passed
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings only)
- `git diff --check`
- `npm test` (609 files passed, 1 skipped; 5277 tests passed, 4 skipped)

## Stage 5 budget check

- `rg "wrapRuntimeHost|CliStateRuntimeEvent|applyToState|CliStateRuntimeEventPayloads" packages/cli/src src/test-kernel/cli -n` returns zero matches.
- Interactive TUI state now enters through direct session facts and explicit approval decision-site updates, not through a runtime-host emission wrapper.
- Headless CLI compatibility remains isolated in the existing public-output projection and is covered by the CLI projection/NDJSON contract tests above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive approval focus, bypass UI state, and how TUI syncs with the session event hub; headless CLI output path is unchanged but TUI behavior regressions are possible if session facts and decision-site patches diverge.
> 
> **Overview**
> Removes the interactive TUI **`wrapRuntimeHost`** layer that intercepted **`CliRuntimeHost.emit`** to patch local **`cliState`**. Chat sessions now wire the **unwrapped** runtime host through **`setupRunHost`**, and durable UI updates come from **`attachTuiRunFactSubscription`** on **`defaultSession().events`** instead of mirrored host emissions.
> 
> **Approval flow** no longer passes the host into **`enqueueTuiApproval`**: foreground modals focus streams by emitting **`setActiveStream`** on the session hub, and bash / tool-edit / super-yolo bypass badges are updated with **`patchStream`** at the decision site while existing **`runtimeHost.emit`** bypass notifications stay for shared approval state.
> 
> Tests were updated to assert session-event focus switching and direct bypass state, and to drop expectations that TUI progress depended on a wrapped host emitter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614e33618b206119c45a0ebb52d2db6a2dd00d19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->