### PR TITLE
test(supabase): catch llm-zoo version skew between package.json and relay deno.json

### DIFF
--- a/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
+++ b/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
@@ -39,7 +39,7 @@ describe('relay shared configuration parity', () => {
     }
   });
 
-  it('keeps the workspace llm-zoo dependency in sync with the relay deno.json pin', () => {
+  it('keeps the workspace llm-zoo range floor in sync with the relay deno.json pin', () => {
     const workspacePackageJson = JSON.parse(
       readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
     ) as { dependencies?: Record<string, string> };
@@ -49,7 +49,10 @@ describe('relay shared configuration parity', () => {
       'package.json is missing an llm-zoo dependency',
     ).toBeDefined();
     // Workspace pin is a caret range (e.g. "^1.12.0"); strip the range
-    // operator to compare against the relay's exact version.
+    // operator to compare against the relay's exact version. This only
+    // checks the declared floor — pnpm may resolve a higher patch/minor
+    // within the caret range, which the resolved-version check below
+    // catches.
     const workspaceVersion = workspaceRange!.replace(/^[\^~]/, '');
 
     const relayDenoJson = JSON.parse(
@@ -68,10 +71,53 @@ describe('relay shared configuration parity', () => {
 
     expect(
       relayVersion,
-      `llm-zoo version skew: package.json pins ${workspaceRange} but relay ` +
-        `deno.json pins ${relaySpecifier}. Update ` +
+      `llm-zoo range floor skew: package.json pins ${workspaceRange} but ` +
+        `relay deno.json pins ${relaySpecifier}. Update ` +
         'supabase/functions/relay/deno.json (and refresh deno.lock) or ' +
         'package.json so both point to the same version.',
     ).toBe(workspaceVersion);
+  });
+
+  it('keeps the pnpm-resolved llm-zoo version in sync with the relay deno.json pin', () => {
+    // package.json declares a caret range, so pnpm can legitimately resolve
+    // a patch/minor above the floor asserted in the previous test (e.g.
+    // ^1.12.0 resolving to 1.12.5) while the relay stays pinned to the
+    // exact 1.12.0 it imports. Compare against the version pnpm actually
+    // resolved in the lockfile so that skew is caught even when it hides
+    // inside the caret range.
+    const pnpmLockYaml = readFileSync(
+      resolve(REPO_ROOT, 'pnpm-lock.yaml'),
+      'utf8',
+    );
+    // Top-level package entries in the pnpm-lock.yaml `packages:` block are
+    // indented exactly two spaces, e.g. "  llm-zoo@1.12.0:". A tolerant
+    // regex avoids pulling in a full YAML parser for a multi-megabyte file.
+    const resolvedMatch = pnpmLockYaml.match(/^ {2}llm-zoo@([^:\s(]+):/m);
+    expect(
+      resolvedMatch,
+      'pnpm-lock.yaml is missing a resolved llm-zoo package entry',
+    ).not.toBeNull();
+    const resolvedVersion = resolvedMatch![1];
+
+    const relayDenoJson = JSON.parse(
+      readFileSync(
+        resolve(REPO_ROOT, 'supabase/functions/relay/deno.json'),
+        'utf8',
+      ),
+    ) as { imports?: Record<string, string> };
+    const relaySpecifier = relayDenoJson.imports?.['llm-zoo'];
+    expect(
+      relaySpecifier,
+      'supabase/functions/relay/deno.json is missing an llm-zoo import',
+    ).toBeDefined();
+    const relayVersion = relaySpecifier!.replace(/^npm:llm-zoo@/, '');
+
+    expect(
+      relayVersion,
+      `llm-zoo version skew: pnpm-lock.yaml resolves llm-zoo@${resolvedVersion} ` +
+        `but relay deno.json pins ${relaySpecifier}. Update ` +
+        'supabase/functions/relay/deno.json (and refresh deno.lock) and/or ' +
+        'the workspace pnpm-lock.yaml so both point to the same version.',
+    ).toBe(resolvedVersion);
   });
 });

--- a/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
+++ b/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -18,6 +22,11 @@ import {
 const CLIENT_TIERS = UserTierSchema.options;
 const RELAY_TIERS = [RELAY_FREE_TIER, RELAY_MAX_TIER, RELAY_ULTRA_TIER];
 
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+
 describe('relay shared configuration parity', () => {
   it('keeps client and relay tier strings identical', () => {
     expect(RELAY_TIERS).toEqual(CLIENT_TIERS);
@@ -28,5 +37,41 @@ describe('relay shared configuration parity', () => {
     for (const tier of CLIENT_TIERS) {
       expect(getRelaySpendingLimit(tier)).toBe(TIER_SPENDING_LIMITS[tier]);
     }
+  });
+
+  it('keeps the workspace llm-zoo dependency in sync with the relay deno.json pin', () => {
+    const workspacePackageJson = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string> };
+    const workspaceRange = workspacePackageJson.dependencies?.['llm-zoo'];
+    expect(
+      workspaceRange,
+      'package.json is missing an llm-zoo dependency',
+    ).toBeDefined();
+    // Workspace pin is a caret range (e.g. "^1.12.0"); strip the range
+    // operator to compare against the relay's exact version.
+    const workspaceVersion = workspaceRange!.replace(/^[\^~]/, '');
+
+    const relayDenoJson = JSON.parse(
+      readFileSync(
+        resolve(REPO_ROOT, 'supabase/functions/relay/deno.json'),
+        'utf8',
+      ),
+    ) as { imports?: Record<string, string> };
+    const relaySpecifier = relayDenoJson.imports?.['llm-zoo'];
+    expect(
+      relaySpecifier,
+      'supabase/functions/relay/deno.json is missing an llm-zoo import',
+    ).toBeDefined();
+    // Relay pin is an exact npm specifier (e.g. "npm:llm-zoo@1.12.0").
+    const relayVersion = relaySpecifier!.replace(/^npm:llm-zoo@/, '');
+
+    expect(
+      relayVersion,
+      `llm-zoo version skew: package.json pins ${workspaceRange} but relay ` +
+        `deno.json pins ${relaySpecifier}. Update ` +
+        'supabase/functions/relay/deno.json (and refresh deno.lock) or ' +
+        'package.json so both point to the same version.',
+    ).toBe(workspaceVersion);
   });
 });


### PR DESCRIPTION
## What / Why

Closes #7769.

#7760 pinned `supabase/functions/relay/deno.json`'s `llm-zoo` import to an
exact version and added `RelaySharedConfigParity.vitest.ts` to catch
tier/spending-limit drift between the client and the relay. But the
workspace `package.json` still pins `llm-zoo` with a caret range
(`^1.12.0`), and nothing in CI compared it against the relay's exact
`deno.json` pin — so version skew in either direction (bump the npm dep
without the relay pin, or vice versa) would go unnoticed until runtime.

This extends the existing parity test with a third case: it reads both
`package.json`'s `dependencies["llm-zoo"]` and
`supabase/functions/relay/deno.json`'s `imports["llm-zoo"]`, strips the
range operator / `npm:llm-zoo@` prefix from each, and asserts the
resulting versions are equal. Any future skew now fails CI the same way
tier/spending-limit drift already does, symmetrically in either direction.

## Verification

- Confirmed the defect still existed at HEAD before fixing: `package.json`
  pinned `^1.12.0`, relay `deno.json` pinned the exact `1.12.0`, and the
  existing parity test only checked tiers/spending limits (no version
  comparison).
- Added the new `it()` case to `RelaySharedConfigParity.vitest.ts`.
- Ran `npx vitest run src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts`
  — 3/3 pass.
- Ran `npx vitest run src/test-kernel/supabase/` — 40/40 pass (no
  regressions in sibling supabase tests).
- **Regression check (revert-style):** temporarily bumped
  `package.json`'s `llm-zoo` to `^1.13.0` (without touching the relay
  pin) and re-ran the test — it fails with a clear message identifying
  both pins and which files to update; reverted the temporary edit
  afterwards (working tree confirmed clean / matches the single intended
  diff before committing).
- `npm run typecheck` — passes.
- `npx eslint src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts`
  and `npx prettier --check` on the same file — clean.

## Net elements (R6)

- 0 new files, 0 new abstractions/helpers.
- +45 lines in one existing test file (one new `it()` block using only
  `node:fs`/`node:path`/`node:url`, already used elsewhere in
  `test-kernel` for repo-root-relative file reads, e.g.
  `src/test-kernel/architecture/progressEventHandlerRetirement.vitest.ts`).
- No production code changed; no new CI workflow step (the existing
  `RelaySharedConfigParity.vitest.ts` suite already runs under `npm test`).

## Consumer counts (R8)

- N/A — no shared helper/abstraction introduced; the new assertion lives
  inline in the single test file it extends, consistent with the other
  two cases in that suite.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or auth impact; failures are limited to dependency pin drift detection.
> 
> **Overview**
> Extends **`RelaySharedConfigParity.vitest.ts`** so CI fails when the workspace and Supabase relay disagree on **`llm-zoo`**, alongside the existing tier and spending-limit checks.
> 
> A **`REPO_ROOT`** helper (same pattern as other `test-kernel` file reads) loads repo files from disk. **Two new cases** assert: (1) the caret **floor** in root `package.json` matches the exact pin in `supabase/functions/relay/deno.json` after stripping `^`/`~` and `npm:llm-zoo@`; (2) the version **pnpm actually resolves** in `pnpm-lock.yaml` (regex on the top-level `llm-zoo@…` entry) matches that relay pin—so skew inside a valid caret range is caught too. Failures include messages pointing at which files to update.
> 
> No production or dependency manifest changes in this diff—tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47431318d3fd150499c1e1cebc731e0f4eeba8e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->