### PR TITLE
Finish RunScope flag collapse

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -15,19 +15,6 @@ export type RoundFinalizedCallback = (
   run: AgentRunStateSnapshot,
 ) => void | Promise<void>;
 
-/** Delegation-scoped policy flags, grouped so they travel together on `AgentCore`. */
-interface DelegationPolicy {
-  /**
-   * Delegation depth: 0 for root (user-initiated), N for a subagent N levels deep.
-   * Set by executeAgent from ExecuteAgentOptions.delegationDepth. Used by the
-   * tool-use flow to gate delegation tools and by the delegation tool itself
-   * to compute the child's depth.
-   */
-  delegationDepth?: number;
-  /** Whether approval or user prompts cannot be answered by the current host. */
-  approvalPromptsUnavailable?: boolean;
-}
-
 export interface AgentCore<C = unknown> {
   modelHandler: IModelHandler<ProviderMessage, unknown, SdkToolCall, C>;
   config: AgentConfig;
@@ -36,9 +23,6 @@ export interface AgentCore<C = unknown> {
   logger: AgentTrace;
   streamStatus: StreamStatusMachine;
   userVarChannels: UserVariableChannels;
-  delegation?: DelegationPolicy;
-  /** Tools unavailable because the current host/runtime cannot support them. */
-  runtimeUnavailableTools?: readonly string[];
   /** Initial user row to log after the flow has inserted launch media. */
   initialUserMessageForTranscript?: string;
 }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -20,6 +20,7 @@ import {
 } from '@agent/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { K_SLICE } from '@agent/core/constants';
+import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
@@ -206,19 +207,17 @@ type ContinuationNodeResult = SkippableNodeResult<{
 }>;
 
 export function responseCycleToolsForModel<C>(
-  services: Pick<
-    ResponseCycleServices<C>,
-    'delegation' | 'modelHandler' | 'runtimeUnavailableTools' | 'setting'
-  >,
+  services: Pick<ResponseCycleServices<C>, 'modelHandler' | 'setting'>,
 ): ToolDefinition[] | undefined {
   if (!services.modelHandler.capabilities.supportsFunctionCalling) {
     return undefined;
   }
-  const runtimeUnavailable = new Set(services.runtimeUnavailableTools ?? []);
+  const runContext = useLaunchRunContext();
+  const runtimeUnavailable = new Set(runContext.runtimeUnavailableTools ?? []);
   return services.setting.tools.filter(
     (tool) =>
       !runtimeUnavailable.has(tool.name) &&
-      (services.delegation?.approvalPromptsUnavailable !== true ||
+      (runContext.approvalPromptsUnavailable !== true ||
         !isApprovalGatedToolName(tool.name)),
   );
 }

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -23,8 +23,6 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly onFollowUpConsumed?: () => void;
   readonly attachedMemoryMisses?: readonly AttachedMemoryMiss[];
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
-  /** Stop after one cycle instead of waiting for a conversational follow-up. */
-  readonly stopAfterCycle?: boolean;
   /** Persist todos to the execution KV store. Injected by runToolUseFlow. */
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
   /** True when this agent was launched as a subagent by an orchestrator. */

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -55,7 +55,7 @@ export class ToolUseWaitNode<C> extends Node<
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
     const { checkInterruption, session, streamStatus, isSubagent } =
       this.services;
-    const { runScope } = useLaunchRunContext();
+    const { runScope, stopAfterCycle } = useLaunchRunContext();
     const { streamId, runtimeHost } = runScope;
 
     if (checkInterruption()) {
@@ -99,14 +99,14 @@ export class ToolUseWaitNode<C> extends Node<
     // genuinely wait. This makes duplicate/skipped delivery structurally
     // impossible and keeps every suspension symmetric, so the loop's interrupt
     // handler always has a real boundary to attach against.
-    if (isSubagent === true && !this.services.stopAfterCycle) {
+    if (isSubagent === true && !stopAfterCycle) {
       streamStatus.transitionToWaiting(streamId, 'wait', {
         trace: this.services.logger,
       });
       return { kind: 'waiting' };
     }
 
-    if (this.services.stopAfterCycle) {
+    if (stopAfterCycle) {
       return { kind: 'stop' };
     }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -66,12 +66,8 @@ export interface RunToolUseFlowInput<
    *  blocking in-flow for the next follow-up — the child-run loop owns
    *  delivery and turn-to-turn continuation. */
   isSubagent?: boolean;
-  /** Tools unavailable because the current host/runtime cannot support them. */
-  runtimeUnavailableTools?: readonly string[];
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
-  /** Stop after one cycle instead of waiting for a conversational follow-up. */
-  stopAfterCycle?: boolean;
   /** Root-run-only: fires with the latest response at every cycle boundary — see `ToolUseServices.onIdle`. */
   onIdle?: (lastResponse: string | undefined) => void;
   /** Fires after a running tool-use chat changes its model. */
@@ -148,7 +144,8 @@ export async function runToolUseFlow<C = unknown>(
   onSetup?: ToolUseFlowSetupCallback,
 ): Promise<RunToolUseFlowResult> {
   const { logger, setting, onInterrupt } = input;
-  const { runScope } = useLaunchRunContext();
+  const runContext = useLaunchRunContext();
+  const { runScope } = runContext;
   const { runtimeHost, streamId, executionId, session: runSession } = runScope;
   // Capture the run's scope at setup. The interrupt closure below fires from
   // the host thread outside the ALS, so it must use this captured session
@@ -158,13 +155,12 @@ export async function runToolUseFlow<C = unknown>(
     runSession.followUps,
   );
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const delegationDepth = input.delegation?.delegationDepth ?? 0;
   const { tools: resolvedTools } = await resolveAgentTools({
     tools: setting.tools,
     registry,
     logger,
-    approvalPromptsUnavailable: input.delegation?.approvalPromptsUnavailable,
-    runtimeUnavailableTools: input.runtimeUnavailableTools,
+    approvalPromptsUnavailable: runContext.approvalPromptsUnavailable,
+    runtimeUnavailableTools: runContext.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
 
@@ -179,7 +175,6 @@ export async function runToolUseFlow<C = unknown>(
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     fileService: new TaskRunFileService(executionId),
-    delegation: { ...input.delegation, delegationDepth },
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();
   let activePersistedFlow: ToolUsePersistedFlow<C> | undefined;

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -56,6 +56,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   createRunContext,
   withRunContext,
+  type CreateLaunchRunContextOptions,
   type CreateRunContextOptions,
 } from './RunContext';
 import { createRunScope, type RunScope } from './RunScope';
@@ -76,10 +77,7 @@ export interface AgentLaunchContext extends AgentCore {
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;
-  streamStatus: StreamStatusMachine;
   attachedMemoryMisses: AttachedMemoryMiss[];
-  /** Whether this tool-use run exits after one cycle instead of idling. */
-  stopAfterCycle?: boolean;
   /**
    * Dispose the run-trace subscribers (channel sink + transcript recorder)
    * registered by {@link createRunTrace}. Must be called once at end-of-run
@@ -134,30 +132,35 @@ const STATUS_MESSAGES: Record<string, string> = {
  */
 function agentContextToRunContext(
   ctx: AgentLaunchContext,
+  options: Pick<
+    CreateLaunchRunContextOptions,
+    | 'delegationDepth'
+    | 'approvalPromptsUnavailable'
+    | 'runtimeUnavailableTools'
+    | 'stopAfterCycle'
+  > = {},
 ): CreateRunContextOptions {
   return {
     runScope: ctx.runScope,
-    runtimeHost: ctx.runScope.runtimeHost,
-    streamId: ctx.runScope.streamId,
-    executionId: ctx.runScope.executionId,
     modelSource: 'live' as const,
     getModel: () => ctx.config.model,
-    agentName: ctx.runScope.agentName,
-    workingDirectory: ctx.runScope.workingDirectory,
-    delegationDepth: ctx.delegation?.delegationDepth,
-    approvalPromptsUnavailable: ctx.delegation?.approvalPromptsUnavailable,
-    runtimeUnavailableTools: ctx.runtimeUnavailableTools,
-    stopAfterCycle: ctx.stopAfterCycle,
-    session: ctx.runScope.session,
+    ...options,
   };
 }
 
 export async function withExecutionRunContext<T>(
   ctx: AgentLaunchContext,
+  options: Pick<
+    CreateLaunchRunContextOptions,
+    | 'delegationDepth'
+    | 'approvalPromptsUnavailable'
+    | 'runtimeUnavailableTools'
+    | 'stopAfterCycle'
+  >,
   fn: () => T | Promise<T>,
 ): Promise<T> {
   return await withRunContext(
-    createRunContext(agentContextToRunContext(ctx)),
+    createRunContext(agentContextToRunContext(ctx, options)),
     fn,
   );
 }

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import { createRunScope, type RunScope } from './RunScope';
+import type { RunScope } from './RunScope';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { SessionHandle } from './SessionHandle';
@@ -47,42 +47,36 @@ export type RunContext = LaunchRunContext | BareRunContext;
 // static string (manual / test path).
 // ---------------------------------------------------------------------------
 
-interface CreateRunContextBase {
-  runtimeHost: AgentRuntimeHost;
-  runScope?: RunScope;
-  streamId?: StreamTabId;
-  executionId?: ExecutionId;
-  agentName?: string;
-  workingDirectory?: string;
+interface CreateRunContextCommon {
   delegationDepth?: number;
   approvalPromptsUnavailable?: boolean;
   runtimeUnavailableTools?: readonly string[];
   stopAfterCycle?: boolean;
-  session?: SessionHandle;
 }
 
-type CreateLaunchRunContextFields = Required<
-  Pick<
-    CreateRunContextBase,
-    'streamId' | 'executionId' | 'agentName' | 'session'
-  >
->;
+interface CreateBareRunContextOptions extends CreateRunContextCommon {
+  runtimeHost: AgentRuntimeHost;
+  streamId?: StreamTabId;
+  executionId?: ExecutionId;
+  agentName?: string;
+  workingDirectory?: string;
+  session?: SessionHandle;
+  /** Discriminator — static model string (manual / test contexts). */
+  modelSource?: 'static';
+  model?: string;
+}
 
-export type CreateRunContextOptions = CreateRunContextBase &
-  (
-    | (CreateLaunchRunContextFields & {
-        /** Discriminator — live model provider (launch contexts). */
-        modelSource: 'live';
-        getModel: () => string | undefined;
-        /** Static fallback used when getModel() returns undefined. */
-        model?: string;
-      })
-    | {
-        /** Discriminator — static model string (manual / test contexts). */
-        modelSource?: 'static';
-        model?: string;
-      }
-  );
+export interface CreateLaunchRunContextOptions extends CreateRunContextCommon {
+  runScope: RunScope;
+  /** Discriminator — live model provider (launch contexts). */
+  modelSource: 'live';
+  getModel: () => string | undefined;
+  /** Static fallback used when getModel() returns undefined. */
+  model?: string;
+}
+
+export type CreateRunContextOptions =
+  CreateLaunchRunContextOptions | CreateBareRunContextOptions;
 
 const runContextScope = new AsyncLocalStorage<RunContext>();
 
@@ -109,7 +103,7 @@ type BareRunContextFieldNames =
  * Fields shared by both `RunContext` kinds, forwarded as-is from the input
  * options.
  */
-function commonRunContextFields<T extends CreateRunContextBase>(
+function commonRunContextFields<T extends CreateRunContextCommon>(
   options: T,
 ): Pick<T, CommonRunContextFieldNames> {
   return {
@@ -121,7 +115,7 @@ function commonRunContextFields<T extends CreateRunContextBase>(
 }
 
 /** Fields used only by the manually constructed `bare` context shape. */
-function bareRunContextFields<T extends CreateRunContextBase>(
+function bareRunContextFields<T extends CreateBareRunContextOptions>(
   options: T,
 ): Pick<T, BareRunContextFieldNames> {
   return {
@@ -144,22 +138,8 @@ function bareRunContextFields<T extends CreateRunContextBase>(
  * context for tests and one-shot tool environments.
  */
 export function createRunContext(options: CreateRunContextOptions): RunContext {
-  if (options.runtimeHost == null) {
-    throw new Error('createRunContext requires an explicit runtimeHost');
-  }
-
   if (options.modelSource === 'live') {
-    const { getModel, model } = options;
-    const runScope =
-      options.runScope ??
-      createRunScope({
-        runtimeHost: options.runtimeHost,
-        streamId: options.streamId,
-        executionId: options.executionId,
-        agentName: options.agentName,
-        workingDirectory: options.workingDirectory,
-        session: options.session,
-      });
+    const { getModel, model, runScope } = options;
     return Object.freeze({
       kind: 'launch',
       ...commonRunContextFields(options),
@@ -168,6 +148,10 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
         return getModel() ?? model;
       },
     });
+  }
+
+  if (options.runtimeHost == null) {
+    throw new Error('createRunContext requires an explicit runtimeHost');
   }
 
   const { model } = options;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -390,13 +390,13 @@ export async function executeAgent(
     session: options.session,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
   });
-  ctx.delegation = {
+  const runContextOptions = {
     delegationDepth: options.delegationDepth ?? 0,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    runtimeUnavailableTools: options.runtimeUnavailableTools,
+    stopAfterCycle: options.stopAfterCycle,
   };
-  ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
-  ctx.stopAfterCycle = options.stopAfterCycle;
-  return withExecutionRunContext(ctx, async () => {
+  return withExecutionRunContext(ctx, runContextOptions, async () => {
     const { setting, config } = ctx;
     const {
       streamId: runStreamId,
@@ -492,24 +492,25 @@ export async function resumeToolUseFromSnapshot(
   // Recover delegation depth from the persisted parent-execution chain
   // so resumed subagents remain gated by the nested-delegation policy
   // instead of silently promoting to root.
-  ctx.delegation = {
-    delegationDepth: await computeDelegationDepthFromStorage(
-      snapshot.executionId,
-    ),
+  const delegationDepth = await computeDelegationDepthFromStorage(
+    snapshot.executionId,
+  );
+  const runContextOptions = {
+    delegationDepth,
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+    runtimeUnavailableTools: options.runtimeUnavailableTools,
   };
-  ctx.runtimeUnavailableTools = options.runtimeUnavailableTools;
   const { setting } = ctx;
   const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
 
-  return withExecutionRunContext(ctx, async () => {
+  return withExecutionRunContext(ctx, runContextOptions, async () => {
     if (setting.agentCategory !== AgentCategory.ToolUse) {
       throw new AgentError(
         'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
       );
     }
 
-    const isSubagent = (ctx.delegation?.delegationDepth ?? 0) > 0;
+    const isSubagent = delegationDepth > 0;
     const result = await runFlowWithLifecycle(
       ctx,
       async (handle) => {

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -2,23 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { responseCycleToolsForModel } from '@agent/core/flows/ResponseCycleFlow';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 
 function toolNames(tools: readonly { name: string }[] | undefined): string[] {
   return tools?.map((tool) => tool.name) ?? [];
 }
 
 function responseServices({
-  approvalPromptsUnavailable,
-  runtimeUnavailableTools,
   supportsFunctionCalling = true,
 }: {
-  approvalPromptsUnavailable?: boolean;
-  runtimeUnavailableTools?: readonly string[];
   supportsFunctionCalling?: boolean;
 }) {
   return {
-    delegation: { approvalPromptsUnavailable },
-    runtimeUnavailableTools,
     modelHandler: {
       capabilities: { supportsFunctionCalling },
     },
@@ -32,6 +28,30 @@ function responseServices({
       ],
     },
   };
+}
+
+function withResponseRunContext<T>(
+  options: {
+    approvalPromptsUnavailable?: boolean;
+    runtimeUnavailableTools?: readonly string[];
+  },
+  fn: () => T,
+): T {
+  return withRunContext(
+    createRunContext({
+      runScope: createRunScope({
+        runtimeHost: { emit: vi.fn() },
+        streamId: 'response-cycle-stream',
+        executionId: 'response-cycle-execution',
+        agentName: 'response-agent',
+        session: {} as any,
+      }),
+      modelSource: 'live',
+      getModel: () => 'deepseekT',
+      ...options,
+    }),
+    fn,
+  ) as T;
 }
 
 describe('response cycle tool visibility', () => {
@@ -55,16 +75,20 @@ describe('response cycle tool visibility', () => {
       expected: ['bash', 'grep', 'write_file', 'wolfram'],
     },
   ])('$name', ({ services, expected }) => {
-    const tools = responseCycleToolsForModel(responseServices(services) as any);
+    const tools = withResponseRunContext(services, () =>
+      responseCycleToolsForModel(responseServices({}) as any),
+    );
 
     expect(toolNames(tools)).toEqual(expected);
   });
 
   it('omits workflow tools when the model handler cannot call functions', () => {
-    const tools = responseCycleToolsForModel(
-      responseServices({
-        supportsFunctionCalling: false,
-      }) as any,
+    const tools = withResponseRunContext({}, () =>
+      responseCycleToolsForModel(
+        responseServices({
+          supportsFunctionCalling: false,
+        }) as any,
+      ),
     );
 
     expect(tools).toBeUndefined();

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -155,6 +155,7 @@ describe('ToolUseWaitNode', () => {
         expect(exec.kind).toBe('stop');
         return node.post(shared, prep, exec);
       },
+      { stopAfterCycle: true },
     );
 
     expect(transition).toBe(FlowTransition.COMPLETE);
@@ -392,12 +393,16 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec({
-          afterError: true,
-          lastResponse: undefined,
-          touchedFiles: [],
-        }),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () =>
+          node.exec({
+            afterError: true,
+            lastResponse: undefined,
+            touchedFiles: [],
+          }),
+        { stopAfterCycle: true },
       );
 
       const goal = GoalStore.getForStream(streamId);

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -13,6 +13,7 @@ import {
   type RetryResult,
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 import type {
   SessionEvent,
   SessionEventHub,
@@ -343,16 +344,25 @@ export function withTestRunContext<T>(
   runtimeHost: AgentRuntimeHost,
   streamId: string,
   fn: () => Promise<T>,
+  options: {
+    delegationDepth?: number;
+    approvalPromptsUnavailable?: boolean;
+    runtimeUnavailableTools?: readonly string[];
+    stopAfterCycle?: boolean;
+  } = {},
 ): Promise<T> {
   return withRunContext(
     createRunContext({
-      runtimeHost,
-      streamId: streamId as StreamTabId,
-      executionId: 'deadbeef' as ExecutionId,
+      runScope: createRunScope({
+        runtimeHost,
+        streamId: streamId as StreamTabId,
+        executionId: 'deadbeef' as ExecutionId,
+        agentName: 'test-agent',
+        session: sessionWithInteractions(runtimeHost.interactions),
+      }),
       modelSource: 'live',
       getModel: () => undefined,
-      agentName: 'test-agent',
-      session: sessionWithInteractions(runtimeHost.interactions),
+      ...options,
     }),
     fn,
   ) as Promise<T>;

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -56,18 +56,31 @@ describe('AgentLaunchContext', () => {
       },
     } as unknown as AgentLaunchContext;
 
-    await withExecutionRunContext(ctx, async () => {
-      const context = useRunContext();
-      expect(context.model).toBe('deepseekT');
-      expect(context.kind).toBe('launch');
-      if (context.kind !== 'launch') {
-        throw new Error('expected launch context');
-      }
-      expect(context.runScope).toBe(runScope);
+    await withExecutionRunContext(
+      ctx,
+      {
+        delegationDepth: 1,
+        approvalPromptsUnavailable: true,
+        runtimeUnavailableTools: ['inquiry'],
+        stopAfterCycle: true,
+      },
+      async () => {
+        const context = useRunContext();
+        expect(context.model).toBe('deepseekT');
+        expect(context.kind).toBe('launch');
+        if (context.kind !== 'launch') {
+          throw new Error('expected launch context');
+        }
+        expect(context.runScope).toBe(runScope);
+        expect(context.delegationDepth).toBe(1);
+        expect(context.approvalPromptsUnavailable).toBe(true);
+        expect(context.runtimeUnavailableTools).toEqual(['inquiry']);
+        expect(context.stopAfterCycle).toBe(true);
 
-      ctx.config.model = 'sonnet46T';
+        ctx.config.model = 'sonnet46T';
 
-      expect(useRunContext().model).toBe('sonnet46T');
-    });
+        expect(useRunContext().model).toBe('sonnet46T');
+      },
+    );
   });
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -16,6 +16,7 @@ import type {
   RetryResult,
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   StreamStatusMachine,
@@ -90,14 +91,16 @@ async function withRetryRunContext<T>(
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => undefined,
-    runtimeHost: noopAgentRuntimeHost,
-    streamId,
-    executionId: `${streamId}-execution` as ExecutionId,
-    agentName: 'retry-test',
-    session: sessionWithInteractions({
-      requestRetry,
-      resolve: () => false,
-      cancel: () => {},
+    runScope: createRunScope({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId,
+      executionId: `${streamId}-execution` as ExecutionId,
+      agentName: 'retry-test',
+      session: sessionWithInteractions({
+        requestRetry,
+        resolve: () => false,
+        cancel: () => {},
+      }),
     }),
   });
   return await withRunContext(context, fn);
@@ -112,11 +115,13 @@ async function withSessionRetryRunContext<T>(
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => undefined,
-    runtimeHost,
-    streamId,
-    executionId: `${streamId}-execution` as ExecutionId,
-    agentName: 'retry-test',
-    session,
+    runScope: createRunScope({
+      runtimeHost,
+      streamId,
+      executionId: `${streamId}-execution` as ExecutionId,
+      agentName: 'retry-test',
+      session,
+    }),
   });
   return await withRunContext(context, fn);
 }

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -56,15 +56,18 @@ describe('RunContext', () => {
 
   it('reads the current model from a live provider', () => {
     let currentModel: string | undefined = 'deepseekT';
-    const context = createRunContext({
+    const runScope = createRunScope({
       runtimeHost: createRuntimeHost(),
       streamId: 'live-model-stream' as StreamTabId,
       executionId: 'live-model-execution' as ExecutionId,
+      agentName: 'test-agent',
+      session: {} as SessionHandle,
+    });
+    const context = createRunContext({
+      runScope,
       modelSource: 'live',
       model: 'fallback-model',
       getModel: () => currentModel,
-      agentName: 'test-agent',
-      session: {} as SessionHandle,
     });
 
     expect(Object.getOwnPropertyDescriptor(context, 'model')?.get).toBeTypeOf(
@@ -94,14 +97,9 @@ describe('RunContext', () => {
       session: {} as SessionHandle,
     });
     const context = createRunContext({
-      runtimeHost,
       runScope,
-      streamId: runScope.streamId,
-      executionId: runScope.executionId,
       modelSource: 'live',
       getModel: () => 'deepseekT',
-      agentName: runScope.agentName,
-      session: runScope.session,
     });
 
     expect(Object.isFrozen(runScope)).toBe(true);


### PR DESCRIPTION
## Summary
- remove the residual delegation/runtime-availability/stop-after-cycle declarations from flow service bags
- make live `createRunContext` construction require a `RunScope`, so ignored flat launch fields disappear
- pass launch policy flags directly into `withExecutionRunContext`, and read them from `useLaunchRunContext()` in flow code
- remove the redundant `AgentLaunchContext.streamStatus` redeclaration inherited from `AgentCore`

Fixes #7737.

## Validation
- `npm test -- src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/ResponseCycleTools.vitest.mts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts src/test-kernel/agent/runtime/RetryState.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent suspension, tool gating, and delegation depth wiring across execute/resume paths; behavior is intended to be equivalent but depends on ALS being set correctly everywhere callers previously passed service fields.
> 
> **Overview**
> Completes the **RunScope / DI cleanup** by moving per-run policy out of flow service bags and launch context fields into the ambient **`RunContext`**.
> 
> **Delegation depth**, **approvalPromptsUnavailable**, **runtimeUnavailableTools**, and **stopAfterCycle** are no longer on `AgentCore`, `ToolUseServices`, or `RunToolUseFlowInput`. `executeAgent` / resume paths pass them into **`withExecutionRunContext`**, and flow code reads them via **`useLaunchRunContext()`** (e.g. tool filtering in `responseCycleToolsForModel`, subagent WAITING vs one-shot stop in `ToolUseWaitNode`, tool resolution in `runToolUseFlow`).
> 
> **`createRunContext`** for live launches now **requires a `RunScope`** instead of synthesizing scope from flat `runtimeHost` / `streamId` fields; launch vs bare construction is split into **`CreateLaunchRunContextOptions`** and **`CreateBareRunContextOptions`**. Tests use **`withTestRunContext`** / explicit `runScope` to mirror production ALS.
> 
> Also drops the redundant **`AgentLaunchContext.streamStatus`** redeclaration (still inherited from `AgentCore`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e483a7ddb78940dd4a522f32364a9954d60efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->