### PR TITLE
fix(extension): package bundled skills in VSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Extension (VS Code)
+
+#### Bug Fixes
+
+- **Bundled skills are available in installed extensions** — VSIX packages now
+  include the built-in skill definitions, so enabling runtime skills exposes
+  the same bundled catalog in installed extensions as in development.
+
 ### Shared (all surfaces)
 
 #### Bug Fixes

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -49,7 +49,6 @@ CLAUDE.md
 # other resources/* entry (agents, docs, examples, templates, ...) is already
 # included by default with no unignore needed at all.
 resources/traceViewer/**
-!resources/skills/**
 
 # Webview HTML entry points (loaded by BaseViewContentProvider)
 !src/webview/*.html

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -49,6 +49,7 @@ CLAUDE.md
 # other resources/* entry (agents, docs, examples, templates, ...) is already
 # included by default with no unignore needed at all.
 resources/traceViewer/**
+!resources/skills/**
 
 # Webview HTML entry points (loaded by BaseViewContentProvider)
 !src/webview/*.html

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1884,55 +1884,55 @@
     "chatSkills": [
       {
         "name": "inline-paper-critic",
-        "path": "../../skills/inline-paper-critic"
+        "path": "resources/skills/inline-paper-critic"
       },
       {
         "name": "lean-blueprint",
-        "path": "../../skills/lean-blueprint"
+        "path": "resources/skills/lean-blueprint"
       },
       {
         "name": "lean-proof-assistant",
-        "path": "../../skills/lean-proof-assistant"
+        "path": "resources/skills/lean-proof-assistant"
       },
       {
         "name": "lean-search",
-        "path": "../../skills/lean-search"
+        "path": "resources/skills/lean-search"
       },
       {
         "name": "lean-simplifier",
-        "path": "../../skills/lean-simplifier"
+        "path": "resources/skills/lean-simplifier"
       },
       {
         "name": "literature-search",
-        "path": "../../skills/literature-search"
+        "path": "resources/skills/literature-search"
       },
       {
         "name": "manuscript-review",
-        "path": "../../skills/manuscript-review"
+        "path": "resources/skills/manuscript-review"
       },
       {
         "name": "math-ocr",
-        "path": "../../skills/math-ocr"
+        "path": "resources/skills/math-ocr"
       },
       {
         "name": "mathematical-enhancer",
-        "path": "../../skills/mathematical-enhancer"
+        "path": "resources/skills/mathematical-enhancer"
       },
       {
         "name": "scientific-presenter",
-        "path": "../../skills/scientific-presenter"
+        "path": "resources/skills/scientific-presenter"
       },
       {
         "name": "scientific-simplifier",
-        "path": "../../skills/scientific-simplifier"
+        "path": "resources/skills/scientific-simplifier"
       },
       {
         "name": "tikz-figure-builder",
-        "path": "../../skills/tikz-figure-builder"
+        "path": "resources/skills/tikz-figure-builder"
       },
       {
         "name": "writing-commenter",
-        "path": "../../skills/writing-commenter"
+        "path": "resources/skills/writing-commenter"
       }
     ]
   },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1884,55 +1884,55 @@
     "chatSkills": [
       {
         "name": "inline-paper-critic",
-        "path": "resources/skills/inline-paper-critic"
+        "path": "resources/skills/inline-paper-critic/SKILL.md"
       },
       {
         "name": "lean-blueprint",
-        "path": "resources/skills/lean-blueprint"
+        "path": "resources/skills/lean-blueprint/SKILL.md"
       },
       {
         "name": "lean-proof-assistant",
-        "path": "resources/skills/lean-proof-assistant"
+        "path": "resources/skills/lean-proof-assistant/SKILL.md"
       },
       {
         "name": "lean-search",
-        "path": "resources/skills/lean-search"
+        "path": "resources/skills/lean-search/SKILL.md"
       },
       {
         "name": "lean-simplifier",
-        "path": "resources/skills/lean-simplifier"
+        "path": "resources/skills/lean-simplifier/SKILL.md"
       },
       {
         "name": "literature-search",
-        "path": "resources/skills/literature-search"
+        "path": "resources/skills/literature-search/SKILL.md"
       },
       {
         "name": "manuscript-review",
-        "path": "resources/skills/manuscript-review"
+        "path": "resources/skills/manuscript-review/SKILL.md"
       },
       {
         "name": "math-ocr",
-        "path": "resources/skills/math-ocr"
+        "path": "resources/skills/math-ocr/SKILL.md"
       },
       {
         "name": "mathematical-enhancer",
-        "path": "resources/skills/mathematical-enhancer"
+        "path": "resources/skills/mathematical-enhancer/SKILL.md"
       },
       {
         "name": "scientific-presenter",
-        "path": "resources/skills/scientific-presenter"
+        "path": "resources/skills/scientific-presenter/SKILL.md"
       },
       {
         "name": "scientific-simplifier",
-        "path": "resources/skills/scientific-simplifier"
+        "path": "resources/skills/scientific-simplifier/SKILL.md"
       },
       {
         "name": "tikz-figure-builder",
-        "path": "resources/skills/tikz-figure-builder"
+        "path": "resources/skills/tikz-figure-builder/SKILL.md"
       },
       {
         "name": "writing-commenter",
-        "path": "resources/skills/writing-commenter"
+        "path": "resources/skills/writing-commenter/SKILL.md"
       }
     ]
   },

--- a/packages/extension/resources/skills/inline-paper-critic/SKILL.md
+++ b/packages/extension/resources/skills/inline-paper-critic/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: inline-paper-critic
+description: Critically annotate technical papers with inline comments about mathematical gaps, unjustified steps, risky assumptions, and verified results. Use when Codex needs to leave compile-safe review comments directly in a LaTeX manuscript, especially in a `\\criticize{comment}{severity}{confidence}` style for derivation-heavy papers where appendices and hidden calculations must be checked carefully.
+---
+
+# Inline Paper Critic
+
+## When to use this skill
+
+Use this skill for inline technical review of mathematical or derivation-heavy papers when the output should be comments embedded in the manuscript rather than a separate review memo.
+
+## Workflow
+
+1. Read the entire manuscript, including appendices and auxiliary files, before deciding that a step is missing or unjustified.
+2. Expand important derivations mentally or on scratch paper before commenting. A good inline critique should come from actual verification, not surface-level suspicion.
+3. Prioritize issues that affect validity: broken proofs, missing essential steps, unjustified coefficients, hidden assumptions, incorrect limits, or inconsistent claims.
+4. If a derivation is already handled in an appendix, say so and adjust severity accordingly rather than treating the main text as simply wrong.
+5. When the document already uses a `\criticize{comment}{severity}{confidence}`-style macro, preserve that format. Otherwise adapt to the local inline annotation convention without losing the same discipline.
+6. If the macro is missing, provide a minimal command definition before inserting annotations:
+
+   ```latex
+   \newcommand{\criticize}[3]{\textcolor{red}{\textbf{[#2|#3]} #1}}
+   ```
+
+   Keep the document's existing color/theme conventions when present.
+
+7. Use inline comments strategically. Group related minor issues and reserve the harshest comments for problems that really threaten the result.
+8. When a calculation checks out, leave explicit verification comments when that helps the author distinguish true problems from confirmed material.
+9. Ensure every inline comment is valid LaTeX and can remain in the document without breaking compilation.
+
+## Quality Bar
+
+- Check appendices before accusing the paper of omission.
+- Base comments on actual mathematical verification whenever possible.
+- Use severity and confidence consistently; do not inflate comments just to sound forceful.
+- Treat severity as impact on validity and confidence as certainty of the diagnosis, not as two versions of the same number.
+- A compile-safe inline review comment is better than a sharper comment that breaks the document.
+- If you verified something as correct, say what you checked.
+
+For a deeper pass over severity discipline, appendix-first review, and compile-safe comment writing, use [references/critique-checklist.md](references/critique-checklist.md).

--- a/packages/extension/resources/skills/inline-paper-critic/agents/openai.yaml
+++ b/packages/extension/resources/skills/inline-paper-critic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Inline Paper Critic'
+  short_description: 'Annotate math papers with technical critique'
+  default_prompt: 'Use $inline-paper-critic to leave compile-safe inline comments on the technical problems and verified results in this manuscript.'

--- a/packages/extension/resources/skills/inline-paper-critic/references/critique-checklist.md
+++ b/packages/extension/resources/skills/inline-paper-critic/references/critique-checklist.md
@@ -1,0 +1,40 @@
+# Critique Checklist
+
+Use this checklist for inline technical criticism of a manuscript.
+
+## Verification before criticism
+
+- Check appendices and supplementary derivations before claiming something is missing.
+- Work through the calculation or proof enough to know whether the issue is real.
+- Distinguish a missing explanation from an actual mathematical error.
+
+## What to comment on
+
+- Broken proofs or unjustified logical steps
+- Missing derivation steps that matter for validity
+- Unjustified coefficients, assumptions, or approximations
+- Contradictions between text, equations, and claimed results
+- Verified calculations that are worth marking as checked
+
+## Severity and confidence
+
+- Reserve the highest severity for issues that endanger the main claim.
+- Use lower severity for exposition or local cleanup.
+- Keep confidence separate from severity; an alarming but uncertain issue should say so.
+- If using a `\criticize{...}{severity}{confidence}` scheme, keep the comment text self-contained and specific enough to survive outside the conversation.
+
+## Typical scale
+
+- Severity 5: invalidates a central claim or proof
+- Severity 4: seriously weakens a major argument
+- Severity 3: important but not fatal gap or inconsistency
+- Severity 2: local but worthwhile fix
+- Severity 1: cosmetic or low-impact cleanup
+
+## LaTeX safety
+
+- Write inline comments that compile cleanly.
+- Use proper math mode, escaped special characters, and reference syntax.
+- If `\criticize` is undefined, add a minimal macro such as
+  `\newcommand{\criticize}[3]{\textcolor{red}{\textbf{[#2|#3]} #1}}` and match local style conventions.
+- Prefer fewer precise comments over many noisy ones.

--- a/packages/extension/resources/skills/lean-blueprint/SKILL.md
+++ b/packages/extension/resources/skills/lean-blueprint/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: lean-blueprint
+description: Create and maintain Lean blueprint documents that connect informal mathematics to Lean 4 formalization. Use when Codex needs to draft or sync blueprint entries, map paper results to Lean declarations, track dependencies between statements, or keep blueprint prose aligned with a changing Lean codebase.
+---
+
+# Lean Blueprint
+
+## When to use this skill
+
+Use this skill for blueprint authoring and maintenance: writing new dependency-tracked blueprint content, syncing an existing blueprint with Lean declarations, or translating Lean formalization progress into human-readable mathematical prose.
+
+## Workflow
+
+1. Survey the Lean project and the existing blueprint files before writing anything. Understand the mathematical architecture and the current formalization status first.
+2. Build or repair the dependency graph from the main results backward. Each node should be a meaningful unit of work for a contributor.
+3. Use the blueprint macros deliberately:
+   - `\lean{Namespace.decl}` to link to Lean declarations
+   - `\leanok` only when the declaration is actually formalized and clean
+   - `\uses{label1,label2}` for dependency tracking
+   - `\notready` for items that still need blueprint work
+   - `\proves{label}` when a proof block is separated from its statement
+4. Write blueprint prose as mathematics, not as disguised Lean syntax. Use conventional notation and let the Lean linkage live in the explicit blueprint macros.
+5. When a declaration exists, verify its name, status, and statement before marking blueprint entries as formalized.
+6. Keep blueprint statements, proof sketches, and dependency annotations synchronized with the real Lean codebase.
+7. Check for drift in both directions: Lean declarations missing from the blueprint, and blueprint entries that no longer match Lean.
+8. Treat the blueprint as a human coordination document first and a status mirror second.
+
+## Quality Bar
+
+- Blueprint prose should read like normal mathematical writing.
+- Never let Lean identifiers leak into the prose body when standard notation exists.
+- Dependencies should be explicit and accurate enough to support parallel work.
+- Formalized status markers should reflect reality, not aspiration.
+- Statement mismatches between blueprint and Lean are real bugs, not cosmetic issues.
+- A reader should be able to understand the mathematical roadmap without reading Lean source first.
+
+For new blueprint skeletons or drift audits, use [references/blueprint-checklist.md](references/blueprint-checklist.md) to check dependency tracking, statement syncing, and notation translation.

--- a/packages/extension/resources/skills/lean-blueprint/agents/openai.yaml
+++ b/packages/extension/resources/skills/lean-blueprint/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Lean Blueprint'
+  short_description: 'Write and sync Lean blueprints'
+  default_prompt: 'Use $lean-blueprint to draft or sync this blueprint against the current Lean project.'

--- a/packages/extension/resources/skills/lean-blueprint/references/blueprint-checklist.md
+++ b/packages/extension/resources/skills/lean-blueprint/references/blueprint-checklist.md
@@ -1,0 +1,28 @@
+# Lean Blueprint Checklist
+
+Use this checklist when authoring or syncing a blueprint against a Lean project.
+
+## Project survey
+
+- Read both the blueprint files and the Lean declarations they reference.
+- Identify the main results, the dependency DAG, and the current formalization status.
+
+## Writing
+
+- Write the prose as standard mathematics, not as Lean syntax with punctuation.
+- Use conventional notation whenever possible.
+- Keep proof sketches strategic and human-readable.
+- Use the explicit blueprint macros consistently: `\lean`, `\leanok`, `\uses`, `\notready`, and `\proves` when appropriate.
+
+## Syncing
+
+- Verify each linked Lean declaration still exists and still states the same mathematics.
+- Update formalization-status markers only after checking the real code.
+- Check for declaration drift in both directions: missing blueprint entries and stale references.
+- Check that the informal blueprint statement still matches the Lean theorem mathematically, not just by name.
+
+## Dependencies
+
+- Keep dependency annotations explicit and accurate.
+- Remove spurious dependencies that hide parallelism.
+- Flag circular mathematical dependencies, not just syntactic graph issues.

--- a/packages/extension/resources/skills/lean-proof-assistant/SKILL.md
+++ b/packages/extension/resources/skills/lean-proof-assistant/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: lean-proof-assistant
+description: Develop and debug Lean 4 proofs in project context. Use when Codex needs to understand a theorem, inspect goals, search for supporting lemmas, write or repair Lean proof terms or tactic scripts, and iterate with diagnostics until the file is clean.
+---
+
+# Lean Proof Assistant
+
+## When to use this skill
+
+Use this skill for day-to-day Lean 4 proof development: proving lemmas, debugging errors, filling gaps, inspecting goals, or turning an informal proof outline into working Lean code.
+
+## Workflow
+
+1. Read the target file and surrounding declarations before editing. Understand the theorem statement, available hypotheses, and local notation.
+2. Check the current diagnostics first. Let the elaborator tell you what is actually wrong before you guess.
+3. Outline the proof strategy informally before writing code when the theorem is nontrivial.
+4. Search for existing lemmas and APIs before inventing helper lemmas or long tactic scripts.
+5. Work in small iterations: edit one proof step, recheck, inspect the new goal state, and continue.
+6. Prefer clear proof structure over brittle wizardry. Use the tactic or term style that makes the mathematical idea easiest to review.
+7. Finish by making the file clean: no broken goals, no stale debugging commands, no accidental scaffolding left behind.
+
+## Quality Bar
+
+- Do not fight the goal blindly. Inspect the precise goal and local context after each meaningful step.
+- Prefer existing Mathlib lemmas over reproving folklore.
+- Keep proofs readable enough that another formalizer can maintain them.
+- Treat diagnostics as ground truth.
+- If a proof attempt becomes opaque or fragile, back up and choose a clearer route.
+
+For stuck proofs or longer debugging sessions, use [references/proof-workflow.md](references/proof-workflow.md) for a stricter loop around search, inspection, iteration, and cleanup.

--- a/packages/extension/resources/skills/lean-proof-assistant/agents/openai.yaml
+++ b/packages/extension/resources/skills/lean-proof-assistant/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Lean Proof Assistant'
+  short_description: 'Develop and debug Lean proofs'
+  default_prompt: 'Use $lean-proof-assistant to prove or repair this Lean theorem and iterate until the file is clean.'

--- a/packages/extension/resources/skills/lean-proof-assistant/references/proof-workflow.md
+++ b/packages/extension/resources/skills/lean-proof-assistant/references/proof-workflow.md
@@ -1,0 +1,23 @@
+# Lean Proof Workflow
+
+Use this checklist when proof development is stuck or the file needs a disciplined debugging loop.
+
+## Core loop
+
+- Read the theorem statement and nearby lemmas first.
+- Check diagnostics before guessing.
+- Inspect the exact goal and local hypotheses after each meaningful step.
+- Edit in small increments and recheck immediately.
+
+## Search and proof strategy
+
+- Search for existing lemmas before proving helpers.
+- Try both type-shape and name-based searches.
+- Prefer clear proof structure over long fragile tactic chains.
+- Use the tactic family that matches the goal shape instead of forcing one hammer everywhere.
+
+## Cleanup
+
+- Remove stale debugging commands and temporary scaffolding.
+- Keep the final proof readable enough for another contributor to maintain.
+- Leave the file with clean diagnostics.

--- a/packages/extension/resources/skills/lean-search/SKILL.md
+++ b/packages/extension/resources/skills/lean-search/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: lean-search
+description: Find existing Lean 4 and Mathlib lemmas, APIs, imports, and formalization patterns. Use when Codex needs to answer whether a result already exists, locate the right theorem or module, understand how Mathlib formalizes a concept, or avoid duplicate formalization work.
+---
+
+# Lean Search
+
+## When to use this skill
+
+Use this skill when the main job is discovery rather than proving: find the right lemma, import, namespace, declaration name, or formalization pattern before writing code.
+
+## Workflow
+
+1. Start from the mathematical content, not from a guessed theorem name.
+2. Search broadly and iteratively. Try multiple surfaces before concluding something is missing: type-shape search, name-pattern search, source grep, module-path discovery, and docs or community references.
+3. Read the actual source around promising hits. The surrounding lemmas and proof patterns often matter more than the first exact match.
+4. Distinguish exact matches, adaptable near-matches, and genuinely missing API.
+5. When something appears missing, say where it would likely belong and what the most general statement should be.
+6. Report enough metadata to make the result usable immediately: full name, import path, statement shape, and any caveats.
+7. Show your search process briefly so another formalizer can trust the conclusion and continue from it.
+
+## Quality Bar
+
+- Prevent duplicate work whenever possible.
+- Do not stop after one search method fails.
+- Prefer Mathlib's general result over a project-specific reproving of the same fact.
+- Show what you searched and what you found so the answer is auditable.
+- When uncertain, provide the best nearby API and explain the gap.
+
+For hard-to-find results, use [references/search-playbook.md](references/search-playbook.md) to run a more disciplined search across theorem names, type shapes, source files, and import paths.

--- a/packages/extension/resources/skills/lean-search/agents/openai.yaml
+++ b/packages/extension/resources/skills/lean-search/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Lean Search'
+  short_description: 'Find Mathlib lemmas and imports'
+  default_prompt: 'Use $lean-search to find the right Mathlib lemmas, imports, and formalization pattern for this statement.'

--- a/packages/extension/resources/skills/lean-search/references/search-playbook.md
+++ b/packages/extension/resources/skills/lean-search/references/search-playbook.md
@@ -1,0 +1,23 @@
+# Lean Search Playbook
+
+Use this playbook when the first obvious search attempt does not find the right API.
+
+## Search order
+
+- Start with type-shape or theorem-name search.
+- Search Mathlib source directly when local packages are available.
+- Read surrounding source, not just isolated hits.
+- Check docs or community references when the local codebase is inconclusive.
+- Do not conclude “missing” after a single failed query; reformulate the statement and search again.
+
+## Reporting results
+
+- Distinguish exact match, near match, and missing result.
+- Include the full declaration name and import path.
+- Explain how a near match needs to be adapted.
+
+## Missing-lemma cases
+
+- Say why the result appears absent.
+- Suggest the likely general statement.
+- Suggest where such a lemma would naturally live.

--- a/packages/extension/resources/skills/lean-simplifier/SKILL.md
+++ b/packages/extension/resources/skills/lean-simplifier/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: lean-simplifier
+description: Refactor Lean 4 code and proofs toward Mathlib-quality style without changing theorem statements or computational meaning. Use when Codex needs to simplify tactic scripts, generalize declarations, improve naming and organization, remove duplication, or make Lean code cleaner and more upstream-ready.
+---
+
+# Lean Simplifier
+
+## When to use this skill
+
+Use this skill when Lean code already works or nearly works, but it is noisy, repetitive, overly specialized, poorly named, or farther from Mathlib style than it should be.
+
+## Workflow
+
+1. Read the file as a whole before changing local proofs. Many style and generality problems only make sense at file scope.
+2. Check diagnostics first so you know whether you are simplifying a clean file or repairing active breakage.
+3. Preserve meaning exactly: theorem statements, definitions, and computed behavior should not change.
+4. Improve the file in the order that usually pays off most: naming and organization, import hygiene, docstrings, proof cleanup, then generalization and deduplication.
+5. Replace brittle tactic chains with clearer arguments when that actually improves reviewability.
+6. Search Mathlib before keeping local lemmas that smell standard.
+7. Recheck after each logical edit and revert any “simplification” that makes the code harder to trust.
+
+## Quality Bar
+
+- Target Mathlib-quality readability, not just shorter code.
+- Prefer the weakest useful assumptions and the most general reusable statement.
+- Do not over-generalize just for aesthetics.
+- Remove debugging leftovers, dead code, and sorry-driven scaffolding.
+- A shorter proof is worse if it becomes opaque.
+
+For serious cleanup or upstream preparation, use [references/simplifier-checklist.md](references/simplifier-checklist.md) to review style, generality, proof cleanup, and lint-facing details.

--- a/packages/extension/resources/skills/lean-simplifier/agents/openai.yaml
+++ b/packages/extension/resources/skills/lean-simplifier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Lean Simplifier'
+  short_description: 'Refactor Lean code toward Mathlib style'
+  default_prompt: 'Use $lean-simplifier to clean up this Lean file without changing what its declarations mean.'

--- a/packages/extension/resources/skills/lean-simplifier/references/simplifier-checklist.md
+++ b/packages/extension/resources/skills/lean-simplifier/references/simplifier-checklist.md
@@ -1,0 +1,27 @@
+# Lean Simplifier Checklist
+
+Use this checklist for deeper cleanup passes aimed at Mathlib-quality code.
+
+## Style and organization
+
+- Keep imports minimal and organized.
+- Use consistent naming that follows Mathlib patterns.
+- Add or improve docstrings for public declarations.
+- Group related declarations and remove dead fragments.
+
+## Proof cleanup
+
+- Replace brittle chains with clearer arguments when possible.
+- Prefer `calc`, well-scoped `simp`, and direct structure over clutter.
+- Avoid shortening proofs at the cost of readability.
+
+## Generality and reuse
+
+- Use the weakest useful assumptions.
+- Merge true duplicates through generalization when it simplifies the API.
+- Search Mathlib before retaining project-local copies of standard results.
+
+## Verification
+
+- Re-run diagnostics after each logical edit.
+- Revert any refactor that introduces new breakage or obscures the argument.

--- a/packages/extension/resources/skills/literature-search/SKILL.md
+++ b/packages/extension/resources/skills/literature-search/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: literature-search
+description: Discover, verify, and synthesize academic literature and web sources for research tasks. Use when Codex needs to find recent papers, trace citations, compare preprints with published versions, verify attributed claims, or build a source-backed literature summary with primary references.
+---
+
+# Literature Search
+
+## When to use this skill
+
+Use this skill for related-work searches, citation verification, research briefings, source-backed summaries, and claim checking across papers, arXiv, DOIs, and the open web.
+
+## Workflow
+
+1. Start from the actual question. Identify the topic, time window, field, and whether the user wants breadth, depth, recency, or verification.
+2. Prefer primary sources. Use publisher pages, DOI metadata, arXiv records, official project pages, and original papers before secondary summaries.
+3. Distinguish source types clearly: peer-reviewed publication, preprint, project page, documentation, benchmark site, or news coverage.
+4. Capture bibliographic facts while searching: title, authors, venue, year, DOI, arXiv ID, and URL.
+5. Cross-check important claims across more than one source when possible, especially for dates, quantitative results, and priority claims.
+6. For literature reviews, group findings by theme or method rather than presenting an unstructured list.
+7. When the user needs a recommendation or synthesis, explain the tradeoffs and evidence rather than only listing papers.
+
+## Quality Bar
+
+- Do not present unverified claims as settled fact.
+- Prefer the latest authoritative version when preprint and journal versions differ.
+- Keep citation details precise enough that a researcher can find the source immediately.
+- Separate what a paper claims from what you infer from it.
+- Note recency explicitly when the topic is moving quickly.
+
+For a deeper evaluation pass, use [references/source-evaluation.md](references/source-evaluation.md) when comparing conflicting sources, building a formal literature review, or checking whether a citation really supports a claim.

--- a/packages/extension/resources/skills/literature-search/agents/openai.yaml
+++ b/packages/extension/resources/skills/literature-search/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Literature Search'
+  short_description: 'Find and verify research sources'
+  default_prompt: 'Use $literature-search to find the most relevant papers and verify the key claims for this topic.'

--- a/packages/extension/resources/skills/literature-search/references/source-evaluation.md
+++ b/packages/extension/resources/skills/literature-search/references/source-evaluation.md
@@ -1,0 +1,25 @@
+# Source Evaluation Checklist
+
+Use this file when the search result needs to be rigorous, citable, or recommendation-grade.
+
+## Source hierarchy
+
+- Prefer original papers, publisher pages, official documentation, and project pages.
+- Treat news posts, blogs, and summaries as secondary context unless the user explicitly wants them.
+
+## Verification
+
+- Confirm title, authors, year, venue, DOI, and arXiv ID.
+- Check whether the paper version you cite is a preprint or a peer-reviewed publication.
+- When a claim matters, verify that the cited source really supports it.
+
+## Synthesis
+
+- Group papers by method, question, or result rather than listing them chronologically.
+- Separate what the source states from your own inference.
+- Note disagreement, uncertainty, or version drift explicitly.
+
+## Recency
+
+- State dates for fast-moving topics.
+- Prefer the most recent authoritative source when multiple versions exist.

--- a/packages/extension/resources/skills/manuscript-review/SKILL.md
+++ b/packages/extension/resources/skills/manuscript-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: manuscript-review
+description: Audit technical manuscripts for mathematical correctness, logical soundness, notation consistency, evidence quality, and figure or code alignment. Use when Codex needs to review a paper, verify derivations, prioritize findings, or produce a rigorous findings-first assessment instead of rewriting prose blindly.
+---
+
+# Manuscript Review
+
+## When to use this skill
+
+Use this skill for serious review passes on papers, notes, appendices, or technical drafts where the main job is to find problems, verify important claims, and report actionable findings.
+
+## Workflow
+
+1. Read the full manuscript context first, including appendices, bibliography, macros, figures, and any supporting code that drives results.
+2. Identify the main claims and the highest-risk derivations, proofs, experiments, and references before going broad.
+3. Verify critical calculations independently when feasible. Check limiting cases, dimensions, signs, factors, boundary conditions, and whether stated results follow from the setup.
+4. Use computational verification tools when available for symbolic algebra, identities, spot checks, and code-backed results. If you verify something numerically or symbolically, say so explicitly in the findings.
+5. Trace notation across the document. Confirm symbols are defined before use and stay stable across sections, figures, and code.
+6. Check code-manuscript consistency when the paper depends on scripts, notebooks, generated figures, or implemented algorithms.
+7. Check whether the manuscript actually delivers the goals stated in the abstract and introduction.
+8. Produce findings first. Order them by severity and point to exact locations.
+9. Distinguish confirmed errors, likely issues, and open questions. Do not blur them together.
+
+## Quality Bar
+
+- Check appendices before claiming a derivation is missing.
+- Focus on issues that affect validity, interpretation, reproducibility, or reader comprehension.
+- Be specific about what you verified and how.
+- Prefer a short list of high-signal findings over a noisy dump of minor edits.
+- If no major issues are found, say that explicitly and note any residual uncertainty or untested areas.
+
+For a formal audit pass, use [references/review-checklist.md](references/review-checklist.md) when the manuscript is mathematically dense, has code-backed figures or computations, or needs a full findings report.

--- a/packages/extension/resources/skills/manuscript-review/agents/openai.yaml
+++ b/packages/extension/resources/skills/manuscript-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Manuscript Review'
+  short_description: 'Audit manuscripts for technical issues'
+  default_prompt: 'Use $manuscript-review to review this paper and report the highest-priority technical findings first.'

--- a/packages/extension/resources/skills/manuscript-review/references/review-checklist.md
+++ b/packages/extension/resources/skills/manuscript-review/references/review-checklist.md
@@ -1,0 +1,34 @@
+# Review Checklist
+
+Use this file when the manuscript needs a formal technical review rather than a quick read.
+
+## Main claims
+
+- Identify the paper's stated goals from the abstract and introduction.
+- Check whether the main body actually delivers each goal.
+
+## Mathematical verification
+
+- Reproduce key derivations independently when feasible.
+- Check signs, factors, dimensions, limits, and boundary conditions.
+- Verify that solutions satisfy the equations they claim to solve.
+- Use symbolic or numerical checks when useful, and report what was checked.
+
+## Appendices and notation
+
+- Check appendices before claiming detail is missing.
+- Confirm every important symbol is defined before use.
+- Track notation consistency across text, equations, figures, captions, and code.
+
+## Figures, code, and references
+
+- Check that figures match the text and that labels are consistent.
+- Compare code-backed claims with the actual implementation when code is available.
+- Verify that cited sources support the specific claims attached to them.
+- Check that quantitative claims in prose match tables, code outputs, and plotted data.
+
+## Findings format
+
+- Lead with findings, ordered by severity.
+- Include exact locations and short explanations of impact.
+- Separate confirmed errors, likely issues, and open questions.

--- a/packages/extension/resources/skills/math-ocr/SKILL.md
+++ b/packages/extension/resources/skills/math-ocr/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: math-ocr
+description: Convert handwritten or image-based mathematical content into notation-consistent LaTeX. Use when Codex needs to transcribe equations from notes, screenshots, whiteboards, or scans, reconcile ambiguous symbols against an existing document, or clean up OCR output into compilable mathematical LaTeX.
+---
+
+# Math OCR
+
+## When to use this skill
+
+Use this skill when the input is handwritten math, a screenshot of equations, or rough symbolic content that must become clean LaTeX matching an existing paper, note set, or slide deck.
+
+## Workflow
+
+1. Read the surrounding LaTeX context first when it exists. Reuse the document's notation, macro names, environment style, and equation conventions.
+2. Inspect the image carefully before transcribing. Identify ambiguous glyphs, line breaks, superscripts, subscripts, delimiters, and alignment structure.
+3. Translate math into the simplest correct LaTeX that matches the target document's style.
+4. Mark uncertainty mentally and resolve it against context instead of guessing in isolation.
+5. If the expression belongs inside a larger derivation, preserve the intended structure rather than producing a flat symbol dump.
+6. Review the transcription once for likely OCR confusions such as similar letters, missing braces, swapped indices, or incorrect nesting.
+
+## Quality Bar
+
+- Notation consistency beats literal shape matching when the handwriting is ambiguous.
+- Preserve mathematical structure, not just token order.
+- Ensure delimiters, fractions, and indices are syntactically sound and compile cleanly.
+- Prefer standard LaTeX environments already used by the target document.
+- Call out unresolved ambiguity instead of silently inventing a precise symbol.
+
+For ambiguity-heavy input, use [references/ocr-checklist.md](references/ocr-checklist.md) when the handwriting is messy, symbols are overloaded, or the result must fit strict manuscript notation.

--- a/packages/extension/resources/skills/math-ocr/agents/openai.yaml
+++ b/packages/extension/resources/skills/math-ocr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Math OCR'
+  short_description: 'Transcribe handwritten math to LaTeX'
+  default_prompt: 'Use $math-ocr to convert this handwritten mathematics into notation-consistent LaTeX.'

--- a/packages/extension/resources/skills/math-ocr/references/ocr-checklist.md
+++ b/packages/extension/resources/skills/math-ocr/references/ocr-checklist.md
@@ -1,0 +1,21 @@
+# OCR Checklist
+
+Use this file when the handwriting or scan quality makes transcription error-prone.
+
+## Context matching
+
+- Reuse the target document's notation, macros, and environment style.
+- Resolve ambiguous symbols against nearby equations or definitions first.
+
+## Common OCR traps
+
+- Similar letters such as `x` and `\chi`, `v` and `\nu`, `l` and `1`
+- Misread superscripts, subscripts, and nested braces
+- Dropped delimiters, alignment markers, or fraction structure
+- Swapped indices or incorrect ordering in tensor-like notation
+
+## Final checks
+
+- Ensure the LaTeX is syntactically valid.
+- Preserve the intended structure of multi-line derivations.
+- Flag unresolved ambiguity instead of inventing precision that is not supported by the image.

--- a/packages/extension/resources/skills/mathematical-enhancer/SKILL.md
+++ b/packages/extension/resources/skills/mathematical-enhancer/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: mathematical-enhancer
+description: Strengthen the mathematical substance of research papers by proposing or implementing better proofs, sharper results, cleaner derivations, and stronger formulations. Use when Codex needs to improve the mathematics itself rather than only the writing, especially by replacing brute-force arguments with better structure or identifying tractable generalizations.
+---
+
+# Mathematical Enhancer
+
+## When to use this skill
+
+Use this skill when a manuscript's main opportunity lies in stronger mathematics: a cleaner proof strategy, a tighter bound, a more general theorem, a resolved loose end, or a more illuminating derivation.
+
+## Workflow
+
+1. Read the whole paper first and identify where the mathematical content is routine, where it is fragile, and where genuine improvement seems possible.
+2. Look for brute-force arguments that can be replaced with more natural structure, known results, or more revealing tools.
+3. Rate candidate improvements by two axes: impact on the paper and confidence that the route is sound.
+4. Separate tractable improvements from speculative ones. Implement the former fully; annotate the latter as explicit suggestions.
+5. When claiming an improvement, actually work it out. Do not gesture at a stronger result unless you can justify the claim.
+6. Distinguish between improvements to mathematical substance and mere exposition. Stay focused on the mathematics.
+7. If a better proof or stronger statement depends on standard results, connect the manuscript clearly to those results instead of rederiving everything from scratch.
+8. Keep any inline annotations compile-safe if you are working directly in LaTeX.
+
+## Quality Bar
+
+- A proposed enhancement should either improve correctness, generality, elegance, or explanatory power.
+- Implement only the improvements you can justify rigorously.
+- Mark speculative or difficult ideas as suggestions, not as accomplished facts.
+- Do not trade away clarity for abstract cleverness if the new argument becomes harder to trust.
+- If the stronger route fails, fall back cleanly instead of leaving half-implemented sophistication behind.
+- High-impact, high-confidence improvements should be implemented, not merely admired.
+
+For a more systematic pass over impact, tractability, and the boundary between implemented improvements and annotated suggestions, use [references/enhancement-checklist.md](references/enhancement-checklist.md).

--- a/packages/extension/resources/skills/mathematical-enhancer/agents/openai.yaml
+++ b/packages/extension/resources/skills/mathematical-enhancer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Mathematical Enhancer'
+  short_description: "Strengthen a paper's mathematics"
+  default_prompt: 'Use $mathematical-enhancer to improve the mathematical substance of this paper and annotate harder extensions separately.'

--- a/packages/extension/resources/skills/mathematical-enhancer/references/enhancement-checklist.md
+++ b/packages/extension/resources/skills/mathematical-enhancer/references/enhancement-checklist.md
@@ -1,0 +1,30 @@
+# Enhancement Checklist
+
+Use this checklist when trying to improve a paper's mathematics rather than just its exposition.
+
+## Look for
+
+- Brute-force proofs that could be replaced by a cleaner idea
+- Standard results that could shorten or strengthen the argument
+- Generalizations that preserve the paper's point while broadening scope
+- Tighter bounds, sharper constants, or cleaner structural statements
+- Loose ends or assumptions that can actually be resolved
+
+## Separate two classes of ideas
+
+- Tractable improvements: implement them fully and verify them
+- Speculative improvements: leave them as explicit suggestions with rationale
+
+## Impact and confidence
+
+- High impact, high confidence: implement
+- High impact, low confidence: annotate as a substantial suggestion
+- Moderate impact, high confidence: implement if it clarifies or strengthens the paper cleanly
+- Low impact: avoid churn unless it unlocks something more important
+
+## Quality control
+
+- Do not claim a stronger result unless you have actually justified it.
+- Keep the improved mathematics readable and trustworthy.
+- Prefer substantial gains over decorative cleverness.
+- Fall back to the original route cleanly if the enhancement does not survive scrutiny.

--- a/packages/extension/resources/skills/scientific-presenter/SKILL.md
+++ b/packages/extension/resources/skills/scientific-presenter/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: scientific-presenter
+description: Build or revise scientific talks, posters, and Beamer slide decks from papers, codebases, figures, or LaTeX templates. Use when Codex needs to turn technical research into a clear presentation, preserve an existing slide theme, generate or improve figures, or iteratively compile and visually check presentation output.
+---
+
+# Scientific Presenter
+
+## When to use this skill
+
+Use this skill for research talks, posters, code walkthrough decks, paper-to-slides conversions, and presentation revisions where visual quality matters as much as technical accuracy.
+
+## Workflow
+
+1. Read any provided `.tex`, `.sty`, poster template, or slide template before planning content. Preserve the existing theme, typography, colors, macros, and structure unless the user asks for a redesign.
+2. Survey the workspace before editing. Identify the core claims, algorithms, figures, tables, equations, and code artifacts that actually belong in the presentation.
+3. Plan the deck around a story rather than around the paper's section order. Make each slide answer one question or advance one idea.
+4. Prefer visual communication. Turn architecture, pipelines, derivations, and comparisons into diagrams, tables, overlays, or compact equations instead of dense prose blocks.
+5. Keep code excerpts short and purposeful. Show only the lines needed to explain the mechanism, result, or design decision.
+6. Compile early and often. After each substantial change, inspect the rendered output and fix layout, overflow, readability, and figure quality issues before continuing.
+7. If figures or plots are generated from code, rerun the code when feasible and verify the resulting assets instead of mocking them by description.
+
+## Quality Bar
+
+- Keep body text readable at presentation scale. Split crowded slides instead of shrinking everything.
+- Use equations sparingly and only when they clarify the argument. Define notation before using it on slides.
+- Keep aspect ratios intact for figures and ensure axes, legends, and units are visible.
+- Use progressive disclosure when the audience must absorb a derivation, algorithm, or workflow in stages.
+- Treat visual QA as mandatory. A slide that compiles but clips, overlaps, or hides labels is not done.
+
+For a stricter final pass, use [references/slide-quality-checklist.md](references/slide-quality-checklist.md) to review slide density, figure quality, poster layout, and Beamer-specific issues.

--- a/packages/extension/resources/skills/scientific-presenter/agents/openai.yaml
+++ b/packages/extension/resources/skills/scientific-presenter/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Scientific Presenter'
+  short_description: 'Build and refine research slide decks'
+  default_prompt: 'Use $scientific-presenter to turn this paper or codebase into a polished scientific talk.'

--- a/packages/extension/resources/skills/scientific-presenter/references/slide-quality-checklist.md
+++ b/packages/extension/resources/skills/scientific-presenter/references/slide-quality-checklist.md
@@ -1,0 +1,34 @@
+# Slide Quality Checklist
+
+Use this checklist when a deck or poster is mostly complete and needs a rigorous visual pass.
+
+## Story and structure
+
+- Make each slide answer one concrete question.
+- Put the thesis, method, result, and takeaway in a visible narrative order.
+- Split slides that mix too many jobs.
+
+## Visual QA
+
+- Check for overflow, clipping, overlapping elements, and unreadably small text.
+- Keep figure aspect ratios intact.
+- Confirm axes, legends, units, and captions are visible.
+- Balance whitespace across slides and poster columns.
+
+## Code and equations
+
+- Show only the lines or formulas needed for the point being made.
+- Prefer pseudocode, overlays, or side-by-side explanation over raw dumps.
+- Define notation before using it on a slide.
+
+## Figures and generated assets
+
+- Regenerate plots from source code when feasible.
+- Inspect generated images or PDFs directly after compilation.
+- Fix missing labels, cropped legends, and poor contrast before moving on.
+
+## Beamer and poster specifics
+
+- Use slide titles consistently.
+- Keep navigation, sectioning, and slide numbers coherent with the chosen template.
+- For posters, check column balance, block boundaries, and header/footer clipping.

--- a/packages/extension/resources/skills/scientific-simplifier/SKILL.md
+++ b/packages/extension/resources/skills/scientific-simplifier/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: scientific-simplifier
+description: Simplify scientific code, LaTeX, and technical prose while preserving exact behavior, results, and meaning. Use when Codex needs to remove duplication, reduce unnecessary abstraction, clean up AI-generated bloat, or make a research codebase or manuscript clearer without changing its substance.
+---
+
+# Scientific Simplifier
+
+## When to use this skill
+
+Use this skill when a scientific project feels bloated, repetitive, over-abstracted, or harder to read than it should be, but the underlying behavior and mathematics must remain unchanged.
+
+## Workflow
+
+1. Inspect the target area before editing. Identify what is duplicated, indirect, dead, formulaic, or misleadingly complex.
+2. Preserve outputs and meaning. Treat simplification as an expression change, not a behavior change.
+3. Remove duplication only after verifying the repeated pieces serve the same purpose, not merely a similar shape.
+4. Prefer direct, idiomatic language and native constructs over custom wrappers or ornamental abstractions.
+5. Tighten scientific prose aggressively: delete filler openings, redundant transitions, vague significance claims, and conversation leakage.
+6. Simplify one logical piece at a time and verify after each change with tests, compilation, or equivalent checks.
+7. Stop when the code or prose reads like a deliberate design, not a pile of edits.
+
+## Quality Bar
+
+- Do not collapse distinct scientific regimes or assumptions into one helper just to save lines.
+- Do not replace clear control flow with clever one-liners.
+- Do not remove notation, equations, or comments that carry real meaning.
+- Prefer smaller, safer edits over sweeping rewrites when the verification surface is large.
+- If a simplification changes results, semantics, or narrative emphasis, revert it.
+
+For a broader cleanup pass, use [references/simplification-checklist.md](references/simplification-checklist.md) when the codebase is large, the prose shows obvious AI artifacts, or you need a more systematic review of duplication and abstraction.

--- a/packages/extension/resources/skills/scientific-simplifier/agents/openai.yaml
+++ b/packages/extension/resources/skills/scientific-simplifier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Scientific Simplifier'
+  short_description: 'Simplify code and technical prose safely'
+  default_prompt: 'Use $scientific-simplifier to make this scientific code or LaTeX clearer without changing its behavior or meaning.'

--- a/packages/extension/resources/skills/scientific-simplifier/references/simplification-checklist.md
+++ b/packages/extension/resources/skills/scientific-simplifier/references/simplification-checklist.md
@@ -1,0 +1,23 @@
+# Simplification Checklist
+
+Use this checklist for a deeper pass when a codebase or manuscript has accumulated obvious complexity.
+
+## Code structure
+
+- Find wrappers, dispatch layers, and factories that add no real abstraction.
+- Remove dead code, unreachable branches, and commented-out blocks.
+- Consolidate true duplicates only after checking semantics.
+- Replace hand-rolled utilities with clear native constructs when that improves readability.
+
+## Scientific prose
+
+- Delete filler openings, repetitive transitions, and empty significance claims.
+- Remove conversation leakage such as change notes or assistant-style narration.
+- Replace vague claims with specific statements or cut them.
+- Introduce notation once and stop re-explaining it.
+
+## Safety checks
+
+- Run tests, compile, or otherwise verify after each logical change.
+- Revert any simplification that changes behavior, results, or scientific meaning.
+- Prefer the smallest edit that materially improves clarity.

--- a/packages/extension/resources/skills/tikz-figure-builder/SKILL.md
+++ b/packages/extension/resources/skills/tikz-figure-builder/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: tikz-figure-builder
+description: Create or refine TikZ figures for technical papers and slides. Use when Codex needs to add a new diagram, improve an existing figure, align a visual with manuscript notation, or iteratively compile and visually read the rendered output until the figure is correct and readable.
+---
+
+# TikZ Figure Builder
+
+## When to use this skill
+
+Use this skill for architecture diagrams, workflows, commutative diagrams, tensor-network sketches, algorithm schematics, annotated plots, and figure cleanups where the final output should be TikZ or closely integrated with LaTeX.
+
+## Workflow
+
+1. Read the surrounding manuscript or slide context before drawing. Match the figure to the notation, vocabulary, and mathematical meaning already in use.
+2. Decide what the figure must communicate. Reduce the diagram to the essential objects, relationships, flow, or geometry.
+3. Prefer reusable styles and compact structure over copy-pasted node formatting.
+4. Compile every substantial TikZ change and visually read the rendered image or PDF, not just the source code. Treat this as an automatic loop: edit, build, read, fix, and rebuild until the figure is stable.
+5. Fix clipping, crowding, label collisions, uneven spacing, unreadable labels, and style drift immediately instead of deferring them.
+6. For mathematically meaningful diagrams, verify that topology, arrow direction, labels, and adjacency actually match the equations or constructions they represent.
+7. Keep captions and in-text references synchronized with the final figure.
+
+## Quality Bar
+
+- A pretty but mathematically wrong diagram is a failure.
+- Labels must be legible and consistent with manuscript notation.
+- Spacing should make structure obvious without decorative clutter.
+- Avoid duplicated style definitions across multiple figures when a shared style can live in the preamble or a common file.
+- Do not stop at source edits alone when a build is possible; the default is to compile, visually read the rendered result, and refine until it is clean.
+- Ensure the figure integrates cleanly into the surrounding text and layout.
+
+For dense or math-sensitive figures, use [references/figure-checklist.md](references/figure-checklist.md) to run a stricter pass over layout, consistency, and rendered correctness.

--- a/packages/extension/resources/skills/tikz-figure-builder/agents/openai.yaml
+++ b/packages/extension/resources/skills/tikz-figure-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'TikZ Figure Builder'
+  short_description: 'Create and refine TikZ diagrams'
+  default_prompt: 'Use $tikz-figure-builder to create or improve a TikZ figure, then iteratively compile and visually read the rendered result until it is clean.'

--- a/packages/extension/resources/skills/tikz-figure-builder/references/figure-checklist.md
+++ b/packages/extension/resources/skills/tikz-figure-builder/references/figure-checklist.md
@@ -1,0 +1,25 @@
+# Figure Checklist
+
+Use this file when a TikZ figure needs a stricter validation pass.
+
+## Technical correctness
+
+- Check that node relationships, arrows, labels, and topology match the underlying math or algorithm.
+- Confirm the figure uses the same notation as the surrounding document.
+
+## Layout
+
+- Check for clipped edges, overlapping labels, uneven spacing, and hard-to-follow routing.
+- Make the visual hierarchy obvious without decorative clutter.
+
+## Reuse and consistency
+
+- Factor repeated styles into shared definitions when multiple figures use the same look.
+- Keep captions and in-text references aligned with the final figure.
+
+## Compile-and-inspect loop
+
+- Recompile after meaningful edits.
+- Visually read the rendered figure, not just the source.
+- Fix layout defects immediately instead of stacking more edits on top.
+- Repeat the loop until clipping, collisions, spacing defects, and notation mismatches are gone rather than stopping after the first successful build.

--- a/packages/extension/resources/skills/writing-commenter/SKILL.md
+++ b/packages/extension/resources/skills/writing-commenter/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: writing-commenter
+description: Review research writing by leaving inline comments on logic, notation, narrative flow, positioning, and editorial impact. Use when Codex needs to annotate a paper or draft with reader-facing comments instead of silently rewriting it, especially for argument structure, symbol consistency, and publication-oriented presentation.
+---
+
+# Writing Commenter
+
+## When to use this skill
+
+Use this skill when the main job is to comment on a manuscript rather than to silently edit it. It is suited to three distinct review modes: logical-flow review, notation review, and editorial elevation where the author should see the reasoning behind suggested changes.
+
+## Workflow
+
+1. Read the full manuscript before commenting. Understand the paper's argument, notation, structure, and current maturity level.
+2. Choose the review mode up front unless the user explicitly asks for a mixed pass:
+   - logical flow: structure, transitions, narrative coherence, balance of explanation
+   - notation: symbol consistency, definition order, convention conflicts, graceful renaming
+   - editorial elevation: title, abstract, framing, audience fit, rhetorical rhythm, figure-caption storytelling
+3. Keep strict scope within the chosen mode. Do not drift into mathematical correctness, generic line edits, or copyediting unless the user asked for that.
+4. Prefer inline comments that point to concrete issues and propose actionable fixes. If the document already has an annotation convention, preserve it.
+5. In logic mode, comment where the reader loses the thread: weak transitions, misplaced paragraphs, unsupported jumps, and broken narrative arc.
+6. In notation mode, comment where symbols are inconsistent, reused confusingly, or introduced too late, and prefer graceful solutions that minimize document-wide churn.
+7. In editorial mode, comment where the paper undersells its contribution, flattens important ideas, fails to position itself for likely reviewers, or misuses figures, tables, and captions as mere decoration.
+8. Keep the comments self-contained and compile-safe when they live inside LaTeX. The document should remain readable and buildable with the comments present.
+
+## Quality Bar
+
+- Comments should be specific enough that an author can act on them immediately.
+- Prefer fewer, higher-signal comments over annotating every sentence.
+- Distinguish local fixes from systemic issues. Do not pretend a document-wide reorganization is a one-line tweak.
+- Preserve the author's voice and technical content; the goal is to diagnose and guide, not to overwrite reflexively.
+- If the document already uses an inline comment macro, match its style and syntax correctly.
+- For a mixed-mode review, still label the issue mentally by mode so the feedback does not blur into generic “make it better” commentary.
+
+For a stricter pass over comment discipline, issue selection, and compile-safe inline annotations, use [references/commenting-checklist.md](references/commenting-checklist.md).

--- a/packages/extension/resources/skills/writing-commenter/agents/openai.yaml
+++ b/packages/extension/resources/skills/writing-commenter/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Writing Commenter'
+  short_description: 'Leave inline comments on research writing'
+  default_prompt: 'Use $writing-commenter to annotate this draft with high-signal inline comments about logic, notation, and editorial impact.'

--- a/packages/extension/resources/skills/writing-commenter/references/commenting-checklist.md
+++ b/packages/extension/resources/skills/writing-commenter/references/commenting-checklist.md
@@ -1,0 +1,33 @@
+# Commenting Checklist
+
+Use this checklist when annotating a paper directly instead of silently rewriting it.
+
+## Focus
+
+- Choose one primary mode unless the user explicitly wants a combined pass.
+- Separate structural issues, notation issues, and editorial-impact issues.
+- Comment on the strongest problems first.
+- Avoid flooding the manuscript with low-value marginal notes.
+
+## Logic and structure
+
+- Flag weak transitions, abrupt jumps, misplaced content, and broken section-to-section flow.
+- Mark concepts used before they are introduced.
+- Distinguish local fixes from problems that require real reorganization.
+
+## Notation
+
+- Track conflicting symbols, reused notation, and undefined quantities.
+- Prefer graceful solutions that minimize unnecessary document-wide renaming.
+
+## Editorial impact
+
+- Mark titles, abstracts, introductions, captions, and claims that undersell or overstate the contribution.
+- Comment from the reader's perspective: what would confuse, bore, or trigger skepticism?
+- Calibrate to audience: editor, expert reviewer, broad peer, or outsider.
+
+## Inline comment discipline
+
+- Keep comments actionable and brief.
+- If the comments live inside LaTeX, keep them compile-safe.
+- Match the document's existing annotation convention when one already exists.

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -35,55 +35,55 @@
       "chatSkills": [
         {
           "name": "inline-paper-critic",
-          "path": "../../skills/inline-paper-critic"
+          "path": "resources/skills/inline-paper-critic"
         },
         {
           "name": "lean-blueprint",
-          "path": "../../skills/lean-blueprint"
+          "path": "resources/skills/lean-blueprint"
         },
         {
           "name": "lean-proof-assistant",
-          "path": "../../skills/lean-proof-assistant"
+          "path": "resources/skills/lean-proof-assistant"
         },
         {
           "name": "lean-search",
-          "path": "../../skills/lean-search"
+          "path": "resources/skills/lean-search"
         },
         {
           "name": "lean-simplifier",
-          "path": "../../skills/lean-simplifier"
+          "path": "resources/skills/lean-simplifier"
         },
         {
           "name": "literature-search",
-          "path": "../../skills/literature-search"
+          "path": "resources/skills/literature-search"
         },
         {
           "name": "manuscript-review",
-          "path": "../../skills/manuscript-review"
+          "path": "resources/skills/manuscript-review"
         },
         {
           "name": "math-ocr",
-          "path": "../../skills/math-ocr"
+          "path": "resources/skills/math-ocr"
         },
         {
           "name": "mathematical-enhancer",
-          "path": "../../skills/mathematical-enhancer"
+          "path": "resources/skills/mathematical-enhancer"
         },
         {
           "name": "scientific-presenter",
-          "path": "../../skills/scientific-presenter"
+          "path": "resources/skills/scientific-presenter"
         },
         {
           "name": "scientific-simplifier",
-          "path": "../../skills/scientific-simplifier"
+          "path": "resources/skills/scientific-simplifier"
         },
         {
           "name": "tikz-figure-builder",
-          "path": "../../skills/tikz-figure-builder"
+          "path": "resources/skills/tikz-figure-builder"
         },
         {
           "name": "writing-commenter",
-          "path": "../../skills/writing-commenter"
+          "path": "resources/skills/writing-commenter"
         }
       ],
       "languageModelTools": [
@@ -760,6 +760,19 @@
   "manifestAssetReferences": [
     "resources/logo-128x128.svg",
     "resources/logo-512x512.png",
+    "resources/skills/inline-paper-critic",
+    "resources/skills/lean-blueprint",
+    "resources/skills/lean-proof-assistant",
+    "resources/skills/lean-search",
+    "resources/skills/lean-simplifier",
+    "resources/skills/literature-search",
+    "resources/skills/manuscript-review",
+    "resources/skills/math-ocr",
+    "resources/skills/mathematical-enhancer",
+    "resources/skills/scientific-presenter",
+    "resources/skills/scientific-simplifier",
+    "resources/skills/tikz-figure-builder",
+    "resources/skills/writing-commenter",
     "resources/walkthroughs/getting-started.md",
     "resources/walkthroughs/media/agent-model-selection.png",
     "resources/walkthroughs/media/api-key-setup.png",
@@ -778,6 +791,7 @@
     "resources/logo-128x128.svg",
     "resources/logo-512x512.png",
     "resources/shared/latex_style_rules.txt",
+    "resources/skills",
     "resources/templates",
     "resources/tool_use_agents",
     "resources/walkthroughs",
@@ -789,6 +803,7 @@
   "requiredVscodeIgnoreLines": [
     "src/**",
     "resources/traceViewer/**",
+    "!resources/skills/**",
     "!src/common/styles/*.css",
     "!src/progressView/*.html",
     "!src/settingsView/*.html",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -803,7 +803,6 @@
   "requiredVscodeIgnoreLines": [
     "src/**",
     "resources/traceViewer/**",
-    "!resources/skills/**",
     "!src/common/styles/*.css",
     "!src/progressView/*.html",
     "!src/settingsView/*.html",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -35,55 +35,55 @@
       "chatSkills": [
         {
           "name": "inline-paper-critic",
-          "path": "resources/skills/inline-paper-critic"
+          "path": "resources/skills/inline-paper-critic/SKILL.md"
         },
         {
           "name": "lean-blueprint",
-          "path": "resources/skills/lean-blueprint"
+          "path": "resources/skills/lean-blueprint/SKILL.md"
         },
         {
           "name": "lean-proof-assistant",
-          "path": "resources/skills/lean-proof-assistant"
+          "path": "resources/skills/lean-proof-assistant/SKILL.md"
         },
         {
           "name": "lean-search",
-          "path": "resources/skills/lean-search"
+          "path": "resources/skills/lean-search/SKILL.md"
         },
         {
           "name": "lean-simplifier",
-          "path": "resources/skills/lean-simplifier"
+          "path": "resources/skills/lean-simplifier/SKILL.md"
         },
         {
           "name": "literature-search",
-          "path": "resources/skills/literature-search"
+          "path": "resources/skills/literature-search/SKILL.md"
         },
         {
           "name": "manuscript-review",
-          "path": "resources/skills/manuscript-review"
+          "path": "resources/skills/manuscript-review/SKILL.md"
         },
         {
           "name": "math-ocr",
-          "path": "resources/skills/math-ocr"
+          "path": "resources/skills/math-ocr/SKILL.md"
         },
         {
           "name": "mathematical-enhancer",
-          "path": "resources/skills/mathematical-enhancer"
+          "path": "resources/skills/mathematical-enhancer/SKILL.md"
         },
         {
           "name": "scientific-presenter",
-          "path": "resources/skills/scientific-presenter"
+          "path": "resources/skills/scientific-presenter/SKILL.md"
         },
         {
           "name": "scientific-simplifier",
-          "path": "resources/skills/scientific-simplifier"
+          "path": "resources/skills/scientific-simplifier/SKILL.md"
         },
         {
           "name": "tikz-figure-builder",
-          "path": "resources/skills/tikz-figure-builder"
+          "path": "resources/skills/tikz-figure-builder/SKILL.md"
         },
         {
           "name": "writing-commenter",
-          "path": "resources/skills/writing-commenter"
+          "path": "resources/skills/writing-commenter/SKILL.md"
         }
       ],
       "languageModelTools": [
@@ -760,19 +760,19 @@
   "manifestAssetReferences": [
     "resources/logo-128x128.svg",
     "resources/logo-512x512.png",
-    "resources/skills/inline-paper-critic",
-    "resources/skills/lean-blueprint",
-    "resources/skills/lean-proof-assistant",
-    "resources/skills/lean-search",
-    "resources/skills/lean-simplifier",
-    "resources/skills/literature-search",
-    "resources/skills/manuscript-review",
-    "resources/skills/math-ocr",
-    "resources/skills/mathematical-enhancer",
-    "resources/skills/scientific-presenter",
-    "resources/skills/scientific-simplifier",
-    "resources/skills/tikz-figure-builder",
-    "resources/skills/writing-commenter",
+    "resources/skills/inline-paper-critic/SKILL.md",
+    "resources/skills/lean-blueprint/SKILL.md",
+    "resources/skills/lean-proof-assistant/SKILL.md",
+    "resources/skills/lean-search/SKILL.md",
+    "resources/skills/lean-simplifier/SKILL.md",
+    "resources/skills/literature-search/SKILL.md",
+    "resources/skills/manuscript-review/SKILL.md",
+    "resources/skills/math-ocr/SKILL.md",
+    "resources/skills/mathematical-enhancer/SKILL.md",
+    "resources/skills/scientific-presenter/SKILL.md",
+    "resources/skills/scientific-simplifier/SKILL.md",
+    "resources/skills/tikz-figure-builder/SKILL.md",
+    "resources/skills/writing-commenter/SKILL.md",
     "resources/walkthroughs/getting-started.md",
     "resources/walkthroughs/media/agent-model-selection.png",
     "resources/walkthroughs/media/api-key-setup.png",

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -50,6 +50,27 @@ export function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+/** Return recursive file paths with stable VSIX-compatible separators. */
+export function collectRelativeFiles(directory) {
+  const visit = (currentDirectory, prefix) => {
+    const files = [];
+    for (const entry of fs.readdirSync(currentDirectory, {
+      withFileTypes: true,
+    })) {
+      const relativePath = path.posix.join(prefix, entry.name);
+      const absolutePath = path.join(currentDirectory, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...visit(absolutePath, relativePath));
+      } else if (entry.isFile()) {
+        files.push(relativePath);
+      }
+    }
+    return files;
+  };
+
+  return visit(directory, '').sort();
+}
+
 function stable(value) {
   if (Array.isArray(value)) return value.map(stable);
   if (!value || typeof value !== 'object') return value;

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -47,6 +47,7 @@ const REQUIRED_PACKAGED_PATHS = [
   'resources/logo-128x128.svg',
   'resources/logo-512x512.png',
   'resources/shared/latex_style_rules.txt',
+  'resources/skills',
   'resources/templates',
   'resources/tool_use_agents',
   'resources/walkthroughs',
@@ -67,6 +68,7 @@ const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
   `resources/${EXCLUDED_TRACE_VIEWER_DIR}/**`,
+  '!resources/skills/**',
   '!src/common/styles/*.css',
   '!src/progressView/*.html',
   '!src/settingsView/*.html',
@@ -143,6 +145,20 @@ function hasFiles(relativeDir) {
   return false;
 }
 
+function collectFiles(directory, prefix = '') {
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const relativePath = path.join(prefix, entry.name);
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(absolutePath, relativePath));
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort();
+}
+
 function buildSnapshot() {
   const packageJson = readJson(packagePath);
   return {
@@ -208,6 +224,31 @@ function verifyAssets(snapshot, failures) {
   }
 }
 
+function verifyBundledSkills(failures) {
+  const sourceDir = path.join(rootDir, 'skills');
+  const packagedDir = path.join(packageDir, 'resources', 'skills');
+  if (!fs.existsSync(sourceDir) || !fs.existsSync(packagedDir)) return;
+
+  const sourceFiles = collectFiles(sourceDir);
+  const packagedFiles = collectFiles(packagedDir);
+  assert(
+    JSON.stringify(packagedFiles) === JSON.stringify(sourceFiles),
+    'Packaged extension skills do not match the canonical skills tree.',
+    failures,
+  );
+
+  for (const relativePath of sourceFiles) {
+    if (!packagedFiles.includes(relativePath)) continue;
+    assert(
+      fs
+        .readFileSync(path.join(packagedDir, relativePath))
+        .equals(fs.readFileSync(path.join(sourceDir, relativePath))),
+      `Packaged extension skill differs from canonical source: ${relativePath}`,
+      failures,
+    );
+  }
+}
+
 function verifyVscodeIgnore(snapshot, failures) {
   if (!fs.existsSync(vscodeIgnorePath)) {
     failures.push(
@@ -251,6 +292,7 @@ if (update) {
 const failures = [];
 verifySnapshot(snapshot, failures);
 verifyAssets(snapshot, failures);
+verifyBundledSkills(failures);
 verifyVscodeIgnore(snapshot, failures);
 
 if (failures.length > 0) {

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -68,7 +68,6 @@ const BUILD_TIME_PACKAGED_PATHS = new Set(['readme.md', 'changelog.md']);
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
   `resources/${EXCLUDED_TRACE_VIEWER_DIR}/**`,
-  '!resources/skills/**',
   '!src/common/styles/*.css',
   '!src/progressView/*.html',
   '!src/settingsView/*.html',

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  collectRelativeFiles,
   EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
@@ -144,20 +145,6 @@ function hasFiles(relativeDir) {
   return false;
 }
 
-function collectFiles(directory, prefix = '') {
-  const files = [];
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const relativePath = path.join(prefix, entry.name);
-    const absolutePath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...collectFiles(absolutePath, relativePath));
-    } else if (entry.isFile()) {
-      files.push(relativePath);
-    }
-  }
-  return files.sort();
-}
-
 function buildSnapshot() {
   const packageJson = readJson(packagePath);
   return {
@@ -226,10 +213,14 @@ function verifyAssets(snapshot, failures) {
 function verifyBundledSkills(failures) {
   const sourceDir = path.join(rootDir, 'skills');
   const packagedDir = path.join(packageDir, 'resources', 'skills');
-  if (!fs.existsSync(sourceDir) || !fs.existsSync(packagedDir)) return;
+  const sourceExists = fs.existsSync(sourceDir);
+  const packagedExists = fs.existsSync(packagedDir);
+  assert(sourceExists, 'Canonical skills directory is missing.', failures);
+  assert(packagedExists, 'Packaged extension skills are missing.', failures);
+  if (!sourceExists || !packagedExists) return;
 
-  const sourceFiles = collectFiles(sourceDir);
-  const packagedFiles = collectFiles(packagedDir);
+  const sourceFiles = collectRelativeFiles(sourceDir);
+  const packagedFiles = collectRelativeFiles(packagedDir);
   assert(
     JSON.stringify(packagedFiles) === JSON.stringify(sourceFiles),
     'Packaged extension skills do not match the canonical skills tree.',
@@ -243,6 +234,27 @@ function verifyBundledSkills(failures) {
         .readFileSync(path.join(packagedDir, relativePath))
         .equals(fs.readFileSync(path.join(sourceDir, relativePath))),
       `Packaged extension skill differs from canonical source: ${relativePath}`,
+      failures,
+    );
+  }
+
+  const packageJson = readJson(packagePath);
+  const chatSkills = packageJson.contributes?.chatSkills ?? [];
+  const expectedNames = sourceFiles
+    .filter((relativePath) => /^[^/]+\/SKILL\.md$/.test(relativePath))
+    .map((relativePath) => relativePath.split('/')[0]);
+  assert(
+    JSON.stringify(chatSkills.map((skill) => skill.name).toSorted()) ===
+      JSON.stringify(expectedNames.toSorted()),
+    'Extension chatSkills must register every canonical bundled skill.',
+    failures,
+  );
+
+  for (const skill of chatSkills) {
+    const expectedPath = `resources/skills/${skill.name}/SKILL.md`;
+    assert(
+      skill.path === expectedPath,
+      `Chat skill ${skill.name} must point to ${expectedPath}.`,
       failures,
     );
   }

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   CATALOG_DERIVED_CONTRIBUTES,
+  collectRelativeFiles,
   EXCLUDED_TRACE_VIEWER_DIR,
   extensionManifestSnapshot,
   readJson,
@@ -47,20 +48,6 @@ function readVsixEntry(vsixPath, entryPath) {
 
 function hashBuffer(buffer) {
   return crypto.createHash('sha256').update(buffer).digest('hex');
-}
-
-function walkFiles(dir, prefix = '') {
-  const results = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const relativePath = path.posix.join(prefix, entry.name);
-    const absolutePath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...walkFiles(absolutePath, relativePath));
-    } else if (entry.isFile()) {
-      results.push(relativePath);
-    }
-  }
-  return results.sort();
 }
 
 function assert(condition, message, failures) {
@@ -136,7 +123,7 @@ const RESOURCE_HASH_EXCLUDED_PREFIX = `${EXCLUDED_TRACE_VIEWER_DIR}/`;
 
 function verifyResourceHashes(vsixPath, entries, failures) {
   const resourcesDir = path.join(extensionDir, 'resources');
-  const sourceFiles = walkFiles(resourcesDir).filter(
+  const sourceFiles = collectRelativeFiles(resourcesDir).filter(
     (file) => !file.startsWith(RESOURCE_HASH_EXCLUDED_PREFIX),
   );
   const sourceFileSet = new Set(sourceFiles);


### PR DESCRIPTION
## Summary

- Package the canonical built-in skill catalog under the extension resources tree.
- Point each VS Code chat-skill contribution at its packaged SKILL.md manifest.
- Make package invariants compare the packaged and canonical skill trees byte for byte and enforce complete manifest registration.
- Share one stable recursive file walker between source-tree and built-VSIX verification.

Closes #7849.

## Issue acceptance gates

- [x] The VSIX contains all 13 bundled skills and all 39 resource files.
- [x] Every chatSkills contribution points to a SKILL.md inside the installed extension.
- [x] Package verification fails if packaged skills diverge from the canonical skills tree or a canonical skill is not registered.
- [x] The production VSIX build and content verification pass.

## Single source of truth

The root skills/ tree remains canonical. packages/extension/resources/skills is the required packaged mirror, and package verification enforces exact path and byte equality.

## Duplication and abstraction budget

The resource mirror is required by VSIX packaging. Existing package scripts now share collectRelativeFiles; no runtime abstraction was added.

## Net elements (R6)

45 files changed; 39 resource files added; 958 insertions and 41 deletions. One shared script helper replaces two recursive walkers; no runtime class or service was added.

## Consumer counts (R8)

n/a — no emit path or public runtime export was deleted or rerouted.

## Host impact

Extension: Installed VSIX builds now expose the bundled skill catalog through valid SKILL.md contribution paths. Desktop and CLI behavior are unchanged.

## Scheduled refactoring

None.

## Validation

- Package invariant check passed.
- Focused skill suites: 13 tests passed.
- npm run typecheck passed.
- npm run lint passed with no errors.
- npm run build:fast passed.
- npm run check:vsix-contents passed against releases/texra-0.39.3.vsix.
- Built VSIX inspection found 13 bundled skills and 39 skill resource files.
- git diff --check passed.

Manual installation verification remains useful for the VS Code host, but the missing-package and invalid-contribution-path failures are mechanically guarded.