### PR TITLE
Fix stale memory prompt assertion on main

### DIFF
--- a/src/test-kernel/agent/utils/promptBuilder.vitest.ts
+++ b/src/test-kernel/agent/utils/promptBuilder.vitest.ts
@@ -41,7 +41,7 @@ describe('PromptBuilder', () => {
     assert.equal(reflectPrompt, 'initial only');
   });
 
-  it('keeps memory checks relevant and schema-valid', async () => {
+  it('keeps memory checks relevant and points view at the memory root', async () => {
     const prompts = await buildInitialToolUsePrompts(
       {
         systemPrompt: 'system',
@@ -57,10 +57,7 @@ describe('PromptBuilder', () => {
       prompts.instructionSuffix,
       /do not read unpinned memory files or write memory/,
     );
-    assert.match(
-      prompts.instructionSuffix,
-      /use the `view` command with path `\/memories`/,
-    );
+    assert.match(prompts.instructionSuffix, /`view`[^`\n]*`\/memories`/);
   });
 
   it('keeps pinned-memory consultation unconditional even for self-contained requests', async () => {


### PR DESCRIPTION
## Summary

- keep the memory-root assertion behavioral instead of matching one obsolete sentence shape
- rename the test to describe the command/path contract it actually protects
- remove three lines of brittle prompt-prose coupling without adding coverage

## Root cause

Recent pinned-memory guidance changed from `use the view command with path /memories` to the equivalent `view the /memories directory`. The behavior remained correct, but the earlier test asserted the exact old prose and broke latest-main CI.

## Validation

- clean `origin/main`: targeted test reproduced the failure (1 failed, 3 passed)
- patched clean worktree: targeted test passes (4 passed)
- latest-main checkout: `npm run typecheck`, `npm run compile:fast`, and `npm run lint` pass
- latest-main full suite reached 5,471 passing tests with only this stale assertion failing before the patch

Closes #7973

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or prompt-builder edits.
> 
> **Overview**
> Updates **`promptBuilder.vitest.ts`** so memory-tool **`instructionSuffix`** checks track behavior instead of one fixed sentence.
> 
> The test is renamed to reflect that it guards the **`view`** + **`/memories`** contract. The assertion no longer requires the old phrase “use the `view` command with path `/memories`”; it now matches any wording where backtick-wrapped **`view`** appears before **`/memories`**. The unpinned-memory restriction assertion is unchanged.
> 
> No production prompt or builder logic is modified—only test coupling to prompt prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b2f052fc0cf0ac8e8980eaa61471a81ad66b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->