### PR TITLE
Run CLI runtime validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
+  schedule:
+    - cron: '17 3 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -178,6 +181,48 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  runtime-validation:
+    name: runtime validation (linux)
+    needs: changes
+    if: github.event_name != 'pull_request' && needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate CLI real-runtime run path
+        run: |
+          set +e
+          start_time="$(date +%s)"
+          pnpm --filter @texra-ai/cli validate:run
+          status="$?"
+          end_time="$(date +%s)"
+          duration="$((end_time - start_time))"
+          {
+            echo '### CLI real-runtime validation'
+            echo
+            echo "- Command: \`pnpm --filter @texra-ai/cli validate:run\`"
+            echo "- Duration: ${duration}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
   docs-check:
     name: docs build
     needs: changes
@@ -213,6 +258,7 @@ jobs:
       - changes
       - validate
       - webview-smoke
+      - runtime-validation
       - docs-check
     if: always()
 
@@ -228,6 +274,10 @@ jobs:
           fi
           if [ '${{ needs.webview-smoke.result }}' != 'success' ] && [ '${{ needs.webview-smoke.result }}' != 'skipped' ]; then
             echo 'Webview smoke result: ${{ needs.webview-smoke.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.runtime-validation.result }}' != 'success' ] && [ '${{ needs.runtime-validation.result }}' != 'skipped' ]; then
+            echo 'Runtime validation result: ${{ needs.runtime-validation.result }}'
             exit 1
           fi
           if [ '${{ needs.docs-check.result }}' != 'success' ] && [ '${{ needs.docs-check.result }}' != 'skipped' ]; then


### PR DESCRIPTION
## Summary
- add `merge_group` and nightly CI triggers
- add a Linux `runtime-validation` job that runs `pnpm --filter @texra-ai/cli validate:run` on non-PR events
- include runtime validation in the aggregate `validate` status and write wall-clock duration to the step summary

Fixes #7680.

## Validation
- `actionlint .github/workflows/ci.yml`
- `pnpm --filter @texra-ai/cli validate:run`
- `git diff --check`

## Notes
This follows the maintainer-approved tiered option: merge-group/main-push/nightly first, ordinary PR-blocking only after timing data shows the job is cheap enough.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application runtime or auth/data paths are modified, and PR CI behavior is unchanged because the new job is skipped on pull_request.
> 
> **Overview**
> Extends **CI triggers** with `merge_group` and a nightly cron (`17 3 * * *`) so the workflow runs on merge queues and scheduled checks, not only push/PR/dispatch.
> 
> Adds a **`runtime-validation` (Linux)** job that installs the workspace and runs `pnpm --filter @texra-ai/cli validate:run` when there are non-docs code changes and the event is **not** an ordinary `pull_request` (main push, merge group, nightly, manual). The step records wall-clock duration in the GitHub step summary and fails the job on non-zero exit.
> 
> Wires **`validate-status`** to depend on `runtime-validation` and treat it like other gates: success or skipped is OK; failure blocks the aggregate validate result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 388ab4ae11bb951d7f295d2c0a0cb807fe00106c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->