### PR TITLE
fix(agent): preserve parent delegation constraints

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -46,6 +46,7 @@ const TraceAgentConfigSchema = NullableFileFieldsSchema.extend({
   agentSource: AgentSourceSchema.nullish(),
   model: z.string(),
   instruction: z.string(),
+  rootUserInstruction: z.string().nullish(),
   displayInstruction: z.string().nullish(),
   agentCategory: AgentCategorySchema,
   editedFiles: z.array(z.string()),

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -25,6 +25,8 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   agentSource: AgentSourceSchema.nullish(),
   model: z.string().prefault(DEFAULT_AGENT_MODEL),
   instruction: z.string().prefault(DEFAULT_AGENT_INSTRUCTION),
+  /** Original user instruction preserved across nested tool-use delegation. */
+  rootUserInstruction: z.string().nullish(),
   /** Optional user-facing text for logs when instruction contains hidden context. */
   displayInstruction: z.string().nullish(),
   agentCategory: z.enum(AgentCategory).prefault(AgentCategory.Workflow),

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -104,6 +104,9 @@ export class ToolUseDispatchNode<C> extends Node<
   ToolUseRoundShared,
   ToolUseRoundServices<C>
 > {
+  /** Instruction snapshot associated with the tool calls being dispatched. */
+  private _currentUserInstruction: string | undefined;
+
   /**
    * Duplicate parallel calls detected during prep(), mapped to the index of
    * their first occurrence. Duplicates are not executed; after the batch
@@ -125,6 +128,7 @@ export class ToolUseDispatchNode<C> extends Node<
   async prep(shared: ToolUseRoundShared): Promise<SdkToolCall[]> {
     this._duplicateToPrimary.clear();
     this._unsafeDuplicateCallIds.clear();
+    this._currentUserInstruction = shared.currentUserInstruction;
     const toolCalls = shared.toolCalls ?? [];
 
     if (shared.shouldStop || toolCalls.length === 0) {
@@ -341,6 +345,7 @@ export class ToolUseDispatchNode<C> extends Node<
     const cloned = super.clone();
     cloned._duplicateToPrimary = new Map();
     cloned._unsafeDuplicateCallIds = new Map();
+    cloned._currentUserInstruction = undefined;
     return cloned;
   }
 
@@ -368,6 +373,8 @@ export class ToolUseDispatchNode<C> extends Node<
         {
           tracker,
           workPlanState,
+          userInstruction:
+            options.config.rootUserInstruction ?? this._currentUserInstruction,
           toolCallId: call.callId,
           signal,
           hooks: {

--- a/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseRoundPrepNode.ts
@@ -8,6 +8,7 @@ import {
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
+  userFollowUpInstruction,
   type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
@@ -75,6 +76,10 @@ export class ToolUseRoundPrepNode<C> extends BaseNode<
     // This ensures user's message typed during tool execution is seen
     // before the model starts thinking/responding
     if (prepRes.queuedFollowUps?.length) {
+      if (!prepRes.synthetic) {
+        const instruction = userFollowUpInstruction(prepRes.queuedFollowUps);
+        if (instruction) shared.currentUserInstruction = instruction;
+      }
       for (const followUp of prepRes.queuedFollowUps) {
         // A non-synthetic follow-up's transcript row must be logged whether
         // appendFollowUpAsUserMessage succeeds or throws (e.g. a corrupt/

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -76,4 +76,6 @@ type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
 export interface ToolUseRoundShared extends ToolUseRoundFields {
   /** Tool calls with proper typing (schema uses z.unknown()) */
   toolCalls?: SdkToolCall[];
+  /** Current user instruction, refreshed when the round consumes user input. */
+  currentUserInstruction?: string;
 }

--- a/src/agent/followUp/ToolFileInteractionContext.ts
+++ b/src/agent/followUp/ToolFileInteractionContext.ts
@@ -35,6 +35,8 @@ export interface ToolCallHooks {
 export interface ToolCallContext {
   toolCallId?: string;
   tracker: FileInteractionState;
+  /** User instruction that led to this tool call, when available. */
+  userInstruction?: string;
   /** Plan and todo progress state. Absent in contexts without work-plan support. */
   workPlanState?: WorkPlanState;
   /** Aborts when the current tool call is cancelled by the owning agent run. */

--- a/src/agent/followUp/followUpMessages.ts
+++ b/src/agent/followUp/followUpMessages.ts
@@ -27,6 +27,17 @@ export function followUpDisplayText(followUp: FollowUpQueueBatchItem): string {
     : followUp.text;
 }
 
+export function userFollowUpInstruction(
+  followUps: readonly FollowUpQueueBatchItem[],
+): string | undefined {
+  const instruction = followUps
+    .filter((followUp) => followUp.origin === 'user')
+    .map((followUp) => followUp.text)
+    .join('\n\n')
+    .trim();
+  return instruction || undefined;
+}
+
 export interface AppendFollowUpResult {
   readonly messages: ProviderMessage[];
   readonly attachmentKinds: MediaAttachmentKind[];

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -73,6 +73,10 @@ export class ToolUseCycleNode<C> extends Node<
       roundIndex: prepRes.runState.totalRounds,
       roundResponseTimeMs: 0,
       systemPrompt: prepRes.systemPrompt,
+      currentUserInstruction:
+        typeof prepRes.userChannels.transient.INSTRUCTION === 'string'
+          ? prepRes.userChannels.transient.INSTRUCTION
+          : undefined,
     };
 
     const flow = createToolUseRoundFlow<C>();
@@ -136,6 +140,10 @@ export class ToolUseCycleNode<C> extends Node<
       }
       return { outcome: 'completed', messages: roundShared.messages };
     } finally {
+      if (roundShared.currentUserInstruction !== undefined) {
+        prepRes.userChannels.transient.INSTRUCTION =
+          roundShared.currentUserInstruction;
+      }
       prepRes.workspaceState.workPlan.clearOnUpdate();
       // Drain in-flight persist writes before returning so they don't
       // race with the projection's writeTodos after this node completes.

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -7,6 +7,7 @@ import { emitRunFact } from '@agent/runtime/runFactEvents';
 import {
   appendFollowUpAsUserMessage,
   followUpDisplayText,
+  userFollowUpInstruction,
   type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
 import { STREAM_PHASE } from '@shared/schemas';
@@ -183,6 +184,10 @@ export class ToolUseWaitNode<C> extends Node<
     // also don't need to be replayed in the chat log.
     if (!execRes.synthetic) {
       onFollowUpConsumed?.();
+      const instruction = userFollowUpInstruction(execRes.followUps);
+      if (instruction && shared.stateSlices) {
+        shared.stateSlices.userChannels.transient.INSTRUCTION = instruction;
+      }
     }
 
     for (const followUp of execRes.followUps) {

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -63,6 +63,7 @@ export type WorkflowAgentProposal = z.infer<typeof WorkflowAgentProposalSchema>;
 /** Tool-use agent proposal - agents access files through their own tools */
 export const ToolUseAgentProposalSchema = BaseProposalFieldsSchema.extend({
   agentCategory: z.literal(AgentCategory.ToolUse),
+  rootUserInstruction: z.string().nullish(),
 });
 export type ToolUseAgentProposal = z.infer<typeof ToolUseAgentProposalSchema>;
 

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -9,8 +9,10 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 import { createRunTrace } from '@transcript';
 import { ToolUseDispatchNode } from '@agent/core/flows/toolUseRound/ToolUseDispatchNode';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { SdkToolCall } from '@agent/types/IModelHandler';
@@ -65,6 +67,7 @@ function makeCall(
 
 interface HarnessOptions {
   tools: Record<string, ITool>;
+  rootUserInstruction?: string;
   checkInterruption?: () => boolean;
   setAbortController?: (controller: AbortController | null) => void;
 }
@@ -72,6 +75,9 @@ interface HarnessOptions {
 function dispatchHarness(opts: HarnessOptions) {
   const runTrace = createRunTrace('DispatchParallelTest' as StreamTabId);
   const services = {
+    config: AgentConfigSchema.parse({
+      rootUserInstruction: opts.rootUserInstruction,
+    }),
     logger: runTrace.trace,
     toolRegistry: new MapToolRegistry(opts.tools),
     checkInterruption: opts.checkInterruption ?? (() => false),
@@ -88,8 +94,14 @@ function dispatchHarness(opts: HarnessOptions) {
 async function runDispatch(
   node: ToolUseDispatchNode<unknown>,
   calls: SdkToolCall[],
+  currentUserInstruction?: string,
 ): Promise<unknown[]> {
-  const shared = { toolCalls: calls, shouldStop: false, messages: [] };
+  const shared = {
+    toolCalls: calls,
+    shouldStop: false,
+    messages: [],
+    currentUserInstruction,
+  };
   const prepped = await (
     node as unknown as { prep(s: unknown): Promise<SdkToolCall[]> }
   ).prep(shared);
@@ -110,6 +122,36 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
   beforeAll(async () => {
     const { initPlatform } = await import('@platform/platform');
     initPlatform(createFakePlatform({ workspacePath: '/workspace' }));
+  });
+
+  it('preserves the unwrapped root instruction across nested delegation', async () => {
+    let observedInstruction: string | undefined;
+    const inspectContext: ITool = {
+      definition: {
+        name: 'inspect_context',
+        description: 'inspect_context',
+        parameters: {},
+      },
+      async call(): Promise<ToolResult> {
+        observedInstruction = getCurrentToolCallContext()?.userInstruction;
+        return { status: 'executed', output: 'ok' };
+      },
+    } as ITool;
+    const { node, dispose } = dispatchHarness({
+      tools: { inspect_context: inspectContext },
+      rootUserInstruction: 'Do not use files or external tools.',
+    });
+
+    try {
+      await runDispatch(
+        node,
+        [makeCall('c1', 'inspect_context', {})],
+        'Wrapped child instruction with prior handoff boilerplate.',
+      );
+      assert.equal(observedInstruction, 'Do not use files or external tools.');
+    } finally {
+      dispose();
+    }
   });
 
   it('executes contiguous parallel-safe calls concurrently, preserving order', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -64,10 +64,13 @@ describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 p
     );
   });
 
-  it('still logs exactly once per queued follow-up on the success path', async () => {
+  it('logs each follow-up and refreshes the instruction from user input', async () => {
     const services = buildServices();
     const node = new ToolUseRoundPrepNode().setServices(services);
-    const shared = buildShared();
+    const shared = {
+      ...buildShared(),
+      currentUserInstruction: 'initial request',
+    };
     const runtimeHost = { emit: vi.fn() };
 
     const transition = await withTestRunContext(
@@ -76,13 +79,20 @@ describe('ToolUseRoundPrepNode follow-up transcript logging (regression: #7508 p
       () =>
         node.post(shared, {
           interrupted: false,
-          queuedFollowUps: [{ text: 'Do the thing.', origin: 'user' }],
+          queuedFollowUps: [
+            { text: 'Do the thing.', origin: 'user' },
+            {
+              text: '<subagent-result>done</subagent-result>',
+              origin: 'subagent_result',
+            },
+          ],
           synthetic: false,
         }),
     );
 
     expect(transition).toBeDefined();
-    expect(services.logger.info).toHaveBeenCalledTimes(1);
+    expect(services.logger.info).toHaveBeenCalledTimes(2);
+    expect(shared.currentUserInstruction).toBe('Do the thing.');
   });
 
   it('does not log synthetic follow-ups', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -9,6 +9,8 @@ import {
 } from '@test/helpers/streamStatusTestUtils';
 import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
 import {
   extractTouchedFiles,
@@ -810,7 +812,14 @@ describe('ToolUseWaitNode', () => {
     const shared: ToolUseRunShared = {
       messages: [],
       shouldSkipCycle: false,
-      stateSlices: null,
+      stateSlices: {
+        runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+        workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+        userChannels: {
+          input: Object.freeze({ INSTRUCTION: 'initial request' }),
+          transient: { INSTRUCTION: 'initial request' },
+        },
+      },
     };
     const createUserFollowUpMessages = vi.fn(
       async (messages: unknown[], userMessage: string) => [
@@ -904,6 +913,9 @@ describe('ToolUseWaitNode', () => {
     expect(info).toHaveBeenCalledWith('please revise the theorem', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
+    expect(shared.stateSlices?.userChannels.transient.INSTRUCTION).toBe(
+      'please revise the theorem',
+    );
   });
 });
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -260,6 +260,38 @@ describe('headless delegation', () => {
     );
   });
 
+  it('carries the current parent instruction into the subagent constraint context', async () => {
+    const parentInstruction =
+      'Do not use plans, todos, files, bash, Wolfram, or other child tools. Delegate exactly once.';
+    await withToolFileInteractionContext(
+      {
+        tracker: {} as never,
+        userInstruction: parentInstruction,
+      },
+      () =>
+        withRunContext(
+          createRunContext({
+            runtimeHost: runtimeHost(),
+            streamId: 'parent-stream',
+            executionId: 'parent-exec',
+            model: 'deepseekT',
+          }),
+          () => callDelegateReview(),
+        ),
+    );
+
+    expect(mocks.executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootUserInstruction: parentInstruction,
+        instruction: expect.stringContaining(
+          `Parent user request (constraint context only):\n${parentInstruction}`,
+        ),
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
+  });
+
   it('tells orchestrators that delegated instructions must carry parent constraints', () => {
     const parameters = new DelegateAgentTool().definition.parameters as {
       properties?: Record<string, { description?: string }>;

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -21,6 +21,7 @@ import {
   getRunContextStreamId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { isChildRunLoopActive } from '@agent/runtime/childRunLoop';
 import {
   sendFollowUp,
@@ -283,6 +284,7 @@ Git worktree support: resolved from the active workspace at runtime.`,
       parentModel: context.model,
       agentCategory: AgentCategory.ToolUse,
     });
+    const rootUserInstruction = getCurrentToolCallContext()?.userInstruction;
 
     // Construct tool-use proposal (no file fields)
     const proposal = ToolUseAgentProposalSchema.parse({
@@ -290,7 +292,11 @@ Git worktree support: resolved from the active workspace at runtime.`,
       agent: agentName,
       agentSource: agent.source,
       model,
-      instruction: withToolUseSubagentHandoffInstruction(input.instruction),
+      instruction: withToolUseSubagentHandoffInstruction(
+        input.instruction,
+        rootUserInstruction,
+      ),
+      rootUserInstruction,
       memories: input.memories,
       workingDirectory: input.working_directory,
     } satisfies ToolUseAgentProposal);

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -115,14 +115,30 @@ const TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION = [
   '- Include the substantive result requested: answer, findings, evidence/checks, and unresolved caveats.',
   '- Do not finish with only status/process notes such as "done", "complete", or "no files were edited"; if no files were edited, state that after the task result.',
 ].join('\n');
-
 export function withToolUseSubagentHandoffInstruction(
   instruction: string,
+  parentInstruction?: string,
 ): string {
-  const trimmed = instruction.trimEnd();
-  return trimmed
-    ? `${trimmed}\n\n${TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION}`
-    : TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION;
+  const trimmed = instruction.trim();
+  const trimmedParent = parentInstruction?.trim();
+  const parts = trimmed ? [trimmed] : [];
+  if (trimmedParent) {
+    parts.push(
+      [
+        ...(trimmedParent === trimmed
+          ? [
+              'The delegated task above is copied verbatim from the parent user request.',
+            ]
+          : ['Parent user request (constraint context only):', trimmedParent]),
+        '',
+        'Constraints in the parent user request are mandatory and override conflicting delegated-task wording or agent workflow defaults.',
+        'Apply every relevant tool, network, file, approval, output-format, and scope constraint to the delegated task.',
+        'Do not repeat orchestration actions assigned to the parent.',
+      ].join('\n'),
+    );
+  }
+  parts.push(TOOL_USE_SUBAGENT_HANDOFF_INSTRUCTION);
+  return parts.join('\n\n');
 }
 
 function ensureWorkingDirectoryExists(dir: string): void {

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -11,6 +11,7 @@ import { renderPrompt } from './promptUtils';
 /** Instructions appended to tool-use agent prompts */
 const TOOL_USE_INSTRUCTIONS = `<tool_use_instructions>
 IMPORTANT — Working directory: The bash tool already executes every command from {{ CWD }}. You are already in the workspace, so run commands directly with relative paths (e.g., \`ls src/\`, \`find . -name "*.tex"\`, \`cat README.md\`). Scope file searches to \`.\` or a subdirectory, or use the glob/grep tools.
+Explicit user constraints override general workflow guidance elsewhere in the agent prompt. If the user forbids memory, planning, todos, file access, or a tool, do not use it; report any resulting conflict instead.
 
 When using a tool, follow the JSON schema exactly and include all required properties.
 Always produce valid JSON when calling a tool.


### PR DESCRIPTION
## Summary

- Preserve the current user instruction through tool dispatch and append it to delegated-agent handoffs as mandatory constraint context.
- Refresh current instruction state only from real user follow-ups, including follow-ups consumed mid-cycle.
- Carry one optional `rootUserInstruction` on delegated children so nested handoffs retain the original constraints without parsing or recursively wrapping prompt text.
- State once in the shared tool-use prompt that explicit user constraints override conflicting workflow defaults.

Closes #7856.

## Issue acceptance gates

- [x] A child receives relevant tool, network, file, approval, output-format, and scope constraints even when the parent omits them from `delegate_agent.instruction`.
- [x] Current-turn user follow-ups replace the mutable instruction before later tool dispatch.
- [x] Subagent results and synthetic queue items cannot overwrite user constraint context.
- [x] Nested delegation keeps the original unwrapped root instruction.
- [x] Verbatim forwarding retains mandatory precedence and no-repeat framing.
- [x] Live PTY reproduction delegates exactly once; the child uses no memory, plans, todos, files, Bash, Wolfram, or other tools.

## Single source of truth

`userChannels.transient.INSTRUCTION` owns the mutable session instruction. `ToolUseRoundShared.currentUserInstruction` is its round projection, and `ToolCallContext.userInstruction` is the dispatch-time tool snapshot. Delegated children additionally carry immutable `AgentConfig.rootUserInstruction`, which is preferred for nested delegation so later follow-ups cannot erase the original parent constraints.

## Duplication and abstraction budget

`userFollowUpInstruction` is the single user-origin filter shared by both follow-up paths. The root value is one optional config field mirrored only where proposal and trace schemas require it; no provider-message parsing or prompt-marker protocol was added.

## Net elements (R6)

17 files changed; 0 files added/deleted; 175 insertions, 12 deletions, net +163 LoC. One exported helper was added. Existing runtime/context types and schemas gained optional fields; no new class or subsystem was introduced.

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted.

## Host impact

Extension: Shared agent-runtime behavior preserves delegation constraints; no host-specific changes.

Desktop: Shared agent-runtime behavior preserves delegation constraints; no host-specific changes.

CLI: Fixes the reproduced TUI delegation regression. The constrained live run dropped from 385,619 to 107,506 total tokens, and child tool calls dropped from 12 to 0.

## Scheduled refactoring

None.

## Validation

- Focused Vitest run — 4 files and 44 tests passed.
- `npm run typecheck` — passed.
- GitHub CI `validate (linux)` — passed in 14m55s; formatting, webview smoke, review, Claude, and Cursor checks also passed.
- `git diff --check` — passed.
- Live `texra-local` PTY reproduction — parent approval included the exact request; child completed with zero tool calls; parent returned the requested four-sentence summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool-use round, wait/prep, and delegation paths where instruction state drives child behavior; scope is bounded with focused tests and optional schema fields.
> 
> **Overview**
> Fixes delegated tool-use agents ignoring parent user constraints (e.g. “no files/tools”) when the orchestrator’s `delegate_agent.instruction` omits them.
> 
> **Instruction plumbing:** `userChannels.transient.INSTRUCTION` is projected per round as `currentUserInstruction`, passed into tool dispatch as `ToolCallContext.userInstruction`, and written back after a cycle. Only **user-origin** follow-ups refresh that state via `userFollowUpInstruction`; synthetic and subagent-result queue items do not.
> 
> **Delegation:** New optional `rootUserInstruction` on agent config/proposals/traces stays immutable on the child so nested delegation prefers the original parent request over wrapped handoff text. `delegate_agent` reads the parent snapshot from tool context, sets `rootUserInstruction` on the child, and `withToolUseSubagentHandoffInstruction` appends mandatory parent constraint context to the child’s instruction.
> 
> **Prompt:** Shared tool-use instructions state that explicit user constraints override conflicting workflow defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0188319611f6e0dcc802cad266243adba107eb43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->