### PR TITLE
refactor(tools): dedupe KV_FILES set between runDirectoryFiles and CLI history

### DIFF
--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -5,6 +5,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isFileNotFoundError } from '@common/errors';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ExecutionId } from '@shared/schemas';
+import { isKVFile as isHistoryKvFile } from '@tools/executions/executionKvFiles';
 import { StorageFS } from '@utils/files';
 import { byStringProp, isObject } from '@utils/core';
 // toPosixPath also trims and resolves `.`/`..` segments beyond a bare slash
@@ -18,22 +19,6 @@ import type { CliHistoryFile } from '../history';
 
 const HISTORY_FILE_SCAN_DEPTH = 2;
 const WORKSPACE_FILE_TOOL_NAMES = new Set(['write_file', 'edit_file']);
-
-const KV_FILES = new Set([
-  'meta.json',
-  'config.json',
-  'conversation.json',
-  'todos.json',
-  'report.json',
-  'workspace-files.json',
-  'result-meta.json',
-]);
-
-function isHistoryKvFile(name: string): boolean {
-  return (
-    KV_FILES.has(name) || name.startsWith('child-') || name.startsWith('flow_')
-  );
-}
 
 export async function listGeneratedFiles(
   id: ExecutionId,

--- a/src/tools/executions/executionKvFiles.ts
+++ b/src/tools/executions/executionKvFiles.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal KV metadata files stored alongside an execution's generated
+ * output. Shared by run-directory listing (`runDirectoryFiles.ts`) and the
+ * CLI's history file listing (`packages/cli/src/runtime/history/generatedFiles.ts`)
+ * so the two stay in sync on what counts as internal metadata.
+ */
+const KV_FILES = new Set([
+  'meta.json',
+  'config.json',
+  'conversation.json',
+  'todos.json',
+  'report.json',
+  'workspace-files.json',
+  'result-meta.json',
+]);
+
+export function isKVFile(name: string): boolean {
+  return (
+    KV_FILES.has(name) || name.startsWith('child-') || name.startsWith('flow_')
+  );
+}

--- a/src/tools/executions/runDirectoryFiles.ts
+++ b/src/tools/executions/runDirectoryFiles.ts
@@ -10,27 +10,12 @@ import { normalizeFilePath } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 
+import { isKVFile } from './executionKvFiles';
+
 export interface RunDirectoryEntry {
   readonly path: string;
   readonly size: number;
   readonly isDir: boolean;
-}
-
-/** Internal KV metadata files stored alongside generated files. */
-const KV_FILES = new Set([
-  'meta.json',
-  'config.json',
-  'conversation.json',
-  'todos.json',
-  'report.json',
-  'workspace-files.json',
-  'result-meta.json',
-]);
-
-function isKVFile(name: string): boolean {
-  return (
-    KV_FILES.has(name) || name.startsWith('child-') || name.startsWith('flow_')
-  );
 }
 
 async function walkDirectory(


### PR DESCRIPTION
## What / why

Fixes #7878.

`src/tools/executions/runDirectoryFiles.ts` and `packages/cli/src/runtime/history/generatedFiles.ts` each defined a literal-identical `KV_FILES` set (7 entries, verbatim) and near-identical `isKVFile`/`isHistoryKvFile` predicate (14 lines each, differing only in function name). Extracted the set + predicate into a new shared module, `src/tools/executions/executionKvFiles.ts`, exporting `isKVFile`.

**Owner choice**: `src/tools/` (not `packages/cli/`), per dependency direction — `packages/cli` already imports from `src/tools` via the `@tools/*` alias (12+ existing CLI files do this), so shared code must not live in `packages/cli` when `src/tools` is itself a consumer.

This is the **narrow re-scope explicitly approved by the maintainer** in the issue comments: only the literal-duplicate `KV_FILES` set + predicate, nothing else. The issue's original ask (unify all 6-7 directory-walk sites across `src/tools/memory/*` and `src/latex/formatter/indentDirectory.ts` into one shared walker) was rejected in the same thread as a net-add trap (BFS/DFS + count/list/side-effect + 4 divergent result types reconciled behind one options-heavy helper, estimated +150 to +300 lines) — that part is explicitly **not** touched here. The walk-loop bodies in both files (filter timing, error handling, output ordering, field naming) are left untouched since they have real behavioral divergence that is not part of the approved scope.

## Verification

- No open PR referenced #7878 (`gh pr list --state open --search "7878 in:body"` — empty) before starting.
- Read the issue body + all comments; the maintainer's "Re-scoped ... (maintainer decision)" comment is binding and is exactly what this PR implements.
- `npm run typecheck` — passes (root `tsc --noEmit`, test-kernel, extension, CLI, trace-viewer all clean).
- `npx eslint` on the three touched files — clean (one auto-fixable `import/order` warning on the new `@tools/*` import in `generatedFiles.ts`, fixed with `--fix`).
- `npx prettier --check` on the three touched files — clean, no reformat churn.
- Targeted test suites covering the two consumers pass: `ExecutionsToolWorkspaceFiles.vitest.ts`, `ExecutionsToolResumability.vitest.ts`, `HistoryStatus.vitest.ts`, `History.vitest.mts` — 75/75 passed. No existing test file directly targets `runDirectoryFiles.ts`/`generatedFiles.ts`'s KV-file predicate, and per the maintainer's binding scope no new tests are required (pure function relocation, behavior unchanged).

## Net elements (R6)

- **+1 file**: `src/tools/executions/executionKvFiles.ts` (new shared module, 21 lines: doc comment + set + function).
- **0 new abstractions beyond the plain function/const relocation** — no new class, port, or facade.
- Net LOC: +24 / −33 across 3 files (≈ −9), in line with the ≈ −6 estimate in the issue's own math.

## Consumer counts (R8)

- `isKVFile` (renamed from the two divergent names) has exactly 2 consumers pre- and post-change: `runDirectoryFiles.ts` (`src/tools/`) and `generatedFiles.ts` (`packages/cli/`, imported as `isHistoryKvFile` to preserve the existing local call-site name). No other call sites exist (verified via grep across `src/` and `packages/`).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure relocation of an identical predicate with two call sites; no logic or walk behavior changes.
> 
> **Overview**
> Duplicates of the execution **internal KV metadata** list (`KV_FILES` plus the `child-*` / `flow_*` basename rules) lived in both `runDirectoryFiles.ts` and the CLI's `generatedFiles.ts`. Those definitions are **moved** into `src/tools/executions/executionKvFiles.ts` with a single exported `isKVFile`.
> 
> Both walkers still own their own traversal and filtering; they now **import** the shared predicate so run-directory listing and CLI history agree on what to skip. The CLI keeps its local name via `import { isKVFile as isHistoryKvFile }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfebd989a4c4805b8d412208280395ed68a9634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->