### PR TITLE
fix: hydrate inquiry prompts from shared progress backend

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -14,6 +14,7 @@ import {
   type ProgressBackendInteractionPayloads,
 } from '@controllers/progressView/backend/events/ProgressInteractionHandler';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
+import { hydrateProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryHydration';
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
@@ -1043,6 +1044,14 @@ export class DesktopProgressBridge {
 
   syncFullView(): void {
     this.syncStreamContent(this.updateStreamMetadata());
+  }
+
+  async hydrateProgressViewInquiries(): Promise<void> {
+    await hydrateProgressViewInquiries({
+      webviewUpdater: this.backend.webviewUpdater,
+      externalInquiry: this.approvalHandlers.externalInquiry,
+      logger: this.logger,
+    });
   }
 
   replayPendingPrompts(): void {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -15,7 +15,10 @@ import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
 type DesktopProgressIpcBridge = Pick<
   DesktopProgressBridge,
-  'progressViewInboundHandlers' | 'syncFullView' | 'replayPendingPrompts'
+  | 'progressViewInboundHandlers'
+  | 'syncFullView'
+  | 'hydrateProgressViewInquiries'
+  | 'replayPendingPrompts'
 >;
 
 export interface DesktopProgressIpcOptions {
@@ -88,11 +91,15 @@ export function createDesktopProgressIpc(
         const progress = getProgress();
         if (progress) {
           progress.syncFullView();
+          void progress.hydrateProgressViewInquiries().catch(reportAsyncError);
           progress.replayPendingPrompts();
         } else if (ensureProgress) {
           void ensureProgress()
             .then((loaded) => {
               loaded.syncFullView();
+              void loaded
+                .hydrateProgressViewInquiries()
+                .catch(reportAsyncError);
               loaded.replayPendingPrompts();
             })
             .catch(reportAsyncError);

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -8,6 +8,7 @@ import {
   replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
+import { hydrateProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryHydration';
 import { repairRestartedStreams } from '@controllers/progressView/backend/restartRepair';
 import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
 import { computeAgentOptionsData } from '@agent/index';
@@ -38,21 +39,12 @@ import {
 import {
   AgentCategory,
   type AgentProposalPermission,
-  type ExternalInquiryPermission,
   type ProgressViewOutboundMessage,
   type ProgressViewPlacement,
   type StreamTabId,
 } from '@shared/schemas';
 import { agentName } from '@shared/schemas/agent';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
-import {
-  getOpenTurnDraft,
-  listThreadsByStatus,
-  listOpenThreads,
-  manifestToTranscript,
-  readExternalInquiryThread,
-} from '@tools/inquiry/externalInquiryStorage';
 
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { createExtensionHostInteractions } from './extensionHostInteractions';
@@ -61,7 +53,6 @@ import type { ProgressBackendInteractionPayloads } from '@controllers/progressVi
 
 import type { MainViewProvider } from '../MainViewProvider';
 
-const MAX_INQUIRY_THREAD_HYDRATION = 100;
 export type ProgressStreamRevealResult = 'revealed' | 'missing';
 
 /**
@@ -365,94 +356,19 @@ export class ProgressViewProvider
     this._pendingUpdateOptions = null;
     this._panelJustDisposed = false;
     this.syncFullView({ forceRebuild: true });
-    // Manifest-backed open inquiries must be re-shown after a full
-    // extension reload — ApprovalRequestHandler.pending is in-memory and
-    // empty at construction. Fire-and-forget: the replay below covers
-    // anything already in-memory; this fills in the durable rows.
-    void this.syncInquiryThreads();
-    void this.hydrateOpenInquiries();
+    // Manifest-backed inquiry state is durable, but handler pending state is
+    // in-memory. Fire-and-forget: replay covers warm targets, hydration covers
+    // host restarts.
+    void this.hydrateProgressViewInquiries();
     this.replayPendingPrompts();
   }
 
-  private async syncInquiryThreads(): Promise<void> {
-    if (!this.webviewUpdater.isAvailable()) return;
-
-    try {
-      const threads = await listThreadsByStatus({
-        status: 'any',
-        scope: 'all',
-        limit: MAX_INQUIRY_THREAD_HYDRATION,
-      });
-      this.webviewUpdater.syncInquiryThreads(threads);
-    } catch {
-      // A damaged manifest should not prevent the progress view from
-      // showing streams or replaying pending request panels.
-    }
-  }
-
-  /**
-   * Read every open inquiry thread from durable storage and re-emit
-   * its `showExternalInquiry` payload so the panel reappears after an
-   * extension reload. No-op when the webview can't accept messages or
-   * when in-memory `pending` already covers everything (a sidebar
-   * toggle, not a fresh reload). `show()` itself is idempotent on
-   * `requestId` via `delivered`, so this gate is a perf optimization,
-   * not a correctness fix.
-   */
-  private async hydrateOpenInquiries(): Promise<void> {
-    if (!this.webviewUpdater.isAvailable()) return;
-    if (this.approvalHandlers.externalInquiry.pendingSize > 0) return;
-
-    const open = await listOpenThreads().catch((error) => {
-      // A storage read failure here silently skips inquiry hydration; log
-      // it so the missing panel reappearance is diagnosable.
-      this.logger.debug(`Failed to list open inquiry threads: ${error}`);
-      return undefined;
+  public async hydrateProgressViewInquiries(): Promise<void> {
+    await hydrateProgressViewInquiries({
+      webviewUpdater: this.webviewUpdater,
+      externalInquiry: this.approvalHandlers.externalInquiry,
+      logger: this.logger,
     });
-    if (!open) return;
-
-    for (const summary of open) {
-      try {
-        const manifest = await readExternalInquiryThread(summary.threadId);
-        if (!manifest || manifest.status !== 'open') continue;
-        if (!manifest.parentStreamId) continue;
-        const lastTurn = manifest.turns.at(-1);
-        if (!lastTurn || lastTurn.kind !== 'open') continue;
-        const isFollowUp = manifest.turns.length > 1;
-        const sessionLinks = collectKnownSessionLinks(manifest);
-        const draft = getOpenTurnDraft(manifest);
-        const transcript = manifestToTranscript(manifest);
-        const hydrationFields = {
-          sessionLinks,
-          draft,
-          transcript,
-        };
-        const basePermission = {
-          requestId: manifest.threadId,
-          threadId: manifest.threadId,
-          question: lastTurn.question,
-          context: lastTurn.context ?? undefined,
-          suggestSearch: lastTurn.suggestSearch ?? undefined,
-          attachFiles: lastTurn.attachFiles ?? undefined,
-          allowBypass: false,
-          streamId: manifest.parentStreamId,
-        };
-        const permission: ExternalInquiryPermission = isFollowUp
-          ? {
-              ...basePermission,
-              ...hydrationFields,
-              mode: 'followUp',
-            }
-          : {
-              ...basePermission,
-              ...hydrationFields,
-              mode: 'new',
-            };
-        this.approvalHandlers.externalInquiry.show(permission);
-      } catch {
-        // Skip threads whose manifest can't be read; surface logs elsewhere.
-      }
-    }
   }
 
   private replayPendingPrompts(): void {

--- a/src/controllers/progressView/backend/externalInquiryHydration.ts
+++ b/src/controllers/progressView/backend/externalInquiryHydration.ts
@@ -1,0 +1,121 @@
+import type { AgentTrace } from '@agent/trace';
+import type { InquiryThreadUpdatedEvent } from '@shared/schemas';
+import { collectKnownSessionLinks } from '@tools/inquiry/externalInquiryResultFormatter';
+import {
+  getOpenTurnDraft,
+  listOpenThreads,
+  listThreadsByStatus,
+  manifestToTranscript,
+  readExternalInquiryThread,
+} from '@tools/inquiry/externalInquiryStorage';
+
+import type { ApprovalRequestHandlerSet } from './progressBackendUiConfig';
+import type { WebviewUpdater } from './WebviewUpdater';
+
+const MAX_INQUIRY_THREAD_HYDRATION = 100;
+
+type InquiryHydrationWebview = Pick<
+  WebviewUpdater,
+  'isAvailable' | 'syncInquiryThreads'
+>;
+
+type ExternalInquiryHandler = Pick<
+  ApprovalRequestHandlerSet['externalInquiry'],
+  'pendingSize' | 'show'
+>;
+
+export interface ProgressInquiryHydrationParams {
+  webviewUpdater: InquiryHydrationWebview;
+  externalInquiry: ExternalInquiryHandler;
+  logger?: Pick<AgentTrace, 'debug'>;
+}
+
+/**
+ * Synchronize the durable inquiry-thread list into the progress view. A damaged
+ * manifest should not prevent stream or prompt replay, so storage errors are
+ * intentionally swallowed here.
+ */
+export async function syncProgressInquiryThreads(
+  params: Pick<ProgressInquiryHydrationParams, 'webviewUpdater'>,
+): Promise<void> {
+  if (!params.webviewUpdater.isAvailable()) return;
+
+  try {
+    const threads: InquiryThreadUpdatedEvent[] = await listThreadsByStatus({
+      status: 'any',
+      scope: 'all',
+      limit: MAX_INQUIRY_THREAD_HYDRATION,
+    });
+    params.webviewUpdater.syncInquiryThreads(threads);
+  } catch {
+    // Inquiry thread history is auxiliary state; stream replay must continue.
+  }
+}
+
+/**
+ * Re-show manifest-backed open inquiry panels after a host restart. The
+ * in-memory handler owns delivery idempotency for the current webview target;
+ * this function only reconstructs missing pending entries from durable storage.
+ */
+export async function hydrateOpenInquiryPermissions(
+  params: ProgressInquiryHydrationParams,
+): Promise<void> {
+  if (!params.webviewUpdater.isAvailable()) return;
+  if (params.externalInquiry.pendingSize > 0) return;
+
+  const open = await listOpenThreads().catch((error) => {
+    params.logger?.debug(`Failed to list open inquiry threads: ${error}`);
+    return undefined;
+  });
+  if (!open) return;
+
+  for (const summary of open) {
+    try {
+      const manifest = await readExternalInquiryThread(summary.threadId);
+      if (!manifest || manifest.status !== 'open') continue;
+      if (!manifest.parentStreamId) continue;
+      const lastTurn = manifest.turns.at(-1);
+      if (!lastTurn || lastTurn.kind !== 'open') continue;
+
+      const hydrationFields = {
+        sessionLinks: collectKnownSessionLinks(manifest),
+        draft: getOpenTurnDraft(manifest),
+        transcript: manifestToTranscript(manifest),
+      };
+      const basePermission = {
+        requestId: manifest.threadId,
+        threadId: manifest.threadId,
+        question: lastTurn.question,
+        context: lastTurn.context ?? undefined,
+        suggestSearch: lastTurn.suggestSearch ?? undefined,
+        attachFiles: lastTurn.attachFiles ?? undefined,
+        allowBypass: false,
+        streamId: manifest.parentStreamId,
+      };
+      params.externalInquiry.show(
+        manifest.turns.length > 1
+          ? {
+              ...basePermission,
+              ...hydrationFields,
+              mode: 'followUp',
+            }
+          : {
+              ...basePermission,
+              ...hydrationFields,
+              mode: 'new',
+            },
+      );
+    } catch {
+      // Skip unreadable manifests; the inquiry list sync logs storage damage.
+    }
+  }
+}
+
+export async function hydrateProgressViewInquiries(
+  params: ProgressInquiryHydrationParams,
+): Promise<void> {
+  await Promise.all([
+    syncProgressInquiryThreads(params),
+    hydrateOpenInquiryPermissions(params),
+  ]);
+}

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -34,12 +34,14 @@ interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
     progress?: {
       syncFullView(): void;
+      hydrateProgressViewInquiries(): Promise<void>;
       replayPendingPrompts(): void;
       progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
     };
     getProgress?: () =>
       | {
           syncFullView(): void;
+          hydrateProgressViewInquiries(): Promise<void>;
           replayPendingPrompts(): void;
           progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
         }
@@ -51,6 +53,7 @@ interface DesktopProgressIpcModule {
     onAsyncError?: (error: unknown) => void;
     ensureProgress?: () => Promise<{
       syncFullView(): void;
+      hydrateProgressViewInquiries(): Promise<void>;
       replayPendingPrompts(): void;
       progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
     }>;
@@ -73,6 +76,7 @@ function createProgress(
 ) {
   return {
     syncFullView: vi.fn(),
+    hydrateProgressViewInquiries: vi.fn(async () => undefined),
     replayPendingPrompts: vi.fn(),
     progressViewInboundHandlers: fillRegistry(progressViewInboundHandlers),
   };
@@ -91,7 +95,10 @@ describe('desktop Progress IPC', () => {
     expect(
       ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
     ).toBe(false);
+    await Promise.resolve();
+
     expect(progress.syncFullView).toHaveBeenCalledTimes(1);
+    expect(progress.hydrateProgressViewInquiries).toHaveBeenCalledTimes(1);
     expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
   });
 
@@ -107,6 +114,7 @@ describe('desktop Progress IPC', () => {
     await Promise.resolve();
 
     expect(progress.syncFullView).toHaveBeenCalledTimes(1);
+    expect(progress.hydrateProgressViewInquiries).toHaveBeenCalledTimes(1);
     expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
   });
 

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -17,7 +17,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 }));
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { hydrateOpenInquiryPermissions } from '@controllers/progressView/backend/externalInquiryHydration';
 import {
   type ExternalInquiryPermission,
   type ExternalInquiryThreadId,
@@ -111,30 +111,44 @@ function createProgressProviderShell(): {
   hydrate: () => Promise<void>;
   show: ReturnType<typeof vi.fn>;
 } {
-  const provider = Object.create(
-    ProgressViewProvider.prototype,
-  ) as ProgressViewProvider;
-  const show = vi.fn();
-  const shell = provider as unknown as {
-    hydrateOpenInquiries(): Promise<void>;
-    webviewUpdater: { isAvailable(): boolean };
-    approvalHandlers: {
-      externalInquiry: {
-        pendingSize: number;
-        show(permission: ExternalInquiryPermission): void;
-      };
-    };
-    logger: { debug(message: string): void };
+  const show = vi.fn<(permission: ExternalInquiryPermission) => void>();
+  return {
+    hydrate: () =>
+      hydrateOpenInquiryPermissions({
+        webviewUpdater: {
+          isAvailable: () => true,
+          syncInquiryThreads: vi.fn(),
+        },
+        externalInquiry: {
+          pendingSize: 0,
+          show,
+        },
+        logger: { debug: vi.fn() },
+      }),
+    show,
   };
-  shell.webviewUpdater = { isAvailable: () => true };
-  shell.approvalHandlers = {
-    externalInquiry: {
-      pendingSize: 0,
-      show,
-    },
+}
+
+function createHydrationShellWithPendingInquiry(): {
+  hydrate: () => Promise<void>;
+  show: ReturnType<typeof vi.fn>;
+} {
+  const show = vi.fn<(permission: ExternalInquiryPermission) => void>();
+  return {
+    hydrate: () =>
+      hydrateOpenInquiryPermissions({
+        webviewUpdater: {
+          isAvailable: () => true,
+          syncInquiryThreads: vi.fn(),
+        },
+        externalInquiry: {
+          pendingSize: 1,
+          show,
+        },
+        logger: { debug: vi.fn() },
+      }),
+    show,
   };
-  shell.logger = { debug: vi.fn() };
-  return { hydrate: () => shell.hydrateOpenInquiries(), show };
 }
 
 describe('external inquiry read boundary', () => {
@@ -197,5 +211,16 @@ describe('external inquiry read boundary', () => {
         ]),
       }),
     );
+  });
+
+  it('does not rehydrate durable inquiries when pending state is already warm', async () => {
+    await seedThread(OPEN_THREAD, openFollowUpLegacyManifest(), {
+      't1/answer.txt': 'Legacy A',
+    });
+    const { hydrate, show } = createHydrationShellWithPendingInquiry();
+
+    await hydrate();
+
+    expect(show).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This completes the DR3 slice of #7749 by moving durable external-inquiry hydration out of the VS Code progress provider and into the shared progress backend layer. The shared helper now:

- syncs durable inquiry thread summaries into the progress view,
- reconstructs open external-inquiry permission payloads from manifests after a host restart, and
- keeps the existing in-memory pending-handler guard so warm target switches do not duplicate panels.

The VS Code provider delegates to this shared helper on webview readiness. The desktop progress bridge exposes the same hydration operation and the desktop progress IPC invokes it on `WEBVIEW_READY`, so desktop restart readiness now reads durable inquiry manifests instead of only accepting live `inquiryThreadUpdated` events.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/tools/InquiryReadBoundary.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run typecheck`
- `npx eslint src/controllers/progressView/backend/externalInquiryHydration.ts packages/extension/src/progressView/ProgressViewProvider.ts packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopProgressIpc.ts src/test-kernel/tools/InquiryReadBoundary.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view readiness and approval replay after restarts; behavior is mostly a refactor with a new desktop path, but incorrect hydration could duplicate or miss inquiry panels.
> 
> **Overview**
> Moves **durable external-inquiry hydration** out of the VS Code progress provider into shared progress-backend helper `externalInquiryHydration.ts`. On webview readiness, hosts now **sync inquiry thread summaries** into the progress view and **reconstruct open inquiry permission panels** from stored manifests when in-memory pending state is empty, preserving the existing **`pendingSize > 0` guard** so warm targets do not duplicate panels.
> 
> The extension provider and desktop `DesktopProgressBridge` both delegate to `hydrateProgressViewInquiries`; desktop progress IPC invokes it on **`WEBVIEW_READY`** (fire-and-forget, with async errors reported) alongside full view sync and pending prompt replay. Tests target the shared hydrator directly and assert the desktop readiness path calls hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80edd7259750ec48f88c3caed9a05c35d153a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->