### PR TITLE
fix: harden cli wake resume

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -416,88 +416,108 @@ export function createChatSessionController(
     publishChatTuiRootRunStartAvailability(session);
   };
 
-  const tryResumeStream = async (streamId: StreamTabId): Promise<boolean> => {
-    if (!chatTuiCanStartRootRun(session)) return false;
+  const tryResumeStream = (streamId: StreamTabId): Promise<boolean> => {
+    if (!chatTuiCanStartRootRun(session)) {
+      return Promise.resolve(true);
+    }
 
-    await snapshotStore.preload([streamId]);
-    const executionId =
-      snapshotStore.getExecutionId(streamId) ??
-      (await snapshotStore.readPersistedExecutionId(streamId));
-    if (!executionId) return false;
-
-    const config =
-      snapshotStore.getRunConfig(streamId) ??
-      (await getExecutionStore(executionId).readConfig());
-    if (!config) return false;
-
-    const currentModel = config.model;
-    const sessionContext = getSessionContext(currentModel);
-    patchSessionMeta({
-      agent: config.agent,
-      model: config.model,
-      modelSource: 'history',
-      canDelegate: chatAgentSupportsDelegation(config.agent),
+    let resolveRun: (resumed: boolean) => void = () => {};
+    let rejectRun: (error: unknown) => void = () => {};
+    const runPromise = new Promise<boolean>((resolve, reject) => {
+      resolveRun = resolve;
+      rejectRun = reject;
     });
+    markChatTuiRunPending(
+      session,
+      runPromise.then(() => undefined),
+    );
 
-    const { runtimeHost, approvalsUnavailable, finalize } =
-      setupRunHost(sessionContext);
-    session.runtimeHost = runtimeHost;
-    session.streamId = streamId;
-    session.executionId = executionId;
-    rootStreamId.set(streamId);
-    activeStreamId.set(streamId);
-    session.runCompleted = false;
-    session.stopRequested = false;
-    session.runExitCode = CliExitCode.Success;
-    publishChatTuiRootRunStartAvailability(session);
+    const runResume = async (): Promise<boolean> => {
+      let finalize = (): void => markChatTuiRunCompleted(session);
+      try {
+        await snapshotStore.preload([streamId]);
+        const executionId =
+          snapshotStore.getExecutionId(streamId) ??
+          (await snapshotStore.readPersistedExecutionId(streamId));
+        if (!executionId) return false;
 
-    const runPromise = setCliHelperModel(currentModel)
-      .then(() =>
-        resolveAndResumeStream(streamId, {
-          runtimeHost,
-          streamStatus: defaultSession().status,
-          resolveResumeState: async () => ({
-            runState: config,
-            executionId,
-            parentStreamId: snapshotStore.getParentStreamId(streamId),
-          }),
-          resumeToolUseSnapshot: (snapshot) =>
-            resumeQueuedToolUseSnapshot(streamId, snapshot, runtimeHost, {
-              session: defaultSession(),
-              approvalPromptsUnavailable: approvalsUnavailable,
-              runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
-              onError: reportRunFailure,
+        const config =
+          snapshotStore.getRunConfig(streamId) ??
+          (await getExecutionStore(executionId).readConfig());
+        if (!config) return false;
+        if (session.stopRequested) return false;
+
+        const currentModel = config.model;
+        const sessionContext = getSessionContext(currentModel);
+        patchSessionMeta({
+          agent: config.agent,
+          model: config.model,
+          modelSource: 'history',
+          canDelegate: chatAgentSupportsDelegation(config.agent),
+        });
+
+        const runHost = setupRunHost(sessionContext);
+        finalize = runHost.finalize;
+        const { runtimeHost, approvalsUnavailable } = runHost;
+        session.runtimeHost = runtimeHost;
+        session.streamId = streamId;
+        session.executionId = executionId;
+        rootStreamId.set(streamId);
+        activeStreamId.set(streamId);
+        session.runCompleted = false;
+        session.stopRequested = false;
+        session.runExitCode = CliExitCode.Success;
+        publishChatTuiRootRunStartAvailability(session);
+
+        const resumed = await setCliHelperModel(currentModel).then(() =>
+          resolveAndResumeStream(streamId, {
+            runtimeHost,
+            streamStatus: defaultSession().status,
+            resolveResumeState: async () => ({
+              runState: config,
+              executionId,
+              parentStreamId: snapshotStore.getParentStreamId(streamId),
             }),
-          executeWorkflow: async () => {
-            throw new Error(
-              'CLI chat cannot auto-resume workflow streams from follow-up wake.',
-            );
-          },
-          reportNoResumableSession: () => {
-            appendLocalAssistantTranscript(
-              'Message queued. Auto-resume found no resumable session state; resume the session manually or start a new agent task.',
-              streamId,
-            );
-          },
-          reportFailure: (_failedStream, error) => reportRunFailure(error),
-        }),
-      )
-      .then((resumed) => {
-        if (session.streamId) {
-          projectStreamTranscript(session.streamId, { finalize: true });
-        }
+            resumeToolUseSnapshot: (snapshot) =>
+              resumeQueuedToolUseSnapshot(streamId, snapshot, runtimeHost, {
+                session: defaultSession(),
+                approvalPromptsUnavailable: approvalsUnavailable,
+                runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+                allowWaitingResult: true,
+                onError: reportRunFailure,
+              }),
+            executeWorkflow: async () => {
+              throw new Error(
+                'CLI chat cannot auto-resume workflow streams from follow-up wake.',
+              );
+            },
+            reportNoResumableSession: () => {
+              appendLocalAssistantTranscript(
+                'Message queued. Auto-resume found no resumable session state; resume the session manually or start a new agent task.',
+                streamId,
+              );
+            },
+            reportFailure: (_failedStream, error) => reportRunFailure(error),
+          }),
+        );
+
         if (resumed) {
+          if (session.streamId) {
+            projectStreamTranscript(session.streamId, { finalize: true });
+          }
           session.runExitCode = CliExitCode.Success;
           notify({ kind: 'agentFinished' });
         }
         return resumed;
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         reportRunFailure(error);
         return false;
-      })
-      .finally(finalize);
-    session.runPromise = runPromise.then(() => undefined);
+      } finally {
+        finalize();
+      }
+    };
+
+    void runResume().then(resolveRun, rejectRun);
 
     return runPromise;
   };

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -11,12 +11,55 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   stopAgentStream: vi.fn(),
   workspaceGet: vi.fn(),
+  getExecutionStore: vi.fn(),
+  setCliHelperModel: vi.fn(),
+  createCliRuntimeHost: vi.fn(),
+  runtimeHostClose: vi.fn(),
+  defaultSession: vi.fn(),
+  streamIsActiveOrResuming: vi.fn(),
+  detachHostInteractions: vi.fn(),
+  attachTerminalResultToast: vi.fn(),
+  attachTuiRunFactSubscription: vi.fn(),
+  createTuiHostInteractions: vi.fn(),
+  resolveAndResumeStream: vi.fn(),
+  isResumeInFlight: vi.fn(),
+  resumeQueuedToolUseSnapshot: vi.fn(),
+  projectStreamTranscript: vi.fn(),
+  notify: vi.fn(),
+  appendLocalAssistantTranscript: vi.fn(),
+  appendLocalErrorTranscript: vi.fn(),
+  appendLocalUserTranscript: vi.fn(),
+  clearLocalTranscript: vi.fn(),
+  moveLocalTranscriptToStream: vi.fn(),
+}));
+
+vi.mock('@agent/storage', () => ({
+  getExecutionStore: mocks.getExecutionStore,
+  registerExecution: vi.fn(),
+  writeTerminalStatus: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/executionRegistry', () => ({
   SharedExecutionRegistry: {
     stopAgentStream: mocks.stopAgentStream,
   },
+}));
+
+vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
+  resolveAndResumeStream: mocks.resolveAndResumeStream,
+  isResumeInFlight: mocks.isResumeInFlight,
+}));
+
+vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
+  resumeQueuedToolUseSnapshot: mocks.resumeQueuedToolUseSnapshot,
+}));
+
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  defaultSession: mocks.defaultSession,
+}));
+
+vi.mock('@agent/runtime/terminalResultToast', () => ({
+  attachTerminalResultToast: mocks.attachTerminalResultToast,
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -27,7 +70,40 @@ vi.mock('@platform/platform', () => ({
   }),
 }));
 
+vi.mock('@cli/runtime/initPlatform', () => ({
+  setCliHelperModel: mocks.setCliHelperModel,
+}));
+
+vi.mock('@cli/runtime/runtimeHost', () => ({
+  createCliRuntimeHost: mocks.createCliRuntimeHost,
+}));
+
+vi.mock('@cli/chat/tui/state/subscribeApprovals', () => ({
+  createTuiHostInteractions: mocks.createTuiHostInteractions,
+}));
+
+vi.mock('@cli/chat/tui/state/subscribeRuntimeHost', () => ({
+  attachTuiRunFactSubscription: mocks.attachTuiRunFactSubscription,
+}));
+
+vi.mock('@cli/chat/tui/state/transcriptProjection', () => ({
+  projectStreamTranscript: mocks.projectStreamTranscript,
+}));
+
+vi.mock('@cli/chat/tui/state/transcript', () => ({
+  appendLocalAssistantTranscript: mocks.appendLocalAssistantTranscript,
+  appendLocalErrorTranscript: mocks.appendLocalErrorTranscript,
+  appendLocalUserTranscript: mocks.appendLocalUserTranscript,
+  clearLocalTranscript: mocks.clearLocalTranscript,
+  moveLocalTranscriptToStream: mocks.moveLocalTranscriptToStream,
+}));
+
+vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
+  notify: mocks.notify,
+}));
+
 import { StreamSnapshotStore } from '@transcript';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
@@ -36,6 +112,7 @@ import {
   chatTuiCanStartRootRun,
   type TuiSession,
 } from '@cli/chat/tui/state/sessionRunState';
+import type { StreamTabId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // ---------------------------------------------------------------------------
@@ -85,6 +162,45 @@ function makeInit(
   };
 }
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeResumeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    agent: 'demo-agent',
+    model: 'demo-model',
+    agentCategory: 'toolUse',
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeResumeSnapshotStore(options: {
+  readonly preload?: () => Promise<void>;
+  readonly executionId?: string | undefined;
+  readonly persistedExecutionId?: string | undefined;
+  readonly config?: AgentConfig | undefined;
+  readonly parentStreamId?: StreamTabId | undefined;
+}): StreamSnapshotStore {
+  return {
+    preload: vi.fn(options.preload ?? (async () => undefined)),
+    getExecutionId: vi.fn(() => options.executionId),
+    readPersistedExecutionId: vi.fn(async () => options.persistedExecutionId),
+    getRunConfig: vi.fn(() => options.config),
+    getParentStreamId: vi.fn(() => options.parentStreamId),
+  } as unknown as StreamSnapshotStore;
+}
+
 // ---------------------------------------------------------------------------
 // Predicate: chatTuiCanStartRootRun
 // ---------------------------------------------------------------------------
@@ -126,6 +242,45 @@ describe('createChatSessionController', () => {
     mocks.stopAgentStream.mockReset();
     mocks.workspaceGet.mockReset();
     mocks.workspaceGet.mockReturnValue(false);
+    mocks.getExecutionStore.mockReset();
+    mocks.setCliHelperModel.mockReset();
+    mocks.setCliHelperModel.mockResolvedValue(undefined);
+    mocks.createCliRuntimeHost.mockReset();
+    mocks.runtimeHostClose.mockReset();
+    mocks.runtimeHostClose.mockResolvedValue(undefined);
+    mocks.createCliRuntimeHost.mockReturnValue({
+      close: mocks.runtimeHostClose,
+      emit: vi.fn(),
+    });
+    mocks.defaultSession.mockReset();
+    mocks.streamIsActiveOrResuming.mockReset();
+    mocks.streamIsActiveOrResuming.mockReturnValue(false);
+    mocks.detachHostInteractions.mockReset();
+    mocks.attachTerminalResultToast.mockReset();
+    mocks.attachTerminalResultToast.mockReturnValue(vi.fn());
+    mocks.attachTuiRunFactSubscription.mockReset();
+    mocks.attachTuiRunFactSubscription.mockReturnValue(vi.fn());
+    mocks.createTuiHostInteractions.mockReset();
+    mocks.createTuiHostInteractions.mockReturnValue({});
+    mocks.defaultSession.mockReturnValue({
+      useHostInteractions: vi.fn(() => mocks.detachHostInteractions),
+      interactions: {},
+      events: {},
+      status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
+    });
+    mocks.resolveAndResumeStream.mockReset();
+    mocks.resolveAndResumeStream.mockResolvedValue(true);
+    mocks.isResumeInFlight.mockReset();
+    mocks.isResumeInFlight.mockReturnValue(false);
+    mocks.resumeQueuedToolUseSnapshot.mockReset();
+    mocks.resumeQueuedToolUseSnapshot.mockResolvedValue(true);
+    mocks.projectStreamTranscript.mockReset();
+    mocks.notify.mockReset();
+    mocks.appendLocalAssistantTranscript.mockReset();
+    mocks.appendLocalErrorTranscript.mockReset();
+    mocks.appendLocalUserTranscript.mockReset();
+    mocks.clearLocalTranscript.mockReset();
+    mocks.moveLocalTranscriptToStream.mockReset();
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -200,6 +355,92 @@ describe('createChatSessionController', () => {
     expect(mocks.stopAgentStream).toHaveBeenCalledWith('stream-1', {
       detachActiveChildren: true,
       runtimeHost,
+    });
+  });
+
+  it('reserves the root-run slot before tryResumeStream awaits persisted state', async () => {
+    const preload = deferred();
+    const session = makeSession({ runCompleted: true });
+    const snapshotStore = makeResumeSnapshotStore({
+      preload: () => preload.promise,
+      executionId: undefined,
+    });
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    const resumed = ctrl.tryResumeStream('stream-1');
+
+    expect(session.runPromise).toBeDefined();
+    expect(session.runCompleted).toBe(false);
+    expect(ctrl.canStartRootRun()).toBe(false);
+
+    preload.resolve(undefined);
+    await expect(resumed).resolves.toBe(false);
+    expect(session.runCompleted).toBe(true);
+  });
+
+  it('treats a busy CLI root slot as a non-dropping wake outcome', async () => {
+    const session = makeSession({
+      runPromise: new Promise(() => {}),
+      runCompleted: false,
+    });
+    const snapshotStore = makeResumeSnapshotStore({});
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    await expect(ctrl.tryResumeStream('child-stream')).resolves.toBe(true);
+
+    expect(snapshotStore.preload).not.toHaveBeenCalled();
+  });
+
+  it('allows WAITING results when auto-resuming queued tool-use snapshots', async () => {
+    const session = makeSession({ runCompleted: true });
+    const config = makeResumeConfig();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config,
+    });
+    mocks.resolveAndResumeStream.mockImplementationOnce(
+      async (
+        _streamId: StreamTabId,
+        ports: { resumeToolUseSnapshot(snapshot: unknown): Promise<boolean> },
+      ) => ports.resumeToolUseSnapshot({ version: 2 }),
+    );
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    await expect(ctrl.tryResumeStream('stream-1')).resolves.toBe(true);
+
+    expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledWith(
+      'stream-1',
+      { version: 2 },
+      expect.any(Object),
+      expect.objectContaining({ allowWaitingResult: true }),
+    );
+    expect(mocks.projectStreamTranscript).toHaveBeenCalledWith('stream-1', {
+      finalize: true,
+    });
+  });
+
+  it('does not finalize the stream transcript when auto-resume returns false', async () => {
+    const session = makeSession({ runCompleted: true });
+    const config = makeResumeConfig();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config,
+    });
+    mocks.resolveAndResumeStream.mockResolvedValueOnce(false);
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    await expect(ctrl.tryResumeStream('stream-1')).resolves.toBe(false);
+
+    expect(mocks.projectStreamTranscript).not.toHaveBeenCalledWith('stream-1', {
+      finalize: true,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Reserve the CLI root-run slot synchronously before `tryResumeStream` awaits persisted state.
- Treat a busy CLI root slot as a non-dropping wake outcome so queued child follow-ups are not released as failures.
- Pass `allowWaitingResult: true` when auto-resuming queued tool-use snapshots.
- Finalize the stream transcript only when auto-resume actually resumes.

Fixes #7805.
Fixes #7806.
Fixes #7807.
Fixes #7808.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/chatSessionController.vitest.mts`
- `npx eslint packages/cli/src/chat/chatSessionController.ts src/test-kernel/cli/chatSessionController.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration for CLI auto-resume and root-run gating, which can affect follow-up delivery and run lifecycle, but scope is limited to `tryResumeStream` with new regression tests.
> 
> **Overview**
> Hardens CLI **follow-up wake** handling in `tryResumeStream` so queued child resumes do not race the root-run slot or get treated as failures when the chat is already busy.
> 
> **`tryResumeStream`** now calls **`markChatTuiRunPending` immediately** (before snapshot preload / persisted execution lookup), so `canStartRootRun()` blocks overlapping root runs while resume is preparing. When the root slot is already taken, it **returns `true` without touching snapshots**, signaling a non-dropping wake so follow-ups are not released as errors.
> 
> Auto-resume passes **`allowWaitingResult: true`** into **`resumeQueuedToolUseSnapshot`**, honors **`stopRequested`** before starting, and only runs **`projectStreamTranscript(..., { finalize: true })`** when resume actually succeeds. Run teardown uses **`try/finally`** with the host **`finalize`** from **`setupRunHost`** instead of chaining everything on a single promise.
> 
> Unit tests mock the resume/runtime stack and cover slot reservation during slow preload, busy-slot behavior, WAITING tool-use snapshots, and transcript finalization gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f953c1c46c377fc4a3a6d85cfade3466ec809d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->