### PR TITLE
refactor: make session fact consumers exhaustive

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -21,6 +21,7 @@ import {
   reduceStreamMeta,
   type StreamMetaCommand,
 } from '@shared/streams/streamMetaReducer';
+import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
@@ -320,12 +321,13 @@ export function attachTuiRunFactSubscription(
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
-      switch (sessionEvent.event.type) {
+      const fact = sessionEvent.event;
+      switch (fact.type) {
         case 'setActiveStream':
-          applySetActiveStream(sessionEvent.event.payload);
+          applySetActiveStream(fact.payload);
           return;
         case 'updateStreamDescription': {
-          const payload = sessionEvent.event.payload;
+          const payload = fact.payload;
           patchStream(payload.streamId, (s) => ({
             ...s,
             description: payload.description,
@@ -333,23 +335,27 @@ export function attachTuiRunFactSubscription(
           return;
         }
         case 'setParentStream':
-          applyParentStream(sessionEvent.event.payload);
+          applyParentStream(fact.payload);
           return;
         case 'removeStream':
-          removeStream(sessionEvent.event.payload.streamId);
+          removeStream(fact.payload.streamId);
           return;
         case 'followUpSent':
           // Active-session follow-ups enter the same queue before the wait node
           // consumes them; refresh immediately so the status bar shows the
           // pending message instead of only seeing the later drain event.
-          refreshQueuedFollowUps(sessionEvent.event.payload.streamId);
+          refreshQueuedFollowUps(fact.payload.streamId);
           return;
         case 'updateQueuedFollowUps':
-          refreshQueuedFollowUps(sessionEvent.event.payload.streamId);
+          refreshQueuedFollowUps(fact.payload.streamId);
           return;
-        default:
+        case 'goalStateChanged':
+        case 'inquiryThreadUpdated':
+        case 'clearMissingOutputs':
+        case 'updateStreamStatus':
           return;
       }
+      assertNever(fact, 'Unhandled TUI session fact');
     },
     { scope: 'session' },
   );

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -21,6 +21,7 @@ import {
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -170,9 +171,17 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           );
         }
         return true;
-      default:
+      case 'goalStateChanged':
+      case 'inquiryThreadUpdated':
+      case 'clearMissingOutputs':
+      case 'updateQueuedFollowUps':
+      case 'followUpSent':
+      case 'setActiveStream':
+      case 'setParentStream':
+      case 'removeStream':
         return false;
     }
+    return assertNever(event, 'Unhandled run-progress renderer session fact');
   }
 
   private handleRunFact(streamId: StreamTabId, event: AgentEvent): boolean {

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -7,6 +7,7 @@ import type {
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import type { StreamTabId } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 import { writeNdjsonStdout } from './logSinks';
 import type {
   CliNdjsonProgressEvent,
@@ -67,6 +68,7 @@ function projectCliSessionFact(
     case 'removeStream':
       return { event: 'removeStream', payload: fact.payload };
   }
+  assertNever(fact, 'Unhandled CLI NDJSON session fact');
 }
 
 function projectCliRunFact(

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -28,6 +28,7 @@ import type { ProgressViewState } from '@shared/progressView/backend/state/Progr
 import { AgentCategory } from '@shared/schemas/agent';
 import { isGoalInFlight, type GoalStatus } from '@shared/schemas/goal';
 import { GoalStore } from '@tools/goal';
+import { assertNever } from '@utils/core';
 import { toLogData } from './desktopLogUtils.js';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
@@ -451,9 +452,14 @@ class DesktopSessionProgressBridgeImpl implements DesktopSessionProgressBridge {
       case 'goalStateChanged':
         this.handleGoalStateChanged(fact.payload.streamId);
         return;
-      default:
+      case 'inquiryThreadUpdated':
+      case 'clearMissingOutputs':
+      case 'updateQueuedFollowUps':
+      case 'followUpSent':
+      case 'removeStream':
         return;
     }
+    assertNever(fact, 'Unhandled desktop session fact');
   }
 
   private handleRunEvent(event: AgentEvent): void {

--- a/src/shared/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/shared/progressView/backend/events/ProgressFactApplier.ts
@@ -46,6 +46,7 @@ import {
   type StreamExecutionState,
 } from '@shared/progressView/backend/state/ProgressViewState';
 import { WebviewBridge } from '@shared/progressView/backend/WebviewBridge';
+import { assertNever } from '@utils/core';
 
 import { withEventErrorHandling } from './errorHandling';
 
@@ -205,6 +206,7 @@ export class ProgressFactApplier {
       case 'removeStream':
         return;
     }
+    assertNever(fact, 'Unhandled progress-view session fact');
   }
 
   handleRunFact(streamId: StreamTabId, event: AgentEvent): void {


### PR DESCRIPTION
## Summary
- Fixes #7689.
- Makes production `SessionFact` consumers compile-loud by ending handled switches with `assertNever`.
- Replaces silent defaults in desktop, CLI TUI, and CLI run-progress consumers with explicit ignored session-fact arms.
- Also covers `RunProgressRenderer`, an additional current session-fact consumer found during the evidence pass.

## Validation
- `npx vitest run src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:fast`
- `npm test`
- `git diff --check`

Trackers: #6968, #6951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only exhaustiveness guards; runtime behavior for handled and intentionally ignored facts should match the previous default branches.
> 
> **Overview**
> Makes **`SessionFact`** handling **compile-exhaustive** across CLI TUI, CLI NDJSON projection, run-progress stderr renderer, desktop session bridge, and shared **`ProgressFactApplier`**.
> 
> Each consumer switch now lists **explicit no-op arms** for session facts it intentionally ignores (instead of a silent **`default`**), and ends with **`assertNever(fact, …)`** so adding a new fact type forces updates at every site. **`subscribeRuntimeHost`** and peers also bind **`sessionEvent.event`** to a local **`fact`** for clearer narrowing before **`assertNever`**.
> 
> **`RunProgressRenderer`** documents ignored session facts by returning **`false`** for those arms, then **`assertNever`** on anything not listed—same exhaustiveness goal without changing which facts update the live status line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f57fe7978f9680ab33a0951aa36f82f7d2f6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->