### PR TITLE
docs: require R6/R8 accounting sections in PR template

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -125,6 +125,7 @@ Mirrors [`docs/proposals/fewer-elements-2026-07.md`](../../../../docs/proposals/
 - **Net-element accounting (R6).** A `refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract` PR body must report constructs added vs deleted (files from diffstat; exported symbols via `^[+-]export` over the diff; class/interface/enum declarations likewise) alongside net LoC. Positive element delta without a stated, staged reason is a merge blocker.
 - **Test budget (R7).** New test file only when the product module has no existing suite (one suite per module, path-mirrored under `src/test-kernel/`; or one suite per named cross-module scenario, stated in the PR body); otherwise extend. Tests pinning #6981-ledgered scaffolding carry an in-file expiry comment naming the row, and their LoC counts double in the R6 net accounting. ≥4 structurally identical cases use `test.each`.
 - **Consumer-grep before emitter deletion (R8).** A PR deleting or re-routing an emit path states the grepped subscriber count for every affected key in its body. Missing count on a deletion PR is a merge blocker (#7398 precedent: a live `bus.on` consumer was severed for 3.5h on main).
+- **Template enforcement.** Reject any `refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract` PR whose body is missing the `## Net elements (R6)` or `## Consumer counts (R8)` sections from `.github/PULL_REQUEST_TEMPLATE.md` — letter-level compliance, not just spirit (#7736).
 
 ## 15. Error-handling and fallback discipline (2026-07 audit)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,14 @@
 
 <!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->
 
+## Net elements (R6)
+
+<!-- Constructs added vs deleted: files (diffstat), exported symbols (`^[+-]export` over the diff), classes/interfaces/enums, net LoC. Required for refactor/simplify/consolidate/dedupe/extract PRs. -->
+
+## Consumer counts (R8)
+
+<!-- Deleting or re-routing an emit path or export? State the grepped subscriber count per affected key. Otherwise: "n/a" + reason. -->
+
 ## Host impact
 
 Extension:


### PR DESCRIPTION
## Summary

Fixes #7736. The 2026-07-09 status audit found codex-authored refactor PR bodies (sampled #7675, #7702, #7698, #7655, #7666) consistently stated "zero-match greps" but omitted the two REQUIRED counts the fewer-elements ruling (`docs/proposals/fewer-elements-2026-07.md`) and the code-review checklist already require in prose: **R6 net-element accounting** and **R8 per-key subscriber counts**. Spirit was satisfied (the greps happened); the letter was absent, so reviewers had to redo the greps to verify. This is a template fix, not per-PR remediation.

## What changed

1. `.github/PULL_REQUEST_TEMPLATE.md` — added two required sections between "Duplication and abstraction budget" and "Host impact":
   - `## Net elements (R6)` — constructs added vs deleted (files from diffstat; exported symbols via `^[+-]export` over the diff; class/interface/enum declarations) alongside net LoC.
   - `## Consumer counts (R8)` — grepped subscriber count per affected key when deleting/re-routing an emit path or export; `"n/a"` + reason otherwise.
2. `.claude/skills/code-review/references/review-checklist.md` §14 (the existing R6/R8 mirror of the fewer-elements ruling) — added one enforcement bullet: reject any `refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract` PR whose body is missing either section.

Both sections are terse HTML-comment prompts (matching the rest of the template) so swarm agents fill them mechanically rather than freeform.

## Net elements (R6)

- Files: 2 changed (`.github/PULL_REQUEST_TEMPLATE.md`, `.claude/skills/code-review/references/review-checklist.md`), 0 added, 0 deleted.
- Exported symbols (`^[+-]export` over the diff): 0 (docs-only change, no code).
- Classes/interfaces/enums: 0.
- Net LoC: `git diff --stat origin/main` → `2 files changed, 9 insertions(+)`. Positive delta is two required template sections plus one checklist enforcement line — the fix the issue asks for, not scope creep.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; this PR only adds template/checklist prose.

## Validation

- `node docs/scripts/check-root-docs.mjs` → `docs boundary OK: every root-level entry is classified (5 public docs, 1 public dirs).` (exit 0). Neither changed file is docs-root-boundary-governed (`.github/`, `.claude/`), but the gate was run per the issue's instruction and confirms no regression.
- Docs-only change (Markdown template/checklist prose): no test suite, `npm run typecheck`, or build applies — nothing here has a runtime surface.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only template and checklist updates; no runtime, auth, or data paths change.
> 
> **Overview**
> Closes the gap where **R6** net-element and **R8** consumer-count rules lived in prose but refactor PRs often skipped the required headings, forcing reviewers to re-grep (#7736).
> 
> **`.github/PULL_REQUEST_TEMPLATE.md`** now includes **`## Net elements (R6)`** and **`## Consumer counts (R8)`** (with HTML-comment prompts) between the duplication budget and host-impact sections so authors fill counts mechanically.
> 
> **`.claude/skills/code-review/references/review-checklist.md`** §14 adds **template enforcement**: merge-block **`refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract`** PRs whose body lacks those exact section headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0344f43c73f279f9cce1e702c5bd2458e8818a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->