### PR TITLE
fix(progress): clear goals for missing stream removal

### DIFF
--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -41,7 +41,10 @@ export class ProgressStreamLifecycleController {
   async deleteStream(stream: StreamTabId): Promise<void> {
     const hasStream =
       this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
-    if (!hasStream) return;
+    if (!hasStream) {
+      await this.deps.state.clearStream(stream);
+      return;
+    }
 
     if (this.deps.host.isStreamInFlight(stream)) {
       // Finished streams should not get synthetic STOPPED transitions or child

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -6,14 +6,16 @@ import { describe, it } from 'vitest';
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
 describe('ProgressStreamLifecycleController', () => {
-  it('ignores deletion for unknown streams', async () => {
+  it('cleans durable state for unknown streams without rendered cleanup', async () => {
     const { controller, recorder, streams } =
       createProgressStreamLifecycleHarness();
 
     await controller.deleteStream('missing');
 
     assert.deepEqual(streams(), ['stream-a', 'stream-b']);
-    assert.equal(recorder.calls.size, 0);
+    assert.deepEqual(recorder.calls.get('clearState'), ['missing']);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), undefined);
   });
 
   it('deletes inactive streams without stopping finished work', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1619,10 +1619,10 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(orphanExecution);
     await writeExecutionConfig(historyExecution);
     await seed.flush();
-    await GoalStore.start(orphanStream, 'sweep this orphan');
 
     const { backend, session } = createIsolatedRecordingBackend();
     try {
+      await GoalStore.start(orphanStream, 'sweep this orphan');
       expect(await StorageFS.exists(streamDataDir(orphanStream))).toBe(true);
       expect(await StorageFS.exists(`executions/${orphanExecution}`)).toBe(
         true,

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -71,6 +71,7 @@ export function createProgressStreamLifecycleHarness(
     getStreamIds: () => streams,
     pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
     clearStream: async (stream) => {
+      recorder.record('clearState', stream);
       streams = streams.filter((candidate) => candidate !== stream);
       if (activeStream === stream) {
         activeStream = streams[0] ?? '';


### PR DESCRIPTION
## Summary

Fix the missed #7729 review gap: `removeStream` for a stream absent from progress/task state now still runs durable state cleanup, so `SessionStores` can forget goal records even when no rendered stream exists. The rendered/UI cleanup remains skipped for that unknown-stream path.

Also moves the orphan-goal test setup inside its `try/finally`, so a thrown `GoalStore.start()` cannot bypass cleanup.

## Issue acceptance gates

Addresses #7733.

- `ProgressStreamLifecycleController.deleteStream()` now calls `state.clearStream(stream)` before returning for unknown streams.
- Controller coverage proves unknown-stream deletion clears durable state but does not run rendered-stream cleanup.
- `ProgressBackend` orphan-sweep test now starts the goal inside the existing cleanup guard.
- No acceptance gates remain incomplete.

## Single source of truth

`ProgressStreamLifecycleController` remains the single deletion coordinator: it decides whether rendered host cleanup is needed, while `ProgressViewState.clearStream()` / `SessionStores.deleteStream()` owns durable cleanup including goal records.

## Duplication and abstraction budget

No abstraction added. The fix preserves #7729's single cleanup owner instead of reintroducing a host-level `GoalStore.forget()` call in the extension message handler.

## Host impact

Extension: `removeStream` events for streams that never rendered now still clear durable stream-owned goal records; rendered UI cleanup remains skipped for absent streams.

Desktop: no direct behavior change; the shared lifecycle controller behavior is tightened for any host using it.

CLI: no runtime impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/controllers/progressView/ProgressStreamLifecycleController.ts src/test-kernel/support/ProgressControllerHarnesses.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm test`

Additional pre-branch focused checks while addressing the review threads:
- `npm test -- src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/cli/History.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm run compile:fast`

Closes #7733

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle-controller behavior change with targeted tests; no auth or broad API surface.
> 
> **Overview**
> Fixes a gap where **removing a stream that is not in progress/task state** did nothing, so durable records (including **goal** data via `SessionStores`) could linger after `removeStream`.
> 
> `ProgressStreamLifecycleController.deleteStream()` now **`await`s `state.clearStream(stream)`** on that unknown-stream path and returns early, so durable cleanup still runs while **rendered host cleanup** (`stopStream`, `cleanupDeletedStream`, webview deletion, active-tab switching) stays skipped.
> 
> Tests assert unknown-stream deletion records **`clearState`** without approval/webview cleanup, and the orphan-goal sweep test moves **`GoalStore.start()`** inside the existing **`try/finally`** so setup failures cannot skip teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ba498ce993daf75d9ad4090072c6c2c5e66b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->