### PR TITLE
Keep presentation events off the NDJSON progress rail

### DIFF
--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -9,7 +9,11 @@ import {
   type RuntimeInteractionEvent,
   type RuntimeInteractionEventPayloads,
 } from '@agent/runtime/runtimeInteractionEvents';
-import type { RuntimePresentationEventPayloads } from '@agent/runtime/runtimePresentationEvents';
+import {
+  isRuntimePresentationEvent,
+  type RuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
+} from '@agent/runtime/runtimePresentationEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
@@ -33,6 +37,46 @@ export type CliRuntimeHost = AgentRuntimeHost & {
   prepareInteractivePrompt?: () => void;
   close(): Promise<void>;
 };
+
+function writeRuntimePresentationNdjson(
+  event: RuntimePresentationEvent,
+  payload: RuntimePresentationEventPayloads[RuntimePresentationEvent],
+): void {
+  switch (event) {
+    case 'requestShowError': {
+      const errorPayload =
+        payload as RuntimePresentationEventPayloads['requestShowError'];
+      writeNdjsonStdout({
+        kind: 'log',
+        ts: new Date().toISOString(),
+        level: 'error',
+        message: errorPayload.message,
+        fields: {},
+      });
+      return;
+    }
+    case 'requestShowInstruction': {
+      const instructionPayload =
+        payload as RuntimePresentationEventPayloads['requestShowInstruction'];
+      writeNdjsonStdout({
+        kind: 'log',
+        ts: new Date().toISOString(),
+        level: 'info',
+        message: instructionPayload.message,
+        fields: {
+          key: instructionPayload.key,
+          actions: instructionPayload.actions,
+          showSuppress: instructionPayload.showSuppress,
+        },
+      });
+      return;
+    }
+    case 'requestOpenFile':
+    case 'showAgentConfigBanner':
+    case 'requestEnsureProgressView':
+      return;
+  }
+}
 
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   let sink: LogSink | undefined;
@@ -78,6 +122,14 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       }
 
       if (context.outputFormat === 'ndjson') {
+        if (isRuntimePresentationEvent(event)) {
+          writeRuntimePresentationNdjson(
+            event,
+            payload as RuntimePresentationEventPayloads[RuntimePresentationEvent],
+          );
+          return;
+        }
+
         const record: CliNdjsonRecord = {
           kind: 'progress',
           event,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1161,6 +1161,60 @@ describe('CLI run progress renderer', () => {
     ]);
   });
 
+  it('routes runtime presentation requests to ndjson logs, not progress events', async () => {
+    const output = await captureStreamWrites(process.stdout, async () => {
+      const host = createCliRuntimeHost(
+        context({ mode: 'headless', outputFormat: 'ndjson' }),
+      );
+
+      host.emit('requestShowError', { message: 'Provider returned 500.' });
+      host.emit('requestShowInstruction', {
+        key: 'latex-compile-failed',
+        message: 'Inspect the log before retrying.',
+        actions: ['open-configuration-guide'],
+        showSuppress: true,
+      });
+      host.emit('requestEnsureProgressView', {});
+
+      await host.close();
+    });
+
+    const records = output
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        kind: 'log',
+        level: 'error',
+        message: 'Provider returned 500.',
+      }),
+      expect.objectContaining({
+        kind: 'log',
+        level: 'info',
+        message: 'Inspect the log before retrying.',
+        fields: {
+          key: 'latex-compile-failed',
+          actions: ['open-configuration-guide'],
+          showSuppress: true,
+        },
+      }),
+    ]);
+    expect(records).not.toContainEqual(
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'requestShowError',
+      }),
+    );
+    expect(records).not.toContainEqual(
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'requestShowInstruction',
+      }),
+    );
+  });
+
   it('maps the global quiet flag into CLI context args', () => {
     expect(
       pickGlobalArgs({


### PR DESCRIPTION
Summary:
- route CLI NDJSON runtime presentation requests through `kind: log` records instead of raw `kind: progress` event names
- suppress presentation-only requests that have no headless output meaning
- add a regression test proving `requestShowError` and `requestShowInstruction` no longer leak as progress events

Addresses the FS10 slice of #7752. DR14 and DR16 remain separate slices.

Validation:
- npm test -- src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts src/test-kernel/cli/CliNdjsonRecordContract.vitest.mts
- npm run typecheck
- npm run lint (0 errors; existing import-order warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output formatting only; no auth, persistence, or runtime execution changes beyond NDJSON record shape.
> 
> **Overview**
> In **NDJSON** output mode, **runtime presentation** events (`requestShowError`, `requestShowInstruction`, etc.) no longer appear as raw `kind: progress` records with presentation event names.
> 
> **Errors** and **instructions** are emitted as structured **`kind: log`** lines (error/info levels, with instruction metadata in `fields`). Presentation-only requests with no headless meaning (`requestOpenFile`, `showAgentConfigBanner`, `requestEnsureProgressView`) are **suppressed** on stdout instead of leaking onto the progress rail.
> 
> A regression test confirms presentation requests do not show up as progress events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e99a9cf79651fd3921300c79c1d03d3ed757435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->