### PR TITLE
refactor(cli): simplify resume in-flight ownership

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -25,10 +25,7 @@ import {
   executeAgent,
   resumeToolUseFromSnapshot,
 } from '@agent/runtime/executeAgent';
-import {
-  isResumeInFlight,
-  resolveAndResumeStream,
-} from '@agent/runtime/resolveAndResumeStream';
+import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
@@ -171,9 +168,6 @@ export interface ChatSessionController {
 
   /** Resume a queued follow-up target from the CLI platform resume port. */
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
-
-  /** Whether a stream resume accepted by this controller is still preparing. */
-  isResumeInFlight(streamId: StreamTabId): boolean;
 
   /** Whether a new root run can be started right now. */
   canStartRootRun(): boolean;
@@ -536,7 +530,6 @@ export function createChatSessionController(
     resume,
     stop,
     tryResumeStream,
-    isResumeInFlight,
     canStartRootRun: () => chatTuiCanStartRootRun(session),
   };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -496,7 +496,6 @@ export async function runChat(
   disposers.push(
     setCliAgentResumeHandler({
       tryResumeStream: (streamId) => chatController.tryResumeStream(streamId),
-      isResumeInFlight: (streamId) => chatController.isResumeInFlight(streamId),
     }),
   );
 

--- a/packages/cli/src/runtime/agentResume.ts
+++ b/packages/cli/src/runtime/agentResume.ts
@@ -1,9 +1,11 @@
+// Local imports - agent
+import { isResumeInFlight } from '@agent/runtime/resolveAndResumeStream';
+
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
 
 export interface CliAgentResumeHandler {
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
-  isResumeInFlight(streamId: StreamTabId): boolean;
 }
 
 let activeHandler: CliAgentResumeHandler | undefined;
@@ -26,5 +28,5 @@ export async function tryResumeCliStream(
 }
 
 export function isCliResumeInFlight(streamId: StreamTabId): boolean {
-  return activeHandler?.isResumeInFlight(streamId) ?? false;
+  return activeHandler != null && isResumeInFlight(streamId);
 }

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UsageLogService } from '@telemetry/UsageLogService';
+import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
+import type { StreamTabId } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 const mocks = vi.hoisted(() => ({
@@ -47,7 +49,12 @@ vi.mock('@cli/runtime/supabaseAuth', () => ({
 }));
 
 vi.mock('@logger/logUtils', () => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  initialize: vi.fn(),
   setOutputChannelFactory: vi.fn(),
+  warn: vi.fn(),
 }));
 
 vi.mock('@model/computeModelOptions', () => ({
@@ -214,24 +221,40 @@ describe('CLI platform init', () => {
     expect(nodePlatformOptions?.agentResume).toBeDefined();
     if (!nodePlatformOptions) throw new Error('expected node platform options');
 
+    const streamId = 'stream:cli-resume' as StreamTabId;
+    let releaseResumeState!: () => void;
+    const pendingResumeState = new Promise<undefined>((resolve) => {
+      releaseResumeState = () => resolve(undefined);
+    });
+    const pendingResume = resolveAndResumeStream(streamId, {
+      runtimeHost: { emit: vi.fn() },
+      streamStatus: { isActiveOrResuming: () => false },
+      resolveResumeState: () => pendingResumeState,
+      resumeToolUseSnapshot: vi.fn(async () => false),
+      executeWorkflow: vi.fn(async () => {}),
+    });
+
+    expect(nodePlatformOptions.agentResume.isResumeInFlight(streamId)).toBe(
+      false,
+    );
+
     const tryResumeStream = vi.fn(async () => true);
-    const isResumeInFlight = vi.fn(() => true);
     const dispose = setCliAgentResumeHandler({
       tryResumeStream,
-      isResumeInFlight,
     });
 
     try {
       await expect(
-        nodePlatformOptions.agentResume.tryResumeStream('stream:cli-resume'),
+        nodePlatformOptions.agentResume.tryResumeStream(streamId),
       ).resolves.toBe(true);
-      expect(tryResumeStream).toHaveBeenCalledWith('stream:cli-resume');
-      expect(
-        nodePlatformOptions.agentResume.isResumeInFlight('stream:cli-resume'),
-      ).toBe(true);
-      expect(isResumeInFlight).toHaveBeenCalledWith('stream:cli-resume');
+      expect(tryResumeStream).toHaveBeenCalledWith(streamId);
+      expect(nodePlatformOptions.agentResume.isResumeInFlight(streamId)).toBe(
+        true,
+      );
     } finally {
       dispose();
+      releaseResumeState();
+      await pendingResume;
     }
   });
 

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -211,8 +211,8 @@ describe('CLI platform init', () => {
 
     type NodePlatformOptions = {
       readonly agentResume: {
-        tryResumeStream(streamId: string): Promise<boolean>;
-        isResumeInFlight(streamId: string): boolean;
+        tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+        isResumeInFlight(streamId: StreamTabId): boolean;
       };
     };
     const createNodePlatformCalls = mocks.createNodePlatform.mock

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -1,9 +1,8 @@
 // Unit tests for the chat-session controller's state transitions.
 // Does not require actual agent execution — the controller's orchestration
 // methods (startRootRun, resume) touch real agent runtime infrastructure,
-// so these tests focus on the pure predicate delegation, the factory
-// contract, and the stop/idle state mutations that are safe to verify
-// without a full agent harness.
+// so these tests focus on the factory contract and the stop/idle state
+// mutations that are safe to verify without a full agent harness.
 
 import PQueue from 'p-queue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,7 +21,6 @@ const mocks = vi.hoisted(() => ({
   attachTuiRunFactSubscription: vi.fn(),
   createTuiHostInteractions: vi.fn(),
   resolveAndResumeStream: vi.fn(),
-  isResumeInFlight: vi.fn(),
   resumeQueuedToolUseSnapshot: vi.fn(),
   projectStreamTranscript: vi.fn(),
   notify: vi.fn(),
@@ -47,7 +45,6 @@ vi.mock('@agent/runtime/executionRegistry', () => ({
 
 vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
   resolveAndResumeStream: mocks.resolveAndResumeStream,
-  isResumeInFlight: mocks.isResumeInFlight,
 }));
 
 vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
@@ -271,8 +268,6 @@ describe('createChatSessionController', () => {
     });
     mocks.resolveAndResumeStream.mockReset();
     mocks.resolveAndResumeStream.mockResolvedValue(true);
-    mocks.isResumeInFlight.mockReset();
-    mocks.isResumeInFlight.mockReturnValue(false);
     mocks.resumeQueuedToolUseSnapshot.mockReset();
     mocks.resumeQueuedToolUseSnapshot.mockResolvedValue(true);
     mocks.projectStreamTranscript.mockReset();


### PR DESCRIPTION
## Summary

- remove `isResumeInFlight` from the chat controller and CLI handler registry
- read the canonical shared runtime predicate directly from the CLI platform adapter
- retain the active-handler guard so non-TUI CLI modes still report `false`
- replace mock-only predicate assertions with a real pending-resume lifecycle test

Closes #7924.

## Issue acceptance gates

- [x] `resumeInFlight` remains owned only by `resolveAndResumeStream.ts`
- [x] the CLI handler registry retains only host-specific `tryResumeStream` behavior
- [x] no active TUI handler still means no CLI resume is in flight
- [x] controller/TUI predicate forwarding is removed
- [x] an actual pending canonical resume verifies both handler-present and handler-absent behavior

## Single source of truth

`resumeInFlight` and `isResumeInFlight()` in the shared resume orchestrator own preparation state. The CLI adapter now consults that owner directly and uses handler presence only as its host-lifecycle gate.

## Duplication and abstraction budget

This removes two interface members, one forwarding lambda, one controller return field, and mock-only predicate plumbing. No state, fallback, wrapper, factory, schema, or dependency layer was added.

## Net elements (R6)

5 files changed; 0 files added/deleted; 40 insertions, 28 deletions, net +12 LoC. Production code is net -6 LoC; tests are net +18 LoC because the former predicate mock was replaced by a real pending-resume lifecycle oracle. No exported function, class, enum, or schema was added or removed.

## Consumer counts (R8)

- `ChatSessionController.isResumeInFlight`: 1 provider / 1 consumer before, 0 / 0 after.
- `CliAgentResumeHandler.isResumeInFlight`: 1 provider / 1 consumer before, 0 / 0 after.
- The canonical predicate keeps one direct CLI consumer, now in `agentResume.ts`.
- `isCliResumeInFlight` keeps one production consumer in the CLI `AgentResumePort` wiring.

## Host impact

Extension: no change.

Desktop: no change.

CLI: behavior preserved; active chat sessions report shared runtime preparation state, while headless/no-handler modes remain `false`.

## Scheduled refactoring

None.

## Validation

- final-head focused Vitest after review feedback: 3 files, 39 tests passed
- broader focused Vitest on the rebased production commit: 5 files, 55 tests passed
- full Vitest before the final non-overlapping rebase: 621 files, 5,455 tests passed; 1 file and 4 tests skipped
- final-head `npm run typecheck` passed, including all four desktop TypeScript configurations
- `npm run compile:fast` passed
- `npm run lint` passed with 0 errors and 52 pre-existing warnings; none are in changed files
- `npm run format` and pre-commit formatting hook passed
- `git diff --check` passed
- live `texra-local` PTY math delegation: one approved `review` child, 0 child tool calls, correct result `2√3`
- targeted PTY harness: 5 subagent follow-up, picker, viewer, and tab-focus scenarios passed

No changelog entry: this is behavior-preserving ownership cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving ownership cleanup with no new state layers; active-handler guard keeps headless CLI reporting false.
> 
> **Overview**
> **Resume preparation state** is no longer forwarded through the chat session controller or the CLI resume handler registry. `isCliResumeInFlight` now reads the canonical `isResumeInFlight()` from `resolveAndResumeStream`, gated only by whether an active TUI handler is registered (headless / no chat session still reports `false`).
> 
> The **handler surface shrinks** to host-specific `tryResumeStream` only: `ChatSessionController`, `CliAgentResumeHandler`, and `runChatTui` wiring drop the duplicate predicate and related mocks. Platform init still exposes `agentResume.isResumeInFlight` via `isCliResumeInFlight`.
> 
> Tests replace **mock-only predicate checks** with a lifecycle test that starts a real pending `resolveAndResumeStream` and asserts in-flight behavior with and without an active handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417f7f22c06b8811d55e24a5754e963f8394c7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->