### PR TITLE
fix: gate desktop progress readiness replay

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -42,6 +42,15 @@ const passThroughCommands = new Set<string>([
   PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,
 ]);
 
+function isProgressWebviewReadyMessage(
+  message: DesktopCommandMessage,
+): boolean {
+  return (
+    message.command === PROGRESS_VIEW_COMMANDS.WEBVIEW_READY &&
+    message.view === 'progress'
+  );
+}
+
 export function createDesktopProgressIpc(
   options: DesktopProgressIpcOptions,
 ): DesktopProgressIpc {
@@ -85,6 +94,7 @@ export function createDesktopProgressIpc(
       // WEBVIEW_READY and pass-through commands return false so sibling
       // handlers in the chain still receive them.
       if (command === PROGRESS_VIEW_COMMANDS.WEBVIEW_READY) {
+        if (!isProgressWebviewReadyMessage(message)) return false;
         const progress = getProgress();
         if (progress) {
           progress.syncFullView();

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -89,10 +89,28 @@ describe('desktop Progress IPC', () => {
     const ipc = createDesktopProgressIpc({ progress });
 
     expect(
-      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'progress',
+      }),
     ).toBe(false);
     expect(progress.syncFullView).toHaveBeenCalledTimes(1);
     expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores main-view readiness broadcasts for Progress prompt replay', async () => {
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'main',
+      }),
+    ).toBe(false);
+
+    expect(progress.syncFullView).not.toHaveBeenCalled();
+    expect(progress.replayPendingPrompts).not.toHaveBeenCalled();
   });
 
   it('replays pending prompts after lazy Progress readiness load', async () => {
@@ -102,7 +120,10 @@ describe('desktop Progress IPC', () => {
     });
 
     expect(
-      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'progress',
+      }),
     ).toBe(false);
     await Promise.resolve();
 


### PR DESCRIPTION
## Summary

Fixes #7779. Desktop `WEBVIEW_READY` is a broadcast sent for both `view: main` and `view: progress`, but the progress IPC replay path should only run for the progress webview.

This change gates the desktop progress readiness replay on the raw message `view === "progress"`, matching the existing desktop main-view startup and onboarding readiness guards. Main-view readiness still returns `false` so sibling handlers can process it, but it no longer calls `syncFullView()` or `replayPendingPrompts()` on the progress bridge.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run typecheck`
- `npx eslint packages/desktop/src/main/desktopProgressIpc.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow desktop IPC guard and tests only; reduces mistaken progress replay with no auth or data-path changes.
> 
> **Overview**
> Desktop **`WEBVIEW_READY`** is broadcast for both **`main`** and **`progress`** webviews. Progress IPC was running **`syncFullView()`** and **`replayPendingPrompts()`** on every readiness message, so a main-view ready signal could incorrectly trigger progress replay.
> 
> This adds **`isProgressWebviewReadyMessage`** and only runs that replay path when the raw message has **`view: 'progress'`**, aligned with the main-view startup handler’s **`view === 'main'`** guard. Main-view readiness still returns **`false`** so sibling handlers see it, but no longer touches the progress bridge.
> 
> Tests now send **`view`** on readiness payloads and assert **`view: 'main'`** does not call sync or replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0b7522c6fe561ff0e581ba32ba842d5f579aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->