### PR TITLE
fix(cli): serialize all NDJSON stdout records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ All notable changes to this project will be documented in this file.
   (`/executions/{id}/result`), so follow-on agents can chain on data instead
   of parsing prose.
 
+### CLI
+
+#### Bug Fixes
+
+- **NDJSON records preserve their emission order under stdout backpressure** —
+  progress, command results, doctor output, and structured error/instruction
+  records now share one queued stdout writer.
+
 ### Desktop
 
 #### Bug Fixes

--- a/packages/cli/src/bin/texra.ts
+++ b/packages/cli/src/bin/texra.ts
@@ -5,6 +5,7 @@ import { runCli } from '../commands/root';
 import { formatCrashReportLine, readCliBugsUrl } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
 import {
+  flushNdjsonStdout,
   installCliPipeErrorHandlers,
   writeTextStderr,
 } from '../runtime/logSinks';
@@ -25,5 +26,9 @@ try {
   if (reportLine) writeTextStderr(reportLine);
   process.exitCode = CliExitCode.AgentError;
 } finally {
-  await tryPlatform()?.lifecycle.runShutdown();
+  try {
+    await tryPlatform()?.lifecycle.runShutdown();
+  } finally {
+    await flushNdjsonStdout();
+  }
 }

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -5,8 +5,13 @@ import { access, stat } from 'node:fs/promises';
 // Third-party imports
 import { satisfies as semverSatisfies } from 'semver';
 
-// Local imports - LaTeX
+// Local imports - platform
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
+
+// Local imports - CLI schemas
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
+
+// Local imports - LaTeX
 import {
   probeLatexToolchain,
   type LatexToolchainProbe,
@@ -383,14 +388,14 @@ export function formatDoctorText(
 export function doctorNdjsonRecords(
   report: DoctorReport,
   ts = new Date().toISOString(),
-): readonly object[] {
+): readonly CliNdjsonRecord[] {
   return [
-    ...report.checks.map((check) => ({
+    ...report.checks.map((check): CliNdjsonRecord => ({
       kind: 'doctor-check',
       ts,
       ...check,
     })),
-    { kind: 'doctor-summary', ts, ok: report.ok },
+    { kind: 'doctor-summary', ts, ok: report.ok } satisfies CliNdjsonRecord,
   ];
 }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -111,15 +111,18 @@ export function installCliShutdownSignalHandlers(
   };
 
   const install = (signal: CliShutdownSignal) => {
-    const handler = () => {
-      void lifecycle
-        .runShutdown()
-        .catch(() => undefined)
-        .then(() => flushNdjsonStdout())
-        .finally(() => {
-          process.exit(exitCodeForSignal(signal));
-        })
-        .catch(() => undefined);
+    const handler = async () => {
+      try {
+        await lifecycle.runShutdown();
+      } catch {
+        // Signal shutdown is best effort; output still gets one final flush.
+      }
+      try {
+        await flushNdjsonStdout();
+      } catch {
+        // A closed stdout pipe must not prevent signal-based termination.
+      }
+      process.exit(exitCodeForSignal(signal));
     };
     process.once(signal, handler);
   };

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -48,7 +48,7 @@ import { applyCliGitAuthorConfig } from './gitAuthor';
 import { isCliResumeInFlight, tryResumeCliStream } from './agentResume';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
-import { writeTextStderr } from './logSinks';
+import { flushNdjsonStdout, writeTextStderr } from './logSinks';
 import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
@@ -112,9 +112,14 @@ export function installCliShutdownSignalHandlers(
 
   const install = (signal: CliShutdownSignal) => {
     const handler = () => {
-      void lifecycle.runShutdown().finally(() => {
-        process.exit(exitCodeForSignal(signal));
-      });
+      void lifecycle
+        .runShutdown()
+        .catch(() => undefined)
+        .then(() => flushNdjsonStdout())
+        .finally(() => {
+          process.exit(exitCodeForSignal(signal));
+        })
+        .catch(() => undefined);
     };
     process.once(signal, handler);
   };

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -169,6 +169,7 @@ export class NdjsonStdoutSink implements LogSink {
   }
 
   writeRecord(record: CliNdjsonRecord): void {
+    if (this.isClosed()) return;
     this.queue.push(record);
     void this.ensureDrain().catch(() => undefined);
   }
@@ -200,7 +201,11 @@ export class NdjsonStdoutSink implements LogSink {
   }
 
   private async drain(): Promise<void> {
-    while (!this.stdoutClosed && this.queue.length > 0) {
+    if (this.isClosed()) {
+      this.closeQueue();
+      return;
+    }
+    while (!this.isClosed() && this.queue.length > 0) {
       const record = this.queue.shift();
       if (!record) continue;
       const line = `${JSON.stringify(record)}\n`;
@@ -208,16 +213,27 @@ export class NdjsonStdoutSink implements LogSink {
       try {
         canContinue = this.stdout.write(line);
       } catch {
-        this.stdoutClosed = true;
-        this.queue.length = 0;
+        this.closeQueue();
         return;
       }
       if (!canContinue && !(await this.waitForStdoutDrain())) {
-        this.stdoutClosed = true;
-        this.queue.length = 0;
+        this.closeQueue();
         return;
       }
     }
+  }
+
+  private isClosed(): boolean {
+    return (
+      this.stdoutClosed ||
+      this.stdout.destroyed ||
+      (this.stdout === process.stdout && closed.stdout)
+    );
+  }
+
+  private closeQueue(): void {
+    this.stdoutClosed = true;
+    this.queue.length = 0;
   }
 
   private waitForStdoutDrain(): Promise<boolean> {

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -104,10 +104,6 @@ function writeRaw(key: StreamKey, text: string): void {
   }
 }
 
-export function writeNdjsonStdout(record: unknown): void {
-  writeRaw('stdout', `${JSON.stringify(record)}\n`);
-}
-
 export function writeTextStdout(text: string): void {
   writeRaw('stdout', `${text}\n`);
 }
@@ -154,18 +150,33 @@ class StderrTextSink implements LogSink {
   }
 }
 
-class NdjsonStdoutSink implements LogSink {
-  private readonly queue: LogRecord[] = [];
+interface NdjsonWritable {
+  readonly destroyed: boolean;
+  write(text: string): boolean;
+  once(event: 'drain' | 'error' | 'close', listener: () => void): unknown;
+  off(event: 'drain' | 'error' | 'close', listener: () => void): unknown;
+}
+
+export class NdjsonStdoutSink implements LogSink {
+  private readonly queue: CliNdjsonRecord[] = [];
   private drainPromise: Promise<void> | undefined;
   private stdoutClosed = false;
 
+  constructor(private readonly stdout: NdjsonWritable = process.stdout) {}
+
   write(record: LogRecord): void {
+    this.writeRecord({ kind: 'log', ...record });
+  }
+
+  writeRecord(record: CliNdjsonRecord): void {
     this.queue.push(record);
     void this.ensureDrain().catch(() => undefined);
   }
 
   async flush(): Promise<void> {
-    await this.ensureDrain();
+    while (this.drainPromise || this.queue.length > 0) {
+      await (this.drainPromise ?? this.ensureDrain());
+    }
   }
 
   async close(): Promise<void> {
@@ -192,11 +203,10 @@ class NdjsonStdoutSink implements LogSink {
     while (!this.stdoutClosed && this.queue.length > 0) {
       const record = this.queue.shift();
       if (!record) continue;
-      const lineRecord: CliNdjsonRecord = { kind: 'log', ...record };
-      const line = `${JSON.stringify(lineRecord)}\n`;
+      const line = `${JSON.stringify(record)}\n`;
       let canContinue: boolean;
       try {
-        canContinue = process.stdout.write(line);
+        canContinue = this.stdout.write(line);
       } catch {
         this.stdoutClosed = true;
         this.queue.length = 0;
@@ -211,7 +221,7 @@ class NdjsonStdoutSink implements LogSink {
   }
 
   private waitForStdoutDrain(): Promise<boolean> {
-    if (process.stdout.destroyed) return Promise.resolve(false);
+    if (this.stdout.destroyed) return Promise.resolve(false);
     return new Promise<boolean>((resolve) => {
       let cleanup = (): void => undefined;
       const onDrain = (): void => {
@@ -223,20 +233,32 @@ class NdjsonStdoutSink implements LogSink {
         resolve(false);
       };
       cleanup = (): void => {
-        process.stdout.off('drain', onDrain);
-        process.stdout.off('error', onClosed);
-        process.stdout.off('close', onClosed);
+        this.stdout.off('drain', onDrain);
+        this.stdout.off('error', onClosed);
+        this.stdout.off('close', onClosed);
       };
-      process.stdout.once('drain', onDrain);
-      process.stdout.once('error', onClosed);
-      process.stdout.once('close', onClosed);
+      this.stdout.once('drain', onDrain);
+      this.stdout.once('error', onClosed);
+      this.stdout.once('close', onClosed);
     });
   }
+}
+
+const ndjsonStdoutSink = new NdjsonStdoutSink();
+
+/** Queue one public NDJSON record on the process-wide stdout serializer. */
+export function writeNdjsonStdout(record: CliNdjsonRecord): void {
+  ndjsonStdoutSink.writeRecord(record);
+}
+
+/** Wait until all queued public NDJSON and structured log records are written. */
+export function flushNdjsonStdout(): Promise<void> {
+  return ndjsonStdoutSink.flush();
 }
 
 // CLI logs to stdout/stderr are not redacted — operators are expected to
 // inspect their own terminals. Desktop logs (which can be exported and shared)
 // are redacted in `desktopAppLog.ts` via the shared `redactSecrets` helper.
 export function createCliLogSink(format: string): LogSink {
-  return format === 'ndjson' ? new NdjsonStdoutSink() : new StderrTextSink();
+  return format === 'ndjson' ? ndjsonStdoutSink : new StderrTextSink();
 }

--- a/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
+++ b/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
@@ -19,7 +19,7 @@ describe('CLI platform signal handlers', () => {
 
   it('exits with signal codes after shutdown instead of re-emitting signals', async () => {
     vi.resetModules();
-    const handlers = new Map<string, () => void>();
+    const handlers = new Map<string, () => unknown>();
     vi.spyOn(process, 'once').mockImplementation(((
       event: string | symbol,
       listener: (...args: unknown[]) => void,
@@ -55,16 +55,16 @@ describe('CLI platform signal handlers', () => {
     expect(handlers.has('SIGINT')).toBe(true);
     expect(handlers.has('SIGTERM')).toBe(true);
 
-    handlers.get('SIGINT')?.();
-    await vi.waitFor(() => expect(exitSpy).toHaveBeenLastCalledWith(130));
+    await handlers.get('SIGINT')?.();
+    expect(exitSpy).toHaveBeenLastCalledWith(130);
     expect(runShutdown).toHaveBeenCalledTimes(1);
     expect(events).toEqual(['shutdown', 'flush', 'exit:130']);
 
     events.length = 0;
-    handlers.get('SIGTERM')?.();
-    await vi.waitFor(() => expect(exitSpy).toHaveBeenLastCalledWith(143));
+    await handlers.get('SIGTERM')?.();
+    expect(exitSpy).toHaveBeenLastCalledWith(143);
     expect(runShutdown).toHaveBeenCalledTimes(2);
     expect(events).toEqual(['shutdown', 'flush', 'exit:143']);
     expect(killSpy).not.toHaveBeenCalled();
-  });
+  }, 30_000);
 });

--- a/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
+++ b/src/test-kernel/cli/InitPlatformSignalHandlers.vitest.mts
@@ -2,14 +2,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { LifecycleHost } from '@platform/interfaces';
 
-const flushPromises = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
+const mocks = vi.hoisted(() => ({
+  flushNdjsonStdout: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  flushNdjsonStdout: mocks.flushNdjsonStdout,
+  writeTextStderr: vi.fn(),
+}));
 
 describe('CLI platform signal handlers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    mocks.flushNdjsonStdout.mockReset();
   });
 
   it('exits with signal codes after shutdown instead of re-emitting signals', async () => {
@@ -24,13 +29,20 @@ describe('CLI platform signal handlers', () => {
       }
       return process;
     }) as typeof process.once);
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => undefined as never) as typeof process.exit);
+    const events: string[] = [];
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code) => {
+      events.push(`exit:${code}`);
+      return undefined as never;
+    }) as typeof process.exit);
     const killSpy = vi
       .spyOn(process, 'kill')
       .mockImplementation((() => true) as typeof process.kill);
-    const runShutdown = vi.fn().mockResolvedValue(undefined);
+    const runShutdown = vi.fn(async () => {
+      events.push('shutdown');
+    });
+    mocks.flushNdjsonStdout.mockImplementation(async () => {
+      events.push('flush');
+    });
     const lifecycle: LifecycleHost = {
       onShutdown: vi.fn(() => ({ dispose: vi.fn() })),
       runShutdown,
@@ -44,14 +56,15 @@ describe('CLI platform signal handlers', () => {
     expect(handlers.has('SIGTERM')).toBe(true);
 
     handlers.get('SIGINT')?.();
-    await flushPromises();
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenLastCalledWith(130));
     expect(runShutdown).toHaveBeenCalledTimes(1);
-    expect(exitSpy).toHaveBeenLastCalledWith(130);
+    expect(events).toEqual(['shutdown', 'flush', 'exit:130']);
 
+    events.length = 0;
     handlers.get('SIGTERM')?.();
-    await flushPromises();
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenLastCalledWith(143));
     expect(runShutdown).toHaveBeenCalledTimes(2);
-    expect(exitSpy).toHaveBeenLastCalledWith(143);
+    expect(events).toEqual(['shutdown', 'flush', 'exit:143']);
     expect(killSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -46,7 +46,7 @@ describe('NdjsonStdoutSink', () => {
   });
 
   it('preserves order across logger and public-record writes', async () => {
-    const { lines, stdout } = createStdoutStub();
+    const { emit, lines, stdout } = createStdoutStub([false, true]);
     const sink = new NdjsonStdoutSink(stdout);
 
     sink.write({
@@ -60,6 +60,7 @@ describe('NdjsonStdoutSink', () => {
       event: 'updateStreamStatus',
       payload: { streamId: 'stream-1', status: 'working' },
     });
+    emit('drain');
     await sink.flush();
 
     expect(lines.map((line) => JSON.parse(line).kind)).toEqual([

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -5,18 +5,26 @@ import { describe, expect, it, vi } from 'vitest';
 import { isCliPipeClosureError, NdjsonStdoutSink } from '@cli/runtime/logSinks';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
-function createStdoutStub() {
+function createStdoutStub(writeResults: boolean[] = [true]) {
   const lines: string[] = [];
+  const listeners = new Map<string, () => void>();
   return {
     lines,
+    emit(event: 'drain' | 'error' | 'close') {
+      listeners.get(event)?.();
+    },
     stdout: {
       destroyed: false,
       write: vi.fn((line: string) => {
         lines.push(line);
-        return true;
+        return writeResults.shift() ?? true;
       }),
-      once: vi.fn(),
-      off: vi.fn(),
+      once: vi.fn((event: string, listener: () => void) => {
+        listeners.set(event, listener);
+      }),
+      off: vi.fn((event: string, listener: () => void) => {
+        if (listeners.get(event) === listener) listeners.delete(event);
+      }),
     },
   };
 }
@@ -59,6 +67,37 @@ describe('NdjsonStdoutSink', () => {
       'progress',
     ]);
   });
+
+  it('preserves records added while stdout is backpressured', async () => {
+    const { emit, lines, stdout } = createStdoutStub([false, true]);
+    const sink = new NdjsonStdoutSink(stdout);
+
+    sink.writeRecord({ kind: 'version', version: '1.0.0' });
+    sink.writeRecord({ kind: 'doctor-summary', ok: true });
+    emit('drain');
+    await sink.flush();
+
+    expect(lines.map((line) => JSON.parse(line).kind)).toEqual([
+      'version',
+      'doctor-summary',
+    ]);
+  });
+
+  it.each(['error', 'close'] as const)(
+    'discards queued and later records after stdout %s',
+    async (event) => {
+      const { emit, lines, stdout } = createStdoutStub([false]);
+      const sink = new NdjsonStdoutSink(stdout);
+
+      sink.writeRecord({ kind: 'version', version: '1.0.0' });
+      sink.writeRecord({ kind: 'doctor-summary', ok: true });
+      emit(event);
+      sink.writeRecord({ kind: 'auth-status', authenticated: false });
+      await sink.flush();
+
+      expect(lines.map((line) => JSON.parse(line).kind)).toEqual(['version']);
+    },
+  );
 });
 
 describe('CLI pipe errors', () => {

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -1,8 +1,67 @@
-import { describe, expect, it } from 'vitest';
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
 
-import { isCliPipeClosureError } from '@cli/runtime/logSinks';
+// Local imports
+import { isCliPipeClosureError, NdjsonStdoutSink } from '@cli/runtime/logSinks';
+import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
-describe('CLI log sinks', () => {
+function createStdoutStub() {
+  const lines: string[] = [];
+  return {
+    lines,
+    stdout: {
+      destroyed: false,
+      write: vi.fn((line: string) => {
+        lines.push(line);
+        return true;
+      }),
+      once: vi.fn(),
+      off: vi.fn(),
+    },
+  };
+}
+
+describe('NdjsonStdoutSink', () => {
+  it('flushes consecutive synchronous writes without stranding the queue', async () => {
+    const { lines, stdout } = createStdoutStub();
+    const sink = new NdjsonStdoutSink(stdout);
+    const records: readonly CliNdjsonRecord[] = [
+      { kind: 'version', version: '1.0.0' },
+      { kind: 'doctor-summary', ok: true },
+    ];
+
+    sink.writeRecord(records[0]);
+    sink.writeRecord(records[1]);
+    await sink.flush();
+
+    expect(lines.map((line) => JSON.parse(line))).toEqual(records);
+  });
+
+  it('preserves order across logger and public-record writes', async () => {
+    const { lines, stdout } = createStdoutStub();
+    const sink = new NdjsonStdoutSink(stdout);
+
+    sink.write({
+      ts: '2026-07-10T00:00:00.000Z',
+      level: 'error',
+      message: 'first',
+      fields: {},
+    });
+    sink.writeRecord({
+      kind: 'progress',
+      event: 'updateStreamStatus',
+      payload: { streamId: 'stream-1', status: 'working' },
+    });
+    await sink.flush();
+
+    expect(lines.map((line) => JSON.parse(line).kind)).toEqual([
+      'log',
+      'progress',
+    ]);
+  });
+});
+
+describe('CLI pipe errors', () => {
   it('recognizes pipe closure errors as non-fatal output events', () => {
     expect(
       isCliPipeClosureError(


### PR DESCRIPTION
## Summary

Give CLI NDJSON output one process-wide, backpressure-aware stdout serializer. Structured presentation logs, progress projection records, doctor records, and one-shot command results now enter the same queue, so logically later records cannot overtake earlier records under stdout backpressure. Normal and signal-driven shutdown both flush the queue before completion.

## Issue acceptance gates

Closes #7802.
Closes #7803.

- Every production `writeNdjsonStdout` caller now enqueues on the same `NdjsonStdoutSink` used by NDJSON logging.
- Normal, SIGINT, and SIGTERM shutdown wait for the shared queue before process completion.
- Consecutive synchronous writes cannot strand a record behind a settled drain promise.
- Mixed log/progress writes preserve order through backpressure.
- Error/close events discard queued and later records without hanging `flush()`.

## Single source of truth

`packages/cli/src/runtime/logSinks.ts` owns the single process-wide `NdjsonStdoutSink` and its drain lifecycle.

## Duplication and abstraction budget

The separate immediate `writeRaw` NDJSON path is deleted. The existing sink is deepened to accept both structured logs and public `CliNdjsonRecord` values; no forwarding layer or second queue is introduced.

## Net elements (R6)

- Files: 7 modified, 0 added, 0 deleted.
- LoC: +219 / -47, net +172 (mostly direct queue/backpressure/signal regressions while retaining prior pipe-error coverage).
- Exports: `NdjsonStdoutSink` is now exported for direct contract testing; `flushNdjsonStdout` is added for shutdown. Existing `writeNdjsonStdout` remains the public record writer with a tighter `CliNdjsonRecord` input.
- New classes/interfaces/enums: one private writable interface; no new runtime class (the sink class already existed).

## Consumer counts (R8)

Four production `writeNdjsonStdout` call sites remain (`runtimeHost`, `sessionProgressSubscription`, `doctor`, and command output); all now enter the shared sink. `createCliLogSink("ndjson")` returns that same sink for presentation logs. Two shutdown owners flush it: normal entry-point finalization and the explicit signal handler before `process.exit`.

## Host impact

Extension: none.

Desktop: none.

CLI: NDJSON byte shapes are unchanged; ordering under backpressure is corrected and queued output is flushed before normal or signal-driven process completion.

## Scheduled refactoring

#7818 remains separate for pruning the per-stream NDJSON status cache on `removeStream`.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli` (128 files, 1,638 tests before the review follow-up)
- focused sink/signal/projection/runtime-host/doctor suites after the follow-up (31 tests; then 7 direct shutdown tests)
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @texra-ai/cli run build`
- targeted ESLint on all changed TypeScript files
- `node packages/cli/dist/bin/texra.js version --output-format ndjson`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI stdout ordering and shutdown flushing only; NDJSON record shapes are unchanged, with regression tests added.
> 
> **Overview**
> **CLI NDJSON output** now goes through a single process-wide `NdjsonStdoutSink` instead of mixing an immediate `writeRaw` path with a separate logging queue. Public records (`writeNdjsonStdout`), NDJSON presentation logs (`createCliLogSink('ndjson')`), doctor lines, progress, and command results all enqueue on the same serializer so **emission order is preserved when stdout is backpressured**.
> 
> The sink **waits for `drain`**, **flushes until the queue is empty**, and **drops queued/later lines** if stdout errors or closes (so `flush()` does not hang). **Normal exit** (`texra.ts` `finally`) and **SIGINT/SIGTERM** handlers run lifecycle shutdown, then **`flushNdjsonStdout()`**, before the process finishes.
> 
> `doctorNdjsonRecords` is typed as `CliNdjsonRecord[]`; CHANGELOG documents the CLI fix. Tests cover sink ordering under backpressure and signal handler ordering (`shutdown` → `flush` → `exit`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880ba81a065d8f74bb3502b67c1bd7cbe17c5e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->