### PR TITLE
fix: open desktop runtime output files

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1020,6 +1020,12 @@ export class DesktopProgressBridge {
     if (!isRuntimePresentationEvent(event)) return;
 
     switch (event) {
+      case 'requestOpenFile': {
+        const { location, preserveFocus } =
+          payload as DesktopPresentationPayloads[typeof event];
+        void this.options.openBuildDisplay?.(location, { preserveFocus });
+        return;
+      }
       case 'requestEnsureProgressView':
         this.sessionProgress.handlePresentationEvent(
           event,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -144,6 +144,9 @@ type DesktopExecution = {
 type RunExecutionRequest = (
   request: unknown,
   options: {
+    runtimeHost: {
+      emit(event: string, payload: unknown): void;
+    };
     openWorkflowOutput(result: {
       outcome: RunOutcome;
       outputs: Array<{ absolutePath: string }>;
@@ -175,7 +178,10 @@ interface DesktopAgentExecutionModule {
     postToRenderer(message: unknown): void;
     opener?: {
       openPath(filePath: string): Promise<void>;
-      openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
+      openBuildDisplay?(
+        location: { absolutePath: string },
+        options?: { preserveFocus?: boolean },
+      ): Promise<void>;
     };
     showErrorMessage?: (message: string) => Promise<void> | void;
     onRunCompleted?: () => void;
@@ -440,7 +446,10 @@ async function createExecution(options: {
   postToRenderer?: (message: unknown) => void;
   opener?: {
     openPath(filePath: string): Promise<void>;
-    openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
+    openBuildDisplay?(
+      location: { absolutePath: string },
+      options?: { preserveFocus?: boolean },
+    ): Promise<void>;
   };
   showErrorMessage?: (message: string) => Promise<void> | void;
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
@@ -2674,6 +2683,47 @@ describe('DesktopProgressBridge', () => {
 
     try {
       await execution.handleExecute({ command: 'execute' });
+      expect(opener.openPath).not.toHaveBeenCalled();
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  it('opens runtime requestOpenFile events through the desktop preview host', async () => {
+    const opener = {
+      openPath: vi.fn(async (_filePath: string) => {}),
+      openBuildDisplay: vi.fn(
+        async (
+          _location: { absolutePath: string },
+          _options?: { preserveFocus?: boolean },
+        ) => {},
+      ),
+    };
+    const runAgent = vi.fn(async (_request, options) => {
+      options.runtimeHost.emit('requestOpenFile', {
+        location: { absolutePath: '/tmp/result.pdf' },
+        preserveFocus: true,
+      });
+    });
+    const execution = await createExecution({
+      opener,
+      runAgent,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(opener.openBuildDisplay).toHaveBeenCalledWith(
+        { absolutePath: '/tmp/result.pdf' },
+        { preserveFocus: true },
+      );
       expect(opener.openPath).not.toHaveBeenCalled();
     } finally {
       execution.dispose();


### PR DESCRIPTION
## Summary

- Route desktop runtime `requestOpenFile` presentation events through the desktop preview host.
- Preserve the runtime `preserveFocus` flag when opening output artifacts.
- Add a desktop execution regression test that emits `requestOpenFile` through `runtimeHost`.

Addresses the desktop `WORKFLOW_AUTO_OPEN_PDF` slice of #7751.

## Validation

- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npx eslint packages/desktop/src/main/desktopAgentExecution.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized desktop presentation wiring with a focused regression test; no auth, data, or shared runtime contract changes beyond forwarding an existing event.
> 
> **Overview**
> **Desktop now opens runtime output files** when the agent emits a `requestOpenFile` presentation event—previously these events were ignored on desktop.
> 
> The bridge handles `requestOpenFile` in `handleInteractionEvent` by calling **`openBuildDisplay`** (LaTeX/PDF preview) instead of plain `openPath`, and forwards the runtime **`preserveFocus`** flag so opening a PDF does not steal focus from the editor when requested.
> 
> Test harness types for **`openBuildDisplay`** now accept an optional `{ preserveFocus }` argument, and a regression test drives `runtimeHost.emit('requestOpenFile', …)` through a full execution to assert preview opens with the right options and **`openPath` is not used**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9897fa878b61b9392f6b2d1b696ed4d167c14ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->