### PR TITLE
fix: use home fallback for desktop skills

### DIFF
--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -184,7 +184,7 @@ export async function initializeElectronPlatform(
   initNodeAgentRuntime(lifecycle);
   initializeNodeGoalPrompts(resourcesPath);
   initializeNodeRuntimeSkills({
-    cwd: workspacePath ?? userDataPath,
+    cwd: workspacePath ?? app.getPath('home'),
     resourcesPath,
   });
 

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -122,6 +122,16 @@ describe('desktop composition root and launch environment', () => {
     );
   });
 
+  it('uses the home directory as the no-workspace skill discovery fallback', async () => {
+    const source = await readFile(
+      repoPath('packages', 'desktop', 'src', 'main', 'platform', 'index.ts'),
+      'utf8',
+    );
+
+    expect(source).toContain("cwd: workspacePath ?? app.getPath('home'),");
+    expect(source).not.toContain('cwd: workspacePath ?? userDataPath,');
+  });
+
   it('resolves workspace paths only from an explicit launch environment', async () => {
     const { resolveWorkspacePath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');


### PR DESCRIPTION
## Summary

- Use the user home directory, not Electron userData, as desktop skill discovery cwd when no workspace is open.
- Add a desktop composition-root regression assertion for the fallback.

Fixes #7777.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts`
- `npm run typecheck`
- `npx eslint packages/desktop/src/main/platform/index.ts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single startup-path change for skill cwd when no workspace is open; no auth, data migration, or core agent runtime logic changes.
> 
> **Overview**
> When the desktop app starts **without an open workspace**, runtime skill discovery now uses the **user home directory** (`app.getPath('home')`) as `cwd` instead of **Electron `userData`**, so skills are found in the same places users expect (e.g. home-based skill layouts) rather than app-internal storage.
> 
> A composition-root regression test locks in the new fallback string and ensures the old `userDataPath` fallback is not reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339acedb202e8bebb0d0a7098b56b9d73142a264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->