### PR TITLE
fix(desktop): wait for tools-panel content before scroll-race probe

### DIFF
--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -114,6 +114,13 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
       tabIndex: SETTINGS_TAB_INDEX.TOOLS,
     },
   );
+  // Wait for both the tab panel to be marked active AND its tools-tab
+  // content to have finished loading. ToolsTab renders a `.loading-state`
+  // placeholder while `loaded` is false and swaps in `<tool-card>` elements
+  // once the tool dashboard data has arrived (see ToolsTab.ts render()); the
+  // panel's scrollHeight only reflects real content after that swap, so
+  // gating on `[active]` alone races the content population and can catch
+  // the panel mid-load (scrollHeight === clientHeight).
   await launched.page.waitForFunction(
     () => {
       const dialog = document.querySelector(
@@ -122,7 +129,12 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
       const settingsApp = dialog?.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       if (!root) return false;
-      return root.querySelector('wa-tab-panel[name="tools"][active]') != null;
+      const panel = root.querySelector('wa-tab-panel[name="tools"][active]');
+      if (!panel) return false;
+      const toolsTab = panel.querySelector('tools-tab');
+      const toolsRoot = toolsTab?.shadowRoot;
+      if (!toolsRoot) return false;
+      return toolsRoot.querySelector('tool-card') != null;
     },
     undefined,
     { timeout: 10_000 },


### PR DESCRIPTION
## What / why

Fixes #7970. Follow-up from #7961 (which fixed the broken import in
`verify-fixes.spec.ts` but explicitly flagged this render-timing race as
out of scope).

The `settings overlay scrolls (Tools tab top + bottom)` test's
`waitForFunction` resolved as soon as `wa-tab-panel[name="tools"]` gained
the `[active]` attribute — before `ToolsTab`'s dashboard content had
finished loading. `ToolsTab.render()` shows a `.loading-state` placeholder
while `loaded === false` and only swaps in `<tool-card>` elements once the
tool-dashboard data arrives (`packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts`).
Probing `scrollHeight`/`clientHeight` at the `[active]`-only checkpoint can
catch the panel mid-load, when both are equal (707 === 707), independent of
whether the panel is visually "active".

## Fix

Extend the existing `waitForFunction` to also require that the `tools-tab`
custom element's shadow root contains at least one `<tool-card>` — a
deterministic content-ready signal driven by the same `loaded`/`items`
state the component itself uses to decide what to render — instead of a
sleep or extra timeout.

```diff
-      return root.querySelector('wa-tab-panel[name="tools"][active]') != null;
+      const panel = root.querySelector('wa-tab-panel[name="tools"][active]');
+      if (!panel) return false;
+      const toolsTab = panel.querySelector('tools-tab');
+      const toolsRoot = toolsTab?.shadowRoot;
+      if (!toolsRoot) return false;
+      return toolsRoot.querySelector('tool-card') != null;
```

## Verification

```
pnpm --filter @texra/desktop build
npx playwright test -c playwright.config.ts tests/e2e/verify-fixes.spec.ts
corepack pnpm --filter @texra/desktop typecheck
```

- **Pre-fix repro (proven failing, not just asserted)**: reverted the diff
  (`git checkout`) in this worktree, rebuilt, and re-ran the spec — the
  "settings overlay scrolls" test failed exactly as described in the issue:
  `Expected: > 707, Received: 707` on
  `expect(probeBefore!.scrollHeight).toBeGreaterThan(probeBefore!.clientHeight)`.
  Reapplied the fix (`git apply`) afterward.
- **Post-fix**: both tests in the spec pass. Ran the full spec **three
  times** after the fix — stable pass every time (`tools panel before
  scroll: { scrollHeight: 1506, clientHeight: 707, ... }`, correctly
  showing real overflow content on every run).
- `corepack pnpm --filter @texra/desktop typecheck` — green (all four
  desktop sub-tsconfigs).
- No sleep/extra-wait was used — the fix is a pure content-readiness
  selector, matching the issue's explicit ask.

## Net elements (R6)

Net **+13/-1 lines, 0 new abstractions**. Extends the existing
`waitForFunction` predicate with two more DOM queries (`tools-tab` element
+ its shadow root's `tool-card` selector) plus an explanatory comment; no
new helper functions, no new test file, no new selector constants beyond
what the component already exposes in its own shadow DOM.

## Consumer counts (R8)

Single-file change (`packages/desktop/tests/e2e/verify-fixes.spec.ts`);
the `<tool-card>` tag name and `tools-tab` custom element are pre-existing
production selectors from `ToolCard.ts`/`ToolsTab.ts`, not new surface —
grepped for other e2e specs relying on the old `[active]`-only wait
pattern for this panel (none; `verify-fixes.spec.ts` is the only spec that
probes Tools-tab scroll metrics).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a Playwright wait predicate; no production runtime behavior.
> 
> **Overview**
> Fixes a flaky **settings overlay scrolls (Tools tab)** e2e test by tightening when Playwright considers the Tools tab ready.
> 
> The `waitForFunction` no longer stops at `wa-tab-panel[name="tools"][active]`. It now also walks into the `tools-tab` shadow root and waits until at least one **`tool-card`** is present—the same signal `ToolsTab` uses once dashboard data has loaded instead of the loading placeholder. That way scroll metrics are read only after the panel has real overflow content, avoiding false `scrollHeight === clientHeight` failures.
> 
> A short comment documents why both checks are needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e226ea33e51e34a429cf320e46c9b1c01e9cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->