### PR TITLE
fix(desktop): report progress restore failures

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -618,10 +618,12 @@ export class DesktopProgressBridge {
       // Mirrors the extension's PROGRESS_VIEW_COMMANDS.RESTORE_STATE handler
       // (`texra.restoreState`): look up the stream's persisted task state and
       // route the renderer to the main view with it.
-      restoreState: (data) => {
+      restoreState: async (data) => {
         const taskState = this.state.snapshots.getTaskState(data.stream);
-        if (taskState) {
-          this.restoreTaskState(taskState);
+        if (taskState && !this.restoreTaskState(taskState)) {
+          await this.options.showErrorMessage?.(
+            'Failed to restore configuration',
+          );
         }
       },
       compactResponse: unsupported(

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -183,6 +183,7 @@ interface DesktopAgentExecutionModule {
 }
 
 type CreateBridgeOptions = {
+  buildMainViewState?: (taskState: unknown) => unknown;
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
   /** Forces `state.streamLogs.load()` to reject, to exercise the restart-repair fallback (catch) path. */
@@ -341,6 +342,11 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
     prepareMainViewExecutionRequest: vi.fn(),
   }));
+  if (options.buildMainViewState) {
+    vi.doMock('@controllers/mainView/MainViewStateRestoreController', () => ({
+      buildMainViewState: options.buildMainViewState,
+    }));
+  }
   mockLoggerModule();
   vi.doMock('vscode', () => ({
     commands: {
@@ -3140,6 +3146,46 @@ describe('DesktopProgressBridge', () => {
         { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },
         expect.objectContaining({ command: COMMON_COMMANDS.STATE_RESTORE }),
       ]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('reports a failed progress-board restore exactly once', async () => {
+    const messages: unknown[] = [];
+    const errors: string[] = [];
+    const buildMainViewState = vi.fn(() => {
+      throw new Error('invalid persisted task state');
+    });
+    const bridge = await createBridge(messages, {
+      buildMainViewState,
+      showErrorMessage: (message) => {
+        errors.push(message);
+      },
+    });
+
+    try {
+      emitRunConfigFact(bridge, {
+        streamId: 'stream-1',
+        executionId: 'ec1003' as ExecutionId,
+        taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
+      });
+      await settleProgressEvents();
+      messages.length = 0;
+
+      const handleRestoreState = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.RESTORE_STATE
+        ],
+      );
+      await handleRestoreState({
+        command: PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
+        stream: 'stream-1',
+      });
+
+      expect(buildMainViewState).toHaveBeenCalledTimes(1);
+      expect(errors).toEqual(['Failed to restore configuration']);
+      expect(messages).toEqual([]);
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
## Summary

The desktop progress-board restore handler now checks the result returned by `restoreTaskState`. When construction of the main-view state fails, it reports `Failed to restore configuration` through the desktop host error-message callback. The lower-level restore helper remains silent, preserving the existing single-report ownership for history setup and agent proposals.

A regression test forces `buildMainViewState` to throw and verifies one error report with no route or persisted-state messages sent to the renderer.

## Verification

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop run build:main`
- `npm run compile:fast`

Closes #7832

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop progress-board restore UX; no auth or persistence changes beyond surfacing an existing failure path.
> 
> **Overview**
> When the progress board **Restore** action runs, the desktop handler now treats a **`false`** from `restoreTaskState` (e.g. `buildMainViewState` throws on bad persisted task state) as a failed restore and shows **`Failed to restore configuration`** via the host **`showErrorMessage`** callback. The handler is **`async`** so that error path can be awaited.
> 
> **`restoreTaskState`** still only returns a boolean and does not surface errors itself, so history/proposal callers keep their existing single place for user-visible failures.
> 
> A regression test stubs **`buildMainViewState`** to throw and asserts one error message and **no** main-route or **`STATE_RESTORE`** renderer posts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a0f822fd3905b66701c6b8f4346860e464f5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->