### PR TITLE
fix: wake queued CLI follow-ups through resume port

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -8,7 +8,11 @@
 import PQueue from 'p-queue';
 
 import { getDefaultStreamLogStore, StreamSnapshotStore } from '@transcript';
-import { registerExecution, writeTerminalStatus } from '@agent/storage';
+import {
+  getExecutionStore,
+  registerExecution,
+  writeTerminalStatus,
+} from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -21,6 +25,11 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
+import {
+  isResumeInFlight,
+  resolveAndResumeStream,
+} from '@agent/runtime/resolveAndResumeStream';
+import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
@@ -44,6 +53,7 @@ import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import {
   EXECUTION_STATUS,
   type ExecutionId,
+  type StreamTabId,
   sumUsageStats,
 } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
@@ -158,6 +168,12 @@ export interface ChatSessionController {
 
   /** Request stop of the active run (idempotent). */
   stop(): void;
+
+  /** Resume a queued follow-up target from the CLI platform resume port. */
+  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+
+  /** Whether a stream resume accepted by this controller is still preparing. */
+  isResumeInFlight(streamId: StreamTabId): boolean;
 
   /** Whether a new root run can be started right now. */
   canStartRootRun(): boolean;
@@ -400,6 +416,92 @@ export function createChatSessionController(
     publishChatTuiRootRunStartAvailability(session);
   };
 
+  const tryResumeStream = async (streamId: StreamTabId): Promise<boolean> => {
+    if (!chatTuiCanStartRootRun(session)) return false;
+
+    await snapshotStore.preload([streamId]);
+    const executionId =
+      snapshotStore.getExecutionId(streamId) ??
+      (await snapshotStore.readPersistedExecutionId(streamId));
+    if (!executionId) return false;
+
+    const config =
+      snapshotStore.getRunConfig(streamId) ??
+      (await getExecutionStore(executionId).readConfig());
+    if (!config) return false;
+
+    const currentModel = config.model;
+    const sessionContext = getSessionContext(currentModel);
+    patchSessionMeta({
+      agent: config.agent,
+      model: config.model,
+      modelSource: 'history',
+      canDelegate: chatAgentSupportsDelegation(config.agent),
+    });
+
+    const { runtimeHost, approvalsUnavailable, finalize } =
+      setupRunHost(sessionContext);
+    session.runtimeHost = runtimeHost;
+    session.streamId = streamId;
+    session.executionId = executionId;
+    rootStreamId.set(streamId);
+    activeStreamId.set(streamId);
+    session.runCompleted = false;
+    session.stopRequested = false;
+    session.runExitCode = CliExitCode.Success;
+    publishChatTuiRootRunStartAvailability(session);
+
+    const runPromise = setCliHelperModel(currentModel)
+      .then(() =>
+        resolveAndResumeStream(streamId, {
+          runtimeHost,
+          streamStatus: defaultSession().status,
+          resolveResumeState: async () => ({
+            runState: config,
+            executionId,
+            parentStreamId: snapshotStore.getParentStreamId(streamId),
+          }),
+          resumeToolUseSnapshot: (snapshot) =>
+            resumeQueuedToolUseSnapshot(streamId, snapshot, runtimeHost, {
+              session: defaultSession(),
+              approvalPromptsUnavailable: approvalsUnavailable,
+              runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+              onError: reportRunFailure,
+            }),
+          executeWorkflow: async () => {
+            throw new Error(
+              'CLI chat cannot auto-resume workflow streams from follow-up wake.',
+            );
+          },
+          reportNoResumableSession: () => {
+            appendLocalAssistantTranscript(
+              'Message queued. Auto-resume found no resumable session state; resume the session manually or start a new agent task.',
+              streamId,
+            );
+          },
+          reportFailure: (_failedStream, error) => reportRunFailure(error),
+        }),
+      )
+      .then((resumed) => {
+        if (session.streamId) {
+          projectStreamTranscript(session.streamId, { finalize: true });
+        }
+        if (resumed) {
+          session.runExitCode = CliExitCode.Success;
+          notify({ kind: 'agentFinished' });
+        }
+        return resumed;
+      })
+      .catch((error: unknown) => {
+        reportRunFailure(error);
+        return false;
+      })
+      .finally(finalize);
+    session.runPromise = runPromise.then(() => undefined);
+
+    return runPromise;
+  };
+
   // -----------------------------------------------------------------------
   // stop
   // -----------------------------------------------------------------------
@@ -413,6 +515,8 @@ export function createChatSessionController(
     startRootRun,
     resume,
     stop,
+    tryResumeStream,
+    isResumeInFlight,
     canStartRootRun: () => chatTuiCanStartRootRun(session),
   };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -25,7 +25,12 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import {
+  presentFollowUpWakeResult,
+  sendFollowUp,
+  wakeQueuedFollowUpStream,
+} from '@agent/followUp/ToolUseFollowUp';
+import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import {
   type CliContext,
   readCliVersion,
@@ -488,6 +493,12 @@ export async function runChat(
     followUpQueue,
     snapshotStore,
   });
+  disposers.push(
+    setCliAgentResumeHandler({
+      tryResumeStream: (streamId) => chatController.tryResumeStream(streamId),
+      isResumeInFlight: (streamId) => chatController.isResumeInFlight(streamId),
+    }),
+  );
 
   const interruptActive = (): void => {
     chatController.stop();
@@ -676,6 +687,15 @@ export async function runChat(
     void followUpQueue.add(async () => {
       let delivered = false;
       let followUpTarget = childFollowUpTarget;
+      const emitQueuedFollowUpsChanged = (streamId: StreamTabId): void => {
+        defaultSession().events.emit({
+          scope: 'session',
+          event: {
+            type: 'updateQueuedFollowUps',
+            payload: { streamId },
+          },
+        });
+      };
       try {
         while (
           !followUpTarget &&
@@ -692,7 +712,25 @@ export async function runChat(
           mediaFiles,
           prepared.displayInstruction,
         );
-        delivered = result.status === 'sent' || result.status === 'queued';
+        if (result.status === 'sent') {
+          emitQueuedFollowUpsChanged(followUpTarget);
+          delivered = true;
+        } else if (result.status === 'queued') {
+          emitQueuedFollowUpsChanged(followUpTarget);
+          const wake = await wakeQueuedFollowUpStream(followUpTarget, result);
+          const presentation = presentFollowUpWakeResult(wake);
+          if (presentation.severity !== 'none') {
+            if (presentation.refreshQueuedFollowUps) {
+              emitQueuedFollowUpsChanged(followUpTarget);
+            }
+            appendLocalAssistantTranscript(
+              presentation.message,
+              followUpTarget,
+            );
+          }
+          delivered =
+            wake.kind !== 'dropped' && wake.kind !== 'queued_resume_failed';
+        }
         if (result.status === 'no_session') {
           // Child stream ids are keys in parentStream; the root session id is not.
           if (followUpTarget === session.streamId) {

--- a/packages/cli/src/runtime/agentResume.ts
+++ b/packages/cli/src/runtime/agentResume.ts
@@ -1,0 +1,30 @@
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+export interface CliAgentResumeHandler {
+  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  isResumeInFlight(streamId: StreamTabId): boolean;
+}
+
+let activeHandler: CliAgentResumeHandler | undefined;
+
+export function setCliAgentResumeHandler(
+  handler: CliAgentResumeHandler,
+): () => void {
+  activeHandler = handler;
+  return () => {
+    if (activeHandler === handler) {
+      activeHandler = undefined;
+    }
+  };
+}
+
+export async function tryResumeCliStream(
+  streamId: StreamTabId,
+): Promise<boolean> {
+  return activeHandler?.tryResumeStream(streamId) ?? false;
+}
+
+export function isCliResumeInFlight(streamId: StreamTabId): boolean {
+  return activeHandler?.isResumeInFlight(streamId) ?? false;
+}

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -45,6 +45,7 @@ import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 // Local imports - CLI runtime
 import { applyCliGitAuthorConfig } from './gitAuthor';
+import { isCliResumeInFlight, tryResumeCliStream } from './agentResume';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { writeTextStderr } from './logSinks';
@@ -199,7 +200,10 @@ export async function initCliPlatform(
         storage: stateStores.storage,
         secrets: getCliSecrets(context.storageRoot),
         lifecycle,
-        agentResume: { tryResumeStream: async () => false },
+        agentResume: {
+          tryResumeStream: tryResumeCliStream,
+          isResumeInFlight: isCliResumeInFlight,
+        },
         agentDirectories,
         getWorkspacePath: () => cliWorkspaceCwd,
         toolAvailability: {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -51,6 +51,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import {
+  presentFollowUpWakeResult,
   sendFollowUp,
   wakeQueuedFollowUpStream,
 } from '@agent/followUp/ToolUseFollowUp';
@@ -1371,21 +1372,18 @@ export class DesktopProgressBridge {
         },
         this.session,
       );
-      if (wake.kind === 'dropped') {
-        this.session.events.emit({
-          scope: 'session',
-          event: {
-            type: 'updateQueuedFollowUps',
-            payload: { streamId },
-          },
-        });
-        await this.options.showInfoMessage?.(
-          'Message dropped because no session was available to receive it. Start a new agent task to continue.',
-        );
-      } else if (wake.kind === 'queued_resume_failed') {
-        await this.options.showInfoMessage?.(
-          'Message queued. Auto-resume failed; start a new agent task to continue.',
-        );
+      const presentation = presentFollowUpWakeResult(wake);
+      if (presentation.severity !== 'none') {
+        if (presentation.refreshQueuedFollowUps) {
+          this.session.events.emit({
+            scope: 'session',
+            event: {
+              type: 'updateQueuedFollowUps',
+              payload: { streamId },
+            },
+          });
+        }
+        await this.options.showInfoMessage?.(presentation.message);
       }
       return;
     }

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - agent
 import { deriveResumability } from '@agent/storage';
 import {
+  presentFollowUpWakeResult,
   sendFollowUp,
   wakeQueuedFollowUpStream,
   type SendFollowUpResult,
@@ -86,20 +87,21 @@ async function handleFollowUpResult(
       break;
     case 'queued':
       emitQueuedFollowUpsChanged(streamId);
-      switch ((await wakeQueuedFollowUpStream(streamId, result)).kind) {
-        case 'dropped':
-          emitQueuedFollowUpsChanged(streamId);
-          await vscode.window.showWarningMessage(
-            'Message dropped — no session available to receive it. Start a new agent task to continue.',
-          );
-          break;
-        case 'queued_resume_failed':
-          await vscode.window.showInformationMessage(
-            'Message queued. Auto-resume failed — start a new agent task to continue.',
-          );
-          break;
-        default:
-          break;
+      {
+        const presentation = presentFollowUpWakeResult(
+          await wakeQueuedFollowUpStream(streamId, result),
+        );
+        if (presentation.severity === 'warning') {
+          if (presentation.refreshQueuedFollowUps) {
+            emitQueuedFollowUpsChanged(streamId);
+          }
+          await vscode.window.showWarningMessage(presentation.message);
+        } else if (presentation.severity === 'info') {
+          if (presentation.refreshQueuedFollowUps) {
+            emitQueuedFollowUpsChanged(streamId);
+          }
+          await vscode.window.showInformationMessage(presentation.message);
+        }
       }
       break;
     case 'no_session':

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -45,6 +45,14 @@ export type FollowUpWakeResult =
   | { kind: 'queued_resume_failed' }
   | { kind: 'dropped' };
 
+export type FollowUpWakePresentation =
+  | { severity: 'none' }
+  | {
+      severity: 'info' | 'warning';
+      message: string;
+      refreshQueuedFollowUps: boolean;
+    };
+
 export interface FollowUpResumePort {
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   isResumeInFlight?(streamId: StreamTabId): boolean;
@@ -107,6 +115,38 @@ export async function wakeQueuedFollowUpStream(
   }
   ownerSession.followUps.release(streamId);
   return { kind: 'dropped' };
+}
+
+/**
+ * Shared host-facing presentation for wake outcomes. It intentionally maps
+ * only queue/wake policy to UI text; provider/model follow-up construction
+ * stays with the caller that owns that context.
+ */
+export function presentFollowUpWakeResult(
+  result: FollowUpWakeResult,
+): FollowUpWakePresentation {
+  switch (result.kind) {
+    case 'dropped':
+      return {
+        severity: 'warning',
+        message:
+          'Message dropped because no session was available to receive it. Start a new agent task to continue.',
+        refreshQueuedFollowUps: true,
+      };
+    case 'queued_resume_failed':
+      return {
+        severity: 'info',
+        message:
+          'Message queued. Auto-resume failed; start a new agent task to continue.',
+        refreshQueuedFollowUps: false,
+      };
+    case 'not_required':
+    case 'queued_without_wake':
+    case 'resumed':
+    case 'resume_in_flight':
+    case 'active_or_resuming':
+      return { severity: 'none' };
+  }
 }
 
 /**

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -26,6 +26,7 @@ import {
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import {
+  presentFollowUpWakeResult,
   sendFollowUp,
   wakeQueuedFollowUpStream,
   wakeOrReleaseQueuedStream,
@@ -118,6 +119,27 @@ describe('ToolUseFollowUp', () => {
     SharedExecutionRegistry.track(handle);
     return executionId;
   }
+
+  it('maps wake outcomes to shared host presentation messages', () => {
+    assert.deepEqual(presentFollowUpWakeResult({ kind: 'dropped' }), {
+      severity: 'warning',
+      message:
+        'Message dropped because no session was available to receive it. Start a new agent task to continue.',
+      refreshQueuedFollowUps: true,
+    });
+    assert.deepEqual(
+      presentFollowUpWakeResult({ kind: 'queued_resume_failed' }),
+      {
+        severity: 'info',
+        message:
+          'Message queued. Auto-resume failed; start a new agent task to continue.',
+        refreshQueuedFollowUps: false,
+      },
+    );
+    assert.deepEqual(presentFollowUpWakeResult({ kind: 'resumed' }), {
+      severity: 'none',
+    });
+  });
 
   it('sends follow-ups to active flow contexts', async () => {
     const calls: string[] = [];

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UsageLogService } from '@telemetry/UsageLogService';
+import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
@@ -193,6 +194,45 @@ describe('CLI platform init', () => {
     expect(vi.mocked(UsageLogService.dispose)).not.toHaveBeenCalled();
     for (const handler of mocks.shutdownHandlers) await handler();
     expect(vi.mocked(UsageLogService.dispose)).toHaveBeenCalled();
+  });
+
+  it('installs a CLI agent resume port that delegates to the active handler', async () => {
+    mocks.tryPlatform.mockReturnValueOnce(undefined);
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+
+    await initCliPlatform(cliContext({ installSignalHandlers: false }));
+
+    type NodePlatformOptions = {
+      readonly agentResume: {
+        tryResumeStream(streamId: string): Promise<boolean>;
+        isResumeInFlight(streamId: string): boolean;
+      };
+    };
+    const createNodePlatformCalls = mocks.createNodePlatform.mock
+      .calls as unknown as Array<[NodePlatformOptions]>;
+    const nodePlatformOptions = createNodePlatformCalls[0]?.[0];
+    expect(nodePlatformOptions?.agentResume).toBeDefined();
+    if (!nodePlatformOptions) throw new Error('expected node platform options');
+
+    const tryResumeStream = vi.fn(async () => true);
+    const isResumeInFlight = vi.fn(() => true);
+    const dispose = setCliAgentResumeHandler({
+      tryResumeStream,
+      isResumeInFlight,
+    });
+
+    try {
+      await expect(
+        nodePlatformOptions.agentResume.tryResumeStream('stream:cli-resume'),
+      ).resolves.toBe(true);
+      expect(tryResumeStream).toHaveBeenCalledWith('stream:cli-resume');
+      expect(
+        nodePlatformOptions.agentResume.isResumeInFlight('stream:cli-resume'),
+      ).toBe(true);
+      expect(isResumeInFlight).toHaveBeenCalledWith('stream:cli-resume');
+    } finally {
+      dispose();
+    }
   });
 
   it('bootstraps bundled agents with the CLI version store', async () => {


### PR DESCRIPTION
## Summary
- replace the CLI false agent-resume stub with a TUI-owned active resume handler
- wake queued CLI follow-ups through the shared resume port and avoid marking dropped or failed wake attempts as delivered
- factor shared follow-up wake presentation text for extension, desktop, and CLI hosts

Addresses the first FS1/CP1 slice of #7747.

## Validation
- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts src/test-kernel/cli/CliInitPlatform.vitest.mts`
- `npm test -- src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/tools/InquiryContinuationSession.vitest.ts src/test-kernel/tools/DelegationTools.vitest.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up delivery and auto-resume orchestration on the CLI and shared wake presentation used by multiple hosts; incorrect resume wiring could drop or mis-report queued messages, though behavior is covered by new/updated tests.
> 
> **Overview**
> **Queued CLI follow-ups can auto-resume the stream** instead of hitting a platform stub that always refused resume. The chat TUI registers a real `agentResume` handler that delegates to `ChatSessionController.tryResumeStream`, which loads persisted execution/config and runs `resolveAndResumeStream` (tool-use snapshot resume; workflows are explicitly rejected).
> 
> **Follow-up wake UX is unified across hosts.** `presentFollowUpWakeResult` maps wake outcomes to shared info/warning copy and whether to refresh the queued-follow-ups UI. Extension, desktop, and CLI use it after `wakeQueuedFollowUpStream`. The CLI only treats a follow-up as delivered when wake does not end in `dropped` or `queued_resume_failed` (and emits `updateQueuedFollowUps` when appropriate).
> 
> **Platform init** wires `tryResumeCliStream` / `isCliResumeInFlight` into `createNodePlatform` instead of `tryResumeStream: async () => false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc253398bbf1031e45a950c48aeaf2524ac39bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->