### PR TITLE
fix(cli): persist terminal status before crash rethrow

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -253,15 +253,15 @@ export async function executeCliRequest(
     const result = await (options.wrap ? options.wrap(invoke) : invoke());
     runResult = { ok: true, result };
   } catch (err) {
+    if (options.markErrorOnThrow && request.executionId) {
+      await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
+    }
     // Only a classified, already-handled AgentError resolves to a non-zero
     // exit code here; anything else (e.g. registerExecution disk I/O,
     // workspaceState.update failures) is unexpected and must keep
     // propagating to bin/texra.ts's crash handler.
     if (!(err instanceof AgentError)) {
       throw err;
-    }
-    if (options.markErrorOnThrow && request.executionId) {
-      await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
     }
   } finally {
     disposeShutdownStatus?.dispose();

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -496,6 +496,23 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
+  it('marks a non-AgentError rejection terminal before rethrowing it', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = baseRequest();
+    const error = new Error('disk full');
+    mocks.runAgent.mockRejectedValueOnce(error);
+
+    await expect(
+      executeCliRequest(request, cliContext(), { markErrorOnThrow: true }),
+    ).rejects.toBe(error);
+
+    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+      'exec-1',
+      EXECUTION_STATUS.ERROR,
+    );
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
   it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();


### PR DESCRIPTION
## Summary

`executeCliRequest` previously classified a rejected CLI run before applying its `markErrorOnThrow` fallback. A non-`AgentError` rejection was therefore rethrown before the execution received an `ERROR` terminal status, leaving persisted flow data falsely resumable.

This change applies the existing terminal-status fallback before error classification. Classified `AgentError` failures are still converted to CLI exit codes, while unexpected failures are still rethrown to `bin/texra.ts`, which remains their only reporting path.

## Issue acceptance gates

Closes #7828.

- Persist `ERROR` when a newly owned CLI execution fails with a non-`AgentError` and `markErrorOnThrow` is enabled.
- Preserve propagation of that same unexpected error to the outer CLI crash handler.
- Cover the combined persistence-and-rethrow behavior with a regression test.

## Single source of truth

`executeCliRequest` remains the owner of fallback terminal-status persistence for the headless executions created by `run`, `agents run`, and `multi-agent run`. `bin/texra.ts` remains the sole reporter for unexpected crashes.

## Duplication and abstraction budget

No reporting path or abstraction was added. The fix only reorders the existing persistence step before the existing error classification.

## Net elements (R6)

Not applicable to this bug fix. No files, exports, classes, interfaces, or enums were added.

## Consumer counts (R8)

Not applicable; no event, export, or subscriber path changed.

## Host impact

Extension: None.

Desktop: None.

CLI: Unexpected run failures now persist a terminal `ERROR` before reaching the existing crash reporter, so the failed run is not offered for resume.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunExecution.vitest.mts` (24 tests passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing import-order warnings)
- `corepack pnpm --filter @texra-ai/cli build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow reorder in existing error handling with a targeted test; no new APIs or reporting paths.
> 
> **Overview**
> When `executeCliRequest` catches a run failure with **`markErrorOnThrow`** enabled, it now writes **`ERROR`** to persisted execution state **before** deciding whether the error is a classified `AgentError` or an unexpected crash.
> 
> Previously, non-`AgentError` rejections (e.g. disk I/O during registration) were rethrown **without** that terminal write, so headless runs that registered an execution could still look resumable after a crash. Classified `AgentError` paths are unchanged (exit code, no rethrow); unexpected errors still propagate to `bin/texra.ts` after persistence.
> 
> A regression test asserts **`writeTerminalStatus('exec-1', ERROR)`** runs before the same error is rethrown when `markErrorOnThrow` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d04a869ad406e8d670f7b3235fa0778fa04d518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->