### PR TITLE
fix(goal): render continuation prompt via shared nunjucks renderer

### DIFF
--- a/src/agent/goal/maybeBuildGoalContinuation.ts
+++ b/src/agent/goal/maybeBuildGoalContinuation.ts
@@ -1,14 +1,9 @@
 import type { StreamTabId } from '@shared/schemas/identifiers';
 import { formatGoalTime, goalElapsedMs } from '@shared/schemas/goal';
 import { GoalStore, isGoalEnabled } from '@tools/goal';
+import { renderPrompt } from '@utils/prompt';
 
 import { getContinuationTemplate } from './promptLoader';
-
-function render(template: string, vars: Record<string, string>): string {
-  return template.replaceAll(/\{\{(\w+)\}\}/g, (match, key: string) =>
-    Object.hasOwn(vars, key) ? vars[key] : match,
-  );
-}
 
 /**
  * Build the pre-wait Goal continuation for a stream.
@@ -38,7 +33,7 @@ export async function maybeBuildGoalContinuation(
   if (!isGoalEnabled()) return null;
 
   const template = await getContinuationTemplate();
-  return render(template, {
+  return renderPrompt(template, {
     objective: goal.objective,
     timeUsed: formatGoalTime(goalElapsedMs(goal)),
   });

--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -99,6 +99,17 @@ describe('maybeBuildGoalContinuation', () => {
     expect(out).not.toContain('plan(command="pause")');
   });
 
+  it('renders an objective containing nunjucks-significant syntax as literal text', async () => {
+    // The objective is a context *value* substituted into the template, not
+    // concatenated into the template source — nunjucks must not re-parse it
+    // as template syntax (no injection, no `{{ 1 + 1 }}` evaluating to `2`).
+    const objective =
+      'Finish {% for x in y %}{{ 1 + 1 }}{# comment #}{% endfor %} the "quoted" \\task\\.';
+    await GoalStore.start(STREAM_ID, objective);
+    const out = await maybeBuildGoalContinuation(STREAM_ID);
+    expect(out).toContain(objective);
+  });
+
   it('continues rendering after more than two hours elapsed', async () => {
     const startedAt = new Date('2026-06-17T00:00:00.000Z');
     const afterTwoHours = new Date(


### PR DESCRIPTION
## What / why

Fixes #7881.

`maybeBuildGoalContinuation.ts` hand-rolled a 6-line mustache-style
`render()` function (`{{key}}` substitution via regex) that duplicated the
project's existing nunjucks-backed `renderPrompt` in
`src/utils/prompt/promptUtils.ts`. That renderer is already used from other
VS Code-free `src/agent/` call sites (`PromptBuilder.ts`,
`polishModel.ts`, `agentTemplateRenderer.ts`), and `nunjucks` is already a
`package.json` dependency — so this is a one-site swap-in of a pre-existing
utility, not a new abstraction.

Follow-up from #7868 (deferred there pending behavioral verification, since
template-rendering changes can subtly alter generated prompt text).

## Behavioral verification

- Confirmed the hand-rolled `{{\w+}}` syntax is a strict subset of nunjucks
  `{{ var }}` interpolation.
- The packaged template (`packages/extension/resources/goal/goal.yaml`) only
  uses `{{objective}}` and `{{timeUsed}}`, both of which are always supplied,
  so the "unknown key" behavioral gap between the two renderers (hand-rolled
  leaves it literal; nunjucks would emit `''`) never triggers.
- `objective`/`timeUsed` are passed as nunjucks **context values**, not
  concatenated into template source, so nunjucks never re-parses them as
  template syntax — no injection risk even when the objective text itself
  contains nunjucks-significant sequences (`{% %}`, `{{ }}`, `{# #}`).
  Added a new test pinning this: an objective containing
  `{% for x in y %}{{ 1 + 1 }}{# comment #}{% endfor %}`, quotes, and
  backslashes renders back out as literal text, byte-identical to the input.
- `renderPrompt`'s `autoescape: false` matches the hand-rolled renderer's raw
  (non-HTML-escaped) substitution.

Honest note on the new test: I verified it via `git diff > patch` +
`git checkout -- <file>` + `git apply patch` (all within this worktree, no
`git stash`) that the new adversarial-text test **also passes against the
pre-fix hand-rolled renderer** — this is expected and not a gap. Both
renderers do a non-re-parsing raw substitution of `{{objective}}`, so a value
containing nunjucks-significant syntax renders identically under both
implementations. The test isn't a regression-catcher for *this* particular
input; it's a pinning test that locks in the byte-identical-output guarantee
the issue asked for, so a future change to either renderer that broke the
"treat values as data, never re-parse" property would be caught.

## Verification commands

```
cd <worktree>
CI=true corepack pnpm install --prefer-offline
npx vitest run src/test-kernel/agent/GoalContinuation.vitest.ts   # 13 passed
npx vitest run src/test-kernel/agent                              # 159 passed | 1 skipped
npx eslint src/agent/goal/maybeBuildGoalContinuation.ts src/test-kernel/agent/GoalContinuation.vitest.ts   # clean
npm run typecheck                                                  # clean (root + test-kernel + cli + desktop + trace-viewer)
```

## Net elements (R6)

- Deleted: hand-rolled `render()` helper (6 lines) + its blank separator line.
- Added: one import (`renderPrompt` from `@utils/prompt`).
- Call site: `render(` → `renderPrompt(`, no signature/shape change (already
  `async`, caller already `await`s it).
- Net: **−5 lines** of production code (2 files changed, +13/−7 including the
  new test).
- No new port, facade, or abstraction — reuses an existing, already-consumed
  utility.

## Consumer counts (R8)

- `maybeBuildGoalContinuation` production call sites: 1
  (`src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts:118`,
  already `await`s the call — unaffected by the internal swap).
- Deleted `render()` helper call sites: 1 (the one being replaced).
- `renderPrompt` existing consumers (unchanged, confirms it's a proven shared
  utility, not new): `PromptBuilder.ts` (3 call sites), `polishModel.ts`,
  `agentTemplateRenderer.ts`, `agentCreatorFlow.ts`.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal renderer swap for an existing template with two known variables; behavior is verified as equivalent with a pinning test for objective text safety.
> 
> **Overview**
> **Goal continuation prompts** now use the shared **`renderPrompt`** (nunjucks) helper instead of a local regex **`{{key}}`** renderer in `maybeBuildGoalContinuation.ts`, aligning with other agent prompt call sites.
> 
> A new test asserts that a goal **objective** containing nunjucks-like syntax (`{% %}`, `{{ }}`, quotes, backslashes) is emitted **unchanged** in the output—values stay data, not re-parsed template source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49663875aeedac2bd3704a83fb5b8e2284904e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->