### PR TITLE
refactor: rename desktop session progress bridge

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -104,10 +104,10 @@ import {
   type DesktopLatexdiffWorkspaceScan,
 } from './desktopProgressFileActions.js';
 import {
-  createDesktopProgressEventBridge,
+  createDesktopSessionProgressBridge,
   type DesktopPresentationPayloads,
-  type DesktopProgressEventBridge,
-} from './desktopProgressEventBridge.js';
+  type DesktopSessionProgressBridge,
+} from './desktopSessionProgressBridge.js';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
 type DesktopUnavailableTool =
@@ -216,11 +216,11 @@ export class DesktopProgressBridge {
   private readonly toolEditApprovals: DesktopToolEditApprovalController;
   private readonly fileActions: DesktopProgressFileActions;
   /**
-   * Extracted progress-event bridge that owns ghost-stream hydration,
-   * stream-snapshot persistence, restored-display sending, and
-   * progress-event → rail-update translation.  See #6329.
+   * Extracted session-progress bridge that owns ghost-stream hydration,
+   * stream-snapshot persistence, restored-display sending, session/run facts,
+   * and window-local presentation requests.  See #6329.
    */
-  private readonly progressEvents: DesktopProgressEventBridge;
+  private readonly sessionProgress: DesktopSessionProgressBridge;
   private readonly restartRepair: Promise<void>;
 
   readonly runtimeHost: AgentRuntimeHost;
@@ -302,10 +302,10 @@ export class DesktopProgressBridge {
     });
     this.state = this.backend.state;
     this.streamLogs = this.state.streamLogs;
-    // Compose the extracted progress-event bridge for ghost-stream hydration,
-    // stream-snapshot persistence, restored-display sending, and progress-event
-    // → rail-update translation.  See #6329.
-    this.progressEvents = createDesktopProgressEventBridge({
+    // Compose the extracted session-progress bridge for ghost-stream hydration,
+    // stream-snapshot persistence, restored-display sending, session/run facts,
+    // and window-local presentation requests.  See #6329.
+    this.sessionProgress = createDesktopSessionProgressBridge({
       state: this.state,
       streamStatus: this.session.status,
       streamSnapshotStore: options.streamSnapshotStore,
@@ -326,11 +326,11 @@ export class DesktopProgressBridge {
     });
     const backendSubscription = this.backend.setupEventListeners();
     const detachSessionProgressFacts = this.session.events.subscribe(
-      (event) => this.progressEvents.onSessionEvent(event),
+      (event) => this.sessionProgress.handleSessionEvent(event),
       { scope: 'session' },
     );
     const detachRunProgressFacts = this.session.events.subscribe(
-      (event) => this.progressEvents.onSessionEvent(event),
+      (event) => this.sessionProgress.handleSessionEvent(event),
       { scope: 'run', types: ['run.config', 'status'] },
     );
     this.restartRepair = this.repairOrphanedStreamsAfterRestart();
@@ -349,7 +349,7 @@ export class DesktopProgressBridge {
       detachRunProgressFacts();
       detachSessionProgressFacts();
       backendSubscription.dispose();
-      this.progressEvents.dispose();
+      this.sessionProgress.dispose();
       unsubscribeResult();
     };
     // Present terminal-error toasts from this window's run results (the run
@@ -716,7 +716,7 @@ export class DesktopProgressBridge {
     for (const handler of Object.values(this.approvalHandlers)) {
       handler.clear();
     }
-    // Ghost-stream state is owned by the extracted progressEvents bridge;
+    // Ghost-stream state is owned by the extracted sessionProgress bridge;
     // onAllStreamsDeleted handles clearing it.
   }
 
@@ -736,7 +736,7 @@ export class DesktopProgressBridge {
     ExecutionId
   > {
     const executionIds = new Map(this.state.snapshots.getExecutionIdMap());
-    for (const [streamId, snapshot] of this.progressEvents.restoredStreams) {
+    for (const [streamId, snapshot] of this.sessionProgress.restoredStreams) {
       if (snapshot.executionId && !executionIds.has(streamId)) {
         executionIds.set(streamId, snapshot.executionId);
       }
@@ -750,7 +750,7 @@ export class DesktopProgressBridge {
   } {
     const activeExecutionIds = new Set(getAllActiveExecutionIds());
     const allExecutionIds = this.getRestartRepairExecutionIdMap();
-    this.progressEvents.forgetActiveRestoredStreams(
+    this.sessionProgress.forgetActiveRestoredStreams(
       activeExecutionIds,
       allExecutionIds,
     );
@@ -797,7 +797,7 @@ export class DesktopProgressBridge {
         repairStreams.add(streamId);
       }
     }
-    for (const [streamId, snapshot] of this.progressEvents.restoredStreams) {
+    for (const [streamId, snapshot] of this.sessionProgress.restoredStreams) {
       const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
       if (executionId && activeExecutionIds.has(executionId)) {
         continue;
@@ -833,7 +833,7 @@ export class DesktopProgressBridge {
   private async repairOrphanedStreamsAfterRestart(): Promise<void> {
     try {
       await this.state.streamLogs.load();
-      this.progressEvents.hydrateRestoredStreams();
+      this.sessionProgress.hydrateRestoredStreams();
       const { activeExecutionIds, allExecutionIds } =
         this.refreshActiveExecutionIds();
       const executionIdMap = new Map(
@@ -875,7 +875,7 @@ export class DesktopProgressBridge {
         repairResult.failedStreams.length > 0 ||
         repairResult.closedWaitingGroups.length > 0 ||
         repairResult.closedFailedGroups.length > 0 ||
-        this.progressEvents.restoredStreams.size > 0
+        this.sessionProgress.restoredStreams.size > 0
       ) {
         this.syncFullView();
       }
@@ -886,7 +886,7 @@ export class DesktopProgressBridge {
           waitingStreams.add(streamId);
         }
       }
-      this.progressEvents.hydrateRestoredStreams();
+      this.sessionProgress.hydrateRestoredStreams();
       const { activeExecutionIds, allExecutionIds } =
         this.refreshActiveExecutionIds();
       let repairExecutionIds = allExecutionIds;
@@ -957,7 +957,7 @@ export class DesktopProgressBridge {
       }
       try {
         const fallbackRepairStreams = new Set([
-          ...this.progressEvents.restoredStreams.keys(),
+          ...this.sessionProgress.restoredStreams.keys(),
           ...waitingStreams,
         ]);
         const repairResult = await repairRestartedStreams({
@@ -1019,13 +1019,13 @@ export class DesktopProgressBridge {
 
     switch (event) {
       case 'requestEnsureProgressView':
-        this.progressEvents.onProgressEvent(
+        this.sessionProgress.handlePresentationEvent(
           event,
           payload as DesktopPresentationPayloads[typeof event],
         );
         return;
       case 'requestShowError':
-        this.progressEvents.onProgressEvent(
+        this.sessionProgress.handlePresentationEvent(
           event,
           payload as DesktopPresentationPayloads[typeof event],
         );
@@ -1068,12 +1068,12 @@ export class DesktopProgressBridge {
   async deleteStream(streamId: StreamTabId): Promise<void> {
     if (
       !this.streamLogs.has(streamId) &&
-      !this.progressEvents.hasRestoredStream(streamId)
+      !this.sessionProgress.hasRestoredStream(streamId)
     ) {
       return;
     }
     this.deletedStreams.add(streamId);
-    this.progressEvents.onStreamDeleted(streamId);
+    this.sessionProgress.onStreamDeleted(streamId);
 
     // Releases approval state (pending approvals, bypass flags, pending
     // requests) and the follow-up queue for this stream.
@@ -1093,7 +1093,7 @@ export class DesktopProgressBridge {
   async deleteAllStreams(): Promise<void> {
     const streamIds = new Set<StreamTabId>([
       ...this.streamLogs.keys(),
-      ...this.progressEvents.restoredStreams.keys(),
+      ...this.sessionProgress.restoredStreams.keys(),
     ]);
     // Approval cleanup (incl. retry/proposal/plan pending state) is scoped
     // to THIS window's streams via the per-stream helper, NOT the process-wide
@@ -1118,7 +1118,7 @@ export class DesktopProgressBridge {
     // Drop persisted ghosts too: a "delete all" should leave nothing
     // for the next launch to hydrate, otherwise users would see the
     // ghosts come back zombie-style after relaunch.
-    await this.progressEvents.onAllStreamsDeleted();
+    await this.sessionProgress.onAllStreamsDeleted();
 
     await this.state.clearAll();
     this.clearDesktopSessionMaps();
@@ -1138,7 +1138,7 @@ export class DesktopProgressBridge {
       this.backend.factApplier.syncStreamContent(streamId, {
         includeActiveState: true,
       });
-      this.progressEvents.sendRestoredDisplay(streamId);
+      this.sessionProgress.sendRestoredDisplay(streamId);
     });
   }
 

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -1,5 +1,5 @@
 /**
- * Desktop progress-event bridge.
+ * Desktop session-progress bridge.
  *
  * Extracted from DesktopProgressBridge to own the ghost-stream hydration,
  * stream-snapshot persistence, restored-display sending, and desktop-local
@@ -33,7 +33,7 @@ import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-export interface DesktopProgressEventBridgeOptions {
+export interface DesktopSessionProgressBridgeOptions {
   /** The owning bridge's progress-view state. */
   state: ProgressViewState;
   /** Session-owned stream status plane for this desktop window. */
@@ -66,12 +66,11 @@ export interface DesktopPresentationPayloads {
   requestShowError: RequestShowErrorPayload;
 }
 
-export type DesktopPresentationProgressEvent =
-  keyof DesktopPresentationPayloads;
+export type DesktopPresentationEvent = keyof DesktopPresentationPayloads;
 
 // ── Public interface ────────────────────────────────────────────────────────
 
-export interface DesktopProgressEventBridge {
+export interface DesktopSessionProgressBridge {
   /** All currently-hydrated ghost streams (keyed by streamId). */
   readonly restoredStreams: ReadonlyMap<StreamTabId, RestoredStreamSnapshot>;
 
@@ -93,16 +92,16 @@ export interface DesktopProgressEventBridge {
   /**
    * Handle a desktop presentation event emitted through the runtime host.
    *
-   * Session and run facts reach this bridge through `onSessionEvent`; this path
+   * Session and run facts reach this bridge through `handleSessionEvent`; this path
    * is only for window-local host requests that have no durable session fact.
    */
-  onProgressEvent<K extends DesktopPresentationProgressEvent>(
+  handlePresentationEvent<K extends DesktopPresentationEvent>(
     event: K,
     payload: DesktopPresentationPayloads[K],
   ): void;
 
   /** Handle session/run facts emitted by this window's SessionEventHub. */
-  onSessionEvent(event: SessionEvent): void;
+  handleSessionEvent(event: SessionEvent): void;
 
   /**
    * Restore a ghost stream's persisted sidecar display (todos, plan, usage,
@@ -128,7 +127,7 @@ export interface DesktopProgressEventBridge {
 
 // ── Implementation ──────────────────────────────────────────────────────────
 
-class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
+class DesktopSessionProgressBridgeImpl implements DesktopSessionProgressBridge {
   readonly restoredStreams = new Map<StreamTabId, RestoredStreamSnapshot>();
 
   /** Ghost streams whose persisted display has already been restored this session. */
@@ -146,7 +145,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
   /** True once `dispose()` has torn down this bridge. */
   private disposed = false;
 
-  constructor(private readonly opts: DesktopProgressEventBridgeOptions) {
+  constructor(private readonly opts: DesktopSessionProgressBridgeOptions) {
     // Hydrate previously-persisted "ghost" streams so the rail shows
     // the user's prior runs at launch (audit item D / trajectory #19).
     // We seed creation timestamps, statuses, descriptions, executionIds,
@@ -159,7 +158,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 
     // Desktop presentation requests are window-owned: root/runtime-host events
     // reach this bridge through `DesktopProgressBridge.handleInteractionEvent` and
-    // then `onProgressEvent` — never through any process-global channel,
+    // then `handlePresentationEvent` — never through any process-global channel,
     // which would make root UI actions cross window boundaries and outlive
     // the owning renderer.
   }
@@ -211,9 +210,9 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     }
   }
 
-  // ── Progress events ──────────────────────────────────────────────────────
+  // ── Presentation events ──────────────────────────────────────────────────
 
-  onProgressEvent<K extends DesktopPresentationProgressEvent>(
+  handlePresentationEvent<K extends DesktopPresentationEvent>(
     event: K,
     payload: DesktopPresentationPayloads[K],
   ): void {
@@ -237,7 +236,7 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
     }
   }
 
-  onSessionEvent(event: SessionEvent): void {
+  handleSessionEvent(event: SessionEvent): void {
     if (this.disposed) return;
     if (event.scope === 'session') {
       this.handleSessionFact(event.event);
@@ -516,12 +515,12 @@ class DesktopProgressEventBridgeImpl implements DesktopProgressEventBridge {
 // ── Factory ─────────────────────────────────────────────────────────────────
 
 /**
- * Create a desktop progress-event bridge that owns ghost-stream hydration,
- * stream-snapshot persistence, restored-display sending, and progress-event →
- * rail-update translation.
+ * Create a desktop session-progress bridge that owns ghost-stream hydration,
+ * stream-snapshot persistence, restored-display sending, session/run fact
+ * handling, and window-local presentation requests.
  */
-export function createDesktopProgressEventBridge(
-  options: DesktopProgressEventBridgeOptions,
-): DesktopProgressEventBridge {
-  return new DesktopProgressEventBridgeImpl(options);
+export function createDesktopSessionProgressBridge(
+  options: DesktopSessionProgressBridgeOptions,
+): DesktopSessionProgressBridge {
+  return new DesktopSessionProgressBridgeImpl(options);
 }

--- a/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
+++ b/src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts
@@ -16,6 +16,11 @@ const RETIRED_MODULE =
 const RETIRED_EXTENSION_PROGRESS_MODULE =
   'packages/extension/src/frontend/events/extensionProgressEvents.ts';
 const RETIRED_SYMBOL = /\bProgressEventHandler\b/;
+const RETIRED_DESKTOP_PROGRESS_BRIDGE_TERMS = [
+  'DesktopProgressEventBridge',
+  'desktopProgressEventBridge',
+  'progress-event bridge',
+] as const;
 
 const SCAN_ROOTS = [
   'packages/cli/src',
@@ -61,6 +66,13 @@ function mentionsRetiredSymbol(file: string): boolean {
   return RETIRED_SYMBOL.test(source);
 }
 
+function mentionsRetiredDesktopProgressBridgeTerm(file: string): boolean {
+  const source = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+  return RETIRED_DESKTOP_PROGRESS_BRIDGE_TERMS.some((term) =>
+    source.includes(term),
+  );
+}
+
 describe('ProgressEventHandler retirement boundary', () => {
   it('removes the retired ProgressEventHandler module', () => {
     expect(existsSync(resolve(REPO_ROOT, RETIRED_MODULE))).toBe(false);
@@ -75,6 +87,14 @@ describe('ProgressEventHandler retirement boundary', () => {
   it('removes the ProgressEventHandler class name from production sources', () => {
     const offenders = SCAN_ROOTS.flatMap(sourceFilesUnder)
       .filter(mentionsRetiredSymbol)
+      .toSorted();
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('removes retired desktop progress bridge vocabulary from production desktop sources', () => {
+    const offenders = sourceFilesUnder('packages/desktop/src')
+      .filter(mentionsRetiredDesktopProgressBridgeTerm)
       .toSorted();
 
     expect(offenders).toEqual([]);

--- a/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
@@ -1,13 +1,13 @@
-// Suites for packages/desktop DesktopProgressEventBridge (stream routing,
+// Suites for packages/desktop DesktopSessionProgressBridge (stream routing,
 // snapshot hydration, dispose guard).
 
 import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import {
-  createDesktopProgressEventBridge,
-  type DesktopProgressEventBridgeOptions,
-} from '@desktop/main/desktopProgressEventBridge';
+  createDesktopSessionProgressBridge,
+  type DesktopSessionProgressBridgeOptions,
+} from '@desktop/main/desktopSessionProgressBridge';
 import {
   AgentCategory,
   type RestoredStreamSnapshot,
@@ -19,14 +19,14 @@ import type { ProgressViewState } from '@shared/progressView/backend/state/Progr
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 // ---------------------------------------------------------------------------
-// DesktopProgressEventBridge
+// DesktopSessionProgressBridge
 // ---------------------------------------------------------------------------
 
 /**
- * Unit tests for the extracted DesktopProgressEventBridge module (issue #6329).
+ * Unit tests for the extracted DesktopSessionProgressBridge module (issue #6329).
  *
  * Covers ghost-stream hydration, snapshot persistence, restored-display
- * sending, progress-event handling, and stream-lifecycle callbacks.
+ * sending, presentation-event handling, and stream-lifecycle callbacks.
  *
  * Desktop presentation routing (requestEnsureProgressView, requestShowError)
  * and session-progress handling are tested through the bridge's public API and
@@ -50,7 +50,7 @@ function createSnapshot(
 }
 
 type BridgeOptions = Parameters<
-  typeof import('@desktop/main/desktopProgressEventBridge').createDesktopProgressEventBridge
+  typeof import('@desktop/main/desktopSessionProgressBridge').createDesktopSessionProgressBridge
 >[0];
 type SnapshotStore = NonNullable<BridgeOptions['streamSnapshotStore']>;
 
@@ -123,7 +123,7 @@ function settleMicrotasks(): Promise<void> {
 // ── Module loading ────────────────────────────────────────────────────────
 
 async function loadBridgeModule(): Promise<
-  typeof import('@desktop/main/desktopProgressEventBridge')
+  typeof import('@desktop/main/desktopSessionProgressBridge')
 > {
   vi.resetModules();
   vi.doMock('@logger', () => ({
@@ -146,8 +146,8 @@ async function loadBridgeModule(): Promise<
   }));
 
   return import(
-    moduleFileUrl(desktopSourcePath('main', 'desktopProgressEventBridge.ts'))
-  ) as Promise<typeof import('@desktop/main/desktopProgressEventBridge')>;
+    moduleFileUrl(desktopSourcePath('main', 'desktopSessionProgressBridge.ts'))
+  ) as Promise<typeof import('@desktop/main/desktopSessionProgressBridge')>;
 }
 
 // Use hoisted vi.mock for modules that need importOriginal to preserve
@@ -162,7 +162,7 @@ vi.mock(import('@shared/schemas/goal'), async (importOriginal) => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
-describe('DesktopProgressEventBridge', () => {
+describe('DesktopSessionProgressBridge', () => {
   let module: Awaited<ReturnType<typeof loadBridgeModule>>;
 
   beforeEach(async () => {
@@ -174,7 +174,7 @@ describe('DesktopProgressEventBridge', () => {
   });
 
   function createBridge(overrides: Partial<BridgeOptions> = {}) {
-    return module.createDesktopProgressEventBridge({
+    return module.createDesktopSessionProgressBridge({
       state: makeMockState(),
       streamStatus: {
         get: vi.fn(() => STREAM_PHASE.CANCELLED),
@@ -326,7 +326,7 @@ describe('DesktopProgressEventBridge', () => {
 
       try {
         expect(bridge.hasRestoredStream('live-stream')).toBe(true);
-        bridge.onSessionEvent({
+        bridge.handleSessionEvent({
           scope: 'run',
           streamId: 'live-stream',
           event: {
@@ -381,15 +381,15 @@ describe('DesktopProgressEventBridge', () => {
     });
   });
 
-  // ── Progress events ─────────────────────────────────────────────────────
+  // ── Presentation events ─────────────────────────────────────────────────
 
-  describe('onProgressEvent', () => {
+  describe('handlePresentationEvent', () => {
     it('routes window-local ensure-progress requests from runtime-host events', () => {
       const routeToProgress = vi.fn();
       const bridge = createBridge({ routeToProgress });
 
       try {
-        bridge.onProgressEvent('requestEnsureProgressView', {});
+        bridge.handlePresentationEvent('requestEnsureProgressView', {});
 
         expect(routeToProgress).toHaveBeenCalledTimes(1);
       } finally {
@@ -402,7 +402,7 @@ describe('DesktopProgressEventBridge', () => {
       const bridge = createBridge({ onShowError });
 
       try {
-        bridge.onProgressEvent('requestShowError', {
+        bridge.handlePresentationEvent('requestShowError', {
           message: 'Root run failed',
         });
 
@@ -413,8 +413,8 @@ describe('DesktopProgressEventBridge', () => {
     });
   });
 
-  describe('onSessionEvent', () => {
-    it('handles session stream facts without progress-event projection', async () => {
+  describe('handleSessionEvent', () => {
+    it('handles session stream facts without presentation-event projection', async () => {
       const upsert = vi.fn(async () => {});
       const streamStatus = {
         get: vi.fn(() => STREAM_PHASE.WAITING),
@@ -429,7 +429,7 @@ describe('DesktopProgressEventBridge', () => {
       });
 
       try {
-        bridge.onSessionEvent({
+        bridge.handleSessionEvent({
           scope: 'session',
           event: {
             type: 'updateStreamStatus',
@@ -468,7 +468,7 @@ describe('DesktopProgressEventBridge', () => {
       });
 
       try {
-        bridge.onSessionEvent({
+        bridge.handleSessionEvent({
           scope: 'run',
           streamId: 'run-fact-stream',
           event: {
@@ -482,7 +482,7 @@ describe('DesktopProgressEventBridge', () => {
             },
           } as any,
         });
-        bridge.onSessionEvent({
+        bridge.handleSessionEvent({
           scope: 'run',
           streamId: 'run-fact-stream',
           event: {
@@ -508,7 +508,7 @@ describe('DesktopProgressEventBridge', () => {
       const bridge = createBridge({ onGoalStateChanged });
 
       try {
-        bridge.onSessionEvent({
+        bridge.handleSessionEvent({
           scope: 'session',
           event: {
             type: 'goalStateChanged',
@@ -542,8 +542,8 @@ describe('DesktopProgressEventBridge', () => {
       });
 
       try {
-        bridge.onProgressEvent('requestEnsureProgressView', {});
-        bridge.onProgressEvent('requestShowError', {
+        bridge.handlePresentationEvent('requestEnsureProgressView', {});
+        bridge.handlePresentationEvent('requestShowError', {
           message: 'Root run failed',
         });
 
@@ -749,7 +749,7 @@ describe('DesktopProgressEventBridge', () => {
       bridge.dispose();
 
       // These should not throw
-      bridge.onProgressEvent('requestShowError', {
+      bridge.handlePresentationEvent('requestShowError', {
         message: 'test',
       });
       bridge.onStreamDeleted('test');
@@ -796,7 +796,7 @@ describe('DesktopProgressEventBridge', () => {
 });
 
 // ---------------------------------------------------------------------------
-// desktopProgressEventBridge
+// desktopSessionProgressBridge
 // ---------------------------------------------------------------------------
 
 /**
@@ -808,7 +808,7 @@ describe('DesktopProgressEventBridge', () => {
  */
 function makeBridge() {
   const calls = { showError: [] as string[], routeToProgress: 0 };
-  const options: DesktopProgressEventBridgeOptions = {
+  const options: DesktopSessionProgressBridgeOptions = {
     // Only the requestShowError / requestEnsureProgressView paths are exercised;
     // neither dereferences `state`, and with no snapshot store constructor-time
     // hydration is a no-op, so a cast placeholder is sufficient here.
@@ -826,28 +826,30 @@ function makeBridge() {
       calls.showError.push(message);
     },
   };
-  return { bridge: createDesktopProgressEventBridge(options), calls };
+  return { bridge: createDesktopSessionProgressBridge(options), calls };
 }
 
-describe('DesktopProgressEventBridge dispose guard (#7377)', () => {
+describe('DesktopSessionProgressBridge dispose guard (#7377)', () => {
   it('routes events before dispose', () => {
     const { bridge, calls } = makeBridge();
 
-    bridge.onProgressEvent('requestShowError', { message: 'boom' });
-    bridge.onProgressEvent('requestEnsureProgressView', {});
+    bridge.handlePresentationEvent('requestShowError', { message: 'boom' });
+    bridge.handlePresentationEvent('requestEnsureProgressView', {});
 
     assert.deepEqual(calls.showError, ['boom']);
     assert.equal(calls.routeToProgress, 1);
   });
 
-  it('no-ops progress events delivered after dispose', () => {
+  it('no-ops presentation events delivered after dispose', () => {
     const { bridge, calls } = makeBridge();
 
     bridge.dispose();
 
     assert.doesNotThrow(() => {
-      bridge.onProgressEvent('requestShowError', { message: 'after-dispose' });
-      bridge.onProgressEvent('requestEnsureProgressView', {});
+      bridge.handlePresentationEvent('requestShowError', {
+        message: 'after-dispose',
+      });
+      bridge.handlePresentationEvent('requestEnsureProgressView', {});
     });
 
     assert.deepEqual(calls.showError, []);


### PR DESCRIPTION
Part of #6968 and #6951. Follows #7702.

## Summary
- Rename the desktop progress-event bridge module to DesktopSessionProgressBridge vocabulary.
- Route session/run facts through handleSessionEvent and window-local presentation requests through handlePresentationEvent.
- Rename the owning DesktopProgressBridge field from progressEvents to sessionProgress.
- Add an architecture guard so retired desktop progress bridge vocabulary does not re-enter production desktop sources.

## Behavior
No intended behavior change. Multi-window isolation, ghost-stream hydration, snapshot persistence, restored-display sending, and dispose ordering are preserved.

## Validation
- Focused desktop and architecture tests passed: 4 files, 97 tests.
- npm run typecheck passed.
- npm run lint passed with 0 errors and existing import-order warnings.
- npm run compile:fast passed.
- git diff --check origin/main...HEAD passed.
- npm test passed: 608 files passed, 1 skipped; 5282 tests passed, 4 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Vocabulary and API renames only; ghost streams, snapshots, restart repair, and dispose guards are unchanged per PR intent.
> 
> **Overview**
> Renames the desktop extracted bridge from **progress-event** to **session-progress** naming (`desktopSessionProgressBridge`, `DesktopSessionProgressBridge`, factory `createDesktopSessionProgressBridge`).
> 
> **`DesktopProgressBridge`** now holds `sessionProgress` instead of `progressEvents`, and callers use **`handleSessionEvent`** for session/run facts and **`handlePresentationEvent`** for window-local runtime-host UI requests (`requestEnsureProgressView`, `requestShowError`). Comments are updated to match the split between durable facts and presentation.
> 
> Tests and imports follow the new module path and method names. An architecture guard fails if retired strings (`DesktopProgressEventBridge`, `desktopProgressEventBridge`, `progress-event bridge`) reappear under `packages/desktop/src`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1a102d3faa941537d3631f7c1fc12c42447c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->