### PR TITLE
Register goal cleanup with session stores

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -84,7 +84,6 @@ import {
 } from '@tools/approval';
 import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
-import { GoalStore } from '@tools/goal';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
@@ -1081,7 +1080,6 @@ export class DesktopProgressBridge {
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
-    await GoalStore.forget(streamId, this.session);
     await this.state.clearStream(streamId);
     this.send({
       command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
@@ -1114,7 +1112,6 @@ export class DesktopProgressBridge {
     // interactions after the visible per-stream sweep. This is session-scoped
     // and does not touch sibling windows.
     this.session.interactions.cancel({ cause: 'All streams deleted.' });
-    await GoalStore.forgetMany([...streamIds], this.session);
     // Drop persisted ghosts too: a "delete all" should leave nothing
     // for the next launch to hydrate, otherwise users would see the
     // ghosts come back zombie-style after relaunch.

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -133,7 +133,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
   public removeStreamFromHost(streamId: StreamTabId): void {
     void this.streamLifecycleController.deleteStream(streamId);
-    void GoalStore.forget(streamId);
   }
 
   /**

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -1,6 +1,5 @@
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
-import { GoalStore } from '@tools/goal';
 
 export interface ProgressStreamLifecycleState {
   getActiveStream(): StreamTabId | '';
@@ -56,12 +55,7 @@ export class ProgressStreamLifecycleController {
     // switch streams synchronously after invoking deleteStream, and that
     // switch belongs to the post-deletion state, not this snapshot.
     const wasActive = this.deps.state.getActiveStream() === stream;
-    await Promise.all([
-      this.deps.state.clearStream(stream),
-      // Deleting the conversation ends any goal with it — without this the
-      // record (and its Goal-tab entry) outlives the stream forever.
-      GoalStore.forget(stream),
-    ]);
+    await this.deps.state.clearStream(stream);
 
     let shouldActivateStream = false;
     const activeAfterClear = this.deps.state.getActiveStream();
@@ -95,7 +89,6 @@ export class ProgressStreamLifecycleController {
     );
 
     this.deps.host.cleanupDeletedStreams(streamIds);
-    await GoalStore.forgetMany(streamIds);
     await this.deps.state.clearAll();
     this.deps.host.rebuildRenderedStreams({ forceRebuild: true });
   }

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -32,6 +32,7 @@ import {
   createBackendStorage,
 } from '@shared/state/PersistedState';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { GoalStore } from '@tools/goal';
 import { clamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { SessionStores } from './SessionStores';
@@ -163,6 +164,10 @@ export class ProgressViewState {
     this.stores = new SessionStores({
       streamLogs: this.streamLogs,
       snapshots: this.snapshots,
+      goalEntries: {
+        forget: (stream) => GoalStore.forget(stream, this.session),
+        forgetMany: (streams) => GoalStore.forgetMany(streams, this.session),
+      },
     });
   }
 

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -19,6 +19,10 @@ export interface SessionStoresOptions {
   streamLogs: StreamLogStore;
   snapshots: StreamSnapshotStore;
   deleteExecution?: (executionId: ExecutionId) => Promise<boolean>;
+  goalEntries?: {
+    forget(stream: StreamTabId): Promise<void>;
+    forgetMany(streams: readonly StreamTabId[]): Promise<void>;
+  };
 }
 
 /**
@@ -34,11 +38,18 @@ export class SessionStores {
   private readonly deleteExecution: (
     executionId: ExecutionId,
   ) => Promise<boolean>;
+  private readonly goalEntries:
+    | {
+        forget(stream: StreamTabId): Promise<void>;
+        forgetMany(streams: readonly StreamTabId[]): Promise<void>;
+      }
+    | undefined;
 
   constructor(options: SessionStoresOptions) {
     this.streamLogs = options.streamLogs;
     this.snapshots = options.snapshots;
     this.deleteExecution = options.deleteExecution ?? deleteStoredExecution;
+    this.goalEntries = options.goalEntries;
   }
 
   async deleteStream(stream: StreamTabId): Promise<void> {
@@ -50,11 +61,13 @@ export class SessionStores {
       this.streamLogs.delete(stream),
       this.snapshots.deleteStream(stream),
       this.deleteExecutionIds(executionId ? [executionId] : []),
+      this.goalEntries?.forget(stream),
     ]);
   }
 
   async deleteAll(): Promise<void> {
     const persistedStreams = await this.snapshots.listPersistedStreams();
+    const streamIds = unique([...persistedStreams, ...this.streamLogs.keys()]);
     const executionIds = new Set<ExecutionId>(
       this.snapshots.getExecutionIdMap().values(),
     );
@@ -67,6 +80,7 @@ export class SessionStores {
       this.streamLogs.clear(),
       this.snapshots.deleteAll(),
       this.deleteExecutionIds(executionIds),
+      this.goalEntries?.forgetMany(streamIds),
     ]);
   }
 
@@ -86,7 +100,10 @@ export class SessionStores {
         try {
           const executionId =
             await this.snapshots.readPersistedExecutionId(stream);
-          await this.snapshots.deleteStream(stream);
+          await Promise.all([
+            this.snapshots.deleteStream(stream),
+            this.goalEntries?.forget(stream),
+          ]);
           sweptStreams.push(stream);
           if (executionId) executionIds.add(executionId);
         } catch (error) {

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -2,14 +2,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-// Standard library imports
-
-// Local imports - shared
-import type { StreamTabId } from '@shared/schemas';
-
-// Local imports - tools
-import { GoalStore } from '@tools/goal';
-
 // Local imports - test support
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
@@ -41,21 +33,6 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('clearBackups'), ['stream-b']);
     assert.deepEqual(recorder.calls.get('clearWebview'), ['stream-b']);
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-b']);
-  });
-
-  it('forgets the stream goal when deleting a stream', async () => {
-    const stream = 'stream-a' as StreamTabId;
-    await GoalStore.forget(stream);
-    await GoalStore.start(stream, 'finish the cleanup');
-    const { controller } = createProgressStreamLifecycleHarness();
-
-    try {
-      await controller.deleteStream(stream);
-
-      assert.equal(GoalStore.getForStream(stream), null);
-    } finally {
-      await GoalStore.forget(stream);
-    }
   });
 
   it('deletes active finished streams and activates the next visible stream', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -49,6 +49,7 @@ import {
   type TodoItem,
   type UpdateStreamDescriptionPayload,
 } from '@shared/schemas';
+import { GoalStore } from '@tools/goal';
 import { StorageFS } from '@utils/files';
 import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 
@@ -1566,6 +1567,7 @@ describe('ProgressBackend', () => {
       );
       await writeExecutionConfig(executionId);
       await backend.state.flush();
+      await GoalStore.start(stream, 'finish the cleanup');
 
       expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
       expect(await StorageFS.exists(streamDataDir(stream))).toBe(true);
@@ -1574,7 +1576,29 @@ describe('ProgressBackend', () => {
 
       expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
       expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
+      expect(GoalStore.getForStream(stream)).toBeNull();
     } finally {
+      await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('forgets goal entries when clearing all streams', async () => {
+    const stream = 'tool@deepseek#b6966b' as StreamTabId;
+    const { backend, session } = createIsolatedRecordingBackend();
+
+    try {
+      await backend.state.streamLogs.load();
+      backend.state.streamLogs.ensureStream(stream);
+      await GoalStore.start(stream, 'clear this goal');
+
+      await backend.state.clearAll();
+
+      expect(GoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      await GoalStore.forget(stream);
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();
@@ -1595,6 +1619,7 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(orphanExecution);
     await writeExecutionConfig(historyExecution);
     await seed.flush();
+    await GoalStore.start(orphanStream, 'sweep this orphan');
 
     const { backend, session } = createIsolatedRecordingBackend();
     try {
@@ -1615,7 +1640,9 @@ describe('ProgressBackend', () => {
       expect(await StorageFS.exists(`executions/${historyExecution}`)).toBe(
         true,
       );
+      expect(GoalStore.getForStream(orphanStream)).toBeNull();
     } finally {
+      await GoalStore.forget(orphanStream);
       await getExecutionStore(historyExecution).clear();
       await backend.state.clearAll();
       backend.dispose();


### PR DESCRIPTION
Fixes #7693.

## Summary
- add an optional `goalEntries` participant to `SessionStores` so stream delete, delete-all, and orphan sweep clean up goal records through the same lifecycle owner
- wire `ProgressViewState` to `GoalStore` with the owning `SessionHandle`
- remove duplicate host-level goal cleanup from extension and desktop stream deletion paths
- move the controller-level goal cleanup assertion to the backend facade tests

## Validation
- `npm test -- src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (5 files, 155 tests passed)
- `npm run typecheck`
- `npm run format`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:fast`

## Follow-up
Rung (b), moving goal entries to the execution-scoped schema-versioned store family with a Memento read shim, remains deferred to the SDK-packaging trigger per the #7693 decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle consolidation with added orphan-sweep goal cleanup; behavior is covered by backend tests and does not touch auth or execution logic.
> 
> **Overview**
> **Goal records are now torn down with the rest of a stream’s durable footprint**, instead of each host calling `GoalStore` on its own.
> 
> `SessionStores` gains an optional `goalEntries` hook that runs `forget` / `forgetMany` alongside transcript, snapshot, and execution cleanup on **single-stream delete**, **delete-all**, and **orphan sweep** at load. `ProgressViewState` wires that hook to `GoalStore` with the owning `SessionHandle`.
> 
> Duplicate `GoalStore.forget*` calls are removed from the VS Code extension message handler, desktop stream deletion, and `ProgressStreamLifecycleController` (those paths already go through `state.clearStream` / `clearAll`). Coverage moves from the lifecycle controller test to `ProgressBackend` tests for clear, clear-all, and orphan sweep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6682db6128e4f4e1800ba1d39945f1ac6af577c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->