### PR TITLE
fix(ci): isolate runtime validation credentials

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -34,6 +34,7 @@ const validationEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER';
 const validationFlagEnv = 'TEXRA_INTERNAL_VALIDATE_MODEL_HANDLER_FLAG';
 const validationFlagContent = 'texra-cli-run-validation\n';
 const validationBundleMarker = validationFlagContent.trim();
+const VALIDATION_FAKE_API_KEY = 'texra-validation-fake-key';
 const ESC = String.fromCharCode(27);
 const validationProviderApiKeyEnv = [
   'OPENAI_API_KEY',
@@ -47,6 +48,9 @@ const validationProviderApiKeyEnv = [
   'MINIMAX_API_KEY',
   'GLM_API_KEY',
 ];
+const validationModelProviderEnv = Object.fromEntries(
+  validationProviderApiKeyEnv.map((name) => [name, VALIDATION_FAKE_API_KEY]),
+);
 
 function isolatedCliHomeEnv(home, overrides = {}) {
   return {
@@ -73,6 +77,7 @@ function run(command, args, options = {}) {
     if (!options.validationFlagPath) {
       throw new Error('validationModel requires validationFlagPath');
     }
+    Object.assign(env, validationModelProviderEnv);
     env[validationEnv] = '1';
     env[validationFlagEnv] = options.validationFlagPath;
   }
@@ -732,7 +737,7 @@ async function validateOrchestrateOnboardingPickers() {
   await validateOrchestrateOnboardingPicker({
     label: 'texra orchestrate included-mode onboarding',
     args: ['orchestrate', '--api-mode', 'included'],
-    env: { ANTHROPIC_API_KEY: 'texra-validation-fake-key' },
+    env: { ANTHROPIC_API_KEY: VALIDATION_FAKE_API_KEY },
     expected: [
       'Subscription or included access needs sign-in for this run:',
       'Use ChatGPT subscription',


### PR DESCRIPTION
## Summary

Make the guarded CLI real-runtime validator self-contained in clean CI. Every subprocess using the internal validation model now receives fake credentials for the existing provider-key list, so model availability resolution succeeds without inheriting developer secrets and the internal handler remains the only model boundary used.

## Issue acceptance gates

Closes #7858.

- The validator no longer depends on configured provider keys.
- Guarded validation subprocesses cannot inherit real provider credentials.
- The full runtime validation passes with all provider keys unset and an isolated home directory.

## Single source of truth

`validationProviderApiKeyEnv` remains the provider credential inventory. `VALIDATION_FAKE_API_KEY` owns the placeholder value, and `validationModelProviderEnv` derives the guarded subprocess environment from both.

## Duplication and abstraction budget

No provider list or fake credential literal is duplicated. One derived environment object owns fake-key injection for every guarded validation subprocess.

## Net elements (R6)

- Files: 1 modified
- Exported symbols: 0
- Classes/interfaces/enums: 0
- LoC: 6 insertions, 1 deletion, net +5

## Consumer counts (R8)

n/a — no emit path or export changed.

## Host impact

Extension: None.

Desktop: None.

CLI: Validation harness only; production bundles retain the existing guarded internal-handler behavior.

## Scheduled refactoring

None.

## Validation

- Credential-free `corepack pnpm --filter @texra-ai/cli validate:run` with all ten provider keys unset and fresh `HOME`/XDG directories — passed before and after review fixes.
- GitHub Actions `runtime validation (linux)` in manually dispatched exact-SHA CI run `29051110260` — passed on the functional patch.
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-run.mjs` — passed.
- `git diff --check` — passed.

