### PR TITLE
fix(shared): widen embedded delivery-tag recognizer to full DELIVERY_TAGS vocabulary

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -28,7 +28,19 @@ import { DELIVERY_TAG, DELIVERY_TAGS } from '@shared/deliveryTags';
 // leak as raw XML into the CLI transcript and queued follow-ups panel.
 const DELIVERY_TAG_NAMES = DELIVERY_TAGS.map((entry) => entry.tag);
 const DELIVERY_TAG_ALTERNATION = DELIVERY_TAG_NAMES.join('|');
-const SUBAGENT_TAG_RE = new RegExp(`^<(${DELIVERY_TAG_ALTERNATION})\\b`);
+// `\b` after the alternation is NOT a safe tag-name terminator here: `-` is a
+// non-word character, so `\b` also matches between `t` and `-` inside e.g.
+// `codex-result-partial`, letting a future hyphen-extended tag prefix-match
+// an existing one (no current DELIVERY_TAGS entry is a prefix of another, but
+// the vocabulary is a shared, growing const). Every producer
+// (deliveryEnvelope.ts / subagentResults.ts / sanitizeTag.ts) only ever
+// follows a tag name with whitespace (attributes), `>` (bare open, e.g.
+// `<execution-activity>`), or `/` (self-closing `... />`), so anchor on that
+// explicit delimiter set instead.
+const TAG_NAME_END = '(?=[\\s/>])';
+const SUBAGENT_TAG_RE = new RegExp(
+  `^<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}`,
+);
 // Embedded-block variants of the same recognizer, for delivery-envelope
 // blocks that appear mid-stream inside assistant-role text rather than as a
 // standalone follow-up message (see findIncompleteEmbeddedSubagentFollowup /
@@ -37,11 +49,11 @@ const SUBAGENT_TAG_RE = new RegExp(`^<(${DELIVERY_TAG_ALTERNATION})\\b`);
 // `claude-agent-error`, and the rest of the non-`subagent-*` families leak as
 // raw XML when embedded (issue #7846, follow-up to #7679/#7788).
 const EMBEDDED_DELIVERY_BLOCK_RE = new RegExp(
-  `<(?:${DELIVERY_TAG_ALTERNATION})\\b[^>]*/>|<(${DELIVERY_TAG_ALTERNATION})\\b[^>]*>[\\s\\S]*?</\\1>`,
+  `<(?:${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}[^>]*/>|<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}[^>]*>[\\s\\S]*?</\\1>`,
   'g',
 );
 const EMBEDDED_DELIVERY_OPEN_RE = new RegExp(
-  `<(${DELIVERY_TAG_ALTERNATION})\\b[^>]*(?:/>|>)`,
+  `<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}[^>]*(?:/>|>)`,
   'g',
 );
 const EMPTY_FOLLOW_UP_SUMMARY = '(empty follow-up)';

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -27,11 +27,23 @@ import { DELIVERY_TAG, DELIVERY_TAGS } from '@shared/deliveryTags';
 // `claude-agent-result`/`claude-agent-error`/`codex-result`/`codex-error`
 // leak as raw XML into the CLI transcript and queued follow-ups panel.
 const DELIVERY_TAG_NAMES = DELIVERY_TAGS.map((entry) => entry.tag);
-const SUBAGENT_TAG_RE = new RegExp(`^<(${DELIVERY_TAG_NAMES.join('|')})\\b`);
-const EMBEDDED_SUBAGENT_BLOCK_RE =
-  /<subagent-(?:progress|result|error)\b[^>]*\/>|<subagent-(progress|result|error)\b[^>]*>[\s\S]*?<\/subagent-\1>/g;
-const EMBEDDED_SUBAGENT_OPEN_RE =
-  /<subagent-(progress|result|error)\b[^>]*(?:\/>|>)/g;
+const DELIVERY_TAG_ALTERNATION = DELIVERY_TAG_NAMES.join('|');
+const SUBAGENT_TAG_RE = new RegExp(`^<(${DELIVERY_TAG_ALTERNATION})\\b`);
+// Embedded-block variants of the same recognizer, for delivery-envelope
+// blocks that appear mid-stream inside assistant-role text rather than as a
+// standalone follow-up message (see findIncompleteEmbeddedSubagentFollowup /
+// summarizeEmbeddedSubagentFollowups below). Previously hard-coded to
+// `subagent-(?:progress|result|error)`, which let `codex-result`,
+// `claude-agent-error`, and the rest of the non-`subagent-*` families leak as
+// raw XML when embedded (issue #7846, follow-up to #7679/#7788).
+const EMBEDDED_DELIVERY_BLOCK_RE = new RegExp(
+  `<(?:${DELIVERY_TAG_ALTERNATION})\\b[^>]*/>|<(${DELIVERY_TAG_ALTERNATION})\\b[^>]*>[\\s\\S]*?</\\1>`,
+  'g',
+);
+const EMBEDDED_DELIVERY_OPEN_RE = new RegExp(
+  `<(${DELIVERY_TAG_ALTERNATION})\\b[^>]*(?:/>|>)`,
+  'g',
+);
 const EMPTY_FOLLOW_UP_SUMMARY = '(empty follow-up)';
 const RESULT_RESPONSE_PREVIEW_LINES = 12;
 const RESULT_RESPONSE_PREVIEW_CHARS = 1400;
@@ -225,10 +237,14 @@ type IncompleteEmbeddedSubagentFollowup = {
   readonly block: string;
 };
 
+function containsEmbeddedDeliveryTag(text: string): boolean {
+  return DELIVERY_TAG_NAMES.some((tag) => text.includes(`<${tag}`));
+}
+
 function findIncompleteEmbeddedSubagentFollowup(
   text: string,
 ): IncompleteEmbeddedSubagentFollowup | undefined {
-  for (const match of text.matchAll(EMBEDDED_SUBAGENT_OPEN_RE)) {
+  for (const match of text.matchAll(EMBEDDED_DELIVERY_OPEN_RE)) {
     const index = match.index;
     const tag = match[1];
     const opening = match[0];
@@ -236,7 +252,7 @@ function findIncompleteEmbeddedSubagentFollowup(
       continue;
     }
 
-    const closing = new RegExp(`</subagent-${tag}>`, 'g');
+    const closing = new RegExp(`</${tag}>`, 'g');
     closing.lastIndex = index + opening.length;
     if (!closing.exec(text)) {
       return { index, block: text.slice(index) };
@@ -247,15 +263,15 @@ function findIncompleteEmbeddedSubagentFollowup(
 
 export function hasIncompleteEmbeddedSubagentFollowup(text: string): boolean {
   return (
-    text.includes('<subagent-') &&
+    containsEmbeddedDeliveryTag(text) &&
     findIncompleteEmbeddedSubagentFollowup(text) !== undefined
   );
 }
 
 export function summarizeEmbeddedSubagentFollowups(text: string): string {
-  if (!text.includes('<subagent-')) return text;
+  if (!containsEmbeddedDeliveryTag(text)) return text;
   const completeSummarized = text.replaceAll(
-    EMBEDDED_SUBAGENT_BLOCK_RE,
+    EMBEDDED_DELIVERY_BLOCK_RE,
     (block) => summarizeSubagentFollowup(block),
   );
   const incomplete = findIncompleteEmbeddedSubagentFollowup(completeSummarized);

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -351,4 +351,25 @@ describe('summarizeSubagentFollowup', () => {
       'exec-1 (research, toolUse) running → completed',
     );
   });
+
+  // `\b` after the tag alternation is not a safe terminator: `-` is a
+  // non-word character, so a future hyphen-extended tag (e.g. a hypothetical
+  // `codex-result-partial`) would prefix-match the existing `codex-result`
+  // entry. No current DELIVERY_TAGS entry is a prefix of another, but the
+  // vocabulary is a shared, growing const, so the recognizers anchor on an
+  // explicit delimiter (whitespace, `/`, or `>`) instead of `\b`. This fake
+  // tag is constructed locally and must never be added to DELIVERY_TAGS.
+  it('does not prefix-match a hyphen-extended fake tag onto a real one', () => {
+    const standalone =
+      '<codex-result-partial id="abc"><response>fake</response></codex-result-partial>';
+    expect(summarizeSubagentFollowup(standalone)).toBe(standalone);
+
+    const embedded = [
+      'before',
+      '<codex-result-partial id="abc">',
+      'still streaming, not a real delivery tag',
+    ].join('\n');
+    expect(hasIncompleteEmbeddedSubagentFollowup(embedded)).toBe(false);
+    expect(summarizeEmbeddedSubagentFollowups(embedded)).toBe(embedded);
+  });
 });

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -149,6 +149,63 @@ describe('summarizeSubagentFollowup', () => {
     ).toBe(false);
   });
 
+  // Embedded-block recognizer (EMBEDDED_DELIVERY_BLOCK_RE /
+  // EMBEDDED_DELIVERY_OPEN_RE) is derived from the same DELIVERY_TAGS
+  // vocabulary as SUBAGENT_TAG_RE, not just `<subagent-*>` — regression
+  // coverage for a non-`subagent` family (`codex-result`) leaking as raw XML
+  // when embedded mid-stream in assistant text (issue #7846, follow-up to
+  // #7679/#7788).
+
+  it('summarizes an embedded codex-result block inside assistant text', () => {
+    const text = [
+      'before',
+      '<codex-result id="abc" thread-id="t1">',
+      '<wall-time>4sec</wall-time>',
+      '<response>Refactor complete.</response>',
+      '</codex-result>',
+      'after',
+    ].join('\n');
+    expect(summarizeEmbeddedSubagentFollowups(text)).toBe(
+      ['before', '✓ codex completed · 4sec\nRefactor complete.', 'after'].join(
+        '\n',
+      ),
+    );
+  });
+
+  it('summarizes an incomplete embedded codex-result block while streaming', () => {
+    const text = [
+      'before',
+      '<codex-result id="abc" thread-id="t1">',
+      'The response is still streaming.',
+    ].join('\n');
+
+    expect(summarizeEmbeddedSubagentFollowups(text)).toBe(
+      ['before', '✓ codex completed'].join('\n'),
+    );
+  });
+
+  it('detects incomplete embedded codex-result blocks', () => {
+    expect(
+      hasIncompleteEmbeddedSubagentFollowup(
+        [
+          'before',
+          '<codex-result id="abc" thread-id="t1">',
+          'The response is still streaming.',
+        ].join('\n'),
+      ),
+    ).toBe(true);
+    expect(
+      hasIncompleteEmbeddedSubagentFollowup(
+        [
+          'before',
+          '<codex-result id="abc" thread-id="t1">',
+          '<response>Done.</response>',
+          '</codex-result>',
+        ].join('\n'),
+      ),
+    ).toBe(false);
+  });
+
   it('summarizes a completed result with wall time and response', () => {
     const xml = [
       '<subagent-result id="abc" agent="research" category="toolUse" status="completed">',


### PR DESCRIPTION
## What / why

Follow-up to #7788 (fixes #7679 for the standalone-message path). `SUBAGENT_TAG_RE` / `summarizeSubagentFollowup` in `src/shared/subagentFollowup.ts` were widened to the full 11-tag `DELIVERY_TAGS` vocabulary, but the *embedded*-block family in the same file was still hard-coded to `subagent-(?:progress|result|error)`:

- `EMBEDDED_SUBAGENT_BLOCK_RE` / `EMBEDDED_SUBAGENT_OPEN_RE`
- the `` `</subagent-${tag}>` `` closing-tag lookup in `findIncompleteEmbeddedSubagentFollowup`
- the `text.includes('<subagent-')` fast-path guards in `hasIncompleteEmbeddedSubagentFollowup` / `summarizeEmbeddedSubagentFollowups`

Since `packages/cli/src/chat/tui/state/subscribeStreamLog.ts` routes every assistant-role transcript entry through these embedded-block helpers, a `<codex-result>` or `<claude-agent-result>` block embedded mid-stream (not just as a standalone follow-up message) leaked as raw XML in the CLI transcript and wasn't recognized as an in-flight pending block.

Fixes #7846.

## Changes

- `src/shared/subagentFollowup.ts`: derive the embedded-block regexes (renamed `EMBEDDED_DELIVERY_BLOCK_RE` / `EMBEDDED_DELIVERY_OPEN_RE` to reflect the widened scope) from the same `DELIVERY_TAG_NAMES` list `SUBAGENT_TAG_RE` already uses, via a new shared `DELIVERY_TAG_ALTERNATION` string (also de-duplicates the three separate `.join('|')` calls). The closing-tag lookup in `findIncompleteEmbeddedSubagentFollowup` now builds `` `</${tag}>` `` from the captured full tag name instead of hard-coding a `subagent-` prefix. Both fast-path `.includes('<subagent-')` guards are replaced by a small `containsEmbeddedDeliveryTag()` helper that checks all 11 tag names (used from the two call sites, satisfying the "called from multiple locations" bar for a new helper).
- `src/test-kernel/cli/SubagentFollowup.vitest.mts`: added embedded-block regression coverage for a non-`subagent` family (`codex-result`), mirroring the existing `<subagent-*>` embedded-block tests — complete block mid-text, incomplete/streaming block, and `hasIncompleteEmbeddedSubagentFollowup` detection.

## Net elements (R6)

- 2 new module-scope symbols in `subagentFollowup.ts`: `DELIVERY_TAG_ALTERNATION` (dedupes 3 existing `.join('|')` call sites) and `containsEmbeddedDeliveryTag()` (used from the 2 existing fast-path call sites, replacing a single-tag `.includes()` each). No new exported API, no new files.
- Renamed `EMBEDDED_SUBAGENT_BLOCK_RE`/`EMBEDDED_SUBAGENT_OPEN_RE` → `EMBEDDED_DELIVERY_BLOCK_RE`/`EMBEDDED_DELIVERY_OPEN_RE` (private, 3 in-file call sites) since they no longer only match `subagent-*`. Exported function/type names (`hasIncompleteEmbeddedSubagentFollowup`, `summarizeEmbeddedSubagentFollowups`, `findIncompleteEmbeddedSubagentFollowup`, `IncompleteEmbeddedSubagentFollowup`) left unchanged — they're consumed by `packages/cli/src/chat/tui/state/subscribeStreamLog.ts` and renaming would only add diff, not clarity.

## Consumer counts (R8)

n/a — no functions deleted or re-routed; this widens existing recognizer regexes/guards in place. The new `containsEmbeddedDeliveryTag()` helper has 2 callers (`hasIncompleteEmbeddedSubagentFollowup`, `summarizeEmbeddedSubagentFollowups`), both pre-existing call sites.

## Tests

`npx vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts` — 28 passed (25 existing + 3 new).

`npm run typecheck` — clean (see PR checks / session notes).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing/display logic in shared subagent follow-up helpers with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **embedded** delivery-envelope XML (e.g. `<codex-result>` mid-stream in assistant text) still showing as raw XML in the CLI transcript after standalone follow-ups were already widened to the full `DELIVERY_TAGS` list.
> 
> In `subagentFollowup.ts`, embedded-block regexes are now derived from the same `DELIVERY_TAG_NAMES` as `SUBAGENT_TAG_RE` (renamed to `EMBEDDED_DELIVERY_*`), closing tags use the captured full tag name instead of a hard-coded `subagent-` prefix, and fast-path checks use `containsEmbeddedDeliveryTag()` across all tags. Tag matching also uses an explicit delimiter lookahead (`(?=[\s/>])`) instead of `\b`, so hyphen-extended fake tag names cannot prefix-match real delivery tags.
> 
> Adds vitest coverage for embedded `codex-result` (complete, streaming, incomplete detection) and for rejecting a hypothetical `codex-result-partial` tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f8b3aadcdd94323d7abf9d9bb77f17c103b7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->