### PR TITLE
fix(desktop): log restoreTaskState's caught buildMainViewState error

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1445,7 +1445,10 @@ export class DesktopProgressBridge {
     let state: MainViewPersistedState;
     try {
       state = buildMainViewState(taskState);
-    } catch {
+    } catch (error) {
+      this.logger.error('Failed to build main-view state for restore', {
+        data: toLogData(error),
+      });
       return false;
     }
     this.postToRenderer({

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -198,6 +198,8 @@ type CreateBridgeOptions = {
   activeExecutionIds?: readonly string[] | (() => readonly string[]);
   showErrorMessage?: (message: string) => Promise<void> | void;
   openPath?: (filePath: string, line?: number) => Promise<void>;
+  /** Captures `this.logger.error(...)` calls made by the bridge under test. */
+  loggerErrorSpy?: ReturnType<typeof vi.fn>;
 };
 
 type TestDesktopStreamSnapshotStore = {
@@ -234,14 +236,14 @@ const SEARCH_TOOL_USE_AGENT_CONFIG = {
   agentCategory: AgentCategory.ToolUse,
 } as const;
 
-function mockLoggerModule(): void {
+function mockLoggerModule(loggerErrorSpy?: ReturnType<typeof vi.fn>): void {
   vi.doMock('@logger', () => ({
     createChannelTrace: () => ({
       emit: vi.fn(),
       debug: () => {},
       info: () => {},
       warn: () => {},
-      error: () => {},
+      error: loggerErrorSpy ?? (() => {}),
     }),
     setDefaultStreamLogStore: () => {},
   }));
@@ -344,7 +346,7 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
     prepareMainViewExecutionRequest: vi.fn(),
   }));
-  mockLoggerModule();
+  mockLoggerModule(options.loggerErrorSpy);
   vi.doMock('vscode', () => ({
     commands: {
       executeCommand: vi.fn(),
@@ -3255,10 +3257,12 @@ describe('DesktopProgressBridge', () => {
   it('surfaces an error when restoreState fails to build main-view state (cursor[bot] #7827)', async () => {
     const messages: unknown[] = [];
     const errors: string[] = [];
+    const loggerErrorSpy = vi.fn();
     const bridge = await createBridge(messages, {
       showErrorMessage: async (message) => {
         errors.push(message);
       },
+      loggerErrorSpy,
     });
 
     try {
@@ -3292,6 +3296,12 @@ describe('DesktopProgressBridge', () => {
 
       expect(messages).toEqual([]);
       expect(errors).toEqual(['Failed to restore state']);
+      // #7860: the caught buildMainViewState() error must be logged, not
+      // silently discarded, even though the user-facing message is unchanged.
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Failed to build main-view state for restore',
+        { data: expect.anything() },
+      );
     } finally {
       bridge.dispose();
     }


### PR DESCRIPTION
## What / why

Closes #7860.

`DesktopProgressBridge.restoreTaskState` (`packages/desktop/src/main/desktopAgentExecution.ts`) caught `buildMainViewState`'s throw and discarded the error entirely before returning `false`. The handler already surfaces a user-facing "Failed to restore state" message (#7847), but the underlying diagnostic — why `buildMainViewState` actually threw — was lost, making it impossible to debug a malformed-restore report.

Follows the maintainer's sketch on the issue exactly: log the caught error via `this.logger.error(...)` before returning `false`, matching the file's existing catch-log-return shape (`reportResumeFailure`'s `this.logger.error(message, { data: toLogData(error) })` pattern, `toLogData` already imported). No user-facing message change.

## Changes

- `packages/desktop/src/main/desktopAgentExecution.ts`: `restoreTaskState`'s catch block now logs `'Failed to build main-view state for restore'` with `{ data: toLogData(error) }` before returning `false`.
- `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`: extended the existing `'surfaces an error when restoreState fails to build main-view state (cursor[bot] #7827)'` test with a `loggerErrorSpy` assertion. Added a `loggerErrorSpy` option to `CreateBridgeOptions` / `mockLoggerModule` (the file's `@logger` mock previously stubbed `error` as a no-op with no way to capture calls) so the test can assert the logger received the error, per the issue's directive to check how the suite mocks/captures the logger.

## Verification

```
npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
# Test Files  1 passed (1) / Tests  69 passed (69)

corepack pnpm --filter @texra/desktop typecheck
# clean

npx tsc --noEmit -p tsconfig.test-kernel.json
# clean
```

## Net elements (R6)

- 0 new files, 0 new exported symbols.
- ~3 lines added to the production catch block (matches the maintainer's sketch estimate).
- Test-support change: `mockLoggerModule` grew one optional parameter (`loggerErrorSpy`) and `CreateBridgeOptions` grew one optional field of the same name, both used by the single extended test to capture the logger call. No new test files; extends the existing suite (R7).

## Consumer counts (R8)

- `mockLoggerModule` has 2 call sites in the test file (`loadBridgeModule`, `createExecution`); only `loadBridgeModule`'s call now threads the optional spy through — `createExecution`'s call is unchanged (still zero-arg, defaulting to a no-op).
- `restoreTaskState` has no other callers changed; its two internal call sites (`agentProposal.restoreTaskState` IPC and the `restoreState` progress-view handler) are unaffected — both already handle the `false` return the same way.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in a failure path; no change to restore success behavior or user-facing error text.
> 
> **Overview**
> When **`restoreTaskState`** fails because **`buildMainViewState`** throws (malformed persisted task state), the desktop bridge still returns **`false`** and callers still show **"Failed to restore state"** — but the underlying error is no longer swallowed.
> 
> The **`catch`** in **`DesktopProgressBridge.restoreTaskState`** now logs **`Failed to build main-view state for restore`** with **`toLogData(error)`**, matching other catch-log-return paths in the same file (e.g. **`reportResumeFailure`**).
> 
> Tests wire an optional **`loggerErrorSpy`** through **`mockLoggerModule`** / **`createBridge`** and assert that log call in the existing restore-failure scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7c88cbac0ebcd53e3dfe2de759f20c83f2fa77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->