### PR TITLE
Clean up goals for unknown progress streams

### DIFF
--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -41,7 +41,10 @@ export class ProgressStreamLifecycleController {
   async deleteStream(stream: StreamTabId): Promise<void> {
     const hasStream =
       this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
-    if (!hasStream) return;
+    if (!hasStream) {
+      await this.deps.state.clearStream(stream);
+      return;
+    }
 
     if (this.deps.host.isStreamInFlight(stream)) {
       // Finished streams should not get synthetic STOPPED transitions or child

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -6,14 +6,17 @@ import { describe, it } from 'vitest';
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
 describe('ProgressStreamLifecycleController', () => {
-  it('ignores deletion for unknown streams', async () => {
+  it('runs durable cleanup for unknown streams without rendered cleanup', async () => {
     const { controller, recorder, streams } =
       createProgressStreamLifecycleHarness();
 
     await controller.deleteStream('missing');
 
     assert.deepEqual(streams(), ['stream-a', 'stream-b']);
-    assert.equal(recorder.calls.size, 0);
+    assert.deepEqual(recorder.calls.get('clearStream'), ['missing']);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), undefined);
+    assert.deepEqual(recorder.calls.get('setActiveStream'), undefined);
   });
 
   it('deletes inactive streams without stopping finished work', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1585,6 +1585,24 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('forgets goal entries when clearing never-registered streams', async () => {
+    const stream = 'tool@deepseek#missing' as StreamTabId;
+    const { backend, session } = createIsolatedRecordingBackend();
+
+    try {
+      await GoalStore.start(stream, 'forget this unregistered goal');
+
+      await backend.state.clearStream(stream);
+
+      expect(GoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('forgets goal entries when clearing all streams', async () => {
     const stream = 'tool@deepseek#b6966b' as StreamTabId;
     const { backend, session } = createIsolatedRecordingBackend();
@@ -1609,20 +1627,21 @@ describe('ProgressBackend', () => {
     const orphanStream = 'tool@deepseek#b6966b' as StreamTabId;
     const orphanExecution = 'b6966b' as ExecutionId;
     const historyExecution = 'c6966c' as ExecutionId;
-    const seed = new StreamSnapshotStore();
-    await seed.load([orphanStream]);
-    seed.setTaskState(
-      orphanStream,
-      toolUseTaskState('search', 'deepseekproT'),
-      orphanExecution,
-    );
-    await writeExecutionConfig(orphanExecution);
-    await writeExecutionConfig(historyExecution);
-    await seed.flush();
-    await GoalStore.start(orphanStream, 'sweep this orphan');
 
     const { backend, session } = createIsolatedRecordingBackend();
     try {
+      const seed = new StreamSnapshotStore();
+      await seed.load([orphanStream]);
+      seed.setTaskState(
+        orphanStream,
+        toolUseTaskState('search', 'deepseekproT'),
+        orphanExecution,
+      );
+      await writeExecutionConfig(orphanExecution);
+      await writeExecutionConfig(historyExecution);
+      await seed.flush();
+      await GoalStore.start(orphanStream, 'sweep this orphan');
+
       expect(await StorageFS.exists(streamDataDir(orphanStream))).toBe(true);
       expect(await StorageFS.exists(`executions/${orphanExecution}`)).toBe(
         true,

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -71,6 +71,7 @@ export function createProgressStreamLifecycleHarness(
     getStreamIds: () => streams,
     pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
     clearStream: async (stream) => {
+      recorder.record('clearStream', stream);
       streams = streams.filter((candidate) => candidate !== stream);
       if (activeStream === stream) {
         activeStream = streams[0] ?? '';


### PR DESCRIPTION
## Summary

Fix the missing durable cleanup path for `removeStream` events where the stream never entered progress/task state. `ProgressStreamLifecycleController.deleteStream()` now still runs `state.clearStream(stream)` for that unknown-stream case, while preserving the existing behavior that skips rendered/UI cleanup for streams that were never rendered.

Also adds backend coverage for the never-registered-stream goal leak and moves orphan-stream test setup fully inside its `try/finally` cleanup scope.

Post-merge note: Copilot flagged reserved/empty unknown stream IDs before merge, but that guard was not included in the merged commit. Follow-up #7755 tracks that guard.

## Issue acceptance gates

Addresses #7734 and #7733.

- Unknown-stream deletion now calls durable state cleanup before returning.
- Rendered cleanup remains skipped for the unknown-stream path.
- Controller coverage asserts durable cleanup without approval/webview/active-tab cleanup.
- Backend coverage proves clearing a never-registered stream forgets its goal entry.
- Orphan-goal test setup is scoped inside `try/finally` cleanup.

## Single source of truth

`ProgressStreamLifecycleController` remains the deletion coordinator, and `ProgressViewState.clearStream()` / `SessionStores.deleteStream()` remains the single durable cleanup path for stream-owned session records, including goals.

## Duplication and abstraction budget

No abstraction, shim, projection, alias, dual-write, fallback, or migration path was added. The PR keeps #7729's cleanup ownership in `SessionStores` instead of reintroducing host-level `GoalStore.forget()` calls.

## Host impact

Extension: `removeStream` events for never-registered or missing progress streams now clear durable goal/session records without touching rendered UI state.

Desktop: shared lifecycle-controller behavior is tightened for hosts using the controller; no desktop-specific UI behavior changes.

CLI: no runtime impact.

## Scheduled refactoring

None.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- Worker handoff reported `npm run typecheck`, `npm run lint` (0 errors; existing warnings), and `git diff --check` before handoff.
- GitHub CI `validate (linux)` passed before merge.

Fixes #7734.
Fixes #7733.
