### PR TITLE
fix(cli): honor cancellation during auto-resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ All notable changes to this project will be documented in this file.
   (`/executions/{id}/result`), so follow-on agents can chain on data instead
   of parsing prose.
 
+### CLI
+
+#### Bug Fixes
+
+- **Ctrl-C reliably cancels queued-follow-up auto-resume** — stopping while an
+  automatic resume is still loading configuration or session data no longer
+  allows that stale preparation to restart the cancelled stream.
+
 ### Desktop
 
 #### Bug Fixes

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -465,7 +465,6 @@ export function createChatSessionController(
         rootStreamId.set(streamId);
         activeStreamId.set(streamId);
         session.runCompleted = false;
-        session.stopRequested = false;
         session.runExitCode = CliExitCode.Success;
         publishChatTuiRootRunStartAvailability(session);
 
@@ -473,6 +472,7 @@ export function createChatSessionController(
           resolveAndResumeStream(streamId, {
             runtimeHost,
             streamStatus: defaultSession().status,
+            isCancellationRequested: () => session.stopRequested,
             resolveResumeState: async () => ({
               runState: config,
               executionId,

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -35,6 +35,8 @@ export interface ResumeStreamPorts {
    * both guards permanently false in multi-session hosts.
    */
   readonly streamStatus: Pick<StreamStatusMachine, 'isActiveOrResuming'>;
+  /** Host-owned cancellation requested while asynchronous resume preparation runs. */
+  readonly isCancellationRequested?: () => boolean;
   /**
    * Resolve the persisted run state + execution id for a stream, or `undefined`
    * when there is nothing to resume. The host owns any "no state" messaging it
@@ -86,7 +88,11 @@ export async function resolveAndResumeStream(
   streamId: StreamTabId,
   ports: ResumeStreamPorts,
 ): Promise<boolean> {
+  const isCancellationRequested = (): boolean =>
+    ports.isCancellationRequested?.() === true;
+
   if (
+    isCancellationRequested() ||
     ports.streamStatus.isActiveOrResuming(streamId) ||
     resumeInFlight.has(streamId)
   ) {
@@ -96,6 +102,7 @@ export async function resolveAndResumeStream(
   resumeInFlight.add(streamId);
   try {
     const resolved = await ports.resolveResumeState(streamId);
+    if (isCancellationRequested()) return false;
     // The host's resolveResumeState owns its own "no persisted state" messaging.
     if (!resolved) return false;
 
@@ -112,6 +119,7 @@ export async function resolveAndResumeStream(
             resolved.executionId,
             resolved.runState,
           );
+    if (isCancellationRequested()) return false;
     if (!resume) {
       await ports.reportNoResumableSession?.(streamId);
       return false;
@@ -141,6 +149,7 @@ export async function resolveAndResumeStream(
     );
     return true;
   } catch (error) {
+    if (isCancellationRequested()) return false;
     await ports.reportFailure?.(streamId, error);
     return false;
   } finally {

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -143,6 +143,51 @@ describe('resolveAndResumeStream', () => {
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
   });
 
+  it('skips resume when cancellation was already requested', async () => {
+    const ports = basePorts({ isCancellationRequested: () => true });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resolveResumeState).not.toHaveBeenCalled();
+    expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
+    expect(isResumeInFlight(STREAM)).toBe(false);
+  });
+
+  it('stops after persisted state resolution when cancellation arrives', async () => {
+    let cancelled = false;
+    const ports = basePorts({
+      isCancellationRequested: () => cancelled,
+      resolveResumeState: vi.fn(async () => {
+        cancelled = true;
+        return {
+          runState: { agent: 'a', model: 'm' } as never,
+          executionId: 'exec-1' as never,
+        };
+      }),
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
+    expect(ports.resumeToolUseSnapshot).not.toHaveBeenCalled();
+    expect(ports.executeWorkflow).not.toHaveBeenCalled();
+    expect(isResumeInFlight(STREAM)).toBe(false);
+  });
+
+  it('stops after resume-data retrieval when cancellation arrives', async () => {
+    let cancelled = false;
+    retrieveSessionResumeDataMock.mockImplementation(async () => {
+      cancelled = true;
+      return { type: 'toolUse', snapshot: { streamId: STREAM } };
+    });
+    const ports = basePorts({
+      isCancellationRequested: () => cancelled,
+    });
+
+    await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
+    expect(ports.resumeToolUseSnapshot).not.toHaveBeenCalled();
+    expect(ports.executeWorkflow).not.toHaveBeenCalled();
+    expect(isResumeInFlight(STREAM)).toBe(false);
+  });
+
   it('guards against the injected session machine, not the process default (#7640)', async () => {
     // Desktop scenario: the window's own session machine has the stream
     // active while the process-global default is empty. The guard must read

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -104,6 +104,7 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
 
 import { StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
@@ -423,6 +424,43 @@ describe('createChatSessionController', () => {
     expect(mocks.projectStreamTranscript).toHaveBeenCalledWith('stream-1', {
       finalize: true,
     });
+  });
+
+  it('does not auto-resume after stop during helper-model setup', async () => {
+    const helperModel = deferred();
+    const session = makeSession({ runCompleted: true });
+    const config = makeResumeConfig();
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config,
+    });
+    mocks.setCliHelperModel.mockReturnValueOnce(helperModel.promise);
+    mocks.resolveAndResumeStream.mockImplementationOnce(
+      async (_streamId: StreamTabId, ports: ResumeStreamPorts) =>
+        ports.isCancellationRequested?.() !== true,
+    );
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    const resumed = ctrl.tryResumeStream('stream-1');
+    await vi.waitFor(() =>
+      expect(mocks.setCliHelperModel).toHaveBeenCalledWith(config.model),
+    );
+    ctrl.stop();
+    helperModel.resolve(undefined);
+
+    await expect(resumed).resolves.toBe(false);
+    expect(mocks.resolveAndResumeStream).toHaveBeenCalledWith(
+      'stream-1',
+      expect.objectContaining({
+        isCancellationRequested: expect.any(Function),
+      }),
+    );
+    expect(mocks.projectStreamTranscript).not.toHaveBeenCalledWith('stream-1', {
+      finalize: true,
+    });
+    expect(mocks.notify).not.toHaveBeenCalledWith({ kind: 'agentFinished' });
   });
 
   it('does not finalize the stream transcript when auto-resume returns false', async () => {


### PR DESCRIPTION
## Summary

Prevent a queued-follow-up auto-resume from restarting after the user presses Ctrl-C during asynchronous preparation. The shared resume orchestrator now accepts a host-owned cancellation predicate and checks it on entry and after each persisted-state retrieval boundary before launching either resume path.

The CLI supplies its durable `session.stopRequested` fact and no longer clears that fact a second time after preparing the runtime host. Manual resume remains valid; this does not prohibit the intentional `CANCELLED -> RUNNING` transition.

## Issue acceptance gates

Closes #7886.

- Cancellation before resume-state resolution performs no I/O or launch.
- Cancellation during state resolution stops before resume-data retrieval.
- Cancellation during resume-data retrieval stops before tool-use or workflow launch.
- Ctrl-C during helper-model setup makes CLI auto-resume resolve false without final transcript or finished notification.
- Every cancelled attempt releases the shared in-flight reservation.

## Single source of truth

The host owns whether cancellation was requested; `resolveAndResumeStream` owns where that fact must be checked across its asynchronous orchestration.

## Duplication and abstraction budget

One optional predicate is added to the existing resume port. The redundant late `session.stopRequested = false` assignment is deleted; `markChatTuiRunPending` remains the sole owner of resetting cancellation when accepting a new attempt. No status vocabulary or transition rule is added.

## Net elements (R6)

- Files: 5 modified, 0 added, 0 deleted.
- LoC: +101 / -1, net +100; 83 lines are race and boundary regression coverage.
- Exports/classes/interfaces/enums: one optional field added to the existing exported `ResumeStreamPorts`; otherwise unchanged.

## Consumer counts (R8)

One CLI auto-resume caller supplies the cancellation predicate. Extension and desktop callers omit it and preserve existing behavior.

## Host impact

Extension: unchanged.

Desktop: unchanged.

CLI: Ctrl-C reliably cancels queued-follow-up auto-resume during configuration/session loading.

## Scheduled refactoring

None.

## Validation

- focused orchestrator/controller suites (30 tests)
- full CLI suite plus resume orchestrator (130 files, 1,655 tests)
- targeted ESLint
- `corepack pnpm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional resume-port field with a single CLI caller; behavior change is scoped to cancelled auto-resume paths and is covered by targeted tests.
> 
> **Overview**
> **Ctrl-C during queued-follow-up auto-resume** no longer lets a cancelled wake finish loading config/session data and relaunch the stream. The shared `resolveAndResumeStream` orchestrator accepts an optional host **`isCancellationRequested`** predicate and bails out (without tool-use/workflow launch) on entry and after each async boundary: persisted state resolution and resume-data retrieval; cancelled attempts still release the in-flight guard.
> 
> The **CLI** wires that predicate to **`session.stopRequested`** and stops clearing that flag mid–`tryResumeStream` prep (manual `resume()` still resets it). Extension and desktop omit the port and behave as before.
> 
> Regression tests cover orchestrator cancellation races and CLI auto-resume aborting during helper-model setup (no finalize transcript or finished notification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d01e74f4cf3fb7b42d283ade98c32d2dcd5b36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->