### PR TITLE
test: ratchet host agent doMock sites

### DIFF
--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -1,93 +1,205 @@
 {
-  "semantics": "vi.mock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current site count exceeds this baseline; a decrease is welcome and should shrink this file.",
+  "semantics": "vi.mock() and vi.doMock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current count for either mock form exceeds this baseline; a decrease is welcome and should shrink this file.",
   "sites": [
     {
       "file": "src/test-kernel/cli/AgentResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/ChatDefaults.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/executionRegistry"
     },
     {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
+      "specifier": "@agent/runtime/resolveAndResumeStream"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
+      "specifier": "@agent/runtime/resumeQueuedToolUse"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
+      "specifier": "@agent/runtime/SessionHandle"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
+      "specifier": "@agent/runtime/terminalResultToast"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
+      "specifier": "@agent/storage"
+    },
+    {
       "file": "src/test-kernel/cli/CliInitPlatform.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index/platformAgentDirectories"
     },
     {
       "file": "src/test-kernel/cli/History.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/InitCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/OnboardingGate.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunChatConfig.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/RunChatRegistration.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/runAgent"
     },
     {
       "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunProgressRenderer.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/SessionResumeRetrieval"
     },
     {
       "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/streamTab"
     },
     {
       "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/ProgressViewBridge"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/ProgressViewBridge"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/SessionHandle"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/storage/detectWaitingStreams"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/StreamStatusService"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/RunContext"
+    },
+    {
+      "file": "src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/index/agentRegistry"
     }
   ]
 }

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -1,7 +1,7 @@
 // QA-2 host-side mock ratchet (issue #7684). Host suites (CLI + desktop, in
 // src/test-kernel/cli and src/test-kernel/desktop) reach into `@agent/*`
-// internals via `vi.mock('@agent/...')`, pinning agent's current internal
-// module layout from outside src/agent. Clones the checked-in-baseline +
+// internals via `vi.mock('@agent/...')` or `vi.doMock('@agent/...')`, pinning
+// agent's current internal module layout from outside src/agent. Clones the checked-in-baseline +
 // AST-scanning vitest pattern from LAY-1 (subsystemEdgeRatchet.vitest.ts,
 // PR #7774): baseline the current site count and fail only on an increase;
 // a decrease (or an @agent restructor removing the need for a mock) is
@@ -16,8 +16,11 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+type MockForm = 'mock' | 'doMock';
+
 interface MockSite {
   file: string;
+  form: MockForm;
   specifier: string;
 }
 
@@ -25,6 +28,8 @@ interface MockBaseline {
   semantics: string;
   sites: MockSite[];
 }
+
+const MOCK_FORMS: MockForm[] = ['mock', 'doMock'];
 
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -50,14 +55,25 @@ function sourceFilesUnder(dir: string): string[] {
     .map((entry) => join(dir, entry));
 }
 
-function isViMockCall(node: ts.Node): node is ts.CallExpression {
-  return (
-    ts.isCallExpression(node) &&
-    ts.isPropertyAccessExpression(node.expression) &&
-    ts.isIdentifier(node.expression.expression) &&
-    node.expression.expression.text === 'vi' &&
-    node.expression.name.text === 'mock'
-  );
+function mockFormFromCall(
+  node: ts.Node,
+): { call: ts.CallExpression; form: MockForm } | null {
+  if (
+    !ts.isCallExpression(node) ||
+    !ts.isPropertyAccessExpression(node.expression) ||
+    !ts.isIdentifier(node.expression.expression) ||
+    node.expression.expression.text !== 'vi'
+  ) {
+    return null;
+  }
+
+  switch (node.expression.name.text) {
+    case 'mock':
+    case 'doMock':
+      return { call: node, form: node.expression.name.text };
+    default:
+      return null;
+  }
 }
 
 function collectAgentMockSites(file: string): MockSite[] {
@@ -71,12 +87,13 @@ function collectAgentMockSites(file: string): MockSite[] {
 
   const sites: MockSite[] = [];
   const visit = (node: ts.Node): void => {
-    if (isViMockCall(node)) {
-      const [specifierArg] = node.arguments;
+    const mock = mockFormFromCall(node);
+    if (mock != null) {
+      const [specifierArg] = mock.call.arguments;
       if (specifierArg != null && ts.isStringLiteralLike(specifierArg)) {
         const specifier = specifierArg.text;
         if (AGENT_SPECIFIER.test(specifier)) {
-          sites.push({ file: repoRelative(file), specifier });
+          sites.push({ file: repoRelative(file), form: mock.form, specifier });
         }
       }
     }
@@ -91,8 +108,18 @@ function collectHostAgentMockSites(): MockSite[] {
     sourceFilesUnder(dir).flatMap(collectAgentMockSites),
   ).toSorted(
     (a, b) =>
-      a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+      a.file.localeCompare(b.file) ||
+      a.form.localeCompare(b.form) ||
+      a.specifier.localeCompare(b.specifier),
   );
+}
+
+function countSitesByForm(sites: MockSite[]): Record<MockForm, number> {
+  const counts: Record<MockForm, number> = { mock: 0, doMock: 0 };
+  for (const { form } of sites) {
+    counts[form] += 1;
+  }
+  return counts;
 }
 
 function readBaseline(): MockBaseline {
@@ -100,16 +127,23 @@ function readBaseline(): MockBaseline {
 }
 
 describe('QA-2 host-side @agent mock ratchet', () => {
-  it("does not increase the count of vi.mock('@agent/...') sites in CLI/desktop suites", () => {
+  it("does not increase the count of either vi.mock or vi.doMock('@agent/...') sites in CLI/desktop suites", () => {
     const baseline = readBaseline();
     const current = collectHostAgentMockSites();
+    const baselineCounts = countSitesByForm(baseline.sites);
+    const currentCounts = countSitesByForm(current);
 
-    expect(
-      current.length,
-      `host-side @agent mock sites grew from ${baseline.sites.length} to ${current.length}:\n` +
-        `${current.map((site) => `${site.file}: ${site.specifier}`).join('\n')}\n\n` +
-        'If this growth is intentional, update host-agent-mock-baseline.json in this PR.',
-    ).toBeLessThanOrEqual(baseline.sites.length);
+    for (const form of MOCK_FORMS) {
+      expect(
+        currentCounts[form],
+        `host-side @agent vi.${form} sites grew from ${baselineCounts[form]} to ${currentCounts[form]}:\n` +
+          `${current
+            .filter((site) => site.form === form)
+            .map((site) => `${site.file}: vi.${site.form}('${site.specifier}')`)
+            .join('\n')}\n\n` +
+          'If this growth is intentional, update host-agent-mock-baseline.json in this PR.',
+      ).toBeLessThanOrEqual(baselineCounts[form]);
+    }
   });
 
   it('keeps the baseline non-empty and ordered', () => {

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -150,7 +150,9 @@ describe('QA-2 host-side @agent mock ratchet', () => {
     const baseline = readBaseline();
     const sortedSites = baseline.sites.toSorted(
       (a, b) =>
-        a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+        a.file.localeCompare(b.file) ||
+        a.form.localeCompare(b.form) ||
+        a.specifier.localeCompare(b.specifier),
     );
 
     expect(baseline.sites.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Extend the QA-2 host-side `@agent/*` mock ratchet to scan both `vi.mock` and `vi.doMock` calls with the TypeScript AST.
- Ratchet each mock form independently so growth in one form cannot be hidden by a reduction in the other.
- Recompute the checked-in baseline from the current tree: 27 `vi.mock` sites and 13 `vi.doMock` sites.

## Validation
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts`
- `npm run typecheck`
- `npm run lint`

Closes #7830

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only architecture guard and baseline JSON; no production runtime behavior changes.
> 
> **Overview**
> Extends the QA-2 host-side `@agent/*` mock ratchet so it tracks **`vi.doMock`** as well as **`vi.mock`**, using the same TypeScript AST scan over CLI and desktop test-kernel suites.
> 
> Each baseline entry now records a **`form`** (`mock` | `doMock`), and the test **fails on growth per form** instead of a single combined count—so adding `doMock` sites cannot be offset by removing `mock` sites. Sorting and failure messages include the mock form. **`host-agent-mock-baseline.json`** is refreshed to the current tree (27 `mock` and 13 `doMock` `@agent/*` sites, including new CLI entries in `chatSessionController` and desktop suites that were previously unracheted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c870a42b7d9559dd8e1e86c1cbaf5bb9928d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->