### PR TITLE
chore: batch micro-cleanup — 12 verified dead micro-items from the simplifier sweep

### DIFF
--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -4,7 +4,7 @@
 // each rebuild them differently.
 
 // Local imports - shared schemas
-import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state
 import {

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -540,7 +540,7 @@ async function requestRetryInteraction(
         return;
       }
       try {
-        await applyRetrySideEffects(request, decision, { isCurrent });
+        await applyRetrySideEffects(decision, { isCurrent });
         if (!isCurrent()) return;
         resolve({ action: 'retry', feedback: decision.userMessage });
       } catch {
@@ -632,10 +632,6 @@ function setTuiApprovalBypassState({
 }
 
 async function applyRetrySideEffects(
-  payload: Pick<
-    RuntimeInteractionEventPayloads['showRetryRequest'],
-    'streamId'
-  >,
   decision: ApprovalDecision,
   options: { isCurrent?: () => boolean } = {},
 ): Promise<void> {

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -6,7 +6,6 @@ import {
   readCliStdinText,
   type CliContext,
 } from '../runtime/cliContext';
-import { CliExitCode } from '../runtime/exitCodes';
 import {
   buildHeadlessRunContext,
   selectCliRunModel,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -71,7 +71,6 @@ import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_PHASE,
   type EndGroupStatus,
-  type AgentProposalPermission,
   type AgentCategoryFilter,
   type MainViewPersistedState,
   type ProgressViewOutboundMessage,
@@ -207,7 +206,6 @@ export class DesktopProgressBridge {
   readonly streamLogs: ProgressBackend['state']['streamLogs'];
   private readonly progressHost: ProgressViewHost;
   private readonly agentProposalController: ProgressViewHost['agentProposalController'];
-  private readonly workflowActions: ProgressViewHost['workflowActionsController'];
   private readonly workflowFileActions: ProgressViewHost['workflowFileActionsController'];
   /**
    * Shown-but-unresolved approval prompts, one {@link ApprovalRequestHandler}
@@ -388,7 +386,6 @@ export class DesktopProgressBridge {
       },
     );
     this.progressHost = this.createProgressViewHost();
-    this.workflowActions = this.progressHost.workflowActionsController;
     this.workflowFileActions = this.progressHost.workflowFileActionsController;
     this.agentProposalController = this.progressHost.agentProposalController;
     this.progressViewInboundHandlers = this.createProgressViewInboundHandlers();

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -114,13 +114,12 @@ const appRoot = root;
 //   - Center: <main-app> when no active stream, else <stream-conversation>
 //   - Right: reserved for future diff/approve UX (collapsed today)
 //
-// `currentRoute` survives only as a backwards-compat hook so existing IPC
+// `setRouteState` survives only as a backwards-compat hook so existing IPC
 // (`desktop:setRoute` from menu/command-palette) still reaches the right
 // surface. `'main' | 'progress'` map to the center pane (progress = focus
 // the active stream); `'settings'` opens the overlay; `'logs'` opens the
 // drawer. The four-route tab bar is gone.
 
-let currentRoute: DesktopRoute = 'main';
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 const rendererPlatform = getRendererPlatform(document.defaultView);
 const desktopCommandEntriesById = new Map(
@@ -143,7 +142,6 @@ function commandTitle(commandId: DesktopCommandId, label: string): string {
 }
 
 function setRouteState(route: DesktopRoute): void {
-  currentRoute = route;
   document.body.dataset.desktopRoute = route;
 }
 

--- a/src/agent/core/state/AgentWorkspaceState.ts
+++ b/src/agent/core/state/AgentWorkspaceState.ts
@@ -204,10 +204,6 @@ export class MediaAttachmentState {
       }
     }
   }
-
-  hasFile(absolutePath: string): boolean {
-    return this.pathSet.has(absolutePath);
-  }
 }
 
 /** Internal schema for reasoning cache state. */

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -158,7 +158,7 @@ export class ToolUseWaitNode<C> extends Node<
   ): Promise<string | undefined> {
     const { onFollowUpConsumed, logger, streamStatus } = this.services;
     const { runScope } = useLaunchRunContext();
-    const { streamId, runtimeHost } = runScope;
+    const { streamId } = runScope;
 
     if (execRes.kind === 'waiting') {
       return FlowTransition.WAITING;

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -106,19 +106,12 @@ export async function resolveAndResumeStream(
     // The host's resolveResumeState owns its own "no persisted state" messaging.
     if (!resolved) return false;
 
-    const resume =
-      resolved.parentStreamId !== undefined
-        ? await retrieveSessionResumeData(
-            streamId,
-            resolved.executionId,
-            resolved.runState,
-            { parentStreamId: resolved.parentStreamId },
-          )
-        : await retrieveSessionResumeData(
-            streamId,
-            resolved.executionId,
-            resolved.runState,
-          );
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      resolved.executionId,
+      resolved.runState,
+      { parentStreamId: resolved.parentStreamId },
+    );
     if (isCancellationRequested()) return false;
     if (!resume) {
       await ports.reportNoResumableSession?.(streamId);

--- a/src/agent/runtime/runtimePresentationEvents.ts
+++ b/src/agent/runtime/runtimePresentationEvents.ts
@@ -23,7 +23,7 @@ export interface RuntimePresentationEventPayloads {
 
 export type RuntimePresentationEvent = keyof RuntimePresentationEventPayloads;
 
-export const RUNTIME_PRESENTATION_EVENTS = [
+const RUNTIME_PRESENTATION_EVENTS = [
   'requestOpenFile',
   'requestShowInstruction',
   'showAgentConfigBanner',

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -25,7 +25,7 @@ import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
 
-import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
+import { getExecutionStore } from './ExecutionKVStore';
 
 const CHANNEL = 'ExecutionListing';
 const INDEX_PATH = `${RUNS_STORAGE_DIR}/index.json`;

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -239,7 +239,7 @@ export class TraceEmitter implements AgentTrace {
     if (!progressEnabled) {
       // Local-only buffering — chunks never emit. `finalize` returns the
       // text but nothing reaches subscribers.
-      return new BufferOnlyStreamHandle(this, id);
+      return new BufferOnlyStreamHandle(id);
     }
 
     const phaseOnly = options.phaseOnly === true;
@@ -406,10 +406,7 @@ class BufferOnlyStreamHandle implements StreamHandle {
   private readonly chunks: string[] = [];
   private finalText: string | undefined;
 
-  constructor(
-    private readonly trace: TraceEmitter,
-    readonly id: string,
-  ) {}
+  constructor(readonly id: string) {}
 
   append(text: string): void {
     if (this.finalText !== undefined || !text) return;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2965,6 +2965,7 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining(taskState.agentConfig),
+        { parentStreamId: undefined },
       );
       expectWorkflowResume(runAgent, taskState, executionId);
     } finally {
@@ -3043,6 +3044,7 @@ describe('DesktopProgressBridge', () => {
         'stream-1',
         executionId,
         expect.objectContaining(taskState.agentConfig),
+        { parentStreamId: undefined },
       );
       expectWorkflowResume(runAgent, taskState, executionId);
     } finally {


### PR DESCRIPTION
## Summary

Batches 12 already-verified dead-code finds that individual area sweeps flagged today but reverted as sub-threshold for their own PRs. Every item was re-verified with a fresh grep against current `origin/main` before applying (main had moved ~6 commits since the original sweep). All 12 items still applied cleanly.

## Items

1. `src/agent/core/state/AgentWorkspaceState.ts` — delete `MediaAttachmentState.hasFile(absolutePath)`.
2. `src/agent/runtime/runtimePresentationEvents.ts` — drop `export` on `RUNTIME_PRESENTATION_EVENTS` (matches sibling `runtimeInteractionEvents.ts`'s private `RUNTIME_INTERACTION_EVENTS`).
3. `src/agent/runtime/resolveAndResumeStream.ts` — collapse the redundant two-branch ternary calling `retrieveSessionResumeData` with/without `{ parentStreamId }`. Safe because `exactOptionalPropertyTypes` is off and the consumer reads `options.parentStreamId` by value (`!== undefined`), not via `in`.
4. `src/agent/storage/executionListing.ts` — remove unused `ExecutionMeta` type import.
5. `src/agent/trace/TraceEmitter.ts` — `BufferOnlyStreamHandle` drops its stored `trace: TraceEmitter` constructor field (never read by `append()`/`finalize()`); updated its one construction site.
6. `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts` — `post()` destructured `runtimeHost` from `runScope` but only used `streamId`; dropped the unused binding.
7. `packages/cli/src/chat/tui/state/subscribeApprovals.ts` — removed the unused `payload` param from `applyRetrySideEffects` (never referenced in the function body) and updated its single call site.
8. `packages/cli/src/commands/agentsRun.ts` — removed unused `CliExitCode` import.
9. `packages/cli/src/chat/tui/state/streamViews.ts` — removed unused `ActiveChildInfo` type import (`StreamTabId` from the same import is still used).
10. `packages/desktop/src/main/desktopAgentExecution.ts` — removed unused `type AgentProposalPermission` import.
11. `packages/desktop/src/main/desktopAgentExecution.ts` — removed the private `workflowActions` field (assigned from `progressHost.workflowActionsController`, never read elsewhere in the file or repo).
12. `packages/desktop/src/renderer/main.ts` — removed the unread module-level `let currentRoute`; kept the `document.body.dataset.desktopRoute = route` side effect in `setRouteState`, which is the actual behavior.

None of the 12 were skipped — all still existed and matched the described zero-consumer shape at the rebased HEAD.

### Incidental test fix

Item 3's ternary collapse changes the exact argument list passed to `retrieveSessionResumeData` when there's no `parentStreamId` (now always passes a 4th `{ parentStreamId: undefined }` arg instead of omitting it — behaviorally identical since the consumer reads by value). Two `DesktopAgentExecution.vitest.mts` assertions pinned the old 3-arg call shape via `toHaveBeenCalledWith`; updated both to the new 4-arg shape (`src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`, "resumes workflow streams from persisted meta" and "resumes hydrated ghost streams using hinted execution ids").

## Net elements (R6)

Pure element deletions, no new files, no new exports, no new abstractions:

- Removed: 1 method (`hasFile`), 1 `export` keyword, 1 type import (`ExecutionMeta`), 1 constructor field (`trace` on `BufferOnlyStreamHandle`), 1 destructured binding (`runtimeHost`), 1 function param (`payload`), 1 unused import (`CliExitCode`), 1 type import (`ActiveChildInfo`), 1 type import (`AgentProposalPermission`), 1 class field (`workflowActions`), 1 module-level `let` (`currentRoute`), 1 redundant branch (ternary → single call).
- Added: 0 new symbols. Two test assertions updated in place (no new tests).
- Net: **-38 / +16 LOC** across 12 files (per `git diff --stat`).

## Consumer counts (R8)

Repo-wide grep (`src/`, `packages/`, `*.ts`/`*.tsx`) immediately before each removal, and again after to confirm zero dangling references:

| # | Symbol | Consumers before (excl. definition) | Consumers after |
|---|---|---|---|
| 1 | `MediaAttachmentState.hasFile(` | 0 | 0 |
| 2 | `RUNTIME_PRESENTATION_EVENTS` (external) | 0 | 0 |
| 3 | `retrieveSessionResumeData` call-shape branches | n/a (behavior-preserving collapse) | n/a |
| 4 | `ExecutionMeta` in `executionListing.ts` | 0 (only the import) | 0 |
| 5 | `this.trace` reads in `BufferOnlyStreamHandle` | 0 | 0 |
| 6 | `runtimeHost` in `ToolUseWaitNode.post()` | 0 | 0 |
| 7 | `applyRetrySideEffects` callers | 1 (updated) | 1 (updated) |
| 8 | `CliExitCode` in `agentsRun.ts` | 0 | 0 |
| 9 | `ActiveChildInfo` in `streamViews.ts` | 0 | 0 |
| 10 | `AgentProposalPermission` in `desktopAgentExecution.ts` | 0 | 0 |
| 11 | `this.workflowActions` in `desktopAgentExecution.ts` | 0 (only the assignment) | 0 |
| 12 | `currentRoute` in `main.ts` | 0 (only the writes) | 0 |

## Verification

```bash
CI=true corepack pnpm install --prefer-offline
npx vitest run src/test-kernel/agent/ src/test-kernel/cli/ src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
npm run typecheck        # covers root, extension, CLI, trace-viewer, and desktop (all in one chain on current main)
corepack pnpm --filter @texra-ai/cli typecheck
corepack pnpm --filter @texra/desktop typecheck
npx eslint <all 12 touched files>
npx prettier --check <all 12 touched files>
```

Results:
- `src/test-kernel/agent/`: 1206 passed, 4 skipped (pre-existing skips)
- `src/test-kernel/cli/`: 1649 passed
- `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`: 71 passed
- Combined re-run on rebased HEAD: 2924 passed, 4 skipped
- `npm run typecheck`: exit 0 (root `tsc --noEmit` chain now includes `@texra/desktop` on current main)
- `@texra-ai/cli typecheck`: exit 0
- `@texra/desktop typecheck`: exit 0
- `eslint`/`prettier --check` on all touched files: clean

## Test plan

- [x] All 12 items re-verified zero-consumer at rebased `origin/main` HEAD before applying
- [x] `npx vitest run src/test-kernel/agent/ src/test-kernel/cli/ src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` green
- [x] `npm run typecheck` green (root + extension + CLI + desktop)
- [x] `corepack pnpm --filter @texra-ai/cli typecheck` green
- [x] `corepack pnpm --filter @texra/desktop typecheck` green
- [x] `eslint` / `prettier --check` clean on touched files

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletions and a behavior-preserving resume call-shape unify; only test mocks were adjusted for the optional fourth argument.
> 
> **Overview**
> Batches **12 verified dead-code removals** across agent runtime, trace, CLI TUI, and desktop—no new behavior or APIs.
> 
> **Agent / trace:** Drops unused `MediaAttachmentState.hasFile`, makes `RUNTIME_PRESENTATION_EVENTS` module-private (like interaction events), collapses `resolveAndResumeStream`’s duplicate `retrieveSessionResumeData` branches into one call that always passes `{ parentStreamId }`, removes an unused `ExecutionMeta` import, trims an unused `runtimeHost` destructure in `ToolUseWaitNode.post`, and stops storing an unused `TraceEmitter` on `BufferOnlyStreamHandle`.
> 
> **CLI / desktop:** Removes unused imports (`ActiveChildInfo`, `CliExitCode`, `AgentProposalPermission`), drops the unread `workflowActions` field on `DesktopProgressBridge`, removes the unused `payload` argument from `applyRetrySideEffects`, and deletes the module-level `currentRoute` variable while keeping `setRouteState`’s `dataset` side effect.
> 
> **Tests:** Two desktop resume tests now expect the unified 4-arg `retrieveSessionResumeData` call shape (`{ parentStreamId: undefined }` when absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f585dc5d84cb3dcc2cf73d3decc38632fa5a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->