### PR TITLE
fix(relay): preserve retired model denial coverage

### DIFF
--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -132,10 +132,11 @@ const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
   )
   .map(toRelayModel);
 
+// Retired-name detection is a denial guard, not an allowlist. Keep every
+// direct-provider retirement so a future unsupported provider cannot bypass
+// the retired-model rejection before normal provider routing.
 const RETIRED_MODEL_PATTERNS = Object.values(MODEL_CONFIGS)
-  .filter(
-    (m) => RELAY_PROVIDERS.has(m.provider) && !m.openRouterOnly && m.retired,
-  )
+  .filter((m) => !m.openRouterOnly && m.retired)
   .flatMap((m) =>
     [m.name, m.fullName, m.openrouterFullName]
       .filter((name): name is string => name != null)


### PR DESCRIPTION
## Summary

Complete the llm-zoo 1.14 adaptation on current `main` by keeping retired-model detection as a denial guard across every direct-provider model. Forwarding eligibility and retired-name rejection are distinct decisions: an unsupported future provider must not bypass the retired-model check.

## Issue acceptance gates

Closes #7945.

- The exhaustive `ModelProvider.META`, relay-version, and GPT-5.5 documentation repairs already landed in `429e38f43` and `6ace94df3`.
- Retired model names are rejected independently of the relay forwarding allowlist.
- Latest-main root type checking and focused relay tests pass.

## Single source of truth

`MODEL_CONFIGS` remains the model catalog. `RELAY_PROVIDERS` determines which live models the relay may forward, while `RETIRED_MODEL_PATTERNS` independently derives every retired direct-provider name for denial.

## Duplication and abstraction budget

No abstraction or duplicate state is added. The change restores the existing distinction between forwarding eligibility and retired-name rejection.

## Net elements (R6)

- Files: +0 / -0.
- Exported symbols: +0 / -0.
- Classes/interfaces/enums: +0 / -0.
- Net lines: +1.

## Consumer counts (R8)

n/a: no export, event, or routing consumer is added, removed, or redirected.

## Host impact

Extension: no behavior change.

Desktop: no behavior change.

CLI: no behavior change.

Relay: retired names remain denied even when their provider is not forwardable.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/supabase/RelayModelAccess.vitest.ts src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts` (2 files, 7 tests)
- `corepack pnpm run typecheck`
- targeted Prettier check
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens relay access control with no API surface change; only expands the retired-name deny list and documents intent.
> 
> **Overview**
> **Retired-model blocking** no longer ties to `RELAY_PROVIDERS`. `RETIRED_MODEL_PATTERNS` is built from every non–OpenRouter-only retired entry in `MODEL_CONFIGS`, not only models whose provider is relay-forwardable.
> 
> `RELAY_MODELS` still uses the provider allowlist for what may be forwarded. Comments clarify that retired-name detection is a separate **denial guard**, so retired names from providers outside the relay set (e.g. after catalog changes) still hit `isRetiredModelRequest` and return 403 before tier routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ef7767b48c0d0243d04a9f07d9f473b6ea58ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->