### PR TITLE
fix(cli): cancel stale auto-resume after Ctrl-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ All notable changes to this project will be documented in this file.
   progress, command results, doctor output, and structured error/instruction
   records now share one queued stdout writer.
 
+- **Ctrl-C cancels pending automatic resumes** — stopping while a queued
+  follow-up is preparing can no longer restart the cancelled stream after an
+  asynchronous model or session-state lookup finishes.
+
 ### Desktop
 
 #### Bug Fixes

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -473,6 +473,7 @@ export function createChatSessionController(
           resolveAndResumeStream(streamId, {
             runtimeHost,
             streamStatus: defaultSession().status,
+            isCancellationRequested: () => session.stopRequested,
             resolveResumeState: async () => ({
               runState: config,
               executionId,

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -27,6 +27,8 @@ interface ResolvedResumeState {
 export interface ResumeStreamPorts {
   /** Runtime host receiving the RESUMING/WAITING status updates. */
   readonly runtimeHost: AgentRuntimeHost;
+  /** True when the host cancelled this resume while it was preparing. */
+  isCancellationRequested?(): boolean;
   /**
    * The status machine of the session that owns this stream — per-window on
    * desktop, the default session's machine in the extension/CLI. The
@@ -87,6 +89,7 @@ export async function resolveAndResumeStream(
   ports: ResumeStreamPorts,
 ): Promise<boolean> {
   if (
+    ports.isCancellationRequested?.() ||
     ports.streamStatus.isActiveOrResuming(streamId) ||
     resumeInFlight.has(streamId)
   ) {
@@ -122,7 +125,10 @@ export async function resolveAndResumeStream(
     // that flips this stream active/resuming while we awaited retrieval. If that
     // happened, abandon the resume rather than clobbering the launched run's
     // status.
-    if (ports.streamStatus.isActiveOrResuming(streamId)) {
+    if (
+      ports.isCancellationRequested?.() ||
+      ports.streamStatus.isActiveOrResuming(streamId)
+    ) {
       return false;
     }
 

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -134,6 +134,21 @@ describe('resolveAndResumeStream', () => {
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
   });
 
+  it('abandons resume when cancellation is requested during retrieval', async () => {
+    let cancellationRequested = false;
+    retrieveSessionResumeDataMock.mockImplementation(async () => {
+      cancellationRequested = true;
+      return { type: 'toolUse', snapshot: { streamId: STREAM } };
+    });
+    const ports = basePorts({
+      isCancellationRequested: () => cancellationRequested,
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resumeToolUseSnapshot).not.toHaveBeenCalled();
+    expect(ports.executeWorkflow).not.toHaveBeenCalled();
+  });
+
   it('skips resume without resolving when the stream is already active', async () => {
     seedStreamStatusForTest(StreamStatusService, STREAM, STREAM_STATUS.RUNNING);
     const ports = basePorts();

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -425,6 +425,37 @@ describe('createChatSessionController', () => {
     });
   });
 
+  it('does not auto-resume after stop during helper-model setup', async () => {
+    const modelSetup = deferred();
+    const session = makeSession({ runCompleted: true });
+    const config = makeResumeConfig();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config,
+    });
+    mocks.setCliHelperModel.mockReturnValueOnce(modelSetup.promise);
+    mocks.resolveAndResumeStream.mockImplementationOnce(
+      async (_streamId, ports: { isCancellationRequested?(): boolean }) =>
+        !(ports.isCancellationRequested?.() ?? false),
+    );
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    const resumed = ctrl.tryResumeStream('stream-1');
+    await vi.waitFor(() => expect(mocks.setCliHelperModel).toHaveBeenCalled());
+    ctrl.stop();
+    modelSetup.resolve(undefined);
+
+    await expect(resumed).resolves.toBe(false);
+    expect(mocks.resolveAndResumeStream).toHaveBeenCalledWith(
+      'stream-1',
+      expect.objectContaining({
+        isCancellationRequested: expect.any(Function),
+      }),
+    );
+  });
+
   it('does not finalize the stream transcript when auto-resume returns false', async () => {
     const session = makeSession({ runCompleted: true });
     const config = makeResumeConfig();


### PR DESCRIPTION
## Summary

- Let hosts provide a live cancellation predicate to the shared resume orchestrator.
- Wire CLI `session.stopRequested` into auto-resume preparation.
- Recheck cancellation immediately before launching a recovered tool-use or workflow resume.

Closes #7886.

## Issue acceptance gates

- [x] Ctrl-C during helper-model setup prevents the queued wake from resuming.
- [x] Cancellation during persisted resume retrieval prevents launch.
- [x] Cancelled preparation does not call tool-use or workflow resume ports.
- [x] Existing active-stream and duplicate-resume guards remain unchanged.

## Single source of truth

`TuiSession.stopRequested` remains the CLI owner of the user's stop decision. `ResumeStreamPorts.isCancellationRequested` exposes that live decision to `resolveAndResumeStream`, which owns the final pre-launch guard after asynchronous preparation.

## Duplication and abstraction budget

No cancellation state or status projection was added. One optional predicate crosses the existing host/runtime boundary; extension and desktop callers remain unchanged because the hook is optional.

## Net elements (R6)

5 files changed; 0 files added/deleted; 58 insertions, 1 deletion, net +57 LoC. The net addition is one optional interface member, two race-focused regression tests, and the changelog entry. No exports, classes, enums, or schemas were added or removed.

## Consumer counts (R8)

n/a — no emit path, event key, or export was deleted or rerouted.

## Host impact

Extension: No behavior change; no cancellation predicate is supplied.

Desktop: No behavior change; no cancellation predicate is supplied.

CLI: Ctrl-C now cancels an automatic resume even when it arrives during asynchronous model or session-state preparation.

## Scheduled refactoring

None.

## Validation

- Focused Vitest: 2 files, 28 tests passed.
- `npm run typecheck` passed.
- `npm run lint` passed with 0 errors and 51 existing warnings.
- `git diff --check` passed.
- GitHub CI `validate (linux)` passed in 18m13s.
- The timing-sensitive window is covered deterministically with deferred helper-model setup and cancellation during resume retrieval rather than a flaky wall-clock PTY test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, optional port hook with CLI-only wiring; existing active-stream and in-flight guards stay the same.
> 
> **Overview**
> **Ctrl-C during CLI auto-resume preparation** no longer restarts a stream after helper-model setup or persisted resume lookup finishes.
> 
> The shared `resolveAndResumeStream` orchestrator accepts an optional **`isCancellationRequested`** hook on `ResumeStreamPorts`. It is checked at entry and again after async resume retrieval, so a cancelled preparation never calls tool-use or workflow resume ports. The CLI chat controller wires **`session.stopRequested`** into that hook for queued follow-up wakes.
> 
> Extension and desktop callers are unchanged because the predicate is optional. Regression tests cover cancellation during retrieval and stop while `setCliHelperModel` is in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e021d3430f03ea133a29fcbb31cf577c36b3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->