### PR TITLE
refactor: localize set task state payload type

### DIFF
--- a/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
+++ b/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
@@ -1,13 +1,15 @@
-import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
+import type { TaskState } from '@agent/core/state/TaskState';
 import type {
   AddOutputFilesPayload,
   ClearMissingOutputsPayload,
+  ExecutionId,
   GoalPausedPayload,
   GoalStateChangedPayload,
   InquiryThreadUpdatedEvent,
   RemoveStreamPayload,
   SetActiveStreamPayload,
   SetParentStreamPayload,
+  StreamTabId,
   UpdateConversationProgressPayload,
   UpdateActiveProcessesPayload,
   UpdateActiveSubagentsPayload,
@@ -41,7 +43,11 @@ export interface CliNdjsonProgressEventPayloads {
   updateMissingOutputs: UpdateMissingOutputsPayload;
   updateCompileFailures: UpdateCompileFailuresPayload;
   clearMissingOutputs: ClearMissingOutputsPayload;
-  setTaskState: SetTaskStatePayload;
+  setTaskState: {
+    streamId: StreamTabId;
+    executionId?: ExecutionId;
+    taskState: TaskState;
+  };
   updateStreamUsage: UpdateStreamUsagePayload;
   /** Inquiry thread state changed (open, answered, dropped, or resume outcome). */
   inquiryThreadUpdated: InquiryThreadUpdatedEvent;

--- a/src/agent/runtime/taskStateProgressPayload.ts
+++ b/src/agent/runtime/taskStateProgressPayload.ts
@@ -1,8 +1,0 @@
-import type { TaskState } from '@agent/core/state/TaskState';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
-
-export interface SetTaskStatePayload {
-  streamId: StreamTabId;
-  executionId?: ExecutionId;
-  taskState: TaskState;
-}

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -1,9 +1,9 @@
 import type { AgentEvent, AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { TaskState } from '@agent/core/state/TaskState';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import type { SetTaskStatePayload } from '@agent/runtime/taskStateProgressPayload';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
@@ -12,6 +12,7 @@ import {
   type AddOutputFilesPayload,
   type ClearMissingOutputsPayload,
   type ConversationProgress,
+  type ExecutionId,
   type GoalStatus,
   type InquiryThreadUpdatedEvent,
   type SetActiveStreamPayload,
@@ -50,6 +51,12 @@ import { withEventErrorHandling } from './errorHandling';
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
+
+type SetTaskStateProgressFact = {
+  streamId: StreamTabId;
+  executionId?: ExecutionId;
+  taskState: TaskState;
+};
 
 export type ProgressEventSubscription = {
   dispose(): void;
@@ -582,7 +589,7 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleSetTaskState(data: SetTaskStatePayload): void {
+  public handleSetTaskState(data: SetTaskStateProgressFact): void {
     const { streamId, executionId, taskState } = data;
     const isActiveStream = this.state.activeStream === streamId;
     const category = taskState.agentConfig.agentCategory;

--- a/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
+++ b/src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts
@@ -17,6 +17,8 @@ const OLD_AGENT_RUNTIME_MODULE =
   'src/agent/runtime/agentRuntimeProgressEvents.ts';
 const OLD_CLI_MODULE = 'packages/cli/src/runtime/cliProgressEvents.ts';
 const CLI_NDJSON_MODULE = 'packages/cli/src/runtime/cliNdjsonProgressEvents.ts';
+const OLD_TASK_STATE_PAYLOAD_MODULE =
+  'src/agent/runtime/taskStateProgressPayload.ts';
 const OLD_AGENT_RUNTIME_ALIAS = '@agent/runtime/agentRuntimeProgressEvents';
 const OLD_CLI_ALIAS = '@cli/runtime/cliProgressEvents';
 const CLI_NDJSON_ALIAS = '@cli/runtime/cliNdjsonProgressEvents';
@@ -172,6 +174,18 @@ describe('agent runtime progress-event vocabulary boundary', () => {
 
     const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
       .filter((file) => importsModule(file, OLD_CLI_MODULE))
+      .toSorted();
+
+    expect(importers).toEqual([]);
+  });
+
+  it('removes the agent-runtime task-state compatibility payload module', () => {
+    expect(existsSync(resolve(REPO_ROOT, OLD_TASK_STATE_PAYLOAD_MODULE))).toBe(
+      false,
+    );
+
+    const importers = SCAN_ROOTS.flatMap(sourceFilesUnder)
+      .filter((file) => importsModule(file, OLD_TASK_STATE_PAYLOAD_MODULE))
       .toSorted();
 
     expect(importers).toEqual([]);


### PR DESCRIPTION
Part of #6968 and #6951. Follows #7704.

## Summary
- Delete the shared runtime compatibility module `taskStateProgressPayload.ts`.
- Inline the `setTaskState` payload shape at the two remaining compatibility boundaries: CLI NDJSON output and ProgressFactApplier.
- Add an architecture guard proving the old runtime payload module remains deleted and unimported by production sources.

## Behavior
No intended runtime or public-output behavior change. CLI NDJSON still emits `setTaskState` progress records with `streamId`, optional `executionId`, and `taskState`.

## Validation
- Focused architecture/CLI/progress backend tests passed: 4 files, 76 tests.
- npm run typecheck passed.
- npm run lint passed with 0 errors and existing import-order warnings.
- npm run compile:fast passed.
- git diff --check origin/main...HEAD passed.
- npm test passed: 608 files passed, 1 skipped; 5283 tests passed, 4 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-localization and module deletion only; intended behavior and public NDJSON shape are unchanged.
> 
> **Overview**
> Removes the shared agent-runtime module `taskStateProgressPayload.ts` and stops exporting a central `SetTaskStatePayload` type.
> 
> The **`setTaskState`** shape (`streamId`, optional `executionId`, `taskState`) is now defined locally at the two remaining compatibility surfaces: **`CliNdjsonProgressEventPayloads`** for `--output-format ndjson` and a private **`SetTaskStateProgressFact`** type on **`ProgressFactApplier.handleSetTaskState`**. No change to the NDJSON record fields or progress-view handling logic.
> 
> An architecture test asserts the deleted module stays gone and that production code does not import it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b3fa2f36456081e3c1fe234ca56c15e9ffea89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->