### PR TITLE
test(cli): add child event order frame checks

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -11,6 +11,8 @@ import React from 'react';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -20,6 +22,7 @@ import {
   LIVE_ELAPSED_STREAM_STATUSES,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  STREAM_PHASE,
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
   TODO_STATUS,
@@ -91,6 +94,8 @@ import {
   type ApprovalDecision,
 } from '../src/chat/tui/state/approvalQueue';
 import { syncStreamLog } from '../src/chat/tui/state/subscribeStreamLog';
+import { subscribeStreamStatus } from '../src/chat/tui/state/subscribeStreamStatus';
+import { attachTuiRunFactSubscription } from '../src/chat/tui/state/subscribeRuntimeHost';
 import { resolveLocalTranscriptStreamId } from '../src/chat/tui/state/transcript';
 import { defaultShortcutModifierLabel } from '../src/runtime/shortcutLabels';
 import { OrchestrationApp } from '../src/orchestration/runOrchestrationTui';
@@ -221,6 +226,20 @@ const DISABLED_MODEL_SWITCH_REASON =
   'different conversation format; start new chat';
 const SHOW_CHILDREN = process.env.HARNESS_CHILDREN === '1';
 const SHOW_NESTED_CHILDREN = process.env.HARNESS_NESTED_CHILDREN === '1';
+const CHILD_EVENT_ORDER_NAMES = [
+  'canonical',
+  'roster-first',
+  'edge-first',
+  'status-first',
+  'promotion-late-roster',
+  'reattach-late-old-roster',
+  'parent-removal',
+  'completion-remove',
+] as const;
+type ChildEventOrder = (typeof CHILD_EVENT_ORDER_NAMES)[number];
+const CHILD_EVENT_ORDER = parseChildEventOrder(
+  process.env.HARNESS_CHILD_EVENT_ORDER,
+);
 const SHOW_TODOS = process.env.HARNESS_TODOS === '1';
 const SHOW_IDLE_TODOS = process.env.HARNESS_TODOS_IDLE === '1';
 const SHOW_COMPLETED_TODOS_ONLY = process.env.HARNESS_TODOS_COMPLETED === '1';
@@ -250,6 +269,20 @@ if (!HARNESS_CWD_INPUT && process.env.HARNESS_KEEP_CWD !== '1') {
 }
 for (const followUp of QUEUED_FOLLOW_UPS) {
   HARNESS_FOLLOW_UP_QUEUE.enqueue(followUp);
+}
+
+function parseChildEventOrder(
+  value: string | undefined,
+): ChildEventOrder | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  const order = CHILD_EVENT_ORDER_NAMES.find(
+    (candidate) => candidate === normalized,
+  );
+  if (order) return order;
+  throw new Error(
+    `Unknown HARNESS_CHILD_EVENT_ORDER ${JSON.stringify(normalized)}; expected one of ${CHILD_EVENT_ORDER_NAMES.join(', ')}`,
+  );
 }
 
 function seedHarnessProjectSkill(): void {
@@ -956,6 +989,256 @@ function harnessInitialEntries(): ConversationEntry[] {
   return makeEntries(ENTRY_COUNT);
 }
 
+type ChildEventStep =
+  | 'A'
+  | 'S(running)'
+  | 'S(terminal)'
+  | 'R_P+'
+  | 'R_P-'
+  | 'R_Q+'
+  | 'E_P+'
+  | 'E_Q+'
+  | 'E0'
+  | 'X(child)'
+  | 'X(P)';
+
+const CHILD_EVENT_SEQUENCES = {
+  canonical: ['A', 'S(running)', 'R_P+', 'E_P+'],
+  'roster-first': ['R_P+', 'A', 'S(running)', 'E_P+'],
+  'edge-first': ['E_P+', 'A', 'S(running)', 'R_P+'],
+  'status-first': ['S(running)', 'A', 'E_P+', 'R_P+'],
+  'promotion-late-roster': ['A', 'S(running)', 'R_P+', 'E_P+', 'E0', 'R_P+'],
+  'reattach-late-old-roster': [
+    'A',
+    'S(running)',
+    'R_P+',
+    'E_P+',
+    'E0',
+    'R_P+',
+    'E_Q+',
+    'R_Q+',
+    'R_P+',
+  ],
+  'parent-removal': ['A', 'S(running)', 'R_P+', 'E_P+', 'X(P)', 'R_P+', 'E_P+'],
+  'completion-remove': [
+    'A',
+    'S(running)',
+    'R_P+',
+    'E_P+',
+    'R_P-',
+    'S(terminal)',
+    'X(child)',
+    'R_P+',
+    'E_P+',
+    'A',
+    'S(running)',
+  ],
+} as const satisfies Record<ChildEventOrder, readonly ChildEventStep[]>;
+
+const HARNESS_EVENT_PARENT_P = STREAM_ID as StreamTabId;
+const HARNESS_EVENT_PARENT_Q = 'harness-event-parent-q' as StreamTabId;
+const HARNESS_EVENT_CHILD = 'harness-event-child-stream' as StreamTabId;
+const HARNESS_EVENT_CHILD_ROW = {
+  kind: 'subagent' as const,
+  executionId: 'harness-event-child' as ExecutionId,
+  agentName: 'eventChild',
+  childStreamId: HARNESS_EVENT_CHILD,
+};
+const CHILD_EVENT_FIXTURE_DISPOSERS: Array<() => void> = [];
+
+function emitHarnessAttachment(
+  hub: SessionEventHub,
+  streamId: StreamTabId,
+  suppressViewSwitch: boolean,
+): void {
+  hub.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload: {
+        streamId,
+        agentCategory: AgentCategory.ToolUse,
+        suppressViewSwitch,
+      },
+    },
+  });
+}
+
+function emitHarnessRoster(
+  hub: SessionEventHub,
+  parentStreamId: StreamTabId,
+  children: readonly ActiveChildInfo[],
+): void {
+  hub.emit({
+    scope: 'run',
+    streamId: parentStreamId,
+    event: {
+      type: 'child.activity',
+      kind: 'subagents',
+      parentStreamId,
+      children,
+    },
+  });
+}
+
+function emitHarnessEdge(
+  hub: SessionEventHub,
+  parentStreamId: StreamTabId | null,
+): void {
+  hub.emit({
+    scope: 'session',
+    event: {
+      type: 'setParentStream',
+      payload: {
+        childStreamId: HARNESS_EVENT_CHILD,
+        parentStreamId,
+      },
+    },
+  });
+}
+
+function emitHarnessRemoval(hub: SessionEventHub, streamId: StreamTabId): void {
+  hub.emit({
+    scope: 'session',
+    event: { type: 'removeStream', payload: { streamId } },
+  });
+}
+
+function omitHarnessRunStartedAt(streamId: StreamTabId): void {
+  const slice = streams.get().get(streamId);
+  if (!slice || slice.runStartedAt === undefined) return;
+  patchStream(streamId, (current) => ({
+    ...current,
+    runStartedAt: undefined,
+  }));
+}
+
+function applyHarnessChildEventStep(
+  hub: SessionEventHub,
+  step: ChildEventStep,
+): void {
+  switch (step) {
+    case 'A':
+      emitHarnessAttachment(hub, HARNESS_EVENT_CHILD, true);
+      return;
+    case 'S(running)': {
+      const cause =
+        StreamStatusService.get(HARNESS_EVENT_CHILD) === undefined
+          ? 'lifecycle'
+          : 'resume';
+      const transitioned = StreamStatusService.transition(
+        HARNESS_EVENT_CHILD,
+        STREAM_PHASE.RUNNING,
+        cause,
+        { events: hub },
+      );
+      if (!transitioned) {
+        throw new Error('HARNESS_CHILD_EVENT_ORDER rejected S(running)');
+      }
+      omitHarnessRunStartedAt(HARNESS_EVENT_CHILD);
+      return;
+    }
+    case 'S(terminal)': {
+      const transitioned = StreamStatusService.transitionToTerminal(
+        HARNESS_EVENT_CHILD,
+        STREAM_PHASE.COMPLETED,
+        { events: hub },
+      );
+      if (!transitioned) {
+        throw new Error('HARNESS_CHILD_EVENT_ORDER rejected S(terminal)');
+      }
+      return;
+    }
+    case 'R_P+':
+      emitHarnessRoster(hub, HARNESS_EVENT_PARENT_P, [HARNESS_EVENT_CHILD_ROW]);
+      return;
+    case 'R_P-':
+      emitHarnessRoster(hub, HARNESS_EVENT_PARENT_P, []);
+      return;
+    case 'R_Q+':
+      emitHarnessRoster(hub, HARNESS_EVENT_PARENT_Q, [HARNESS_EVENT_CHILD_ROW]);
+      return;
+    case 'E_P+':
+      emitHarnessEdge(hub, HARNESS_EVENT_PARENT_P);
+      return;
+    case 'E_Q+':
+      emitHarnessEdge(hub, HARNESS_EVENT_PARENT_Q);
+      return;
+    case 'E0':
+      emitHarnessEdge(hub, null);
+      return;
+    case 'X(child)':
+      emitHarnessRemoval(hub, HARNESS_EVENT_CHILD);
+      return;
+    case 'X(P)':
+      emitHarnessRemoval(hub, HARNESS_EVENT_PARENT_P);
+      return;
+  }
+}
+
+async function writeHarnessChildEventCheckpoint(label: string): Promise<void> {
+  const checkpoint = `\u001BPtexra-harness-child-event:${label}\u001B\\`;
+  await new Promise<void>((resolve, reject) => {
+    HARNESS_STDOUT.write(checkpoint, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function runHarnessChildEventOrder(
+  ink: ReturnType<typeof render>,
+  hub: SessionEventHub,
+  order: ChildEventOrder,
+): Promise<void> {
+  emitHarnessAttachment(hub, HARNESS_EVENT_PARENT_Q, true);
+  hub.emit({
+    scope: 'session',
+    event: {
+      type: 'updateStreamDescription',
+      payload: {
+        streamId: HARNESS_EVENT_PARENT_Q,
+        description: 'new parent Q',
+      },
+    },
+  });
+  patchStream(HARNESS_EVENT_PARENT_Q, (slice) => ({
+    ...slice,
+    entries: [
+      harnessMessageEntry(
+        'harness-event-parent-q-ready',
+        'Harness new parent Q.',
+      ),
+    ],
+  }));
+  ink.rerender(renderHarnessApp());
+  await ink.waitUntilRenderFlush();
+  await writeHarnessChildEventCheckpoint('setup');
+
+  for (const [index, step] of CHILD_EVENT_SEQUENCES[order].entries()) {
+    applyHarnessChildEventStep(hub, step);
+    ink.rerender(renderHarnessApp());
+    await ink.waitUntilRenderFlush();
+    await writeHarnessChildEventCheckpoint(`step-${index + 1}`);
+  }
+
+  if (streams.get().has(HARNESS_EVENT_CHILD)) {
+    patchStream(HARNESS_EVENT_CHILD, (slice) => ({
+      ...slice,
+      description: 'event-driven child fixture',
+      entries: makeChildEntries('eventChild', 'event-order'),
+    }));
+    ink.rerender(renderHarnessApp());
+    await ink.waitUntilRenderFlush();
+  }
+  if (order === 'parent-removal') {
+    emitHarnessAttachment(hub, HARNESS_EVENT_PARENT_Q, false);
+    ink.rerender(renderHarnessApp());
+    await ink.waitUntilRenderFlush();
+  }
+  await writeHarnessChildEventCheckpoint('ready');
+}
+
 sessionMeta.set({
   agent: 'chat',
   model: 'harness-model',
@@ -1637,32 +1920,52 @@ function handleHarnessCtrlC(): void {
 const restoreStdoutListenerLimit = installTuiStdoutListenerLimit(
   process.stdout,
 );
-const ink = render(
-  <App
-    onSubmit={handleHarnessSubmit}
-    onKillExecution={markHarnessExecutionStopped}
-    canInterruptActiveRun={() => canInterrupt}
-    canStopActiveRun={() => canInterrupt}
-    colorEnabled={HARNESS_COLOR_ENABLED}
-    onInterruptActive={markHarnessInterrupted}
-    onTranscriptViewportChange={
-      viewportController.handleTranscriptViewportChange
-    }
-    onCtrlC={handleHarnessCtrlC}
-  />,
-  {
-    stdout: HARNESS_STDOUT,
-    stderr: process.stderr,
-    stdin: process.stdin,
-    exitOnCtrlC: false,
-  },
-);
+function renderHarnessApp(): React.JSX.Element {
+  return (
+    <App
+      onSubmit={handleHarnessSubmit}
+      onKillExecution={markHarnessExecutionStopped}
+      canInterruptActiveRun={() => canInterrupt}
+      canStopActiveRun={() => canInterrupt}
+      colorEnabled={HARNESS_COLOR_ENABLED}
+      onInterruptActive={markHarnessInterrupted}
+      onTranscriptViewportChange={
+        viewportController.handleTranscriptViewportChange
+      }
+      onCtrlC={handleHarnessCtrlC}
+    />
+  );
+}
+
+const ink = render(renderHarnessApp(), {
+  stdout: HARNESS_STDOUT,
+  stderr: process.stderr,
+  stdin: process.stdin,
+  exitOnCtrlC: false,
+});
 inkRef.current = ink;
+
+if (CHILD_EVENT_ORDER) {
+  const hub = new SessionEventHub();
+  CHILD_EVENT_FIXTURE_DISPOSERS.push(
+    attachTuiRunFactSubscription(hub),
+    subscribeStreamStatus(),
+  );
+  void runHarnessChildEventOrder(ink, hub, CHILD_EVENT_ORDER).catch((error) => {
+    process.stderr.write(
+      `[tui-harness] HARNESS_CHILD_EVENT_ORDER failed: ${toErrorMessage(error)}\n`,
+    );
+    void exitHarness(1);
+  });
+}
 
 let harnessExiting = false;
 async function exitHarness(exitCode: number): Promise<void> {
   if (harnessExiting) return;
   harnessExiting = true;
+  for (const dispose of CHILD_EVENT_FIXTURE_DISPOSERS.splice(0).toReversed()) {
+    dispose();
+  }
   ink.unmount();
   try {
     await tryPlatform()?.lifecycle.runShutdown();

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -53,6 +53,7 @@ const LF = String.fromCharCode(10); // Ctrl-J
 const KITTY_SHIFT_ENTER = ESC + '[13;2u';
 const UP = ESC + '[A';
 const DOWN = ESC + '[B';
+const BACK_TAB = ESC + '[Z';
 const PAGE_DOWN = ESC + '[6~';
 const ANSI_SGR_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*m`, 'g');
 const shortcutModifierLabel = process.platform === 'darwin' ? 'Esc' : 'Alt';
@@ -96,6 +97,202 @@ const PHYSICIST_LOCAL_TOOL_USE_AGENTS = [
 ].join('||');
 const PHYSICIST_WORKFLOW_AGENTS = ['correct', 'polish'].join('||');
 const TWO_OPENAI_MODELS = ['gpt55', 'gpt55pro'].join('||');
+const CHILD_EVENT_READY_MARKER = 'texra-harness-child-event:ready';
+const CHILD_EVENT_ROOT_HEADER = 'agent: chat · model: harness-model';
+const CHILD_EVENT_TEXT = 'eventChild is checking the event-order details';
+const CHILD_EVENT_Q_TEXT = 'Harness new parent Q.';
+const CHILD_EVENT_REMOVED_TEXT = ['eventChild', '1 sub', 'parent: main'];
+const CLOSE_CHILD_EVENT_PANEL = { input: ESC };
+
+function childEventEnv(order) {
+  return {
+    HARNESS_CAN_INTERRUPT: '1',
+    HARNESS_CHILD_EVENT_ORDER: order,
+    HARNESS_ENTRIES: '2',
+  };
+}
+
+function childEventCheckpoint(input, name, expect = [], unexpect = []) {
+  return { input, checkpoint: { name, expect, unexpect } };
+}
+
+function childEventScenario(name, order, details) {
+  return {
+    name: `child-event-order-${name}`,
+    cols: 100,
+    rows: 20,
+    env: childEventEnv(order),
+    sharedWorkspace: 'child-event-order',
+    bootRawExpect: CHILD_EVENT_READY_MARKER,
+    frame: 'viewport',
+    ...details,
+  };
+}
+
+const CHILD_EVENT_EQUIVALENCE_KEYS = [
+  childEventCheckpoint('\t', 'Tab focuses the child', [
+    CHILD_EVENT_TEXT,
+    '[1:eventChild]*',
+  ]),
+  childEventCheckpoint(BACK_TAB, 'Shift-Tab returns to the parent', [
+    CHILD_EVENT_ROOT_HEADER,
+    '[main] 1:eventChild*',
+  ]),
+  childEventCheckpoint(
+    ESC + 's',
+    'subagent picker',
+    ['Subagents', 'Stream: main', 'eventChild', 'f focus'],
+    ['Tasks and sub-workflows'],
+  ),
+  CLOSE_CHILD_EVENT_PANEL,
+  childEventCheckpoint(
+    ESC + 'p',
+    'task picker',
+    ['Tasks and sub-workflows', 'Stream: main', 'eventChild', 'k kill'],
+    ['Subagents'],
+  ),
+  CLOSE_CHILD_EVENT_PANEL,
+];
+
+function equivalentChildEventScenario(order, equivalentFrameTo) {
+  return childEventScenario(order, order, {
+    keys: CHILD_EVENT_EQUIVALENCE_KEYS,
+    expect: [
+      CHILD_EVENT_ROOT_HEADER,
+      'eventChild running',
+      '1 sub',
+      '[main] 1:eventChild*',
+    ],
+    ...(equivalentFrameTo ? { equivalentFrameTo } : {}),
+  });
+}
+
+const CHILD_EVENT_ORDER_SCENARIOS = [
+  equivalentChildEventScenario('canonical'),
+  equivalentChildEventScenario('roster-first', 'child-event-order-canonical'),
+  equivalentChildEventScenario('edge-first', 'child-event-order-canonical'),
+  equivalentChildEventScenario('status-first', 'child-event-order-canonical'),
+  childEventScenario('follow-up', 'canonical', {
+    keys: [
+      childEventCheckpoint('\t', 'follow-up child focus', [
+        CHILD_EVENT_TEXT,
+        '[1:eventChild]*',
+      ]),
+      'child event follow-up',
+      '\r',
+    ],
+    expect: ['Harness received: child event follow-up', '[1:eventChild]*'],
+    unexpect: ['entry-1 chat history line', 'entry-2 chat history line'],
+  }),
+  childEventScenario('promotion-late-roster', 'promotion-late-roster', {
+    keys: [
+      childEventCheckpoint(
+        ESC + 'p',
+        'promoted child is historical only',
+        ['Tasks and sub-workflows', 'eventChild'],
+        ['k kill', '1 sub'],
+      ),
+      CLOSE_CHILD_EVENT_PANEL,
+      childEventCheckpoint(
+        '\t',
+        'promoted retained child remains focusable',
+        [CHILD_EVENT_ROOT_HEADER, CHILD_EVENT_TEXT],
+        ['subagent:', 'parent: main', '1 sub'],
+      ),
+      childEventCheckpoint(
+        BACK_TAB,
+        'promoted child has no stale back edge',
+        [CHILD_EVENT_ROOT_HEADER, CHILD_EVENT_TEXT],
+        ['subagent:', 'parent: main', '1 sub'],
+      ),
+    ],
+    expect: [CHILD_EVENT_ROOT_HEADER, CHILD_EVENT_TEXT],
+    unexpect: ['subagent:', 'parent: main', '1 sub', 'k kill'],
+  }),
+  childEventScenario('reattach-late-old-roster', 'reattach-late-old-roster', {
+    keys: [
+      childEventCheckpoint(
+        ESC + 'p',
+        'old parent retains only history',
+        ['Tasks and sub-workflows', 'eventChild'],
+        ['k kill', '1 sub'],
+      ),
+      CLOSE_CHILD_EVENT_PANEL,
+      childEventCheckpoint('\t', 'reattached child focus', [
+        CHILD_EVENT_TEXT,
+        '[1:eventChild]*',
+      ]),
+      childEventCheckpoint(
+        BACK_TAB,
+        'back focus follows the new parent',
+        [CHILD_EVENT_Q_TEXT, 'eventChild running', '1 sub'],
+        ['entry-1 chat history line'],
+      ),
+      childEventCheckpoint(
+        ESC + 's',
+        'new parent owns the active child control',
+        ['Subagents', 'eventChild', 'f focus'],
+      ),
+      CLOSE_CHILD_EVENT_PANEL,
+    ],
+    expect: [CHILD_EVENT_Q_TEXT, 'eventChild running', '1 sub'],
+    unexpect: ['entry-1 chat history line'],
+  }),
+  childEventScenario('parent-removal', 'parent-removal', {
+    keys: [
+      childEventCheckpoint(
+        '\t',
+        'forward focus ignores the removed parent tree',
+        [CHILD_EVENT_Q_TEXT],
+        CHILD_EVENT_REMOVED_TEXT,
+      ),
+      childEventCheckpoint(
+        BACK_TAB,
+        'back focus remains interactive after parent removal',
+        [CHILD_EVENT_Q_TEXT],
+        CHILD_EVENT_REMOVED_TEXT,
+      ),
+      childEventCheckpoint(
+        ESC + 's',
+        'removed parent exposes no subagent picker target',
+        [CHILD_EVENT_Q_TEXT],
+        ['Subagents', 'eventChild', '1 sub'],
+      ),
+      childEventCheckpoint(
+        ESC + 'p',
+        'removed parent exposes no task picker target',
+        [CHILD_EVENT_Q_TEXT],
+        ['Tasks and sub-workflows', 'eventChild', 'k kill'],
+      ),
+    ],
+    expect: [CHILD_EVENT_Q_TEXT],
+    unexpect: ['eventChild', '1 sub', 'parent: main', 'k kill'],
+  }),
+  childEventScenario('completion-remove', 'completion-remove', {
+    keys: [
+      childEventCheckpoint(
+        '\t',
+        'removed child is not a forward focus target',
+        [CHILD_EVENT_ROOT_HEADER],
+        CHILD_EVENT_REMOVED_TEXT,
+      ),
+      childEventCheckpoint(
+        ESC + 's',
+        'removed child exposes no subagent picker target',
+        [],
+        ['Subagents', 'eventChild', '1 sub'],
+      ),
+      childEventCheckpoint(
+        ESC + 'p',
+        'removed child exposes no task picker target',
+        [],
+        ['Tasks and sub-workflows', 'eventChild', 'k kill'],
+      ),
+    ],
+    expect: [CHILD_EVENT_ROOT_HEADER],
+    unexpect: ['eventChild', '1 sub', 'parent: main', 'k kill'],
+  }),
+];
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(dirname, '..');
@@ -1882,6 +2079,7 @@ const SCENARIOS = [
     expect: ['[/status]details', '[/model]models'],
     unexpect: ['Apply edit to draft.tex?', '1 approval'],
   },
+  ...CHILD_EVENT_ORDER_SCENARIOS,
   {
     name: 'subagents',
     frame: 'scrollback',
@@ -3029,6 +3227,16 @@ const only = args.scenarios;
 const scenarioByName = new Map(
   SCENARIOS.map((scenario) => [scenario.name, scenario]),
 );
+for (const scenario of SCENARIOS) {
+  if (!scenario.equivalentFrameTo) continue;
+  const oracle = scenarioByName.get(scenario.equivalentFrameTo);
+  if (!oracle) {
+    console.error(
+      `[validate-tui] ${scenario.name} names an unknown frame oracle: ${scenario.equivalentFrameTo}`,
+    );
+    process.exit(1);
+  }
+}
 const unknownScenarios = [
   ...new Set(only.filter((name) => !scenarioByName.has(name))),
 ];
@@ -3041,8 +3249,22 @@ if (unknownScenarios.length > 0) {
   );
   process.exit(1);
 }
+function selectedScenariosWithFrameOracles(names) {
+  const selected = [];
+  const seen = new Set();
+  const add = (name) => {
+    if (seen.has(name)) return;
+    const scenario = scenarioByName.get(name);
+    if (scenario.equivalentFrameTo) add(scenario.equivalentFrameTo);
+    seen.add(name);
+    selected.push(scenario);
+  };
+  for (const name of names) add(name);
+  return selected;
+}
+
 const scenarios = only.length
-  ? only.map((name) => scenarioByName.get(name))
+  ? selectedScenariosWithFrameOracles(only)
   : SCENARIOS;
 if (args.listSelected) {
   console.log(scenarios.map((scenario) => scenario.name).join('\n'));
@@ -3142,6 +3364,22 @@ function scenarioRows(scenario) {
   return Number(scenario.rows ?? DEFAULT_ROWS);
 }
 
+for (const scenario of SCENARIOS) {
+  if (!scenario.equivalentFrameTo) continue;
+  const oracle = scenarioByName.get(scenario.equivalentFrameTo);
+  if (
+    scenarioCols(scenario) !== scenarioCols(oracle) ||
+    scenarioRows(scenario) !== scenarioRows(oracle) ||
+    (scenario.frame ?? DEFAULT_FRAME_MODE) !==
+      (oracle.frame ?? DEFAULT_FRAME_MODE)
+  ) {
+    console.error(
+      `[validate-tui] ${scenario.name} must match ${oracle.name} dimensions and frame mode`,
+    );
+    process.exit(1);
+  }
+}
+
 function makeTerm(scenario) {
   return new Terminal({
     cols: scenarioCols(scenario),
@@ -3176,6 +3414,62 @@ function scenarioFrame(scenario, fullFrame, rows) {
   throw new Error(
     `unknown validate-tui frame mode for ${scenario.name}: ${frameMode}`,
   );
+}
+
+function exactFrameDifference(actualFrame, expectedFrame, oracleName) {
+  const actual = Buffer.from(actualFrame, 'utf8');
+  const expected = Buffer.from(expectedFrame, 'utf8');
+  if (actual.equals(expected)) return undefined;
+
+  const sharedLength = Math.min(actual.length, expected.length);
+  let offset = 0;
+  while (offset < sharedLength && actual[offset] === expected[offset]) {
+    offset += 1;
+  }
+  const byteAt = (bytes) =>
+    offset < bytes.length
+      ? `0x${bytes[offset].toString(16).padStart(2, '0')}`
+      : 'end-of-frame';
+  return `rendered frame is not byte-identical to ${oracleName}: first UTF-8 byte difference at ${offset} (${byteAt(actual)} != ${byteAt(expected)}; ${actual.length} != ${expected.length} bytes)`;
+}
+
+function equivalentFrameFailures(result, oracle) {
+  const failures = [];
+  const finalDifference = exactFrameDifference(
+    result.frame,
+    oracle.frame,
+    oracle.name,
+  );
+  if (finalDifference) failures.push(finalDifference);
+
+  const actualCheckpoints = result.checkpointFrames ?? [];
+  const expectedCheckpoints = oracle.checkpointFrames ?? [];
+  if (actualCheckpoints.length !== expectedCheckpoints.length) {
+    failures.push(
+      `checkpoint frame count differs from ${oracle.name}: ${actualCheckpoints.length} != ${expectedCheckpoints.length}`,
+    );
+  }
+  const comparableCount = Math.min(
+    actualCheckpoints.length,
+    expectedCheckpoints.length,
+  );
+  for (let index = 0; index < comparableCount; index += 1) {
+    const actual = actualCheckpoints[index];
+    const expected = expectedCheckpoints[index];
+    if (actual.name !== expected.name) {
+      failures.push(
+        `checkpoint ${index + 1} differs from ${oracle.name}: ${JSON.stringify(actual.name)} != ${JSON.stringify(expected.name)}`,
+      );
+      continue;
+    }
+    const difference = exactFrameDifference(
+      actual.frame,
+      expected.frame,
+      `${oracle.name} checkpoint ${JSON.stringify(expected.name)}`,
+    );
+    if (difference) failures.push(difference);
+  }
+  return failures;
 }
 
 function expectedFrameTextVisible(scenario, frame) {
@@ -3267,6 +3561,7 @@ function orderedTextFailure(frame, check) {
 }
 
 const SNAPSHOT_WORKSPACES_DIR = 'workspaces';
+const sharedWorkspaceDirs = new Map();
 
 function snapshotScenarioSlug(index, name) {
   const prefix = String(index + 1).padStart(2, '0');
@@ -3284,6 +3579,17 @@ function snapshotWorkspaceDir(index, name) {
     SNAPSHOT_WORKSPACES_DIR,
     snapshotScenarioSlug(index, name),
   );
+}
+
+function sharedScenarioWorkspaceDir(key) {
+  const existing = sharedWorkspaceDirs.get(key);
+  if (existing) return existing;
+  const dir = snapshotDir
+    ? path.join(snapshotDir, SNAPSHOT_WORKSPACES_DIR, `shared-${key}`)
+    : mkdtempSync(path.join(tmpdir(), `texra-tui-${key}-`));
+  mkdirSync(dir, { recursive: true });
+  sharedWorkspaceDirs.set(key, dir);
+  return dir;
 }
 
 function resetSnapshotDir(dir) {
@@ -3558,7 +3864,9 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     return renderFrame(term);
   };
   const childEnv = scenarioChildEnv(scenario, cols, rows);
-  const workspaceDir = snapshotWorkspaceDir(index, scenario.name);
+  const workspaceDir = scenario.sharedWorkspace
+    ? sharedScenarioWorkspaceDir(scenario.sharedWorkspace)
+    : snapshotWorkspaceDir(index, scenario.name);
   if (workspaceDir && childEnv.HARNESS_CWD == null) {
     mkdirSync(workspaceDir, { recursive: true });
     childEnv.HARNESS_CWD = workspaceDir;
@@ -3608,6 +3916,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     if (exited) break;
     if (
       (await frameSnapshot()).includes(bootExpect) &&
+      (!scenario.bootRawExpect || rawOutput.includes(scenario.bootRawExpect)) &&
       Date.now() - lastData > 600
     ) {
       booted = true;
@@ -3615,10 +3924,50 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     }
   }
 
+  const checkpointFailures = [];
+  const checkpointFrames = [];
+  const checkKeyCheckpoint = async (checkpoint) => {
+    const deadline = Date.now() + Number(checkpoint.settleMs ?? 2500);
+    let checkpointFrame = '';
+    while (Date.now() < deadline) {
+      const fullCheckpointFrame = await frameSnapshot();
+      checkpointFrame = scenarioFrame(scenario, fullCheckpointFrame, rows);
+      const expectedVisible = (checkpoint.expect ?? []).every((text) =>
+        checkpointFrame.includes(text),
+      );
+      const unexpectedAbsent = (checkpoint.unexpect ?? []).every(
+        (text) => !checkpointFrame.includes(text),
+      );
+      if (expectedVisible && unexpectedAbsent && Date.now() - lastData >= 100) {
+        break;
+      }
+      await sleep(60);
+    }
+    const prefix = `checkpoint ${JSON.stringify(checkpoint.name)}`;
+    for (const text of checkpoint.expect ?? []) {
+      if (!checkpointFrame.includes(text)) {
+        checkpointFailures.push(
+          `${prefix} expected text missing: ${JSON.stringify(text)}`,
+        );
+      }
+    }
+    for (const text of checkpoint.unexpect ?? []) {
+      if (checkpointFrame.includes(text)) {
+        checkpointFailures.push(
+          `${prefix} unexpected text present: ${JSON.stringify(text)}`,
+        );
+      }
+    }
+    checkpointFrames.push({ name: checkpoint.name, frame: checkpointFrame });
+  };
+
   for (const key of scenario.keys ?? []) {
     const input = typeof key === 'string' ? key : key.input;
     child.write(input);
     await sleep(Number(key.delayMs ?? scenario.keyDelayMs ?? 500));
+    if (typeof key !== 'string' && key.checkpoint) {
+      await checkKeyCheckpoint(key.checkpoint);
+    }
   }
   for (const resize of scenario.resizes ?? []) {
     child.resize(Number(resize.cols ?? cols), Number(resize.rows ?? rows));
@@ -3667,7 +4016,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     (t) => !collapsedFrame.includes(t),
   );
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
-  const failures = [];
+  const failures = [...checkpointFailures];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
   for (const t of missing)
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
@@ -3759,6 +4108,7 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     skipped: false,
     failures,
     frame,
+    checkpointFrames,
     rows,
   };
 }
@@ -3771,6 +4121,19 @@ const results = [];
 for (const [index, scenario] of scenarios.entries()) {
   // eslint-disable-next-line no-await-in-loop
   const result = await runScenario(scenario, index);
+  if (!result.skipped && scenario.equivalentFrameTo) {
+    const oracle = results.find(
+      (candidate) => candidate.name === scenario.equivalentFrameTo,
+    );
+    if (!oracle || oracle.skipped) {
+      result.failures.push(
+        `byte-equivalence oracle unavailable: ${scenario.equivalentFrameTo}`,
+      );
+    } else {
+      result.failures.push(...equivalentFrameFailures(result, oracle));
+    }
+    result.ok = result.failures.length === 0;
+  }
   results.push(result);
   writeSnapshot(index, result.name, result.frame);
   if (result.skipped) {
@@ -3792,6 +4155,11 @@ for (const [index, scenario] of scenarios.entries()) {
   }
 }
 writeSnapshotReport(results);
+if (!snapshotDir) {
+  for (const dir of sharedWorkspaceDirs.values()) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 console.log('');
 console.log(

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -3251,15 +3251,30 @@ if (unknownScenarios.length > 0) {
 }
 function selectedScenariosWithFrameOracles(names) {
   const selected = [];
-  const seen = new Set();
-  const add = (name) => {
-    if (seen.has(name)) return;
+  const availableOracles = new Set();
+  const addOracle = (name, ancestors = []) => {
+    if (availableOracles.has(name)) return;
+    if (ancestors.includes(name)) {
+      console.error(
+        `[validate-tui] cyclic frame oracle: ${[...ancestors, name].join(' -> ')}`,
+      );
+      process.exit(1);
+    }
     const scenario = scenarioByName.get(name);
-    if (scenario.equivalentFrameTo) add(scenario.equivalentFrameTo);
-    seen.add(name);
+    if (scenario.equivalentFrameTo) {
+      addOracle(scenario.equivalentFrameTo, [...ancestors, name]);
+    }
+    availableOracles.add(name);
     selected.push(scenario);
   };
-  for (const name of names) add(name);
+  for (const name of names) {
+    const scenario = scenarioByName.get(name);
+    if (scenario.equivalentFrameTo) addOracle(scenario.equivalentFrameTo);
+    // Explicit selections preserve their order and multiplicity. A selected
+    // oracle can still satisfy a later scenario's prerequisite.
+    selected.push(scenario);
+    availableOracles.add(name);
+  }
   return selected;
 }
 

--- a/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
+++ b/src/test-kernel/cli/TuiValidatorArgs.vitest.mts
@@ -150,6 +150,24 @@ describe('TUI validator args', () => {
     expect(result.stderr).toBe('');
   });
 
+  it('inserts a frame oracle once without deduplicating explicit scenarios', () => {
+    const result = runValidator([
+      '--list-selected',
+      'child-event-order-roster-first',
+      'compact-user-question',
+      'child-event-order-roster-first',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split('\n')).toEqual([
+      'child-event-order-canonical',
+      'child-event-order-roster-first',
+      'compact-user-question',
+      'child-event-order-roster-first',
+    ]);
+    expect(result.stderr).toBe('');
+  });
+
   it('treats a leading package-manager separator as transparent for selected scenarios', () => {
     const result = runValidator([
       '--',


### PR DESCRIPTION
## Summary

- add the opt-in `HARNESS_CHILD_EVENT_ORDER` fixture for the eight event sequences specified by the accepted child-stream consolidation design
- drive attachment, status, roster, edge, completion, promotion, reattachment, and removal through `SessionEventHub`, `StreamStatusService`, and the production TUI subscriptions rather than direct child-map mutation
- exercise focus, backward focus, subagent and task pickers, follow-up routing, and stale-parent/control suppression through PTY scenarios
- compare the canonical, roster-first, edge-first, and status-first rendered viewports byte-for-byte at four interaction checkpoints and at the final frame

## Design

Each event step uses fixed stream and execution identifiers, removes wall-clock-derived child timing, waits for an Ink render checkpoint, and then continues. The validator uses one shared workspace and fixed `100 x 20` dimensions for the order-equivalent scenarios so filesystem paths and geometry cannot create irrelevant frame differences.

`equivalentFrameTo` is a validator-level oracle. Selecting a dependent scenario automatically selects its canonical oracle first without deduplicating explicit scenario arguments; oracle cycles fail with a diagnostic. The comparison uses the exact UTF-8 bytes of the xterm-emulated viewport returned by the existing frame renderer; substring assertions remain only for scenario-specific semantic checks.

No production runtime or TUI component changes are included.

## Validation

- `npm run validate:tui`: all 150 scenarios passed
- post-fix focused event-order validation: all 9 scenarios passed
- TUI validator argument regressions: 12 tests passed
- `npm run typecheck` passed on the implementation
- post-rebase CLI typecheck passed
- repository formatter commit hook passed
- `git diff --check origin/main...HEAD`

## Scope

The patch changes two scripts and one validator-argument test (`+727/-23`). Most lines encode the accepted PTY acceptance matrix: eight production-path event sequences, nine interactive scenarios, deterministic checkpoints, and exact frame-oracle support. It adds no production abstraction or state owner.

Closes #7972

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and validator scripts only; no production auth, data, or TUI runtime paths change.
> 
> **Overview**
> Adds **CLI-only** regression coverage for child-stream consolidation: no production TUI or runtime behavior changes.
> 
> **`tui-harness`** gains opt-in **`HARNESS_CHILD_EVENT_ORDER`** with eight fixed event sequences (attachment, status, roster, parent edge, promotion, reattachment, parent/child removal). Steps are emitted through **`SessionEventHub`**, **`StreamStatusService`**, and the same TUI subscriptions as production (`attachTuiRunFactSubscription`, `subscribeStreamStatus`), with Ink rerenders and stdout checkpoints instead of mutating child maps directly. Harness teardown disposes those subscriptions.
> 
> **`validate-tui`** adds nine PTY scenarios (Tab/Shift-Tab focus, pickers, follow-up routing, stale controls) plus **`equivalentFrameTo`** byte-identical viewport oracles, per-keystroke checkpoints, **`sharedWorkspace`**, and **`bootRawExpect`**. **`--list-selected`** auto-inserts frame oracles once while keeping explicit duplicate scenario names.
> 
> A small **vitest** case locks in oracle insertion order for **`--list-selected`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b430b0bdba8c5e605b6ee2bc5c5824aa9fe02942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->