### PR TITLE
fix: dedupe cli run progress status updates

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -119,6 +119,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private lastLine = '';
   private liveLine = false;
   private rootStreamId: StreamTabId | undefined;
+  private rootStreamStatus: StreamPhase | undefined;
   private rootStreamTerminal = false;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -297,7 +298,9 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
   private applyStatus(streamId: StreamTabId, status: StreamPhase): void {
     if (!this.isRootStream(streamId)) return;
+    if (this.rootStreamStatus === status) return;
 
+    this.rootStreamStatus = status;
     this.state.phase = formatRunProgressStatus(status);
     this.rootStreamTerminal = isTerminalStreamStatus(status);
     if (this.rootStreamTerminal) {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -948,6 +948,84 @@ describe('CLI run progress renderer', () => {
     expect(output).toContain('polish paper.tex · 0s');
   });
 
+  it('renders traced run-status facts for attached run progress rendering', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const events = new SessionEventHub();
+      const host = createCliRuntimeHost(
+        context({
+          colorEnabled: false,
+          quietLogs: true,
+          renderRunProgress: true,
+        }),
+      );
+      const detach = host.attachRunProgressRenderer(events);
+
+      emitWorkflowRunConfig(events);
+      events.emit({
+        scope: 'run',
+        streamId: 'stream-1' as StreamTabId,
+        event: {
+          type: 'status',
+          streamId: 'stream-1' as StreamTabId,
+          phase: STREAM_PHASE.COMPLETED,
+          previousPhase: STREAM_PHASE.RUNNING,
+          cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+        },
+      });
+
+      detach();
+      await host.close();
+    });
+
+    expect(output).toBe(
+      'polish paper.tex · 0s\npolish paper.tex · done · 0s\n',
+    );
+  });
+
+  it('deduplicates matching run and session stream-status facts', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const events = new SessionEventHub();
+      const host = createCliRuntimeHost(
+        context({
+          colorEnabled: false,
+          quietLogs: true,
+          renderRunProgress: true,
+        }),
+      );
+      const detach = host.attachRunProgressRenderer(events);
+
+      emitWorkflowRunConfig(events);
+      events.emit({
+        scope: 'run',
+        streamId: 'stream-1' as StreamTabId,
+        event: {
+          type: 'status',
+          streamId: 'stream-1' as StreamTabId,
+          phase: STREAM_PHASE.COMPLETED,
+          previousPhase: STREAM_PHASE.RUNNING,
+          cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+        },
+      });
+      events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateStreamStatus',
+          payload: {
+            streamId: 'stream-1' as StreamTabId,
+            status: STREAM_PHASE.COMPLETED,
+          },
+        },
+      });
+
+      detach();
+      await host.close();
+    });
+
+    expect(output).toBe(
+      'polish paper.tex · 0s\npolish paper.tex · done · 0s\n',
+    );
+  });
+
   it('preserves the live progress line before interactive prompts', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
       const events = new SessionEventHub();


### PR DESCRIPTION
## Summary
- Keep traced run-scoped `status` events subscribed for CLI run-progress rendering.
- Make root-stream status application idempotent so matching run and session status facts do not render duplicate terminal lines.
- Add regression tests for both paths: traced run status alone renders completion, and a matching session status fact after the run status does not render a second completion line.

## Design note
The first version tried to remove `status` from the run-fact subscription. Review correctly showed that traced CLI runs may publish terminal status only through the run trace; the session `updateStreamStatus` fact is gated off when a trace is present. The final fix therefore preserves both delivery paths and deduplicates at the renderer state transition.

Fixes #7697.
Tracks #7695, #6968, #6951.

## Validation
- `npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `npm run typecheck`
- `git diff --check`
- Earlier pre-review validation on this branch also passed:
  - `npm run compile:fast`
  - `npm run lint` (0 errors; existing import-order warnings remain)
  - `npm test` (608 files passed, 1 skipped; 5285 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI display logic with no auth, data, or execution-path changes; risk is limited to run-progress wording/timing on stderr.
> 
> **Overview**
> Fixes duplicate **done** (and other phase) lines on the CLI run-progress stderr line when the same root stream status arrives more than once—e.g. from both run-scoped `status` facts and session `updateStreamStatus`.
> 
> `DefaultRunProgressRenderer` now remembers the last applied root stream phase and **skips** `applyStatus` when the phase is unchanged, so repeated events do not trigger extra renders or heartbeat churn.
> 
> Adds integration tests on the attached renderer: one for run-scoped completion status, and one asserting run + session completion facts produce a single terminal line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfbed00c2110b359cee31b6bb8d280933aa261f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->