### PR TITLE
fix(agent): map OpenAI Chat Completions cache_write_tokens to cacheCreationTokens

### DIFF
--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -136,6 +136,8 @@ export function normalizeOpenAIUsage(
           outputTokens: usage.completion_tokens ?? 0,
           cachedTokens,
           cacheMissTokens,
+          cacheCreationTokens:
+            usage.prompt_tokens_details?.cache_write_tokens ?? 0,
           reasoningTokens:
             usage.completion_tokens_details?.reasoning_tokens ?? 0,
         };

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts
@@ -192,6 +192,39 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
     assert.equal(usage.cacheMissInputTokens, 30);
   });
 
+  it('maps prompt_tokens_details.cache_write_tokens to cacheCreationTokens', () => {
+    const handler = new ModelHandlerDeepSeek(buildConfig());
+
+    const usage = handler.normalizeUsage(
+      {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 10, cache_write_tokens: 15 },
+      } as any,
+      2500,
+    );
+
+    assert.equal(usage.cacheCreationTokens, 15);
+    assert.equal(usage.cachedInputTokens, 10);
+  });
+
+  it('defaults cacheCreationTokens to undefined when cache_write_tokens is absent', () => {
+    const handler = new ModelHandlerDeepSeek(buildConfig());
+
+    const usage = handler.normalizeUsage(
+      {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 0 },
+      } as any,
+      2500,
+    );
+
+    assert.equal(usage.cacheCreationTokens, undefined);
+  });
+
   it('passes thinking toggle and low effort in OpenAI wire format', async () => {
     const handler = new ModelHandlerDeepSeek(
       buildConfig({


### PR DESCRIPTION
## What / why

Follow-up from #7884 (which mapped `input_tokens_details.cache_write_tokens` to
`cacheCreationTokens` for the **Responses** API only, per #7865's scoped
mandate). Verified that `openai@6.46.0`'s vendored types also declare an
optional `CompletionUsage.PromptTokensDetails.cache_write_tokens` field for the
**Chat Completions** API:

```
node_modules/.pnpm/openai@6.46.0_.../openai/resources/completions.d.ts:150
        cache_write_tokens?: number;
```

`normalizeOpenAIUsage`'s `extract` (`src/agent/modelHandlers/openai/openAIUsage.ts`)
never read this field, so any real `cache_write_tokens` value returned on the
Chat Completions path (used by OpenAI itself and every OpenAI-compatible
provider routed through `ModelHandlerOpenAI` — DeepSeek, Kimi, DashScope,
etc.) was silently dropped, exactly like the Responses API bug fixed in #7884.

Fixes #7894.

## Change

One-line mapping added to `normalizeOpenAIUsage`'s extractor, mirroring the
existing `normalizeOpenAIResponseUsage` mapping added in #7884:

```ts
cacheCreationTokens:
  usage.prompt_tokens_details?.cache_write_tokens ?? 0,
```

(`UsageNormalizer.normalizeUsage` already collapses a `0` extract value to
`undefined` on the final `NormalizedUsage`, matching the Responses-side
behavior — no separate handling needed.)

## Pricing (intentionally untouched)

Per the issue's verify-first mandate (re-checked following #7884/#7865's
approach): the live OpenAI pricing page shows no Chat-Completions-specific
cache-write surcharge distinct from the Responses API — the same models and
rates apply to both surfaces, and #7884 already confirmed that every
currently-shipped OpenAI model (gpt-5.5, gpt-5.4, gpt-5.3-codex, etc.) has no
cache-write surcharge; only the not-yet-shipped gpt-5.6 family does. No
speculative pricing knob added.

## Verification

```
npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAINormalize.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIEndTag.vitest.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
# 6 files, 64 tests passed

npm run typecheck   # clean
npx eslint src/agent/modelHandlers/openai/openAIUsage.ts \
  src/test-kernel/agent/modelHandlers/ModelHandlerDeepSeek.vitest.ts   # clean
npx prettier --check <same files>   # clean
```

Regression-tested the fix: reverted only `openAIUsage.ts` via
`git diff > patch && git checkout -- <file>`, confirmed the new
`maps prompt_tokens_details.cache_write_tokens to cacheCreationTokens` test
fails (`undefined !== 15`) on pre-fix code, then `git apply` restored the fix
and reran the full suite green.

## Net elements (R6)

+2 lines of production code (one mapping in an existing `extract` callback);
no new types, functions, files, or abstractions. +2 test cases appended to an
existing `describe` block that already exercises this same code path
(`ModelHandlerDeepSeek tool conversion`), analogous to the two tests #7884
added for the Responses side.

## Consumer counts (R8)

`normalizeOpenAIUsage` is the single Chat Completions usage-normalization
function, used by every `ModelHandlerOpenAI`-derived handler (OpenAI itself,
DeepSeek, Kimi, DashScope, and any other OpenAI-compatible provider on this
path) via `ModelHandlerOpenAI.normalizeUsage` — one call site
(`modelHandlerOpenAI.ts:1019`), so no fan-out or divergent-copy risk.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive field on existing usage normalization with tests; no auth, pricing, or behavioral API changes.
> 
> **Overview**
> **Chat Completions** usage normalization now surfaces **`prompt_tokens_details.cache_write_tokens`** as **`cacheCreationTokens`**, matching the mapping already used on the **Responses** API path in `normalizeOpenAIUsage`.
> 
> Previously those values were dropped for every OpenAI-compatible handler on the Chat Completions route (OpenAI, DeepSeek, Kimi, DashScope, etc.). Downstream usage accounting that already sums `cacheCreationTokens` can now see them when providers return the field. Pricing logic is unchanged.
> 
> Two **DeepSeek** handler tests cover the mapped value and the case where the field is absent (normalized to `undefined` when zero/missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1c601065d15d54f09ba4375b820149da1ef716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->