### PR TITLE
docs(relay): scope secrets to deployment project

### DIFF
--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -29,11 +29,13 @@ The API keys are stored as Supabase secrets and the relay forwards requests to t
 ```bash
 cd /path/to/TeXRA
 supabase login
+export SUPABASE_PROJECT_REF="your-project-ref"
 node scripts/deploy-relay.mjs
 ```
 
-The script deploys to the production Supabase project by default. Set
-`SUPABASE_PROJECT_REF` to deploy the relay to another project.
+Set `SUPABASE_PROJECT_REF` to the target project's reference. The deploy script
+and the secret commands below use this exported value so that they always
+target the same project.
 
 ### 2. Set API Key Secrets
 
@@ -41,13 +43,13 @@ Store your API keys as Supabase secrets:
 
 ```bash
 # Required secrets (set only the ones you want to support)
-supabase secrets set OPENAI_API_KEY="sk-..."
-supabase secrets set ANTHROPIC_API_KEY="sk-ant-..."
-supabase secrets set GOOGLE_API_KEY="AIza..."
-supabase secrets set XAI_API_KEY="xai-..."
-supabase secrets set DEEPSEEK_API_KEY="sk-..."
-supabase secrets set MOONSHOT_API_KEY="sk-..."
-supabase secrets set DASHSCOPE_API_KEY="sk-..."
+supabase secrets set OPENAI_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set ANTHROPIC_API_KEY="sk-ant-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set XAI_API_KEY="xai-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set DEEPSEEK_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set MOONSHOT_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
+supabase secrets set DASHSCOPE_API_KEY="sk-..." --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
 ### 3. Verify Deployment

--- a/src/test-kernel/scripts/RelaySetupGuide.vitest.ts
+++ b/src/test-kernel/scripts/RelaySetupGuide.vitest.ts
@@ -1,0 +1,90 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import MarkdownIt from 'markdown-it';
+import { parse as parseShell } from 'shell-quote';
+import { describe, expect, it } from 'vitest';
+
+interface ParsedCommand {
+  source: string;
+  tokens: string[];
+}
+
+const SHELL_LANGUAGES = new Set(['bash', 'sh', 'shell', 'zsh']);
+const RELEVANT_COMMAND =
+  /\b(?:export\s+SUPABASE_PROJECT_REF=|node\s+scripts\/deploy-relay\.mjs\b|supabase\s+secrets\s+set\b)/;
+
+const guidePath = fileURLToPath(
+  new URL('../../../docs/supabase/RELAY_SETUP.md', import.meta.url),
+);
+const guide = readFileSync(guidePath, 'utf8');
+
+function parseRelevantCommands(markdown: string): ParsedCommand[] {
+  const commandBlocks = new MarkdownIt().parse(markdown, {}).filter((token) => {
+    if (token.type === 'code_block') return true;
+    const language = token.info.trim().split(/\s+/, 1)[0];
+    return token.type === 'fence' && SHELL_LANGUAGES.has(language);
+  });
+
+  return commandBlocks.flatMap((block) =>
+    block.content
+      .replaceAll(/\\\r?\n[ \t]*/g, ' ')
+      .split(/\r?\n/)
+      .map((source) => source.trim())
+      .filter(
+        (source) => !source.startsWith('#') && RELEVANT_COMMAND.test(source),
+      )
+      .map((source) => ({
+        source,
+        tokens: parseShell(source, (name) => `$${name}`).filter(
+          (token): token is string => typeof token === 'string',
+        ),
+      })),
+  );
+}
+
+describe('Relay setup guide', () => {
+  const commands = parseRelevantCommands(guide);
+
+  it('exports one project reference before deploying the relay', () => {
+    const exportIndexes = commands
+      .map(({ tokens }, index) => ({ index, tokens }))
+      .filter(
+        ({ tokens }) =>
+          tokens[0] === 'export' &&
+          tokens.some((token) => token.startsWith('SUPABASE_PROJECT_REF=')),
+      )
+      .map(({ index }) => index);
+
+    expect(exportIndexes).toEqual([expect.any(Number)]);
+    const deployIndex = commands.findIndex(
+      ({ tokens }) =>
+        tokens[0] === 'node' && tokens[1] === 'scripts/deploy-relay.mjs',
+    );
+    expect(deployIndex).toBeGreaterThan(exportIndexes[0] ?? Number.MAX_VALUE);
+  });
+
+  it('passes the exported project reference to every secrets set command', () => {
+    const secretCommands = commands.filter(
+      ({ tokens }) =>
+        tokens[0] === 'supabase' &&
+        tokens[1] === 'secrets' &&
+        tokens[2] === 'set',
+    );
+
+    expect(secretCommands.length).toBeGreaterThan(0);
+    for (const command of secretCommands) {
+      const flagIndex = command.tokens.indexOf('--project-ref', 3);
+      expect(
+        flagIndex,
+        `missing --project-ref in: ${command.source}`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        command.tokens[flagIndex + 1],
+        `wrong project reference in: ${command.source}`,
+      ).toBe('$SUPABASE_PROJECT_REF');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Export one SUPABASE_PROJECT_REF in the relay setup procedure.
- Reuse that reference for relay deployment and every documented secret write.
- Add a structured Markdown/shell regression guard for command ordering and project scoping.

Closes #7768.

## Issue acceptance gates

- [x] Deployment and secret commands consume the same explicit project reference.
- [x] A stale local Supabase link cannot redirect the documented secret commands.
- [x] Every documented supabase secrets set command is checked structurally.

## Single source of truth

The exported SUPABASE_PROJECT_REF is the sole project selector in the setup procedure; deploy-relay.mjs and all secret commands consume it.

## Duplication and abstraction budget

No runtime abstraction was added. The test uses the existing Markdown and shell parsers and checks only the two command-level invariants.

## Net elements (R6)

2 files changed; 101 insertions and 9 deletions. One focused test file was added; no production code or runtime types changed.

## Consumer counts (R8)

n/a — no emit path or public export was deleted or rerouted.

## Host impact

Deployment documentation only. Extension, desktop, and CLI runtime behavior are unchanged.

## Scheduled refactoring

None.

## Validation

- Focused documentation suite: 2 tests passed.
- Full Vitest suite: 5,421 passed and 4 skipped.
- npm run typecheck passed.
- npm run compile:fast passed.
- npm run format passed.
- npm run lint passed with no errors.
- git diff --check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc regression tests only; no runtime, auth, or deployment script behavior changes beyond what operators copy from the guide.
> 
> **Overview**
> The relay setup guide now treats a single **`export SUPABASE_PROJECT_REF`** as the project selector for the whole procedure: it appears before **`node scripts/deploy-relay.mjs`**, and every documented **`supabase secrets set`** includes **`--project-ref "$SUPABASE_PROJECT_REF"`** so secret writes cannot follow a stale local Supabase link to the wrong project.
> 
> A new Vitest suite parses shell blocks in **`RELAY_SETUP.md`** and enforces that ordering and that every secrets command passes the exported reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ab3d2f301706e4e8fd519a60fb96be69526e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->