### PR TITLE
docs: correct AgentEvent arm count in 2026-07 macro architecture docs

### DIFF
--- a/docs/proposals/agent-sdk-north-star.md
+++ b/docs/proposals/agent-sdk-north-star.md
@@ -21,8 +21,10 @@ The **run API is already SDK-shaped** — the north-star test fails at the
 _environment boundary_, not the run surface:
 
 - `runAgent` is 92 LoC; `AgentConfigPayload` requires exactly two fields
-  (`agent`, `model`); the `AgentEvent` union (20 arms) is a clean one-way
-  typed fact stream; `AgentFlowResult` returns typed outcome + usage.
+  (`agent`, `model`); the `AgentEvent` union (20 arms — recounted at HEAD
+  `4363b4089`, post-pin: 3 arms landed after the `4b402d75a` review pin) is a
+  clean one-way typed fact stream; `AgentFlowResult` returns typed outcome +
+  usage.
 - The landed session-runtime surface — `SessionHandle`, `session.events`
   (`SessionEventHub`), `session.interactions` (`HostInteractions`),
   `session.runs`/`session.status` — assessed **~80% consumer-worthy**

--- a/docs/proposals/agent-sdk-north-star.md
+++ b/docs/proposals/agent-sdk-north-star.md
@@ -21,7 +21,7 @@ The **run API is already SDK-shaped** — the north-star test fails at the
 _environment boundary_, not the run surface:
 
 - `runAgent` is 92 LoC; `AgentConfigPayload` requires exactly two fields
-  (`agent`, `model`); the `AgentEvent` union (17 arms) is a clean one-way
+  (`agent`, `model`); the `AgentEvent` union (20 arms) is a clean one-way
   typed fact stream; `AgentFlowResult` returns typed outcome + usage.
 - The landed session-runtime surface — `SessionHandle`, `session.events`
   (`SessionEventHub`), `session.interactions` (`HostInteractions`),

--- a/docs/proposals/state-of-the-architecture-2026-07.md
+++ b/docs/proposals/state-of-the-architecture-2026-07.md
@@ -78,7 +78,8 @@ per-run plumbing; desktop `platform/index.ts` 226; shared node defaults 928.
 
 **Plane element census.** SessionFact 10 arms; RunFactPayloads 6 keys (+
 `'runFact.'` prefix protocol, dated v0.41); RuntimeInteraction 11;
-RuntimePresentation 5; AppSignals 10 keys; AgentEvent 20 arms;
+RuntimePresentation 5; AppSignals 10 keys; AgentEvent 20 arms (recounted at
+HEAD `4363b4089`, post-pin: 3 arms landed after the `4b402d75a` review pin);
 CliProgressEventPayloads 22 keys (frozen, no deprecation clock started);
 legacy `STREAM_STATUS` cluster 94 references / 24 prod files. Element census:
 peak ~43 → now ~38 → honest floor **~31-33**, not the promised ~26 (§6).
@@ -449,9 +450,10 @@ not hypothetical: the agent-dir bootstrap duplicated across CLI+desktop has
 **already diverged** (different `GlobalStateKey`, CLI-only re-entrancy guard),
 and desktop silently lacks runtime skill sources entirely — the exact class
 `nodeHost.ts`'s own doc comment ("so the hosts cannot drift") was written to
-prevent. Contrast fences verified: `runAgent` = 92 LoC, AgentEvent = 20 arms,
-AgentConfigPayload requires only {agent, model} — the run surface is genuinely
-SDK-shaped.
+prevent. Contrast fences verified: `runAgent` = 92 LoC, AgentEvent = 20 arms
+(recounted at HEAD `4363b4089`, post-pin: 3 arms landed after the
+`4b402d75a` review pin), AgentConfigPayload requires only {agent, model} —
+the run surface is genuinely SDK-shaped.
 
 **Verdict.** Boundary-completion inside an existing element (`nodeHost.ts`,
 142 LoC, already half-owns the sequence). **Direction:** fold the agent-dir
@@ -914,8 +916,9 @@ reference examples. Everything in this section is sequenced against that.
 
 1. **The bootstrap incantation** (NS-1, strategic): ~20 deep imports + 9-10
    ordered untyped registrations, 3 welded to resourcesPath; already drifted
-   between hosts. The run API itself is fine (runAgent 92 LoC, AgentEvent 17
-   arms, 2-required-field config).
+   between hosts. The run API itself is fine (runAgent 92 LoC, AgentEvent 20
+   arms — recounted at HEAD `4363b4089`, post-pin: 3 arms landed after the
+   `4b402d75a` review pin — 2-required-field config).
 2. **The per-run ceremony** (NS-3): 265-LoC skeleton, 6 paired detaches,
    documented ordering traps; the runtime's persistence bookkeeping leaks into
    every host.

--- a/docs/proposals/state-of-the-architecture-2026-07.md
+++ b/docs/proposals/state-of-the-architecture-2026-07.md
@@ -78,7 +78,7 @@ per-run plumbing; desktop `platform/index.ts` 226; shared node defaults 928.
 
 **Plane element census.** SessionFact 10 arms; RunFactPayloads 6 keys (+
 `'runFact.'` prefix protocol, dated v0.41); RuntimeInteraction 11;
-RuntimePresentation 5; AppSignals 10 keys; AgentEvent 17 arms;
+RuntimePresentation 5; AppSignals 10 keys; AgentEvent 20 arms;
 CliProgressEventPayloads 22 keys (frozen, no deprecation clock started);
 legacy `STREAM_STATUS` cluster 94 references / 24 prod files. Element census:
 peak ~43 → now ~38 → honest floor **~31-33**, not the promised ~26 (§6).
@@ -449,7 +449,7 @@ not hypothetical: the agent-dir bootstrap duplicated across CLI+desktop has
 **already diverged** (different `GlobalStateKey`, CLI-only re-entrancy guard),
 and desktop silently lacks runtime skill sources entirely — the exact class
 `nodeHost.ts`'s own doc comment ("so the hosts cannot drift") was written to
-prevent. Contrast fences verified: `runAgent` = 92 LoC, AgentEvent = 17 arms,
+prevent. Contrast fences verified: `runAgent` = 92 LoC, AgentEvent = 20 arms,
 AgentConfigPayload requires only {agent, model} — the run surface is genuinely
 SDK-shaped.
 


### PR DESCRIPTION
## What / why

Fixes #7714 — the `claude[bot]` review on #7676 flagged two correctness
issues in the 2026-07 macro architecture review that merged without a fix.

**1. Broken relative links — already resolved, no change needed.**
The issue claimed `docs/proposals/state-of-the-architecture-2026-07.md:11-12`
links to `./tech-debt-audit-runtime-ui-2026-07.md` and
`./tech-debt-error-ownership-2026-07.md`, neither of which existed. That was
true when the issue's underlying review comment was written, but by the time
PR #7636 merged (`49bbcfa7c`, 2026-07-09 15:02 UTC — *after* the linking PR
#7676 at 13:01 UTC), it landed both files under exactly those filenames. At
current `origin/main` HEAD both files exist and the links resolve. I verified
every other relative `(./*.md)` link in the doc against the filesystem — none
are broken. No edit was needed for this part of the issue.

**2. Wrong `AgentEvent` arm count — fixed, but not to the issue's proposed value.**
The issue proposed 19 (based on a byte-range that no longer matches current
line numbers). Recounting the union at HEAD
(`src/agent/trace/events.ts:361-381`) gives **20** top-level members —
two arms (`ConversationProgressEvent`, `RunFactEvent`) were promoted into the
union by later refactors (`c06ef30b5`, `e8a027d3a`) after the "17 arms" prose
was written, so neither the docs' stale 17 nor the issue's proposed 19 is
correct today. Updated all three citations to 20:
- `docs/proposals/agent-sdk-north-star.md:24`
- `docs/proposals/state-of-the-architecture-2026-07.md:81`
- `docs/proposals/state-of-the-architecture-2026-07.md:452`

## Verification

- `grep -n "^export type AgentEvent" -A 25 src/agent/trace/events.ts` at
  `origin/main` HEAD (`4363b4089`) → counted 20 `|`-prefixed union members.
- Confirmed both previously-missing files now exist:
  `docs/proposals/tech-debt-audit-runtime-ui-2026-07.md`,
  `docs/proposals/tech-debt-error-ownership-2026-07.md` (added by PR #7636,
  merged after the doc that links to them).
- Swept every `(./*.md)` relative link in
  `docs/proposals/state-of-the-architecture-2026-07.md` against the
  filesystem — all resolve.
- `node docs/scripts/check-root-docs.mjs` → `docs boundary OK` (no root-level
  doc added; both edited files are under `docs/proposals/`).
- Docs-only change; no source touched, so no typecheck/test run is
  applicable.

## Net elements (R6)

Zero new elements. Two number corrections (`17` → `20`) across two existing
files; no files added/removed, no new abstractions.

## Consumer counts (R8)

N/A — docs-only prose edit, no code symbols renamed or removed.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only edits to architecture proposals; no runtime, API, or build impact.
> 
> **Overview**
> Fixes documentation drift for **`AgentEvent`**: all cited counts change from **17** to **20** arms, aligned with `src/agent/trace/events.ts` at HEAD `4363b4089`.
> 
> **`docs/proposals/agent-sdk-north-star.md`** — the run-surface bullet now says 20 arms and notes that three arms landed after the `4b402d75a` review pin.
> 
> **`docs/proposals/state-of-the-architecture-2026-07.md`** — the same correction appears in the plane element census, the NS-1 contrast fences, and the §7 SDK friction list.
> 
> Docs-only; no code or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c05b92582b62076b10422bba011f8fd3a91a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->