### PR TITLE
fix(desktop): retarget verify-fixes.spec.ts off the moved settingsViewCommands module

### DIFF
--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -9,12 +9,15 @@ import {
 
 // Inlined rather than imported from src/shared: Playwright's ESM loader can't
 // resolve a relative .js import of a TS file under src/shared (see
-// tests/e2e/README.md § Cross-package imports; settingsPersistence.spec.ts
-// does the same). Source of truth: SETTINGS_VIEW_CMD.SET_TAB in
-// src/shared/ipc.ts; SETTINGS_TAB.TOOLS (index of 'TOOLS' in
-// SETTINGS_TAB_ORDER) in src/shared/schemas/settingsView/data.ts.
+// packages/desktop/tests/e2e/README.md § Cross-package imports;
+// settingsPersistence.spec.ts does the same). Source of truth:
+// SETTINGS_VIEW_CMD.SET_TAB in src/shared/ipc.ts; SETTINGS_TAB_INDEX.TOOLS
+// (index of 'TOOLS' in SETTINGS_TAB_ORDER) in
+// src/shared/schemas/settingsView/data.ts.
 const SET_TAB_COMMAND = 'setTab';
-const TOOLS_TAB_INDEX = 5;
+const SETTINGS_TAB_INDEX = {
+  TOOLS: 5,
+} as const;
 
 let launched: LaunchedApp;
 
@@ -108,7 +111,7 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
     },
     {
       command: SET_TAB_COMMAND,
-      tabIndex: TOOLS_TAB_INDEX,
+      tabIndex: SETTINGS_TAB_INDEX.TOOLS,
     },
   );
   await launched.page.waitForFunction(

--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -1,13 +1,20 @@
 import { test, expect } from '@playwright/test';
 
-import { SETTINGS_VIEW_CMD } from '../../../../src/common/webview/settingsViewCommands.js';
-import { SETTINGS_TAB } from '../../../../src/shared/schemas/settingsViewMessages.js';
 import {
   closeTexraApp,
   dismissOnboarding,
   launchTexraApp,
   type LaunchedApp,
 } from './electronApp.js';
+
+// Inlined rather than imported from src/shared: Playwright's ESM loader can't
+// resolve a relative .js import of a TS file under src/shared (see
+// tests/e2e/README.md § Cross-package imports; settingsPersistence.spec.ts
+// does the same). Source of truth: SETTINGS_VIEW_CMD.SET_TAB in
+// src/shared/ipc.ts; SETTINGS_TAB.TOOLS (index of 'TOOLS' in
+// SETTINGS_TAB_ORDER) in src/shared/schemas/settingsView/data.ts.
+const SET_TAB_COMMAND = 'setTab';
+const TOOLS_TAB_INDEX = 5;
 
 let launched: LaunchedApp;
 
@@ -100,8 +107,8 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
       window.postMessage({ command, tabIndex }, '*');
     },
     {
-      command: SETTINGS_VIEW_CMD.SET_TAB,
-      tabIndex: SETTINGS_TAB.TOOLS,
+      command: SET_TAB_COMMAND,
+      tabIndex: TOOLS_TAB_INDEX,
     },
   );
   await launched.page.waitForFunction(


### PR DESCRIPTION
## What / why

Fixes #7952. `packages/desktop/tests/e2e/verify-fixes.spec.ts` imported
`SETTINGS_VIEW_CMD` from `../../../../src/common/webview/settingsViewCommands.js`
— a module that no longer exists (`SETTINGS_VIEW_CMD` moved to
`src/shared/ipc.ts` in PR #4596, `refactor: move webview IPC command
constants to src/shared/ipc/`). The spec could not resolve at all.

Retargeting the import to `src/shared/ipc.js` isn't enough on its own:
Playwright's ESM loader can't resolve a relative `.js` import of a TS file
under `src/shared/...` (it resolves the path but then chokes on named
exports as if the module were CommonJS). This is a known, already-documented
constraint — `packages/desktop/tests/e2e/README.md` § "Cross-package
imports" says to inline the constants instead, and the sibling
`settingsPersistence.spec.ts` already does exactly that (`const
SETTINGS_TAB_INDEX = { MEMORY: 0 } as const;`, `command: 'setTab'`
inlined). So this PR follows the same established pattern: both imports
(`SETTINGS_VIEW_CMD`, `SETTINGS_TAB`) are dropped and replaced with two
local constants (`SET_TAB_COMMAND = 'setTab'`, `TOOLS_TAB_INDEX = 5`), with
a comment pointing back at the source of truth
(`SETTINGS_VIEW_CMD.SET_TAB` in `src/shared/ipc.ts`, `SETTINGS_TAB.TOOLS`
— i.e. the index of `'TOOLS'` in `SETTINGS_TAB_ORDER` — in
`src/shared/schemas/settingsView/data.ts`).

**Decision: retarget, not delete.** The spec's assertions are not stale
incident residue — I verified against current `origin/main` that the DOM
shape it checks is still live: `MainApp.ts` still renders
`<latexdiffs-section>` behind `.view-header`, `styles.ts` still defines
`.view-header`, and `wa-dialog.desktop-settings-overlay` /
`wa-tab-panel[name="tools"]` are still the current desktop settings-overlay
structure (same selectors used by the still-passing `screenshots.spec.ts`).
Nothing here is dead.

## Desktop e2e in CI

`grep -rn "test:e2e\|playwright" .github/workflows/*.yml` returns nothing —
desktop e2e is **not wired into any CI job** today (confirmed empty grep
across the whole `.github/workflows/` directory). That's why this import
break went unnoticed. Per the issue, that CI-coverage gap belongs to
#7844's discussion, not this PR.

## Verification

Ran locally in the worktree (macOS, no CI gate exists for this suite):

```
pnpm --filter @texra/desktop build
npx playwright test --list -c playwright.config.ts tests/e2e/verify-fixes.spec.ts
npx playwright test -c playwright.config.ts tests/e2e/verify-fixes.spec.ts
npm run typecheck   # covers desktop via `corepack pnpm --filter @texra/desktop typecheck`
```

- **Pre-fix repro** (proven failing, not just asserted): reverted the diff
  with `git apply -R`, re-ran `playwright test --list` →
  `Error: Cannot find module '.../src/common/webview/settingsViewCommands.js'`,
  exactly the issue's reported symptom. Then reapplied and confirmed
  `--list` finds both tests.
- **Post-fix**: both tests execute. `main view no longer renders inner
  Launcher/Progress toolbar` passes. `settings overlay scrolls (Tools tab
  top + bottom)` fails on an assertion (`scrollHeight` not yet `>
  clientHeight` at probe time) — I isolated this with a diagnostic
  extra-wait (not committed) and confirmed it's a **pre-existing render
  timing race** in the test's own `waitForFunction` (it resolves as soon as
  the tab panel is marked `[active]`, before the tools-list content has
  finished populating), fully independent of the import path. It
  reproduces identically regardless of which module the constants come
  from, so it's out of scope for #7952 (which is specifically about import
  resolution) — flagging it here rather than silently patching over it.
  Filing as a follow-up if desired.
- `npm run typecheck` — green (root, test-kernel, extension, cli,
  trace-viewer, and desktop sub-tsconfigs all pass).

## Net elements (R6)

Net **-1 net export dependency, +2 local constants, -2 imports**. No new
abstractions: two inline `const` primitives replacing two broken/unsafe
cross-package imports, mirroring the pattern already used one file over
(`settingsPersistence.spec.ts`). Nothing new to delete later — this is a
straight retarget within an existing, unmodified test file structure.

## Consumer counts (R8)

`SETTINGS_VIEW_CMD` / `SETTINGS_TAB` are not removed from their real
homes (`src/shared/ipc.ts`, `src/shared/schemas/settingsView/data.ts`) —
only this one file's now-broken cross-package import of them is dropped.
Grepped for other consumers of the same broken path
(`src/common/webview/settingsViewCommands`): none — `verify-fixes.spec.ts`
was the only remaining reference to the pre-#4596 module location.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact; only risk is duplicated constants drifting from shared sources.
> 
> **Overview**
> Fixes broken module resolution in `verify-fixes.spec.ts` after `SETTINGS_VIEW_CMD` moved out of the removed `settingsViewCommands` module.
> 
> The spec **drops** imports from `src/common/webview/settingsViewCommands.js` and `settingsViewMessages`, and **inlines** `SET_TAB_COMMAND` (`'setTab'`) and `SETTINGS_TAB_INDEX.TOOLS` (`5`), with comments pointing at `src/shared/ipc.ts` and `src/shared/schemas/settingsView/data.ts`. The Tools-tab scroll test now posts those local values instead of `SETTINGS_VIEW_CMD.SET_TAB` / `SETTINGS_TAB.TOOLS`—same pattern as `settingsPersistence.spec.ts` for Playwright’s cross-package `src/shared` import limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0d9929ad716a5da6fcee205f8bdce75088b824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->