### PR TITLE
refactor(cli): consolidate list-highlight wraparound logic

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -17,7 +17,6 @@ import {
   buildChildControlItems,
   childPickerKeyAction,
   liveChildExecutionElapsedKey,
-  nextPickerIndex,
   subagentPickerSelection,
   type ChildControlItem,
   type ChildControlMode,
@@ -40,7 +39,10 @@ import {
 import { textDisplayWidth } from '../render/terminalText';
 import { KEY_HINT_SEPARATOR, KeyHints, type KeyHint } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
-import { SELECT_LABEL_MAX_COLS } from '../ui/Select';
+import {
+  nextWrappingHighlightIndex,
+  SELECT_LABEL_MAX_COLS,
+} from '../ui/Select';
 import type { StreamSlice } from '../state/cliState';
 
 interface ChildControlPickerProps {
@@ -832,12 +834,20 @@ export function ChildControlPicker({
           return;
         case 'up':
           setHighlight((current) =>
-            nextPickerIndex(current, items.length, 'up'),
+            nextWrappingHighlightIndex({
+              direction: -1,
+              highlight: current,
+              itemCount: items.length,
+            }),
           );
           return;
         case 'down':
           setHighlight((current) =>
-            nextPickerIndex(current, items.length, 'down'),
+            nextWrappingHighlightIndex({
+              direction: 1,
+              highlight: current,
+              itemCount: items.length,
+            }),
           );
           return;
         case 'jump':

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -23,6 +23,7 @@ import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import {
+  nextWrappingHighlightIndex,
   selectVisibleInlineOverflowText,
   Select,
   visibleSelectRange,
@@ -356,11 +357,23 @@ function MultiSelectQuestion(
       return;
     }
     if (key.upArrow) {
-      setHighlight((h) => (h <= 0 ? options.length - 1 : h - 1));
+      setHighlight((h) =>
+        nextWrappingHighlightIndex({
+          direction: -1,
+          highlight: h,
+          itemCount: options.length,
+        }),
+      );
       return;
     }
     if (key.downArrow) {
-      setHighlight((h) => (h + 1) % options.length);
+      setHighlight((h) =>
+        nextWrappingHighlightIndex({
+          direction: 1,
+          highlight: h,
+          itemCount: options.length,
+        }),
+      );
       return;
     }
     if (input === ' ') {

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -451,18 +451,6 @@ export function numericFocusTargetForActiveStream(init: {
   }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;
 }
 
-export function nextPickerIndex(
-  index: number,
-  length: number,
-  direction: 'down' | 'up',
-): number {
-  if (length <= 0) return 0;
-  if (direction === 'up') {
-    return index <= 0 ? length - 1 : index - 1;
-  }
-  return (index + 1) % length;
-}
-
 export type SubagentPickerSelection =
   | { readonly kind: 'view'; readonly streamId: StreamTabId }
   | { readonly kind: 'detail'; readonly executionId: string };

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -35,7 +35,6 @@ import {
   childPickerKeyAction,
   hasChildControlItems,
   liveChildExecutionElapsedKey,
-  nextPickerIndex,
   numericFocusTargetForActiveStream,
   resolveChildControlDisplayTargets,
   resolveChildControlStreamTarget,
@@ -1064,8 +1063,6 @@ describe('CLI child execution controls', () => {
       kind: 'jump',
       index: 2,
     });
-    expect(nextPickerIndex(0, 3, 'up')).toBe(2);
-    expect(nextPickerIndex(2, 3, 'down')).toBe(0);
   });
 
   it('advertises only applicable keys for child pickers', () => {


### PR DESCRIPTION
## Summary

A UI-consistency audit of the CLI TUI found the same "move highlighted index up/down with wraparound" arithmetic implemented three separate times: the canonical `nextWrappingHighlightIndex` in `ui/Select.tsx` (already used by `SlashPalette.tsx`), a duplicate `nextPickerIndex` helper in `state/childControls.ts` used by `ChildControlPicker.tsx`, and an inline reimplementation inside `UserQuestion.tsx`'s `MultiSelectQuestion`. This PR consolidates both duplicates onto the existing shared helper.

## Issue acceptance gates

No tracked issue — found during a routine UI-consistency audit. Acceptance gate: no duplicate wraparound-index implementations remain; behavior is unchanged.

## Single source of truth

`nextWrappingHighlightIndex` in `packages/cli/src/chat/tui/ui/Select.tsx` is now the sole implementation of highlight-index wraparound, used by `SlashPalette.tsx`, `ChildControlPicker.tsx`, and `UserQuestion.tsx`.

## Duplication and abstraction budget

Removed: `nextPickerIndex` in `state/childControls.ts` (and its direct-call tests) and the inline up/down arrow handlers in `UserQuestion.tsx`. No new abstraction added — both call sites now import the existing `ui/Select` export instead of adding another wrapper.

## Host impact

Extension: none.

Desktop: none.

CLI: `ChildControlPicker` and the multi-select `UserQuestion` prompt now share the same wraparound logic as `SlashPalette`; behavior at the boundaries (first/last item) is identical to before.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SlashPalette.vitest.mts src/test-kernel/cli/UserQuestion.vitest.mts` — pass
- `npx vitest run src/test-kernel/cli` — 128 files / 1619 tests pass
- `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- `npx eslint` on all changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01HKCk2Me6hNkCWNYiowg3FX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CLI TUI navigation refactor with no auth, data, or API changes; intended behavior is unchanged.
> 
> **Overview**
> **Consolidates** duplicate “move highlight up/down with wraparound” logic onto the shared **`nextWrappingHighlightIndex`** helper in `ui/Select.tsx`.
> 
> **`ChildControlPicker`** and **`UserQuestion`** multi-select now import that helper instead of **`nextPickerIndex`** in `childControls.ts` or inline modulo arithmetic. **`nextPickerIndex`** and its direct unit tests are **removed**; boundary behavior at the first/last item should stay the same as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad6eb29377175a39372cb340a1aa31a1cd13d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->