### PR TITLE
fix(progress): route removeStream through shared backend

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -267,6 +267,7 @@ export class DesktopProgressBridge {
       },
       hasTarget: () => true,
       getStreamControls: getProgressStreamControls,
+      deleteStream: (stream) => this.deleteStream(stream),
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
       configureUi: ({ webviewUpdater }) => {

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -456,7 +456,9 @@ class DesktopSessionProgressBridgeImpl implements DesktopSessionProgressBridge {
       case 'clearMissingOutputs':
       case 'updateQueuedFollowUps':
       case 'followUpSent':
+        return;
       case 'removeStream':
+        // Shared ProgressBackend fact handling owns lifecycle deletion.
         return;
     }
     assertNever(fact, 'Unhandled desktop session fact');

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -131,8 +131,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     context.subscriptions.push({ dispose: unsubscribeGoal });
   }
 
-  public removeStreamFromHost(streamId: StreamTabId): void {
-    void this.streamLifecycleController.deleteStream(streamId);
+  public removeStreamFromHost(streamId: StreamTabId): Promise<void> {
+    return this.streamLifecycleController.deleteStream(streamId);
   }
 
   /**

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -113,6 +113,8 @@ export class ProgressViewProvider
       sendMessage: (message) => this.sendToActiveProgressWebview(message),
       hasTarget: () => this.getActiveWebview() !== undefined,
       getStreamControls: getProgressStreamControls,
+      deleteStream: (stream) =>
+        this.messageHandler.removeStreamFromHost(stream),
       getUnsupportedCommands: () =>
         this.messageHandler.getUnsupportedCommands(),
       configureUi: ({ webviewUpdater: u }) => {
@@ -168,6 +170,7 @@ export class ProgressViewProvider
       new VscodePromptHost(),
       defaultSession().interactions,
     );
+    const progressBackendSubscription = this.backend.setupEventListeners();
     this.detachHostInteractions = defaultSession().useHostInteractions(
       createExtensionHostInteractions({
         runtimeHost: extensionAgentRuntimeHost,
@@ -183,23 +186,10 @@ export class ProgressViewProvider
         );
       },
     );
-    const detachRemoveStreamCleanup = defaultSession().events.subscribe(
-      (sessionEvent) => {
-        if (
-          sessionEvent.scope === 'session' &&
-          sessionEvent.event.type === 'removeStream'
-        ) {
-          this.messageHandler.removeStreamFromHost(
-            sessionEvent.event.payload.streamId,
-          );
-        }
-      },
-      { scope: 'session' },
-    );
     this._disposables.push(
+      progressBackendSubscription,
       { dispose: this.detachHostInteractions },
       { dispose: detachExtensionInteractionEvents },
-      { dispose: detachRemoveStreamCleanup },
     );
 
     ProgressViewProvider._instance = this;
@@ -221,7 +211,6 @@ export class ProgressViewProvider
   public async initialize(): Promise<void> {
     await this.backend.load();
     this._disposables.push(
-      this.backend.setupEventListeners(),
       attachProgressBackendAppSignals(this.backend, appSignals),
     );
     this.logger.debug('ProgressViewProvider initialized');

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -6,6 +6,7 @@ import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater
 import {
   ProgressFactApplier,
   PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES,
+  type DeleteProgressStream,
   type GetProgressStreamControls,
   type ProgressEventSubscription,
 } from '@controllers/progressView/backend/events/ProgressFactApplier';
@@ -41,6 +42,7 @@ export interface ProgressBackendOptions {
   hasTarget(): boolean;
   configureUi(services: ProgressBackendServices): ProgressBackendUiConfig;
   getStreamControls?: GetProgressStreamControls;
+  deleteStream?: DeleteProgressStream;
   /** Session that owns this backend's coordination state (defaults to the process session). */
   session?: SessionHandle;
   /**
@@ -105,6 +107,7 @@ export class ProgressBackend {
       this.webviewBridge,
       ui.hasPendingPermissions,
       options.getStreamControls,
+      options.deleteStream,
     );
     this.interactionHandler = new ProgressInteractionHandler(ui.callbacks);
   }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -74,6 +74,10 @@ export type GetProgressStreamControls = (
   stream: StreamTabId,
 ) => ProgressStreamControls;
 
+export type DeleteProgressStream = (
+  stream: StreamTabId,
+) => void | Promise<void>;
+
 export const PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] =
   [
     'conversation.progress',
@@ -111,6 +115,7 @@ export class ProgressFactApplier {
     private webviewBridge: WebviewBridge,
     private readonly hasPendingPermissions: (streamId: string) => boolean,
     private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
+    private readonly deleteStream: DeleteProgressStream = () => undefined,
   ) {
     this.logger = createChannelTrace('ProgressFactApplier');
   }
@@ -203,6 +208,9 @@ export class ProgressFactApplier {
         );
         return;
       case 'removeStream':
+        this.applyFact('failed to handle removeStream fact', () =>
+          this.deleteStream(fact.payload.streamId),
+        );
         return;
     }
     assertNever(fact, 'Unhandled progress-view session fact');

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -239,6 +239,79 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('routes removeStream session facts through the shared lifecycle delete path', async () => {
+    const session = new SessionHandle();
+    const deletedStreams: StreamTabId[] = [];
+    const backendRef: { current?: ProgressBackend } = {};
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      session,
+      sendMessage: vi.fn(() => true),
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+      deleteStream: async (stream) => {
+        const currentBackend = backendRef.current;
+        if (!currentBackend) {
+          throw new Error('Progress backend was not initialized');
+        }
+        await currentBackend.state.clearStream(stream);
+        deletedStreams.push(stream);
+      },
+    });
+    backendRef.current = backend;
+    const subscription = backend.setupEventListeners();
+    const streamId = 'desktop-child-stream' as StreamTabId;
+
+    try {
+      backend.state.streamLogs.ensureStream(streamId);
+      backend.state.getOrCreateStreamState(streamId, AgentCategory.ToolUse);
+
+      session.events.emit({
+        scope: 'session',
+        event: { type: 'removeStream', payload: { streamId } },
+      });
+
+      await vi.waitFor(() => expect(deletedStreams).toEqual([streamId]));
+      expect(backend.state.streamLogs.has(streamId)).toBe(false);
+      expect(backend.state.getStreamState(streamId)).toBeUndefined();
+    } finally {
+      subscription.dispose();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('handles removeStream session facts before backend load', async () => {
+    const session = new SessionHandle();
+    const deletedStreams: StreamTabId[] = [];
+    const backend = new ProgressBackend({
+      storage: new MemoryMementoStorage(),
+      session,
+      sendMessage: vi.fn(() => true),
+      hasTarget: () => true,
+      configureUi: () => createUiConfig(),
+      deleteStream: async (stream) => {
+        deletedStreams.push(stream);
+      },
+    });
+    const subscription = backend.setupEventListeners();
+    const streamId = 'preload-child-stream' as StreamTabId;
+
+    try {
+      session.events.emit({
+        scope: 'session',
+        event: { type: 'removeStream', payload: { streamId } },
+      });
+
+      await vi.waitFor(() => expect(deletedStreams).toEqual([streamId]));
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('uses the injected target predicate before sending messages', () => {
     const sent = vi.fn(() => true);
     let hasTarget = false;

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -353,4 +353,19 @@ describe('progress-view onboarding refresh wiring', () => {
 
     await expect(provider.refreshOnboardingFunnel()).resolves.toBeUndefined();
   });
+
+  it('returns deletion failures from host removeStream handling', async () => {
+    const context = createExtensionContext();
+    const provider = createProgressViewProvider();
+    const handler = createMessageHandler(provider, context);
+    const deletionError = new Error('delete failed');
+    const clearStream = provider.state.clearStream as ReturnType<typeof vi.fn>;
+    clearStream.mockRejectedValue(deletionError);
+
+    const result = handler.removeStreamFromHost('missing' as StreamTabId);
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toBe(deletionError);
+    expect(clearStream).toHaveBeenCalledWith('missing');
+  });
 });


### PR DESCRIPTION
## Summary

Route `removeStream` session facts through the shared progress backend instead of leaving extension and desktop split across host-local handlers.

The shared `ProgressFactApplier` now accepts a host lifecycle delete callback and invokes it for `removeStream`. Extension and desktop both inject their existing stream deletion paths, so child-stream auto-close cleanup reaches the same tab/resource lifecycle used by explicit deletion.

## Issue acceptance gates

Addresses #7639.

- Shared `ProgressFactApplier` no longer no-ops `removeStream`.
- Extension no longer owns a direct `defaultSession().events` duplicate `removeStream` subscription.
- Desktop routes `removeStream` through the same shared backend callback instead of the desktop bridge no-op.
- Backend coverage asserts a `removeStream` session fact reaches the lifecycle delete path and clears stream state.
- Extension coverage asserts the host callback returns lifecycle deletion failures to shared backend error handling.
- No acceptance gates remain incomplete.

## Single source of truth

`ProgressBackend`/`ProgressFactApplier` is now the single shared consumer for progress-view `removeStream` session facts. Hosts provide only the existing lifecycle deletion callback.

## Duplication and abstraction budget

Removed the extension-only session subscription duplicate and kept desktop bridge handling as a documented no-op because shared backend fact handling now owns lifecycle deletion. This PR is not net-negative in lines; the added mass lives in one shared backend callback seam plus regression coverage that replaces the host-local behavior split.

No shim, projection, alias, dual-write, fallback, or migration path was added. No legacy-retirement ledger row is needed.

## Host impact

Extension: child-stream `removeStream` facts now flow through shared backend handling. The provider registers backend session listeners during construction, before `backend.load()`, and returns the deletion promise so backend error handling can log failures.

Desktop: child-stream `removeStream` facts now call `desktopAgentExecution.deleteStream()`, so desktop releases stream state through the same lifecycle path.

CLI: no behavior change; existing CLI projection of `removeStream` is untouched.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/controllers/progressView/backend/events/ProgressFactApplier.ts src/controllers/progressView/backend/ProgressBackend.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/extension/src/progressView/ProgressViewMessageHandler.ts packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopSessionProgressBridge.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts`
- `npm test -- src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `npm test`

Closes #7639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes progress-view stream lifecycle for child auto-close on extension and desktop; mistakes could leave orphan tabs or double-delete, but behavior is centralized with regression tests.
> 
> **Overview**
> **`removeStream` session facts now drive stream teardown through one shared path** instead of host-specific listeners or no-ops.
> 
> `ProgressBackend` / `ProgressFactApplier` accept an optional **`deleteStream`** callback and invoke it when a `removeStream` fact arrives (previously ignored in the applier). **Extension** wires that to `ProgressStreamLifecycleController.deleteStream`, drops its extra `defaultSession().events` subscription, and registers backend session listeners at construction so facts are handled before `load()`. **`removeStreamFromHost`** now returns the deletion promise so failures propagate to shared error handling. **Desktop** injects `DesktopProgressBridge.deleteStream`; the session-progress bridge explicitly skips `removeStream` because lifecycle deletion is owned by the backend.
> 
> Tests cover routing through the delete callback (including before backend load) and extension host deletion failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f74c7c9c7d435c47b711b6e631e58374fba33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->