### PR TITLE
fix(test): parse pnpm-lock.yaml precisely for the llm-zoo skew check

### DIFF
--- a/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
+++ b/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
@@ -1,8 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 import {
   FREE_TIER,
@@ -26,6 +28,8 @@ const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
   '../../..',
 );
+
+const require = createRequire(import.meta.url);
 
 describe('relay shared configuration parity', () => {
   it('keeps client and relay tier strings identical', () => {
@@ -89,15 +93,48 @@ describe('relay shared configuration parity', () => {
       resolve(REPO_ROOT, 'pnpm-lock.yaml'),
       'utf8',
     );
-    // Top-level package entries in the pnpm-lock.yaml `packages:` block are
-    // indented exactly two spaces, e.g. "  llm-zoo@1.12.0:". A tolerant
-    // regex avoids pulling in a full YAML parser for a multi-megabyte file.
-    const resolvedMatch = pnpmLockYaml.match(/^ {2}llm-zoo@([^:\s(]+):/m);
+    // Scanning the deduplicated `packages:` catalog with a regex is
+    // ambiguous: it can match a transitive dependency's `llm-zoo@…:` entry,
+    // or (once workspace members' ranges diverge) the wrong one of several
+    // peer-suffixed keys for the same package. Read the root importer's
+    // resolved version directly instead — `importers['.'].dependencies` is
+    // unambiguous by construction.
+    const lockfile = parseYaml(pnpmLockYaml) as {
+      importers?: Record<
+        string,
+        { dependencies?: Record<string, { version?: string }> }
+      >;
+    };
+    const rootLlmZoo = lockfile.importers?.['.']?.dependencies?.['llm-zoo'];
     expect(
-      resolvedMatch,
-      'pnpm-lock.yaml is missing a resolved llm-zoo package entry',
-    ).not.toBeNull();
-    const resolvedVersion = resolvedMatch![1];
+      rootLlmZoo?.version,
+      "pnpm-lock.yaml is missing the root importer's resolved llm-zoo version",
+    ).toBeDefined();
+    // pnpm suffixes the version with resolved peer deps, e.g.
+    // "1.12.0(zod@4.4.3)"; strip that to get the plain semver.
+    const resolvedVersion = rootLlmZoo!.version!.replace(/\(.*\)$/, '');
+
+    // Strongest oracle: compare against the version pnpm actually installed
+    // on disk, not just what the lockfile claims it resolved. This catches
+    // any remaining lockfile-parsing mistake, not just the wrong-entry class
+    // above. llm-zoo's `exports` map has no `./package.json` subpath, so
+    // resolve it by walking the same node_modules search path Node itself
+    // would use for the package's main entry point.
+    const llmZooPackageJsonPath = (require.resolve.paths('llm-zoo') ?? [])
+      .map((dir) => resolve(dir, 'llm-zoo', 'package.json'))
+      .find((candidate) => existsSync(candidate));
+    expect(
+      llmZooPackageJsonPath,
+      'could not resolve an installed llm-zoo/package.json',
+    ).toBeDefined();
+    const installedPackageJson = JSON.parse(
+      readFileSync(llmZooPackageJsonPath!, 'utf8'),
+    ) as { version?: string };
+    expect(
+      installedPackageJson.version,
+      "pnpm-lock.yaml's resolved llm-zoo version does not match the " +
+        'installed llm-zoo/package.json version',
+    ).toBe(resolvedVersion);
 
     const relayDenoJson = JSON.parse(
       readFileSync(


### PR DESCRIPTION
## What / why

Fixes #7927.

`RelaySharedConfigParity.vitest.ts`'s "keeps the pnpm-resolved llm-zoo
version in sync with the relay deno.json pin" test (added in #7918) extracted
the resolved `llm-zoo` version from `pnpm-lock.yaml` with a tolerant,
no-`g`-flag regex over the deduplicated `packages:` catalog:

```ts
const resolvedMatch = pnpmLockYaml.match(/^ {2}llm-zoo@([^:\s(]+):/m);
```

As flagged in #7918's review, this matches the *first* top-level
`llm-zoo@…:` key in that catalog — not specifically the version pnpm
resolved for the root importer (`.`). It happened to pass today because
there's currently only one distinct resolved version, but the moment two
workspace members' `llm-zoo` ranges diverge (or a transitive dependency
pins its own `llm-zoo@…` entry), the regex can silently pick the wrong one.

The `pnpm-lock.yaml` in this repo already demonstrates part of the
ambiguity: the `packages:` catalog carries *two* keys for the same
resolved version — `llm-zoo@1.12.0:` and the peer-suffixed
`llm-zoo@1.12.0(zod@4.4.3):` — while the root importer's own
`dependencies['llm-zoo'].version` field is unambiguous.

### Fix

- Parse `pnpm-lock.yaml` with the `yaml` package (already a regular
  dependency, used elsewhere in the repo — no new dependency added) and
  read `importers['.'].dependencies['llm-zoo'].version` directly, which is
  unambiguous by construction (strip the trailing peer-dep suffix pnpm
  appends, e.g. `1.12.0(zod@4.4.3)` → `1.12.0`).
- Add the strongest available oracle: assert the extracted version equals
  the version of the `llm-zoo` package actually installed on disk (read
  from its `package.json`, resolved via the same `node_modules` search path
  Node uses for the package's main entry — `llm-zoo`'s `exports` map has no
  `./package.json` subpath, so `require.resolve('llm-zoo/package.json')`
  doesn't work directly). This kills the whole regex-fragility class, not
  just the one entry-matching bug.

## Verification commands

```bash
npx vitest run src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
npx vitest run src/test-kernel/supabase
npx tsc --noEmit -p tsconfig.test-kernel.json
npx eslint src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
npx prettier --check src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
```

All pass (4/4 in the target file, 41/41 across `src/test-kernel/supabase`).

### Proof the fix actually catches a wrong-entry match

Built a synthetic `pnpm-lock.yaml` with a decoy top-level `llm-zoo@1.9.9:`
entry inserted immediately *before* the real `llm-zoo@1.12.0:` entry in the
`packages:` catalog (simulating a transitive dependency pinning a different
exact version, or a divergent workspace-member range):

- **Old regex code** (`git stash`-free revert via patch/checkout, run
  against the decoy lockfile): extracts `1.9.9` — the wrong entry — and
  fails with a spurious version-skew error.
- **New importers-based code** against the same decoy lockfile: still
  correctly extracts `1.12.0`, unaffected by the decoy, and passes.

This confirms the old approach was reproducibly fragile against exactly the
scenario in the issue, and the fix is immune to it.

## Net elements (R6)

- 0 new files, 0 new abstractions/helpers extracted (all logic inlined in
  the single existing `it()` block it replaces).
- 1 new import (`yaml`'s `parse`) — already a workspace `dependencies` entry
  used elsewhere in the repo (e.g. `src/tools/memory/memoryMeta.ts`,
  `src/agent/runtime/agentLoad.ts`); no `package.json` change.
- Net diff: +46/−9 lines in one file (the extra lines are the added oracle
  assertion, which is new coverage, not incidental churn).

## Consumer counts (R8)

- `RelaySharedConfigParity.vitest.ts` is the sole consumer of the
  lockfile-parsing logic being replaced; no other files read
  `pnpm-lock.yaml` for this purpose. No shared helper was extracted (single
  caller), consistent with the repo's single-caller-extraction rule.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or auth behavior impact; slightly heavier lockfile parsing in one vitest file.
> 
> **Overview**
> Hardens **`RelaySharedConfigParity.vitest.ts`** so the **pnpm-resolved `llm-zoo` vs relay `deno.json` pin** test no longer scrapes the lockfile `packages:` catalog with a regex (which could pick a transitive or peer-suffixed `llm-zoo@…` entry).
> 
> The test now **parses `pnpm-lock.yaml`** and reads **`importers['.'].dependencies['llm-zoo'].version`**, stripping pnpm’s peer suffix (e.g. `1.12.0(zod@4.4.3)` → `1.12.0`). It also **asserts that version matches the installed `llm-zoo` `package.json`**, resolved via `require.resolve.paths` because the package has no `./package.json` export.
> 
> **Test-only change** in a single vitest file; uses the existing **`yaml`** dependency plus `existsSync` / `createRequire`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074453d5b1fa17a8d518728fdc440dd20950a70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->