### PR TITLE
fix(desktop): await restartRepair before checking streamLogs in revealStream

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1088,7 +1088,8 @@ export class DesktopProgressBridge {
    * Goals panel (issue #7751 FS6) so jumping from a goal entry to its owning
    * run works the same way on both hosts.
    */
-  revealStream(streamId: StreamTabId): void {
+  async revealStream(streamId: StreamTabId): Promise<void> {
+    await this.restartRepair;
     if (!this.streamLogs.has(streamId)) {
       return;
     }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -610,7 +610,7 @@ function createWindow(options: {
     revealStream: async (streamId) => {
       try {
         const execution = await getAgentExecution();
-        execution.progress.revealStream(streamId);
+        await execution.progress.revealStream(streamId);
       } catch (error) {
         if (!windowClosed) reportAsyncError(error);
       }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -75,7 +75,7 @@ type TestableBridge = Bridge & {
   syncFullView(): void;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   setActiveStream(streamId: StreamTabId): void;
-  revealStream(streamId: StreamTabId): void;
+  revealStream(streamId: StreamTabId): Promise<void>;
   deleteStream(streamId: StreamTabId): Promise<void>;
   deleteAllStreams(): Promise<void>;
   progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
@@ -189,6 +189,8 @@ type CreateBridgeOptions = {
   kvRead?: (key: string) => Promise<unknown> | unknown;
   /** Forces `state.streamLogs.load()` to reject, to exercise the restart-repair fallback (catch) path. */
   streamLogsLoadError?: Error;
+  /** Delays `state.streamLogs.load()`'s directory scan until this resolves, to exercise the narrow startup window before restart repair has populated `streamLogs` (issue #7850). */
+  streamLogsLoadGate?: Promise<void>;
   retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
@@ -330,6 +332,9 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
       async listKeys(): Promise<string[]> {
         if (options.streamLogsLoadError && this.dir === STREAM_LOGS_DIR) {
           throw options.streamLogsLoadError;
+        }
+        if (options.streamLogsLoadGate && this.dir === STREAM_LOGS_DIR) {
+          await options.streamLogsLoadGate;
         }
         if (!options.kvStoreBacking) return [];
         const prefix = `${this.dir}/`;
@@ -1783,7 +1788,7 @@ describe('DesktopProgressBridge', () => {
       });
       messages.length = 0;
 
-      bridge.revealStream('goal-owning-stream');
+      await bridge.revealStream('goal-owning-stream');
 
       expect(messages).toContainEqual({
         command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
@@ -1813,10 +1818,67 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages);
 
     try {
-      bridge.revealStream('missing-goal-stream');
+      await bridge.revealStream('missing-goal-stream');
 
       expect(messages).toEqual([]);
     } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('waits for desktop startup repair before revealing a goal-owned stream (issue #7850)', async () => {
+    // Regression test: revealStream() used to check streamLogs.has()
+    // synchronously, before streamLogs.load() (which only resolves inside
+    // restartRepair) had populated it. A goal-owned stream restored from a
+    // prior session would look "unknown" during that narrow startup window
+    // and reveal would silently no-op. Gate the on-disk stream-log scan and
+    // assert reveal does not route until restartRepair (and thus the load)
+    // has actually completed.
+    let finishStreamLogsLoad!: () => void;
+    const streamLogsLoadGate = new Promise<void>((resolve) => {
+      finishStreamLogsLoad = resolve;
+    });
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages, {
+      streamLogsLoadGate,
+      kvStoreBacking: new Map<string, unknown>([
+        [
+          `${STREAM_LOGS_DIR}/goal-owning-stream`,
+          [
+            {
+              id: 'entry-1',
+              text: 'restored from a prior session',
+              level: LOG_LEVELS.INFO,
+              timestamp: Date.now(),
+            },
+          ],
+        ],
+      ]),
+    });
+
+    try {
+      const revealPromise = bridge.revealStream('goal-owning-stream');
+
+      // streamLogs.load() is still gated, so the stream has not been
+      // repaired into this window's streamLogs yet.
+      await settleProgressEvents();
+      expect(messages).toEqual([]);
+
+      finishStreamLogsLoad();
+      await revealPromise;
+
+      expect(messages).toContainEqual({
+        command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+        route: 'progress',
+      });
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
+      ).toContainEqual({
+        activeStream: 'goal-owning-stream',
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      });
+    } finally {
+      finishStreamLogsLoad();
       bridge.dispose();
     }
   });


### PR DESCRIPTION
## What / Why

Fixes #7850.

`DesktopProgressBridge.revealStream()` (`packages/desktop/src/main/desktopAgentExecution.ts`) checked `this.streamLogs.has(streamId)` synchronously before routing, but `streamLogs.load()` only resolves inside `repairOrphanedStreamsAfterRestart()` (the promise stored as `this.restartRepair`). Every other stream-touching entry point in the same class — `tryResumeStream`, `sendFollowUp`, `runExecution` — already awaits `this.restartRepair` first for exactly this reason. A goal-owned `streamId` restored from `GoalStore`/`workspaceState` after a fresh app launch can reference a prior-session run that this window hasn't repaired into `streamLogs` yet, so a user opening Settings and clicking "reveal" during that narrow startup window got a silent no-op instead of navigating to progress.

This was flagged by `claude[bot]`'s review during #7825 (unresolved thread, not addressed before merge).

Fix: make `revealStream` `async` and `await this.restartRepair` before the `streamLogs.has()` check, threading the `await` through `index.ts`'s `revealStream` IPC callback. `desktopSettingsIpc.ts`'s `options.revealStream` was already typed and plumbed as `Promise<void>` (`options.revealStream?.(streamId) ?? Promise.resolve()`), so no change was needed there — it already forwards whatever promise `index.ts` now properly awaits.

## Net elements (R6)

Net +0 abstractions. One method signature change (`void` → `async ... Promise<void>`) plus one `await` added at its single caller in `index.ts`. No new types, wrappers, or indirection layers.

## Consumer counts (R8)

n/a — no code deleted or re-routed; this only adds an `await` to an existing call chain (`revealStream` has exactly one production caller: `index.ts`'s `revealStream` IPC handler, which in turn is the sole target of `desktopSettingsIpc.ts`'s `options.revealStream`).

## Tests

- Extended `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`:
  - Updated the two existing `revealStream` tests to `await` the now-async call.
  - Added `waits for desktop startup repair before revealing a goal-owned stream (issue #7850)`: gates the on-disk stream-log directory scan (new `streamLogsLoadGate` test option, mirroring the existing `streamLogsLoadError` option) behind a controllable promise, seeds a persisted stream-log entry for a goal-owned stream, and asserts `revealStream()` does not route until the gate — and therefore `restartRepair` — resolves. Verified this test fails (no route message emitted) against the pre-fix code and passes after the fix.
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts` — 112 passed.
- `npx vitest run src/test-kernel/desktop/` (full desktop test-kernel suite) — 425 passed, 41 files.
- `npx tsc --noEmit` (root) — clean.
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- `corepack pnpm --filter @texra/desktop typecheck` — clean.
- `npx eslint` on the three changed files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow timing fix on an existing navigation path; behavior unchanged once startup repair has finished.
> 
> **Overview**
> Fixes a **silent no-op** when revealing a goal-owned run from Settings right after launch: `revealStream` used to call `streamLogs.has(streamId)` before startup **restart repair** finished loading persisted stream logs.
> 
> **`DesktopProgressBridge.revealStream`** is now `async`, **`await`s `this.restartRepair`** (same pattern as `tryResumeStream`, `sendFollowUp`, and `runExecution`), then routes to progress and selects the stream. The **`index.ts` Settings IPC** handler awaits that promise.
> 
> Tests add a **`streamLogsLoadGate`** fixture and a regression case that proves reveal does not navigate until repair completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee8ade1741502211e3ccef546cf20d6e959a305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->