### PR TITLE
fix(cli): keep completed terminal status when wrap cleanup throws post-run

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -249,11 +249,23 @@ export async function executeCliRequest(
   let runResult:
     | { readonly ok: true; readonly result: ExecuteAgentResult }
     | { readonly ok: false } = { ok: false };
+  // Distinguishes a failed run from a failure in `options.wrap`'s post-run
+  // cleanup: once invoke() has resolved, AgentRunLifecycle has already
+  // persisted the run's true terminal status (e.g. COMPLETED), and a later
+  // cleanup rejection must not overwrite it with ERROR (#7863).
+  let invokeSettledOk = false;
+  const trackedInvoke = async (): Promise<ExecuteAgentResult> => {
+    const result = await invoke();
+    invokeSettledOk = true;
+    return result;
+  };
   try {
-    const result = await (options.wrap ? options.wrap(invoke) : invoke());
+    const result = await (options.wrap
+      ? options.wrap(trackedInvoke)
+      : trackedInvoke());
     runResult = { ok: true, result };
   } catch (err) {
-    if (options.markErrorOnThrow && request.executionId) {
+    if (options.markErrorOnThrow && request.executionId && !invokeSettledOk) {
       await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
     }
     // Only a classified, already-handled AgentError resolves to a non-zero

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -513,6 +513,32 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps a completed run terminal status when wrap cleanup fails after invoke succeeded (#7863)', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = baseRequest();
+    // runAgent resolves (default mock): the lifecycle has already persisted
+    // the run's true terminal status. A rejection from wrap's post-run
+    // cleanup must still propagate to the crash handler, but must NOT
+    // overwrite that status with ERROR.
+    const cleanupError = new Error('workspaceState.update failed');
+
+    await expect(
+      executeCliRequest(request, cliContext(), {
+        markErrorOnThrow: true,
+        wrap: async (run) => {
+          await run();
+          throw cleanupError;
+        },
+      }),
+    ).rejects.toBe(cleanupError);
+
+    expect(mocks.writeTerminalStatus).not.toHaveBeenCalledWith(
+      'exec-1',
+      EXECUTION_STATUS.ERROR,
+    );
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
   it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();


### PR DESCRIPTION
## Summary

Fixes #7863 (the codex P2 + late claude CHANGES_REQUESTED on #7839 that merged unaddressed — this is the babysitter making good on it).

`executeCliRequest`'s `markErrorOnThrow` wrote `EXECUTION_STATUS.ERROR` for **any** rejection reaching its catch block — including one thrown by `options.wrap`'s post-run cleanup *after* `invoke()` had already resolved and `AgentRunLifecycle` persisted the run's true terminal status. The `multi-agent run` path hits exactly this: `withCliMultiAgentPresetVisibility`'s `finally` issues `workspaceState.update` calls post-run; if one rejects, a successfully COMPLETED run was rewritten to ERROR and dropped from resume.

Fix: a `trackedInvoke` closure flips `invokeSettledOk` once the run itself resolves; the catch only writes ERROR when `!invokeSettledOk`. Pre-run wrap failures still mark ERROR (a registered-but-never-ran execution must not stay resumable), and every non-`AgentError` still propagates to the crash handler unchanged.

## Verification

- `npx vitest run src/test-kernel/cli/RunExecution.vitest.mts` — 25 passed (new case: wrap cleanup throws after success → ERROR not written, rejection still propagates)
- `corepack pnpm --filter @texra-ai/cli typecheck` — clean

## Net elements (R6)

0 files/exports/classes added or deleted; +1 local closure, ~+12 LoC in `runExecution.ts`, +1 test case extending the existing suite (R7).

## Consumer counts (R8)

n/a — no emit path or export deleted/re-routed; `writeTerminalStatus` call sites unchanged in count, one gained a guard.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on an existing ERROR write path in CLI execution; behavior for failed runs and non-AgentError propagation is unchanged aside from the fixed edge case.
> 
> **Overview**
> Fixes a bug where **`markErrorOnThrow`** could rewrite a **COMPLETED** execution to **ERROR** when `options.wrap`’s post-run cleanup failed after the agent run had already finished and persisted its real terminal status (e.g. multi-agent preset visibility updating workspace state).
> 
> **`executeCliRequest`** now runs the core agent via **`trackedInvoke`**, which sets **`invokeSettledOk`** once **`invoke()`** resolves. The catch block only calls **`writeTerminalStatus(..., ERROR)`** when **`markErrorOnThrow`** is on and **`!invokeSettledOk`**, so pre-run failures still get ERROR while post-run wrap cleanup errors still propagate without clobbering the stored outcome.
> 
> A new test asserts that wrap cleanup rejection after a successful run does not write ERROR and still runs host cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b68467177582b22e599c2b176a3ebc1abfda3996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->