### PR TITLE
refactor: inline single-caller build* helpers (#7745)

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -12,10 +12,7 @@ import * as vscode from 'vscode';
 
 // Shared schemas and dispatchers
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
-import {
-  buildToolDashboardItems,
-  buildToolDashboardTerminalAction,
-} from '@controllers/settingsView/ToolDashboardData';
+import { buildToolDashboardItems } from '@controllers/settingsView/ToolDashboardData';
 import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
@@ -73,6 +70,7 @@ import {
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
+import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
   getLastCheckResults,
   refreshToolAvailability,
@@ -108,6 +106,39 @@ import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 // Re-use the shared type helper for extracting specific message types.
 type MessageFor<C extends SettingsViewInboundMessage['command']> =
   SettingsMessageFor<C>;
+
+// Plans the terminal command for a tool-dashboard install/auth action.
+// Extension-only: unlike the desktop's tool-command handling, no other
+// host calls this, so it's kept local to its single caller rather than
+// exported from the shared settingsView controllers.
+type ToolTerminalAction =
+  | {
+      readonly kind: 'terminal';
+      readonly name: string;
+      readonly command: string;
+    }
+  | {
+      readonly kind: 'none';
+      readonly reason: 'unknownTool' | 'missingCommand';
+    };
+
+export function planToolTerminalAction(input: {
+  readonly toolId: string;
+  readonly commandKind: 'install' | 'auth';
+}): ToolTerminalAction {
+  const def = findExternalToolDef(input.toolId);
+  if (!def) return { kind: 'none', reason: 'unknownTool' };
+
+  const command =
+    input.commandKind === 'install' ? def.installCommand : def.authCommand;
+  if (!command) return { kind: 'none', reason: 'missingCommand' };
+
+  return {
+    kind: 'terminal',
+    name: `TeXRA: ${def.name}`,
+    command,
+  };
+}
 
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
@@ -508,7 +539,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private handleRunToolCommand(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.RUN_TOOL_COMMAND>,
   ): void {
-    const action = buildToolDashboardTerminalAction({
+    const action = planToolTerminalAction({
       toolId: data.toolId,
       commandKind: data.kind,
     });

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -109,8 +109,9 @@ type MessageFor<C extends SettingsViewInboundMessage['command']> =
 
 // Plans the terminal command for a tool-dashboard install/auth action.
 // Extension-only: unlike the desktop's tool-command handling, no other
-// host calls this, so it's kept local to its single caller rather than
-// exported from the shared settingsView controllers.
+// host calls this, so it's kept next to its single production caller
+// rather than living in the shared settingsView controllers (exported
+// here only so the Vitest suite can import it directly).
 type ToolTerminalAction =
   | {
       readonly kind: 'terminal';
@@ -124,7 +125,9 @@ type ToolTerminalAction =
 
 export function planToolTerminalAction(input: {
   readonly toolId: string;
-  readonly commandKind: 'install' | 'auth';
+  readonly commandKind: MessageFor<
+    typeof SETTINGS_VIEW_CMD.RUN_TOOL_COMMAND
+  >['kind'];
 }): ToolTerminalAction {
   const def = findExternalToolDef(input.toolId);
   if (!def) return { kind: 'none', reason: 'unknownTool' };

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -1,4 +1,3 @@
-import type { TaskState } from '@agent/core/state/TaskState';
 import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { isNonEmptyString } from '@utils/core';
@@ -20,31 +19,6 @@ export interface FileContext {
 }
 
 // ── File context ─────────────────────────────────────────────
-
-export function buildFileContextFromTaskState(
-  taskState: TaskState,
-): FileContext {
-  const { agentConfig } = taskState;
-  const context: FileContext = {};
-
-  if (agentConfig.agent) {
-    context.agent = agentConfig.agent;
-  }
-
-  const arrayFields = [
-    'inputFiles',
-    'contextFiles',
-    'mediaFiles',
-    'outputFiles',
-  ] as const;
-  for (const field of arrayFields) {
-    if (agentConfig[field].length > 0) {
-      context[field] = agentConfig[field];
-    }
-  }
-
-  return context;
-}
 
 function formatFileContext(ctx: FileContext): string {
   const lines: string[] = ['Current context:'];

--- a/src/controllers/progressView/ProgressFollowUpPolishController.ts
+++ b/src/controllers/progressView/ProgressFollowUpPolishController.ts
@@ -1,7 +1,6 @@
 // Local imports - agent
 import type { TaskState } from '@agent/core/state/TaskState';
 import {
-  buildFileContextFromTaskState,
   polishTextWithAI,
   type FileContext,
 } from '@agent/runtime/textEnhancement';
@@ -71,7 +70,7 @@ export class ProgressFollowUpPolishController {
     }
 
     try {
-      const fileContext = buildFileContextFromTaskState(input.taskState);
+      const fileContext = this.buildFileContext(input.taskState);
       const result = await this.deps.polishText(input.text, fileContext);
       if (result.success) {
         return {
@@ -102,6 +101,29 @@ export class ProgressFollowUpPolishController {
         ...(error instanceof Error && { logData: error }),
       };
     }
+  }
+
+  private buildFileContext(taskState: TaskState): FileContext {
+    const { agentConfig } = taskState;
+    const context: FileContext = {};
+
+    if (agentConfig.agent) {
+      context.agent = agentConfig.agent;
+    }
+
+    const arrayFields = [
+      'inputFiles',
+      'contextFiles',
+      'mediaFiles',
+      'outputFiles',
+    ] as const;
+    for (const field of arrayFields) {
+      if (agentConfig[field].length > 0) {
+        context[field] = agentConfig[field];
+      }
+    }
+
+    return context;
   }
 
   private createUpdate(

--- a/src/controllers/settingsView/ToolDashboardData.ts
+++ b/src/controllers/settingsView/ToolDashboardData.ts
@@ -9,7 +9,6 @@
 // Local imports
 import type {
   ToolDashboardItem,
-  ToolCommandKind,
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
 import { findExternalToolDef } from '@tools/externalToolDefs';
@@ -19,17 +18,6 @@ import {
   type ExternalToolCheckResult,
 } from '@tools/toolAvailability';
 import { getDisabledToolIds } from '@utils/config/constants';
-
-export type ToolDashboardTerminalAction =
-  | {
-      readonly kind: 'terminal';
-      readonly name: string;
-      readonly command: string;
-    }
-  | {
-      readonly kind: 'none';
-      readonly reason: 'unknownTool' | 'missingCommand';
-    };
 
 // ============================================================
 // Tool description enrichment
@@ -184,22 +172,4 @@ export async function buildToolDashboardItems(
   }
 
   return [...builtinItems, ...externalItems];
-}
-
-export function buildToolDashboardTerminalAction(input: {
-  readonly toolId: string;
-  readonly commandKind: ToolCommandKind;
-}): ToolDashboardTerminalAction {
-  const def = findExternalToolDef(input.toolId);
-  if (!def) return { kind: 'none', reason: 'unknownTool' };
-
-  const command =
-    input.commandKind === 'install' ? def.installCommand : def.authCommand;
-  if (!command) return { kind: 'none', reason: 'missingCommand' };
-
-  return {
-    kind: 'terminal',
-    name: `TeXRA: ${def.name}`,
-    command,
-  };
 }

--- a/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
+++ b/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-import { buildToolDashboardTerminalAction } from '@controllers/settingsView/ToolDashboardData';
+import { planToolTerminalAction } from '@settingsView/SettingsViewMessageHandler';
 
-describe('ToolDashboardData', () => {
+describe('planToolTerminalAction', () => {
   it('plans install terminal actions from tool definitions', () => {
     assert.deepEqual(
-      buildToolDashboardTerminalAction({
+      planToolTerminalAction({
         toolId: 'codex',
         commandKind: 'install',
       }),
@@ -20,7 +20,7 @@ describe('ToolDashboardData', () => {
 
   it('plans auth terminal actions from tool definitions', () => {
     assert.deepEqual(
-      buildToolDashboardTerminalAction({
+      planToolTerminalAction({
         toolId: 'claude-agent',
         commandKind: 'auth',
       }),
@@ -34,7 +34,7 @@ describe('ToolDashboardData', () => {
 
   it('does not ask the handler to open a terminal without a command', () => {
     assert.deepEqual(
-      buildToolDashboardTerminalAction({
+      planToolTerminalAction({
         toolId: 'texra-cli',
         commandKind: 'auth',
       }),
@@ -42,7 +42,7 @@ describe('ToolDashboardData', () => {
     );
 
     assert.deepEqual(
-      buildToolDashboardTerminalAction({
+      planToolTerminalAction({
         toolId: 'missing-tool',
         commandKind: 'install',
       }),

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -55,6 +55,7 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import {
   importClaudeAgentSdk,
   findClaudeBinaryPath,
@@ -577,7 +578,17 @@ async function launchClaudeAgentSession(
 ): Promise<ToolResult> {
   const config = await getClaudeAgentConfig();
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
-  const workspace = config.buildClaudeAgentWorkspaceOptions(workingDir);
+  // Mirrors codex behavior so subagents can see the project: when the call
+  // is made from inside the workspace, the agent runs in that directory but
+  // is also granted read access to the workspace root so it can inspect
+  // sibling files. Out-of-workspace cwds run isolated (matches codex). The
+  // claude-agent-sdk's `Options` type names these fields `cwd` /
+  // `additionalDirectories`, unlike codex's `workingDirectory`.
+  const resolvedWorkspace = buildAgentWorkspaceOptions(workingDir);
+  const workspace = {
+    cwd: resolvedWorkspace.workingDirectory,
+    additionalDirectories: resolvedWorkspace.additionalDirectories,
+  };
   const env = await config.buildClaudeAgentEnv();
   const agentConfig = config.buildClaudeAgentConfig(input.prompt);
   const preview = truncateWithEllipsis(input.prompt, 60);

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -25,7 +25,6 @@ import {
 } from '@shared/schemas/agentCliSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { safeHomedir } from '@utils/system/platformPaths';
-import { buildAgentWorkspaceOptions } from './agentWorkspaceOptions';
 import { createEnumStateGetter } from './support/enumConfig';
 import {
   CLAUDE_AGENT_NAME,
@@ -228,38 +227,6 @@ export async function buildClaudeAgentEnv(
   }
 
   return env;
-}
-
-// ============================================================================
-// Workspace options — mirrors codex behavior so subagents can see the project
-// ============================================================================
-
-export interface ClaudeAgentWorkspaceOptions {
-  cwd?: string;
-  additionalDirectories?: string[];
-}
-
-/**
- * Compute the cwd + extra-roots the SDK should see.
- *
- * When the call is made from inside the workspace, the agent runs in that
- * directory but is also granted read access to the workspace root so it can
- * inspect sibling files. Out-of-workspace cwds run isolated (matches codex).
- */
-export function buildClaudeAgentWorkspaceOptions(
-  workingDirectoryInput?: string | null,
-): ClaudeAgentWorkspaceOptions {
-  const workspace = buildAgentWorkspaceOptions(workingDirectoryInput);
-  const options: ClaudeAgentWorkspaceOptions = {};
-
-  if (workspace.workingDirectory) {
-    options.cwd = workspace.workingDirectory;
-  }
-  if (workspace.additionalDirectories) {
-    options.additionalDirectories = workspace.additionalDirectories;
-  }
-
-  return options;
 }
 
 // ============================================================================


### PR DESCRIPTION
## What / why

Closes #7745.

CLAUDE.md's "Discouraged Factory Patterns" section bans single-caller
extractions across a file boundary. Issue #7745 listed three exported
`build*` functions defined in one file and called from exactly one
production call site each. Re-verified all three against current
`origin/main` HEAD (2026-07-10) — all three still exist with a single
non-test caller — so they're sanctioned single-caller flattenings per
CLAUDE.md and this PR inlines them:

1. **`buildFileContextFromTaskState`** (`src/agent/runtime/textEnhancement.ts`)
   — its only caller was `ProgressFollowUpPolishController.polishFollowUp`.
   Inlined as a private `buildFileContext` method on that controller; the
   `FileContext` type/`formatFileContext`/`polishTextWithAI` stay in
   `textEnhancement.ts` since those are used elsewhere too.

2. **`buildToolDashboardTerminalAction`** (`src/controllers/settingsView/ToolDashboardData.ts`)
   — its only caller was `SettingsViewMessageHandler.handleRunToolCommand`.
   The issue also flagged that, unlike its directory-siblings
   (`SettingsMemoryControllerFactory.ts`, etc.), it wasn't actually shared
   across the extension/desktop hosts (desktop's `desktopSettingsIpc.ts`
   never calls it) — so keeping it in the shared `controllers/settingsView`
   directory was misleading. Moved the pure planning function into
   `SettingsViewMessageHandler.ts` (renamed `planToolTerminalAction`,
   still a standalone pure function so it stays independently unit-testable
   without instantiating the whole handler class or mocking
   `vscode.window.createTerminal`).

3. **`buildClaudeAgentWorkspaceOptions`** (`src/tools/claudeAgentConfig.ts`)
   — its only caller was `launchClaudeAgentSession` in `claudeAgent.ts`. It
   thinly wrapped the still-shared `buildAgentWorkspaceOptions` (used by both
   `claudeAgent.ts` and `codex.ts`), renaming `workingDirectory` → `cwd` and
   dropping `undefined` keys. Inlined the renaming directly at the call site;
   `buildAgentWorkspaceOptions` itself is untouched since `codex.ts` depends
   on its `workingDirectory`-named return shape.

## Verification

```
npm run typecheck   # full workspace (extension/desktop/cli/trace-viewer) - clean
npm run lint         # 0 errors (pre-existing import/order warnings elsewhere, untouched files)
npx prettier --check <changed files>   # clean
npx vitest run \
  src/test-kernel/controllers/ProgressFollowUpPolishController.vitest.ts \
  src/test-kernel/settings/PlanToolTerminalAction.vitest.ts \
  src/test-kernel/tools/ClaudeAgentConfig.vitest.ts \
  src/test-kernel/tools/AgentWorkspaceOptions.vitest.ts
# 4 files, 21 tests passed
npx vitest run src/test-kernel/tools/SubagentResults.vitest.ts \
  src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts \
  src/test-kernel/settings
# 14 files, 58 tests passed
```

`src/test-kernel/controllers/ToolDashboardData.vitest.ts` was renamed to
`src/test-kernel/settings/PlanToolTerminalAction.vitest.ts` and repointed at
the relocated `planToolTerminalAction` export — same three test cases,
unchanged assertions, only the import path and function name moved with the
code (R7: extends the existing suite in place rather than dropping coverage).

## Net elements (R6)

- 0 new files, 0 new abstractions/exports beyond what already existed.
- 3 exported `build*` functions removed (2 became private/local, 1 became
  a same-file standalone function under its single caller).
- 1 test file renamed in place, no new test files.
- Net: **-25 LOC** (78 insertions / 103 deletions across 7 files).

## Consumer counts (R8)

Re-verified via repo-wide `git grep` against `origin/main` before editing:

- `buildFileContextFromTaskState`: 1 non-test caller (`ProgressFollowUpPolishController.ts:74`).
- `buildToolDashboardTerminalAction`: 1 non-test caller (`SettingsViewMessageHandler.ts:511`); confirmed desktop's `desktopSettingsIpc.ts` has zero references.
- `buildClaudeAgentWorkspaceOptions`: 1 caller (`claudeAgent.ts:580`, via the lazily-loaded `claudeAgentConfig` module).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocations and inlining with equivalent behavior; tests were repointed, not rewritten.
> 
> **Overview**
> Removes three exported **`build*`** helpers that each had a single production caller, per the discouraged single-caller factory pattern.
> 
> **Follow-up polish:** `buildFileContextFromTaskState` is gone from `textEnhancement.ts`; **`ProgressFollowUpPolishController`** now builds **`FileContext`** in a private **`buildFileContext`** method. Shared polish APIs and types stay in **`textEnhancement.ts`**.
> 
> **Settings tool dashboard:** **`buildToolDashboardTerminalAction`** is removed from **`ToolDashboardData.ts`** (dashboard data only). Extension **`SettingsViewMessageHandler`** owns **`planToolTerminalAction`**, which **`handleRunToolCommand`** uses to open install/auth terminal commands. Tests import the renamed export from the message handler module.
> 
> **Claude agent workspace:** **`buildClaudeAgentWorkspaceOptions`** is removed from **`claudeAgentConfig.ts`**. **`launchClaudeAgentSession`** in **`claudeAgent.ts`** maps **`buildAgentWorkspaceOptions`** directly to SDK **`cwd`** / **`additionalDirectories`** (same codex-aligned behavior, no extra wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514a32e35f96f2d8bc9954b6948c587e23210f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->