### PR TITLE
test: widen QA-2 host-mock ratchet to vi.doMock + allow empty baseline (#7817 follow-up)

### DIFF
--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -1,5 +1,5 @@
 {
-  "semantics": "vi.mock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current site count exceeds this baseline; a decrease is welcome and should shrink this file.",
+  "semantics": "vi.mock()/vi.doMock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current site count exceeds this baseline; a decrease is welcome and should shrink this file.",
   "sites": [
     {
       "file": "src/test-kernel/cli/AgentResolution.vitest.mts",
@@ -28,6 +28,26 @@
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
       "specifier": "@agent/runtime/executionRegistry"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/runtime/resolveAndResumeStream"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/runtime/resumeQueuedToolUse"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/runtime/SessionHandle"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/runtime/terminalResultToast"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/CliInitPlatform.vitest.mts",
@@ -88,6 +108,58 @@
     {
       "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
       "specifier": "@agent/storage"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/ProgressViewBridge"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/ProgressViewBridge"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/SessionHandle"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "specifier": "@agent/storage/detectWaitingStreams"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts",
+      "specifier": "@agent/runtime/StreamStatusService"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts",
+      "specifier": "@agent/runtime/RunContext"
+    },
+    {
+      "file": "src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts",
+      "specifier": "@agent/index/agentRegistry"
     }
   ]
 }

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -1,7 +1,8 @@
 // QA-2 host-side mock ratchet (issue #7684). Host suites (CLI + desktop, in
 // src/test-kernel/cli and src/test-kernel/desktop) reach into `@agent/*`
-// internals via `vi.mock('@agent/...')`, pinning agent's current internal
-// module layout from outside src/agent. Clones the checked-in-baseline +
+// internals via `vi.mock('@agent/...')` or `vi.doMock('@agent/...')`,
+// pinning agent's current internal module layout from outside src/agent.
+// Clones the checked-in-baseline +
 // AST-scanning vitest pattern from LAY-1 (subsystemEdgeRatchet.vitest.ts,
 // PR #7774): baseline the current site count and fail only on an increase;
 // a decrease (or an @agent restructor removing the need for a mock) is
@@ -9,7 +10,7 @@
 
 // Node imports
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Third-party imports
@@ -50,13 +51,15 @@ function sourceFilesUnder(dir: string): string[] {
     .map((entry) => join(dir, entry));
 }
 
+const VI_MOCK_METHODS = new Set(['mock', 'doMock']);
+
 function isViMockCall(node: ts.Node): node is ts.CallExpression {
   return (
     ts.isCallExpression(node) &&
     ts.isPropertyAccessExpression(node.expression) &&
     ts.isIdentifier(node.expression.expression) &&
     node.expression.expression.text === 'vi' &&
-    node.expression.name.text === 'mock'
+    VI_MOCK_METHODS.has(node.expression.name.text)
   );
 }
 
@@ -100,7 +103,7 @@ function readBaseline(): MockBaseline {
 }
 
 describe('QA-2 host-side @agent mock ratchet', () => {
-  it("does not increase the count of vi.mock('@agent/...') sites in CLI/desktop suites", () => {
+  it("does not increase the count of vi.mock()/vi.doMock('@agent/...') sites in CLI/desktop suites", () => {
     const baseline = readBaseline();
     const current = collectHostAgentMockSites();
 
@@ -112,14 +115,13 @@ describe('QA-2 host-side @agent mock ratchet', () => {
     ).toBeLessThanOrEqual(baseline.sites.length);
   });
 
-  it('keeps the baseline non-empty and ordered', () => {
+  it('keeps the baseline ordered (an empty baseline is a valid, welcome outcome)', () => {
     const baseline = readBaseline();
     const sortedSites = baseline.sites.toSorted(
       (a, b) =>
         a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
     );
 
-    expect(baseline.sites.length).toBeGreaterThan(0);
     expect(baseline.sites).toEqual(sortedSites);
   });
 });


### PR DESCRIPTION
## What / why

Follow-up to #7817 (QA-2 host-mock ratchet), which merged while its triaged review findings were still open (the head branch is deleted, so this lands the fixes as a fresh PR off `main`):

1. **Unused import (Copilot / claude[bot] / texra-review).** `dirname` was imported from `node:path` in `hostAgentMockRatchet.vitest.ts` but never used — removed.

2. **codex P2 — the AST scan missed `vi.doMock`.** The ratchet only matched `vi.mock(...)`, but desktop suites already mock `@agent/*` internals via `vi.doMock(...)` (`DesktopAgentExecution.vitest.mts`, `DesktopSessionProgressBridge.vitest.mts`, `DesktopToolEditApproval.vitest.mts`, `ElectronMainViewIpc.vitest.mts`) — so future desktop additions using the same pattern would never grow `current.length` and the ratchet would miss exactly the host-side agent mocks it exists to track. The scan now matches both methods, and `host-agent-mock-baseline.json` is regenerated against current `main`: **22 → 40 sites** (13 `doMock` sites the old scan was blind to, plus 5 `@agent/*` sites `src/test-kernel/cli/chatSessionController.vitest.mts` gained on `main` since #7817's baseline was computed).

3. **Empty baseline must pass (Copilot).** The "keeps the baseline non-empty" assertion contradicted the ratchet's own goal — legitimately reaching 0 host-side `@agent` mocks would have failed the suite. The ordering assertion stays; the non-empty requirement is dropped.

## Verification

- `npx vitest run src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts src/test-kernel/scripts/CheckTestLocGrowth.vitest.mts src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts src/test-kernel/architecture/dependencyDirection.vitest.ts src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts` — 5 files, 40/40 passed (on this branch, rebased on `main`)
- `npm run check:test-loc-growth` — D8 script unaffected (warn-only report prints as designed)
- `npm run typecheck` — clean (root, test-kernel, extension, CLI, trace-viewer)
- `npx prettier --check` on both touched files — clean

Housekeeping note: the pre-merge automation also re-pushed the (deleted) `claude/issue-7684-qa2-d8-ratchets` branch with an earlier version of this fix; that branch is superseded by this PR and can be deleted.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only architecture ratchet and baseline JSON changes; no production runtime behavior.
> 
> **Overview**
> Fixes gaps in the QA-2 host-side `@agent` mock ratchet so it actually tracks how CLI/desktop tests mock agent internals.
> 
> The AST scanner now treats **`vi.doMock('@agent/...')`** the same as **`vi.mock`**, which closes a hole where desktop suites already used `doMock` but new sites would not increase the ratchet count. **`host-agent-mock-baseline.json`** is refreshed to match current `main` (**22 → 40** sites), including previously invisible `doMock` entries and newer `chatSessionController` mocks.
> 
> The ordering check remains, but the suite **no longer requires a non-empty baseline**, so driving host-side `@agent` mocks down to zero is a valid pass. An unused **`dirname`** import is removed from the ratchet test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62a86a2f1c14cfcfc6823395c2083f8c52e5e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->