### PR TITLE
test: make approval replay list exhaustive

### DIFF
--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -33,6 +33,13 @@ export interface ApprovalRequestHandlerSet {
   userQuestion: ApprovalRequestHandler<UserQuestionPermission, 'requestId'>;
 }
 
+type ReplayableApprovalRequestHandlerSet = {
+  [K in keyof ApprovalRequestHandlerSet]: Pick<
+    ApprovalRequestHandlerSet[K],
+    'replay'
+  >;
+};
+
 /**
  * Host-specific show/resolve transport for one approval kind. retry and
  * agentProposal differ across hosts (the extension shows a retry panel and
@@ -136,15 +143,23 @@ export function buildApprovalRequestHandlerSet(
 }
 
 export function replayApprovalRequestHandlers(
-  handlers: ApprovalRequestHandlerSet,
+  handlers: ReplayableApprovalRequestHandlerSet,
 ): void {
-  handlers.toolEdit.replay();
-  handlers.bash.replay();
-  handlers.externalInquiry.replay();
-  handlers.retry.replay();
-  handlers.agentProposal.replay();
-  handlers.planApproval.replay();
-  handlers.userQuestion.replay();
+  const replayOrder = {
+    toolEdit: true,
+    bash: true,
+    externalInquiry: true,
+    retry: true,
+    agentProposal: true,
+    planApproval: true,
+    userQuestion: true,
+  } satisfies Record<keyof ApprovalRequestHandlerSet, true>;
+
+  for (const key of Object.keys(replayOrder) as Array<
+    keyof ApprovalRequestHandlerSet
+  >) {
+    handlers[key].replay();
+  }
 }
 
 export interface ProgressBackendUiConfigParams {

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -8,17 +8,22 @@ import {
 describe('ApprovalRequestHandlerSet helpers', () => {
   it('replays every pending prompt kind', () => {
     const replayCalls = {
-      toolEdit: vi.fn(),
-      bash: vi.fn(),
-      externalInquiry: vi.fn(),
-      retry: vi.fn(),
-      agentProposal: vi.fn(),
-      planApproval: vi.fn(),
-      userQuestion: vi.fn(),
-    };
+      toolEdit: vi.fn<() => void>(),
+      bash: vi.fn<() => void>(),
+      externalInquiry: vi.fn<() => void>(),
+      retry: vi.fn<() => void>(),
+      agentProposal: vi.fn<() => void>(),
+      planApproval: vi.fn<() => void>(),
+      userQuestion: vi.fn<() => void>(),
+    } satisfies Record<
+      keyof ApprovalRequestHandlerSet,
+      ReturnType<typeof vi.fn>
+    >;
     const handlers = Object.fromEntries(
       Object.entries(replayCalls).map(([key, replay]) => [key, { replay }]),
-    ) as unknown as ApprovalRequestHandlerSet;
+    ) as {
+      [K in keyof typeof replayCalls]: { replay: (typeof replayCalls)[K] };
+    };
 
     replayApprovalRequestHandlers(handlers);
 


### PR DESCRIPTION
## Summary

Fixes #7780. The progress backend replay helper now has a compile-time exhaustive replay order for every key in `ApprovalRequestHandlerSet`, so adding or renaming a handler forces the replay list to be updated.

The regression test no longer builds the handler set with `as unknown as ApprovalRequestHandlerSet`; its mock call map is also exhaustive over `keyof ApprovalRequestHandlerSet`, so the test fails to compile if a prompt handler is omitted.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts`
- `npm run typecheck`
- `npx eslint src/controllers/progressView/backend/progressBackendUiConfig.ts src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves the same replay order and behavior; changes are typing and test structure only.
> 
> **Overview**
> Makes **approval replay** stay in sync with `ApprovalRequestHandlerSet` at compile time, so a new or renamed pending-approval handler forces updates to both the replay helper and its test.
> 
> `replayApprovalRequestHandlers` now takes a **`ReplayableApprovalRequestHandlerSet`** (each entry only needs `replay`) and drives replay from a `replayOrder` object that **`satisfies Record<keyof ApprovalRequestHandlerSet, true>`**, replacing seven hand-written `handlers.*.replay()` calls with a typed loop over the same keys and order.
> 
> The vitest helper drops **`as unknown as ApprovalRequestHandlerSet`**; the mock `replayCalls` map is exhaustive over `keyof ApprovalRequestHandlerSet` via `satisfies`, so omitting a handler kind fails typecheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf9041c9f4b8dd2d90cd14a453d0cdb8c530821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->