### PR TITLE
refactor: restrict CLI progress projection to NDJSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,7 +433,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - Use `isFileNotFoundError()` from `@common/errors` instead of `instanceof vscode.FileSystemError`
 - Return error results instead of calling `vscode.window.show*Message()` from business logic — let the caller (command layer) handle UI
 - Add typed `Platform` ports (like `toolAvailability.isVscodeExtensionInstalled`) for platform-specific capabilities needed in agnostic code
-- New run-scoped facts extend `AgentEvent` (trace) or `ProgressEventPayloads` emitted via the run's `runtimeHost` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to `emitRuntimeEvent()` — see `src/agent/runtime/emitRuntimeEvent.ts` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
+- New run-scoped facts extend `AgentEvent` (trace), and session-scoped facts extend `SessionFact` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to `emitRuntimeEvent()` — see `src/agent/runtime/emitRuntimeEvent.ts` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
 
 ### Path Aliases
 

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -185,10 +185,13 @@ export async function executeCliRequest(
     defaultSession(),
     interactionHost,
   );
-  const detachSessionProgressProjection = attachCliSessionProgressProjection(
-    defaultSession().events,
-    interactionHost,
-  );
+  const detachSessionProgressProjection =
+    runContext.outputFormat === 'ndjson'
+      ? attachCliSessionProgressProjection(
+          defaultSession().events,
+          interactionHost,
+        )
+      : () => undefined;
   const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
     beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
   });

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -25,25 +25,6 @@ import {
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
 import type { CliContext } from './cliContext';
-import type { CliProgressEventPayloads } from './cliProgressEvents';
-
-const RUN_PROGRESS_EVENTS = [
-  'setTaskState',
-  'updateConversationProgress',
-  'updateRoundStage',
-  'updateActiveProcesses',
-  'updateActiveSubagents',
-  'updateStreamStatus',
-  'updateStreamDescription',
-] as const satisfies readonly (keyof CliProgressEventPayloads)[];
-
-export type RunProgressEvent = (typeof RUN_PROGRESS_EVENTS)[number];
-
-const RunProgressEventSet: ReadonlySet<string> = new Set(RUN_PROGRESS_EVENTS);
-
-export function isRunProgressEvent(event: string): event is RunProgressEvent {
-  return RunProgressEventSet.has(event);
-}
 
 const RUN_PROGRESS_RUN_FACT_TYPES = [
   'conversation.progress',

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -29,7 +29,6 @@ import {
 import {
   attachRunProgressRenderer,
   createRunProgressRenderer,
-  isRunProgressEvent,
 } from './runProgressRenderer';
 import type { CliContext } from './cliContext';
 import type {
@@ -109,15 +108,6 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
           (payload as RuntimePresentationEventPayloads['requestShowError'])
             .message,
         );
-        return;
-      }
-
-      if (
-        !isRuntimePresentationEvent(event) &&
-        !isRuntimeInteractionEvent(event) &&
-        isRunProgressEvent(event) &&
-        runProgress
-      ) {
         return;
       }
 

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -20,7 +20,6 @@ const OLD_AGENT_RUNTIME_ALIAS = '@agent/runtime/agentRuntimeProgressEvents';
 const CLI_ALIAS = '@cli/runtime/cliProgressEvents';
 
 const ALLOWED_PRODUCTION_IMPORTERS = [
-  'packages/cli/src/runtime/runProgressRenderer.ts',
   'packages/cli/src/runtime/runtimeHost.ts',
   'packages/cli/src/runtime/sessionProgressSubscription.ts',
 ] as const;

--- a/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
+++ b/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
@@ -19,6 +19,7 @@ const TARGET_ALIAS = '@cli/runtime/sessionProgressSubscription';
 const ALLOWED_IMPORTERS = [
   'packages/cli/src/runtime/runExecution.ts',
   'src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts',
+  'src/test-kernel/cli/RunExecution.vitest.mts',
 ] as const;
 
 const SCAN_ROOTS = [

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -24,6 +24,7 @@ import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCap
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
   detachRunProgressRenderer: vi.fn(),
+  detachSessionProgressProjection: vi.fn(),
   createHeadlessCliHostInteractions: vi.fn(),
   createCliRuntimeHost: vi.fn(),
   installCliApprovalHandlers: vi.fn(),
@@ -77,6 +78,12 @@ vi.mock('@cli/runtime/approvalAdapter', () => ({
 vi.mock('@cli/runtime/terminalStatus', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/terminalStatus')>()),
   readCliTerminalStatus: mocks.readCliTerminalStatus,
+}));
+
+vi.mock('@cli/runtime/sessionProgressSubscription', () => ({
+  attachCliSessionProgressProjection: vi.fn(
+    () => mocks.detachSessionProgressProjection,
+  ),
 }));
 
 vi.mock('@cli/runtime/logSinks', () => ({
@@ -153,6 +160,39 @@ describe('executeCliRequest', () => {
         .splice(0)
         .map((dir) => rm(dir, { recursive: true, force: true })),
     );
+  });
+
+  it.each(['text', 'json'] as const)(
+    'does not attach the CLI progress projection for %s output',
+    async (outputFormat) => {
+      const { executeCliRequest } = await import('@cli/runtime/runExecution');
+      const { attachCliSessionProgressProjection } =
+        await import('@cli/runtime/sessionProgressSubscription');
+      const attachProjection = vi.mocked(attachCliSessionProgressProjection);
+      const request = baseRequest();
+
+      await executeCliRequest(request, cliContext({ outputFormat }));
+
+      expect(attachProjection).not.toHaveBeenCalled();
+      expect(mocks.detachSessionProgressProjection).not.toHaveBeenCalled();
+    },
+  );
+
+  it('attaches the CLI progress projection for NDJSON output before the run starts', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { attachCliSessionProgressProjection } =
+      await import('@cli/runtime/sessionProgressSubscription');
+    const attachProjection = vi.mocked(attachCliSessionProgressProjection);
+    const request = baseRequest();
+
+    await executeCliRequest(request, cliContext({ outputFormat: 'ndjson' }));
+
+    expect(attachProjection).toHaveBeenCalledTimes(1);
+    expect(mocks.runAgent).toHaveBeenCalledTimes(1);
+    expect(attachProjection.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.runAgent.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(mocks.detachSessionProgressProjection).toHaveBeenCalledTimes(1);
   });
 
   it('marks headless never runs as approval-unavailable for agent execution', async () => {


### PR DESCRIPTION
Part of #6968 and #6951.

## Summary
- Attach the CLI session progress projection only for NDJSON output, preserving it as the public NDJSON compatibility boundary.
- Remove the obsolete runtime-host suppression path and renderer-side progress-event vocabulary classifier.
- Add RunExecution coverage for text/json non-attachment and NDJSON attach-before-run ordering.
- Update architecture guards and stale guidance so new runtime facts point to AgentEvent / SessionFact rather than a new progress-event subscribe surface.

## Validation
- Focused architecture and CLI runtime tests passed: 7 files, 212 tests.
- npm run typecheck passed.
- npm run lint passed with 0 errors and existing import-order warnings.
- npm run compile:fast passed.
- git diff --check origin/main...HEAD passed.
- npm test passed: 608 files passed, 1 skipped; 5280 tests passed, 4 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI output-path refactor with behavioral tests; no auth, persistence, or agent-core logic changes beyond wiring.
> 
> **Overview**
> **CLI headless runs** now wire `attachCliSessionProgressProjection` only when `outputFormat === 'ndjson'`, keeping that path as the NDJSON public compatibility boundary; **text** and **json** runs skip it and use a no-op detach.
> 
> The obsolete **runtime-host** branch that suppressed progress events when the run-progress renderer was active is removed, along with **`isRunProgressEvent`** and the renderer-side progress-event vocabulary in `runProgressRenderer.ts`. NDJSON still emits progress records from `runtimeHost.emit`; non-NDJSON progress UX continues via the session-fact–driven run progress renderer where enabled.
> 
> **Tests and docs:** `RunExecution` tests assert non-attachment for text/json, NDJSON attach-before-`runAgent`, and teardown; architecture allowlists drop `runProgressRenderer` as a `cliProgressEvents` importer and allow the new test file for `sessionProgressSubscription`. **CLAUDE.md** now says new session-scoped facts extend **`SessionFact`**, not only **`AgentEvent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d174b30c038d94d26d96ecc2d2b29a262513228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->