### PR TITLE
fix(desktop): bundle HTML export template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ All notable changes to this project will be documented in this file.
 
 ### Desktop
 
+#### Bug Fixes
+
+- **HTML chat export works in packaged desktop builds** — desktop packaging now
+  includes the standalone trace-viewer template used to create self-contained
+  HTML exports.
+
 #### Improvements
 
 - **Runtime skills are available in desktop agent runs** — desktop now loads

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "validate:tui": "corepack pnpm --filter @texra-ai/cli validate:tui",
     "workspace:typecheck": "corepack pnpm --recursive --if-present typecheck",
     "workspace:build": "corepack pnpm --recursive --if-present build",
-    "desktop:build": "corepack pnpm --filter @texra/desktop build",
+    "desktop:build": "corepack pnpm --filter @texra/trace-viewer run build && corepack pnpm --filter @texra/desktop build",
     "desktop:package:local": "node scripts/run-desktop-package-local.mjs",
     "desktop:package:dist": "corepack pnpm run desktop:build && corepack pnpm --filter @texra/desktop package:dist",
     "desktop:package:smoke": "node scripts/smoke-desktop-package-launch.mjs",

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -658,6 +658,13 @@ async function checkBundledResources(app, failures) {
       );
     }
   }
+
+  await checkExists(
+    app,
+    'resources/traceViewerStandalone/index.html',
+    'trace-viewer standalone HTML template',
+    failures,
+  );
 }
 
 async function checkMonacoWorkerAssets(app, failures) {
@@ -746,6 +753,7 @@ const summary = [
   '- dist/renderer/assets/*.css',
   '- dist/renderer/assets Monaco worker chunks',
   '- resources/agents, resources/tool_use_agents, and resources/skills',
+  '- resources/traceViewerStandalone/index.html',
   '- package.json runtime dependencies',
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -204,6 +204,21 @@ describe('desktop Codex package payload', () => {
     expect(desktopHook.default).toBe(rootHook.default);
   });
 
+  it('requires the standalone trace-viewer template in packaged resources', () => {
+    const { packageRoot, resourcesDir } = createFakeDesktopPackage([
+      'darwin-arm64',
+    ]);
+    rmSync(
+      join(resourcesDir, 'resources', 'traceViewerStandalone', 'index.html'),
+    );
+
+    const result = runVerifierResult(packageRoot);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Missing trace-viewer standalone HTML template: resources/traceViewerStandalone/index.html',
+    );
+  });
+
   it('keeps pnpm platform settings in the workspace manifest', () => {
     const rootPackageJson = JSON.parse(
       readFileSync(repoPath('package.json'), 'utf8'),
@@ -304,6 +319,10 @@ function createFakeDesktopPackage(
   writeText(
     join(appRoot, 'resources/skills/example/SKILL.md'),
     'name: example\n\ndescription: Example bundled skill.\n',
+  );
+  writeText(
+    join(appRoot, 'resources/traceViewerStandalone/index.html'),
+    '<!doctype html>\n',
   );
 
   for (const dependencyName of Object.keys(readDesktopDependencies())) {


### PR DESCRIPTION
## Summary

Packaged desktop builds did not contain the standalone trace-viewer template introduced as a runtime dependency of HTML history export in #7827. The release jobs build only the root `desktop:build` target before electron-builder copies `packages/extension/resources`, so the generated and gitignored template was absent when packaging began.

This change makes the trace-viewer build part of `desktop:build`. That command is shared by all three desktop release jobs, `desktop:package:dist`, and `desktop:package:local`, so the resource is produced at the narrow common build boundary without changing export or resource-path runtime code. The desktop package verifier now requires the exact standalone HTML file.

Closes #7834.

## Issue acceptance gates

- The macOS, Linux, and Windows release paths generate `traceViewerStandalone/index.html` through their existing `desktop:build` invocation.
- Packaged application verification rejects a build missing `resources/traceViewerStandalone/index.html`.
- Regression coverage removes that file from an otherwise valid package fixture and asserts the verifier failure.
- A real unpacked macOS package contains the generated 5,325,715-byte template at `TeXRA.app/Contents/Resources/resources/traceViewerStandalone/index.html`.

## Single source of truth

The root `desktop:build` script owns preparation of generated resources required by desktop packaging. `scripts/verify-desktop-package.mjs` owns the corresponding packaged-artifact contract.

## Duplication and abstraction budget

No abstraction was added. Extending the shared root build command avoids three duplicated workflow steps and also covers local package commands.

## Net elements (R6)

- Files changed: 4; no new files.
- Net diff: +34/-1.
- Exports, classes, interfaces, and enums added or removed: none.

## Consumer counts (R8)

n/a. No event, export, or runtime consumer was deleted or rerouted.

## Host impact

Extension: No runtime change. Its existing trace-viewer build remains unchanged.

Desktop: HTML chat export now has its standalone template in packaged applications, and package validation enforces that requirement.

CLI: No runtime or packaging change.

## Scheduled refactoring

None.

## Validation

- `npm run format` — pass
- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCodexPayload.vitest.mts` — 1 file, 12 tests pass
- `npm run typecheck` — pass
- `corepack pnpm --filter @texra/desktop run typecheck` — pass
- `npm run lint` — pass with 0 errors and 51 pre-existing import-order warnings
- `npm run compile:fast` — pass
- `npm run desktop:build` — pass; generates both trace-viewer bundles before the desktop build
- `npm run check:desktop-build-artifacts` — pass
- `corepack pnpm --filter @texra/desktop run package:dir` — pass
- Packaged standalone-template existence and size check — pass
- `npm run check:desktop-package` — the new resource check passes, but the full verifier exits on an unrelated current-`main` startup-graph finding: the packaged desktop main graph eagerly includes five `openai@6.45.0` SDK inputs. This change does not touch desktop runtime imports or the startup-graph check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-order and packaging verification only; no runtime export logic changes beyond ensuring the template is present in packaged apps.
> 
> **Overview**
> **Packaged desktop builds were missing the generated standalone trace-viewer HTML** that HTML history export loads at runtime, so export failed after release packaging that only ran `desktop:build` before copying resources.
> 
> The root **`desktop:build`** script now runs **`@texra/trace-viewer` build** before the desktop package build, so release jobs, `desktop:package:dist`, and local package flows all produce the template at the shared build boundary without changing export or path-resolution code.
> 
> **`scripts/verify-desktop-package.mjs`** now fails the check if **`resources/traceViewerStandalone/index.html`** is absent, with a regression test that removes the file from a fake package fixture. **CHANGELOG** documents the desktop bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07ff433800dd57d8188ad3fc39c84ca3c92532a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->