### PR TITLE
test(relay): cover retired-model denial for providers outside RELAY_PROVIDERS

### DIFF
--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -83,6 +83,10 @@ describe('relay tier model access', () => {
     // filtered by RELAY_PROVIDERS.has(m.provider) — a retired model from a
     // provider the relay cannot forward to (here 'meta') must still be
     // rejected as a denial guard, independent of forwarding eligibility.
+    // Assert the fixture premise against the same source RELAY_PROVIDERS is
+    // built from, so this test fails loudly (instead of going vacuous) if
+    // 'meta' is ever added to the relay allowlist.
+    assert.equal(TIER_CONFIG.providers.includes('meta'), false);
     assert.equal(isRetiredModelRequest('legacy-meta-model'), true);
     assert.equal(isModelAllowedForTier(MAX_TIER, 'legacy-meta-model'), false);
     assert.equal(isModelAllowedForTier(ULTRA_TIER, 'legacy-meta-model'), false);

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -2,7 +2,29 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
+
+// A retired model whose provider is not in RELAY_PROVIDERS (e.g. 'meta') is
+// not currently present in the pinned llm-zoo registry, so this synthetic
+// entry pins down the RETIRED_MODEL_PATTERNS derivation directly: it must
+// keep covering every retired, non-openRouterOnly model regardless of
+// forwarding-provider eligibility (see #7947, #7953).
+vi.mock('llm-zoo', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('llm-zoo')>();
+  return {
+    ...actual,
+    MODEL_CONFIGS: {
+      ...actual.MODEL_CONFIGS,
+      retiredOutsideRelayProviders: {
+        name: 'legacy-meta-model',
+        fullName: 'legacy-meta-model',
+        provider: 'meta',
+        retired: true,
+        openRouterOnly: false,
+      },
+    },
+  };
+});
 
 // Local imports - Supabase relay
 import {
@@ -54,5 +76,15 @@ describe('relay tier model access', () => {
       false,
     );
     assert.equal(isModelAllowedForTier(ULTRA_TIER, 'unknown-model'), true);
+  });
+
+  it('denies retired models from providers outside RELAY_PROVIDERS', () => {
+    // Regression coverage for #7953: RETIRED_MODEL_PATTERNS must not be
+    // filtered by RELAY_PROVIDERS.has(m.provider) — a retired model from a
+    // provider the relay cannot forward to (here 'meta') must still be
+    // rejected as a denial guard, independent of forwarding eligibility.
+    assert.equal(isRetiredModelRequest('legacy-meta-model'), true);
+    assert.equal(isModelAllowedForTier(MAX_TIER, 'legacy-meta-model'), false);
+    assert.equal(isModelAllowedForTier(ULTRA_TIER, 'legacy-meta-model'), false);
   });
 });


### PR DESCRIPTION
## What / Why

Closes #7953.

`RETIRED_MODEL_PATTERNS` in `supabase/functions/relay/models.ts` was fixed in
#7947 to derive retired-name denial independently of `RELAY_PROVIDERS`, so a
retired model whose provider is outside the relay-forwarding allowlist is
still rejected by `isRetiredModelRequest` / `isModelAllowedForTier` for
MAX/ULTRA tiers. That fix shipped without a regression test — flagged three
times in #7947's review — leaving `RelayModelAccess.vitest.ts` covering only
retired names from providers already in `RELAY_PROVIDERS` (Anthropic's
`haiku3`/`claude-3-haiku`).

I verified the pinned `llm-zoo@1.14.0` registry currently has **no** retired,
non-`openRouterOnly` model outside `RELAY_PROVIDERS` (checked every provider,
including `meta`, the example cited in the issue and the #7947 review
comment), so a test using only real catalog data would not exercise the
guard. This PR mocks the `llm-zoo` module (following the existing
`vi.mock('llm-zoo', ...)` pattern in
`src/test-kernel/cli/ModelAccess.vitest.mts`) with one synthetic retired
`meta`-provider entry, then asserts `isRetiredModelRequest(...) === true` and
`isModelAllowedForTier(MAX_TIER/ULTRA_TIER, ...) === false`. This pins the
guard down deterministically regardless of future catalog drift and directly
guards against `RELAY_PROVIDERS.has(m.provider)` being silently
reintroduced into `RETIRED_MODEL_PATTERNS`.

Test-only change — no production code touched.

## Verification

- Proved the new assertion actually exercises the denial path: in this
  worktree, temporarily re-added `RELAY_PROVIDERS.has(m.provider)` to the
  `RETIRED_MODEL_PATTERNS` filter (the pre-#7947 bug) and reran the suite —
  the new test failed (`isRetiredModelRequest('legacy-meta-model')` returned
  `false`) while the other 3 pre-existing tests in the file still passed.
  Restored the production file via `git checkout --` afterward (verified
  `git diff origin/main` shows only the test file changed).
- `CI=true corepack pnpm exec vitest run src/test-kernel/supabase/RelayModelAccess.vitest.ts src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts` — 2 files, 8 tests, all pass (with the real fix in place).
- `npm run typecheck` — passes (covers root, test-kernel, CLI, trace-viewer, desktop).
- `corepack pnpm exec eslint src/test-kernel/supabase/RelayModelAccess.vitest.ts` — clean.
- `corepack pnpm exec prettier --check` — clean (ran `--write` once to match repo formatting).

## Net elements (R6)

- Files: +0 / -0 (existing test file extended, no new files).
- Exported symbols: +0 / -0.
- Classes/interfaces/enums: +0 / -0.
- Net lines: +33 (one new `it` block + one file-level `vi.mock('llm-zoo', ...)` needed to construct a synthetic retired-model fixture absent from the pinned registry).

## Consumer counts (R8)

n/a — test-only change; no export, event, or routing consumer added, removed, or redirected.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or relay logic modified; risk is limited to test maintenance if the mock or tier config assumptions drift.
> 
> **Overview**
> Adds regression coverage in `RelayModelAccess.vitest.ts` for **#7953**: retired models must still be denied on MAX/ULTRA even when their provider is **not** in the relay forwarding allowlist.
> 
> Because the pinned `llm-zoo` catalog has no real retired, non–`openRouterOnly` model outside `RELAY_PROVIDERS`, the test **mocks `llm-zoo`** (same `importOriginal` pattern as `ModelAccess.vitest.mts`) with a synthetic retired `meta` entry (`legacy-meta-model`). The new case asserts `meta` is absent from `TIER_CONFIG.providers`, then checks `isRetiredModelRequest` and `isModelAllowedForTier` reject that name—pinning that `RETIRED_MODEL_PATTERNS` must not be filtered by `RELAY_PROVIDERS`.
> 
> **Test-only**; no production changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d43e8fc3374512f28b1503f17c9463670bd3802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->