### PR TITLE
fix(desktop): resolve revealStream category from persisted state, not session-only kind

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -14,6 +14,7 @@ import {
   type ProgressBackendInteractionPayloads,
 } from '@controllers/progressView/backend/events/ProgressInteractionHandler';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
+import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
 import { hydrateProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryHydration';
 import {
   buildApprovalRequestHandlerSet,
@@ -1087,14 +1088,19 @@ export class DesktopProgressBridge {
    * Mirrors the extension's `revealProgressStream` for the desktop Settings
    * Goals panel (issue #7751 FS6) so jumping from a goal entry to its owning
    * run works the same way on both hosts.
+   *
+   * Resolves category via `buildStreamInfo` (persisted config/hints), not
+   * `getStreamState()`'s ephemeral session-only kind, so a goal-owned stream
+   * restored from `workspaceState` that hasn't emitted a live fact yet this
+   * session still matches the current filter instead of unconditionally
+   * resetting it to 'all' (#7851).
    */
   revealStream(streamId: StreamTabId): void {
     if (!this.streamLogs.has(streamId)) {
       return;
     }
     const filter = this.state.agentCategoryFilter;
-    const category = this.state.getStreamState(streamId)?.kind;
-    if (filter !== 'all' && filter !== category) {
+    if (buildStreamInfo(this.state, streamId, filter) === null) {
       this.state.agentCategoryFilter = 'all';
     }
     this.routeToProgress();

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1821,6 +1821,48 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('revealStream keeps a matching filter for a restored stream with no live session facts yet (issue #7851)', async () => {
+    const messages: unknown[] = [];
+    // A goal-owned stream restored from persisted workspaceState at launch,
+    // via stream-snapshot hydration -- its category lives in persisted
+    // hints, not in any live session fact (none has been emitted yet this
+    // session, so `getStreamState(streamId)?.kind` is undefined).
+    const bridge = await createBridge(messages, {
+      streamSnapshotStore: createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId: 'ghost-tool-use-stream',
+          agentCategory: AgentCategory.ToolUse,
+        }),
+      ]),
+    });
+
+    try {
+      const filterStreams = assertSupported(
+        bridge.progressViewInboundHandlers[
+          PROGRESS_VIEW_COMMANDS.FILTER_STREAMS
+        ],
+      );
+      await filterStreams({
+        command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS,
+        filter: 'toolUse',
+      });
+      messages.length = 0;
+
+      bridge.revealStream('ghost-tool-use-stream');
+
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+          -1,
+        ),
+      ).toMatchObject({
+        activeStream: 'ghost-tool-use-stream',
+        agentFilter: 'toolUse',
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('restores a ghost stream display from shared streamData sidecars', async () => {
     const messages: unknown[] = [];
     const plan = {


### PR DESCRIPTION
## What / Why

Fixes #7851.

`DesktopProgressBridge.revealStream()` read `this.state.getStreamState(streamId)?.kind`
to decide whether to widen the current category filter — that map is
ephemeral, session-only state populated lazily only once a stream has
emitted a live fact this session. For a goal-owned stream restored from
persisted `workspaceState` that hasn't emitted any facts yet this session,
`category` read as `undefined`, so the filter-visibility check
unconditionally reset the filter to `'all'` even when the stream's real
(persisted) category already satisfied the current filter.

This aligns desktop's `revealStream` with the extension's
`ProgressViewProvider.revealStream`, which resolves category through
`buildStreamInfo` — reading persisted `AgentConfig`/hints instead of
live-session state — so the filter-widening check now returns the same
answer on both hosts for a stream that hasn't emitted a fact yet this
session.

Flagged by `claude[bot]`'s review during #7825 (not addressed before merge,
per the issue).

## Net elements (R6)

- +1 import (`buildStreamInfo`, already exported and used by the extension's
  equivalent — no new abstraction).
- Net function body: -1 line (one `getStreamState()` lookup + a 2-line
  condition collapse into a single `buildStreamInfo(...) === null` check,
  the same pattern `ProgressViewProvider.revealStream` already uses).
- +1 regression test.

## Consumer counts (R8)

n/a — no helper deleted or re-routed; `buildStreamInfo` already has two
call sites in the extension's `streamInfoUtils.ts` module plus its own
internal `buildStreamInfos`, and desktop's `this.state` is the same
host-neutral `ProgressViewState` type it already expects.

## Testing

- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` — 70/70 pass.
- New test `revealStream keeps a matching filter for a restored stream with no live session facts yet (issue #7851)` fails against the pre-fix code (`agentFilter: 'all'` instead of `'toolUse'`) and passes against the fix — verified by manually reverting the source change and re-running.
- `corepack pnpm --filter @texra/desktop typecheck` — clean.
- `npm run typecheck` (root: `src/` + test-kernel + CLI + extension + trace-viewer) — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in desktop progress navigation with extension parity and a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes **#7851**: when jumping from Goals to a run, desktop **`revealStream`** no longer widens the progress rail filter to **`all`** just because the stream has not emitted live session facts yet this launch.
> 
> **`DesktopProgressBridge.revealStream`** now uses **`buildStreamInfo`** (persisted run config / stream hints), matching the extension’s **`revealProgressStream`**, instead of **`getStreamState(streamId)?.kind`**, which stays empty for restored “ghost” streams until facts arrive. The filter is reset only when **`buildStreamInfo(..., filter) === null`** (stream does not match the active category).
> 
> Adds a regression test for a snapshot-hydrated **toolUse** stream with **`toolUse`** filter already set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab029c87467f37830bdeb9380c46dbc2d2a0955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->