### PR TITLE
fix(cli): prune removed stream status cache

### DIFF
--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -256,6 +256,8 @@ export function attachCliSessionProgressProjection(
       const streamId = projected.payload.streamId;
       if (lastStatusByStream.get(streamId) === key) return;
       lastStatusByStream.set(streamId, key);
+    } else if (projected.event === 'removeStream') {
+      lastStatusByStream.delete(projected.payload.streamId);
     }
     emitProjectedProgressEvent(writeRecord, projected);
   }

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -367,6 +367,38 @@ describe('attachCliSessionProgressProjection', () => {
     }
   });
 
+  it('forgets the last status when a stream is removed', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+
+    try {
+      emitSessionStatus(events, resumingStatusPayload);
+      emitSessionStatus(events, resumingStatusPayload);
+      events.emit({
+        scope: 'session',
+        event: { type: 'removeStream', payload: { streamId } },
+      });
+      emitSessionStatus(events, resumingStatusPayload);
+
+      expect(writeRecord).toHaveBeenCalledTimes(3);
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        1,
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        2,
+        progressRecord('removeStream', { streamId }),
+      );
+      expect(writeRecord).toHaveBeenNthCalledWith(
+        3,
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+    } finally {
+      detach();
+    }
+  });
+
   it('drops malformed retained run facts instead of forwarding unchecked payloads', () => {
     const events = new SessionEventHub();
     const writeRecord = recordWriter();


### PR DESCRIPTION
## Summary

Release the CLI NDJSON status-deduplication entry when a stream is removed. Long-lived CLI sessions that create and auto-close child streams no longer retain one status key per historical stream, and reusing a stream identifier begins with a fresh deduplication state.

## Issue acceptance gates

Closes #7818.

- `removeStream` deletes the matching `lastStatusByStream` entry before publication.
- Re-emitting the same status after removal produces a new public record instead of being suppressed by stale state.

## Single source of truth

`attachCliSessionProgressProjection` remains the sole owner of its per-subscription status deduplication map and now owns that map's complete lifecycle.

## Duplication and abstraction budget

No abstraction is added. The existing `removeStream` arm performs the corresponding one-line state deletion at the projection owner.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- LoC: +34 / -0, net +34 (32 lines are the regression test).
- Exports/classes/interfaces/enums: unchanged.

## Consumer counts (R8)

One `removeStream` projection path enters `emitProjected`; it now prunes the one cache owned by that subscription before writing the public record.

## Host impact

Extension: none.

Desktop: none.

CLI: prevents unbounded per-stream status-key retention in long-lived NDJSON sessions; wire output is unchanged except that a recreated stream can publish its initial status.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm vitest run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts` (15 tests)
- targeted ESLint
- `corepack pnpm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI projection lifecycle fix with a targeted test; no auth, data, or wire-format changes beyond correct dedup after stream removal.
> 
> **Overview**
> **CLI NDJSON progress projection** now drops a stream’s deduplication entry when `removeStream` is projected, so long-lived sessions don’t accumulate one status key per historical stream.
> 
> After removal, the same `updateStreamStatus` payload is written again instead of being suppressed by stale cache—important when a stream id is reused. Public wire shape is unchanged aside from that behavior.
> 
> A regression test covers remove-then-re-emit status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab221ac98b52a0b2d6cfbc39651911e67dbbb456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->