### PR TITLE
test: fence production src from host aliases

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -482,6 +482,52 @@ export default tseslint.config(
     },
   },
 
+  // Production core code must not reach back into host-owned layers. The only
+  // intentional prose reference in this area is a JSDoc note in
+  // src/shared/state/PersistedState.ts; import declarations stay forbidden.
+  {
+    files: ['src/**/*.{ts,tsx,mts,cts}'],
+    ignores: ['src/test-kernel/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@common/state',
+              message:
+                'Production src code must not import host-owned state helpers; route host access through platform or host adapters.',
+            },
+            {
+              name: '@common/webview',
+              message:
+                'Production src code must not import host-owned webview helpers; route host access through platform or host adapters.',
+            },
+          ],
+          patterns: [
+            {
+              group: [
+                '@webview/*',
+                '@commands/*',
+                '@progressView/*',
+                '@settingsView/*',
+                '@frontend/*',
+                '@extensionSchemas/*',
+                '@resources/*',
+                '@common/state/*',
+                '@common/webview/*',
+                '@cli/*',
+                '@desktop/*',
+              ],
+              message:
+                'Production src code must not import extension, CLI, or desktop host layers; route host access through platform or host adapters.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // Configuration for JavaScript view modules
   {
     files: [

--- a/src/test-kernel/architecture/dependencyDirection.vitest.ts
+++ b/src/test-kernel/architecture/dependencyDirection.vitest.ts
@@ -64,6 +64,25 @@ const SHARED_AGENT_IMPORT_ALLOWLIST_SET = new Set<string>(
   SHARED_AGENT_IMPORT_ALLOWLIST,
 );
 
+const HOST_LAYER_IMPORT_SPECIFIERS = [
+  '@common/state',
+  '@common/webview',
+] as const;
+
+const HOST_LAYER_IMPORT_PREFIXES = [
+  '@webview/',
+  '@commands/',
+  '@progressView/',
+  '@settingsView/',
+  '@frontend/',
+  '@extensionSchemas/',
+  '@resources/',
+  '@common/state/',
+  '@common/webview/',
+  '@cli/',
+  '@desktop/',
+] as const;
+
 /** Drop comments so a prose mention like "do not import from 'vscode'" can't
  *  trip the import patterns. Naive `//` stripping is fine here: a real import
  *  precedes any trailing comment, and cutting mid-string only matters on lines
@@ -94,6 +113,13 @@ function sourceFilesUnder(zone: string): string[] {
     .map((rel) => join(absoluteZone, rel));
 }
 
+function productionSrcFiles(): string[] {
+  return sourceFilesUnder('src').filter((file) => {
+    const repoRelative = relative(REPO_ROOT, file).replaceAll('\\', '/');
+    return !repoRelative.startsWith('src/test-kernel/');
+  });
+}
+
 function importsVscode(file: string): boolean {
   const source = stripComments(readFileSync(file, 'utf8'));
   return VSCODE_IMPORT_PATTERNS.some((pattern) => pattern.test(source));
@@ -102,6 +128,23 @@ function importsVscode(file: string): boolean {
 function importsAgent(file: string): boolean {
   const source = stripComments(readFileSync(file, 'utf8'));
   return AGENT_IMPORT_PATTERNS.some((pattern) => pattern.test(source));
+}
+
+function importSpecifiers(file: string): string[] {
+  const source = stripComments(readFileSync(file, 'utf8'));
+  return [...source.matchAll(/\b(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)]
+    .map((match) => match[1])
+    .filter((specifier): specifier is string => specifier !== undefined);
+}
+
+function importsHostLayer(file: string): boolean {
+  return importSpecifiers(file).some(
+    (specifier) =>
+      HOST_LAYER_IMPORT_SPECIFIERS.includes(
+        specifier as (typeof HOST_LAYER_IMPORT_SPECIFIERS)[number],
+      ) ||
+      HOST_LAYER_IMPORT_PREFIXES.some((prefix) => specifier.startsWith(prefix)),
+  );
 }
 
 describe('VS Code-free zones never import vscode', () => {
@@ -132,5 +175,20 @@ describe('Shared layer dependency direction', () => {
       .toSorted();
 
     expect(offenders).toEqual([]);
+  });
+});
+
+describe('Production core never imports host layers', () => {
+  it('has no imports from extension, CLI, or desktop aliases', () => {
+    const offenders = productionSrcFiles()
+      .filter(importsHostLayer)
+      .map((file) => relative(REPO_ROOT, file).replaceAll('\\', '/'))
+      .toSorted();
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('actually scans production src files', () => {
+    expect(productionSrcFiles().length).toBeGreaterThan(500);
   });
 });


### PR DESCRIPTION
## Summary
- Add the R-a production `src/**` core-to-host import fence in ESLint.
- Mirror the same host-alias fence in `dependencyDirection.vitest.ts` so an eslint-disable cannot bypass the architecture gate.
- Keep the slice zero-baseline: no allowlist or baseline file is needed.

## Guarded Boundary
Production `src/**`, excluding `src/test-kernel/**`, may not import extension/CLI/desktop host aliases such as `@webview/*`, `@progressView/*`, `@frontend/*`, `@common/state/*`, `@common/webview/*`, `@cli/*`, or `@desktop/*`.

This is only R-a from #7684. The deeper-width, subsystem-edge, host-mock, and test-LoC ratchets remain separate work.

Part of #7684.
Tracks #6953.

## Validation
- `npx vitest run src/test-kernel/architecture/dependencyDirection.vitest.ts`
- `npx vitest run src/test-kernel/architecture`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run format`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy-only change (lint + tests); no runtime behavior, with a clean baseline and test-kernel excluded from the fence.
> 
> **Overview**
> Adds the **R-a** architecture boundary so production core under `src/**` (excluding `src/test-kernel/**`) cannot import extension, CLI, or desktop host aliases.
> 
> **ESLint** gets a new `no-restricted-imports` block on `eslint.config.mjs` that errors on `@common/state`, `@common/webview`, and patterns like `@webview/*`, `@commands/*`, `@progressView/*`, `@settingsView/*`, `@frontend/*`, `@extensionSchemas/*`, `@resources/*`, `@cli/*`, and `@desktop/*`, with messages directing callers to platform or host adapters.
> 
> **Vitest** mirrors the same specifiers and prefixes in `dependencyDirection.vitest.ts` via `importsHostLayer` and a `productionSrcFiles()` scan, so a local `eslint-disable` cannot bypass the gate in CI. A file-count assertion (`> 500`) guards against a broken walk. The slice is **zero-baseline**—no allowlist file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea608d12f628cb48eda4db070cbb68f818cf194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->