### PR TITLE
fix(cli): consume classified run failures into exit codes instead of rethrowing

### DIFF
--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -15,8 +15,10 @@ try {
   process.exitCode = result.exitCode;
 } catch (error) {
   writeTextStderr(`TeXRA CLI failed: ${toErrorMessage(error)}`);
-  // Usage errors are handled inside runCli (exit 2) and never reach here; this
-  // catch only fires on UNEXPECTED crashes, so point the user at the tracker.
+  // Usage errors are handled inside runCli (exit 2) and classified run
+  // failures are consumed into an exit code at executeCliRequest (never
+  // rethrown past it — see runtime/runExecution.ts), so this catch only
+  // fires on genuinely UNEXPECTED crashes; point the user at the tracker.
   // formatCrashReportLine keeps the report link off the usage path even if a
   // usage error is ever rethrown.
   const reportLine = formatCrashReportLine(error, await readCliBugsUrl());

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -6,6 +6,7 @@ import {
   StreamSnapshotStore,
 } from '@transcript';
 import { writeTerminalStatus } from '@agent/storage';
+import { AgentError } from '@common/errors';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -158,12 +159,16 @@ export async function executeCliToolUseConfig(
  * lifecycle and status handling, which is how their behavior diverged before.
  *
  * A classified run failure (AgentRunLifecycle already ran it through
- * `classifyAgentError` and wrote the terminal outcome before rethrowing for
- * the extension host) is consumed here into a non-zero exit code instead of
- * being rethrown — otherwise it reaches `bin/texra.ts`'s crash handler and
- * gets misreported as an unexpected crash, printed a second time alongside a
- * "please report it" line (issue #7645). Flows' own rethrow stays untouched;
- * only this CLI boundary stops propagating it further.
+ * `classifyAgentError` and wrote the terminal outcome before rethrowing an
+ * `AgentError` for the extension host) is consumed here into a non-zero exit
+ * code instead of being rethrown — otherwise it reaches `bin/texra.ts`'s
+ * crash handler and gets misreported as an unexpected crash, printed a
+ * second time alongside a "please report it" line (issue #7645). Flows' own
+ * rethrow stays untouched; only this CLI boundary stops propagating it
+ * further. Only `AgentError` — the classified, already-handled shape — takes
+ * this path; any other rejection (e.g. `registerExecution` disk I/O,
+ * `workspaceState.update` failures) is genuinely unexpected and is rethrown
+ * so the crash handler still reports it.
  */
 export async function executeCliRequest(
   request: ValidatedExecutionRequest,
@@ -247,7 +252,14 @@ export async function executeCliRequest(
   try {
     const result = await (options.wrap ? options.wrap(invoke) : invoke());
     runResult = { ok: true, result };
-  } catch {
+  } catch (err) {
+    // Only a classified, already-handled AgentError resolves to a non-zero
+    // exit code here; anything else (e.g. registerExecution disk I/O,
+    // workspaceState.update failures) is unexpected and must keep
+    // propagating to bin/texra.ts's crash handler.
+    if (!(err instanceof AgentError)) {
+      throw err;
+    }
     if (options.markErrorOnThrow && request.executionId) {
       await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
     }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -101,11 +101,15 @@ export async function executeCliConfig<
     return { ok: false, exitCode: CliExitCode.Usage };
   }
 
-  const { result, terminalStatus } = await executeCliRequest(
+  const execution = await executeCliRequest(
     validation.request,
     runContext,
     executeOptions,
   );
+  if (!execution.ok) {
+    return execution;
+  }
+  const { result, terminalStatus } = execution;
 
   if (expectedCategory !== undefined && result.category !== expectedCategory) {
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
@@ -152,12 +156,23 @@ export async function executeCliToolUseConfig(
  * wrapped), always close the host, and resolve the terminal status.
  * Centralizing this stops the three runners from drifting apart on host
  * lifecycle and status handling, which is how their behavior diverged before.
+ *
+ * A classified run failure (AgentRunLifecycle already ran it through
+ * `classifyAgentError` and wrote the terminal outcome before rethrowing for
+ * the extension host) is consumed here into a non-zero exit code instead of
+ * being rethrown — otherwise it reaches `bin/texra.ts`'s crash handler and
+ * gets misreported as an unexpected crash, printed a second time alongside a
+ * "please report it" line (issue #7645). Flows' own rethrow stays untouched;
+ * only this CLI boundary stops propagating it further.
  */
 export async function executeCliRequest(
   request: ValidatedExecutionRequest,
   runContext: CliContext,
   options: CliExecuteOptions = {},
-): Promise<{ result: ExecuteAgentResult; terminalStatus: ExecutionStatus }> {
+): Promise<
+  | { ok: true; result: ExecuteAgentResult; terminalStatus: ExecutionStatus }
+  | { ok: false; exitCode: CliExitCode }
+> {
   const runtimeHost = createCliRuntimeHost(runContext);
   const snapshotStore = new StreamSnapshotStore();
   const detachSnapshotEvents = snapshotStore.attachSessionEvents(
@@ -226,14 +241,16 @@ export async function executeCliRequest(
     // Persistence stays disabled; the run still executes in-memory as before.
   }
 
-  let result: ExecuteAgentResult;
+  let runResult:
+    | { readonly ok: true; readonly result: ExecuteAgentResult }
+    | { readonly ok: false } = { ok: false };
   try {
-    result = await (options.wrap ? options.wrap(invoke) : invoke());
-  } catch (error) {
+    const result = await (options.wrap ? options.wrap(invoke) : invoke());
+    runResult = { ok: true, result };
+  } catch {
     if (options.markErrorOnThrow && request.executionId) {
       await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
     }
-    throw error;
   } finally {
     disposeShutdownStatus?.dispose();
     // If the run settles while shutdown is in progress, keep the
@@ -257,6 +274,17 @@ export async function executeCliRequest(
     }
   }
 
-  const terminalStatus = await readCliTerminalStatus(result);
-  return { result, terminalStatus };
+  if (!runResult.ok) {
+    // The message was already presented once via the run's `result` event
+    // (attachTerminalResultToast → requestShowError); nothing more to print
+    // here. Reuse the same status→exit-code mapping the non-throw ERROR path
+    // uses below, so approval-denied stays distinct from a generic failure.
+    return {
+      ok: false,
+      exitCode: terminalStatusExitCode(EXECUTION_STATUS.ERROR, runContext),
+    };
+  }
+
+  const terminalStatus = await readCliTerminalStatus(runResult.result);
+  return { ok: true, result: runResult.result, terminalStatus };
 }

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { AgentError } from '@common/errors';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
@@ -458,7 +459,7 @@ describe('executeCliRequest', () => {
     const store = getDefaultStreamLogStore();
     const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
-    mocks.runAgent.mockRejectedValueOnce(new Error('boom'));
+    mocks.runAgent.mockRejectedValueOnce(new AgentError('boom'));
 
     // #7645: a classified run failure resolves to a non-zero exit code
     // instead of rethrowing — otherwise it reaches bin/texra.ts's crash
@@ -471,10 +472,33 @@ describe('executeCliRequest', () => {
     expect(flushSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('rethrows a non-AgentError rejection instead of swallowing it into an exit code', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { getDefaultStreamLogStore } = await import('@transcript');
+    const request = baseRequest();
+    const store = getDefaultStreamLogStore();
+    const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
+    const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
+    // An unclassified failure (e.g. registerExecution disk I/O,
+    // workspaceState.update) is genuinely unexpected — it must keep
+    // propagating so bin/texra.ts's crash handler reports it, instead of
+    // being swallowed into a bare non-zero exit with no stderr.
+    mocks.runAgent.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(executeCliRequest(request, cliContext())).rejects.toThrow(
+      'disk full',
+    );
+
+    // Cleanup still runs via `finally` even though the error propagates.
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
   it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
-    mocks.runAgent.mockRejectedValueOnce(new Error('provider boom'));
+    mocks.runAgent.mockRejectedValueOnce(new AgentError('provider boom'));
 
     const result = await executeCliRequest(request, cliContext(), {
       markErrorOnThrow: true,
@@ -496,7 +520,7 @@ describe('executeCliRequest', () => {
     const request = baseRequest();
     const context = cliContext();
     markApprovalDenied(context);
-    mocks.runAgent.mockRejectedValueOnce(new Error('approval denied'));
+    mocks.runAgent.mockRejectedValueOnce(new AgentError('approval denied'));
 
     const result = await executeCliRequest(request, context);
 

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -70,7 +70,8 @@ vi.mock('@cli/runtime/runtimeHost', () => ({
   createCliRuntimeHost: mocks.createCliRuntimeHost,
 }));
 
-vi.mock('@cli/runtime/approvalAdapter', () => ({
+vi.mock('@cli/runtime/approvalAdapter', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@cli/runtime/approvalAdapter')>()),
   createHeadlessCliHostInteractions: mocks.createHeadlessCliHostInteractions,
 }));
 
@@ -459,12 +460,50 @@ describe('executeCliRequest', () => {
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     mocks.runAgent.mockRejectedValueOnce(new Error('boom'));
 
-    await expect(executeCliRequest(request, cliContext())).rejects.toThrow(
-      'boom',
-    );
+    // #7645: a classified run failure resolves to a non-zero exit code
+    // instead of rethrowing — otherwise it reaches bin/texra.ts's crash
+    // handler and gets misreported as an unexpected crash (double-printed
+    // message + a false "please report it" line).
+    const result = await executeCliRequest(request, cliContext());
 
+    expect(result).toEqual({ ok: false, exitCode: CliExitCode.AgentError });
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(flushSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = baseRequest();
+    mocks.runAgent.mockRejectedValueOnce(new Error('provider boom'));
+
+    const result = await executeCliRequest(request, cliContext(), {
+      markErrorOnThrow: true,
+    });
+
+    expect(result).toEqual({ ok: false, exitCode: CliExitCode.AgentError });
+    // markErrorOnThrow still records the terminal status, same as before.
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+      'exec-1',
+      EXECUTION_STATUS.ERROR,
+    );
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a classified run failure to ApprovalDenied when the run denied approval', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const { markApprovalDenied } =
+      await import('@cli/runtime/approval/approvalPolicy');
+    const request = baseRequest();
+    const context = cliContext();
+    markApprovalDenied(context);
+    mocks.runAgent.mockRejectedValueOnce(new Error('approval denied'));
+
+    const result = await executeCliRequest(request, context);
+
+    expect(result).toEqual({
+      ok: false,
+      exitCode: CliExitCode.ApprovalDenied,
+    });
   });
 
   it('closes the runtime host when sidecar flush fails', async () => {


### PR DESCRIPTION
## What / why

Closes #7645 (audit finding UICPL-02, PR #7636).

Headless `texra run` presented a routine provider failure as an unexpected
CLI crash:

1. `AgentRunLifecycle` runs the error through `classifyAgentError`, writes
   the terminal outcome, presents the message once via the run's `result`
   event (`attachTerminalResultToast` → `requestShowError` → CLI logger
   stderr), then rethrows an `AgentError` for the extension host.
2. That rethrow used to keep propagating past `executeCliRequest` /
   `executeCliConfig`, all the way to `bin/texra.ts`'s catch-all, which
   printed `"TeXRA CLI failed: ..."` (the **same message again**) plus
   `formatCrashReportLine`'s "please report it" line — even though the
   failure was already fully classified.

**Fix** (per the issue's implementation sketch): `executeCliRequest`
(`packages/cli/src/runtime/runExecution.ts`) now catches the run failure,
keeps the existing `markErrorOnThrow` terminal-status write, and resolves to
`{ ok: false, exitCode }` instead of rethrowing — reusing the same
`terminalStatusExitCode` mapping the non-throw ERROR path already used, so
approval-denied stays a distinct exit code from a generic agent error.
`executeCliConfig` forwards that `ok:false` result unchanged (its three
callers — `run`, `agents run`, `multi-agent run` — already branch on
`execution.ok` for the validation/category-mismatch cases). `bin/texra.ts`'s
crash catch itself is untouched; its comment now correctly states it only
fires on genuinely unclassified throws.

No CLI error-classification framework was added in `bin` — `classifyAgentError`
already exists and is consumed at the `executeCliRequest` boundary, per the
issue's rejected-trap note.

## Verification

- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/RunExecution.vitest.mts` — 22 passed (extended: `flushes the stream log store even when the run throws` now asserts `{ ok: false, exitCode: CliExitCode.AgentError }` instead of `rejects.toThrow`; added `resolves a classified run failure to a non-zero exit code without rethrowing` and `maps a classified run failure to ApprovalDenied when the run denied approval`).
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/` — 128 files / 1617 tests passed (includes `WorkflowRunCommand.vitest.mts`, which still exercises the pre-run usage-error throws — unaffected, those never reach `executeCliRequest`).
- `npm test` (full suite) — 612 files / 5308 passed, 4 pre-existing skipped, 0 failures.
- `npm run typecheck` — clean across root, test-kernel, `@texra-ai/cli`, and `@texra/trace-viewer` projects.

Headless parity: `executeCliToolUseConfig`'s existing success-path assertions
(`derives the CLI display result and exit code for tool-use configs`, `uses
the resolved terminal status for tool-use JSON output`) are unchanged and
still pass byte-for-byte — the success branch of `executeCliRequest` /
`executeCliConfig` was not touched, only the failure branch's control flow.

## Net elements (R6)

- Files: 0 added, 0 deleted (3 edited: `packages/cli/src/bin/texra.ts`,
  `packages/cli/src/runtime/runExecution.ts`,
  `src/test-kernel/cli/RunExecution.vitest.mts`).
- Exports/classes: 0 added, 0 deleted. `executeCliRequest`'s return type
  changed from an unconditional `{ result, terminalStatus }` object to the
  discriminated union `{ ok: true; result; terminalStatus } | { ok: false;
  exitCode }` (same exported function name/arity).
- LoC: production +40/-10 (net +30, `bin/texra.ts` + `runExecution.ts`);
  tests +43/-4 (net +39, all inside the pre-existing `RunExecution.vitest.mts`
  suite — no new test file). The sketch predicted "net ~0"; the actual delta
  is dominated by the new discriminated-union return type's extra braces and
  the two added regression tests, not by any new abstraction — it deletes the
  double-print + false bug-report solicitation as intended.

## Consumer counts (R8)

`executeCliRequest`'s return shape changed. Grepped call sites:
`grep -rn "executeCliRequest(" packages/cli/src --include="*.ts"` → exactly
one call site, `executeCliConfig` in the same file (`runExecution.ts`),
updated in this PR. No other production caller; no test imports
`executeCliRequest`'s return shape except the suite extended here.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI headless execution error boundary and `executeCliRequest`'s return type, but scope is limited to consuming `AgentError` while preserving rethrow for unclassified failures.
> 
> **Overview**
> Fixes **#7645**: routine headless agent failures no longer bubble to `bin/texra.ts` as “unexpected” crashes with a **duplicate** error line and a false “please report it” prompt.
> 
> **`executeCliRequest`** now catches **`AgentError`** (already classified and shown once via the run’s result toast), keeps optional **`markErrorOnThrow`** terminal writes, and returns **`{ ok: false, exitCode }`** using the same **`terminalStatusExitCode`** mapping as the non-throw ERROR path (so approval-denied stays a distinct exit code). **`executeCliConfig`** forwards that failure shape unchanged. Any **non-`AgentError`** rejection still **rethrows** so the top-level crash handler can report genuinely unexpected failures.
> 
> **`bin/texra.ts`** only updates comments to document that classified failures are handled at the execution boundary. Tests in **`RunExecution.vitest.mts`** assert the new return shape, rethrow behavior, **`markErrorOnThrow`**, and approval-denied exit mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f3914deb3714c007c511060762d4865587be62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->