### PR TITLE
Fix Agent Review completion blocking

### DIFF
--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -335,6 +335,7 @@ class AgentReviewServiceImpl {
         {
           runtimeHost: extensionAgentRuntimeHost,
           openWorkflowOutput: openFinalOutputIfAvailable,
+          stopAfterCycle: true,
         },
       );
       outcome = result.outcome;


### PR DESCRIPTION
## Summary

- run the extension `changeReviewer` as a one-cycle tool-use session
- let the normal run lifecycle reach a terminal outcome and clear Agent Review's in-flight guard
- avoid a second UI/session completion listener or timeout-based cleanup

## Root cause

Agent Review awaited `runAgent()` without `stopAfterCycle`. After rendering its final response, the root tool-use reviewer entered `ToolUseWaitNode`'s interactive follow-up wait instead of returning a terminal result. The service's `finally` block therefore never ran, leaving `Reviewing changes…` and `texra.agentReview.running` stuck.

Closes #7976.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` (623 files; 5,472 passed, 4 skipped)
- focused `ToolUseWaitNode.vitest.ts` (16 passed)

No new mock test was added: `ToolUseWaitNode` already covers the `stopAfterCycle` terminal contract, and another Agent Review wrapper test would duplicate that behavior without a distinct failure oracle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-option change to extension Agent Review run behavior; aligns with existing CLI one-shot tool-use runs and fixes stuck UI state.
> 
> **Overview**
> Fixes Agent Review getting stuck on **Reviewing changes…** and leaving `texra.agentReview.running` set after the reviewer finishes.
> 
> `runAgent` for `changeReviewer` now passes **`stopAfterCycle: true`**, so the session ends with a terminal outcome after its first model/tool cycle instead of blocking in the interactive follow-up wait. That lets `runReview`'s `finally` clear the in-flight guard and update the panel summary as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2f884a1aff4fd161a5ba0dd662e6768d9be0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->