### PR TITLE
refactor(cli): consolidate child-stream relationship state into one map

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -69,6 +69,12 @@ import {
   type ConversationEntry,
 } from '../src/chat/tui/state/cliState';
 import {
+  activeSubagentsFor,
+  applySubagentRoster,
+  childStreamEntries,
+  visibleSubagentRows,
+} from '../src/chat/tui/state/childExecutions';
+import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage,
 } from '../src/chat/tui/state/focusedChildFollowUp';
@@ -704,14 +710,6 @@ function makeChildEntries(agent: string, action: string): ConversationEntry[] {
   ];
 }
 
-function stoppedChild(child: ActiveChildInfo): ActiveChildInfo {
-  return {
-    ...child,
-    status: STREAM_STATUS.STOPPED,
-    startedAt: undefined,
-  };
-}
-
 function isDifferentExecution(
   child: ActiveChildInfo,
   executionId: string,
@@ -1043,12 +1041,18 @@ if (SHOW_CHILDREN) {
   const activeSubagents = childStreams.filter(
     (child) => child.status !== STREAM_STATUS.ERROR,
   );
+  // Seed through the real transition functions rather than poking StreamSlice
+  // fields directly: register the complete roster first (so the errored
+  // child gets a retained row), then re-apply the roster with it omitted —
+  // mirroring the production sequence where a roster stops including a child
+  // once it leaves the runtime's active registry, while its retained history
+  // survives.
+  applySubagentRoster(STREAM_ID, childStreams);
+  applySubagentRoster(STREAM_ID, activeSubagents);
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
     status: STREAM_STATUS.RUNNING,
     runStartedAt: startedAt,
-    activeSubagents,
-    childStreams,
     activeProcesses: [
       {
         kind: 'process' as const,
@@ -1078,16 +1082,11 @@ if (SHOW_CHILDREN) {
     const addNestedChildren =
       SHOW_NESTED_CHILDREN && child.agentName === 'strategy';
     setParentStream(streamId, STREAM_ID);
+    if (addNestedChildren) applySubagentRoster(streamId, [nestedStrategyChild]);
     patchStream(streamId, (slice) => ({
       ...slice,
       status: child.status,
       description: `${child.agentName} sub-workflow`,
-      activeSubagents: addNestedChildren
-        ? [nestedStrategyChild]
-        : slice.activeSubagents,
-      childStreams: addNestedChildren
-        ? [nestedStrategyChild]
-        : slice.childStreams,
       activeProcesses: addNestedChildren
         ? [nestedStrategyProcess]
         : slice.activeProcesses,
@@ -1283,22 +1282,20 @@ if (SHOW_AGENT_PROPOSAL) {
 
 function markHarnessInterrupted(): void {
   canInterrupt = false;
-  const parentSlice = streams.get().get(STREAM_ID);
   const childStreamIds = new Set(
-    [
-      ...(parentSlice?.activeSubagents ?? []),
-      ...(parentSlice?.childStreams ?? []),
-    ]
+    visibleSubagentRows(STREAM_ID, childStreamEntries.get(), streams.get())
       .map((child) => child.childStreamId)
       .filter((streamId): streamId is string => streamId !== undefined),
   );
+  // Clear active roster membership through the real transition function;
+  // each retained row's status comes from its own StreamSlice, set by the
+  // per-child patchStream loop below.
+  applySubagentRoster(STREAM_ID, []);
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
     status: STREAM_STATUS.STOPPED,
     runStartedAt: undefined,
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: slice.childStreams.map(stoppedChild),
     entries: [
       ...slice.entries,
       {
@@ -1420,10 +1417,15 @@ function markHarnessExecutionStopped(executionId: string): void {
   const parentSlice = streams.get().get(STREAM_ID);
   if (!parentSlice) return;
 
+  const activeSubagentRows = activeSubagentsFor(
+    STREAM_ID,
+    childStreamEntries.get(),
+    streams.get(),
+  );
   const executionRows = [
-    ...parentSlice.activeSubagents,
+    ...activeSubagentRows,
     ...parentSlice.activeProcesses,
-    ...parentSlice.childStreams,
+    ...visibleSubagentRows(STREAM_ID, childStreamEntries.get(), streams.get()),
   ];
   const executionRow = executionRows.find(
     (child) => child.executionId === executionId,
@@ -1431,16 +1433,16 @@ function markHarnessExecutionStopped(executionId: string): void {
   if (!executionRow) return;
 
   const messageId = `harness-killed-${executionId}-${Date.now()}`;
+  applySubagentRoster(
+    STREAM_ID,
+    activeSubagentRows.filter((child) =>
+      isDifferentExecution(child, executionId),
+    ),
+  );
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
-    activeSubagents: slice.activeSubagents.filter((child) =>
-      isDifferentExecution(child, executionId),
-    ),
     activeProcesses: slice.activeProcesses.filter((child) =>
       isDifferentExecution(child, executionId),
-    ),
-    childStreams: slice.childStreams.map((child) =>
-      child.executionId === executionId ? stoppedChild(child) : child,
     ),
     entries: [
       ...slice.entries,
@@ -1476,6 +1478,7 @@ function handleHarnessSubmit(line: string): void {
   if (focusedChildRoute.kind === 'reject') {
     appendHarnessAssistantTranscript(
       stoppedFocusedChildFollowUpMessage({
+        childStreamEntries: childStreamEntries.get(),
         parentStream: parentStream.get(),
         streamId: focusedChildRoute.streamId,
         streams: streams.get(),

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -59,8 +59,6 @@ import {
   activeStreamId as activeStreamIdSignal,
   rootRunStartAvailable,
   rootStreamId,
-  parentStream,
-  setParentStream,
   resetCliState,
   sessionMeta,
   setCliSessionModelOverride,
@@ -72,6 +70,8 @@ import {
   activeSubagentsFor,
   applySubagentRoster,
   childStreamEntries,
+  parentStream,
+  setParentStream,
   visibleSubagentRows,
 } from '../src/chat/tui/state/childExecutions';
 import {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -12,6 +12,7 @@ import {
 } from '@common/constants/streamStatus';
 import {
   TODO_STATUS,
+  type ActiveChildInfo,
   type StreamLifecycleStatus,
   type StreamTabId,
   type TodoItem,
@@ -66,6 +67,10 @@ import {
   parentStream as parentStreamSignal,
   streams as streamsSignal,
 } from './state/cliState';
+import {
+  childStreamEntries as childStreamEntriesSignal,
+  visibleSubagentRows,
+} from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { streamDisplayLabel } from './state/streamViews';
@@ -98,6 +103,7 @@ const APPROVAL_FOREGROUND_MAX_ROWS = 18;
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation or push the input bar off-screen.
 const BOTTOM_PANEL_MAX_ROWS = 10;
+const EMPTY_SUBAGENT_ROWS: readonly ActiveChildInfo[] = [];
 const COMPACT_STATIC_TRANSCRIPT_MAX_ROWS = 14;
 // A bare Esc and the second key of an `Esc s` / `Esc p` chord are two
 // separate keystrokes on terminals without true Meta-key detection (macOS
@@ -566,6 +572,7 @@ export function App(props: AppProps): React.JSX.Element {
   const rootStreamId = useSignal(rootStreamIdSignal);
   const streams = useSignal(streamsSignal);
   const parentStream = useSignal(parentStreamSignal);
+  const childStreamEntries = useSignal(childStreamEntriesSignal);
   const activeForm = useSignal(activeFormSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
@@ -588,6 +595,7 @@ export function App(props: AppProps): React.JSX.Element {
   });
   const childControlTargets = resolveChildControlDisplayTargets({
     activeStreamId,
+    childStreamEntries,
     parentStream,
     streams,
   });
@@ -685,6 +693,7 @@ export function App(props: AppProps): React.JSX.Element {
     !foregroundOpen && queuedFollowUpMessages.length > 0;
   const streamTabItems = streamTabsDisplayItems({
     activeStreamId,
+    childStreamEntries,
     parentStream,
     streams,
     width: columns,
@@ -717,6 +726,13 @@ export function App(props: AppProps): React.JSX.Element {
         tipVisible: tipRowVisible,
       });
   const subagentPanelTarget = childControlTargets.tasks;
+  const subagentPanelRows = subagentPanelTarget.streamId
+    ? visibleSubagentRows(
+        subagentPanelTarget.streamId,
+        childStreamEntries,
+        streams,
+      )
+    : EMPTY_SUBAGENT_ROWS;
   const hasSubagentPanel = !foregroundOpen && subagentPanelTarget.hasItems;
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
     foregroundOpen,
@@ -766,7 +782,10 @@ export function App(props: AppProps): React.JSX.Element {
   // shorter than the cap.
   const subagentContentRows =
     hasSubagentPanel && subagentPanelTarget.slice
-      ? subagentPanelRowCount(subagentPanelTarget.slice)
+      ? subagentPanelRowCount(
+          subagentPanelRows,
+          subagentPanelTarget.slice.activeProcesses,
+        )
       : 0;
   const todosPlanContentRows =
     hasTodosPlanPanel && activeSlice
@@ -795,6 +814,7 @@ export function App(props: AppProps): React.JSX.Element {
             onClose={() => transcriptViewerStreamIdSignal.set(undefined)}
             slice={streams.get(transcriptViewerStreamId)}
             title={streamDisplayLabel({
+              childStreamEntries,
               parentStream,
               streamId: transcriptViewerStreamId,
               streams,
@@ -823,6 +843,7 @@ export function App(props: AppProps): React.JSX.Element {
               transcriptViewerStreamIdSignal.set(streamId)
             }
             onKillExecution={props.onKillExecution}
+            childStreamEntries={childStreamEntries}
             slice={target.slice}
             streamScopeDetail={target.streamScopeDetail}
             streams={streams}
@@ -879,6 +900,7 @@ export function App(props: AppProps): React.JSX.Element {
     if (digit !== undefined) {
       const target = numericFocusTargetForActiveStream({
         activeStreamId,
+        childStreamEntries,
         parentStream,
         streams,
         zeroBasedIndex: digit - 1,
@@ -1031,7 +1053,9 @@ export function App(props: AppProps): React.JSX.Element {
           <Box flexDirection="column" overflowY="hidden">
             <SubagentList
               maxRows={subagentRows}
-              slice={subagentPanelTarget.slice}
+              subagents={subagentPanelRows}
+              activeProcesses={subagentPanelTarget.slice?.activeProcesses}
+              processOutput={subagentPanelTarget.slice?.processOutput}
             />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -64,11 +64,11 @@ import {
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen as slashPaletteOpenSignal,
   transcriptViewerStreamId as transcriptViewerStreamIdSignal,
-  parentStream as parentStreamSignal,
   streams as streamsSignal,
 } from './state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
+  parentStream as parentStreamSignal,
   visibleSubagentRows,
 } from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -43,6 +43,10 @@ import {
   nextWrappingHighlightIndex,
   SELECT_LABEL_MAX_COLS,
 } from '../ui/Select';
+import {
+  activeSubagentsFor,
+  type ChildStreamEntries,
+} from '../state/childExecutions';
 import type { StreamSlice } from '../state/cliState';
 
 interface ChildControlPickerProps {
@@ -50,6 +54,7 @@ interface ChildControlPickerProps {
   readonly streamLabel: string | undefined;
   readonly activeStreamId: StreamTabId | undefined;
   readonly availableRows?: number;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly mode: ChildControlMode;
   readonly onClose: () => void;
   readonly onEscapeActionChange?: (action: string) => void;
@@ -739,6 +744,7 @@ export function ChildControlPicker({
   streamLabel,
   activeStreamId,
   availableRows,
+  childStreamEntries,
   mode,
   onClose,
   onEscapeActionChange,
@@ -749,11 +755,25 @@ export function ChildControlPicker({
   streamScopeDetail,
   streams,
 }: ChildControlPickerProps): React.JSX.Element {
-  const liveElapsedKey = liveChildExecutionElapsedKey(slice);
+  const liveElapsedKey = activeStreamId
+    ? liveChildExecutionElapsedKey(
+        activeSubagentsFor(activeStreamId, childStreamEntries, streams),
+        slice?.activeProcesses ?? [],
+      )
+    : undefined;
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
   const items = useMemo(
-    () => (slice ? buildChildControlItems(slice, mode, streams, nowMs) : []),
-    [mode, nowMs, slice, streams],
+    () =>
+      slice && activeStreamId
+        ? buildChildControlItems(
+            activeStreamId,
+            childStreamEntries,
+            streams,
+            mode,
+            nowMs,
+          )
+        : [],
+    [activeStreamId, childStreamEntries, mode, nowMs, slice, streams],
   );
   const [highlight, setHighlight] = useState(0);
   const [tailExecutionId, setTailExecutionId] = useState<string | undefined>(

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -14,7 +14,6 @@ import type { StreamTabId } from '@shared/schemas';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import {
-  parentStream as parentStreamSignal,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
   type ConversationEntry,
@@ -23,6 +22,7 @@ import {
 } from '../state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
+  parentStream as parentStreamSignal,
   type ChildStreamEntries,
 } from '../state/childExecutions';
 import { streamViewForId } from '../state/streamViews';

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -21,6 +21,10 @@ import {
   type SessionMeta,
   type StreamSlice,
 } from '../state/cliState';
+import {
+  childStreamEntries as childStreamEntriesSignal,
+  type ChildStreamEntries,
+} from '../state/childExecutions';
 import { streamViewForId } from '../state/streamViews';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
@@ -73,6 +77,7 @@ function shortenCwd(cwd: string): string {
 export function sessionHeaderIdentityLine(
   meta: SessionMeta,
   context: {
+    readonly childStreamEntries?: ChildStreamEntries;
     readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
     readonly streamId?: StreamTabId;
     readonly streams?: ReadonlyMap<StreamTabId, StreamSlice>;
@@ -86,6 +91,7 @@ export function sessionHeaderIdentityLine(
     const model = slice?.model || meta.model || '—';
     const view = streamViewForId({
       activeStreamId: context.streamId,
+      childStreamEntries: context.childStreamEntries ?? new Map(),
       parentStream,
       streamId: context.streamId,
       streams: context.streams,
@@ -234,6 +240,7 @@ function staticUserBottomMarginRows({
 export function appendStaticTranscriptItems({
   currentItems,
   streams,
+  childStreamEntries = new Map(),
   meta,
   maxRows,
   parentStream = new Map(),
@@ -242,6 +249,7 @@ export function appendStaticTranscriptItems({
 }: {
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly childStreamEntries?: ChildStreamEntries;
   readonly meta: SessionMeta;
   readonly maxRows?: number;
   readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
@@ -263,6 +271,7 @@ export function appendStaticTranscriptItems({
       kind: 'header',
       compact: maxRows !== undefined && maxRows < FULL_SESSION_HEADER_ROWS,
       identityLine: sessionHeaderIdentityLine(meta, {
+        childStreamEntries,
         parentStream,
         streamId: scrollbackStreamId,
         streams,
@@ -339,11 +348,13 @@ export function StaticConversationTranscript({
   const streams = useSignal(streamsSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);
+  const childStreamEntries = useSignal(childStreamEntriesSignal);
   const [state, setState] = useState<StaticTranscriptState>(() => ({
     ownerKey,
     items: appendStaticTranscriptItems({
       currentItems: [],
       streams,
+      childStreamEntries,
       meta: sessionMeta,
       maxRows,
       parentStream,
@@ -358,6 +369,7 @@ export function StaticConversationTranscript({
       : appendStaticTranscriptItems({
           currentItems: [],
           streams,
+          childStreamEntries,
           meta: sessionMeta,
           maxRows,
           parentStream,
@@ -377,6 +389,7 @@ export function StaticConversationTranscript({
       const nextItems = appendStaticTranscriptItems({
         currentItems: isHardReset || ownerChanged ? [] : current.items,
         streams,
+        childStreamEntries,
         meta: sessionMeta,
         maxRows,
         parentStream,
@@ -389,6 +402,7 @@ export function StaticConversationTranscript({
       return { ownerKey, items: nextItems };
     });
   }, [
+    childStreamEntries,
     maxRows,
     ownerKey,
     parentStream,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -59,6 +59,10 @@ import {
   type StreamSlice,
 } from '../state/cliState';
 import {
+  activeSubagentsFor,
+  childStreamEntries as childStreamEntriesSignal,
+} from '../state/childExecutions';
+import {
   activeStreamScope,
   nearestActiveStreamAncestor,
 } from '../state/streamViews';
@@ -619,6 +623,10 @@ interface StatusBarVisibleStream {
 interface StatusBarStreamTarget {
   readonly ctrlCAction: CtrlCAction;
   readonly displaySlice: StreamSlice | undefined;
+  /** The stream id `displaySlice` was resolved for — the live-ancestor
+   *  fallback can surface an ancestor other than the nominally "active" id,
+   *  so this is not always `activeStreamId`. */
+  readonly displayStreamId: StreamTabId | undefined;
   /** True when `displaySlice` belongs to a child/subagent stream rather than
    *  the root session (the live-ancestor fallback can surface an ancestor
    *  other than the nominally "active" id, so this is derived from whichever
@@ -640,12 +648,11 @@ export function statusBarStreamTarget({
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StatusBarStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const liveAncestor = nearestActiveStreamAncestor({
+  const liveAncestor = nearestActiveStreamAncestor<StreamSlice>({
     activeStreamId,
     parentStream,
     values: streams,
-    canUseValue: (stream: StatusBarVisibleStream) =>
-      isLiveElapsedStatus(stream.status),
+    canUseValue: (stream) => isLiveElapsedStatus(stream.status),
   });
   const canStopVisibleRun =
     canStopActiveRun &&
@@ -658,6 +665,7 @@ export function statusBarStreamTarget({
       parentStream,
     }),
     displaySlice: activeSlice ?? liveAncestor?.value,
+    displayStreamId,
     isChildStream:
       displayStreamId !== undefined &&
       parentStream.get(displayStreamId) !== undefined,
@@ -840,6 +848,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const activeStreamId = useSignal(activeStreamIdSignal);
   const streams = useSignal(streamsSignal);
   const parentStream = useSignal(parentStreamSignal);
+  const childStreamEntries = useSignal(childStreamEntriesSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const pendingExitHint = useSignal(pendingExitHintSignal);
   const pendingExitResumeId = useSignal(pendingExitResumeIdSignal);
@@ -909,7 +918,14 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     queuedFollowUpPreview: props.queuedFollowUpPreview,
     usage: statusSlice?.usage,
     roundStage: statusSlice?.roundStage,
-    activeSubagents: statusSlice?.activeSubagents.length ?? 0,
+    activeSubagents:
+      target.displayStreamId !== undefined
+        ? activeSubagentsFor(
+            target.displayStreamId,
+            childStreamEntries,
+            streams,
+          ).length
+        : 0,
     activeProcesses: statusSlice?.activeProcesses.length ?? 0,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -50,7 +50,6 @@ import {
   pendingExitHint as pendingExitHintSignal,
   pendingExitResumeId as pendingExitResumeIdSignal,
   activeStreamId as activeStreamIdSignal,
-  parentStream as parentStreamSignal,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
   NO_BYPASS,
@@ -61,6 +60,7 @@ import {
 import {
   activeSubagentsFor,
   childStreamEntries as childStreamEntriesSignal,
+  parentStream as parentStreamSignal,
 } from '../state/childExecutions';
 import {
   activeStreamScope,

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -14,6 +14,10 @@ import {
   streams as streamsSignal,
   type StreamSlice,
 } from '../state/cliState';
+import {
+  childStreamEntries as childStreamEntriesSignal,
+  type ChildStreamEntries,
+} from '../state/childExecutions';
 import { activeStreamTreeViews } from '../state/streamViews';
 import { useSignal } from '../state/useSignal';
 
@@ -186,6 +190,7 @@ function collapseMiddle(
 
 export function streamTabsDisplayItems(init: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly width: number;
@@ -261,8 +266,10 @@ function StreamTabsStripFromState(props: {
   const activeStreamId = useSignal(activeStreamIdSignal);
   const streams = useSignal(streamsSignal);
   const parentStream = useSignal(parentStreamSignal);
+  const childStreamEntries = useSignal(childStreamEntriesSignal);
   const items = streamTabsDisplayItems({
     activeStreamId,
+    childStreamEntries,
     streams,
     parentStream,
     width: props.width,

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -10,12 +10,12 @@ import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { textDisplayWidth, truncateToWidth } from '../render/terminalText';
 import {
   activeStreamId as activeStreamIdSignal,
-  parentStream as parentStreamSignal,
   streams as streamsSignal,
   type StreamSlice,
 } from '../state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
+  parentStream as parentStreamSignal,
   type ChildStreamEntries,
 } from '../state/childExecutions';
 import { activeStreamTreeViews } from '../state/streamViews';

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -14,13 +14,10 @@ import {
   liveChildExecutionElapsedKey,
   processTailLines,
 } from '../state/childControls';
-import {
-  childExecutionLabel,
-  visibleSubagentRows,
-} from '../state/childExecutions';
+import { childExecutionLabel } from '../state/childExecutions';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
-import type { ProcessOutputTail, StreamSlice } from '../state/cliState';
+import type { ProcessOutputTail } from '../state/cliState';
 
 interface RowProps {
   readonly child: ActiveChildInfo;
@@ -147,37 +144,40 @@ export function compactRows(params: {
 }
 
 /**
- * Natural (uncapped) compact-row count for a slice's children: one row per
- * visible subagent and active process. Drives the bottom-panel reservation in
- * App so the panel takes only the height it needs.
+ * Natural (uncapped) compact-row count: one row per visible subagent and
+ * active process. Drives the bottom-panel reservation in App so the panel
+ * takes only the height it needs.
  */
-export function subagentPanelRowCount(slice: {
-  readonly activeSubagents: readonly ActiveChildInfo[];
-  readonly childStreams: readonly ActiveChildInfo[];
-  readonly activeProcesses: readonly ActiveChildInfo[];
-}): number {
-  return visibleSubagentRows(slice).length + slice.activeProcesses.length;
+export function subagentPanelRowCount(
+  subagents: readonly ActiveChildInfo[],
+  activeProcesses: readonly ActiveChildInfo[],
+): number {
+  return subagents.length + activeProcesses.length;
 }
 
 export interface SubagentListProps {
   readonly maxRows?: number;
-  readonly slice?: Pick<
-    StreamSlice,
-    'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
-  >;
+  /** Already-derived visible subagent rows (retained order, active overlay)
+   *  for the target parent stream — computed once by the caller from
+   *  `childExecutions.ts#visibleSubagentRows` so this stays a stateless
+   *  props-in renderer. */
+  readonly subagents?: readonly ActiveChildInfo[];
+  readonly activeProcesses?: readonly ActiveChildInfo[];
+  readonly processOutput?: ReadonlyMap<string, ProcessOutputTail>;
 }
 
 export function SubagentList(
   props: SubagentListProps = {},
 ): React.JSX.Element | null {
-  const slice = props.slice;
-  const activeProcesses = slice?.activeProcesses ?? [];
-  const processOutput = slice?.processOutput;
-  const subagents = slice ? visibleSubagentRows(slice) : [];
-  const liveElapsedKey = liveChildExecutionElapsedKey(slice);
+  const subagents = props.subagents ?? [];
+  const activeProcesses = props.activeProcesses ?? [];
+  const processOutput = props.processOutput;
+  const liveElapsedKey = liveChildExecutionElapsedKey(
+    subagents,
+    activeProcesses,
+  );
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
 
-  if (!slice) return null;
   if (subagents.length === 0 && activeProcesses.length === 0) return null;
   if (props.maxRows !== undefined && props.maxRows <= 0) return null;
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -107,6 +107,7 @@ import {
   pendingExitHint,
   pendingExitResumeId,
 } from './state/cliState';
+import { childStreamEntries as childStreamEntriesSignal } from './state/childExecutions';
 import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
@@ -228,6 +229,7 @@ function stoppedFocusedChildFollowUpMessage(streamId: StreamTabId): string {
   const parentStream = parentStreamSignal.get();
   const streams = streamsSignal.get();
   return focusedChildStoppedMessage({
+    childStreamEntries: childStreamEntriesSignal.get(),
     parentStream,
     streamId,
     streams,
@@ -834,6 +836,7 @@ export async function runChat(
     const streams = streamsSignal.get();
     const hint = formatResumeHint(
       collectResumeTargets({
+        childStreamEntries: childStreamEntriesSignal.get(),
         rootExecutionId: session.executionId,
         streams,
       }),

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -99,7 +99,6 @@ import { createTuiViewportController } from './render/tuiViewportController';
 import { clearApprovals } from './state/approvalQueue';
 import {
   activeStreamId as activeStreamIdSignal,
-  parentStream as parentStreamSignal,
   resetCliState,
   patchSessionMeta,
   sessionMeta as sessionMetaSignal,
@@ -107,7 +106,10 @@ import {
   pendingExitHint,
   pendingExitResumeId,
 } from './state/cliState';
-import { childStreamEntries as childStreamEntriesSignal } from './state/childExecutions';
+import {
+  childStreamEntries as childStreamEntriesSignal,
+  parentStream as parentStreamSignal,
+} from './state/childExecutions';
 import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -15,9 +15,11 @@ import { formatCompactDuration } from '@utils/core';
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
 import {
+  activeSubagentsFor,
   childExecutionKey,
   childExecutionLabel,
   visibleSubagentRows,
+  type ChildStreamEntries,
 } from './childExecutions';
 import {
   activeStreamTreeEntries,
@@ -30,6 +32,8 @@ import type {
   ProcessOutputTail,
   StreamSlice,
 } from './cliState';
+
+const EMPTY_PROCESS_OUTPUT: ReadonlyMap<string, ProcessOutputTail> = new Map();
 
 export type ChildControlMode = 'subagents' | 'tasks';
 
@@ -250,22 +254,34 @@ export function processTailLines(
 }
 
 export function buildChildControlItems(
-  slice: Pick<
-    StreamSlice,
-    'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
+  parentStreamId: StreamTabId,
+  childStreamEntries: ChildStreamEntries,
+  streams: ReadonlyMap<
+    StreamTabId,
+    Pick<
+      StreamSlice,
+      'activeProcesses' | 'description' | 'entries' | 'processOutput' | 'status'
+    >
   >,
   mode: ChildControlMode,
-  streamsById: ReadonlyMap<
-    StreamTabId,
-    Pick<StreamSlice, 'description' | 'entries'>
-  > = new Map(),
   nowMs?: number,
 ): readonly ChildControlItem[] {
-  const activeKeys = new Set(slice.activeSubagents.map(childExecutionKey));
-  const subagentItems = visibleSubagentRows(slice).map((child) =>
+  const parentSlice = streams.get(parentStreamId);
+  const activeProcesses = parentSlice?.activeProcesses ?? [];
+  const processOutput = parentSlice?.processOutput ?? EMPTY_PROCESS_OUTPUT;
+  const activeKeys = new Set(
+    activeSubagentsFor(parentStreamId, childStreamEntries, streams).map(
+      childExecutionKey,
+    ),
+  );
+  const subagentItems = visibleSubagentRows(
+    parentStreamId,
+    childStreamEntries,
+    streams,
+  ).map((child) =>
     buildChildControlItem(child, {
-      streamsById,
-      processOutput: slice.processOutput,
+      streamsById: streams,
+      processOutput,
       nowMs,
       killable: activeKeys.has(childExecutionKey(child)),
     }),
@@ -276,10 +292,10 @@ export function buildChildControlItems(
 
   return [
     ...subagentItems,
-    ...slice.activeProcesses.map((child) =>
+    ...activeProcesses.map((child) =>
       buildChildControlItem(child, {
-        streamsById,
-        processOutput: slice.processOutput,
+        streamsById: streams,
+        processOutput,
         nowMs,
         killable: true,
       }),
@@ -287,37 +303,48 @@ export function buildChildControlItems(
   ];
 }
 
-function hasVisibleSubagents(
-  slice: Pick<StreamSlice, 'activeSubagents' | 'childStreams'> | undefined,
-): boolean {
-  return slice !== undefined && visibleSubagentRows(slice).length > 0;
-}
-
 export function hasChildControlItems(
-  slice:
-    | Pick<StreamSlice, 'activeProcesses' | 'activeSubagents' | 'childStreams'>
-    | undefined,
+  parentStreamId: StreamTabId | undefined,
+  childStreamEntries: ChildStreamEntries,
+  streams: ReadonlyMap<
+    StreamTabId,
+    Pick<StreamSlice, 'activeProcesses' | 'status'>
+  >,
   mode: ChildControlMode,
 ): boolean {
-  if (slice === undefined) return false;
-  return mode === 'subagents'
-    ? hasVisibleSubagents(slice)
-    : visibleSubagentRows(slice).length > 0 || slice.activeProcesses.length > 0;
+  if (parentStreamId === undefined) return false;
+  if (mode === 'subagents') {
+    return (
+      visibleSubagentRows(parentStreamId, childStreamEntries, streams).length >
+      0
+    );
+  }
+  return (
+    visibleSubagentRows(parentStreamId, childStreamEntries, streams).length >
+      0 || (streams.get(parentStreamId)?.activeProcesses.length ?? 0) > 0
+  );
 }
 
 export function resolveChildControlStreamTarget({
   activeStreamId,
+  childStreamEntries,
   mode,
   parentStream,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly mode: ChildControlMode;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): ChildControlStreamTarget {
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const activeHasRows = hasChildControlItems(activeSlice, mode);
+  const activeHasRows = hasChildControlItems(
+    activeStreamId,
+    childStreamEntries,
+    streams,
+    mode,
+  );
   if (!activeStreamId || activeHasRows) {
     return {
       hasItems: activeHasRows,
@@ -330,7 +357,8 @@ export function resolveChildControlStreamTarget({
     activeStreamId,
     parentStream,
     values: streams,
-    canUseValue: (slice) => hasChildControlItems(slice, mode),
+    canUseValue: (_slice, streamId) =>
+      hasChildControlItems(streamId, childStreamEntries, streams, mode),
   });
   if (ancestor) {
     return {
@@ -359,23 +387,27 @@ function childControlFallbackDetail(
 
 function resolveChildControlDisplayTarget({
   activeStreamId,
+  childStreamEntries,
   mode,
   parentStream,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly mode: ChildControlMode;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): ChildControlDisplayTarget {
   const target = resolveChildControlStreamTarget({
     activeStreamId,
+    childStreamEntries,
     mode,
     parentStream,
     streams,
   });
   const streamLabel = target.streamId
     ? streamDisplayLabel({
+        childStreamEntries,
         parentStream,
         streamId: target.streamId,
         streams,
@@ -383,6 +415,7 @@ function resolveChildControlDisplayTarget({
     : undefined;
   const fallbackFromStreamLabel = target.fallbackFromStreamId
     ? streamDisplayLabel({
+        childStreamEntries,
         parentStream,
         streamId: target.fallbackFromStreamId,
         streams,
@@ -401,22 +434,26 @@ function resolveChildControlDisplayTarget({
 
 export function resolveChildControlDisplayTargets({
   activeStreamId,
+  childStreamEntries,
   parentStream,
   streams,
 }: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): ChildControlDisplayTargets {
   return {
     subagents: resolveChildControlDisplayTarget({
       activeStreamId,
+      childStreamEntries,
       mode: 'subagents',
       parentStream,
       streams,
     }),
     tasks: resolveChildControlDisplayTarget({
       activeStreamId,
+      childStreamEntries,
       mode: 'tasks',
       parentStream,
       streams,
@@ -425,11 +462,10 @@ export function resolveChildControlDisplayTargets({
 }
 
 export function liveChildExecutionElapsedKey(
-  slice: Pick<StreamSlice, 'activeProcesses' | 'activeSubagents'> | undefined,
+  activeSubagents: readonly ActiveChildInfo[],
+  activeProcesses: readonly ActiveChildInfo[],
 ): string | undefined {
-  if (slice === undefined) return undefined;
-
-  const liveKeys = [...slice.activeSubagents, ...slice.activeProcesses]
+  const liveKeys = [...activeSubagents, ...activeProcesses]
     .filter(hasLiveChildElapsed)
     .map((child) => `${child.executionId}:${child.startedAt}`)
     .sort();
@@ -438,6 +474,7 @@ export function liveChildExecutionElapsedKey(
 
 export function numericFocusTargetForActiveStream(init: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly zeroBasedIndex: number;
@@ -446,6 +483,7 @@ export function numericFocusTargetForActiveStream(init: {
   const shortcutIndex = init.zeroBasedIndex + 1;
   return activeStreamTreeEntries({
     activeStreamId: init.activeStreamId,
+    childStreamEntries: init.childStreamEntries,
     parentStream: init.parentStream,
     streams: init.streams,
   }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -146,6 +146,40 @@ export function setParentStream(
   CHILD_STREAMS.set(out);
 }
 
+/** Field-by-field comparison of the persisted roster summary — avoids a
+ *  spurious `changed` on a same-content roster snapshot the runtime resends
+ *  as a fresh array/object on every poll. */
+function summaryUnchanged(
+  a: ChildStreamEntry['summary'],
+  b: ChildStreamEntry['summary'],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.agentName === b.agentName &&
+    a.executionId === b.executionId &&
+    a.startedAt === b.startedAt &&
+    a.elapsed === b.elapsed &&
+    a.toolName === b.toolName
+  );
+}
+
+/** Whether applying `nextEntry` over `entry` would be a no-op — compares only
+ *  the fields `applySubagentRoster` itself writes (summary, active/retained
+ *  parent, retained order), never `edgeParentStreamId`/`removed`. */
+function subagentEntryUnchanged(
+  entry: ChildStreamEntry | undefined,
+  nextEntry: ChildStreamEntry,
+): boolean {
+  return (
+    entry !== undefined &&
+    entry.activeParentStreamId === nextEntry.activeParentStreamId &&
+    entry.retainedParentStreamId === nextEntry.retainedParentStreamId &&
+    entry.retainedOrder === nextEntry.retainedOrder &&
+    summaryUnchanged(entry.summary, nextEntry.summary)
+  );
+}
+
 /**
  * `child.activity(kind: 'subagents')` roster snapshot for one parent: the
  * accepted children become the complete active-membership snapshot for that
@@ -213,6 +247,7 @@ export function applySubagentRoster(
         ? ++maxRetainedOrder
         : entry?.retainedOrder,
     };
+    if (subagentEntryUnchanged(entry, nextEntry)) continue;
     out.set(childStreamId, nextEntry);
     changed = true;
   }

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -1,5 +1,389 @@
-// Local imports - shared schemas
-import type { ActiveChildInfo } from '@shared/schemas';
+// Owner of the CLI TUI's child-stream relationship state: the live
+// active-subagent roster, the retained child-stream history, and the current
+// child -> parent topology. These are three views of one child-stream
+// record — kept in one signal-backed map (`CHILD_STREAMS`) instead of three
+// separately-mutated collections — with different authority and lifetime
+// rules exposed only through the pure selectors below.
+//
+// See docs/proposals/cli-child-stream-state-consolidation.md for the
+// accepted design, the load-bearing event-ordering census, and the
+// transition/selector semantics this module implements. `activeProcesses`
+// is explicitly out of scope: a process has no `childStreamId` and no
+// independent `StreamSlice`, so it stays a plain `StreamSlice` field.
+
+import { computed, signal, type Signal } from '@lit-labs/signals';
+import type {
+  ActiveChildInfo,
+  StreamTabId,
+  SubagentChildInfo,
+} from '@shared/schemas';
+
+import type { StreamSlice } from './cliState';
+
+/**
+ * One child stream's relationship state. Also doubles as a minimal removal
+ * tombstone (`removed: true`, every other field absent) for a stream
+ * identity — child or parent — that must never be resurrected by a later
+ * fact.
+ */
+export interface ChildStreamEntry {
+  /** Latest roster metadata, excluding identity and status. */
+  readonly summary?: Omit<SubagentChildInfo, 'childStreamId' | 'status'>;
+  /** Parent whose latest roster includes this child. */
+  readonly activeParentStreamId?: StreamTabId;
+  /** Parent under which the child first acquired a retained row. */
+  readonly retainedParentStreamId?: StreamTabId;
+  /** One-based, first-seen order within `retainedParentStreamId`. */
+  readonly retainedOrder?: number;
+  /**
+   * `undefined`: no explicit edge fact observed; use the retained parent
+   * provisionally. A string is the explicit current parent. `null` means
+   * explicitly promoted to top-level.
+   */
+  readonly edgeParentStreamId?: StreamTabId | null;
+  /** Explicit `removeStream` tombstone for this session-scoped identity. */
+  readonly removed: boolean;
+}
+
+export type ChildStreamEntries = ReadonlyMap<StreamTabId, ChildStreamEntry>;
+
+const CHILD_STREAMS = signal<ChildStreamEntries>(new Map());
+
+/**
+ * Read-only view of the child-stream relationship map for components that
+ * need to re-render on a change (subscribe via `useSignal`). Never write
+ * through this — use the transition functions below.
+ */
+export const childStreamEntries: Signal.Computed<ChildStreamEntries> = computed(
+  () => CHILD_STREAMS.get(),
+);
+
+function candidateParent(
+  entry: ChildStreamEntry,
+): StreamTabId | null | undefined {
+  return entry.edgeParentStreamId !== undefined
+    ? entry.edgeParentStreamId
+    : entry.retainedParentStreamId;
+}
+
+/**
+ * The current parent for a non-removed child: explicit edge wins over a
+ * roster-derived provisional parent, and a tombstoned candidate parent
+ * resolves to no parent (so late child facts cannot revive a removed
+ * ancestor).
+ */
+function effectiveParentFromEntries(
+  childStreamId: StreamTabId,
+  entries: ChildStreamEntries,
+): StreamTabId | undefined {
+  const entry = entries.get(childStreamId);
+  if (!entry || entry.removed) return undefined;
+  const candidate = candidateParent(entry);
+  if (!candidate) return undefined;
+  if (entries.get(candidate)?.removed) return undefined;
+  return candidate;
+}
+
+/**
+ * Derived child -> current-parent topology. Not stored or independently
+ * mutated — recomputed from `CHILD_STREAMS` on every read. Kept under the
+ * same export name/shape the CLI previously stored as a writable signal so
+ * every existing `useSignal(parentStream)` consumer is unchanged.
+ */
+export const parentStream: Signal.Computed<
+  ReadonlyMap<StreamTabId, StreamTabId>
+> = computed(() => {
+  const entries = CHILD_STREAMS.get();
+  const out = new Map<StreamTabId, StreamTabId>();
+  for (const childStreamId of entries.keys()) {
+    const parent = effectiveParentFromEntries(childStreamId, entries);
+    if (parent) out.set(childStreamId, parent);
+  }
+  return out;
+});
+
+/** Whether a stream identity (child or parent) carries a removal tombstone. */
+export function isChildStreamRemoved(streamId: StreamTabId): boolean {
+  return CHILD_STREAMS.get().get(streamId)?.removed === true;
+}
+
+export function resetChildStreamEntries(): void {
+  CHILD_STREAMS.set(new Map());
+}
+
+// ---------------------------------------------------------------------------
+// transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Explicit `setParentStream(child, parent)` session fact. `null` means the
+ * runtime promoted the child to a top-level stream. An explicit edge
+ * outranks roster-derived topology and, once observed, only a later
+ * explicit edge can change current topology again.
+ */
+export function setParentStream(
+  childStreamId: StreamTabId,
+  parentStreamId: StreamTabId | null | undefined,
+): void {
+  if (parentStreamId === undefined) return;
+  const current = CHILD_STREAMS.get();
+  const entry = current.get(childStreamId);
+  if (entry?.removed) return;
+  if (parentStreamId !== null && current.get(parentStreamId)?.removed) return;
+  if (entry?.edgeParentStreamId === parentStreamId) return;
+
+  const nextActiveParentStreamId =
+    entry?.activeParentStreamId === parentStreamId
+      ? entry.activeParentStreamId
+      : undefined;
+  const next: ChildStreamEntry = {
+    ...(entry ?? { removed: false }),
+    edgeParentStreamId: parentStreamId,
+    activeParentStreamId: nextActiveParentStreamId,
+  };
+  const out = new Map(current);
+  out.set(childStreamId, next);
+  CHILD_STREAMS.set(out);
+}
+
+/**
+ * `child.activity(kind: 'subagents')` roster snapshot for one parent: the
+ * accepted children become the complete active-membership snapshot for that
+ * parent at this hub position. A late roster from an incompatible (explicitly
+ * edged-elsewhere, or promoted) child cannot resurrect active membership or
+ * overwrite a newer parent's summary metadata.
+ */
+export function applySubagentRoster(
+  parentStreamId: StreamTabId,
+  children: readonly ActiveChildInfo[],
+): void {
+  const current = CHILD_STREAMS.get();
+  if (current.get(parentStreamId)?.removed) return;
+
+  const subagents = children.filter(
+    (child): child is SubagentChildInfo => child.kind === 'subagent',
+  );
+
+  const accepted = new Map<StreamTabId, SubagentChildInfo>();
+  for (const child of subagents) {
+    const entry = current.get(child.childStreamId);
+    if (entry?.removed) continue;
+    const edge = entry?.edgeParentStreamId;
+    if (edge !== undefined && edge !== parentStreamId) continue;
+    accepted.set(child.childStreamId, child);
+  }
+
+  let maxRetainedOrder = 0;
+  for (const entry of current.values()) {
+    if (
+      entry.retainedParentStreamId === parentStreamId &&
+      entry.retainedOrder !== undefined &&
+      entry.retainedOrder > maxRetainedOrder
+    ) {
+      maxRetainedOrder = entry.retainedOrder;
+    }
+  }
+
+  const out = new Map(current);
+  let changed = false;
+
+  // Clear active membership for entries previously active under this parent
+  // but absent or incompatible with this snapshot.
+  for (const [childStreamId, entry] of current) {
+    if (entry.activeParentStreamId !== parentStreamId) continue;
+    if (accepted.has(childStreamId)) continue;
+    out.set(childStreamId, { ...entry, activeParentStreamId: undefined });
+    changed = true;
+  }
+
+  for (const [childStreamId, child] of accepted) {
+    const entry = out.get(childStreamId);
+    const {
+      childStreamId: _childStreamId,
+      status: _status,
+      ...summary
+    } = child;
+    const isFirstRetained = entry?.retainedParentStreamId === undefined;
+    const nextEntry: ChildStreamEntry = {
+      ...(entry ?? { removed: false }),
+      summary,
+      activeParentStreamId: parentStreamId,
+      retainedParentStreamId: entry?.retainedParentStreamId ?? parentStreamId,
+      retainedOrder: isFirstRetained
+        ? ++maxRetainedOrder
+        : entry?.retainedOrder,
+    };
+    out.set(childStreamId, nextEntry);
+    changed = true;
+  }
+
+  if (changed) CHILD_STREAMS.set(out);
+}
+
+/**
+ * `removeStream` fact for a child or parent stream identity. Tombstones the
+ * stream so no later roster, edge, attachment, or status fact can
+ * resurrect it, and — when the removed stream was itself a parent — clears
+ * every association pointing at it, replacing current-topology edges with
+ * explicit top-level edges so no selector returns it as an ancestor.
+ */
+export function applyChildStreamRemoval(streamId: StreamTabId): void {
+  const current = CHILD_STREAMS.get();
+  const out = new Map(current);
+  out.set(streamId, { removed: true });
+
+  for (const [childStreamId, entry] of current) {
+    if (childStreamId === streamId || entry.removed) continue;
+    let next = entry;
+    if (next.activeParentStreamId === streamId) {
+      next = { ...next, activeParentStreamId: undefined };
+    }
+    if (next.retainedParentStreamId === streamId) {
+      next = {
+        ...next,
+        retainedParentStreamId: undefined,
+        retainedOrder: undefined,
+      };
+    }
+    if (next.edgeParentStreamId === streamId) {
+      next = { ...next, edgeParentStreamId: null };
+    }
+    if (next !== entry) out.set(childStreamId, next);
+  }
+
+  CHILD_STREAMS.set(out);
+}
+
+// ---------------------------------------------------------------------------
+// selectors
+// ---------------------------------------------------------------------------
+
+function reconstruct(
+  childStreamId: StreamTabId,
+  entry: ChildStreamEntry,
+  streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
+): SubagentChildInfo | undefined {
+  if (!entry.summary) return undefined;
+  return {
+    ...entry.summary,
+    kind: 'subagent',
+    childStreamId,
+    status: streams.get(childStreamId)?.status,
+  };
+}
+
+/**
+ * Active subagent roster for a parent: entries whose active membership was
+ * last confirmed by that parent's roster and whose current effective parent
+ * still agrees. A terminal status that arrives after roster removal cannot
+ * make a retained child active again — this selector, not status, decides
+ * killability.
+ */
+export function activeSubagentsFor(
+  parentStreamId: StreamTabId,
+  entries: ChildStreamEntries,
+  streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
+): readonly SubagentChildInfo[] {
+  if (entries.get(parentStreamId)?.removed) return [];
+  const out: SubagentChildInfo[] = [];
+  for (const [childStreamId, entry] of entries) {
+    if (entry.removed || entry.activeParentStreamId !== parentStreamId) {
+      continue;
+    }
+    if (effectiveParentFromEntries(childStreamId, entries) !== parentStreamId) {
+      continue;
+    }
+    const info = reconstruct(childStreamId, entry, streams);
+    if (info) out.push(info);
+  }
+  return out;
+}
+
+/**
+ * Retained child-stream history for a parent, in first-seen order. Survives
+ * roster omission and terminal status; only explicit removal of the child or
+ * this parent erases the association.
+ */
+export function retainedChildStreamsFor(
+  parentStreamId: StreamTabId,
+  entries: ChildStreamEntries,
+  streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
+): readonly SubagentChildInfo[] {
+  if (entries.get(parentStreamId)?.removed) return [];
+  const rows: Array<{ order: number; info: SubagentChildInfo }> = [];
+  for (const [childStreamId, entry] of entries) {
+    if (entry.removed || entry.retainedParentStreamId !== parentStreamId) {
+      continue;
+    }
+    const info = reconstruct(childStreamId, entry, streams);
+    if (info) rows.push({ order: entry.retainedOrder ?? 0, info });
+  }
+  rows.sort((left, right) => left.order - right.order);
+  return rows.map((row) => row.info);
+}
+
+/**
+ * Retained order is primary; active metadata overlays the matching retained
+ * row, and active children not yet retained are appended as a partial-state
+ * fallback. Composition only — not cached in another signal.
+ */
+export function visibleSubagentRows(
+  parentStreamId: StreamTabId,
+  entries: ChildStreamEntries,
+  streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
+): readonly SubagentChildInfo[] {
+  const retained = retainedChildStreamsFor(parentStreamId, entries, streams);
+  const active = activeSubagentsFor(parentStreamId, entries, streams);
+  const activeByKey = new Map(
+    active.map((child) => [child.childStreamId, child]),
+  );
+  const retainedKeys = new Set(retained.map((child) => child.childStreamId));
+  return [
+    ...retained.map((child) => activeByKey.get(child.childStreamId) ?? child),
+    ...active.filter((child) => !retainedKeys.has(child.childStreamId)),
+  ];
+}
+
+/**
+ * Focus-cycle order for a parent's descendants: retained children first (in
+ * retained order), then current-topology children not already present (in
+ * map insertion order). Deliberately broader than current topology alone —
+ * a promoted retained row stays a historical focus target from its former
+ * parent. A child `StreamSlice` must exist before it is focusable.
+ */
+export function focusOrderDescendants(
+  parentStreamId: StreamTabId,
+  entries: ChildStreamEntries,
+  streams: ReadonlyMap<StreamTabId, StreamSlice>,
+): readonly StreamTabId[] {
+  const out: StreamTabId[] = [];
+  const seen = new Set<StreamTabId>();
+  for (const child of retainedChildStreamsFor(
+    parentStreamId,
+    entries,
+    streams,
+  )) {
+    if (!streams.has(child.childStreamId) || seen.has(child.childStreamId)) {
+      continue;
+    }
+    seen.add(child.childStreamId);
+    out.push(child.childStreamId);
+  }
+  for (const [childStreamId, entry] of entries) {
+    if (entry.removed || seen.has(childStreamId)) continue;
+    if (effectiveParentFromEntries(childStreamId, entries) !== parentStreamId) {
+      continue;
+    }
+    if (!streams.has(childStreamId)) continue;
+    seen.add(childStreamId);
+    out.push(childStreamId);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// generic child-execution helpers (subagents and processes)
+// ---------------------------------------------------------------------------
 
 export function childExecutionKey(child: ActiveChildInfo): string {
   return child.kind === 'subagent' ? child.childStreamId : child.executionId;
@@ -11,35 +395,4 @@ export function childExecutionLabel(child: ActiveChildInfo): string {
   // entry. `kind` isn't needed here — it's `childExecutionKey` that actually
   // discriminates (only subagents have a stream tab to key by).
   return child.agentName || child.toolName || child.executionId;
-}
-
-export function mergeChildStreams(
-  current: readonly ActiveChildInfo[],
-  next: readonly ActiveChildInfo[],
-): readonly ActiveChildInfo[] {
-  const byStream = new Map<string, ActiveChildInfo>();
-  for (const child of [...current, ...next]) {
-    byStream.set(childExecutionKey(child), child);
-  }
-  return [...byStream.values()];
-}
-
-/** Retained child streams own display order; active rows overlay live status. */
-export function visibleSubagentRows(slice: {
-  readonly activeSubagents: readonly ActiveChildInfo[];
-  readonly childStreams: readonly ActiveChildInfo[];
-}): readonly ActiveChildInfo[] {
-  const activeByKey = new Map(
-    slice.activeSubagents.map((child) => [childExecutionKey(child), child]),
-  );
-  const retainedKeys = new Set(slice.childStreams.map(childExecutionKey));
-  return [
-    ...slice.childStreams.map(
-      (child) => activeByKey.get(childExecutionKey(child)) ?? child,
-    ),
-    // Defensive fallback for partial slices where live rows arrive first.
-    ...slice.activeSubagents.filter(
-      (child) => !retainedKeys.has(childExecutionKey(child)),
-    ),
-  ];
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -3,6 +3,7 @@
  * focus, overlays, exit hints) lives here as signals; formerly one file per
  * slice under `cliState/`.
  */
+import { signal, type Signal } from '@lit-labs/signals';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
@@ -20,8 +21,21 @@ import {
   type TodoItem,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { signal, type Signal } from '@lit-labs/signals';
+import {
+  applyChildStreamRemoval,
+  isChildStreamRemoved,
+  parentStream,
+  resetChildStreamEntries,
+  setParentStream,
+} from './childExecutions';
 import type { ChildControlMode } from './childControls';
+
+// Child-stream relationship topology (roster, retained history, current
+// parent) is owned by `childExecutions.ts`; re-exported here so every
+// existing `import { parentStream, setParentStream } from './cliState'`
+// consumer is unchanged. See that module for the map, transitions, and
+// selectors.
+export { parentStream, setParentStream };
 
 // ---------------------------------------------------------------------------
 // types
@@ -130,11 +144,7 @@ export interface StreamSlice {
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUps: number;
   readonly queuedFollowUpMessages: readonly string[];
-  readonly activeSubagents: readonly ActiveChildInfo[];
   readonly activeProcesses: readonly ActiveChildInfo[];
-  /** Child streams seen for this parent. This keeps completed/waiting
-   * subagent pages addressable after they leave the active list. */
-  readonly childStreams: readonly ActiveChildInfo[];
   readonly todos: readonly TodoItem[];
   readonly plan: Plan | null;
   /** Tailed stdout/stderr per execution id; latest only — capped at
@@ -185,9 +195,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     entries: [],
     queuedFollowUps: 0,
     queuedFollowUpMessages: [],
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: [],
     todos: [],
     plan: null,
     processOutput: new Map(),
@@ -242,43 +250,15 @@ function streamSliceWithStatus(
   return { ...slice, status, substate, runStartedAt };
 }
 
-function updateChildStatusReferences(
-  children: readonly ActiveChildInfo[],
-  childStreamId: StreamTabId,
-  status: StreamLifecycleStatus,
-): readonly ActiveChildInfo[] {
-  let out: ActiveChildInfo[] | undefined;
-  children.forEach((child, index) => {
-    if (
-      child.kind !== 'subagent' ||
-      child.childStreamId !== childStreamId ||
-      child.status === status
-    ) {
-      return;
-    }
-    out ??= [...children];
-    out[index] = { ...child, status };
-  });
-  return out ?? children;
-}
-
-function withMirroredChildStreamStatus(
-  slice: StreamSlice,
-  childStreamId: StreamTabId,
-  status: StreamLifecycleStatus,
-): StreamSlice {
-  return mapChildStreamReferenceLists(slice, (children) =>
-    updateChildStatusReferences(children, childStreamId, status),
-  );
-}
-
 /**
  * Apply a stream-status event once to the CLI state mirror.
  *
  * Runtime status still originates in StreamStatusService, but TUI renderers
- * should read only StreamSlice data. Updating retained parent child rows here
- * keeps side panels, tab labels, focus routing, and follow-up targeting on the
- * same state snapshot instead of re-querying the runtime service at render time.
+ * should read only StreamSlice data. The child `StreamSlice` is the single
+ * status owner for retained/active child rows too: `childExecutions.ts`'s
+ * selectors read status from here directly, so no copy into another
+ * collection is needed. A status for a stream tombstoned by `removeStream`
+ * is ignored — removal is final for that stream identity.
  */
 export function setStreamStatusInCliState({
   nowMs = Date.now(),
@@ -291,9 +271,8 @@ export function setStreamStatusInCliState({
   readonly substate?: StreamSubstate;
   readonly streamId: StreamTabId;
 }): void {
+  if (isChildStreamRemoved(streamId)) return;
   const current = STREAMS.get();
-  let out: Map<StreamTabId, StreamSlice> | undefined;
-
   const existingSlice = current.get(streamId);
   const targetSlice = streamSliceWithStatus(
     existingSlice ?? emptySlice(streamId),
@@ -301,58 +280,10 @@ export function setStreamStatusInCliState({
     substate,
     nowMs,
   );
-  if (targetSlice !== existingSlice) {
-    out = new Map(current);
-    out.set(streamId, targetSlice);
-  }
-
-  const readable = out ?? current;
-  for (const [id, slice] of readable) {
-    const next = withMirroredChildStreamStatus(slice, streamId, status);
-    if (next === slice) continue;
-    out ??= new Map(current);
-    out.set(id, next);
-  }
-
-  if (out) STREAMS.set(out);
-}
-
-function mapChildStreamReferenceLists(
-  slice: StreamSlice,
-  mapChildren: (
-    children: readonly ActiveChildInfo[],
-  ) => readonly ActiveChildInfo[],
-): StreamSlice {
-  const activeSubagents = mapChildren(slice.activeSubagents);
-  const activeProcesses = mapChildren(slice.activeProcesses);
-  const childStreams = mapChildren(slice.childStreams);
-  if (
-    activeSubagents === slice.activeSubagents &&
-    activeProcesses === slice.activeProcesses &&
-    childStreams === slice.childStreams
-  ) {
-    return slice;
-  }
-  return { ...slice, activeSubagents, activeProcesses, childStreams };
-}
-
-function removeChildStreamReference(
-  children: readonly ActiveChildInfo[],
-  streamId: StreamTabId,
-): readonly ActiveChildInfo[] {
-  const next = children.filter(
-    (child) => child.kind !== 'subagent' || child.childStreamId !== streamId,
-  );
-  return next.length === children.length ? children : next;
-}
-
-function scrubChildStreamReferences(
-  slice: StreamSlice,
-  streamId: StreamTabId,
-): StreamSlice {
-  return mapChildStreamReferenceLists(slice, (children) =>
-    removeChildStreamReference(children, streamId),
-  );
+  if (targetSlice === existingSlice) return;
+  const out = new Map(current);
+  out.set(streamId, targetSlice);
+  STREAMS.set(out);
 }
 
 // ---------------------------------------------------------------------------
@@ -410,74 +341,6 @@ export const activeStreamId = ACTIVE_STREAM_ID;
 export const rootStreamId = ROOT_STREAM_ID;
 /** Whether starting a new root run is currently available. */
 export const rootRunStartAvailable = ROOT_RUN_START_AVAILABLE;
-
-// ---------------------------------------------------------------------------
-// parentStreamSlice
-// ---------------------------------------------------------------------------
-
-// child -> parent map populated from child stream ownership events. The focus
-// cycle (Ctrl-A / Ctrl-B) walks this when stepping back to the parent, and
-// transcript rendering uses it to keep child streams scoped to their own
-// history.
-
-const PARENT_STREAM = signal<ReadonlyMap<StreamTabId, StreamTabId>>(new Map());
-
-/** child -> parent stream-id map. */
-export const parentStream = PARENT_STREAM;
-
-interface ParentStreamEdgeUpdate {
-  readonly childStreamId?: StreamTabId;
-  readonly parentStreamId: StreamTabId | null | undefined;
-}
-
-function parentStreamMapUpdate(
-  current: ReadonlyMap<StreamTabId, StreamTabId>,
-  updates: readonly ParentStreamEdgeUpdate[],
-): Map<StreamTabId, StreamTabId> | undefined {
-  let out: Map<StreamTabId, StreamTabId> | undefined;
-  for (const { childStreamId, parentStreamId } of updates) {
-    if (!childStreamId) continue;
-    const readable = out ?? current;
-    if (parentStreamId == null) {
-      if (!readable.has(childStreamId)) continue;
-      out ??= new Map(current);
-      out.delete(childStreamId);
-      continue;
-    }
-    if (readable.get(childStreamId) === parentStreamId) continue;
-    out ??= new Map(current);
-    out.set(childStreamId, parentStreamId);
-  }
-  return out;
-}
-
-function commitParentStreamEdges(
-  updates: readonly ParentStreamEdgeUpdate[],
-): void {
-  const next = parentStreamMapUpdate(PARENT_STREAM.get(), updates);
-  if (next) PARENT_STREAM.set(next);
-}
-
-export function setParentStream(
-  childStreamId: StreamTabId,
-  parentStreamId: StreamTabId | null | undefined,
-): void {
-  // A null parent means the runtime promoted this child to a top-level stream.
-  commitParentStreamEdges([{ childStreamId, parentStreamId }]);
-}
-
-export function registerChildStreams(
-  parentStreamId: StreamTabId,
-  children: readonly ActiveChildInfo[],
-): void {
-  commitParentStreamEdges(
-    children.map((child) => ({
-      childStreamId:
-        child.kind === 'subagent' ? child.childStreamId : undefined,
-      parentStreamId,
-    })),
-  );
-}
 
 // ---------------------------------------------------------------------------
 // foregroundOverlaySlice
@@ -576,33 +439,22 @@ export function bumpCodexPreferenceVersion(): void {
 // ---------------------------------------------------------------------------
 
 // Cross-slice cleanup when a stream goes away: drops it from the streams map,
-// scrubs any child-reference lists that pointed at it, clears focus if it was
-// active, and drops parent-map edges that touched it.
+// clears focus if it was active, and tombstones the stream identity in the
+// child-stream relationship map (childExecutions.ts) so no later roster,
+// edge, attachment, or status fact for it — or, if it was itself a parent,
+// for its former children — can resurrect it.
 
 export function removeStream(streamId: StreamTabId): void {
   const current = streams.get();
-  const out = new Map(current);
-  let changed = out.delete(streamId);
-  for (const [id, slice] of out) {
-    const next = scrubChildStreamReferences(slice, streamId);
-    if (next === slice) continue;
-    out.set(id, next);
-    changed = true;
+  if (current.has(streamId)) {
+    const out = new Map(current);
+    out.delete(streamId);
+    streams.set(out);
   }
-  if (changed) streams.set(out);
   if (activeStreamId.get() === streamId) {
     activeStreamId.set(undefined);
   }
-  // Drop any parent-map edges that touched this stream so the focus cycle
-  // never lands on a stale id.
-  const parents = parentStream.get();
-  let nextParents: Map<StreamTabId, StreamTabId> | undefined;
-  for (const [child, parent] of parents) {
-    if (child !== streamId && parent !== streamId) continue;
-    if (!nextParents) nextParents = new Map(parents);
-    nextParents.delete(child);
-  }
-  if (nextParents) parentStream.set(nextParents);
+  applyChildStreamRemoval(streamId);
 }
 
 // ---------------------------------------------------------------------------
@@ -626,7 +478,7 @@ export function resetCliState(
   rootStreamId.set(undefined);
   streams.set(new Map());
   rootRunStartAvailable.set(true);
-  parentStream.set(new Map());
+  resetChildStreamEntries();
   activeForm.set(undefined);
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -24,18 +24,9 @@ import {
 import {
   applyChildStreamRemoval,
   isChildStreamRemoved,
-  parentStream,
   resetChildStreamEntries,
-  setParentStream,
 } from './childExecutions';
 import type { ChildControlMode } from './childControls';
-
-// Child-stream relationship topology (roster, retained history, current
-// parent) is owned by `childExecutions.ts`; re-exported here so every
-// existing `import { parentStream, setParentStream } from './cliState'`
-// consumer is unchanged. See that module for the map, transitions, and
-// selectors.
-export { parentStream, setParentStream };
 
 // ---------------------------------------------------------------------------
 // types

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -11,9 +11,12 @@
 // shift over a letter to the unshifted Ctrl combo (see 10-architecture.md).
 
 import { type StreamTabId } from '@shared/schemas';
-import { unique } from '@utils/core';
 
-import { visibleSubagentRows } from './childExecutions';
+import {
+  childStreamEntries as childStreamEntriesSignal,
+  focusOrderDescendants,
+  type ChildStreamEntries,
+} from './childExecutions';
 import {
   activeStreamId,
   parentStream,
@@ -21,58 +24,32 @@ import {
   type StreamSlice,
 } from './cliState';
 
-function orderedDescendantsFromSlice(
-  slice:
-    | Pick<StreamSlice, 'activeSubagents' | 'activeProcesses' | 'childStreams'>
-    | undefined,
-): StreamTabId[] {
-  if (!slice) return [];
-  const out: StreamTabId[] = [];
-  for (const child of [
-    ...visibleSubagentRows(slice),
-    ...slice.activeProcesses,
-  ]) {
-    if (child.kind === 'subagent') out.push(child.childStreamId);
-  }
-  return unique(out);
-}
-
+/**
+ * Ordered descendant stream ids for a parent's focus cycle: retained
+ * children first (in retained order), then current-topology children not
+ * already present. See `childExecutions.ts#focusOrderDescendants` for the
+ * full ordering contract — this stays a thin wrapper so callers keep a
+ * stable `{ parent, childStreamEntries, streams }` shape.
+ */
 export function orderedDescendantsFromTree(init: {
   readonly parent: StreamTabId;
-  readonly parentSlice: StreamSlice | undefined;
-  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StreamTabId[] {
-  const out = orderedDescendantsFromSlice(init.parentSlice).filter((id) =>
-    init.streams.has(id),
-  );
-  const seen = new Set(out);
-  // `parentStream` is populated by its own `setParentStream` event, decoupled
-  // from the `activeSubagents`/`childStreams` updates the slice-derived list
-  // above reads. This walk is not redundant with it: it catches an edge
-  // registered before its parent's slice reflects the child (event-ordering),
-  // so a child stream is never unreachable from the focus cycle.
-  for (const [child, recordedParent] of init.parentStream) {
-    if (
-      recordedParent !== init.parent ||
-      !init.streams.has(child) ||
-      seen.has(child)
-    ) {
-      continue;
-    }
-    seen.add(child);
-    out.push(child);
-  }
-  return out;
+  return [
+    ...focusOrderDescendants(
+      init.parent,
+      init.childStreamEntries,
+      init.streams,
+    ),
+  ];
 }
 
 function orderedDescendants(parent: StreamTabId): StreamTabId[] {
-  const streams = streamsSignal.get();
   return orderedDescendantsFromTree({
     parent,
-    parentSlice: streams.get(parent),
-    parentStream: parentStream.get(),
-    streams,
+    childStreamEntries: childStreamEntriesSignal.get(),
+    streams: streamsSignal.get(),
   });
 }
 

--- a/packages/cli/src/chat/tui/state/focusCycle.ts
+++ b/packages/cli/src/chat/tui/state/focusCycle.ts
@@ -15,11 +15,11 @@ import { type StreamTabId } from '@shared/schemas';
 import {
   childStreamEntries as childStreamEntriesSignal,
   focusOrderDescendants,
+  parentStream,
   type ChildStreamEntries,
 } from './childExecutions';
 import {
   activeStreamId,
-  parentStream,
   streams as streamsSignal,
   type StreamSlice,
 } from './cliState';

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -7,6 +7,7 @@ import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
 
 import { resolveChildControlDisplayTargets } from './childControls';
 import { activeStreamScope } from './streamViews';
+import type { ChildStreamEntries } from './childExecutions';
 import type { StreamSlice } from './cliState';
 
 export type FocusedChildFollowUpRoute =
@@ -76,12 +77,14 @@ export function focusedChildInputDisabledMessage(init: {
 }
 
 export function stoppedFocusedChildFollowUpMessage(init: {
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): string {
   const controls = resolveChildControlDisplayTargets({
     activeStreamId: init.streamId,
+    childStreamEntries: init.childStreamEntries,
     parentStream: init.parentStream,
     streams: init.streams,
   });

--- a/packages/cli/src/chat/tui/state/resumeHint.ts
+++ b/packages/cli/src/chat/tui/state/resumeHint.ts
@@ -15,7 +15,11 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 
-import { childExecutionLabel } from './childExecutions';
+import {
+  childExecutionLabel,
+  retainedChildStreamsFor,
+  type ChildStreamEntries,
+} from './childExecutions';
 import type { StreamSlice } from './cliState';
 
 export interface ResumeTarget {
@@ -26,6 +30,7 @@ export interface ResumeTarget {
 }
 
 export interface ResumeTargetsInput {
+  readonly childStreamEntries: ChildStreamEntries;
   readonly rootExecutionId: string | undefined;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
@@ -123,6 +128,7 @@ export function formatResumeUsage(
  *  executionId. Subagents whose stream isn't a tool-use agent — workflow
  *  children, tool processes — are skipped because they can't be resumed. */
 export function collectResumeTargets({
+  childStreamEntries,
   rootExecutionId,
   streams,
 }: ResumeTargetsInput): readonly ResumeTarget[] {
@@ -134,9 +140,13 @@ export function collectResumeTargets({
     seen.add(rootExecutionId);
   }
 
-  for (const slice of streams.values()) {
-    for (const child of slice.childStreams) {
-      if (child.kind !== 'subagent' || seen.has(child.executionId)) continue;
+  for (const streamId of streams.keys()) {
+    for (const child of retainedChildStreamsFor(
+      streamId,
+      childStreamEntries,
+      streams,
+    )) {
+      if (seen.has(child.executionId)) continue;
       const childSlice = streams.get(child.childStreamId);
       if (childSlice?.category !== AgentCategory.ToolUse) continue;
       seen.add(child.executionId);

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -11,6 +11,7 @@ import {
   childExecutionKey,
   childExecutionLabel,
   visibleSubagentRows,
+  type ChildStreamEntries,
 } from './childExecutions';
 import { orderedDescendantsFromTree } from './focusCycle';
 import type { StreamSlice } from './cliState';
@@ -78,7 +79,7 @@ export function nearestActiveStreamAncestor<T>(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly values: ReadonlyMap<StreamTabId, T>;
-  readonly canUseValue: (value: T) => boolean;
+  readonly canUseValue: (value: T, streamId: StreamTabId) => boolean;
 }): ActiveStreamAncestor<T> | undefined {
   const activeStreamId = init.activeStreamId;
   if (activeStreamId === undefined) return undefined;
@@ -88,7 +89,7 @@ export function nearestActiveStreamAncestor<T>(init: {
   while (parentStreamId && !visited.has(parentStreamId)) {
     visited.add(parentStreamId);
     const value = init.values.get(parentStreamId);
-    if (value !== undefined && init.canUseValue(value)) {
+    if (value !== undefined && init.canUseValue(value, parentStreamId)) {
       return { streamId: parentStreamId, value };
     }
     parentStreamId = init.parentStream.get(parentStreamId);
@@ -96,25 +97,22 @@ export function nearestActiveStreamAncestor<T>(init: {
   return undefined;
 }
 
-const emptyChildReferenceSlice = {
-  activeSubagents: [],
-  childStreams: [],
-} satisfies Pick<StreamSlice, 'activeSubagents' | 'childStreams'>;
-
 function childStreamReferenceLabel(
-  parent:
-    | Pick<StreamSlice, 'activeSubagents' | 'activeProcesses' | 'childStreams'>
-    | undefined,
+  parentStreamId: StreamTabId,
+  childStreamEntries: ChildStreamEntries,
+  streams: ReadonlyMap<StreamTabId, StreamSlice>,
   streamId: StreamTabId,
 ): string {
+  const parentSlice = streams.get(parentStreamId);
   const child = [
-    ...visibleSubagentRows(parent ?? emptyChildReferenceSlice),
-    ...(parent?.activeProcesses ?? []),
+    ...visibleSubagentRows(parentStreamId, childStreamEntries, streams),
+    ...(parentSlice?.activeProcesses ?? []),
   ].find((entry) => childExecutionKey(entry) === streamId);
   return child ? childExecutionLabel(child) : streamId;
 }
 
 export function streamDisplayLabel(init: {
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streamId: StreamTabId;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
@@ -122,13 +120,16 @@ export function streamDisplayLabel(init: {
   const parentStreamId = init.parentStream.get(init.streamId);
   if (!parentStreamId) return 'main';
   return childStreamReferenceLabel(
-    init.streams.get(parentStreamId),
+    parentStreamId,
+    init.childStreamEntries,
+    init.streams,
     init.streamId,
   );
 }
 
 export function streamViewForId(init: {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly shortcutIndex?: number;
   readonly streamId: StreamTabId;
@@ -141,6 +142,7 @@ export function streamViewForId(init: {
     parentId,
     parentLabel: parentId
       ? streamDisplayLabel({
+          childStreamEntries: init.childStreamEntries,
           parentStream: init.parentStream,
           streamId: parentId,
           streams: init.streams,
@@ -154,6 +156,7 @@ export function streamViewForId(init: {
 
 interface OrderedStreamViewInput {
   readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
@@ -169,8 +172,7 @@ export function activeStreamTreeEntries(
   if (!root) return [];
   const ordered = orderedDescendantsFromTree({
     parent: root,
-    parentSlice: init.streams.get(root),
-    parentStream: init.parentStream,
+    childStreamEntries: init.childStreamEntries,
     streams: init.streams,
   });
   const out: ActiveStreamTreeEntry[] = [];
@@ -192,6 +194,7 @@ export function activeStreamTreeViews(
   return ordered.map((entry) =>
     streamViewForId({
       activeStreamId: init.activeStreamId,
+      childStreamEntries: init.childStreamEntries,
       parentStream: init.parentStream,
       shortcutIndex: entry.shortcutIndex,
       streamId: entry.id,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -25,13 +25,12 @@ import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
-  registerChildStreams,
   setParentStream,
   removeStream,
   patchStream,
   type StreamSlice,
 } from './cliState';
-import { mergeChildStreams } from './childExecutions';
+import { applySubagentRoster, isChildStreamRemoved } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';
@@ -64,6 +63,9 @@ function applySetActiveStream(payload: SetActiveStreamPayload): void {
     activeStreamId.set(undefined);
     return;
   }
+  // A stream identity tombstoned by removeStream is never resurrected; a
+  // fresh activation after removal uses a distinct StreamTabId.
+  if (isChildStreamRemoved(next)) return;
   // Register background child streams without stealing focus from the
   // parent page. This mirrors the extension progress view contract.
   // Capture the agent category so the exit hint can list only resumable
@@ -118,34 +120,11 @@ function applyRoundStage(payload: UpdateRoundStagePayload): void {
   });
 }
 
-function sameActiveChildren(
-  left: readonly ActiveChildInfo[],
-  right: readonly ActiveChildInfo[],
-): boolean {
-  return (
-    left.length === right.length && left.every((item, i) => item === right[i])
-  );
-}
-
 function applyActiveSubagents(payload: {
   parentStreamId: StreamTabId;
   children: readonly ActiveChildInfo[];
 }): void {
-  registerChildStreams(payload.parentStreamId, payload.children);
-  patchStream(payload.parentStreamId, (s) => {
-    const childStreams = mergeChildStreams(s.childStreams, payload.children);
-    if (
-      sameActiveChildren(s.activeSubagents, payload.children) &&
-      sameActiveChildren(s.childStreams, childStreams)
-    ) {
-      return s;
-    }
-    return {
-      ...s,
-      activeSubagents: payload.children,
-      childStreams,
-    };
-  });
+  applySubagentRoster(payload.parentStreamId, payload.children);
 }
 
 function applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -25,12 +25,15 @@ import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
-  setParentStream,
   removeStream,
   patchStream,
   type StreamSlice,
 } from './cliState';
-import { applySubagentRoster, isChildStreamRemoved } from './childExecutions';
+import {
+  applySubagentRoster,
+  isChildStreamRemoved,
+  setParentStream,
+} from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
 import { appendLocalAssistantTranscript } from './transcript';

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -5,13 +5,13 @@ import { type StreamLifecycleStatus, type StreamTabId } from '@shared/schemas';
 import {
   activeStreamId,
   rootStreamId,
-  parentStream,
   registerCliStateResetHook,
   removeStream,
   patchStream,
   streams,
   type ConversationEntry,
 } from './cliState';
+import { parentStream } from './childExecutions';
 import { activeStreamParentOrSelfId } from './streamViews';
 
 export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;

--- a/packages/cli/src/chat/tui/state/useSignal.ts
+++ b/packages/cli/src/chat/tui/state/useSignal.ts
@@ -14,6 +14,18 @@ type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
  * in the notify callback — the wrapper does that here so consumers see every
  * update.
  *
+ * The notify callback runs synchronously inside the producer's own `.set()`
+ * call, while the signal graph is still in its "notification phase" —
+ * `Signal.subtle.Watcher`'s documented constraint is that no signal read may
+ * recompute a `Computed` during that phase. `useSyncExternalStore` can call
+ * our `getSnapshot` (`signal.get()`) synchronously from within `notify()`
+ * (React's `checkIfSnapshotChanged`), so a watched `Signal.Computed` whose
+ * dependency just changed would recompute — and read further signals — still
+ * inside that phase, tripping the polyfill's assertion. `@lit-labs/signals`'s
+ * own `SignalWatcher` mixin avoids this by deferring every notify to a
+ * microtask (see its `effectWatcher`); we do the same here so `getSnapshot`
+ * only ever runs once the triggering `.set()` call has fully unwound.
+ *
  * The subscribe callback is memoized per signal: `useSyncExternalStore`
  * unsubscribes and resubscribes whenever the subscribe reference changes, so
  * an inline closure would tear down and rebuild the Watcher on every render
@@ -22,9 +34,15 @@ type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
 export function useSignal<T>(signal: ReadableSignal<T>): T {
   const subscribe = useCallback(
     (notify: () => void) => {
+      let notifyPending = false;
       const watcher = new Signal.subtle.Watcher(() => {
-        notify();
-        watcher.watch();
+        if (notifyPending) return;
+        notifyPending = true;
+        queueMicrotask(() => {
+          notifyPending = false;
+          notify();
+          watcher.watch();
+        });
       });
       watcher.watch(signal);
       return () => watcher.unwatch(signal);

--- a/packages/cli/src/chat/tui/state/useSignal.ts
+++ b/packages/cli/src/chat/tui/state/useSignal.ts
@@ -30,22 +30,37 @@ type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
  * unsubscribes and resubscribes whenever the subscribe reference changes, so
  * an inline closure would tear down and rebuild the Watcher on every render
  * — per signal, per component, at streaming cadence.
+ *
+ * A change notification is already queued in the microtask above when the
+ * component unmounts (or, under React StrictMode's dev-mode mount/cleanup/
+ * remount, when this particular subscription is torn down): the cleanup
+ * below only calls `watcher.unwatch(signal)`, so without a disposed guard
+ * the pending microtask would still fire `notify()` on an unmounted
+ * subscriber and re-arm the watcher via `watcher.watch()`, leaking it.
+ * `disposed` is scoped to this one `subscribe()` invocation, so StrictMode's
+ * remount creates a fresh watcher/flag pair rather than sharing state with
+ * the torn-down one.
  */
 export function useSignal<T>(signal: ReadableSignal<T>): T {
   const subscribe = useCallback(
     (notify: () => void) => {
       let notifyPending = false;
+      let disposed = false;
       const watcher = new Signal.subtle.Watcher(() => {
         if (notifyPending) return;
         notifyPending = true;
         queueMicrotask(() => {
           notifyPending = false;
+          if (disposed) return;
           notify();
           watcher.watch();
         });
       });
       watcher.watch(signal);
-      return () => watcher.unwatch(signal);
+      return () => {
+        disposed = true;
+        watcher.unwatch(signal);
+      };
     },
     [signal],
   );

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - CLI TUI state
 import {
+  buildChildStreamEntries,
+  type ChildStreamEntryRow,
+} from '@test/support/childStreamEntries';
+import {
   compactPickerOverflowText,
   computePickerListLayout,
   computeTaskDetailLayout,
@@ -39,7 +43,11 @@ import {
   resolveChildControlDisplayTargets,
   resolveChildControlStreamTarget,
 } from '@cli/chat/tui/state/childControls';
-import { visibleSubagentRows } from '@cli/chat/tui/state/childExecutions';
+import {
+  activeSubagentsFor,
+  visibleSubagentRows,
+  type ChildStreamEntries,
+} from '@cli/chat/tui/state/childExecutions';
 import { streamDisplayLabel } from '@cli/chat/tui/state/streamViews';
 import {
   NO_BYPASS,
@@ -52,6 +60,7 @@ import {
   STREAM_STATUS,
   TOOL_USE_STATUS,
   type NormalizedToolUse,
+  type StreamTabId,
 } from '@shared/schemas';
 
 function tail(stdout: string, stderr = ''): ProcessOutputTail {
@@ -80,11 +89,7 @@ function toolUse(
 
 function slice(
   overrides: Partial<StreamSlice> = {},
-): Pick<
-  StreamSlice,
-  'activeProcesses' | 'activeSubagents' | 'childStreams' | 'processOutput'
-> &
-  StreamSlice {
+): Pick<StreamSlice, 'activeProcesses' | 'processOutput'> & StreamSlice {
   return {
     streamId: 'root',
     category: undefined,
@@ -98,9 +103,7 @@ function slice(
     entries: [],
     queuedFollowUps: 0,
     queuedFollowUpMessages: [],
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: [],
     todos: [],
     plan: null,
     processOutput: new Map(),
@@ -109,38 +112,93 @@ function slice(
   };
 }
 
+/** Build a `{ id: StreamSlice }` streams map entry carrying just the status
+ *  each `ChildStreamEntryRow` used to embed directly — the new selectors
+ *  read status from the child's own `StreamSlice`, not the roster row. */
+function childStatusStreams(
+  rows: readonly ChildStreamEntryRow[],
+): ReadonlyMap<StreamTabId, StreamSlice> {
+  return new Map(
+    rows.map((row) => [
+      row.childStreamId,
+      slice({
+        streamId: row.childStreamId,
+        // Test fixtures reuse the loosely-typed `ActiveChildInfo.status`
+        // strings (e.g. legacy 'stopped'/'initializing') that
+        // `StreamLifecycleStatusSchema` accepts and normalizes at runtime,
+        // but the static `StreamLifecycleStatus` type doesn't include them.
+        status: row.status as StreamSlice['status'],
+      }),
+    ]),
+  );
+}
+
+/** Build a `ChildStreamEntries` map for `parentStreamId` plus a merged
+ *  `streams` map (parent + each child's own status slice, with `extraStreams`
+ *  overlaid last so a test's own per-child slice overrides win). */
+function childFixture(
+  parentStreamId: StreamTabId,
+  init: {
+    readonly retained?: readonly ChildStreamEntryRow[];
+    readonly activeOnly?: readonly ChildStreamEntryRow[];
+    readonly parentSlice?: StreamSlice;
+    readonly extraStreams?: ReadonlyMap<StreamTabId, StreamSlice>;
+  },
+): {
+  readonly entries: ChildStreamEntries;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+} {
+  const rows = [...(init.retained ?? []), ...(init.activeOnly ?? [])];
+  const streams = new Map<StreamTabId, StreamSlice>([
+    [parentStreamId, init.parentSlice ?? slice({ streamId: parentStreamId })],
+    ...childStatusStreams(rows),
+    ...(init.extraStreams ?? []),
+  ]);
+  return {
+    entries: buildChildStreamEntries({
+      parentStreamId,
+      retained: init.retained,
+      activeOnly: init.activeOnly,
+    }),
+    streams,
+  };
+}
+
 describe('CLI child execution controls', () => {
   it('maps Alt-number focus jumps to visible descendant streams', () => {
-    const root = slice({
-      // Only subagents own a stream tab, so both live-only ("agent-1", still in
-      // activeSubagents but not yet retained in childStreams) and
-      // retained ("agent-2") subagent rows are valid focus-jump targets —
-      // background processes never are.
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-        },
-        {
-          kind: 'subagent',
-          executionId: 'agent-3',
-          agentName: 'bash',
-          childStreamId: 'child-b',
-        },
-      ],
-      childStreams: [
+    // Only subagents own a stream tab, so a retained row is a valid
+    // focus-jump target only once its own `StreamSlice` exists ("agent-1"
+    // has none yet and is skipped); an active-only row with an edge is
+    // reachable once its slice exists ("agent-3") — background processes
+    // never are.
+    const entries = buildChildStreamEntries({
+      parentStreamId: 'root' as StreamTabId,
+      retained: [
         {
           kind: 'subagent',
           executionId: 'agent-2',
           agentName: 'critic',
-          childStreamId: 'child-c',
+          childStreamId: 'child-c' as StreamTabId,
+        },
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a' as StreamTabId,
+          active: false,
+        },
+      ],
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-3',
+          agentName: 'bash',
+          childStreamId: 'child-b' as StreamTabId,
         },
       ],
     });
     const streams = new Map<StreamSlice['streamId'], StreamSlice>([
-      ['root', root],
+      ['root', slice({ streamId: 'root' })],
       ['child-b', slice({ streamId: 'child-b' })],
       ['child-c', slice({ streamId: 'child-c' })],
     ]);
@@ -148,6 +206,7 @@ describe('CLI child execution controls', () => {
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'root',
+        childStreamEntries: entries,
         parentStream: new Map(),
         streams,
         zeroBasedIndex: 0,
@@ -156,6 +215,7 @@ describe('CLI child execution controls', () => {
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'root',
+        childStreamEntries: entries,
         parentStream: new Map(),
         streams,
         zeroBasedIndex: 1,
@@ -164,6 +224,7 @@ describe('CLI child execution controls', () => {
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'root',
+        childStreamEntries: entries,
         parentStream: new Map(),
         streams,
         zeroBasedIndex: 2,
@@ -172,16 +233,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('maps Alt-number focus jumps through the focused child stream tree', () => {
-    const root = slice({
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-        },
-      ],
-      childStreams: [
+    const { entries } = childFixture('root', {
+      retained: [
         {
           kind: 'subagent',
           executionId: 'agent-2',
@@ -189,9 +242,17 @@ describe('CLI child execution controls', () => {
           childStreamId: 'child-b',
         },
       ],
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+        },
+      ],
     });
     const streams = new Map<StreamSlice['streamId'], StreamSlice>([
-      ['root', root],
+      ['root', slice({ streamId: 'root' })],
       ['child-a', slice({ streamId: 'child-a' })],
       ['child-b', slice({ streamId: 'child-b' })],
     ]);
@@ -206,6 +267,7 @@ describe('CLI child execution controls', () => {
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'child-a',
+        childStreamEntries: entries,
         parentStream,
         streams,
         zeroBasedIndex: 0,
@@ -214,6 +276,7 @@ describe('CLI child execution controls', () => {
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'child-a',
+        childStreamEntries: entries,
         parentStream,
         streams,
         zeroBasedIndex: 1,
@@ -222,27 +285,7 @@ describe('CLI child execution controls', () => {
   });
 
   it('builds subagent and process picker items with stable labels and tails', () => {
-    const state = slice({
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-          status: 'running',
-          elapsed: '12s',
-        },
-      ],
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-2',
-          agentName: 'reviewer',
-          childStreamId: 'child-b',
-          status: 'stopped',
-          elapsed: '20s',
-        },
-      ],
+    const parentSlice = slice({
       activeProcesses: [
         {
           kind: 'process',
@@ -254,8 +297,34 @@ describe('CLI child execution controls', () => {
       ],
       processOutput: new Map([['proc-1', tail('first\nsecond\n', 'warning')]]),
     });
+    const { entries, streams } = childFixture('root', {
+      parentSlice,
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-2',
+          agentName: 'reviewer',
+          childStreamId: 'child-b',
+          status: 'stopped',
+          elapsed: '20s',
+          active: false,
+        },
+      ],
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'running',
+          elapsed: '12s',
+        },
+      ],
+    });
 
-    expect(buildChildControlItems(state, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-2',
         childStreamId: 'child-b',
@@ -277,7 +346,9 @@ describe('CLI child execution controls', () => {
         tailLines: [],
       },
     ]);
-    expect(buildChildControlItems(state, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-2',
         childStreamId: 'child-b',
@@ -308,18 +379,7 @@ describe('CLI child execution controls', () => {
   });
 
   it('derives live elapsed text for running child executions', () => {
-    const state = slice({
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-          status: 'running',
-          startedAt: 1_000,
-          elapsed: '1s',
-        },
-      ],
+    const parentSlice = slice({
       activeProcesses: [
         {
           kind: 'process',
@@ -331,9 +391,23 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
+    const { entries, streams } = childFixture('root', {
+      parentSlice,
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'running',
+          startedAt: 1_000,
+          elapsed: '1s',
+        },
+      ],
+    });
 
     expect(
-      buildChildControlItems(state, 'subagents', new Map(), 62_000),
+      buildChildControlItems('root', entries, streams, 'subagents', 62_000),
     ).toMatchObject([
       {
         executionId: 'agent-1',
@@ -341,7 +415,7 @@ describe('CLI child execution controls', () => {
         elapsed: '1m 1s',
       },
     ]);
-    expect(childElapsed(state.activeProcesses[0], 62_000)).toBe('1s');
+    expect(childElapsed(parentSlice.activeProcesses[0], 62_000)).toBe('1s');
     expect(
       childElapsed(
         { startedAt: 0, status: STREAM_STATUS.RUNNING, elapsed: '1s' },
@@ -351,17 +425,7 @@ describe('CLI child execution controls', () => {
   });
 
   it('uses CLI-facing labels in picker descriptions', () => {
-    const state = slice({
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'review',
-          childStreamId: 'child-a',
-          status: STREAM_STATUS.WAITING,
-          elapsed: '20s',
-        },
-      ],
+    const parentSlice = slice({
       activeProcesses: [
         {
           kind: 'process',
@@ -373,15 +437,32 @@ describe('CLI child execution controls', () => {
       ],
       processOutput: new Map([['proc-1', tail('last line')]]),
     });
+    const { entries, streams } = childFixture('root', {
+      parentSlice,
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'child-a',
+          status: STREAM_STATUS.WAITING,
+          elapsed: '20s',
+        },
+      ],
+    });
 
-    expect(buildChildControlItems(state, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         description: 'waiting for you · 20s',
         statusLabel: 'waiting for you',
       },
     ]);
-    expect(buildChildControlItems(state, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         description: 'waiting for you · 20s',
@@ -396,64 +477,92 @@ describe('CLI child execution controls', () => {
   });
 
   it('keys live child elapsed timers by active execution identity', () => {
-    expect(liveChildExecutionElapsedKey(undefined)).toBeUndefined();
+    expect(liveChildExecutionElapsedKey([], [])).toBeUndefined();
 
-    const state = slice({
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          childStreamId: 'agent-2-stream',
-          executionId: 'agent-2',
-          agentName: 'critic',
-          status: 'running',
-          startedAt: 2_000,
-        },
-        {
-          kind: 'subagent',
-          childStreamId: 'agent-1-stream',
-          executionId: 'agent-1',
-          agentName: 'reviewer',
-          status: 'initializing',
-          startedAt: 1_000,
-        },
-      ],
-      activeProcesses: [
-        {
-          kind: 'process',
-          executionId: 'proc-1',
-          agentName: 'latexmk',
-          status: 'waiting',
-          startedAt: 500,
-          elapsed: '1s',
-        },
-      ],
-    });
+    const activeSubagents = activeSubagentsFor(
+      'root',
+      buildChildStreamEntries({
+        parentStreamId: 'root',
+        activeOnly: [
+          {
+            kind: 'subagent',
+            childStreamId: 'agent-2-stream',
+            executionId: 'agent-2',
+            agentName: 'critic',
+            status: 'running',
+            startedAt: 2_000,
+          },
+          {
+            kind: 'subagent',
+            childStreamId: 'agent-1-stream',
+            executionId: 'agent-1',
+            agentName: 'reviewer',
+            status: 'initializing',
+            startedAt: 1_000,
+          },
+        ],
+      }),
+      new Map([
+        [
+          'agent-2-stream',
+          slice({ streamId: 'agent-2-stream', status: 'running' }),
+        ],
+        [
+          'agent-1-stream',
+          slice({
+            streamId: 'agent-1-stream',
+            status: 'initializing' as StreamSlice['status'],
+          }),
+        ],
+      ]),
+    );
+    const activeProcesses = [
+      {
+        kind: 'process' as const,
+        executionId: 'proc-1',
+        agentName: 'latexmk',
+        status: 'waiting',
+        startedAt: 500,
+        elapsed: '1s',
+      },
+    ];
 
-    expect(liveChildExecutionElapsedKey(state)).toBe(
+    expect(liveChildExecutionElapsedKey(activeSubagents, activeProcesses)).toBe(
       'agent-1:1000,agent-2:2000',
     );
     expect(
       liveChildExecutionElapsedKey(
-        slice({
-          activeSubagents: [
-            {
-              kind: 'subagent',
-              childStreamId: 'agent-1-stream',
-              executionId: 'agent-1',
-              agentName: 'critic',
-              status: 'completed',
-              startedAt: 1_000,
-              elapsed: '1s',
-            },
-          ],
-        }),
+        activeSubagentsFor(
+          'root',
+          buildChildStreamEntries({
+            parentStreamId: 'root',
+            activeOnly: [
+              {
+                kind: 'subagent',
+                childStreamId: 'agent-1-stream',
+                executionId: 'agent-1',
+                agentName: 'critic',
+                status: 'completed',
+                startedAt: 1_000,
+                elapsed: '1s',
+              },
+            ],
+          }),
+          new Map([
+            [
+              'agent-1-stream',
+              slice({ streamId: 'agent-1-stream', status: 'completed' }),
+            ],
+          ]),
+        ),
+        [],
       ),
     ).toBeUndefined();
   });
 
   it('uses stream descriptions as visible task commands', () => {
-    const state = slice({
-      activeSubagents: [
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -462,25 +571,29 @@ describe('CLI child execution controls', () => {
           status: 'running',
         },
       ],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: 'running',
+            description: 'timeout 1800 texra run paper',
+            entries: [
+              {
+                id: 'entry-1',
+                role: 'assistant',
+                text: 'line one\nline two',
+                finalized: true,
+              },
+            ],
+          }),
+        ],
+      ]),
     });
-    const streams = new Map([
-      [
-        'child-a',
-        slice({
-          description: 'timeout 1800 texra run paper',
-          entries: [
-            {
-              id: 'entry-1',
-              role: 'assistant',
-              text: 'line one\nline two',
-              finalized: true,
-            },
-          ],
-        }),
-      ],
-    ]);
 
-    expect(buildChildControlItems(state, 'tasks', streams)).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         label: 'bash',
@@ -491,8 +604,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('includes tool and process transcript rows in task details', () => {
-    const state = slice({
-      activeSubagents: [
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -501,45 +614,49 @@ describe('CLI child execution controls', () => {
           status: 'completed',
         },
       ],
-    });
-    const streams = new Map([
-      [
-        'child-a',
-        slice({
-          entries: [
-            {
-              id: 'tool-1',
-              role: 'tool',
-              text: '',
-              finalized: true,
-              toolUse: toolUse(
-                'bash',
-                { command: 'pnpm test' },
-                {
-                  headerSummary: 'pnpm test',
-                  outputText: 'ok\nsecond line',
-                },
-              ),
-            },
-            {
-              id: 'process-1',
-              role: 'process',
-              text: '',
-              finalized: true,
-              process: {
-                executionId: 'proc-1',
-                title: 'latexmk',
-                status: 'completed',
-                isError: false,
-                tailLines: ['built pdf'],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: 'completed',
+            entries: [
+              {
+                id: 'tool-1',
+                role: 'tool',
+                text: '',
+                finalized: true,
+                toolUse: toolUse(
+                  'bash',
+                  { command: 'pnpm test' },
+                  {
+                    headerSummary: 'pnpm test',
+                    outputText: 'ok\nsecond line',
+                  },
+                ),
               },
-            },
-          ],
-        }),
-      ],
-    ]);
+              {
+                id: 'process-1',
+                role: 'process',
+                text: '',
+                finalized: true,
+                process: {
+                  executionId: 'proc-1',
+                  title: 'latexmk',
+                  status: 'completed',
+                  isError: false,
+                  tailLines: ['built pdf'],
+                },
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
 
-    expect(buildChildControlItems(state, 'tasks', streams)).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         tailLines: [
@@ -554,8 +671,16 @@ describe('CLI child execution controls', () => {
   });
 
   it('keeps retained subagent streams selectable after they leave the active list', () => {
-    const state = slice({
-      activeSubagents: [
+    const { entries, streams } = childFixture('root', {
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'completed',
+          active: false,
+        },
         {
           kind: 'subagent',
           executionId: 'agent-2',
@@ -564,25 +689,11 @@ describe('CLI child execution controls', () => {
           status: 'running',
         },
       ],
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-          status: 'completed',
-        },
-        {
-          kind: 'subagent',
-          executionId: 'agent-2',
-          agentName: 'polisher',
-          childStreamId: 'child-b',
-          status: 'waiting',
-        },
-      ],
     });
 
-    expect(buildChildControlItems(state, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         childStreamId: 'child-a',
@@ -603,8 +714,16 @@ describe('CLI child execution controls', () => {
   });
 
   it('keeps retained subagent streams visible in the side-panel row model', () => {
-    const state = slice({
-      activeSubagents: [
+    const { entries, streams } = childFixture('root', {
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'completed',
+          active: false,
+        },
         {
           kind: 'subagent',
           executionId: 'agent-2',
@@ -613,25 +732,9 @@ describe('CLI child execution controls', () => {
           status: 'running',
         },
       ],
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-          status: 'completed',
-        },
-        {
-          kind: 'subagent',
-          executionId: 'agent-2',
-          agentName: 'polisher',
-          childStreamId: 'child-b',
-          status: 'waiting',
-        },
-      ],
     });
 
-    expect(visibleSubagentRows(state)).toMatchObject([
+    expect(visibleSubagentRows('root', entries, streams)).toMatchObject([
       {
         kind: 'subagent',
         executionId: 'agent-1',
@@ -645,12 +748,20 @@ describe('CLI child execution controls', () => {
         status: 'running',
       },
     ]);
-    expect(hasChildControlItems(state, 'tasks')).toBe(true);
+    expect(hasChildControlItems('root', entries, streams, 'tasks')).toBe(true);
   });
 
   it('keeps stopped subagents in their retained task order', () => {
-    const state = slice({
-      activeSubagents: [
+    const { entries, streams } = childFixture('root', {
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'critic',
+          childStreamId: 'child-a',
+          status: 'stopped',
+          active: false,
+        },
         {
           kind: 'subagent',
           executionId: 'agent-2',
@@ -659,25 +770,11 @@ describe('CLI child execution controls', () => {
           status: 'running',
         },
       ],
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: 'child-a',
-          status: 'stopped',
-        },
-        {
-          kind: 'subagent',
-          executionId: 'agent-2',
-          agentName: 'polisher',
-          childStreamId: 'child-b',
-          status: 'waiting',
-        },
-      ],
     });
 
-    expect(buildChildControlItems(state, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('root', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         kind: 'subagent',
         executionId: 'agent-1',
@@ -698,25 +795,25 @@ describe('CLI child execution controls', () => {
   });
 
   it('opens the child side panel when only retained subagent streams remain', () => {
-    const state = slice({
-      childStreams: [
+    const { entries, streams } = childFixture('root', {
+      retained: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
           status: 'completed',
+          active: false,
         },
       ],
     });
 
-    expect(hasChildControlItems(state, 'tasks')).toBe(true);
+    expect(hasChildControlItems('root', entries, streams, 'tasks')).toBe(true);
   });
 
   it('falls back to the parent subagent list when the focused child is a leaf', () => {
-    const parent = slice({
-      streamId: 'main',
-      activeSubagents: [
+    const { entries, streams } = childFixture('main', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -726,21 +823,20 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
-    const child = slice({ streamId: 'review-stream' });
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       mode: 'subagents',
       parentStream: new Map([['review-stream', 'main']]),
-      streams: new Map([
-        ['main', parent],
-        ['review-stream', child],
-      ]),
+      streams,
     });
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('main', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         childStreamId: 'review-stream',
@@ -751,9 +847,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('labels child-control stream scopes with friendly stream names', () => {
-    const parent = slice({
-      streamId: 'main',
-      activeSubagents: [
+    const { entries, streams } = childFixture('main', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -763,15 +858,11 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
-    const child = slice({ streamId: 'review-stream' });
     const parentStream = new Map([['review-stream', 'main']] as const);
-    const streams = new Map([
-      ['main', parent],
-      ['review-stream', child],
-    ] as const);
 
     expect(
       streamDisplayLabel({
+        childStreamEntries: entries,
         parentStream,
         streamId: 'main',
         streams,
@@ -779,6 +870,7 @@ describe('CLI child execution controls', () => {
     ).toBe('main');
     expect(
       streamDisplayLabel({
+        childStreamEntries: entries,
         parentStream,
         streamId: 'review-stream',
         streams,
@@ -787,9 +879,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('resolves child-control display targets with labels and availability', () => {
-    const parent = slice({
-      streamId: 'main',
-      activeSubagents: [
+    const { entries, streams } = childFixture('main', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -799,15 +890,12 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
-    const child = slice({ streamId: 'review-stream' });
     const parentStream = new Map([['review-stream', 'main']] as const);
     const targets = resolveChildControlDisplayTargets({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       parentStream,
-      streams: new Map([
-        ['main', parent],
-        ['review-stream', child],
-      ] as const),
+      streams,
     });
 
     expect(targets.subagents).toMatchObject({
@@ -827,9 +915,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('keeps subagent controls on the focused child when it has descendants', () => {
-    const child = slice({
-      streamId: 'review-stream',
-      activeSubagents: [
+    const { entries, streams } = childFixture('review-stream', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-2',
@@ -841,14 +928,17 @@ describe('CLI child execution controls', () => {
     });
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       mode: 'subagents',
       parentStream: new Map([['review-stream', 'main']]),
-      streams: new Map([['review-stream', child]]),
+      streams,
     });
 
     expect(target.streamId).toBe('review-stream');
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('review-stream', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-2',
         childStreamId: 'detail-stream',
@@ -862,6 +952,7 @@ describe('CLI child execution controls', () => {
     const child = slice({ streamId: 'review-stream' });
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: new Map(),
       mode: 'subagents',
       parentStream: new Map([['review-stream', 'main']]),
       streams: new Map([
@@ -876,9 +967,8 @@ describe('CLI child execution controls', () => {
   });
 
   it('falls back to the nearest ancestor subagent list when a focused grandchild is a leaf', () => {
-    const main = slice({
-      streamId: 'main',
-      activeSubagents: [
+    const { entries, streams: mainFixtureStreams } = childFixture('main', {
+      activeOnly: [
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -888,26 +978,28 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
-    const child = slice({ streamId: 'review-stream' });
-    const grandchild = slice({ streamId: 'detail-stream' });
+    const streams = new Map([
+      ...mainFixtureStreams,
+      ['review-stream', slice({ streamId: 'review-stream' })],
+      ['detail-stream', slice({ streamId: 'detail-stream' })],
+    ]);
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'detail-stream',
+      childStreamEntries: entries,
       mode: 'subagents',
       parentStream: new Map([
         ['review-stream', 'main'],
         ['detail-stream', 'review-stream'],
       ]),
-      streams: new Map([
-        ['main', main],
-        ['review-stream', child],
-        ['detail-stream', grandchild],
-      ]),
+      streams,
     });
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('detail-stream');
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'subagents')).toMatchObject([
+    expect(
+      buildChildControlItems('main', entries, streams, 'subagents'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         childStreamId: 'review-stream',
@@ -918,35 +1010,35 @@ describe('CLI child execution controls', () => {
   });
 
   it('falls back to the parent task list when the focused child is a leaf', () => {
-    const child = slice({ streamId: 'review-stream' });
+    const { entries, streams: mainFixtureStreams } = childFixture('main', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const streams = new Map([
+      ...mainFixtureStreams,
+      ['review-stream', slice({ streamId: 'review-stream' })],
+    ]);
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       mode: 'tasks',
       parentStream: new Map([['review-stream', 'main']]),
-      streams: new Map([
-        [
-          'main',
-          slice({
-            streamId: 'main',
-            activeSubagents: [
-              {
-                kind: 'subagent',
-                executionId: 'agent-1',
-                agentName: 'review',
-                childStreamId: 'review-stream',
-                status: 'running',
-              },
-            ],
-          }),
-        ],
-        ['review-stream', child],
-      ]),
+      streams,
     });
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('main', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         childStreamId: 'review-stream',
@@ -957,35 +1049,32 @@ describe('CLI child execution controls', () => {
   });
 
   it('falls back to retained parent task rows when only stopped child streams remain', () => {
-    const child = slice({ streamId: 'review-stream' });
+    const { entries, streams } = childFixture('main', {
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'stopped',
+          active: false,
+        },
+      ],
+    });
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       mode: 'tasks',
       parentStream: new Map([['review-stream', 'main']]),
-      streams: new Map([
-        [
-          'main',
-          slice({
-            streamId: 'main',
-            childStreams: [
-              {
-                kind: 'subagent',
-                executionId: 'agent-1',
-                agentName: 'review',
-                childStreamId: 'review-stream',
-                status: 'stopped',
-              },
-            ],
-          }),
-        ],
-        ['review-stream', child],
-      ]),
+      streams,
     });
 
     expect(target.streamId).toBe('main');
     expect(target.fallbackFromStreamId).toBe('review-stream');
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('main', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'agent-1',
         childStreamId: 'review-stream',
@@ -1009,34 +1098,32 @@ describe('CLI child execution controls', () => {
         },
       ],
     });
+    const { entries, streams: mainFixtureStreams } = childFixture('main', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'review',
+          childStreamId: 'review-stream',
+          status: 'running',
+        },
+      ],
+    });
+    const streams = new Map([...mainFixtureStreams, ['review-stream', child]]);
     const target = resolveChildControlStreamTarget({
       activeStreamId: 'review-stream',
+      childStreamEntries: entries,
       mode: 'tasks',
       parentStream: new Map([['review-stream', 'main']]),
-      streams: new Map([
-        [
-          'main',
-          slice({
-            streamId: 'main',
-            activeSubagents: [
-              {
-                kind: 'subagent',
-                executionId: 'agent-1',
-                agentName: 'review',
-                childStreamId: 'review-stream',
-                status: 'running',
-              },
-            ],
-          }),
-        ],
-        ['review-stream', child],
-      ]),
+      streams,
     });
 
     expect(target.streamId).toBe('review-stream');
     expect(target.slice).toBe(child);
     expect(target.hasItems).toBe(true);
-    expect(buildChildControlItems(target.slice!, 'tasks')).toMatchObject([
+    expect(
+      buildChildControlItems('review-stream', entries, streams, 'tasks'),
+    ).toMatchObject([
       {
         executionId: 'proc-1',
         kind: 'process',

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   LIVE_TAIL_ROWS,
@@ -895,15 +896,6 @@ describe('CLI conversation transcript splitting', () => {
         ROOT,
         sliceWithEntries(ROOT, [entry('u1', 'user', 'send scouts', true)], {
           model: 'deepseekT',
-          activeSubagents: [
-            {
-              kind: 'subagent',
-              executionId: 'ei_search',
-              agentName: 'search',
-              childStreamId: CHILD,
-              status: STREAM_STATUS.RUNNING,
-            },
-          ],
         }),
       ],
       [
@@ -913,9 +905,22 @@ describe('CLI conversation transcript splitting', () => {
         }),
       ],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: ROOT,
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'ei_search',
+          agentName: 'search',
+          childStreamId: CHILD,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ],
+    });
 
     expect(
       sessionHeaderIdentityLine(SESSION_META, {
+        childStreamEntries,
         parentStream: new Map([[CHILD, ROOT]]),
         streamId: CHILD,
         streams,
@@ -927,6 +932,7 @@ describe('CLI conversation transcript splitting', () => {
         scrollbackStreamId: CHILD,
         currentItems: [],
         streams,
+        childStreamEntries,
         meta: SESSION_META,
         parentStream: new Map([[CHILD, ROOT]]),
       })[0],
@@ -1267,9 +1273,7 @@ function sliceWithEntries(
     entries,
     queuedFollowUps: 0,
     queuedFollowUpMessages: [],
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: [],
     todos: [],
     plan: null,
     processOutput: new Map(),

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildChildStreamEntries,
+  type ChildStreamEntryRow,
+} from '@test/support/childStreamEntries';
+import {
   collectResumeUsage,
   collectResumeTargets,
   formatResumeCommand,
@@ -9,12 +13,7 @@ import {
   type ResumeUsageStats,
 } from '@cli/chat/tui/state/resumeHint';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
-import {
-  AgentCategory,
-  type ActiveChildInfo,
-  type StreamTabId,
-  type SubagentChildInfo,
-} from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 
 function makeSlice(
   over: Partial<StreamSlice> & { streamId: string },
@@ -31,9 +30,7 @@ function makeSlice(
     entries: [],
     queuedFollowUps: 0,
     queuedFollowUpMessages: [],
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: [],
     todos: [],
     plan: null,
     processOutput: new Map(),
@@ -44,11 +41,11 @@ function makeSlice(
 }
 
 function child(
-  over: Partial<SubagentChildInfo> & {
+  over: Partial<ChildStreamEntryRow> & {
     executionId: string;
     childStreamId: StreamTabId;
   },
-): ActiveChildInfo {
+): ChildStreamEntryRow {
   return { kind: 'subagent', agentName: 'agent', ...over };
 }
 
@@ -58,18 +55,35 @@ function streamsOf(
   return new Map(slices.map((s) => [s.streamId, s]));
 }
 
+const EMPTY_CHILD_STREAM_ENTRIES = buildChildStreamEntries({
+  parentStreamId: 'main@m#root' as StreamTabId,
+});
+
 describe('collectResumeTargets', () => {
   it('returns just the main session when there are no subagents', () => {
     const streams = streamsOf(makeSlice({ streamId: 'main@m#root' }));
-    expect(collectResumeTargets({ rootExecutionId: 'root', streams })).toEqual([
-      { executionId: 'root', label: 'main', isRoot: true },
-    ]);
+    expect(
+      collectResumeTargets({
+        childStreamEntries: EMPTY_CHILD_STREAM_ENTRIES,
+        rootExecutionId: 'root',
+        streams,
+      }),
+    ).toEqual([{ executionId: 'root', label: 'main', isRoot: true }]);
   });
 
   it('lists tool-use subagents and excludes workflow children', () => {
-    const root = makeSlice({
-      streamId: 'main@m#root',
-      childStreams: [
+    const root = makeSlice({ streamId: 'main@m#root' });
+    const reviewer = makeSlice({
+      streamId: 'reviewer@m#rev',
+      category: AgentCategory.ToolUse,
+    });
+    const builder = makeSlice({
+      streamId: 'builder@m#flow',
+      category: AgentCategory.Workflow,
+    });
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root.streamId,
+      retained: [
         child({
           executionId: 'rev',
           agentName: 'reviewer',
@@ -82,17 +96,10 @@ describe('collectResumeTargets', () => {
         }),
       ],
     });
-    const reviewer = makeSlice({
-      streamId: 'reviewer@m#rev',
-      category: AgentCategory.ToolUse,
-    });
-    const builder = makeSlice({
-      streamId: 'builder@m#flow',
-      category: AgentCategory.Workflow,
-    });
 
     expect(
       collectResumeTargets({
+        childStreamEntries,
         rootExecutionId: 'root',
         streams: streamsOf(root, reviewer, builder),
       }),
@@ -103,9 +110,11 @@ describe('collectResumeTargets', () => {
   });
 
   it('skips children whose stream never reported a category (processes/unknown)', () => {
-    const root = makeSlice({
-      streamId: 'main@m#root',
-      childStreams: [
+    const root = makeSlice({ streamId: 'main@m#root' });
+    const shell = makeSlice({ streamId: 'bash@tool#sh' }); // category undefined
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root.streamId,
+      retained: [
         child({
           executionId: 'sh',
           agentName: 'bash',
@@ -113,9 +122,10 @@ describe('collectResumeTargets', () => {
         }),
       ],
     });
-    const shell = makeSlice({ streamId: 'bash@tool#sh' }); // category undefined
+
     expect(
       collectResumeTargets({
+        childStreamEntries,
         rootExecutionId: 'root',
         streams: streamsOf(root, shell),
       }),
@@ -124,7 +134,11 @@ describe('collectResumeTargets', () => {
 
   it('returns nothing when there is no root execution yet', () => {
     expect(
-      collectResumeTargets({ rootExecutionId: undefined, streams: new Map() }),
+      collectResumeTargets({
+        childStreamEntries: EMPTY_CHILD_STREAM_ENTRIES,
+        rootExecutionId: undefined,
+        streams: new Map(),
+      }),
     ).toEqual([]);
   });
 });

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  buildChildStreamEntries,
+  type ChildStreamEntryRow,
+} from '@test/support/childStreamEntries';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   activeStreamParentOrSelfId,
@@ -14,12 +18,7 @@ import {
   streamTabsDisplayItems,
 } from '@cli/chat/tui/panes/StreamTabsStrip';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
-import {
-  STREAM_PHASE,
-  STREAM_STATUS,
-  type ActiveChildInfo,
-  type StreamTabId,
-} from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 function streamId(value: string): StreamTabId {
   return value as StreamTabId;
@@ -31,14 +30,16 @@ function child(init: {
   readonly agentName?: string;
   readonly toolName?: string;
   readonly status?: string;
-}): ActiveChildInfo {
+  readonly active?: boolean;
+}): ChildStreamEntryRow {
   return {
     kind: 'subagent',
     executionId: init.executionId,
     agentName: init.agentName ?? '',
-    childStreamId: init.childStreamId,
+    childStreamId: streamId(init.childStreamId),
     toolName: init.toolName,
     status: init.status,
+    active: init.active,
   };
 }
 
@@ -59,9 +60,7 @@ function slice(
     entries: [],
     queuedFollowUps: 0,
     queuedFollowUpMessages: [],
-    activeSubagents: [],
     activeProcesses: [],
-    childStreams: [],
     todos: [],
     plan: null,
     processOutput: new Map(),
@@ -69,6 +68,10 @@ function slice(
     ...init,
   };
 }
+
+const EMPTY_CHILD_STREAM_ENTRIES = buildChildStreamEntries({
+  parentStreamId: streamId('root'),
+});
 
 describe('active stream scope', () => {
   it('owns the active stream child/root projection', () => {
@@ -176,6 +179,7 @@ describe('CLI stream tabs strip', () => {
     expect(
       streamTabsDisplayItems({
         activeStreamId: root,
+        childStreamEntries: EMPTY_CHILD_STREAM_ENTRIES,
         streams,
         parentStream: new Map(),
         width: 80,
@@ -188,32 +192,21 @@ describe('CLI stream tabs strip', () => {
     const child1 = streamId('child-1');
     const child2 = streamId('child-2');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_STATUS.RUNNING,
-          activeSubagents: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'setup',
-            }),
-          ],
-          activeProcesses: [
-            child({
-              executionId: 'p1',
-              childStreamId: child2,
-              toolName: 'bash',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
       [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
       [child2, slice('child-2', { status: STREAM_STATUS.RUNNING })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      activeOnly: [
+        child({ executionId: 'r1', childStreamId: child1, agentName: 'setup' }),
+        child({ executionId: 'p1', childStreamId: child2, toolName: 'bash' }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: child2,
+      childStreamEntries,
       streams,
       parentStream: new Map([
         [child1, root],
@@ -234,32 +227,22 @@ describe('CLI stream tabs strip', () => {
     const child1 = streamId('child-1');
     const child2 = streamId('child-2');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          activeSubagents: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'setup',
-            }),
-          ],
-          activeProcesses: [
-            child({
-              executionId: 'p1',
-              childStreamId: child2,
-              toolName: 'bash',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root')],
       [child1, slice('child-1')],
       [child2, slice('child-2')],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      activeOnly: [
+        child({ executionId: 'r1', childStreamId: child1, agentName: 'setup' }),
+        child({ executionId: 'p1', childStreamId: child2, toolName: 'bash' }),
+      ],
+    });
 
     expect(
       activeStreamTreeEntries({
         activeStreamId: child2,
+        childStreamEntries,
         parentStream: new Map([
           [child1, root],
           [child2, root],
@@ -281,9 +264,14 @@ describe('CLI stream tabs strip', () => {
       [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
       [child2, slice('child-2', { status: STREAM_STATUS.WAITING })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      edgeOnly: [child1, child2],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: child2,
+      childStreamEntries,
       streams,
       parentStream: new Map([
         [child1, root],
@@ -302,24 +290,24 @@ describe('CLI stream tabs strip', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_STATUS.WAITING,
-          childStreams: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'polish',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_STATUS.WAITING })],
       [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      retained: [
+        child({
+          executionId: 'r1',
+          childStreamId: child1,
+          agentName: 'polish',
+          active: false,
+        }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: root,
+      childStreamEntries,
       streams,
       parentStream: new Map([[child1, root]]),
       width: 80,
@@ -335,24 +323,24 @@ describe('CLI stream tabs strip', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_PHASE.CANCELLED,
-          childStreams: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'strategy',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_PHASE.CANCELLED })],
       [child1, slice('child-1', { status: STREAM_PHASE.CANCELLED })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      retained: [
+        child({
+          executionId: 'r1',
+          childStreamId: child1,
+          agentName: 'strategy',
+          active: false,
+        }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: child1,
+      childStreamEntries,
       streams,
       parentStream: new Map([[child1, root]]),
       width: 80,
@@ -368,24 +356,24 @@ describe('CLI stream tabs strip', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_STATUS.READY,
-          childStreams: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'strategy',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_STATUS.READY })],
       [child1, slice('child-1', { status: STREAM_PHASE.FAILED })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      retained: [
+        child({
+          executionId: 'r1',
+          childStreamId: child1,
+          agentName: 'strategy',
+          active: false,
+        }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: child1,
+      childStreamEntries,
       streams,
       parentStream: new Map([[child1, root]]),
       width: 80,
@@ -404,36 +392,37 @@ describe('CLI stream tabs strip', () => {
     const child1 = streamId('child-1');
     const grandchild1 = streamId('grandchild-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          childStreams: [
-            child({
-              executionId: 'r1',
-              childStreamId: child1,
-              agentName: 'review',
-            }),
-          ],
-        }),
-      ],
-      [
-        child1,
-        slice('child-1', {
-          status: STREAM_STATUS.RUNNING,
-          activeSubagents: [
-            child({
-              executionId: 'r2',
-              childStreamId: grandchild1,
-              agentName: 'detail-review',
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root')],
+      [child1, slice('child-1', { status: STREAM_STATUS.RUNNING })],
       [grandchild1, slice('grandchild-1', { status: STREAM_STATUS.RUNNING })],
+    ]);
+    const childStreamEntries = new Map([
+      ...buildChildStreamEntries({
+        parentStreamId: root,
+        retained: [
+          child({
+            executionId: 'r1',
+            childStreamId: child1,
+            agentName: 'review',
+            active: false,
+          }),
+        ],
+      }),
+      ...buildChildStreamEntries({
+        parentStreamId: child1,
+        activeOnly: [
+          child({
+            executionId: 'r2',
+            childStreamId: grandchild1,
+            agentName: 'detail-review',
+          }),
+        ],
+      }),
     ]);
 
     const items = streamTabsDisplayItems({
       activeStreamId: grandchild1,
+      childStreamEntries,
       streams,
       parentStream: new Map([
         [child1, root],
@@ -454,23 +443,23 @@ describe('CLI stream tabs strip', () => {
       streamId(`child-${i + 1}`),
     );
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          activeSubagents: childIds.map((id, i) =>
-            child({
-              executionId: `r${i}`,
-              childStreamId: id,
-              agentName: `subagent-${i + 1}`,
-            }),
-          ),
-        }),
-      ],
+      [root, slice('root')],
       ...childIds.map((id) => [id, slice(id)] as const),
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      activeOnly: childIds.map((id, i) =>
+        child({
+          executionId: `r${i}`,
+          childStreamId: id,
+          agentName: `subagent-${i + 1}`,
+        }),
+      ),
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: childIds[2],
+      childStreamEntries,
       streams,
       parentStream: new Map(childIds.map((id) => [id, root] as const)),
       width: 20,
@@ -491,39 +480,38 @@ describe('CLI stream tabs strip', () => {
     const leanSolver = streamId('lean-stream');
     const reviewer = streamId('reviewer-stream');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_STATUS.RUNNING,
-          activeSubagents: [
-            child({
-              executionId: 'strategy',
-              childStreamId: strategy,
-              agentName: 'strategy',
-              status: STREAM_STATUS.RUNNING,
-            }),
-            child({
-              executionId: 'lean',
-              childStreamId: leanSolver,
-              agentName: 'leanSolver',
-              status: STREAM_STATUS.WAITING,
-            }),
-            child({
-              executionId: 'review',
-              childStreamId: reviewer,
-              agentName: 'reviewer',
-              status: STREAM_STATUS.RUNNING,
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
       [strategy, slice('strategy-stream', { status: STREAM_STATUS.RUNNING })],
       [leanSolver, slice('lean-stream', { status: STREAM_STATUS.WAITING })],
       [reviewer, slice('reviewer-stream', { status: STREAM_STATUS.RUNNING })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      activeOnly: [
+        child({
+          executionId: 'strategy',
+          childStreamId: strategy,
+          agentName: 'strategy',
+          status: STREAM_STATUS.RUNNING,
+        }),
+        child({
+          executionId: 'lean',
+          childStreamId: leanSolver,
+          agentName: 'leanSolver',
+          status: STREAM_STATUS.WAITING,
+        }),
+        child({
+          executionId: 'review',
+          childStreamId: reviewer,
+          agentName: 'reviewer',
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: root,
+      childStreamEntries,
       streams,
       parentStream: new Map([
         [strategy, root],
@@ -657,32 +645,31 @@ describe('CLI stream tabs strip', () => {
     const middle = streamId('middle-stream');
     const active = streamId('active-stream');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [
-        root,
-        slice('root', {
-          status: STREAM_STATUS.RUNNING,
-          activeSubagents: [
-            child({
-              executionId: 'middle',
-              childStreamId: middle,
-              agentName: 'veryLongMiddleAgent',
-              status: STREAM_STATUS.RUNNING,
-            }),
-            child({
-              executionId: 'active',
-              childStreamId: active,
-              agentName: 'activeTarget',
-              status: STREAM_STATUS.RUNNING,
-            }),
-          ],
-        }),
-      ],
+      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
       [middle, slice('middle-stream', { status: STREAM_STATUS.RUNNING })],
       [active, slice('active-stream', { status: STREAM_STATUS.RUNNING })],
     ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: root,
+      activeOnly: [
+        child({
+          executionId: 'middle',
+          childStreamId: middle,
+          agentName: 'veryLongMiddleAgent',
+          status: STREAM_STATUS.RUNNING,
+        }),
+        child({
+          executionId: 'active',
+          childStreamId: active,
+          agentName: 'activeTarget',
+          status: STREAM_STATUS.RUNNING,
+        }),
+      ],
+    });
 
     const items = streamTabsDisplayItems({
       activeStreamId: active,
+      childStreamEntries,
       streams,
       parentStream: new Map([
         [middle, root],

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -18,8 +18,6 @@ import {
   activeStreamId,
   rootRunStartAvailable,
   rootStreamId,
-  parentStream,
-  setParentStream,
   removeStream,
   resetCliState,
   patchStream,
@@ -55,7 +53,9 @@ import {
   applySubagentRoster,
   childStreamEntries,
   isChildStreamRemoved,
+  parentStream,
   retainedChildStreamsFor,
+  setParentStream,
   visibleSubagentRows,
 } from '@cli/chat/tui/state/childExecutions';
 import {
@@ -3621,5 +3621,18 @@ describe('child-stream ordered transition matrix', () => {
     expect(parentStream.get().get(kid)).toBeUndefined();
     expect(activeRows(parentP)).toEqual([]);
     expect(retainedRows(parentP)).toEqual([]);
+  });
+
+  it('12. identical roster snapshot applied twice is a no-op (no store write)', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    const entriesAfterFirst = childStreamEntries.get();
+
+    // The runtime resends a fresh array/row object on every poll even when
+    // nothing changed; `rosterRow` below is a distinct object with identical
+    // field values, not `===` to the first call's row.
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+
+    expect(childStreamEntries.get()).toBe(entriesAfterFirst);
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -23,6 +23,7 @@ import {
   removeStream,
   resetCliState,
   patchStream,
+  setStreamStatusInCliState,
   streams,
 } from '@cli/chat/tui/state/cliState';
 import {
@@ -49,7 +50,14 @@ import {
 } from '@cli/chat/tui/state/focusCycle';
 import { hasChildControlItems } from '@cli/chat/tui/state/childControls';
 import { focusedChildInputDisabledMessage } from '@cli/chat/tui/state/focusedChildFollowUp';
-import { visibleSubagentRows } from '@cli/chat/tui/state/childExecutions';
+import {
+  activeSubagentsFor,
+  applySubagentRoster,
+  childStreamEntries,
+  isChildStreamRemoved,
+  retainedChildStreamsFor,
+  visibleSubagentRows,
+} from '@cli/chat/tui/state/childExecutions';
 import {
   finalizeSettledPrefix,
   syncStreamLog,
@@ -125,7 +133,9 @@ describe('cliState Phase 4 fields', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     const slice = streams.get().get(root);
     expect(slice).toBeDefined();
-    expect(slice?.activeSubagents).toEqual([]);
+    expect(
+      activeSubagentsFor(root, childStreamEntries.get(), streams.get()),
+    ).toEqual([]);
     expect(slice?.activeProcesses).toEqual([]);
     expect(slice?.todos).toEqual([]);
     expect(slice?.plan).toBeNull();
@@ -157,29 +167,22 @@ describe('cliState Phase 4 fields', () => {
 
   it('removes stale child rows when a stream is removed', () => {
     activeStreamId.set(root);
+    // Roster-first (rule 3): registers both the retained history row and
+    // active membership, then the explicit edge arrives.
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'agent-1',
+        agentName: 'critic',
+        childStreamId: child1,
+        status: STREAM_STATUS.RUNNING,
+      },
+    ]);
     setParentStream(child1, root);
+    // Processes never own a stream tab, so an unrelated background process
+    // must be untouched by removing child1's stream below.
     patchStream(root, (s) => ({
       ...s,
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'history-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: 'completed',
-        },
-      ],
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'agent-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_STATUS.RUNNING,
-        },
-      ],
-      // Processes never own a stream tab, so an unrelated background process
-      // must be untouched by removing child1's stream below.
       activeProcesses: [
         {
           kind: 'process',
@@ -191,10 +194,22 @@ describe('cliState Phase 4 fields', () => {
     }));
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
 
-    expect(hasChildControlItems(streams.get().get(root), 'tasks')).toBe(true);
-    expect(hasChildControlItems(streams.get().get(root), 'subagents')).toBe(
-      true,
-    );
+    expect(
+      hasChildControlItems(
+        root,
+        childStreamEntries.get(),
+        streams.get(),
+        'tasks',
+      ),
+    ).toBe(true);
+    expect(
+      hasChildControlItems(
+        root,
+        childStreamEntries.get(),
+        streams.get(),
+        'subagents',
+      ),
+    ).toBe(true);
     expect(nextFocusForward()).toBe(child1);
 
     removeStream(child1);
@@ -202,44 +217,55 @@ describe('cliState Phase 4 fields', () => {
     const parent = streams.get().get(root);
     expect(parent).toBeDefined();
     if (!parent) throw new Error('missing parent stream');
-    expect(parent.childStreams).toEqual([]);
-    expect(parent.activeSubagents).toEqual([]);
+    expect(
+      retainedChildStreamsFor(root, childStreamEntries.get(), streams.get()),
+    ).toEqual([]);
+    expect(
+      activeSubagentsFor(root, childStreamEntries.get(), streams.get()),
+    ).toEqual([]);
     // Unaffected: process-1 never referenced child1's stream.
     expect(parent.activeProcesses).toMatchObject([
       { executionId: 'process-1' },
     ]);
-    expect(visibleSubagentRows(parent)).toEqual([]);
+    expect(
+      visibleSubagentRows(root, childStreamEntries.get(), streams.get()),
+    ).toEqual([]);
+    expect(isChildStreamRemoved(child1)).toBe(true);
     // Still true: the untouched process-1 counts as a task-mode item.
-    expect(hasChildControlItems(parent, 'tasks')).toBe(true);
-    expect(hasChildControlItems(parent, 'subagents')).toBe(false);
+    expect(
+      hasChildControlItems(
+        root,
+        childStreamEntries.get(),
+        streams.get(),
+        'tasks',
+      ),
+    ).toBe(true);
+    expect(
+      hasChildControlItems(
+        root,
+        childStreamEntries.get(),
+        streams.get(),
+        'subagents',
+      ),
+    ).toBe(false);
     expect(nextFocusForward()).toBeUndefined();
   });
 
   it('updates retained child rows when a failed subagent leaves the active list', () => {
     const dispose = subscribeStreamStatus();
     try {
-      patchStream(root, (s) => ({
-        ...s,
-        activeSubagents: [
-          {
-            kind: 'subagent',
-            executionId: 'agent-1',
-            agentName: 'codex',
-            childStreamId: child1,
-            status: STREAM_STATUS.RUNNING,
-          },
-        ],
-        childStreams: [
-          {
-            kind: 'subagent',
-            executionId: 'agent-1',
-            agentName: 'codex',
-            childStreamId: child1,
-            status: STREAM_STATUS.RUNNING,
-          },
-        ],
-      }));
-      patchStream(root, (s) => ({ ...s, activeSubagents: [] }));
+      applySubagentRoster(root, [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'codex',
+          childStreamId: child1,
+          status: STREAM_STATUS.RUNNING,
+        },
+      ]);
+      // A later, empty roster clears active membership; the retained row
+      // survives and its status is read live from the child's own slice.
+      applySubagentRoster(root, []);
 
       StreamStatusService.transition(
         child1,
@@ -247,10 +273,13 @@ describe('cliState Phase 4 fields', () => {
         'restart-repair',
       );
 
-      const parent = streams.get().get(root);
-      expect(parent?.activeSubagents).toEqual([]);
-      expect(parent?.childStreams[0]?.status).toBe(STREAM_PHASE.FAILED);
-      expect(visibleSubagentRows(parent!)).toMatchObject([
+      expect(
+        activeSubagentsFor(root, childStreamEntries.get(), streams.get()),
+      ).toEqual([]);
+      expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.FAILED);
+      expect(
+        visibleSubagentRows(root, childStreamEntries.get(), streams.get()),
+      ).toMatchObject([
         {
           kind: 'subagent',
           executionId: 'agent-1',
@@ -1452,18 +1481,15 @@ describe('CLI TUI row allocation', () => {
 
   it('ignores stale child row status when routing focused child follow-ups', () => {
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(root, (s) => ({
-      ...s,
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'child-exec-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_PHASE.COMPLETED,
-        },
-      ],
-    }));
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'child-exec-1',
+        agentName: 'critic',
+        childStreamId: child1,
+        status: STREAM_PHASE.COMPLETED,
+      },
+    ]);
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     setParentStream(child1, root);
 
@@ -1476,18 +1502,15 @@ describe('CLI TUI row allocation', () => {
 
   it('uses child slice status as a fallback for focused child follow-ups', () => {
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(root, (s) => ({
-      ...s,
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'child-exec-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_STATUS.RUNNING,
-        },
-      ],
-    }));
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'child-exec-1',
+        agentName: 'critic',
+        childStreamId: child1,
+        status: STREAM_STATUS.RUNNING,
+      },
+    ]);
     patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.CANCELLED }));
     setParentStream(child1, root);
 
@@ -1588,18 +1611,15 @@ describe('CLI TUI row allocation', () => {
   it('mirrors running child status events into focused child routing', () => {
     const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(root, (s) => ({
-      ...s,
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'child-exec-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_PHASE.COMPLETED,
-        },
-      ],
-    }));
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'child-exec-1',
+        agentName: 'critic',
+        childStreamId: child1,
+        status: STREAM_PHASE.COMPLETED,
+      },
+    ]);
     patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.CANCELLED }));
     setParentStream(child1, root);
 
@@ -1612,9 +1632,13 @@ describe('CLI TUI row allocation', () => {
 
       activeStreamId.set(child1);
       expect(streams.get().get(child1)?.status).toBe(STREAM_STATUS.RUNNING);
-      expect(streams.get().get(root)?.childStreams[0]?.status).toBe(
-        STREAM_STATUS.RUNNING,
-      );
+      expect(
+        retainedChildStreamsFor(
+          root,
+          childStreamEntries.get(),
+          streams.get(),
+        )[0]?.status,
+      ).toBe(STREAM_STATUS.RUNNING);
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'accept',
         streamId: child1,
@@ -1627,18 +1651,15 @@ describe('CLI TUI row allocation', () => {
   it('mirrors stopped child status events into focused child routing', () => {
     const dispose = subscribeStreamStatus();
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(root, (s) => ({
-      ...s,
-      childStreams: [
-        {
-          kind: 'subagent',
-          executionId: 'child-exec-1',
-          agentName: 'critic',
-          childStreamId: child1,
-          status: STREAM_STATUS.RUNNING,
-        },
-      ],
-    }));
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'child-exec-1',
+        agentName: 'critic',
+        childStreamId: child1,
+        status: STREAM_STATUS.RUNNING,
+      },
+    ]);
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     setParentStream(child1, root);
 
@@ -1651,9 +1672,13 @@ describe('CLI TUI row allocation', () => {
 
       activeStreamId.set(child1);
       expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.CANCELLED);
-      expect(streams.get().get(root)?.childStreams[0]?.status).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
+      expect(
+        retainedChildStreamsFor(
+          root,
+          childStreamEntries.get(),
+          streams.get(),
+        )[0]?.status,
+      ).toBe(STREAM_PHASE.CANCELLED);
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'reject',
         streamId: child1,
@@ -2621,6 +2646,9 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     };
 
     try {
+      // The child's own status is the single owner the roster selectors read
+      // from (rule 8: the roster's copied status is discarded).
+      patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
       hub.emit({
         scope: 'run',
         streamId: root,
@@ -2642,8 +2670,12 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         },
       });
 
-      expect(streams.get().get(root)?.activeSubagents).toEqual([child]);
-      expect(streams.get().get(root)?.childStreams).toEqual([child]);
+      expect(
+        activeSubagentsFor(root, childStreamEntries.get(), streams.get()),
+      ).toEqual([child]);
+      expect(
+        retainedChildStreamsFor(root, childStreamEntries.get(), streams.get()),
+      ).toEqual([child]);
       expect(parentStream.get().get(child1)).toBe(root);
       expect(parentStream.get().get(child2)).toBe(root);
     } finally {
@@ -3276,29 +3308,26 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 describe('focusCycle', () => {
   it('Ctrl-A cycles through siblings then wraps back to the parent', () => {
     activeStreamId.set(root);
+    // Only subagents own a stream tab, so both live siblings are modeled as
+    // subagents here — a background process is never itself a focus target.
+    applySubagentRoster(root, [
+      {
+        kind: 'subagent',
+        executionId: 'e1',
+        agentName: 'a',
+        childStreamId: child1,
+      },
+      {
+        kind: 'subagent',
+        executionId: 'e2',
+        agentName: 'b',
+        childStreamId: child2,
+      },
+    ]);
     setParentStream(child1, root);
     setParentStream(child2, root);
     patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
     patchStream(child2, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    patchStream(root, (s) => ({
-      ...s,
-      // Only subagents own a stream tab, so both live siblings are modeled as
-      // subagents here — a background process is never itself a focus target.
-      activeSubagents: [
-        {
-          kind: 'subagent',
-          executionId: 'e1',
-          agentName: 'a',
-          childStreamId: child1,
-        },
-        {
-          kind: 'subagent',
-          executionId: 'e2',
-          agentName: 'b',
-          childStreamId: child2,
-        },
-      ],
-    }));
     // root → first descendant.
     expect(nextFocusForward()).toBe(child1);
     // child1 → next sibling resolved through the parent's descendant list.
@@ -3324,5 +3353,273 @@ describe('focusCycle', () => {
     expect(nextFocusBack()).toBe(root);
     activeStreamId.set(root);
     expect(nextFocusBack()).toBeUndefined();
+  });
+});
+
+// Ordered event-transition matrix for the child-stream relationship map
+// (docs/proposals/cli-child-stream-state-consolidation.md, "Race-regression
+// plan" / "Ordered unit matrix"). Each scenario drives the real transition
+// functions the production event handlers call
+// (subscribeRuntimeHost.applyActiveSubagents -> applySubagentRoster,
+// subscribeRuntimeHost.applyParentStream -> setParentStream, cliState's
+// removeStream -> applyChildStreamRemoval) in the stated order and asserts
+// the load-bearing checkpoint(s) each sequence exists to prove, per the
+// design's precedence rule:
+//   removeStream tombstone > explicit edge > roster-derived parent > none.
+describe('child-stream ordered transition matrix', () => {
+  const parentP = 'parent-p' as StreamTabId;
+  const parentQ = 'parent-q' as StreamTabId;
+  const kid = 'kid' as StreamTabId;
+
+  function rosterRow(status?: string) {
+    return {
+      kind: 'subagent' as const,
+      executionId: 'kid-exec',
+      agentName: 'kid-agent',
+      childStreamId: kid,
+      status,
+    };
+  }
+
+  function activeRows(parent: StreamTabId) {
+    return activeSubagentsFor(parent, childStreamEntries.get(), streams.get());
+  }
+
+  function retainedRows(parent: StreamTabId) {
+    return retainedChildStreamsFor(
+      parent,
+      childStreamEntries.get(),
+      streams.get(),
+    );
+  }
+
+  it('1. canonical order: A, S(running), R_P+, E_P+', () => {
+    patchStream(kid, (s) => ({ ...s, status: undefined }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+
+    expect(parentStream.get().get(kid)).toBe(parentP);
+    expect(activeRows(parentP)).toMatchObject([
+      { status: STREAM_STATUS.RUNNING },
+    ]);
+    expect(retainedRows(parentP)).toMatchObject([
+      { status: STREAM_STATUS.RUNNING },
+    ]);
+  });
+
+  it('2. roster first: R_P+, A, S(running), E_P+', () => {
+    applySubagentRoster(parentP, [rosterRow()]);
+    patchStream(kid, (s) => ({ ...s, status: undefined }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    setParentStream(kid, parentP);
+
+    expect(parentStream.get().get(kid)).toBe(parentP);
+    expect(activeRows(parentP)).toHaveLength(1);
+    expect(retainedRows(parentP)).toHaveLength(1);
+  });
+
+  it('3. edge first: E_P+, A, S(running), R_P+', () => {
+    setParentStream(kid, parentP);
+    // The roster hasn't arrived yet, but the edge alone already makes the
+    // child reachable from the focus cycle once its slice exists (invariant
+    // 6: an edge-only child is focusable once its StreamSlice exists).
+    patchStream(kid, (s) => ({ ...s, status: undefined }));
+    expect(parentStream.get().get(kid)).toBe(parentP);
+
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+
+    expect(activeRows(parentP)).toHaveLength(1);
+    expect(retainedRows(parentP)).toHaveLength(1);
+  });
+
+  it('4. status first: S(running), A, E_P+, R_P+', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    setParentStream(kid, parentP);
+    applySubagentRoster(parentP, [rosterRow()]);
+
+    expect(parentStream.get().get(kid)).toBe(parentP);
+    expect(activeRows(parentP)).toMatchObject([
+      { status: STREAM_STATUS.RUNNING },
+    ]);
+  });
+
+  it('5. completion: A, S(running), R_P+, E_P+, R_P-, S(terminal)', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+
+    // Untrack (roster omission) arrives before the terminal status.
+    applySubagentRoster(parentP, []);
+    expect(activeRows(parentP)).toEqual([]);
+    expect(retainedRows(parentP)).toHaveLength(1);
+
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.COMPLETED }));
+
+    expect(activeRows(parentP)).toEqual([]);
+    expect(retainedRows(parentP)).toMatchObject([
+      { status: STREAM_PHASE.COMPLETED },
+    ]);
+  });
+
+  it('6. promotion with stale roster: A, S(running), R_P+, E_P+, E0, R_P+', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    setParentStream(kid, parentP);
+
+    setParentStream(kid, null);
+    expect(parentStream.get().has(kid)).toBe(false);
+
+    // A stale roster from the former parent must not resurrect the edge or
+    // active membership.
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+
+    expect(parentStream.get().has(kid)).toBe(false);
+    expect(activeRows(parentP)).toEqual([]);
+    // The historical row remains reachable from the former parent.
+    expect(retainedRows(parentP)).toMatchObject([{ executionId: 'kid-exec' }]);
+  });
+
+  it('7. explicit reattachment: (6) then E_Q+, R_Q+, R_P+', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    setParentStream(kid, parentP);
+    setParentStream(kid, null);
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+
+    setParentStream(kid, parentQ);
+    applySubagentRoster(parentQ, [rosterRow(STREAM_STATUS.RUNNING)]);
+    // Late roster from the old parent must not erase active membership or
+    // metadata under the new parent.
+    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+
+    expect(parentStream.get().get(kid)).toBe(parentQ);
+    expect(activeRows(parentQ)).toMatchObject([{ executionId: 'kid-exec' }]);
+    expect(activeRows(parentP)).toEqual([]);
+    // The historical row from the first parent survives (invariant 5/6).
+    expect(retainedRows(parentP)).toMatchObject([{ executionId: 'kid-exec' }]);
+  });
+
+  it('8. child removal with late facts: (5) then X(child), R_P+, E_P+, A, S(terminal)', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+    applySubagentRoster(parentP, []);
+    setStreamStatusInCliState({
+      status: STREAM_PHASE.COMPLETED,
+      streamId: kid,
+    });
+
+    removeStream(kid);
+    expect(isChildStreamRemoved(kid)).toBe(true);
+
+    // Every later fact for the removed id must remain suppressed — status
+    // facts go through `setStreamStatusInCliState` (the actual production
+    // fact-application path), which checks the tombstone directly; a raw
+    // `patchStream` call (used elsewhere in this file as a low-level test
+    // shortcut) intentionally has no such guard.
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+    setStreamStatusInCliState({ status: STREAM_STATUS.RUNNING, streamId: kid });
+
+    expect(activeRows(parentP)).toEqual([]);
+    expect(retainedRows(parentP)).toEqual([]);
+    expect(parentStream.get().has(kid)).toBe(false);
+    expect(streams.get().has(kid)).toBe(false);
+  });
+
+  it('9. fresh activation after removal uses a distinct id, not the removed one', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+    removeStream(kid);
+
+    const freshKid = 'kid-2' as StreamTabId;
+    patchStream(freshKid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    setParentStream(freshKid, parentP);
+    applySubagentRoster(parentP, [
+      {
+        kind: 'subagent',
+        executionId: 'kid-2-exec',
+        agentName: 'kid-agent',
+        childStreamId: freshKid,
+        status: STREAM_STATUS.RUNNING,
+      },
+    ]);
+
+    expect(isChildStreamRemoved(kid)).toBe(true);
+    expect(activeRows(parentP)).toMatchObject([{ childStreamId: freshKid }]);
+    expect(parentStream.get().get(freshKid)).toBe(parentP);
+  });
+
+  it('10. two-child retention keeps stable order across reordering and shrinking rosters', () => {
+    const kidA = 'kid-a' as StreamTabId;
+    const kidB = 'kid-b' as StreamTabId;
+    const rowA = (status?: string) => ({
+      kind: 'subagent' as const,
+      executionId: 'exec-a',
+      agentName: 'a',
+      childStreamId: kidA,
+      status,
+    });
+    const rowB = (status?: string) => ({
+      kind: 'subagent' as const,
+      executionId: 'exec-b',
+      agentName: 'b',
+      childStreamId: kidB,
+      status,
+    });
+    patchStream(kidA, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kidB, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+
+    // First-seen order: A then B.
+    applySubagentRoster(parentP, [rowA(), rowB()]);
+    expect(retainedRows(parentP).map((r) => r.childStreamId)).toEqual([
+      kidA,
+      kidB,
+    ]);
+
+    // A later roster reorders (B, A) — retained order must not change.
+    applySubagentRoster(parentP, [rowB(), rowA()]);
+    expect(retainedRows(parentP).map((r) => r.childStreamId)).toEqual([
+      kidA,
+      kidB,
+    ]);
+
+    // Shrink to just B; A completes.
+    applySubagentRoster(parentP, [rowB()]);
+    patchStream(kidA, (s) => ({ ...s, status: STREAM_PHASE.COMPLETED }));
+
+    expect(activeRows(parentP).map((r) => r.childStreamId)).toEqual([kidB]);
+    // Retained order is still stable and A's historical row survives.
+    expect(retainedRows(parentP).map((r) => r.childStreamId)).toEqual([
+      kidA,
+      kidB,
+    ]);
+    expect(
+      visibleSubagentRows(parentP, childStreamEntries.get(), streams.get()).map(
+        (r) => r.status,
+      ),
+    ).toEqual([STREAM_PHASE.COMPLETED, STREAM_STATUS.RUNNING]);
+  });
+
+  it('11. parent removal with late facts: P -> child, X(P), R_P+, E_P+', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+    patchStream(parentP, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+
+    removeStream(parentP);
+    expect(isChildStreamRemoved(parentP)).toBe(true);
+
+    // Late facts naming the removed parent must not resurrect it as an
+    // ancestor anywhere.
+    applySubagentRoster(parentP, [rosterRow()]);
+    setParentStream(kid, parentP);
+
+    expect(parentStream.get().get(kid)).toBeUndefined();
+    expect(activeRows(parentP)).toEqual([]);
+    expect(retainedRows(parentP)).toEqual([]);
   });
 });

--- a/src/test-kernel/support/childStreamEntries.ts
+++ b/src/test-kernel/support/childStreamEntries.ts
@@ -1,0 +1,104 @@
+// Test-only builder for the CLI TUI's `ChildStreamEntries` map
+// (`packages/cli/src/chat/tui/state/childExecutions.ts`). Selector-level
+// suites (ChildControls, StreamTabsStrip, ResumeHint, ConversationPane) build
+// an already-settled map directly here instead of driving
+// `applySubagentRoster`/`setParentStream` through a real event sequence —
+// ordering/race-transition coverage belongs to the ordered matrix in
+// TuiStateAndFocus.vitest.mts.
+
+import type {
+  ChildStreamEntries,
+  ChildStreamEntry,
+} from '@cli/chat/tui/state/childExecutions';
+import type { StreamTabId, SubagentChildInfo } from '@shared/schemas';
+
+export interface ChildStreamEntryRow extends SubagentChildInfo {
+  /** Explicit current edge, when the row needs one beyond the retained/active
+   *  parent implied by its placement. `null` marks an explicit promotion. */
+  readonly edgeParentStreamId?: StreamTabId | null;
+  readonly removed?: boolean;
+  /** Set `false` for a retained row that has left the active roster (e.g. it
+   *  completed) while its retained history row remains. Defaults to `true`. */
+  readonly active?: boolean;
+}
+
+function toEntry(
+  row: ChildStreamEntryRow,
+  parentDefaults: {
+    readonly activeParentStreamId?: StreamTabId;
+    readonly edgeParentStreamId?: StreamTabId | null;
+    readonly retainedParentStreamId?: StreamTabId;
+    readonly retainedOrder?: number;
+  },
+): ChildStreamEntry {
+  const {
+    childStreamId: _childStreamId,
+    status: _status,
+    edgeParentStreamId,
+    removed,
+    active,
+    ...summary
+  } = row;
+  return {
+    summary,
+    activeParentStreamId:
+      active === false ? undefined : parentDefaults.activeParentStreamId,
+    retainedParentStreamId: parentDefaults.retainedParentStreamId,
+    retainedOrder: parentDefaults.retainedOrder,
+    edgeParentStreamId: edgeParentStreamId ?? parentDefaults.edgeParentStreamId,
+    removed: removed ?? false,
+  };
+}
+
+/**
+ * Build a `ChildStreamEntries` map for one parent: `retained` rows (in
+ * order) get both retained and active membership; `activeOnly` rows get an
+ * explicit edge plus active membership without a retained association under
+ * this parent (the cross-parent-reattachment / partial-state shape
+ * `visibleSubagentRows` falls back over — effective parent still resolves to
+ * `parentStreamId` via the edge, matching what a real `setParentStream` +
+ * roster-without-first-retention sequence produces). Merge maps from
+ * multiple calls with `new Map([...a, ...b])` for multi-parent fixtures.
+ */
+export function buildChildStreamEntries(init: {
+  readonly parentStreamId: StreamTabId;
+  readonly retained?: readonly ChildStreamEntryRow[];
+  readonly activeOnly?: readonly ChildStreamEntryRow[];
+  /** Explicit `setParentStream` edge with no roster ever having supplied
+   *  display metadata — the "edge arrived, no summary yet" shape. */
+  readonly edgeOnly?: readonly StreamTabId[];
+}): ChildStreamEntries {
+  const {
+    parentStreamId,
+    retained = [],
+    activeOnly = [],
+    edgeOnly = [],
+  } = init;
+  const map = new Map<StreamTabId, ChildStreamEntry>();
+  retained.forEach((row, index) => {
+    map.set(
+      row.childStreamId,
+      toEntry(row, {
+        activeParentStreamId: parentStreamId,
+        retainedParentStreamId: parentStreamId,
+        retainedOrder: index + 1,
+      }),
+    );
+  });
+  for (const row of activeOnly) {
+    map.set(
+      row.childStreamId,
+      toEntry(row, {
+        activeParentStreamId: parentStreamId,
+        edgeParentStreamId: parentStreamId,
+      }),
+    );
+  }
+  for (const childStreamId of edgeOnly) {
+    map.set(childStreamId, {
+      edgeParentStreamId: parentStreamId,
+      removed: false,
+    });
+  }
+  return map;
+}


### PR DESCRIPTION
Implements #7951.

## What

Implements the accepted design in `docs/proposals/cli-child-stream-state-consolidation.md`
(#7941, closing #7864): consolidates the CLI TUI's three subagent-relationship
representations — the live `activeSubagents` roster, the retained `childStreams`
history, and the `parentStream` child→parent topology — into one CLI-local
`Map<StreamTabId, ChildStreamEntry>` owned by `packages/cli/src/chat/tui/state/childExecutions.ts`,
exposed only through pure selectors and transition functions.

- **New owner** (`childExecutions.ts`): `ChildStreamEntry`/`ChildStreamEntries`,
  the `CHILD_STREAMS` signal (private), transition functions
  (`setParentStream`, `applySubagentRoster`, `applyChildStreamRemoval`,
  `resetChildStreamEntries`), and selectors (`activeSubagentsFor`,
  `retainedChildStreamsFor`, `visibleSubagentRows`, `focusOrderDescendants`,
  `isChildStreamRemoved`, plus the derived `parentStream` and
  `childStreamEntries` computed signals). Implements the precedence rule from
  the design's "Authority and transition semantics": `removeStream` tombstone
  > explicit edge > roster-derived parent > none, with status read live from
  each child's own `StreamSlice` (no status field on `ChildStreamEntry`, so
  `updateChildStatusReferences`/`withMirroredChildStreamStatus`/the three-list
  status traversal in `setStreamStatusInCliState` are deleted entirely).
- **`cliState.ts`**: `activeSubagents`/`childStreams` removed from
  `StreamSlice`; `parentStream`/`setParentStream` are now thin re-exports of
  the `childExecutions.ts` owner (same import path, same names — zero
  call-site churn for those two symbols specifically); `removeStream` and
  `resetCliState` now delegate the child-stream half of their job to
  `applyChildStreamRemoval`/`resetChildStreamEntries`.
- **One atomic cutover**, no dual-write stage: `subscribeRuntimeHost.ts`'s
  `applyActiveSubagents`/`applyParentStream` route directly to
  `applySubagentRoster`/`setParentStream`; every CLI reader (`App.tsx`,
  `StatusBar.tsx`, `StreamTabsStrip.tsx`, `StaticConversationTranscript.tsx`,
  `SubagentList.tsx`, `ChildControlPicker.tsx`, `childControls.ts`,
  `streamViews.ts`, `focusCycle.ts`, `resumeHint.ts`,
  `focusedChildFollowUp.ts`, `runChatTui.tsx`) switched to the selectors in
  the same commit.
- **Dev harness** (`packages/cli/scripts/tui-harness.tsx`) seeds through the
  real `applySubagentRoster`/`setParentStream` transition functions instead of
  poking `StreamSlice` fields directly.
- **Bug fix in `useSignal.ts`** (found by running the existing `validate:tui`
  PTY harness against this diff, see Verification): `parentStream` is now a
  `Signal.Computed` (previously a plain `Signal.State`) — the first CLI
  `Computed` ever routed through `useSignal`. `useSyncExternalStore` can call
  our `getSnapshot` synchronously from inside `notify()` while a signal
  `.set()` call is still unwinding its watcher notifications; reading a
  `Computed` there recomputes it, which itself reads further signals — and
  `Signal.subtle.Watcher` asserts against exactly that ("signal read during
  notification phase"). `/clear` (`resetCliState()`, which fires several
  `.set()` calls back-to-back including the new `resetChildStreamEntries()`)
  crashed the harness on `main`-plus-this-diff before the fix. Fixed by
  deferring `notify()` to a microtask, mirroring `@lit-labs/signals`'s own
  `SignalWatcher`/`effectWatcher`, which already uses exactly this pattern
  internally for the same reason.

## Why

`activeSubagents`, `childStreams`, and `parentStream` were three views of one
child-stream relationship, mutated independently with duplicated
status-mirroring machinery (`updateChildStatusReferences`,
`withMirroredChildStreamStatus`, a three-list traversal in
`setStreamStatusInCliState`) that risked drift between them. The design doc's
load-bearing race census (roster-before-edge, edge-before-roster,
completion-before-terminal-status, promotion with a stale roster,
reattachment, removal with late facts) drove the transition semantics and the
test matrix below.

## Verification

```
npm run typecheck          # root + test-kernel + cli + desktop + extension + trace-viewer — all green
npm run check:cli-architecture
npm run lint                # 0 errors (pre-existing import/order warnings elsewhere, untouched files)
npm test                    # 621 files / 5459 tests passed, 1 file / 4 tests skipped (pre-existing)
npx vitest run src/test-kernel/cli/   # 128 files / 1652 tests passed
npm run validate:tui       # PTY harness: 79/80 scenarios pass; the 1 failure
                            # (model-switch-compatible-only, "GPT-5.5" missing)
                            # is a pre-existing hardcoded-model-name mismatch in
                            # validate-tui.mjs unrelated to this diff (verified:
                            # it references a model list this PR never touches)
```

`TuiStateAndFocus.vitest.mts` gained a new `describe('child-stream ordered
transition matrix', ...)` covering the design's 11-sequence ordered unit
matrix (canonical/roster-first/edge-first/status-first orderings, completion,
promotion-with-stale-roster, explicit reattachment, child removal with late
facts, fresh activation after removal, two-child retention order stability,
parent removal with late facts), asserting effective parent, active rows, and
retained rows at the load-bearing checkpoints in each sequence — driven
through the real `applySubagentRoster`/`setParentStream`/`removeStream`/
`setStreamStatusInCliState` functions, not hand-built state. One of these
(scenario 8) is a proven regression test: it fails if `setStreamStatusInCliState`'s
tombstone guard is removed (verified locally by reverting that guard).

`ChildControls.vitest.mts`, `StreamTabsStrip.vitest.mts`, `ResumeHint.vitest.mts`,
and 2 fixtures in `ConversationPane.vitest.mts` were converted from
`StreamSlice.activeSubagents`/`childStreams` fixtures to a new shared
selector-level test builder, `src/test-kernel/support/childStreamEntries.ts`
(`buildChildStreamEntries`), used by all four files — a DRY extraction, not a
new test suite (R7): it has no `it`/`describe` of its own and follows the
existing `test-kernel/support/` convention (`FakePlatform.ts`,
`asyncTestUtils.ts`, ...).

### Not completed in this PR

The design's acceptance-gate items 4-5 ask for byte-identical PTY frame
checks for order-equivalent cases via a new opt-in
`HARNESS_CHILD_EVENT_ORDER` fixture in `packages/cli/scripts/tui-harness.tsx`
plus `validate-tui.mjs` assertions. That fixture was not built in this PR —
the vitest-level ordered matrix above is real, event-sequence-driven coverage
of the same 11 scenarios (through the production transition functions), but
it is not the rendered-byte-level PTY layer the design calls for. I ran the
**existing, unmodified** `npm run validate:tui` scenarios against this diff:
79/80 pass (the 1 failure is pre-existing and unrelated — see Verification),
including a crash the harness caught in `slash-clear` that this PR's
`useSignal.ts` fix resolves (see "Bug fix in `useSignal.ts`" above) — real
evidence the rendered TUI is not regressed for every scenario the current
harness exercises, short of the new event-ordering fixture. Filing a
follow-up issue for the `HARNESS_CHILD_EVENT_ORDER` fixture and the
byte-identical frame assertions is recommended before this is considered
fully gate-complete.

## Net elements (R6)

Using the method in `fewer-elements-2026-07.md` (files from the diffstat,
`^[+-]export` over the diff, class/interface/enum declarations the same way),
measured on the actual diff (this PR replaces the design doc's estimates):

- **Production files:** 17 modified, 0 added (deepened the existing
  `childExecutions.ts` per the design's preference, no new module; includes
  the `useSignal.ts` bug fix). Design estimated "add 0... modify
  approximately 12-16": close (one more file than the high end, for the
  signal-phase fix the design didn't anticipate).
- **Production lines:** net **+320** (724 insertions / 404 deletions). Design
  estimated net **-40 to -100**; the difference is almost entirely the new
  `childExecutions.ts` transition/selector bodies plus doc comments — the
  design's own estimate flagged this range as approximate and gated a
  positive *production*-line result on maintainer re-review, which this PR
  requests.
- **Class/interface/enum declarations:** delete 1 (`ParentStreamEdgeUpdate`),
  add 1 (`ChildStreamEntry`) — **net 0**, matching the design's estimate
  exactly.
- **Authoritative mutable collections:** delete 3 (`StreamSlice.activeSubagents`,
  `StreamSlice.childStreams`, the `PARENT_STREAM` signal), add 1
  (`CHILD_STREAMS`, private) — **net -2**, matching the design's estimate
  exactly.
- **Exported-symbol delta (`^[+-]export` line count):** **+17 / -8, net +9**.
  This diverges from the design's estimate (`+2/-5, net -3` via "one narrow
  owner facade"). I chose flat top-level exports
  (`activeSubagentsFor`/`retainedChildStreamsFor`/`applySubagentRoster`/
  `applyChildStreamRemoval`/`isChildStreamRemoved`/`resetChildStreamEntries`/
  `focusOrderDescendants`/the two computed signals) over bundling them into
  one facade object, specifically so `parentStream` and `setParentStream` —
  used across 16+ consumer files and dozens of tests — keep their exact prior
  export names and import path (`./cliState`), at zero call-site churn for
  those two symbols. Semantically: 2 exported symbols are deleted
  (`registerChildStreams`, `mergeChildStreams`); 10 are genuinely new
  capability (the interface/type, the 4 new selectors, 3 of the transition
  functions, and the new `childStreamEntries` computed signal) — a net **+8**
  new *symbols*, not just diff-line noise, though inflated further to +9 by
  the mechanical line-count method double-counting unchanged functions
  (`childExecutionKey`/`childExecutionLabel`) that moved within the same file
  during a full-file rewrite. This is a deliberate, disclosed tradeoff between
  R5 (minimal consumer-facing diff) and R6 (exported-symbol delta), flagged
  here per the design's own instruction that a positive delta needs a stated
  reason and is subject to explicit maintainer re-review, not a silent
  pass/fail.
- **Callable declarations** (`function`/arrow-function declarations):
  **+15 / -18, net -3** in production code.
- **Test files:** 5 modified, 1 added (`src/test-kernel/support/childStreamEntries.ts`,
  a shared test-fixture builder, not a test suite — see "Verification" above).
- **Test lines:** net **+493** (1159 insertions / 666 deletions), close to the
  design's estimated **+200 to +320** but higher, mostly the new 11-scenario
  ordered matrix (~230 lines) plus the mechanical fixture-shape rewrite across
  4 existing files.
- **Whole-diff net lines:** **+813** (23 files, 1883 insertions / 1070
  deletions), above the design's stated **+100 to +280** range. Per the
  design's own R6 gate language ("A non-negative production-line result or
  whole-diff result above the stated range requires explicit maintainer
  re-review even if tests pass"), this PR is explicitly flagged for that
  re-review rather than asserting compliance.
- **New shared planes, vocabularies, schemas, reducers, or persistence
  stores:** **0** — nothing added under `src/shared/` or the webview; the
  event hub and `StreamSnapshotStore` are unchanged (acceptance-gate item 7).
- `activeProcesses` and its output lifecycle are untouched (acceptance-gate
  item 6).

## Consumer counts (R8)

Grep-verified caller counts (excluding `childExecutions.ts` itself) before
treating any of these as a justified shared selector:

- `activeSubagentsFor`: 6 files
- `retainedChildStreamsFor`: 2 files
- `visibleSubagentRows`: 8 files
- `applySubagentRoster`: 4 files
- `applyChildStreamRemoval`: 2 files (`cliState.removeStream`, the new ordered
  test matrix)
- `isChildStreamRemoved`: 3 files
- `childStreamEntries` (the computed signal): 17 files
- `focusOrderDescendants`: 1 file (`focusCycle.ts`'s
  `orderedDescendantsFromTree` wrapper, itself called from 2 sites) — kept as
  its own selector, not inlined, because it is exactly the composed selector
  the design specifies (retained-first-then-topology, `streams.has()`-gated)
  and is the unit under direct test in the ordered matrix.
- `resetChildStreamEntries`: 1 file (`cliState.resetCliState`) — matches the
  existing one-call-site reset-hook pattern every other slice in `cliState.ts`
  already uses.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor of CLI focus routing, subagent UI, and stream removal semantics with many touchpoints; behavior is heavily tested but event-ordering edge cases are complex.
> 
> **Overview**
> **Child-stream state** moves from three independently mutated views (`StreamSlice.activeSubagents`, `childStreams`, and a writable `parentStream` map) into a single signal-backed `CHILD_STREAMS` map in `childExecutions.ts`, with transitions (`applySubagentRoster`, `setParentStream`, `applyChildStreamRemoval`) and selectors (`activeSubagentsFor`, `retainedChildStreamsFor`, `visibleSubagentRows`, derived `parentStream`). Child **status** is no longer mirrored on parent slices; selectors read each child's `StreamSlice` instead, so status-copy machinery in `cliState` is removed.
> 
> **Consumers** (App, status bar, stream tabs, subagent panel, child controls, resume hints, runtime subscription, TUI harness) now pass `childStreamEntries` and call the selectors rather than reading slice fields. `removeStream` / `resetCliState` tombstone or reset relationship state through the new module.
> 
> **`useSignal`** defers watcher `notify()` to a microtask so subscribing to `Signal.Computed` (e.g. `parentStream`) does not recompute during the notification phase—fixing harness crashes on rapid resets like `/clear`.
> 
> Tests add an ordered transition matrix and shared `buildChildStreamEntries` fixtures; production net is more lines than the design estimated due to the new owner implementation and comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1dbf6c4a017356cef5bac75efaebcb31288ada4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->