### PR TITLE
refactor(tools): delete contextHelpers.ts getRunContext* re-export shim

### DIFF
--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -17,7 +17,10 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { isChildRunLoopActive } from '@agent/runtime/childRunLoop';
 import {
   sendFollowUp,
@@ -42,7 +45,7 @@ import {
   formatSubagentError,
 } from '@tools/subagentResults';
 import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
-import { getRunContextStreamId, requireRunStream } from '@tools/contextHelpers';
+import { requireRunStream } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utils

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -3,11 +3,13 @@ import { toJSONSchema, z } from 'zod';
 
 // Internal imports
 import { platform } from '@platform/platform';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextWorkingDirectory,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import * as logger from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { type ToolResult, ToolError } from '@shared/schemas/toolResult';
-import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -25,7 +25,11 @@ import {
   resolveExecutionWorkspaceFilePath,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import {
   AgentExecutionHandle,
@@ -42,12 +46,7 @@ import {
 } from '@shared/constants/toolDefaults';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import {
-  getRunContextExecutionId,
-  getRunContextStreamId,
-  requireRunStream,
-  requireStreamId,
-} from '@tools/contextHelpers';
+import { requireRunStream, requireStreamId } from '@tools/contextHelpers';
 import { assertNoParentTraversal } from '@tools/pathResolution';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { clamp, unique } from '@utils/core';

--- a/src/tools/OpenPdfTool.ts
+++ b/src/tools/OpenPdfTool.ts
@@ -2,12 +2,14 @@
 import { z } from 'zod';
 
 // Local imports - runtime
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 
 // Type imports
 import type { FileLocation } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { getRunContextExecutionId } from '@tools/contextHelpers';
 
 // Local imports - tools
 import {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -5,7 +5,10 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 // Local imports - tool definitions
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
@@ -14,7 +17,6 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
-import { getRunContextExecutionId } from '@tools/contextHelpers';
 import {
   appendApprovalDiffNote,
   requestApprovedEditContent,

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { getRunContextStreamId, tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import { getRunContextStreamId, tryUseRunContext } from '@agent/runtime/RunContext';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
-import {
-  getRunContextStreamId,
-  requireRuntimeHost,
-} from '@tools/contextHelpers';
+import { requireRuntimeHost } from '@tools/contextHelpers';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,5 +1,9 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextSession,
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   defaultSession,
   type SessionHandle,
@@ -10,10 +14,6 @@ import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { recordToolFileRead } from '@tools/fileInteractions';
-import {
-  getRunContextSession,
-  getRunContextStreamId,
-} from '@tools/contextHelpers';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -16,6 +16,10 @@ import {
   type ToolCallContext,
 } from '@agent/followUp/ToolFileInteractionContext';
 import type { ExecutionInterruptHandler } from '@agent/runtime/ExecutionHandle';
+import {
+  getRunContextExecutionId,
+  getRunContextWorkingDirectory,
+} from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -30,11 +34,7 @@ import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
-import {
-  getRunContextExecutionId,
-  getRunContextWorkingDirectory,
-  requireRunStream,
-} from '@tools/contextHelpers';
+import { requireRunStream } from '@tools/contextHelpers';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -37,16 +37,16 @@ import {
   type ChildRunPorts,
   type ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
-import { MESSAGE_TYPES } from '@shared/schemas';
-import { type ToolResult } from '@shared/schemas/toolResult';
 import {
   getRunContextExecutionId,
   getRunContextStreamId,
   getRunContextWorkingDirectory,
-  requireRunStream,
-} from '@tools/contextHelpers';
+} from '@agent/runtime/RunContext';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
+import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
+import { MESSAGE_TYPES } from '@shared/schemas';
+import { type ToolResult } from '@shared/schemas/toolResult';
+import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds, isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -30,6 +30,11 @@ import {
 } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
+import {
+  getRunContextExecutionId,
+  getRunContextStreamId,
+  getRunContextWorkingDirectory,
+} from '@agent/runtime/RunContext';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   startChildRunLoop,
@@ -46,12 +51,7 @@ import type {
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { CodexSandboxModeSchema } from '@shared/schemas/agentCliSettings';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import {
-  getRunContextExecutionId,
-  getRunContextStreamId,
-  getRunContextWorkingDirectory,
-  requireRunStream,
-} from '@tools/contextHelpers';
+import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { formatWallTimeSeconds } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -2,10 +2,12 @@
 import { z } from 'zod';
 
 // Internal imports
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextWorkingDirectory,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import * as logger from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 

--- a/src/tools/contextHelpers.ts
+++ b/src/tools/contextHelpers.ts
@@ -16,15 +16,6 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 import { ToolError } from '@shared/schemas/toolResult';
 
-export {
-  getRunContextAgentName,
-  getRunContextExecutionId,
-  getRunContextRuntimeHost,
-  getRunContextSession,
-  getRunContextStreamId,
-  getRunContextWorkingDirectory,
-} from '@agent/runtime/RunContext';
-
 /**
  * Return the active RunContext's runtime host, throwing a ToolError if no
  * run is active or the launch had no host. Use from tools that need to

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -19,7 +19,11 @@ import {
   getAgentFlowErrorResult,
   type AgentFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  getRunContextRuntimeHost,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import { startChildRunLoop } from '@agent/runtime/childRunLoop';
@@ -38,10 +42,6 @@ import {
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
-import {
-  getRunContextExecutionId,
-  getRunContextRuntimeHost,
-} from '@tools/contextHelpers';
 import {
   buildSubagentFailureResultMeta,
   formatSubagentError,

--- a/src/tools/executions/summaryFormat.ts
+++ b/src/tools/executions/summaryFormat.ts
@@ -7,7 +7,10 @@
  */
 
 import type { ChildRecord, ExecutionMeta, TodoEntry } from '@agent/storage';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   AgentExecutionHandle,
   type ExecutionHandle,
@@ -22,7 +25,6 @@ import {
   getAvailablePaths,
   getExecutionStatusInfo,
 } from '../executionFormatters';
-import { getRunContextStreamId } from '../contextHelpers';
 
 /** Options controlling how showSummary renders a result report. */
 export interface ExecutionSummaryOptions {

--- a/src/tools/executions/waitCoordination.ts
+++ b/src/tools/executions/waitCoordination.ts
@@ -4,7 +4,10 @@
  * break a blocking wait early.
  */
 
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   ACTIVE_STATUSES,
   AgentExecutionHandle,
@@ -12,7 +15,6 @@ import {
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { onFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { STREAM_STATUS } from '@shared/schemas';
-import { getRunContextStreamId } from '@tools/contextHelpers';
 
 /**
  * Single-pass check: should the wait endpoint skip blocking on this execution?

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -19,12 +19,12 @@
 
 import { z } from 'zod';
 
-import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   getRunContextWorkingDirectory,
-  requireRunStream,
-} from '@tools/contextHelpers';
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { requireRunStream } from '@tools/contextHelpers';
 import { parseWorkingDirectory } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -1,7 +1,10 @@
 import { Mutex } from 'async-mutex';
 
 import { platform, tryWorkspaceState } from '@platform/platform';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextSession,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   defaultSession,
   type SessionHandle,
@@ -13,7 +16,6 @@ import {
   type Goal,
   type GoalStatus,
 } from '@shared/schemas/goal';
-import { getRunContextSession } from '@tools/contextHelpers';
 import { filterNotNull, unique, hexId12 } from '@utils/core';
 
 const STREAM_KEY_PREFIX = 'goals:byStream:';

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -17,7 +17,12 @@
 
 import { z } from 'zod';
 
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextExecutionId,
+  getRunContextSession,
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   defaultSession,
   type SessionHandle,
@@ -31,12 +36,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import {
-  getRunContextExecutionId,
-  getRunContextSession,
-  getRunContextStreamId,
-  requireRuntimeHost,
-} from '@tools/contextHelpers';
+import { requireRuntimeHost } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 import { formatResultCount } from '@utils/text/stringUtils';
 

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -17,7 +17,10 @@ import {
   wakeQueuedFollowUpStream,
   type FollowUpWakeResult,
 } from '@agent/followUp/ToolUseFollowUp';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextSession,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import {
   defaultSession,
   type SessionHandle,
@@ -31,7 +34,6 @@ import type {
   StreamTabId,
 } from '@shared/schemas';
 import { formatRelativeTime } from '@shared/utils/string';
-import { getRunContextSession } from '@tools/contextHelpers';
 import { truncateSummary, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import {

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -6,14 +6,14 @@ import { z } from 'zod';
 
 // Local imports
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import { tryUseRunContext } from '@agent/runtime/RunContext';
-import { debug } from '@logger/logUtils';
-import { formatRelativeTime } from '@shared/utils/string';
-import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   getRunContextAgentName,
   getRunContextExecutionId,
-} from '@tools/contextHelpers';
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
+import { debug } from '@logger/logUtils';
+import { formatRelativeTime } from '@shared/utils/string';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { splitContentLines } from '@utils/text/stringUtils';

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -2,11 +2,13 @@
 import * as path from 'node:path';
 
 // Local imports - runtime
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextWorkingDirectory,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 
 // Local imports - tools
 import { ToolError } from '@shared/schemas/toolResult';
-import { getRunContextWorkingDirectory } from '@tools/contextHelpers';
 
 // Local imports - core utilities
 import { WorkspaceFS } from '@utils/files';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -20,6 +20,10 @@ import { z } from 'zod';
 // Local imports - tools
 import type { WorkPlanState } from '@agent/core/state/AgentWorkspaceState';
 import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
+import {
+  getRunContextRuntimeHost,
+  getRunContextStreamId,
+} from '@agent/runtime/RunContext';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import {
   getCurrentToolContexts,
@@ -35,11 +39,7 @@ import {
 } from '@shared/schemas/goal';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { proposalApprovalState } from '@tools/approval';
-import {
-  getRunContextRuntimeHost,
-  getRunContextStreamId,
-  requireStreamId,
-} from '@tools/contextHelpers';
+import { requireStreamId } from '@tools/contextHelpers';
 import {
   GoalStore,
   isGoalEnabled,

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -1,7 +1,10 @@
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
-import { tryUseRunContext } from '@agent/runtime/RunContext';
+import {
+  getRunContextStreamId,
+  tryUseRunContext,
+} from '@agent/runtime/RunContext';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { createChannelTrace } from '@logger';
 import {
@@ -10,10 +13,7 @@ import {
   type UserQuestionAnswers,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import {
-  getRunContextStreamId,
-  requireRuntimeHost,
-} from '@tools/contextHelpers';
+import { requireRuntimeHost } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 const logger = createChannelTrace('UserQuestionTool');


### PR DESCRIPTION
## What / Why

Closes #7659, closes #7667 — the R1-dated (2026-07-17) RunScope-train shims.

**#7667 (contextHelpers.ts re-export shim, addressed here):** PR #7666 added six
`getRunContext*` accessors to `RunContext.ts` and re-exported them from
`src/tools/contextHelpers.ts` (lines ~19-26) as a pure pass-through alias with
no added logic. Per #6951's binding rule, "Temporary exceptions (shims,
aliases, dual-writes, projections) are legal only with a #6981 ledger row and a
removal trigger. No row, no merge." The PR merged with neither. This PR follows
the issue's preferred option 1: inline the imports at every call site and
delete the re-export block.

**#7659 (RunScope dual-write shim on `AgentLaunchContext`/`LaunchRunContext`):
already resolved, no change needed here.** Re-verified at HEAD before starting
— PR #7758 ("Finish RunScope flag collapse", merged 2026-07-09, same day) beat
this PR to it: `AgentLaunchContext` now only carries `runScope: RunScope` (no
more flat `runtimeHost`/`streamId`/`executionId`/`agentName`/
`workingDirectory`/`session` fields), and `LaunchRunContext` in `RunContext.ts`
is `{ kind: 'launch', runScope: RunScope } & RunContextCommon` — no flat
identity fields on either interface. (`BareRunContext`, a distinct variant for
manual/test contexts, intentionally keeps flat fields — that was never what
#7659 flagged.) Confirmed `da227d451` is an ancestor of this branch's base.

## Changes

- `src/tools/contextHelpers.ts`: delete the `export { getRunContext* } from
  '@agent/runtime/RunContext'` re-export block. The file keeps
  `requireRuntimeHost`/`requireStreamId`/`requireRunStream` — real logic
  (throw-if-missing wrappers), not re-exports — and its own import of the
  accessors it composes them from.
- 22 referencing files: retarget `getRunContext*` imports from
  `@tools/contextHelpers` to `@agent/runtime/RunContext`, merging with each
  file's existing `RunContext` import where one already existed (14 of the 22
  already imported `tryUseRunContext` from there). 12 files no longer import
  `contextHelpers.ts` at all after the change; 10 still do, for
  `requireRuntimeHost`/`requireStreamId`/`requireRunStream`.

## Net elements (R6)

- Files changed: 23 (`contextHelpers.ts` + 22 referencing files).
- No new files, exports, or classes added.
- Deleted: the 6-line `export { ... } from '@agent/runtime/RunContext'`
  re-export block (8 lines incl. braces) from `contextHelpers.ts`.
- Diff: +102 / -94 (net +8 LoC) — the "+" side is import-list churn spread
  across 22 files (each retargeted import needs its own `from` clause), not
  new logic; no behavior change.

## Consumer counts (R8)

Re-routing the `getRunContext*` import path, so per the rule:

- `grep -rl "@tools/contextHelpers\|\.\./contextHelpers\|\./contextHelpers" --include="*.ts" src packages` → **22 files** before this change (matches issue's "~21" estimate; the extra one is `src/tools/executions/summaryFormat.ts`, which uses a relative `'../contextHelpers'` import the alias-only grep in the issue missed).
- After: `grep -rln "getRunContext.*from '.*contextHelpers'"` → **0** (re-export fully removed).
- After: `grep -rl "@tools/contextHelpers\|\.\./contextHelpers\|\./contextHelpers"` → **10 files** (the ones still using `requireRuntimeHost`/`requireStreamId`/`requireRunStream`, which remain real functions in `contextHelpers.ts`, not re-exports).

## Verification

- `npm run typecheck` — the workspace-wide script (root `tsc --noEmit`, the test-kernel project, `texra` (extension) typecheck, `@texra-ai/cli` typecheck, `@texra/trace-viewer` typecheck) — all passed, 0 errors.
- `npm run lint` — 0 errors (49 pre-existing warnings elsewhere in the repo, none in touched files).
- Targeted: `npx vitest run --config vitest.config.mjs src/test-kernel/tools/ src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts` → **80 files / 478 tests passed**.
- Full suite: `npm test` → **611 files passed, 1 skipped (612); 5304 tests passed, 4 skipped (5308)**.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; remaining contextHelpers APIs are unchanged.
> 
> **Overview**
> Removes the **pass-through re-export** of six `getRunContext*` helpers from `contextHelpers.ts` and imports them **directly from `@agent/runtime/RunContext`** at tool and approval call sites (22 files).
> 
> `contextHelpers.ts` **keeps** the throw-if-missing wrappers (`requireRuntimeHost`, `requireStreamId`, `requireRunStream`); only the alias layer is deleted. **No runtime behavior change**—import path cleanup tied to removing an undocumented shim (#7667).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d2a391f41a8f109ccb39c2c876446cd51b0544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->