### PR TITLE
chore(extension): delete dead imports, an unused param, and dead CSS

### DIFF
--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -13,7 +13,6 @@ import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResu
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { registerCommands } from '@commands/_shared/registerCommands';
-import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { STREAM_PHASE } from '@shared/schemas';

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { type OAuthProvider, getExternalAuthCallbackUri } from '@auth/config';
-import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from '@auth/constants';
+import { AUTH_PROVIDER_ID } from '@auth/constants';
 import { showSettingsView } from '@commands/settings';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
 import { SupabaseAuthProvider } from '@frontend/auth/SupabaseAuthProvider';

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -399,7 +399,7 @@ export class BackgroundTasksPanel extends LitElement {
               ? repeat(
                   active,
                   (c) => c.executionId,
-                  (c) => this.renderTaskItem(c, kind),
+                  (c) => this.renderTaskItem(c),
                 )
               : nothing
           }
@@ -415,10 +415,7 @@ export class BackgroundTasksPanel extends LitElement {
     `;
   }
 
-  private renderTaskItem(
-    child: ActiveChildInfo,
-    kind: 'process' | 'subagent',
-  ): TemplateResult {
+  private renderTaskItem(child: ActiveChildInfo): TemplateResult {
     const icon = getTaskIcon(child);
     const entry = this.processOutputs.get(child.executionId);
     const childStreamId =

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -47,9 +47,6 @@ import {
 // Local imports - progress view styles
 import { logStyles } from '../styles/logStyles';
 
-// Local imports - progress view events
-import { ProgressEvents } from '../events';
-
 // Local imports - progress view formatters
 import { getCopyContent } from '../formatters/copyContentStore';
 import { getProposalInput } from '../formatters/proposalInputStore';

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.styles.ts
@@ -14,15 +14,6 @@ export const latexTabStyles: CSSResult = css`
     margin-bottom: var(--wa-space-s);
   }
 
-  .latex-title {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-2xs);
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-medium);
-    color: var(--wa-color-text-normal);
-  }
-
   .latex-description {
     margin-bottom: var(--wa-space-s);
     color: var(--color-text-secondary);

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -16,7 +16,6 @@ import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClien
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { workspaceSM, globalSM } from '@common/state';
 import {
-  isFileNotFoundError,
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -16,10 +16,7 @@ import {
   type MultiFiles,
 } from '@shared/schemas';
 
-import {
-  type SessionType,
-  type MultipleDocumentFileType,
-} from './constants';
+import { type SessionType, type MultipleDocumentFileType } from './constants';
 
 // =========================================================================
 // Default State

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -17,7 +17,6 @@ import {
 } from '@shared/schemas';
 
 import {
-  SESSION_TYPES,
   type SessionType,
   type MultipleDocumentFileType,
 } from './constants';


### PR DESCRIPTION
## Summary

Deletion-only simplification pass over `packages/extension/src/`. This
area is unusually clean (`knip --include files,exports,types,duplicates`
finds **zero** unused files/exports/types in it — the swarm's ongoing
dead-export sweeps already keep it tidy), because knip only tracks
unused cross-file *exports*. It doesn't catch unused local
imports/parameters, and this repo's own tooling doesn't either:
`@typescript-eslint/no-unused-vars` is set to `'off'` repo-wide in
`eslint.config.mjs`, and no tsconfig sets
`noUnusedLocals`/`noUnusedParameters`. So genuinely dead local imports
silently accumulate with nothing in CI to catch them.

I temporarily re-enabled `@typescript-eslint/no-unused-vars` for a
one-off scan (not committed — `eslint.config.mjs` is untouched) and
verified each hit individually, plus a static scan of `*.styles.ts`
files for CSS selectors never referenced by their paired component
template.

## Deletions (each grep-verified — see commit message for full detail)

- **`commands/agent/followUpCommand.ts`** — `extensionAgentRuntimeHost`
  import unused (only the import line in this file).
- **`commands/auth/authCommands.ts`** — `AUTH_COMMANDS` import unused
  in this file (symbol itself stays live — used in
  `setupAssistantCommand.ts`, `SettingsViewMessageHandler.ts`,
  `src/tools/setup/InvokeCommandTool.ts`, etc.).
- **`progressView/frontend/components/LogList.ts`** — `ProgressEvents`
  import unused; also removed the now-headless
  `// Local imports - progress view events` comment that described
  only this import.
- **`settingsView/handlers/agentHandlers.ts`** — `isFileNotFoundError`
  import unused in this file (19 other usages repo-wide).
- **`webview/frontend/store.ts`** — `SESSION_TYPES` value import
  unused in this file (still exported/used across
  `mainViewActions.ts`, `mainViewState.ts`, `persistence.ts`,
  `MainApp.ts`, `InstructionPanel.ts`, etc.).
- **`progressView/frontend/components/BackgroundTasksPanel.ts`** —
  private `renderTaskItem`'s `kind` parameter was never read in the
  method body (the lookalike `child.kind` is a different, used
  property on the `child` argument). Single call site updated to drop
  the now-removed second argument.
- **`settingsView/frontend/tabs/LaTeXTab.styles.ts`** — `.latex-title`
  CSS rule has no matching `class="latex-title"` anywhere in the
  paired `LaTeXTab.ts` template (the sibling `.latex-header`/
  `.latex-description` classes the same stylesheet defines are both
  used). Pure dead CSS, no visual effect from deleting it.

### Explicitly investigated and NOT touched (false positives, reverted)

- `.code-block` in `BashRequestPanel.styles.ts` — rendered dynamically
  by the shared `htmlBuilders.ts` code-block formatter, not a literal
  class in the component file.
- `.approval-request__actions` in `ToolEditRequestPanel.styles.ts` —
  constructed dynamically as `${prefix}__actions` by the shared
  `renderRequestShell()` in `BaseFeedbackPanel.ts`.
- `.workflow-proposal__{input,output}-files` in
  `ProposalRequestPanel.styles.ts` — constructed dynamically as
  `` `workflow-proposal__${label.toLowerCase()}-files` ``.
- All other `no-unused-vars` hits across the package are `_`-prefixed
  by convention (interface-required-but-unused callback signatures,
  e.g. VS Code API stubs) — intentional, left alone.

## Verification

- `node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js packages/extension/src` — 0 errors (same 5 pre-existing import/order warnings, unrelated)
- `npm run typecheck` (`tsc --noEmit` across all workspaces) — clean
- `npx vitest run` — 621 files / 5455 tests passed (1 pre-existing skip), 0 failures

## Net elements (R6)

- Files touched: 7 (no files added or deleted)
- Exported symbols: unchanged — only local imports, one private-method
  parameter, and dead CSS were removed; no public surface changed
- Net LOC: 7 files changed, **3 insertions(+), 21 deletions(-) → −18 net**

## Consumer counts (R8)

Each deleted import/param had exactly one reference in its file (the
declaration itself). Where the underlying symbol remains exported
elsewhere, repo-wide grep confirmed multiple other live consumers
(counts listed per-item in the commit message).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletions of unused symbols and CSS; exported symbols and runtime paths are unchanged.
> 
> **Overview**
> Deletion-only cleanup in **`packages/extension/src`**: removes unused local imports, one unused private method parameter, and a CSS rule with no matching template class. **No public API or behavior changes.**
> 
> **Commands & handlers:** Drops unused imports from `followUpCommand.ts` (`extensionAgentRuntimeHost`), `authCommands.ts` (`AUTH_COMMANDS` — still used elsewhere), `agentHandlers.ts` (`isFileNotFoundError`), and `webview/frontend/store.ts` (`SESSION_TYPES`).
> 
> **Progress view UI:** In `LogList.ts`, removes the unused `ProgressEvents` import and its section comment. In `BackgroundTasksPanel.ts`, `renderTaskItem` no longer takes a `kind` argument (it was never read; `child.kind` is separate); the call site passes only the child.
> 
> **Settings LaTeX tab:** Deletes the unused `.latex-title` rule from `LaTeXTab.styles.ts` (no `class="latex-title"` in the paired component).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfcf2d781dc4afb9a0735858aeadcb7ce26083bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->