### PR TITLE
fix(agent): delete unreachable raw-SDK bypass branches in textConnection

### DIFF
--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -106,7 +106,7 @@ export async function bestConnectionMethod(
 }
 
 /**
- * Determines the best way to connect two strings in a LaTeX context using Claude
+ * Determines the best way to connect two strings through the configured helper model.
  */
 export async function bestConnectionMethodAnthropic(
   str1: string,

--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -1,9 +1,3 @@
-import Anthropic from '@anthropic-ai/sdk';
-import OpenAI from 'openai';
-import { MODEL_CONFIGS } from 'llm-zoo';
-
-import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
-import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
 import {
   createHelperModelKit,
   runHelperModelCompletion,
@@ -101,36 +95,10 @@ async function bestConnectionMethodWithHelperModel(
 export async function bestConnectionMethod(
   str1: string,
   str2: string,
-  openaiApiKey?: string,
   n: number = 1,
 ): Promise<ConnectionResult> {
   try {
-    if (!openaiApiKey) {
-      return await bestConnectionMethodWithHelperModel(str1, str2, n);
-    }
-
-    const prompt = buildPrompt(str1, str2);
-    const handler = new ModelHandlerOpenAI(MODEL_CONFIGS['gpt41']);
-    const baseURL = handler.getBaseUrl() ?? undefined;
-    const client = new OpenAI({ apiKey: openaiApiKey, baseURL });
-
-    const completion = await client.chat.completions.create({
-      model: 'gpt-4.1',
-      temperature: 0,
-      n,
-      messages: [
-        {
-          role: 'system',
-          content: SYSTEM_PROMPT,
-        },
-        { role: 'user', content: prompt },
-      ],
-    });
-
-    const choices = completion.choices.map(
-      (choice) => choice.message.content?.trim() ?? '',
-    );
-    return getMajorityChoice(choices);
+    return await bestConnectionMethodWithHelperModel(str1, str2, n);
   } catch (err) {
     logConnectionError('bestConnectionMethod', err);
     return DEFAULT_RESULT;
@@ -143,37 +111,10 @@ export async function bestConnectionMethod(
 export async function bestConnectionMethodAnthropic(
   str1: string,
   str2: string,
-  anthropicApiKey?: string,
   n: number = 1,
 ): Promise<ConnectionResult> {
   try {
-    if (!anthropicApiKey) {
-      return await bestConnectionMethodWithHelperModel(str1, str2, n);
-    }
-
-    const prompt = buildPrompt(str1, str2);
-    const handler = new ModelHandlerAnthropic(MODEL_CONFIGS['sonnet37']);
-    const baseURL = handler.getBaseUrl() ?? undefined;
-    const client = new Anthropic({ apiKey: anthropicApiKey, baseURL });
-
-    const choices = await Promise.all(
-      Array.from({ length: n }, () =>
-        client.messages
-          .create({
-            model: 'claude-3-7-sonnet-20250219',
-            max_tokens: 128,
-            messages: [{ role: 'user', content: prompt }],
-          })
-          .then((response) => {
-            const textBlock = response.content.find(
-              (block) => block.type === 'text',
-            );
-            return textBlock?.text.trim() || 'B';
-          }),
-      ),
-    );
-
-    return getMajorityChoice(choices);
+    return await bestConnectionMethodWithHelperModel(str1, str2, n);
   } catch (err) {
     logConnectionError('bestConnectionMethodAnthropic', err);
     return DEFAULT_RESULT;

--- a/src/test-kernel/agent/TextConnectionHelperModel.vitest.ts
+++ b/src/test-kernel/agent/TextConnectionHelperModel.vitest.ts
@@ -14,7 +14,7 @@ describe('bestConnectionMethod helper model routing', () => {
     createHelperModelKit.mockReset();
   });
 
-  it('uses the configured helper model when no provider key is passed', async () => {
+  it('uses the configured helper model', async () => {
     const initializeMessages = vi.fn(async () => [{ role: 'user' }]);
     const createResponse = vi.fn(async () => ({ response: { id: 'r1' } }));
     const extractResponse = vi.fn(() => ({


### PR DESCRIPTION
## What / Why

Closes #7880.

`bestConnectionMethod` and `bestConnectionMethodAnthropic` in
`src/agent/runtime/textConnection.ts` each took an optional
`openaiApiKey`/`anthropicApiKey` param that gated a raw-SDK branch
(constructing a bare `OpenAI`/`Anthropic` client directly, bypassing
`ModelHandler`). Every call site in the repo invokes these functions
with only `(str1, str2)`, so the key param is always `undefined` and
execution always took the `bestConnectionMethodWithHelperModel` path —
which already routes through `ModelHandler` via
`createHelperModelKit()` / `runHelperModelCompletion()`
(`src/agent/runtime/helperModel.ts`, added by #6730's helper-model
centralization). The raw-SDK branches were unreachable dead code.

Per the maintainer's binding re-scope comment on the issue: delete the
dead branches rather than plumbing an API-key-override capability into
`ModelHandler` to serve a path with zero current callers (that would
be a net-add serving unreachable code — the exact parameter-accretion
trap this repo's history warns against).

Change: removed the raw-SDK branches, the now-unused `openaiApiKey?`
/ `anthropicApiKey?` params, and the now-unused `Anthropic`, `OpenAI`,
`MODEL_CONFIGS`, `ModelHandlerOpenAI`, `ModelHandlerAnthropic` imports.
Both exported functions are now thin wrappers around
`bestConnectionMethodWithHelperModel` — kept as two named functions
(rather than collapsed to one) so `connectionTests.ts`'s
OpenAI/Anthropic-labeled dev test-command output is preserved with no
other file needing to change. No `ModelHandler` changes; no new test
infra. Behavior is unchanged for every real caller (the helper-model
path they all already hit is untouched).

## Verification commands

```
CI=true corepack pnpm install --prefer-offline
npx vitest run src/test-kernel/agent/TextConnectionHelperModel.vitest.ts   # 1 passed
npx vitest run src/test-kernel/agent                                       # 159 passed | 1 skipped, 1194 passed | 4 skipped
npx eslint src/agent/runtime/textConnection.ts                             # clean
npm run typecheck                                                          # clean (root + test-kernel + cli + trace-viewer)
```

Type-level guard: removing the optional key params is proven by
`npm run typecheck` passing across all call sites (`CycleServices.ts`,
`ResponseCycleFlow.ts`, `ResponseCycleNode.ts`,
`connectionTests.ts`, `TextConnectionHelperModel.vitest.ts`) — no
runtime regression test needed for this since it's a pure deletion of
an already-unreachable branch (see R8 call-site grep below: every
call site already passes exactly 2 args, so no caller's behavior can
change). The existing `TextConnectionHelperModel.vitest.ts` already
covers the one live path and needed no changes.

## Net elements (R6)

- `src/agent/runtime/textConnection.ts`: 181 → 122 lines. Net **−59
  LOC** in this PR (2 insertions, 61 deletions), all within the one
  file the issue scoped. No new abstractions, no new files, no
  reformat churn.
- (The re-scope comment's −80 to −100 estimate assumed collapsing the
  two functions into one; this PR keeps both as thin wrappers instead,
  per the re-scope's explicitly offered alternative, to avoid touching
  `connectionTests.ts`'s two labeled dev-test invocations — smaller
  diff, same dead-code deletion.)

## Consumer counts (R8)

Grepped every call site of `bestConnectionMethod` /
`bestConnectionMethodAnthropic` in the repo — all 2-arg, none pass a
key:

1. `src/agent/core/flows/ResponseCycleFlow.ts:314` —
   `this.services.bestConnectionMethod(str1, str2)` (production path;
   `CycleServices.ts:65` types the service field as `(str1, str2) =>
   Promise<...>`, no key/`n` param, wired from
   `ResponseCycleNode.ts:103`).
2. `packages/extension/src/commands/tests/connectionTests.ts:44,49` —
   `runConnectionTests('OpenAI', testCases, bestConnectionMethod)` /
   `runConnectionTests('Anthropic', testCases,
   bestConnectionMethodAnthropic)`, both invoked internally as
   `method(str1, str2)` (dev command `texra.testConnection`, typed via
   `ConnectionMethod = (str1, str2) => Promise<{connector}>`).
3. `src/test-kernel/agent/TextConnectionHelperModel.vitest.ts:40` —
   `bestConnectionMethod('left', 'right')`.

All 3 sites already omit the key/`n` args; none needed changes.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unreachable branches with unchanged runtime behavior for all existing two-argument call sites; typecheck covers signature changes.
> 
> **Overview**
> **`bestConnectionMethod`** and **`bestConnectionMethodAnthropic`** in `textConnection.ts` no longer accept optional provider API keys or construct bare **OpenAI** / **Anthropic** clients. Both exports are thin wrappers around **`bestConnectionMethodWithHelperModel`** (via **`createHelperModelKit`** / **`runHelperModelCompletion`**), which was already the only path used by production and dev callers.
> 
> Unused imports (**`ModelHandlerOpenAI`**, **`ModelHandlerAnthropic`**, **`MODEL_CONFIGS`**, SDK clients) are dropped. The two function names remain so dev connection tests can still label OpenAI vs Anthropic runs without other file changes.
> 
> The vitest case title is updated to reflect that the helper model is always used (not only when no key is passed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778b77963541e0cdce6e0a9b4037340d8acf3d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->