### PR TITLE
refactor: delete PocketFlow dead width (BatchNode + always-empty params channel)

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -33,7 +33,3 @@ export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {
   onInterrupt?: () => void;
   onRoundFinalized?: RoundFinalizedCallback;
 }
-
-export interface FlowParams {
-  [key: string]: unknown;
-}

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -1,4 +1,3 @@
-import type { NonIterableObject } from '@agent/node';
 import {
   type BaseInvocationPrepResult,
   type BaseInvocationSuccessData,
@@ -64,9 +63,8 @@ type InvocationServices = Pick<
 
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,
-  TParams extends NonIterableObject = NonIterableObject,
   TServices extends InvocationServices = InvocationServices,
-> extends RetryableInvocationNode<TShared, TParams, TServices> {
+> extends RetryableInvocationNode<TShared, TServices> {
   private readonly _config: ModelInvocationConfig<TShared, TServices>;
 
   constructor(config: ModelInvocationConfig<TShared, TServices>) {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -13,7 +13,6 @@ import {
   saveCycleDebug,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   isTokenLimitStopReason,
   type ProviderStopReason,
@@ -107,7 +106,6 @@ interface ResponsePrepResult {
  */
 class ResponsePrepNode<C> extends BaseNode<
   ResponseCycleShared,
-  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ResponsePrepResult> {
@@ -233,7 +231,6 @@ export function responseCycleToolsForModel<C>(
  */
 class ResponseProcessNode<C> extends BaseNode<
   ResponseCycleShared,
-  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ProcessPrepResult> {
@@ -436,7 +433,6 @@ class ResponseProcessNode<C> extends BaseNode<
  */
 class ResponseCycleFinalizeNode<C> extends BaseNode<
   ResponseCycleShared,
-  FlowParams,
   ResponseCycleServices<C>
 > {
   /** Finalize the round by recording stats and invoking callback. */
@@ -470,7 +466,6 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
  */
 class ResponseContinuationNode<C> extends BaseNode<
   ResponseCycleShared,
-  FlowParams,
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ContinuationPrepResult> {
@@ -586,13 +581,11 @@ class ResponseContinuationNode<C> extends BaseNode<
  */
 export function createResponseCycleFlow<C>(): Flow<
   ResponseCycleShared,
-  FlowParams,
   ResponseCycleServices<C>
 > {
   const prepNode = new ResponsePrepNode<C>();
   const invokeNode = new ModelInvocationNode<
     ResponseCycleShared,
-    FlowParams,
     ResponseCycleServices<C>
   >({
     operationName: 'Model invocation',
@@ -626,7 +619,5 @@ export function createResponseCycleFlow<C>(): Flow<
 
   continuationNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ResponseCycleShared, FlowParams, ResponseCycleServices<C>>(
-    prepNode,
-  );
+  return new Flow<ResponseCycleShared, ResponseCycleServices<C>>(prepNode);
 }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -2,7 +2,7 @@
 
 import { StatusCodes } from 'http-status-codes';
 
-import { Node, type NonIterableObject } from '@agent/node';
+import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -77,9 +77,8 @@ async function tryRefreshClient(
 /** Base class for model/tool invocation nodes with retry support. */
 export abstract class RetryableInvocationNode<
   S,
-  P extends NonIterableObject = NonIterableObject,
   Svc extends RetryableNodeServices = RetryableNodeServices,
-> extends Node<S, P, Svc> {
+> extends Node<S, Svc> {
   protected _userCancelled = false;
   protected _hasAttemptedTokenRefresh = false;
   protected _persistent401Error: Error | null = null;

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -18,7 +18,6 @@
 // Local imports - core flow primitives
 import { Flow } from '@agent/node';
 import { defaultPostCompactionContext } from '@agent/core/flows/CommonCycleTypes';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
@@ -45,13 +44,11 @@ export { type ToolUseRoundShared } from './toolUseRound/roundShared';
  */
 export function createToolUseRoundFlow<C>(): Flow<
   ToolUseRoundShared,
-  FlowParams,
   ToolUseRoundServices<C>
 > {
   const prepNode = new ToolUseRoundPrepNode<C>();
   const callNode = new ModelInvocationNode<
     ToolUseRoundShared,
-    FlowParams,
     ToolUseRoundServices<C>
   >({
     operationName: 'Tool-use call',
@@ -82,7 +79,5 @@ export function createToolUseRoundFlow<C>(): Flow<
   processNode.on(FlowTransition.CONTINUE, prepNode);
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ToolUseRoundShared, FlowParams, ToolUseRoundServices<C>>(
-    prepNode,
-  );
+  return new Flow<ToolUseRoundShared, ToolUseRoundServices<C>>(prepNode);
 }

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -1,5 +1,5 @@
 // Local imports - core flow primitives
-import { BatchNode } from '@agent/node';
+import { Node } from '@agent/node';
 import {
   emitToolUseCard,
   endToolUseCard,
@@ -15,7 +15,6 @@ import type {
   FileInteractionState,
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
@@ -101,9 +100,8 @@ interface ToolExecutionResult {
  *
  * Batches follow-up messages for Google/DeepSeek handlers to preserve thought signatures.
  */
-export class ToolUseDispatchNode<C> extends BatchNode<
+export class ToolUseDispatchNode<C> extends Node<
   ToolUseRoundShared,
-  FlowParams,
   ToolUseRoundServices<C>
 > {
   /**

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -3,7 +3,6 @@ import { BaseNode } from '@agent/node';
 import { logWebFetch, logWebSearch } from '@agent/trace';
 import { recordCycleMetrics } from '@agent/core/state/AgentState';
 import { extractModelResponse } from '@agent/core/flows/CommonCycleTypes';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { appendFollowUpAsUserMessage } from '@agent/followUp/followUpMessages';
 import type { SdkToolCall } from '@agent/types/IModelHandler';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
@@ -83,7 +82,6 @@ interface ToolUseProcessPrepResult {
 /** Processes the model response to extract tool calls and usage data. */
 export class ToolUseProcessNode<C> extends BaseNode<
   ToolUseRoundShared,
-  FlowParams,
   ToolUseRoundServices<C>
 > {
   async prep(shared: ToolUseRoundShared): Promise<ToolUseProcessPrepResult> {

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -5,7 +5,6 @@ import {
   resetCycleState,
   saveCycleDebug,
 } from '@agent/core/flows/CommonCycleTypes';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
@@ -40,7 +39,6 @@ interface ToolUseRoundPrepResult {
  */
 export class ToolUseRoundPrepNode<C> extends BaseNode<
   ToolUseRoundShared,
-  FlowParams,
   ToolUseRoundServices<C>
 > {
   async prep(_shared: ToolUseRoundShared): Promise<ToolUseRoundPrepResult> {

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -2,7 +2,6 @@ import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 
 import { getFilesForRound } from '../helpers';
@@ -18,7 +17,6 @@ interface PrepInput {
 
 export class MediaExtractionNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<PrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -27,7 +27,6 @@ import {
 } from '@agent/output/compileFailureRoundContext';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { tryOperation } from '@agent/output/outputOperations';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import {
   MESSAGE_TYPES,
   type AgentFileLocation,
@@ -59,7 +58,6 @@ interface OutputExecResult {
 
 export class OutputNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  FlowParams,
   ReflectionServices<C>
 > {
   private outputDependencies(): OutputDependencies {

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -4,7 +4,6 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { appendCompileFailureRoundContext } from '@agent/output/compileFailureRoundContext';
 
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import type {
   ReflectionFlowShared,
   RoundContext,
@@ -19,7 +18,6 @@ interface PrepInput {
 
 export class PrepareContextNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<PrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -12,7 +12,6 @@ import type {
   ConversationRoundStateSnapshot,
 } from '@agent/core/state/AgentState';
 import { bestConnectionMethod } from '@agent/runtime/textConnection';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { ensureError } from '@utils/errors/errorMessage';
@@ -40,7 +39,6 @@ type CycleOutcome =
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<CyclePrepInput> {

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -1,6 +1,5 @@
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { getTeXCountStats } from '@latex/texcount';
 import type { FileLocation } from '@shared/schemas';
 
@@ -10,7 +9,6 @@ import type { ReflectionServices } from '../ReflectionServices';
 
 export class TeXCountNode<C = unknown> extends Node<
   ReflectionFlowShared,
-  FlowParams,
   ReflectionServices<C>
 > {
   async prep(shared: ReflectionFlowShared): Promise<FileLocation[]> {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -261,7 +261,6 @@ export async function runReflectionFlow<C = unknown>(
 
     const pf = new RoundPersistedFlow<
       ReflectionFlowShared,
-      Record<string, unknown>,
       ReflectionServices<C>
     >(prepContextNode, kv, {
       parentStage,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -9,7 +9,6 @@ import {
 } from '@agent/core/flows/ToolUseRoundFlow';
 import { withModelClient } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { buildFailedRetryInfo } from '@common/errors';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import type { RetryErrorInfo } from '@shared/schemas';
@@ -34,7 +33,6 @@ type ToolUseCycleOutcome =
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
-  FlowParams,
   ToolUseServices<C>
 > {
   async prep(shared: ToolUseRunShared): Promise<CyclePrepResult> {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -4,7 +4,6 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
@@ -25,7 +24,6 @@ type PrepareExecResult =
  */
 export class ToolUsePrepareNode<C> extends Node<
   ToolUseRunShared,
-  FlowParams,
   ToolUseServices<C>
 > {
   async exec(

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -9,7 +9,6 @@ import {
   followUpDisplayText,
   type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
-import type { FlowParams } from '@agent/core/flows/BaseFlowServices';
 import { STREAM_PHASE } from '@shared/schemas';
 import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
@@ -29,7 +28,6 @@ interface WaitPrepResult {
 
 export class ToolUseWaitNode<C> extends Node<
   ToolUseRunShared,
-  FlowParams,
   ToolUseServices<C>
 > {
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -127,7 +127,6 @@ export type ToolUseFlowSetupCallback = (
 
 type ToolUsePersistedFlow<C> = PersistedFlow<
   ToolUseRunShared,
-  Record<string, unknown>,
   ToolUseServices<C>
 >;
 

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -24,20 +24,13 @@ logger.initialize(CHANNEL);
  *
  * Type parameters:
  * - S: Shared state type (mutable, flows through nodes)
- * - P: Params type (per-execution parameters)
  * - Svc: Services type (immutable dependencies, set once)
  *
  * Architecture:
  * - shared: Mutable state passed through prep/post
- * - _params: Per-execution parameters
  * - _services: Immutable dependencies (propagated by Flow)
  */
-class BaseNode<
-  S = unknown,
-  P extends NonIterableObject = NonIterableObject,
-  Svc = unknown,
-> {
-  protected _params: P = {} as P;
+class BaseNode<S = unknown, Svc = unknown> {
   protected _services: Svc = {} as Svc;
   protected _successors: Map<Action, BaseNode> = new Map();
 
@@ -74,10 +67,6 @@ class BaseNode<
       logger.warn(CHANNEL, "Node won't run successors. Use Flow.");
     return await this._run(shared);
   }
-  setParams(params: P): this {
-    this._params = params;
-    return this;
-  }
   setServices(services: Svc): this {
     this._services = services;
     return this;
@@ -110,18 +99,13 @@ class BaseNode<
   clone(): this {
     const clonedNode = Object.create(Object.getPrototypeOf(this));
     Object.assign(clonedNode, this);
-    clonedNode._params = { ...this._params };
     // Services are immutable, shallow copy is safe
     clonedNode._services = this._services;
     clonedNode._successors = new Map(this._successors);
     return clonedNode;
   }
 }
-class Node<
-  S = unknown,
-  P extends NonIterableObject = NonIterableObject,
-  Svc = unknown,
-> extends BaseNode<S, P, Svc> {
+class Node<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
   maxRetries: number;
   wait: number;
   /**
@@ -155,7 +139,7 @@ class Node<
    *
    * @example
    * ```typescript
-   * class MyNode extends Node<S, P> {
+   * class MyNode extends Node<S> {
    *   async retryPrompt(prepRes: unknown, error: Error): Promise<boolean> {
    *     const result = await showRetryDialog(error.message);
    *     return result === 'retry';
@@ -254,32 +238,7 @@ class Node<
     );
   }
 }
-class BatchNode<
-  S = unknown,
-  P extends NonIterableObject = NonIterableObject,
-  Svc = unknown,
-> extends Node<S, P, Svc> {
-  /**
-   * Subclasses may override `_exec` entirely (e.g. ToolUseDispatchNode's
-   * barrier-scheduled concurrent dispatch); any lifecycle behavior added
-   * here must not assume every subclass routes through this loop.
-   */
-  async _exec(items: unknown[]): Promise<unknown[]> {
-    if (!Array.isArray(items)) return [];
-    const results: unknown[] = [];
-    for (const item of items) {
-      // Check abort signal before each batch item for responsive cancellation
-      if (this.signal?.aborted) break;
-      results.push(await super._exec(item));
-    }
-    return results;
-  }
-}
-class Flow<
-  S = unknown,
-  P extends NonIterableObject = NonIterableObject,
-  Svc = unknown,
-> extends BaseNode<S, P, Svc> {
+class Flow<S = unknown, Svc = unknown> extends BaseNode<S, Svc> {
   start: BaseNode;
   constructor(start: BaseNode) {
     super();
@@ -288,7 +247,6 @@ class Flow<
   protected async _orchestrate(shared: S): Promise<void> {
     let current: BaseNode | undefined = this.start.clone();
     while (current) {
-      current.setParams(this._params);
       // Propagate services to each node (immutable, same instance)
       current.setServices(this._services);
       const action = await current._run(shared);
@@ -305,4 +263,4 @@ class Flow<
     throw new Error("Flow can't exec.");
   }
 }
-export { BaseNode, Node, BatchNode, Flow };
+export { BaseNode, Node, Flow };

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -2,10 +2,6 @@ import pRetry, { AbortError } from 'p-retry';
 
 import * as logger from '@logger/logUtils';
 
-export type NonIterableObject = Partial<Record<string, unknown>> & {
-  [Symbol.iterator]?: never;
-};
-
 /** Flow transition action - typically 'default' or a custom action name */
 export type Action = string;
 

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -35,7 +35,13 @@ interface FlowCursor {
 export interface FlowRecord {
   schemaVersion?: number;
   flowName: string;
-  params: Record<string, unknown>;
+  /**
+   * Legacy per-execution params, always `{}` in practice — the params
+   * channel was removed from the node/flow engine. Kept optional so a
+   * tolerant reader still accepts records written before the removal;
+   * new records omit it entirely.
+   */
+  params?: Record<string, unknown>;
   shared: unknown;
   createdAt: string;
   /**
@@ -80,14 +86,12 @@ export interface StepResult<S> {
  * - Resume replays by navigating the graph, not re-executing nodes
  *
  * @template S - Shared state type (must be serializable via structuredClone)
- * @template P - Params type (must be serializable)
  * @template Svc - Services type (NOT serialized - injected at runtime)
  */
 export class PersistedFlow<
   S = Record<string, unknown>,
-  P extends Record<string, unknown> = Record<string, unknown>,
   Svc = unknown,
-> extends Flow<S, P, Svc> {
+> extends Flow<S, Svc> {
   protected readonly runId: string;
   protected readonly kv: ExecutionKVStore;
 
@@ -192,14 +196,12 @@ export class PersistedFlow<
       };
     }
 
-    const params = flow.params as P;
     const shared = flow.shared as S;
 
     if (!shared) {
       throw new Error('Missing shared state in flow record');
     }
 
-    cursor.setParams(params);
     cursor.setServices(this._services);
     const action = await cursor._run(shared);
     const waiting = action === FlowTransition.WAITING;
@@ -358,7 +360,6 @@ export class PersistedFlow<
     const record: FlowRecord = {
       schemaVersion: FLOW_RECORD_SCHEMA_VERSION,
       flowName: 'texra',
-      params: this._params as Record<string, unknown>,
       shared: this.serializeShared(shared),
       createdAt: new Date().toISOString(),
       cursor: { nextNodeId: this.idForNode(this.start) },

--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -100,9 +100,8 @@ export interface RoundCallbacks<S extends RoundAwareState> {
  */
 export class RoundPersistedFlow<
   S extends RoundAwareState = RoundAwareState,
-  P extends Record<string, unknown> = Record<string, unknown>,
   Svc = unknown,
-> extends PersistedFlow<S, P, Svc> {
+> extends PersistedFlow<S, Svc> {
   private readonly callbacks: RoundCallbacks<S>;
   private readonly parentStage: StageHandle | null;
   private currentRoundStage: StageHandle | null = null;

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -21,7 +21,9 @@ const CHANNEL = 'Resumability';
 
 const ResumableFlowRecordSchema = z.looseObject({
   flowName: z.string(),
-  params: z.record(z.string(), z.unknown()),
+  // Legacy records carry an (always-empty) params bag; new records omit it
+  // entirely after the params channel was deleted (#7691).
+  params: z.record(z.string(), z.unknown()).optional(),
   shared: z.record(z.string(), z.unknown()),
   createdAt: z.string(),
   nodes: z.array(z.looseObject({ action: z.string().optional() })),

--- a/src/test-kernel/agent/PocketFlowNode.vitest.ts
+++ b/src/test-kernel/agent/PocketFlowNode.vitest.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BaseNode } from '@agent/node';
+import * as logger from '@logger/logUtils';
+
+class TestNode extends BaseNode<Record<string, never>> {}
+
+describe('BaseNode.getNextNode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['complete', 'finalize'] as const)(
+    "returns undefined silently for the terminal action '%s' when unregistered",
+    (action) => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const node = new TestNode();
+      // Register an unrelated successor so `_successors.size > 0`, which is
+      // the branch that would otherwise trigger the "Flow ends" warning.
+      node.on('default', new TestNode());
+
+      expect(node.getNextNode(action)).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('warns when a non-terminal unregistered action falls through', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const node = new TestNode();
+    node.on('default', new TestNode());
+
+    expect(node.getNextNode('unregistered-action')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'PocketFlow',
+      expect.stringContaining(
+        "Flow ends: 'unregistered-action' not found in [default]",
+      ),
+    );
+  });
+
+  it('does not warn when no successors are registered at all', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const node = new TestNode();
+
+    expect(node.getNextNode('anything')).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -84,7 +84,7 @@ function dispatchHarness(opts: HarnessOptions) {
   return { node, dispose: () => runTrace.dispose() };
 }
 
-/** prep() then the batch executor, mirroring BatchNode's _run sequence. */
+/** prep() then the batch executor, mirroring Node's _run sequence. */
 async function runDispatch(
   node: ToolUseDispatchNode<unknown>,
   calls: SdkToolCall[],

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -7,7 +7,6 @@ import {
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
 import { noopTrace, type AgentTrace } from '@agent/trace';
-import type { NonIterableObject } from '@agent/node';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
@@ -48,7 +47,6 @@ interface TestRetryServices {
 
 class ExposedRetryNode extends RetryableInvocationNode<
   unknown,
-  NonIterableObject,
   TestRetryServices
 > {
   protected getOperationName(): string {


### PR DESCRIPTION
## What / why

Closes #7691 (TAX-2, 2026-07 macroscopic architecture review — `docs/proposals/state-of-the-architecture-2026-07.md`).

The vendored PocketFlow engine (`src/agent/node/index.ts`) carried provably dead width:

1. **`BatchNode`'s loop was dead.** Its only subclass, `ToolUseDispatchNode`, overrides `_exec` entirely with its own barrier-scheduled concurrent-dispatch implementation (the class docstring already said as much: "Subclasses may override `_exec` entirely"). `BatchNode` added nothing over `Node` for that consumer, so `ToolUseDispatchNode` now extends `Node` directly and `BatchNode` is deleted.
2. **The `P` (params) generic was always `{}`.** `setParams`/`_params`/the params-clone in `BaseNode.clone()` were threaded through `BaseNode`/`Node`/`Flow` and 18 downstream signature sites, but nothing ever called `setParams` with a non-empty value — `Flow._orchestrate` only ever propagated its own default `{}` back onto each node.

## Changes

1. `src/agent/node/index.ts`: deleted `BatchNode`; removed the `P` generic + `_params`/`setParams`/params-clone from `BaseNode`/`Node`/`Flow`.
2. Let `tsc` find the ~18 signature sites (every `Node<S, P, Svc>` / `Flow<S, P, Svc>` / `BaseNode<S, P, Svc>` instantiation drops to the two-generic form) and fixed them mechanically — no behavior change. `FlowParams` (`src/agent/core/flows/BaseFlowServices.ts`) is now unused and deleted.
3. `FlowRecord.params` (`src/agent/node/persistedFlow.ts`) is now optional with a tolerant reader — a real fixture in `PersistedFlow.vitest.ts` writes `params: {}` for the legacy-record test cases, confirming the field was always empty in practice. New records omit it entirely; old records with the field still parse (no schemaVersion bump needed).
4. Tests: dropped the params/batch-adjacent generic-arg boilerplate together with the code (R7 — no dedicated params/batch test cases existed to remove, confirming the channel was untested-because-unused). Added a new `src/test-kernel/agent/PocketFlowNode.vitest.ts` (no prior suite covered `src/agent/node/index.ts` directly) with the `getNextNode` terminal-action case PR #7638's review suggested — `'complete'`/`'finalize'` return `undefined` silently when unregistered, an unregistered non-terminal action still warns, and no-successors-at-all doesn't warn.

**First verified BatchNode + params were still genuinely unused at HEAD** before starting: grepped `setParams`/`BatchNode` consumers outside tests (only the one `ToolUseDispatchNode extends BatchNode` production use, and it overrides `_exec` fully) and confirmed no sibling PR had started using them since the issue was filed.

Did **not** touch prep/exec/post, clone-per-run, or the replay cursors (fenced framework-idiomatic per the issue's rejected-trap list).

## Verification

- `npm run typecheck` — clean (full workspace, including `tsconfig.test-kernel.json` and the CLI/desktop/trace-viewer sub-projects).
- Targeted suites, all passing:
  - `src/test-kernel/agent/PocketFlowNode.vitest.ts` (new)
  - `src/test-kernel/agent/PersistedFlow.vitest.ts`
  - `src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts`
  - `src/test-kernel/agent/runtime/RetryState.vitest.ts`
  - `src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts`
  - `src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts` (reflection-flow integration)
  - `src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts` (tool-use-flow integration)
  - Broader sweep: `src/test-kernel/agent/core`, `src/test-kernel/agent/followUp` — 28 files / 163 tests, all passing.
- `npx eslint` on every touched file — clean (one import-order warning in the new test file, fixed).

## Net elements (R6)

- Classes: `-1` (`BatchNode` deleted).
- Generics: `-1` type parameter across `BaseNode`/`Node`/`Flow`/`PersistedFlow`/`RoundPersistedFlow`/`RetryableInvocationNode`/`ModelInvocationNode` and the ~18 call sites that instantiated them.
- Interfaces: `-1` (`FlowParams` deleted from `BaseFlowServices.ts`, now fully unused).
- Files: `+1` new test file (`src/test-kernel/agent/PocketFlowNode.vitest.ts`, 48 lines) — no existing suite covered this module.
- LoC: production (`src/agent`) `21 insertions(+), 108 deletions(-)` → net **-87**. Full diff (prod + test) `70 insertions(+), 111 deletions(-)` → net **-41**, after adding the new terminal-action test suite.

## Consumer counts (R8)

- `BatchNode` export: 1 production consumer (`ToolUseDispatchNode`), migrated to `Node`; 0 remaining after this PR (grepped `grep -rn "BatchNode" --include="*.ts" src packages`, only the deleted class definition/export and a since-updated test comment referenced it).
- `setParams`/`_params`: 0 consumers found outside `src/agent/node/index.ts` itself before this PR (grepped `setParams\b` across `src`/`packages`) — dead width, not a re-routed emit path.
- `FlowParams` type: 0 consumers left after removing the 18 signature sites that imported it (grepped `FlowParams` across `src`/`packages` post-edit — zero hits outside its own now-deleted declaration).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core flow orchestration and persisted-run resume path across reflection and tool-use agents, though behavior is intended to be unchanged aside from logging noise reduction.
> 
> **Overview**
> Removes unused width from the vendored PocketFlow layer in `src/agent/node/index.ts`: **`BatchNode`** is deleted (its only consumer, `ToolUseDispatchNode`, already overrode `_exec` and now extends **`Node`** directly), and the **`P` / params** generic plus `_params`, **`setParams`**, and params cloning are dropped from **`BaseNode`**, **`Node`**, and **`Flow`**.
> 
> Call sites across response/tool-use/reflection flows are updated to the two-type-parameter form; **`FlowParams`** is removed from **`BaseFlowServices`**. **`PersistedFlow`** / **`RoundPersistedFlow`** and resumability parsing treat **`FlowRecord.params`** as optional so legacy records with `{}` still load while new writes omit the field.
> 
> Adds **`PocketFlowNode.vitest.ts`** to assert terminal actions **`complete`** / **`finalize`** end silently without spurious "Flow ends" warnings when unregistered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe085ae4c67a4e3188d4d46d4cb5675403231263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->