### PR TITLE
fix(model-handlers): bound OpenRouter SDK retry window to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **OpenRouter transient server errors no longer stall a request for up to an
+  hour** — the OpenRouter SDK's built-in retry window is now capped at 30
+  seconds, so a persistent 5XX surfaces through TeXRA's visible retry/failure
+  path instead of backing off invisibly inside a single attempt.
 - **Web search/fetch links now block dangerous URL schemes** — a link
   surfaced from a web search result or fetched page can no longer use a
   `javascript:`/`data:`/`vbscript:`/`file:` URL to become a live,

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -138,6 +138,24 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       apiKey,
       appTitle: 'TeXRA.ai',
       ...(baseUrl ? { serverURL: baseUrl } : {}),
+      // @openrouter/sdk@0.13.31 chatSend.js:46-58 defaults retryConfig to a
+      // 3_600_000ms (1h) maxElapsedTime backoff, so a transient 5XX can hang
+      // inside a single "attempt" for up to an hour before TeXRA's flow-level
+      // retry ever sees it (#7643). Bound it here instead: same backoff shape,
+      // maxElapsedTime capped to 30s (~5 attempts of transient-blip
+      // resilience), then the failure surfaces through the flow's visible
+      // retry/failure path. Ownership of 5XX retries is unchanged — see
+      // isAutoRetryManagedByProvider below.
+      retryConfig: {
+        strategy: 'backoff',
+        backoff: {
+          initialInterval: 500,
+          maxInterval: 8_000,
+          exponent: 1.5,
+          maxElapsedTime: 30_000,
+        },
+        retryConnectionErrors: true,
+      },
     });
   }
 
@@ -150,8 +168,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     const statusCode = detectStatusCode(error);
-    // @openrouter/sdk v0.13.21 defaults chatSend retryCodes to ["5XX"];
-    // 429/408 HTTP responses remain owned by TeXRA's flow retry.
+    // @openrouter/sdk v0.13.21 defaults chatSend retryCodes to ["5XX"]; the
+    // SDK's retry window is now bounded to 30s (see getClient() above), but
+    // ownership is unchanged — 5XX HTTP responses remain provider-managed here,
+    // and 429/408 HTTP responses remain owned by TeXRA's flow retry.
     return statusCode !== undefined && statusCode >= 500;
   }
 

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -168,7 +168,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     const statusCode = detectStatusCode(error);
-    // @openrouter/sdk v0.13.21 defaults chatSend retryCodes to ["5XX"]; the
+    // @openrouter/sdk v0.13.31 defaults chatSend retryCodes to ["5XX"]; the
     // SDK's retry window is now bounded to 30s (see getClient() above), but
     // ownership is unchanged — 5XX HTTP responses remain provider-managed here,
     // and 429/408 HTTP responses remain owned by TeXRA's flow retry.

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -192,6 +192,10 @@ describe('ModelHandlerOpenRouterNative getClient retryConfig', () => {
 
     // Constructing the SDK client is synchronous, local option-merging (no
     // network call), so inspecting the stored options is safe here.
+    // Reaches into the SDK client's private `_options` (no public accessor).
+    // A future @openrouter/sdk bump renaming it makes `options` undefined and
+    // the deepEqual below throw — a loud failure, not silent under-assertion.
+    // Re-check this access on SDK bumps.
     const options = (client as unknown as { _options: Record<string, unknown> })
       ._options;
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -174,3 +174,36 @@ describe('ModelHandlerOpenRouterNative retry ownership', () => {
     );
   });
 });
+
+describe('ModelHandlerOpenRouterNative getClient retryConfig', () => {
+  it('bounds the SDK retry window instead of the 1h default (#7643)', async () => {
+    class TestableHandler extends ModelHandlerOpenRouterNative {
+      protected override async getApiKey(): Promise<string> {
+        return 'test-api-key';
+      }
+
+      override getBaseUrl(): string | null {
+        return null;
+      }
+    }
+
+    const handler = new TestableHandler(buildConfig());
+    const client = await handler.getClient();
+
+    // Constructing the SDK client is synchronous, local option-merging (no
+    // network call), so inspecting the stored options is safe here.
+    const options = (client as unknown as { _options: Record<string, unknown> })
+      ._options;
+
+    assert.deepEqual(options.retryConfig, {
+      strategy: 'backoff',
+      backoff: {
+        initialInterval: 500,
+        maxInterval: 8_000,
+        exponent: 1.5,
+        maxElapsedTime: 30_000,
+      },
+      retryConnectionErrors: true,
+    });
+  });
+});


### PR DESCRIPTION
## What / why

Fixes #7643 (Finding EP-2, surfaced by the 2026-07 runtime↔UI / data-model
audit, PR #7636).

`ModelHandlerOpenRouterNative.getClient()` constructed `new OpenRouter({...})`
with no `retryConfig`, so the SDK's own default governed: `@openrouter/sdk@0.13.31`
`chatSend.js:46-58` defaults `retryConfig.backoff.maxElapsedTime` to
`3_600_000` ms (1h). A transient 5XX therefore presented to the user as a
~1-hour hang inside a single "attempt", before TeXRA's flow-level retry ever
got a chance to run.

Per the maintainer-approved Decision on the issue, this PR passes an explicit
bounded backoff `retryConfig` in `getClient()` — same shape as the SDK
default, `maxElapsedTime` capped from 1h to 30s (~5 attempts of
transient-blip resilience), `retryConnectionErrors: true`. Ownership of 5XX
retries is **unchanged** — `isAutoRetryManagedByProvider` still treats 5XX as
provider-managed; that question is explicitly deferred to #7642's
owner-selector ruling and is out of scope here.

## Rejected trap (honored)

Did **not** merge the OpenRouter handler into OpenAI's to "share" retry
config — the retry-config split is a per-provider SDK fact, kept as-is.

## Verification

- `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts` — 11 passed (1 file), including a new shape assertion that `getClient()` constructs the SDK client with the exact bounded `retryConfig` (no network — the SDK constructor only merges options synchronously; verified against `node_modules/@openrouter/sdk/esm/lib/sdks.js`).
- `npm run typecheck` — clean (root `tsc --noEmit`, test-kernel project, CLI, desktop/trace-viewer sub-typechecks).
- `npx prettier --check` on both touched files — clean.

## Net elements (R6)

- Files touched: 2 (`modelHandlerOpenRouterNative.ts`, its existing test suite `ModelHandlerOpenRouterNative.vitest.ts`) — no new files.
- Exports/classes added: 0. No new abstractions — inline `retryConfig` object literal in the existing `getClient()` call, plus one new `describe` block appended to the existing suite.
- Net LoC: +22 in the handler (retryConfig object + updated comments), +33 in the test suite. Matches the sketch's "+~12 LoC config, 0 new elements" in spirit (extra lines are the SDK-citation comment plus the required test coverage).

## Consumer counts (R8)

n/a — no emit path, export, or public API surface was deleted or re-routed;
this only adds a constructor option to an internal SDK client instance.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized OpenRouter client construction and retry timing only; no change to which errors TeXRA vs the SDK owns.
> 
> **Overview**
> Fixes **#7643**: OpenRouter calls could appear hung for up to an hour when the SDK retried 5XX errors inside one attempt.
> 
> `ModelHandlerOpenRouterNative.getClient()` now passes an explicit **`retryConfig`** with the same backoff shape as the SDK default but **`maxElapsedTime` capped at 30s** (~5 transient retries), plus **`retryConnectionErrors: true`**. After that window, failures reach TeXRA’s flow-level retry/failure UI instead of backing off invisibly.
> 
> **5XX retry ownership is unchanged** — `isAutoRetryManagedByProvider` still treats 5XX as provider-managed; 429/408 stay on TeXRA’s flow retry. Comments were updated to cite SDK v0.13.31.
> 
> **CHANGELOG** documents the user-visible fix. A new Vitest case asserts the constructed client’s `retryConfig` shape (via SDK private `_options`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54b0227305c91d31c6c9b41ef05f2f0e1078df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->