### PR TITLE
Fix false-success CLI wakes for child follow-ups

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -418,7 +418,7 @@ export function createChatSessionController(
 
   const tryResumeStream = (streamId: StreamTabId): Promise<boolean> => {
     if (!chatTuiCanStartRootRun(session)) {
-      return Promise.resolve(true);
+      return Promise.resolve(false);
     }
 
     let resolveRun: (resumed: boolean) => void = () => {};

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -717,6 +717,12 @@ export async function runChat(
           delivered = true;
         } else if (result.status === 'queued') {
           emitQueuedFollowUpsChanged(followUpTarget);
+          if (
+            defaultSession().executions.isChildRunLoopActive(followUpTarget)
+          ) {
+            delivered = true;
+            return;
+          }
           const wake = await wakeQueuedFollowUpStream(followUpTarget, result);
           const presentation = presentFollowUpWakeResult(wake);
           if (presentation.severity !== 'none') {

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -425,23 +425,13 @@ async function deliverTurn<TTurn>(params: {
 }
 
 /**
- * Stream ids with a live loop currently blocked in `queue.waitAndDrainAll`,
- * in this process. `delegate_agent`'s resume path (`sendFollowUp` +
- * `wakeQueuedFollowUpStream`) uses this to skip the generic host-level wake
- * for a stream the loop is already listening on: enqueueing into that same
- * `FollowUpQueue` instance resolves the loop's pending wait directly (see
- * `FollowUpQueue.enqueueItem`), so an additional wake would race a second,
- * competing resume through `resolveAndResumeStream`'s host-level
- * restart-recovery path against this loop's own in-flight continuation. A
- * stream with no live loop here (a genuine restart, or a root/non-loop run)
- * still needs that generic wake — this set only ever suppresses a redundant
- * one.
+ * True when this session owns a live child-run loop for `streamId`. Enqueueing
+ * into that loop's `FollowUpQueue` wakes its pending wait directly, so callers
+ * use this to avoid racing a second host-level resume. A genuine restart has
+ * no registered loop and still needs the generic wake path.
  */
-const activeChildRunLoops = new Set<StreamTabId>();
-
-/** True when a child-run loop is currently alive (blocked between turns or mid-turn) for `streamId` in this process. */
 export function isChildRunLoopActive(streamId: StreamTabId): boolean {
-  return activeChildRunLoops.has(streamId);
+  return currentSession().executions.isChildRunLoopActive(streamId);
 }
 
 /**
@@ -482,7 +472,8 @@ export function startChildRunLoop<TTurn>(
     detachLoopInterrupt = handle.attachInterruptHandler(loop);
   };
   attachLoopInterrupt();
-  activeChildRunLoops.add(childStreamId);
+  const unregisterChildRunLoop =
+    runSession.executions.registerChildRunLoop(childStreamId);
 
   const sessionStage = childStream
     ? logger.openStage(strategy.stageLabel)
@@ -601,7 +592,7 @@ export function startChildRunLoop<TTurn>(
       }
     } finally {
       detachLoopInterrupt?.();
-      activeChildRunLoops.delete(childStreamId);
+      unregisterChildRunLoop();
       runSession.followUps.release(childStreamId);
       strategy.onSessionCleanup?.();
       params.recordCost?.(latestCostUsd);

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -132,6 +132,7 @@ export type ManualCompactionRequestResult =
  */
 export class ExecutionRegistry {
   private readonly handles = new Map<string, ExecutionHandle>();
+  private readonly activeChildRunLoops = new Set<StreamTabId>();
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
   private readonly disposeStatusListener: () => void;
   private readonly processOutput: ProcessOutputPoller;
@@ -216,12 +217,26 @@ export class ExecutionRegistry {
     this.disposeStatusListener();
     const executionIds = [...this.handles.keys()];
     this.handles.clear();
+    this.activeChildRunLoops.clear();
     this.processOutput.dispose();
     for (const executionId of executionIds) {
       this.notifyWaiters(executionId);
     }
     this.changeCallbacks.clear();
     this.persistentListeners.clear();
+  }
+
+  /** Register a live child-run loop and return its lifecycle disposer. */
+  registerChildRunLoop(streamId: StreamTabId): () => void {
+    this.activeChildRunLoops.add(streamId);
+    return () => {
+      this.activeChildRunLoops.delete(streamId);
+    };
+  }
+
+  /** True while this session owns a live child-run loop for `streamId`. */
+  isChildRunLoopActive(streamId: StreamTabId): boolean {
+    return this.activeChildRunLoops.has(streamId);
   }
 
   /** Register an execution handle. */

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -381,7 +381,7 @@ describe('createChatSessionController', () => {
     expect(session.runCompleted).toBe(true);
   });
 
-  it('treats a busy CLI root slot as a non-dropping wake outcome', async () => {
+  it('declines a wake while the CLI root slot is busy', async () => {
     const session = makeSession({
       runPromise: new Promise(() => {}),
       runCompleted: false,
@@ -391,7 +391,7 @@ describe('createChatSessionController', () => {
       makeInit({ session, snapshotStore }),
     );
 
-    await expect(ctrl.tryResumeStream('child-stream')).resolves.toBe(true);
+    await expect(ctrl.tryResumeStream('child-stream')).resolves.toBe(false);
 
     expect(snapshotStore.preload).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- make the CLI resume port reject a wake while the root run slot is busy instead of reporting false success
- let a live child-run loop consume its focused follow-up directly without racing the generic restart wake
- move live child-loop ownership into the session-scoped `ExecutionRegistry` as the single source of truth

## Root cause

The CLI resume handler returned `true` whenever another root run occupied the session, even though it neither loaded nor resumed the requested persisted stream. Callers interpreted that as `resumed` and suppressed failure presentation. Live child loops do not need that generic wake because enqueueing resolves their own queue wait, so the TUI now checks the session-owned loop state before attempting restart recovery.

## Test scope

This updates the existing controller contract test rather than adding overlapping coverage. The child-loop, delegation, follow-up, TUI state, and import-boundary tests already cover the surrounding behavior.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 52 existing warnings)
- `npm test` (621 files passed, 5,448 tests passed)
- full CLI PTY harness (141 scenarios)
- live TTY dogfood with a focused native subagent follow-up

Closes #7966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration for CLI stream resume and child follow-up wakes—areas where races previously caused false success or duplicate resumes—but the diff is narrow and covered by an updated controller contract test.
> 
> **Overview**
> Fixes CLI follow-up and resume behavior where callers could treat a **declined** wake as success, and where a generic host-level resume could race an already-listening child-run loop.
> 
> **`tryResumeStream`** now returns **`false`** when the root run slot is busy (`chatTuiCanStartRootRun` is false), instead of **`true`** without loading or resuming anything—so wake paths no longer suppress failure UI incorrectly.
> 
> When a focused child follow-up is **queued**, the TUI checks **`defaultSession().executions.isChildRunLoopActive(followUpTarget)`** before **`wakeQueuedFollowUpStream`**. If a live loop owns that stream, enqueue alone wakes its **`FollowUpQueue`** wait, so the path marks delivery successful and skips the redundant generic restart wake.
> 
> Live child-loop registration moves from a module-level **`Set`** in **`childRunLoop`** into the session **`ExecutionRegistry`** via **`registerChildRunLoop`** / **`isChildRunLoopActive`**, cleared on registry **`dispose`**, as the single source of truth for “is this stream’s loop alive in this process?”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ce06a515a7fc3a94738e4b3780ac947dbdf746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->