### PR TITLE
test(ci): QA-2 host-mock ratchet + D8 test-LoC growth detector (#7684 remainder)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Check dead-code ratchet
         run: pnpm run check:dead-code-ratchet
 
+      - name: Check test-kernel LoC growth (warn-only)
+        run: pnpm run check:test-loc-growth
+
       - name: Check extension package invariants
         run: pnpm run check:extension-package-invariants
 

--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -1,0 +1,93 @@
+{
+  "semantics": "vi.mock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current site count exceeds this baseline; a decrease is welcome and should shrink this file.",
+  "sites": [
+    {
+      "file": "src/test-kernel/cli/AgentResolution.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/AgentsCommand.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/ChatDefaults.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/runtime/executionRegistry"
+    },
+    {
+      "file": "src/test-kernel/cli/CliInitPlatform.vitest.mts",
+      "specifier": "@agent/index/platformAgentDirectories"
+    },
+    {
+      "file": "src/test-kernel/cli/History.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/InitCommand.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/OnboardingGate.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/RunChatConfig.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/RunChatRegistration.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/cli/RunProgressRenderer.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
+    },
+    {
+      "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "specifier": "@agent/runtime/streamTab"
+    },
+    {
+      "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "specifier": "@agent/index"
+    },
+    {
+      "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "specifier": "@agent/storage"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "check:cli-orchestration-manifest": "node scripts/check-cli-orchestration-manifest.mjs",
     "check:dead-code": "knip --no-progress --include files,exports,types,duplicates",
     "check:dead-code-ratchet": "node scripts/check-dead-code-ratchet.mjs",
+    "check:test-loc-growth": "node scripts/check-test-loc-growth.mjs",
     "texra-local:build": "corepack pnpm --filter @texra-ai/cli run prepare:trace-viewer-assets && corepack pnpm --filter @texra-ai/cli run bundle && corepack pnpm --filter @texra-ai/cli run copy:resources && corepack pnpm --filter @texra-ai/cli run copy:docs",
     "texra-local:link": "node scripts/link-texra-local.mjs",
     "check:desktop-installers": "node scripts/verify-desktop-installer-artifacts.mjs",

--- a/scripts/check-test-loc-growth.d.mts
+++ b/scripts/check-test-loc-growth.d.mts
@@ -1,0 +1,14 @@
+export interface LocDelta {
+  current: number;
+  baseline: number;
+  delta: number;
+}
+
+export function countLines(content: string): number;
+
+export function computeLocDelta(
+  currentLoc: number,
+  baselineLoc: number,
+): LocDelta;
+
+export function collectTestKernelFiles(dir: string): string[];

--- a/scripts/check-test-loc-growth.mjs
+++ b/scripts/check-test-loc-growth.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// D8 test-LoC growth detector (issue #7684): reports the line-count delta
+// of src/test-kernel/** against the checked-in baseline
+// (test-kernel-loc-baseline.json). Unlike check-dead-code-ratchet.mjs this
+// is WARN-ONLY — it never fails CI — because the R7 judgment rules on
+// test-kernel growth are qualitative (is a suite addition earning its
+// LoC?), not a hard ratchet; this just surfaces the number so growth isn't
+// invisible.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const baselinePath = path.join(rootDir, 'test-kernel-loc-baseline.json');
+const testKernelDir = path.join(rootDir, 'src', 'test-kernel');
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
+
+export function countLines(content) {
+  if (content.length === 0) {
+    return 0;
+  }
+  const lines = content.split('\n');
+  if (lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines.length;
+}
+
+export function computeLocDelta(currentLoc, baselineLoc) {
+  return {
+    current: currentLoc,
+    baseline: baselineLoc,
+    delta: currentLoc - baselineLoc,
+  };
+}
+
+// Split out from computeTestKernelLoc() so the walk can be exercised without
+// touching the filesystem in tests, matching parseKnipIssues()'s split in
+// check-dead-code-ratchet.mjs.
+export function collectTestKernelFiles(dir) {
+  return readdirSync(dir, { recursive: true })
+    .filter((entry) => SOURCE_FILE.test(entry) && !entry.endsWith('.d.ts'))
+    .map((entry) => path.join(dir, entry))
+    .toSorted();
+}
+
+function computeTestKernelLoc(dir) {
+  return collectTestKernelFiles(dir).reduce(
+    (total, file) => total + countLines(readFileSync(file, 'utf8')),
+    0,
+  );
+}
+
+function main() {
+  const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const current = computeTestKernelLoc(testKernelDir);
+  const { delta } = computeLocDelta(current, baseline.testKernelLoc);
+  const direction = delta > 0 ? 'grew' : delta < 0 ? 'shrank' : 'is unchanged';
+
+  console.log(
+    `test-kernel LoC: ${current} (baseline ${baseline.testKernelLoc}, ${direction} by ${Math.abs(delta)} lines)`,
+  );
+
+  if (delta > 0) {
+    console.log(
+      'D8 warn-only report (issue #7684): test-kernel grew past its checked-in baseline. ' +
+        'This does not fail CI. If the growth is a judged, earning-its-LoC addition, update ' +
+        'test-kernel-loc-baseline.json in this PR; otherwise no action is required.',
+    );
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -1,0 +1,125 @@
+// QA-2 host-side mock ratchet (issue #7684). Host suites (CLI + desktop, in
+// src/test-kernel/cli and src/test-kernel/desktop) reach into `@agent/*`
+// internals via `vi.mock('@agent/...')`, pinning agent's current internal
+// module layout from outside src/agent. Clones the checked-in-baseline +
+// AST-scanning vitest pattern from LAY-1 (subsystemEdgeRatchet.vitest.ts,
+// PR #7774): baseline the current site count and fail only on an increase;
+// a decrease (or an @agent restructor removing the need for a mock) is
+// always welcome and should shrink host-agent-mock-baseline.json.
+
+// Node imports
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+interface MockSite {
+  file: string;
+  specifier: string;
+}
+
+interface MockBaseline {
+  semantics: string;
+  sites: MockSite[];
+}
+
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+const BASELINE_PATH = resolve(REPO_ROOT, 'host-agent-mock-baseline.json');
+
+const HOST_DIRS = [
+  resolve(REPO_ROOT, 'src/test-kernel/cli'),
+  resolve(REPO_ROOT, 'src/test-kernel/desktop'),
+];
+
+const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
+const AGENT_SPECIFIER = /^@agent(?:\/|$)/;
+
+function repoRelative(path: string): string {
+  return relative(REPO_ROOT, path).replaceAll('\\', '/');
+}
+
+function sourceFilesUnder(dir: string): string[] {
+  return (readdirSync(dir, { recursive: true }) as string[])
+    .filter((entry) => SOURCE_FILE.test(entry) && !entry.endsWith('.d.ts'))
+    .map((entry) => join(dir, entry));
+}
+
+function isViMockCall(node: ts.Node): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'vi' &&
+    node.expression.name.text === 'mock'
+  );
+}
+
+function collectAgentMockSites(file: string): MockSite[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const sites: MockSite[] = [];
+  const visit = (node: ts.Node): void => {
+    if (isViMockCall(node)) {
+      const [specifierArg] = node.arguments;
+      if (specifierArg != null && ts.isStringLiteralLike(specifierArg)) {
+        const specifier = specifierArg.text;
+        if (AGENT_SPECIFIER.test(specifier)) {
+          sites.push({ file: repoRelative(file), specifier });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return sites;
+}
+
+function collectHostAgentMockSites(): MockSite[] {
+  return HOST_DIRS.flatMap((dir) =>
+    sourceFilesUnder(dir).flatMap(collectAgentMockSites),
+  ).toSorted(
+    (a, b) =>
+      a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+  );
+}
+
+function readBaseline(): MockBaseline {
+  return JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as MockBaseline;
+}
+
+describe('QA-2 host-side @agent mock ratchet', () => {
+  it("does not increase the count of vi.mock('@agent/...') sites in CLI/desktop suites", () => {
+    const baseline = readBaseline();
+    const current = collectHostAgentMockSites();
+
+    expect(
+      current.length,
+      `host-side @agent mock sites grew from ${baseline.sites.length} to ${current.length}:\n` +
+        `${current.map((site) => `${site.file}: ${site.specifier}`).join('\n')}\n\n` +
+        'If this growth is intentional, update host-agent-mock-baseline.json in this PR.',
+    ).toBeLessThanOrEqual(baseline.sites.length);
+  });
+
+  it('keeps the baseline non-empty and ordered', () => {
+    const baseline = readBaseline();
+    const sortedSites = baseline.sites.toSorted(
+      (a, b) =>
+        a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+    );
+
+    expect(baseline.sites.length).toBeGreaterThan(0);
+    expect(baseline.sites).toEqual(sortedSites);
+  });
+});

--- a/src/test-kernel/scripts/CheckTestLocGrowth.vitest.mts
+++ b/src/test-kernel/scripts/CheckTestLocGrowth.vitest.mts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeLocDelta,
+  countLines,
+} from '../../../scripts/check-test-loc-growth.mjs';
+
+describe('check-test-loc-growth countLines', () => {
+  it('counts lines for content with a trailing newline', () => {
+    expect(countLines('a\nb\nc\n')).toBe(3);
+  });
+
+  it('counts lines for content without a trailing newline', () => {
+    expect(countLines('a\nb\nc')).toBe(3);
+  });
+
+  it('returns 0 for empty content', () => {
+    expect(countLines('')).toBe(0);
+  });
+
+  it('counts a single line with no newline as 1', () => {
+    expect(countLines('a')).toBe(1);
+  });
+});
+
+describe('check-test-loc-growth computeLocDelta', () => {
+  it('reports a positive delta when current exceeds baseline', () => {
+    expect(computeLocDelta(150, 100)).toEqual({
+      current: 150,
+      baseline: 100,
+      delta: 50,
+    });
+  });
+
+  it('reports a negative delta when current is below baseline', () => {
+    expect(computeLocDelta(80, 100)).toEqual({
+      current: 80,
+      baseline: 100,
+      delta: -20,
+    });
+  });
+
+  it('reports a zero delta when current equals baseline', () => {
+    expect(computeLocDelta(100, 100)).toEqual({
+      current: 100,
+      baseline: 100,
+      delta: 0,
+    });
+  });
+});

--- a/test-kernel-loc-baseline.json
+++ b/test-kernel-loc-baseline.json
@@ -1,0 +1,4 @@
+{
+  "semantics": "D8 warn-only test-LoC baseline (issue #7684): total line count of src/test-kernel/** (.ts/.tsx/.mts/.cts, excluding .d.ts). check:test-loc-growth reports the delta against this number and never fails CI; update this file when a deliberate, judged addition should reset the baseline.",
+  "testKernelLoc": 147904
+}


### PR DESCRIPTION
## What / why

Issue #7684 REMAINDER: R-a (core→host import fence, PR #7721) and LAY-1 (subsystem-edge baseline, PR #7774) already landed. This PR ships the two remaining independently-shippable ratchets from the issue, following the two landed siblings' patterns exactly (R-b stays gated on #6968, per the issue).

**QA-2 — host-side `@agent` mock ratchet.** CLI/desktop `test-kernel` suites reach into `@agent/*` internals via `vi.mock('@agent/...')`, pinning agent's current internal module layout from outside `src/agent` (the same surface R-b's per-host `@agent/*` baseline cares about). Clones LAY-1's checked-in-baseline + TS-AST-scanning vitest pattern (`architecture-edges-baseline.json` / `subsystemEdgeRatchet.vitest.ts`, PR #7774):
- `host-agent-mock-baseline.json` — baselines the current sites.
- `src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts` — recomputes the current site count on every run and fails only if it grows past the baseline; shrinking (or `@agent` restructuring away the need to mock) is always welcome.

Recomputed count: **22 sites across 17 suites** in `src/test-kernel/cli/**` + `src/test-kernel/desktop/**` (the issue's own text flags this as stale — "the audit counted 52 sites/32 suites — recompute"). The audit's 52/32 figure counted *all* `vi.mock()` targets in those suites (148 total today, confirming its own staleness call-out), with `@agent/storage` named as the "#1 target, 23 sites" concentration; this ratchet scopes to the `@agent/*`-specifier subset specifically, since that's the SDK-boundary-sensitive surface R-b already tracks (`@agent/storage` = 9, `@agent/index` family = 8, plus 5 other single-site `@agent/runtime/*` specifiers = 22).

**D8 — test-LoC growth detector.** Extends the `scripts/check-dead-code-ratchet.mjs` CI-step family with `scripts/check-test-loc-growth.mjs`: sums line counts across `src/test-kernel/**` and reports the delta against the checked-in `test-kernel-loc-baseline.json` (147,904 lines as of this PR). Unlike the dead-code ratchet, **this never fails CI** — growth > 0 only prints a note — because the R7 judgment rules on test-kernel growth are qualitative ("does a suite addition earn its LoC?"), not a hard gate; the detector's job is only to make the number visible in every CI run per the issue's D8 sketch. Wired as its own "Check test-kernel LoC growth (warn-only)" step in `ci.yml` right after "Check dead-code ratchet". Unit-tested (`countLines`/`computeLocDelta`) the same way `CheckDeadCodeRatchet.vitest.mts` tests its sibling script's pure functions — mirrored file naming and a matching `.d.mts` type declaration.

## Verification

- `npx vitest run src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts src/test-kernel/scripts/CheckTestLocGrowth.vitest.mts src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts src/test-kernel/architecture/dependencyDirection.vitest.ts src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` — 5 files / 40 tests passed
- `npm run test` (full kernel suite) — 614 passed / 1 skipped (615 files), 5323 passed / 4 skipped (5327 tests)
- `npm run typecheck` — clean (root, test-kernel project, extension, CLI, trace-viewer)
- `npm run check:dead-code-ratchet` — OK, unaffected by the new files
- `npm run check:test-loc-growth` — `test-kernel LoC: 147904 (baseline 147904, is unchanged by 0 lines)`
- `npx prettier --check` on all touched files — clean
- `npx eslint` on the new `.ts`/`.mts` test files — clean (the new `scripts/check-test-loc-growth.mjs` itself isn't covered by `npm run lint`'s glob, same as its sibling `scripts/check-dead-code-ratchet.mjs` today — confirmed by running raw `eslint` against both and seeing the identical pre-existing `no-undef: console` gap on the already-merged sibling)

## Net elements (R6)

Two small commits, config/test-only, no code moves:

- `+1` script: `scripts/check-test-loc-growth.mjs` (D8)
- `+1` type declaration: `scripts/check-test-loc-growth.d.mts` (D8)
- `+1` vitest suite: `src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts` (QA-2)
- `+1` vitest suite: `src/test-kernel/scripts/CheckTestLocGrowth.vitest.mts` (D8)
- `+1` npm script: `check:test-loc-growth` in `package.json` (D8)
- `+1` CI step in `.github/workflows/ci.yml` (D8)
- `+2` checked-in baseline JSON files: `host-agent-mock-baseline.json` (QA-2), `test-kernel-loc-baseline.json` (D8)
- `0` deletions, `0` files moved
- Net: +371 lines across 8 files (2 commits), entirely new config/test/baseline files — no production `src/` changes.

## Consumer counts (R8)

n/a — no emit path or export is deleted or re-routed; both ratchets are additive, read-only scanners over existing test files and CI wiring.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CI and test-kernel architecture checks only; no runtime, auth, or product code paths change.
> 
> **Overview**
> Adds two **issue #7684** guardrails, both config/test/CI only—no production `src/` changes.
> 
> **QA-2 (hard ratchet):** `host-agent-mock-baseline.json` plus `hostAgentMockRatchet.vitest.ts` AST-scan CLI/desktop `test-kernel` for `vi.mock('@agent/...')` sites (22 baselined). Kernel tests **fail** if the site count grows past the baseline; shrinking the baseline is expected when mocks go away.
> 
> **D8 (visibility only):** `scripts/check-test-loc-growth.mjs` sums LoC under `src/test-kernel/**` against `test-kernel-loc-baseline.json` (~147k lines), exposed as `pnpm run check:test-loc-growth` and a new **warn-only** CI step after the dead-code ratchet—it logs growth and **never fails** CI. Pure helpers are covered by `CheckTestLocGrowth.vitest.mts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da59192d048f7a22515f6d8b7a430fb2db911487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->