### PR TITLE
fix(cli): verify setup relay credentials

### DIFF
--- a/packages/cli/src/runtime/credentialStatus.ts
+++ b/packages/cli/src/runtime/credentialStatus.ts
@@ -10,13 +10,12 @@ import { hasAnyProviderApiKey } from '@controllers/onboarding/onboardingFunnel';
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 
-import { getCliAuthProvider } from './supabaseAuth';
+import { getCliAuthProfile } from './supabaseAuth';
 import type { CliApiMode } from './apiAccessMode';
 
 async function hasIncludedRelaySignIn(): Promise<boolean> {
-  return await getCliAuthProvider()
-    .isAuthenticated()
-    .catch(() => false);
+  const profile = await getCliAuthProfile().catch(() => undefined);
+  return profile?.authenticated ?? false;
 }
 
 export async function hasCliCredentialForApiMode(

--- a/src/test-kernel/cli/CredentialStatus.vitest.mts
+++ b/src/test-kernel/cli/CredentialStatus.vitest.mts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   isCodexSubscriptionActive: vi.fn(),
-  isAuthenticated: vi.fn(),
+  getCliAuthProfile: vi.fn(),
   lookupApiKey: vi.fn(),
 }));
 
@@ -11,7 +11,7 @@ vi.mock('@auth/codex', () => ({
 }));
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => ({ isAuthenticated: mocks.isAuthenticated }),
+  getCliAuthProfile: mocks.getCliAuthProfile,
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -29,13 +29,13 @@ const { hasCliCredentialForApiMode } =
 describe('CLI credential status', () => {
   beforeEach(() => {
     mocks.isCodexSubscriptionActive.mockReset().mockResolvedValue(false);
-    mocks.isAuthenticated.mockReset();
+    mocks.getCliAuthProfile.mockReset();
     mocks.lookupApiKey.mockReset();
   });
 
   it('counts an active ChatGPT subscription in every API mode', async () => {
     mocks.isCodexSubscriptionActive.mockResolvedValue(true);
-    mocks.isAuthenticated.mockRejectedValue(
+    mocks.getCliAuthProfile.mockRejectedValue(
       new Error('relay sign-in must not be checked'),
     );
     mocks.lookupApiKey.mockRejectedValue(
@@ -45,25 +45,28 @@ describe('CLI credential status', () => {
     await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
     await expect(hasCliCredentialForApiMode('included')).resolves.toBe(true);
     await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(true);
-    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(mocks.getCliAuthProfile).not.toHaveBeenCalled();
     expect(mocks.lookupApiKey).not.toHaveBeenCalled();
   });
 
-  it('is true when signed in, without checking any provider key', async () => {
-    mocks.isAuthenticated.mockResolvedValue(true);
+  it('is true for a verified relay sign-in, without checking provider keys', async () => {
+    mocks.getCliAuthProfile.mockResolvedValue({
+      authenticated: true,
+      credentialSource: 'relayToken',
+    });
     await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
     expect(mocks.lookupApiKey).not.toHaveBeenCalled();
   });
 
   it('is true when a provider key resolves even though signed out', async () => {
-    mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.getCliAuthProfile.mockResolvedValue({ authenticated: false });
     mocks.lookupApiKey.mockResolvedValue(undefined);
     mocks.lookupApiKey.mockResolvedValueOnce('sk-test');
     await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(true);
   });
 
   it('does not count provider keys as included-relay credentials', async () => {
-    mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.getCliAuthProfile.mockResolvedValue({ authenticated: false });
     mocks.lookupApiKey.mockRejectedValue(
       new Error('provider keys must not be checked'),
     );
@@ -72,36 +75,38 @@ describe('CLI credential status', () => {
   });
 
   it('does not count relay sign-in as a personal API-key credential', async () => {
-    mocks.isAuthenticated.mockRejectedValue(
+    mocks.getCliAuthProfile.mockRejectedValue(
       new Error('relay sign-in must not be checked'),
     );
     mocks.lookupApiKey.mockResolvedValue(undefined);
     await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(false);
-    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(mocks.getCliAuthProfile).not.toHaveBeenCalled();
     expect(mocks.lookupApiKey).toHaveBeenCalled();
   });
 
   it('counts provider keys as personal API-key credentials', async () => {
-    mocks.isAuthenticated.mockResolvedValue(false);
     mocks.lookupApiKey.mockResolvedValue(undefined);
     mocks.lookupApiKey.mockResolvedValueOnce('sk-test');
     await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(true);
   });
 
   it('ignores blank provider keys for personal API-key credentials', async () => {
-    mocks.isAuthenticated.mockResolvedValue(false);
     mocks.lookupApiKey.mockResolvedValue('   ');
     await expect(hasCliCredentialForApiMode('personal')).resolves.toBe(false);
   });
 
-  it('is false when signed out and no provider key resolves', async () => {
-    mocks.isAuthenticated.mockResolvedValue(false);
+  it('rejects a server-rejected relay token when no provider key resolves', async () => {
+    mocks.getCliAuthProfile.mockResolvedValue({
+      authenticated: false,
+      credentialSource: 'relayToken',
+      note: 'The server rejected this relay token.',
+    });
     mocks.lookupApiKey.mockResolvedValue(undefined);
     await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(false);
   });
 
   it('treats an auth-check failure as not signed in', async () => {
-    mocks.isAuthenticated.mockRejectedValue(new Error('offline'));
+    mocks.getCliAuthProfile.mockRejectedValue(new Error('offline'));
     mocks.lookupApiKey.mockResolvedValue(undefined);
     await expect(hasCliCredentialForApiMode(undefined)).resolves.toBe(false);
   });


### PR DESCRIPTION
## Summary

- make the CLI onboarding credential gate consume the canonical verified auth profile
- stop an unprobed expired or revoked `TEXRA_RELAY_TOKEN` from suppressing `texra setup` onboarding
- rewire the existing credential-status suite without adding tests

## Root cause

#7904 verifies relay tokens inside the setup-agent reporting tools, but `runSetup()` decides whether to show onboarding before those tools run. That earlier decision called the cache-only `SupabaseClient.isAuthenticated()` adapter, which intentionally treats an unprobed relay token as usable.

The setup result therefore depended on whether another command had already cached the token rejection.

## Single source of truth

`getCliAuthProfile()` remains the owner of relay-token verification, stored-session fallback, and transient-network behavior. The credential gate now reads only its `authenticated` result; it does not add another probe, cache, or relay-specific branch.

## Test budget

- no new test file
- no increase in test count
- the existing signed-out case now represents a server-rejected relay profile
- the existing suite mock is moved from the cache-only provider to the verified profile boundary
- no duplicate `runSetup()` branch test

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/CredentialStatus.vitest.mts` — 9 tests passed
- touched-file ESLint passed
- touched-file Prettier check passed
- `npm run typecheck` passed
- `npm run compile:fast` passed
- `corepack pnpm --filter @texra-ai/cli run bundle` passed
- `git diff --check` passed
- real PTY: with an isolated empty `HOME`/`CODEX_HOME`, no provider keys, and a server-rejected fake `TEXRA_RELAY_TOKEN`, `texra-local setup` opened the Welcome to TeXRA credential picker; Esc exited cleanly with code 0
- latest `main` CI is fully green, including kernel tests, TUI smoke, compile, VSIX packaging, runtime validation, and webview smoke

The full test suite is intentionally left to CI rather than duplicated locally.

No changelog entry: #7904 already added the user-facing entry for rejected relay tokens in setup; this PR completes that promised behavior at the earlier CLI gate.

Closes #7931
