### PR TITLE
fix: dedupe cli ndjson status projection

### DIFF
--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -6,7 +6,7 @@ import type {
 } from '@agent/runtime/SessionEventHub';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
-import type { StreamTabId } from '@shared/schemas';
+import type { StreamTabId, UpdateStreamStatusPayload } from '@shared/schemas';
 import { assertNever } from '@utils/core';
 import { writeNdjsonStdout } from './logSinks';
 import type {
@@ -229,6 +229,16 @@ function emitProjectedProgressEvent(
   });
 }
 
+function statusProjectionKey(payload: UpdateStreamStatusPayload): string {
+  return JSON.stringify([
+    payload.streamId,
+    payload.status,
+    payload.previousStatus ?? null,
+    payload.cause ?? null,
+    payload.substate ?? null,
+  ]);
+}
+
 /**
  * Headless CLI compatibility adapter. Public NDJSON output still speaks the
  * frozen progress-event vocabulary inside `kind: "progress"` records, so this
@@ -238,11 +248,23 @@ export function attachCliSessionProgressProjection(
   events: SessionEventHub,
   writeRecord: CliNdjsonProgressRecordWriter = writeNdjsonStdout,
 ): () => void {
+  const lastStatusByStream = new Map<StreamTabId, string>();
+
+  function emitProjected(projected: CliProjectedNdjsonProgressEvent): void {
+    if (projected.event === 'updateStreamStatus') {
+      const key = statusProjectionKey(projected.payload);
+      const streamId = projected.payload.streamId;
+      if (lastStatusByStream.get(streamId) === key) return;
+      lastStatusByStream.set(streamId, key);
+    }
+    emitProjectedProgressEvent(writeRecord, projected);
+  }
+
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
       const projected = projectCliSessionFact(sessionEvent.event);
-      if (projected) emitProjectedProgressEvent(writeRecord, projected);
+      if (projected) emitProjected(projected);
     },
     { scope: 'session' },
   );
@@ -253,7 +275,7 @@ export function attachCliSessionProgressProjection(
         sessionEvent.streamId,
         sessionEvent.event,
       );
-      if (projected) emitProjectedProgressEvent(writeRecord, projected);
+      if (projected) emitProjected(projected);
     },
     { scope: 'run', types: CLI_RUN_PROGRESS_EVENT_TYPES },
   );

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -8,12 +8,16 @@ import {
   attachCliSessionProgressProjection,
   type CliNdjsonProgressRecordWriter,
 } from '@cli/runtime/sessionProgressSubscription';
-import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
+import {
+  STREAM_TRANSITION_CAUSE,
+  type StreamTransitionCause,
+} from '@common/constants/streamStatus';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
   type ExecutionId,
   type StreamTabId,
+  type UpdateStreamStatusPayload,
 } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
@@ -71,6 +75,51 @@ function setupTraceProjection() {
       detachTrace();
     },
   };
+}
+
+type RunStatusProjectionPayload = UpdateStreamStatusPayload & {
+  cause: StreamTransitionCause;
+};
+
+const resumingStatusPayload: RunStatusProjectionPayload = {
+  streamId,
+  status: STREAM_PHASE.RUNNING,
+  previousStatus: STREAM_PHASE.WAITING,
+  cause: STREAM_TRANSITION_CAUSE.RESUME,
+  substate: STREAM_SUBSTATE.RESUMING,
+};
+
+function emitRunStatus(
+  events: SessionEventHub,
+  payload: RunStatusProjectionPayload,
+): void {
+  events.emit({
+    scope: 'run',
+    streamId,
+    event: {
+      type: 'status',
+      streamId: payload.streamId,
+      phase: payload.status,
+      cause: payload.cause,
+      ...(payload.previousStatus
+        ? { previousPhase: payload.previousStatus }
+        : {}),
+      ...(payload.substate ? { substate: payload.substate } : {}),
+    },
+  });
+}
+
+function emitSessionStatus(
+  events: SessionEventHub,
+  payload: UpdateStreamStatusPayload,
+): void {
+  events.emit({
+    scope: 'session',
+    event: {
+      type: 'updateStreamStatus',
+      payload,
+    },
+  });
 }
 
 describe('attachCliSessionProgressProjection', () => {
@@ -249,6 +298,69 @@ describe('attachCliSessionProgressProjection', () => {
           cause: STREAM_TRANSITION_CAUSE.RESUME,
           substate: STREAM_SUBSTATE.RESUMING,
         }),
+      );
+    } finally {
+      detach();
+    }
+  });
+
+  it('emits one NDJSON stream-status record for duplicate run-then-session status facts', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+
+    try {
+      emitRunStatus(events, resumingStatusPayload);
+      emitSessionStatus(events, resumingStatusPayload);
+
+      expect(writeRecord).toHaveBeenCalledTimes(1);
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+    } finally {
+      detach();
+    }
+  });
+
+  it('emits one NDJSON stream-status record for duplicate session-then-run status facts', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+
+    try {
+      emitSessionStatus(events, resumingStatusPayload);
+      emitRunStatus(events, resumingStatusPayload);
+
+      expect(writeRecord).toHaveBeenCalledTimes(1);
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+    } finally {
+      detach();
+    }
+  });
+
+  it('keeps same-phase stream-status records when substate changes', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+    const startingPayload: RunStatusProjectionPayload = {
+      ...resumingStatusPayload,
+      substate: STREAM_SUBSTATE.STARTING,
+    };
+
+    try {
+      emitRunStatus(events, resumingStatusPayload);
+      emitSessionStatus(events, startingPayload);
+
+      expect(writeRecord).toHaveBeenCalledTimes(2);
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        1,
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        2,
+        progressRecord('updateStreamStatus', startingPayload),
       );
     } finally {
       detach();


### PR DESCRIPTION
## Summary

This addresses the DR14 slice of #7752. The CLI NDJSON projection now owns status idempotency at the public-output boundary instead of relying on renderer-side duplicate suppression.

The projection keeps a per-stream last-published status key over:

- `streamId`,
- `status`,
- `previousStatus`,
- `cause`, and
- `substate`.

Only exact logical duplicate `updateStreamStatus` records are suppressed. Same-phase records with a different substate still pass through, so launch/resume overlay changes are not erased.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `npx eslint packages/cli/src/runtime/sessionProgressSubscription.ts src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI NDJSON output filtering with targeted tests; no changes to runtime status semantics or auth/data paths.
> 
> **Overview**
> Moves **status idempotency** into the CLI NDJSON adapter (`attachCliSessionProgressProjection`) so headless consumers no longer see duplicate `updateStreamStatus` progress records when the same logical status arrives from both **run** (`status` facts) and **session** (`updateStreamStatus` facts).
> 
> Before emitting, the projection tracks a per-stream key built from `streamId`, `status`, `previousStatus`, `cause`, and `substate`; an exact match is dropped. Records that differ only in **substate** (e.g. resuming vs starting under the same phase) still pass through.
> 
> Vitest coverage adds helpers and cases for run-then-session and session-then-run duplicates, plus substate changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b09003b28c394bfd8f07978812d50b23a844c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->