### PR TITLE
refactor: simplify bare run context construction

### DIFF
--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -90,15 +90,6 @@ type CommonRunContextFieldNames =
   | 'runtimeUnavailableTools'
   | 'stopAfterCycle';
 
-type BareRunContextFieldNames =
-  | CommonRunContextFieldNames
-  | 'runtimeHost'
-  | 'streamId'
-  | 'executionId'
-  | 'agentName'
-  | 'workingDirectory'
-  | 'session';
-
 /**
  * Fields shared by both `RunContext` kinds, forwarded as-is from the input
  * options.
@@ -111,22 +102,7 @@ function commonRunContextFields<T extends CreateRunContextCommon>(
     approvalPromptsUnavailable: options.approvalPromptsUnavailable,
     runtimeUnavailableTools: options.runtimeUnavailableTools,
     stopAfterCycle: options.stopAfterCycle,
-  } as Pick<T, CommonRunContextFieldNames>;
-}
-
-/** Fields used only by the manually constructed `bare` context shape. */
-function bareRunContextFields<T extends CreateBareRunContextOptions>(
-  options: T,
-): Pick<T, BareRunContextFieldNames> {
-  return {
-    ...commonRunContextFields(options),
-    runtimeHost: options.runtimeHost,
-    streamId: options.streamId,
-    executionId: options.executionId,
-    agentName: options.agentName,
-    workingDirectory: options.workingDirectory,
-    session: options.session,
-  } as Pick<T, BareRunContextFieldNames>;
+  } satisfies Pick<T, CommonRunContextFieldNames>;
 }
 
 /**
@@ -157,11 +133,17 @@ export function createRunContext(options: CreateRunContextOptions): RunContext {
   const { model } = options;
   return Object.freeze({
     kind: 'bare',
-    ...bareRunContextFields(options),
+    ...commonRunContextFields(options),
+    runtimeHost: options.runtimeHost,
+    streamId: options.streamId,
+    executionId: options.executionId,
+    agentName: options.agentName,
+    workingDirectory: options.workingDirectory,
+    session: options.session,
     get model() {
       return model;
     },
-  });
+  } satisfies BareRunContext);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Inline the single-use bare-context field forwarding into `createRunContext`.
- Remove the obsolete `BareRunContextFieldNames` type and helper.
- Replace weakening type assertions with `satisfies` checks so object-literal fields remain compiler-verified.

## Issue acceptance gates

Closes #7671.

- `bareRunContextFields` is inlined into the bare branch.
- `BareRunContextFieldNames` is deleted.
- Both former `as Pick<...>` assertions are replaced by `satisfies` checks.

## Single source of truth

`src/agent/runtime/RunContext.ts` continues to own run-context construction. The bare branch of `createRunContext` now directly owns its field projection.

## Duplication and abstraction budget

The single-caller `bareRunContextFields` pass-through abstraction is removed. No new abstraction or duplication is introduced.

## Net elements (R6)

- 1 file changed: 9 insertions, 27 deletions (net -18 lines).
- Deleted one private type alias and one private helper.
- Added no files, exports, classes, interfaces, or enums.

## Consumer counts (R8)

n/a. The deleted helper and type were private to `RunContext.ts`; the helper had exactly one caller, which is now inlined. No emit path or export is changed.

## Host impact

Extension: No behavior change.

Desktop: No behavior change.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/agent/runtime/RunContext.ts`
- `corepack pnpm exec prettier --check src/agent/runtime/RunContext.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/RunContext.vitest.ts` (6 passed)
- `npm run typecheck`
- `corepack pnpm exec eslint src/agent/runtime/RunContext.ts`
- `npm run lint` (0 errors; 51 pre-existing import-order warnings outside this change)
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private factory refactor in `RunContext.ts` with tests passing; no API or behavioral change to extension, desktop, or CLI.
> 
> **Overview**
> **`createRunContext`** no longer uses a private **`bareRunContextFields`** helper or **`BareRunContextFieldNames`** type. The bare (`static` model) branch now spreads **`commonRunContextFields`** and assigns bare-only fields (`runtimeHost`, `streamId`, `executionId`, etc.) inline on the frozen object.
> 
> Type safety shifts from **`as Pick<...>`** casts to **`satisfies`** on **`commonRunContextFields`**’ return value and on the bare context literal (**`satisfies BareRunContext`**), so excess-property and shape checks stay at compile time without widening. Net reduction in **`RunContext.ts`** only; no export or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b0b0b2ea3b686d9a231dad0c8c36856c0b57c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->