### PR TITLE
fix(runtime): route requestShowInstruction to CLI stderr and desktop dialog

### DIFF
--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -49,8 +49,7 @@ export type CliRuntimeHost = AgentRuntimeHost & {
  */
 const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
   [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra config)',
-  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]:
-    'see the configuration guide',
+  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
   [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
 };
 

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -16,6 +16,7 @@ import {
 } from '@agent/runtime/runtimePresentationEvents';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
+import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
 
 // Local imports - CLI runtime
 import { handleCliApprovalEvent } from './approvalAdapter';
@@ -36,6 +37,21 @@ export type CliRuntimeHost = AgentRuntimeHost & {
   attachRunProgressRenderer(events: SessionEventHub): () => void;
   prepareInteractivePrompt?: () => void;
   close(): Promise<void>;
+};
+
+/**
+ * Human-readable phrasing for {@link InstructionAction} tokens printed to
+ * stderr in text mode. Mirrors what the VS Code extension's
+ * `INSTRUCTION_ACTION_VIEW` (packages/extension/src/frontend/events/
+ * agentEventListeners.ts) conveys via its button titles, translated to CLI
+ * phrasing since there's no button to click here. Unknown/future tokens fall
+ * back to the raw token rather than failing.
+ */
+const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
+  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra config)',
+  [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]:
+    'see the configuration guide',
+  [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
 };
 
 function writeRuntimePresentationNdjson(
@@ -157,7 +173,9 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         const instructionPayload =
           payload as RuntimePresentationEventPayloads['requestShowInstruction'];
         const hint = instructionPayload.actions?.length
-          ? ` (${instructionPayload.actions.join(', ')})`
+          ? ` (${instructionPayload.actions
+              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
+              .join(', ')})`
           : '';
         ensureLogger().info(`${instructionPayload.message}${hint}`);
         return;

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -149,6 +149,20 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
         return;
       }
 
+      if (event === 'requestShowInstruction') {
+        // Not gated by quietLogs (below): unlike the debug fallback, this is
+        // an actionable instruction (e.g. missing API key), not routine
+        // progress noise.
+        runProgress?.preserve();
+        const instructionPayload =
+          payload as RuntimePresentationEventPayloads['requestShowInstruction'];
+        const hint = instructionPayload.actions?.length
+          ? ` (${instructionPayload.actions.join(', ')})`
+          : '';
+        ensureLogger().info(`${instructionPayload.message}${hint}`);
+        return;
+      }
+
       if (context.quietLogs) return;
 
       ensureLogger().debug(`Runtime event: ${String(event)}`);

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1024,6 +1024,7 @@ export class DesktopProgressBridge {
         );
         return;
       case 'requestShowError':
+      case 'requestShowInstruction':
         this.sessionProgress.handlePresentationEvent(
           event,
           payload as DesktopPresentationPayloads[typeof event],

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -20,6 +20,7 @@ import {
   type ProgressViewOutboundMessage,
   type RequestEnsureProgressViewPayload,
   type RequestShowErrorPayload,
+  type RequestShowInstructionPayload,
   type RestoredStreamSnapshot,
   type SetActiveStreamPayload,
   type StreamTabId,
@@ -58,13 +59,17 @@ export interface DesktopSessionProgressBridgeOptions {
     active: boolean,
     opts?: { status?: GoalStatus; objective?: string },
   ) => void;
-  /** Called when a `requestShowError` event fires. */
+  /**
+   * Called when a `requestShowError` (or `requestShowInstruction`, folded
+   * into the same dialog surface) event fires.
+   */
   onShowError: (message: string) => void;
 }
 
 export interface DesktopPresentationPayloads {
   requestEnsureProgressView: RequestEnsureProgressViewPayload;
   requestShowError: RequestShowErrorPayload;
+  requestShowInstruction: RequestShowInstructionPayload;
 }
 
 export type DesktopPresentationEvent = keyof DesktopPresentationPayloads;
@@ -231,6 +236,13 @@ class DesktopSessionProgressBridgeImpl implements DesktopSessionProgressBridge {
         return;
       case 'requestShowError': {
         const data = payload as RequestShowErrorPayload;
+        this.opts.onShowError(data.message);
+        return;
+      }
+      case 'requestShowInstruction': {
+        // No second dialog surface: fold the instruction into the same
+        // error-dialog path `requestShowError` uses (one dialog per host).
+        const data = payload as RequestShowInstructionPayload;
         this.opts.onShowError(data.message);
         return;
       }

--- a/src/shared/agent/terminalResultPresentation.ts
+++ b/src/shared/agent/terminalResultPresentation.ts
@@ -29,7 +29,7 @@ export type TerminalResultToast =
     };
 
 const MISSING_API_KEY_MESSAGE =
-  'API key not found. Set your API key in the extension settings and run again.';
+  'API key not found. Set your API key in Settings and run again.';
 
 /**
  * Map a terminal `result` event to the toast a host should present, or `null`

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -16,6 +16,7 @@ import {
   type ActiveChildInfo,
   type ConversationProgress,
   type ExecutionId,
+  type InstructionAction,
   type RoundStage,
   type StreamPhase,
   type StreamTabId,
@@ -1070,7 +1071,7 @@ describe('CLI run progress renderer', () => {
     expect(stdout).toBe('');
   });
 
-  it('prints requestShowInstruction text and action hint to stderr in text mode', async () => {
+  it('prints requestShowInstruction text and a human-readable action hint to stderr in text mode', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
       const host = createCliRuntimeHost(context({ outputFormat: 'text' }));
 
@@ -1085,9 +1086,31 @@ describe('CLI run progress renderer', () => {
       await host.close();
     });
 
+    // The raw InstructionAction tokens are translated to human phrasing
+    // (mirroring the extension's INSTRUCTION_ACTION_VIEW), not printed
+    // verbatim.
     expect(output).toContain(
-      'API key not found. Set your API key in Settings and run again. (set-api-key, open-configuration-guide)',
+      'API key not found. Set your API key in Settings and run again. (set your API key (texra config), see the configuration guide)',
     );
+    expect(output).not.toContain('set-api-key');
+    expect(output).not.toContain('open-configuration-guide');
+  });
+
+  it('falls back to the raw token for an unrecognized action in the instruction hint', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const host = createCliRuntimeHost(context({ outputFormat: 'text' }));
+
+      host.emit('requestShowInstruction', {
+        key: 'futureInstruction',
+        message: 'Something needs attention.',
+        actions: ['some-future-action' as InstructionAction],
+        showSuppress: false,
+      });
+
+      await host.close();
+    });
+
+    expect(output).toContain('Something needs attention. (some-future-action)');
   });
 
   it('does not gate requestShowInstruction behind quietLogs in text mode', async () => {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1070,6 +1070,44 @@ describe('CLI run progress renderer', () => {
     expect(stdout).toBe('');
   });
 
+  it('prints requestShowInstruction text and action hint to stderr in text mode', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const host = createCliRuntimeHost(context({ outputFormat: 'text' }));
+
+      host.emit('requestShowInstruction', {
+        key: 'missingApiKey',
+        message:
+          'API key not found. Set your API key in Settings and run again.',
+        actions: ['set-api-key', 'open-configuration-guide'],
+        showSuppress: false,
+      });
+
+      await host.close();
+    });
+
+    expect(output).toContain(
+      'API key not found. Set your API key in Settings and run again. (set-api-key, open-configuration-guide)',
+    );
+  });
+
+  it('does not gate requestShowInstruction behind quietLogs in text mode', async () => {
+    const output = await captureStreamWrites(process.stderr, async () => {
+      const host = createCliRuntimeHost(
+        context({ outputFormat: 'text', quietLogs: true }),
+      );
+
+      host.emit('requestShowInstruction', {
+        key: 'missingApiKey',
+        message:
+          'API key not found. Set your API key in Settings and run again.',
+      });
+
+      await host.close();
+    });
+
+    expect(output).toContain('API key not found.');
+  });
+
   it('writes projected subagent progress records to stdout in ndjson mode', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
       const events = new SessionEventHub();

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -734,12 +734,25 @@ describe('DesktopProgressBridge', () => {
       bridge.handleInteractionEvent('requestShowError', {
         message: 'Root run failed',
       });
+      bridge.handleInteractionEvent('requestShowInstruction', {
+        key: 'missingApiKey',
+        message:
+          'API key not found. Set your API key in Settings and run again.',
+        actions: ['set-api-key', 'open-configuration-guide'],
+        showSuppress: false,
+      });
 
       expect(messages).toContainEqual({
         command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
         route: 'progress',
       });
       expect(showErrorMessage).toHaveBeenCalledWith('Root run failed');
+      // Folded into the same dialog surface as requestShowError — no second
+      // subscribe surface or dialog for instructions.
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        'API key not found. Set your API key in Settings and run again.',
+      );
+      expect(showErrorMessage).toHaveBeenCalledTimes(2);
     } finally {
       bridge.dispose();
     }

--- a/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
@@ -411,6 +411,28 @@ describe('DesktopSessionProgressBridge', () => {
         bridge.dispose();
       }
     });
+
+    it('folds requestShowInstruction into the same dialog surface as requestShowError', () => {
+      const onShowError = vi.fn();
+      const bridge = createBridge({ onShowError });
+
+      try {
+        bridge.handlePresentationEvent('requestShowInstruction', {
+          key: 'missingApiKey',
+          message:
+            'API key not found. Set your API key in Settings and run again.',
+          actions: ['set-api-key', 'open-configuration-guide'],
+          showSuppress: false,
+        });
+
+        expect(onShowError).toHaveBeenCalledTimes(1);
+        expect(onShowError).toHaveBeenCalledWith(
+          'API key not found. Set your API key in Settings and run again.',
+        );
+      } finally {
+        bridge.dispose();
+      }
+    });
   });
 
   describe('handleSessionEvent', () => {


### PR DESCRIPTION
## What / Why

Fixes #7644 (Finding EP-3, medium). `requestShowInstruction` — the actionable
missing-API-key toast (SET_API_KEY / OPEN_CONFIGURATION_GUIDE) and the
missing-output-files notice — only reached the VS Code extension. CLI silently
swallowed it into a debug log; desktop had no handler at all. Also fixes the
host-neutral `@shared` message that hardcoded "the extension settings" even
though CLI/desktop users have no such settings surface.

Follows the maintainer-approved Decision + implementation sketch on the issue
exactly:

1. **CLI** (`packages/cli/src/runtime/runtimeHost.ts`): added a real
   `requestShowInstruction` branch in the text-mode emit path (mirroring the
   adjacent `requestShowError` branch) that prints the instruction message +
   its action-token hint to stderr. Placed *before* the `quietLogs` early
   return, so the instruction itself is never suppressed by `--quiet` (only
   the generic debug-log fallback is gated).
2. **Desktop** (`packages/desktop/src/main/desktopSessionProgressBridge.ts` +
   `desktopAgentExecution.ts`): folded `requestShowInstruction` into the same
   `onShowError` dialog callback `requestShowError` already uses — one dialog
   surface per host, no second surface, no new option added to
   `DesktopSessionProgressBridgeOptions`.
3. **De-hardcode** (`src/shared/agent/terminalResultPresentation.ts`):
   reworded `MISSING_API_KEY_MESSAGE` from "Set your API key in the extension
   settings" to host-neutral "Set your API key in Settings".

No new subscribe surface, no cross-host instruction reducer — the CLI ndjson
path (already routing `requestShowInstruction` to a structured log record)
and the extension's existing handler are untouched.

## Verification

- `npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/shared/terminalResultPresentation.vitest.ts` → 4 files, 120 tests passed (includes 4 new tests: 2 CLI text-mode instruction/quietLogs tests, 2 desktop bridge/execution instruction-folding tests).
- `npm run typecheck` → clean (root, test-kernel, cli, desktop, trace-viewer projects).
- `npx prettier --check` on the touched production files (clean); ran `--write` on the touched test files to match repo formatting.

## Net elements (R6)

- 0 new files, 0 new exports/classes/interfaces added as standalone surfaces.
- `DesktopPresentationPayloads` gained one member (`requestShowInstruction`) on
  the existing discriminated map — not a new type.
- Production diff: +30/-2 across 3 files (`runtimeHost.ts`,
  `desktopAgentExecution.ts`, `desktopSessionProgressBridge.ts`,
  `terminalResultPresentation.ts`), in line with the sketch's ~+20 LoC
  estimate.
- Test diff: +38/-0 (CLI), +22/-0 + +13/-0 (desktop) — additive coverage only,
  extended the existing per-module suites (no new test files, per R7).

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed away from an existing
consumer. `requestShowInstruction` gained additional consumers (CLI stderr,
desktop dialog) without removing the extension's existing handler or the
CLI's existing ndjson-mode handling.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive presentation routing and copy change; extension and CLI ndjson behavior unchanged; covered by targeted tests.
> 
> **Overview**
> **`requestShowInstruction`** (e.g. missing API key, configuration hints) now reaches **CLI** and **desktop** hosts instead of being dropped or buried in debug logs.
> 
> In **CLI text mode**, `runtimeHost` handles the event like `requestShowError`: it preserves run progress, logs the message to **stderr** with optional **human-readable action hints** (mapped from `InstructionAction` tokens; unknown actions stay as raw tokens), and runs **before** the `quietLogs` guard so `--quiet` does not hide actionable instructions.
> 
> **Desktop** wires the same presentation event through `desktopAgentExecution` into `desktopSessionProgressBridge`, which shows the instruction message via the existing **`onShowError`** dialog path—no separate instruction UI.
> 
> The shared **`MISSING_API_KEY_MESSAGE`** in `terminalResultPresentation.ts` is reworded from “extension settings” to host-neutral **“Settings”**.
> 
> Tests cover CLI hints, quiet bypass, desktop folding into `showErrorMessage`, and the updated copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70bb8eb0901a7d7f3a07b693bcfc665021148de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->