### PR TITLE
fix(shared): derive delivery-envelope tag lists from one owned DELIVERY_TAGS const

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -17,7 +17,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { CopyButtonController } from '@shared/litControllers';
 import { compactIconActionButtonStyles } from '@shared/styles';
 import { decodeXmlEntities } from '@shared/subagentFollowup';
-import { DELIVERY_TAGS } from '@shared/deliveryTags';
+import { DELIVERY_TAGS, type DeliveryTagName } from '@shared/deliveryTags';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -40,8 +40,14 @@ const STRUCTURED_DELIVERY_PATTERN = new RegExp(
   `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,
 );
 
-function getStructuredDeliveryTag(text: string): string | null {
-  return STRUCTURED_DELIVERY_PATTERN.exec(text)?.[1] ?? null;
+function getStructuredDeliveryTag(text: string): DeliveryTagName | null {
+  // Safe cast: the pattern's only alternation group is STRUCTURED_DELIVERY_TAGS
+  // (DeliveryTagName[]), so a match can only capture one of those values.
+  return (
+    (STRUCTURED_DELIVERY_PATTERN.exec(text)?.[1] as
+      | DeliveryTagName
+      | undefined) ?? null
+  );
 }
 
 @customElement('user-message')

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -45,8 +45,7 @@ function getStructuredDeliveryTag(text: string): DeliveryTagName | null {
   // (DeliveryTagName[]), so a match can only capture one of those values.
   return (
     (STRUCTURED_DELIVERY_PATTERN.exec(text)?.[1] as
-      | DeliveryTagName
-      | undefined) ?? null
+      DeliveryTagName | undefined) ?? null
   );
 }
 

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -17,6 +17,7 @@ import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { CopyButtonController } from '@shared/litControllers';
 import { compactIconActionButtonStyles } from '@shared/styles';
 import { decodeXmlEntities } from '@shared/subagentFollowup';
+import { DELIVERY_TAGS } from '@shared/deliveryTags';
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
@@ -26,30 +27,14 @@ import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { formatDisplayTimestamp } from '../formatters/timestampUtils';
 
-const STRUCTURED_DELIVERY_TAGS = [
-  'background-result',
-  'background-error',
-  'codex-result',
-  'codex-error',
-  'execution-activity',
-  'github-webhook-activity',
-  'subagent-progress',
-  'subagent-result',
-  'subagent-error',
-] as const;
+// Derived from the single owned DELIVERY_TAGS list (@shared/deliveryTags) so
+// a new child-run kind only needs one entry there — see that module for the
+// escaped-subset rationale.
+const STRUCTURED_DELIVERY_TAGS = DELIVERY_TAGS.map((entry) => entry.tag);
 
-// Subset whose content is XML-entity-escaped and needs decoding for display.
-// subagent-progress is included because the "todos" variant runs todo text
-// through escapeText(), producing &amp;/&lt; entities in the body.
-const XML_ESCAPED_TAGS = new Set([
-  'background-result',
-  'background-error',
-  'codex-result',
-  'codex-error',
-  'subagent-progress',
-  'subagent-result',
-  'subagent-error',
-]);
+const XML_ESCAPED_TAGS = new Set(
+  DELIVERY_TAGS.filter((entry) => entry.escaped).map((entry) => entry.tag),
+);
 
 const STRUCTURED_DELIVERY_PATTERN = new RegExp(
   `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -20,13 +20,14 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
+import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { StreamTabId } from '@shared/schemas';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 import { currentSession, type SessionHandle } from './SessionHandle';
 
 const logger = createChannelTrace('ExecutionSubscriptionBinder');
 
-const TAG = 'execution-activity';
+const TAG = DELIVERY_TAG.executionActivity;
 
 interface Disposable {
   dispose: () => void;

--- a/src/shared/deliveryTags.ts
+++ b/src/shared/deliveryTags.ts
@@ -1,0 +1,56 @@
+// Single source of truth for the child-run delivery-envelope XML root tags
+// (`<subagent-result>`, `<codex-error>`, `<execution-activity>`, …) that
+// producers (src/tools/*, src/agent/runtime/ExecutionSubscriptionBinder.ts)
+// mint and render surfaces (progressView UserMessage, the CLI transcript)
+// must recognize. Previously each render surface hand-listed the tag
+// vocabulary separately from the producers, so a new child-run kind (e.g.
+// `claude-agent-result`) could ship without ever being added to a render
+// list and would render as raw XML. Adding a new child-run kind is now one
+// entry here.
+//
+// Intentionally has NO host imports (no vscode, no Ink/React) so both
+// @shared (webview) and the CLI can consume it, matching subagentFollowup.ts.
+
+/** Canonical tag names, referenced by producers instead of string literals. */
+export const DELIVERY_TAG = {
+  subagentProgress: 'subagent-progress',
+  subagentResult: 'subagent-result',
+  subagentError: 'subagent-error',
+  backgroundResult: 'background-result',
+  backgroundError: 'background-error',
+  codexResult: 'codex-result',
+  codexError: 'codex-error',
+  claudeAgentResult: 'claude-agent-result',
+  claudeAgentError: 'claude-agent-error',
+  githubWebhookActivity: 'github-webhook-activity',
+  executionActivity: 'execution-activity',
+} as const;
+
+export interface DeliveryTagEntry {
+  readonly tag: string;
+  /**
+   * Whether the envelope body is XML-entity-escaped (via `escapeText()` in
+   * the producer) and needs `decodeXmlEntities()` before display.
+   * `subagent-progress` is included because its "todos" variant runs todo
+   * text through `escapeText()`, producing `&amp;`/`&lt;` entities in the
+   * body. `github-webhook-activity` / `execution-activity` use
+   * `wrapAndSanitizeTag()` instead, which neutralizes embedded tag names
+   * rather than XML-entity-escaping, so they are not in the escaped subset.
+   */
+  readonly escaped: boolean;
+}
+
+/** Every recognized child-run delivery-envelope tag, in no particular order. */
+export const DELIVERY_TAGS: readonly DeliveryTagEntry[] = [
+  { tag: DELIVERY_TAG.subagentProgress, escaped: true },
+  { tag: DELIVERY_TAG.subagentResult, escaped: true },
+  { tag: DELIVERY_TAG.subagentError, escaped: true },
+  { tag: DELIVERY_TAG.backgroundResult, escaped: true },
+  { tag: DELIVERY_TAG.backgroundError, escaped: true },
+  { tag: DELIVERY_TAG.codexResult, escaped: true },
+  { tag: DELIVERY_TAG.codexError, escaped: true },
+  { tag: DELIVERY_TAG.claudeAgentResult, escaped: true },
+  { tag: DELIVERY_TAG.claudeAgentError, escaped: true },
+  { tag: DELIVERY_TAG.githubWebhookActivity, escaped: false },
+  { tag: DELIVERY_TAG.executionActivity, escaped: false },
+];

--- a/src/shared/deliveryTags.ts
+++ b/src/shared/deliveryTags.ts
@@ -26,8 +26,11 @@ export const DELIVERY_TAG = {
   executionActivity: 'execution-activity',
 } as const;
 
+/** Every canonical tag name — the union `DELIVERY_TAGS` entries must draw from. */
+export type DeliveryTagName = (typeof DELIVERY_TAG)[keyof typeof DELIVERY_TAG];
+
 export interface DeliveryTagEntry {
-  readonly tag: string;
+  readonly tag: DeliveryTagName;
   /**
    * Whether the envelope body is XML-entity-escaped (via `escapeText()` in
    * the producer) and needs `decodeXmlEntities()` before display.

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -1,8 +1,12 @@
-// Host-neutral parsing/formatting for the subagent follow-up XML blocks
-// produced by src/tools/subagentResults.ts (`<subagent-progress>`,
-// `<subagent-result>`, `<subagent-error>`). These blocks are FollowUpQueue
-// messages addressed to the orchestrator *model*, injected into the
-// conversation as user turns.
+// Host-neutral parsing/formatting for the child-run delivery-envelope XML
+// blocks produced by src/tools/subagentResults.ts, codex.ts, claudeAgent.ts,
+// github/formatUtils.ts, and ExecutionSubscriptionBinder.ts (the tags owned
+// by @shared/deliveryTags: `<subagent-progress>`, `<subagent-result>`,
+// `<subagent-error>`, `<background-result>`, `<background-error>`,
+// `<codex-result>`, `<codex-error>`, `<claude-agent-result>`,
+// `<claude-agent-error>`, `<github-webhook-activity>`,
+// `<execution-activity>`). These blocks are FollowUpQueue messages addressed
+// to the orchestrator *model*, injected into the conversation as user turns.
 //
 // Both hosts render them: the CLI transcript collapses each block to a terse
 // status line (summarizeSubagentFollowup), and the extension ProgressView
@@ -14,8 +18,16 @@
 
 import escapeRegExp from 'escape-string-regexp';
 import { safeParseJson } from '@common/parsing/safeParseJson';
+import { DELIVERY_TAG, DELIVERY_TAGS } from '@shared/deliveryTags';
 
-const SUBAGENT_TAG_RE = /^<subagent-(?:progress|result|error)\b/;
+// Derived from the single owned DELIVERY_TAGS list (@shared/deliveryTags),
+// same derivation pattern UserMessage.ts uses for its structured-delivery
+// recognizer — so a future child-run kind only needs one entry there. Before
+// this, a bare `subagent-(?:progress|result|error)` recognizer let
+// `claude-agent-result`/`claude-agent-error`/`codex-result`/`codex-error`
+// leak as raw XML into the CLI transcript and queued follow-ups panel.
+const DELIVERY_TAG_NAMES = DELIVERY_TAGS.map((entry) => entry.tag);
+const SUBAGENT_TAG_RE = new RegExp(`^<(${DELIVERY_TAG_NAMES.join('|')})\\b`);
 const EMBEDDED_SUBAGENT_BLOCK_RE =
   /<subagent-(?:progress|result|error)\b[^>]*\/>|<subagent-(progress|result|error)\b[^>]*>[\s\S]*?<\/subagent-\1>/g;
 const EMBEDDED_SUBAGENT_OPEN_RE =
@@ -164,15 +176,21 @@ export function summarizeSubagentFollowup(text: unknown): string {
   if (normalized === undefined) return EMPTY_FOLLOW_UP_SUMMARY;
 
   const trimmed = normalized.trim();
-  if (!SUBAGENT_TAG_RE.test(trimmed)) return normalized;
+  const tag = SUBAGENT_TAG_RE.exec(trimmed)?.[1];
+  if (!tag) return normalized;
 
-  const agent = attr(trimmed, 'agent') ?? 'subagent';
-
-  if (trimmed.startsWith('<subagent-progress')) {
+  if (tag === DELIVERY_TAG.subagentProgress) {
+    const agent = attr(trimmed, 'agent') ?? 'subagent';
     return `⟳ ${agent} · ${progressDetail(trimmed)}`;
   }
 
-  if (trimmed.startsWith('<subagent-result')) {
+  // Result/error envelopes share one shape across families
+  // (formatChildRunDelivery/formatChildRunError): subagent-*, background-*,
+  // codex-*, claude-agent-*. Agent-CLI producers (codex.ts, claudeAgent.ts)
+  // don't set an `agent` attribute, so fall back to the tag's own family name
+  // (e.g. `codex-result` → `codex`) rather than the generic `subagent`.
+  if (tag.endsWith('-result')) {
+    const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-result'.length);
     const status = attr(trimmed, 'status') ?? 'completed';
     const wall = innerTag(trimmed, 'wall-time');
     const response = innerTag(trimmed, 'response');
@@ -181,12 +199,21 @@ export function summarizeSubagentFollowup(text: unknown): string {
     return preview ? `${head}\n${preview}` : head;
   }
 
-  // <subagent-error>
-  const wall = innerTag(trimmed, 'wall-time');
-  const message = innerTag(trimmed, 'message');
-  const retryable = attr(trimmed, 'retryable') === 'true';
-  const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
-  return message ? `${head}\n${decodeXmlEntities(message)}` : head;
+  if (tag.endsWith('-error')) {
+    const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-error'.length);
+    const wall = innerTag(trimmed, 'wall-time');
+    const message = innerTag(trimmed, 'message');
+    const retryable = attr(trimmed, 'retryable') === 'true';
+    const head = `✗ ${agent} failed${wall ? ` · ${wall}` : ''}${retryable ? ' (retryable)' : ''}`;
+    return message ? `${head}\n${decodeXmlEntities(message)}` : head;
+  }
+
+  // Activity envelopes (github-webhook-activity, execution-activity) wrap a
+  // plain sanitized text body — no attribute schema, so surface its first
+  // line instead of the raw wrapper tags.
+  const body = elementBody(trimmed, tag);
+  const firstLine = body?.split('\n')[0]?.trim();
+  return firstLine || normalized;
 }
 
 export function summarizeFollowupMessage(text: unknown): string {

--- a/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
+++ b/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
@@ -44,6 +44,24 @@ describe('CLI queued follow-up panel display model', () => {
     ]);
   });
 
+  // Regression coverage (issue #7679, codex P2): the recognizer in
+  // subagentFollowup.ts is derived from the full DELIVERY_TAGS vocabulary,
+  // not just `<subagent-*>` — agent-CLI child-run families (codex,
+  // claude-agent) must also render summarized here instead of raw XML.
+  it('summarizes queued claude-agent-result follow-up payloads', () => {
+    const display = queuedFollowUpPanelDisplay({
+      messages: [
+        '<orchestrator-followup><claude-agent-result id="child-q" session-id="s1"><response>Done.</response></claude-agent-result></orchestrator-followup>',
+      ],
+      maxRows: 3,
+      width: 80,
+    });
+
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '1. ✓ claude-agent completed Done.',
+    ]);
+  });
+
   it('keeps malformed queued follow-up entries renderable', () => {
     const display = queuedFollowUpPanelDisplay({
       messages: [undefined as unknown as string],

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -240,4 +240,56 @@ describe('summarizeSubagentFollowup', () => {
       ),
     ).toBe('✗ lean failed · 1sec\nrate limit: <tokens> & retries exhausted');
   });
+
+  // Recognizer is derived from @shared/deliveryTags' DELIVERY_TAGS (11
+  // entries), not just `<subagent-*>` — regression coverage for
+  // claude-agent-result/error and codex-result/error leaking as raw XML in
+  // the CLI transcript/queued follow-ups panel (codex review, issue #7679).
+  // One case per newly-recognized tag family.
+
+  it('summarizes a background-result block, falling back to the tag family name', () => {
+    const xml = [
+      '<background-result id="abc" command="npm test">',
+      '<wall-time>3sec</wall-time>',
+      '</background-result>',
+    ].join('\n');
+    expect(summarizeSubagentFollowup(xml)).toBe('✓ background completed · 3sec');
+  });
+
+  it('summarizes a codex-result block without an agent attribute', () => {
+    const xml = [
+      '<codex-result id="abc" thread-id="t1">',
+      '<wall-time>4sec</wall-time>',
+      '<response>Refactor complete.</response>',
+      '</codex-result>',
+    ].join('\n');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '✓ codex completed · 4sec\nRefactor complete.',
+    );
+  });
+
+  it('summarizes a claude-agent-error block without an agent attribute', () => {
+    const xml = [
+      '<claude-agent-error id="abc">',
+      '<message>Provider returned 500 &amp; retried</message>',
+      '</claude-agent-error>',
+    ].join('\n');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '✗ claude-agent failed\nProvider returned 500 & retried',
+    );
+  });
+
+  it('summarizes a github-webhook-activity block as its first body line', () => {
+    const xml =
+      '<github-webhook-activity>\nPR #42 opened by octocat\n</github-webhook-activity>';
+    expect(summarizeSubagentFollowup(xml)).toBe('PR #42 opened by octocat');
+  });
+
+  it('summarizes an execution-activity block as its first body line', () => {
+    const xml =
+      '<execution-activity>\nexec-1 (research, toolUse) running → completed\n</execution-activity>';
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      'exec-1 (research, toolUse) running → completed',
+    );
+  });
 });

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -253,7 +253,9 @@ describe('summarizeSubagentFollowup', () => {
       '<wall-time>3sec</wall-time>',
       '</background-result>',
     ].join('\n');
-    expect(summarizeSubagentFollowup(xml)).toBe('✓ background completed · 3sec');
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      '✓ background completed · 3sec',
+    );
   });
 
   it('summarizes a codex-result block without an agent attribute', () => {

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -1,0 +1,71 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component type
+import type { UserMessage } from '@progressView/frontend/components/UserMessage';
+
+// Local imports - single owned delivery-tag list this suite pins against
+import { DELIVERY_TAGS } from '@shared/deliveryTags';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+async function mount(text: string): Promise<UserMessage> {
+  const element = document.createElement('user-message') as UserMessage;
+  element.text = text;
+  element.logId = 'log-1';
+  element.timestamp = Date.now();
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+/**
+ * Pins the DELIVERY_TAGS list (@shared/deliveryTags) to the UserMessage
+ * renderer: one case per tag so a future child-run kind added there without
+ * a matching render behaves is caught here, not by raw XML leaking into the
+ * transcript (the claude-agent-result/error bug this suite guards against).
+ */
+describe('user-message structured delivery', () => {
+  useLitComponentTestDom(() =>
+    import('@progressView/frontend/components/UserMessage'),
+  );
+
+  for (const { tag, escaped } of DELIVERY_TAGS) {
+    it(`renders <${tag}> as a structured delivery bubble`, async () => {
+      const body = escaped ? 'a &amp; b' : 'a & b';
+      const element = await mount(`<${tag} id="x">${body}</${tag}>`);
+
+      const bubble = element.shadowRoot?.querySelector('.user-message');
+      expect(
+        bubble?.classList.contains('user-message--structured-delivery'),
+      ).toBe(true);
+      expect(
+        element.shadowRoot?.querySelector(
+          '.user-message-content.markdown-content',
+        ),
+      ).toBeTruthy();
+
+      // The raw-copy affordance (and the entity-decoding it exists for) only
+      // applies to the XML-escaped subset.
+      const rawCopyButton = element.shadowRoot?.querySelector(
+        '#user-message-raw-copy-button',
+      );
+      expect(Boolean(rawCopyButton)).toBe(escaped);
+    });
+  }
+
+  it('renders plain (non-delivery) text as an unstructured message', async () => {
+    const element = await mount('hello world');
+
+    const bubble = element.shadowRoot?.querySelector('.user-message');
+    expect(
+      bubble?.classList.contains('user-message--structured-delivery'),
+    ).toBe(false);
+    expect(
+      element.shadowRoot?.querySelector(
+        '.user-message-content.markdown-content',
+      ),
+    ).toBeFalsy();
+  });
+});

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -23,7 +23,7 @@ async function mount(text: string): Promise<UserMessage> {
 /**
  * Pins the DELIVERY_TAGS list (@shared/deliveryTags) to the UserMessage
  * renderer: one case per tag so a future child-run kind added there without
- * a matching render behaves is caught here, not by raw XML leaking into the
+ * a matching render is caught here, not by raw XML leaking into the
  * transcript (the claude-agent-result/error bug this suite guards against).
  */
 describe('user-message structured delivery', () => {

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -27,8 +27,8 @@ async function mount(text: string): Promise<UserMessage> {
  * transcript (the claude-agent-result/error bug this suite guards against).
  */
 describe('user-message structured delivery', () => {
-  useLitComponentTestDom(() =>
-    import('@progressView/frontend/components/UserMessage'),
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/UserMessage'),
   );
 
   for (const { tag, escaped } of DELIVERY_TAGS) {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -43,6 +43,7 @@ import {
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
+import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { type ToolResult } from '@shared/schemas/toolResult';
@@ -158,7 +159,7 @@ function formatClaudeDelivery(
       : undefined;
   return formatChildRunDelivery(
     {
-      tag: 'claude-agent-result',
+      tag: DELIVERY_TAG.claudeAgentResult,
       executionId,
       prompt,
       attributes: [{ name: 'session-id', value: turn.sessionId || null }],
@@ -485,7 +486,7 @@ function startClaudeAgentLoop(params: {
       formatClaudeDelivery(executionId, lastPrompt, wallTimeMs, turn),
     formatError: (turn, err) =>
       formatChildRunError(
-        { tag: 'claude-agent-error', executionId, prompt: lastPrompt },
+        { tag: DELIVERY_TAG.claudeAgentError, executionId, prompt: lastPrompt },
         {
           message: toErrorMessage(
             err ?? turn?.errorMessage ?? turn?.finalResponse,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -48,6 +48,7 @@ import type {
   TodoItem,
   ToolUseLog,
 } from '@shared/schemas';
+import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
@@ -145,7 +146,7 @@ function formatCodexDelivery(
 ): string {
   return formatChildRunDelivery(
     {
-      tag: 'codex-result',
+      tag: DELIVERY_TAG.codexResult,
       executionId,
       prompt,
       attributes: [{ name: 'thread-id', value: threadId || null }],
@@ -441,7 +442,7 @@ function startCodexLoop(params: {
       formatCodexDelivery(executionId, lastPrompt, wallTimeMs, turn, thread.id),
     formatError: (_turn, err) =>
       formatChildRunError(
-        { tag: 'codex-error', executionId, prompt: lastPrompt },
+        { tag: DELIVERY_TAG.codexError, executionId, prompt: lastPrompt },
         { message: toErrorMessage(err) },
       ),
     onSessionCleanup: () => {

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -7,12 +7,13 @@
  * paths (PR / repo / issue).
  */
 
+import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { isNonEmptyString } from '@utils/core';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import type { GhIssueComment } from './prTypes';
 
-const WEBHOOK_TAG = 'github-webhook-activity';
+const WEBHOOK_TAG = DELIVERY_TAG.githubWebhookActivity;
 
 /**
  * Wrap formatter output in the `<github-webhook-activity>` envelope. The

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -18,6 +18,7 @@ import type {
   TodoItem,
   WorkPlanSnapshot,
 } from '@shared/schemas';
+import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { OutputFileSummary } from '@shared/schemas/output';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { countByStatus, STATUS_DISPLAY } from '@shared/schemas/todoDisplay';
@@ -195,7 +196,7 @@ export function formatSubagentDelivery(
 
   return formatChildRunDelivery(
     {
-      tag: 'subagent-result',
+      tag: DELIVERY_TAG.subagentResult,
       executionId: result.executionId,
       attributes: [
         { name: 'agent', value: agentName },
@@ -229,7 +230,7 @@ export function formatSubagentError(
   const formatted = normalizeProviderError(err);
   return formatChildRunError(
     {
-      tag: 'subagent-error',
+      tag: DELIVERY_TAG.subagentError,
       executionId,
       attributes: [
         { name: 'agent', value: agentName },
@@ -260,6 +261,7 @@ export function formatSubagentProgress(
   agentName: string,
   update: SubagentProgressUpdate,
 ): string {
+  const tag = DELIVERY_TAG.subagentProgress;
   const idAttr = `id="${escapeAttr(executionId)}"`;
   const agentAttr = `agent="${escapeAttr(agentName)}"`;
 
@@ -273,9 +275,9 @@ export function formatSubagentProgress(
         })
         .join('\n');
       return [
-        `<subagent-progress ${idAttr} ${agentAttr} type="todos" completed="${completed}" active="${inProgress}" pending="${pending}">`,
+        `<${tag} ${idAttr} ${agentAttr} type="todos" completed="${completed}" active="${inProgress}" pending="${pending}">`,
         items,
-        '</subagent-progress>',
+        `</${tag}>`,
       ].join('\n');
     }
 
@@ -292,18 +294,18 @@ export function formatSubagentProgress(
       if (update.cost !== undefined) {
         attrs.push(`cost="${update.cost.toFixed(4)}"`);
       }
-      return `<subagent-progress ${idAttr} ${agentAttr} ${attrs.join(' ')} />`;
+      return `<${tag} ${idAttr} ${agentAttr} ${attrs.join(' ')} />`;
     }
 
     case 'plan': {
       if (!update.plan) {
-        return `<subagent-progress ${idAttr} ${agentAttr} type="plan" status="cleared" />`;
+        return `<${tag} ${idAttr} ${agentAttr} type="plan" status="cleared" />`;
       }
-      return `<subagent-progress ${idAttr} ${agentAttr} type="plan" status="updated" summary="${escapeAttr(planSummaryLine(update.plan.objective))}" />`;
+      return `<${tag} ${idAttr} ${agentAttr} type="plan" status="updated" summary="${escapeAttr(planSummaryLine(update.plan.objective))}" />`;
     }
 
     case 'started':
-      return `<subagent-progress ${idAttr} ${agentAttr} type="started" />`;
+      return `<${tag} ${idAttr} ${agentAttr} type="started" />`;
   }
 }
 
@@ -366,8 +368,9 @@ export function formatBashDelivery(
 ): string {
   const stdoutPreview = lastNLines(outputTail, OUTPUT_PREVIEW_LINES);
   const stderrPreview = lastNLines(stderrTail, OUTPUT_PREVIEW_LINES);
+  const tag = DELIVERY_TAG.backgroundResult;
   const lines = [
-    `<background-result id="${escapeAttr(executionId)}" command="${escapeAttr(command)}">`,
+    `<${tag} id="${escapeAttr(executionId)}" command="${escapeAttr(command)}">`,
     `<exit-code>${result.exitCode ?? 'unknown'}</exit-code>`,
     `<wall-time>${formatDuration(wallTimeMs)}</wall-time>`,
   ];
@@ -393,7 +396,7 @@ export function formatBashDelivery(
   if (stderrPreview) {
     lines.push(`<stderr-preview>${escapeText(stderrPreview)}</stderr-preview>`);
   }
-  lines.push('</background-result>');
+  lines.push(`</${tag}>`);
   return lines.join('\n');
 }
 
@@ -406,10 +409,11 @@ export function formatBashError(
   err: unknown,
 ): string {
   const message = toErrorMessage(err);
+  const tag = DELIVERY_TAG.backgroundError;
   return [
-    `<background-error id="${escapeAttr(executionId)}" command="${escapeAttr(command)}">`,
+    `<${tag} id="${escapeAttr(executionId)}" command="${escapeAttr(command)}">`,
     `<message>${escapeText(message)}</message>`,
-    '</background-error>',
+    `</${tag}>`,
   ].join('\n');
 }
 


### PR DESCRIPTION
## What / why

Fixes #7679 (macro-review MIL-1 finding). The child-run delivery-envelope tag
vocabulary (11 tags: `subagent-result/error/progress`,
`background-result/error`, `codex-result/error`, `claude-agent-result/error`,
`github-webhook-activity`, `execution-activity`) had no owning list — each
producer minted tags ad-hoc and `UserMessage.ts:29-56` hand-listed
`STRUCTURED_DELIVERY_TAGS` (9 entries) and `XML_ESCAPED_TAGS` (7 entries)
separately, deriving the recognizer regex from the hand-list. This let
`claude-agent-result`/`claude-agent-error` (added in 37ba7e562) ship without
ever being added to the render list, so those envelopes rendered as **raw
XML** in the ProgressView transcript instead of a structured bubble.

Fix (consume, don't relocate — per the issue's implementation sketch):

- New `src/shared/deliveryTags.ts` exports `DELIVERY_TAGS` (11 entries, each
  with an `escaped: boolean` flag) and a `DELIVERY_TAG` name map. Host-neutral
  (no vscode/Ink/React imports), a sibling of `subagentFollowup.ts` — **not**
  `src/tools/deliveryEnvelope.ts`, which is not webview-importable.
- `UserMessage.ts` now derives `STRUCTURED_DELIVERY_TAGS`, `XML_ESCAPED_TAGS`,
  and the recognizer regex from `DELIVERY_TAGS` instead of hand-listing them.
  Adding `claude-agent-result`/`claude-agent-error` as two entries is the
  actual bug fix — they use the same `formatChildRunDelivery`/
  `formatChildRunError` escaping path as `codex-result`/`codex-error`
  (`escapeText()` on the response/message body), so they're in the escaped
  subset alongside their sibling family.
- The 5 producer modules (`subagentResults.ts`, `codex.ts`, `claudeAgent.ts`,
  `github/formatUtils.ts`, `ExecutionSubscriptionBinder.ts`) now reference
  `DELIVERY_TAG.*` constants instead of repeating the tag string literals —
  producers themselves are untouched otherwise (consume, don't relocate).

Verified the escaped-subset semantics before deriving: the 7 existing
`XML_ESCAPED_TAGS` entries (`background-result/error`, `codex-result/error`,
`subagent-progress/result/error`) carry over unchanged; `github-webhook-activity`
and `execution-activity` stay unescaped (they go through
`wrapAndSanitizeTag()`, which neutralizes embedded tag names rather than
XML-entity-escaping, so decoding would be a no-op/wrong for them).

## Verification

- `npx vitest run src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts` — new suite, 12/12 pass (one case per `DELIVERY_TAGS` entry + one plain-text control case)
- `npx vitest run src/test-kernel/tools/SubagentResults.vitest.ts src/test-kernel/tools/GitHubPREventFormatting.vitest.ts src/test-kernel/tools/GitHubSubscriptionTool.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts` — 56/56 pass (producer modules touched by this PR)
- `npm run typecheck` — passes (root `tsc --noEmit`, test-kernel project, and the `texra`/`@texra-ai/cli`/`@texra/trace-viewer` sub-typechecks)
- `npx eslint` on all 8 touched/added files — clean (0 errors, 0 warnings after fixing one `import/order` warning)

## Net elements (R6)

- Added: `src/shared/deliveryTags.ts` (56 lines) — one new owned const module.
- Added: `src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts` (71 lines) — new suite (none existed for this component).
- Deleted: 2 hand-lists in `UserMessage.ts` (`STRUCTURED_DELIVERY_TAGS` literal array, `XML_ESCAPED_TAGS` literal `Set`), replaced by derivations from `DELIVERY_TAGS`.
- Modified (no new exports/files): `subagentResults.ts`, `codex.ts`, `claudeAgent.ts`, `github/formatUtils.ts`, `ExecutionSubscriptionBinder.ts` — tag string literals swapped for `DELIVERY_TAG.*` references.
- Diff stat: 8 files changed, 162 insertions(+), 42 deletions(-) (bulk of insertions is the new const module + new test suite, both required by the sketch — "add a future child-run kind = one list entry" is now true; a new render-surface test is the same one-line-per-tag pattern).

## Consumer counts (R8)

Not a deletion/re-route of an emit path or export — this PR only changes
*how* 5 producer modules obtain existing tag string literals (import a
constant instead of typing the literal) and *how* `UserMessage.ts` computes
its already-existing `STRUCTURED_DELIVERY_TAGS`/`XML_ESCAPED_TAGS`/regex
locals (derived instead of hand-typed). No public API, emitted event shape,
or XML wire format changed — `n/a`.

## Verified

- `packages/extension/src/progressView/frontend/components/UserMessage.ts` (the render surface, :29-56 before this PR)
- `src/tools/deliveryEnvelope.ts` (confirmed not webview-importable, per the sketch's explicit rejection)
- `src/tools/subagentResults.ts`, `src/tools/codex.ts`, `src/tools/claudeAgent.ts`, `src/tools/github/formatUtils.ts`, `src/agent/runtime/ExecutionSubscriptionBinder.ts` (all 5 producer modules)
- `src/shared/subagentFollowup.ts` (sibling module referenced by the sketch; kept separate since it's scoped to `<subagent-*>` parsing/summarization, not the full tag vocabulary)
- CLI (`packages/cli/src`) and `src/agent/followUp` — grepped for any hand-listed copies of the 11 tag names; none found, so no additional consumer needed updating

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shared vocabulary and display-path refactor only; XML wire format and public APIs are unchanged, with regression tests per tag.
> 
> **Overview**
> Introduces **`@shared/deliveryTags`** as the single owned list of 11 child-run delivery envelope XML tags (`DELIVERY_TAG` map plus per-tag **`escaped`** flag), so producers and render surfaces no longer maintain separate hand-written vocabularies.
> 
> **ProgressView `UserMessage`** now derives structured-delivery recognition, the matcher regex, and the XML-entity decode subset from **`DELIVERY_TAGS`** instead of local arrays—adding **`claude-agent-result`** / **`claude-agent-error`** to that list fixes envelopes that previously showed as **raw XML** instead of structured bubbles.
> 
> Five producer call sites (**`subagentResults`**, **`codex`**, **`claudeAgent`**, **`github/formatUtils`**, **`ExecutionSubscriptionBinder`**) switch from string literals to **`DELIVERY_TAG.*`**. **`summarizeSubagentFollowup`** builds its opener regex from the full tag list and generalizes summaries for **`*-result`**, **`*-error`**, and activity envelopes so the CLI queued-follow-ups panel no longer dumps codex/claude-agent XML.
> 
> Regression tests pin one case per **`DELIVERY_TAGS`** entry for **`UserMessage`** rendering and extend CLI follow-up summarization coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0472fd10e071038992f887d4c15fb1bc735eae7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->