### PR TITLE
fix(agent): keep pinned-memory checks unconditional

### DIFF
--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -55,19 +55,40 @@ describe('PromptBuilder', () => {
 
     assert.match(
       prompts.instructionSuffix,
-      /For a self-contained request, do not inspect or write memory/,
+      /do not inspect or write unpinned memory/,
     );
     assert.match(
       prompts.instructionSuffix,
       /use the `view` command with path `\/memories`/,
     );
+  });
+
+  it('keeps pinned-memory consultation unconditional even for self-contained requests', async () => {
+    // Regression test for #7957: relevance gating (added in #7855) must not
+    // silently drop pinned memories, which are documented as loading every
+    // session (docs/guide/memory.md, MemoryTool's description).
+    const prompts = await buildInitialToolUsePrompts(
+      {
+        systemPrompt: 'system',
+        userPrefix: '',
+        userRequest: 'request',
+      } as AgentPrompt,
+      {},
+      undefined,
+      { resolvedToolNames: ['memory'] },
+    );
+
     assert.match(
       prompts.instructionSuffix,
-      /When memory is relevant, consult pinned memories first/,
+      /Always consult pinned memories at session start, even for requests that otherwise look self-contained/,
+    );
+    assert.match(
+      prompts.instructionSuffix,
+      /Pinned memories are always loaded: use the `view` command with path `\/memories` at session start regardless of how self-contained the request looks/,
     );
     assert.doesNotMatch(
       prompts.instructionSuffix,
-      /Always consult pinned memories at session start/,
+      /When memory is relevant, consult pinned memories first/,
     );
   });
 });

--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -82,7 +82,10 @@ describe('PromptBuilder', () => {
     // files must be individually viewed at session start — a directory
     // listing alone does not load their content — and this must hold even
     // for self-contained-looking requests.
-    assert.match(prompts.instructionSuffix, /Pinned memories are always loaded/);
+    assert.match(
+      prompts.instructionSuffix,
+      /Pinned memories are always loaded/,
+    );
     assert.match(
       prompts.instructionSuffix,
       /`view` each \[pinned\] file|`view` each pinned file|read each pinned memory file/,

--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -55,7 +55,7 @@ describe('PromptBuilder', () => {
 
     assert.match(
       prompts.instructionSuffix,
-      /do not inspect or write unpinned memory/,
+      /do not read unpinned memory files or write memory/,
     );
     assert.match(
       prompts.instructionSuffix,
@@ -78,13 +78,18 @@ describe('PromptBuilder', () => {
       { resolvedToolNames: ['memory'] },
     );
 
+    // Behavioral contract, not exact prose (review note on #7959): pinned
+    // files must be individually viewed at session start — a directory
+    // listing alone does not load their content — and this must hold even
+    // for self-contained-looking requests.
+    assert.match(prompts.instructionSuffix, /Pinned memories are always loaded/);
     assert.match(
       prompts.instructionSuffix,
-      /Always consult pinned memories at session start, even for requests that otherwise look self-contained/,
+      /`view` each \[pinned\] file|`view` each pinned file|read each pinned memory file/,
     );
     assert.match(
       prompts.instructionSuffix,
-      /Pinned memories are always loaded: use the `view` command with path `\/memories` at session start regardless of how self-contained the request looks/,
+      /regardless of how self-contained|even for requests that otherwise look self-contained/,
     );
     assert.doesNotMatch(
       prompts.instructionSuffix,

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -33,10 +33,10 @@ The following imported skills are available. If one is relevant, inspect its SKI
 
 /** Base memory instructions for all agents with memory enabled. */
 const MEMORY_TOOL_INSTRUCTIONS = `<memory_tool_instructions>
-Pinned memories are always loaded: use the \`view\` command with path \`/memories\` at session start regardless of how self-contained the request looks, so pinned notes still apply. Beyond that, use memory when the request may depend on prior sessions, durable user preferences, or shared agent context; for a self-contained request, do not inspect or write unpinned memory merely because the tool is available.
+Pinned memories are always loaded (unless the user forbids memory use): at session start, \`view\` the \`/memories\` directory to find entries marked [pinned] — if the listing is truncated, continue it until you have seen every [pinned] entry — then \`view\` each pinned file so its content actually applies, regardless of how self-contained the request looks. Beyond that, use memory when the request may depend on prior sessions, durable user preferences, or shared agent context; for a self-contained request, do not read unpinned memory files or write memory merely because the tool is available (the directory listing itself is fine — needed to find pinned entries).
 
 MEMORY PROTOCOL:
-1. Always use the \`view\` command with path \`/memories\` at session start to check for pinned notes; when memory is relevant beyond that, review the rest of the directory for earlier progress.
+1. At session start (unless the user forbids memory use), \`view\` \`/memories\`, then \`view\` each [pinned] file found; when memory is relevant beyond that, review the rest of the directory for earlier progress.
 2. ... (work on the task) ...
    - For long-running work that needs continuity, record durable progress and decisions in memory.
    - Record user preferences: writing style, coding conventions, formatting requirements, workflow preferences, and any explicit or implicit guidelines the user follows.
@@ -49,7 +49,7 @@ Note: when editing your memory folder, always try to keep its content up-to-date
 PINNED MEMORIES:
 Some memories may be marked as "pinned" (shown with [pinned] in directory listings and file headers). These are core long-term insights—techniques, strategies, pitfalls, and best practices accumulated over time. They represent the kind of knowledge a seasoned researcher would build up through years of project experience.
 
-- Always consult pinned memories at session start, even for requests that otherwise look self-contained; they contain the most valuable accumulated knowledge.
+- Always read each pinned memory file at session start (unless the user forbids memory use), even for requests that otherwise look self-contained; they contain the most valuable accumulated knowledge, and the directory listing alone does not load their content.
 - When you discover a reusable trick, technique, strategy, pitfall, or best practice, consider using the \`pin\` command to mark it as a core memory.
 - Do NOT pin task-specific progress notes or ephemeral status updates. Only pin long-term reusable insights.
 - Use \`unpin\` to remove the pinned status when a memory is no longer relevant as a core insight.

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -33,10 +33,10 @@ The following imported skills are available. If one is relevant, inspect its SKI
 
 /** Base memory instructions for all agents with memory enabled. */
 const MEMORY_TOOL_INSTRUCTIONS = `<memory_tool_instructions>
-Use memory when the request may depend on prior sessions, durable user preferences, or shared agent context. For a self-contained request, do not inspect or write memory merely because the tool is available.
+Pinned memories are always loaded: use the \`view\` command with path \`/memories\` at session start regardless of how self-contained the request looks, so pinned notes still apply. Beyond that, use memory when the request may depend on prior sessions, durable user preferences, or shared agent context; for a self-contained request, do not inspect or write unpinned memory merely because the tool is available.
 
 MEMORY PROTOCOL:
-1. When memory is relevant, use the \`view\` command with path \`/memories\` to check for earlier progress.
+1. Always use the \`view\` command with path \`/memories\` at session start to check for pinned notes; when memory is relevant beyond that, review the rest of the directory for earlier progress.
 2. ... (work on the task) ...
    - For long-running work that needs continuity, record durable progress and decisions in memory.
    - Record user preferences: writing style, coding conventions, formatting requirements, workflow preferences, and any explicit or implicit guidelines the user follows.
@@ -49,7 +49,7 @@ Note: when editing your memory folder, always try to keep its content up-to-date
 PINNED MEMORIES:
 Some memories may be marked as "pinned" (shown with [pinned] in directory listings and file headers). These are core long-term insights—techniques, strategies, pitfalls, and best practices accumulated over time. They represent the kind of knowledge a seasoned researcher would build up through years of project experience.
 
-- When memory is relevant, consult pinned memories first; they contain the most valuable accumulated knowledge.
+- Always consult pinned memories at session start, even for requests that otherwise look self-contained; they contain the most valuable accumulated knowledge.
 - When you discover a reusable trick, technique, strategy, pitfall, or best practice, consider using the \`pin\` command to mark it as a core memory.
 - Do NOT pin task-specific progress notes or ephemeral status updates. Only pin long-term reusable insights.
 - Use \`unpin\` to remove the pinned status when a memory is no longer relevant as a core insight.


### PR DESCRIPTION
## What / why

Closes #7957 (follow-up from #7855, flagged in [review comment](https://github.com/LionSR/TeXRA/pull/7855#discussion_r3559714460)).

#7855 made shared memory prompting relevance-based: models are told to skip memory reads/writes on self-contained requests, and this gate covered *pinned* memories too ("When memory is relevant, consult pinned memories first..."). But:

- `docs/guide/memory.md` documents pinned notes as loading "every session" (as opposed to unpinned notes, which are "searchable context... on demand").
- `MemoryTool`'s own tool description says: "Pinned memories are always loaded at session start."
- There is no runtime path that injects pinned content without a `memory view` call — the pin machinery (`src/tools/memory/MemoryTool.ts`) only marks/lists metadata.

So gating pinned-memory consultation on the model first inferring relevance could silently stop pinned conventions/preferences from applying to fresh, self-contained-looking requests — contradicting the documented contract.

Per the issue's two options, this implements: **keep pinned-memory consultation unconditional while leaving unpinned memory relevance-based.**

### Change

In `src/utils/prompt/PromptBuilder.ts`'s `MEMORY_TOOL_INSTRUCTIONS`:
- Intro line and MEMORY PROTOCOL step 1 now instruct the model to always `view /memories` at session start for pinned notes, regardless of how self-contained the request looks; the relevance gate now applies only to *unpinned* memory (progress notes/context).
- The PINNED MEMORIES bullet reverts to "Always consult pinned memories at session start, even for requests that otherwise look self-contained" (was "When memory is relevant, consult pinned memories first").

No other prompt blocks (orchestrator/subagent memory protocol, git-history bullet) were touched — those are relevance-based by design and out of scope for this issue.

## Verification

```
corepack pnpm exec vitest run src/test-kernel/agent/utils/promptBuilder.vitest.ts src/test-kernel/skills/RuntimeSkills.vitest.mts
corepack pnpm exec prettier --check src/utils/prompt/PromptBuilder.ts src/test-kernel/agent/utils/promptBuilder.vitest.ts
corepack pnpm exec eslint src/utils/prompt/PromptBuilder.ts src/test-kernel/agent/utils/promptBuilder.vitest.ts
npm run typecheck
git diff --check
```

All passed (7/7 tests in the two suites; typecheck covers extension/CLI/trace-viewer/desktop; 0 lint errors on touched files).

### Regression-test proof (pre-fix failure)

The new test `keeps pinned-memory consultation unconditional even for self-contained requests` was verified to **fail on pre-fix code**: saved the `PromptBuilder.ts` diff as a patch, reverted only that file to origin/main HEAD (`git checkout -- src/utils/prompt/PromptBuilder.ts`) while keeping the new test, ran the suite (2 failed — including the pre-existing "keeps memory checks relevant and schema-valid" test, which was updated for the same reason), then re-applied the patch (`git apply`) and confirmed all 7 tests pass. No `git stash` was used.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Tests: 1 new case added (regression for #7957); 1 existing case in the same file trimmed to drop assertions that now contradict restored behavior (moved those assertions into the new case).
- Net LoC: +27/−6 (test coverage extension + prompt string fix); no new abstractions.

## Consumer counts (R8)

n/a — no exported symbol, event key, or emit path is added, deleted, or rerouted. `MEMORY_TOOL_INSTRUCTIONS` is an internal module-scope constant with its single consumer (`buildInitialToolUsePrompts`) unchanged.

## Host impact

Extension / Desktop / CLI: all three hosts share `src/utils/prompt/PromptBuilder.ts` as the single owner of tool-use memory instructions (per #7855's stated invariant), so this is a single prompt-text change with identical effect across all hosts. No UI or host API change.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-text-only change to shared agent instructions with no runtime or API changes; risk is limited to model behavior around when it reads memory.
> 
> **Overview**
> Reverts **relevance gating for pinned memories** in `MEMORY_TOOL_INSTRUCTIONS` so agents are told to always `view` `/memories` and each `[pinned]` file at session start, including on requests that look self-contained. The self-contained skip now applies only to **unpinned** memory reads and writes (directory listing for pinned discovery is still allowed).
> 
> MEMORY PROTOCOL step 1 and the PINNED MEMORIES bullet are updated to match docs/MemoryTool (“pinned loads every session”); orchestrator/subagent memory blocks are unchanged.
> 
> Tests in `promptBuilder.vitest.ts` are adjusted for the new unpinned-only gate and a regression case asserts pinned consultation stays unconditional and the old “When memory is relevant, consult pinned memories first” wording is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1c11bdc32b37f0495998d1e88ff8f8893ca4ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->