### PR TITLE
fix(ci): include desktop in root typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "capture:walkthrough-media": "node scripts/capture-walkthrough-media.mjs",
     "smoke:webviews": "corepack pnpm run vite:webviews && corepack pnpm run smoke:webviews:run",
     "smoke:webviews:run": "node scripts/smoke-webviews-electron.mjs",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck && corepack pnpm --filter @texra-ai/cli typecheck && corepack pnpm --filter @texra/trace-viewer run typecheck",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck && corepack pnpm --filter @texra-ai/cli typecheck && corepack pnpm --filter @texra/trace-viewer run typecheck && corepack pnpm --filter @texra/desktop typecheck",
     "compile:fast": "corepack pnpm --filter texra compile:fast",
     "compile:safe": "npm run typecheck && npm run compile:fast",
     "watch:fast": "corepack pnpm --filter texra watch:fast",


### PR DESCRIPTION
## Summary

Make the repository-wide typecheck include the desktop package's canonical typecheck command. This brings the desktop main process, preload, renderer, and shared desktop configuration under the same CI and release gate as the root, extension, CLI, and trace-viewer code.

## Issue acceptance gates

Closes #7844.

- The root `typecheck` script delegates to `@texra/desktop typecheck`.
- The desktop package remains responsible for its four TypeScript configurations.
- Existing CI and release jobs inherit the change because both call the root `pnpm run typecheck`.
- A deliberate desktop-main type error makes the root command fail.

## Single source of truth

`packages/desktop/package.json` remains the sole definition of which desktop TypeScript configurations must pass. The root script only invokes that package-level command.

## Duplication and abstraction budget

No configuration list is copied into the root script and no abstraction is added. The change adds one package delegation alongside the existing extension, CLI, and trace-viewer delegations.

## Net elements (R6)

- Files: +0 / -0.
- Exported symbols: +0 / -0.
- Classes/interfaces/enums: +0 / -0.
- Net lines: 0.

## Consumer counts (R8)

n/a: no export or event path changes. The two existing consumers of the root gate are `.github/workflows/ci.yml` and `.github/workflows/release.yml`.

## Host impact

Extension: no change.

Desktop: all four desktop TypeScript configurations now participate in the root gate.

CLI: no change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm run typecheck`
- negative control: introduced a temporary desktop-main type error, confirmed root typecheck failed with `TS2322`, then reverted it
- `corepack pnpm run lint` (0 errors; 52 pre-existing warnings)
- `corepack pnpm exec prettier --check package.json`
- JSON parse check
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line script change with no runtime or API impact; only expands static type-check coverage for desktop.
> 
> **Overview**
> Extends the root **`typecheck`** script so it also runs **`@texra/desktop typecheck`**, matching how extension, CLI, and trace-viewer are already delegated. Desktop’s four TypeScript configs (main, preload, renderer, shared) stay defined only in **`packages/desktop/package.json`**; the root change is a single extra filter invocation.
> 
> CI (**`validate`**) and **release** already call **`pnpm run typecheck`**, so desktop TypeScript errors now fail those gates without any workflow edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb1f5f7a91207228fd0434afe60545f04ff564d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->