### PR TITLE
fix(desktop): gate theme/debug-mode readiness sync to the main webview

### DIFF
--- a/packages/desktop/src/main/desktopViewStateIpc.ts
+++ b/packages/desktop/src/main/desktopViewStateIpc.ts
@@ -56,9 +56,15 @@ export function createDesktopViewStateIpc(
   nativeTheme.on('updated', postTheme);
 
   const handler = createCommandHandler({
-    [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: () => {
-      postTheme();
-      postDebugMode();
+    // WEBVIEW_READY is a broadcast: sync theme/debug-mode only for the main
+    // webview, but return `false` so sibling handlers still receive it.
+    [MAIN_VIEW_COMMANDS.WEBVIEW_READY]: {
+      when: (message) => message.view === 'main',
+      run: () => {
+        postTheme();
+        postDebugMode();
+      },
+      claim: false,
     },
     [MAIN_VIEW_COMMANDS.GET_THEME]: () => postTheme(),
     [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]: () => postDebugMode(),

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -97,7 +97,9 @@ interface DesktopViewStateIpcModule {
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
     },
   ): {
-    handleMessage(message: { command: string }): boolean;
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean;
     dispose(): void;
   };
 }
@@ -206,9 +208,22 @@ describe('desktop IPC adapters', () => {
       { debugMode: true },
     );
 
+    // WEBVIEW_READY is a broadcast every webview posts on mount; only the
+    // main webview's readiness should sync theme/debug-mode here.
     expect(
-      stateIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY }),
-    ).toBe(true);
+      stateIpc.handleMessage({
+        command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'progress',
+      }),
+    ).toBe(false);
+    expect(postToRenderer).not.toHaveBeenCalled();
+
+    expect(
+      stateIpc.handleMessage({
+        command: MAIN_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'main',
+      }),
+    ).toBe(false);
     expect(postToRenderer).toHaveBeenCalledWith({
       command: COMMON_COMMANDS.THEME_SET,
       theme: 'dark',

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -214,9 +214,23 @@ describe('desktop main-view IPC', () => {
 
     rendererListener?.(
       { sender: webContents },
-      { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY },
+      { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY, view: 'progress' },
     );
-    expect(sends).toEqual([
+    expect(sends).toEqual([]);
+
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY, view: 'main' },
+    );
+    // Filter to the theme/debug-mode pushes: WEBVIEW_READY(view:'main') is a
+    // broadcast, so sibling handlers (e.g. main-view startup) also react.
+    expect(
+      sends.filter(({ message }) =>
+        [COMMON_COMMANDS.THEME_SET, COMMON_COMMANDS.DEBUG_MODE_SET].includes(
+          (message as { command?: string }).command as never,
+        ),
+      ),
+    ).toEqual([
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
         message: { command: COMMON_COMMANDS.THEME_SET, theme: 'dark' },


### PR DESCRIPTION
## What / why

Follow-up from #7812. That PR gated the desktop **progress**
`WEBVIEW_READY` handler on `message.view === 'progress'`, since desktop's
renderer posts one `WEBVIEW_READY` message per webview
(`packages/desktop/src/renderer/main.ts:809-810`: one `view: 'main'`, one
`view: 'progress'`). The PR's own review (`claude[bot]`) flagged that
`packages/desktop/src/main/desktopViewStateIpc.ts` has the same unguarded
pattern: its `MAIN_VIEW_COMMANDS.WEBVIEW_READY` handler unconditionally
called `postTheme()` / `postDebugMode()` for *every* readiness broadcast,
not just `view: 'main'`, so it double-fired on desktop boot.

Fixes #7820 by gating that handler on `message.view === 'main'`, matching
the pattern already used by `desktopMainViewStartup.ts`,
`desktopOnboardingIpc.ts`, and (as of #7812) `desktopProgressIpc.ts`.
`createCommandHandler`'s existing `when` guard (`desktopIpcTypes.ts`)
covers this — no new abstraction.

## Net elements (R6)

Net +0 abstractions. One handler entry changed from a bare function to the
existing `{ when, run, claim }` object form already used by three sibling
handlers for the identical `WEBVIEW_READY` broadcast-guard pattern.

## Consumer counts (R8)

n/a — no shared helper added, removed, or re-routed; only a call-site
literal changed shape (bare function → object form of the same
`CommandHandlerEntry` type already used elsewhere).

## Tests

Extended the existing coverage for this module (R7):

- `src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts` — direct unit
  test for `createDesktopViewStateIpc`: asserts `WEBVIEW_READY` with
  `view: 'progress'` is a no-op (returns `false`, no `postToRenderer`
  calls) and `view: 'main'` still syncs theme/debug-mode.
- `src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts` — full IPC-chain
  integration test: asserts a `view: 'progress'` `WEBVIEW_READY` produces
  no theme/debug-mode pushes, and a `view: 'main'` one still does (filtered
  from other sibling handlers' pushes on the same broadcast, since this is
  a full-chain test).
- Widened the `DesktopViewStateIpcModule` test-only type to
  `{ command: string } & Record<string, unknown>` (matching the sibling
  onboarding/execution module types already in the same file) so `view`
  type-checks on the test call sites.

## Verification

- `npx vitest run src/test-kernel/desktop/` — 41 files / 424 tests pass.
- `corepack pnpm --filter @texra/desktop typecheck` — clean.
- `npm run typecheck` (root, covers `src/` + test-kernel) — clean.
- `npx eslint` / `npx prettier --check` on changed files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small desktop IPC guard aligned with existing sibling handlers; no auth, data, or API surface changes.
> 
> **Overview**
> Desktop posts **`WEBVIEW_READY` once per webview** (`main` and `progress`). **`createDesktopViewStateIpc`** used to call **`postTheme()`** / **`postDebugMode()`** on every readiness message, so theme and debug-mode pushes **ran twice at boot**.
> 
> The **`WEBVIEW_READY`** handler now uses the existing **`{ when, run, claim: false }`** shape: it syncs only when **`message.view === 'main'`** and still **does not claim** the broadcast so other IPC handlers keep seeing the same message—same pattern as startup, onboarding, and progress handlers.
> 
> **Tests** assert **`view: 'progress'`** is a no-op for view-state sync and **`view: 'main'`** still pushes **`THEME_SET`** / **`DEBUG_MODE_SET`** (unit + full main-view IPC chain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac3925838badfb8dfe479fe4186d4cef3927a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->