### PR TITLE
fix(cli): reject slash continuations in delivery tags

### DIFF
--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -35,9 +35,9 @@ const DELIVERY_TAG_ALTERNATION = DELIVERY_TAG_NAMES.join('|');
 // the vocabulary is a shared, growing const). Every producer
 // (deliveryEnvelope.ts / subagentResults.ts / sanitizeTag.ts) only ever
 // follows a tag name with whitespace (attributes), `>` (bare open, e.g.
-// `<execution-activity>`), or `/` (self-closing `... />`), so anchor on that
-// explicit delimiter set instead.
-const TAG_NAME_END = '(?=[\\s/>])';
+// `<execution-activity>`), or the exact `/>` self-closing delimiter, so anchor
+// on those delimiters instead of accepting any slash continuation.
+const TAG_NAME_END = '(?=[\\s>]|/>)';
 const SUBAGENT_TAG_RE = new RegExp(
   `^<(${DELIVERY_TAG_ALTERNATION})${TAG_NAME_END}`,
 );

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -352,24 +352,19 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
-  // `\b` after the tag alternation is not a safe terminator: `-` is a
-  // non-word character, so a future hyphen-extended tag (e.g. a hypothetical
-  // `codex-result-partial`) would prefix-match the existing `codex-result`
-  // entry. No current DELIVERY_TAGS entry is a prefix of another, but the
-  // vocabulary is a shared, growing const, so the recognizers anchor on an
-  // explicit delimiter (whitespace, `/`, or `>`) instead of `\b`. This fake
-  // tag is constructed locally and must never be added to DELIVERY_TAGS.
-  it('does not prefix-match a hyphen-extended fake tag onto a real one', () => {
-    const standalone =
-      '<codex-result-partial id="abc"><response>fake</response></codex-result-partial>';
-    expect(summarizeSubagentFollowup(standalone)).toBe(standalone);
+  it('does not prefix-match invalid tag-name continuations', () => {
+    for (const continuation of ['-partial', '/foo']) {
+      const fakeTag = `codex-result${continuation}`;
+      const standalone = `<${fakeTag} id="abc"><response>fake</response></${fakeTag}>`;
+      expect(summarizeSubagentFollowup(standalone)).toBe(standalone);
 
-    const embedded = [
-      'before',
-      '<codex-result-partial id="abc">',
-      'still streaming, not a real delivery tag',
-    ].join('\n');
-    expect(hasIncompleteEmbeddedSubagentFollowup(embedded)).toBe(false);
-    expect(summarizeEmbeddedSubagentFollowups(embedded)).toBe(embedded);
+      const embedded = [
+        'before',
+        `<${fakeTag} id="abc">`,
+        'still streaming, not a real delivery tag',
+      ].join('\n');
+      expect(hasIncompleteEmbeddedSubagentFollowup(embedded)).toBe(false);
+      expect(summarizeEmbeddedSubagentFollowups(embedded)).toBe(embedded);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- require an exact `/>` delimiter when recognizing shared delivery tags
- reject malformed slash continuations such as `<codex-result/foo>` instead of treating them as real subagent output
- reuse the existing invalid-continuation regression test rather than adding another test case

## Root cause

The shared tag-name boundary accepted any slash after a known delivery-tag name. The renderer therefore prefix-matched malformed tag names, summarized them as completed subagent deliveries, and could drop ordinary trailing assistant text.

The shared delivery-tag parser remains the single owner of this boundary rule; no parallel recognizer or new abstraction is introduced.

## Test budget

- no new test file
- no increase in test count
- one existing boundary test now covers both hyphen and slash continuations

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/SubagentFollowup.vitest.mts` — 29 tests passed after rebasing onto latest `main`
- focused CLI follow-up suites — 3 files, 150 tests passed
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` — 0 errors, 52 existing warnings
- touched-file Prettier and ESLint checks
- `git diff --check`
- real PTY dogfood: delegated a surjection-counting problem to one Codex child, approved it interactively, opened the child stream, and verified the parent rendered the completed delivery without raw XML

No changelog entry: this is an internal malformed-input rendering correction with no new user-facing capability.

Closes #7929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parser-boundary fix in CLI follow-up rendering with targeted regression coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Tightens shared delivery-tag boundary matching in `subagentFollowup.ts` so malformed names like `<codex-result/foo>` are no longer treated as real envelopes (e.g. `codex-result`).
> 
> **`TAG_NAME_END`** now allows whitespace, `>`, or the exact self-closing `/>` delimiter instead of treating any `/` after a known tag name as valid. That stops prefix matches on slash continuations, which could wrongly summarize fake tags as completed subagent output and drop trailing assistant text.
> 
> The existing invalid-continuation regression test now loops over both hyphen (`-partial`) and slash (`/foo`) fake tags for standalone and embedded paths, without adding new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531cde2e7721ad64d9189efb45fc95f070fc82f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->