### PR TITLE
test(cli): add HARNESS_CHILD_EVENT_ORDER fixture for byte-identical PTY frames

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -11,8 +11,11 @@ import React from 'react';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { platform, tryPlatform } from '@platform/platform';
 import {
@@ -20,6 +23,7 @@ import {
   LIVE_ELAPSED_STREAM_STATUSES,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
@@ -91,6 +95,8 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
+import { attachTuiRunFactSubscription } from '../src/chat/tui/state/subscribeRuntimeHost';
+import { subscribeStreamStatus } from '../src/chat/tui/state/subscribeStreamStatus';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { defaultShortcutModifierLabel } from '../src/runtime/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
@@ -221,19 +227,26 @@ const DISABLED_MODEL_SWITCH_REASON =
   'different conversation format; start new chat';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
-// Opt-in fixture for the PTY byte-identity check (issue #7972, follow-up from
-// #7967 / acceptance-gate items 4-5 in
-// docs/proposals/cli-child-stream-state-consolidation.md): seeds one child
-// stream through the same order-equivalent event sequences as the vitest
-// "child-stream ordered transition matrix"
-// (src/test-kernel/cli/TuiStateAndFocus.vitest.mts, scenarios 1-4) so
-// validate-tui.mjs can assert the rendered frame is byte-identical no matter
-// which order the roster/edge/status facts arrive in.
+// Opt-in fixture for the PTY ordering tests (issue #7972, follow-up from
+// #7967 / the "PTY ordering tests" section of
+// docs/proposals/cli-child-stream-state-consolidation.md): drives one child
+// stream through the real event-subscription path
+// (attachTuiRunFactSubscription + subscribeStreamStatus, exactly as
+// runChatTui.tsx/chatSessionController.ts wire a real run — see
+// `seedChildEventOrderFixture` below) in each of the eight orderings the
+// design names, so validate-tui.mjs can assert both intermediate render
+// checkpoints and (for the four order-equivalent cases) a byte-identical
+// settled frame no matter which order the attachment/roster/edge/status
+// facts arrive in.
 const CHILD_EVENT_ORDER_VALUES = [
   'canonical',
   'roster-first',
   'edge-first',
   'status-first',
+  'promotion-late-roster',
+  'reattach-late-old-roster',
+  'parent-removal',
+  'completion-remove',
 ] as const;
 type ChildEventOrder = (typeof CHILD_EVENT_ORDER_VALUES)[number];
 const CHILD_EVENT_ORDER_RAW = process.env.HARNESS_CHILD_EVENT_ORDER?.trim();
@@ -1011,47 +1024,258 @@ if (SHOW_SUBAGENT_FOLLOWUPS) {
   seedSubagentFollowupTranscript();
 }
 
-// One child stream, its roster/edge/status facts applied through the real
-// transition functions in each of the four orderings the vitest matrix
-// proves order-equivalent (canonical/roster-first/edge-first/status-first —
-// see the `CHILD_EVENT_ORDER_VALUES` comment above). No `startedAt` is set,
-// so `childElapsed` returns the static `elapsed` string instead of a
-// live-ticking duration (packages/cli/src/chat/tui/state/childControls.ts) —
-// required for the rendered frame to be byte-identical across separate
-// process launches, not just across orderings within one launch.
-const CHILD_EVENT_ORDER_STREAM_ID = 'harness-child-event-order-stream';
+// One child stream, its attachment/roster/edge/status/removal facts driven
+// through the real production subscription path rather than the CHILD_STREAMS
+// map mutators (`applySubagentRoster`/`setParentStream`) directly — a
+// regression in `attachTuiRunFactSubscription` or `subscribeStreamStatus`
+// wiring must be able to fail these scenarios, matching the "PTY ordering
+// tests" section of docs/proposals/cli-child-stream-state-consolidation.md.
+// No `startedAt` is set on the roster row, so `childElapsed` returns the
+// static `elapsed` string instead of a live-ticking duration
+// (packages/cli/src/chat/tui/state/childControls.ts); `setActiveStream`
+// always sets `suppressViewSwitch: true` so the harness's own active/focused
+// stream (and its live wall-clock `runStartedAt` elapsed display) stays on
+// the root session throughout — required for the four order-equivalent
+// scenarios' settled frame to be byte-identical across separate process
+// launches, not just across orderings within one launch.
+const CHILD_EVENT_ORDER_STREAM_ID =
+  'harness-child-event-order-stream' as StreamTabId;
 const CHILD_EVENT_ORDER_EXECUTION_ID = 'harness-child-event-order-exec';
 const CHILD_EVENT_ORDER_AGENT_NAME = 'orderChecker';
+// Second, never-displayed parent identity used only by the promotion/
+// reattachment/parent-removal orderings (matrix scenarios 7/11 in
+// TuiStateAndFocus.vitest.mts) — reusing the harness's own root `STREAM_ID`
+// as a *removable* parent would tear down the harness's own active session.
+const CHILD_EVENT_ORDER_OTHER_PARENT_ID =
+  'harness-child-event-order-other-parent' as StreamTabId;
+// Small but non-zero: each step must land in its own macrotask so Ink
+// commits (and the PTY validator can observe) a render between ordered
+// facts, per the "deterministic harness checkpoint" requirement in the
+// design doc. The validator polls for each checkpoint's expected text
+// rather than relying on this delay's exact value.
+const CHILD_EVENT_ORDER_STEP_DELAY_MS = Number(
+  process.env.HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS ?? '60',
+);
 
-function seedChildEventOrderFixture(order: ChildEventOrder): void {
-  const childStreamId = CHILD_EVENT_ORDER_STREAM_ID;
-  const rosterRow: ActiveChildInfo = {
+function childEventOrderRosterRow(): ActiveChildInfo {
+  return {
     kind: 'subagent',
     executionId: CHILD_EVENT_ORDER_EXECUTION_ID,
     agentName: CHILD_EVENT_ORDER_AGENT_NAME,
-    childStreamId,
+    childStreamId: CHILD_EVENT_ORDER_STREAM_ID,
     elapsed: '1m 4s',
   };
-  const applyStatus = () =>
-    patchStream(childStreamId, (slice) => ({
-      ...slice,
-      status: STREAM_STATUS.RUNNING,
-      description: `${CHILD_EVENT_ORDER_AGENT_NAME} sub-workflow`,
-      entries: makeChildEntries(
-        CHILD_EVENT_ORDER_AGENT_NAME,
-        CHILD_EVENT_ORDER_EXECUTION_ID,
-      ),
-    }));
-  const applyRoster = () => applySubagentRoster(STREAM_ID, [rosterRow]);
-  const applyEdge = () => setParentStream(childStreamId, STREAM_ID);
+}
 
-  const orderedSteps: Record<ChildEventOrder, readonly (() => void)[]> = {
-    canonical: [applyStatus, applyRoster, applyEdge],
-    'roster-first': [applyRoster, applyStatus, applyEdge],
-    'edge-first': [applyEdge, applyStatus, applyRoster],
-    'status-first': [applyStatus, applyEdge, applyRoster],
+// `child.activity(kind: 'subagents')` run fact — the real roster wiring
+// (`ExecutionRegistry.emitChildActivity`, src/agent/runtime/executionRegistry.ts).
+function emitChildEventOrderRoster(
+  parentStreamId: StreamTabId,
+  children: readonly ActiveChildInfo[],
+): void {
+  defaultSession().events.emit({
+    scope: 'run',
+    streamId: parentStreamId,
+    event: {
+      type: 'child.activity',
+      kind: 'subagents',
+      parentStreamId,
+      children,
+    },
+  });
+}
+
+// `setParentStream` session fact — the real edge wiring
+// (`ExecutionRegistry.emitParentStreamUpdate`).
+function emitChildEventOrderEdge(
+  childStreamId: StreamTabId,
+  parentStreamId: StreamTabId | null,
+): void {
+  defaultSession().events.emit({
+    scope: 'session',
+    event: {
+      type: 'setParentStream',
+      payload: { childStreamId, parentStreamId },
+    },
+  });
+}
+
+// `removeStream` session fact — the real removal wiring (src/tools/childStream.ts).
+function emitChildEventOrderRemoval(streamId: StreamTabId): void {
+  defaultSession().events.emit({
+    scope: 'session',
+    event: { type: 'removeStream', payload: { streamId } },
+  });
+}
+
+// `setActiveStream` session fact ("attachment") — always background-registers
+// (`suppressViewSwitch: true`) so the harness's own active/focused stream
+// never becomes the child (see the wall-clock note above).
+function emitChildEventOrderAttachment(streamId: StreamTabId): void {
+  defaultSession().events.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload: { streamId, suppressViewSwitch: true },
+    },
+  });
+}
+
+// Real `StreamStatusService` transitions — `subscribeStreamStatus()` is what
+// projects these into `cliState` (see `seedChildEventOrderFixture`), exactly
+// as `runChatTui.tsx` wires it for a real session.
+function transitionChildEventOrderRunning(streamId: StreamTabId): void {
+  StreamStatusService.transition(
+    streamId,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    { events: defaultSession().events },
+  );
+}
+
+function transitionChildEventOrderTerminal(streamId: StreamTabId): void {
+  StreamStatusService.transitionToTerminal(streamId, STREAM_PHASE.COMPLETED, {
+    events: defaultSession().events,
+  });
+}
+
+// Late resume-transition attempt for an already-removed stream: unlike a
+// repeated terminal transition (a same-value no-op the status machine drops
+// before it ever reaches `cliState`), COMPLETED -> RUNNING via `resume` is a
+// transition the machine itself allows, so it reaches
+// `setStreamStatusInCliState` and actually exercises that function's
+// `isChildStreamRemoved` tombstone guard (see `completion-remove` below).
+function attemptChildEventOrderLateResume(streamId: StreamTabId): void {
+  StreamStatusService.transition(
+    streamId,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.RESUME,
+    { events: defaultSession().events },
+  );
+}
+
+/**
+ * The eight orderings named by the design doc's "PTY ordering tests"
+ * section, expressed as the ordered real-fact steps
+ * `seedChildEventOrderFixture` schedules one macrotask apart. `canonical`
+ * through `status-first` are byte-identical settled orderings of the same
+ * four facts (attachment, running status, roster, edge) — see the vitest
+ * "child-stream ordered transition matrix" (scenarios 1-4,
+ * src/test-kernel/cli/TuiStateAndFocus.vitest.mts) this mirrors at the PTY
+ * layer. The remaining four correct old ambiguous transients (promotion,
+ * reattachment, parent removal, completion+removal — matrix scenarios 6, 7,
+ * 11, and 5-then-8) get their own checkpoint expectations in
+ * validate-tui.mjs rather than byte-equivalence.
+ */
+function childEventOrderSteps(order: ChildEventOrder): readonly (() => void)[] {
+  const child = CHILD_EVENT_ORDER_STREAM_ID;
+  const root = STREAM_ID as StreamTabId;
+  const other = CHILD_EVENT_ORDER_OTHER_PARENT_ID;
+  const A = () => emitChildEventOrderAttachment(child);
+  const Srun = () => transitionChildEventOrderRunning(child);
+  const Sterm = () => transitionChildEventOrderTerminal(child);
+  const RPlus = (parent: StreamTabId) =>
+    emitChildEventOrderRoster(parent, [childEventOrderRosterRow()]);
+  const RMinus = (parent: StreamTabId) => emitChildEventOrderRoster(parent, []);
+  const EPlus = (parent: StreamTabId) => emitChildEventOrderEdge(child, parent);
+  const E0 = () => emitChildEventOrderEdge(child, null);
+  const X = (streamId: StreamTabId) => emitChildEventOrderRemoval(streamId);
+
+  switch (order) {
+    case 'canonical':
+      return [A, Srun, () => RPlus(root), () => EPlus(root)];
+    case 'roster-first':
+      return [() => RPlus(root), A, Srun, () => EPlus(root)];
+    case 'edge-first':
+      return [() => EPlus(root), A, Srun, () => RPlus(root)];
+    case 'status-first':
+      return [Srun, A, () => EPlus(root), () => RPlus(root)];
+    case 'promotion-late-roster':
+      // Matrix 6: A, S(running), R_P+, E_P+, E0, R_P+ — a stale roster from
+      // the former parent must not resurrect the edge or active membership.
+      return [
+        A,
+        Srun,
+        () => RPlus(root),
+        () => EPlus(root),
+        E0,
+        () => RPlus(root),
+      ];
+    case 'reattach-late-old-roster':
+      // Matrix 7 (relabeled so the *current* parent is the renderable root):
+      // attach/run/roster/edge under `other`, promote, a stale `other`
+      // roster, then an explicit edge+roster to `root`, and finally a late
+      // roster from `other` again — which must not erase active membership
+      // under `root`.
+      return [
+        A,
+        Srun,
+        () => RPlus(other),
+        () => EPlus(other),
+        E0,
+        () => RPlus(other),
+        () => EPlus(root),
+        () => RPlus(root),
+        () => RPlus(other),
+      ];
+    case 'parent-removal':
+      // Matrix 11: P -> child, X(P), R_P+, E_P+ — `other` stands in for the
+      // removed parent so the harness's own active root session is never
+      // torn down by the removal itself.
+      return [
+        Srun,
+        () => RPlus(other),
+        () => EPlus(other),
+        () => X(other),
+        () => RPlus(other),
+        () => EPlus(other),
+      ];
+    case 'completion-remove':
+      // Matrix 5 then 8: roster omission arrives before the terminal status,
+      // then the child itself is removed and every later fact for it —
+      // including a late attachment and a late resume attempt — must stay
+      // suppressed.
+      return [
+        A,
+        Srun,
+        () => RPlus(root),
+        () => EPlus(root),
+        () => RMinus(root),
+        Sterm,
+        () => X(child),
+        () => RPlus(root),
+        () => EPlus(root),
+        A,
+        () => attemptChildEventOrderLateResume(child),
+      ];
+  }
+}
+
+function seedChildEventOrderFixture(order: ChildEventOrder): void {
+  // Mirror real CLI startup: `runChatTui.tsx` installs `subscribeStreamStatus()`
+  // once per session, and `chatSessionController.ts`'s `setupRunHost` attaches
+  // `attachTuiRunFactSubscription(defaultSession().events)` per run. Attaching
+  // both here — instead of calling `applySubagentRoster`/`setParentStream`
+  // directly — means a regression in either subscription would leave these
+  // scenarios failing instead of silently green.
+  subscribeStreamStatus();
+  attachTuiRunFactSubscription(defaultSession().events);
+
+  const steps = childEventOrderSteps(order);
+  let stepIndex = 0;
+  const runNextStep = (): void => {
+    if (stepIndex >= steps.length) return;
+    const step = steps[stepIndex];
+    stepIndex += 1;
+    step();
+    setTimeout(runNextStep, CHILD_EVENT_ORDER_STEP_DELAY_MS);
   };
-  for (const step of orderedSteps[order]) step();
+  // Deferred, not called inline: `seedChildEventOrderFixture` itself still
+  // runs before `render()` in source order (like every other opt-in harness
+  // fixture below), but every step above must run after `<App>` has mounted
+  // so Ink actually renders each intermediate state instead of only the
+  // fully-seeded final one.
+  setTimeout(runNextStep, CHILD_EVENT_ORDER_STEP_DELAY_MS);
 }
 
 if (SHOW_CHILDREN) {

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -221,6 +221,33 @@ const DISABLED_MODEL_SWITCH_REASON =
   'different conversation format; start new chat';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
+// Opt-in fixture for the PTY byte-identity check (issue #7972, follow-up from
+// #7967 / acceptance-gate items 4-5 in
+// docs/proposals/cli-child-stream-state-consolidation.md): seeds one child
+// stream through the same order-equivalent event sequences as the vitest
+// "child-stream ordered transition matrix"
+// (src/test-kernel/cli/TuiStateAndFocus.vitest.mts, scenarios 1-4) so
+// validate-tui.mjs can assert the rendered frame is byte-identical no matter
+// which order the roster/edge/status facts arrive in.
+const CHILD_EVENT_ORDER_VALUES = [
+  'canonical',
+  'roster-first',
+  'edge-first',
+  'status-first',
+] as const;
+type ChildEventOrder = (typeof CHILD_EVENT_ORDER_VALUES)[number];
+const CHILD_EVENT_ORDER_RAW = process.env.HARNESS_CHILD_EVENT_ORDER?.trim();
+if (
+  CHILD_EVENT_ORDER_RAW &&
+  !(CHILD_EVENT_ORDER_VALUES as readonly string[]).includes(
+    CHILD_EVENT_ORDER_RAW,
+  )
+) {
+  throw new Error(
+    `HARNESS_CHILD_EVENT_ORDER must be one of ${CHILD_EVENT_ORDER_VALUES.join(', ')}, got ${JSON.stringify(CHILD_EVENT_ORDER_RAW)}`,
+  );
+}
+const CHILD_EVENT_ORDER = CHILD_EVENT_ORDER_RAW as ChildEventOrder | undefined;
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
 const SHOW_COMPLETED_TODOS_ONLY = process.env.HARNESS_TODOS_COMPLETED === '1';
@@ -984,6 +1011,49 @@ if (SHOW_SUBAGENT_FOLLOWUPS) {
   seedSubagentFollowupTranscript();
 }
 
+// One child stream, its roster/edge/status facts applied through the real
+// transition functions in each of the four orderings the vitest matrix
+// proves order-equivalent (canonical/roster-first/edge-first/status-first —
+// see the `CHILD_EVENT_ORDER_VALUES` comment above). No `startedAt` is set,
+// so `childElapsed` returns the static `elapsed` string instead of a
+// live-ticking duration (packages/cli/src/chat/tui/state/childControls.ts) —
+// required for the rendered frame to be byte-identical across separate
+// process launches, not just across orderings within one launch.
+const CHILD_EVENT_ORDER_STREAM_ID = 'harness-child-event-order-stream';
+const CHILD_EVENT_ORDER_EXECUTION_ID = 'harness-child-event-order-exec';
+const CHILD_EVENT_ORDER_AGENT_NAME = 'orderChecker';
+
+function seedChildEventOrderFixture(order: ChildEventOrder): void {
+  const childStreamId = CHILD_EVENT_ORDER_STREAM_ID;
+  const rosterRow: ActiveChildInfo = {
+    kind: 'subagent',
+    executionId: CHILD_EVENT_ORDER_EXECUTION_ID,
+    agentName: CHILD_EVENT_ORDER_AGENT_NAME,
+    childStreamId,
+    elapsed: '1m 4s',
+  };
+  const applyStatus = () =>
+    patchStream(childStreamId, (slice) => ({
+      ...slice,
+      status: STREAM_STATUS.RUNNING,
+      description: `${CHILD_EVENT_ORDER_AGENT_NAME} sub-workflow`,
+      entries: makeChildEntries(
+        CHILD_EVENT_ORDER_AGENT_NAME,
+        CHILD_EVENT_ORDER_EXECUTION_ID,
+      ),
+    }));
+  const applyRoster = () => applySubagentRoster(STREAM_ID, [rosterRow]);
+  const applyEdge = () => setParentStream(childStreamId, STREAM_ID);
+
+  const orderedSteps: Record<ChildEventOrder, readonly (() => void)[]> = {
+    canonical: [applyStatus, applyRoster, applyEdge],
+    'roster-first': [applyRoster, applyStatus, applyEdge],
+    'edge-first': [applyEdge, applyStatus, applyRoster],
+    'status-first': [applyStatus, applyEdge, applyRoster],
+  };
+  for (const step of orderedSteps[order]) step();
+}
+
 if (SHOW_CHILDREN) {
   const startedAt = Date.now() - 74_000;
   const nestedStartedAt = startedAt + 24_000;
@@ -1122,6 +1192,10 @@ if (SHOW_CHILDREN) {
       runStartedAt: nestedStartedAt,
     }));
   }
+}
+
+if (CHILD_EVENT_ORDER) {
+  seedChildEventOrderFixture(CHILD_EVENT_ORDER);
 }
 
 if (SHOW_TODOS) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -113,9 +113,24 @@ const HARNESS = process.env.TEXRA_TUI_HARNESS
 // `mkdtempSync` cwd (tui-harness.tsx's default) — the harness reflects `cwd`
 // in rendered session chrome, and a different path per scenario would fail
 // the comparison for a reason unrelated to child-stream event ordering.
+// Removed on every exit path (including `--help`/`--list`, which never touch
+// it) rather than only after a run that selects these scenarios, so it never
+// leaks a temp dir the way an un-cleaned-up `mkdtempSync` normally would.
 const CHILD_EVENT_ORDER_CWD = mkdtempSync(
   path.join(tmpdir(), 'texra-tui-child-event-order-'),
 );
+process.on('exit', () => {
+  rmSync(CHILD_EVENT_ORDER_CWD, { recursive: true, force: true });
+});
+// Each ordered fact lands in its own macrotask inside the harness (see
+// `seedChildEventOrderFixture` in tui-harness.tsx). This must clear the boot
+// detector's own 600ms PTY-quiet gate (below) — otherwise a fast-firing
+// fixture keeps resetting that timer and boot detection doesn't settle until
+// the whole sequence has already finished, collapsing every checkpoint into
+// the final frame. Checkpoints themselves wait for their expected text
+// (not a fixed sleep), so this value only needs to clear that gate, not
+// bound total scenario time precisely.
+const HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS = '900';
 
 // --- scenarios (verified against the committed harness) ------------------
 const SCENARIOS = [
@@ -1911,14 +1926,24 @@ const SCENARIOS = [
     ],
     unexpect: ['[Option-p]tasks', '[Option-s]subagents'],
   },
-  // Rendered-byte-level counterpart to the vitest "child-stream ordered
-  // transition matrix" (src/test-kernel/cli/TuiStateAndFocus.vitest.mts,
-  // scenarios 1-4): the same roster/edge/status facts arrive in a different
-  // order in each of these four scenarios but must converge on the same
-  // final child-stream state per the design's precedence rule
-  // (docs/proposals/cli-child-stream-state-consolidation.md), so their
-  // rendered PTY frames must be byte-identical. `compareGroup` below drives
-  // that check post-run (issue #7972).
+  // PTY ordering tests (issue #7972): the harness drives one child stream's
+  // attachment/roster/edge/status/removal facts through the real
+  // `attachTuiRunFactSubscription`/`subscribeStreamStatus` subscription path —
+  // not the CHILD_STREAMS map mutators directly — one macrotask apart, so
+  // Ink actually renders each intermediate state. `checkpoints` (handled in
+  // `runScenarioWithResources`) polls for each ordered fact's expected text in
+  // turn, so a transiently-wrong frame (a stale control, a premature or
+  // missing active count) fails the scenario, not just the final settled one.
+  //
+  // `canonical`/`roster-first`/`edge-first`/`status-first` apply the same four
+  // facts (attachment, running status, roster, edge) in every order the
+  // vitest "child-stream ordered transition matrix" proves order-equivalent
+  // (src/test-kernel/cli/TuiStateAndFocus.vitest.mts, scenarios 1-4) and must
+  // converge on a byte-identical settled frame — `compareGroup` drives that
+  // check post-run. The remaining four correct old ambiguous transients
+  // (promotion, reattachment, parent removal, completion+removal — matrix
+  // scenarios 6, 7, 11, and 5-then-8) get their own checkpoint expectations
+  // instead of byte-equivalence, per the design doc.
   {
     name: 'child-event-order-canonical',
     compareGroup: 'child-event-order',
@@ -1926,9 +1951,26 @@ const SCENARIOS = [
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILD_EVENT_ORDER: 'canonical',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
       HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
     },
-    bootExpect: '[Tab]streams',
+    // Steps: A, S(running), R_P+, E_P+.
+    checkpoints: [
+      {
+        expect: ['[Tab]streams'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['[Tab]streams'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+      {
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+    ],
     expect: ['orderChecker', '1 sub', '[Tab]streams'],
   },
   {
@@ -1938,9 +1980,28 @@ const SCENARIOS = [
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILD_EVENT_ORDER: 'roster-first',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
       HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
     },
-    bootExpect: '[Tab]streams',
+    // Steps: R_P+, A, S(running), E_P+.
+    checkpoints: [
+      {
+        // Active via the roster's retained-parent fallback, before the
+        // child's own StreamSlice exists — not yet focusable.
+        expect: ['1 sub', 'orderChecker · 1m 4s'],
+        unexpect: ['[Tab]streams', 'orderChecker running'],
+      },
+      {
+        expect: ['[Tab]streams', '1:orderChecker'],
+        unexpect: ['1:orderChecker*', 'orderChecker running'],
+      },
+      {
+        expect: ['orderChecker running', '1:orderChecker*'],
+      },
+      {
+        expect: ['orderChecker running', '1:orderChecker*'],
+      },
+    ],
     expect: ['orderChecker', '1 sub', '[Tab]streams'],
   },
   {
@@ -1950,9 +2011,29 @@ const SCENARIOS = [
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILD_EVENT_ORDER: 'edge-first',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
       HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
     },
-    bootExpect: '[Tab]streams',
+    // Steps: E_P+, A, S(running), R_P+.
+    checkpoints: [
+      {
+        // Reachable via the explicit edge alone (focus-cycle invariant), but
+        // not yet counted active — that needs the roster.
+        expect: ['[Tab]streams', 'harness-child-eve'],
+        unexpect: ['1 sub', 'orderChecker', 'harness-child-eve…*'],
+      },
+      {
+        expect: ['harness-child-eve…*'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['harness-child-eve…*'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+    ],
     expect: ['orderChecker', '1 sub', '[Tab]streams'],
   },
   {
@@ -1962,10 +2043,193 @@ const SCENARIOS = [
     env: {
       HARNESS_ENTRIES: '4',
       HARNESS_CHILD_EVENT_ORDER: 'status-first',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
       HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
     },
-    bootExpect: '[Tab]streams',
+    // Steps: S(running), A, E_P+, R_P+.
+    checkpoints: [
+      {
+        expect: ['[Tab]streams'],
+        unexpect: ['1 sub', 'orderChecker', 'harness-child-eve'],
+      },
+      {
+        expect: ['harness-child-eve…*'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['harness-child-eve…*'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+    ],
     expect: ['orderChecker', '1 sub', '[Tab]streams'],
+  },
+  // The remaining four orderings correct old ambiguous transients (promotion,
+  // reattachment, parent removal, completion+removal) instead of being
+  // order-equivalent with the four above, so they get their own checkpoint
+  // expectations — no `compareGroup` — per the design doc.
+  {
+    name: 'child-event-order-promotion-late-roster',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'promotion-late-roster',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
+    },
+    // Steps: A, S(running), R_P+, E_P+, E0 (promote to top-level), R_P+ (late,
+    // stale roster from the former parent).
+    checkpoints: [
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
+      { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
+      {
+        // Promoted to top-level: no longer active under root, but the
+        // retained/historical row survives.
+        expect: ['1:main*', 'orderChecker running'],
+        unexpect: ['1 sub', '1:orderChecker*'],
+      },
+      {
+        // A stale roster resend from the former parent must not resurrect
+        // the edge or active membership.
+        expect: ['1:main*', 'orderChecker running'],
+        unexpect: ['1 sub', '1:orderChecker*'],
+      },
+    ],
+    // Prove the TUI is still interactive after the late fact: Tab finds the
+    // promoted (now top-level) stream reachable and switches to it — its
+    // status bar shows a real, wall-clock elapsed time once focused, so this
+    // only asserts the exit path still works cleanly rather than exact text.
+    keys: ['\t'],
+    expectExit: true,
+  },
+  {
+    name: 'child-event-order-reattach-late-old-roster',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'reattach-late-old-roster',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
+    },
+    // Steps: A, S(running), R_other+, E_other+, E0, R_other+ (stale), E_P+
+    // (root), R_P+ (root), R_other+ (late, stale — from the child's former,
+    // never-displayed parent).
+    checkpoints: [
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      // Facts scoped to the never-displayed former parent must not leak into
+      // root's own view at any point.
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      {
+        expect: ['harness-child-eve…*'],
+        unexpect: ['1 sub', 'orderChecker'],
+      },
+      {
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+      {
+        // A late, stale roster from the child's former parent must not erase
+        // active membership under the new (root) parent.
+        expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
+      },
+    ],
+    // Prove the TUI is still interactive: Tab finds the reattached child
+    // reachable and switches focus to it (a real, wall-clock elapsed time
+    // appears once focused), so this only asserts the exit path still works
+    // cleanly rather than exact post-focus text.
+    keys: ['\t'],
+    expectExit: true,
+  },
+  {
+    name: 'child-event-order-parent-removal',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'parent-removal',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
+    },
+    // Steps: S(running) [child], R_other+, E_other+, X(other) [parent
+    // removal], R_other+ (late), E_other+ (late) — `other` is never root, so
+    // none of this should ever surface on root's own view; the assertion is
+    // that late facts naming a removed parent don't resurrect it anywhere or
+    // wedge the TUI.
+    checkpoints: [
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { unexpect: ['1 sub', 'orderChecker'] },
+      { unexpect: ['1 sub', 'orderChecker'] },
+      { unexpect: ['1 sub', 'orderChecker'] },
+      { unexpect: ['1 sub', 'orderChecker'] },
+      { unexpect: ['1 sub', 'orderChecker'] },
+    ],
+    // Prove the TUI is still interactive after the removal + late facts:
+    // nothing under the removed parent was ever reachable from root, so Tab
+    // is a no-op here (unlike promotion/reattachment above) and the frame —
+    // and the exit path — must stay exactly as before.
+    keys: ['\t'],
+    expect: ['◆ — personal'],
+    unexpect: ['1 sub', 'orderChecker'],
+    expectExit: true,
+  },
+  {
+    name: 'child-event-order-completion-remove',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'completion-remove',
+      HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS,
+    },
+    // Steps: A, S(running), R_P+, E_P+, R_P- (roster omission), S(terminal),
+    // X(child), R_P+ (late), E_P+ (late), A (late), late resume attempt.
+    checkpoints: [
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
+      { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
+      {
+        // Untrack (roster omission) arrives before the terminal status: the
+        // retained/historical row survives, but active membership does not.
+        expect: ['orderChecker running'],
+        unexpect: ['1 sub'],
+      },
+      {
+        expect: ['orderChecker completed', '1:orderChecker(completed)'],
+        unexpect: ['1 sub', 'orderChecker running'],
+      },
+      {
+        // Removal scrubs every trace, including the retained/historical row.
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+      },
+      {
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+      },
+      {
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+      },
+      {
+        // A late re-attachment attempt for the removed id must stay ignored.
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+      },
+      {
+        // A late resume-transition attempt is the one status fact that would
+        // otherwise reach `setStreamStatusInCliState` (a repeated terminal
+        // transition is a same-value no-op the status machine drops before
+        // it gets there) — it must still stay suppressed by the removal
+        // tombstone.
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+      },
+    ],
+    // Prove the TUI is still interactive after the removal + late facts:
+    // the removed child is unreachable, so Tab is a no-op and the frame —
+    // and the exit path — must stay exactly as before.
+    keys: ['\t'],
+    expect: ['◆ — personal'],
+    unexpect: ['orderChecker', '1 sub'],
+    expectExit: true,
   },
   {
     name: 'failed-subagent-status',
@@ -3680,6 +3944,66 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     }
   }
 
+  // Ordered render checkpoints (issue #7972): scenarios that drive the
+  // harness's opt-in event-ordering fixture (see
+  // `HARNESS_CHILD_EVENT_ORDER`/`seedChildEventOrderFixture` in
+  // tui-harness.tsx) apply one fact per macrotask after boot instead of
+  // seeding everything up front, so this polls for each checkpoint's
+  // expected text in turn — catching a transiently-wrong frame (a stale
+  // control, a premature or lingering active count) between ordered facts,
+  // not just whatever the fully-settled scrollback happens to look like.
+  // A checkpoint whose expect/unexpect condition is already (trivially)
+  // satisfied by the previous checkpoint's frame — the harness applies
+  // several ordered facts in a row with no new visible text, e.g. a bare
+  // running-status transition before any roster/edge fact — resolves as
+  // soon as the PTY is quiet, in well under the harness's own per-step
+  // delay. Without pacing, that lets the validator race checkpoints ahead
+  // of the harness's real progress: by the time it reaches a later
+  // checkpoint with a genuinely new expectation, the harness may not have
+  // gotten there yet, so it fails as "missing" rather than "not yet true".
+  // Pace evaluation to the harness's own schedule (still poll-based beyond
+  // that, so CI slowness only ever costs time, never correctness).
+  const checkpointStepDelayMs = Number(
+    scenario.env?.HARNESS_CHILD_EVENT_ORDER_STEP_DELAY_MS ?? 0,
+  );
+  const checkpointsStart = Date.now();
+  const checkpointFailures = [];
+  for (const [checkpointIndex, checkpoint] of (
+    scenario.checkpoints ?? []
+  ).entries()) {
+    const minReadyAt =
+      checkpointsStart + checkpointStepDelayMs * (checkpointIndex + 1);
+    if (Date.now() < minReadyAt) await sleep(minReadyAt - Date.now());
+    const checkpointDeadline =
+      Date.now() +
+      Number(checkpoint.timeoutMs ?? scenario.checkpointMs ?? 4000);
+    let checkpointFrame = scenarioFrame(scenario, await frameSnapshot(), rows);
+    while (Date.now() < checkpointDeadline) {
+      if (exited) break;
+      const quiet = Date.now() - lastData >= 150;
+      checkpointFrame = scenarioFrame(scenario, await frameSnapshot(), rows);
+      const satisfied =
+        (checkpoint.expect ?? []).every((t) => checkpointFrame.includes(t)) &&
+        (checkpoint.unexpect ?? []).every((t) => !checkpointFrame.includes(t));
+      if (quiet && satisfied) break;
+      await sleep(40);
+    }
+    for (const t of checkpoint.expect ?? []) {
+      if (!checkpointFrame.includes(t)) {
+        checkpointFailures.push(
+          `checkpoint ${checkpointIndex + 1}: expected text missing: ${JSON.stringify(t)}`,
+        );
+      }
+    }
+    for (const t of checkpoint.unexpect ?? []) {
+      if (checkpointFrame.includes(t)) {
+        checkpointFailures.push(
+          `checkpoint ${checkpointIndex + 1}: unexpected text present: ${JSON.stringify(t)}`,
+        );
+      }
+    }
+  }
+
   for (const key of scenario.keys ?? []) {
     const input = typeof key === 'string' ? key : key.input;
     child.write(input);
@@ -3732,7 +4056,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     (t) => !collapsedFrame.includes(t),
   );
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
-  const failures = [];
+  const failures = [...checkpointFailures];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
   for (const t of missing)
     failures.push(`expected text missing: ${JSON.stringify(t)}`);

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -107,6 +107,15 @@ const DEFAULT_HARNESS_RELATIVE_PATH = path.join(
 const HARNESS = process.env.TEXRA_TUI_HARNESS
   ? path.resolve(process.env.TEXRA_TUI_HARNESS)
   : path.resolve(CLI_ROOT, DEFAULT_HARNESS_RELATIVE_PATH);
+// The `child-event-order-*` scenarios (issue #7972) must render
+// byte-identical frames across separate process launches, so they share one
+// fixed working directory instead of each getting its own random
+// `mkdtempSync` cwd (tui-harness.tsx's default) — the harness reflects `cwd`
+// in rendered session chrome, and a different path per scenario would fail
+// the comparison for a reason unrelated to child-stream event ordering.
+const CHILD_EVENT_ORDER_CWD = mkdtempSync(
+  path.join(tmpdir(), 'texra-tui-child-event-order-'),
+);
 
 // --- scenarios (verified against the committed harness) ------------------
 const SCENARIOS = [
@@ -1901,6 +1910,62 @@ const SCENARIOS = [
       ']tasks',
     ],
     unexpect: ['[Option-p]tasks', '[Option-s]subagents'],
+  },
+  // Rendered-byte-level counterpart to the vitest "child-stream ordered
+  // transition matrix" (src/test-kernel/cli/TuiStateAndFocus.vitest.mts,
+  // scenarios 1-4): the same roster/edge/status facts arrive in a different
+  // order in each of these four scenarios but must converge on the same
+  // final child-stream state per the design's precedence rule
+  // (docs/proposals/cli-child-stream-state-consolidation.md), so their
+  // rendered PTY frames must be byte-identical. `compareGroup` below drives
+  // that check post-run (issue #7972).
+  {
+    name: 'child-event-order-canonical',
+    compareGroup: 'child-event-order',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'canonical',
+      HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
+    },
+    bootExpect: '[Tab]streams',
+    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+  },
+  {
+    name: 'child-event-order-roster-first',
+    compareGroup: 'child-event-order',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'roster-first',
+      HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
+    },
+    bootExpect: '[Tab]streams',
+    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+  },
+  {
+    name: 'child-event-order-edge-first',
+    compareGroup: 'child-event-order',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'edge-first',
+      HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
+    },
+    bootExpect: '[Tab]streams',
+    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+  },
+  {
+    name: 'child-event-order-status-first',
+    compareGroup: 'child-event-order',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILD_EVENT_ORDER: 'status-first',
+      HARNESS_CWD: CHILD_EVENT_ORDER_CWD,
+    },
+    bootExpect: '[Tab]streams',
+    expect: ['orderChecker', '1 sub', '[Tab]streams'],
   },
   {
     name: 'failed-subagent-status',
@@ -3763,6 +3828,41 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
   };
 }
 
+// Post-run byte-identity check for scenarios flagged with the same
+// `compareGroup` (issue #7972): asserts their rendered frames are exactly
+// equal, not just similar — the rendered-byte-level counterpart to a
+// vitest-level event-ordering equivalence. Only checked when every group
+// member actually ran (not platform-skipped, not excluded by a `scenario`
+// name filter on the command line).
+function compareGroupFailures(selectedScenarios, results) {
+  const resultByName = new Map(results.map((result) => [result.name, result]));
+  const groups = new Map();
+  for (const scenario of selectedScenarios) {
+    if (!scenario.compareGroup) continue;
+    const names = groups.get(scenario.compareGroup) ?? [];
+    names.push(scenario.name);
+    groups.set(scenario.compareGroup, names);
+  }
+  const failures = [];
+  for (const [group, names] of groups) {
+    if (names.length < 2) continue;
+    const members = names.map((name) => ({
+      name,
+      result: resultByName.get(name),
+    }));
+    if (members.some(({ result }) => !result || result.skipped)) continue;
+    const [first, ...rest] = members;
+    for (const other of rest) {
+      if (other.result.frame !== first.result.frame) {
+        failures.push(
+          `compare group ${JSON.stringify(group)}: ${JSON.stringify(first.name)} and ${JSON.stringify(other.name)} rendered different PTY frames (byte-identical check failed)`,
+        );
+      }
+    }
+  }
+  return failures;
+}
+
 if (snapshotDir) resetSnapshotDir(snapshotDir);
 
 let failed = 0;
@@ -3792,6 +3892,11 @@ for (const [index, scenario] of scenarios.entries()) {
   }
 }
 writeSnapshotReport(results);
+
+for (const failure of compareGroupFailures(scenarios, results)) {
+  failed += 1;
+  console.log(`✗ ${failure}`);
+}
 
 console.log('');
 console.log(


### PR DESCRIPTION
Closes #7972.

## What

Follow-up from #7967 (CLI child-stream state consolidation), which
explicitly deferred acceptance-gate items 4-5 of
`docs/proposals/cli-child-stream-state-consolidation.md`: byte-identical
PTY frame checks for order-equivalent child-stream event sequences, via
an opt-in `HARNESS_CHILD_EVENT_ORDER` fixture in
`packages/cli/scripts/tui-harness.tsx` plus `validate-tui.mjs`
assertions. #7967 shipped the vitest-level "child-stream ordered
transition matrix" (`TuiStateAndFocus.vitest.mts`, 11 scenarios driven
through the real transition functions) covering the same
roster-first/edge-first/status-first orderings, but not the
rendered-byte-level PTY layer the design calls for. This PR builds that
missing layer.

- **`tui-harness.tsx`**: new opt-in `HARNESS_CHILD_EVENT_ORDER` env var
  (`canonical` | `roster-first` | `edge-first` | `status-first`, throws on
  an unrecognized value). `seedChildEventOrderFixture()` seeds one
  synthetic child stream (`orderChecker`) through the real
  `applySubagentRoster`/`setParentStream`/`patchStream(status)`
  transition functions, in each of the four orderings the vitest matrix's
  scenarios 1-4 prove order-equivalent. No `startedAt` is set on the
  child, so `childElapsed` (`state/childControls.ts`) returns the static
  `elapsed` string instead of a live-ticking duration — required so the
  rendered frame is byte-identical across separate process launches, not
  just across orderings within one launch.
- **`validate-tui.mjs`**: four new scenarios
  (`child-event-order-{canonical,roster-first,edge-first,status-first}`),
  each setting `HARNESS_CHILD_EVENT_ORDER` and sharing one fixed
  `HARNESS_CWD` (so the cwd text in the rendered session chrome doesn't
  itself break the comparison for a reason unrelated to child-stream
  ordering). A new generic `compareGroup` scenario field plus
  `compareGroupFailures()` — run once after the main per-scenario loop —
  asserts every scenario sharing a `compareGroup` rendered an exactly
  equal frame; it's a no-op when a group is filtered to fewer than two
  members (e.g. via a `scenario` name argument on the CLI) or any member
  was platform-skipped.

## Verification

- `corepack pnpm --filter @texra-ai/cli typecheck` — clean.
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 124
  passed (the vitest ordered matrix this PR complements, unaffected).
- `node scripts/validate-tui.mjs` (full suite, from `packages/cli`) — all
  **145** scenarios passed (141 pre-existing + the 4 new ones), including
  the byte-identity `compareGroup` check.
- **Regression-test proof (git-stash-forbidden rule; patched in the
  worktree, reverted after)**: temporarily broke
  `applySubagentRoster`'s edge-compatibility guard in
  `childExecutions.ts` (`edge !== undefined && edge !== parentStreamId`
  → `edge === undefined || edge !== parentStreamId`, requiring an edge to
  already exist before a roster row is accepted). Reran the 4 new
  scenarios: `canonical` and `roster-first` (roster arrives before edge)
  failed their own `expect` assertions (the child never became active),
  and the `compareGroup` check correctly flagged `canonical` vs.
  `edge-first`/`status-first` as non-identical frames — 4/4 failed.
  Reverted the guard (`git diff` on the file empty again) and reran: all
  4 scenarios pass and are byte-identical, confirming the check both
  catches a real order-dependence regression and passes on current,
  correct behavior.
- `npx prettier --check` on both touched files — clean.

## Net elements (R6)

Test-infra only; no production source under `src/` or `packages/*/src/`
touched.

- **Files touched:** 2 (`packages/cli/scripts/tui-harness.tsx`,
  `packages/cli/scripts/validate-tui.mjs`), both existing dev/test
  scripts — no new files.
- **Lines:** net **+179** (179 insertions / 0 deletions) — additive only,
  matching a "add an opt-in fixture + assertions" scope.
- **Exported/callable declarations:** 0 new production exports (both
  files are top-level scripts, not modules other code imports). New
  script-local declarations: 1 function in `tui-harness.tsx`
  (`seedChildEventOrderFixture`), 1 function in `validate-tui.mjs`
  (`compareGroupFailures`) — the second is a generic, reusable
  `compareGroup` mechanism (not special-cased to this one fixture), so
  any future opt-in fixture needing the same byte-identity check reuses
  it instead of duplicating the comparison logic.
- **New shared planes, vocabularies, schemas, reducers, or persistence
  stores:** 0.

## Consumer counts (R8)

- `compareGroupFailures`: 1 call site (the post-run loop after all
  scenarios finish) — matches the existing one-call-site pattern every
  other post-run helper in this file already uses
  (`writeSnapshotReport`, `resetSnapshotDir`).
- `seedChildEventOrderFixture`: 1 call site (`if (CHILD_EVENT_ORDER)`),
  matching every other opt-in `SHOW_*`/`HARNESS_*` fixture function in
  this harness (`seedLiveToolOnlyTranscript`,
  `seedSubagentFollowupTranscript`, etc. — none of them have more than
  one caller either).
- `compareGroup` (the new scenario field): 4 scenarios in this PR. Kept
  as a generic field on the existing scenario-object shape rather than a
  one-off `childEventOrderScenarios` array, since the scenario loop,
  `--snapshot-dir`, `--no-build`, and per-scenario `only`/name filtering
  machinery all already operate uniformly over `SCENARIOS`.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI test harness scripts (`tui-harness.tsx`, `validate-tui.mjs`); no production `src/` behavior is modified.
> 
> **Overview**
> Adds **issue #7972** acceptance coverage for child-stream fact ordering at the rendered PTY layer, complementing the vitest transition matrix from #7967.
> 
> **`tui-harness.tsx`** introduces opt-in `HARNESS_CHILD_EVENT_ORDER` with **eight** orderings (`canonical` through `completion-remove`). `seedChildEventOrderFixture` wires **`subscribeStreamStatus`** and **`attachTuiRunFactSubscription`** like production, then emits real session/run facts (`child.activity`, `setParentStream`, `setActiveStream` with `suppressViewSwitch`, `removeStream`, `StreamStatusService` transitions) on a **deferred macrotask schedule** so Ink can render intermediate states. Static roster `elapsed` and suppressed view switch keep settled frames stable for cross-process comparison.
> 
> **`validate-tui.mjs`** adds matching scenarios: per-step **`checkpoints`** (paced to harness step delay so the validator does not race ahead), a shared **`HARNESS_CWD`** for the four order-equivalent cases, post-run **`compareGroup`** byte-identity for those four, and dedicated checkpoint expectations for promotion, reattachment, parent removal, and completion+removal (some scenarios assert Tab still exits cleanly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ecb987179c7cce9a4c7fd73bd9609fe6065af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->