### PR TITLE
refactor: scope CLI progress vocabulary to NDJSON

### DIFF
--- a/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
+++ b/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
@@ -24,16 +24,16 @@ import type {
 } from '@shared/schemas';
 
 /**
- * Progress payloads retained for CLI public-output compatibility.
+ * Progress payloads retained only for CLI NDJSON public-output compatibility.
  *
  * Session- and run-scoped state changes are owned by `SessionEventHub` and
- * `AgentEvent`; this table only types the remaining explicit progress sink
- * used by CLI compatibility adapters. Do not add new fact keys here. New
- * durable state should extend the session/run fact vocabulary first, then
- * choose an explicit host projection only when a retained public surface
- * requires it.
+ * `AgentEvent`; this table only types the remaining `kind: "progress"` record
+ * names in `--output-format ndjson`. It is not a runtime-host event bus. Do
+ * not add new fact keys here. New durable state should extend the session/run
+ * fact vocabulary first, then choose an explicit NDJSON projection only when a
+ * retained public output surface requires it.
  */
-export interface CliProgressEventPayloads {
+export interface CliNdjsonProgressEventPayloads {
   // Run/stream progress.
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: UpdateStreamStatusPayload;
@@ -66,11 +66,4 @@ export interface CliProgressEventPayloads {
   goalStateChanged: GoalStateChangedPayload;
 }
 
-export type CliProgressEvent = keyof CliProgressEventPayloads;
-
-export interface CliProgressSink {
-  emit<K extends CliProgressEvent>(
-    event: K,
-    payload: CliProgressEventPayloads[K],
-  ): void;
-}
+export type CliNdjsonProgressEvent = keyof CliNdjsonProgressEventPayloads;

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -187,10 +187,7 @@ export async function executeCliRequest(
   );
   const detachSessionProgressProjection =
     runContext.outputFormat === 'ndjson'
-      ? attachCliSessionProgressProjection(
-          defaultSession().events,
-          interactionHost,
-        )
+      ? attachCliSessionProgressProjection(defaultSession().events)
       : () => undefined;
   const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
     beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -4,16 +4,12 @@ import type {
   AgentRuntimeEventPayloads,
   AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
-import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 import {
   isRuntimeInteractionEvent,
   type RuntimeInteractionEvent,
   type RuntimeInteractionEventPayloads,
 } from '@agent/runtime/runtimeInteractionEvents';
-import {
-  isRuntimePresentationEvent,
-  type RuntimePresentationEventPayloads,
-} from '@agent/runtime/runtimePresentationEvents';
+import type { RuntimePresentationEventPayloads } from '@agent/runtime/runtimePresentationEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
@@ -31,22 +27,12 @@ import {
   createRunProgressRenderer,
 } from './runProgressRenderer';
 import type { CliContext } from './cliContext';
-import type {
-  CliProgressEvent,
-  CliProgressEventPayloads,
-  CliProgressSink,
-} from './cliProgressEvents';
 
-export type CliRuntimeEventPayloads = AgentRuntimeEventPayloads &
-  CliProgressEventPayloads;
-export type CliRuntimeEvent = AgentRuntimeEvent | CliProgressEvent;
-
-export type CliRuntimeHost = AgentRuntimeHost &
-  CliProgressSink & {
-    attachRunProgressRenderer(events: SessionEventHub): () => void;
-    prepareInteractivePrompt?: () => void;
-    close(): Promise<void>;
-  };
+export type CliRuntimeHost = AgentRuntimeHost & {
+  attachRunProgressRenderer(events: SessionEventHub): () => void;
+  prepareInteractivePrompt?: () => void;
+  close(): Promise<void>;
+};
 
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   let sink: LogSink | undefined;
@@ -71,9 +57,9 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   return {
     attachRunProgressRenderer: attachProgressRenderer,
     prepareInteractivePrompt,
-    emit<K extends CliRuntimeEvent>(
+    emit<K extends AgentRuntimeEvent>(
       event: K,
-      payload: CliRuntimeEventPayloads[K],
+      payload: AgentRuntimeEventPayloads[K],
     ) {
       if (closed) return;
 
@@ -113,15 +99,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
 
       if (context.quietLogs) return;
 
-      if (event === 'setTaskState') {
-        const data = payload as SetTaskStatePayload;
-        ensureLogger().info('Task state registered', {
-          streamId: data.streamId,
-        });
-        return;
-      }
-
-      ensureLogger().debug(`Progress event: ${String(event)}`);
+      ensureLogger().debug(`Runtime event: ${String(event)}`);
     },
     async close() {
       closed = true;

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -5,19 +5,22 @@ import type {
   SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { StreamTabId } from '@shared/schemas';
+import { writeNdjsonStdout } from './logSinks';
 import type {
-  CliProgressEvent,
-  CliProgressEventPayloads,
-  CliProgressSink,
-} from './cliProgressEvents';
+  CliNdjsonProgressEvent,
+  CliNdjsonProgressEventPayloads,
+} from './cliNdjsonProgressEvents';
 
-type CliProjectedProgressEvent = {
-  [K in CliProgressEvent]: {
+type CliProjectedNdjsonProgressEvent = {
+  [K in CliNdjsonProgressEvent]: {
     readonly event: K;
-    readonly payload: CliProgressEventPayloads[K];
+    readonly payload: CliNdjsonProgressEventPayloads[K];
   };
-}[CliProgressEvent];
+}[CliNdjsonProgressEvent];
+
+export type CliNdjsonProgressRecordWriter = (record: CliNdjsonRecord) => void;
 
 const CLI_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
   'conversation.progress',
@@ -36,12 +39,12 @@ const CLI_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
 ];
 
 /**
- * Project session facts onto the frozen host-progress vocabulary for headless
- * CLI public output. `followUpSent` is intentionally session-local.
+ * Project session facts onto the frozen NDJSON progress-event vocabulary.
+ * `followUpSent` is intentionally session-local.
  */
 function projectCliSessionFact(
   fact: SessionFact,
-): CliProjectedProgressEvent | undefined {
+): CliProjectedNdjsonProgressEvent | undefined {
   switch (fact.type) {
     case 'goalStateChanged':
       return { event: 'goalStateChanged', payload: fact.payload };
@@ -69,7 +72,7 @@ function projectCliSessionFact(
 function projectCliRunFact(
   streamId: StreamTabId,
   event: AgentEvent,
-): CliProjectedProgressEvent | undefined {
+): CliProjectedNdjsonProgressEvent | undefined {
   if (event.type === 'usage') {
     const payload = toUpdateStreamUsagePayload(event.data, streamId);
     return payload ? { event: 'updateStreamUsage', payload } : undefined;
@@ -213,26 +216,31 @@ function projectCliRunFact(
 }
 
 function emitProjectedProgressEvent(
-  runtimeHost: CliProgressSink,
-  projected: CliProjectedProgressEvent,
+  writeRecord: CliNdjsonProgressRecordWriter,
+  projected: CliProjectedNdjsonProgressEvent,
 ): void {
-  runtimeHost.emit(projected.event, projected.payload);
+  writeRecord({
+    kind: 'progress',
+    event: projected.event,
+    ts: new Date().toISOString(),
+    payload: projected.payload,
+  });
 }
 
 /**
- * Headless CLI compatibility adapter. Public CLI output still speaks the
- * frozen host progress-event vocabulary, so this boundary alone re-emits
- * session facts through `runtimeHost.emit`.
+ * Headless CLI compatibility adapter. Public NDJSON output still speaks the
+ * frozen progress-event vocabulary inside `kind: "progress"` records, so this
+ * boundary alone projects session/run facts into that public wire shape.
  */
 export function attachCliSessionProgressProjection(
   events: SessionEventHub,
-  runtimeHost: CliProgressSink,
+  writeRecord: CliNdjsonProgressRecordWriter = writeNdjsonStdout,
 ): () => void {
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
       const projected = projectCliSessionFact(sessionEvent.event);
-      if (projected) emitProjectedProgressEvent(runtimeHost, projected);
+      if (projected) emitProjectedProgressEvent(writeRecord, projected);
     },
     { scope: 'session' },
   );
@@ -243,7 +251,7 @@ export function attachCliSessionProgressProjection(
         sessionEvent.streamId,
         sessionEvent.event,
       );
-      if (projected) emitProjectedProgressEvent(runtimeHost, projected);
+      if (projected) emitProjectedProgressEvent(writeRecord, projected);
     },
     { scope: 'run', types: CLI_RUN_PROGRESS_EVENT_TYPES },
   );

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -15,12 +15,13 @@ const REPO_ROOT = resolve(
 const LEGACY_MODULE = 'src/agent/runtime/hostProgressEvents.ts';
 const OLD_AGENT_RUNTIME_MODULE =
   'src/agent/runtime/agentRuntimeProgressEvents.ts';
-const CLI_MODULE = 'packages/cli/src/runtime/cliProgressEvents.ts';
+const OLD_CLI_MODULE = 'packages/cli/src/runtime/cliProgressEvents.ts';
+const CLI_NDJSON_MODULE = 'packages/cli/src/runtime/cliNdjsonProgressEvents.ts';
 const OLD_AGENT_RUNTIME_ALIAS = '@agent/runtime/agentRuntimeProgressEvents';
-const CLI_ALIAS = '@cli/runtime/cliProgressEvents';
+const OLD_CLI_ALIAS = '@cli/runtime/cliProgressEvents';
+const CLI_NDJSON_ALIAS = '@cli/runtime/cliNdjsonProgressEvents';
 
 const ALLOWED_PRODUCTION_IMPORTERS = [
-  'packages/cli/src/runtime/runtimeHost.ts',
   'packages/cli/src/runtime/sessionProgressSubscription.ts',
 ] as const;
 
@@ -105,7 +106,8 @@ function resolveAgentAlias(specifier: string): string | null {
 }
 
 function resolveCliAlias(specifier: string): string | null {
-  if (specifier === CLI_ALIAS) return CLI_MODULE;
+  if (specifier === OLD_CLI_ALIAS) return OLD_CLI_MODULE;
+  if (specifier === CLI_NDJSON_ALIAS) return CLI_NDJSON_MODULE;
   if (!specifier.startsWith('@cli/')) return null;
   return `packages/cli/src/${specifier.slice('@cli/'.length)}`;
 }
@@ -165,11 +167,21 @@ describe('agent runtime progress-event vocabulary boundary', () => {
     expect(importers).toEqual([]);
   });
 
-  it('keeps the CLI progress vocabulary scoped to the CLI package', () => {
-    expect(existsSync(resolve(REPO_ROOT, CLI_MODULE))).toBe(true);
+  it('removes the neutral CLI progress vocabulary module', () => {
+    expect(existsSync(resolve(REPO_ROOT, OLD_CLI_MODULE))).toBe(false);
 
     const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
-      .filter((file) => importsModule(file, CLI_MODULE))
+      .filter((file) => importsModule(file, OLD_CLI_MODULE))
+      .toSorted();
+
+    expect(importers).toEqual([]);
+  });
+
+  it('keeps the CLI compatibility vocabulary NDJSON-projection only', () => {
+    expect(existsSync(resolve(REPO_ROOT, CLI_NDJSON_MODULE))).toBe(true);
+
+    const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
+      .filter((file) => importsModule(file, CLI_NDJSON_MODULE))
       .toSorted();
 
     expect(importers).toEqual([...ALLOWED_PRODUCTION_IMPORTERS].toSorted());

--- a/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
+++ b/src/test-kernel/architecture/cliSessionProgressProjectionBoundary.vitest.ts
@@ -20,6 +20,7 @@ const ALLOWED_IMPORTERS = [
   'packages/cli/src/runtime/runExecution.ts',
   'src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts',
   'src/test-kernel/cli/RunExecution.vitest.mts',
+  'src/test-kernel/cli/RunProgressRenderer.vitest.mts',
 ] as const;
 
 const SCAN_ROOTS = [
@@ -134,7 +135,7 @@ function importsTargetModule(file: string): boolean {
 }
 
 describe('CLI session progress projection boundary', () => {
-  it('keeps sessionProgressSubscription scoped to headless CLI output', () => {
+  it('keeps sessionProgressSubscription scoped to headless CLI NDJSON output', () => {
     expect(existsSync(resolve(REPO_ROOT, TARGET_MODULE))).toBe(true);
 
     const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -3,10 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { logConversationProgress, TraceEmitter } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import type { CliProgressSink } from '@cli/runtime/cliProgressEvents';
-import { attachCliSessionProgressProjection } from '@cli/runtime/sessionProgressSubscription';
+import {
+  attachCliSessionProgressProjection,
+  type CliNdjsonProgressRecordWriter,
+} from '@cli/runtime/sessionProgressSubscription';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
   STREAM_PHASE,
@@ -38,29 +39,32 @@ function workflowConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
   };
 }
 
-function hostWithInteractions(
-  interactions?: Partial<HostInteractions>,
-): CliProgressSink & { interactions: HostInteractions } {
-  return {
-    emit: vi.fn(),
-    interactions: {
-      resolve: () => false,
-      cancel: () => {},
-      ...interactions,
-    },
-  };
+function recordWriter(): CliNdjsonProgressRecordWriter {
+  return vi.fn() as CliNdjsonProgressRecordWriter;
+}
+
+function progressRecord(event: string, payload: unknown) {
+  return expect.objectContaining({
+    kind: 'progress',
+    event,
+    ts: expect.any(String),
+    payload,
+  });
 }
 
 function setupTraceProjection() {
   const events = new SessionEventHub();
-  const host = hostWithInteractions();
+  const writeRecord = recordWriter();
   const trace = new TraceEmitter();
   const detachTrace = trace.subscribe((event) =>
     events.emit({ scope: 'run', streamId, event }),
   );
-  const detachProjection = attachCliSessionProgressProjection(events, host);
+  const detachProjection = attachCliSessionProgressProjection(
+    events,
+    writeRecord,
+  );
   return {
-    host,
+    writeRecord,
     trace,
     detachAll: () => {
       detachProjection();
@@ -70,10 +74,10 @@ function setupTraceProjection() {
 }
 
 describe('attachCliSessionProgressProjection', () => {
-  it('re-emits retained session facts through the headless CLI host rail', () => {
+  it('writes retained session facts as public NDJSON progress records', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -84,7 +88,9 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledWith('setActiveStream', { streamId });
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('setActiveStream', { streamId }),
+      );
 
       detach();
       events.emit({
@@ -95,7 +101,7 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledTimes(1);
+      expect(writeRecord).toHaveBeenCalledTimes(1);
     } finally {
       detach();
     }
@@ -103,8 +109,8 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('keeps followUpSent session-local', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -115,16 +121,16 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).not.toHaveBeenCalled();
+      expect(writeRecord).not.toHaveBeenCalled();
     } finally {
       detach();
     }
   });
 
-  it('re-emits removeStream through the headless CLI host rail', () => {
+  it('writes removeStream as a public NDJSON progress record', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -135,18 +141,18 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledWith('removeStream', {
-        streamId,
-      });
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('removeStream', { streamId }),
+      );
     } finally {
       detach();
     }
   });
 
-  it('re-emits valid retained run facts through the headless CLI host rail', () => {
+  it('writes valid retained run facts as public NDJSON progress records', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -163,11 +169,13 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledWith('updateStreamUsage', {
-        streamId,
-        storageKey: 'run-a',
-        usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
-      });
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateStreamUsage', {
+          streamId,
+          storageKey: 'run-a',
+          usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+        }),
+      );
     } finally {
       detach();
     }
@@ -175,8 +183,8 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('projects run config facts to the public setTaskState event', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
     const config = workflowConfig({
       inputFiles: ['paper.tex', 'appendix.tex'],
       contextFiles: ['notes.md'],
@@ -194,19 +202,21 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledWith('setTaskState', {
-        streamId,
-        executionId,
-        taskState: {
-          agentConfig: config,
-          activeFiles: {
-            input: true,
-            context: true,
-            media: false,
-            output: false,
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('setTaskState', {
+          streamId,
+          executionId,
+          taskState: {
+            agentConfig: config,
+            activeFiles: {
+              input: true,
+              context: true,
+              media: false,
+              output: false,
+            },
           },
-        },
-      });
+        }),
+      );
     } finally {
       detach();
     }
@@ -214,8 +224,8 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('projects status facts to the public stream-status event', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -231,13 +241,15 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).toHaveBeenCalledWith('updateStreamStatus', {
-        streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.WAITING,
-        cause: STREAM_TRANSITION_CAUSE.RESUME,
-        substate: STREAM_SUBSTATE.RESUMING,
-      });
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateStreamStatus', {
+          streamId,
+          status: STREAM_PHASE.RUNNING,
+          previousStatus: STREAM_PHASE.WAITING,
+          cause: STREAM_TRANSITION_CAUSE.RESUME,
+          substate: STREAM_SUBSTATE.RESUMING,
+        }),
+      );
     } finally {
       detach();
     }
@@ -245,8 +257,8 @@ describe('attachCliSessionProgressProjection', () => {
 
   it('drops malformed retained run facts instead of forwarding unchecked payloads', () => {
     const events = new SessionEventHub();
-    const host = hostWithInteractions();
-    const detach = attachCliSessionProgressProjection(events, host);
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
       events.emit({
@@ -274,42 +286,44 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(host.emit).not.toHaveBeenCalled();
+      expect(writeRecord).not.toHaveBeenCalled();
     } finally {
       detach();
     }
   });
 
   it('derives updateConversationProgress from a typed conversation progress event', () => {
-    const { host, trace, detachAll } = setupTraceProjection();
+    const { writeRecord, trace, detachAll } = setupTraceProjection();
 
     try {
       logConversationProgress(trace, {
         toolCallCount: 5,
       });
 
-      expect(host.emit).toHaveBeenCalledWith('updateConversationProgress', {
-        streamId,
-        progress: { toolCallCount: 5 },
-      });
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateConversationProgress', {
+          streamId,
+          progress: { toolCallCount: 5 },
+        }),
+      );
     } finally {
       detachAll();
     }
   });
 
   it('ignores unrelated domain events and stops forwarding after detach', () => {
-    const { host, trace, detachAll } = setupTraceProjection();
+    const { writeRecord, trace, detachAll } = setupTraceProjection();
 
     trace.domain({ key: 'webSearch', data: { query: 'irrelevant' } });
-    expect(host.emit).not.toHaveBeenCalled();
+    expect(writeRecord).not.toHaveBeenCalled();
 
     detachAll();
     logConversationProgress(trace, { toolCallCount: 0 });
-    expect(host.emit).not.toHaveBeenCalled();
+    expect(writeRecord).not.toHaveBeenCalled();
   });
 
   it('ignores legacy conversationProgress domain payloads', () => {
-    const { host, trace, detachAll } = setupTraceProjection();
+    const { writeRecord, trace, detachAll } = setupTraceProjection();
 
     try {
       trace.domain({ key: 'conversationProgress', data: undefined });
@@ -319,14 +333,14 @@ describe('attachCliSessionProgressProjection', () => {
       });
       trace.domain({ key: 'conversationProgress', data: 'not an object' });
 
-      expect(host.emit).not.toHaveBeenCalled();
+      expect(writeRecord).not.toHaveBeenCalled();
     } finally {
       detachAll();
     }
   });
 
   it('projects typed todo and plan run facts', () => {
-    const { host, trace, detachAll } = setupTraceProjection();
+    const { writeRecord, trace, detachAll } = setupTraceProjection();
     const todos = [
       {
         content: 'Check the compactness lemma.',
@@ -342,14 +356,20 @@ describe('attachCliSessionProgressProjection', () => {
       trace.emit({ type: 'updateTodos', streamId, todos });
       trace.emit({ type: 'updatePlan', streamId, plan });
 
-      expect(host.emit).toHaveBeenNthCalledWith(1, 'updateTodos', {
-        streamId,
-        todos,
-      });
-      expect(host.emit).toHaveBeenNthCalledWith(2, 'updatePlan', {
-        streamId,
-        plan,
-      });
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        1,
+        progressRecord('updateTodos', {
+          streamId,
+          todos,
+        }),
+      );
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        2,
+        progressRecord('updatePlan', {
+          streamId,
+          plan,
+        }),
+      );
     } finally {
       detachAll();
     }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -188,6 +188,7 @@ describe('executeCliRequest', () => {
     await executeCliRequest(request, cliContext({ outputFormat: 'ndjson' }));
 
     expect(attachProjection).toHaveBeenCalledTimes(1);
+    expect(attachProjection.mock.calls[0]?.[1]).toBeUndefined();
     expect(mocks.runAgent).toHaveBeenCalledTimes(1);
     expect(attachProjection.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.runAgent.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
@@ -316,7 +317,7 @@ describe('executeCliRequest', () => {
     );
   });
 
-  it('persists headless stream sidecars from session events without double-counting legacy host usage', async () => {
+  it('persists headless stream sidecars from session events', async () => {
     await installStoragePlatform();
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
@@ -329,7 +330,7 @@ describe('executeCliRequest', () => {
       activeForm: 'Writing the introduction',
     };
 
-    mocks.runAgent.mockImplementationOnce(async (_request, options) => {
+    mocks.runAgent.mockImplementationOnce(async () => {
       const { getExecutionStore } = await import('@agent/storage');
       const { AgentConfigSchema } =
         await import('@agent/core/definition/AgentConfig');
@@ -388,17 +389,6 @@ describe('executeCliRequest', () => {
             parentStreamId,
           },
         },
-      });
-      // This is the legacy projected event still visible on the public host
-      // channel. It must not be persisted a second time by the CLI bridge.
-      options.runtimeHost.emit('updateStreamUsage', {
-        streamId,
-        storageKey: 'run-1' as StorageKey,
-        usage: { inputTokens: 100, outputTokens: 20, cost: 0.5 },
-      });
-      options.runtimeHost.emit('updateTodos', {
-        streamId,
-        todos: [todo],
       });
       return {
         category: 'toolUse',

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -8,6 +8,7 @@ import {
   shouldRenderRunProgress,
 } from '@cli/runtime/runProgressRenderer';
 import { createCliRuntimeHost } from '@cli/runtime/runtimeHost';
+import { attachCliSessionProgressProjection } from '@cli/runtime/sessionProgressSubscription';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
@@ -991,24 +992,29 @@ describe('CLI run progress renderer', () => {
     expect(stdout).toBe('');
   });
 
-  it('writes subagent progress events to stdout in ndjson mode', async () => {
+  it('writes projected subagent progress records to stdout in ndjson mode', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
-      const host = createCliRuntimeHost(
-        context({ outputFormat: 'ndjson', renderRunProgress: false }),
-      );
-      host.emit('updateActiveSubagents', {
-        parentStreamId: 'parent-stream',
-        children: [
-          {
-            kind: 'subagent',
-            executionId: 'child-execution',
-            childStreamId: 'child-stream',
-            agentName: 'review',
-            status: 'running',
-          },
-        ],
+      const events = new SessionEventHub();
+      const detach = attachCliSessionProgressProjection(events);
+      events.emit({
+        scope: 'run',
+        streamId: 'parent-stream' as StreamTabId,
+        event: {
+          type: 'child.activity',
+          kind: 'subagents',
+          parentStreamId: 'parent-stream',
+          children: [
+            {
+              kind: 'subagent',
+              executionId: 'child-execution',
+              childStreamId: 'child-stream',
+              agentName: 'review',
+              status: 'running',
+            },
+          ],
+        },
       });
-      await host.close();
+      detach();
     });
 
     const records = output
@@ -1036,19 +1042,30 @@ describe('CLI run progress renderer', () => {
     ]);
   });
 
-  it('does not write late ndjson progress after the runtime host closes', async () => {
+  it('does not write late ndjson progress after the projection detaches', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
-      const host = createCliRuntimeHost(
-        context({ outputFormat: 'ndjson', renderRunProgress: false }),
-      );
-      host.emit('updateStreamStatus', {
-        streamId: 'stream-1',
-        status: STREAM_PHASE.RUNNING,
+      const events = new SessionEventHub();
+      const detach = attachCliSessionProgressProjection(events);
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamStatus',
+          payload: {
+            streamId: 'stream-1' as StreamTabId,
+            status: STREAM_PHASE.RUNNING,
+          },
+        },
       });
-      await host.close();
-      host.emit('updateStreamDescription', {
-        streamId: 'stream-1',
-        description: 'late helper label',
+      detach();
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamDescription',
+          payload: {
+            streamId: 'stream-1' as StreamTabId,
+            description: 'late helper label',
+          },
+        },
       });
     });
 


### PR DESCRIPTION
Part of #6968 and #6951. Follows #7701.

## Summary
- Rename the retained CLI progress vocabulary to an NDJSON-specific module and guard the old neutral module name as deleted.
- Make sessionProgressSubscription project session/run facts directly to public NDJSON progress records.
- Narrow createCliRuntimeHost back to AgentRuntimeHost events so non-NDJSON runtime-host paths no longer accept bus-shaped progress names.
- Preserve the public NDJSON record shape: kind progress, event, ts, payload.

## Validation
- Focused architecture and CLI runtime tests passed: 6 files, 94 tests.
- npm run typecheck passed.
- npm run lint passed with 0 errors and existing import-order warnings.
- npm run compile:fast passed.
- git diff --check origin/main...HEAD passed.
- npm test passed: 608 files passed, 1 skipped; 5281 tests passed, 4 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how headless NDJSON progress is produced (direct projection vs host bus) while preserving the public wire format; regressions would mainly show up in `--output-format ndjson` consumers or tooling that assumed progress could be emitted via `runtimeHost`.
> 
> **Overview**
> **Scopes the retained CLI progress vocabulary to NDJSON** by renaming it to `cliNdjsonProgressEvents` and treating the old neutral module as removed. Architecture tests now require that vocabulary to be imported only from the NDJSON projection path.
> 
> **`attachCliSessionProgressProjection` no longer goes through `runtimeHost.emit`.** It writes public `kind: "progress"` NDJSON records (same `event`, `ts`, `payload` shape) via an injectable writer, defaulting to `writeNdjsonStdout`. Headless NDJSON runs attach it with only `SessionEventHub`—no runtime host argument.
> 
> **`CliRuntimeHost` is narrowed back to `AgentRuntimeHost`:** progress bus names and `CliProgressSink` are dropped, including special-case logging for `setTaskState`. NDJSON mode on the host still wraps **agent runtime** `emit` calls as progress records; session/run fact progress is owned solely by the projection subscriber.
> 
> Tests and import-boundary checks were updated to match (including NDJSON tests that drive `SessionEventHub` instead of `host.emit` for subagent progress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea90d38807d1ce5c9d150c3086dd1269435217df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->