### PR TITLE
fix: hide setup-platform tools outside extension

### DIFF
--- a/packages/cli/src/runtime/unavailableTools.ts
+++ b/packages/cli/src/runtime/unavailableTools.ts
@@ -1,5 +1,6 @@
 import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { SETUP_PLATFORM_TOOL_NAMES } from '@tools/setup/platform';
 
 type CliUnavailableTool =
   RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
@@ -14,9 +15,9 @@ type CliUnavailableTool =
  * that flow, so the `inquiry` tool is excluded from the agent's effective tool
  * list for all CLI runs.
  *
- * The `list_api_keys` audit tool depends on the setup-platform adapter that is
- * currently wired by the VS Code extension host. Hide it until the CLI provides
- * the same SecretStorage enumeration surface.
+ * The setup-platform-backed tools are currently wired only by the VS Code
+ * extension host. Hide them until the CLI provides an honest SetupPlatform
+ * adapter for secrets, commands, extensions, auth, config, and terminal runs.
  *
  * The `inline_comment` tool is backed by VS Code's CommentController, which the
  * CLI has no equivalent for, so it is hidden too.
@@ -30,7 +31,7 @@ type CliUnavailableTool =
  */
 export const CLI_UNAVAILABLE_TOOLS: readonly CliUnavailableTool[] = [
   'inquiry',
-  'list_api_keys',
+  ...SETUP_PLATFORM_TOOL_NAMES,
   'inline_comment',
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -85,6 +85,7 @@ import {
 } from '@tools/approval';
 import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { SETUP_PLATFORM_TOOL_NAMES } from '@tools/setup/platform';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
@@ -114,7 +115,7 @@ type DesktopUnavailableTool =
   RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
 
 const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
-  'list_api_keys',
+  ...SETUP_PLATFORM_TOOL_NAMES,
   'inline_comment',
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
 ];

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -20,6 +20,7 @@ import {
   type TodoItem,
 } from '@shared/schemas';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { SETUP_PLATFORM_TOOL_NAMES } from '@tools/setup/platform';
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
@@ -252,7 +253,7 @@ describe('executeCliRequest', () => {
         approvalPromptsUnavailable: false,
         runtimeUnavailableTools: [
           'inquiry',
-          'list_api_keys',
+          ...SETUP_PLATFORM_TOOL_NAMES,
           'inline_comment',
           DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
         ],
@@ -273,7 +274,7 @@ describe('executeCliRequest', () => {
       expect.objectContaining({
         runtimeUnavailableTools: [
           'inquiry',
-          'list_api_keys',
+          ...SETUP_PLATFORM_TOOL_NAMES,
           'inline_comment',
           DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
           'custom_tool',

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -40,6 +40,7 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { assertSupported } from '@shared/utils/dispatcher';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { SETUP_PLATFORM_TOOL_NAMES } from '@tools/setup/platform';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -2515,7 +2516,7 @@ describe('DesktopProgressBridge', () => {
         expect.objectContaining({
           openWorkflowOutput: expect.any(Function),
           runtimeUnavailableTools: [
-            'list_api_keys',
+            ...SETUP_PLATFORM_TOOL_NAMES,
             'inline_comment',
             DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
           ],

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -100,6 +100,20 @@ export interface SetupPlatform {
   terminal: SetupTerminalAdapter;
 }
 
+/** Tools whose implementation calls {@link getSetupPlatform}. */
+export const SETUP_PLATFORM_TOOL_NAMES = [
+  'probe_environment',
+  'verify_setup',
+  'set_api_key',
+  'unset_api_key',
+  'list_api_keys',
+  'invoke_command',
+  'install_vscode_extension',
+  'read_config',
+  'update_config',
+  'send_to_terminal',
+] as const;
+
 let platform: SetupPlatform | undefined;
 
 /** Register the platform implementation. Called once from `extension.ts`. */


### PR DESCRIPTION
## Summary
- centralize the tool names whose implementations require `getSetupPlatform()`
- hide that full setup-platform-backed family from CLI and desktop runtime tool resolution
- update CLI and desktop runtime tests so the unavailable lists cannot regress to only `list_api_keys`

This is the minimum honest fix for #7748. It avoids inventing a partial desktop/CLI `SetupPlatform` while the current adapter still expects VS Code-specific command, extension, config, secret, auth, and terminal surfaces.

Fixes #7748.

## Validation
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts`
- `npx eslint src/tools/setup/platform.ts packages/cli/src/runtime/unavailableTools.ts packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows the agent tool surface on CLI/desktop to avoid runtime failures when setup tools are invoked without a wired platform; no change to extension behavior or credential handling.
> 
> **Overview**
> Hides the full family of **setup-platform-backed agent tools** from CLI and desktop runs, not only `list_api_keys`, until those hosts provide a real `SetupPlatform` adapter.
> 
> A shared **`SETUP_PLATFORM_TOOL_NAMES`** list in `platform.ts` names every tool that calls `getSetupPlatform()` (environment probe, setup verify, API key get/set/list, config read/update, command invoke, VS Code extension install, terminal send, etc.). **CLI** and **desktop** runtime unavailable-tool lists now spread that constant instead of hard-coding a single tool, with comments updated to match.
> 
> **CLI** and **desktop** tests assert `runtimeUnavailableTools` includes `...SETUP_PLATFORM_TOOL_NAMES` so the exclusion set cannot shrink back to one tool by accident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8f3309d6556d859e601c2bd7f46969dc2194bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->