### PR TITLE
refactor: share agent runtime template tokens

### DIFF
--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -15,6 +15,7 @@ import {
   runHelperModelCompletion,
 } from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
+import { buildUserVarPassthrough } from '@agent/utils/userVars';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -189,20 +190,6 @@ export interface AgentCreatorUI {
 /** Total AI generation attempts (1 initial + 1 validation retry) before template fallback. */
 const AI_GENERATION_ATTEMPTS = 2;
 
-const TOOL_USE_VARS = ['INSTRUCTION'];
-
-const WORKFLOW_VARS = [
-  'INPUT_FILE',
-  'INPUT_CONTENT',
-  'INPUT_FILES',
-  'ALL_INPUTS',
-  'ALL_CONTEXTS',
-  'LIST_OF_ALL_CONTEXTS',
-  'ADDITIONAL_INPUTS',
-  'INSTRUCTION',
-  'OUTPUT_FILES',
-];
-
 const DESCRIPTION_PROMPTS: Record<AgentCategory, string> = {
   toolUse:
     'What should this agent do? Mention capabilities it needs (e.g., search papers, edit files, browse the web)',
@@ -210,14 +197,7 @@ const DESCRIPTION_PROMPTS: Record<AgentCategory, string> = {
     'What should this agent do? Mention whether it rewrites existing documents or creates new ones',
 };
 
-function buildPassthrough(vars: string[]): Record<string, string> {
-  return Object.fromEntries(vars.map((v) => [v, `{{ ${v} }}`]));
-}
-
-const PASSTHROUGH: Record<AgentCategory, Record<string, string>> = {
-  toolUse: buildPassthrough(TOOL_USE_VARS),
-  workflow: buildPassthrough(WORKFLOW_VARS),
-};
+const PASSTHROUGH = buildUserVarPassthrough();
 
 /* autoescape off: templates contain Nunjucks/YAML syntax, not HTML.
  * Isolated Environment so the setting does not leak into Nunjucks' shared
@@ -387,7 +367,7 @@ class GenerateNode extends Node<AgentCreatorShared> {
     const prompts = config[blueprint.category];
     const schemaRef = getSchemaReference(blueprint.category);
     const renderVars = {
-      ...PASSTHROUGH[blueprint.category],
+      ...PASSTHROUGH,
       ...blueprint.aiVars,
     };
     const systemPrompt =

--- a/src/agent/templates/agentTemplateRenderer.ts
+++ b/src/agent/templates/agentTemplateRenderer.ts
@@ -1,5 +1,7 @@
 import * as nunjucks from 'nunjucks';
 
+import { buildUserVarPassthrough } from '@agent/utils/userVars';
+
 export type AgentTemplateKind = 'toolUse' | 'workflowSingle';
 
 export const AGENT_TEMPLATE_FILES: Record<AgentTemplateKind, string> = {
@@ -25,34 +27,9 @@ export interface AgentTemplateVars {
 // otherwise set for every other caller.
 const env = new nunjucks.Environment(null, { autoescape: false });
 
-/**
- * Tokens that the generated agent itself needs to keep literal. They are
- * consumed by the agent runtime when the agent runs, not at template-render
- * time. Map each to its literal form so Nunjucks leaves it alone.
- */
-const AGENT_RUNTIME_TOKENS = [
-  'INSTRUCTION',
-  'INPUT_FILE',
-  'INPUT_CONTENT',
-  'INPUT_FILES',
-  'ALL_INPUTS',
-  'ALL_CONTEXTS',
-  'LIST_OF_ALL_CONTEXTS',
-  'ALL_AUXILIARYS',
-  'ALL_REFERENCES',
-  'ADDITIONAL_INPUTS',
-  'REFERENCE_CONTENT',
-  'AUXILIARY_CONTENT',
-  'OUTPUT_FILES',
-] as const;
-
 // Frozen so the shared module-level instance can't be mutated even if a
 // caller forgets to spread it before passing to nunjucks.renderString.
-const PASSTHROUGH: Readonly<Record<string, string>> = Object.freeze(
-  Object.fromEntries(
-    AGENT_RUNTIME_TOKENS.map((token) => [token, `{{ ${token} }}`]),
-  ),
-);
+const PASSTHROUGH = buildUserVarPassthrough();
 
 export const DEFAULT_AGENT_TEMPLATE_TOOLS_YAML = [
   'bash',

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -38,6 +38,76 @@ const SHARED_LATEX_RULES_REL = '../shared/latex_style_rules.txt';
 export type UserVars = Record<string, unknown>;
 
 /**
+ * Fixed runtime template variables owned by `buildUserVars`.
+ *
+ * Agent-creation templates render once when a YAML file is produced, then the
+ * generated agent renders again at runtime. These tokens must pass through the
+ * creation render literally so the runtime render can substitute them later.
+ * User-defined `requiredFiles` / pattern variables are intentionally not in
+ * this fixed list; they remain caller-supplied names and `throwOnUndefined`
+ * stays disabled until there is a separate validation story for them.
+ */
+export const USER_VAR_RUNTIME_TOKENS = [
+  'MODEL',
+  'INSTRUCTION',
+  'IS_OPENAI_MODEL',
+  'IS_ANTHROPIC_MODEL',
+  'IS_GOOGLE_MODEL',
+  'WORKFLOW_AGENTS',
+  'TOOL_USE_AGENTS',
+  'CWD',
+  'DEFAULT_BIB_PATH',
+  'BUILTIN_WORKFLOW_DIR',
+  'BUILTIN_TOOLUSE_DIR',
+  'CUSTOM_AGENTS_DIR',
+  'AGENT_DOCS_DIR',
+  'INPUT_FILE',
+  'INPUT_CONTENT',
+  'INPUT_FILES',
+  'ALL_INPUTS',
+  'LIST_OF_ALL_INPUTS',
+  'REFERENCE_FILE',
+  'REFERENCE_CONTENT',
+  'REFERENCE_FILES',
+  'ALL_REFERENCES',
+  'LIST_OF_ALL_REFERENCES',
+  'CONTEXT_FILE',
+  'CONTEXT_CONTENT',
+  'ALL_CONTEXTS',
+  'LIST_OF_ALL_CONTEXTS',
+  'ALL_AUXILIARYS',
+  'LIST_OF_ALL_AUXILIARYS',
+  'EDITED_FILE',
+  'EDITED_CONTENT',
+  'EDITED_FILES',
+  'ALL_EDITEDS',
+  'LIST_OF_ALL_EDITEDS',
+  'MEDIA_FILE',
+  'MEDIA_CONTENT',
+  'OUTPUT_FILES',
+  'AUTO_EXTRACT_FIGURE',
+  'AUTO_EXTRACT_TIKZ_FIGURE',
+  'INCLUDE_TEX_COUNT',
+  'PRINT_INPUT_PROMPT',
+  'AUTO_COMPILE_INPUT_PDF',
+  'CODEX_GUIDANCE',
+  'CLAUDE_CODE_GUIDANCE',
+  'ROUNDS',
+  'LATEX_STYLE_RULES',
+  'ATTACHED_MEMORIES',
+  'ATTACHED_MEMORY_MISSES',
+  'AVAILABLE_SKILLS',
+] as const;
+
+export function buildUserVarPassthrough(): Readonly<Record<string, string>> {
+  return Object.freeze(
+    Object.fromEntries(
+      USER_VAR_RUNTIME_TOKENS.map((token) => [token, `{{ ${token} }}`]),
+    ),
+  );
+}
+
+/**
  * Information about a loaded file for prompt variable substitution.
  * Extends FileListEntry with required source and varName fields.
  * Compatible with FileListEntry (can be passed to AgentTrace.fileList).

--- a/src/test-kernel/agent/AgentTemplateRenderer.vitest.ts
+++ b/src/test-kernel/agent/AgentTemplateRenderer.vitest.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_AGENT_TEMPLATE_TOOLS_YAML,
   renderAgentTemplateString,
 } from '@agent/templates/agentTemplateRenderer';
+import {
+  buildUserVarPassthrough,
+  USER_VAR_RUNTIME_TOKENS,
+} from '@agent/utils/userVars';
 
 describe('renderAgentTemplateString', () => {
   it('preserves agent runtime variables for the generated agent', () => {
@@ -59,5 +63,17 @@ describe('renderAgentTemplateString', () => {
     });
 
     assert.match(rendered, /\{\{ ALL_CONTEXTS \}\}/);
+  });
+
+  it('derives passthrough variables from the shared user-vars owner', () => {
+    assert.ok(USER_VAR_RUNTIME_TOKENS.includes('ALL_CONTEXTS'));
+    assert.ok(USER_VAR_RUNTIME_TOKENS.includes('LIST_OF_ALL_CONTEXTS'));
+
+    const passthrough = buildUserVarPassthrough();
+    assert.equal(passthrough.ALL_CONTEXTS, '{{ ALL_CONTEXTS }}');
+    assert.equal(
+      passthrough.LIST_OF_ALL_CONTEXTS,
+      '{{ LIST_OF_ALL_CONTEXTS }}',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Export a single fixed runtime-token passthrough list from `userVars.ts`, the owner of runtime prompt variables.
- Route both agent-template render paths through the shared passthrough helper.
- Add a regression guard for the `ALL_CONTEXTS` / `LIST_OF_ALL_CONTEXTS` aliases.

Fixes #7791.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/AgentTemplateRenderer.vitest.ts`
- `npm run typecheck`
- `npx eslint src/agent/utils/userVars.ts src/agent/templates/agentTemplateRenderer.ts src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts src/test-kernel/agent/AgentTemplateRenderer.vitest.ts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with broader literal passthrough at YAML creation time; no auth or runtime execution logic changes, with regression tests on template rendering.
> 
> **Overview**
> **Centralizes** which Nunjucks placeholders must survive agent-creation rendering into `userVars.ts`, next to runtime prompt variable ownership.
> 
> Adds `USER_VAR_RUNTIME_TOKENS` and `buildUserVarPassthrough()` (frozen `{{ TOKEN }}` map). **Removes** duplicate passthrough lists from `agentTemplateRenderer` and `agentCreatorFlow`, and **drops** category-specific workflow vs tool-use token subsets so both creation paths use one shared list aligned with `buildUserVars`.
> 
> Adds a vitest guard that `ALL_CONTEXTS` / `LIST_OF_ALL_CONTEXTS` stay in the shared list and map correctly—addressing token drift between creation and runtime render (fixes #7791).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5992b82637bc58d445a2bb0c019c86752ac0aa7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->