### PR TITLE
docs(supabase): pin secrets set to the deployed relay project ref

### DIFF
--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -37,17 +37,24 @@ The script deploys to the production Supabase project by default. Set
 
 ### 2. Set API Key Secrets
 
-Store your API keys as Supabase secrets:
+Store your API keys as Supabase secrets. Pass the same `--project-ref` used
+in step 1 — `supabase secrets set` otherwise operates on whatever project is
+_linked_ in this checkout (or fails if none is linked), which on a fresh
+checkout means the keys silently land on the wrong project or nowhere at all:
 
 ```bash
+# Same ref as `node scripts/deploy-relay.mjs` (defaults to the production
+# project; matches $SUPABASE_PROJECT_REF if you overrode it above).
+PROJECT_REF="${SUPABASE_PROJECT_REF:-jntubmcgbhwtcktubelv}"
+
 # Required secrets (set only the ones you want to support)
-supabase secrets set OPENAI_API_KEY="sk-..."
-supabase secrets set ANTHROPIC_API_KEY="sk-ant-..."
-supabase secrets set GOOGLE_API_KEY="AIza..."
-supabase secrets set XAI_API_KEY="xai-..."
-supabase secrets set DEEPSEEK_API_KEY="sk-..."
-supabase secrets set MOONSHOT_API_KEY="sk-..."
-supabase secrets set DASHSCOPE_API_KEY="sk-..."
+supabase secrets set OPENAI_API_KEY="sk-..." --project-ref "$PROJECT_REF"
+supabase secrets set ANTHROPIC_API_KEY="sk-ant-..." --project-ref "$PROJECT_REF"
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref "$PROJECT_REF"
+supabase secrets set XAI_API_KEY="xai-..." --project-ref "$PROJECT_REF"
+supabase secrets set DEEPSEEK_API_KEY="sk-..." --project-ref "$PROJECT_REF"
+supabase secrets set MOONSHOT_API_KEY="sk-..." --project-ref "$PROJECT_REF"
+supabase secrets set DASHSCOPE_API_KEY="sk-..." --project-ref "$PROJECT_REF"
 ```
 
 ### 3. Verify Deployment

--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -29,11 +29,12 @@ The API keys are stored as Supabase secrets and the relay forwards requests to t
 ```bash
 cd /path/to/TeXRA
 supabase login
+export SUPABASE_PROJECT_REF="${SUPABASE_PROJECT_REF:-jntubmcgbhwtcktubelv}"
 node scripts/deploy-relay.mjs
 ```
 
-The script deploys to the production Supabase project by default. Set
-`SUPABASE_PROJECT_REF` to deploy the relay to another project.
+The exported reference defaults to the production project. Set
+`SUPABASE_PROJECT_REF` before running the block to target another project.
 
 ### 2. Set API Key Secrets
 
@@ -43,18 +44,14 @@ _linked_ in this checkout (or fails if none is linked), which on a fresh
 checkout means the keys silently land on the wrong project or nowhere at all:
 
 ```bash
-# Same ref as `node scripts/deploy-relay.mjs` (defaults to the production
-# project; matches $SUPABASE_PROJECT_REF if you overrode it above).
-PROJECT_REF="${SUPABASE_PROJECT_REF:-jntubmcgbhwtcktubelv}"
-
 # Required secrets (set only the ones you want to support)
-supabase secrets set OPENAI_API_KEY="sk-..." --project-ref "$PROJECT_REF"
-supabase secrets set ANTHROPIC_API_KEY="sk-ant-..." --project-ref "$PROJECT_REF"
-supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref "$PROJECT_REF"
-supabase secrets set XAI_API_KEY="xai-..." --project-ref "$PROJECT_REF"
-supabase secrets set DEEPSEEK_API_KEY="sk-..." --project-ref "$PROJECT_REF"
-supabase secrets set MOONSHOT_API_KEY="sk-..." --project-ref "$PROJECT_REF"
-supabase secrets set DASHSCOPE_API_KEY="sk-..." --project-ref "$PROJECT_REF"
+supabase secrets set OPENAI_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set ANTHROPIC_API_KEY="sk-ant-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set XAI_API_KEY="xai-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set DEEPSEEK_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set MOONSHOT_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set DASHSCOPE_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
 ### 3. Verify Deployment


### PR DESCRIPTION
## Summary

- Export one SUPABASE_PROJECT_REF before deploying the relay.
- Pass that same reference to every documented supabase secrets set command.
- Explain why unqualified secret writes can target a stale linked project.

Closes #7768.

## Issue acceptance gates

- [x] Deployment and secret commands consume one explicit project reference.
- [x] The documented flow does not depend on the checkout linked-project state.
- [x] The production default and operator override match deploy-relay.mjs.

## Single source of truth

SUPABASE_PROJECT_REF is exported once in step 1 and consumed by the deploy script and every secret command in step 2.

## Duplication and abstraction budget

One existing documentation file changed. No second shell variable, test helper, script, or runtime abstraction was added.

## Net elements (R6)

1 file changed; 14 insertions and 10 deletions. No files or abstractions added.

## Consumer counts (R8)

n/a — this changes operator commands only.

## Host impact

Deployment documentation only. Extension, desktop, and CLI runtime behavior are unchanged.

## Scheduled refactoring

None.

## Validation

- Prettier passed for docs/supabase/RELAY_SETUP.md.
- Documentation boundary check passed.
- git diff --check passed.