### PR TITLE
test(tools): dispose SessionHandle instances in concurrency test

### DIFF
--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -22,11 +22,19 @@ import {
 /**
  * Proves the desktop multi-window invariant: two runs owned by distinct
  * sessions never cross-talk, even when both requests are in flight at once.
- * The approval queue is shared, but each request must resolve through the
- * `SessionHandle.interactions` owner captured by its run context.
+ * Each request must resolve through the `SessionHandle.interactions` owner
+ * captured by its run context.
  */
 describe('Concurrent session tool edit approval handlers', () => {
   setupPlatform({ workspacePath: '/workspace', config: {}, files: {} });
+
+  const testSessions: SessionHandle[] = [];
+
+  function createTestSession(): SessionHandle {
+    const session = new SessionHandle();
+    testSessions.push(session);
+    return session;
+  }
 
   beforeEach(() => {
     cleanupAllApprovals();
@@ -34,6 +42,7 @@ describe('Concurrent session tool edit approval handlers', () => {
 
   afterEach(() => {
     cleanupAllApprovals();
+    for (const session of testSessions.splice(0)) session.dispose();
   });
 
   it('routes each in-flight request through its owning session', async () => {
@@ -53,8 +62,8 @@ describe('Concurrent session tool edit approval handlers', () => {
       return { accepted: true, appliedContent: 'from-b' };
     };
 
-    const sessionA = new SessionHandle();
-    const sessionB = new SessionHandle();
+    const sessionA = createTestSession();
+    const sessionB = createTestSession();
     sessionA.useHostInteractions({
       requestToolEditApproval: handlerA,
       resolve: () => false,
@@ -90,9 +99,9 @@ describe('Concurrent session tool edit approval handlers', () => {
       sourceTool: 'write_file',
     };
 
-    // Fire both without awaiting between them — the shared approval queue
-    // serializes execution, but each call must still resolve through the
-    // handler captured from its own RunContext, not whichever ran last.
+    // Fire both without awaiting between them — each call must still
+    // resolve through the handler captured from its own RunContext, not
+    // whichever ran last.
     const resultAPromise = withRunContext(contextA, () =>
       requestToolEditApproval(requestA),
     );


### PR DESCRIPTION
## What / Why

Closes #7754.

Follow-up from #7739 (Route tool edit approvals through sessions). Two
independent review passes (`claude[bot]` and `Copilot`) flagged that the
new concurrency test's `sessionA`/`sessionB` are constructed with
`new SessionHandle()` but never disposed, and it wasn't addressed before
merge.

`SessionHandle`'s constructor registers itself in the module-level
`liveSessions` Set (`src/agent/runtime/SessionHandle.ts:145`), which holds
strong references. Undisposed instances stay alive for the rest of the
worker process, so `getAllActiveExecutionIds()` and any other cross-session
aggregation keep seeing these two sessions (each with an installed
`requestToolEditApproval` handler) after the test finishes — unlike the
established pattern elsewhere in the suite (`SessionIsolation.vitest.ts`,
`DesktopToolEditApproval.vitest.mts`), both of which track created sessions
and dispose them in `afterEach`.

Changes, scoped entirely to
`src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts`:

- Track `sessionA`/`sessionB` in a `testSessions` array (via a
  `createTestSession()` helper, mirroring `DesktopToolEditApproval.vitest.mts`)
  and dispose them in the existing `afterEach`.
- Reworded the suite docstring and an inline comment that both said "the
  approval queue is shared" — `requestToolEditApproval` no longer routes
  through `toolEditApprovalController.enqueue` at all (per #7739); it
  resolves directly through the owning session's
  `interactions.requestToolEditApproval`, so the "shared queue" phrasing
  was stale and misleading.

## Verification

```
npx vitest run src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
npx vitest run src/test-kernel/tools/                     # 78 files / 459 tests passed
npm run typecheck                                          # root + test-kernel + cli + desktop + trace-viewer, clean
npx eslint src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
npx prettier --check src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
```

All green.

This is a resource-hygiene fix (session objects leaking into the
module-level `liveSessions` Set), not a functional-correctness bug the
existing test's assertions can observe — the test passes identically
before and after. Per source inspection, `SessionHandle`'s constructor adds
`this` to `liveSessions` unconditionally
(`src/agent/runtime/SessionHandle.ts:145`), and `dispose()` →
`deregisterSession()` removes it synchronously
(`src/agent/runtime/SessionHandle.ts:271-272`) when no active executions are
pending — exactly this test's case (sessions here only carry host
interactions, no active executions). No new production-facing assertion
surface was added, since doing so would go beyond "keep the diff to the
test file" for a test-hygiene-only issue.

## Net elements (R6)

+16/-7 lines, all within one test file. No new abstractions: `testSessions`
+ `createTestSession()` is copied verbatim in shape from the existing
`DesktopToolEditApproval.vitest.mts` pattern (single caller, same file,
mirrors prior art — not a new shared helper).

## Consumer counts (R8)

n/a — nothing deleted or re-routed; this only adds disposal calls and
rewords two comments in a single test file.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup and comment fixes; no production code or observable test assertion changes.
> 
> **Overview**
> Fixes **test resource hygiene** in `ConcurrentToolEditApprovalHandlers.vitest.ts` so `SessionHandle` instances are not left registered in the module-level `liveSessions` set after the suite runs.
> 
> The test now tracks sessions via a `testSessions` array and a `createTestSession()` helper (same pattern as other approval/isolation tests) and **disposes every created session in `afterEach`**. Assertions and behavior are unchanged.
> 
> Comment updates remove outdated **“shared approval queue”** wording now that tool edit approval resolves through each session’s `interactions.requestToolEditApproval` rather than a global queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef030516bf05b554f3ae0a4c186b59b48110d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->