### PR TITLE
Replay pending prompts from shared handler set

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -17,6 +17,7 @@ import { ProgressBackend } from '@controllers/progressView/backend/ProgressBacke
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
+  replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
 import {
@@ -1042,6 +1043,10 @@ export class DesktopProgressBridge {
 
   syncFullView(): void {
     this.syncStreamContent(this.updateStreamMetadata());
+  }
+
+  replayPendingPrompts(): void {
+    replayApprovalRequestHandlers(this.approvalHandlers);
   }
 
   setActiveStream(streamId: StreamTabId): void {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -15,7 +15,7 @@ import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
 type DesktopProgressIpcBridge = Pick<
   DesktopProgressBridge,
-  'progressViewInboundHandlers' | 'syncFullView'
+  'progressViewInboundHandlers' | 'syncFullView' | 'replayPendingPrompts'
 >;
 
 export interface DesktopProgressIpcOptions {
@@ -88,9 +88,13 @@ export function createDesktopProgressIpc(
         const progress = getProgress();
         if (progress) {
           progress.syncFullView();
+          progress.replayPendingPrompts();
         } else if (ensureProgress) {
           void ensureProgress()
-            .then((loaded) => loaded.syncFullView())
+            .then((loaded) => {
+              loaded.syncFullView();
+              loaded.replayPendingPrompts();
+            })
             .catch(reportAsyncError);
         }
         return false;

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -5,6 +5,7 @@ import { ProgressBackend } from '@controllers/progressView/backend/ProgressBacke
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
+  replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { repairRestartedStreams } from '@controllers/progressView/backend/restartRepair';
@@ -459,15 +460,9 @@ export class ProgressViewProvider
       return;
     }
 
-    this.approvalHandlers.toolEdit.replay();
-    this.approvalHandlers.bash.replay();
-    this.approvalHandlers.externalInquiry.replay();
+    replayApprovalRequestHandlers(this.approvalHandlers);
     // YOLO / Super YOLO state is already sent by syncFullView() which is
     // always called before replayPendingPrompts() in markWebviewReady().
-
-    this.approvalHandlers.retry.replay();
-    this.approvalHandlers.agentProposal.replay();
-    this.approvalHandlers.planApproval.replay();
   }
 
   public getPendingAgentProposal(

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -135,6 +135,18 @@ export function buildApprovalRequestHandlerSet(
   };
 }
 
+export function replayApprovalRequestHandlers(
+  handlers: ApprovalRequestHandlerSet,
+): void {
+  handlers.toolEdit.replay();
+  handlers.bash.replay();
+  handlers.externalInquiry.replay();
+  handlers.retry.replay();
+  handlers.agentProposal.replay();
+  handlers.planApproval.replay();
+  handlers.userQuestion.replay();
+}
+
 export interface ProgressBackendUiConfigParams {
   handlers: ApprovalRequestHandlerSet;
   /** Transport for the bypass-state pushes (handlers own their own transport). */

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -32,15 +32,28 @@ function fillRegistry(
 
 interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
-    progress: {
+    progress?: {
       syncFullView(): void;
+      replayPendingPrompts(): void;
       progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
     };
+    getProgress?: () =>
+      | {
+          syncFullView(): void;
+          replayPendingPrompts(): void;
+          progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
+        }
+      | undefined;
     onUnsupportedCommand?: (
       message: { command: string },
       reason?: string,
     ) => void;
     onAsyncError?: (error: unknown) => void;
+    ensureProgress?: () => Promise<{
+      syncFullView(): void;
+      replayPendingPrompts(): void;
+      progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
+    }>;
   }): {
     handleMessage(
       message: { command: string } & Record<string, unknown>,
@@ -60,6 +73,7 @@ function createProgress(
 ) {
   return {
     syncFullView: vi.fn(),
+    replayPendingPrompts: vi.fn(),
     progressViewInboundHandlers: fillRegistry(progressViewInboundHandlers),
   };
 }
@@ -78,6 +92,22 @@ describe('desktop Progress IPC', () => {
       ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
     ).toBe(false);
     expect(progress.syncFullView).toHaveBeenCalledTimes(1);
+    expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays pending prompts after lazy Progress readiness load', async () => {
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({
+      ensureProgress: async () => progress,
+    });
+
+    expect(
+      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
+    ).toBe(false);
+    await Promise.resolve();
+
+    expect(progress.syncFullView).toHaveBeenCalledTimes(1);
+    expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches recognized Progress commands through the bridge registry', async () => {

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  replayApprovalRequestHandlers,
+  type ApprovalRequestHandlerSet,
+} from '@controllers/progressView/backend/progressBackendUiConfig';
+
+describe('ApprovalRequestHandlerSet helpers', () => {
+  it('replays every pending prompt kind', () => {
+    const replayCalls = {
+      toolEdit: vi.fn(),
+      bash: vi.fn(),
+      externalInquiry: vi.fn(),
+      retry: vi.fn(),
+      agentProposal: vi.fn(),
+      planApproval: vi.fn(),
+      userQuestion: vi.fn(),
+    };
+    const handlers = Object.fromEntries(
+      Object.entries(replayCalls).map(([key, replay]) => [key, { replay }]),
+    ) as unknown as ApprovalRequestHandlerSet;
+
+    replayApprovalRequestHandlers(handlers);
+
+    for (const replay of Object.values(replayCalls)) {
+      expect(replay).toHaveBeenCalledTimes(1);
+    }
+  });
+});


### PR DESCRIPTION
Summary:
- add a shared `replayApprovalRequestHandlers` helper for the full approval handler set
- switch the VS Code progress provider to the shared replay path, including `userQuestion`
- replay pending prompts from desktop Progress readiness, including lazy bridge initialization

This addresses the DR2 slice of #7749. DR3 durable external-inquiry rehydration remains a separate slice.

Validation:
- `npm test -- src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopHostInteractions.vitest.mts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only re-display in-memory pending approvals on webview readiness; no auth, persistence, or approval-resolution logic changes.
> 
> **Overview**
> Introduces shared **`replayApprovalRequestHandlers`** so every approval kind (including **`userQuestion`**) is re-sent to the webview through one path instead of per-host copy-paste.
> 
> The VS Code progress provider now calls that helper in **`replayPendingPrompts`**, which closes a gap where user-question prompts were not replayed after webview/placement changes.
> 
> Desktop now mirrors readiness behavior: on **`WEBVIEW_READY`**, after **`syncFullView`**, it also runs **`replayPendingPrompts`** on the progress bridge—including when the bridge is loaded lazily via **`ensureProgress`**—so pending approval UI is not lost when the renderer attaches late.
> 
> Tests cover the shared replay helper and desktop IPC readiness (immediate and lazy load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05af1fb8857a1af0a3bd81c5abc4ab35260bd0e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->