### PR TITLE
docs(agent-architecture): update stale documentTag references in hero components

### DIFF
--- a/docs/.vitepress/components/AgentAnatomyHero.vue
+++ b/docs/.vitepress/components/AgentAnatomyHero.vue
@@ -11,7 +11,7 @@ import MockCard from './MockCard.vue';
 // Standalone (no MockupFrame). The root carries `.mockup` so the shared `--mk-*`
 // colour + dimensional tokens (theme/mockup.css) resolve here and the card flips
 // cleanly between the docs light / dark themes. Keys mirror the YAML on the page
-// verbatim (inherits: polish, agentCategory: workflow, rounds: 2, documentTag,
+// verbatim (inherits: polish, agentCategory: workflow, rounds: 2,
 // systemPrompt / userPrefix / userRequest).
 
 // The three top-level YAML sections, each captioned by its role.
@@ -23,7 +23,7 @@ const bands = [
   {
     key: 'settings:',
     role: 'how it behaves',
-    fields: ['agentCategory: workflow', 'rounds: 2', 'documentTag: documents'],
+    fields: ['agentCategory: workflow', 'rounds: 2'],
   },
   {
     key: 'prompts:',

--- a/docs/.vitepress/components/AgentYamlHero.vue
+++ b/docs/.vitepress/components/AgentYamlHero.vue
@@ -31,12 +31,6 @@ import MockCard from './MockCard.vue';
         >
         <span class="yh-note">workflow vs toolUse</span>
       </div>
-      <div class="yh-line indent">
-        <code class="yh-code"
-          ><span class="kw">documentTag</span>: document</code
-        >
-        <span class="yh-note">XML output wrapper</span>
-      </div>
 
       <div class="yh-gap"></div>
 

--- a/docs/guide/multiple-output.md
+++ b/docs/guide/multiple-output.md
@@ -57,7 +57,7 @@ This is the crucial part for generating multiple distinct files:
 2. **Agent Generates Structured XML:** The selected agent must be designed (through its `prompts`) to produce a _single XML response_ containing separate blocks for each intended output file, using a structure like this:
 
    ```xml
-   <documents>  <!-- the agent's configured documentTag; "documents" by default -->
+   <documents>  <!-- fixed protocol container, not agent-configurable -->
      <document name="chapter2.tex">
        % ... content for the first output file ...
      </document>


### PR DESCRIPTION
## What / Why

Closes #7926.

Follow-up from #7916 (`docs(agent-architecture): update stale settings.documentTag references`). #7916 fixed three stale `settings.documentTag` / `settings.endTag` prose references in `docs/guide/agent-architecture.md` to match the fixed `<documents><document name="...">` protocol (`src/shared/constants/outputProtocol.ts`), but a `claude[bot]` review on that PR flagged the *interactive/visual* counterparts rendered directly on those same pages as out of scope:

- `docs/.vitepress/components/AgentYamlHero.vue` (used by `agent-architecture.md`, "Understanding the YAML Structure") — dropped the `documentTag: document` / "XML output wrapper" example line, matching the settings example the fixed prose above it now shows (`agentCategory` only).
- `docs/.vitepress/components/AgentAnatomyHero.vue` (used by `custom-agents.md`, already corrected post-#7621) — dropped `documentTag` from the header comment's field list and from the `settings:` band's `fields` array.
- `docs/guide/multiple-output.md` — reworded the inline XML example comment from "the agent's configured documentTag; \"documents\" by default" to "fixed protocol container, not agent-configurable".

Grepped `docs/` (including `.vitepress`) for remaining `documentTag`/`endTag` mentions after editing: the only hits left are in `docs/prds/**`, `docs/proposals/**`, and `docs/supabase/**` — all excluded from the published site by `docs/.vitepress/publicDocs.js` (internal/historical), including `docs/proposals/unified-output-protocol.md` which is the design doc *documenting* the deprecation itself. Left those untouched per the issue instructions ("historical proposals stay").

## Verification

```
node docs/scripts/check-root-docs.mjs
# docs boundary OK: every root-level entry is classified (5 public docs, 1 public dirs).

npx prettier --check docs/.vitepress/components/AgentAnatomyHero.vue docs/.vitepress/components/AgentYamlHero.vue docs/guide/multiple-output.md
# All matched files use Prettier code style!

grep -rn "documentTag\|endTag" docs/
# only docs/prds/**, docs/proposals/**, docs/supabase/** remain (excluded from publicDocs.js)
```

## Net elements (R6)

Pure deletion/reword, no new abstractions: 3 files changed, +3/-9 lines. No new components, props, or fields added.

## Consumer counts (R8)

N/A — docs-only content edit; no shared helpers touched.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and illustrative UI copy only; no runtime or agent schema changes.
> 
> **Overview**
> Follow-up to prose fixes for the **fixed** `<documents>` / `<document name="...">` output protocol: published docs visuals no longer imply agents configure `settings.documentTag`.
> 
> **`AgentYamlHero.vue`** drops the `documentTag: document` example line and its “XML output wrapper” annotation so the settings block matches current YAML (e.g. `agentCategory` only). **`AgentAnatomyHero.vue`** removes `documentTag` from the header comment and from the `settings:` band field list. **`multiple-output.md`** rewords the XML sample comment from “the agent's configured documentTag” to **fixed protocol container, not agent-configurable**.
> 
> Docs-only deletions/rewording (~+3/-9 lines); internal `docs/prds/**` and `docs/proposals/**` mentions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678a0a0a1205315ebc97bfaf3955c408f0afccf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->