### PR TITLE
fix(cli): use generic command approval wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ All notable changes to this project will be documented in this file.
   progress, command results, doctor output, and structured error/instruction
   records now share one queued stdout writer.
 
+- **Shell-backed tool approvals use command-neutral wording** — Wolfram and
+  other command-backed tools no longer appear as Bash actions in the prompt,
+  session shortcut, status details, headless summary, or rejection message.
+
 ### Desktop
 
 #### Bug Fixes

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -620,7 +620,7 @@ function seedLiveToolOnlyTranscript(): void {
 
 function makeRejectedBashToolEntries(): ConversationEntry[] {
   const command = "printf 'approval-reject-live\\n'";
-  const message = `User rejected bash command: ${command}`;
+  const message = `User rejected command: ${command}`;
   return [
     {
       id: 'rejected-bash-user',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -298,11 +298,11 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '0', HARNESS_REJECTED_BASH_TOOL: '1' },
     expect: [
       "● bash (printf 'approval-reject-live\\n')",
-      "⎿ User rejected bash command: printf 'approval-reject-live\\n'",
+      "⎿ User rejected command: printf 'approval-reject-live\\n'",
     ],
     maxOccurrences: [
       {
-        text: "User rejected bash command: printf 'approval-reject-live\\n'",
+        text: "User rejected command: printf 'approval-reject-live\\n'",
         max: 1,
       },
     ],
@@ -1264,11 +1264,11 @@ const SCENARIOS = [
     resizes: [{ cols: 120 }],
     expect: [
       'agent: chat · model: harness-model',
-      'Run bash command?',
+      'Run command?',
       '$ npm run compile:safe',
       'Directory:',
       'y approve',
-      'a approve bash for session',
+      'a commands for session',
       'Use foreground panel shortcuts',
     ],
     unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
@@ -1280,11 +1280,11 @@ const SCENARIOS = [
       },
       {
         before: 'agent: chat · model: harness-model',
-        after: 'Run bash command?',
+        after: 'Run command?',
       },
     ],
     maxBlankLinesBetween: [
-      { from: 'entry-4 chat history line', to: 'Run bash command?', max: 3 },
+      { from: 'entry-4 chat history line', to: 'Run command?', max: 3 },
     ],
   },
   {
@@ -1295,14 +1295,14 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     frame: 'viewport',
     expect: [
-      'Run bash command?',
+      'Run command?',
       '$ npm run compile:safe',
       'Directory:',
       'y approve',
       'n reject',
       'Esc cancel',
     ],
-    unexpect: [' · …', 'a bash session'],
+    unexpect: [' · …', 'a cmd session'],
   },
   {
     name: 'bash-approval-feedback',
@@ -1313,7 +1313,7 @@ const SCENARIOS = [
     keys: ['e', 'use portable python3 instead'],
     frame: 'viewport',
     expect: [
-      'Run bash command?',
+      'Run command?',
       '> use portable python3 instead',
       'Enter send note',
       'Esc back',
@@ -1332,7 +1332,7 @@ const SCENARIOS = [
     },
     bootExpect: '[Ctrl-C]',
     expect: [
-      'Run bash command?',
+      'Run command?',
       'Directory:',
       "$ python3 << 'EOF'",
       'more rows',
@@ -1353,7 +1353,7 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     frame: 'viewport',
     expect: [
-      'Run bash command?',
+      'Run command?',
       'Directory:',
       "$ python3 << 'EOF'",
       'more rows',
@@ -1375,7 +1375,7 @@ const SCENARIOS = [
     keys: [DOWN, DOWN, DOWN],
     frame: 'viewport',
     expect: [
-      'Run bash command?',
+      'Run command?',
       'Directory:',
       'x2 = 1 + 2 * y * y',
       'previous',
@@ -1397,7 +1397,7 @@ const SCENARIOS = [
     keys: [PAGE_DOWN],
     frame: 'viewport',
     expect: [
-      'Run bash command?',
+      'Run command?',
       'Directory:',
       'for y in range(1, 100):',
       'previous',
@@ -1416,7 +1416,7 @@ const SCENARIOS = [
     },
     bootExpect: '[Ctrl-C]',
     frame: 'viewport',
-    expect: ['Run bash command?', 'Directory:', 'rows hidden', 'y approve'],
+    expect: ['Run command?', 'Directory:', 'rows hidden', 'y approve'],
     unexpect: ['[Option-p]tasks'],
   },
   {
@@ -1426,7 +1426,7 @@ const SCENARIOS = [
     keys: ['a'],
     frame: 'viewport',
     expect: ['AUTO-BASH', '[/status]details', '[/model]models'],
-    unexpect: ['AUTO-APPROVE', 'Run bash command?', '1 approval'],
+    unexpect: ['AUTO-APPROVE', 'Run command?', '1 approval'],
   },
   {
     name: 'bash-approval-approve-twice',
@@ -1440,7 +1440,7 @@ const SCENARIOS = [
     settleMs: 6000,
     frame: 'viewport',
     expect: ['SECOND-BASH-APPROVED', '[/status]details', '[/model]models'],
-    unexpect: ['Run bash command?', '1 approval'],
+    unexpect: ['Run command?', '1 approval'],
   },
   {
     name: 'bash-approval-session-status',
@@ -1450,10 +1450,10 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       'approval: ask before privileged actions',
-      'auto-approvals: bash commands',
+      'auto-approvals: commands',
       'AUTO-BASH',
     ],
-    unexpect: ['Run bash command?', '1 approval'],
+    unexpect: ['Run command?', '1 approval'],
   },
   {
     name: 'team-status-empty-subagents-hidden',
@@ -1466,8 +1466,8 @@ const SCENARIOS = [
     bootExpect: '[Ctrl-C]',
     keys: ['a', '/status', '\r'],
     frame: 'viewport',
-    expect: ['team: Physicist', 'auto-approvals: bash commands', 'AUTO-BASH'],
-    unexpect: ['Run bash command?', '1 approval', ']subagents'],
+    expect: ['team: Physicist', 'auto-approvals: commands', 'AUTO-BASH'],
+    unexpect: ['Run command?', '1 approval', ']subagents'],
   },
   {
     name: 'agent-proposal-long',
@@ -1823,7 +1823,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       'PLAN-GOAL',
-      'auto-approvals: bash commands',
+      'auto-approvals: commands',
       'status: running',
       'goal: active',
       'goal objective: Coordinate a short math proof through CLI chat.',
@@ -2049,7 +2049,7 @@ const SCENARIOS = [
     keys: ['\t', '\t', '\t', '\t'],
     expect: [
       'agent: chat · model: harness-model',
-      'Run bash command?',
+      'Run command?',
       '$ npm run compile:safe',
       'y approve',
       '[main]*',

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -30,7 +30,7 @@ export interface BashApprovalProps {
 
 export type BashCommandDisplayLine = ScrollableDisplayLine<'command'>;
 
-const BASH_APPROVAL_TITLE = 'Run bash command?';
+const COMMAND_APPROVAL_TITLE = 'Run command?';
 const DEFAULT_BASH_COMMAND_ROWS = 12;
 const COMPACT_BASH_COMMAND_ROWS = 3;
 const BASH_APPROVAL_SPACIOUS_FIXED_ROWS_EXCLUDING_TITLE = 7;
@@ -40,7 +40,7 @@ export function bashApprovalCommandRowsBudget({
   availableRows,
   columns,
   extraFixedRows = 0,
-  title = BASH_APPROVAL_TITLE,
+  title = COMMAND_APPROVAL_TITLE,
 }: {
   readonly availableRows?: number;
   readonly columns: number;
@@ -169,8 +169,8 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
     <ConfirmCard
       borderStyle="double"
       color="yellow"
-      title={BASH_APPROVAL_TITLE}
-      alwaysAllow={{ kind: 'bash', label: 'approve bash for session' }}
+      title={COMMAND_APPROVAL_TITLE}
+      alwaysAllow={{ kind: 'bash', label: 'commands for session' }}
       onDecide={props.onDecide}
     >
       {cwdLine ? <Text dimColor>{cwdLine}</Text> : null}

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -104,8 +104,8 @@ function hintsFit(
 
 function compactHintAction(action: string): string {
   switch (action) {
-    case 'approve bash for session':
-      return 'bash session';
+    case 'commands for session':
+      return 'cmd session';
     case 'approve edits for session':
       return 'edit session';
     case 'feedback':

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -72,7 +72,7 @@ function activeApprovalBypassLabels(
   if (!bypasses) return [];
   const labels: string[] = [];
   if (bypasses.superYolo) labels.push('delegated tasks');
-  if (bypasses.bash) labels.push('bash commands');
+  if (bypasses.bash) labels.push('commands');
   if (bypasses.toolEdit) labels.push('file edits');
   return labels;
 }

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -13,7 +13,7 @@ export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
       const data =
         payload as RuntimeInteractionEventPayloads['showBashPermission'];
       const cwd = data.cwd ? `Directory: ${data.cwd}\n` : '';
-      return `Bash command requested:\n${cwd}${data.command}`;
+      return `Command requested:\n${cwd}${data.command}`;
     }
     case 'showPlanApproval': {
       const data =

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -30,12 +30,12 @@ describe('CLI confirm-card key handling', () => {
   it('shows scoped session-wide approval hints for approval modals', () => {
     expect(
       confirmCardKeyHints({
-        alwaysAllowLabel: 'approve bash for session',
+        alwaysAllowLabel: 'commands for session',
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'approve bash for session' },
+      { key: 'a', action: 'commands for session' },
       { key: 'e', action: 'feedback' },
       { key: 'Esc', action: 'cancel' },
     ]);
@@ -47,12 +47,12 @@ describe('CLI confirm-card key handling', () => {
     ).toContainEqual({ key: 'a', action: 'approve edits for session' });
 
     const compactRendered = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'approve bash for session',
+      alwaysAllowLabel: 'commands for session',
       maxColumns: 72,
     })
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
-    expect(compactRendered).toContain('a bash session');
+    expect(compactRendered).toContain('a commands for session');
     expect(compactRendered.length).toBeLessThanOrEqual(72);
   });
 
@@ -66,22 +66,22 @@ describe('CLI confirm-card key handling', () => {
   it('compacts long optional approval hints before hiding cancel', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve bash for session',
+        alwaysAllowLabel: 'commands for session',
         maxColumns: 80,
       }),
     ).toEqual(
-      confirmCardKeyHints({ alwaysAllowLabel: 'approve bash for session' }),
+      confirmCardKeyHints({ alwaysAllowLabel: 'commands for session' }),
     );
 
     const compact = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'approve bash for session',
+      alwaysAllowLabel: 'commands for session',
       maxColumns: 60,
     });
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'bash session' },
+      { key: 'a', action: 'cmd session' },
       { key: 'e', action: 'note' },
       { key: 'Esc', action: 'cancel' },
     ]);
@@ -99,14 +99,14 @@ describe('CLI confirm-card key handling', () => {
 
   it('keeps session-scope hints before feedback on mid-width terminals', () => {
     const compact = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'approve bash for session',
+      alwaysAllowLabel: 'commands for session',
       maxColumns: 50,
     });
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'bash session' },
+      { key: 'a', action: 'cmd session' },
       { key: 'Esc', action: 'cancel' },
     ]);
     expect(
@@ -117,7 +117,7 @@ describe('CLI confirm-card key handling', () => {
   it('drops optional approval hints before hiding cancel on narrow terminals', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve bash for session',
+        alwaysAllowLabel: 'commands for session',
         maxColumns: 42,
       }),
     ).toEqual([
@@ -129,7 +129,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve bash for session',
+        alwaysAllowLabel: 'commands for session',
         maxColumns: 36,
       }),
     ).toEqual([
@@ -140,7 +140,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'approve bash for session',
+        alwaysAllowLabel: 'commands for session',
         maxColumns: 10,
       }),
     ).toEqual([{ key: 'Esc', action: 'cancel' }]);

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -214,7 +214,7 @@ describe('CLI session status formatter', () => {
     });
 
     expect(status).toContain(
-      'auto-approvals: delegated tasks, bash commands, file edits',
+      'auto-approvals: delegated tasks, commands, file edits',
     );
     expect(status).not.toContain('all privileged actions');
   });

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -96,8 +96,7 @@ describe('CLI tool renderer registry', () => {
   });
 
   it('renders bash approval rejections once when output and error match', () => {
-    const message =
-      "User rejected bash command: printf 'approval-reject-live\\n'";
+    const message = "User rejected command: printf 'approval-reject-live\\n'";
     const entry = toolUse(
       'bash',
       { command: "printf 'approval-reject-live\\n'" },
@@ -112,13 +111,13 @@ describe('CLI tool renderer registry', () => {
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● bash (printf 'approval-reject-live\\n')",
-        "⎿ User rejected bash command: printf 'approval-reject-live\\n'",
+        "⎿ User rejected command: printf 'approval-reject-live\\n'",
       ]
     `);
   });
 
   it('keeps long duplicate error output in the full transcript view', () => {
-    const message = `User rejected bash command: ${'diagnostic detail '.repeat(30)}`;
+    const message = `User rejected command: ${'diagnostic detail '.repeat(30)}`;
     const entry = toolUse(
       'bash',
       { command: 'run-diagnostic' },
@@ -133,7 +132,7 @@ describe('CLI tool renderer registry', () => {
     const lines = toolUseDisplayLines(entry, { elide: false });
 
     expect(lines[1]).toBe(`⎿ ${message}`);
-    expect(lines[2]).toContain('User rejected bash command: diagnostic detail');
+    expect(lines[2]).toContain('User rejected command: diagnostic detail');
     expect(lines[2].length).toBeLessThan(lines[1].length);
   });
 

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -156,7 +156,7 @@ describe('BashTool error feedback', () => {
 
   it('reports a real rejection distinctly from an approval timeout', async () => {
     // Regression coverage for #7444: a host-side approval timeout must not
-    // collapse into the same "User rejected bash command" shape as an
+    // collapse into the same "User rejected command" shape as an
     // explicit reject once it reaches the agent.
     vi.mocked(requestBashApproval).mockResolvedValueOnce({
       accepted: false,
@@ -164,7 +164,7 @@ describe('BashTool error feedback', () => {
     });
     const rejected = await new BashTool().call({ command: 'echo rejected' });
     expect(rejected.status).toBe('error');
-    expect(rejected.error).toContain('User rejected bash command');
+    expect(rejected.error).toContain('User rejected command');
 
     vi.mocked(requestBashApproval).mockResolvedValueOnce({
       accepted: false,
@@ -173,7 +173,7 @@ describe('BashTool error feedback', () => {
     });
     const timedOut = await new BashTool().call({ command: 'echo timeout' });
     expect(timedOut.status).toBe('error');
-    expect(timedOut.error).not.toContain('User rejected bash command');
+    expect(timedOut.error).not.toContain('User rejected command');
     expect(timedOut.error).toContain('timed out');
   });
 });

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -120,8 +120,8 @@ export function buildBashApprovalRejectedResult(
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
   const message = timedOut
-    ? `Bash command approval timed out: ${preview}`
-    : `User rejected bash command: ${preview}`;
+    ? `Command approval timed out: ${preview}`
+    : `User rejected command: ${preview}`;
   const feedback = userMessage?.trim();
   return {
     status: 'error',


### PR DESCRIPTION
## Summary

- Use command-neutral wording for CLI shell-command approval cards, headless summaries, status details, and rejection results.
- Clarify that the session shortcut applies to commands, not only the visible Bash tool.
- Keep the internal Bash approval queue and schemas unchanged; no new approval kind or state was added.

Closes #7869.

## Issue acceptance gates

- [x] Shell-backed Wolfram approvals no longer appear as Bash actions.
- [x] The session shortcut states its command-wide scope.
- [x] Headless summaries, status details, explicit rejections, and timeouts use the same neutral command vocabulary.
- [x] Wide and narrow approval layouts preserve their existing actions and spacing.

## Single source of truth

The existing Bash approval controller remains the runtime owner of shell-command approval and session bypass. This PR changes only the CLI presentation and the shared tool-result wording produced by `buildBashApprovalRejectedResult`.

## Duplication and abstraction budget

No abstraction or schema field was added. The fix reuses the existing approval path and aligns CLI copy with the extension's already-generic command wording.

## Net elements (R6)

12 files changed; 0 files added/deleted; 58 insertions, 55 deletions, net +3 LoC (the net addition is the changelog entry). No exports, classes, interfaces, enums, or schemas were added or removed.

## Consumer counts (R8)

n/a — no emit path, event key, or export was deleted or rerouted.

## Host impact

Extension: No behavior change; its approval panel already says "Allow this command to execute."

Desktop: No behavior change.

CLI: Approval cards say "Run command?", the session shortcut says "commands for session", `/status` reports "auto-approvals: commands", and headless/rejection/timeout results use command-neutral wording.

## Scheduled refactoring

None. Internal Bash-named types remain stable because they still own the shared shell-command gate; renaming them would add churn without changing behavior.

## Validation

- Live `texra-local chat --model deepseekT --approval-policy ask` determinant task reproduced the Wolfram/Bash wording mismatch on current `main`.
- Focused Vitest: 5 files, 49 tests passed.
- Focused PTY validation: all 15 affected approval/status scenarios passed, including wide, narrow, compact, session-bypass, rejection, hidden-root-stream, team-status, and goal-status layouts.
- Visually inspected generated wide and narrow approval PNG frames.
- `npm run typecheck` passed.
- `npm run lint` passed with 0 errors and 52 existing warnings.
- `npm run texra-local:build && npm run texra-local:link` passed.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible copy and test expectations only; approval behavior and internal Bash-named controllers are unchanged.
> 
> **Overview**
> **Fixes misleading "Bash" wording** for any shell-backed tool (e.g. Wolfram) that still goes through the existing Bash approval path.
> 
> Approval UI now says **"Run command?"** and the session shortcut is **"commands for session"** (compact: **"cmd session"**). `/status` lists **auto-approvals: commands** when the bash bypass is on. Headless summaries use **"Command requested:"** instead of **"Bash command requested:"**.
> 
> Shared tool errors from `buildBashApprovalRejectedResult` use **"User rejected command"** and **"Command approval timed out"**, matching transcript rendering and harness/PTY expectations. **No new approval kind or schema** — only strings and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772eeb65c9acd678978c61107c3535c63f7ff40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->