### PR TITLE
fix: package bundled skills with desktop

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -31,6 +31,10 @@ extraResources:
     to: resources
     filter:
       - '**/*'
+  - from: ../../skills
+    to: resources/skills
+    filter:
+      - '**/*'
 mac:
   category: public.app-category.productivity
   icon: build/icon.icns

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -43,7 +43,7 @@ const desktopVscodeFreeSourceDirSet = new Set(desktopVscodeFreeSourceDirs);
 const desktopSourceBoundaryDirs = [
   ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
 ];
-const bundledAgentResourceDirs = ['agents', 'tool_use_agents'];
+const bundledRuntimeResourceDirs = ['agents', 'tool_use_agents', 'skills'];
 const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
@@ -650,7 +650,7 @@ async function checkRuntimeDependencies(app, appPackageJson, failures) {
 }
 
 async function checkBundledResources(app, failures) {
-  for (const directoryName of bundledAgentResourceDirs) {
+  for (const directoryName of bundledRuntimeResourceDirs) {
     const entries = await app.listDir(`resources/${directoryName}`);
     if (entries.length === 0) {
       failures.push(
@@ -745,7 +745,7 @@ const summary = [
   '- dist/renderer/assets/*.js',
   '- dist/renderer/assets/*.css',
   '- dist/renderer/assets Monaco worker chunks',
-  '- resources/agents and resources/tool_use_agents',
+  '- resources/agents, resources/tool_use_agents, and resources/skills',
   '- package.json runtime dependencies',
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -301,6 +301,10 @@ function createFakeDesktopPackage(
     join(appRoot, 'resources/tool_use_agents/example.yaml'),
     'name: example\n',
   );
+  writeText(
+    join(appRoot, 'resources/skills/example/SKILL.md'),
+    'name: example\n\ndescription: Example bundled skill.\n',
+  );
 
   for (const dependencyName of Object.keys(readDesktopDependencies())) {
     writeJson(join(appRoot, 'node_modules', dependencyName, 'package.json'), {


### PR DESCRIPTION
## Summary

Fixes #7776. Desktop packaged resources now include the repo-root `skills/` tree at `resources/skills`, matching the runtime source that `initializeNodeRuntimeSkills({ resourcesPath })` registers for bundled skills.

The desktop package verifier now treats `resources/skills` as a required bundled runtime resource alongside `resources/agents` and `resources/tool_use_agents`, so a packaged build fails verification if the bundled skills directory is missing or empty.

## Validation

- `npx prettier --write packages/desktop/electron-builder.yml scripts/verify-desktop-package.mjs`
- `node --check scripts/verify-desktop-package.mjs`
- `git diff --check`

I could not run `node scripts/verify-desktop-package.mjs` against a packaged app in this worktree because `packages/desktop/dist-packaged` is not present locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and verification-only changes; no runtime logic changes beyond ensuring bundled skills are present in the installer.
> 
> **Overview**
> Packaged TeXRA desktop builds now copy the repo-root **`skills/`** tree into **`resources/skills`**, so bundled skill discovery matches what the runtime expects under `resourcesPath` (alongside existing extension `resources`).
> 
> The desktop package verifier treats **`resources/skills`** as a required non-empty bundled runtime directory, renamed from agent-only checks to **`bundledRuntimeResourceDirs`** (`agents`, `tool_use_agents`, `skills`). The fake packaged-app fixture used in **`DesktopCodexPayload`** tests now seeds an example **`SKILL.md`** so verification passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447055f8d3dc2dce30424e615da200f5aff72be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->