### PR TITLE
fix(desktop): wire history rerun/restore/export to shared owners

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -470,23 +470,7 @@ export class DesktopProgressBridge {
       agentProposal: {
         getPendingProposal: (proposalId) =>
           this.approvalHandlers.agentProposal.get(proposalId),
-        restoreTaskState: async (taskState) => {
-          let state: MainViewPersistedState;
-          try {
-            state = buildMainViewState(taskState);
-          } catch {
-            return false;
-          }
-          this.postToRenderer({
-            command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
-            route: 'main',
-          });
-          this.postToRenderer({
-            command: COMMON_COMMANDS.STATE_RESTORE,
-            state,
-          });
-          return true;
-        },
+        restoreTaskState: async (taskState) => this.restoreTaskState(taskState),
         settleProposal: (proposalId, result) => {
           const resolved = this.session.interactions.resolve(proposalId, {
             kind: 'proposal',
@@ -631,10 +615,15 @@ export class DesktopProgressBridge {
       restoreProposalConfig: async (data) => {
         await this.agentProposalController.restoreProposalConfig(data.proposal);
       },
-      // Not yet wired on desktop.
-      restoreState: unsupported(
-        'Restoring a saved run is not available in the desktop app yet.',
-      ),
+      // Mirrors the extension's PROGRESS_VIEW_COMMANDS.RESTORE_STATE handler
+      // (`texra.restoreState`): look up the stream's persisted task state and
+      // route the renderer to the main view with it.
+      restoreState: (data) => {
+        const taskState = this.state.snapshots.getTaskState(data.stream);
+        if (taskState) {
+          this.restoreTaskState(taskState);
+        }
+      },
       compactResponse: unsupported(
         'Compacting a response is not available in the desktop app yet.',
       ),
@@ -1405,6 +1394,31 @@ export class DesktopProgressBridge {
 
   async openFileCompile(filePath: string): Promise<void> {
     await this.fileActions.openFileCompile(filePath);
+  }
+
+  /**
+   * Restore a task's setup into the main view: builds the host-neutral
+   * persisted-state snapshot and routes the renderer there. Shared by the
+   * in-session "restore this proposal" flow (`agentProposal.restoreTaskState`
+   * above) and desktop history's "Setup" action (settings IPC), which mirrors
+   * the extension's `texra.restoreState` command.
+   */
+  restoreTaskState(taskState: TaskState): boolean {
+    let state: MainViewPersistedState;
+    try {
+      state = buildMainViewState(taskState);
+    } catch {
+      return false;
+    }
+    this.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+      route: 'main',
+    });
+    this.postToRenderer({
+      command: COMMON_COMMANDS.STATE_RESTORE,
+      state,
+    });
+    return true;
   }
 
   async runExecution(

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -535,9 +535,7 @@ export function createDesktopSettingsIpc(
   async function readHistoryConfig(
     historyId: string,
   ): Promise<AgentConfig | undefined> {
-    const raw = await getExecutionStore(
-      historyId as ExecutionId,
-    ).readConfig();
+    const raw = await getExecutionStore(historyId as ExecutionId).readConfig();
     return raw ? AgentConfigSchema.parse(raw) : undefined;
   }
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
 import { platform, tryPlatform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
@@ -7,13 +10,21 @@ import {
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import {
+  ChatExportController,
+  type ExportInputStatus,
+} from '@controllers/settingsView/ChatExportController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
-import { deleteAllExecutions, deleteExecution } from '@agent/storage';
+import {
+  deleteAllExecutions,
+  deleteExecution,
+  getExecutionStore,
+} from '@agent/storage';
 import {
   computeAgentOptionsData,
   getAgentsByCategory,
@@ -22,6 +33,16 @@ import {
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
+import {
+  validateExecutionRequest,
+  type ValidatedExecutionRequest,
+} from '@agent/core/state/executionRequests';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+import type { TaskState } from '@agent/core/state/TaskState';
 import {
   codexCoordinator,
   getChatGptAuthStatus,
@@ -141,6 +162,27 @@ export interface DesktopSettingsIpcOptions {
   openPath?: (filePath: string) => Promise<void>;
   revealPath?: (filePath: string) => Promise<void>;
   openExternalUrl?: (url: string) => Promise<void>;
+  /**
+   * Resolved `packages/extension/resources` tree (ElectronPlatformInitResult
+   * .resourcesPath). Used to locate the chat-export LaTeX preamble and the
+   * bundled trace-viewer standalone template — the same assets the
+   * extension's `HistoryHandlers` loads, reached here via `fs` instead of an
+   * esbuild text import.
+   */
+  resourcesPath?: string;
+  /**
+   * Run an agent (history "Rerun"). Delegates to the same host-neutral
+   * `runAgent` the extension's `runExecuteCommand` calls, via the desktop
+   * agent-execution bridge's `DesktopProgressBridge.runExecution`.
+   */
+  runExecution?: (request: ValidatedExecutionRequest) => Promise<void>;
+  /**
+   * Restore a task's setup into the main view (history "Setup"). Delegates to
+   * `DesktopProgressBridge.restoreTaskState`, the desktop equivalent of the
+   * extension's `texra.restoreState` command. Returns `false` when the config
+   * failed to convert to a persisted main-view state.
+   */
+  restoreTaskState?: (taskState: TaskState) => Promise<boolean>;
   /**
    * Offer the ChatGPT sign-in URL as a copyable link. `openExternalUrl` only
    * targets the system default browser; this lets a user whose ChatGPT
@@ -488,6 +530,168 @@ export function createDesktopSettingsIpc(
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
     });
+  }
+
+  async function readHistoryConfig(
+    historyId: string,
+  ): Promise<AgentConfig | undefined> {
+    const raw = await getExecutionStore(
+      historyId as ExecutionId,
+    ).readConfig();
+    return raw ? AgentConfigSchema.parse(raw) : undefined;
+  }
+
+  async function rerunHistoryAgent(historyId: string): Promise<void> {
+    const config = await readHistoryConfig(historyId);
+    if (!config) {
+      await options.showInfoMessage?.('History item not found');
+      return;
+    }
+    const validated = validateExecutionRequest({ config });
+    if (!validated.valid) {
+      await options.showErrorMessage?.(validated.message);
+      return;
+    }
+    await options.showInfoMessage?.('Rerunning agent from history');
+    await options.runExecution?.(validated.request);
+  }
+
+  async function restoreHistoryAgent(historyId: string): Promise<void> {
+    const config = await readHistoryConfig(historyId);
+    if (!config) {
+      await options.showInfoMessage?.('History item not found');
+      return;
+    }
+    const restored =
+      (await options.restoreTaskState?.(agentConfigToTaskState(config))) ??
+      false;
+    if (!restored) {
+      await options.showErrorMessage?.('Failed to restore configuration');
+    }
+  }
+
+  /**
+   * Resolved `resources/` tree, throwing if the host wired the IPC without
+   * one — export is only reachable when `resourcesPath` is supplied (see
+   * `DesktopSettingsIpcOptions.resourcesPath`).
+   */
+  function getResourcesPath(): string {
+    if (!options.resourcesPath) {
+      throw new Error(
+        'Desktop settings IPC missing resourcesPath; cannot export chat.',
+      );
+    }
+    return options.resourcesPath;
+  }
+
+  let chatExportController: ChatExportController | undefined;
+  function getChatExportController(): ChatExportController {
+    if (!chatExportController) {
+      const latexPreamble = readFileSync(
+        path.join(getResourcesPath(), 'templates', 'chatExport.tex'),
+        'utf8',
+      );
+      chatExportController = new ChatExportController({ latexPreamble });
+    }
+    return chatExportController;
+  }
+
+  async function reportExportInputError(
+    status: Exclude<ExportInputStatus, 'ok'>,
+  ): Promise<void> {
+    switch (status) {
+      case 'config_missing':
+        await options.showInfoMessage?.('History item not found');
+        return;
+      case 'conversation_missing':
+        await options.showInfoMessage?.(
+          'No conversation data available for this execution',
+        );
+        return;
+    }
+  }
+
+  async function reportHtmlExportError(
+    status: 'config_missing' | 'streamLogs_missing',
+  ): Promise<void> {
+    switch (status) {
+      case 'config_missing':
+        await options.showInfoMessage?.('History item not found');
+        return;
+      case 'streamLogs_missing':
+        await options.showInfoMessage?.(
+          'No stored transcript available for this execution — it may predate transcript persistence.',
+        );
+        return;
+    }
+  }
+
+  async function exportHistoryChatHtml(historyId: string): Promise<void> {
+    const controller = getChatExportController();
+    const outcome = await controller.exportAsHtml(
+      historyId,
+      path.join(getResourcesPath(), 'traceViewerStandalone', 'index.html'),
+    );
+    if (outcome.status !== 'ok') {
+      await reportHtmlExportError(outcome.status);
+      return;
+    }
+    const { absolutePath, storagePath } = outcome.result;
+    await options.openPath?.(absolutePath);
+    await options.showInfoMessage?.(
+      `Chat exported: ${path.basename(storagePath)}`,
+    );
+  }
+
+  async function exportHistoryChat(
+    historyId: string,
+    format: 'md' | 'tex' | 'html',
+  ): Promise<void> {
+    if (format === 'html') {
+      await exportHistoryChatHtml(historyId);
+      return;
+    }
+
+    const controller = getChatExportController();
+    const result = await controller.buildExportInput(historyId);
+    if (result.status !== 'ok') {
+      await reportExportInputError(result.status);
+      return;
+    }
+    const { exportInput } = result;
+
+    if (format === 'md') {
+      const { absolutePath, storagePath } = await controller.exportAsMarkdown(
+        historyId,
+        exportInput,
+      );
+      await options.openPath?.(absolutePath);
+      await options.showInfoMessage?.(
+        `Chat exported: ${path.basename(storagePath)}`,
+      );
+      return;
+    }
+
+    const { absolutePath, storagePath, pdfPath, logTail } =
+      await controller.exportAsLatex(historyId, exportInput);
+    if (pdfPath) {
+      await options.openPath?.(pdfPath);
+      await options.showInfoMessage?.(
+        `Chat exported and compiled: ${path.basename(storagePath).replace('.tex', '.pdf')}`,
+      );
+      return;
+    }
+    if (logTail) {
+      onError(
+        new Error(
+          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
+        ),
+      );
+    }
+    await options.openPath?.(absolutePath);
+    await options.showInfoMessage?.(
+      'LaTeX compilation failed. The .tex source file has been opened instead.',
+    );
   }
 
   async function postToolDashboardData(postOptions?: {
@@ -1075,21 +1279,11 @@ export function createDesktopSettingsIpc(
       getData: () => postHistoryData(),
       deleteAgent: (historyId) => deleteHistoryItem(historyId),
       clear: () => clearHistory(),
-      rerunAgent: unsupported(
-        'Rerun from history is not available in the desktop app yet.',
-      ),
-      restoreAgent: unsupported(
-        'Setup from history is not available in the desktop app yet.',
-      ),
-      exportChatMd: unsupported(
-        'Markdown export from history is not available in the desktop app yet.',
-      ),
-      exportChatTex: unsupported(
-        'LaTeX export from history is not available in the desktop app yet.',
-      ),
-      exportChatHtml: unsupported(
-        'HTML export from history is not available in the desktop app yet.',
-      ),
+      rerunAgent: (data) => rerunHistoryAgent(data.historyId),
+      restoreAgent: (data) => restoreHistoryAgent(data.historyId),
+      exportChatMd: (data) => exportHistoryChat(data.historyId, 'md'),
+      exportChatTex: (data) => exportHistoryChat(data.historyId, 'tex'),
+      exportChatHtml: (data) => exportHistoryChat(data.historyId, 'html'),
     },
     profile: {
       getData: () => postProfileData(),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -273,6 +273,8 @@ function createWindow(options: {
    * veteran from a fresh install. See ElectronPlatformInitResult.hasPriorInstall.
    */
   hasPriorInstall: boolean;
+  /** See ElectronPlatformInitResult.resourcesPath. */
+  resourcesPath: string;
 }): void {
   const window = new BrowserWindow({
     width: 960,
@@ -577,6 +579,15 @@ function createWindow(options: {
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     sendStartupCatalogData: true,
     modelListRefresh,
+    resourcesPath: options.resourcesPath,
+    // Rerun/Restore from history: same host-neutral owners the extension's
+    // history handlers call (runAgent / buildMainViewState), reached through
+    // the desktop agent-execution bridge instead of a vscode command.
+    runExecution: async (request) => {
+      await (await getAgentExecution()).progress.runExecution(request);
+    },
+    restoreTaskState: async (taskState) =>
+      (await getAgentExecution()).progress.restoreTaskState(taskState),
     promptSecret: (input) =>
       promptInRenderer(window, { ...input, password: true }),
     promptText: (input) => promptInRenderer(window, input),
@@ -975,6 +986,7 @@ if (protocolLifecycle.shouldContinue) {
           streamSnapshotStore,
           progressSnapshotStore: platformInit.progressSnapshotStore,
           hasPriorInstall: platformInit.hasPriorInstall,
+          resourcesPath: platformInit.resourcesPath,
         });
       reopenMainWindow();
 

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -49,6 +49,13 @@ export interface ElectronPlatformInitResult {
    * (`extension.ts` LAST_KNOWN_VERSION comment).
    */
   hasPriorInstall: boolean;
+  /**
+   * Resolved `packages/extension/resources` tree (bundled verbatim as
+   * `extraResources` — see `electron-builder.yml`). Threaded out so callers
+   * that need a specific bundled asset (e.g. the chat-export templates) don't
+   * each re-resolve it.
+   */
+  resourcesPath: string;
 }
 
 const WORKSPACE_CONFIG_MIGRATED_KEY =
@@ -200,5 +207,6 @@ export async function initializeElectronPlatform(
     lifecycle,
     progressSnapshotStore: snapshotStore,
     hasPriorInstall,
+    resourcesPath,
   };
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3099,6 +3099,60 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it("restores a stream's task state into the main view (history 'Setup' / Progress board restore)", async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      emitRunConfigFact(bridge, {
+        streamId: 'stream-1',
+        executionId: 'ec1002' as ExecutionId,
+        taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
+      });
+      await settleProgressEvents();
+      messages.length = 0;
+
+      const handleRestoreState = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.RESTORE_STATE
+        ],
+      );
+      expect(handleRestoreState).toBeTypeOf('function');
+      await handleRestoreState({
+        command: PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
+        stream: 'stream-1',
+      });
+
+      expect(messages).toEqual([
+        { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },
+        expect.objectContaining({ command: COMMON_COMMANDS.STATE_RESTORE }),
+      ]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('ignores restoreState for a stream with no persisted task state', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      const handleRestoreState = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.RESTORE_STATE
+        ],
+      );
+      await handleRestoreState({
+        command: PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
+        stream: 'stream-unknown',
+      });
+
+      expect(messages).toEqual([]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('flushes debounced stream logs before shutdown can drop them', async () => {
     const streamId = 'shutdown-flush' as StreamTabId;
     const kvStoreBacking = new Map<string, unknown>();

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1974,9 +1974,8 @@ describe('desktop settings IPC', () => {
   it('reruns an agent from history through the shared runAgent path', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const { getExecutionStore } = await import('@agent/storage');
-    const { AgentConfigSchema } = await import(
-      '@agent/core/definition/AgentConfig'
-    );
+    const { AgentConfigSchema } =
+      await import('@agent/core/definition/AgentConfig');
     const { AgentCategory } = await import('@shared/schemas/agent');
 
     const historyId = 'aaaa1111';
@@ -2017,9 +2016,8 @@ describe('desktop settings IPC', () => {
   it("restores a history item's setup into the main view", async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const { getExecutionStore } = await import('@agent/storage');
-    const { AgentConfigSchema } = await import(
-      '@agent/core/definition/AgentConfig'
-    );
+    const { AgentConfigSchema } =
+      await import('@agent/core/definition/AgentConfig');
     const { AgentCategory } = await import('@shared/schemas/agent');
 
     const historyId = 'bbbb2222';

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -13,7 +13,11 @@ import {
 } from '@tools/worktreeConfig';
 import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
-import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import {
+  desktopSourcePath,
+  moduleFileUrl,
+  repoPath,
+} from './desktopTestPaths.mjs';
 
 const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
 const computeModelOptionsData = vi.hoisted(() =>
@@ -25,6 +29,33 @@ const computeModelOptionsData = vi.hoisted(() =>
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData,
   invalidateModelOptionsCache,
+}));
+
+// The export wiring tests below assert desktopSettingsIpc.ts's history
+// actions call through to ChatExportController with the right arguments and
+// react to its result — ChatExportController's own formatting/compile/write
+// behavior already has dedicated coverage (ChatExportController.vitest.ts,
+// ChatExportControllerHtml.vitest.ts), so it's mocked here rather than
+// re-exercised.
+const chatExportMocks = vi.hoisted(() => ({
+  buildExportInput: vi.fn(),
+  exportAsMarkdown: vi.fn(),
+  exportAsLatex: vi.fn(),
+  exportAsHtml: vi.fn(),
+  constructorDeps: [] as unknown[],
+}));
+
+vi.mock('@controllers/settingsView/ChatExportController', () => ({
+  ChatExportController: class {
+    buildExportInput = chatExportMocks.buildExportInput;
+    exportAsMarkdown = chatExportMocks.exportAsMarkdown;
+    exportAsLatex = chatExportMocks.exportAsLatex;
+    exportAsHtml = chatExportMocks.exportAsHtml;
+
+    constructor(deps: unknown) {
+      chatExportMocks.constructorDeps.push(deps);
+    }
+  },
 }));
 
 interface StateStore {
@@ -83,6 +114,12 @@ interface DesktopSettingsIpcModule {
     selectCustomAgentDirectory?: () => Promise<string | undefined>;
     openPath?: (filePath: string) => Promise<void>;
     openExternalUrl?: (url: string) => Promise<void>;
+    resourcesPath?: string;
+    runExecution?: (request: {
+      config: Record<string, unknown>;
+      executionId?: string;
+    }) => Promise<void>;
+    restoreTaskState?: (taskState: unknown) => Promise<boolean>;
     installToolExtension?: (extensionId: string) => Promise<void>;
     promptSecret?: (input: {
       title: string;
@@ -1934,29 +1971,281 @@ describe('desktop settings IPC', () => {
     });
   });
 
-  it('surfaces unsupported desktop history actions instead of dropping them', async () => {
+  it('reruns an agent from history through the shared runAgent path', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
-    const messages: string[] = [];
+    const { getExecutionStore } = await import('@agent/storage');
+    const { AgentConfigSchema } = await import(
+      '@agent/core/definition/AgentConfig'
+    );
+    const { AgentCategory } = await import('@shared/schemas/agent');
+
+    const historyId = 'aaaa1111';
+    const config = AgentConfigSchema.parse({
+      agent: 'chat',
+      model: 'deepseekT',
+      instruction: 'Check a proof.',
+      agentCategory: AgentCategory.ToolUse,
+    });
+    await getExecutionStore(historyId).writeConfig(config);
+
+    const infos: string[] = [];
+    const runRequests: unknown[] = [];
     const settings = createDesktopSettingsIpc({
       workspaceState: new MemoryStateStore(),
       globalState: new MemoryStateStore(),
       postToRenderer: () => {},
       showInfoMessage: async (message) => {
-        messages.push(message);
+        infos.push(message);
+      },
+      runExecution: async (request) => {
+        runRequests.push(request);
       },
     });
 
     expect(
       settings.handleMessage({
         command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-        historyId: 'abcdef',
+        historyId,
       }),
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(messages).toEqual([
-      'Rerun from history is not available in the desktop app yet.',
+    expect(infos).toEqual(['Rerunning agent from history']);
+    expect(runRequests).toEqual([{ config, executionId: undefined }]);
+  });
+
+  it("restores a history item's setup into the main view", async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const { getExecutionStore } = await import('@agent/storage');
+    const { AgentConfigSchema } = await import(
+      '@agent/core/definition/AgentConfig'
+    );
+    const { AgentCategory } = await import('@shared/schemas/agent');
+
+    const historyId = 'bbbb2222';
+    const config = AgentConfigSchema.parse({
+      agent: 'chat',
+      model: 'deepseekT',
+      instruction: 'Check a proof.',
+      agentCategory: AgentCategory.ToolUse,
+    });
+    await getExecutionStore(historyId).writeConfig(config);
+
+    const errors: string[] = [];
+    const restoredTaskStates: unknown[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      showErrorMessage: async (message) => {
+        errors.push(message);
+      },
+      restoreTaskState: async (taskState) => {
+        restoredTaskStates.push(taskState);
+        return true;
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+        historyId,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(errors).toEqual([]);
+    expect(restoredTaskStates).toEqual([{ agentConfig: config }]);
+  });
+
+  it('reports missing history items for rerun and restore instead of dropping them', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const infos: string[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      showInfoMessage: async (message) => {
+        infos.push(message);
+      },
+    });
+
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId: 'ffff9999',
+    });
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+      historyId: 'ffff9999',
+    });
+    await flushAsyncWork();
+
+    expect(infos).toEqual(['History item not found', 'History item not found']);
+  });
+
+  it('exports a history chat to Markdown via the shared ChatExportController', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const exportInput = {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: { agent: 'chat' },
+      conversation: [],
+    };
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput,
+    });
+    chatExportMocks.exportAsMarkdown.mockResolvedValue({
+      storagePath: 'executions/abc/chat.md',
+      absolutePath: '/tmp/executions/abc/chat.md',
+    });
+
+    const opened: string[] = [];
+    const infos: string[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      resourcesPath: repoPath('packages', 'extension', 'resources'),
+      openPath: async (filePath) => {
+        opened.push(filePath);
+      },
+      showInfoMessage: async (message) => {
+        infos.push(message);
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'abc',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(chatExportMocks.buildExportInput).toHaveBeenCalledWith('abc');
+    expect(chatExportMocks.exportAsMarkdown).toHaveBeenCalledWith(
+      'abc',
+      exportInput,
+    );
+    expect(opened).toEqual(['/tmp/executions/abc/chat.md']);
+    expect(infos).toEqual(['Chat exported: chat.md']);
+    // Constructed from the real bundled `templates/chatExport.tex` (the
+    // LaTeX-export dependency), not a mocked/stubbed preamble.
+    expect(chatExportMocks.constructorDeps.at(-1)).toMatchObject({
+      latexPreamble: expect.stringContaining('\\documentclass'),
+    });
+  });
+
+  it('falls back to opening the .tex source when LaTeX compilation fails', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const exportInput = {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: { agent: 'chat' },
+      conversation: [],
+    };
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput,
+    });
+    chatExportMocks.exportAsLatex.mockResolvedValue({
+      storagePath: 'executions/abc/chat.tex',
+      absolutePath: '/tmp/executions/abc/chat.tex',
+      pdfPath: undefined,
+      logTail: '! Undefined control sequence.',
+    });
+
+    const opened: string[] = [];
+    const infos: string[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      resourcesPath: repoPath('packages', 'extension', 'resources'),
+      openPath: async (filePath) => {
+        opened.push(filePath);
+      },
+      showInfoMessage: async (message) => {
+        infos.push(message);
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+        historyId: 'abc',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(opened).toEqual(['/tmp/executions/abc/chat.tex']);
+    expect(infos).toEqual([
+      'LaTeX compilation failed. The .tex source file has been opened instead.',
     ]);
+  });
+
+  it('exports a history chat to HTML via the shared trace-viewer template', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    chatExportMocks.exportAsHtml.mockResolvedValue({
+      status: 'ok',
+      result: {
+        storagePath: 'executions/abc/chat.html',
+        absolutePath: '/tmp/executions/abc/chat.html',
+      },
+    });
+
+    const opened: string[] = [];
+    const resourcesPath = repoPath('packages', 'extension', 'resources');
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      resourcesPath,
+      openPath: async (filePath) => {
+        opened.push(filePath);
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
+        historyId: 'abc',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(chatExportMocks.exportAsHtml).toHaveBeenCalledWith(
+      'abc',
+      `${resourcesPath}/traceViewerStandalone/index.html`,
+    );
+    expect(opened).toEqual(['/tmp/executions/abc/chat.html']);
+  });
+
+  it('reports a missing history item on export instead of throwing', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'config_missing',
+    });
+
+    const infos: string[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      resourcesPath: repoPath('packages', 'extension', 'resources'),
+      showInfoMessage: async (message) => {
+        infos.push(message);
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'missing',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(infos).toEqual(['History item not found']);
   });
 
   it('ignores unsupported or malformed settings messages', async () => {


### PR DESCRIPTION
## What / why

Closes #7750 (FS8 + FS9 from `docs/proposals/host-parity-audit-2026-07.md`).

Desktop history's Rerun/Restore/Export were `unsupported()` stubs that the
shared frontend masked with an `unsupportedCommands` hide-the-button
mechanism, instead of being wired to the same host-neutral owners the
extension already calls. This PR wires all five commands
(`RERUN_AGENT`, `RESTORE_AGENT`, `EXPORT_CHAT_MD/TEX/HTML`) plus the
Progress board's own `RESTORE_STATE` command through thin desktop IPC rows:

- **Rerun** (`desktopSettingsIpc.ts`): loads the execution's config via
  `getExecutionStore`/`AgentConfigSchema` (same as the extension's
  `HistoryHandlers.handleRerunAgent`), validates it with
  `validateExecutionRequest`, and calls a new `runExecution` option wired in
  `index.ts` to `DesktopProgressBridge.runExecution` — the same host-neutral
  `runAgent` the extension's `runExecuteCommand` calls.
- **Restore** (history "Setup" + the Progress board's `RESTORE_STATE`):
  both now go through a new public `DesktopProgressBridge.restoreTaskState`
  method, extracted (not duplicated) from the existing
  `agentProposal.restoreTaskState` closure — same
  `buildMainViewState` + `SET_ROUTE` + `STATE_RESTORE` sequence the
  extension's `texra.restoreState` command runs.
- **Export** (md/tex/html): `desktopSettingsIpc.ts` builds the same
  host-neutral `ChatExportController` the extension's `HistoryHandlers`
  uses, sourcing the LaTeX preamble (`templates/chatExport.tex`) and the
  trace-viewer standalone template from the bundled `resources/` tree —
  already shipped to desktop verbatim via `electron-builder.yml`'s
  `extraResources`. `ElectronPlatformInitResult` now threads out
  `resourcesPath` so `index.ts` passes it down instead of re-resolving it.

All three actions are host-neutral; none needed a platform-only fence.
Deleting the `unsupported(...)` stubs shrinks the `unsupportedCommands` set
the desktop settings IPC broadcasts via `SET_UNSUPPORTED_COMMANDS`, so
`HistoryItemElement`'s existing `isKnownUnsupported(...)` gating un-hides the
Setup/Rerun/Export buttons automatically — no frontend change needed.

## Verification

- `npm run typecheck` (root workspace: root tsconfig, test-kernel,
  extension, CLI, trace-viewer) — pass
- `packages/desktop && npm run typecheck` (main/preload/renderer tsconfigs;
  not covered by the root `typecheck` script) — pass
- `npx vitest run src/test-kernel/desktop` — 41 files / 418 tests pass
  (includes the extended `DesktopSettingsIpc.vitest.mts` and
  `DesktopAgentExecution.vitest.mts` suites below)
- `eslint` on all touched files — 0 errors (1 pre-existing, unrelated
  import-order warning in `DesktopSettingsIpc.vitest.mts` at an import line
  this PR doesn't touch)

Tests extended (existing suites, no new test files — R7):
- `src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`: replaced the
  stale "surfaces unsupported desktop history actions" test with real
  wiring coverage — rerun success (calls `runExecution` with the validated
  request), restore success (calls `restoreTaskState` with the converted
  task state), missing-history-item handling for both, Markdown export
  success, LaTeX-compile-failure fallback (opens `.tex` source), HTML
  export success (template path composed from `resourcesPath`), and a
  missing-history-item export error path. `ChatExportController` itself is
  mocked (it already has dedicated coverage in
  `ChatExportController.vitest.ts` / `ChatExportControllerHtml.vitest.ts`);
  these tests assert the desktop IPC row's wiring, not the controller's
  internals.
- `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`: added
  coverage for the Progress board's `RESTORE_STATE` handler (restores a
  stream's persisted task state into the main view; no-ops for a stream
  with no persisted state).

## Net elements (R6)

- Files changed: 6 (`packages/desktop/src/main/{desktopSettingsIpc.ts,
  desktopAgentExecution.ts, index.ts, platform/index.ts}`,
  `src/test-kernel/desktop/{DesktopSettingsIpc.vitest.mts,
  DesktopAgentExecution.vitest.mts}`) — 0 new files.
- Exports/classes added: 0. Added one new **public method** on an existing
  class (`DesktopProgressBridge.restoreTaskState`), extracted from an
  existing closure (not new logic) so both the in-session proposal-restore
  path and the new history/Progress-board restore paths share one owner.
  Added two new **options fields** on the existing
  `DesktopSettingsIpcOptions` interface (`runExecution`, `restoreTaskState`)
  plus one plumbing field (`resourcesPath`) — no new interfaces/classes.
- Exports/classes deleted: 0. Deleted 5 `unsupported(...)` stub entries in
  `desktopSettingsIpc.ts` (rerun, restore, export×3) and 1 in
  `desktopAgentExecution.ts` (`RESTORE_STATE`).
- Net LoC: production code `+226/−26` across the 4 main-process files
  (`git diff --stat origin/main`); the increase is the export-wiring glue
  (`ChatExportController` construction, error-status mapping) that the
  extension's `HistoryHandlers.ts` already carries as its own per-host copy
  — this PR is desktop's first version of that glue, not duplicated logic
  layered on top of something already there.

## Consumer counts (R8)

- `unsupported(...)` stub deletions (6 total): each was declared exactly
  once, consumed only by the `unsupportedCommands()` broadcast/dispatcher —
  no other reader. `grep -rn "'Rerun from history is not available\|Setup from history is not available\|Markdown export from history\|LaTeX export from history\|HTML export from history\|Restoring a saved run is not available'" packages/desktop/src` → 0 hits after this change (all removed).
- `DesktopProgressBridge.restoreTaskState` (new public method): 2 call
  sites after this change (`agentProposal.restoreTaskState` closure,
  `progressViewInboundHandlers.restoreState`) — both in
  `desktopAgentExecution.ts` — plus the new `restoreTaskState` option wired
  through `index.ts` into `desktopSettingsIpc.ts`'s history restore. No
  external consumers changed shape; the extracted method has the exact
  return type (`boolean`) the closure it replaces already had.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New execution and navigation paths from history (rerun starts agents; restore mutates main-view state) plus file I/O for exports; logic reuses shared controllers rather than new bespoke runtime, but user-triggered runs and opens are still meaningful scope.
> 
> **Overview**
> **Desktop history and progress restore** now match extension behavior instead of showing “not available” stubs. Settings history actions **Rerun**, **Setup**, and **Export** (Markdown, LaTeX, HTML) load execution config from storage, validate where needed, and delegate to host-neutral code paths already used elsewhere.
> 
> **Rerun** reads config via `getExecutionStore`, validates with `validateExecutionRequest`, and runs through `DesktopProgressBridge.runExecution` (same `runAgent` path as the extension). **Setup** converts config to task state and calls a new shared **`restoreTaskState`** on `DesktopProgressBridge`, which builds main-view persisted state and posts `SET_ROUTE` + `STATE_RESTORE`; proposal restore and history Setup both use this method. **Progress board `RESTORE_STATE`** looks up the stream’s persisted task state and uses the same restore helper.
> 
> **Export** wires `ChatExportController` in settings IPC: LaTeX preamble and HTML trace-viewer template load from bundled `resourcesPath` (threaded from `ElectronPlatformInitResult` through `createWindow` into settings IPC). Export surfaces user-facing errors for missing history, conversation, or transcripts; LaTeX compile failure opens the `.tex` source.
> 
> Removing the history/restore **unsupported** handlers shrinks the desktop `unsupportedCommands` set, so existing UI gating un-hides those buttons without renderer changes. Tests replace the old “unsupported” expectations with wiring coverage for rerun, restore, exports, and `RESTORE_STATE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d906288febcc07a9424a8b3d834824237055a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->