### PR TITLE
refactor: replace hand-rolled bounded-collection eviction with lru-cache

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -14,6 +14,7 @@
  * component is re-mounted with fresh @state.
  */
 
+import { LRUCache } from 'lru-cache';
 import { html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -51,7 +52,7 @@ import type { PermissionState } from '../permissionState';
 
 const DRAFT_CACHE_CAP = 50;
 const DRAFT_SAVE_DELAY_MS = 400;
-const draftCache = new Map<string, InquiryDraft>();
+const draftCache = new LRUCache<string, InquiryDraft>({ max: DRAFT_CACHE_CAP });
 const resolvedIds = createBoundedIdSet(DRAFT_CACHE_CAP);
 const INQUIRY_SUBMIT_ACTION = 'submit';
 
@@ -163,10 +164,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
     if (resolvedIds.has(ids.requestId)) return;
     if (draft) {
       draftCache.set(ids.requestId, draft);
-      if (draftCache.size > DRAFT_CACHE_CAP) {
-        const oldest = draftCache.keys().next().value;
-        if (oldest !== undefined) draftCache.delete(oldest);
-      }
     } else {
       draftCache.delete(ids.requestId);
     }

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from 'lru-cache';
 import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 import {
@@ -15,11 +16,13 @@ const logger = createChannelTrace('ToolUseFollowUpQueue');
  * default instance so unmigrated default-session callers stay byte-identical.
  */
 export class ToolUseFollowUpQueue {
+  static readonly RELEASED_CAP = 500;
   private static readonly defaultQueue = new ToolUseFollowUpQueue();
   private readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
-  private readonly released = new Set<StreamTabId>();
-  static readonly RELEASED_CAP = 500;
+  private readonly released = new LRUCache<StreamTabId, true>({
+    max: ToolUseFollowUpQueue.RELEASED_CAP,
+  });
   /** Observers notified whenever a stream's queue is released. */
   private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
@@ -117,13 +120,7 @@ export class ToolUseFollowUpQueue {
   }
 
   private rememberReleased(streamId: StreamTabId): void {
-    this.released.delete(streamId);
-    this.released.add(streamId);
-    while (this.released.size > ToolUseFollowUpQueue.RELEASED_CAP) {
-      const oldest = this.released.values().next().value;
-      if (oldest === undefined) return;
-      this.released.delete(oldest);
-    }
+    this.released.set(streamId, true);
   }
 
   static onRelease(observer: (streamId: StreamTabId) => void): () => void {


### PR DESCRIPTION
## Summary

Found via an audit for hand-rolled code duplicating existing dependencies: two places manually implemented bounded-collection eviction (cap + oldest-entry delete) instead of reusing `lru-cache`, which is already a direct dependency and already used for this exact purpose elsewhere in the same files' neighborhoods.

- `packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts` — `draftCache` was a plain `Map` with a manual `size > cap` eviction loop, sitting one line away from `resolvedIds`, which already wraps `LRUCache` via `createBoundedIdSet`.
- `src/agent/followUp/ToolUseFollowUpQueueManager.ts` — `released` was a `Set` capped at 500 via manual delete+re-add "move to end" plus a `while` eviction loop.

## Issue acceptance gates

No linked issue — proactive cleanup from a reinvented-wheel audit. Both hand-rolled eviction sites are now backed by `LRUCache`.

## Single source of truth

`lru-cache`'s `LRUCache` now owns bounded-eviction behavior in both places, matching the pattern already used by `createBoundedIdSet` (webview) and `ExecutionKVStore`/`TierService`/`relayToken` (agent runtime).

## Duplication and abstraction budget

Removed two independent hand-rolled eviction implementations (~14 lines total). No new abstraction added — both call sites reuse the existing `lru-cache` dependency directly, consistent with how it's already used elsewhere in each of these modules.

## Host impact

Extension: `ExternalInquiryPanel`'s draft cache now evicts by true LRU (least-recently-*used*) instead of FIFO-by-insertion-order — a behavior fix, not just a refactor, since the old code evicted the oldest-inserted key even if it was just re-set.

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes.
- `npx eslint` on both changed files — clean (fixed one `import/order` warning).
- `npx prettier --check` on both changed files — passes.
- `npx vitest run src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts` — 26/26 passing (these caught a static-field-initialization-order bug in the first pass: `RELEASED_CAP` needed to be declared before `defaultQueue` since the default instance is constructed at static-field-init time).
- Full `src/test-kernel` suite — 5287 passed, 1 pre-existing unrelated failure (`SystemUtils.vitest.ts` process-group abort test, a sandbox/OS limitation confirmed to fail identically on `main` before this change), 7 skipped.
- No test exists for `ExternalInquiryPanel.ts` specifically; behavior verified by code inspection and the type/lint/format checks above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pin97XzKDVNJgqzrKM4xHL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with a minor eviction semantics fix on draft cache; follow-up discard behavior stays cap-bounded with standard LRU touch-on-set.
> 
> **Overview**
> Replaces two custom cap-and-evict-oldest loops with **`lru-cache`**’s `LRUCache`, matching how neighboring code already bounds in-memory maps (e.g. `createBoundedIdSet` beside `draftCache`).
> 
> In **`ExternalInquiryPanel`**, the inquiry **draft cache** is now an `LRUCache` (max 50); the manual `size > cap` delete is removed. Eviction is **true LRU** on access/update, not FIFO by `Map` insertion order.
> 
> In **`ToolUseFollowUpQueue`**, the **released-stream** guard moves from a capped `Set` with delete/re-add plus a `while` loop to an `LRUCache` (max 500); `rememberReleased` is a single `set`. **`RELEASED_CAP`** is declared before the static `defaultQueue` so init order is safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8d52cb5cc90c2c7059dfdfc6bf1d42d5c6ea83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->