### PR TITLE
fix: clear transcript response correlator before tools

### DIFF
--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -120,6 +120,41 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     expect(modelResponseEntries[1]?.id).not.toBe(output.id);
   });
 
+  it('does not let an earlier invocation in the same round stage overwrite a later finalized response', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:inner-round-reset' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const round = trace.openStage('r0', { kind: 'round', index: 0 });
+    round.run(() => {
+      const toolRequest = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+      toolRequest.append('I will inspect the file.');
+      toolRequest.finalize();
+
+      trace.toolStart({
+        logId: 'tool:read',
+        toolName: 'read',
+        input: { path: 'paper.tex' },
+      });
+      trace.toolEnd({ logId: 'tool:read', status: 'completed' });
+
+      trace.responseFinalized('The file contains the theorem statement.');
+    });
+    round.end();
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const modelResponseEntries = entries.filter(
+      (e) => e.messageType === MESSAGE_TYPES.MODEL_RESPONSE,
+    );
+    expect(modelResponseEntries.map((e) => e.text)).toEqual([
+      'I will inspect the file.',
+      'The file contains the theorem statement.',
+    ]);
+    expect(modelResponseEntries[1]?.id).not.toBe(modelResponseEntries[0]?.id);
+  });
+
   it('ignores an empty finalized response', () => {
     const trace = new TraceEmitter();
     const store = new StreamLogStore();

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -113,12 +113,13 @@ export function attachTranscriptRecorder(
   // rely on that distinction to tell a root run's terminal status apart from
   // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
   const stageKinds = new Map<string, 'run' | 'round' | 'phase' | 'session'>();
-  // Id of the round's own MODEL_RESPONSE stream entry, so a subsequent
-  // `response.finalized` event (#7086) can upsert that entry's text instead
-  // of appending a duplicate row. Set on `stream.start` for a MODEL_RESPONSE
-  // stream, consumed (and cleared) by `response.finalized`, and reset at
-  // every round boundary so a round that never streamed can't accidentally
-  // reuse an earlier round's stream id.
+  // Id of the current model invocation's MODEL_RESPONSE stream entry, so a
+  // subsequent `response.finalized` event (#7086) can upsert that entry's text
+  // instead of appending a duplicate row. Set on `stream.start` for a
+  // MODEL_RESPONSE stream, consumed (and cleared) by `response.finalized`, and
+  // reset when the invocation proceeds to tool execution. A single tool-use
+  // round stage can contain several model invocations, so the outer round
+  // stage is too coarse to be the only reset boundary.
   let pendingModelResponseId: string | undefined;
 
   const flushStream = (state: StreamSinkState, id: string): void => {
@@ -256,6 +257,7 @@ export function attachTranscriptRecorder(
       }
 
       case 'tool.start':
+        pendingModelResponseId = undefined;
         // event.logId is the canonical id — SDK consumers correlate
         // tool.start/end by it and the store entry shares the same id so
         // callers can lookup with store.get(streamId).find(e => e.id === logId).


### PR DESCRIPTION
## Summary
- clear the transcript recorder model-response correlator when a streamed invocation proceeds to tool execution
- preserve the existing #7086 upsert path for the current invocation
- add a regression test for two model invocations inside one outer tool-use round stage

Fixes #7782.

## Validation
- `corepack pnpm install` (new worktree dependency setup)
- `npx vitest run --config vitest.config.mjs src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; existing import-order warnings)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to transcript event correlation with a targeted regression test; no auth, persistence schema, or API surface changes.
> 
> **Overview**
> Fixes transcript corruption when a **single tool-use round** runs more than one model invocation: an earlier streamed `MODEL_RESPONSE` was still linked via `pendingModelResponseId`, so a later `response.finalized` could **upsert** that row instead of appending a new one.
> 
> **`attachTranscriptRecorder`** now clears `pendingModelResponseId` on **`tool.start`** (in addition to round `stage.start`), so the #7086 upsert path only applies to the **current** invocation before tools run. A regression test covers stream → tool → `response.finalized` inside one round and expects two distinct `MODEL_RESPONSE` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f4dce047bc0ca77b9ba5ed5157db43f7a12695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->