### PR TITLE
fix: route presentation ndjson through log sink

### DIFF
--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -173,37 +173,39 @@ class NdjsonStdoutSink implements LogSink {
   }
 
   private ensureDrain(): Promise<void> {
-    this.drainPromise ??= this.drain();
+    if (!this.drainPromise) {
+      const promise = this.drain();
+      this.drainPromise = promise;
+      void promise.finally(() => {
+        if (this.drainPromise === promise) {
+          this.drainPromise = undefined;
+        }
+        if (!this.stdoutClosed && this.queue.length > 0) {
+          void this.ensureDrain().catch(() => undefined);
+        }
+      });
+    }
     return this.drainPromise;
   }
 
   private async drain(): Promise<void> {
-    try {
-      while (!this.stdoutClosed && this.queue.length > 0) {
-        const record = this.queue.shift();
-        if (!record) continue;
-        const lineRecord: CliNdjsonRecord = { kind: 'log', ...record };
-        const line = `${JSON.stringify(lineRecord)}\n`;
-        let canContinue: boolean;
-        try {
-          canContinue = process.stdout.write(line);
-        } catch {
-          this.stdoutClosed = true;
-          this.queue.length = 0;
-          return;
-        }
-        if (!canContinue && !(await this.waitForStdoutDrain())) {
-          this.stdoutClosed = true;
-          this.queue.length = 0;
-          return;
-        }
+    while (!this.stdoutClosed && this.queue.length > 0) {
+      const record = this.queue.shift();
+      if (!record) continue;
+      const lineRecord: CliNdjsonRecord = { kind: 'log', ...record };
+      const line = `${JSON.stringify(lineRecord)}\n`;
+      let canContinue: boolean;
+      try {
+        canContinue = process.stdout.write(line);
+      } catch {
+        this.stdoutClosed = true;
+        this.queue.length = 0;
+        return;
       }
-    } finally {
-      if (!this.stdoutClosed && this.queue.length > 0) {
-        this.drainPromise = this.drain();
-        await this.drainPromise;
-      } else {
-        this.drainPromise = undefined;
+      if (!canContinue && !(await this.waitForStdoutDrain())) {
+        this.stdoutClosed = true;
+        this.queue.length = 0;
+        return;
       }
     }
   }

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -39,6 +39,7 @@ export type CliRuntimeHost = AgentRuntimeHost & {
 };
 
 function writeRuntimePresentationNdjson(
+  logger: Logger,
   event: RuntimePresentationEvent,
   payload: RuntimePresentationEventPayloads[RuntimePresentationEvent],
 ): void {
@@ -46,28 +47,16 @@ function writeRuntimePresentationNdjson(
     case 'requestShowError': {
       const errorPayload =
         payload as RuntimePresentationEventPayloads['requestShowError'];
-      writeNdjsonStdout({
-        kind: 'log',
-        ts: new Date().toISOString(),
-        level: 'error',
-        message: errorPayload.message,
-        fields: {},
-      });
+      logger.error(errorPayload.message);
       return;
     }
     case 'requestShowInstruction': {
       const instructionPayload =
         payload as RuntimePresentationEventPayloads['requestShowInstruction'];
-      writeNdjsonStdout({
-        kind: 'log',
-        ts: new Date().toISOString(),
-        level: 'info',
-        message: instructionPayload.message,
-        fields: {
-          key: instructionPayload.key,
-          actions: instructionPayload.actions,
-          showSuppress: instructionPayload.showSuppress,
-        },
+      logger.info(instructionPayload.message, {
+        key: instructionPayload.key,
+        actions: instructionPayload.actions,
+        showSuppress: instructionPayload.showSuppress,
       });
       return;
     }
@@ -124,6 +113,7 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (context.outputFormat === 'ndjson') {
         if (isRuntimePresentationEvent(event)) {
           writeRuntimePresentationNdjson(
+            ensureLogger(),
             event,
             payload as RuntimePresentationEventPayloads[RuntimePresentationEvent],
           );


### PR DESCRIPTION
## Summary
- route runtime presentation NDJSON logs through the CLI logger and `NdjsonStdoutSink` instead of hand-written stdout records
- fix the NDJSON sink drain lifecycle so immediate consecutive writes cannot strand queued records behind an already-completed drain promise

Fixes #7772.

## Validation
- `corepack pnpm install` (new worktree dependency setup)
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/RunProgressRenderer.vitest.mts`
- `npx eslint packages/cli/src/runtime/runtimeHost.ts packages/cli/src/runtime/logSinks.ts`
- `npm run format`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI stdout/NDJSON ordering and backpressure behavior for runtime presentation output; scope is limited to CLI logging infrastructure, not auth or data handling.
> 
> **Overview**
> **NDJSON presentation events** (runtime errors and instructions) now go through the shared CLI `Logger` and `NdjsonStdoutSink` instead of ad-hoc `writeNdjsonStdout` log records, so they share the same queued, backpressure-aware stdout path as other CLI logs.
> 
> **`NdjsonStdoutSink` drain scheduling** is reworked: when a drain finishes, the in-flight promise is cleared and a new drain is started if the queue still has entries. That avoids back-to-back writes leaving records stuck after an already-settled `drainPromise` (issue #7772). Recursive re-drain from inside `drain()`’s `finally` block is removed in favor of this `ensureDrain` + `finally` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217d4e6e9c47ec56a8ddd3e50bc761fea9f479ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->