### PR TITLE
refactor(cli): extract task detail view

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -11,7 +11,6 @@ import type { StreamTabId } from '@shared/schemas';
 // Local imports - CLI state and UI
 import { clamp, clampIndex } from '@utils/core';
 
-import { isJumpToBottomInput, isJumpToTopInput } from '../input/inputKeys';
 import {
   CHILD_CONTROL_MODE_COPY,
   buildChildControlItems,
@@ -22,20 +21,6 @@ import {
   type ChildControlMode,
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
-import {
-  jumpTaskDetailScrollState,
-  moveTaskDetailScrollState,
-  pageTaskDetailScrollState,
-  syncTaskDetailScrollState,
-  taskDetailFollowTailScrollOffsetForColumns,
-  taskDetailInitialScrollOffset,
-  taskDetailScrollableOutputRowCountForColumns,
-  taskDetailScrollContextKey,
-  taskDetailVisibleOutputRowsFromOffsetForColumns,
-  taskDetailVisibleScrollOffset,
-  type TaskDetailScrollContext,
-  type TaskDetailScrollState,
-} from '../state/taskDetailScroll';
 import { textDisplayWidth } from '../render/terminalText';
 import { KEY_HINT_SEPARATOR, KeyHints, type KeyHint } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
@@ -47,6 +32,7 @@ import {
   activeSubagentsFor,
   type ChildStreamEntries,
 } from '../state/childExecutions';
+import { TaskDetailView } from './TaskDetailView';
 import type { StreamSlice } from '../state/cliState';
 
 interface ChildControlPickerProps {
@@ -68,18 +54,8 @@ interface ChildControlPickerProps {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
 
-export const TASK_DETAIL_LABEL_WIDTH = 13;
 const ULTRA_COMPACT_PICKER_MAX_ROWS = 6;
-const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
-const NARROW_TASK_DETAIL_HINT_MAX_COLUMNS = 56;
 const PICKER_HORIZONTAL_CHROME_COLUMNS = 4;
-const MIN_COLUMNS_FOR_KILL_HINT = 44;
-// PgUp/PgDn and g/G are the least essential task-detail hints — they
-// duplicate `TranscriptViewer`'s paging bindings but the arrow-key scroll
-// hint above already covers the same affordance more compactly. Only surface
-// them once there's room for the full hint row (scroll + page + top/bottom +
-// focus stream + kill + back) without crowding out the higher-priority ones.
-const MIN_COLUMNS_FOR_PAGE_JUMP_HINTS = 84;
 
 export function pickerTitle(mode: ChildControlMode): string {
   return CHILD_CONTROL_MODE_COPY[mode].title;
@@ -95,15 +71,6 @@ export function isUltraCompactPickerRows(
   return (
     availableRows !== undefined &&
     availableRows <= ULTRA_COMPACT_PICKER_MAX_ROWS
-  );
-}
-
-export function isUltraCompactTaskDetailRows(
-  availableRows: number | undefined,
-): boolean {
-  return (
-    availableRows !== undefined &&
-    availableRows <= ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS
   );
 }
 
@@ -203,45 +170,6 @@ function framedPickerHintColumns(
     : Math.max(0, availableColumns - PICKER_HORIZONTAL_CHROME_COLUMNS);
 }
 
-export function taskDetailKeyHintsForColumns({
-  availableColumns,
-  canFocusStream,
-  canKill,
-  showScrollHint,
-}: {
-  readonly availableColumns?: number;
-  readonly canFocusStream: boolean;
-  readonly canKill: boolean;
-  readonly showScrollHint: boolean;
-}): readonly KeyHint[] {
-  const narrow =
-    availableColumns !== undefined &&
-    availableColumns <= NARROW_TASK_DETAIL_HINT_MAX_COLUMNS;
-  const hints: KeyHint[] = [];
-  if (showScrollHint) hints.push({ key: '↑/↓', action: 'scroll' });
-  if (
-    showScrollHint &&
-    (availableColumns === undefined ||
-      availableColumns >= MIN_COLUMNS_FOR_PAGE_JUMP_HINTS)
-  ) {
-    hints.push({ key: 'PgUp/PgDn', action: 'page' });
-    hints.push({ key: 'g/G', action: 'top/bottom' });
-  }
-  if (canFocusStream) {
-    hints.push({ key: 'f', action: narrow ? 'focus' : 'focus stream' });
-  }
-  if (
-    canKill &&
-    (!narrow ||
-      availableColumns === undefined ||
-      availableColumns >= MIN_COLUMNS_FOR_KILL_HINT)
-  ) {
-    hints.push({ key: 'k', action: 'kill' });
-  }
-  hints.push({ key: 'Esc', action: 'back' });
-  return hints;
-}
-
 function PickerItemHead({
   highlighted,
   index,
@@ -314,31 +242,6 @@ function renderItem(
   );
 }
 
-function metaLine(
-  label: string,
-  value: string | null | undefined,
-): React.JSX.Element | null {
-  if (!value) return null;
-  return (
-    <Box>
-      <Box width={TASK_DETAIL_LABEL_WIDTH}>
-        <Text bold>{label}:</Text>
-      </Box>
-      <Text>{value}</Text>
-    </Box>
-  );
-}
-
-interface TaskDetailLayout {
-  readonly compact: boolean;
-  readonly showCommand: boolean;
-  readonly showExpandedMeta: boolean;
-  readonly showHints: boolean;
-  readonly showOutputLabel: boolean;
-  readonly showTitle: boolean;
-  readonly visibleLineCount: number;
-}
-
 interface PickerListLayout {
   readonly end: number;
   readonly hiddenAfter: number;
@@ -361,51 +264,6 @@ export function compactPickerOverflowText({
   if (earlier > 0 && more > 0) return `+${earlier} earlier, +${more} more`;
   if (earlier > 0) return `+${earlier} earlier`;
   return `+${more} more`;
-}
-
-export function taskDetailCommandLabel(kind: ChildControlItem['kind']): string {
-  return kind === 'process' ? 'Command' : 'Description';
-}
-
-export function computeTaskDetailLayout({
-  availableRows,
-  hasTailLines,
-  metaRows,
-}: {
-  readonly availableRows?: number;
-  readonly hasTailLines: boolean;
-  readonly metaRows: number;
-}): TaskDetailLayout {
-  const rows = Math.max(0, availableRows ?? 18);
-  const showExpandedMeta = rows >= 16;
-  const compact = !showExpandedMeta;
-  const showHints = rows > ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS;
-  const showTitle = rows >= 9;
-  const showOutputLabel = rows >= 10;
-  const showCommand = rows >= 12;
-  const renderedMetaRows = showExpandedMeta ? metaRows : 1;
-  const gapRows = showExpandedMeta ? 2 : 0;
-  const fixedRows =
-    2 + // border
-    (showTitle ? 1 : 0) +
-    renderedMetaRows +
-    (showCommand ? 1 : 0) +
-    (showOutputLabel ? 1 : 0) +
-    (showHints ? 1 : 0) +
-    gapRows;
-  const availableOutputRows = Math.max(0, rows - fixedRows);
-  return {
-    compact,
-    showCommand,
-    showExpandedMeta,
-    showHints,
-    showOutputLabel,
-    showTitle,
-    visibleLineCount:
-      hasTailLines && rows >= fixedRows + 1
-        ? Math.max(1, availableOutputRows)
-        : availableOutputRows,
-  };
 }
 
 export function computePickerListLayout({
@@ -458,285 +316,6 @@ export function computePickerListLayout({
     start,
     visibleCount,
   };
-}
-
-function TaskOutput({
-  childStreamId,
-  tailLines,
-  truncateTailRows = false,
-  visibleTail,
-  visibleLineCount,
-}: {
-  readonly childStreamId: StreamTabId | undefined;
-  readonly tailLines: readonly string[];
-  readonly truncateTailRows?: boolean;
-  readonly visibleTail: readonly string[];
-  readonly visibleLineCount: number;
-}): React.JSX.Element | null {
-  if (tailLines.length > 0) {
-    if (visibleLineCount <= 0) return null;
-    return (
-      <>
-        {visibleTail.map((line, index) => (
-          <Text
-            key={`${index}:${line}`}
-            dimColor
-            wrap={truncateTailRows ? 'truncate-end' : undefined}
-          >
-            {line}
-          </Text>
-        ))}
-      </>
-    );
-  }
-  if (visibleLineCount === 0) return null;
-  if (childStreamId) {
-    return (
-      <Text dimColor>Open the task stream to see its live transcript.</Text>
-    );
-  }
-  return <Text dimColor>No output captured yet.</Text>;
-}
-
-function TaskDetailView({
-  availableColumns,
-  availableRows,
-  item,
-  onBack,
-  onFocusStream,
-  onKill,
-}: {
-  readonly availableColumns?: number;
-  readonly availableRows?: number;
-  readonly item: ChildControlItem;
-  readonly onBack: () => void;
-  readonly onFocusStream: () => void;
-  readonly onKill: () => void;
-}): React.JSX.Element {
-  const metaParts = [
-    item.kind === 'process' ? 'shell' : 'stream',
-    item.label,
-    item.statusLabel,
-    item.elapsed,
-  ].filter((part): part is string => Boolean(part));
-  const layout = computeTaskDetailLayout({
-    availableRows,
-    hasTailLines: item.tailLines.length > 0,
-    metaRows: metaParts.length,
-  });
-  const scrollableOutputRows = taskDetailScrollableOutputRowCountForColumns({
-    availableColumns,
-    compact: layout.compact,
-    tailLines: item.tailLines,
-  });
-  const maxOffset = taskDetailInitialScrollOffset(
-    scrollableOutputRows,
-    layout.visibleLineCount,
-  );
-  const followOffset = taskDetailFollowTailScrollOffsetForColumns({
-    availableColumns,
-    compact: layout.compact,
-    tailLines: item.tailLines,
-    visibleRowBudget: layout.visibleLineCount,
-  });
-  const scrollContext: TaskDetailScrollContext = {
-    availableColumns,
-    compact: layout.compact,
-    tailLines: item.tailLines,
-  };
-  const scrollContextKey = taskDetailScrollContextKey(scrollContext);
-  const [scrollState, setScrollState] = useState<TaskDetailScrollState>(() => ({
-    executionId: item.executionId,
-    followsTail: true,
-    offset: followOffset,
-  }));
-  const offset = taskDetailVisibleScrollOffset(
-    scrollState,
-    maxOffset,
-    followOffset,
-    scrollContext,
-  );
-  const visibleLineCount = layout.visibleLineCount;
-  const visibleTail = taskDetailVisibleOutputRowsFromOffsetForColumns({
-    availableColumns,
-    compact: layout.compact,
-    offset,
-    tailLines: item.tailLines,
-    visibleRowBudget: layout.visibleLineCount,
-  });
-  const truncateTailRows = layout.compact;
-  const compactMeta = metaParts.join(' · ');
-  const commandLabel = taskDetailCommandLabel(item.kind);
-  const ultraCompact = isUltraCompactTaskDetailRows(availableRows);
-  const showScrollHint = maxOffset > 0 && !ultraCompact;
-  const hints = taskDetailKeyHintsForColumns({
-    availableColumns,
-    canFocusStream: Boolean(item.childStreamId),
-    canKill: item.killable,
-    showScrollHint,
-  });
-
-  useEffect(() => {
-    setScrollState((current) =>
-      syncTaskDetailScrollState(
-        current,
-        item.executionId,
-        maxOffset,
-        followOffset,
-        scrollContext,
-      ),
-    );
-  }, [item.executionId, followOffset, maxOffset, scrollContextKey]);
-
-  useInput((input, key) => {
-    const action = childPickerKeyAction({
-      input,
-      ctrl: key.ctrl,
-      escape: key.escape,
-      meta: key.meta,
-      upArrow: key.upArrow,
-      downArrow: key.downArrow,
-      return: key.return,
-    });
-    if (action.kind === 'close') onBack();
-    if (action.kind === 'kill' && item.killable) onKill();
-    if (action.kind === 'up') {
-      setScrollState((current) =>
-        moveTaskDetailScrollState(
-          current,
-          maxOffset,
-          'up',
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (action.kind === 'down') {
-      setScrollState((current) =>
-        moveTaskDetailScrollState(
-          current,
-          maxOffset,
-          'down',
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (key.pageUp) {
-      setScrollState((current) =>
-        pageTaskDetailScrollState(
-          current,
-          maxOffset,
-          'up',
-          visibleLineCount,
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (key.pageDown) {
-      setScrollState((current) =>
-        pageTaskDetailScrollState(
-          current,
-          maxOffset,
-          'down',
-          visibleLineCount,
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (isJumpToTopInput(input)) {
-      setScrollState((current) =>
-        jumpTaskDetailScrollState(
-          current,
-          maxOffset,
-          'top',
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (isJumpToBottomInput(input)) {
-      setScrollState((current) =>
-        jumpTaskDetailScrollState(
-          current,
-          maxOffset,
-          'bottom',
-          followOffset,
-          scrollContext,
-        ),
-      );
-    }
-    if (input.toLowerCase() === 'f' && item.childStreamId) onFocusStream();
-  });
-
-  if (ultraCompact) {
-    return (
-      <Box flexDirection="column" minWidth={0} width={availableColumns}>
-        <Text bold color="cyan" wrap="truncate-end">
-          {`Task details · ${commandLabel}: ${item.command}`}
-        </Text>
-        <KeyHints hints={hints} confirmCancel={false} />
-      </Box>
-    );
-  }
-
-  return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
-      width={availableColumns}
-    >
-      {layout.showTitle ? (
-        <Text bold color="cyan">
-          Task details
-        </Text>
-      ) : null}
-      {layout.showExpandedMeta ? (
-        <>
-          {metaLine('Type', item.kind === 'process' ? 'shell' : 'stream')}
-          {metaLine('Name', item.label)}
-          {metaLine('Status', item.statusLabel)}
-          {metaLine('Runtime', item.elapsed)}
-        </>
-      ) : (
-        <Text
-          bold={!layout.showTitle}
-          color={!layout.showTitle ? 'cyan' : undefined}
-          dimColor={layout.showTitle}
-          wrap="truncate-end"
-        >
-          {compactMeta}
-        </Text>
-      )}
-      {layout.showCommand ? (
-        <Box marginTop={layout.compact ? 0 : 1}>
-          <Box width={TASK_DETAIL_LABEL_WIDTH}>
-            <Text bold>{`${commandLabel}:`}</Text>
-          </Box>
-          <Text wrap="truncate-end">{item.command}</Text>
-        </Box>
-      ) : null}
-      <Box flexDirection="column" marginTop={layout.compact ? 0 : 1}>
-        {layout.showOutputLabel ? <Text bold>Output:</Text> : null}
-        <TaskOutput
-          childStreamId={item.childStreamId}
-          tailLines={item.tailLines}
-          truncateTailRows={truncateTailRows}
-          visibleTail={visibleTail}
-          visibleLineCount={visibleLineCount}
-        />
-      </Box>
-      {layout.showHints ? (
-        <Box marginTop={layout.compact ? 0 : 1}>
-          <KeyHints hints={hints} confirmCancel={false} />
-        </Box>
-      ) : null}
-    </Box>
-  );
 }
 
 export function ChildControlPicker({

--- a/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
+++ b/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
@@ -1,0 +1,439 @@
+// Task detail view for the CLI child execution controls.
+
+// Third-party imports
+import { useEffect, useState } from 'react';
+
+import { Box, Text, useInput } from 'ink';
+
+// Local imports - shared schemas
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - CLI state and UI
+import { isJumpToBottomInput, isJumpToTopInput } from '../input/inputKeys';
+import {
+  childPickerKeyAction,
+  type ChildControlItem,
+} from '../state/childControls';
+import {
+  jumpTaskDetailScrollState,
+  moveTaskDetailScrollState,
+  pageTaskDetailScrollState,
+  syncTaskDetailScrollState,
+  taskDetailFollowTailScrollOffsetForColumns,
+  taskDetailInitialScrollOffset,
+  taskDetailScrollableOutputRowCountForColumns,
+  taskDetailScrollContextKey,
+  taskDetailVisibleOutputRowsFromOffsetForColumns,
+  taskDetailVisibleScrollOffset,
+  type TaskDetailScrollContext,
+  type TaskDetailScrollState,
+} from '../state/taskDetailScroll';
+import { KeyHints, type KeyHint } from '../ui/KeyHints';
+
+export const TASK_DETAIL_LABEL_WIDTH = 13;
+const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
+const NARROW_TASK_DETAIL_HINT_MAX_COLUMNS = 56;
+const MIN_COLUMNS_FOR_KILL_HINT = 44;
+// PgUp/PgDn and g/G are the least essential task-detail hints — they
+// duplicate `TranscriptViewer`'s paging bindings but the arrow-key scroll
+// hint above already covers the same affordance more compactly. Only surface
+// them once there's room for the full hint row (scroll + page + top/bottom +
+// focus stream + kill + back) without crowding out the higher-priority ones.
+const MIN_COLUMNS_FOR_PAGE_JUMP_HINTS = 84;
+
+export function isUltraCompactTaskDetailRows(
+  availableRows: number | undefined,
+): boolean {
+  return (
+    availableRows !== undefined &&
+    availableRows <= ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS
+  );
+}
+
+export function taskDetailKeyHintsForColumns({
+  availableColumns,
+  canFocusStream,
+  canKill,
+  showScrollHint,
+}: {
+  readonly availableColumns?: number;
+  readonly canFocusStream: boolean;
+  readonly canKill: boolean;
+  readonly showScrollHint: boolean;
+}): readonly KeyHint[] {
+  const narrow =
+    availableColumns !== undefined &&
+    availableColumns <= NARROW_TASK_DETAIL_HINT_MAX_COLUMNS;
+  const hints: KeyHint[] = [];
+  if (showScrollHint) hints.push({ key: '↑/↓', action: 'scroll' });
+  if (
+    showScrollHint &&
+    (availableColumns === undefined ||
+      availableColumns >= MIN_COLUMNS_FOR_PAGE_JUMP_HINTS)
+  ) {
+    hints.push({ key: 'PgUp/PgDn', action: 'page' });
+    hints.push({ key: 'g/G', action: 'top/bottom' });
+  }
+  if (canFocusStream) {
+    hints.push({ key: 'f', action: narrow ? 'focus' : 'focus stream' });
+  }
+  if (
+    canKill &&
+    (!narrow ||
+      availableColumns === undefined ||
+      availableColumns >= MIN_COLUMNS_FOR_KILL_HINT)
+  ) {
+    hints.push({ key: 'k', action: 'kill' });
+  }
+  hints.push({ key: 'Esc', action: 'back' });
+  return hints;
+}
+
+function metaLine(
+  label: string,
+  value: string | null | undefined,
+): React.JSX.Element | null {
+  if (!value) return null;
+  return (
+    <Box>
+      <Box width={TASK_DETAIL_LABEL_WIDTH}>
+        <Text bold>{label}:</Text>
+      </Box>
+      <Text>{value}</Text>
+    </Box>
+  );
+}
+
+interface TaskDetailLayout {
+  readonly compact: boolean;
+  readonly showCommand: boolean;
+  readonly showExpandedMeta: boolean;
+  readonly showHints: boolean;
+  readonly showOutputLabel: boolean;
+  readonly showTitle: boolean;
+  readonly visibleLineCount: number;
+}
+
+export function taskDetailCommandLabel(kind: ChildControlItem['kind']): string {
+  return kind === 'process' ? 'Command' : 'Description';
+}
+
+export function computeTaskDetailLayout({
+  availableRows,
+  hasTailLines,
+  metaRows,
+}: {
+  readonly availableRows?: number;
+  readonly hasTailLines: boolean;
+  readonly metaRows: number;
+}): TaskDetailLayout {
+  const rows = Math.max(0, availableRows ?? 18);
+  const showExpandedMeta = rows >= 16;
+  const compact = !showExpandedMeta;
+  const showHints = rows > ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS;
+  const showTitle = rows >= 9;
+  const showOutputLabel = rows >= 10;
+  const showCommand = rows >= 12;
+  const renderedMetaRows = showExpandedMeta ? metaRows : 1;
+  const gapRows = showExpandedMeta ? 2 : 0;
+  const fixedRows =
+    2 + // border
+    (showTitle ? 1 : 0) +
+    renderedMetaRows +
+    (showCommand ? 1 : 0) +
+    (showOutputLabel ? 1 : 0) +
+    (showHints ? 1 : 0) +
+    gapRows;
+  const availableOutputRows = Math.max(0, rows - fixedRows);
+  return {
+    compact,
+    showCommand,
+    showExpandedMeta,
+    showHints,
+    showOutputLabel,
+    showTitle,
+    visibleLineCount:
+      hasTailLines && rows >= fixedRows + 1
+        ? Math.max(1, availableOutputRows)
+        : availableOutputRows,
+  };
+}
+
+function TaskOutput({
+  childStreamId,
+  tailLines,
+  truncateTailRows = false,
+  visibleTail,
+  visibleLineCount,
+}: {
+  readonly childStreamId: StreamTabId | undefined;
+  readonly tailLines: readonly string[];
+  readonly truncateTailRows?: boolean;
+  readonly visibleTail: readonly string[];
+  readonly visibleLineCount: number;
+}): React.JSX.Element | null {
+  if (tailLines.length > 0) {
+    if (visibleLineCount <= 0) return null;
+    return (
+      <>
+        {visibleTail.map((line, index) => (
+          <Text
+            key={`${index}:${line}`}
+            dimColor
+            wrap={truncateTailRows ? 'truncate-end' : undefined}
+          >
+            {line}
+          </Text>
+        ))}
+      </>
+    );
+  }
+  if (visibleLineCount === 0) return null;
+  if (childStreamId) {
+    return (
+      <Text dimColor>Open the task stream to see its live transcript.</Text>
+    );
+  }
+  return <Text dimColor>No output captured yet.</Text>;
+}
+
+export function TaskDetailView({
+  availableColumns,
+  availableRows,
+  item,
+  onBack,
+  onFocusStream,
+  onKill,
+}: {
+  readonly availableColumns?: number;
+  readonly availableRows?: number;
+  readonly item: ChildControlItem;
+  readonly onBack: () => void;
+  readonly onFocusStream: () => void;
+  readonly onKill: () => void;
+}): React.JSX.Element {
+  const metaParts = [
+    item.kind === 'process' ? 'shell' : 'stream',
+    item.label,
+    item.statusLabel,
+    item.elapsed,
+  ].filter((part): part is string => Boolean(part));
+  const layout = computeTaskDetailLayout({
+    availableRows,
+    hasTailLines: item.tailLines.length > 0,
+    metaRows: metaParts.length,
+  });
+  const scrollableOutputRows = taskDetailScrollableOutputRowCountForColumns({
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+  });
+  const maxOffset = taskDetailInitialScrollOffset(
+    scrollableOutputRows,
+    layout.visibleLineCount,
+  );
+  const followOffset = taskDetailFollowTailScrollOffsetForColumns({
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+    visibleRowBudget: layout.visibleLineCount,
+  });
+  const scrollContext: TaskDetailScrollContext = {
+    availableColumns,
+    compact: layout.compact,
+    tailLines: item.tailLines,
+  };
+  const scrollContextKey = taskDetailScrollContextKey(scrollContext);
+  const [scrollState, setScrollState] = useState<TaskDetailScrollState>(() => ({
+    executionId: item.executionId,
+    followsTail: true,
+    offset: followOffset,
+  }));
+  const offset = taskDetailVisibleScrollOffset(
+    scrollState,
+    maxOffset,
+    followOffset,
+    scrollContext,
+  );
+  const visibleLineCount = layout.visibleLineCount;
+  const visibleTail = taskDetailVisibleOutputRowsFromOffsetForColumns({
+    availableColumns,
+    compact: layout.compact,
+    offset,
+    tailLines: item.tailLines,
+    visibleRowBudget: layout.visibleLineCount,
+  });
+  const truncateTailRows = layout.compact;
+  const compactMeta = metaParts.join(' · ');
+  const commandLabel = taskDetailCommandLabel(item.kind);
+  const ultraCompact = isUltraCompactTaskDetailRows(availableRows);
+  const showScrollHint = maxOffset > 0 && !ultraCompact;
+  const hints = taskDetailKeyHintsForColumns({
+    availableColumns,
+    canFocusStream: Boolean(item.childStreamId),
+    canKill: item.killable,
+    showScrollHint,
+  });
+
+  useEffect(() => {
+    setScrollState((current) =>
+      syncTaskDetailScrollState(
+        current,
+        item.executionId,
+        maxOffset,
+        followOffset,
+        scrollContext,
+      ),
+    );
+  }, [item.executionId, followOffset, maxOffset, scrollContextKey]);
+
+  useInput((input, key) => {
+    const action = childPickerKeyAction({
+      input,
+      ctrl: key.ctrl,
+      escape: key.escape,
+      meta: key.meta,
+      upArrow: key.upArrow,
+      downArrow: key.downArrow,
+      return: key.return,
+    });
+    if (action.kind === 'close') onBack();
+    if (action.kind === 'kill' && item.killable) onKill();
+    if (action.kind === 'up') {
+      setScrollState((current) =>
+        moveTaskDetailScrollState(
+          current,
+          maxOffset,
+          'up',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (action.kind === 'down') {
+      setScrollState((current) =>
+        moveTaskDetailScrollState(
+          current,
+          maxOffset,
+          'down',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (key.pageUp) {
+      setScrollState((current) =>
+        pageTaskDetailScrollState(
+          current,
+          maxOffset,
+          'up',
+          visibleLineCount,
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (key.pageDown) {
+      setScrollState((current) =>
+        pageTaskDetailScrollState(
+          current,
+          maxOffset,
+          'down',
+          visibleLineCount,
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (isJumpToTopInput(input)) {
+      setScrollState((current) =>
+        jumpTaskDetailScrollState(
+          current,
+          maxOffset,
+          'top',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (isJumpToBottomInput(input)) {
+      setScrollState((current) =>
+        jumpTaskDetailScrollState(
+          current,
+          maxOffset,
+          'bottom',
+          followOffset,
+          scrollContext,
+        ),
+      );
+    }
+    if (input.toLowerCase() === 'f' && item.childStreamId) onFocusStream();
+  });
+
+  if (ultraCompact) {
+    return (
+      <Box flexDirection="column" minWidth={0} width={availableColumns}>
+        <Text bold color="cyan" wrap="truncate-end">
+          {`Task details · ${commandLabel}: ${item.command}`}
+        </Text>
+        <KeyHints hints={hints} confirmCancel={false} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      flexDirection="column"
+      paddingX={1}
+      width={availableColumns}
+    >
+      {layout.showTitle ? (
+        <Text bold color="cyan">
+          Task details
+        </Text>
+      ) : null}
+      {layout.showExpandedMeta ? (
+        <>
+          {metaLine('Type', item.kind === 'process' ? 'shell' : 'stream')}
+          {metaLine('Name', item.label)}
+          {metaLine('Status', item.statusLabel)}
+          {metaLine('Runtime', item.elapsed)}
+        </>
+      ) : (
+        <Text
+          bold={!layout.showTitle}
+          color={!layout.showTitle ? 'cyan' : undefined}
+          dimColor={layout.showTitle}
+          wrap="truncate-end"
+        >
+          {compactMeta}
+        </Text>
+      )}
+      {layout.showCommand ? (
+        <Box marginTop={layout.compact ? 0 : 1}>
+          <Box width={TASK_DETAIL_LABEL_WIDTH}>
+            <Text bold>{`${commandLabel}:`}</Text>
+          </Box>
+          <Text wrap="truncate-end">{item.command}</Text>
+        </Box>
+      ) : null}
+      <Box flexDirection="column" marginTop={layout.compact ? 0 : 1}>
+        {layout.showOutputLabel ? <Text bold>Output:</Text> : null}
+        <TaskOutput
+          childStreamId={item.childStreamId}
+          tailLines={item.tailLines}
+          truncateTailRows={truncateTailRows}
+          visibleTail={visibleTail}
+          visibleLineCount={visibleLineCount}
+        />
+      </Box>
+      {layout.showHints ? (
+        <Box marginTop={layout.compact ? 0 : 1}>
+          <KeyHints hints={hints} confirmCancel={false} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/state/taskDetailScroll.ts
+++ b/packages/cli/src/chat/tui/state/taskDetailScroll.ts
@@ -1,4 +1,4 @@
-// Scroll/tail state machine for ChildControlPicker's task-detail view.
+// Scroll/tail state machine for TaskDetailView.
 //
 // This parallels `useScrollableOffset.ts` (bounded modal scrolling) and
 // `transcriptScroll.ts` (follow-tail line scrolling) but can't reuse either

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -9,17 +9,19 @@ import {
 import {
   compactPickerOverflowText,
   computePickerListLayout,
-  computeTaskDetailLayout,
   emptyPickerText,
   isUltraCompactPickerRows,
-  isUltraCompactTaskDetailRows,
   pickerKeyHints,
   pickerKeyHintsForColumns,
   pickerTitle,
+} from '@cli/chat/tui/modals/ChildControlPicker';
+import {
+  computeTaskDetailLayout,
+  isUltraCompactTaskDetailRows,
   TASK_DETAIL_LABEL_WIDTH,
   taskDetailCommandLabel,
   taskDetailKeyHintsForColumns,
-} from '@cli/chat/tui/modals/ChildControlPicker';
+} from '@cli/chat/tui/modals/TaskDetailView';
 import {
   jumpTaskDetailScrollState,
   moveTaskDetailScrollState,


### PR DESCRIPTION
## Summary

Extract the complete task-detail render subtree from `ChildControlPicker` into `TaskDetailView`.

The new component owns the detail layout, output rendering, scroll state, keyboard handling, and detail-specific key hints. `ChildControlPicker` retains list selection, mode switching, and the transition into and out of the detail view. The six-property boundary is explicit: dimensions, selected item, back, focus, and kill actions.

This is a literal move along an existing render-tree boundary. No state policy, key binding, rendered text, or mount behavior is redesigned.

## Issue acceptance gates

This is one bounded part of the narrowed CLI decomposition in #6680:

- [x] Reduce `ChildControlPicker.tsx` from 1,004 to 583 lines.
- [x] Move the complete detail subtree rather than extracting a single-caller helper.
- [x] Preserve detail scroll/follow-tail state and input activation.
- [x] Move test-consumed detail exports to their owning module with no compatibility re-export.
- [x] Keep picker selection and mode policy in `ChildControlPicker`.
- [ ] `App.tsx` and `StatusBar.tsx` remain separate #6680 slices.

## Single source of truth

`TaskDetailView.tsx` now owns every task-detail layout, scrolling, key-hint, and rendering decision. `ChildControlPicker.tsx` owns the picker list and supplies only the selected item plus user actions.

## Duplication and abstraction budget

No logic is duplicated. The extraction adds one component boundary that corresponds to a distinct mounted view with its own hooks and input handler. It does not add a hook, factory, reducer, barrel, compatibility export, or pass-through service.

## Net elements (R6)

- Files: 4 changed; 1 added; 0 deleted.
- Lines: +446 / -426; net +20 from module and import boundaries.
- `ChildControlPicker.tsx`: 1,004 -> 583 lines.
- `TaskDetailView.tsx`: 0 -> 439 lines.
- Raw `^[+-]export` lines: +6 / -5. Five helper exports move modules; the one net export is the component.
- Classes/interfaces/enums: +0 / -0.

## Consumer counts (R8)

No event, signal, or command key changes.

- `TaskDetailView`: 1 production consumer, `ChildControlPicker`.
- Five moved detail helper exports: 0 production consumers and 1 test-module consumer. The test imports the new owner directly.
- Compatibility re-exports: 0.

## Host impact

Extension: none.

Desktop: none.

CLI: internal TUI module ownership only; rendered frames and controls are unchanged.

## Scheduled refactoring

The remaining `App.tsx` and `StatusBar.tsx` decomposition stays tracked by #6680. No temporary shim or compatibility layer is introduced by this PR.

## Validation

- focused `ChildControls` Vitest suite: 44 passed
- task-detail PTY scenarios: 10 passed
- full Vitest suite: 5,474 passed, 4 skipped
- CLI typecheck
- `npm run compile:fast`
- ESLint: no errors and no new warnings
- Prettier
- `git diff --check origin/main...HEAD`

Refs #6680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural file split with no intended changes to scroll policy, bindings, or rendering; risk is limited to import/export wiring mistakes.
> 
> **Overview**
> Moves the child-execution **task detail** UI out of `ChildControlPicker` into a new `TaskDetailView` module so the picker file only handles list selection, mode switching, and mounting the detail view when a task is selected.
> 
> `TaskDetailView` now owns layout budgeting, output rendering, follow-tail scroll state, keyboard handling, and column-aware key hints. Detail-related exports (`computeTaskDetailLayout`, `taskDetailKeyHintsForColumns`, etc.) move with it; tests import them from the new module with no compatibility re-exports from the picker. `taskDetailScroll.ts` is retargeted in a comment only—behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce960fb1f6a3970637fc8244004eb87e3b596d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->