### PR TITLE
fix(desktop): stabilize tools scroll e2e readiness

### DIFF
--- a/packages/desktop/tests/e2e/verify-fixes.spec.ts
+++ b/packages/desktop/tests/e2e/verify-fixes.spec.ts
@@ -114,6 +114,7 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
       tabIndex: SETTINGS_TAB_INDEX.TOOLS,
     },
   );
+  // The panel becomes active before its asynchronous dashboard content renders.
   await launched.page.waitForFunction(
     () => {
       const dialog = document.querySelector(
@@ -122,7 +123,18 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
       const settingsApp = dialog?.querySelector('settings-app');
       const root = settingsApp?.shadowRoot;
       if (!root) return false;
-      return root.querySelector('wa-tab-panel[name="tools"][active]') != null;
+      const panel = root.querySelector<HTMLElement>(
+        'wa-tab-panel[name="tools"][active]',
+      );
+      const toolsTab = panel?.querySelector<HTMLElement & { loaded: boolean }>(
+        'tools-tab',
+      );
+      if (!panel || toolsTab?.loaded !== true || !toolsTab.shadowRoot) {
+        return false;
+      }
+      const hasRenderedTools =
+        toolsTab.shadowRoot.querySelectorAll('tool-card').length > 0;
+      return hasRenderedTools && panel.scrollHeight > panel.clientHeight;
     },
     undefined,
     { timeout: 10_000 },
@@ -148,7 +160,25 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
     );
     if (panel) panel.scrollTop = panel.scrollHeight;
   });
-  await launched.page.waitForTimeout(150);
+  await launched.page.waitForFunction(
+    () => {
+      const dialog = document.querySelector(
+        'wa-dialog.desktop-settings-overlay',
+      );
+      const settingsApp = dialog?.querySelector('settings-app');
+      const root = settingsApp?.shadowRoot;
+      const panel = root?.querySelector<HTMLElement>(
+        'wa-tab-panel[name="tools"]',
+      );
+      return (
+        panel != null &&
+        panel.scrollTop > 0 &&
+        panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 1
+      );
+    },
+    undefined,
+    { timeout: 5000 },
+  );
 
   const probeAfter = await readToolsPanelMetrics();
   console.log('tools panel after scroll:', probeAfter);
@@ -161,7 +191,11 @@ test('settings overlay scrolls (Tools tab top + bottom)', async ({}, testInfo) =
   expect(probeBefore).not.toBeNull();
   expect(probeAfter).not.toBeNull();
   // Real verification: the panel must be scrollable (content > viewport),
-  // and scrollTop must move when we set it.
+  // start at the top, and reach the bottom when scrolled.
   expect(probeBefore!.scrollHeight).toBeGreaterThan(probeBefore!.clientHeight);
+  expect(probeBefore!.scrollTop).toBe(0);
   expect(probeAfter!.scrollTop).toBeGreaterThan(0);
+  expect(
+    probeAfter!.scrollTop + probeAfter!.clientHeight,
+  ).toBeGreaterThanOrEqual(probeAfter!.scrollHeight - 1);
 });


### PR DESCRIPTION
## Summary

The desktop Tools-tab scroll test previously waited only for the tab panel's `active` attribute. That state is set before the asynchronous tools dashboard has rendered, so the test could read `scrollHeight` while the panel still contained only its loading state.

This change makes the test wait for the actual readiness conditions it asserts:

- the Tools panel is active
- `tools-tab.loaded` is true
- at least one `tool-card` has rendered
- the panel has measurable overflow

The fixed 150 ms post-scroll delay is also replaced with a semantic wait for the panel to reach its clamped bottom position. Final assertions now pin the top position, overflow, movement, and bottom position.

## Validation

- desktop build
- desktop typecheck
- exact Playwright spec: 2 tests passed
- scroll test repeated five times: 5 tests passed
- `npm run format`
- `npm run lint`: 0 errors (51 existing warnings)

Closes #7970

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test-only changes with no production code paths affected.
> 
> **Overview**
> The **settings Tools tab scroll** Playwright test no longer treats an active `wa-tab-panel` as “ready.” It now waits until `tools-tab` is loaded, at least one `tool-card` exists, and the panel has real overflow before measuring scroll metrics.
> 
> After programmatic scroll, the fixed **150 ms** delay is replaced by waiting until `scrollTop` reflects a clamped bottom position. Assertions now require the panel to start at the top (`scrollTop === 0`) and to reach the bottom within one pixel, in addition to overflow and post-scroll movement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9379fa9ac684ba7261485d8593ed16881a57f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->