### PR TITLE
feat(desktop): add lightweight update-check notification (#7682)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@types/semver": "^7.7.1",
     "electron": "^43.1.0",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.28.1",
@@ -36,6 +37,7 @@
     "@fortawesome/free-solid-svg-icons": "^7.3.0",
     "@openai/codex-sdk": "^0.144.1",
     "@sentry/electron": "^7.15.0",
-    "fix-path": "^5.0.0"
+    "fix-path": "^5.0.0",
+    "semver": "^7.8.5"
   }
 }

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -57,6 +57,15 @@ export interface DesktopProtocolApp {
 export interface DesktopProtocolLifecycle {
   router: DesktopProtocolCallbackRouter;
   shouldContinue: boolean;
+  /**
+   * True only for the single process holding Electron's single-instance
+   * lock. A second "open folder in new window" launch runs as its own
+   * process with `shouldContinue: true` but does NOT hold the lock — use
+   * this to gate process-singleton behavior (e.g. the desktop update
+   * check) that would otherwise duplicate across those processes, since
+   * each has an independent in-memory view of persisted global state.
+   */
+  ownsSingleInstanceLock: boolean;
 }
 
 export interface InstallDesktopProtocolOptions {
@@ -157,7 +166,7 @@ export function installDesktopProtocolCallbackLifecycle(
 
   if (!ownsSingleInstanceLock && !isExplicitNewWindow) {
     app.quit();
-    return { router, shouldContinue: false };
+    return { router, shouldContinue: false, ownsSingleInstanceLock };
   }
 
   if (ownsSingleInstanceLock) {
@@ -181,7 +190,7 @@ export function installDesktopProtocolCallbackLifecycle(
 
   router.routeArgv(options.argv ?? []);
 
-  return { router, shouldContinue: true };
+  return { router, shouldContinue: true, ownsSingleInstanceLock };
 }
 
 function normalizeProtocolPath(url: URL): string {

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -1,0 +1,125 @@
+import { gt as semverGt, valid as semverValid } from 'semver';
+
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import type { StateStore } from '@platform/interfaces';
+
+/**
+ * Lightweight desktop update check (issue #7682, decision: arm b).
+ *
+ * Polls the public `texra-ai/texra-desktop-releases` repo's latest GitHub
+ * release and, when it is newer than the running build, hands the release
+ * off to a caller-supplied `notify` callback (a native dialog with a
+ * download link — see `createWindow` in `index.ts`). Deliberately NOT a full
+ * updater: no download, no install, no feed files. Disable entirely with
+ * `TEXRA_NO_UPDATE_CHECK=1`, mirroring the CLI's `updateChecker.ts`.
+ */
+
+const RELEASES_API_URL =
+  'https://api.github.com/repos/texra-ai/texra-desktop-releases/releases/latest';
+const FETCH_TIMEOUT_MS = 5000;
+/** Poll at most once per day so a normal multi-launch day makes one request. */
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
+
+export interface DesktopLatestRelease {
+  /** Release version with any leading `v` stripped, e.g. `0.40.0`. */
+  version: string;
+  /** GitHub release page URL — installers are attached there. */
+  url: string;
+}
+
+/**
+ * True when `latest` is strictly newer than `current` under semver
+ * precedence. Unparseable input yields `false` so a malformed API response
+ * can never trigger a bogus update notification.
+ */
+export function isNewerDesktopVersion(
+  latest: string,
+  current: string,
+): boolean {
+  const a = semverValid(latest.trim(), { loose: true });
+  const b = semverValid(current.trim(), { loose: true });
+  if (!a || !b) return false;
+  return semverGt(a, b);
+}
+
+/** Fetch the latest release's version + page URL, or undefined on any failure. */
+export async function fetchLatestDesktopRelease(options?: {
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<DesktopLatestRelease | undefined> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  try {
+    const response = await fetchImpl(RELEASES_API_URL, {
+      signal: AbortSignal.timeout(options?.timeoutMs ?? FETCH_TIMEOUT_MS),
+      headers: { accept: 'application/vnd.github+json' },
+    });
+    if (!response.ok) return undefined;
+    const body = (await response.json()) as {
+      tag_name?: unknown;
+      html_url?: unknown;
+    };
+    const tag = typeof body.tag_name === 'string' ? body.tag_name : undefined;
+    const url = typeof body.html_url === 'string' ? body.html_url : undefined;
+    if (!tag || !url) return undefined;
+    return { version: tag.replace(/^v/, ''), url };
+  } catch {
+    return undefined;
+  }
+}
+
+export interface CheckForDesktopUpdateOptions {
+  currentVersion: string;
+  globalState: StateStore;
+  /** Skip entirely for unpackaged/dev runs, whose version is not meaningful. */
+  isPackaged: boolean;
+  notify: (release: DesktopLatestRelease) => Promise<void> | void;
+  now?: () => number;
+  fetchRelease?: typeof fetchLatestDesktopRelease;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Once per day (persisted in global state) and once per process, check for a
+ * newer desktop release and notify at most once per release version. Failures
+ * are silent so a flaky network never interrupts startup.
+ */
+export async function checkForDesktopUpdate({
+  currentVersion,
+  globalState,
+  isPackaged,
+  notify,
+  now = Date.now,
+  fetchRelease = fetchLatestDesktopRelease,
+  env = process.env,
+}: CheckForDesktopUpdateOptions): Promise<void> {
+  if (!isPackaged) return;
+  if (env[UPDATE_CHECK_SKIP_ENV]) return;
+
+  const lastCheckedAt = globalState.get<number>(
+    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+    0,
+  );
+  const nowMs = now();
+  if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return;
+  await globalState.update(
+    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+    nowMs,
+  );
+
+  const release = await fetchRelease();
+  if (!release || !isNewerDesktopVersion(release.version, currentVersion)) {
+    return;
+  }
+
+  const lastNotifiedVersion = globalState.get<string>(
+    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
+  );
+  if (lastNotifiedVersion === release.version) return;
+
+  await notify(release);
+  await globalState.update(
+    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
+    release.version,
+  );
+}

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -16,6 +16,15 @@ import type { StateStore } from '@platform/interfaces';
 
 const RELEASES_API_URL =
   'https://api.github.com/repos/texra-ai/texra-desktop-releases/releases/latest';
+/**
+ * Known-constant releases page, always opened verbatim instead of the
+ * unauthenticated API response's `html_url` — see `notify` wiring in
+ * `index.ts`. Never build a URL to open from network-provided data.
+ */
+export const DESKTOP_RELEASES_PAGE_URL =
+  'https://github.com/texra-ai/texra-desktop-releases/releases';
+/** Stable identifier for GitHub API request logging/diagnostics. */
+const GITHUB_USER_AGENT = 'TeXRA-Desktop';
 const FETCH_TIMEOUT_MS = 5000;
 /** Poll at most once per day so a normal multi-launch day makes one request. */
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -24,8 +33,6 @@ const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 export interface DesktopLatestRelease {
   /** Release version with any leading `v` stripped, e.g. `0.40.0`. */
   version: string;
-  /** GitHub release page URL — installers are attached there. */
-  url: string;
 }
 
 /**
@@ -43,7 +50,7 @@ export function isNewerDesktopVersion(
   return semverGt(a, b);
 }
 
-/** Fetch the latest release's version + page URL, or undefined on any failure. */
+/** Fetch the latest release's version, or undefined on any failure. */
 export async function fetchLatestDesktopRelease(options?: {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
@@ -52,17 +59,16 @@ export async function fetchLatestDesktopRelease(options?: {
   try {
     const response = await fetchImpl(RELEASES_API_URL, {
       signal: AbortSignal.timeout(options?.timeoutMs ?? FETCH_TIMEOUT_MS),
-      headers: { accept: 'application/vnd.github+json' },
+      headers: {
+        accept: 'application/vnd.github+json',
+        'user-agent': GITHUB_USER_AGENT,
+      },
     });
     if (!response.ok) return undefined;
-    const body = (await response.json()) as {
-      tag_name?: unknown;
-      html_url?: unknown;
-    };
+    const body = (await response.json()) as { tag_name?: unknown };
     const tag = typeof body.tag_name === 'string' ? body.tag_name : undefined;
-    const url = typeof body.html_url === 'string' ? body.html_url : undefined;
-    if (!tag || !url) return undefined;
-    return { version: tag.replace(/^v/, ''), url };
+    if (!tag) return undefined;
+    return { version: tag.replace(/^v/, '') };
   } catch {
     return undefined;
   }
@@ -80,9 +86,12 @@ export interface CheckForDesktopUpdateOptions {
 }
 
 /**
- * Once per day (persisted in global state) and once per process, check for a
- * newer desktop release and notify at most once per release version. Failures
- * are silent so a flaky network never interrupts startup.
+ * At most once per day (persisted in global state), check for a newer
+ * desktop release and notify at most once per release version. The daily
+ * throttle stamp is only persisted after a successful fetch, so a failed
+ * check (network hiccup, GitHub API hiccup, timeout) simply retries on the
+ * next launch instead of being suppressed for a full day; failures never
+ * interrupt startup.
  */
 export async function checkForDesktopUpdate({
   currentVersion,
@@ -102,13 +111,15 @@ export async function checkForDesktopUpdate({
   );
   const nowMs = now();
   if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return;
+
+  const release = await fetchRelease();
+  if (!release) return;
+  // Only persist the throttle stamp once the fetch actually succeeded.
   await globalState.update(
     GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
     nowMs,
   );
-
-  const release = await fetchRelease();
-  if (!release || !isNewerDesktopVersion(release.version, currentVersion)) {
+  if (!isNewerDesktopVersion(release.version, currentVersion)) {
     return;
   }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -58,7 +58,10 @@ import {
   setupCommandNeedsInteractiveTerminal,
 } from './desktopSetupTerminal.js';
 import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
-import { checkForDesktopUpdate } from './desktopUpdateChecker.js';
+import {
+  checkForDesktopUpdate,
+  DESKTOP_RELEASES_PAGE_URL,
+} from './desktopUpdateChecker.js';
 import {
   createDesktopAuthCallbackState,
   createDesktopAuthCoordinator,
@@ -327,24 +330,32 @@ function createWindow(options: {
   // Lightweight update check (issue #7682, arm b): at most once/day, notifies
   // at most once per release via a native dialog linking to the GitHub
   // release page. Not a full updater — no download, no install, no feed
-  // files. Disable with TEXRA_NO_UPDATE_CHECK=1.
-  checkForDesktopUpdate({
-    currentVersion: app.getVersion(),
-    globalState: platform().globalState,
-    isPackaged: app.isPackaged,
-    notify: async (release) => {
-      const { response } = await dialog.showMessageBox(window, {
-        type: 'info',
-        message: `TeXRA ${release.version} is available (you have ${app.getVersion()}).`,
-        buttons: ['Download', 'Later'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (response === 0) {
-        await shell.openExternal(release.url);
-      }
-    },
-  }).catch(reportAsyncError);
+  // files. Disable with TEXRA_NO_UPDATE_CHECK=1. Gated on owning the
+  // single-instance lock so an "open folder in new window" launch (which
+  // deliberately runs as its own process) never duplicates the check or
+  // dialog alongside the primary process.
+  if (protocolLifecycle.ownsSingleInstanceLock) {
+    checkForDesktopUpdate({
+      currentVersion: app.getVersion(),
+      globalState: platform().globalState,
+      isPackaged: app.isPackaged,
+      notify: async (release) => {
+        const { response } = await dialog.showMessageBox(window, {
+          type: 'info',
+          message: `TeXRA ${release.version} is available (you have ${app.getVersion()}).`,
+          buttons: ['Download', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        });
+        if (response === 0) {
+          // Open the known-constant releases page rather than any
+          // network-provided URL, so an unauthenticated API response can
+          // never influence what shell.openExternal opens.
+          await shell.openExternal(DESKTOP_RELEASES_PAGE_URL);
+        }
+      },
+    }).catch(reportAsyncError);
+  }
   const setupCommandCwd = options.workspacePath ?? app.getPath('home');
   const setupTerminalRunner = createDesktopTerminalRunner({
     cwd: setupCommandCwd,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -58,6 +58,7 @@ import {
   setupCommandNeedsInteractiveTerminal,
 } from './desktopSetupTerminal.js';
 import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
+import { checkForDesktopUpdate } from './desktopUpdateChecker.js';
 import {
   createDesktopAuthCallbackState,
   createDesktopAuthCoordinator,
@@ -323,6 +324,27 @@ function createWindow(options: {
   const showInfoMessage = async (message: string) => {
     await dialog.showMessageBox(window, { type: 'info', message });
   };
+  // Lightweight update check (issue #7682, arm b): at most once/day, notifies
+  // at most once per release via a native dialog linking to the GitHub
+  // release page. Not a full updater — no download, no install, no feed
+  // files. Disable with TEXRA_NO_UPDATE_CHECK=1.
+  checkForDesktopUpdate({
+    currentVersion: app.getVersion(),
+    globalState: platform().globalState,
+    isPackaged: app.isPackaged,
+    notify: async (release) => {
+      const { response } = await dialog.showMessageBox(window, {
+        type: 'info',
+        message: `TeXRA ${release.version} is available (you have ${app.getVersion()}).`,
+        buttons: ['Download', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      if (response === 0) {
+        await shell.openExternal(release.url);
+      }
+    },
+  }).catch(reportAsyncError);
   const setupCommandCwd = options.workspacePath ?? app.getPath('home');
   const setupTerminalRunner = createDesktopTerminalRunner({
     cwd: setupCommandCwd,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,10 +483,16 @@ importers:
       fix-path:
         specifier: ^5.0.0
         version: 5.0.0
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       electron:
         specifier: ^43.1.0
         version: 43.1.0

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -139,6 +139,10 @@ export enum GlobalStateKey {
   // Desktop-only crash reporting
   DESKTOP_CRASH_REPORTING_ENABLED = 'texra.desktop.crashReporting.enabled',
 
+  // Desktop-only lightweight update check (see desktopUpdateChecker.ts)
+  DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT = 'texra.desktop.updateCheck.lastCheckedAt',
+  DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION = 'texra.desktop.updateCheck.lastNotifiedVersion',
+
   // Experimental
   INLINE_CRITICISM_ENABLED = 'texra.inlineCriticism.enabled',
 

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -22,10 +22,10 @@ class MemoryStateStore {
 
 interface DesktopLatestRelease {
   version: string;
-  url: string;
 }
 
 interface DesktopUpdateCheckerModule {
+  DESKTOP_RELEASES_PAGE_URL: string;
   isNewerDesktopVersion(latest: string, current: string): boolean;
   checkForDesktopUpdate(options: {
     currentVersion: string;
@@ -62,10 +62,17 @@ describe('desktop update checker', () => {
     });
   });
 
+  it('exposes a known-constant releases page URL (never opens API-provided URLs)', async () => {
+    const { DESKTOP_RELEASES_PAGE_URL } = await loadDesktopUpdateChecker();
+
+    expect(DESKTOP_RELEASES_PAGE_URL).toBe(
+      'https://github.com/texra-ai/texra-desktop-releases/releases',
+    );
+  });
+
   describe('checkForDesktopUpdate', () => {
     const release: DesktopLatestRelease = {
       version: '0.40.0',
-      url: 'https://github.com/texra-ai/texra-desktop-releases/releases/tag/v0.40.0',
     };
 
     it('skips entirely for unpackaged (dev) runs', async () => {
@@ -218,6 +225,55 @@ describe('desktop update checker', () => {
       nowMs += 24 * 60 * 60 * 1000;
       await run();
       expect(notifyCalls).toBe(1);
+    });
+
+    it('does not persist the throttle stamp on a failed fetch, so the next launch retries', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let fetchCalls = 0;
+      const nowMs = Date.UTC(2026, 0, 1);
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: () => {},
+        now: () => nowMs,
+        fetchRelease: async () => {
+          fetchCalls += 1;
+          return undefined; // simulates a network/API failure
+        },
+      });
+
+      expect(fetchCalls).toBe(1);
+      expect(
+        globalState.values.get(
+          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+        ),
+      ).toBeUndefined();
+
+      // Immediately "relaunching" (same day) must retry rather than being
+      // throttled for a full 24h off the back of the earlier failure.
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: () => {},
+        now: () => nowMs + 1000,
+        fetchRelease: async () => {
+          fetchCalls += 1;
+          return release;
+        },
+      });
+
+      expect(fetchCalls).toBe(2);
+      expect(
+        globalState.values.get(
+          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+        ),
+      ).toBe(nowMs + 1000);
     });
   });
 });

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+class MemoryStateStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
+
+interface DesktopLatestRelease {
+  version: string;
+  url: string;
+}
+
+interface DesktopUpdateCheckerModule {
+  isNewerDesktopVersion(latest: string, current: string): boolean;
+  checkForDesktopUpdate(options: {
+    currentVersion: string;
+    globalState: MemoryStateStore;
+    isPackaged: boolean;
+    notify: (release: DesktopLatestRelease) => Promise<void> | void;
+    now?: () => number;
+    fetchRelease?: () => Promise<DesktopLatestRelease | undefined>;
+    env?: NodeJS.ProcessEnv;
+  }): Promise<void>;
+}
+
+async function loadDesktopUpdateChecker(): Promise<DesktopUpdateCheckerModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopUpdateChecker.ts'))
+  ) as Promise<DesktopUpdateCheckerModule>;
+}
+
+describe('desktop update checker', () => {
+  describe('isNewerDesktopVersion', () => {
+    it('is true only when latest strictly outranks current', async () => {
+      const { isNewerDesktopVersion } = await loadDesktopUpdateChecker();
+
+      expect(isNewerDesktopVersion('0.40.0', '0.39.3')).toBe(true);
+      expect(isNewerDesktopVersion('0.39.3', '0.39.3')).toBe(false);
+      expect(isNewerDesktopVersion('0.38.0', '0.39.3')).toBe(false);
+    });
+
+    it('treats unparseable versions as not newer', async () => {
+      const { isNewerDesktopVersion } = await loadDesktopUpdateChecker();
+
+      expect(isNewerDesktopVersion('not-a-version', '0.39.3')).toBe(false);
+      expect(isNewerDesktopVersion('0.40.0', 'not-a-version')).toBe(false);
+    });
+  });
+
+  describe('checkForDesktopUpdate', () => {
+    const release: DesktopLatestRelease = {
+      version: '0.40.0',
+      url: 'https://github.com/texra-ai/texra-desktop-releases/releases/tag/v0.40.0',
+    };
+
+    it('skips entirely for unpackaged (dev) runs', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let fetchCalls = 0;
+      let notifyCalls = 0;
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: false,
+        notify: () => {
+          notifyCalls += 1;
+        },
+        fetchRelease: async () => {
+          fetchCalls += 1;
+          return release;
+        },
+      });
+
+      expect(fetchCalls).toBe(0);
+      expect(notifyCalls).toBe(0);
+    });
+
+    it('skips entirely when TEXRA_NO_UPDATE_CHECK is set', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let fetchCalls = 0;
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: { TEXRA_NO_UPDATE_CHECK: '1' },
+        notify: () => {},
+        fetchRelease: async () => {
+          fetchCalls += 1;
+          return release;
+        },
+      });
+
+      expect(fetchCalls).toBe(0);
+    });
+
+    it('notifies once when a newer release is found, and persists the notified version', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      const notified: DesktopLatestRelease[] = [];
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: (r) => {
+          notified.push(r);
+        },
+        fetchRelease: async () => release,
+      });
+
+      expect(notified).toEqual([release]);
+      expect(
+        globalState.values.get(
+          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
+        ),
+      ).toBe('0.40.0');
+    });
+
+    it('does not notify when the latest release is not newer', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let notifyCalls = 0;
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.40.0',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: () => {
+          notifyCalls += 1;
+        },
+        fetchRelease: async () => release,
+      });
+
+      expect(notifyCalls).toBe(0);
+    });
+
+    it('throttles repeated checks within the same day', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let fetchCalls = 0;
+      // A realistic epoch timestamp: on the very first check ever,
+      // `lastCheckedAt` defaults to 0, and this must be far enough past that
+      // default to *not* be throttled (matching a real first launch).
+      let nowMs = Date.UTC(2026, 0, 1);
+
+      const run = () =>
+        checkForDesktopUpdate({
+          currentVersion: '0.39.3',
+          globalState,
+          isPackaged: true,
+          env: {},
+          notify: () => {},
+          now: () => nowMs,
+          fetchRelease: async () => {
+            fetchCalls += 1;
+            return release;
+          },
+        });
+
+      await run();
+      expect(fetchCalls).toBe(1);
+
+      // Same process, ten minutes later: still throttled.
+      nowMs += 10 * 60 * 1000;
+      await run();
+      expect(fetchCalls).toBe(1);
+
+      // A full day later: throttle window has elapsed.
+      nowMs += 24 * 60 * 60 * 1000;
+      await run();
+      expect(fetchCalls).toBe(2);
+    });
+
+    it('does not re-notify for a release version already notified', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let notifyCalls = 0;
+      let nowMs = Date.UTC(2026, 0, 1);
+
+      const run = () =>
+        checkForDesktopUpdate({
+          currentVersion: '0.39.3',
+          globalState,
+          isPackaged: true,
+          env: {},
+          notify: () => {
+            notifyCalls += 1;
+          },
+          now: () => nowMs,
+          fetchRelease: async () => release,
+        });
+
+      await run();
+      expect(notifyCalls).toBe(1);
+
+      // Next day, same latest release: throttle window elapsed so it fetches
+      // again, but must not re-notify for a version already announced.
+      nowMs += 24 * 60 * 60 * 1000;
+      await run();
+      expect(notifyCalls).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a lightweight update-check notification to the desktop app, closing
#7682.

## Why

Desktop was the only TeXRA distribution channel with no update surface at
all (no `updater`/`autoUpdater`/`checkForUpdate` anywhere in
`packages/desktop/src`, confirmed still true at this PR's base commit).
The issue's maintainer-approved decision (2026-07-09) picked **arm (b)**:
a lightweight version-check toast, explicitly *not* a full
`electron-updater` (feed generation / signing / rollback are out of
scope), sequenced after Stage-5 close-out (#6968, closed).

## What changed

- `packages/desktop/src/main/desktopUpdateChecker.ts` (new): polls the
  public `texra-ai/texra-desktop-releases` repo's latest GitHub release
  (unauthenticated REST API), compares against the running build's
  version with `semver`, and hands a newer release off to a caller-supplied
  `notify` callback. Throttled to once/day via two new desktop-only
  `GlobalStateKey` entries (`DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT`,
  `DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION` in
  `src/shared/state/stateKeys.ts`, following the existing
  `DESKTOP_CRASH_REPORTING_ENABLED` desktop-only-key precedent), and
  notifies at most once per release version. Skips entirely for
  unpackaged/dev runs and when `TEXRA_NO_UPDATE_CHECK` is set (mirrors the
  CLI's `updateChecker.ts` opt-out).
- `packages/desktop/src/main/index.ts`: wires the check into
  `createWindow`, firing once on startup (non-blocking,
  `.catch(reportAsyncError)`). The `notify` callback reuses the existing
  `dialog.showMessageBox` pattern already used throughout desktop
  (`showInfoMessage`/`showErrorMessage`) with a "Download" button that
  opens the GitHub release page via `shell.openExternal` — no download, no
  install.
- `packages/desktop/package.json`: adds `semver` (dependency) /
  `@types/semver` (devDependency), reusing the exact version pins already
  used by the CLI's `updateChecker.ts`.

Explicitly out of scope (per the decision): `electron-updater`,
`latest.yml` feeds, code-signing interplay, auto-install.

## Verification commands

```
cd packages/desktop && npx tsc --noEmit -p tsconfig.main.json   # clean
npm run typecheck                                                 # clean (covers desktop)
npx eslint packages/desktop/src/main/desktopUpdateChecker.ts \
  packages/desktop/src/main/index.ts src/shared/state/stateKeys.ts \
  src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts          # clean
npx vitest run src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts   # 8/8 pass
npx vitest run src/test-kernel/desktop \
  src/test-kernel/shared/stateSettings.vitest.ts \
  src/test-kernel/shared/settingsConfiguration.vitest.ts            # 44 files / 466 tests pass
```

## Net elements (R6)

- 1 new production file (`desktopUpdateChecker.ts`, 125 lines).
- 1 new test file (`DesktopUpdateChecker.vitest.mts`), following the
  existing `DesktopCrashReporting.vitest.mts` sibling-module convention
  (dynamic import of the TS source + a locally inlined `MemoryStateStore`
  fake — no new test infrastructure).
- 2 small edits (`index.ts` +22 lines to wire the startup call;
  `stateKeys.ts` +4 lines for the two new desktop-only state keys).
- 1 new runtime dependency (`semver`), already vetted and pinned
  identically by `packages/cli`.
- Production diff: ~155 lines, matching the decision's "~100-150 LoC, 1
  new file, 0 new infra" budget (no new IPC message types, no settings-UI
  toggle, no new abstraction layer — the disable knob is the same
  `TEXRA_NO_UPDATE_CHECK` env var the CLI already established, and the
  notification path is the desktop's existing `dialog.showMessageBox`
  usage, not a new webview component).

## Consumer counts (R8)

- `checkForDesktopUpdate` / `fetchLatestDesktopRelease` /
  `isNewerDesktopVersion`: 1 production caller each (`index.ts`'s
  `createWindow`), consistent with this being a single-purpose desktop-only
  module, not a shared abstraction.
- The two new `GlobalStateKey` entries: each has exactly 1 reader/writer
  (inside `desktopUpdateChecker.ts`), matching the existing
  `DESKTOP_CRASH_REPORTING_ENABLED` precedent of an ungated, UI-less,
  desktop-only state flag.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-blocking startup network call with conservative semver parsing and a hard-coded external URL; no install or auto-update path.
> 
> **Overview**
> Packaged TeXRA Desktop now gets a **lightweight “new version available” path** (issue #7682, arm b): poll GitHub’s latest `texra-ai/texra-desktop-releases` tag, compare with `semver`, and show a native **Download / Later** dialog—no auto-download or `electron-updater`.
> 
> **`desktopUpdateChecker.ts`** runs at most once per day (persisted `DESKTOP_UPDATE_CHECK_*` global keys), notifies at most once per release version, skips dev/unpackaged builds and `TEXRA_NO_UPDATE_CHECK=1`, and only writes the daily throttle after a successful fetch so failed checks retry on the next launch. **Download** opens a fixed `DESKTOP_RELEASES_PAGE_URL`, not API-derived links.
> 
> **`createWindow`** fires the check asynchronously on startup; it runs only when **`protocolLifecycle.ownsSingleInstanceLock`** is true so secondary “new window” processes don’t duplicate checks or dialogs. **`desktopProtocolCallbacks`** exposes that flag on the lifecycle return value.
> 
> Adds **`semver`** to desktop deps and **vitest** coverage for version logic, throttling, opt-out, and fetch-failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721461b2bfc2c6e0d55d458c5d3de343150ec27f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->