### PR TITLE
docs: fix stale emitRuntimeEvent reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,7 +433,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - Use `isFileNotFoundError()` from `@common/errors` instead of `instanceof vscode.FileSystemError`
 - Return error results instead of calling `vscode.window.show*Message()` from business logic — let the caller (command layer) handle UI
 - Add typed `Platform` ports (like `toolAvailability.isVscodeExtensionInstalled`) for platform-specific capabilities needed in agnostic code
-- New run-scoped facts extend `AgentEvent` (trace), and session-scoped facts extend `SessionFact` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to `emitRuntimeEvent()` — see `src/agent/runtime/emitRuntimeEvent.ts` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
+- New run-scoped facts extend `AgentEvent` (trace), and session-scoped facts extend `SessionFact` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to session-owned event-hub emission — see `SessionHandle.events` / `SessionEventHub` in `src/agent/runtime/` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
 
 ### Path Aliases
 


### PR DESCRIPTION
## What / why

Fixes #7657.

#7655 deleted `src/agent/runtime/emitRuntimeEvent.ts` after migrating its `src/tools` call sites to session-owned event-hub emission (`SessionHandle.events` / `SessionEventHub`), and tightened `sessionFactAmbientHelperRetirement.vitest.ts` to require zero production references to the symbol. Both automated PR reviewers on #7655 flagged that this left two docs describing `emitRuntimeEvent` as the sanctioned/current emit path, uncaught because the architecture guard only scans `.ts`/`.tsx`/`.mts`/`.cts` sources, not docs.

- `CLAUDE.md:436` still cited the deleted file as the migration target for the closed `bus.emit` exception — fixed here to point at `SessionHandle.events` / `SessionEventHub` in `src/agent/runtime/`, which is what the exception actually closed onto (verified against `SessionEventHub.ts` and `SessionHandle.ts` at HEAD).
- `src/agent/runtime/README.md:17`'s module-map row had already been fixed by `87c0a4c08` ("docs: refresh runtime session emission map"), landed on `main` ahead of this branch — no change needed there.

Grepped the rest of the repo's normative docs (`AGENTS.md`, `.claude/skills/code-review/SKILL.md`) for `emitRuntimeEvent`: no other hits. Remaining hits are all in `docs/proposals/*` and `docs/agent-sdk-readiness-audit.md`, which are historical/point-in-time audit records (left untouched per the issue's scope) plus the architecture-guard test file's own assertion text (not a doc claim).

## Verification

- Docs-only change; no build/test/typecheck required per the issue.
- `grep -n "emitRuntimeEvent" CLAUDE.md src/agent/runtime/README.md AGENTS.md` — no hits after the change.
- Did not touch anything under `docs/`, so the `docs-root-boundary` pre-commit gate is not applicable.

## Net elements (R6)

- Files changed: 1 (`CLAUDE.md`)
- Lines: +1/-1 (single sentence edit, no new files/exports/classes)

## Consumer counts (R8)

n/a — doc prose edit only, no code export, emit path, or subscribe surface added/removed/re-routed.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix; no runtime, API, or behavior changes.
> 
> **Overview**
> **Updates the VS Code-free-zone event-emission rule** in `CLAUDE.md` so it no longer points at the removed `emitRuntimeEvent.ts` helper.
> 
> The closed `bus.emit` grandfather exception is now documented as having migrated to **session-owned emission** via `SessionHandle.events` / `SessionEventHub` under `src/agent/runtime/`, matching the current runtime after #7655.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c383c6438a46d203f7fd0599e9d758d06c17d46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->