### PR TITLE
refactor: single-source launch stream status

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -21,13 +21,13 @@ export interface AgentCore<C = unknown> {
   setting: AgentSetting;
   prompt: AgentPrompt;
   logger: AgentTrace;
-  streamStatus: StreamStatusMachine;
   userVarChannels: UserVariableChannels;
   /** Initial user row to log after the flow has inserted launch media. */
   initialUserMessageForTranscript?: string;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {
+  streamStatus: StreamStatusMachine;
   checkInterruption: () => boolean;
   setAbortController: (ctrl: AbortController | null) => void;
   onInterrupt?: () => void;

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -54,9 +54,9 @@ export interface ModelInvocationConfig<TShared, TServices> {
  */
 type InvocationServices = Pick<
   AgentCore,
-  'modelHandler' | 'logger' | 'setting' | 'config' | 'streamStatus'
+  'modelHandler' | 'logger' | 'setting' | 'config'
 > &
-  Pick<BaseFlowContextInit, 'setAbortController'> & {
+  Pick<BaseFlowContextInit, 'setAbortController' | 'streamStatus'> & {
     readonly client: unknown;
     readonly refreshClient?: () => Promise<void>;
   };

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -251,7 +251,6 @@ async function beginRunStage(
 async function assembleAgentLaunchContext(
   input: AgentLaunchInput,
   executionId: ExecutionId,
-  streamStatus: StreamStatusMachine,
   runtimeHost: AgentRuntimeHost,
   reservedStreamId: StreamTabId | undefined,
   onActivated: (streamId: StreamTabId) => void,
@@ -462,7 +461,6 @@ async function assembleAgentLaunchContext(
     attachedMemoryMisses,
     usageMonitor,
     runScope,
-    streamStatus,
     initialUserMessageForTranscript: initialMediaMayBeInserted
       ? initialInstruction
       : undefined,
@@ -611,7 +609,6 @@ export async function buildAgentLaunchContext(
     const ctx = await assembleAgentLaunchContext(
       { ...input, session: launchSession },
       executionId,
-      streamStatus,
       runtimeHost,
       reservedStreamId,
       (streamId) => {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -196,12 +196,13 @@ export async function finalizeRunTerminal(
 }
 
 function transitionRunStart(ctx: AgentLaunchContext): void {
-  const { streamId } = ctx.runScope;
+  const { streamId, session } = ctx.runScope;
+  const streamStatus = session.status;
   const options = {
     trace: ctx.logger,
   };
   if (
-    ctx.streamStatus.transition(
+    streamStatus.transition(
       streamId,
       STREAM_PHASE.RUNNING,
       'lifecycle',
@@ -210,7 +211,7 @@ function transitionRunStart(ctx: AgentLaunchContext): void {
   ) {
     return;
   }
-  const resumed = ctx.streamStatus.transition(
+  const resumed = streamStatus.transition(
     streamId,
     STREAM_PHASE.RUNNING,
     'resume',
@@ -219,7 +220,7 @@ function transitionRunStart(ctx: AgentLaunchContext): void {
   if (resumed) {
     return;
   }
-  if (ctx.streamStatus.get(streamId) === STREAM_PHASE.RUNNING) {
+  if (streamStatus.get(streamId) === STREAM_PHASE.RUNNING) {
     return;
   }
   logger.warn('Failed to transition run to RUNNING', {
@@ -306,7 +307,7 @@ export async function runFlowWithLifecycle(
     finalizeRunTerminal({
       handle,
       executions: session.executions,
-      streamStatus: ctx.streamStatus,
+      streamStatus: session.status,
       usage: ctx.usageMonitor.lastTotals(),
       isSubagent: options?.isSubagent ?? false,
       stage: ctx.parentStage,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -154,12 +154,17 @@ async function runToolUseAgent(
     'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle'
   >,
 ): Promise<AgentRuntimeFlowResult> {
-  const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
+  const {
+    streamId: runStreamId,
+    executionId: runExecutionId,
+    session: runSession,
+  } = ctx.runScope;
   const onRoundFinalized = createUsageRecordingCallback(ctx);
   try {
     const result = await runToolUseFlow(
       {
         ...ctx,
+        streamStatus: runSession.status,
         ...createInterruptCallbacks(),
         onRoundFinalized,
         setting,
@@ -244,6 +249,7 @@ async function runReflectionAgent(
   try {
     result = await runReflectionFlow({
       ...ctx,
+      streamStatus: runSession.status,
       ...interruptCallbacks,
       onRoundFinalized,
       setting,
@@ -501,7 +507,11 @@ export async function resumeToolUseFromSnapshot(
     runtimeUnavailableTools: options.runtimeUnavailableTools,
   };
   const { setting } = ctx;
-  const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
+  const {
+    streamId: runStreamId,
+    executionId: runExecutionId,
+    session: runSession,
+  } = ctx.runScope;
 
   return withExecutionRunContext(ctx, runContextOptions, async () => {
     if (setting.agentCategory !== AgentCategory.ToolUse) {
@@ -517,6 +527,7 @@ export async function resumeToolUseFromSnapshot(
         const result = await runToolUseFlow(
           {
             ...ctx,
+            streamStatus: runSession.status,
             ...createInterruptCallbacks(),
             onRoundFinalized: createUsageRecordingCallback(ctx),
             setting,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -71,12 +71,10 @@ async function initLifecycleTestPlatform(firstRunDone: boolean) {
 function createLifecycleContext({
   executionId,
   streamId,
-  streamStatus,
   agent = 'test-agent',
 }: {
   executionId: ExecutionId;
   streamId: StreamTabId;
-  streamStatus: StreamStatusMachine;
   agent?: string;
 }): {
   ctx: AgentLaunchContext;
@@ -123,7 +121,6 @@ function createLifecycleContext({
     setting,
     prompt,
     runScope,
-    streamStatus,
     logger: noopTrace,
     parentStage: noopTrace.openStage('Run: test-agent'),
     storageKey,
@@ -168,11 +165,10 @@ function lifecycleFixture(
   const executionId =
     `e${(lifecycleFixtureCounter++).toString(16).padStart(5, '0')}` as ExecutionId;
   const streamId = `stream-${slug}` as StreamTabId;
-  const streamStatus = new StreamStatusMachine();
+  const streamStatus = defaultSession().status;
   const { ctx, explicit } = createLifecycleContext({
     executionId,
     streamId,
-    streamStatus,
     agent,
   });
   return { executionId, streamId, streamStatus, ctx, explicit };
@@ -222,21 +218,16 @@ describe('runFlowWithLifecycle', () => {
     });
   }
 
-  it('finalizes the stream status owner from the launch context', async () => {
+  it('finalizes the status machine owned by the run session', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'lifecycle-status-owner',
     );
 
     try {
-      seedStreamStatusForTest(
-        StreamStatusService,
-        streamId,
-        STREAM_STATUS.WAITING,
-      );
-
       // The lifecycle owns the whole transition (RUNNING on entry, terminal
-      // on exit) against the ctx-owned registry; the module-global
-      // StreamStatusService must stay untouched.
+      // on exit) against the run session's one status machine.
+      expect(streamStatus).toBe(ctx.runScope.session.status);
+      expect(StreamStatusService).toBe(streamStatus);
       await runFlowWithLifecycle(ctx, async () => ({
         category: 'toolUse',
         outcome: RUN_OUTCOME.COMPLETED,
@@ -245,10 +236,8 @@ describe('runFlowWithLifecycle', () => {
       }));
 
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_STATUS.WAITING);
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(StreamStatusService, streamId);
     }
   });
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -227,7 +227,6 @@ describe('runFlowWithLifecycle', () => {
       // The lifecycle owns the whole transition (RUNNING on entry, terminal
       // on exit) against the run session's one status machine.
       expect(streamStatus).toBe(ctx.runScope.session.status);
-      expect(StreamStatusService).toBe(streamStatus);
       await runFlowWithLifecycle(ctx, async () => ({
         category: 'toolUse',
         outcome: RUN_OUTCOME.COMPLETED,

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -20,7 +20,6 @@ import {
   defaultSession,
 } from '@agent/runtime/SessionHandle';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
@@ -51,7 +50,6 @@ function initTestPlatform(): Promise<void> {
 function createLifecycleContext(
   executionId: ExecutionId,
   streamId: StreamTabId,
-  streamStatus: StreamStatusMachine,
   session: SessionHandle,
 ): AgentLaunchContext {
   const explicit = createRecordingHost();
@@ -95,7 +93,6 @@ function createLifecycleContext(
     setting,
     prompt,
     runScope,
-    streamStatus,
     logger: noopTrace,
     parentStage: noopTrace.openStage('Run: assistant'),
     storageKey,
@@ -168,14 +165,8 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
     await initTestPlatform();
     const executionId = 'e15001' as ExecutionId;
     const streamId = 'stream:iso-track' as StreamTabId;
-    const streamStatus = new StreamStatusMachine();
     const sessionB = new SessionHandle();
-    const ctx = createLifecycleContext(
-      executionId,
-      streamId,
-      streamStatus,
-      sessionB,
-    );
+    const ctx = createLifecycleContext(executionId, streamId, sessionB);
 
     try {
       await runFlowWithLifecycle(ctx, async () => {
@@ -198,7 +189,7 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
         defaultSession().executions.getHandle(executionId),
       ).toBeUndefined();
     } finally {
-      clearStreamStatusForTest(streamStatus, streamId);
+      clearStreamStatusForTest(sessionB.status, streamId);
       sessionB.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -50,7 +50,6 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
   const n = counter++;
   const executionId = `a${n.toString(16).padStart(5, '0')}` as ExecutionId;
   const streamId = `stream:result-${n}` as StreamTabId;
-  const streamStatus = new StreamStatusMachine();
   const config = AgentConfigSchema.parse({
     agent: 'assistant',
     model: 'test-model',
@@ -63,6 +62,7 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
   const storageKey = executionId as unknown as StorageKey;
   const logger = overrides?.logger ?? new TraceEmitter();
   const session = defaultSession();
+  const streamStatus = session.status;
   const runScope = createRunScope({
     runtimeHost: explicit.host,
     streamId,
@@ -92,7 +92,6 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
     setting,
     prompt,
     runScope,
-    streamStatus,
     logger,
     parentStage: logger.openStage('Run: assistant'),
     storageKey,


### PR DESCRIPTION
## Summary

- Remove `streamStatus` from `AgentCore` and therefore from `AgentLaunchContext`.
- Read lifecycle status from the session carried by `RunScope`.
- Inject that same session-owned machine only at flow-service construction boundaries that operate on it.
- Correct typed fixtures so they can no longer construct divergent launch-context and session status machines.

Part of #6968.

## Issue acceptance gates

- `AgentLaunchContext` no longer carries a duplicate status-machine field.
- `AgentRunLifecycle` has zero `ctx.streamStatus` reads.
- Fresh tool-use, reflection, and resumed tool-use flows all receive `runScope.session.status` at construction.
- Typed lifecycle fixtures construct and assert one session-owned status machine.

## Single source of truth

`RunScope.session.status` is the sole status owner for an agent launch. Before this change, `AgentLaunchContext.streamStatus` and `AgentLaunchContext.runScope.session.status` could be independently constructed even though production intended them to be identical.

Flow nodes still receive a `streamStatus` service because retry and waiting nodes operate that capability directly, but every flow receives the value from `runScope.session.status` at its construction boundary.

## Duplication and abstraction budget

The change deletes a duplicated run-level field and one assembly parameter. It adds no wrapper, factory, compatibility alias, or forwarding layer. The narrower `BaseFlowContextInit` retains only the capability required by flow nodes.

## Net elements (R6)

- 8 files changed: 30 insertions, 42 deletions (net -12 lines).
- No new files, exports, classes, interfaces, enums, or compatibility aliases.
- One field moves from the broad `AgentCore` shape to the narrower `BaseFlowContextInit` shape.

## Consumer counts (R8)

No event or public export is removed. The deleted `AgentLaunchContext.streamStatus` field had two production read sites in `AgentRunLifecycle`; both now read `runScope.session.status`. The three flow-construction sites inject that same owner explicitly.

## Host impact

Extension: no intended behavior change.

Desktop: no intended behavior change; non-default sessions now necessarily finalize their own status machine.

CLI: no intended output change; fresh and resumed flow construction both use the run session status owner.

## Scheduled refactoring

The legacy `STREAM_STATUS` vocabulary and direct default-session singleton exports remain scheduled for D1 Sweep 2 under #6982 and #7694. This PR does not introduce a temporary shim.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; 51 pre-existing import-order warnings)
- `npm run typecheck`
- Focused runtime tests: 35 passed
- Full suite: 5,361 passed and 4 skipped; one existing `hostAgentMockRatchet` baseline failure remains because current main counts 27 host-side agent mocks against a baseline of 22
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches run lifecycle and stream-phase transitions across sessions; behavior should be unchanged when context and session already matched, but wrong session wiring would now surface as status bugs.
> 
> **Overview**
> **Stream phase ownership** is consolidated on the run session: `streamStatus` is removed from `AgentCore` / `AgentLaunchContext`, and lifecycle plus terminal finalization read **`ctx.runScope.session.status`** instead of a parallel field on the launch bag.
> 
> Flow construction still passes a `streamStatus` service (now on **`BaseFlowContextInit`**, not broad `AgentCore`), but **`executeAgent`** injects **`runSession.status`** when starting tool-use, reflection, and resumed tool-use flows. **`ModelInvocationNode`** types that dependency from the flow-init shape.
> 
> Launch assembly drops the extra **`streamStatus`** parameter; acquisition/compensation already use **`launchSession.status`**. Tests build fixtures from the session-owned machine so launch context and status cannot diverge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dadca33a316e24f8b95be7c1a542abeeb92270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->