### PR TITLE
fix(agent): skip irrelevant memory checks

### DIFF
--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest';
 
 // Type imports
 import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
-import { PromptBuilder } from '@utils/prompt';
+import { buildInitialToolUsePrompts, PromptBuilder } from '@utils/prompt';
 
 describe('PromptBuilder', () => {
   it('uses array-based userRequest entries for reflections', async () => {
@@ -39,5 +39,27 @@ describe('PromptBuilder', () => {
     // Single-template agents reuse the template for subsequent rounds
     const reflectPrompt = await builder.buildUserRequest(1);
     assert.equal(reflectPrompt, 'initial only');
+  });
+
+  it('keeps memory checks relevant and schema-valid', async () => {
+    const prompts = await buildInitialToolUsePrompts(
+      {
+        systemPrompt: 'system',
+        userPrefix: '',
+        userRequest: 'request',
+      } as AgentPrompt,
+      {},
+      undefined,
+      { resolvedToolNames: ['memory'] },
+    );
+
+    assert.match(
+      prompts.instructionSuffix,
+      /For a self-contained request, do not inspect or write memory/,
+    );
+    assert.match(
+      prompts.instructionSuffix,
+      /use the `view` command with path `\/memories`/,
+    );
   });
 });

--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -61,5 +61,13 @@ describe('PromptBuilder', () => {
       prompts.instructionSuffix,
       /use the `view` command with path `\/memories`/,
     );
+    assert.match(
+      prompts.instructionSuffix,
+      /When memory is relevant, consult pinned memories first/,
+    );
+    assert.doesNotMatch(
+      prompts.instructionSuffix,
+      /Always consult pinned memories at session start/,
+    );
   });
 });

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -49,7 +49,7 @@ Note: when editing your memory folder, always try to keep its content up-to-date
 PINNED MEMORIES:
 Some memories may be marked as "pinned" (shown with [pinned] in directory listings and file headers). These are core long-term insights—techniques, strategies, pitfalls, and best practices accumulated over time. They represent the kind of knowledge a seasoned researcher would build up through years of project experience.
 
-- Always consult pinned memories at session start; they contain the most valuable accumulated knowledge.
+- When memory is relevant, consult pinned memories first; they contain the most valuable accumulated knowledge.
 - When you discover a reusable trick, technique, strategy, pitfall, or best practice, consider using the \`pin\` command to mark it as a core memory.
 - Do NOT pin task-specific progress notes or ephemeral status updates. Only pin long-term reusable insights.
 - Use \`unpin\` to remove the pinned status when a memory is no longer relevant as a core insight.

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -33,12 +33,12 @@ The following imported skills are available. If one is relevant, inspect its SKI
 
 /** Base memory instructions for all agents with memory enabled. */
 const MEMORY_TOOL_INSTRUCTIONS = `<memory_tool_instructions>
-IMPORTANT: ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE.
+Use memory when the request may depend on prior sessions, durable user preferences, or shared agent context. For a self-contained request, do not inspect or write memory merely because the tool is available.
 
 MEMORY PROTOCOL:
-1. Use the \`view\` command of your \`memory\` tool to check for earlier progress.
+1. When memory is relevant, use the \`view\` command with path \`/memories\` to check for earlier progress.
 2. ... (work on the task) ...
-   - As you make progress, record status, progress, and thoughts in your memory.
+   - For long-running work that needs continuity, record durable progress and decisions in memory.
    - Record user preferences: writing style, coding conventions, formatting requirements, workflow preferences, and any explicit or implicit guidelines the user follows.
    - When git is available, look into git history (commit messages, PR descriptions, recent changes) to understand project context, coding patterns, and conventions.
 
@@ -59,12 +59,12 @@ Some memories may be marked as "pinned" (shown with [pinned] in directory listin
 const ORCHESTRATOR_MEMORY_INSTRUCTIONS = `<orchestrator_memory_protocol>
 The /memories directory is shared with all subagents you launch. Subagents can read and write the same files. Use this for persistent context that should survive across conversations—not as a substitute for subagent result delivery (subagents report back automatically via follow-up messages). Good uses: project conventions, user preferences, research bibliographies that build up over time.
 
-Beyond basic progress tracking, record reusable intelligence: what approaches worked or failed and why, project structure and conventions you discovered, user preferences revealed through corrections or rejections, and effective problem-solving strategies. Consult these at session start instead of rediscovering from scratch.
+For continuation or delegation-heavy work, consult relevant memories instead of rediscovering context. Record reusable intelligence: what approaches worked or failed and why, project structure and conventions you discovered, user preferences revealed through corrections or rejections, and effective problem-solving strategies.
 </orchestrator_memory_protocol>`;
 
 /** Memory instructions for subagents launched by an orchestrator. */
 const SUBAGENT_MEMORY_INSTRUCTIONS = `<subagent_memory_protocol>
-The /memories directory is shared with the orchestrator and other subagents. Check /memories first—it may contain context from prior sessions or other agents. Write to memory for information that should persist beyond this session (e.g., discovered conventions, useful references). Your primary results should go in your response, not in memory.
+The /memories directory is shared with the orchestrator and other subagents. Check it when your delegated task may depend on context from prior sessions or sibling agents. Write to memory for information that should persist beyond this session (e.g., discovered conventions, useful references). Your primary results should go in your response, not in memory.
 </subagent_memory_protocol>`;
 
 /**


### PR DESCRIPTION
## Summary

- make shared memory prompting relevance-based instead of mandatory for every request
- give models the schema-valid `/memories` path when a memory lookup is warranted
- keep orchestrator and subagent memory guidance focused on continuation and shared context
- add focused prompt-contract coverage

Closes #7854.

## Issue acceptance gates

- [x] Self-contained requests are explicitly allowed to skip memory reads and writes.
- [x] Relevant memory reads specify `view` with path `/memories`.
- [x] Orchestrator and subagent guidance no longer reintroduces an unconditional startup scan.
- [x] A rebuilt CLI answered a fresh self-contained GCD prompt without memory, plan, todo, or other tool calls.

## Single source of truth

`src/utils/prompt/PromptBuilder.ts` remains the single owner of shared tool-use memory instructions across hosts and agent roles.

## Duplication and abstraction budget

No abstraction was added. The change removes conflicting blanket policy from the existing shared prompt owner instead of adding agent- or host-specific exceptions.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Tests: 1 focused case added.
- Net LoC: +30 (`37` additions, `7` deletions).

## Consumer counts (R8)

n/a — no emit path, event key, or export is deleted or rerouted.

## Host impact

Extension: Memory-enabled tool-use agents skip irrelevant startup scans; no UI or host API change.

Desktop: Same shared prompt behavior; no UI or host API change.

CLI: Same shared prompt behavior. Verified with a rebuilt `texra-local` TTY session in a fresh workspace.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/agent/utils/promptBuilder.vitest.ts src/test-kernel/skills/RuntimeSkills.vitest.mts` — 2 files, 6 tests passed.
- `npm run typecheck` — passed across the workspace.
- `corepack pnpm exec prettier --check src/utils/prompt/PromptBuilder.ts src/test-kernel/agent/utils/promptBuilder.vitest.ts` — passed.
- `npm run lint` — 0 errors; 52 pre-existing import-order warnings outside this diff.
- `git diff --check` — passed.
- `npm run texra-local:build && npm run texra-local:link` — passed.
- Live TTY: `gemini35f` answered a fresh self-contained GCD prompt directly in 8 seconds with no tool calls; session total was 21,770 tokens.
- Post-change CLI regression suite: 128 CLI test files / 1,635 tests passed.
- Pre-change PTY sweep on the same refreshed `main`: all 141 validator scenarios passed; the prompt-only fix does not alter TUI rendering or interaction code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change in shared agent instructions; no auth, data paths, or runtime logic altered beyond model behavior guidance.
> 
> **Overview**
> **Memory-enabled tool-use agents** no longer get blanket “always read memory at session start” instructions. Shared text in `PromptBuilder.ts` now tells models to use memory only when the request depends on prior sessions, preferences, or shared context, and to skip reads/writes on self-contained tasks.
> 
> When a lookup is warranted, the protocol specifies **`view` with path `/memories`** (schema-valid) instead of a vague directory scan. Pinned-memory and orchestrator/subagent blocks are aligned the same way—consult when continuation or delegation needs context, not unconditionally.
> 
> A **vitest contract** asserts the built `instructionSuffix` includes the new relevance wording and `/memories` path, and omits the old “always consult pinned memories at session start” line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd224fc03c670abbc5039a21d87289671bc6ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->