### PR TITLE
refactor(github): hoist gitHubTokenExists precedence into shared helper

### DIFF
--- a/packages/extension/src/frontend/secretManager.ts
+++ b/packages/extension/src/frontend/secretManager.ts
@@ -13,8 +13,7 @@ import {
 } from '@model/apiProviders';
 import {
   GITHUB_TOKEN_STORAGE_KEY,
-  getGitHubEnvToken,
-  normalizeGitHubToken,
+  resolveGitHubTokenSource,
 } from '@tools/github/githubAuth';
 
 export type { ApiProvider };
@@ -58,10 +57,7 @@ export class SecretManager {
   }
 
   public static async gitHubTokenExists(): Promise<'secret' | 'env' | 'none'> {
-    const stored = normalizeGitHubToken(await this.get(this.GITHUB_TOKEN_KEY));
-    if (stored) return 'secret';
-    if (getGitHubEnvToken()) return 'env';
-    return 'none';
+    return resolveGitHubTokenSource(platform().secrets);
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -90,3 +90,66 @@ describe('getGitHubToken', () => {
     await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-env-token');
   });
 });
+
+describe('resolveGitHubTokenSource', () => {
+  it('reports "secret" when a persisted token exists, even with env vars set', async () => {
+    const githubAuth = await import('@tools/github/githubAuth');
+
+    await installPlatform({
+      secrets: {
+        [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: 'gh-secret-token',
+      },
+      secretsEnv: {
+        GH_TOKEN: 'gh-env-token',
+        GITHUB_TOKEN: 'github-env-token',
+      },
+    });
+
+    const { platform } = await import('@platform/platform');
+
+    await expect(
+      githubAuth.resolveGitHubTokenSource(platform().secrets),
+    ).resolves.toBe('secret');
+  });
+
+  it('reports "env" when no persisted token exists but an env var does', async () => {
+    const githubAuth = await import('@tools/github/githubAuth');
+
+    await installPlatform({
+      secretsEnv: { GH_TOKEN: 'gh-env-token' },
+    });
+
+    const { platform } = await import('@platform/platform');
+
+    await expect(
+      githubAuth.resolveGitHubTokenSource(platform().secrets),
+    ).resolves.toBe('env');
+  });
+
+  it('reports "none" when neither a persisted token nor an env var exists', async () => {
+    const githubAuth = await import('@tools/github/githubAuth');
+
+    await installPlatform({});
+
+    const { platform } = await import('@platform/platform');
+
+    await expect(
+      githubAuth.resolveGitHubTokenSource(platform().secrets),
+    ).resolves.toBe('none');
+  });
+
+  it('ignores a blank persisted token and falls back to an env var', async () => {
+    const githubAuth = await import('@tools/github/githubAuth');
+
+    await installPlatform({
+      secrets: { [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: '   ' },
+      secretsEnv: { GH_TOKEN: 'gh-env-token' },
+    });
+
+    const { platform } = await import('@platform/platform');
+
+    await expect(
+      githubAuth.resolveGitHubTokenSource(platform().secrets),
+    ).resolves.toBe('env');
+  });
+});

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -49,9 +49,7 @@ export async function getGitHubToken(): Promise<string | undefined> {
 export async function resolveGitHubTokenSource(
   secrets: PlatformSecrets,
 ): Promise<'secret' | 'env' | 'none'> {
-  if (
-    normalizeGitHubToken(await secrets.getStored(GITHUB_TOKEN_STORAGE_KEY))
-  ) {
+  if (normalizeGitHubToken(await secrets.getStored(GITHUB_TOKEN_STORAGE_KEY))) {
     return 'secret';
   }
   return GITHUB_TOKEN_ENV_VARS.some((name) =>

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -9,6 +9,7 @@
  * tools work in the CLI and desktop too, not just the extension.
  */
 import { tryPlatform } from '@platform/platform';
+import type { PlatformSecrets } from '@platform/secrets';
 
 /** SecretStorage key under which the GitHub PAT is persisted. */
 export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
@@ -34,4 +35,28 @@ export function getGitHubEnvToken(): string | undefined {
 export async function getGitHubToken(): Promise<string | undefined> {
   const stored = await tryPlatform()?.secrets.get(GITHUB_TOKEN_STORAGE_KEY);
   return normalizeGitHubToken(stored) ?? getGitHubEnvToken();
+}
+
+/**
+ * Precedence-ordered GitHub-token *source* check: a persisted secret wins
+ * over environment-variable fallbacks. Unlike `getGitHubToken`, this reports
+ * which source backs the token (rather than the token value itself), which
+ * is what credential-status surfaces need. Single owner for the setup tool's
+ * environment probe (`src/tools/setup/platform.ts`) and the extension's
+ * `SecretManager.gitHubTokenExists()`, which previously duplicated this
+ * precedence chain.
+ */
+export async function resolveGitHubTokenSource(
+  secrets: PlatformSecrets,
+): Promise<'secret' | 'env' | 'none'> {
+  if (
+    normalizeGitHubToken(await secrets.getStored(GITHUB_TOKEN_STORAGE_KEY))
+  ) {
+    return 'secret';
+  }
+  return GITHUB_TOKEN_ENV_VARS.some((name) =>
+    normalizeGitHubToken(secrets.getEnv(name)),
+  )
+    ? 'env'
+    : 'none';
 }

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -18,11 +18,7 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import { platform as currentPlatform } from '@platform/platform';
-import {
-  GITHUB_TOKEN_ENV_VARS,
-  GITHUB_TOKEN_STORAGE_KEY,
-  normalizeGitHubToken,
-} from '@tools/github/githubAuth';
+import { resolveGitHubTokenSource } from '@tools/github/githubAuth';
 import type { TerminalRunResult, TerminalRunner } from '@hosts/uiHosts';
 
 /** Per-provider API key surface. */
@@ -166,20 +162,7 @@ export function createDefaultSetupPlatform(): SetupPlatform {
       storedApiKeyExists: async (provider) =>
         (await secrets.listStoredKeys()).includes(apiKeySecretName(provider)),
       anyUsableCredentialExists: () => hasUsableSetupCredential(secrets),
-      gitHubTokenExists: async () => {
-        if (
-          normalizeGitHubToken(
-            await secrets.getStored(GITHUB_TOKEN_STORAGE_KEY),
-          )
-        ) {
-          return 'secret';
-        }
-        return GITHUB_TOKEN_ENV_VARS.some((name) =>
-          normalizeGitHubToken(secrets.getEnv(name)),
-        )
-          ? 'env'
-          : 'none';
-      },
+      gitHubTokenExists: () => resolveGitHubTokenSource(secrets),
       listStoredKeys: () => secrets.listStoredKeys(),
     },
     auth: { getStatus: defaultAuthStatus },


### PR DESCRIPTION
## What

Hoists the duplicated GitHub-token precedence chain (persisted secret wins
over `GITHUB_TOKEN`/`GH_TOKEN` env-var fallback) into a single shared helper,
`resolveGitHubTokenSource(secrets: PlatformSecrets)` in
`src/tools/github/githubAuth.ts` (VS Code-free zone). Both prior call sites
now route through it:

- `src/tools/setup/platform.ts` — `createDefaultSetupPlatform().secrets.gitHubTokenExists`
- `packages/extension/src/frontend/secretManager.ts` — `SecretManager.gitHubTokenExists()`

## Why

Follow-up from #7841: that PR's `createDefaultSetupPlatform()` re-implemented
the precedence chain that already had an owner in
`SecretManager.gitHubTokenExists()` (`anyUsableCredentialExists` was hoisted
in the same PR's review cycle; `gitHubTokenExists` was flagged as the other
half but left un-hoisted, tracked as #7890).

Before hoisting, I verified the two implementations were semantically
identical, not just superficially similar:

- Both check the persisted secret first via a *stored-only* read (no env
  override): `secrets.getStored(GITHUB_TOKEN_STORAGE_KEY)` in
  `platform.ts` vs. `SecretManager`'s raw `this.storage.get(GITHUB_TOKEN_KEY)`
  — the latter reads the same underlying `vscode.SecretStorage` instance
  that `VscodeSecrets` (used for `platform().secrets`) wraps, since both are
  initialized from the same `context` in `extension.ts` (`SecretManager.initialize(context)`
  and `secrets: new VscodeSecrets(context)`).
- Both normalize with the same `normalizeGitHubToken` (trim, empty → undefined).
- Both fall back to the same `GITHUB_TOKEN_ENV_VARS` (`GH_TOKEN`, `GITHUB_TOKEN`)
  checked via the same underlying `process.env` read (`secrets.getEnv(name)`
  for `VscodeSecrets` is a passthrough to `process.env[name]`, same as
  `getGitHubEnvToken()`'s direct `process.env[envVar]` read).

`SecretManager.gitHubTokenExists()` is switched to read through
`platform().secrets` (a pattern this class already uses for `apiKeyExists`
and `hasUsableApiKey`) rather than the raw `vscode.SecretStorage`, which is
what makes routing through the shared, `PlatformSecrets`-typed helper
possible without changing behavior.

## Verification

```
cd <worktree>
npx vitest run src/test-kernel/tools/GitHubAuth.vitest.ts \
  src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts \
  src/test-kernel/model/ApiProviders.vitest.ts \
  src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
# 3 test files -> 4 files, 31 tests, all pass

npx vitest run src/test-kernel/tools
# 78 test files, 463 tests, all pass

npm run typecheck
# root tsc --noEmit, test-kernel tsconfig, extension, CLI, trace-viewer — all pass

npx eslint packages/extension/src/frontend/secretManager.ts \
  src/test-kernel/tools/GitHubAuth.vitest.ts \
  src/tools/github/githubAuth.ts src/tools/setup/platform.ts
# 0 errors; the 3 import/order warnings in platform.ts are pre-existing on
# origin/main (confirmed by linting the unmodified origin/main copy of the
# file) — not introduced by this change.
```

Regression-test-fails-on-pre-fix confirmed: applied the diff, reverted just
the four production/library files via `git diff > patch` +
`git checkout -- <file>` (not `git stash`, forbidden in this shared repo),
re-ran `GitHubAuth.vitest.ts` — the four new `resolveGitHubTokenSource`
tests failed with `TypeError: githubAuth.resolveGitHubTokenSource is not a
function` (the pre-existing `getGitHubToken` tests still passed). Reapplied
the patch and all 10 tests in the file pass.

## Net elements (R6)

- **+1** exported function: `resolveGitHubTokenSource` in `src/tools/github/githubAuth.ts`.
- **0** new files, **0** new interfaces/types.
- Net diff: +92/-25 across 4 files, mostly test additions (63 lines) covering
  the new helper's four precedence branches; the two call sites shrink
  (platform.ts: -17 net lines of duplicated logic; secretManager.ts: -5 net
  lines).
- No new abstraction layer — `resolveGitHubTokenSource` sits next to the
  existing `getGitHubToken`/`getGitHubEnvToken`/`normalizeGitHubToken`
  helpers in the same file, at the same level.

## Consumer counts (R8)

- `gitHubTokenExists` (the interface method / class method name) —
  unchanged, still 2 implementations + 3 call sites (`githubSubscriptionHandlers.ts`,
  `ProbeEnvironmentTool.ts`, and the `SetupSecretsAdapter` interface
  declaration) plus 2 test fixtures (`fixtures.ts`, `ApiProviders.vitest.ts`)
  — none of these needed to change; they call the same method names with the
  same signatures.
- `resolveGitHubTokenSource` (new): 2 production call sites
  (`src/tools/setup/platform.ts`, `packages/extension/src/frontend/secretManager.ts`)
  + 4 new direct unit tests in `src/test-kernel/tools/GitHubAuth.vitest.ts`.
- No deletions of shared surface, so no broader consumer-count audit applies.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving deduplication of credential-status probing only; no changes to token resolution used for GitHub API calls.
> 
> **Overview**
> Consolidates duplicated GitHub token **source** detection (persisted secret vs `GH_TOKEN`/`GITHUB_TOKEN` env vs none) into **`resolveGitHubTokenSource`** in `githubAuth.ts`, using the same normalization and precedence as before.
> 
> **`SecretManager.gitHubTokenExists()`** and **`createDefaultSetupPlatform().secrets.gitHubTokenExists`** now call that helper instead of inlining the logic; the extension path reads through **`platform().secrets`** rather than raw VS Code secret storage. **`getGitHubToken`** is unchanged.
> 
> Adds unit tests for all four precedence branches on the new helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f086ee77a91a697f74c15d1370e578b0c2a6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->