### PR TITLE
Consolidate duplicated helpers and swap in native/existing utilities

### DIFF
--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -20,6 +20,7 @@ import {
 } from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
+import { previousRowsText } from '../render/overflowText';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
 import {
@@ -243,7 +244,7 @@ export function boundedUserQuestionPromptLines({
       ? [
           {
             kind: 'overflow' as const,
-            text: `... ${hiddenBefore} previous rows`,
+            text: previousRowsText(hiddenBefore),
           },
         ]
       : []),

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -1,8 +1,6 @@
 import { Box, Text } from 'ink';
-import stringWidth from 'string-width';
 
-import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-
+import { numberedFollowUpPreview } from '../render/followUpPreview';
 import { truncateSummaryToWidth } from '../render/terminalText';
 
 const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
@@ -54,17 +52,10 @@ export function queuedFollowUpPanelDisplay({
     : Math.min(messages.length, messageSlots);
   const rows: QueuedFollowUpPanelRow[] = messages
     .slice(0, visibleMessageCount)
-    .map((message, index) => {
-      const prefix = `${index + 1}. `;
-      const bodyWidth = Math.max(0, contentWidth - stringWidth(prefix));
-      return {
-        kind: 'message',
-        text: `${prefix}${truncateSummaryToWidth(
-          summarizeFollowupMessage(message),
-          bodyWidth,
-        )}`,
-      };
-    });
+    .map((message, index) => ({
+      kind: 'message',
+      text: numberedFollowUpPreview(message, index, contentWidth),
+    }));
 
   const hiddenCount = messages.length - visibleMessageCount;
   if (hiddenCount > 0) {

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -2,7 +2,6 @@ import { Box, Text, useWindowSize } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { useEffect, useState } from 'react';
-import stringWidth from 'string-width';
 
 import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import { isCodexSubscriptionActive } from '@auth/codex';
@@ -29,7 +28,11 @@ import {
   formatCompactTokenCount,
 } from '@utils/core';
 
-import { truncateSummaryToWidth } from '../render/terminalText';
+import { numberedFollowUpPreview } from '../render/followUpPreview';
+import {
+  textDisplayWidth,
+  truncateSummaryToWidth,
+} from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
 import { STATUS_DIAMOND } from '../ui/glyphs';
 import {
@@ -212,19 +215,6 @@ const STATUS_BAR_COMPACT_PRIORITY = {
   thinking: 75,
 } as const;
 
-function numberedQueuedFollowUpPreview(
-  message: string,
-  index: number,
-  maxColumns: number,
-): string {
-  const prefix = `${index + 1}. `;
-  const bodyColumns = Math.max(0, maxColumns - stringWidth(prefix));
-  return `${prefix}${truncateSummaryToWidth(
-    summarizeFollowupMessage(message),
-    bodyColumns,
-  )}`;
-}
-
 function queuedFollowUpsListSummary(
   messages: readonly string[],
   maxColumns: number,
@@ -235,15 +225,15 @@ function queuedFollowUpsListSummary(
     overflowCount > 0 ? `+${overflowCount} more` : undefined;
   const separatorColumns =
     Math.max(0, previewItems.length - 1 + (overflowMarker ? 1 : 0)) *
-    stringWidth(QUEUED_FOLLOW_UP_SEPARATOR);
-  const overflowColumns = overflowMarker ? stringWidth(overflowMarker) : 0;
+    textDisplayWidth(QUEUED_FOLLOW_UP_SEPARATOR);
+  const overflowColumns = overflowMarker ? textDisplayWidth(overflowMarker) : 0;
   const itemColumns = Math.floor(
     (maxColumns - separatorColumns - overflowColumns) / previewItems.length,
   );
   if (itemColumns < QUEUED_FOLLOW_UP_MIN_ITEM_PREVIEW) return undefined;
 
   const previewParts = previewItems.map((message, index) =>
-    numberedQueuedFollowUpPreview(message, index, itemColumns),
+    numberedFollowUpPreview(message, index, itemColumns),
   );
   if (overflowMarker) previewParts.push(overflowMarker);
   return previewParts.join(QUEUED_FOLLOW_UP_SEPARATOR);
@@ -296,7 +286,7 @@ function pendingInteractionSegment({
 }
 
 function statusBarSegmentWidth(segment: StatusBarSegment): number {
-  return stringWidth(segment.text) + (segment.badge ? 2 : 0);
+  return textDisplayWidth(segment.text) + (segment.badge ? 2 : 0);
 }
 
 export function statusBarSegmentText(segment: StatusBarSegment): string {
@@ -541,7 +531,7 @@ function joinStatusBindings(bindings: readonly string[]): string {
 }
 
 function fitsStatusBindings(text: string, maxColumns: number | undefined) {
-  return maxColumns === undefined || stringWidth(text) <= maxColumns;
+  return maxColumns === undefined || textDisplayWidth(text) <= maxColumns;
 }
 
 function foregroundBindingsText(

--- a/packages/cli/src/chat/tui/render/ansiMarkdown.ts
+++ b/packages/cli/src/chat/tui/render/ansiMarkdown.ts
@@ -14,7 +14,6 @@ import { highlight, supportsLanguage } from 'cli-highlight';
 import { LRUCache } from 'lru-cache';
 import Token from 'markdown-it/lib/token.mjs';
 import pico from 'picocolors';
-import stringWidth from 'string-width';
 
 import {
   createMarkdownProcessor,
@@ -25,6 +24,7 @@ import {
 } from '@shared/markdown';
 import { wrapAnsiToWidth } from './ansiWrap';
 import { normalizeKnownHtmlForCliMarkdown } from './htmlMarkdownNormalize';
+import { textDisplayWidth } from './terminalText';
 
 import type { RenderRule } from 'markdown-it/lib/renderer.mjs';
 
@@ -116,12 +116,12 @@ function tableColWidths(
   if (usable < numCols * TABLE_MIN_COL_WIDTH) return undefined;
 
   // Natural width per column = widest cell content + padding (clamped to the
-  // minimum). `stringWidth` strips ANSI and counts wide glyphs as 2 cells.
+  // minimum). `textDisplayWidth` strips ANSI and counts wide glyphs as 2 cells.
   const natural = Array.from({ length: numCols }, (_, col) => {
-    let widest = head[col] === undefined ? 0 : stringWidth(head[col]);
+    let widest = head[col] === undefined ? 0 : textDisplayWidth(head[col]);
     for (const row of rows) {
       const cell = row[col];
-      if (cell !== undefined) widest = Math.max(widest, stringWidth(cell));
+      if (cell !== undefined) widest = Math.max(widest, textDisplayWidth(cell));
     }
     return Math.max(TABLE_MIN_COL_WIDTH, widest + TABLE_CELL_PADDING);
   });

--- a/packages/cli/src/chat/tui/render/followUpPreview.ts
+++ b/packages/cli/src/chat/tui/render/followUpPreview.ts
@@ -1,0 +1,17 @@
+import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+
+import { textDisplayWidth, truncateSummaryToWidth } from './terminalText';
+
+/** Render `"{index+1}. {summary}"`, truncating the summary to fit `maxColumns`. */
+export function numberedFollowUpPreview(
+  message: string,
+  index: number,
+  maxColumns: number,
+): string {
+  const prefix = `${index + 1}. `;
+  const bodyColumns = Math.max(0, maxColumns - textDisplayWidth(prefix));
+  return `${prefix}${truncateSummaryToWidth(
+    summarizeFollowupMessage(message),
+    bodyColumns,
+  )}`;
+}

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 
 import { GoogleGenAI, type File } from '@google/genai';
-import { ReasoningEffort } from 'llm-zoo';
+import { ReasoningEffort, type ModelCapabilities } from 'llm-zoo';
 
 import type { AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
@@ -26,6 +26,16 @@ import type { MediaFileResult } from '../support/MediaAttachmentProcessor';
 /** Whether the model is a Gemini 3 variant (different thinking/media rules). */
 export function isGemini3Model(fullName: string): boolean {
   return /^gemini-3[\.\-]/.test(fullName);
+}
+
+/** Whether the model can accept file attachments (image/video or native audio). */
+export function supportsGoogleFileUploads(
+  capabilities: Pick<
+    ModelCapabilities,
+    'supportsVision' | 'supportsNativeAudio'
+  >,
+): boolean {
+  return capabilities.supportsVision || capabilities.supportsNativeAudio;
 }
 
 interface ResolveGoogleClientParams {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -51,6 +51,7 @@ import {
   isGemini3Model,
   resolveGeminiThinkingLevel,
   resolveGoogleClient,
+  supportsGoogleFileUploads,
   uploadGoogleMediaEntries,
 } from './googleHandlerShared';
 import { computeGooglePrice, normalizeGoogleUsage } from './googleUsage';
@@ -106,9 +107,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   private googleClient: GoogleGenAI | null = null;
 
   private supportsFileUploads(): boolean {
-    return (
-      this.capabilities.supportsVision || this.capabilities.supportsNativeAudio
-    );
+    return supportsGoogleFileUploads(this.capabilities);
   }
 
   private isGemini3Model(): boolean {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -56,6 +56,7 @@ import {
   isGemini3Model,
   resolveGeminiThinkingLevel,
   resolveGoogleClient,
+  supportsGoogleFileUploads,
   uploadGoogleMediaEntries,
 } from './googleHandlerShared';
 
@@ -500,9 +501,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
   // ===========================================================================
 
   private supportsFileUploads(): boolean {
-    return (
-      this.capabilities.supportsVision || this.capabilities.supportsNativeAudio
-    );
+    return supportsGoogleFileUploads(this.capabilities);
   }
 
   private isGemini3Model(): boolean {

--- a/src/shared/files/pastedImageConstants.ts
+++ b/src/shared/files/pastedImageConstants.ts
@@ -1,8 +1,8 @@
-import { nanoid } from 'nanoid';
+import { generateShortId } from '@utils/core';
 
 export const PASTED_PREFIX = 'pasted_';
 
 /** Generate a pasted-image filename: `pasted_<timestamp>_<rand>.<ext>`. */
 export function generatePastedImageName(ext: string): string {
-  return `${PASTED_PREFIX}${Date.now()}_${nanoid(6)}.${ext}`;
+  return `${PASTED_PREFIX}${Date.now()}_${generateShortId(6)}.${ext}`;
 }

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -95,6 +95,17 @@ const busyIconButtonStyles: CSSResult = css`
   }
 `;
 
+/**
+ * Single-line text truncation declarations (no selector). Interpolate this
+ * into a rule when the truncated target is a shadow part (e.g.
+ * `::part(label)`) that can't take the `.truncate` class directly.
+ */
+export const truncateTextRule: CSSResult = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 export const commonViewStyles: CSSResult = css`
   .view-header {
     display: flex;
@@ -477,8 +488,6 @@ export const commonViewStyles: CSSResult = css`
 
   /* Utility: single-line text truncation with ellipsis */
   .truncate {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    ${truncateTextRule}
   }
 `;

--- a/src/shared/styles/requestPanelSharedStyles.ts
+++ b/src/shared/styles/requestPanelSharedStyles.ts
@@ -22,6 +22,8 @@
 
 import { css, unsafeCSS, type CSSResult } from 'lit';
 
+import { truncateTextRule } from './commonViewStyles';
+
 /**
  * Shared selector groups for :is() consolidation.
  * To add a new request panel type, add an entry to the PANEL_TYPES table below
@@ -248,9 +250,7 @@ export const requestPanelSharedStyles: CSSResult = css`
   .approval-request__actions wa-button[data-action]::part(label),
   .approval-request__actions .diff-dropdown .diff-main-button::part(label) {
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    ${truncateTextRule}
   }
 
   /* Shared action button colors */

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -111,14 +111,11 @@ async function fetchLocalhost(
   url: string,
   timeoutMs = ZOTERO_PROBE_TIMEOUT_MS,
 ): Promise<Pick<Response, 'ok' | 'status'>> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response | undefined;
   try {
-    response = await fetch(url, { signal: controller.signal });
+    response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
     return { ok: response.ok, status: response.status };
   } finally {
-    clearTimeout(timeout);
     await response?.body?.cancel().catch(() => undefined);
   }
 }

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -14,13 +14,13 @@ import { defineTool } from '@tools/core/define';
 import { WorkspaceFS } from '@utils/files';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
-import { resolveLatexFileOrThrow } from './figureExtractionShared';
+import {
+  resolveLatexFileOrThrow,
+  texPathField,
+} from './figureExtractionShared';
 
 const ExtractBibliographyInputSchema = z.strictObject({
-  texPath: z
-    .string()
-    .min(1, 'texPath is required.')
-    .describe('Path to the LaTeX file to scan for citations.'),
+  texPath: texPathField('Path to the LaTeX file to scan for citations.'),
   bibPath: z
     .string()
     .min(1, 'bibPath cannot be empty if provided.')

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -13,13 +13,11 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   resolveLatexFileOrThrow,
+  texPathField,
 } from './figureExtractionShared';
 
 const ExtractFiguresInputSchema = z.strictObject({
-  texPath: z
-    .string()
-    .min(1, 'texPath is required.')
-    .describe('Path to the primary LaTeX file to inspect.'),
+  texPath: texPathField('Path to the primary LaTeX file to inspect.'),
 });
 
 export type ExtractFiguresInput = z.infer<typeof ExtractFiguresInputSchema>;

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -14,13 +14,11 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
   resolveLatexFileOrThrow,
+  texPathField,
 } from './figureExtractionShared';
 
 const ExtractTikzInputSchema = z.strictObject({
-  texPath: z
-    .string()
-    .min(1, 'texPath is required.')
-    .describe('Path to the LaTeX file containing TikZ figures.'),
+  texPath: texPathField('Path to the LaTeX file containing TikZ figures.'),
   compile: z
     .boolean()
     .describe('Compile extracted TikZ pictures into standalone PDFs.')

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { ToolError, type ToolFileAttachment } from '@shared/schemas/toolResult';
 import { buildFileAttachment } from '@tools/attachments';
 import {
@@ -5,6 +7,11 @@ import {
   type WorkspacePathResolution,
 } from '@tools/pathResolution';
 import { WorkspaceFS } from '@utils/files';
+
+/** Shared `texPath` Zod field for LaTeX extraction tools, with a per-tool description. */
+export function texPathField(description: string): z.ZodString {
+  return z.string().min(1, 'texPath is required.').describe(description);
+}
 
 interface LatexFileResolution {
   path: WorkspacePathResolution;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -59,7 +59,7 @@ import {
 } from '@shared/schemas';
 import { getCleanAgentName } from '@shared/schemas/agent';
 
-import { mapToRecord } from '@utils/core';
+import { mapToRecord, normalizeFilePath } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import {
@@ -112,7 +112,7 @@ interface WorkflowStreamMatch {
 
 function normalizeOutputFiles(outputFiles?: readonly string[]): string[] {
   return (outputFiles ?? [])
-    .map((file) => file.replaceAll('\\', '/'))
+    .map((file) => normalizeFilePath(file))
     .filter((file) => file.length > 0)
     .sort();
 }
@@ -950,12 +950,12 @@ export class StreamSnapshotStore {
    */
   findWorkflowStreamsMatching(match: WorkflowStreamMatch): StreamTabId[] {
     const wantAgent = getCleanAgentName(match.agent);
-    const wantFile = match.inputFile.replaceAll('\\', '/');
+    const wantFile = normalizeFilePath(match.inputFile);
     const wantOutputFiles = normalizeOutputFiles(match.outputFiles);
     const result: StreamTabId[] = [];
     for (const [stream, cfg] of this.runConfigs) {
       if (cfg.agentCategory !== 'workflow') continue;
-      const cfgPrimaryInput = (cfg.inputFiles[0] ?? '').replaceAll('\\', '/');
+      const cfgPrimaryInput = normalizeFilePath(cfg.inputFiles[0] ?? '');
       if (
         getCleanAgentName(cfg.agent) !== wantAgent ||
         cfg.model !== match.model ||

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -14,8 +14,6 @@
  *     buffered + flushed on an interval
  *   - finalize flushes any pending chunks immediately
  */
-import { nanoid } from 'nanoid';
-
 import type {
   AgentEvent,
   AgentTrace,
@@ -33,6 +31,7 @@ import {
   type StreamTabId,
   type ToolUseLog,
 } from '@shared/schemas';
+import { generateShortId } from '@utils/core';
 
 import { type StreamLogStore } from './StreamLogStore';
 
@@ -188,7 +187,7 @@ export function attachTranscriptRecorder(
     verbose?: boolean;
   }): void => {
     store.append(streamId, {
-      id: nanoid(),
+      id: generateShortId(),
       type: STREAM_LOG_ENTRY_TYPES.LOG,
       level: params.level ?? 'info',
       timestamp: Date.now(),

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -15,7 +15,7 @@
  * (the single home for generic string helpers) and are re-exported here for
  * existing @utils/core consumers.
  */
-import { customAlphabet } from 'nanoid';
+import { customAlphabet, nanoid } from 'nanoid';
 
 import type { ExecutionId } from '@shared/schemas';
 
@@ -321,6 +321,16 @@ export const hexId12 = customAlphabet('0123456789abcdef', 12);
 /** Generate a compact 12-char hex execution ID (48 bits of entropy). */
 export function generateExecutionId(): ExecutionId {
   return hexId12() as ExecutionId;
+}
+
+/**
+ * Generate a short unique ID for non-schema-constrained uses (temp
+ * filenames, log entry IDs). Defaults to nanoid's standard 21-char
+ * URL-safe alphabet; pass `size` for a shorter ID. Use {@link hexId12}
+ * instead when a schema constrains the ID to lowercase hex.
+ */
+export function generateShortId(size?: number): string {
+  return nanoid(size);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 // Third-party imports
 import mime from 'mime-types';
 
+import { normalizeFilePath } from '@utils/core';
+
 const AUDIO_MIME_TYPE_OVERRIDES: Readonly<Record<string, string>> = {
   // mime-types does not expose every audio subtype accepted by current model SDKs.
   '.alaw': 'audio/alaw',
@@ -18,7 +20,7 @@ const AUDIO_MIME_TYPE_OVERRIDES: Readonly<Record<string, string>> = {
  * extensionless paths that have a directory separator.
  */
 function getExtension(pathOrExtension: string): string {
-  const normalized = pathOrExtension.replaceAll('\\', '/');
+  const normalized = normalizeFilePath(pathOrExtension);
   const hasPathSeparator = normalized.includes('/');
   const fileName = normalized.split('/').at(-1) ?? normalized;
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path';
 // Platform imports
 import { platform } from '@platform/platform';
 
+import { normalizeFilePath } from '@utils/core';
+
 // Local imports - filesystem
 import { RelativeFS } from './relativeFS';
 import {
@@ -33,7 +35,7 @@ export class WorkspaceFS extends RelativeFS {
     if (!this.getPath()) {
       return filePath;
     }
-    return platform().workspace.asRelativePath(filePath).replaceAll('\\', '/');
+    return normalizeFilePath(platform().workspace.asRelativePath(filePath));
   }
 
   /** Absolute path from relative. Already-absolute paths pass through. */

--- a/src/utils/files/workspaceRoot.ts
+++ b/src/utils/files/workspaceRoot.ts
@@ -1,5 +1,7 @@
 import * as path from 'node:path';
 
+import { normalizeFilePath } from '@utils/core';
+
 import { findExternalRoot, type MatchedExternalRoot } from './externalRoots';
 
 /**
@@ -42,7 +44,7 @@ export function locatePathInRoot(
 ): ResolvedPath {
   // Normalize backslashes before posix.normalize so '..' segments collapse correctly.
   // On POSIX, backslashes are valid filename chars — path.normalize would preserve them.
-  const relative = path.posix.normalize(inputPath.replaceAll('\\', '/'));
+  const relative = path.posix.normalize(normalizeFilePath(inputPath));
   if (relative.startsWith('..')) {
     return annotateExternal({
       kind: 'external',

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -4,12 +4,12 @@ import * as path from 'node:path';
 
 // Third-party imports
 import { PDFDocument } from '@cantoo/pdf-lib';
-import { nanoid } from 'nanoid';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
+import { generateShortId } from '@utils/core';
 import { AbsoluteFS, getMimeType, WorkspaceFS } from '@utils/files';
 import { checkMultipleToolsInstalled } from '@utils/system';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -132,7 +132,10 @@ async function resizeImageIfNeeded(imagePath: string): Promise<string> {
   }
 
   const ext = path.extname(imagePath);
-  const tempPath = path.join(os.tmpdir(), `texra-resized-${nanoid()}${ext}`);
+  const tempPath = path.join(
+    os.tmpdir(),
+    `texra-resized-${generateShortId()}${ext}`,
+  );
 
   // ImageMagick v7+: magick input -resize ... output
   // GraphicsMagick: gm convert input -resize ... output

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -11,7 +11,7 @@ import which from 'which';
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
-import { unique } from '@utils/core';
+import { normalizeFilePath, unique } from '@utils/core';
 import { hasExtension } from '@utils/core/pathCore';
 
 /** Whether the current platform is Windows (cached at module load). */
@@ -183,7 +183,7 @@ function getExtraDirs(): string[] {
 
   const homeDir = process.env.HOME || process.env.USERPROFILE;
   if (homeDir) {
-    const normalized = homeDir.replaceAll('\\', '/');
+    const normalized = normalizeFilePath(homeDir);
     texDistPatterns.push(`${normalized}/texlive/*/bin/*`);
     texDistPatterns.push(`${normalized}/TinyTeX/bin/*`);
     for (const tool of TEX_TOOLS) {


### PR DESCRIPTION
## Summary

Ran a codebase-wide sweep (five parallel scans over utils/common, agent core, tools/latex, the CLI package, and extension/desktop) for duplicated logic and hand-rolled code that could reuse a native method or an existing shared helper. Applied the safe, mechanical fixes; flagged the larger/riskier ones as follow-ups rather than editing them unattended (see "Scheduled refactoring").

Applied in this PR:
- Reuse `@utils/core`'s `normalizeFilePath()` instead of 7 inline `.replaceAll('\\', '/')` call sites (`workspaceRoot.ts`, `workspaceFS.ts`, `mimeUtils.ts`, `platformPaths.ts`, `StreamSnapshotStore.ts`).
- Add `generateShortId()` next to `hexId12` as the single entry point for non-schema-constrained IDs, replacing 3 divergent raw `nanoid()` call sites (`img.ts`, `pastedImageConstants.ts`, `TexraTranscriptRecorder.ts`).
- Extract `truncateTextRule` (shared CSS) instead of duplicating the overflow/ellipsis/nowrap declarations across two stylesheets.
- Extract `supportsGoogleFileUploads()` into `googleHandlerShared.ts`, removing a verbatim-duplicated private method from both Google model handlers.
- Add a `texPathField()` factory for the `texPath` Zod field repeated across the three LaTeX extraction tools.
- Swap `fetchLocalhost`'s manual `AbortController` + `setTimeout` for native `AbortSignal.timeout()`.
- CLI TUI: reuse `previousRowsText()` instead of an inline duplicate literal in `UserQuestion.tsx`; extract `numberedFollowUpPreview()` shared by `StatusBar` and `QueuedFollowUpsPanel`; route `ansiMarkdown.ts`'s and `StatusBar`'s direct `string-width` usage through the project's `textDisplayWidth()` wrapper.

## Issue acceptance gates

No linked issue — this is a proactive consolidation sweep. Acceptance gate: every change is a behavior-preserving refactor (verified by full test suite + typecheck + lint), not a functional change.

## Single source of truth

- `normalizeFilePath()` (`@utils/core`) — backslash-to-forward-slash path normalization.
- `generateShortId()` (`@utils/core`) — short non-schema ID generation (pairs with the existing `hexId12`/`generateExecutionId` for hex-constrained IDs).
- `truncateTextRule` (`@shared/styles/commonViewStyles`) — single-line ellipsis truncation CSS.
- `supportsGoogleFileUploads()` (`googleHandlerShared.ts`) — file-upload capability check for both Google handlers.
- `texPathField()` (`figureExtractionShared.ts`) — the `texPath` Zod field for LaTeX extraction tools.
- `numberedFollowUpPreview()` (`render/followUpPreview.ts`) — numbered queued-follow-up preview text for both `StatusBar` and `QueuedFollowUpsPanel`.
- `textDisplayWidth()` (`render/terminalText.ts`) — already the canonical width-measurement wrapper; two more call sites now route through it instead of importing `string-width` directly.

## Duplication and abstraction budget

Removed: 7 duplicated path-normalization call sites, 3 divergent ID-generation conventions, 1 duplicated CSS block, 1 verbatim-duplicated method across two Google handlers, 1 duplicated Zod field (x3), 1 duplicated numbered-preview algorithm (x2), 3 direct `string-width` imports that bypassed the project's own wrapper, and one hand-rolled abort-timer in favor of native `AbortSignal.timeout()`.

Added: 5 small single-purpose helpers (`generateShortId`, `truncateTextRule`, `supportsGoogleFileUploads`, `texPathField`, `numberedFollowUpPreview`), each with 2+ call sites (no single-caller extractions). No new classes, ports, or facades.

## Net elements (R6)

24 files changed (+120/-86), one new file (`packages/cli/src/chat/tui/render/followUpPreview.ts`, 16 lines). Net exported symbols: +5 functions/consts, 0 removed exports (the removed duplicate code was all private/inline). Net LoC: +34, almost entirely doc comments on the new shared helpers — the duplicated logic itself nets out roughly flat since each removal was small.

## Consumer counts (R8)

No emit paths or exports were deleted or re-routed; this PR only adds shared call targets for existing call sites. n/a.

## Host impact

Extension: none (the `commonViewStyles`/`requestPanelSharedStyles` CSS change is behavior-preserving — same computed styles, one fewer duplicated block).

Desktop: none.

CLI: `StatusBar`, `QueuedFollowUpsPanel`, `UserQuestion`, and `ansiMarkdown` render identically; only the width-measurement and preview-text call paths were consolidated onto shared helpers.

## Scheduled refactoring

Flagged as follow-ups, not implemented here (larger scope, touch core run paths, need design review before an unattended change):
- A "check a `Map<key, Promise>`, return in-flight or start one" single-flight pattern hand-rolled 4x (`apiProviders.ts`, `computeModelOptions.ts`, `ProcessOutputPoller.ts`, `ToolUseFollowUp.ts`).
- A recursive directory-walk pattern reimplemented in 6-7 tool files with drifting semantics (depth bound, gitignore filtering, symlink handling).
- Duplicated file-listing/selection orchestration between the VS Code extension and the Electron desktop host.
- A near-duplicate model-invocation path in `textConnection.ts` bypassing the `ModelHandler` abstraction.
- A hand-rolled mustache-style template renderer in `maybeBuildGoalContinuation.ts` duplicating the project's existing `nunjucks`-based template renderer.
- Three CLI-side findings intentionally left alone due to behavior-affecting edge cases: the "clip prefix before a fixed suffix" width algorithm (uses different clip functions - with/without ellipsis - across its 3 call sites), the CSI/SGR escape-boundary scanner in `noColorOutput.ts` (fixing it changes actual escape-handling behavior), and the manual CLI flag re-scanning that bypasses `citty`'s own parsing.

## Validation

- `npm run typecheck` — passes (0 errors).
- `npm run lint` — 0 errors; only pre-existing warnings in files this PR did not touch.
- `npm test` — 5388 passed, 1 failed (`SystemUtils.vitest.ts` "aborts shell command process groups including children" — unrelated to this diff, a process-group/signal test that doesn't touch any file changed here; consistent with a sandboxed-container limitation, not a regression).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014vV4zfpcd9xevz7y8QLjzR

---
_Generated by [Claude Code](https://claude.ai/code/session_014vV4zfpcd9xevz7y8QLjzR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are small refactors with broad but shallow touch points; no auth, payment, or API contract changes, and the author validated via typecheck, lint, and tests.
> 
> **Overview**
> This PR is a **behavior-preserving consolidation sweep** across utils, Google handlers, LaTeX tools, web styles, and the CLI TUI.
> 
> **Paths & IDs:** Inline backslash-to-slash normalization is replaced with `normalizeFilePath()` in workspace, mime, platform path, and stream-matching code. **`generateShortId()`** becomes the shared non-schema ID helper (replacing scattered `nanoid()` uses for pasted images, transcript logs, and temp image paths).
> 
> **Google & tools:** **`supportsGoogleFileUploads()`** is extracted for both Google model handlers. LaTeX extraction tools share **`texPathField()`** for the `texPath` Zod field. Zotero localhost probes use **`AbortSignal.timeout()`** instead of manual abort timers.
> 
> **UI:** **`truncateTextRule`** is shared for ellipsis truncation (including shadow-part selectors). CLI follow-up previews use new **`numberedFollowUpPreview()`**; overflow copy uses **`previousRowsText()`**. Terminal width measurement routes through **`textDisplayWidth()`** instead of direct `string-width` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a167bd83837c0dacc6f50b74b40611109a5f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->