### PR TITLE
fix(test-kernel): special-case @common/state and @common/webview in subsystem ratchet

### DIFF
--- a/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
+++ b/src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
@@ -39,6 +39,13 @@ const SOURCE_FILE = /\.(?:ts|tsx|mts|cts)$/;
 const SUBSYSTEM_ALIASES = new Map<string, string>([
   ['@agent', 'agent'],
   ['@auth', 'auth'],
+  // tsconfig.json carves these two @common/* aliases out to
+  // packages/extension/src/common/* (VS Code-coupled Memento/webview-base
+  // modules), not src/common/*. Map them to distinct pseudo-subsystems so a
+  // future src/-side import of either produces a genuine new-edge ratchet
+  // failure instead of being silently absorbed into the `common` baseline.
+  ['@common/state', 'common-state-extension'],
+  ['@common/webview', 'common-webview-extension'],
   ['@common', 'common'],
   ['@controllers', 'controllers'],
   ['@eventBus', 'eventBus'],
@@ -86,13 +93,20 @@ function resolveImportedSubsystem(
     );
   }
 
+  // Match the most specific (longest) alias so a carve-out like
+  // `@common/state` wins over the broader `@common` alias regardless of
+  // map insertion order.
+  let bestMatch: { alias: string; subsystem: string } | null = null;
   for (const [alias, subsystem] of SUBSYSTEM_ALIASES) {
-    if (specifier === alias || specifier.startsWith(`${alias}/`)) {
-      return subsystem;
+    if (
+      (specifier === alias || specifier.startsWith(`${alias}/`)) &&
+      (bestMatch == null || alias.length > bestMatch.alias.length)
+    ) {
+      bestMatch = { alias, subsystem };
     }
   }
 
-  return null;
+  return bestMatch?.subsystem ?? null;
 }
 
 function stringLiteralText(node: ts.Node): string | null {
@@ -361,5 +375,41 @@ describe('LAY-1 subsystem edge ratchet', () => {
 
     expect(baseline.edges.length).toBeGreaterThan(90);
     expect(baseline.edges).toEqual(sortedEdges);
+  });
+
+  it('does not bucket @common/state or @common/webview imports into the already-whitelisted common edge', () => {
+    // tsconfig.json carves these two aliases out to
+    // packages/extension/src/common/* (VS Code-coupled), not src/common/*.
+    // A src/-side import of either must not resolve to the generic `common`
+    // subsystem, because `agent -> common` (etc.) is already whitelisted in
+    // the baseline and would silently absorb the violating import.
+    const file = join(SRC_ROOT, 'agent', 'example.ts');
+    const stateSubsystem = resolveImportedSubsystem(file, '@common/state');
+    const webviewSubsystem = resolveImportedSubsystem(file, '@common/webview');
+
+    expect(stateSubsystem).not.toBe('common');
+    expect(webviewSubsystem).not.toBe('common');
+    expect(resolveImportedSubsystem(file, '@common/state/foo')).toBe(
+      stateSubsystem,
+    );
+    expect(resolveImportedSubsystem(file, '@common/webview/foo')).toBe(
+      webviewSubsystem,
+    );
+    // The generic `@common` alias (src/common/*) is unaffected.
+    expect(resolveImportedSubsystem(file, '@common/foo')).toBe('common');
+
+    // A hypothetical future `agent -> @common/state` import must surface as
+    // a genuine new-edge ratchet violation, not be silently absorbed.
+    const violations = findRatchetViolations(
+      [{ from: 'agent', to: stateSubsystem ?? '', kind: 'value' }],
+      readBaseline().edges,
+    );
+    expect(violations).toEqual([
+      {
+        edge: `agent->${stateSubsystem}`,
+        reason: 'new-edge',
+        currentKind: 'value',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## What / Why

Fixes #7786.

`resolveImportedSubsystem` in `src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts`
resolved any `@common/...` specifier to the `common` subsystem via a plain
prefix match. But `tsconfig.json` carves `@common/state` and `@common/webview`
out to `packages/extension/src/common/*` (the VS Code-coupled Memento /
webview-base modules) — not `src/common/*`. A future `src/`-side import of
either alias (exactly the agnostic-zone → VS Code coupling CLAUDE.md's
"Separation of Concerns" section forbids) would have been silently bucketed
into the already-whitelisted `X -> common` baseline edge, so the ratchet
would pass instead of catching it.

Fix:
- Map `@common/state` and `@common/webview` to two distinct pseudo-subsystem
  names (`common-state-extension`, `common-webview-extension`) in
  `SUBSYSTEM_ALIASES`, so an edge into either isn't already present in
  `architecture-edges-baseline.json` and a future import trips a genuine
  `new-edge` ratchet violation.
- Changed the alias-matching loop in `resolveImportedSubsystem` to pick the
  most specific (longest) matching alias instead of the first one found by
  Map iteration order, so the `@common/state`/`@common/webview` carve-outs
  reliably win over the broader `@common` alias regardless of where they're
  declared in the map.

Only the architecture test file is touched — no production `src/` file
currently imports either alias, so `architecture-edges-baseline.json` is
unchanged (zero current impact, matching the issue's "known gap, not
currently violated" framing).

## Verification

```
npx vitest run src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
npx vitest run src/test-kernel/architecture
npm run typecheck
npx prettier --check src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
npx eslint src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts
```

All pass. `npm run typecheck` runs the full workspace chain (root `tsc`,
`tsconfig.test-kernel.json`, `texra`, `@texra-ai/cli`, `@texra/trace-viewer`)
clean.

Added a new `it(...)` in the same `describe('LAY-1 subsystem edge ratchet')`
block (R7: extends the existing suite for the module, no new test file) that:
1. asserts `resolveImportedSubsystem` no longer resolves `@common/state` /
   `@common/webview` (and subpaths) to `'common'`, while `@common/foo` still
   does;
2. asserts a synthetic `agent -> common-state-extension` edge is flagged as a
   `new-edge` violation by `findRatchetViolations` against the real baseline.

Confirmed the new test **fails on pre-fix code**: saved the production-code
hunk as a patch, reverted it with `git apply -R` (leaving the new test in
place), reran the suite (1 failure — `expected 'common' not to be 'common'`),
then restored the fix with `git apply` and reran (3/3 pass). Used
`git apply`/`git checkout -- <file>` inside this isolated worktree only, no
`git stash`.

## Net elements (R6)

+53/-3 lines, all in one existing test file
(`src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts`). No new
files, no new abstractions — two new map entries, one loop tweak (first-match
→ longest-match, still the same `Map` and same call sites), one new `it()`
block. No baseline JSON change (no current violating import exists).

## Consumer counts (R8)

n/a — nothing deleted or re-routed. `resolveImportedSubsystem` and
`SUBSYSTEM_ALIASES` are both private to this single test file (not exported,
no other callers); `grep -rn "resolveImportedSubsystem\|SUBSYSTEM_ALIASES" src/`
confirms both symbols are defined and used only within
`subsystemEdgeRatchet.vitest.ts`.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to private helpers in one architecture vitest file; no production or baseline JSON updates.
> 
> **Overview**
> Closes a **false-negative** in the LAY-1 subsystem edge ratchet: imports of `@common/state` and `@common/webview` were resolved to the generic `common` subsystem, so forbidden `src/` → extension-coupled paths could hide behind already-whitelisted `* -> common` baseline edges.
> 
> The ratchet test maps those two aliases to distinct pseudo-subsystems (`common-state-extension`, `common-webview-extension`) and updates **`resolveImportedSubsystem`** to pick the **longest** matching alias so carve-outs beat `@common`. A new test asserts those specifiers are not bucketed as `common` and that a synthetic edge into the extension pseudo-subsystem is reported as a **`new-edge`** violation.
> 
> **No baseline JSON change** — no current `src/` imports use these aliases; behavior is preventive only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9ee1f5937121e217b84dc9ea628e75720af84b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->