### PR TITLE
test: per-form host @agent mock ratchet (rebase of #7843)

### DIFF
--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -1,164 +1,204 @@
 {
-  "semantics": "vi.mock()/vi.doMock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current site count exceeds this baseline; a decrease is welcome and should shrink this file.",
+  "semantics": "vi.mock() and vi.doMock() call sites in host-side (CLI + desktop) test-kernel suites (src/test-kernel/cli/**, src/test-kernel/desktop/**) that mock an internal @agent/* module specifier. Each site pins @agent's current internal module layout from outside src/agent, per issue #7684 QA-2. The ratchet fails only when the current count for either mock form exceeds this baseline; a decrease is welcome and should shrink this file.",
   "sites": [
     {
       "file": "src/test-kernel/cli/AgentResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/AgentsRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/ChatDefaults.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/executionRegistry"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/resolveAndResumeStream"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/resumeQueuedToolUse"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/SessionHandle"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/terminalResultToast"
     },
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/CliInitPlatform.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index/platformAgentDirectories"
     },
     {
       "file": "src/test-kernel/cli/History.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/InitCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/MultiAgentRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/OnboardingGate.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunChatConfig.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/RunChatRegistration.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/runAgent"
     },
     {
       "file": "src/test-kernel/cli/RunExecution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/cli/RunProgressRenderer.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/SessionResumeRetrieval"
     },
     {
       "file": "src/test-kernel/cli/SessionResumeResolution.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/streamTab"
     },
     {
       "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/index"
     },
     {
       "file": "src/test-kernel/cli/WorkflowRunCommand.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/storage"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/executeAgent"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/executeAgent"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/ProgressViewBridge"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/ProgressViewBridge"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/runAgent"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/runAgent"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/SessionHandle"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/SessionResumeRetrieval"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/SessionResumeRetrieval"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/storage/detectWaitingStreams"
     },
     {
       "file": "src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/StreamStatusService"
     },
     {
       "file": "src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/runtime/RunContext"
     },
     {
       "file": "src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts",
+      "form": "doMock",
       "specifier": "@agent/index/agentRegistry"
     }
   ]

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -17,8 +17,11 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+type MockForm = 'mock' | 'doMock';
+
 interface MockSite {
   file: string;
+  form: MockForm;
   specifier: string;
 }
 
@@ -26,6 +29,8 @@ interface MockBaseline {
   semantics: string;
   sites: MockSite[];
 }
+
+const MOCK_FORMS: MockForm[] = ['mock', 'doMock'];
 
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -51,16 +56,25 @@ function sourceFilesUnder(dir: string): string[] {
     .map((entry) => join(dir, entry));
 }
 
-const VI_MOCK_METHODS = new Set(['mock', 'doMock']);
+function mockFormFromCall(
+  node: ts.Node,
+): { call: ts.CallExpression; form: MockForm } | null {
+  if (
+    !ts.isCallExpression(node) ||
+    !ts.isPropertyAccessExpression(node.expression) ||
+    !ts.isIdentifier(node.expression.expression) ||
+    node.expression.expression.text !== 'vi'
+  ) {
+    return null;
+  }
 
-function isViMockCall(node: ts.Node): node is ts.CallExpression {
-  return (
-    ts.isCallExpression(node) &&
-    ts.isPropertyAccessExpression(node.expression) &&
-    ts.isIdentifier(node.expression.expression) &&
-    node.expression.expression.text === 'vi' &&
-    VI_MOCK_METHODS.has(node.expression.name.text)
-  );
+  switch (node.expression.name.text) {
+    case 'mock':
+    case 'doMock':
+      return { call: node, form: node.expression.name.text };
+    default:
+      return null;
+  }
 }
 
 function collectAgentMockSites(file: string): MockSite[] {
@@ -74,12 +88,13 @@ function collectAgentMockSites(file: string): MockSite[] {
 
   const sites: MockSite[] = [];
   const visit = (node: ts.Node): void => {
-    if (isViMockCall(node)) {
-      const [specifierArg] = node.arguments;
+    const mock = mockFormFromCall(node);
+    if (mock != null) {
+      const [specifierArg] = mock.call.arguments;
       if (specifierArg != null && ts.isStringLiteralLike(specifierArg)) {
         const specifier = specifierArg.text;
         if (AGENT_SPECIFIER.test(specifier)) {
-          sites.push({ file: repoRelative(file), specifier });
+          sites.push({ file: repoRelative(file), form: mock.form, specifier });
         }
       }
     }
@@ -94,8 +109,18 @@ function collectHostAgentMockSites(): MockSite[] {
     sourceFilesUnder(dir).flatMap(collectAgentMockSites),
   ).toSorted(
     (a, b) =>
-      a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+      a.file.localeCompare(b.file) ||
+      a.form.localeCompare(b.form) ||
+      a.specifier.localeCompare(b.specifier),
   );
+}
+
+function countSitesByForm(sites: MockSite[]): Record<MockForm, number> {
+  const counts: Record<MockForm, number> = { mock: 0, doMock: 0 };
+  for (const { form } of sites) {
+    counts[form] += 1;
+  }
+  return counts;
 }
 
 function readBaseline(): MockBaseline {
@@ -103,16 +128,23 @@ function readBaseline(): MockBaseline {
 }
 
 describe('QA-2 host-side @agent mock ratchet', () => {
-  it("does not increase the count of vi.mock()/vi.doMock('@agent/...') sites in CLI/desktop suites", () => {
+  it("does not increase the count of either vi.mock or vi.doMock('@agent/...') sites in CLI/desktop suites", () => {
     const baseline = readBaseline();
     const current = collectHostAgentMockSites();
+    const baselineCounts = countSitesByForm(baseline.sites);
+    const currentCounts = countSitesByForm(current);
 
-    expect(
-      current.length,
-      `host-side @agent mock sites grew from ${baseline.sites.length} to ${current.length}:\n` +
-        `${current.map((site) => `${site.file}: ${site.specifier}`).join('\n')}\n\n` +
-        'If this growth is intentional, update host-agent-mock-baseline.json in this PR.',
-    ).toBeLessThanOrEqual(baseline.sites.length);
+    for (const form of MOCK_FORMS) {
+      expect(
+        currentCounts[form],
+        `host-side @agent vi.${form} sites grew from ${baselineCounts[form]} to ${currentCounts[form]}:\n` +
+          `${current
+            .filter((site) => site.form === form)
+            .map((site) => `${site.file}: vi.${site.form}('${site.specifier}')`)
+            .join('\n')}\n\n` +
+          'If this growth is intentional, update host-agent-mock-baseline.json in this PR.',
+      ).toBeLessThanOrEqual(baselineCounts[form]);
+    }
   });
 
   it('keeps the baseline ordered (an empty baseline is a valid, welcome outcome)', () => {

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -151,7 +151,9 @@ describe('QA-2 host-side @agent mock ratchet', () => {
     const baseline = readBaseline();
     const sortedSites = baseline.sites.toSorted(
       (a, b) =>
-        a.file.localeCompare(b.file) || a.specifier.localeCompare(b.specifier),
+        a.file.localeCompare(b.file) ||
+        a.form.localeCompare(b.form) ||
+        a.specifier.localeCompare(b.specifier),
     );
 
     expect(baseline.sites).toEqual(sortedSites);

--- a/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
+++ b/src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts
@@ -17,7 +17,9 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-type MockForm = 'mock' | 'doMock';
+const MOCK_FORMS = ['mock', 'doMock'] as const;
+
+type MockForm = (typeof MOCK_FORMS)[number];
 
 interface MockSite {
   file: string;
@@ -30,7 +32,13 @@ interface MockBaseline {
   sites: MockSite[];
 }
 
-const MOCK_FORMS: MockForm[] = ['mock', 'doMock'];
+function compareSites(a: MockSite, b: MockSite): number {
+  return (
+    a.file.localeCompare(b.file) ||
+    a.form.localeCompare(b.form) ||
+    a.specifier.localeCompare(b.specifier)
+  );
+}
 
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -107,17 +115,17 @@ function collectAgentMockSites(file: string): MockSite[] {
 function collectHostAgentMockSites(): MockSite[] {
   return HOST_DIRS.flatMap((dir) =>
     sourceFilesUnder(dir).flatMap(collectAgentMockSites),
-  ).toSorted(
-    (a, b) =>
-      a.file.localeCompare(b.file) ||
-      a.form.localeCompare(b.form) ||
-      a.specifier.localeCompare(b.specifier),
-  );
+  ).toSorted(compareSites);
 }
 
 function countSitesByForm(sites: MockSite[]): Record<MockForm, number> {
   const counts: Record<MockForm, number> = { mock: 0, doMock: 0 };
   for (const { form } of sites) {
+    if (!(form in counts)) {
+      throw new Error(
+        `host-agent-mock-baseline.json entry has unknown form ${JSON.stringify(form)} — expected one of: ${MOCK_FORMS.join(', ')}`,
+      );
+    }
     counts[form] += 1;
   }
   return counts;
@@ -149,12 +157,7 @@ describe('QA-2 host-side @agent mock ratchet', () => {
 
   it('keeps the baseline ordered (an empty baseline is a valid, welcome outcome)', () => {
     const baseline = readBaseline();
-    const sortedSites = baseline.sites.toSorted(
-      (a, b) =>
-        a.file.localeCompare(b.file) ||
-        a.form.localeCompare(b.form) ||
-        a.specifier.localeCompare(b.specifier),
-    );
+    const sortedSites = baseline.sites.toSorted(compareSites);
 
     expect(baseline.sites).toEqual(sortedSites);
   });


### PR DESCRIPTION
## Summary

Rebase of #7843 (credit: codex) onto current main, superseding it — #7843 went CONFLICTING after #7848 landed main's combined-form ratchet (single 40-site baseline counting `vi.mock` + `vi.doMock` together).

This keeps the strictly stronger per-form semantics from #7843:

- `MockSite` gains a `form: 'mock' | 'doMock'` field; the collector tags each site.
- The ratchet asserts per form, so `vi.doMock` growth can no longer hide behind a `vi.mock` reduction (and vice versa) — under main's combined count, swapping 3 `vi.mock` for 3 `vi.doMock` reads as "no growth".
- Baseline recomputed from the current tree: 27 `vi.mock` + 13 `vi.doMock` = same 40 sites main's baseline already accepts; no growth is being laundered here.
- Ordering test sorts by `file` → `form` → `specifier`, matching the collector (this addresses the one P2 all three bots raised on #7843), and keeps main's "an empty baseline is a valid, welcome outcome" semantics (no non-empty assertion).

Conflict resolution detail: took the per-form collector (`mockFormFromCall`) over main's `VI_MOCK_METHODS` set, kept main's comment wording and empty-baseline-valid test title.

Closes #7830.

## Verification

- `npx vitest run src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts` — 2 passed (baseline matches the current tree)
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean

## Net elements (R6)

- Files: 0 added / 0 deleted (2 modified: the ratchet test + its baseline JSON)
- Exports/classes: none added or deleted (test-internal helpers only; `isViMockCall` replaced by `mockFormFromCall`)
- Net LoC: ~ +72 (per-form loop, form fields in baseline entries)

## Consumer counts (R8)

n/a — no emit path or export is deleted or re-routed; the baseline JSON is consumed only by this test.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only architecture ratchet and baseline JSON; no production or export surface changes.
> 
> **Overview**
> Strengthens the QA-2 host-side `@agent` mock ratchet so **`vi.mock` and `vi.doMock` are capped separately**, instead of a single combined site count that could hide swapping one form for the other.
> 
> Each baseline entry and collected site now includes **`form: 'mock' | 'doMock'`**; the AST collector uses **`mockFormFromCall`** to tag sites. The main assertion loops over both forms and fails only when **either** count exceeds the baseline (27 `mock` + 13 `doMock` in the updated JSON). Ordering is aligned via **`compareSites`** (`file` → `form` → `specifier`) for both the scan and the baseline-order test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a85f0fe8a0dfb810b17e8b47441e776c797681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->