### PR TITLE
fix(desktop): normalize malformed history configs

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -33,10 +33,7 @@ import {
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
-import {
-  AgentConfigSchema,
-  type AgentConfig,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   validateExecutionRequest,
   type ValidatedExecutionRequest,
@@ -532,11 +529,8 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  async function readHistoryConfig(
-    historyId: string,
-  ): Promise<AgentConfig | undefined> {
-    const raw = await getExecutionStore(historyId as ExecutionId).readConfig();
-    return raw ? AgentConfigSchema.parse(raw) : undefined;
+  function readHistoryConfig(historyId: string): Promise<AgentConfig | null> {
+    return getExecutionStore(historyId as ExecutionId).readConfig();
   }
 
   async function rerunHistoryAgent(historyId: string): Promise<void> {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -287,6 +287,7 @@ function inactiveLatexSettingsStatus(): unknown {
 describe('desktop settings IPC', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     setGitAuthorEnv({});
     setWorktreeSupportEnabled(false);
   });
@@ -1854,6 +1855,58 @@ describe('desktop settings IPC', () => {
     await flushAsyncWork();
 
     expect(infos).toEqual(['History item not found', 'History item not found']);
+  });
+
+  it('reports malformed history configs without entering the dispatcher error path', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const { getExecutionStore } = await import('@agent/storage');
+    const logger = await import('@logger/logUtils');
+
+    const historyId = 'badc0f19';
+    await getExecutionStore(historyId).write('config', {
+      inputFiles: [],
+      outputFiles: ['orphaned-output.tex'],
+    });
+
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const showInfoMessage = vi.fn(async () => {});
+    const onError = vi.fn();
+    const runExecution = vi.fn(async () => {});
+    const restoreTaskState = vi.fn(async () => true);
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: () => {},
+      modelListRefresh: Promise.resolve(),
+      showInfoMessage,
+      onError,
+      runExecution,
+      restoreTaskState,
+    });
+
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId,
+    });
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+      historyId,
+    });
+    await flushAsyncWork();
+
+    expect(showInfoMessage).toHaveBeenCalledTimes(2);
+    expect(showInfoMessage).toHaveBeenCalledWith('History item not found');
+    expect(onError).not.toHaveBeenCalled();
+    expect(runExecution).not.toHaveBeenCalled();
+    expect(restoreTaskState).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${historyId} config.json`,
+      ),
+      { data: expect.any(Error) },
+    );
   });
 
   it('exports a history chat to Markdown via the shared ChatExportController', async () => {


### PR DESCRIPTION
## Summary

- Delegate history-config loading to `ExecutionKVStore`'s validated reader.
- Treat malformed and legacy persisted configs as unavailable, so rerun and restore use the existing `History item not found` user-facing path instead of leaking a raw `ZodError` through IPC dispatch.
- Preserve the storage layer's structured warning diagnostics and cover the malformed-config path for rerun and restore.

## Verification

- `npm run format`
- focused Vitest coverage for desktop settings IPC
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

Closes #7833

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop IPC error-handling change with tests; no auth, data migration, or execution-runtime behavior changes beyond safer config reads.
> 
> **Overview**
> Desktop history **rerun** and **restore** no longer parse `config.json` with `AgentConfigSchema` in `desktopSettingsIpc`; they call `getExecutionStore(...).readConfig()` instead.
> 
> **Malformed or legacy persisted configs** are treated as missing: users still see **History item not found**, while `ExecutionKVStore` logs its existing parse warning. Raw `ZodError`s no longer bubble through the IPC dispatcher `onError` path.
> 
> Tests add coverage for that malformed-config behavior for both commands and `vi.restoreAllMocks()` in `afterEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33da642730b1b0ff69e4766a2dcd3c76d907b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->