### PR TITLE
test(cli): stabilize model-switch TUI validation

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -864,8 +864,9 @@ const SCENARIOS = [
     env: {
       ANTHROPIC_API_KEY: 'harness-anthropic-key',
       HARNESS_CAN_SELECT_MODEL: '1',
-      HARNESS_DISABLED_MODEL_SWITCHES: 'sonnet46T||opus48T',
+      HARNESS_DISABLED_MODEL_SWITCHES: 'sonnet46T',
       HARNESS_ENTRIES: '4',
+      HARNESS_VISIBLE_MODELS: 'sonnet46T||gpt56',
       OPENAI_API_KEY: 'harness-openai-key',
     },
     keys: ['/model', '\r'],
@@ -876,7 +877,7 @@ const SCENARIOS = [
       'Choose the model for future turns.',
       'Sonnet 4.6',
       'different conversation format',
-      'GPT-5.5',
+      'GPT-5.6 Sol',
     ],
     unexpect: [
       'Harness model selected.',


### PR DESCRIPTION
## Summary

- Pin `model-switch-compatible-only` to the two model entries it actually exercises.
- Update the compatible model expectation from GPT-5.5 to GPT-5.6 Sol.
- Remove the now-hidden Opus disable fixture so the scenario declares only relevant state.

## Root cause

The PTY scenario read the full ambient model registry while asserting the previous preferred GPT label. The llm-zoo 1.14 adaptation made GPT-5.6 the preferred OpenAI model, so the otherwise healthy full TUI harness failed on stale catalog text.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build model-switch-compatible-only`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --no-build --snapshot-dir /private/tmp/texra-tui-snapshots-fixed-20260710.7h5ejY` (141/141 scenarios)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 52 existing warnings)
- `npm test` (5,448 passed; 4 skipped)

Closes #7963.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and assertion updates in validate-tui.mjs; no production CLI or model-switch logic changes.
> 
> **Overview**
> Updates the **`model-switch-compatible-only`** PTY scenario so it no longer depends on the full ambient model registry after **llm-zoo** preferred OpenAI labels moved to **GPT-5.6 Sol**.
> 
> The scenario now sets **`HARNESS_VISIBLE_MODELS`** to `sonnet46T` and `gpt56`, drops **Opus** from **`HARNESS_DISABLED_MODEL_SWITCHES`**, and asserts **GPT-5.6 Sol** instead of **GPT-5.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845ed3dd08f3866ad2778cd70089c4a2b90284ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->