### PR TITLE
fix(cli): add exhaustiveness guard to NDJSON presentation event switch

### DIFF
--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -17,6 +17,7 @@ import {
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 
 // Local imports - CLI runtime
 import { handleCliApprovalEvent } from './approvalAdapter';
@@ -79,6 +80,8 @@ function writeRuntimePresentationNdjson(
     case 'showAgentConfigBanner':
     case 'requestEnsureProgressView':
       return;
+    default:
+      assertNever(event, 'Unhandled CLI NDJSON presentation event');
   }
 }
 


### PR DESCRIPTION
## What

Add the closing `default: assertNever(event, 'Unhandled CLI NDJSON presentation event')` branch to the `writeRuntimePresentationNdjson` switch in `packages/cli/src/runtime/runtimeHost.ts`, matching the exhaustiveness-guard pattern already used in the sibling projector (`packages/cli/src/runtime/sessionProgressSubscription.ts:71`, `projectCliSessionFact`).

## Why

Follow-up from #7763 (Keep presentation events off the NDJSON progress rail). Three independent reviewers on that PR (the TeXRA agent review bot, Copilot, `claude[bot]`) flagged that the switch over `RuntimePresentationEvent` had no `default`/exhaustiveness guard, none of which was addressed before merge (#7771).

Without the guard, an unfrozen/renamed `RuntimePresentationEvent` could silently fall through the switch with no compile error and no test failure — either leaking out unhandled or silently vanishing from NDJSON output. That's the exact failure mode the parent issue (#7752, FS10) was filed to prevent.

I scoped this PR to the required exhaustiveness guard only (the issue body's second bullet — genericizing the function to drop the `as ...` casts — is phrased as an optional "consider," a separate Copilot suggestion; keeping this PR to the minimal fix per R5).

## Verification

- **Type-level proof (the actual guard):** temporarily removed the `case 'requestOpenFile':` arm from the switch and reran `npx tsc --noEmit -p packages/cli/tsconfig.json`. It failed exactly as intended:
  ```
  packages/cli/src/runtime/runtimeHost.ts(83,19): error TS2345: Argument of type '"requestOpenFile"' is not assignable to parameter of type 'never'.
  ```
  Reverted via `git apply` of the saved diff (no `git stash` used) and confirmed a clean `tsc --noEmit` afterward. This is the proof requested by the issue: removing any switch arm now fails typecheck, since `event` at the `default:` branch only narrows to `never` when every `RuntimePresentationEvent` member has its own case.
- `npx eslint packages/cli/src/runtime/runtimeHost.ts --max-warnings=0` — clean.
- `npm run typecheck` (full workspace: root, test-kernel, `texra` extension, `@texra-ai/cli`, trace-viewer) — clean.
- Targeted suites exercising `createCliRuntimeHost`/`writeRuntimePresentationNdjson` via `src/test-kernel/cli/*.vitest.mts`:
  ```
  CI=true npx vitest run --config vitest.config.mjs \
    src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts \
    src/test-kernel/cli/chatSessionController.vitest.mts \
    src/test-kernel/cli/TuiApprovalRetry.vitest.mts \
    src/test-kernel/cli/TuiStateAndFocus.vitest.mts \
    src/test-kernel/cli/RunExecution.vitest.mts \
    src/test-kernel/cli/RunProgressRenderer.vitest.mts
  ```
  → 6 files, 210 tests passed.
- No new test file added: neither `runtimeHost.ts` nor its sibling `sessionProgressSubscription.ts` (which already uses the same `assertNever` pattern) has a dedicated unit-test file to extend, and the issue itself states the proof is the typecheck failure above, not a runtime assertion (an `assertNever` throw can't be exercised without bypassing the type system).

## Net elements (R6)

+3 lines, 0 new files, 0 new abstractions. One new import (`assertNever` from `@utils/core`, already used elsewhere in this package) and one `default` switch arm reusing the existing helper.

## Consumer counts (R8)

`assertNever` is an existing shared helper (`src/utils/core/index.ts`) already used by 8+ call sites across `packages/cli`, `packages/desktop`, `packages/extension`, and `src/`. This PR adds one more consumer to an established, multi-caller utility — not a new single-caller abstraction.

Fixes #7771

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Three-line change reusing an established helper; behavior for existing events is unchanged and only typecheck coverage improves.
> 
> **Overview**
> Adds a **`default`** branch to **`writeRuntimePresentationNdjson`** in `runtimeHost.ts` that calls **`assertNever(event, …)`**, so the switch over **`RuntimePresentationEvent`** is compile-time exhaustive.
> 
> This mirrors the existing pattern in **`sessionProgressSubscription.ts`** (`projectCliSessionFact`). New or renamed presentation event types will fail **`tsc`** instead of silently falling through with no NDJSON handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497f80ccbe74dae6162c15c8739bf7d0b3d1154f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->