### PR TITLE
fix: dedupe GettingStartedAction command map across Main and Progress views

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -33,11 +33,8 @@ import type { PromptHost } from '@hosts/uiHosts';
 import { isApiProvider } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  GETTING_STARTED_COMMANDS,
-  type GettingStartedAction,
-  type StreamTabId,
-} from '@shared/schemas';
+import type { GettingStartedAction, StreamTabId } from '@shared/schemas';
+import { GETTING_STARTED_COMMANDS } from '@shared/schemas/mainView';
 import { isGoalInFlight } from '@shared/schemas/goal';
 import {
   dispatchProgressViewInbound,

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -33,7 +33,11 @@ import type { PromptHost } from '@hosts/uiHosts';
 import { isApiProvider } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { GettingStartedAction, StreamTabId } from '@shared/schemas';
+import {
+  GETTING_STARTED_COMMANDS,
+  type GettingStartedAction,
+  type StreamTabId,
+} from '@shared/schemas';
 import { isGoalInFlight } from '@shared/schemas/goal';
 import {
   dispatchProgressViewInbound,
@@ -297,15 +301,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async runGettingStartedAction(
     action: GettingStartedAction,
   ): Promise<void> {
-    const commands = {
-      runSetup: 'texra.runSetupAssistant',
-      createSampleProject: 'texra.createSampleProject',
-      cloneOverleaf: 'texra.cloneOverleafProject',
-      downloadArxiv: 'texra.downloadArXivSource',
-      openWalkthrough: 'texra.openGettingStarted',
-    } satisfies Record<GettingStartedAction, string>;
-
-    await safeExecuteCommand(commands[action], [], this.viewName);
+    await safeExecuteCommand(
+      GETTING_STARTED_COMMANDS[action],
+      [],
+      this.viewName,
+    );
     if (action === 'runSetup') {
       await this.provider.refreshOnboardingFunnel();
     }

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -22,8 +22,8 @@ import { isDebugModeEnabled } from '@logger/logUtils';
 import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchMainViewInbound,
+  GETTING_STARTED_COMMANDS,
   MainViewInboundHandlerRegistry,
-  type GettingStartedAction,
 } from '@shared/schemas';
 import { PROVIDER_URLS } from '@shared/constants/providers';
 import { getConfig, updateConfig, SETTINGS_QUERY } from '@utils/config';
@@ -43,14 +43,6 @@ export interface MainViewOnboardingHooks {
    */
   refreshOnboardingFunnel(): Promise<void>;
 }
-
-const GETTING_STARTED_COMMANDS = {
-  runSetup: 'texra.runSetupAssistant',
-  createSampleProject: 'texra.createSampleProject',
-  cloneOverleaf: 'texra.cloneOverleafProject',
-  downloadArxiv: 'texra.downloadArXivSource',
-  openWalkthrough: 'texra.openGettingStarted',
-} satisfies Record<GettingStartedAction, string>;
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -321,11 +321,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         await this.refreshAfterCredentialChange();
       },
       [MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP]: async () => {
-        await safeExecuteCommand('texra.runSetupAssistant', [], this.viewName);
+        await safeExecuteCommand(
+          GETTING_STARTED_COMMANDS.runSetup,
+          [],
+          this.viewName,
+        );
         await this.onboarding?.refreshOnboardingFunnel();
       },
       [MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED]: () =>
-        safeExecuteCommand('texra.openGettingStarted', [], this.viewName),
+        safeExecuteCommand(
+          GETTING_STARTED_COMMANDS.openWalkthrough,
+          [],
+          this.viewName,
+        ),
       [MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP]: async () => {
         await setFirstRunDone(this.context.globalState, true);
         await this.onboarding?.refreshOnboardingFunnel();

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -282,6 +282,19 @@ export const GettingStartedActionSchema = z.enum([
 ]);
 export type GettingStartedAction = z.infer<typeof GettingStartedActionSchema>;
 
+/**
+ * Single source of truth for the getting-started action command IDs, shared
+ * by the Main view banner and the Progress view empty-state list so the two
+ * surfaces can't drift out of sync.
+ */
+export const GETTING_STARTED_COMMANDS = {
+  runSetup: 'texra.runSetupAssistant',
+  createSampleProject: 'texra.createSampleProject',
+  cloneOverleaf: 'texra.cloneOverleafProject',
+  downloadArxiv: 'texra.downloadArXivSource',
+  openWalkthrough: 'texra.openGettingStarted',
+} satisfies Record<GettingStartedAction, string>;
+
 const GettingStartedActionDetailSchema = z.object({
   action: GettingStartedActionSchema,
 });


### PR DESCRIPTION
## Summary

`MainViewMessageHandler` and `ProgressViewMessageHandler` each hardcoded their own copy of the `GettingStartedAction -> command ID` map (`runSetup`, `createSampleProject`, `cloneOverleaf`, `downloadArxiv`, `openWalkthrough`). Both the Main view's "Getting Started" banner and the Progress view's empty-state action list dispatch this same logical action through their own duplicated literal, and nothing enforced the two stayed in sync — a future command-ID rename applied to only one file would silently break the other surface.

Found during an abstraction-layer audit of the codebase (duplicate UI control check per `.claude/skills/code-review/SKILL.md` §5 — "one home per user action").

## Issue acceptance gates

No tracked issue; this addresses a duplicate-control finding from a self-initiated abstraction-layer review. Acceptance gate: the two handlers no longer maintain independent copies of the command map, and both keep working (verified via `npm run typecheck` and `eslint`).

## Single source of truth

`GETTING_STARTED_COMMANDS` in `src/shared/schemas/mainView/state.ts` (next to the `GettingStartedActionSchema`/`GettingStartedAction` type it's keyed by) is now the sole owner of the action-to-command-ID mapping. It's a plain host-neutral `const`, consistent with `src/shared/`'s VS Code-free zone rule.

## Duplication and abstraction budget

Removed: two independently-maintained 5-entry literal maps (in `MainViewMessageHandler.ts` and `ProgressViewMessageHandler.ts`). No new abstraction layer was introduced — the map moves to the same shared schema module that already owns the `GettingStartedAction` enum/type, so this is data consolidation, not a new port/facade.

## Net elements (R6)

3 files changed, +24/-19 lines. No new exported functions/classes; one new exported `const` (`GETTING_STARTED_COMMANDS`) replaces two now-deleted local `const`s of the same shape. Net: -1 duplicated declaration.

## Consumer counts (R8)

n/a — this is not an emit-path or export removal/reroute; it's collapsing two duplicate literals into the one shared constant both existing call sites already needed.

## Host impact

Extension: both `MainViewMessageHandler` (webview) and `ProgressViewMessageHandler` (progress view) now import the same `GETTING_STARTED_COMMANDS` from `@shared/schemas`.

Desktop: no change (desktop reuses the same extension-side handlers).

CLI: no change (getting-started banner/action flow is VS Code-webview-only).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes across the full workspace.
- `npx eslint <the three changed files>` — no errors.
- Did not run the full app/webview manually (no UI harness available in this environment); the change is a pure data-source consolidation with identical resulting command IDs, so existing behavior is preserved by construction.


---
_Generated by [Claude Code](https://claude.ai/code/session_013w5Y8vj1wgVKKECANFKyEi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical command strings; no auth, data, or IPC contract changes beyond import paths.
> 
> **Overview**
> **Getting-started actions** (setup assistant, sample project, Overleaf clone, arXiv download, walkthrough) now resolve VS Code command IDs from one shared map instead of two copy-pasted literals in the Main and Progress message handlers.
> 
> `GETTING_STARTED_COMMANDS` lives in `src/shared/schemas/mainView/state.ts` beside `GettingStartedAction`, typed with `satisfies Record<GettingStartedAction, string>`. **Main** and **Progress** handlers import it and call `safeExecuteCommand(GETTING_STARTED_COMMANDS[action], …)` (or specific keys for onboarding shortcuts). Post-`runSetup` onboarding funnel refresh behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf4547b110b66ba392474dce3eaa89038640c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->