### PR TITLE
refactor(latex): move texcount/latexdiff-fixer logic out of VS Code command

### DIFF
--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -13,14 +13,17 @@ import {
   type LaTeXGuardOptions,
 } from '@frontend/editor/activeFileGuards';
 import { runLatexFormatter } from '@latex/texFormatter';
-import { getTeXCount, type TexcountMode } from '@latex/texcount';
+import {
+  getTeXCount,
+  parseTexCountStats,
+  type TexcountMode,
+} from '@latex/texcount';
 import { indentLatexFilesInDirectory } from '@latex/formatter/indentDirectory';
-import { detectGeneratedLatexdiffArtifact } from '@latex/latexdiff/diffFileNameManager';
+import { buildLatexdiffAwareFixInstruction } from '@latex/latexdiff/diffFileNameManager';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { AgentCategory } from '@shared/schemas';
-import { delay, filterNotNull } from '@utils/core';
-import { AbsoluteFS, WorkspaceFS } from '@utils/files';
+import { delay } from '@utils/core';
 
 import { getIndentTeXNotification } from './latexHousekeepingNotifications';
 
@@ -81,9 +84,9 @@ export async function handleFixCompilation(): Promise<void> {
           // latexFixer is a tool-use agent; without this the config category
           // prefaults to workflow and resolveAgentForLaunch can't find it.
           agentCategory: AgentCategory.ToolUse,
-          instruction: await buildFixCompilationInstruction(
+          instruction: await buildLatexdiffAwareFixInstruction(
+            `Fix the LaTeX compilation errors in ${relativePath}.`,
             editor.document.fileName,
-            relativePath,
           ),
         },
         // This is a "run latexFixer" command, so prefer the helper model.
@@ -91,39 +94,6 @@ export async function handleFixCompilation(): Promise<void> {
       });
     },
   );
-}
-
-/**
- * Generated latexdiff artifacts are valid fixer targets — latexdiff itself
- * often emits non-compiling markup that regenerating the diff would only
- * reproduce — but the fixer should know the file is a diff so it repairs the
- * markup in place, and should propagate source-rooted fixes to the source so
- * they survive regeneration.
- */
-async function buildFixCompilationInstruction(
-  activeFilePath: string,
-  relativePath: string,
-): Promise<string> {
-  const base = `Fix the LaTeX compilation errors in ${relativePath}.`;
-  const artifact = detectGeneratedLatexdiffArtifact(activeFilePath);
-  if (!artifact) return base;
-
-  const sourceExists = await AbsoluteFS.exists(artifact.sourcePath);
-  // A user may legitimately keep a source file named chapter_diff.tex. Treat
-  // a plain `_diff` suffix as generated only when the inferred source exists.
-  if (artifact.kind === 'workspaceDiff' && !sourceExists) {
-    return base;
-  }
-
-  const sourceHint = sourceExists
-    ? ` generated from ${WorkspaceFS.relativePath(artifact.sourcePath)}`
-    : '';
-  return [
-    base,
-    `This file is a latexdiff artifact${sourceHint}.`,
-    'If an error comes from broken latexdiff markup (\\DIFadd/\\DIFdel or the DIF preamble blocks), repair the markup in place and keep the diff annotations intact.',
-    'If an error originates in the original source document, fix the source too so a regenerated diff stays fixed.',
-  ].join(' ');
 }
 
 export async function handleApplyReplacements(): Promise<void> {
@@ -223,20 +193,7 @@ export async function handleGetTeXCount(): Promise<void> {
             return;
           }
 
-          const patterns: [RegExp, string][] = [
-            [/Words in text:\s*(\d+)/, 'Text: $1 words'],
-            [/Words in headers:\s*(\d+)/, 'Headers: $1'],
-            [/Words in float captions:\s*(\d+)/, 'Captions: $1'],
-            [/Number of inline math:\s*(\d+)/, 'Inline math: $1'],
-            [/Number of displayed math:\s*(\d+)/, 'Display math: $1'],
-          ];
-
-          const stats = patterns
-            .map(([pattern, template]) => {
-              const match = output.match(pattern);
-              return match ? { label: template.replace('$1', match[1]) } : null;
-            })
-            .filter(filterNotNull);
+          const stats = parseTexCountStats(output);
 
           await vscode.window.showQuickPick(stats, {
             placeHolder: 'TeXCount Results (press Esc to dismiss)',

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -15,7 +15,7 @@ import {
 import { runLatexFormatter } from '@latex/texFormatter';
 import {
   getTeXCount,
-  parseTexCountStats,
+  parseTeXCountStats,
   type TexcountMode,
 } from '@latex/texcount';
 import { indentLatexFilesInDirectory } from '@latex/formatter/indentDirectory';
@@ -193,7 +193,7 @@ export async function handleGetTeXCount(): Promise<void> {
             return;
           }
 
-          const stats = parseTexCountStats(output);
+          const stats = parseTeXCountStats(output);
 
           await vscode.window.showQuickPick(stats, {
             placeHolder: 'TeXCount Results (press Esc to dismiss)',

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -5,6 +5,7 @@ import {
   extractLastRoundMatch,
   extractLastRoundModelMatch,
 } from '@agent/utils/mergeFileUtils';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 
 type GeneratedLatexdiffArtifactKind =
   'workspaceDiff' | 'versionControlDiff' | 'betweenRoundDiff';
@@ -116,4 +117,38 @@ export function detectGeneratedLatexdiffArtifact(
   }
 
   return null;
+}
+
+/**
+ * Augment a fix-agent instruction with latexdiff-artifact awareness.
+ *
+ * Generated latexdiff artifacts are valid fixer targets — latexdiff itself
+ * often emits non-compiling markup that regenerating the diff would only
+ * reproduce — but the fixer should know the file is a diff so it repairs the
+ * markup in place, and should propagate source-rooted fixes to the source so
+ * they survive regeneration.
+ */
+export async function buildLatexdiffAwareFixInstruction(
+  base: string,
+  activeFilePath: string,
+): Promise<string> {
+  const artifact = detectGeneratedLatexdiffArtifact(activeFilePath);
+  if (!artifact) return base;
+
+  const sourceExists = await AbsoluteFS.exists(artifact.sourcePath);
+  // A user may legitimately keep a source file named chapter_diff.tex. Treat
+  // a plain `_diff` suffix as generated only when the inferred source exists.
+  if (artifact.kind === 'workspaceDiff' && !sourceExists) {
+    return base;
+  }
+
+  const sourceHint = sourceExists
+    ? ` generated from ${WorkspaceFS.relativePath(artifact.sourcePath)}`
+    : '';
+  return [
+    base,
+    `This file is a latexdiff artifact${sourceHint}.`,
+    'If an error comes from broken latexdiff markup (\\DIFadd/\\DIFdel or the DIF preamble blocks), repair the markup in place and keep the diff annotations intact.',
+    'If an error originates in the original source document, fix the source too so a regenerated diff stays fixed.',
+  ].join(' ');
 }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -303,7 +303,7 @@ export async function getTeXCount(
   }
 }
 
-export interface TexCountStat {
+export interface TeXCountStat {
   label: string;
 }
 
@@ -317,7 +317,7 @@ const TEXCOUNT_STAT_PATTERNS: readonly [RegExp, string][] = [
 ];
 
 /** Parse texcount's raw text output into the headline stats it reports. */
-export function parseTexCountStats(output: string): TexCountStat[] {
+export function parseTeXCountStats(output: string): TeXCountStat[] {
   return TEXCOUNT_STAT_PATTERNS.map(([pattern, template]) => {
     const match = output.match(pattern);
     return match ? { label: template.replace('$1', match[1]) } : null;

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -303,6 +303,27 @@ export async function getTeXCount(
   }
 }
 
+export interface TexCountStat {
+  label: string;
+}
+
+/** Headline stats extracted from texcount's raw text report, in display order. */
+const TEXCOUNT_STAT_PATTERNS: readonly [RegExp, string][] = [
+  [/Words in text:\s*(\d+)/, 'Text: $1 words'],
+  [/Words in headers:\s*(\d+)/, 'Headers: $1'],
+  [/Words in float captions:\s*(\d+)/, 'Captions: $1'],
+  [/Number of inline math:\s*(\d+)/, 'Inline math: $1'],
+  [/Number of displayed math:\s*(\d+)/, 'Display math: $1'],
+];
+
+/** Parse texcount's raw text output into the headline stats it reports. */
+export function parseTexCountStats(output: string): TexCountStat[] {
+  return TEXCOUNT_STAT_PATTERNS.map(([pattern, template]) => {
+    const match = output.match(pattern);
+    return match ? { label: template.replace('$1', match[1]) } : null;
+  }).filter(filterNotNull);
+}
+
 export async function getTeXCountStats(
   filePaths: string | string[],
   channel: string = CHANNEL,

--- a/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
+++ b/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
@@ -1,11 +1,13 @@
 import * as path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildBetweenRoundDiffSuffix,
+  buildLatexdiffAwareFixInstruction,
   detectGeneratedLatexdiffArtifact,
 } from '@latex/latexdiff/diffFileNameManager';
+import { AbsoluteFS } from '@utils/files';
 
 describe('detectGeneratedLatexdiffArtifact', () => {
   it.each([
@@ -52,5 +54,41 @@ describe('buildBetweenRoundDiffSuffix', () => {
 
   it('accepts string round captures (e.g. from a regex match)', () => {
     expect(buildBetweenRoundDiffSuffix('2', '1')).toBe('_diffr2r1');
+  });
+});
+
+describe('buildLatexdiffAwareFixInstruction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('leaves the base instruction untouched for a plain source file', async () => {
+    const base = 'Fix the LaTeX compilation errors in main.tex.';
+    expect(await buildLatexdiffAwareFixInstruction(base, '/paper/main.tex')).toBe(
+      base,
+    );
+  });
+
+  it('adds latexdiff-artifact guidance when the inferred source exists', async () => {
+    vi.spyOn(AbsoluteFS, 'exists').mockResolvedValue(true);
+    const base = 'Fix the LaTeX compilation errors in main-diffea268c1.tex.';
+
+    const instruction = await buildLatexdiffAwareFixInstruction(
+      base,
+      '/paper/main-diffea268c1.tex',
+    );
+
+    expect(instruction.startsWith(base)).toBe(true);
+    expect(instruction).toContain('latexdiff artifact');
+    expect(instruction).toContain('generated from');
+  });
+
+  it('treats a bare `_diff` suffix as a real filename when no source exists', async () => {
+    vi.spyOn(AbsoluteFS, 'exists').mockResolvedValue(false);
+    const base = 'Fix the LaTeX compilation errors in revised_diff.tex.';
+
+    expect(
+      await buildLatexdiffAwareFixInstruction(base, '/paper/revised_diff.tex'),
+    ).toBe(base);
   });
 });

--- a/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
+++ b/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
@@ -64,9 +64,9 @@ describe('buildLatexdiffAwareFixInstruction', () => {
 
   it('leaves the base instruction untouched for a plain source file', async () => {
     const base = 'Fix the LaTeX compilation errors in main.tex.';
-    expect(await buildLatexdiffAwareFixInstruction(base, '/paper/main.tex')).toBe(
-      base,
-    );
+    expect(
+      await buildLatexdiffAwareFixInstruction(base, '/paper/main.tex'),
+    ).toBe(base);
   });
 
   it('adds latexdiff-artifact guidance when the inferred source exists', async () => {

--- a/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
+++ b/src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts
@@ -7,7 +7,7 @@ import {
   buildLatexdiffAwareFixInstruction,
   detectGeneratedLatexdiffArtifact,
 } from '@latex/latexdiff/diffFileNameManager';
-import { AbsoluteFS } from '@utils/files';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 
 describe('detectGeneratedLatexdiffArtifact', () => {
   it.each([
@@ -71,6 +71,7 @@ describe('buildLatexdiffAwareFixInstruction', () => {
 
   it('adds latexdiff-artifact guidance when the inferred source exists', async () => {
     vi.spyOn(AbsoluteFS, 'exists').mockResolvedValue(true);
+    vi.spyOn(WorkspaceFS, 'relativePath').mockReturnValue('main.tex');
     const base = 'Fix the LaTeX compilation errors in main-diffea268c1.tex.';
 
     const instruction = await buildLatexdiffAwareFixInstruction(
@@ -78,9 +79,14 @@ describe('buildLatexdiffAwareFixInstruction', () => {
       '/paper/main-diffea268c1.tex',
     );
 
-    expect(instruction.startsWith(base)).toBe(true);
-    expect(instruction).toContain('latexdiff artifact');
-    expect(instruction).toContain('generated from');
+    expect(instruction).toBe(
+      [
+        base,
+        'This file is a latexdiff artifact generated from main.tex.',
+        'If an error comes from broken latexdiff markup (\\DIFadd/\\DIFdel or the DIF preamble blocks), repair the markup in place and keep the diff annotations intact.',
+        'If an error originates in the original source document, fix the source too so a regenerated diff stays fixed.',
+      ].join(' '),
+    );
   });
 
   it('treats a bare `_diff` suffix as a real filename when no source exists', async () => {

--- a/src/test-kernel/latex/TeXCountStats.vitest.ts
+++ b/src/test-kernel/latex/TeXCountStats.vitest.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseTexCountStats } from '@latex/texcount';
+import { parseTeXCountStats } from '@latex/texcount';
 
-describe('parseTexCountStats', () => {
+describe('parseTeXCountStats', () => {
   it('extracts every recognized stat from a full texcount report', () => {
     const output = [
       'Words in text: 1234',
@@ -15,7 +15,7 @@ describe('parseTexCountStats', () => {
       'Number of displayed math: 7',
     ].join('\n');
 
-    expect(parseTexCountStats(output)).toEqual([
+    expect(parseTeXCountStats(output)).toEqual([
       { label: 'Text: 1234 words' },
       { label: 'Headers: 12' },
       { label: 'Captions: 34' },
@@ -25,13 +25,13 @@ describe('parseTexCountStats', () => {
   });
 
   it('omits stats missing from the report instead of padding with blanks', () => {
-    expect(parseTexCountStats('Words in text: 10')).toEqual([
+    expect(parseTeXCountStats('Words in text: 10')).toEqual([
       { label: 'Text: 10 words' },
     ]);
   });
 
   it('returns an empty array when nothing matches', () => {
-    expect(parseTexCountStats('texcount produced no usable output')).toEqual(
+    expect(parseTeXCountStats('texcount produced no usable output')).toEqual(
       [],
     );
   });

--- a/src/test-kernel/latex/TexCountStats.vitest.ts
+++ b/src/test-kernel/latex/TexCountStats.vitest.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTexCountStats } from '@latex/texcount';
+
+describe('parseTexCountStats', () => {
+  it('extracts every recognized stat from a full texcount report', () => {
+    const output = [
+      'Words in text: 1234',
+      'Words in headers: 12',
+      'Words in float captions: 34',
+      'Number of headers: 5',
+      'Number of floats/tables/figures: 6/1/2',
+      'Number of math inlines: 0',
+      'Number of inline math: 89',
+      'Number of displayed math: 7',
+    ].join('\n');
+
+    expect(parseTexCountStats(output)).toEqual([
+      { label: 'Text: 1234 words' },
+      { label: 'Headers: 12' },
+      { label: 'Captions: 34' },
+      { label: 'Inline math: 89' },
+      { label: 'Display math: 7' },
+    ]);
+  });
+
+  it('omits stats missing from the report instead of padding with blanks', () => {
+    expect(parseTexCountStats('Words in text: 10')).toEqual([
+      { label: 'Text: 10 words' },
+    ]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(parseTexCountStats('texcount produced no usable output')).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

A codebase-wide audit for overlapping/confusing responsibilities (see full findings below) turned up several instances of host-neutral logic living inside VS Code-only command handlers. The clearest, most tractable case: `packages/extension/src/commands/latex/latexCommands.ts` embedded two pieces of pure LaTeX-domain logic that have nothing to do with VS Code:

- A regex table parsing texcount's raw text report into headline stats (`handleGetTeXCount`).
- A latexdiff-artifact-aware fix-instruction builder (`buildFixCompilationInstruction`, used by `handleFixCompilation`) that re-derives context `src/latex/latexdiff/diffFileNameManager.ts` already owns (`detectGeneratedLatexdiffArtifact`).

Neither function imported `vscode`. Per this repo's VS Code-free-zone rules, `src/latex/` is the correct owner, not a `packages/extension/src/commands/` file — and today only the extension can reach this logic; the CLI and desktop hosts would have to reimplement texcount's output grammar and latexdiff-artifact awareness from scratch to add equivalent features.

This PR moves both into `src/latex/`:
- `parseTexCountStats` → `src/latex/texcount.ts` (already owns the texcount result schema/types).
- `buildLatexdiffAwareFixInstruction` → `src/latex/latexdiff/diffFileNameManager.ts`, next to `detectGeneratedLatexdiffArtifact`, its only real dependency. Generalized to take a `base` instruction string so it isn't hardcoded to the compilation-fixer wording.

`latexCommands.ts` now just calls through to these host-neutral helpers; no behavior change.

## Issue acceptance gates

No tracked issue — this is a proactive consolidation from a scheduled responsibility-overlap audit. Gate: the extracted logic is reachable from `src/latex/` without a `vscode` import, and `latexCommands.ts` no longer defines domain logic inline.

## Single source of truth

- `src/latex/texcount.ts` is now the sole owner of "how to read texcount's raw report" (running it *and* parsing its stats).
- `src/latex/latexdiff/diffFileNameManager.ts` is now the sole owner of latexdiff-artifact detection *and* the fix-instruction guidance derived from it.

## Duplication and abstraction budget

Removed: the two-file split where `latexCommands.ts` had to privately understand texcount's output format and latexdiff-artifact semantics that `src/latex/` already modeled. No new abstraction layer was added — the logic moved to an existing, on-topic module; no new class/interface beyond one plain data type (`TexCountStat`).

## Net elements (R6)

Diffstat: 5 files changed, 143 insertions(+), 54 deletions(-) (2 files are new/extended tests).
Exported symbols: +3 (`parseTexCountStats`, `TexCountStat`, `buildLatexdiffAwareFixInstruction`), 0 removed (the moved logic was module-private before, not exported).
No new classes; one new plain interface (`TexCountStat`).

## Consumer counts (R8)

Not deleting or re-routing any emit path or subscribed export. Both extracted functions have exactly 1 call site each (`latexCommands.ts`), same as before the move — grepped repo-wide to confirm no other caller exists yet.

## Host impact

Extension: `handleGetTeXCount` / `handleFixCompilation` behavior unchanged; now call through to `src/latex/` helpers instead of inlining the logic.

Desktop: no current caller, but `src/latex/` helpers are now reachable if a desktop-side LaTeX feature needs them.

CLI: no current caller, but the texcount stats parser and latexdiff-aware fix instruction are now importable without pulling in `vscode`.

## Scheduled refactoring

None. Other findings from the same audit (services/context-type proliferation in `src/agent/core/flows`, `AgentReviewService` mixing controller-shaped orchestration with VS Code UI plumbing outside `src/controllers/`, three coexisting config-read paths in `src/utils/config/providerConfig.ts`) are noted for a future pass but are larger/riskier refactors intentionally left out of this PR — see body below for the full audit writeup.

## Validation

- `npm run typecheck` — passes across all workspace packages (extension, cli, trace-viewer).
- `npm run lint` — 0 errors; pre-existing warnings only, none in touched files.
- `npx vitest run src/test-kernel/latex/TexCountStats.vitest.ts src/test-kernel/latex/GeneratedLatexdiffArtifact.vitest.ts src/test-kernel/tools/TexcountTool.vitest.ts` — 17/17 passed (new + extended tests covering both extracted functions).
- `npm test` (full suite) — 618/620 test files passed; the 1 failure (`SystemUtils.vitest.ts` process-group-abort test) is a pre-existing sandbox/environment limitation unrelated to this change (verified: fails identically on `main`-equivalent code, touches OS process-group signal delivery, nothing to do with LaTeX/texcount).

---

### Full audit: other overlapping-responsibility findings (not addressed in this PR)

1. **`AgentReviewService` (`packages/extension/src/frontend/review/AgentReviewService.ts`, ~590 lines)** breaks the controller/command convention used everywhere else (mainView, progressView, settingsView each split into a host-neutral `src/controllers/<area>` plus a thin extension shim). This file mixes host-neutral orchestration (`runAgent`, diff collection, review state machine) with `vscode.Diagnostic`/`vscode.window.withProgress` calls in one class, with no path for CLI/desktop reuse. Worth a dedicated PR given the size and stateful complexity (generation tracking, restore-on-failure semantics) — too risky to split blind without live VS Code testing.
2. **Services/context-type proliferation in `src/agent/core/flows` vs `src/agent/implementations/flows`**: `BaseFlowServices`, `CycleServices` (three types), `ToolUseServices`, `ReflectionServices` — seven similarly-named service/context bags. The code itself has an inline comment acknowledging a near name-collision between two of them. A `FlowServices<T>` generic composed via intersection could likely replace several of these, but touching the flow engine's type layer needs deeper PocketFlow-specific review.
3. **Three coexisting config-read paths in one file**: `src/utils/config/providerConfig.ts` mixes raw `tryGlobalState()?.get(...)`, the catalog-driven `readPlatformSetting()`, and the legacy `getConfig()` — each individually justified by inline comments (migration-in-progress, CLI per-process override, legacy back-compat), so not a clean-cut bug, but it means "how do I read a setting" currently has three valid-looking answers in this codebase.
4. **`src/platform/` vs `src/hosts/`**: both define ways to surface things to the user (`ToolNotificationHandler`/`ToolMissingHandler` on the `Platform` object vs. `PromptHost` wired through `SessionHandle.interactions`), with no documented rule for which one a new "notify/confirm" capability should extend. Separately, `CLAUDE.md` describes `src/hosts/` as covering "clipboard, prompts, terminals, diff views, and openers," but there is no clipboard port there today — clipboard logic is scattered per-host (`packages/cli/src/runtime/clipboard*.ts`, `src/shared/utils/clipboard*.ts`, ad hoc command-level usage). Worth a docs/architecture-note pass rather than a code refactor.
5. **`src/tools/` vs `src/skills/`**: cleanly decoupled in code (zero cross-imports) but nothing documents *why* two separate "give the agent a capability" mechanisms exist. Onboarding-clarity issue, not a bug — a one-paragraph note in either directory's entry point would resolve it.

Items 1–3 are the strongest candidates for a follow-up PR, roughly in that order of impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J5pBv2JrxF9nBDB1AhAaiG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure relocation and thin delegation in the extension; same call sites and logic, plus new unit tests only.
> 
> **Overview**
> Moves **host-neutral LaTeX logic** out of `latexCommands.ts` into `src/latex/`, so CLI/desktop can reuse it without duplicating texcount grammar or latexdiff semantics.
> 
> **TeX count:** `parseTeXCountStats` and a `TeXCountStat` type now live in `texcount.ts` next to `getTeXCount`. The extension’s TeX count command still shows the same quick-pick labels; it just calls the shared parser instead of an inline regex table.
> 
> **Compilation fixer:** `buildLatexdiffAwareFixInstruction` moves to `diffFileNameManager.ts` beside `detectGeneratedLatexdiffArtifact`. It takes a **base** instruction string (the command supplies the “fix errors in …” wording) and appends the same latexdiff-artifact guidance as before, including the `_diff` vs real-filename guard when the inferred source is missing.
> 
> Kernel tests cover both extracted helpers; extension behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475428354f585439812f94b7102a512c5a08c015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->