### PR TITLE
fix(cli): await team restoration during shutdown

### DIFF
--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -447,6 +447,7 @@ export async function withCliMultiAgentPresetVisibility<T>(
   let restorePromise: Promise<void> | undefined;
   const restoreVisibility = (): Promise<void> => {
     restorePromise ??= (async () => {
+      // A partial apply still needs rollback; the original error continues from the try block.
       await visibilityApplied.catch(() => undefined);
       await workspaceState.update(
         WorkspaceStateKey.ENABLED_AGENTS,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -469,8 +469,11 @@ export async function withCliMultiAgentPresetVisibility<T>(
     await visibilityApplied;
     return await operation();
   } finally {
-    shutdownRestore.dispose();
-    await restoreVisibility();
+    try {
+      await restoreVisibility();
+    } finally {
+      shutdownRestore.dispose();
+    }
   }
 }
 

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -436,9 +436,18 @@ export async function withCliMultiAgentPresetVisibility<T>(
     WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
   );
 
+  const visibilityApplied = (async () => {
+    await workspaceState.update(WorkspaceStateKey.ENABLED_AGENTS, [
+      ...plan.workflowAgentKeys,
+    ]);
+    await workspaceState.update(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS, [
+      ...plan.toolUseAgentKeys,
+    ]);
+  })();
   let restorePromise: Promise<void> | undefined;
   const restoreVisibility = (): Promise<void> => {
     restorePromise ??= (async () => {
+      await visibilityApplied.catch(() => undefined);
       await workspaceState.update(
         WorkspaceStateKey.ENABLED_AGENTS,
         previousWorkflowAgents,
@@ -456,12 +465,7 @@ export async function withCliMultiAgentPresetVisibility<T>(
   );
 
   try {
-    await workspaceState.update(WorkspaceStateKey.ENABLED_AGENTS, [
-      ...plan.workflowAgentKeys,
-    ]);
-    await workspaceState.update(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS, [
-      ...plan.toolUseAgentKeys,
-    ]);
+    await visibilityApplied;
     return await operation();
   } finally {
     shutdownRestore.dispose();

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,3 +1,4 @@
+import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import {
   BUILTIN_TEAM_ROOT_AGENT_NAMES,
@@ -427,7 +428,7 @@ export async function withCliMultiAgentPresetVisibility<T>(
   plan: CliMultiAgentPresetRunPlan,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const workspaceState = platform().workspaceState;
+  const { lifecycle, workspaceState } = platform();
   const previousWorkflowAgents = workspaceState.get<string[] | undefined>(
     WorkspaceStateKey.ENABLED_AGENTS,
   );
@@ -435,24 +436,36 @@ export async function withCliMultiAgentPresetVisibility<T>(
     WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
   );
 
-  await workspaceState.update(WorkspaceStateKey.ENABLED_AGENTS, [
-    ...plan.workflowAgentKeys,
-  ]);
-  await workspaceState.update(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS, [
-    ...plan.toolUseAgentKeys,
-  ]);
+  let restorePromise: Promise<void> | undefined;
+  const restoreVisibility = (): Promise<void> => {
+    restorePromise ??= (async () => {
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_AGENTS,
+        previousWorkflowAgents,
+      );
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        previousToolUseAgents,
+      );
+    })();
+    return restorePromise;
+  };
+  const shutdownRestore = lifecycle.onShutdown(
+    SHUTDOWN_PHASE.BEFORE,
+    restoreVisibility,
+  );
 
   try {
+    await workspaceState.update(WorkspaceStateKey.ENABLED_AGENTS, [
+      ...plan.workflowAgentKeys,
+    ]);
+    await workspaceState.update(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS, [
+      ...plan.toolUseAgentKeys,
+    ]);
     return await operation();
   } finally {
-    await workspaceState.update(
-      WorkspaceStateKey.ENABLED_AGENTS,
-      previousWorkflowAgents,
-    );
-    await workspaceState.update(
-      WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-      previousToolUseAgents,
-    );
+    shutdownRestore.dispose();
+    await restoreVisibility();
   }
 }
 

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -808,9 +808,18 @@ describe('CLI multi-agent presets', () => {
       ],
     });
 
-    await withCliMultiAgentPresetVisibility(plan, () =>
-      lifecycle.runShutdown(),
-    );
+    let markOperationStarted!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      markOperationStarted = resolve;
+    });
+    const pending = withCliMultiAgentPresetVisibility(plan, async () => {
+      markOperationStarted();
+      await new Promise<never>(() => undefined);
+    });
+    void pending.catch(() => undefined);
+
+    await operationStarted;
+    await lifecycle.runShutdown();
 
     expect({
       workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+// Node.js imports
+import { setTimeout as sleep } from 'node:timers/promises';
 
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
 import { platform } from '@platform/platform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -788,45 +794,126 @@ describe('CLI multi-agent presets', () => {
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
   });
 
-  it('restores temporary team visibility during platform shutdown', async () => {
-    const { lifecycle, workspaceState } = platform();
-    const previousWorkflowAgents = ['builtInWorkflow:generic'];
-    const previousToolUseAgents = ['builtInToolUse:agent'];
-    await workspaceState.update(
-      WorkspaceStateKey.ENABLED_AGENTS,
-      previousWorkflowAgents,
-    );
-    await workspaceState.update(
-      WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-      previousToolUseAgents,
-    );
-    const preset = findPreset('physicist');
-    const plan = planCliMultiAgentPresetRun(preset, {
-      workflowAgents: [agent('correct', AgentCategory.Workflow)],
-      toolUseAgents: [
-        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
-      ],
+  describe('temporary team visibility lifecycle', () => {
+    setupPlatform();
+
+    it('restores temporary team visibility during platform shutdown', async () => {
+      const { lifecycle, workspaceState } = platform();
+      const previousWorkflowAgents = ['builtInWorkflow:generic'];
+      const previousToolUseAgents = ['builtInToolUse:agent'];
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_AGENTS,
+        previousWorkflowAgents,
+      );
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        previousToolUseAgents,
+      );
+      const preset = findPreset('physicist');
+      const plan = planCliMultiAgentPresetRun(preset, {
+        workflowAgents: [agent('correct', AgentCategory.Workflow)],
+        toolUseAgents: [
+          agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+        ],
+      });
+
+      let markOperationStarted!: () => void;
+      const operationStarted = new Promise<void>((resolve) => {
+        markOperationStarted = resolve;
+      });
+      const pending = withCliMultiAgentPresetVisibility(plan, async () => {
+        markOperationStarted();
+        await new Promise<never>(() => undefined);
+      });
+      void pending.catch(() => undefined);
+
+      await operationStarted;
+      await lifecycle.runShutdown();
+
+      expect({
+        workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),
+        toolUse: workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+      }).toEqual({
+        workflow: previousWorkflowAgents,
+        toolUse: previousToolUseAgents,
+      });
     });
 
-    let markOperationStarted!: () => void;
-    const operationStarted = new Promise<void>((resolve) => {
-      markOperationStarted = resolve;
-    });
-    const pending = withCliMultiAgentPresetVisibility(plan, async () => {
-      markOperationStarted();
-      await new Promise<never>(() => undefined);
-    });
-    void pending.catch(() => undefined);
+    it('keeps shutdown waiting until normal restoration finishes', async () => {
+      const { lifecycle, workspaceState } = platform();
+      const previousWorkflowAgents = ['builtInWorkflow:generic'];
+      const previousToolUseAgents = ['builtInToolUse:agent'];
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_AGENTS,
+        previousWorkflowAgents,
+      );
+      await workspaceState.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        previousToolUseAgents,
+      );
+      const plan = planCliMultiAgentPresetRun(findPreset('physicist'), {
+        workflowAgents: [agent('correct', AgentCategory.Workflow)],
+        toolUseAgents: [
+          agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+        ],
+      });
 
-    await operationStarted;
-    await lifecycle.runShutdown();
+      let pauseRestoration = false;
+      let markRestorationStarted!: () => void;
+      const restorationStarted = new Promise<void>((resolve) => {
+        markRestorationStarted = resolve;
+      });
+      let releaseRestoration!: () => void;
+      const restorationReleased = new Promise<void>((resolve) => {
+        releaseRestoration = resolve;
+      });
+      const updateState = workspaceState.update.bind(workspaceState);
+      const updateSpy = vi
+        .spyOn(workspaceState, 'update')
+        .mockImplementation(async (key, value) => {
+          if (pauseRestoration && key === WorkspaceStateKey.ENABLED_AGENTS) {
+            markRestorationStarted();
+            await restorationReleased;
+          }
+          await updateState(key, value);
+        });
 
-    expect({
-      workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),
-      toolUse: workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
-    }).toEqual({
-      workflow: previousWorkflowAgents,
-      toolUse: previousToolUseAgents,
+      const operation = withCliMultiAgentPresetVisibility(plan, async () => {
+        expect({
+          workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),
+          toolUse: workspaceState.get(
+            WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+          ),
+        }).toEqual({
+          workflow: plan.workflowAgentKeys,
+          toolUse: plan.toolUseAgentKeys,
+        });
+        pauseRestoration = true;
+      });
+
+      await restorationStarted;
+      let shutdownSettled = false;
+      const shutdown = lifecycle.runShutdown().then(() => {
+        shutdownSettled = true;
+      });
+
+      try {
+        await sleep(0);
+        expect(shutdownSettled).toBe(false);
+      } finally {
+        releaseRestoration();
+      }
+
+      await Promise.all([operation, shutdown]);
+      updateSpy.mockRestore();
+
+      expect({
+        workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),
+        toolUse: workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+      }).toEqual({
+        workflow: previousWorkflowAgents,
+        toolUse: previousToolUseAgents,
+      });
     });
   });
 });

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { platform } from '@platform/platform';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -19,7 +20,9 @@ import {
   cliMultiAgentPresetTeamLaunchBlockReason,
   planCliMultiAgentPresets,
   planCliMultiAgentPresetRun,
+  withCliMultiAgentPresetVisibility,
 } from '@cli/runtime/multiAgentPresets';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 function agent(
   name: string,
@@ -783,5 +786,38 @@ describe('CLI multi-agent presets', () => {
     expect(plan.rootAgent?.name).toBe('leanOrchestrator');
     expect(plan.missingToolUseAgents).toEqual([]);
     expect(cliMultiAgentPlanHasGaps(plan)).toBe(true);
+  });
+
+  it('restores temporary team visibility during platform shutdown', async () => {
+    const { lifecycle, workspaceState } = platform();
+    const previousWorkflowAgents = ['builtInWorkflow:generic'];
+    const previousToolUseAgents = ['builtInToolUse:agent'];
+    await workspaceState.update(
+      WorkspaceStateKey.ENABLED_AGENTS,
+      previousWorkflowAgents,
+    );
+    await workspaceState.update(
+      WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      previousToolUseAgents,
+    );
+    const preset = findPreset('physicist');
+    const plan = planCliMultiAgentPresetRun(preset, {
+      workflowAgents: [agent('correct', AgentCategory.Workflow)],
+      toolUseAgents: [
+        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+      ],
+    });
+
+    await withCliMultiAgentPresetVisibility(plan, () =>
+      lifecycle.runShutdown(),
+    );
+
+    expect({
+      workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),
+      toolUse: workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    }).toEqual({
+      workflow: previousWorkflowAgents,
+      toolUse: previousToolUseAgents,
+    });
   });
 });

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -902,10 +902,10 @@ describe('CLI multi-agent presets', () => {
         expect(shutdownSettled).toBe(false);
       } finally {
         releaseRestoration();
+        updateSpy.mockRestore();
       }
 
       await Promise.all([operation, shutdown]);
-      updateSpy.mockRestore();
 
       expect({
         workflow: workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS),


### PR DESCRIPTION
## Summary

Keep the CLI team-visibility shutdown callback registered until the shared restoration promise settles. Add a controlled lifecycle regression in which normal cleanup begins, the first restoration write pauses, and platform shutdown starts concurrently.

## Issue acceptance gates

Follow-up hardening for #7933 after its original idle-exit fix landed directly on `main`.

- Shutdown and normal completion share one idempotent restoration promise.
- A shutdown beginning during normal restoration waits for both workspace-state writes.
- The shutdown registration is disposed after restoration, including the restoration-error path.
- Existing idle-shutdown restoration coverage remains intact with a fresh lifecycle per test.

## Single source of truth

`restoreVisibility()` remains the one owner of restoration work and its idempotent promise. The lifecycle callback and normal `finally` path both await that same promise.

## Duplication and abstraction budget

No production abstraction is added. The test suite creates a fresh fake platform for each lifecycle case because `runShutdown()` is intentionally one-shot.

## Net elements (R6)

- Files: 2 modified; no files added or deleted.
- Exported symbols: +0 / -0.
- Classes/interfaces/enums: +0 / -0.
- Lines against current `main`: +132 / -42; net +90, all but three net production lines in focused lifecycle coverage and per-test isolation.

## Consumer counts (R8)

n/a: no emit path or exported API is deleted or rerouted.

## Host impact

Extension: unchanged.

Desktop: unchanged.

CLI: shutdown cannot complete inside the narrow interval between normal cleanup starting and persisted visibility restoration settling.

## Scheduled refactoring

None.

## Validation

- regression test confirmed to fail against the previous disposal order
- `corepack pnpm exec vitest run src/test-kernel/cli/MultiAgentPresets.vitest.mts` (36 passed)
- `corepack pnpm run typecheck`
- targeted ESLint on the two changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering fix in CLI multi-agent visibility teardown plus focused lifecycle tests; no auth or API surface changes.
> 
> **Overview**
> **`withCliMultiAgentPresetVisibility`** now **awaits** the shared `restoreVisibility()` promise in its `finally` block **before** unregistering the `SHUTDOWN_PHASE.BEFORE` callback, with disposal still running on the restoration-error path via a nested `try/finally`.
> 
> That closes a race where platform shutdown could finish while workspace enabled-agent keys were only partly rolled back after normal team-run cleanup had started.
> 
> Tests add a **`temporary team visibility lifecycle`** block with per-test platform setup and a regression that pauses the first restoration write so **`runShutdown()`** must wait until both workspace updates complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83e331eb48f5ef8c5fe3f8abf4bfd161c1005a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->