### PR TITLE
fix: preserve agent-core host import fence

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,48 @@ const VSCODE_FREE_ZONE_DIRS = [
   'packages/extension/src/settingsView/frontend',
 ].map((dir) => path.join(__dirname, dir));
 
+const HOST_LAYER_RESTRICTED_IMPORT_PATHS = [
+  {
+    name: '@common/state',
+    message:
+      'Production src code must not import host-owned state helpers; route host access through platform or host adapters.',
+  },
+  {
+    name: '@common/webview',
+    message:
+      'Production src code must not import host-owned webview helpers; route host access through platform or host adapters.',
+  },
+];
+
+const HOST_LAYER_RESTRICTED_IMPORT_PATTERNS = [
+  {
+    group: [
+      '@webview/**',
+      '@commands/**',
+      '@progressView/**',
+      '@settingsView/**',
+      '@frontend/**',
+      '@extensionSchemas/**',
+      '@resources/**',
+      '@common/state/**',
+      '@common/webview/**',
+      '@cli/**',
+      '@desktop/**',
+    ],
+    message:
+      'Production src code must not import extension, CLI, or desktop host layers; route host access through platform or host adapters.',
+  },
+];
+
+const AGENT_CORE_RESTRICTED_IMPORT_PATTERNS = [
+  {
+    group: ['@agent/modelHandlers', '@agent/modelHandlers/**'],
+    message:
+      'Agent core must not import model handler implementations; move provider-neutral contracts to @agent/types or a core helper.',
+  },
+  ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
+];
+
 function isUnderDir(filename, dir) {
   const relativePath = path.relative(dir, filename);
   return (
@@ -492,37 +534,8 @@ export default tseslint.config(
       'no-restricted-imports': [
         'error',
         {
-          paths: [
-            {
-              name: '@common/state',
-              message:
-                'Production src code must not import host-owned state helpers; route host access through platform or host adapters.',
-            },
-            {
-              name: '@common/webview',
-              message:
-                'Production src code must not import host-owned webview helpers; route host access through platform or host adapters.',
-            },
-          ],
-          patterns: [
-            {
-              group: [
-                '@webview/**',
-                '@commands/**',
-                '@progressView/**',
-                '@settingsView/**',
-                '@frontend/**',
-                '@extensionSchemas/**',
-                '@resources/**',
-                '@common/state/**',
-                '@common/webview/**',
-                '@cli/**',
-                '@desktop/**',
-              ],
-              message:
-                'Production src code must not import extension, CLI, or desktop host layers; route host access through platform or host adapters.',
-            },
-          ],
+          paths: HOST_LAYER_RESTRICTED_IMPORT_PATHS,
+          patterns: HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
         },
       ],
     },
@@ -536,13 +549,8 @@ export default tseslint.config(
       'no-restricted-imports': [
         'error',
         {
-          patterns: [
-            {
-              group: ['@agent/modelHandlers', '@agent/modelHandlers/**'],
-              message:
-                'Agent core must not import model handler implementations; move provider-neutral contracts to @agent/types or a core helper.',
-            },
-          ],
+          paths: HOST_LAYER_RESTRICTED_IMPORT_PATHS,
+          patterns: AGENT_CORE_RESTRICTED_IMPORT_PATTERNS,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Share the host-layer `no-restricted-imports` option set and compose it into the `src/agent/core/**` override, so ESLint flat-config replacement no longer drops the host-layer import fence when adding the agent-core model-handler fence.

## Issue acceptance gates

Addresses #7730.

- Re-verified the cited overlapping `no-restricted-imports` blocks in `eslint.config.mjs`; the agent-core override was still replacing the production host-layer restriction for `src/agent/core/**`.
- Temporary scratch-import probe under `src/agent/core/__lint_restriction_probe__.ts` confirmed both `@agent/modelHandlers/openai/modelHandlerOpenAI` and `@webview/frontend/MainApp` fail lint from agent core.
- No acceptance gates remain incomplete.

## Single source of truth

`HOST_LAYER_RESTRICTED_IMPORT_PATHS` and `HOST_LAYER_RESTRICTED_IMPORT_PATTERNS` in `eslint.config.mjs` now own the host-layer alias restriction vocabulary. The agent-core override reuses those constants and only adds the model-handler implementation restriction.

## Duplication and abstraction budget

Removed the duplicated inline host-layer import-fence options and avoided a drifting second list. No pass-through layer was added; the small net line increase lives in named ESLint rule constants so overlapping flat-config blocks compose the same option set instead of silently replacing it.

## Host impact

Extension: no runtime impact; lint again blocks agent-core imports of extension/webview aliases.

Desktop: no runtime impact; lint again blocks agent-core imports of desktop aliases.

CLI: no runtime impact; lint again blocks agent-core imports of CLI aliases.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write eslint.config.mjs`
- Temporary scratch probe: `corepack pnpm exec eslint src/agent/core/__lint_restriction_probe__.ts` failed with the expected two `no-restricted-imports` errors, then the probe file was deleted.
- `corepack pnpm exec eslint eslint.config.mjs src/agent/core`
- `npm test -- src/test-kernel/architecture/dependencyDirection.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm test`

Closes #7730

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only ESLint config change with no runtime behavior; it restores intended architecture import guards for `src/agent/core`.
> 
> **Overview**
> Fixes a **flat-config composition bug** where the `src/agent/core/**` `no-restricted-imports` override **replaced** the broader production rule, so agent core was no longer blocked from importing extension/CLI/desktop host aliases.
> 
> Host-layer restrictions are extracted into **`HOST_LAYER_RESTRICTED_IMPORT_PATHS`** and **`HOST_LAYER_RESTRICTED_IMPORT_PATTERNS`**, reused for all of `src/**` and composed into **`AGENT_CORE_RESTRICTED_IMPORT_PATTERNS`** (model-handler ban plus the same host patterns). The agent-core block now sets both **`paths`** and **`patterns`** from those constants so host and model-handler fences apply together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff681008db2cd4e090479c9a616fdae2e805b722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->