### PR TITLE
fix(scripts): handle spawnSync failures explicitly in deploy-relay

### DIFF
--- a/scripts/deploy-relay.mjs
+++ b/scripts/deploy-relay.mjs
@@ -15,4 +15,20 @@ const args = [
 ];
 
 const result = spawnSync('supabase', args, { stdio: 'inherit' });
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    console.error(
+      'deploy-relay: supabase CLI not found on PATH. Install it and retry.',
+    );
+  } else {
+    console.error('deploy-relay: failed to spawn supabase CLI:', result.error);
+  }
+  process.exit(1);
+}
+if (result.signal) {
+  console.error(
+    `deploy-relay: supabase CLI was killed by signal ${result.signal}`,
+  );
+  process.exit(1);
+}
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## What / Why

Fixes #7767. `scripts/deploy-relay.mjs` ran `spawnSync('supabase', args, { stdio: 'inherit' })` and only checked `result.status`. `spawnSync` surfaces spawn-level failures (e.g. `supabase` not on `PATH`) via `result.error`, not `result.status` — no child process ever runs in that case, so `stdio: 'inherit'` forwards nothing, and the script silently exited 1 with zero diagnostic output.

This PR checks `result.error` explicitly (special-casing `ENOENT` with an actionable "supabase CLI not found on PATH" message) and `result.signal` (the CLI was killed by a signal) before falling back to the existing `result.status ?? 1` passthrough for normal non-zero exits.

Flagged by Copilot review on #7760: https://github.com/LionSR/TeXRA/pull/7760#discussion_r3552993031

## Verification

No vitest suite exists for `scripts/`, and `scripts/` is out of scope for `npm run lint` (`package.json` lint globs are `src`/`packages/*/src` only), so this was verified manually by running the script directly under controlled `PATH`s in the worktree:

- **Pre-fix baseline** (`git diff > patch && git checkout -- scripts/deploy-relay.mjs`, ran, then `git apply patch`): with `PATH` containing no `supabase` binary, the script exited 1 with **no stderr output at all** — reproducing the exact silent-failure defect from the issue.
- **Post-fix, spawn failure (ENOENT)**: `env -i PATH="<dir-without-supabase>" node scripts/deploy-relay.mjs` → prints `deploy-relay: supabase CLI not found on PATH. Install it and retry.` and exits 1.
- **Post-fix, existing non-zero exit-code passthrough preserved**: a stub `supabase` script on `PATH` that exits 3 → script prints the stub's own output and exits 3 (unchanged behavior, confirming the new checks don't regress the ordinary failure path).
- `npm run typecheck` — clean (script is JS; no TS surface affected).
- `npx prettier --check scripts/deploy-relay.mjs` — clean.

Note: an earlier manual test in this session accidentally included the real `/opt/homebrew/bin` on `PATH`, which resolved the real, already-authenticated `supabase` CLI and triggered one real `supabase functions deploy relay --no-verify-jwt --project-ref jntubmcgbhwtcktubelv` against production. This deployed the unmodified `supabase/functions/relay/*` source already on `origin/main` (this PR does not touch that directory), so it is a no-op redeploy of already-current code, not a behavior change — flagging for visibility per repo norms around relay deploys.

## Net elements (R6)

+16 lines, 0 new files, 0 new abstractions. No wrapper functions or helpers added — the two new checks are inline `if` blocks mirroring the existing `result.error` check already used in `scripts/check-dead-code-ratchet.mjs`.

## Consumer counts (R8)

n/a — no code deleted or re-routed; this only adds explicit checks before the existing `process.exit(result.status ?? 1)` line, which is unchanged.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-script diagnostics only; no changes to relay runtime, auth, or app code.
> 
> **Overview**
> **`scripts/deploy-relay.mjs`** now treats `spawnSync` spawn-level failures before relying on `result.status`, fixing silent exit code 1 when the `supabase` CLI never starts (e.g. missing from `PATH`).
> 
> On **`result.error`**, it logs a clear message—**ENOENT** gets an actionable “CLI not found on PATH” hint—and exits 1; other spawn errors are logged with the error object. On **`result.signal`**, it reports that the CLI was killed and exits 1. Normal non-zero CLI exits still pass through **`result.status ?? 1`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2d98fa1a0d472235512328a7c43823f951ddae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->