### PR TITLE
refactor: reuse output execution id

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -99,10 +99,9 @@ export class OutputNode<C = unknown> extends Node<
 
     // Resolve to pre-run snapshots once so mapping, latexdiff, and diff
     // stats all see the same base locations (see snapshotResolution).
-    const { runScope } = useLaunchRunContext();
     const diffBaseFiles = await resolveBaseFilesForDiff(
       baseFiles,
-      runScope.executionId,
+      outputDependencies.executionId,
     );
 
     let mapping: RoundFileMapping | undefined;


### PR DESCRIPTION
## Summary

- Reuse the execution ID already captured in the output dependencies when resolving diff base files.
- Remove the redundant launch run-context read from OutputNode.exec().

## Checks

- corepack pnpm exec prettier --write src/agent/implementations/flows/reflection/nodes/OutputNode.ts
- npm run typecheck
- npm run compile:fast
- npm run lint (passes with 51 pre-existing import-order warnings outside this change)
- corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/ReflectionOutputLocation.vitest.ts src/test-kernel/agent/output/OutputProgressEvents.vitest.ts (8 tests passed)
- npm test (5,361 tests passed; one unrelated architecture ratchet test failed because the current CLI/desktop mock count is 27 while its baseline is 22)

Closes #7664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-variable source change with no behavior change intended; same execution id as before via outputDependencies().
> 
> **Overview**
> **OutputNode** no longer reads launch run context inside `exec()` when resolving diff base files for mapping, latexdiff, and diff stats.
> 
> `resolveBaseFilesForDiff` now takes **`outputDependencies.executionId`**, which `outputDependencies()` already derives from the same run scope used elsewhere in the node—removing a duplicate `useLaunchRunContext()` call on that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfea7e1fb66723b19b34c4c612cf41945d2ceef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->