### PR TITLE
docs(agent-core): fix stale RunScope/AgentLaunchContext comments

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -122,13 +122,11 @@ const STATUS_MESSAGES: Record<string, string> = {
  * This is the single owner of the launch-context → ambient-context mapping, so
  * new per-run flags (e.g. `stopAfterCycle`, `approvalPromptsUnavailable`,
  * `runtimeUnavailableTools`) live in one place and are never silently dropped.
- * The ambient context is intentionally a flat projection, so two fields are
- * renamed from their nested `AgentCore` positions:
- *  - `AgentConfig.agent`  → `RunContext.agentName`
- *  - `AgentConfig.model`  → `RunContext.model`
- *
- * `RunContext.model` reads through `getModel` so tools observe model switches
- * applied to `AgentLaunchContext.config.model` during an interactive session.
+ * Run identity (`streamId`/`executionId`/`agentName`/`workingDirectory`)
+ * travels via `ctx.runScope` unchanged; only `AgentConfig.model` is renamed
+ * here, to `RunContext.model`, reading through `getModel` so tools observe
+ * model switches applied to `AgentLaunchContext.config.model` during an
+ * interactive session.
  */
 function agentContextToRunContext(
   ctx: AgentLaunchContext,

--- a/src/agent/runtime/RunScope.ts
+++ b/src/agent/runtime/RunScope.ts
@@ -6,11 +6,9 @@ import type { SessionHandle } from './SessionHandle';
 /**
  * Canonical identity and ownership scope for a launched agent run.
  *
- * This object is deliberately smaller than `AgentLaunchContext`: it contains
- * only the facts that identify the run and the session that owns its runtime
- * state. Older flat fields remain on launch contexts for compatibility, but
- * new runtime code should prefer carrying this object when it needs the full
- * run scope.
+ * `AgentLaunchContext` and the ambient `RunContext` both carry this object
+ * (not flat `streamId`/`executionId`/`agentName` fields) whenever they need
+ * run identity or the session that owns runtime state.
  */
 export interface RunScope {
   readonly runtimeHost: AgentRuntimeHost;


### PR DESCRIPTION
## What / Why

Periodic simplify sweep (no issue — cites "periodic simplify sweep" + PR #7676 §10). Scope: code merged in the last ~3 days, hunt class (d) — stale comments describing pre-migration behavior in touched files.

`da227d451` ("finish runscope flag collapse", #7758, landed 2026-07-09) deleted the flat `streamId`/`executionId`/`agentName`/`workingDirectory` fields from `AgentLaunchContext` and from `RunContext`'s launch path, consolidating run identity onto `ctx.runScope`. Two doc comments in the same files still described the pre-migration shape:

- `src/agent/runtime/RunScope.ts` — the interface docstring claimed "older flat fields remain on launch contexts for compatibility." They no longer do; `AgentLaunchContext` only carries `runScope: RunScope` for identity.
- `src/agent/runtime/AgentLaunchContext.ts` — `agentContextToRunContext()`'s docstring claimed the projection renames both `AgentConfig.agent` → `RunContext.agentName` and `AgentConfig.model` → `RunContext.model`. Reading the function body confirms it no longer touches `agentName` at all (that field travels via `ctx.runScope`, assigned earlier in the launch pipeline); only `model` is actually projected by this function today.

Both fixes are comment-only — no behavior change.

## Verification

- `npm run typecheck` — passes (all workspace projects).
- `npx eslint src/agent/runtime/RunScope.ts src/agent/runtime/AgentLaunchContext.ts` — clean.
- `npx vitest run src/test-kernel/agent/runtime/RunContext.vitest.ts src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts` — 2 files, 8 tests, all passed.

## Net elements (R6)

- Files touched: 2 (`src/agent/runtime/RunScope.ts`, `src/agent/runtime/AgentLaunchContext.ts`)
- No exports, classes, or functions added or deleted — comment text only.
- Net LoC: **-4** (8 insertions, 12 deletions).

## Consumer counts (R8)

n/a — no emit path, export, or public API surface changed; this PR only edits doc comments inside two existing functions' JSDoc.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or export changes.
> 
> **Overview**
> **Comment-only** alignment after the run-scope collapse (#7758): docstrings no longer describe flat `streamId`/`executionId`/`agentName` on launch contexts or a dual rename of `AgentConfig.agent` and `model` in `agentContextToRunContext`.
> 
> The **`RunScope`** interface doc now states that **`AgentLaunchContext`** and ambient **`RunContext`** carry **`runScope`** for run identity, not legacy flat fields. The **`agentContextToRunContext`** doc now says identity fields travel via **`ctx.runScope`** unchanged and only **`AgentConfig.model`** is projected to **`RunContext.model`** (via **`getModel`** for live model switches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0e0310576684a3c251c16ca15ad7a14a2e370c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->