### PR TITLE
test(cli): cover exhaustive NDJSON projection policy

### DIFF
--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -1,9 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { logConversationProgress, TraceEmitter } from '@agent/trace';
+import {
+  logConversationProgress,
+  TraceEmitter,
+  type AgentEvent,
+} from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import {
+  SessionEventHub,
+  type SessionEvent,
+  type SessionFact,
+} from '@agent/runtime/SessionEventHub';
+import type {
+  CliNdjsonProgressEvent,
+  CliNdjsonProgressEventPayloads,
+} from '@cli/runtime/cliNdjsonProgressEvents';
 import {
   attachCliSessionProgressProjection,
   type CliNdjsonProgressRecordWriter,
@@ -16,6 +28,7 @@ import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
   type ExecutionId,
+  type StorageKey,
   type StreamTabId,
   type UpdateStreamStatusPayload,
 } from '@shared/schemas';
@@ -23,8 +36,18 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const streamId = 'stream:cli-session-projection' as StreamTabId;
 const executionId = 'execution:cli-session-projection' as ExecutionId;
+const childStreamId = 'stream:cli-child' as StreamTabId;
+const childExecutionId = 'execution:cli-child' as ExecutionId;
+const processExecutionId = 'execution:cli-process' as ExecutionId;
+const storageKey = 'run-a' as StorageKey;
 
-function workflowConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+type WorkflowConfig = Omit<AgentConfig, 'agentCategory'> & {
+  agentCategory: typeof AgentCategory.Workflow;
+};
+
+function workflowConfig(
+  overrides: Partial<Omit<AgentConfig, 'agentCategory'>> = {},
+): WorkflowConfig {
   return {
     agent: 'polish',
     agentCategory: AgentCategory.Workflow,
@@ -42,6 +65,258 @@ function workflowConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
     ...overrides,
   };
 }
+
+function sessionFact<K extends SessionFact['type']>(
+  type: K,
+  payload: Extract<SessionFact, { type: K }>['payload'],
+): SessionEvent {
+  return {
+    scope: 'session',
+    event: { type, payload } as Extract<SessionFact, { type: K }>,
+  };
+}
+
+function runEvent(event: AgentEvent): SessionEvent {
+  return { scope: 'run', streamId, event };
+}
+
+type ProgressProjectionCases = {
+  [K in CliNdjsonProgressEvent]: {
+    readonly source: SessionEvent;
+    readonly payload: CliNdjsonProgressEventPayloads[K];
+  };
+};
+
+const projectionConfig = workflowConfig({
+  inputFiles: ['paper.tex', 'appendix.tex'],
+  contextFiles: ['notes.md'],
+});
+const inquiryThread = {
+  threadId: 'ei_123456789abc',
+  parentStreamId: streamId,
+  status: 'open' as const,
+  lastQuestionPreview: 'Which boundary condition is intended?',
+  lastActivityIso: '2026-07-10T12:00:00.000Z',
+  turnCount: 1,
+};
+const child = {
+  kind: 'subagent' as const,
+  executionId: childExecutionId,
+  childStreamId,
+  agentName: 'review',
+  status: 'running',
+};
+const process = {
+  kind: 'process' as const,
+  executionId: processExecutionId,
+  agentName: 'latexmk',
+  status: 'running',
+};
+
+const PROGRESS_PROJECTION_CASES = {
+  setActiveStream: {
+    source: sessionFact('setActiveStream', { streamId }),
+    payload: { streamId },
+  },
+  updateStreamStatus: {
+    source: sessionFact('updateStreamStatus', {
+      streamId,
+      status: STREAM_PHASE.RUNNING,
+    }),
+    payload: { streamId, status: STREAM_PHASE.RUNNING },
+  },
+  addOutputFiles: {
+    source: runEvent({
+      type: 'addOutputFiles',
+      streamId,
+      executionId,
+      filesByRound: { 1: [] },
+    }),
+    payload: { streamId, executionId, filesByRound: { 1: [] } },
+  },
+  updateMissingOutputs: {
+    source: runEvent({
+      type: 'updateMissingOutputs',
+      streamId,
+      executionId,
+      filesByRound: { 1: ['missing.tex'] },
+    }),
+    payload: {
+      streamId,
+      executionId,
+      filesByRound: { 1: ['missing.tex'] },
+    },
+  },
+  updateCompileFailures: {
+    source: runEvent({
+      type: 'updateCompileFailures',
+      streamId,
+      executionId,
+      filesByRound: { 1: [] },
+    }),
+    payload: { streamId, executionId, filesByRound: { 1: [] } },
+  },
+  clearMissingOutputs: {
+    source: sessionFact('clearMissingOutputs', { streamId }),
+    payload: { streamId },
+  },
+  setTaskState: {
+    source: runEvent({
+      type: 'run.config',
+      streamId,
+      executionId,
+      config: projectionConfig,
+    }),
+    payload: {
+      streamId,
+      executionId,
+      taskState: {
+        agentConfig: projectionConfig,
+        activeFiles: {
+          input: true,
+          context: true,
+          media: false,
+          output: false,
+        },
+      },
+    },
+  },
+  updateStreamUsage: {
+    source: runEvent({
+      type: 'usage',
+      stats: {},
+      data: {
+        streamId,
+        storageKey,
+        usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+      },
+    }),
+    payload: {
+      streamId,
+      storageKey,
+      usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
+    },
+  },
+  inquiryThreadUpdated: {
+    source: sessionFact('inquiryThreadUpdated', inquiryThread),
+    payload: inquiryThread,
+  },
+  updateTodos: {
+    source: runEvent({
+      type: 'updateTodos',
+      streamId,
+      todos: [
+        {
+          content: 'Check the compactness lemma.',
+          status: 'pending',
+          activeForm: 'Checking the compactness lemma.',
+        },
+      ],
+    }),
+    payload: {
+      streamId,
+      todos: [
+        {
+          content: 'Check the compactness lemma.',
+          status: 'pending',
+          activeForm: 'Checking the compactness lemma.',
+        },
+      ],
+    },
+  },
+  updatePlan: {
+    source: runEvent({
+      type: 'updatePlan',
+      streamId,
+      plan: { objective: 'Check the compactness lemma.' },
+    }),
+    payload: {
+      streamId,
+      plan: { objective: 'Check the compactness lemma.' },
+    },
+  },
+  updateConversationProgress: {
+    source: runEvent({
+      type: 'conversation.progress',
+      progress: { toolCallCount: 5 },
+    }),
+    payload: { streamId, progress: { toolCallCount: 5 } },
+  },
+  updateRoundStage: {
+    source: runEvent({
+      type: 'stage.start',
+      id: 'round-2',
+      label: 'Round 3',
+      kind: 'round',
+      index: 2,
+      total: 4,
+    }),
+    payload: { streamId, roundStage: { index: 2, total: 4 } },
+  },
+  updateQueuedFollowUps: {
+    source: sessionFact('updateQueuedFollowUps', { streamId }),
+    payload: { streamId },
+  },
+  goalPaused: {
+    source: runEvent({ type: 'goalPaused', streamId }),
+    payload: { streamId },
+  },
+  updateActiveSubagents: {
+    source: runEvent({
+      type: 'child.activity',
+      kind: 'subagents',
+      parentStreamId: streamId,
+      children: [child],
+    }),
+    payload: { parentStreamId: streamId, children: [child] },
+  },
+  updateActiveProcesses: {
+    source: runEvent({
+      type: 'child.activity',
+      kind: 'processes',
+      parentStreamId: streamId,
+      processes: [process],
+    }),
+    payload: { parentStreamId: streamId, processes: [process] },
+  },
+  updateProcessOutput: {
+    source: runEvent({
+      type: 'process.output',
+      parentStreamId: streamId,
+      executionId: processExecutionId,
+      stdout: 'compiled paper.pdf\n',
+      stderr: '',
+    }),
+    payload: {
+      parentStreamId: streamId,
+      executionId: processExecutionId,
+      stdout: 'compiled paper.pdf\n',
+      stderr: '',
+    },
+  },
+  updateStreamDescription: {
+    source: sessionFact('updateStreamDescription', {
+      streamId,
+      description: 'Checking the compactness lemma',
+    }),
+    payload: { streamId, description: 'Checking the compactness lemma' },
+  },
+  setParentStream: {
+    source: sessionFact('setParentStream', {
+      childStreamId,
+      parentStreamId: streamId,
+    }),
+    payload: { childStreamId, parentStreamId: streamId },
+  },
+  removeStream: {
+    source: sessionFact('removeStream', { streamId: childStreamId }),
+    payload: { streamId: childStreamId },
+  },
+  goalStateChanged: {
+    source: sessionFact('goalStateChanged', { streamId }),
+    payload: { streamId },
+  },
+} satisfies ProgressProjectionCases;
 
 function recordWriter(): CliNdjsonProgressRecordWriter {
   return vi.fn() as CliNdjsonProgressRecordWriter;
@@ -123,6 +398,29 @@ function emitSessionStatus(
 }
 
 describe('attachCliSessionProgressProjection', () => {
+  it('projects every public NDJSON progress event with its typed payload', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+    const cases = Object.entries(PROGRESS_PROJECTION_CASES);
+
+    try {
+      for (const projection of Object.values(PROGRESS_PROJECTION_CASES)) {
+        events.emit(projection.source);
+      }
+
+      expect(writeRecord).toHaveBeenCalledTimes(cases.length);
+      for (const [index, [event, projection]] of cases.entries()) {
+        expect(writeRecord).toHaveBeenNthCalledWith(
+          index + 1,
+          progressRecord(event, projection.payload),
+        );
+      }
+    } finally {
+      detach();
+    }
+  });
+
   it('writes retained session facts as public NDJSON progress records', () => {
     const events = new SessionEventHub();
     const writeRecord = recordWriter();
@@ -171,101 +469,6 @@ describe('attachCliSessionProgressProjection', () => {
       });
 
       expect(writeRecord).not.toHaveBeenCalled();
-    } finally {
-      detach();
-    }
-  });
-
-  it('writes removeStream as a public NDJSON progress record', () => {
-    const events = new SessionEventHub();
-    const writeRecord = recordWriter();
-    const detach = attachCliSessionProgressProjection(events, writeRecord);
-
-    try {
-      events.emit({
-        scope: 'session',
-        event: {
-          type: 'removeStream',
-          payload: { streamId },
-        },
-      });
-
-      expect(writeRecord).toHaveBeenCalledWith(
-        progressRecord('removeStream', { streamId }),
-      );
-    } finally {
-      detach();
-    }
-  });
-
-  it('writes valid retained run facts as public NDJSON progress records', () => {
-    const events = new SessionEventHub();
-    const writeRecord = recordWriter();
-    const detach = attachCliSessionProgressProjection(events, writeRecord);
-
-    try {
-      events.emit({
-        scope: 'run',
-        streamId,
-        event: {
-          type: 'usage',
-          stats: {},
-          data: {
-            streamId,
-            storageKey: 'run-a',
-            usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
-          },
-        },
-      });
-
-      expect(writeRecord).toHaveBeenCalledWith(
-        progressRecord('updateStreamUsage', {
-          streamId,
-          storageKey: 'run-a',
-          usage: { inputTokens: 10, outputTokens: 20, cost: 0.01 },
-        }),
-      );
-    } finally {
-      detach();
-    }
-  });
-
-  it('projects run config facts to the public setTaskState event', () => {
-    const events = new SessionEventHub();
-    const writeRecord = recordWriter();
-    const detach = attachCliSessionProgressProjection(events, writeRecord);
-    const config = workflowConfig({
-      inputFiles: ['paper.tex', 'appendix.tex'],
-      contextFiles: ['notes.md'],
-    });
-
-    try {
-      events.emit({
-        scope: 'run',
-        streamId,
-        event: {
-          type: 'run.config',
-          streamId,
-          executionId,
-          config,
-        },
-      });
-
-      expect(writeRecord).toHaveBeenCalledWith(
-        progressRecord('setTaskState', {
-          streamId,
-          executionId,
-          taskState: {
-            agentConfig: config,
-            activeFiles: {
-              input: true,
-              context: true,
-              media: false,
-              output: false,
-            },
-          },
-        }),
-      );
     } finally {
       detach();
     }

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type {
+  RuntimePresentationEvent,
+  RuntimePresentationEventPayloads,
+} from '@agent/runtime/runtimePresentationEvents';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import {
@@ -47,6 +51,67 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
     ...overrides,
   };
 }
+
+type RuntimePresentationNdjsonPolicy =
+  | {
+      readonly kind: 'log';
+      readonly level: 'error' | 'info';
+      readonly message: string;
+      readonly fields: Readonly<Record<string, unknown>>;
+    }
+  | { readonly kind: 'suppressed' };
+
+type RuntimePresentationNdjsonCases = {
+  [K in RuntimePresentationEvent]: {
+    readonly payload: RuntimePresentationEventPayloads[K];
+    readonly policy: RuntimePresentationNdjsonPolicy;
+  };
+};
+
+const RUNTIME_PRESENTATION_NDJSON_CASES = {
+  requestShowError: {
+    payload: { message: 'Provider returned 500.' },
+    policy: {
+      kind: 'log',
+      level: 'error',
+      message: 'Provider returned 500.',
+      fields: {},
+    },
+  },
+  requestShowInstruction: {
+    payload: {
+      key: 'latex-compile-failed',
+      message: 'Inspect the log before retrying.',
+      actions: ['open-configuration-guide'],
+      showSuppress: true,
+    },
+    policy: {
+      kind: 'log',
+      level: 'info',
+      message: 'Inspect the log before retrying.',
+      fields: {
+        key: 'latex-compile-failed',
+        actions: ['open-configuration-guide'],
+        showSuppress: true,
+      },
+    },
+  },
+  requestOpenFile: {
+    payload: {
+      location: { kind: 'external', absolutePath: '/tmp/paper.tex' },
+      preserveFocus: false,
+    },
+    policy: { kind: 'suppressed' },
+  },
+  showAgentConfigBanner: {
+    payload: { agentName: 'polish' },
+    policy: { kind: 'suppressed' },
+  },
+  requestEnsureProgressView: {
+    payload: {},
+    policy: { kind: 'suppressed' },
+  },
+} satisfies RuntimePresentationNdjsonCases;
 
 function workflowTaskState(
   overrides: {
@@ -1222,20 +1287,20 @@ describe('CLI run progress renderer', () => {
     ]);
   });
 
-  it('routes runtime presentation requests to ndjson logs, not progress events', async () => {
+  it('applies an explicit ndjson policy to every runtime presentation request', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
       const host = createCliRuntimeHost(
         context({ mode: 'headless', outputFormat: 'ndjson' }),
       );
 
-      host.emit('requestShowError', { message: 'Provider returned 500.' });
-      host.emit('requestShowInstruction', {
-        key: 'latex-compile-failed',
-        message: 'Inspect the log before retrying.',
-        actions: ['open-configuration-guide'],
-        showSuppress: true,
-      });
-      host.emit('requestEnsureProgressView', {});
+      for (const [event, testCase] of Object.entries(
+        RUNTIME_PRESENTATION_NDJSON_CASES,
+      ) as [
+        RuntimePresentationEvent,
+        RuntimePresentationNdjsonCases[RuntimePresentationEvent],
+      ][]) {
+        host.emit(event, testCase.payload);
+      }
 
       await host.close();
     });
@@ -1245,35 +1310,14 @@ describe('CLI run progress renderer', () => {
       .split('\n')
       .map((line) => JSON.parse(line) as Record<string, unknown>);
 
-    expect(records).toEqual([
-      expect.objectContaining({
-        kind: 'log',
-        level: 'error',
-        message: 'Provider returned 500.',
-      }),
-      expect.objectContaining({
-        kind: 'log',
-        level: 'info',
-        message: 'Inspect the log before retrying.',
-        fields: {
-          key: 'latex-compile-failed',
-          actions: ['open-configuration-guide'],
-          showSuppress: true,
-        },
-      }),
-    ]);
-    expect(records).not.toContainEqual(
-      expect.objectContaining({
-        kind: 'progress',
-        event: 'requestShowError',
-      }),
+    const expectedRecords = Object.values(
+      RUNTIME_PRESENTATION_NDJSON_CASES,
+    ).flatMap(({ policy }) =>
+      policy.kind === 'log'
+        ? [expect.objectContaining({ ...policy, ts: expect.any(String) })]
+        : [],
     );
-    expect(records).not.toContainEqual(
-      expect.objectContaining({
-        kind: 'progress',
-        event: 'requestShowInstruction',
-      }),
-    );
+    expect(records).toEqual(expectedRecords);
   });
 
   it('maps the global quiet flag into CLI context args', () => {


### PR DESCRIPTION
## Summary

Complete the DR16 slice of the CLI NDJSON rail audit with compile-time exhaustive projection tests. The tests now cover every frozen public progress event and every runtime presentation event, including child streams, process activity, usage, plans, inquiries, and presentation-only suppression.

## Issue acceptance gates

Closes #7752.

- FS10 already landed in #7763 and DR14 already landed in #7809.
- All 22 `CliNdjsonProgressEventPayloads` entries have a typed source event and exact projected payload.
- All five runtime presentation events have an explicit NDJSON policy: two become log records and three are suppressed.
- The session-local `followUpSent` fact remains covered separately as intentionally absent from the public rail.
- Adding a new named event without a case produces a TypeScript exhaustiveness error.
- No production behavior changes.

## Single source of truth

The tests derive completeness from `CliNdjsonProgressEventPayloads` and `RuntimePresentationEventPayloads`, the same typed maps that define the public progress vocabulary and runtime presentation vocabulary.

## Duplication and abstraction budget

One exhaustive table replaces three duplicated happy-path tests. Existing dedicated tests remain only where they verify additional behavior such as detachment, malformed input, status deduplication, suppression, or trace integration. No production abstraction is added.

## Net elements (R6)

- Files: +0 / -0.
- Exported symbols: +0 / -0.
- Classes/interfaces/enums: +0 / -0.
- Net lines: +247 test lines.

## Consumer counts (R8)

n/a: test-only change; no event emitter, subscriber, or export is changed.

## Host impact

Extension: no change.

Desktop: no change.

CLI: the NDJSON compatibility contract gains exhaustive regression coverage.

## Scheduled refactoring

None.

## Validation

- independent adversarial review of exhaustiveness, key/payload correlation, policy counts, and duplicate tests
- focused Vitest: 3 files, 44 tests
- `corepack pnpm run typecheck`
- targeted ESLint
- targeted Prettier check
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no runtime, API, or export changes; risk is limited to test maintenance and false confidence if fixtures drift from real projection code.
> 
> **Overview**
> Adds **compile-time exhaustive Vitest tables** for the CLI NDJSON rail so the public contract stays aligned with the typed vocabularies—no production code changes.
> 
> In **`CliSessionProgressSubscription.vitest.mts`**, a `PROGRESS_PROJECTION_CASES` map keyed by every `CliNdjsonProgressEvent` pairs session/run source events with expected `CliNdjsonProgressEventPayloads`, and a single test asserts each maps to the right `progress` NDJSON record. That **replaces** several one-off happy-path tests (`removeStream`, usage, `setTaskState`, etc.) while keeping tests for detachment, deduplication, malformed facts, and trace paths.
> 
> In **`RunProgressRenderer.vitest.mts`**, `RUNTIME_PRESENTATION_NDJSON_CASES` covers all five `RuntimePresentationEvent` values with an explicit policy (log vs suppressed). The NDJSON integration test **loops every case** instead of only error/instruction examples.
> 
> New events missing from either table should **fail TypeScript exhaustiveness** via `satisfies` on the typed maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c670b75e7279f8628b518a143fb888bd412438b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->