### PR TITLE
test(cli): cover persisted child wake failure

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -166,7 +166,10 @@ export interface ChatSessionController {
   /** Request stop of the active run (idempotent). */
   stop(): void;
 
-  /** Resume a queued follow-up target from the CLI platform resume port. */
+  /**
+   * Attempt to resume a queued follow-up target from the CLI platform port.
+   * Returns true only when this controller accepts the target resume.
+   */
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
 
   /** Whether a new root run can be started right now. */

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -52,6 +52,7 @@ vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
 }));
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
+  currentSession: mocks.defaultSession,
   defaultSession: mocks.defaultSession,
 }));
 
@@ -101,6 +102,7 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
 
 import { StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -376,7 +378,7 @@ describe('createChatSessionController', () => {
     expect(session.runCompleted).toBe(true);
   });
 
-  it('declines a wake while the CLI root slot is busy', async () => {
+  it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {
     const session = makeSession({
       runPromise: new Promise(() => {}),
       runCompleted: false,
@@ -386,7 +388,13 @@ describe('createChatSessionController', () => {
       makeInit({ session, snapshotStore }),
     );
 
-    await expect(ctrl.tryResumeStream('child-stream')).resolves.toBe(false);
+    await expect(
+      wakeQueuedFollowUpStream(
+        'child-stream',
+        { status: 'queued', reason: 'waiting' },
+        ctrl,
+      ),
+    ).resolves.toEqual({ kind: 'queued_resume_failed' });
 
     expect(snapshotStore.preload).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Current main already contains the production correction from `5c35766b8`:

- a busy CLI root slot returns `false` instead of claiming another stream's resume
- a registered live child loop suppresses the generic host wake
- a persisted child without a live loop continues through the ordinary wake-result policy

This PR closes the remaining regression-coverage gap:

- documents that `ChatSessionController.tryResumeStream()` returns `true` only when the controller accepts the target resume
- drives the busy-slot controller through `wakeQueuedFollowUpStream()` and asserts `queued_resume_failed`, rather than testing only the lower-level boolean
- verifies that the persisted snapshot is not preloaded while the root slot is occupied

The test composes the controller and wake policy at their real boundary. Existing child-loop lifecycle tests separately prove live-loop registration and generic-wake suppression.

## Validation

- focused controller, child-loop, wake, and delegation suites: 46 tests passed
- `npm run format`
- `npm run typecheck`
- `npm run lint`: 0 errors (51 existing warnings)
- `npm run compile:fast`
- `npm run check:cli-architecture`
- `npm run check:cli-orchestration-manifest`

## Residual Risk

There is no additional Ink end-to-end fixture in this PR. The behavior is covered by the composed controller/wake regression plus the existing live child-loop tests.

Closes #7966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production logic changes in this diff.
> 
> **Overview**
> Clarifies **`ChatSessionController.tryResumeStream()`** so its contract states it returns **`true` only when the controller accepts** the target resume (not merely that a wake was attempted).
> 
> The busy-root-slot regression is exercised at the **real integration point**: the test now drives **`wakeQueuedFollowUpStream()`** with the controller as the resume port and expects **`queued_resume_failed`**, instead of only asserting **`false`** from **`tryResumeStream()`** in isolation. It still verifies **`snapshotStore.preload`** is **not** called while the root run slot is occupied.
> 
> Test harness adds a **`currentSession`** mock alongside **`defaultSession`** so wake policy can run in the controller unit suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a902d539567b61214eb5902be1283631afb642a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->