### PR TITLE
fix(agent-runtime): restore readonly run scope

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -73,7 +73,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 const logger = createChannelTrace('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore {
-  runScope: RunScope;
+  readonly runScope: RunScope;
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;


### PR DESCRIPTION
## Summary

Restore the compile-time immutability contract for `AgentLaunchContext.runScope` by marking the property `readonly`.

The stale `RunScope` compatibility comment identified in the issue was already corrected on current `main` by commit `fe0e03105`; this PR preserves that corrected documentation.

## Issue acceptance gates

- Restore `readonly` on `AgentLaunchContext.runScope`.
- Keep the corrected `RunScope` documentation, which now states that run identity and session ownership are carried by `RunScope`.
- No runtime behavior change.

Closes #7669

## Single source of truth

`RunScope` remains the canonical object for run identity and session ownership.

## Duplication and abstraction budget

No duplication or abstraction was added.

## Net elements (R6)

n/a: one existing interface property modifier changed; no elements added or deleted.

## Consumer counts (R8)

n/a: no export, event, or routing path was added, removed, or redirected.

## Host impact

Extension: None; type-contract correction only.

Desktop: None; type-contract correction only.

CLI: None; type-contract correction only.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `corepack pnpm exec prettier --check src/agent/runtime/AgentLaunchContext.ts src/agent/runtime/RunScope.ts`
- `npm test -- src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts` (2 tests passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single interface property modifier; no logic, exports, or runtime paths changed.
> 
> **Overview**
> Restores the **compile-time immutability** contract on `AgentLaunchContext` by marking `runScope` as `readonly`, aligning it with `RunScope` (frozen at creation) and preventing reassignment on launch context objects.
> 
> No runtime or behavioral change—TypeScript interface contract only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19f08be2dc67bb1dc16eb6cd94c3a2f6b854ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->