### PR TITLE
fix(agent): map OpenAI Responses cache_write_tokens to cacheCreationTokens

### DIFF
--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -97,6 +97,8 @@ export function normalizeOpenAIResponseUsage(
         inputTokens: usage.input_tokens ?? 0,
         outputTokens: usage.output_tokens ?? 0,
         cachedTokens: usage.input_tokens_details?.cached_tokens ?? 0,
+        cacheCreationTokens:
+          usage.input_tokens_details?.cache_write_tokens ?? 0,
         reasoningTokens: usage.output_tokens_details?.reasoning_tokens ?? 0,
       }),
     },

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -32,7 +32,10 @@ import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller'
 
 // Type imports
 import { pathToLocation } from '@utils/files';
-import type { ResponseInputItem } from 'openai/resources/responses/responses';
+import type {
+  ResponseInputItem,
+  ResponseUsage,
+} from 'openai/resources/responses/responses';
 
 // pathToLocation and FlexibleFS resolve through platform services, so this
 // suite needs the real node fs rather than the in-memory default.
@@ -1054,5 +1057,38 @@ describe('ModelHandlerOpenAIResponse.initializeOutputAndPrefill', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('ModelHandlerOpenAIResponse.normalizeUsage', () => {
+  it('maps input_tokens_details.cache_write_tokens to cacheCreationTokens', () => {
+    const handler = createHandler();
+    const usage: ResponseUsage = {
+      input_tokens: 100,
+      output_tokens: 20,
+      total_tokens: 120,
+      input_tokens_details: { cached_tokens: 10, cache_write_tokens: 15 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    } as ResponseUsage;
+
+    const normalized = handler.normalizeUsage(usage, 0);
+
+    assert.equal(normalized.cacheCreationTokens, 15);
+    assert.equal(normalized.cachedInputTokens, 10);
+  });
+
+  it('defaults cacheCreationTokens to undefined when cache_write_tokens is absent', () => {
+    const handler = createHandler();
+    const usage: ResponseUsage = {
+      input_tokens: 100,
+      output_tokens: 20,
+      total_tokens: 120,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    } as ResponseUsage;
+
+    const normalized = handler.normalizeUsage(usage, 0);
+
+    assert.equal(normalized.cacheCreationTokens, undefined);
   });
 });


### PR DESCRIPTION
## What / why

Closes #7865.

`openai` 6.46.0 (landed in #7862) added `input_tokens_details.cache_write_tokens`
to the Responses API's `ResponseUsage`. We zeroed it in the synthesized fallback
(type fix) but `normalizeOpenAIResponseUsage`'s `extract` never read the real
value — OpenAI cache-write counts were silently dropped on the floor while
Anthropic's already flow through `NormalizedUsage.cacheCreationTokens`
(`RunUsageAccumulator.ts:117`). This PR adds the one-line mapping:

```ts
cacheCreationTokens: usage.input_tokens_details?.cache_write_tokens ?? 0,
```

in `normalizeOpenAIResponseUsage`'s `extract`
(`src/agent/modelHandlers/openai/openAIUsage.ts`). Usage displays now report
cache writes for OpenAI Responses-API runs the same way they already do for
Anthropic. No new fields, no new vocabulary.

Chat Completions (`normalizeOpenAIUsage` / `ExtendedCompletionUsage`) is left
untouched — the issue scopes the mapping to the Responses API only, and the
implementation sketch calls for exactly "the one-line extract mapping." (Note:
the vendored `openai` SDK types do also declare an optional
`CompletionUsage.PromptTokensDetails.cache_write_tokens`, but wiring that up is
out of scope for this issue; flagging for a follow-up if the maintainer wants
Chat Completions parity.)

## Pricing verification

Per the issue's verify-first mandate for half (2), I checked OpenAI's live,
current pricing page (`https://developers.openai.com/api/docs/pricing`,
fetched raw HTML — not summarized/blog sources, several of which gave
contradictory/hallucination-flavored answers) for every OpenAI model this repo
ships (`node_modules/llm-zoo` `ModelProvider.OPENAI` entries: `gpt-4.1*`,
`gpt-4o*`, `gpt-4-turbo`, `gpt-4.5-preview`, `chatgpt-4o-latest`, `o1*`, `o3*`,
`o4-mini*`, `gpt-oss-*`, `gpt-5*` through `gpt-5.5-pro`).

Findings from the raw pricing-table data:

- The **only** models on the current pricing page with a cache-write price
  above the standard input rate are the **`gpt-5.6-*` family** (`sol`/`terra`/
  `luna`), e.g. `gpt-5.6-sol`: input `$5.00`/1M, cache write `$6.25`/1M — a
  1.25x surcharge, mirroring Anthropic. **`gpt-5.6` is not in this repo's
  shipped model list** (`llm-zoo`'s newest is `gpt-5.5-pro-2026-04-23` /
  `gpt-5.4*`), so the surcharge does not apply to any model we ship today.
- Every currently-shipped model that still appears on the pricing page
  (`gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`,
  `gpt-5.3-codex`, `gpt-5.4-pro`) shows **`-` (no cache-write charge)** in the
  cache-writes column.
- The older models we still ship in `llm-zoo` (`gpt-4.1`, `gpt-4o`,
  `gpt-4-turbo`, `gpt-4.5-preview`, `o1*`, `o3`, `o3-mini`, `o3-pro`,
  `o4-mini`, `gpt-oss-*`, `chatgpt-4o-latest`) **no longer appear on the
  current pricing page at all** (retired from the live catalog); no surcharge
  claim can be sourced for them either way.

Conclusion: **no shipped OpenAI model currently bills cache writes above the
standard input rate**, so per the issue's instruction ("If no surcharge
exists... do NOT add a speculative knob") the pricing half is **skipped**.
`OpenAIPricingConfig` / `computeStandardPrice` are untouched. If/when `llm-zoo`
adds `gpt-5.6*`, a `cacheWriteMultiplier` on `OpenAIPricingConfig` (mirroring
Anthropic's `cacheDiscountFactor` pattern) would be the config-driven surcharge
to add at that point — not added here since it would be speculative for models
we don't ship.

## Verification

```
npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
# Test Files  1 passed (1) / Tests  24 passed (24)

npx vitest run src/test-kernel/agent/modelHandlers/
# Test Files  54 passed | 1 skipped (55) / Tests  429 passed | 4 skipped (433)

npm run typecheck
# passes (tsc --noEmit x3 + package typechecks), no errors

npx eslint src/agent/modelHandlers/openai/openAIUsage.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
# clean

npx prettier --check src/agent/modelHandlers/openai/openAIUsage.ts src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
# All matched files use Prettier code style!
```

Added two cases to the existing `ModelHandlerOpenAIResponse.vitest.ts` suite
(new `ModelHandlerOpenAIResponse.normalizeUsage` describe block, calling the
handler's existing public `normalizeUsage()` method — no new test file, no new
helpers):
- `cache_write_tokens` present → `cacheCreationTokens` mapped through.
- `cache_write_tokens` absent → `cacheCreationTokens` stays `undefined` (matches
  `normalizeUsage`'s existing `|| undefined` convention for all other optional
  cache fields).

## Net elements (R6)

- 0 new files.
- 0 new exports, 0 new types, 0 new abstractions.
- 1 new field mapped in an existing `extract` callback (1 line).
- 2 new test cases in the existing suite file (no new describe-block pattern
  beyond what the file already uses).
- Pricing config: untouched (0 lines) — verified-and-skipped per the issue's
  explicit "do NOT add a speculative knob" instruction.

## Consumer counts (R8)

- `normalizeOpenAIResponseUsage` has exactly 1 caller:
  `ModelHandlerOpenAIResponse.normalizeUsage` — the change is fully contained,
  no fan-out to update.
- `NormalizedUsage.cacheCreationTokens` is an existing field already consumed
  by usage-display code for Anthropic; no consumer changes needed since this
  PR just populates an already-plumbed field for a second provider.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field mapping in usage normalization with no pricing or auth changes; behavior is additive for reporting only.
> 
> **Overview**
> OpenAI Responses API usage normalization now reads **`input_tokens_details.cache_write_tokens`** and sets **`NormalizedUsage.cacheCreationTokens`**, so cache-write counts show up in run usage the same way Anthropic’s already do via `RunUsageAccumulator`. Chat Completions normalization is unchanged.
> 
> **Pricing** is not modified: cache-write billing is only wired for display/accumulation through the existing field.
> 
> Tests cover mapping when the field is present and **`undefined`** when it is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458454534e0adafd299f7eb9af5a16afebe050ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->