### PR TITLE
fix(progressView): give replayOrder excess-property checking

### DIFF
--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -145,7 +145,7 @@ export function buildApprovalRequestHandlerSet(
 export function replayApprovalRequestHandlers(
   handlers: ReplayableApprovalRequestHandlerSet,
 ): void {
-  const replayOrder = {
+  const replayOrder: Record<keyof ApprovalRequestHandlerSet, true> = {
     toolEdit: true,
     bash: true,
     externalInquiry: true,
@@ -153,7 +153,7 @@ export function replayApprovalRequestHandlers(
     agentProposal: true,
     planApproval: true,
     userQuestion: true,
-  } satisfies Record<keyof ApprovalRequestHandlerSet, true>;
+  };
 
   for (const key of Object.keys(replayOrder) as Array<
     keyof ApprovalRequestHandlerSet


### PR DESCRIPTION
## What / Why

Fixes #7822.

`replayApprovalRequestHandlers` (`src/controllers/progressView/backend/progressBackendUiConfig.ts`) built `replayOrder` with `satisfies Record<keyof ApprovalRequestHandlerSet, true>`. `satisfies` enforces exhaustiveness (rejects a *missing* key) but does not trigger excess-property checking, so a stray extra key on the object literal would still compile. Since the loop casts `Object.keys(replayOrder)` to `Array<keyof ApprovalRequestHandlerSet>` and calls `handlers[key].replay()`, a stray key would flow through as `handlers[key] === undefined` and throw at runtime.

Flagged by Copilot on #7813 (unaddressed at merge): https://github.com/LionSR/TeXRA/pull/7813#discussion_r3553889361

Fix: give `replayOrder` an explicit `Record<keyof ApprovalRequestHandlerSet, true>` type annotation instead of `satisfies`. A directly-typed object literal gets TypeScript's excess-property check, while `Record`'s required keys still enforce exhaustiveness (missing-key case unchanged).

Verified locally that reintroducing a stray key (`strayKey: true`) now fails `tsc --noEmit` with `TS2353: Object literal may only specify known properties, and 'strayKey' does not exist in type 'Record<keyof ApprovalRequestHandlerSet, true>'`, then reverted before committing.

## Tests

This is a type-level guard (excess-property checking on an object literal), not runtime behavior — `satisfies`/annotation differences only affect what `tsc` accepts, not what code executes. Per the repo's guidance for type-level guards, the "test" is that typecheck fails when the guard is violated (verified above), so no new runtime test was added. The existing exhaustive-replay runtime test (`src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts`, added in #7813) still passes unchanged and continues to cover the missing-key/replay-order behavior.

- `npx vitest run src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts` — pass
- `npx vitest run src/test-kernel/progressView` — 35 files / 202 tests pass
- `npm run typecheck` (root `tsc --noEmit`, test-kernel, `texra` extension, `@texra-ai/cli`, `@texra/trace-viewer`) — pass

## Net elements (R6)

+2/-2 lines in one file: replaced `satisfies Record<...>` with a `: Record<...>` type annotation on the same object literal. No new files, no new abstractions.

## Consumer counts (R8)

n/a — no helper added, removed, or re-routed; only a type annotation changed on an existing local variable.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only annotation swap in progress-view replay wiring; no runtime or security impact.
> 
> **Overview**
> In **`replayApprovalRequestHandlers`**, the **`replayOrder`** map is now typed with an explicit **`Record<keyof ApprovalRequestHandlerSet, true>`** annotation instead of **`satisfies`** on the same literal.
> 
> That turns on TypeScript **excess-property checking** on the object literal, so an extra key (e.g. a typo) fails **`tsc`** instead of compiling and later blowing up when the loop calls **`handlers[key].replay()`** on **`undefined`**. Required keys on **`Record`** still enforce exhaustiveness when a handler kind is missing—unchanged from before.
> 
> No runtime behavior change; only what the typechecker accepts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62a503f2663a6c1e2f45ebb6662a8ac037b1c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->