### PR TITLE
fix(cli): point SET_API_KEY instruction hint at texra setup, not nonexistent texra config

### DIFF
--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -48,7 +48,7 @@ export type CliRuntimeHost = AgentRuntimeHost & {
  * back to the raw token rather than failing.
  */
 const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
-  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra config)',
+  [INSTRUCTION_ACTION.SET_API_KEY]: 'set your API key (texra setup)',
   [INSTRUCTION_ACTION.OPEN_CONFIGURATION_GUIDE]: 'see the configuration guide',
   [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
 };

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1090,7 +1090,7 @@ describe('CLI run progress renderer', () => {
     // (mirroring the extension's INSTRUCTION_ACTION_VIEW), not printed
     // verbatim.
     expect(output).toContain(
-      'API key not found. Set your API key in Settings and run again. (set your API key (texra config), see the configuration guide)',
+      'API key not found. Set your API key in Settings and run again. (set your API key (texra setup), see the configuration guide)',
     );
     expect(output).not.toContain('set-api-key');
     expect(output).not.toContain('open-configuration-guide');


### PR DESCRIPTION
## What / why

Follow-up from #7794 (fix(runtime): route `requestShowInstruction` to CLI stderr and desktop dialog), flagged in review (https://github.com/LionSR/TeXRA/pull/7794#discussion_r3554002772) but not fixed before merge.

`INSTRUCTION_ACTION_HINT[SET_API_KEY]` in `packages/cli/src/runtime/runtimeHost.ts` phrased the hint as `'set your API key (texra config)'`. `texra config` is not a real CLI subcommand — `/config` is an interactive-only Ink TUI slash command inside `texra chat` (`packages/cli/src/chat/tui/commands/registerBuiltins.tsx`), and `rootCommand.subCommands` (`packages/cli/src/commands/root.ts`) has no `config` entry. A headless `texra run`/`--print` user acting on the hint would get an "unknown command" error, defeating the actionability goal of the parent fix (#7644).

Fixes: repoint the hint at `texra setup`, matching the phrasing already used for this exact case in `packages/cli/src/runtime/doctor.ts:213,242` and `packages/cli/src/runtime/modelAccess.ts:146`.

Closes #7829.

## Verification

```
npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts
# Test Files  1 passed (1)
# Tests  30 passed (30)

corepack pnpm --filter @texra-ai/cli typecheck
# clean, no errors
```

## Net elements (R6)

- 0 new files, 0 new abstractions, 0 new exports.
- 2-line diff across 2 existing files: one string literal changed in `runtimeHost.ts`, one matching test assertion updated in `RunProgressRenderer.vitest.mts`.

## Consumer counts (R8)

- `INSTRUCTION_ACTION_HINT` has a single call site (`runtimeHost.ts`, printed to stderr in text-mode `requestShowInstruction` handling); the changed string has exactly one test assertion pinning it (updated in this PR). No other callers or fixtures reference the old `texra config` phrasing (verified via repo-wide grep — the only other `texra config` hits are an unrelated test-describe string and an unrelated code comment about non-texra config files).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a stderr hint string and its test; no runtime behavior beyond the corrected user-facing command name.
> 
> **Overview**
> Text-mode **`requestShowInstruction`** hints for missing API keys now tell users to run **`texra setup`** instead of **`texra config`**, which is not a real CLI subcommand (only an in-chat TUI slash command).
> 
> The **`INSTRUCTION_ACTION_HINT`** string in `runtimeHost.ts` is updated to match wording already used in `doctor.ts` and `modelAccess.ts`. The **`RunProgressRenderer`** test expectation is updated to pin the new phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ffe96c6db0c9c176e6884278433d2add8d805a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->