### PR TITLE
fix(progress): guard unknown stream cleanup ids

### DIFF
--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -1,3 +1,6 @@
+// Local imports - transcript
+import { canUseStreamDataDir } from '@transcript/streamDataPaths';
+
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
 
@@ -39,6 +42,8 @@ export class ProgressStreamLifecycleController {
   }
 
   async deleteStream(stream: StreamTabId): Promise<void> {
+    if (!canUseStreamDataDir(stream)) return;
+
     const hasStream =
       this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
     if (!hasStream) {

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -1,3 +1,6 @@
+// Local imports - transcript
+import { canUseStreamDataDir } from '@transcript/streamDataPaths';
+
 // Local imports - agent
 import { deleteExecution as deleteStoredExecution } from '@agent/storage/executionListing';
 
@@ -10,7 +13,7 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 // Local imports - utils
 import { unique } from '@utils/core';
 
-// Local imports - transcript
+// Local imports - transcript types
 import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
 
 const CHANNEL = 'SessionStores';
@@ -53,6 +56,8 @@ export class SessionStores {
   }
 
   async deleteStream(stream: StreamTabId): Promise<void> {
+    if (!canUseStreamDataDir(stream)) return;
+
     const executionId =
       this.snapshots.getExecutionId(stream) ??
       (await this.snapshots.readPersistedExecutionId(stream));

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -2,6 +2,9 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
 // Local imports - test support
 import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
@@ -17,6 +20,40 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
     assert.deepEqual(recorder.calls.get('deleteWebview'), undefined);
     assert.deepEqual(recorder.calls.get('setActiveStream'), undefined);
+  });
+
+  it('refuses reserved unknown stream ids before durable cleanup', async () => {
+    const { controller, recorder, streams } =
+      createProgressStreamLifecycleHarness();
+
+    await controller.deleteStream('' as StreamTabId);
+    await controller.deleteStream('.' as StreamTabId);
+    await controller.deleteStream('..' as StreamTabId);
+
+    assert.deepEqual(streams(), ['stream-a', 'stream-b']);
+    assert.deepEqual(recorder.calls.get('clearStream'), undefined);
+  });
+
+  it('refuses reserved known stream ids before rendered or durable cleanup', async () => {
+    const reservedStreams = [
+      '' as StreamTabId,
+      '.' as StreamTabId,
+      '..' as StreamTabId,
+    ];
+    const { controller, recorder, streams } =
+      createProgressStreamLifecycleHarness({
+        streams: [...reservedStreams, 'stream-a'],
+        activeStream: 'stream-a',
+      });
+
+    for (const stream of reservedStreams) {
+      await controller.deleteStream(stream);
+    }
+
+    assert.deepEqual(streams(), ['', '.', '..', 'stream-a']);
+    assert.deepEqual(recorder.calls.get('clearStream'), undefined);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), undefined);
   });
 
   it('deletes inactive streams without stopping finished work', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - transcript
 import { streamDataDir, StreamSnapshotStore } from '@transcript';
+import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
 
 // Local imports - agent
 import {
@@ -1670,6 +1671,25 @@ describe('ProgressBackend', () => {
       expect(GoalStore.getForStream(stream)).toBeNull();
     } finally {
       await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('clearStream refuses reserved stream ids before durable store cleanup', async () => {
+    const sentinel = path.join(STREAM_DATA_DIR, 'sentinel.json');
+    await StorageFS.ensureDir(STREAM_DATA_DIR);
+    await StorageFS.write(sentinel, '{}');
+
+    const { backend, session } = createIsolatedRecordingBackend();
+    try {
+      await backend.state.clearStream('' as StreamTabId);
+      await backend.state.clearStream('.' as StreamTabId);
+      await backend.state.clearStream('..' as StreamTabId);
+
+      expect(await StorageFS.exists(sentinel)).toBe(true);
+    } finally {
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -14,6 +14,7 @@ import {
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
 import { getExecutionStore } from '@agent/storage';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
@@ -769,6 +770,19 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
 
     expect(await StorageFS.exists(dir)).toBe(false);
+  });
+
+  it('deleteStream refuses reserved stream ids before sidecar directory removal', async () => {
+    const sentinel = path.join(STREAM_DATA_DIR, 'sentinel.json');
+    await StorageFS.ensureDir(STREAM_DATA_DIR);
+    await StorageFS.write(sentinel, '{}');
+
+    const store = new StreamSnapshotStore();
+    await store.deleteStream('' as StreamTabId);
+    await store.deleteStream('.' as StreamTabId);
+    await store.deleteStream('..' as StreamTabId);
+
+    expect(await StorageFS.exists(sentinel)).toBe(true);
   });
 
   it('returns a frozen shared empty work plan default', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -63,6 +63,7 @@ import { mapToRecord } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import {
+  canUseStreamDataDir,
   decodeStreamId,
   STREAM_DATA_DIR,
   STREAM_DATA_KEYS,
@@ -728,6 +729,10 @@ export class StreamSnapshotStore {
     const pending = this.cancelPendingWritesForStream(stream);
     this.evict(stream);
     await Promise.all(pending);
+    // Keep this after pending-write cancellation so reserved ids cannot leave
+    // older write chains free to recreate a non-stream-owned sidecar path.
+    if (!canUseStreamDataDir(stream)) return;
+
     await this.kv(stream).deleteDir();
   }
 

--- a/src/transcript/streamDataPaths.ts
+++ b/src/transcript/streamDataPaths.ts
@@ -53,6 +53,17 @@ function encodeStreamId(id: string): string {
   return encodeURIComponent(id);
 }
 
+const RESERVED_STREAM_DATA_SEGMENTS = new Set(['', '.', '..']);
+
+export function canUseStreamDataDir(streamId: string): boolean {
+  try {
+    return !RESERVED_STREAM_DATA_SEGMENTS.has(encodeStreamId(streamId));
+  } catch {
+    // Malformed UTF-16 cannot be encoded into a stream-owned sidecar segment.
+    return false;
+  }
+}
+
 /** Decode a persisted stream directory name. Invalid legacy names are skipped. */
 export function decodeStreamId(encoded: string): string | undefined {
   try {


### PR DESCRIPTION
## Summary

Guard the progress stream lifecycle and shared durable cleanup paths so reserved or empty stream IDs cannot reach stream sidecar directory deletion.

`ProgressStreamLifecycleController.deleteStream()` now asks the stream sidecar path module whether the ID can own a stream-data directory before either unknown or known stream deletion can call `state.clearStream(...)`. The shared backend cleanup path also refuses those IDs in `SessionStores.deleteStream()`, and `StreamSnapshotStore.deleteStream()` refuses the final sidecar directory delete for direct store callers.

## Issue acceptance gates

Addresses #7755.

- Valid unknown stream IDs still call durable cleanup and skip rendered/UI cleanup.
- Unknown `''`, `'.'`, and `'..'` stream IDs do not call `state.clearStream()` through the lifecycle controller.
- Known `''`, `'.'`, and `'..'` stream IDs are also refused before rendered or durable cleanup through the lifecycle controller.
- Shared durable cleanup now refuses reserved stream IDs before deleting stream sidecar storage, covering desktop's direct backend delete path as well as extension lifecycle deletion.
- Focused lifecycle-controller, backend-state, and snapshot-store coverage asserts the valid unknown cleanup path plus reserved unknown, reserved known, shared cleanup, and direct sidecar-delete paths.
- No acceptance gates remain incomplete.

## Single source of truth

`streamDataPaths.ts` owns stream sidecar path validity next to `streamDataDir()` and the encoding/decoding helpers. `ProgressStreamLifecycleController`, `SessionStores`, and `StreamSnapshotStore` consume that helper at their respective deletion boundaries. This PR does not change the on-disk format.

## Duplication and abstraction budget

No abstraction, shim, projection, alias, dual-write, fallback, or migration path was added. The line increase is the explicit reserved-segment guard at shared deletion boundaries plus regression coverage for both host-routed and direct store deletion.

## Host impact

Extension: malformed stream-delete payloads for `''`, `.`, or `..` are ignored before rendered or durable cleanup; normal valid unknown stream cleanup from `removeStream` is unchanged.

Desktop: direct backend deletion and `removeStream` fact cleanup now refuse reserved sidecar IDs before durable stream cleanup can delete `streamData/` or its parent storage path; valid stream deletion is unchanged.

CLI: no runtime impact.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/transcript/streamDataPaths.ts src/controllers/progressView/ProgressStreamLifecycleController.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts`
- `corepack pnpm exec prettier --write src/controllers/progressView/backend/state/SessionStores.ts src/transcript/StreamSnapshotStore.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `npm test -- src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`
- `corepack pnpm exec eslint src/controllers/progressView/ProgressStreamLifecycleController.ts src/transcript/streamDataPaths.ts src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts`
- `corepack pnpm exec eslint src/controllers/progressView/backend/state/SessionStores.ts src/transcript/StreamSnapshotStore.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; 49 existing import-order warnings remain)
- `npm test`

Closes #7755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Prevents malformed delete requests from removing `streamData/` or parent storage paths; changes are narrow early returns with regression tests and no format migration.
> 
> **Overview**
> Adds **`canUseStreamDataDir()`** in `streamDataPaths.ts` so stream IDs whose encoded directory segment is `''`, `'.'`, or `'..'` (or unencodable UTF-16) are treated as invalid for stream-owned `streamData/` paths.
> 
> **Deletion paths** now no-op on those IDs before durable or UI cleanup: `ProgressStreamLifecycleController.deleteStream`, `SessionStores.deleteStream`, and the final `deleteDir` step in `StreamSnapshotStore.deleteStream` (still cancels pending writes first so reserved IDs cannot leave write chains that recreate bad paths).
> 
> Valid unknown stream cleanup is unchanged. New tests cover lifecycle, backend `clearStream`, and direct snapshot store deletion, including a sentinel file under `streamData/` to ensure the parent tree is not removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00860f85ef9f3971d80057c04dcfb91d48f9d362. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->