### PR TITLE
fix(agent): consume native child follow-ups once

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -10,6 +10,7 @@ import {
   userFollowUpInstruction,
   type AppendFollowUpResult,
 } from '@agent/followUp/followUpMessages';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { STREAM_PHASE } from '@shared/schemas';
 import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
@@ -31,6 +32,10 @@ export class ToolUseWaitNode<C> extends Node<
   ToolUseRunShared,
   ToolUseServices<C>
 > {
+  constructor(private drainedFollowUps?: readonly FollowUpQueueBatchItem[]) {
+    super();
+  }
+
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {
     const { modelHandler, isSubagent, onIdle } = this.services;
 
@@ -90,23 +95,35 @@ export class ToolUseWaitNode<C> extends Node<
       this.services.onIdle?.(prepRes.lastResponse);
     }
 
-    // Subagent mode always exits WAITING here, carrying this cycle's turn
-    // facts (lastResponse/touchedFiles/totalCostUsd) — no in-flow delivery,
-    // no "already queued" fast path. The child-run loop (the one delivery
-    // site) formats and delivers after suspension, then decides whether to
-    // resume immediately (a follow-up already raced into the queue) or
-    // genuinely wait. This makes duplicate/skipped delivery structurally
-    // impossible and keeps every suspension symmetric, so the loop's interrupt
-    // handler always has a real boundary to attach against.
-    if (isSubagent === true && !stopAfterCycle) {
+    if (stopAfterCycle) {
+      return { kind: 'stop' };
+    }
+
+    // A native child-run loop has already drained this batch from the stream
+    // queue before it resumes the persisted flow. Consume that handoff once
+    // and advance directly to the cycle node. Re-appending it through
+    // ToolUseSessionLifecycle would return it to the same queue owner and make
+    // every later WAITING suspension resume with the identical batch.
+    const drainedFollowUps = this.drainedFollowUps;
+    this.drainedFollowUps = undefined;
+    if (drainedFollowUps && drainedFollowUps.length > 0) {
+      return {
+        kind: 'continue',
+        followUps: drainedFollowUps,
+        synthetic: false,
+      };
+    }
+
+    // With no externally consumed batch, subagent mode always exits WAITING
+    // here, carrying this cycle's turn facts
+    // (lastResponse/touchedFiles/totalCostUsd). The child-run loop formats and
+    // delivers after suspension, then owns the next queue wait. This keeps
+    // every ordinary suspension symmetric and leaves one delivery site.
+    if (isSubagent === true) {
       streamStatus.transitionToWaiting(streamId, 'wait', {
         trace: this.services.logger,
       });
       return { kind: 'waiting' };
-    }
-
-    if (stopAfterCycle) {
-      return { kind: 'stop' };
     }
 
     // The Goal continuation runs BEFORE `waitForFollowUp` blocks; once
@@ -168,10 +185,10 @@ export class ToolUseWaitNode<C> extends Node<
       return FlowTransition.COMPLETE;
     }
 
-    // User sent a follow-up — clear any prior error/cancellation state
-    // so the next cycle starts fresh and runToolUseFlow won't treat
-    // a previously-recovered error as a terminal failure. Only reachable in
-    // root (non-subagent) mode: subagent mode always exits above.
+    // A user follow-up is ready for the next cycle. Clear any prior
+    // error/cancellation state so runToolUseFlow does not treat a recovered
+    // error as terminal. Root flows arrive here from their session queue;
+    // resumed subagents arrive here through the one-shot handoff above.
     shared.lastError = undefined;
     shared.userCancelledRetry = undefined;
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -22,6 +22,7 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { deriveRunOutcome } from '@common/constants/streamStatus';
@@ -60,11 +61,14 @@ export interface RunToolUseFlowInput<
 > extends BaseFlowContextInit<C> {
   setting: AgentToolUseSetting;
   resumeSnapshot?: ToolUseSessionSnapshot | null;
+  /** One batch already drained by an external child-turn owner. */
+  drainedFollowUps?: readonly FollowUpQueueBatchItem[];
   onFollowUpConsumed?: () => void;
   /** When true, delegation tools are filtered out to prevent nesting, and
-   *  every cycle suspends at WAITING (see `ToolUseWaitNode`) instead of
-   *  blocking in-flow for the next follow-up — the child-run loop owns
-   *  delivery and turn-to-turn continuation. */
+   *  every completed model cycle suspends at WAITING (see `ToolUseWaitNode`)
+   *  instead of blocking in-flow for the next follow-up. A resumed flow may
+   *  first consume `drainedFollowUps`; the child-run loop still owns
+   *  delivery and every later turn boundary. */
   isSubagent?: boolean;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
@@ -368,7 +372,7 @@ export async function runToolUseFlow<C = unknown>(
 
     const prepareNode = new ToolUsePrepareNode<C>();
     const cycleNode = new ToolUseCycleNode<C>();
-    const waitNode = new ToolUseWaitNode<C>();
+    const waitNode = new ToolUseWaitNode<C>(input.drainedFollowUps);
     prepareNode.next(cycleNode);
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -67,8 +67,8 @@ export interface ChildRunPorts {
  * `runTurn` with the seeded initial prompt; native: the `executeAgent`
  * call itself). `runTurn` produces every following turn's outcome, given the
  * follow-up items the loop drained since the previous turn (agent-CLI joins
- * their text into one prompt; native replays them as queued follow-ups via
- * `resumeQueuedToolUseSnapshot`'s `extraFollowUps`).
+ * their text into one prompt; native injects the already-consumed batch at
+ * the resumed flow's persisted WAITING boundary without re-enqueueing it).
  *
  * Per-turn call order: `launch`/`runTurn` → `getUsage` (turn summary) →
  * `isTurnError` → `onTurnError` (if true) → `onTurnSuccess` (only when the
@@ -167,7 +167,7 @@ export interface ChildRunStrategy<TTurn> {
 export interface ChildRunLoopParams<TTurn> {
   /**
    * Presentation/lifecycle wrapper for agent-CLI child streams. Native
-   * strategies omit this — `executeAgent`/`resumeQueuedToolUseSnapshot`
+   * strategies omit this — `executeAgent`/`resumeToolUseFromSnapshot`
    * already own handle creation, tracking, and terminal finalization for
    * every turn via `runFlowWithLifecycle`, so there is no separate stream tab
    * for this loop to finalize.

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -8,6 +8,7 @@ import {
   type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
+import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   runReflectionFlow,
   type RunReflectionFlowResult,
@@ -471,6 +472,12 @@ export async function executeAgent(
 
 export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly setupSession?: (session: IToolUseSession) => void;
+  /**
+   * Follow-ups already drained by an external turn owner. The resumed flow
+   * consumes this batch once at its persisted WAITING cursor; it must never
+   * pass through the stream queue again.
+   */
+  readonly drainedFollowUps?: readonly FollowUpQueueBatchItem[];
 }
 
 export async function resumeToolUseFromSnapshot(
@@ -532,6 +539,7 @@ export async function resumeToolUseFromSnapshot(
             onRoundFinalized: createUsageRecordingCallback(ctx),
             setting,
             resumeSnapshot: snapshot,
+            drainedFollowUps: options.drainedFollowUps,
             // Derive from the recovered parent chain: any execution with a
             // parent is a subagent. Without this, the rebuilt system prompt
             // would drop subagent-specific instructions (e.g. the shared

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -127,6 +127,81 @@ describe('ToolUseWaitNode', () => {
     expect(waitForFollowUp).not.toHaveBeenCalled();
   });
 
+  it('advances a drained child-loop batch once without reading the session queue', async () => {
+    const shared: ToolUseRunShared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+    };
+    const runtimeHost = { emit: vi.fn() };
+    const waitForFollowUp = vi.fn();
+    const createUserFollowUpMessages = vi.fn(
+      async (_messages: unknown[], text: string) => [
+        { role: 'user', content: text },
+      ],
+    );
+    const onFollowUpConsumed = vi.fn();
+    const batch = [
+      {
+        text: 'state where finiteness is used',
+        displayText: 'clarify finiteness',
+        origin: 'user' as const,
+      },
+    ];
+    const services = {
+      checkInterruption: () => false,
+      isSubagent: true,
+      logger: { emit: vi.fn(), error: vi.fn(), info: vi.fn() },
+      modelHandler: {
+        createUserFollowUpMessages,
+        extractAssistantText: () => undefined,
+      },
+      onFollowUpConsumed,
+      runtimeHost,
+      session: {
+        hasQueuedFollowUp: () => false,
+        waitForFollowUp,
+      },
+      streamStatus: new StreamStatusMachine(),
+      streamId: 'test-stream',
+    } as unknown as ToolUseServices;
+    const node = new ToolUseWaitNode(batch).setServices(services);
+    const prep = await node.prep(shared);
+
+    const first = await withTestRunContext(
+      runtimeHost,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        const transition = await node.post(shared, prep, exec);
+        return { exec, transition };
+      },
+    );
+    const second = await withTestRunContext(runtimeHost, 'test-stream', () =>
+      node.exec(prep),
+    );
+
+    expect(first).toEqual({
+      exec: {
+        kind: 'continue',
+        followUps: batch,
+        synthetic: false,
+      },
+      transition: FlowTransition.CONTINUE,
+    });
+    expect(second).toEqual({ kind: 'waiting' });
+    expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
+    expect(createUserFollowUpMessages).toHaveBeenCalledWith(
+      [],
+      'state where finiteness is used',
+    );
+    expect(shared.messages).toEqual([
+      { role: 'user', content: 'state where finiteness is used' },
+    ]);
+    expect(onFollowUpConsumed).toHaveBeenCalledOnce();
+    expect(waitForFollowUp).not.toHaveBeenCalled();
+  });
+
   it('stops instead of suspending when stopAfterCycle is set (headless in-band subagent)', async () => {
     const shared: ToolUseRunShared = {
       messages: [],

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -1,7 +1,16 @@
 // Third-party imports
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
+import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
+import {
+  isChildRunLoopActive,
+  startChildRunLoop,
+} from '@agent/runtime/childRunLoop';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   STREAM_PHASE,
   type ExecutionId,
@@ -9,35 +18,46 @@ import {
 } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
+  deliverChildRunFollowUp: vi.fn(),
   executeAgent: vi.fn(),
+  persistChildRunReport: vi.fn(),
+  persistChildRunResultMeta: vi.fn(),
   readConfig: vi.fn(),
-  resumeQueuedToolUseSnapshot: vi.fn(),
+  resumeToolUseFromSnapshot: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
+  writeTerminalStatus: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
   executeAgent: mocks.executeAgent,
+  resumeToolUseFromSnapshot: mocks.resumeToolUseFromSnapshot,
 }));
 
 vi.mock('@agent/storage', () => ({
   getExecutionStore: vi.fn(() => ({ readConfig: mocks.readConfig })),
+  writeTerminalStatus: mocks.writeTerminalStatus,
 }));
 
 vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
   retrieveSessionResumeData: mocks.retrieveSessionResumeData,
 }));
 
-vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
-  resumeQueuedToolUseSnapshot: mocks.resumeQueuedToolUseSnapshot,
+vi.mock('@tools/childRunDelivery', () => ({
+  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
+  persistChildRunReport: mocks.persistChildRunReport,
+  persistChildRunResultMeta: mocks.persistChildRunResultMeta,
 }));
 
 import { createNativeToolUseStrategy } from '@tools/delegation/nativeToolUseStrategy';
+
+const ownedSessions = new Set<SessionHandle>();
 
 function fakePorts() {
   return { notify: vi.fn(), recordCost: vi.fn() };
 }
 
-function baseParams() {
+function baseParams(parentSession = new SessionHandle()) {
+  if (parentSession !== defaultSession()) ownedSessions.add(parentSession);
   return {
     configPayload: {
       agent: 'review',
@@ -47,7 +67,7 @@ function baseParams() {
     executionId: 'exec-1' as ExecutionId,
     agentName: 'review',
     orchestratorStreamId: 'orchestrator-stream' as StreamTabId,
-    parentSession: { tag: 'parent-session' } as never,
+    parentSession,
     runtimeHost: { emit: vi.fn() } as never,
     startedAt: Date.now(),
     delegationDepth: 1,
@@ -57,7 +77,16 @@ function baseParams() {
 
 describe('NativeToolUseStrategy', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
+    mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
+    mocks.writeTerminalStatus.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    for (const session of ownedSessions) session.dispose();
+    ownedSessions.clear();
   });
 
   it('resolveDeliveryTarget follows the live run handle, including after detach', async () => {
@@ -155,8 +184,12 @@ describe('NativeToolUseStrategy', () => {
     expect(errMsg).toContain('model overloaded');
   });
 
-  it('runTurn drives the persisted flow-record cursor via retrieveSessionResumeData + resumeQueuedToolUseSnapshot', async () => {
-    const params = baseParams();
+  it('runTurn hands its consumed batch directly to the persisted flow cursor', async () => {
+    const params = {
+      ...baseParams(),
+      approvalPromptsUnavailable: true,
+      runtimeUnavailableTools: ['ask_user'],
+    };
     const strategy = createNativeToolUseStrategy(params);
     const childStreamId = 'child-stream' as StreamTabId;
 
@@ -185,18 +218,13 @@ describe('NativeToolUseStrategy', () => {
       type: 'toolUse',
       snapshot,
     });
-    mocks.resumeQueuedToolUseSnapshot.mockImplementationOnce(
-      async (_streamId, _snapshot, _host, options) => {
-        options.onResult({
-          category: 'toolUse',
-          outcome: 'completed',
-          lastResponse: 'done',
-          executionId: params.executionId,
-          streamId: childStreamId,
-        });
-        return true;
-      },
-    );
+    mocks.resumeToolUseFromSnapshot.mockResolvedValueOnce({
+      category: 'toolUse',
+      outcome: 'completed',
+      lastResponse: 'done',
+      executionId: params.executionId,
+      streamId: childStreamId,
+    });
 
     const turn = await strategy.runTurn!(
       [{ text: 'keep going', origin: 'user' }],
@@ -209,13 +237,14 @@ describe('NativeToolUseStrategy', () => {
       params.executionId,
       config,
     );
-    expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledWith(
-      childStreamId,
+    expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledWith(
       snapshot,
       params.runtimeHost,
       expect.objectContaining({
         allowWaitingResult: true,
-        extraFollowUps: [
+        approvalPromptsUnavailable: true,
+        parentStreamId: params.orchestratorStreamId,
+        drainedFollowUps: [
           {
             text: 'keep going',
             displayText: undefined,
@@ -223,12 +252,14 @@ describe('NativeToolUseStrategy', () => {
             origin: 'user',
           },
         ],
+        runtimeUnavailableTools: ['ask_user'],
+        session: params.parentSession,
       }),
     );
     expect(strategy.isTerminal(turn)).toBe(true);
   });
 
-  it('preserves #7491: a failed resume (resumeQueuedToolUseSnapshot returns false) throws, delivering formatError to the parent', async () => {
+  it('preserves #7491: a failed direct resume throws for child-loop error delivery', async () => {
     const params = baseParams();
     const strategy = createNativeToolUseStrategy(params);
     const childStreamId = 'child-stream' as StreamTabId;
@@ -255,16 +286,148 @@ describe('NativeToolUseStrategy', () => {
       },
     });
     const resumeError = new Error('resume storage unreadable');
-    mocks.resumeQueuedToolUseSnapshot.mockImplementationOnce(
-      async (_streamId, _snapshot, _host, options) => {
-        await options.onError(resumeError);
-        return false;
-      },
-    );
+    mocks.resumeToolUseFromSnapshot.mockRejectedValueOnce(resumeError);
 
     await expect(
       strategy.runTurn!([], fakePorts(), new AbortController()),
     ).rejects.toBe(resumeError);
+  });
+
+  it('consumes one child-loop follow-up in one resumed WAITING turn without requeueing it', async () => {
+    const session = defaultSession();
+    const childStreamId = 'native-follow-up-loop-child' as StreamTabId;
+    const parentStreamId = 'native-follow-up-loop-parent' as StreamTabId;
+    const executionId = 'native-follow-up-loop-exec' as ExecutionId;
+    const runtimeHost = { emit: vi.fn() } as never;
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'review',
+      'toolUse',
+      runtimeHost,
+    );
+    const params = {
+      ...baseParams(session),
+      executionId,
+      orchestratorStreamId: parentStreamId,
+      runtimeHost,
+    };
+    const waitingTurn = (lastResponse: string) => ({
+      category: 'toolUse' as const,
+      outcome: STREAM_PHASE.WAITING,
+      lastResponse,
+      executionId,
+      streamId: childStreamId,
+    });
+
+    mocks.executeAgent.mockImplementationOnce(
+      async (_config, _executionId, options) => {
+        session.status.transition(
+          childStreamId,
+          STREAM_PHASE.RUNNING,
+          'lifecycle',
+        );
+        session.executions.trackAgentExecution(handle, {
+          status: STREAM_PHASE.RUNNING,
+        });
+        options.onStreamResolved?.(childStreamId);
+        options.onRun?.(handle);
+        session.status.transitionToWaiting(childStreamId, 'wait');
+        return waitingTurn('initial response');
+      },
+    );
+    const config = { agentCategory: 'toolUse' };
+    const snapshot = {
+      agentConfig: config,
+      executionId,
+      messages: [],
+    };
+    mocks.readConfig.mockResolvedValue(config);
+    mocks.retrieveSessionResumeData.mockResolvedValue({
+      type: 'toolUse',
+      snapshot,
+    });
+    mocks.resumeToolUseFromSnapshot.mockImplementation(
+      async (_snapshot, _host, options) => {
+        if (mocks.resumeToolUseFromSnapshot.mock.calls.length > 1) {
+          throw new Error('the same follow-up batch resumed more than once');
+        }
+        // This branch models the former queue-owning wrapper. Before the fix,
+        // NativeToolUseStrategy called that wrapper, which supplied
+        // setupSession and thereby put the child-loop batch back into this
+        // exact queue. Keeping the branch in the integration fixture makes a
+        // regression fail after two turns instead of spinning indefinitely.
+        if (options.setupSession) {
+          options.setupSession(
+            new ToolUseSessionLifecycle(childStreamId, session.followUps),
+          );
+        }
+        options.onRun?.(handle);
+        session.status.transitionToWaiting(childStreamId, 'wait');
+        return waitingTurn('follow-up response');
+      },
+    );
+
+    const strategy = createNativeToolUseStrategy(params);
+    try {
+      startChildRunLoop({
+        childStreamId,
+        parentStreamId,
+        executionId,
+        agentName: params.agentName,
+        strategy,
+      });
+      await vi.waitFor(() =>
+        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
+      );
+
+      session.followUps.acquire(childStreamId).enqueue({
+        text: 'Also state exactly where finiteness is used.',
+        origin: 'user',
+      });
+
+      await vi.waitFor(() =>
+        expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledTimes(1),
+      );
+      await vi.waitFor(() =>
+        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(2),
+      );
+      // Give an accidentally re-enqueued batch enough time to start a second
+      // immediate resume. The guarded mock above prevents an actual busy loop.
+      await sleep(50);
+
+      expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.resumeToolUseFromSnapshot.mock.calls[0]?.[2].drainedFollowUps,
+      ).toEqual([
+        {
+          text: 'Also state exactly where finiteness is used.',
+          displayText: undefined,
+          mediaFiles: undefined,
+          origin: 'user',
+        },
+      ]);
+      expect(session.followUps.getAll(childStreamId)).toEqual([]);
+      expect(session.status.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
+      const resumedDeliveries = mocks.deliverChildRunFollowUp.mock.calls.filter(
+        ([delivery]) => delivery.followUp.text.includes('follow-up response'),
+      );
+      expect(resumedDeliveries).toHaveLength(1);
+    } finally {
+      const handleWasTracked =
+        session.executions.getHandle(executionId) !== undefined;
+      if (isChildRunLoopActive(childStreamId)) handle.interrupt();
+      await vi.waitFor(() =>
+        expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      );
+      if (handleWasTracked) await handle.result;
+      if (session.executions.getHandle(executionId)) {
+        session.executions.untrack(executionId);
+      }
+      session.followUps.release(childStreamId);
+      session.status.clearStream(childStreamId);
+    }
   });
 
   it('records the run cumulative cost via ports.recordCost on every turn', async () => {

--- a/src/tools/delegation/nativeToolUseStrategy.ts
+++ b/src/tools/delegation/nativeToolUseStrategy.ts
@@ -5,7 +5,8 @@
  * capturing the live run handle via `onRun`. `runTurn` is every following
  * turn: resolve the persisted flow-record cursor for this execution
  * (`retrieveSessionResumeData`) and drive it to the next WAITING/terminal
- * boundary via `resumeQueuedToolUseSnapshot`. Delivery choreography
+ * boundary via `resumeToolUseFromSnapshot`, handing it the batch already
+ * consumed by `childRunLoop`. Delivery choreography
  * (format/persist/manifest/deliver), duplicate-delivery prevention (there is
  * exactly one delivery site — the loop), and WAITING-cleanup registration all
  * live in the loop; this strategy owns only what is specific to a native
@@ -19,9 +20,11 @@ import {
   type AgentFlowResult,
   type AgentRuntimeFlowResult,
 } from '@agent/runtime/AgentFlowResult';
-import { executeAgent } from '@agent/runtime/executeAgent';
+import {
+  executeAgent,
+  resumeToolUseFromSnapshot,
+} from '@agent/runtime/executeAgent';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
-import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
@@ -30,8 +33,11 @@ import type {
   ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
   RUN_OUTCOME,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -84,7 +90,7 @@ export function createNativeToolUseStrategy(
 ): ChildRunStrategy<AgentRuntimeFlowResult> {
   let runHandle: AgentRunHandle | undefined;
   // Captured for the turn currently in flight; read once the call resolves.
-  // `executeAgent`/`resumeQueuedToolUseSnapshot` never reject for a
+  // `executeAgent`/`resumeToolUseFromSnapshot` never reject for a
   // subagent's own application-level failure (runFlowWithLifecycle returns a
   // terminal failed result instead) — the real underlying error is only
   // observable through this callback.
@@ -180,10 +186,23 @@ export function createNativeToolUseStrategy(
           );
         }
 
-        let result: AgentRuntimeFlowResult | undefined;
-        let resumeError: unknown;
-        const resumed = await resumeQueuedToolUseSnapshot(
+        // childRunLoop already consumed this batch from the stream queue. A
+        // queued-resume wrapper would append it to ToolUseSessionLifecycle,
+        // which is backed by that same queue; the next WAITING result would
+        // therefore feed the identical batch back into this method forever.
+        // Hand it directly to the persisted WAITING cursor instead. Any item
+        // that races into the queue after this drain remains there for the
+        // loop's next turn.
+        params.parentSession.status.transition(
           streamId,
+          STREAM_PHASE.RUNNING,
+          STREAM_TRANSITION_CAUSE.RESUME,
+          {
+            events: params.parentSession.events,
+            substate: STREAM_SUBSTATE.RESUMING,
+          },
+        );
+        return await resumeToolUseFromSnapshot(
           resume.snapshot,
           params.runtimeHost,
           {
@@ -192,48 +211,25 @@ export function createNativeToolUseStrategy(
             runtimeUnavailableTools: params.runtimeUnavailableTools,
             parentStreamId: params.orchestratorStreamId,
             allowWaitingResult: true,
-            // The loop's queue never admits synthetic (goal-continuation)
-            // items for a subagent — that path is root-only — but the type
-            // is shared with root's batch shape, so downgrade defensively
-            // rather than silently dropping content on a future change.
-            extraFollowUps: followUps.map((item) => ({
+            // The loop's queue never admits synthetic goal continuations for
+            // a subagent, but its batch type is shared with root flows. Keep
+            // the existing defensive downgrade rather than silently dropping
+            // a future synthetic item.
+            drainedFollowUps: followUps.map((item) => ({
               text: item.text,
               displayText: item.displayText,
               mediaFiles: item.mediaFiles,
               origin: item.origin === 'synthetic' ? 'user' : item.origin,
             })),
             onProgress: (update) => ports.notify(update),
-            onResult: (r) => {
-              result = r;
-            },
-            onRunError: (err, r) => {
+            onRunError: (err) => {
               lastErr = err;
-              result = r;
             },
             onRun: (handle) => {
               runHandle = handle;
             },
-            onError: (err) => {
-              resumeError = err;
-            },
           },
         );
-        if (!resumed) {
-          // Preserves #7491: a failed resume (e.g. unreadable resume
-          // storage) throws here, so the loop's own catch classifies it as a
-          // failed turn and delivers `formatError` to the parent — the same
-          // terminal error-delivery path a resumed turn's own failure takes.
-          throw (
-            resumeError ??
-            new Error(`Failed to resume native subagent ${params.executionId}.`)
-          );
-        }
-        if (result === undefined) {
-          throw new Error(
-            `Native subagent ${params.executionId} resumed without producing a result.`,
-          );
-        }
-        return result;
       }),
 
     isTerminal: (turn) => !isWaitingFlowResult(turn),


### PR DESCRIPTION
## Summary

- hand the child loop's already-drained follow-up batch directly to the persisted `WAITING` cursor
- keep `childRunLoop` as the sole owner of the child stream queue while preserving resume policy and status transitions
- add boundary coverage proving one follow-up produces one resumed turn, one delivery, an empty queue, and one final `WAITING` state

## Design

The previous native strategy passed a batch drained by `childRunLoop` through the general queued-resume wrapper. That wrapper appended the batch to the same stream queue, while subagent flows suspend before reading that queue. The loop therefore drained and re-appended the same batch indefinitely.

The resumed flow now receives a `drainedFollowUps` handoff. `ToolUseWaitNode` consumes that handoff once at the persisted `WAITING` cursor and then returns to the ordinary subagent suspension path. Follow-ups that arrive during the resumed model turn remain in the queue for the next loop iteration.

## Validation

- `npm test -- --run src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts src/test-kernel/tools/NativeToolUseStrategy.vitest.ts` (24 tests)
- `npm run typecheck`
- targeted ESLint for all changed TypeScript files
- repository formatter commit hook
- `git diff --check origin/main...HEAD`

Closes #7968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent turn boundaries, follow-up queue ownership, and resume/status transitions; incorrect handoff could still duplicate or drop follow-ups, though targeted tests cover the regression.
> 
> **Overview**
> Fixes native tool-use subagents getting stuck in an infinite resume loop when the child-run loop delivered a follow-up.
> 
> **`drainedFollowUps` handoff:** Batches already drained by `childRunLoop` are passed through `resumeToolUseFromSnapshot` → `runToolUseFlow` → `ToolUseWaitNode`, which consumes them **once** at the persisted `WAITING` cursor and continues to the next model cycle without touching the stream follow-up queue again.
> 
> **Native strategy:** `NativeToolUseStrategy.runTurn` now calls `resumeToolUseFromSnapshot` with `drainedFollowUps` instead of `resumeQueuedToolUseSnapshot` / `extraFollowUps`, which had re-appended the same batch to the queue the loop already owned.
> 
> **Tests:** Unit coverage on `ToolUseWaitNode` one-shot consumption, plus an integration test that one enqueued follow-up yields one resume, one delivery, an empty queue, and a final `WAITING` state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3207c468fa36b44da9e93ec959e7b3609a368832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->