### PR TITLE
fix(ci): give nightly schedule runs a distinct concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # Nightly `schedule` runs use github.ref == refs/heads/main, the same ref a
+  # push to main uses. Without the event_name suffix, cancel-in-progress would
+  # let a same-ref push cancel the nightly runtime-validation timing run (or
+  # vice versa) — see #7756.
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What / Why

Fixes #7756.

`.github/workflows/ci.yml`'s concurrency group was `ci-${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. That worked while `push`/`pull_request`/`workflow_dispatch` were the only triggers, since each ref maps to one active run at a time. #7743 added a nightly `schedule` trigger (`cron: '17 3 * * *'`) to collect wall-clock timing samples for the `runtime-validation` job. A `schedule` event's `github.ref` defaults to the default branch (`refs/heads/main`) — the same ref a regular `push` to `main` uses — so a push landing at/near the 03:17 UTC cron fire lets `cancel-in-progress` cancel either run, silently dropping a nightly timing data point. That undermines the #7680 tiered-rollout plan, which gates promoting `runtime-validation` to a PR-blocking check on a week of nightly p95 timing data.

Fix: suffix the concurrency group with `github.event_name` so `schedule` runs get their own lane and are never preempted by a same-ref `push`/`workflow_dispatch`, and vice versa.

```diff
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
```

## Verification

- `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(d['concurrency'])"` — YAML parses, new group template printed correctly.
- `actionlint .github/workflows/ci.yml` — clean, no findings.
- `CI=true corepack pnpm install --prefer-offline` — clean install.
- `npm run typecheck` — passes (this is a YAML-only change; no TS source touched).
- Checked the repo's other `schedule`-triggered workflows (`issue-tree.yml`, `repository-quality-improver.yml`, `update-agents-docs.lock.yml`) — none of them key their concurrency group on `github.ref`, so none share this collision pattern; only `ci.yml` needed the fix, matching the issue's scope.

No behavioral/functional test exists for a concurrency-group string (it's evaluated by GitHub's own scheduler, not our code), so there's no unit test to extend — the YAML-syntax + actionlint checks above are the applicable verification for this class of change.

## Net elements (R6)

+5/-1 lines, one file (`.github/workflows/ci.yml`). No new abstractions, jobs, or workflows added — a one-line concurrency-group key edit plus an explanatory comment.

## Consumer counts (R8)

N/A — nothing deleted or re-routed. Grepped for other workflows that both (a) have a `schedule` trigger and (b) key `concurrency.group` on `github.ref`: none found (see Verification above), so no other workflow needed the same fix.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI concurrency configuration with no application or security impact; behavior change is limited to which GitHub Actions runs cancel each other.
> 
> **Overview**
> Fixes **#7756** by changing the CI workflow’s **concurrency group** so nightly `schedule` runs are not cancelled by (or cancelling) `push`/`workflow_dispatch` runs on the same ref.
> 
> The group key in `.github/workflows/ci.yml` now includes **`${{ github.event_name }}`** in addition to workflow and ref. Nightly cron jobs use `github.ref` on `main` like ordinary pushes; with `cancel-in-progress: true`, sharing one group could drop **`runtime-validation`** timing samples needed for the tiered rollout in **#7680**. A short comment documents why the suffix is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47fa80981694c23a8a17efbd9b6eb4d7c9b36851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->