### PR TITLE
Preserve agent-core host import fence

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,39 @@ const ALIAS_CONFIGS = [
   aliasConfigForRoot(__dirname),
 ];
 
+const PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATHS = [
+  {
+    name: '@common/state',
+    message:
+      'Production src code must not import host-owned state helpers; route host access through platform or host adapters.',
+  },
+  {
+    name: '@common/webview',
+    message:
+      'Production src code must not import host-owned webview helpers; route host access through platform or host adapters.',
+  },
+];
+
+const PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATTERNS = [
+  {
+    group: [
+      '@webview/**',
+      '@commands/**',
+      '@progressView/**',
+      '@settingsView/**',
+      '@frontend/**',
+      '@extensionSchemas/**',
+      '@resources/**',
+      '@common/state/**',
+      '@common/webview/**',
+      '@cli/**',
+      '@desktop/**',
+    ],
+    message:
+      'Production src code must not import extension, CLI, or desktop host layers; route host access through platform or host adapters.',
+  },
+];
+
 const VSCODE_FREE_ZONE_DIRS = [
   'src/agent',
   'src/model',
@@ -492,37 +525,8 @@ export default tseslint.config(
       'no-restricted-imports': [
         'error',
         {
-          paths: [
-            {
-              name: '@common/state',
-              message:
-                'Production src code must not import host-owned state helpers; route host access through platform or host adapters.',
-            },
-            {
-              name: '@common/webview',
-              message:
-                'Production src code must not import host-owned webview helpers; route host access through platform or host adapters.',
-            },
-          ],
-          patterns: [
-            {
-              group: [
-                '@webview/**',
-                '@commands/**',
-                '@progressView/**',
-                '@settingsView/**',
-                '@frontend/**',
-                '@extensionSchemas/**',
-                '@resources/**',
-                '@common/state/**',
-                '@common/webview/**',
-                '@cli/**',
-                '@desktop/**',
-              ],
-              message:
-                'Production src code must not import extension, CLI, or desktop host layers; route host access through platform or host adapters.',
-            },
-          ],
+          paths: PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATHS,
+          patterns: PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
         },
       ],
     },
@@ -536,12 +540,14 @@ export default tseslint.config(
       'no-restricted-imports': [
         'error',
         {
+          paths: PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATHS,
           patterns: [
             {
               group: ['@agent/modelHandlers', '@agent/modelHandlers/**'],
               message:
                 'Agent core must not import model handler implementations; move provider-neutral contracts to @agent/types or a core helper.',
             },
+            ...PRODUCTION_HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- share the production host-layer `no-restricted-imports` paths and patterns in `eslint.config.mjs`
- apply that shared host-layer restriction inside the narrower `src/agent/core/**` override alongside the model-handler restriction

Fixes #7730.

## Validation
- temporary scratch file under `src/agent/core/` with imports from `@agent/modelHandlers/openai/modelHandlerOpenAI` and `@webview/frontend/MainApp` fails lint with both expected `no-restricted-imports` errors
- `corepack pnpm exec eslint eslint.config.mjs src/agent/core`
- `git diff --check`
- commit hook: `npm run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only refactor with no runtime behavior change; risk is limited to ESLint rule coverage for `src/agent/core/**`.
> 
> **Overview**
> Fixes a gap where **`src/agent/core/**`** only enforced the model-handler import ban and no longer blocked extension/CLI/desktop and other host-layer imports.
> 
> The production host-layer **`no-restricted-imports`** paths and patterns are **extracted into shared constants** in `eslint.config.mjs` and reused by both the broad `src/**` rule and the narrower agent-core override. The agent-core block now applies **both** the model-handler restriction and the same host-layer paths/patterns (via spread), so lint again reports both violations for core code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088f39a5ffe70e31a6c4aafd74b367c4fb0aff5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->