### PR TITLE
fix(prompt): gate git-history lookup on task relevance

### DIFF
--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -69,5 +69,13 @@ describe('PromptBuilder', () => {
       prompts.instructionSuffix,
       /Always consult pinned memories at session start/,
     );
+    assert.match(
+      prompts.instructionSuffix,
+      /When project context, coding patterns, or conventions are relevant to the task and git is available, look into git history/,
+    );
+    assert.doesNotMatch(
+      prompts.instructionSuffix,
+      /^ +- When git is available, look into git history/m,
+    );
   });
 });

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -40,7 +40,7 @@ MEMORY PROTOCOL:
 2. ... (work on the task) ...
    - For long-running work that needs continuity, record durable progress and decisions in memory.
    - Record user preferences: writing style, coding conventions, formatting requirements, workflow preferences, and any explicit or implicit guidelines the user follows.
-   - When git is available, look into git history (commit messages, PR descriptions, recent changes) to understand project context, coding patterns, and conventions.
+   - When project context, coding patterns, or conventions are relevant to the task and git is available, look into git history (commit messages, PR descriptions, recent changes) to understand them.
 
 Your memory persists across conversations, allowing you to continue tasks and remember user preferences over time.
 


### PR DESCRIPTION
## What / Why

Follow-up from #7855, flagged in review (unaddressed at merge):
https://github.com/LionSR/TeXRA/pull/7855#discussion_r3559701342

`MEMORY_TOOL_INSTRUCTIONS` in `src/utils/prompt/PromptBuilder.ts` made the shared
memory protocol relevance-gated, but one bullet under the "work on the task"
section still read unconditionally: *"When git is available, look into git
history (commit messages, PR descriptions, recent changes) to understand
project context, coding patterns, and conventions."* That bullet wasn't gated
by the same relevance test as the rest of the block, so a memory-enabled agent
could still be pushed toward unnecessary git-history tool traffic on a
self-contained request — the same problem class #7855 fixed for memory itself.

This PR gates the git-history bullet on task relevance, using the same
vocabulary #7855 introduced elsewhere in the block (`When memory is relevant,
...`):

```
- When project context, coding patterns, or conventions are relevant to the task and git is available, look into git history (commit messages, PR descriptions, recent changes) to understand them.
```

`git is available` stays as a precondition (git-history lookup is impossible
without it), and relevance is now an explicit additional gate, matching the
rest of the protocol.

Closes #7956.

## Verification

- `corepack pnpm exec vitest run src/test-kernel/agent/utils/promptBuilder.vitest.ts src/test-kernel/skills/RuntimeSkills.vitest.mts` — 2 files, 6 tests passed.
- Regression proof: reverted only `PromptBuilder.ts` to pre-fix content (via `git diff` → `git checkout --` → re-apply, no `git stash`) with the new test assertions in place — the new `assert.match`/`assert.doesNotMatch` pair fails against the unconditional pre-fix bullet, confirming the test actually exercises the fix.
- `npm run typecheck` — passed across the whole workspace (root, test-kernel, extension, CLI, trace-viewer, desktop).
- `corepack pnpm exec eslint src/utils/prompt/PromptBuilder.ts src/test-kernel/agent/utils/promptBuilder.vitest.ts` — 0 errors/warnings.
- `corepack pnpm exec prettier --check src/utils/prompt/PromptBuilder.ts src/test-kernel/agent/utils/promptBuilder.vitest.ts` — passed.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Tests: 2 assertions added to the existing `keeps memory checks relevant and schema-valid` case (no new test file — extends existing prompt-contract coverage per R7).
- Net LoC: +8 (9 additions, 1 deletion).

## Consumer counts (R8)

n/a — no emit path, event key, export, or public API is added, deleted, or rerouted. This is a wording-only change to a prompt string constant already exclusively owned by `src/utils/prompt/PromptBuilder.ts`.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-string-only change with no API or runtime logic; effect is reduced unnecessary git-history tool use on self-contained requests.
> 
> **Overview**
> Aligns the **git history** bullet in `MEMORY_TOOL_INSTRUCTIONS` with the relevance-gated memory protocol from #7855. Agents with memory enabled are no longer told to consult git history whenever git exists; they are only nudged when **project context, patterns, or conventions matter for the task** and git is available.
> 
> The existing `keeps memory checks relevant and schema-valid` test now asserts the new phrasing and rejects the old unconditional bullet (`When git is available, look into git history` as a standalone step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e371a7ccf1cdcfec77563b9f53594b05ef3506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->