### PR TITLE
Route tool edit approvals through sessions

### DIFF
--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -20,7 +20,6 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
-import { setActiveCliToolEditApprovalHandler } from './initPlatform';
 
 import { type CliDecisionApprovalEvent } from './approvalEvents';
 import { type CliContext } from './cliContext';
@@ -89,18 +88,6 @@ async function decideToolEdit(
     hooks,
   );
   return toToolEditResult(decision, request.proposedContent);
-}
-
-export function installCliApprovalHandlers(
-  context: CliContext,
-  hooks: CliApprovalPromptHooks = {},
-): () => void {
-  setActiveCliToolEditApprovalHandler((request) =>
-    decideToolEdit(request, context, hooks),
-  );
-  return () => {
-    setActiveCliToolEditApprovalHandler(undefined);
-  };
 }
 
 async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -53,7 +53,7 @@ import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
 
 // Type imports - platform and CLI runtime
-import type { LifecycleHost, ToolEditApprovalPort } from '@platform/interfaces';
+import type { LifecycleHost } from '@platform/interfaces';
 import type { LogBackend } from './supabaseAuth';
 import type { CliContext } from './cliContext';
 
@@ -62,49 +62,6 @@ let cliWorkspaceCwd = '';
 let quietPlatformLogs = false;
 let shutdownHandlersInstalled = false;
 type CliShutdownSignal = 'SIGINT' | 'SIGTERM';
-
-// ---------------------------------------------------------------------------
-// Session-scoped tool-edit approval handler
-// ---------------------------------------------------------------------------
-//
-// The Platform port `toolEditApproval` is frozen at initPlatform time, but the
-// actual approval UI is session-scoped — the CLI opens and closes a TUI session
-// (or a headless approval prompt) independently of the platform life span.
-//
-// We bridge the two lifetimes with a single mutable reference: `initCliPlatform`
-// installs a delegating handler that reads this reference; `subscribeApprovals`
-// (TUI) and `installCliApprovalHandlers` (headless) write and clear it per
-// session, exactly as they did with the defunct `setToolEditApprovalHandler`.
-
-let activeCliToolEditApprovalHandler: ToolEditApprovalPort | undefined;
-
-/** Install the active session's tool-edit approval handler (or clear it). */
-export function setActiveCliToolEditApprovalHandler(
-  handler: ToolEditApprovalPort | undefined,
-): void {
-  activeCliToolEditApprovalHandler = handler;
-}
-
-/**
- * Return a Platform-compatible `toolEditApproval` port that delegates to the
- * handler installed by {@link setActiveCliToolEditApprovalHandler}.
- *
- * Used both by {@link initCliPlatform} (wired into the frozen Platform at
- * startup) and by unit tests that exercise the CLI approval adapter against a
- * {@link createFakePlatform}.
- */
-export function createCliToolEditApprovalPort(): ToolEditApprovalPort {
-  return (request) => {
-    const handler = activeCliToolEditApprovalHandler;
-    if (!handler) {
-      throw new Error(
-        'No active session for tool edit approval. ' +
-          'Start a chat session or use --print with an approval policy.',
-      );
-    }
-    return handler(request);
-  };
-}
 
 type CliPlatformInitOptions = Pick<
   CliContext,
@@ -249,7 +206,6 @@ export async function initCliPlatform(
           isTexraCliEntrypoint: () =>
             isTexraCliEntrypointPath(readCliEntrypointPath()),
         },
-        toolEditApproval: createCliToolEditApprovalPort(),
       }),
     );
     if (context.installSignalHandlers !== false) {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -19,10 +19,7 @@ import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
-import {
-  createHeadlessCliHostInteractions,
-  installCliApprovalHandlers,
-} from './approvalAdapter';
+import { createHeadlessCliHostInteractions } from './approvalAdapter';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
 import { CliExitCode } from './exitCodes';
@@ -189,9 +186,6 @@ export async function executeCliRequest(
     runContext.outputFormat === 'ndjson'
       ? attachCliSessionProgressProjection(defaultSession().events)
       : () => undefined;
-  const uninstallApprovalHandlers = installCliApprovalHandlers(runContext, {
-    beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
-  });
   const ownedExecutionId = options.registerExecution
     ? request.executionId
     : undefined;
@@ -251,7 +245,6 @@ export async function executeCliRequest(
     detachRunProgressRenderer();
     detachSessionProgressProjection();
     detachHostInteractions();
-    uninstallApprovalHandlers();
     try {
       try {
         flushPendingRunTraces();

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1197,11 +1197,6 @@ export class DesktopProgressBridge {
           runtimeHost: this.runtimeHost,
           session: this.session,
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-          toolEditApprovalHandler: (approvalRequest) =>
-            this.toolEditApprovals.requestApproval(
-              approvalRequest,
-              this.session,
-            ),
           reportFailure: (error) => this.reportResumeFailure(streamId, error),
         }),
       executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
@@ -1410,8 +1405,6 @@ export class DesktopProgressBridge {
       runtimeHost: this.runtimeHost,
       session: this.session,
       runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-      toolEditApprovalHandler: (approvalRequest) =>
-        this.toolEditApprovals.requestApproval(approvalRequest, this.session),
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
       openWorkflowOutput: async (result) => {
         // Gate, outcome check, and final-output selection are shared policy

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -28,7 +28,6 @@ import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 import { createTexraTempDir } from './desktopTempDir.js';
-import { setDesktopToolEditApprovalHandler } from './platform/index.js';
 
 export interface DesktopToolEditApprovalOptions {
   runtimeHost: AgentRuntimeHost;
@@ -46,12 +45,6 @@ export interface DesktopToolEditApprovalController {
     action: ToolEditApprovalAction;
     feedback?: string;
   }): boolean;
-  /**
-   * This window's tool-edit approval handler. Pass this to `runAgent`/
-   * `resumeToolUseSnapshot` as `toolEditApprovalHandler` so a request always
-   * resolves through this window's controller, not whichever window's
-   * controller last wrote the shared `platform().toolEditApproval` fallback.
-   */
   requestApproval(
     request: ToolEditApprovalRequest,
     session?: SessionHandle,
@@ -74,11 +67,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   private readonly pending = new Map<string, DesktopPendingToolEditApproval>();
   private disposed = false;
 
-  constructor(private readonly options: DesktopToolEditApprovalOptions) {
-    setDesktopToolEditApprovalHandler((request) =>
-      this.requestApproval(request),
-    );
-  }
+  constructor(private readonly options: DesktopToolEditApprovalOptions) {}
 
   async requestApproval(
     request: ToolEditApprovalRequest,
@@ -162,7 +151,6 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    setDesktopToolEditApprovalHandler(undefined);
     for (const requestId of [...this.pending.keys()]) {
       this.settle(requestId, { accepted: false });
     }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../desktopAgentResume.js';
 
 // Type imports - platform
-import type { LifecycleHost, ToolEditApprovalPort } from '@platform/interfaces';
+import type { LifecycleHost } from '@platform/interfaces';
 
 export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
@@ -52,37 +52,6 @@ export interface ElectronPlatformInitResult {
 
 const WORKSPACE_CONFIG_MIGRATED_KEY =
   'desktop.workspaceConfigMigratedToProject';
-
-// ---------------------------------------------------------------------------
-// Session-scoped tool-edit approval handler
-// ---------------------------------------------------------------------------
-//
-// The Platform port `toolEditApproval` is frozen at initPlatform time, but the
-// DesktopToolEditApprovalController is created per session.  The delegating
-// handler installed below reads this mutable reference so the active controller
-// can register and unregister itself via `setDesktopToolEditApprovalHandler`.
-
-let activeDesktopToolEditApprovalHandler: ToolEditApprovalPort | undefined;
-
-/**
- * Register the active session's desktop tool-edit approval handler.
- * Called by {@link DesktopToolEditApprovalControllerImpl} constructor / dispose.
- */
-export function setDesktopToolEditApprovalHandler(
-  handler: ToolEditApprovalPort | undefined,
-): void {
-  activeDesktopToolEditApprovalHandler = handler;
-}
-
-export function createDesktopToolEditApprovalPort(): ToolEditApprovalPort {
-  return (request) => {
-    const handler = activeDesktopToolEditApprovalHandler;
-    if (!handler) {
-      throw new Error('No active desktop tool-edit approval controller.');
-    }
-    return handler(request);
-  };
-}
 
 export async function initializeElectronPlatform(
   mainDirname: string,
@@ -186,7 +155,6 @@ export async function initializeElectronPlatform(
       },
       agentDirectories,
       getWorkspacePath: () => workspacePath,
-      toolEditApproval: createDesktopToolEditApprovalPort(),
     }),
   );
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -61,10 +61,7 @@ import { killActiveRecording } from '@frontend/media/audio';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { registerFileDecorations } from '@frontend/ui/fileDecorations';
 import { registerWelcomeView } from '@frontend/ui/welcomeView';
-import {
-  initializeNativeToolEditApproval,
-  nativeRequestApproval,
-} from '@frontend/approval/nativeToolEditApproval';
+import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolEditApproval';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@frontend/auth/UriHandler';
 import { registerAgentEventListeners } from '@frontend/events/agentEventListeners';
@@ -262,8 +259,6 @@ export async function activate(context: vscode.ExtensionContext) {
         void vscode.window.showInformationMessage(message);
       }
     },
-    toolEditApproval: (request) =>
-      nativeRequestApproval(request, { session: defaultSession() }),
   });
   registerAgentFeatures();
   // `disposeStatusListener` and `statusBarItem` are owned solely by

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -67,7 +67,6 @@ import {
 import { getStreamTabId } from './streamTab';
 import { currentSession, type SessionHandle } from './SessionHandle';
 import type { StreamStatusMachine } from './StreamStatusService';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('AgentLaunchContext');
@@ -81,11 +80,6 @@ export interface AgentLaunchContext extends AgentCore {
   attachedMemoryMisses: AttachedMemoryMiss[];
   /** Whether this tool-use run exits after one cycle instead of idling. */
   stopAfterCycle?: boolean;
-  /**
-   * Per-run override for the host's tool-edit approval UI, projected onto the
-   * ambient {@link RunContext}. See `RunContext.toolEditApprovalHandler`.
-   */
-  toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Dispose the run-trace subscribers (channel sink + transcript recorder)
    * registered by {@link createRunTrace}. Must be called once at end-of-run
@@ -155,7 +149,6 @@ function agentContextToRunContext(
     runtimeUnavailableTools: ctx.runtimeUnavailableTools,
     stopAfterCycle: ctx.stopAfterCycle,
     session: ctx.runScope.session,
-    toolEditApprovalHandler: ctx.toolEditApprovalHandler,
   };
 }
 

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { createRunScope, type RunScope } from './RunScope';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { SessionHandle } from './SessionHandle';
@@ -14,15 +13,6 @@ interface RunContextCommon {
   readonly approvalPromptsUnavailable?: boolean;
   readonly runtimeUnavailableTools?: readonly string[];
   readonly stopAfterCycle?: boolean;
-  /**
-   * Per-run override for the host's tool-edit approval UI. Takes priority over
-   * `platform().toolEditApproval` when present — hosts that manage more than
-   * one concurrent session per process (e.g. desktop's one window per
-   * `DesktopAgentExecution`) thread their session-scoped handler here instead
-   * of relying on the frozen, process-wide Platform port, which only ever
-   * holds one active handler at a time.
-   */
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
 }
 
 export interface LaunchRunContext extends RunContextCommon {
@@ -69,7 +59,6 @@ interface CreateRunContextBase {
   runtimeUnavailableTools?: readonly string[];
   stopAfterCycle?: boolean;
   session?: SessionHandle;
-  toolEditApprovalHandler?: ToolEditApprovalPort;
 }
 
 type CreateLaunchRunContextFields = Required<
@@ -105,8 +94,7 @@ type CommonRunContextFieldNames =
   | 'delegationDepth'
   | 'approvalPromptsUnavailable'
   | 'runtimeUnavailableTools'
-  | 'stopAfterCycle'
-  | 'toolEditApprovalHandler';
+  | 'stopAfterCycle';
 
 type BareRunContextFieldNames =
   | CommonRunContextFieldNames
@@ -129,7 +117,6 @@ function commonRunContextFields<T extends CreateRunContextBase>(
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
-    toolEditApprovalHandler: options.toolEditApprovalHandler,
   } as Pick<T, CommonRunContextFieldNames>;
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -56,7 +56,6 @@ import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
 import { getProgressViewBridge } from './ProgressViewBridge';
 import type { SessionHandle } from './SessionHandle';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 import type { AgentExecutionHandle, AgentRunHandle } from './executionRegistry';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
@@ -312,13 +311,6 @@ export interface SubagentRunOptions {
   /** Session owning this run's coordination state. Defaults to the process session. */
   session?: SessionHandle;
   /**
-   * Per-run override for the host's tool-edit approval UI. Hosts that manage
-   * more than one concurrent session per process (e.g. desktop, one window per
-   * run) pass their session-scoped handler here instead of relying on the
-   * frozen, process-wide `platform().toolEditApproval` port.
-   */
-  toolEditApprovalHandler?: ToolEditApprovalPort;
-  /**
    * Fires when the subagent run itself fails, so a caller can report the
    * failure up the delegation chain. Distinct from a host-level failure
    * surface such as `ResumeQueuedToolUseOptions.onError` (log + toast for a
@@ -404,7 +396,6 @@ export async function executeAgent(
   };
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   ctx.stopAfterCycle = options.stopAfterCycle;
-  ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   return withExecutionRunContext(ctx, async () => {
     const { setting, config } = ctx;
     const {
@@ -508,7 +499,6 @@ export async function resumeToolUseFromSnapshot(
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
   };
   ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
-  ctx.toolEditApprovalHandler = options.toolEditApprovalHandler;
   const { setting } = ctx;
   const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
 

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -85,7 +85,6 @@ export async function resumeQueuedToolUseSnapshot(
       session: options.session,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
-      toolEditApprovalHandler: options.toolEditApprovalHandler,
       parentStreamId:
         options.parentStreamId ?? snapshot.parentStreamId ?? undefined,
       allowWaitingResult: options.allowWaitingResult,

--- a/src/agent/runtime/resumeToolUseSnapshot.ts
+++ b/src/agent/runtime/resumeToolUseSnapshot.ts
@@ -15,7 +15,6 @@
  */
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { resumeQueuedToolUseSnapshot } from './resumeQueuedToolUse';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { SessionHandle } from './SessionHandle';
@@ -27,8 +26,6 @@ export interface ResumeToolUseHostOptions {
   readonly explicitFollowUp?: string;
   /** Tools hidden because the current host/runtime cannot support them. */
   readonly runtimeUnavailableTools?: readonly string[];
-  /** Per-run override for the host's tool-edit approval UI — see `ExecuteAgentOptions.toolEditApprovalHandler`. */
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   /**
    * Session owning this run's coordination state. Host-path callers (e.g. the
    * desktop progress-view IPC handler) thread their window session; defaults to
@@ -59,7 +56,6 @@ export async function resumeToolUseSnapshot(
     {
       session: options.session,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
-      toolEditApprovalHandler: options.toolEditApprovalHandler,
       extraFollowUps:
         options.explicitFollowUp !== undefined
           ? [{ text: options.explicitFollowUp, origin: 'user' as const }]

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -19,7 +19,6 @@ export interface RunAgentOptions extends Pick<
   | 'stopAfterCycle'
   | 'approvalPromptsUnavailable'
   | 'runtimeUnavailableTools'
-  | 'toolEditApprovalHandler'
   | 'session'
   | 'modelHandlerCompatibilityKey'
   | 'onRun'
@@ -80,7 +79,6 @@ export async function runAgent(
     stopAfterCycle: options.stopAfterCycle,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
-    toolEditApprovalHandler: options.toolEditApprovalHandler,
     session: options.session,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
     onRun: options.onRun,

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -39,7 +39,6 @@ import type {
   StateStore,
   StorageProvider,
   ToolAvailabilityHost,
-  ToolEditApprovalPort,
 } from '../interfaces';
 import type { Platform } from '../platform';
 import type { PlatformSecrets } from '../secrets';
@@ -63,13 +62,6 @@ export interface NodePlatformServices {
   readonly getWorkspacePath: () => string | undefined;
   /** Host-specific availability overrides merged over the no-op defaults. */
   readonly toolAvailability?: Partial<ToolAvailabilityHost>;
-  /**
-   * Tool-edit approval handler override.  If omitted, the returned Platform
-   * object carries a default that throws — hosts that run agents with tool-use
-   * must provide a real handler here, wired either directly (extension) or via a
-   * session-scoped indirection (CLI, desktop).
-   */
-  readonly toolEditApproval?: ToolEditApprovalPort;
 }
 
 export interface NodeAgentDirectoryBootstrapOptions {
@@ -110,17 +102,6 @@ export function createNodePlatform(services: NodePlatformServices): Platform {
     // ports are optional and single-implementer (VS Code only); core call
     // sites already treat an absent port as a no-op, so omitting them here is
     // enough — no per-host stub needed.
-    // Default handler throws — a host must override this to support tool-edit
-    // approvals.  CLI and desktop override via a session-scoped indirection
-    // (see the host's own initPlatform code); the extension wires its native
-    // handler directly.
-    toolEditApproval:
-      services.toolEditApproval ??
-      (() => {
-        throw new Error(
-          'Tool edit approval is not available: no handler has been configured.',
-        );
-      }),
   };
 }
 

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -212,17 +212,11 @@ export const NO_TOOL_AVAILABILITY_HOST: ToolAvailabilityHost = Object.freeze({
 // ---------------------------------------------------------------------------
 
 /**
- * Tool-edit approval handler, wired at `initPlatform` once per process and
- * consumed by the shared `requestToolEditApproval` entry point.
+ * Tool-edit approval request / result shapes.
  *
- * The handler receives the proposed edit (already carrying a `streamId` for
- * session routing, and enough content context to let the host surface the
- * change before returning a decision).  It replaces the prior
- * `setToolEditApprovalHandler` module-global singleton.
- *
- * Request / result shapes are defined here as the single Platform contract;
- * `@tools/approval/toolEditApproval` re-exports these types for existing
- * approval call sites.
+ * Hosts receive these through `SessionHandle.interactions`, not through the
+ * process-wide Platform object. `@tools/approval/toolEditApproval` re-exports
+ * these types for existing approval call sites.
  */
 
 /** Platform-level contract for a tool-edit approval request. */
@@ -243,10 +237,6 @@ export interface ToolEditApprovalResult {
   readonly lineChanges?: { readonly added: number; readonly removed: number };
   readonly startLine?: number;
 }
-
-export type ToolEditApprovalPort = (
-  request: ToolEditApprovalRequest,
-) => Promise<ToolEditApprovalResult>;
 
 // ---------------------------------------------------------------------------
 // Tool notifications

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -18,7 +18,6 @@ import type {
   LinterProvider,
   ToolMissingHandler,
   ToolNotificationHandler,
-  ToolEditApprovalPort,
   WorkspaceProvider,
   StorageProvider,
   LifecycleHost,
@@ -71,8 +70,6 @@ export interface Platform {
    * callers treat an absent port as a no-op.
    */
   readonly toolNotificationHandler?: ToolNotificationHandler;
-  /** Host-provided tool-edit approval UI (diff viewer + accept/reject). */
-  readonly toolEditApproval: ToolEditApprovalPort;
 }
 
 let _platform: Readonly<Platform> | null = null;

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import { appSignals } from '@eventBus/AppSignals';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -22,22 +23,23 @@ let testApprovalHandler:
   | undefined;
 
 function installTestPlatform(): Promise<void> {
-  return installPlatform(
-    {
-      workspacePath,
-      storagePath,
-      globalStoragePath: '/global/.texra/storage',
-    },
-    {
-      toolEditApproval: (request) => {
+  return installPlatform({
+    workspacePath,
+    storagePath,
+    globalStoragePath: '/global/.texra/storage',
+  }).then(() => {
+    defaultSession().useHostInteractions({
+      requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {
           throw new Error('No test handler. Set `testApprovalHandler`.');
         }
         return handler(request);
       },
-    },
-  );
+      resolve: () => false,
+      cancel: () => undefined,
+    });
+  });
 }
 
 const executionId = 'abcdef' as ExecutionId;
@@ -112,6 +114,7 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.read = originalAbsoluteRead;
     FlexibleFS.read = originalFlexibleRead;
     testApprovalHandler = undefined;
+    defaultSession().interactions.dispose();
     cleanupAllApprovals();
   });
 

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -6,6 +6,7 @@ import { waitForRecordedEvent } from '@test/support/asyncTestUtils';
 import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { StreamTabId } from '@shared/schemas';
 import { AskUserQuestionTool } from '@tools/userQuestion';
@@ -30,10 +31,9 @@ let testApprovalHandler:
   | undefined;
 
 function installTestPlatform(): Promise<void> {
-  return installPlatform(
-    {},
-    {
-      toolEditApproval: (request) => {
+  return installPlatform({}).then(() => {
+    defaultSession().useHostInteractions({
+      requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {
           throw new Error(
@@ -42,8 +42,10 @@ function installTestPlatform(): Promise<void> {
         }
         return handler(request);
       },
-    },
-  );
+      resolve: () => false,
+      cancel: () => undefined,
+    });
+  });
 }
 
 function inToolContext<T>(
@@ -64,6 +66,7 @@ describe('human prompt progress events', () => {
 
   afterEach(() => {
     cleanupAllApprovals();
+    defaultSession().interactions.dispose();
     testApprovalHandler = undefined;
   });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -7,11 +7,8 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
 }));
 
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
-import {
-  setActiveCliToolEditApprovalHandler,
-  createCliToolEditApprovalPort,
-} from '@cli/runtime/initPlatform';
 import {
   appendCliApiSwitchHint,
   approvalPromptAllowed,
@@ -23,10 +20,10 @@ import {
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecisionForApproval,
-  installCliApprovalHandlers,
   isCliApiSwitchableRetry,
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
+import type { CliApprovalPromptHooks } from '@cli/runtime/approval/approvalPolicy';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
@@ -49,6 +46,15 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
   };
 }
 
+function useCliHostInteractions(
+  cliContext: CliContext,
+  hooks: CliApprovalPromptHooks = {},
+): void {
+  defaultSession().useHostInteractions(
+    createHeadlessCliHostInteractions(cliContext, hooks),
+  );
+}
+
 const credentialExhaustedRetry: RuntimeInteractionEventPayloads['showRetryRequest'] =
   {
     streamId:
@@ -63,20 +69,13 @@ const credentialExhaustedRetry: RuntimeInteractionEventPayloads['showRetryReques
   };
 
 beforeEach(async () => {
-  // Wire the Platform with a delegating port that reads the CLI's active
-  // approval handler — the same pattern used by `initCliPlatform`.
   const { initPlatform: init } = await import('@platform/platform');
   const { createFakePlatform } = await import('@test/support/FakePlatform');
-  init(
-    createFakePlatform(
-      {},
-      { toolEditApproval: createCliToolEditApprovalPort() },
-    ),
-  );
+  init(createFakePlatform());
 });
 
 afterEach(() => {
-  setActiveCliToolEditApprovalHandler(undefined);
+  defaultSession().interactions.dispose();
   handleExternalInquiryActionMock.mockClear();
 });
 
@@ -291,7 +290,7 @@ describe('formatToolEditApprovalSummary', () => {
 
   it('passes the diff summary to the interactive approval prompt', async () => {
     let promptSummary = '';
-    installCliApprovalHandlers(
+    useCliHostInteractions(
       context({
         approvalPrompt: async (request) => {
           promptSummary = request.summary;
@@ -315,7 +314,7 @@ describe('formatToolEditApprovalSummary', () => {
 
   it('runs the before-prompt hook for tool edit approvals', async () => {
     const events: string[] = [];
-    installCliApprovalHandlers(
+    useCliHostInteractions(
       context({
         approvalPrompt: async () => {
           events.push('prompt');
@@ -341,7 +340,7 @@ describe('formatToolEditApprovalSummary', () => {
   });
 
   it('passes one-line rejection feedback to the tool result', async () => {
-    installCliApprovalHandlers(
+    useCliHostInteractions(
       context({
         approvalPrompt: async () => 'n proof misses the p = 5 case',
       }),
@@ -364,7 +363,7 @@ describe('formatToolEditApprovalSummary', () => {
     const prompts: string[] = [];
     const summaries: string[] = [];
     const answers = ['n', 'use the workspace-local file path'];
-    installCliApprovalHandlers(
+    useCliHostInteractions(
       context({
         approvalPrompt: async (request) => {
           prompts.push(request.prompt);
@@ -423,7 +422,7 @@ describe('formatToolEditApprovalSummary', () => {
   });
 
   it('skips prompting for auto-approved edits', async () => {
-    installCliApprovalHandlers(
+    useCliHostInteractions(
       context({
         approvalPolicy: 'yolo',
         approvalPrompt: async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   detachSessionProgressProjection: vi.fn(),
   createHeadlessCliHostInteractions: vi.fn(),
   createCliRuntimeHost: vi.fn(),
-  installCliApprovalHandlers: vi.fn(),
+  disposeHostInteractions: vi.fn(),
   prepareInteractivePrompt: vi.fn(),
   readCliTerminalStatus: vi.fn(),
   runAgent: vi.fn(),
@@ -72,7 +72,6 @@ vi.mock('@cli/runtime/runtimeHost', () => ({
 
 vi.mock('@cli/runtime/approvalAdapter', () => ({
   createHeadlessCliHostInteractions: mocks.createHeadlessCliHostInteractions,
-  installCliApprovalHandlers: mocks.installCliApprovalHandlers,
 }));
 
 vi.mock('@cli/runtime/terminalStatus', async (importOriginal) => ({
@@ -133,8 +132,8 @@ function stubRunExecutionDeps(): void {
     pending: vi.fn(() => []),
     resolve: vi.fn(() => false),
     cancel: vi.fn(),
+    dispose: mocks.disposeHostInteractions,
   });
-  mocks.installCliApprovalHandlers.mockReturnValue(vi.fn());
   mocks.createCliRuntimeHost.mockReturnValue({
     emit: vi.fn(),
     attachRunProgressRenderer: vi.fn(() => mocks.detachRunProgressRenderer),
@@ -283,36 +282,37 @@ describe('executeCliRequest', () => {
     );
   });
 
-  it('installs CLI approval handlers with the runtime prompt hook', async () => {
+  it('installs CLI host interactions with the runtime prompt hook', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
     const context = cliContext({ mode: 'interactive', approvalPolicy: 'ask' });
 
     await executeCliRequest(request, context);
 
-    expect(mocks.installCliApprovalHandlers).toHaveBeenCalledWith(
+    expect(mocks.createHeadlessCliHostInteractions).toHaveBeenCalledWith(
       context,
       expect.objectContaining({ beforePrompt: expect.any(Function) }),
     );
 
-    const hooks = mocks.installCliApprovalHandlers.mock.calls[0]?.[1] as {
+    const hooks = mocks.createHeadlessCliHostInteractions.mock
+      .calls[0]?.[1] as {
       beforePrompt?: () => void;
     };
     hooks.beforePrompt?.();
     expect(mocks.prepareInteractivePrompt).toHaveBeenCalledTimes(1);
   });
 
-  it('restores CLI approval handlers before closing the runtime host', async () => {
+  it('restores CLI host interactions before closing the runtime host', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
-    const uninstall = vi.fn();
-    mocks.installCliApprovalHandlers.mockReturnValue(uninstall);
 
     await executeCliRequest(request, cliContext());
 
-    expect(uninstall).toHaveBeenCalledTimes(1);
+    expect(mocks.disposeHostInteractions).toHaveBeenCalledTimes(1);
     expect(mocks.close).toHaveBeenCalledTimes(1);
-    expect(uninstall.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      mocks.disposeHostInteractions.mock.invocationCallOrder[0],
+    ).toBeLessThan(
       mocks.close.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
   });

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -52,10 +52,6 @@ interface DesktopToolEditApprovalModule {
   };
 }
 
-interface DesktopPlatformModule {
-  createDesktopToolEditApprovalPort(): import('@platform/interfaces').ToolEditApprovalPort;
-}
-
 interface RecordingRuntimeHost extends AgentRuntimeHost {
   shownToolEditPermissions: RuntimeInteractionEventPayloads['showToolEditPermission'][];
   resolvedToolEditPermissions: RuntimeInteractionEventPayloads['resolveToolEditPermission'][];
@@ -165,11 +161,10 @@ async function loadApprovalModules(workspacePath = '/workspace') {
       tryUseRunContext: vi.fn(() =>
         activeToolEditApproval
           ? {
-              runtimeHost: {
+              session: {
                 interactions: {
                   requestToolEditApproval: activeToolEditApproval,
                 },
-                emit: () => {},
               },
             }
           : undefined,
@@ -200,26 +195,17 @@ async function loadApprovalModules(workspacePath = '/workspace') {
     };
   });
 
-  const [
-    { initPlatform },
-    { createFakePlatform },
-    { nodeFilesystem },
-    desktopPlatformModule,
-  ] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-    import('@platform/defaults/nodeFilesystem'),
-    import(
-      moduleFileUrl(desktopSourcePath('main', 'platform', 'index.ts'))
-    ) as Promise<DesktopPlatformModule>,
-  ]);
+  const [{ initPlatform }, { createFakePlatform }, { nodeFilesystem }] =
+    await Promise.all([
+      import('@platform/platform'),
+      import('@test/support/FakePlatform'),
+      import('@platform/defaults/nodeFilesystem'),
+    ]);
   initPlatform(
     createFakePlatform(
       { workspacePath },
       {
         fs: nodeFilesystem,
-        toolEditApproval:
-          desktopPlatformModule.createDesktopToolEditApprovalPort(),
       },
     ),
   );

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -131,9 +131,6 @@ describe('desktop agent directory bootstrap', () => {
       addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
       toolMissingHandler: () => {},
       toolNotificationHandler: () => {},
-      toolEditApproval: () => {
-        throw new Error('Tool edit approval not available in this test.');
-      },
     });
 
     return {

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -531,12 +531,6 @@ export function createFakePlatform(
     addCriticismSink: () => ({ accepted: false, resolvedPath: '' }),
     toolMissingHandler: () => {},
     toolNotificationHandler: () => {},
-    toolEditApproval: () => {
-      throw new Error(
-        'Tool edit approval is not available in the fake platform. ' +
-          'Override with `createFakePlatform({}, { toolEditApproval: ... })`.',
-      );
-    },
     ...overrides,
   };
 }

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -8,6 +8,7 @@ import { setupPlatform } from '@test/support/setupPlatform';
 // Local imports - agent types
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 
 // Local imports - tools
 import type { StreamTabId } from '@shared/schemas';
@@ -19,26 +20,13 @@ import {
 } from '@tools/approval/toolEditApproval';
 
 /**
- * Proves the desktop multi-window fix: two runs with distinct
- * `toolEditApprovalHandler`s on their `RunContext` never cross-talk, even when
- * both requests are in flight at once (the shared approval queue serializes
- * execution but must not leak which handler a given request resolves through).
- * Before this fix, every host routed through the single process-wide
- * `platform().toolEditApproval` port, so a second window's handler silently
- * stole the first window's in-flight prompt.
+ * Proves the desktop multi-window invariant: two runs owned by distinct
+ * sessions never cross-talk, even when both requests are in flight at once.
+ * The approval queue is shared, but each request must resolve through the
+ * `SessionHandle.interactions` owner captured by its run context.
  */
-describe('Concurrent per-run tool edit approval handlers', () => {
-  setupPlatform(
-    { workspacePath: '/workspace', config: {}, files: {} },
-    {
-      toolEditApproval: () => {
-        throw new Error(
-          'platform().toolEditApproval should not be reached when the ' +
-            'RunContext supplies its own toolEditApprovalHandler',
-        );
-      },
-    },
-  );
+describe('Concurrent session tool edit approval handlers', () => {
+  setupPlatform({ workspacePath: '/workspace', config: {}, files: {} });
 
   beforeEach(() => {
     cleanupAllApprovals();
@@ -48,7 +36,7 @@ describe('Concurrent per-run tool edit approval handlers', () => {
     cleanupAllApprovals();
   });
 
-  it('routes each in-flight request through its own run handler, never the other', async () => {
+  it('routes each in-flight request through its owning session', async () => {
     const seenByA: ToolEditApprovalRequest[] = [];
     const seenByB: ToolEditApprovalRequest[] = [];
 
@@ -65,15 +53,28 @@ describe('Concurrent per-run tool edit approval handlers', () => {
       return { accepted: true, appliedContent: 'from-b' };
     };
 
+    const sessionA = new SessionHandle();
+    const sessionB = new SessionHandle();
+    sessionA.useHostInteractions({
+      requestToolEditApproval: handlerA,
+      resolve: () => false,
+      cancel: () => undefined,
+    });
+    sessionB.useHostInteractions({
+      requestToolEditApproval: handlerB,
+      resolve: () => false,
+      cancel: () => undefined,
+    });
+
     const contextA = createRunContext({
       runtimeHost: noopAgentRuntimeHost,
       streamId: 'windowA@model: test.tex' as StreamTabId,
-      toolEditApprovalHandler: handlerA,
+      session: sessionA,
     });
     const contextB = createRunContext({
       runtimeHost: noopAgentRuntimeHost,
       streamId: 'windowB@model: test.tex' as StreamTabId,
-      toolEditApprovalHandler: handlerB,
+      session: sessionB,
     });
 
     const requestA: ToolEditApprovalRequest = {

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -67,7 +67,6 @@ describe('executeSubagent childStreamId derivation', () => {
       delegationDepth: 0,
       approvalPromptsUnavailable: false,
       runtimeUnavailableTools: [],
-      toolEditApprovalHandler: undefined,
       stopAfterCycle: false,
     });
     mocks.currentSession.mockReturnValue({ tag: 'parent-session' });

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -8,6 +8,7 @@ import { installPlatform as installFakePlatform } from '@test/support/setupPlatf
 // Local imports - agent types
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 
 // Local imports - tools
 import type { StreamTabId } from '@shared/schemas';
@@ -37,20 +38,20 @@ async function installPlatform(
   files: Record<string, string | Uint8Array> = {},
 ) {
   testApprovalHandler = undefined;
-  await installFakePlatform(
-    { workspacePath: '/workspace', config, files },
-    {
-      toolEditApproval: (request) => {
-        const handler = testApprovalHandler;
-        if (!handler) {
-          throw new Error(
-            'No test approval handler configured. Set `testApprovalHandler` first.',
-          );
-        }
-        return handler(request);
-      },
+  await installFakePlatform({ workspacePath: '/workspace', config, files });
+  defaultSession().useHostInteractions({
+    requestToolEditApproval: (request) => {
+      const handler = testApprovalHandler;
+      if (!handler) {
+        throw new Error(
+          'No test approval handler configured. Set `testApprovalHandler` first.',
+        );
+      }
+      return handler(request);
     },
-  );
+    resolve: () => false,
+    cancel: () => undefined,
+  });
 }
 
 async function callTextEditorInRun(
@@ -89,6 +90,7 @@ describe('Tool edit approval gating', () => {
     WorkspaceFS.write = originalWrite;
     WorkspaceFS.appendFile = originalAppend;
     testApprovalHandler = undefined;
+    defaultSession().interactions.dispose();
     cleanupAllApprovals();
   });
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,7 +1,9 @@
-import { platform } from '@platform/platform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { StreamTabId } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
@@ -9,7 +11,7 @@ import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import {
-  getRunContextRuntimeHost,
+  getRunContextSession,
   getRunContextStreamId,
 } from '@tools/contextHelpers';
 import { WorkspaceFS } from '@utils/files';
@@ -238,24 +240,16 @@ export async function requestToolEditApproval(
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
 
-  const hostInteraction =
-    getRunContextRuntimeHost(context)?.interactions?.requestToolEditApproval?.(
-      preparedRequest,
-    );
+  const hostInteraction = (
+    getRunContextSession(context) ?? defaultSession()
+  ).interactions.requestToolEditApproval(preparedRequest);
   if (hostInteraction) {
     return finalizeApprovalResult(await hostInteraction, preparedRequest);
   }
 
-  const result = await toolEditApprovalController.enqueue(async () => {
-    // Prefer the run's own approval channel (set by hosts that manage more
-    // than one concurrent session per process, e.g. desktop's one window per
-    // run) over the frozen, process-wide Platform port, which only ever holds
-    // one active handler at a time.
-    const handler =
-      context?.toolEditApprovalHandler ?? platform().toolEditApproval;
-    return handler(preparedRequest);
-  });
-  return finalizeApprovalResult(result, preparedRequest);
+  throw new Error(
+    'Tool edit approval requires session.interactions.requestToolEditApproval.',
+  );
 }
 
 function finalizeApprovalResult(

--- a/src/tools/delegation/nativeToolUseStrategy.ts
+++ b/src/tools/delegation/nativeToolUseStrategy.ts
@@ -35,7 +35,6 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 
 import {
   buildSubagentFailureResultMeta,
@@ -55,7 +54,6 @@ export interface NativeToolUseStrategyParams {
   readonly workingDirectory?: string;
   readonly approvalPromptsUnavailable?: boolean;
   readonly runtimeUnavailableTools?: readonly string[];
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   /** Fires with the resolved child stream id — the caller inherits approvals onto it. */
   readonly onStreamResolved: (streamId: StreamTabId) => void;
 }
@@ -145,7 +143,6 @@ export function createNativeToolUseStrategy(
           delegationDepth: params.delegationDepth,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
           runtimeUnavailableTools: params.runtimeUnavailableTools,
-          toolEditApprovalHandler: params.toolEditApprovalHandler,
           allowWaitingResult: true,
           onStreamResolved: params.onStreamResolved,
           onProgress: (update) => ports.notify(update),
@@ -193,7 +190,6 @@ export function createNativeToolUseStrategy(
             session: params.parentSession,
             approvalPromptsUnavailable: params.approvalPromptsUnavailable,
             runtimeUnavailableTools: params.runtimeUnavailableTools,
-            toolEditApprovalHandler: params.toolEditApprovalHandler,
             parentStreamId: params.orchestratorStreamId,
             allowWaitingResult: true,
             // The loop's queue never admits synthetic (goal-continuation)

--- a/src/tools/delegation/nativeWorkflowStrategy.ts
+++ b/src/tools/delegation/nativeWorkflowStrategy.ts
@@ -14,7 +14,6 @@ import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { ToolEditApprovalPort } from '@platform/interfaces';
 
 import {
   buildSubagentFailureResultMeta,
@@ -34,7 +33,6 @@ export interface NativeWorkflowStrategyParams {
   readonly workingDirectory?: string;
   readonly approvalPromptsUnavailable?: boolean;
   readonly runtimeUnavailableTools?: readonly string[];
-  readonly toolEditApprovalHandler?: ToolEditApprovalPort;
   readonly onStreamResolved: (streamId: StreamTabId) => void;
 }
 
@@ -79,7 +77,6 @@ export function createNativeWorkflowStrategy(
           delegationDepth: params.delegationDepth,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
           runtimeUnavailableTools: params.runtimeUnavailableTools,
-          toolEditApprovalHandler: params.toolEditApprovalHandler,
           onStreamResolved: params.onStreamResolved,
           onProgress: (update) => ports.notify(update),
           onRunError: (err) => {

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -208,7 +208,6 @@ export async function executeSubagent(
         delegationDepth: parentDelegationDepth + 1,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
         runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
-        toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
         stopAfterCycle: true,
         onStreamResolved: inheritChildStreamApprovals,
         onRunError: (err) => {
@@ -273,7 +272,6 @@ export async function executeSubagent(
     workingDirectory,
     approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
     runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
-    toolEditApprovalHandler: parentContext.toolEditApprovalHandler,
     onStreamResolved: inheritChildStreamApprovals,
   };
 


### PR DESCRIPTION
## Summary
- remove the legacy `Platform.toolEditApproval` port and the CLI/desktop bridge handlers that fed it
- remove the per-run `toolEditApprovalHandler` override from launch, resume, and delegation paths
- route tool-edit approval requests through `SessionHandle.interactions`, with tests migrated to session-scoped handlers

Fixes #7641.

## Validation
- `npm test -- src/test-kernel/tools/ToolEditApprovalGate.vitest.ts src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts src/test-kernel/cli/ApprovalAdapter.vitest.mts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings)

## Notes
- The shared tool-edit approval controller still owns bypass and pending-prompt cleanup for host surfaces. This PR deletes the old handler-routing fallback, not the UI-state machinery.
- Making all HostInteractions methods required is still a separate Stage 3 tightening step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every host surfaces file-edit prompts and fixes multi-window routing on session ownership; miswired sessions would fail at runtime, but behavior is covered by migrated approval tests.
> 
> **Overview**
> **Tool-edit approval is no longer a frozen `Platform` port or a per-run `RunContext` override.** Hosts register UI through `SessionHandle.interactions` (e.g. CLI headless `createHeadlessCliHostInteractions` on the default session, desktop per-window sessions), and `requestToolEditApproval` resolves via the run’s session (or `defaultSession()`), erroring if no handler is installed.
> 
> **Removed plumbing:** CLI/desktop `setActive*ToolEditApprovalHandler` / `create*ToolEditApprovalPort`, `installCliApprovalHandlers`, extension `initPlatform({ toolEditApproval })`, and threading `toolEditApprovalHandler` through `executeAgent`, resume, and subagent delegation options. Platform types keep request/result shapes only; `ToolEditApprovalPort` and `Platform.toolEditApproval` are gone.
> 
> **Tests** now stub `defaultSession().useHostInteractions({ requestToolEditApproval: ... })` instead of overriding platform approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f325ea48b56e18b2e65c105930ddbf161ca12c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->