### PR TITLE
refactor(latex): unify workspace source resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Workflow LaTeX compilation resolves source directories consistently** —
+  compile checks and latexdiff PDF builds now share one workspace-source
+  resolver, and a real workspace folder named `r1`, `r2`, and so on is no
+  longer mistaken for a run-storage round folder.
 - **OpenRouter transient server errors no longer stall a request for up to an
   hour** — the OpenRouter SDK's built-in retry window is now capped at 30
   seconds, so a persistent 5XX surfaces through TeXRA's visible retry/failure

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -391,6 +391,8 @@ export class LatexDiffManager {
       sourceLocation.kind === 'runStorage'
         ? path.dirname(sourceLocation.absolutePath)
         : null,
+      // Snapshot bases live under `original/`, while between-round bases live
+      // under `r<N>/`; map either back without confusing a real `r<N>` folder.
       resolveWorkspaceSourceDir(referenceLocation) ??
         path.dirname(referenceLocation.absolutePath),
     ].filter((dir): dir is string => dir !== null);

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -16,14 +16,12 @@ import {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
-import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import {
   createExternalLocation,
   createRunStorageLocation,
   createWorkspaceLocation,
   FlexibleFS,
   TaskRunFileService,
-  WorkspaceFS,
 } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
@@ -33,6 +31,7 @@ import {
   publishCompiledPdfArtifact,
   type CompiledPdfArtifact,
 } from './compiledPdfArtifacts';
+import { resolveWorkspaceSourceDir } from './compileCheck';
 import { tryOperation } from './outputOperations';
 import type { RoundFileEntry, RoundFileMapping } from './types';
 
@@ -66,37 +65,6 @@ export class LatexDiffManager {
       .fs.realPath(location.absolutePath)
       .catch(() => location.absolutePath);
     return path.dirname(resolved);
-  }
-
-  /**
-   * Directory of the document's live workspace source, the one place that
-   * carries the `figures/` and `.bib` dependencies the diff still `\input`s.
-   * The base location is never the live workspace file: `resolveBaseFilesForDiff`
-   * (`snapshotResolution.ts`) rewrites a round diff base to its
-   * `executions/<id>/original/<rel>` snapshot, and a between-round diff base is
-   * the prior round's output at `r<N>/<rel>`. Both keep the path
-   * workspace-relative apart from a leading run-storage `r<N>/` round segment,
-   * so strip that and map onto the workspace root; fall back to the file's own
-   * directory for external bases or when no workspace is open.
-   *
-   * Assumption: a leading `r<digits>/` segment is a run-storage round prefix,
-   * not a real workspace folder. A document whose live source genuinely sits
-   * under a top-level `r<digits>/` folder (e.g. a "revision 1" `r1/`) would be
-   * mis-stripped: unavoidable with a relativePath-only heuristic, and rare
-   * since it collides with the round-directory naming.
-   */
-  private resolveWorkspaceSourceDir(location: FileLocation): string {
-    const workspaceRoot = WorkspaceFS.getPath();
-    if (workspaceRoot && location.kind !== 'external') {
-      const separatorMatch = /^([^/\\]+)[/\\]/.exec(location.relativePath);
-      const workspaceRelative =
-        separatorMatch &&
-        parseWorkflowOutputRoundDir(separatorMatch[1]) !== null
-          ? location.relativePath.slice(separatorMatch[0].length)
-          : location.relativePath;
-      return path.join(workspaceRoot, path.dirname(workspaceRelative));
-    }
-    return path.dirname(location.absolutePath);
   }
 
   private logLatexdiffResult(
@@ -423,7 +391,8 @@ export class LatexDiffManager {
       sourceLocation.kind === 'runStorage'
         ? path.dirname(sourceLocation.absolutePath)
         : null,
-      this.resolveWorkspaceSourceDir(referenceLocation),
+      resolveWorkspaceSourceDir(referenceLocation) ??
+        path.dirname(referenceLocation.absolutePath),
     ].filter((dir): dir is string => dir !== null);
     const compiled = await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -25,6 +25,7 @@ import {
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { readPlatformSetting } from '@utils/config/platformSettings';
+import { getRunDir } from '@utils/files/runStorageFs';
 
 import {
   publishCompiledPdfArtifact,
@@ -67,8 +68,8 @@ function getCompileDisplayName(file: OutputFileInfo): string {
 
 /**
  * Resolve a workspace/run-storage location back to its live source folder.
- * A run-storage location's leading `r<digits>/` round segment is removed;
- * workspace locations retain the same segment as a real directory name.
+ * A round output's leading `r<digits>/` segment is removed. Workspace files
+ * and original snapshots retain the same segment as a real directory name.
  */
 export function resolveWorkspaceSourceDir(
   location: FileLocation,
@@ -76,10 +77,13 @@ export function resolveWorkspaceSourceDir(
   const workspaceRoot = WorkspaceFS.getPath();
   if (!workspaceRoot || location.kind === 'external') return undefined;
 
-  const separatorMatch =
+  const runStorageRelative =
     location.kind === 'runStorage'
-      ? /^([^/\\]+)[/\\]/.exec(location.relativePath)
+      ? path.relative(getRunDir(location.executionId), location.absolutePath)
       : null;
+  const separatorMatch = runStorageRelative
+    ? /^([^/\\]+)[/\\]/.exec(runStorageRelative)
+    : null;
   const workspaceRelative =
     separatorMatch && parseWorkflowOutputRoundDir(separatorMatch[1]) !== null
       ? location.relativePath.slice(separatorMatch[0].length)

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -13,6 +13,7 @@ import type {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
+import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import {
   createRunStorageLocation,
   FlexibleFS,
@@ -64,22 +65,27 @@ function getCompileDisplayName(file: OutputFileInfo): string {
   return srcBase && !GENERIC_OUTPUT_STEMS.has(srcBase) ? srcBase : rawBase;
 }
 
-function resolveWorkspaceSourceDir(
-  outputFile: OutputFileInfo,
-  fallbackRelativePath: string,
-): string[] {
+/**
+ * Resolve a workspace/run-storage location back to its live source folder.
+ * A run-storage location's leading `r<digits>/` round segment is removed;
+ * workspace locations retain the same segment as a real directory name.
+ */
+export function resolveWorkspaceSourceDir(
+  location: FileLocation,
+): string | undefined {
   const workspaceRoot = WorkspaceFS.getPath();
-  if (!workspaceRoot) return [];
+  if (!workspaceRoot || location.kind === 'external') return undefined;
 
-  const source = outputFile.source.trim();
-  const located =
-    source.length > 0 ? WorkspaceFS.locatePath(source) : undefined;
-  const sourceRelativePath =
-    located?.kind === 'workspace' ? located.relativePath : fallbackRelativePath;
+  const separatorMatch =
+    location.kind === 'runStorage'
+      ? /^([^/\\]+)[/\\]/.exec(location.relativePath)
+      : null;
+  const workspaceRelative =
+    separatorMatch && parseWorkflowOutputRoundDir(separatorMatch[1]) !== null
+      ? location.relativePath.slice(separatorMatch[0].length)
+      : location.relativePath;
 
-  return path.isAbsolute(sourceRelativePath)
-    ? []
-    : [path.join(workspaceRoot, path.dirname(sourceRelativePath))];
+  return path.join(workspaceRoot, path.dirname(workspaceRelative));
 }
 
 /**
@@ -298,10 +304,13 @@ async function compileOne(
     // The output compiles from `buildDir`, not its original workspace folder.
     // For extracted outputs, the run-storage basename can be generic while
     // outputFile.source carries the real workspace path.
-    const extraInputDirs = resolveWorkspaceSourceDir(
-      outputFile,
-      pathForSafeName,
-    );
+    const source = outputFile.source.trim();
+    const locatedSource =
+      source.length > 0 ? WorkspaceFS.locatePath(source) : undefined;
+    const sourceLocation =
+      locatedSource?.kind === 'workspace' ? locatedSource : outputFile.location;
+    const sourceDir = resolveWorkspaceSourceDir(sourceLocation);
+    const extraInputDirs = sourceDir ? [sourceDir] : [];
 
     // execa's timeout option kills the child process on expiry, so we don't
     // orphan hanging latexmk/pdflatex runs.

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -12,7 +12,10 @@ import {
   AgentWorkflowSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
-import { runCompileCheck } from '@agent/output/compileCheck';
+import {
+  resolveWorkspaceSourceDir,
+  runCompileCheck,
+} from '@agent/output/compileCheck';
 import { createOutputState, ensureRoundData } from '@agent/output/outputState';
 
 // Local imports - shared
@@ -26,6 +29,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 // Local imports - file utilities
 import {
   TaskRunFileService,
+  createExternalLocation,
   createRunStorageLocation,
   createWorkspaceLocation,
 } from '@utils/files';
@@ -97,6 +101,23 @@ function initLatexPlatform(files: Record<string, string>): Promise<void> {
   });
 }
 
+function diffCompiler(manager: LatexDiffManager) {
+  return manager as unknown as {
+    compileDiffIfSuccessful(
+      result: { success: boolean; diffFileName?: string },
+      referenceLocation: FileLocation,
+      diffDirectory: {
+        absolutePath: string;
+        relativePath: string;
+        executionId: ExecutionId;
+      },
+      round: number,
+      sourceLocation: FileLocation,
+      pdfStemSuffix: string,
+    ): Promise<unknown>;
+  };
+}
+
 describe('workflow LaTeX compile input directories', () => {
   beforeEach(() => {
     mocks.compileLatex2Pdf.mockClear();
@@ -133,6 +154,94 @@ describe('workflow LaTeX compile input directories', () => {
     );
   });
 
+  it.each(['', '/external/source/main.tex'])(
+    'falls back to the output location for source %j',
+    async (source) => {
+      const executionId = `compile-output-dir-${source ? 'external' : 'empty'}`;
+      const texPath = path.join(runDir(executionId), 'r2', 'Draft', 'main.tex');
+      await initLatexPlatform({
+        [texPath]: '\\documentclass{article}\\begin{document}Hi\\end{document}',
+      });
+
+      const outputState = createOutputState();
+      ensureRoundData(outputState, 2).outputs = [
+        outputFile(
+          executionId,
+          path.join('r2', 'Draft', 'main.tex'),
+          source,
+          2,
+        ),
+      ];
+
+      await runCompileCheck(
+        {
+          fileService: new TaskRunFileService(executionId),
+          outputState,
+          logger: logger(),
+          streamId: 'compile-stream',
+        },
+        2,
+      );
+
+      expect(mocks.compileLatex2Pdf).toHaveBeenCalledWith(
+        expect.objectContaining({ absolutePath: texPath }),
+        expect.objectContaining({
+          extraInputDirs: [path.join(workspacePath, 'Draft')],
+        }),
+      );
+    },
+  );
+
+  it('resolves workspace and round-storage paths through one owner', async () => {
+    const executionId = 'shared-source-resolver';
+    await initLatexPlatform({});
+
+    expect(
+      resolveWorkspaceSourceDir(
+        createWorkspaceLocation(
+          path.join(workspacePath, 'Draft', 'main.tex'),
+          path.join('Draft', 'main.tex'),
+        ),
+      ),
+    ).toBe(path.join(workspacePath, 'Draft'));
+    expect(
+      resolveWorkspaceSourceDir(
+        runStorageFile(executionId, path.join('r3', 'Draft', 'main.tex')),
+      ),
+    ).toBe(path.join(workspacePath, 'Draft'));
+    expect(
+      resolveWorkspaceSourceDir(
+        createWorkspaceLocation(
+          path.join(workspacePath, 'r3', 'Draft', 'main.tex'),
+          path.join('r3', 'Draft', 'main.tex'),
+        ),
+      ),
+    ).toBe(path.join(workspacePath, 'r3', 'Draft'));
+  });
+
+  it('does not map external locations into the workspace', async () => {
+    await initLatexPlatform({});
+
+    expect(
+      resolveWorkspaceSourceDir(
+        createExternalLocation('/external/project/main.tex'),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns no workspace source directory when no workspace is open', async () => {
+    await installPlatform({ storagePath, workspacePath: undefined });
+
+    expect(
+      resolveWorkspaceSourceDir(
+        createWorkspaceLocation(
+          path.join(workspacePath, 'Draft', 'main.tex'),
+          path.join('Draft', 'main.tex'),
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
   it('compiles diffs with revised round inputs before workspace fallbacks', async () => {
     const executionId = 'latexdiff-input-dir';
     await initLatexPlatform({});
@@ -148,28 +257,15 @@ describe('workflow LaTeX compile input directories', () => {
       new TaskRunFileService(executionId),
     );
 
-    const referenceLocation = createWorkspaceLocation(
-      path.join(workspacePath, 'Draft', 'main.tex'),
-      'Draft/main.tex',
+    const referenceLocation = runStorageFile(
+      executionId,
+      path.join('r1', 'Draft', 'main.tex'),
     );
     const sourceLocation = runStorageFile(
       executionId,
       path.join('r2', 'Draft', 'main.tex'),
     );
-    const compileDiff = manager as unknown as {
-      compileDiffIfSuccessful(
-        result: { success: boolean; diffFileName?: string },
-        referenceLocation: FileLocation,
-        diffDirectory: {
-          absolutePath: string;
-          relativePath: string;
-          executionId: ExecutionId;
-        },
-        round: number,
-        sourceLocation: FileLocation,
-        pdfStemSuffix: string,
-      ): Promise<unknown>;
-    };
+    const compileDiff = diffCompiler(manager);
 
     await compileDiff.compileDiffIfSuccessful(
       { success: true, diffFileName: 'main-diff.tex' },
@@ -198,6 +294,47 @@ describe('workflow LaTeX compile input directories', () => {
           path.join(runDir(executionId), 'r2', 'Draft'),
           path.join(workspacePath, 'Draft'),
         ],
+      }),
+    );
+  });
+
+  it('keeps an external latexdiff reference in its own directory', async () => {
+    const executionId = 'latexdiff-external-input-dir';
+    await initLatexPlatform({});
+    const manager = new LatexDiffManager(
+      AgentWorkflowSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+      }),
+      () => ({}),
+      [],
+      logger(),
+      'diff-stream',
+      new TaskRunFileService(executionId),
+    );
+    const referenceLocation = createExternalLocation(
+      '/external/project/main.tex',
+    );
+
+    await diffCompiler(manager).compileDiffIfSuccessful(
+      { success: true, diffFileName: 'main-diff.tex' },
+      referenceLocation,
+      {
+        absolutePath: path.join(runDir(executionId), 'diff', 'r1'),
+        relativePath: path.join('diff', 'r1'),
+        executionId,
+      },
+      1,
+      createWorkspaceLocation(
+        path.join(workspacePath, 'Draft', 'main.tex'),
+        path.join('Draft', 'main.tex'),
+      ),
+      '-diff',
+    );
+
+    expect(mocks.compileLatex2Pdf).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        extraInputDirs: ['/external/project'],
       }),
     );
   });

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -211,6 +211,15 @@ describe('workflow LaTeX compile input directories', () => {
     ).toBe(path.join(workspacePath, 'Draft'));
     expect(
       resolveWorkspaceSourceDir(
+        createRunStorageLocation(
+          path.join(runDir(executionId), 'original', 'r3', 'Draft', 'main.tex'),
+          path.join('r3', 'Draft', 'main.tex'),
+          executionId,
+        ),
+      ),
+    ).toBe(path.join(workspacePath, 'r3', 'Draft'));
+    expect(
+      resolveWorkspaceSourceDir(
         createWorkspaceLocation(
           path.join(workspacePath, 'r3', 'Draft', 'main.tex'),
           path.join('r3', 'Draft', 'main.tex'),


### PR DESCRIPTION
## Summary

Collapse the two workspace-source-directory derivations in compile checks and latexdiff into one exported resolver owned by `compileCheck.ts`. The resolver maps workspace and run-storage locations to the live workspace source folder; caller-specific result shape and external/no-workspace fallback remain at their callers.

The consolidation also removes the old path-shape ambiguity: only `runStorage` locations strip a leading `r<N>/` workflow round segment. A genuine workspace directory named `r1`, `r2`, and so on remains a real directory.

## Issue acceptance gates

Closes #7469. Item 1 was previously completed by #7551; this PR completes the remaining dual-`resolveWorkspaceSourceDir` item under the maintainer decision recorded on 2026-07-09.

- Exactly one production resolver definition remains.
- Compile check still prefers a valid workspace `OutputFileInfo.source`, then falls back to the output location.
- Latexdiff still uses the reference file's absolute parent for external/no-workspace locations.
- Run-storage round prefixes are stripped; workspace folders with the same spelling are retained.

## Single source of truth

`resolveWorkspaceSourceDir(FileLocation)` in `src/agent/output/compileCheck.ts` solely owns the workspace-root mapping decision.

## Duplication and abstraction budget

The 31-line private `LatexDiffManager.resolveWorkspaceSourceDir` implementation is deleted. No module, options object, schema field, compatibility export, or persisted migration is introduced.

## Net elements (R6)

- Files: 4 modified, 0 added, 0 deleted.
- LoC: +190 / -71, net +119; production code is net negative, while characterization/regression coverage expands substantially.
- Exports: one existing resolver is made public within the internal agent-output surface.
- Classes/interfaces/enums: unchanged.

## Consumer counts (R8)

Two production consumers remain: compile check and latexdiff PDF compilation. Both call the one resolver; repo search shows exactly one definition.

## Host impact

Extension: shared workflow compile/diff behavior uses the consolidated resolver.

Desktop: same shared behavior.

CLI: same shared behavior.

## Scheduled refactoring

None. The other #7469 item was completed by #7551.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts` (8 tests)
- related compile/latexdiff focused suites during the first pass (16 tests across available files)
- targeted ESLint
- `corepack pnpm run typecheck`
- `git diff --check`
- repo search confirming one resolver definition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow LaTeX compile and diff input paths across all hosts; behavior change is intentional for edge-case folder names but could affect builds that previously resolved inputs incorrectly.
> 
> **Overview**
> Workflow **compile checks** and **latexdiff PDF builds** now share a single exported `resolveWorkspaceSourceDir` in `compileCheck.ts`; the duplicate private resolver in `LatexDiffManager` is removed.
> 
> The shared logic only strips a leading `r<N>/` segment for **run-storage round outputs** (detected via `parseWorkflowOutputRoundDir` on the path under the run directory). Workspace files and `original/` snapshots keep a top-level folder literally named `r1`, `r2`, etc., so those paths map to the correct live source directory instead of being treated as workflow round prefixes.
> 
> Compile checks still prefer a workspace `outputFile.source` when it resolves, then fall back to the output location for `extraInputDirs`. Latexdiff still prepends the revised round directory and uses the shared resolver for the reference file, falling back to the reference file’s parent for external paths or when no workspace is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ef541078173b8e79a7b5065d7a4eb66d6ca693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->