### PR TITLE
fix: update tui bash bypass for goal auto-approval

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -10,6 +10,7 @@
 import { signal, type Signal } from '@lit-labs/signals';
 import PQueue from 'p-queue';
 
+import type { ApprovalBypassKind as HostApprovalBypassKind } from '@agent/runtime/HostInteractions';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { StreamTabId } from '@shared/schemas';
 import type {
@@ -26,7 +27,7 @@ import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import { assertNever } from '@utils/core';
 
-export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
+export type ApprovalBypassKind = HostApprovalBypassKind;
 export type ApprovalQueueStatusKind = 'approval' | 'question' | 'request';
 
 export type ApprovalPayload =

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -155,7 +155,11 @@ export function createTuiHostInteractions(
         request.streamId
       ) {
         setToolEditApprovalSessionBypass(request.streamId, true, host);
-        setTuiApprovalBypassState(request.streamId, 'toolEdit', true);
+        setTuiApprovalBypassState({
+          streamId: request.streamId,
+          kind: 'toolEdit',
+          bypassActive: true,
+        });
       }
       return decision.accepted
         ? { accepted: true, appliedContent: request.proposedContent }
@@ -238,6 +242,7 @@ export function createTuiHostInteractions(
     openExternalInquiry(request) {
       return openExternalInquiryInteraction(request, context);
     },
+    setApprovalBypassState: setTuiApprovalBypassState,
     resolve: () => false,
     cancel(selector: HostInteractionCancelSelector = {}) {
       // Retry routes live outside the modal queue (the pre-queue auto-switch
@@ -450,7 +455,11 @@ async function requestBashInteraction(
   const decision = await decideWithPolicy(context, 'bash', payload);
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true, host);
-    setTuiApprovalBypassState(request.streamId, 'bash', true);
+    setTuiApprovalBypassState({
+      streamId: request.streamId,
+      kind: 'bash',
+      bypassActive: true,
+    });
   }
   return {
     accepted: decision.accepted,
@@ -481,7 +490,11 @@ async function requestProposalInteraction(
     request.streamId
   ) {
     proposalApprovalState.setBypass(request.streamId, true, host);
-    setTuiApprovalBypassState(request.streamId, 'superYolo', true);
+    setTuiApprovalBypassState({
+      streamId: request.streamId,
+      kind: 'superYolo',
+      bypassActive: true,
+    });
   }
   const feedback = feedbackOnReject(decision);
   return decision.accepted
@@ -603,11 +616,15 @@ function markIfRejected(context: CliContext, decision: ApprovalDecision): void {
   if (!decision.accepted) markApprovalDenied(context);
 }
 
-function setTuiApprovalBypassState(
-  streamId: string,
-  kind: ApprovalBypassKind,
-  bypassActive: boolean,
-): void {
+function setTuiApprovalBypassState({
+  streamId,
+  kind,
+  bypassActive,
+}: {
+  readonly streamId: string;
+  readonly kind: ApprovalBypassKind;
+  readonly bypassActive: boolean;
+}): void {
   patchStream(streamId, (s) => ({
     ...s,
     bypass: { ...s.bypass, [kind]: bypassActive },

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -108,6 +108,14 @@ export type PendingInteractionKind =
   | 'userQuestion'
   | 'externalInquiry';
 
+export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
+
+export interface HostApprovalBypassStateUpdate {
+  readonly streamId: StreamTabId;
+  readonly kind: ApprovalBypassKind;
+  readonly bypassActive: boolean;
+}
+
 /**
  * Selector for {@link HostInteractions.cancel}.
  *
@@ -176,6 +184,7 @@ export interface HostInteractions {
   openExternalInquiry?(
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined;
+  setApprovalBypassState?(update: HostApprovalBypassStateUpdate): void;
   resolve(requestId: string, result: HostInteractionResolution): boolean;
   /** Settle pending requests matching the selector with their reject/cancel defaults. */
   cancel(selector?: HostInteractionCancelSelector): void;
@@ -254,6 +263,10 @@ export class SessionHostInteractions implements HostInteractions {
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined {
     return this.active.openExternalInquiry?.(request);
+  }
+
+  setApprovalBypassState(update: HostApprovalBypassStateUpdate): void {
+    this.active.setApprovalBypassState?.(update);
   }
 
   resolve(requestId: string, result: HostInteractionResolution): boolean {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -97,6 +97,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import { AgentCategory } from '@shared/schemas';
+import { setGoalSessionBashAutoApproval } from '@tools/goal';
 
 function context(): CliContext {
   return {
@@ -216,6 +217,46 @@ describe('TUI retry approvals', () => {
       );
     } finally {
       dispose();
+    }
+  });
+
+  it('updates TUI bash bypass state when goal auto-approval is enabled and cleared', async () => {
+    const runtimeHost = host();
+    const interactions = createTuiHostInteractions(runtimeHost, context());
+    const hostWithInteractions = {
+      ...runtimeHost,
+      interactions,
+    } satisfies CliRuntimeHost;
+    try {
+      await setGoalSessionBashAutoApproval(
+        'goal-bypass-stream',
+        true,
+        hostWithInteractions,
+      );
+      expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(true);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateBashApprovalBypassState',
+        {
+          streamId: 'goal-bypass-stream',
+          bypassActive: true,
+        },
+      );
+
+      await setGoalSessionBashAutoApproval(
+        'goal-bypass-stream',
+        false,
+        hostWithInteractions,
+      );
+      expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(false);
+      expect(runtimeHost.emit).toHaveBeenCalledWith(
+        'updateBashApprovalBypassState',
+        {
+          streamId: 'goal-bypass-stream',
+          bypassActive: false,
+        },
+      );
+    } finally {
+      interactions.dispose?.();
     }
   });
 

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -28,4 +28,9 @@ export async function setGoalSessionBashAutoApproval(
   const { setBashApprovalSessionBypass } =
     await import('@tools/approval/bashApproval');
   setBashApprovalSessionBypass(streamId, enabled, runtimeHost);
+  runtimeHost.interactions?.setApprovalBypassState?.({
+    streamId,
+    kind: 'bash',
+    bypassActive: enabled,
+  });
 }


### PR DESCRIPTION
## Summary
- Add a small `HostInteractions.setApprovalBypassState` hook for host-local approval bypass UI state.
- Have goal bash auto-approval call that hook after updating the shared bash approval bypass controller.
- Reuse the same TUI stream-state patching path for normal approval decisions and goal-driven bash bypass changes.
- Add a regression test for enabling and clearing the TUI bash bypass badge through goal auto-approval.

## Design note
This keeps #7698's runtime-host wrapper deletion intact. The goal path now reports the host-local UI state change through the session-owned HostInteractions port, rather than restoring broad `runtimeHost.emit` interception.

Fixes #7699.
Tracks #6968, #6951.

## Validation
- `pnpm vitest run src/test-kernel/cli/TuiApprovalRetry.vitest.mts`
- `pnpm run typecheck`
- `git diff --check origin/main...HEAD`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow host-port extension and TUI state sync for approval bypass badges; bash bypass behavior still goes through existing approval modules with optional host UI updates.
> 
> **Overview**
> Adds **`HostInteractions.setApprovalBypassState`** (with shared **`ApprovalBypassKind`** / **`HostApprovalBypassStateUpdate`**) so hosts can mirror session bypass flags in local UI state without intercepting **`runtimeHost.emit`**.
> 
> The TUI wires this to **`setTuiApprovalBypassState`**, which now takes a single object argument; modal approval paths (bash, tool edit, super-yolo) use the same hook. **`setGoalSessionBashAutoApproval`** calls it after **`setBashApprovalSessionBypass`**, so enabling or clearing goal bash auto-approval updates the per-stream bypass badge the same way as an in-modal “remember for session” choice.
> 
> A regression test covers goal-driven enable/clear of the TUI bash bypass while still asserting the existing **`updateBashApprovalBypassState`** emit from the shared approval controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cd336bda8859d3dae94c87d4406fed8235d8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->