### PR TITLE
Share Node host runtime skill sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ All notable changes to this project will be documented in this file.
   (`/executions/{id}/result`), so follow-on agents can chain on data instead
   of parsing prose.
 
+### Desktop
+
+#### Improvements
+
+- **Runtime skills are available in desktop agent runs** — desktop now loads
+  project, user, and bundled skills through the same shared Node-host defaults
+  as the CLI.
+
 ## [0.39.3] - 2026-07-03
 
 ### Shared (all surfaces)

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -9,7 +9,12 @@ import {
   createNodePlatform,
   initNodeAgentRuntime,
   initializeNodeGoalPrompts,
+  initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
+import {
+  TEXRA_CONFIG_FILE_NAME,
+  workspaceTexraConfigPath,
+} from '@platform/defaults/nodeStorage';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
 
@@ -17,11 +22,6 @@ import { initPlatform, platform, tryPlatform } from '@platform/platform';
 import { UsageLogService } from '@telemetry/UsageLogService';
 
 // Local imports - agent index
-import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
-import {
-  TEXRA_CONFIG_FILE_NAME,
-  workspaceTexraConfigPath,
-} from '@platform/defaults/nodeStorage';
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 
 // Local imports - auth
@@ -277,13 +277,9 @@ export async function initCliPlatform(
     versionStateKey: GlobalStateKey.CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION,
   });
 
-  setRuntimeSkillSources(
-    defaultSkillSources(
-      {
-        cwd: context.cwd,
-        resourcesPath: context.resourcesPath,
-      },
-      context.skillSourceOptions,
-    ),
-  );
+  initializeNodeRuntimeSkills({
+    cwd: context.cwd,
+    resourcesPath: context.resourcesPath,
+    skillSourceOptions: context.skillSourceOptions,
+  });
 }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -9,6 +9,7 @@ import {
   createNodePlatform,
   initNodeAgentRuntime,
   initializeNodeGoalPrompts,
+  initializeNodeRuntimeSkills,
 } from '@platform/defaults/nodeHost';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
@@ -182,6 +183,10 @@ export async function initializeElectronPlatform(
   // before the Lean adapter dispose.
   initNodeAgentRuntime(lifecycle);
   initializeNodeGoalPrompts(resourcesPath);
+  initializeNodeRuntimeSkills({
+    cwd: workspacePath ?? userDataPath,
+    resourcesPath,
+  });
 
   await bootstrapNodeAgentDirectories({
     channel: 'desktop',

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -16,6 +16,9 @@
 // Node imports
 import { join } from 'node:path';
 
+// Local imports - skills
+import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
+
 // Local imports - agent + tools (composition wiring)
 import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal/promptLoader';
@@ -32,6 +35,7 @@ import { platform } from '../platform';
 
 // Type imports
 import type { JsonConfigProviderOptions } from './jsonConfigProvider';
+import type { SkillSourceOptions } from '@skills/index';
 import type {
   AgentDirectoriesPort,
   AgentResumePort,
@@ -69,6 +73,12 @@ export interface NodeAgentDirectoryBootstrapOptions {
   readonly resourcesPath: string;
   readonly currentVersion: string | undefined;
   readonly versionStateKey: string;
+}
+
+export interface NodeRuntimeSkillOptions {
+  readonly cwd: string;
+  readonly resourcesPath: string;
+  readonly skillSourceOptions?: SkillSourceOptions;
 }
 
 const bootstrappedAgentDirectoryResources = new Map<string, string>();
@@ -132,6 +142,28 @@ export function initNodeAgentRuntime(lifecycle: LifecycleHost): void {
  */
 export function initializeNodeGoalPrompts(resourcesPath: string): void {
   initializeGoalPrompts(join(resourcesPath, 'goal', 'goal.yaml'));
+}
+
+/**
+ * Register runtime skill sources for a Node host.
+ *
+ * The CLI and desktop hosts use the same precedence: explicit custom roots,
+ * project skills, user skills, and bundled skills. The CLI supplies custom and
+ * interop options from command-line flags; desktop uses the defaults so it
+ * always gets project, user, and bundled runtime skills.
+ */
+export function initializeNodeRuntimeSkills(
+  options: NodeRuntimeSkillOptions,
+): void {
+  setRuntimeSkillSources(
+    defaultSkillSources(
+      {
+        cwd: options.cwd,
+        resourcesPath: options.resourcesPath,
+      },
+      options.skillSourceOptions,
+    ),
+  );
 }
 
 /**

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import type { SkillSource } from '@skills/loadSkills';
 
 const mocks = vi.hoisted(() => ({
   authProvider: {
@@ -18,13 +17,12 @@ const mocks = vi.hoisted(() => ({
   createNodePlatform: vi.fn(() => ({})),
   initializeCliSupabaseAuth: vi.fn(),
   initializeNodeGoalPrompts: vi.fn(),
+  initializeNodeRuntimeSkills: vi.fn(),
   initNodeAgentRuntime: vi.fn(),
   initializeServerSideKeyAccess: vi.fn(),
   serverSideKeyService: {
     setUseIncludedModelAccess: vi.fn(),
   },
-  defaultSkillSources: vi.fn<() => SkillSource[]>(() => []),
-  setRuntimeSkillSources: vi.fn(),
   getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
   invalidateModelOptionsCache: vi.fn(),
   tryPlatform: vi.fn(),
@@ -70,11 +68,7 @@ vi.mock('@platform/defaults/nodeHost', () => ({
   createNodePlatform: mocks.createNodePlatform,
   initNodeAgentRuntime: mocks.initNodeAgentRuntime,
   initializeNodeGoalPrompts: mocks.initializeNodeGoalPrompts,
-}));
-
-vi.mock('@skills/index', () => ({
-  defaultSkillSources: mocks.defaultSkillSources,
-  setRuntimeSkillSources: mocks.setRuntimeSkillSources,
+  initializeNodeRuntimeSkills: mocks.initializeNodeRuntimeSkills,
 }));
 
 vi.mock('@telemetry/UsageLogService', () => ({
@@ -296,16 +290,7 @@ describe('CLI platform init', () => {
     ).toHaveBeenCalledWith(true);
   });
 
-  it('registers CLI runtime skill sources from context options', async () => {
-    const sources: SkillSource[] = [
-      {
-        scope: 'custom' as const,
-        path: '/tmp/project/vendor/skills',
-        label: 'custom',
-        required: true,
-      },
-    ];
-    mocks.defaultSkillSources.mockReturnValueOnce(sources);
+  it('registers CLI runtime skill sources through the shared Node host helper', async () => {
     mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
 
     await initCliPlatform(
@@ -317,16 +302,13 @@ describe('CLI platform init', () => {
       }),
     );
 
-    expect(mocks.defaultSkillSources).toHaveBeenCalledWith(
-      {
-        cwd: '/tmp/project',
-        resourcesPath: '/tmp/resources',
-      },
-      {
+    expect(mocks.initializeNodeRuntimeSkills).toHaveBeenCalledWith({
+      cwd: '/tmp/project',
+      resourcesPath: '/tmp/resources',
+      skillSourceOptions: {
         includeInterop: true,
         additionalPaths: ['vendor/skills'],
       },
-    );
-    expect(mocks.setRuntimeSkillSources).toHaveBeenCalledWith(sources);
+    });
   });
 });

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -39,6 +39,14 @@ interface NodeHostModule {
     currentVersion: string | undefined;
     versionStateKey: string;
   }): Promise<void>;
+  initializeNodeRuntimeSkills(options: {
+    cwd: string;
+    resourcesPath: string;
+    skillSourceOptions?: {
+      includeInterop?: boolean;
+      additionalPaths?: readonly string[];
+    };
+  }): void;
 }
 
 interface PlatformAgentDirectoriesModule {
@@ -87,6 +95,7 @@ describe('desktop agent directory bootstrap', () => {
         join(resourcesPath, 'tool_use_agents', 'researcher.yaml'),
         'name: researcher\n',
       ),
+      mkdir(join(resourcesPath, 'skills'), { recursive: true }),
       mkdir(workspacePath, { recursive: true }),
     ]);
 
@@ -241,5 +250,44 @@ describe('desktop agent directory bootstrap', () => {
     expect(
       globalStateStore.get(GlobalStateKey.LAST_KNOWN_VERSION),
     ).toBeUndefined();
+  });
+
+  it('registers runtime skills through the shared Node host defaults', async () => {
+    const { resourcesPath } = await createHarness();
+    const { initializeNodeRuntimeSkills } =
+      await loadPlatformDefaultsModule<NodeHostModule>('nodeHost.ts');
+    const { listRuntimeSkillSources } = await import('@skills/runtimeSkills');
+
+    initializeNodeRuntimeSkills({
+      cwd: '/tmp/project',
+      resourcesPath,
+      skillSourceOptions: {
+        includeInterop: true,
+        additionalPaths: ['vendor/skills'],
+      },
+    });
+
+    const sources = listRuntimeSkillSources();
+    expect(sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          scope: 'custom',
+          path: '/tmp/project/vendor/skills',
+          required: true,
+        }),
+        expect.objectContaining({
+          scope: 'project',
+          path: '/tmp/project/.texra/skills',
+        }),
+        expect.objectContaining({
+          scope: 'interop',
+          path: '/tmp/project/.codex/skills',
+        }),
+        expect.objectContaining({
+          scope: 'bundled',
+          path: join(resourcesPath, 'skills'),
+        }),
+      ]),
+    );
   });
 });

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -105,6 +105,23 @@ describe('desktop composition root and launch environment', () => {
     );
   });
 
+  it('initializes desktop runtime skills from the resolved resource bundle', async () => {
+    const source = await readFile(
+      repoPath('packages', 'desktop', 'src', 'main', 'platform', 'index.ts'),
+      'utf8',
+    );
+
+    expect(
+      source.indexOf('const resourcesPath = resolveResourcesPath'),
+    ).toBeGreaterThanOrEqual(0);
+    expect(source.indexOf('initializeNodeRuntimeSkills({')).toBeGreaterThan(
+      source.indexOf('const resourcesPath = resolveResourcesPath'),
+    );
+    expect(source.indexOf('initializeNodeRuntimeSkills({')).toBeLessThan(
+      source.indexOf('bootstrapNodeAgentDirectories('),
+    );
+  });
+
   it('resolves workspace paths only from an explicit launch environment', async () => {
     const { resolveWorkspacePath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');


### PR DESCRIPTION
Summary:
- move Node-host runtime skill-source registration into `src/platform/defaults/nodeHost.ts`
- keep CLI skill-source behavior by delegating to the shared helper
- initialize desktop runtime skills from the same shared defaults, so desktop loads project, user, and bundled skills
- add focused CLI and desktop composition coverage
- document the desktop behavior change in the changelog

Fixes #7738.

Validation:
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
- corepack pnpm exec tsc --noEmit -p tsconfig.json
- corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json
- corepack pnpm --filter @texra-ai/cli typecheck
- corepack pnpm exec eslint src/platform/defaults/nodeHost.ts packages/cli/src/runtime/initPlatform.ts packages/desktop/src/main/platform/index.ts src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
- git diff --check

Known current-main issue observed while validating:
- corepack pnpm --filter @texra/desktop typecheck still fails in untouched `packages/desktop/src/main/desktopAgentExecution.ts` because `runtimeHost` is present in two `StreamStatusEmitOptions` literals. This branch does not touch that file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composition-root refactor plus enabling skills on desktop using the same defaults as CLI; no auth or data-path changes beyond skill discovery roots.
> 
> **Overview**
> Centralizes Node-host **runtime skill source** wiring in `initializeNodeRuntimeSkills` (`nodeHost.ts`), which applies the same `defaultSkillSources` → `setRuntimeSkillSources` precedence (custom, project, user, bundled) for both hosts.
> 
> The **CLI** drops inline `@skills` calls and forwards `cwd`, `resourcesPath`, and CLI `skillSourceOptions` to that helper, so flag-driven behavior is unchanged. **Desktop** now calls the helper during platform init (after goal prompts, before agent directory bootstrap), using the resolved workspace or `userData` as `cwd` and default skill options—so agent runs can load project, user, and bundled skills like the CLI.
> 
> Tests assert CLI init delegates to the helper and that the helper registers the expected source list; a composition-root test locks desktop init ordering. The changelog notes the desktop behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f064b05cdb17e78a641f204a53d782e151c6b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->