### PR TITLE
Fix desktop status emit option typecheck

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -864,7 +864,6 @@ export class DesktopProgressBridge {
         closeRunningGroups: (streamIds, status, now) =>
           this.closeRunningTaskGroupsForStreams(streamIds, status, now),
         statusEmitOptions: {
-          runtimeHost: this.runtimeHost,
           trace: this.logger,
         },
         logger: this.logger,
@@ -968,7 +967,6 @@ export class DesktopProgressBridge {
           closeRunningGroups: (streamIds, status, now) =>
             this.closeRunningTaskGroupsForStreams(streamIds, status, now),
           statusEmitOptions: {
-            runtimeHost: this.runtimeHost,
             trace: this.logger,
           },
           logger: this.logger,


### PR DESCRIPTION
Summary:
- remove stale `runtimeHost` properties from desktop restart-repair `StreamStatusEmitOptions`
- keep restart repair status emission on the remaining trace path

This fixes the current-main desktop package typecheck break exposed while validating #7764.

Validation:
- corepack pnpm --filter @texra/desktop typecheck
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/progressView/RestartRepair.vitest.ts
- corepack pnpm exec eslint packages/desktop/src/main/desktopAgentExecution.ts
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only alignment with no behavioral change beyond removing an unused property that no longer exists on the options type.
> 
> **Overview**
> Fixes a **desktop package typecheck failure** by dropping the obsolete `runtimeHost` field from `statusEmitOptions` on both `repairRestartedStreams` calls in `repairOrphanedStreamsAfterRestart` (primary path and degraded fallback).
> 
> Restart-repair status emission now matches the extension wiring and the current `StreamStatusEmitOptions` shape: only **`trace`** is passed alongside the existing `logger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad17673888f2a5b105ccf5eb80f057ade9a452f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->