### PR TITLE
test(desktop): gate packaged launch readiness

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Smoke-test Linux packaged desktop app
         run: >-
           xvfb-run --auto-servernum pnpm run desktop:package:smoke -- --app
-          packages/desktop/dist-packaged/linux-unpacked/@texradesktop
+          packages/desktop/dist-packaged/linux-unpacked/texra
 
       - name: Upload Linux desktop installers
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Check macOS desktop installer artifacts
         run: pnpm run check:desktop-installers
 
+      - name: Smoke-test macOS packaged desktop app
+        run: >-
+          pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/mac-universal/TeXRA.app/Contents/MacOS/TeXRA
+
       - name: Upload macOS desktop installers
         uses: actions/upload-artifact@v7
         with:
@@ -145,6 +150,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Linux desktop smoke dependencies
+        run: pnpm --filter @texra/desktop exec playwright install-deps chromium
+
       - name: Build desktop app
         run: pnpm run desktop:build
 
@@ -156,6 +164,11 @@ jobs:
 
       - name: Check Linux desktop installer artifacts
         run: pnpm run check:desktop-installers
+
+      - name: Smoke-test Linux packaged desktop app
+        run: >-
+          xvfb-run --auto-servernum pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/linux-unpacked/@texradesktop
 
       - name: Upload Linux desktop installers
         uses: actions/upload-artifact@v7
@@ -225,6 +238,11 @@ jobs:
 
       - name: Check Windows desktop installer artifacts
         run: pnpm run check:desktop-installers
+
+      - name: Smoke-test Windows packaged desktop app
+        run: >-
+          pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/win-unpacked/TeXRA.exe
 
       - name: Upload Windows desktop installer
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -102,16 +102,16 @@ jobs:
           fi
           pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
+      - name: Smoke-test macOS packaged desktop app
+        run: >-
+          pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/mac-universal/TeXRA.app/Contents/MacOS/TeXRA
+
       - name: Check macOS packaged desktop app contents
         run: pnpm run check:desktop-package
 
       - name: Check macOS desktop installer artifacts
         run: pnpm run check:desktop-installers
-
-      - name: Smoke-test macOS packaged desktop app
-        run: >-
-          pnpm run desktop:package:smoke -- --app
-          packages/desktop/dist-packaged/mac-universal/TeXRA.app/Contents/MacOS/TeXRA
 
       - name: Upload macOS desktop installers
         uses: actions/upload-artifact@v7
@@ -159,16 +159,16 @@ jobs:
       - name: Package Linux desktop installers
         run: pnpm --filter @texra/desktop package:dist
 
+      - name: Smoke-test Linux packaged desktop app
+        run: >-
+          xvfb-run --auto-servernum pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/linux-unpacked/texra
+
       - name: Check Linux packaged desktop app contents
         run: pnpm run check:desktop-package
 
       - name: Check Linux desktop installer artifacts
         run: pnpm run check:desktop-installers
-
-      - name: Smoke-test Linux packaged desktop app
-        run: >-
-          xvfb-run --auto-servernum pnpm run desktop:package:smoke -- --app
-          packages/desktop/dist-packaged/linux-unpacked/texra
 
       - name: Upload Linux desktop installers
         uses: actions/upload-artifact@v7
@@ -233,16 +233,16 @@ jobs:
       - name: Package Windows desktop installer
         run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
+      - name: Smoke-test Windows packaged desktop app
+        run: >-
+          pnpm run desktop:package:smoke -- --app
+          packages/desktop/dist-packaged/win-unpacked/TeXRA.exe
+
       - name: Check Windows packaged desktop app contents
         run: pnpm run check:desktop-package
 
       - name: Check Windows desktop installer artifacts
         run: pnpm run check:desktop-installers
-
-      - name: Smoke-test Windows packaged desktop app
-        run: >-
-          pnpm run desktop:package:smoke -- --app
-          packages/desktop/dist-packaged/win-unpacked/TeXRA.exe
 
       - name: Upload Windows desktop installer
         uses: actions/upload-artifact@v7

--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -426,10 +426,14 @@ npm run build:initial
 That command builds the Electron desktop app and the VS Code extension package, then checks that the
 desktop build artifacts and `.vsix` are present.
 
-`npm run desktop:package:smoke` launches the packaged app briefly from the command line using an
-isolated temporary user profile. It fails on early exits, desktop startup failures, unsupported
-dynamic `require()` calls, or runtime VS Code import errors. Set `TEXRA_DESKTOP_LAUNCH_SMOKE_MS` to
-change the default 8 second launch window.
+`npm run desktop:package:smoke` uses Playwright's Electron support to launch an unpacked packaged app
+with an isolated temporary profile and workspace. It asserts that Electron reports `app.isPackaged`,
+then waits up to 30 seconds for a visible desktop shell, a rendered `main-app` shadow root, and the
+theme state returned by the `WEBVIEW_READY` to `desktopViewState` IPC round trip. The desktop package
+workflow runs this readiness gate against Electron Builder's `mac-universal`, `win-unpacked`, and
+`linux-unpacked` outputs on their respective operating systems before uploading installer artifacts.
+This gate validates the unpacked application, not installer mounting, installation, uninstallation,
+or operating-system trust dialogs.
 
 ### Local macOS Desktop Installer
 

--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -430,11 +430,14 @@ desktop build artifacts and `.vsix` are present.
 with an isolated temporary profile and workspace. Launch has a 30-second timeout; after launch, the
 smoke asserts that Electron reports `app.isPackaged`, then waits up to 30 seconds for a visible desktop
 shell, a rendered `main-app` shadow root, and the theme state returned by the `WEBVIEW_READY` to
-`desktopViewState` IPC round trip. The desktop package
-workflow runs this readiness gate against Electron Builder's `mac-universal`, `win-unpacked`, and
-`linux-unpacked` outputs on their respective operating systems before uploading installer artifacts.
-This gate validates the unpacked application, not installer mounting, installation, uninstallation,
-or operating-system trust dialogs.
+`desktopViewState` IPC round trip. The packaged child inherits only an explicit allowlist of operating-
+system path, display, and locale variables; signing credentials and future job-level secrets are
+excluded by default. Process errors fail readiness immediately but remain separate from actual process
+exit observation, so teardown still waits for termination and escalates to a forced stop when needed.
+The desktop package workflow runs this readiness gate against Electron Builder's `mac-universal`,
+`win-unpacked`, and `linux-unpacked` outputs on their respective operating systems before uploading
+installer artifacts. This gate validates the unpacked application, not installer mounting,
+installation, uninstallation, or operating-system trust dialogs.
 
 ### Local macOS Desktop Installer
 

--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -427,9 +427,10 @@ That command builds the Electron desktop app and the VS Code extension package, 
 desktop build artifacts and `.vsix` are present.
 
 `npm run desktop:package:smoke` uses Playwright's Electron support to launch an unpacked packaged app
-with an isolated temporary profile and workspace. It asserts that Electron reports `app.isPackaged`,
-then waits up to 30 seconds for a visible desktop shell, a rendered `main-app` shadow root, and the
-theme state returned by the `WEBVIEW_READY` to `desktopViewState` IPC round trip. The desktop package
+with an isolated temporary profile and workspace. Launch has a 30-second timeout; after launch, the
+smoke asserts that Electron reports `app.isPackaged`, then waits up to 30 seconds for a visible desktop
+shell, a rendered `main-app` shadow root, and the theme state returned by the `WEBVIEW_READY` to
+`desktopViewState` IPC round trip. The desktop package
 workflow runs this readiness gate against Electron Builder's `mac-universal`, `win-unpacked`, and
 `linux-unpacked` outputs on their respective operating systems before uploading installer artifacts.
 This gate validates the unpacked application, not installer mounting, installation, uninstallation,

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -54,6 +54,7 @@ win:
         - x64
 linux:
   category: Office
+  executableName: texra
   icon: build/icon.png
   maintainer: TeXRA.ai <contact@texra.ai>
   target:

--- a/scripts/desktop-package-smoke-environment.d.mts
+++ b/scripts/desktop-package-smoke-environment.d.mts
@@ -1,0 +1,9 @@
+export interface DesktopSmokePaths {
+  profile: string;
+  userData: string;
+}
+
+export function buildDesktopSmokeEnvironment(
+  sourceEnvironment: NodeJS.ProcessEnv,
+  paths: DesktopSmokePaths,
+): NodeJS.ProcessEnv;

--- a/scripts/desktop-package-smoke-environment.mjs
+++ b/scripts/desktop-package-smoke-environment.mjs
@@ -1,0 +1,73 @@
+// Node imports
+import { join } from 'node:path';
+
+const PASSTHROUGH_ENV_NAMES = new Set([
+  'COLORTERM',
+  'COMSPEC',
+  'DBUS_SESSION_BUS_ADDRESS',
+  'DISPLAY',
+  'DYLD_LIBRARY_PATH',
+  'LANG',
+  'LANGUAGE',
+  'LC_ADDRESS',
+  'LC_ALL',
+  'LC_COLLATE',
+  'LC_CTYPE',
+  'LC_IDENTIFICATION',
+  'LC_MEASUREMENT',
+  'LC_MESSAGES',
+  'LC_MONETARY',
+  'LC_NAME',
+  'LC_NUMERIC',
+  'LC_PAPER',
+  'LC_TELEPHONE',
+  'LC_TIME',
+  'LD_LIBRARY_PATH',
+  'PATH',
+  'PATHEXT',
+  'SHELL',
+  'SYSTEMROOT',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'WAYLAND_DISPLAY',
+  'WINDIR',
+  'XAUTHORITY',
+  'XDG_CURRENT_DESKTOP',
+  'XDG_DATA_DIRS',
+  'XDG_RUNTIME_DIR',
+  'XDG_SESSION_TYPE',
+]);
+
+function mayPassThrough(name) {
+  return PASSTHROUGH_ENV_NAMES.has(name.toUpperCase());
+}
+
+/**
+ * Build the packaged-smoke child environment from an explicit system-variable
+ * allowlist. Signing credentials and future job-level secrets are excluded by
+ * default rather than depending on a synchronized denylist.
+ */
+export function buildDesktopSmokeEnvironment(sourceEnvironment, paths) {
+  const environment = Object.fromEntries(
+    Object.entries(sourceEnvironment).filter(
+      ([name, value]) => value != null && mayPassThrough(name),
+    ),
+  );
+
+  return {
+    ...environment,
+    APPDATA: join(paths.profile, 'AppData', 'Roaming'),
+    ELECTRON_ENABLE_LOGGING: '1',
+    HOME: paths.profile,
+    LOCALAPPDATA: join(paths.profile, 'AppData', 'Local'),
+    NODE_ENV: 'production',
+    TEXRA_DESKTOP_E2E_USER_DATA_PATH: paths.userData,
+    TEXRA_DISABLE_KEYCHAIN: '1',
+    TEXRA_NO_UPDATE_CHECK: '1',
+    USERPROFILE: paths.profile,
+    XDG_CACHE_HOME: join(paths.profile, '.cache'),
+    XDG_CONFIG_HOME: join(paths.profile, '.config'),
+  };
+}

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -234,7 +234,7 @@ async function closeApplication(application, exitPromise) {
   const child = application.process();
   if (hasExited(child)) return;
 
-  const closeFailure = await Promise.race([
+  let closeFailure = await Promise.race([
     application.close().then(
       () => null,
       (error) => error,
@@ -243,7 +243,17 @@ async function closeApplication(application, exitPromise) {
       () => new Error('ElectronApplication.close() timed out.'),
     ),
   ]);
-  if (!closeFailure) return;
+  if (!closeFailure) {
+    if (hasExited(child)) return;
+    const exitObserved = await Promise.race([
+      exitPromise.then(() => true),
+      delay(SHUTDOWN_GRACE_MS).then(() => false),
+    ]);
+    if (exitObserved && hasExited(child)) return;
+    closeFailure = new Error(
+      'ElectronApplication.close() completed before the process exited.',
+    );
+  }
 
   appendDiagnostic(
     'teardown',

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -1,3 +1,4 @@
+// Node.js imports
 import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -5,6 +6,7 @@ import { join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+// Local imports - smoke process helpers
 import {
   appendBoundedLog,
   delay,
@@ -45,6 +47,27 @@ function appendDiagnostic(label, value) {
   );
 }
 
+function createRuntimeFailureSignal() {
+  let firstError;
+  let resolveFirstError;
+  const promise = new Promise((resolvePromise) => {
+    resolveFirstError = resolvePromise;
+  });
+  return {
+    get error() {
+      return firstError;
+    },
+    promise,
+    report(label, value) {
+      const message = String(value).trim() || label;
+      appendDiagnostic(label, message);
+      if (firstError) return;
+      firstError = new Error(`${label}: ${message}`);
+      resolveFirstError(firstError);
+    },
+  };
+}
+
 function defaultPackagedExecutables() {
   if (process.platform === 'darwin') {
     const appExecutable = ['TeXRA.app', 'Contents', 'MacOS', 'TeXRA'];
@@ -77,7 +100,8 @@ async function resolvePackagedExecutable(argv) {
     try {
       await access(candidate);
       return candidate;
-    } catch {
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
       // Try the local architecture fallback on macOS.
     }
   }
@@ -98,7 +122,6 @@ async function createIsolation(root) {
     profile,
     userData: join(profile, 'user-data'),
     workspace: join(root, 'workspace'),
-    artifacts: join(root, 'playwright-artifacts'),
   };
   await Promise.all(
     Object.values(paths).map((path) => mkdir(path, { recursive: true })),
@@ -145,35 +168,40 @@ function observeExit(child) {
   });
 }
 
-function observeApplication(application) {
+function observeApplication(application, runtimeFailure) {
   const child = application.process();
   child.stdout?.on('data', (chunk) => appendDiagnostic('stdout', chunk));
   child.stderr?.on('data', (chunk) => appendDiagnostic('stderr', chunk));
   application.on('console', (message) => {
-    appendDiagnostic(`main ${message.type()}`, message.text());
+    const label = `main ${message.type()}`;
+    if (message.type() === 'error') {
+      runtimeFailure.report(label, message.text());
+    } else {
+      appendDiagnostic(label, message.text());
+    }
   });
 }
 
-function observePage(page) {
+function observePage(page, runtimeFailure) {
   page.on('console', (message) => {
     if (message.type() === 'error' || message.type() === 'warning') {
       appendDiagnostic(`renderer ${message.type()}`, message.text());
     }
   });
   page.on('pageerror', (error) => {
-    appendDiagnostic('renderer exception', error.message);
+    runtimeFailure.report('renderer exception', error.message);
   });
-  page.on('crash', () => appendDiagnostic('renderer', 'page crashed'));
+  page.on('crash', () => runtimeFailure.report('renderer', 'page crashed'));
 }
 
-async function waitForReadiness(application) {
+async function waitForReadiness(application, runtimeFailure) {
   const isPackaged = await application.evaluate(({ app }) => app.isPackaged);
   if (!isPackaged) {
     throw new Error('Electron main process reported app.isPackaged = false.');
   }
 
   const page = await application.firstWindow({ timeout: 0 });
-  observePage(page);
+  observePage(page, runtimeFailure);
   const handle = await page.waitForFunction(
     () => {
       const shell = document.querySelector('.desktop-shell');
@@ -217,17 +245,20 @@ async function closeApplication(application, exitPromise) {
   ]);
   if (!closeFailure) return;
 
-  if (!hasExited(child)) {
-    appendDiagnostic(
-      'teardown',
-      'graceful close failed; forcing the Electron process to stop',
-    );
-    await stopChild(child, exitPromise, {
-      graceMs: SHUTDOWN_GRACE_MS,
-      label: 'Packaged app',
-    });
-  }
-  throw closeFailure;
+  appendDiagnostic(
+    'teardown',
+    `graceful close did not complete: ${errorMessage(closeFailure)}`,
+  );
+  if (hasExited(child)) return;
+
+  appendDiagnostic(
+    'teardown',
+    'forcing the Electron process to stop after graceful close failed',
+  );
+  await stopChild(child, exitPromise, {
+    graceMs: SHUTDOWN_GRACE_MS,
+    label: 'Packaged app',
+  });
 }
 
 function errorMessage(error) {
@@ -252,31 +283,40 @@ try {
   application = await electron.launch({
     executablePath,
     args: ['--texra-workspace', paths.workspace],
-    artifactsDir: paths.artifacts,
     cwd: paths.workspace,
     env: childEnvironment(paths),
     timeout: READINESS_TIMEOUT_MS,
   });
 
   const child = application.process();
-  observeApplication(application);
+  const runtimeFailure = createRuntimeFailureSignal();
+  observeApplication(application, runtimeFailure);
   exitPromise = observeExit(child);
   phase = 'waiting for packaged desktop readiness';
 
-  readiness = await Promise.race([
-    waitForReadiness(application),
-    exitPromise.then((exit) => {
-      const description = exit.error
-        ? `process error: ${errorMessage(exit.error)}`
-        : formatExit(exit);
-      throw new Error(`Packaged app exited before readiness (${description}).`);
-    }),
-    delay(READINESS_TIMEOUT_MS).then(() => {
-      throw new Error(
-        `TeXRA readiness was not reached within ${READINESS_TIMEOUT_MS}ms.`,
-      );
-    }),
+  const outcome = await Promise.race([
+    waitForReadiness(application, runtimeFailure).then(
+      (value) => ({ kind: 'ready', value }),
+      (error) => ({ kind: 'failure', error }),
+    ),
+    exitPromise.then((exit) => ({ kind: 'exit', exit })),
+    runtimeFailure.promise.then((error) => ({ kind: 'failure', error })),
+    delay(READINESS_TIMEOUT_MS).then(() => ({ kind: 'timeout' })),
   ]);
+  if (outcome.kind === 'failure') throw outcome.error;
+  if (outcome.kind === 'exit') {
+    const description = outcome.exit.error
+      ? `process error: ${errorMessage(outcome.exit.error)}`
+      : formatExit(outcome.exit);
+    throw new Error(`Packaged app exited before readiness (${description}).`);
+  }
+  if (outcome.kind === 'timeout') {
+    throw new Error(
+      `TeXRA readiness was not reached within ${READINESS_TIMEOUT_MS}ms.`,
+    );
+  }
+  readiness = outcome.value;
+  if (runtimeFailure.error) throw runtimeFailure.error;
   if (hasExited(child)) {
     throw new Error('Packaged app exited while reporting readiness.');
   }

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -6,6 +6,9 @@ import { join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+// Local imports - packaged smoke environment
+import { buildDesktopSmokeEnvironment } from './desktop-package-smoke-environment.mjs';
+
 // Local imports - smoke process helpers
 import {
   appendBoundedLog,
@@ -25,16 +28,6 @@ const { _electron: electron } = desktopRequire('playwright');
 const READINESS_TIMEOUT_MS = 30_000;
 const SHUTDOWN_GRACE_MS = 5_000;
 const MAX_DIAGNOSTIC_CHARS = 32_000;
-const SENSITIVE_ENV_PREFIXES = [
-  'APPLE_',
-  'AZURE_',
-  'CSC_',
-  'DESKTOP_MACOS_',
-  'DESKTOP_WINDOWS_',
-  'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_',
-  'WIN_CSC_',
-];
-
 let diagnosticOutput = '';
 
 function appendDiagnostic(label, value) {
@@ -129,47 +122,11 @@ async function createIsolation(root) {
   return paths;
 }
 
-function childEnvironment(paths) {
-  const env = Object.fromEntries(
-    Object.entries(process.env).filter((entry) => entry[1] != null),
-  );
-  for (const name of Object.keys(env)) {
-    if (SENSITIVE_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))) {
-      delete env[name];
-    }
-  }
-
-  return {
-    ...env,
-    APPDATA: join(paths.profile, 'AppData', 'Roaming'),
-    ELECTRON_ENABLE_LOGGING: '1',
-    HOME: paths.profile,
-    LOCALAPPDATA: join(paths.profile, 'AppData', 'Local'),
-    NODE_ENV: 'production',
-    TEXRA_DESKTOP_E2E_USER_DATA_PATH: paths.userData,
-    TEXRA_DISABLE_KEYCHAIN: '1',
-    TEXRA_NO_UPDATE_CHECK: '1',
-    USERPROFILE: paths.profile,
-    XDG_CACHE_HOME: join(paths.profile, '.cache'),
-    XDG_CONFIG_HOME: join(paths.profile, '.config'),
-  };
-}
-
-function observeExit(child) {
-  if (hasExited(child)) {
-    return Promise.resolve({
-      code: child.exitCode,
-      signal: child.signalCode,
-    });
-  }
-  return waitForExit(child).catch((error) => {
-    appendDiagnostic('process error', error.message);
-    return { code: child.exitCode, signal: child.signalCode, error };
-  });
-}
-
 function observeApplication(application, runtimeFailure) {
   const child = application.process();
+  child.on('error', (error) => {
+    runtimeFailure.report('process error', errorMessage(error));
+  });
   child.stdout?.on('data', (chunk) => appendDiagnostic('stdout', chunk));
   child.stderr?.on('data', (chunk) => appendDiagnostic('stderr', chunk));
   application.on('console', (message) => {
@@ -264,12 +221,12 @@ async function closeApplication(application, exitPromise) {
     );
   }
 
+  if (hasExited(child)) return;
+
   appendDiagnostic(
     'teardown',
     `graceful close did not complete: ${errorMessage(closeFailure)}`,
   );
-  if (hasExited(child)) return;
-
   appendDiagnostic(
     'teardown',
     'forcing the Electron process to stop after graceful close failed',
@@ -303,14 +260,14 @@ try {
     executablePath,
     args: ['--texra-workspace', paths.workspace],
     cwd: paths.workspace,
-    env: childEnvironment(paths),
+    env: buildDesktopSmokeEnvironment(process.env, paths),
     timeout: READINESS_TIMEOUT_MS,
   });
 
   const child = application.process();
   const runtimeFailure = createRuntimeFailureSignal();
   observeApplication(application, runtimeFailure);
-  exitPromise = observeExit(child);
+  exitPromise = waitForExit(child);
   phase = 'waiting for packaged desktop readiness';
 
   const outcome = await Promise.race([
@@ -324,9 +281,7 @@ try {
   ]);
   if (outcome.kind === 'failure') throw outcome.error;
   if (outcome.kind === 'exit') {
-    const description = outcome.exit.error
-      ? `process error: ${errorMessage(outcome.exit.error)}`
-      : formatExit(outcome.exit);
+    const description = formatExit(outcome.exit);
     throw new Error(`Packaged app exited before readiness (${description}).`);
   }
   if (outcome.kind === 'timeout') {
@@ -344,7 +299,7 @@ try {
 } finally {
   if (application) {
     try {
-      exitPromise ??= observeExit(application.process());
+      exitPromise ??= waitForExit(application.process());
       await closeApplication(application, exitPromise);
     } catch (error) {
       if (failure) {

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -1,187 +1,332 @@
-import { access, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
-import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+
 import {
   appendBoundedLog,
+  delay,
   formatExit,
-  formatOutput,
   hasExited,
-  readPendingExit,
-  readPositiveNumber,
   stopChild,
-  waitForClose,
   waitForExit,
-  waitForExitOrTimeout,
 } from './smoke-process-utils.mjs';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
-const DEFAULT_TIMEOUT_MS = 8_000;
-const SHUTDOWN_GRACE_MS = 3_000;
-const MAX_LOG_CHARS = 256_000;
-const fatalLogPatterns = [
-  {
-    label: 'VS Code runtime import',
-    pattern:
-      /Cannot find (?:module|package) ['"]vscode['"]|ERR_MODULE_NOT_FOUND.*['"]vscode['"]|from ['"]vscode['"]/i,
-  },
-  {
-    label: 'desktop startup failure',
-    pattern: /Failed to start TeXRA desktop|Fatal TeXRA desktop error/i,
-  },
-  {
-    label: 'unhandled runtime exception',
-    pattern: /Uncaught Exception|UnhandledPromiseRejection/i,
-  },
-  {
-    label: 'esbuild dynamic require failure',
-    pattern: /Dynamic require of ["'][^"']+["'] is not supported/i,
-  },
-  {
-    label: 'constructor startup failure',
-    pattern: /TypeError: .* is not a constructor/i,
-  },
-  {
-    label: 'packaged asset load failure',
-    pattern:
-      /Failed to load URL:.*ERR_FILE_NOT_FOUND|Unable to load preload script|preload\/index\.cjs not found/i,
-  },
+const desktopRoot = join(repoRoot, 'packages', 'desktop');
+const packagedRoot = join(desktopRoot, 'dist-packaged');
+const desktopRequire = createRequire(join(desktopRoot, 'package.json'));
+const { _electron: electron } = desktopRequire('playwright');
+
+const READINESS_TIMEOUT_MS = 30_000;
+const SHUTDOWN_GRACE_MS = 5_000;
+const MAX_DIAGNOSTIC_CHARS = 32_000;
+const SENSITIVE_ENV_PREFIXES = [
+  'APPLE_',
+  'AZURE_',
+  'CSC_',
+  'DESKTOP_MACOS_',
+  'DESKTOP_WINDOWS_',
+  'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_',
+  'WIN_CSC_',
 ];
 
-function defaultPackagedExecutable() {
-  if (process.platform !== 'darwin') return undefined;
-  const archDir = process.arch === 'arm64' ? 'mac-arm64' : 'mac';
-  return join(
-    repoRoot,
-    'packages',
-    'desktop',
-    'dist-packaged',
-    archDir,
-    'TeXRA.app',
-    'Contents',
-    'MacOS',
-    'TeXRA',
+let diagnosticOutput = '';
+
+function appendDiagnostic(label, value) {
+  const text = String(value).trim();
+  if (!text) return;
+  diagnosticOutput = appendBoundedLog(
+    diagnosticOutput,
+    `[${label}] ${text}\n`,
+    MAX_DIAGNOSTIC_CHARS,
   );
 }
 
-function parseAppPath(argv) {
+function defaultPackagedExecutables() {
+  if (process.platform === 'darwin') {
+    const appExecutable = ['TeXRA.app', 'Contents', 'MacOS', 'TeXRA'];
+    const localArchDir = process.arch === 'arm64' ? 'mac-arm64' : 'mac';
+    return [
+      join(packagedRoot, 'mac-universal', ...appExecutable),
+      join(packagedRoot, localArchDir, ...appExecutable),
+    ];
+  }
+  if (process.platform === 'win32') {
+    return [join(packagedRoot, 'win-unpacked', 'TeXRA.exe')];
+  }
+  if (process.platform === 'linux') {
+    return [join(packagedRoot, 'linux-unpacked', '@texradesktop')];
+  }
+  return [];
+}
+
+async function resolvePackagedExecutable(argv) {
   const appFlagIndex = argv.indexOf('--app');
-  if (appFlagIndex === -1) return defaultPackagedExecutable();
-  const value = argv[appFlagIndex + 1];
-  if (!value) {
+  const appFlagValue = appFlagIndex === -1 ? undefined : argv[appFlagIndex + 1];
+  if (appFlagIndex !== -1 && !appFlagValue) {
     throw new Error('Missing value after --app.');
   }
-  return resolve(value);
-}
 
-async function assertExecutableExists(executablePath) {
-  if (!executablePath) {
-    throw new Error(
-      'No default packaged app path is available on this platform. Pass --app <executable>.',
-    );
+  const candidates = appFlagValue
+    ? [resolve(appFlagValue)]
+    : defaultPackagedExecutables();
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Try the local architecture fallback on macOS.
+    }
   }
-  try {
-    await access(executablePath);
-  } catch (error) {
-    throw new Error(
-      [
-        `Packaged desktop executable was not found: ${executablePath}`,
-        'Run `npm run desktop:package:local` first.',
-        error instanceof Error ? error.message : String(error),
-      ].join('\n'),
-    );
-  }
-}
 
-function findFatalLog(output) {
-  return fatalLogPatterns.find(({ pattern }) => pattern.test(output));
-}
-
-function failIfFatalLog(output) {
-  const fatalLog = findFatalLog(output);
-  if (!fatalLog) return;
-
-  console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
-  console.error(formatOutput(output));
-  process.exit(1);
-}
-
-function failEarlyExit(exit, timeoutMs, output) {
-  failIfFatalLog(output);
-  console.error(
-    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
-      exit,
-    )}.`,
+  const expectedPaths =
+    candidates.length > 0
+      ? candidates.map((candidate) => `- ${candidate}`).join('\n')
+      : '- pass --app <executable> on this platform';
+  throw new Error(
+    `Packaged desktop executable was not found.\n${expectedPaths}\n` +
+      'Package the desktop app before running the smoke.',
   );
-  console.error(formatOutput(output));
-  process.exit(1);
 }
 
-const executablePath = parseAppPath(process.argv.slice(2));
-const timeoutMs = readPositiveNumber(
-  process.env.TEXRA_DESKTOP_LAUNCH_SMOKE_MS,
-  DEFAULT_TIMEOUT_MS,
-);
+async function createIsolation(root) {
+  const profile = join(root, 'profile');
+  const paths = {
+    profile,
+    userData: join(profile, 'user-data'),
+    workspace: join(root, 'workspace'),
+    artifacts: join(root, 'playwright-artifacts'),
+  };
+  await Promise.all(
+    Object.values(paths).map((path) => mkdir(path, { recursive: true })),
+  );
+  return paths;
+}
 
-await assertExecutableExists(executablePath);
+function childEnvironment(paths) {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter((entry) => entry[1] != null),
+  );
+  for (const name of Object.keys(env)) {
+    if (SENSITIVE_ENV_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+      delete env[name];
+    }
+  }
 
-const smokeHome = await mkdtemp(join(tmpdir(), 'texra-desktop-smoke-home-'));
-let output = '';
-let result;
+  return {
+    ...env,
+    APPDATA: join(paths.profile, 'AppData', 'Roaming'),
+    ELECTRON_ENABLE_LOGGING: '1',
+    HOME: paths.profile,
+    LOCALAPPDATA: join(paths.profile, 'AppData', 'Local'),
+    NODE_ENV: 'production',
+    TEXRA_DESKTOP_E2E_USER_DATA_PATH: paths.userData,
+    TEXRA_DISABLE_KEYCHAIN: '1',
+    TEXRA_NO_UPDATE_CHECK: '1',
+    USERPROFILE: paths.profile,
+    XDG_CACHE_HOME: join(paths.profile, '.cache'),
+    XDG_CONFIG_HOME: join(paths.profile, '.config'),
+  };
+}
+
+function observeExit(child) {
+  if (hasExited(child)) {
+    return Promise.resolve({
+      code: child.exitCode,
+      signal: child.signalCode,
+    });
+  }
+  return waitForExit(child).catch((error) => {
+    appendDiagnostic('process error', error.message);
+    return { code: child.exitCode, signal: child.signalCode, error };
+  });
+}
+
+function observeApplication(application) {
+  const child = application.process();
+  child.stdout?.on('data', (chunk) => appendDiagnostic('stdout', chunk));
+  child.stderr?.on('data', (chunk) => appendDiagnostic('stderr', chunk));
+  application.on('console', (message) => {
+    appendDiagnostic(`main ${message.type()}`, message.text());
+  });
+}
+
+function observePage(page) {
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      appendDiagnostic(`renderer ${message.type()}`, message.text());
+    }
+  });
+  page.on('pageerror', (error) => {
+    appendDiagnostic('renderer exception', error.message);
+  });
+  page.on('crash', () => appendDiagnostic('renderer', 'page crashed'));
+}
+
+async function waitForReadiness(application) {
+  const isPackaged = await application.evaluate(({ app }) => app.isPackaged);
+  if (!isPackaged) {
+    throw new Error('Electron main process reported app.isPackaged = false.');
+  }
+
+  const page = await application.firstWindow({ timeout: 0 });
+  observePage(page);
+  const handle = await page.waitForFunction(
+    () => {
+      const shell = document.querySelector('.desktop-shell');
+      const mainApp = document.querySelector(
+        'main-app[data-desktop-view="main"]',
+      );
+      const shellReady =
+        shell instanceof HTMLElement &&
+        shell.isConnected &&
+        shell.getClientRects().length > 0 &&
+        window.getComputedStyle(shell).visibility !== 'hidden';
+      const mainAppReady =
+        mainApp instanceof HTMLElement &&
+        mainApp.isConnected &&
+        (mainApp.shadowRoot?.childElementCount ?? 0) > 0;
+      const theme = document.body.dataset.vscodeThemeKind;
+      const themeReady =
+        theme === 'dark' || theme === 'light' || theme === 'high-contrast';
+      return shellReady && mainAppReady && themeReady ? { theme } : false;
+    },
+    undefined,
+    { polling: 100, timeout: 0 },
+  );
+  const readiness = await handle.jsonValue();
+  await handle.dispose();
+  return readiness;
+}
+
+async function closeApplication(application, exitPromise) {
+  const child = application.process();
+  if (hasExited(child)) return;
+
+  const closeFailure = await Promise.race([
+    application.close().then(
+      () => null,
+      (error) => error,
+    ),
+    delay(SHUTDOWN_GRACE_MS).then(
+      () => new Error('ElectronApplication.close() timed out.'),
+    ),
+  ]);
+  if (!closeFailure) return;
+
+  if (!hasExited(child)) {
+    appendDiagnostic(
+      'teardown',
+      'graceful close failed; forcing the Electron process to stop',
+    );
+    await stopChild(child, exitPromise, {
+      graceMs: SHUTDOWN_GRACE_MS,
+      label: 'Packaged app',
+    });
+  }
+  throw closeFailure;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+let executablePath;
+let temporaryRoot;
+let application;
+let exitPromise;
+let readiness;
+let failure;
+let phase = 'resolving packaged executable';
 
 try {
-  const child = spawn(executablePath, [], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      ELECTRON_ENABLE_LOGGING: process.env.ELECTRON_ENABLE_LOGGING ?? '1',
-      HOME: smokeHome,
-      XDG_CONFIG_HOME: join(smokeHome, '.config'),
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
+  executablePath = await resolvePackagedExecutable(process.argv.slice(2));
+  phase = 'creating isolated profile and workspace';
+  temporaryRoot = await mkdtemp(join(tmpdir(), 'texra-package-smoke-'));
+  const paths = await createIsolation(temporaryRoot);
+
+  phase = 'launching packaged Electron app';
+  application = await electron.launch({
+    executablePath,
+    args: ['--texra-workspace', paths.workspace],
+    artifactsDir: paths.artifacts,
+    cwd: paths.workspace,
+    env: childEnvironment(paths),
+    timeout: READINESS_TIMEOUT_MS,
   });
 
-  child.stdout.on('data', (chunk) => {
-    output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
-  });
-  child.stderr.on('data', (chunk) => {
-    output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
-  });
+  const child = application.process();
+  observeApplication(application);
+  exitPromise = observeExit(child);
+  phase = 'waiting for packaged desktop readiness';
 
-  const exitPromise = waitForExit(child);
-  const closePromise = waitForClose(child);
-  result = await waitForExitOrTimeout(exitPromise, timeoutMs);
-
-  if (result.timeout) {
-    if (hasExited(child)) {
-      result.exit = await exitPromise;
-    } else {
-      result.exit = await readPendingExit(exitPromise);
-      if (!result.exit) {
-        await stopChild(child, exitPromise, {
-          graceMs: SHUTDOWN_GRACE_MS,
-          label: 'Packaged app',
-        });
+  readiness = await Promise.race([
+    waitForReadiness(application),
+    exitPromise.then((exit) => {
+      const description = exit.error
+        ? `process error: ${errorMessage(exit.error)}`
+        : formatExit(exit);
+      throw new Error(`Packaged app exited before readiness (${description}).`);
+    }),
+    delay(READINESS_TIMEOUT_MS).then(() => {
+      throw new Error(
+        `TeXRA readiness was not reached within ${READINESS_TIMEOUT_MS}ms.`,
+      );
+    }),
+  ]);
+  if (hasExited(child)) {
+    throw new Error('Packaged app exited while reporting readiness.');
+  }
+} catch (error) {
+  failure = { error, phase };
+} finally {
+  if (application) {
+    try {
+      exitPromise ??= observeExit(application.process());
+      await closeApplication(application, exitPromise);
+    } catch (error) {
+      if (failure) {
+        appendDiagnostic('teardown', errorMessage(error));
+      } else {
+        failure = { error, phase: 'closing packaged Electron app' };
       }
     }
   }
 
-  await closePromise;
-} finally {
-  await rm(smokeHome, { force: true, recursive: true });
+  if (temporaryRoot) {
+    try {
+      await rm(temporaryRoot, {
+        force: true,
+        maxRetries: 3,
+        recursive: true,
+        retryDelay: 100,
+      });
+    } catch (error) {
+      if (failure) {
+        appendDiagnostic('cleanup', errorMessage(error));
+      } else {
+        failure = { error, phase: 'removing temporary smoke directories' };
+      }
+    }
+  }
 }
 
-if (result.exit) {
-  failEarlyExit(result.exit, timeoutMs, output);
-}
-
-failIfFatalLog(output);
-
-console.log(
-  `Desktop launch smoke passed for ${executablePath} after ${timeoutMs}ms.`,
-);
-if (output.trim().length > 0) {
-  console.log(formatOutput(output));
+if (failure) {
+  console.error(
+    `Desktop package launch smoke failed while ${failure.phase}: ${errorMessage(
+      failure.error,
+    )}`,
+  );
+  if (executablePath) console.error(`Executable: ${executablePath}`);
+  if (diagnosticOutput.trim()) {
+    console.error(`Diagnostics:\n${diagnosticOutput.trim()}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Desktop package launch smoke passed: packaged app reached TeXRA readiness (${readiness.theme}) at ${executablePath}.`,
+  );
 }

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -16,7 +16,7 @@ import {
   formatExit,
   hasExited,
   stopChild,
-  waitForExit,
+  waitForTermination,
 } from './smoke-process-utils.mjs';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
@@ -267,7 +267,7 @@ try {
   const child = application.process();
   const runtimeFailure = createRuntimeFailureSignal();
   observeApplication(application, runtimeFailure);
-  exitPromise = waitForExit(child);
+  exitPromise = waitForTermination(child);
   phase = 'waiting for packaged desktop readiness';
 
   const outcome = await Promise.race([
@@ -299,7 +299,7 @@ try {
 } finally {
   if (application) {
     try {
-      exitPromise ??= waitForExit(application.process());
+      exitPromise ??= waitForTermination(application.process());
       await closeApplication(application, exitPromise);
     } catch (error) {
       if (failure) {

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -180,6 +180,16 @@ function observeApplication(application, runtimeFailure) {
       appendDiagnostic(label, message.text());
     }
   });
+
+  const observedPages = new WeakSet();
+  const observeNewPage = (page) => {
+    if (observedPages.has(page)) return;
+    observedPages.add(page);
+    observePage(page, runtimeFailure);
+  };
+  const context = application.context();
+  context.on('page', observeNewPage);
+  for (const page of context.pages()) observeNewPage(page);
 }
 
 function observePage(page, runtimeFailure) {
@@ -194,14 +204,13 @@ function observePage(page, runtimeFailure) {
   page.on('crash', () => runtimeFailure.report('renderer', 'page crashed'));
 }
 
-async function waitForReadiness(application, runtimeFailure) {
+async function waitForReadiness(application) {
   const isPackaged = await application.evaluate(({ app }) => app.isPackaged);
   if (!isPackaged) {
     throw new Error('Electron main process reported app.isPackaged = false.');
   }
 
   const page = await application.firstWindow({ timeout: 0 });
-  observePage(page, runtimeFailure);
   const handle = await page.waitForFunction(
     () => {
       const shell = document.querySelector('.desktop-shell');
@@ -305,7 +314,7 @@ try {
   phase = 'waiting for packaged desktop readiness';
 
   const outcome = await Promise.race([
-    waitForReadiness(application, runtimeFailure).then(
+    waitForReadiness(application).then(
       (value) => ({ kind: 'ready', value }),
       (error) => ({ kind: 'failure', error }),
     ),

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -58,7 +58,7 @@ function defaultPackagedExecutables() {
     return [join(packagedRoot, 'win-unpacked', 'TeXRA.exe')];
   }
   if (process.platform === 'linux') {
-    return [join(packagedRoot, 'linux-unpacked', '@texradesktop')];
+    return [join(packagedRoot, 'linux-unpacked', 'texra')];
   }
   return [];
 }

--- a/scripts/smoke-process-utils.d.mts
+++ b/scripts/smoke-process-utils.d.mts
@@ -16,6 +16,11 @@ export interface ExitObservable {
   ): unknown;
 }
 
+export interface ErrorObservable extends ExitObservable {
+  once(event: 'error', listener: (error: Error) => void): unknown;
+  off(event: 'error', listener: (error: Error) => void): unknown;
+}
+
 export interface StoppableChild extends ExitObservable {
   kill(signal: NodeJS.Signals): unknown;
 }
@@ -30,7 +35,9 @@ export function formatExit(exit: ProcessExit): string;
 
 export function hasExited(child: ExitObservable): boolean;
 
-export function waitForExit(child: ExitObservable): Promise<ProcessExit>;
+export function waitForExit(child: ErrorObservable): Promise<ProcessExit>;
+
+export function waitForTermination(child: ExitObservable): Promise<ProcessExit>;
 
 export function delay(ms: number): Promise<void>;
 

--- a/scripts/smoke-process-utils.d.mts
+++ b/scripts/smoke-process-utils.d.mts
@@ -1,0 +1,41 @@
+export interface ProcessExit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface ExitObservable {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  once(
+    event: 'exit',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+  off(
+    event: 'exit',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+}
+
+export interface StoppableChild extends ExitObservable {
+  kill(signal: NodeJS.Signals): unknown;
+}
+
+export function appendBoundedLog(
+  current: string,
+  chunk: string | Uint8Array,
+  maxLogChars: number,
+): string;
+
+export function formatExit(exit: ProcessExit): string;
+
+export function hasExited(child: ExitObservable): boolean;
+
+export function waitForExit(child: ExitObservable): Promise<ProcessExit>;
+
+export function delay(ms: number): Promise<void>;
+
+export function stopChild(
+  child: StoppableChild,
+  exitPromise: Promise<ProcessExit>,
+  options: { graceMs: number; label?: string },
+): Promise<ProcessExit>;

--- a/scripts/smoke-process-utils.d.mts
+++ b/scripts/smoke-process-utils.d.mts
@@ -16,7 +16,7 @@ export interface ExitObservable {
   ): unknown;
 }
 
-export interface ErrorObservable extends ExitObservable {
+export interface ProcessErrorObservable {
   once(event: 'error', listener: (error: Error) => void): unknown;
   off(event: 'error', listener: (error: Error) => void): unknown;
 }
@@ -35,8 +35,12 @@ export function formatExit(exit: ProcessExit): string;
 
 export function hasExited(child: ExitObservable): boolean;
 
-export function waitForExit(child: ErrorObservable): Promise<ProcessExit>;
+/** Wait for process exit, rejecting if the child reports a process error. */
+export function waitForExit(
+  child: ExitObservable & ProcessErrorObservable,
+): Promise<ProcessExit>;
 
+/** Wait for actual process exit without treating an error event as exit. */
 export function waitForTermination(child: ExitObservable): Promise<ProcessExit>;
 
 export function delay(ms: number): Promise<void>;

--- a/scripts/smoke-process-utils.mjs
+++ b/scripts/smoke-process-utils.mjs
@@ -3,10 +3,6 @@ export function appendBoundedLog(current, chunk, maxLogChars) {
   return next.length > maxLogChars ? next.slice(-maxLogChars) : next;
 }
 
-export function formatOutput(output) {
-  return output.trim().length > 0 ? output.trim() : '(no output)';
-}
-
 export function formatExit(exit) {
   return exit.signal ?? `code ${exit.code}`;
 }
@@ -22,12 +18,6 @@ export function waitForExit(child) {
   });
 }
 
-export function waitForClose(child) {
-  return new Promise((resolve) => {
-    child.once('close', (code, signal) => resolve({ code, signal }));
-  });
-}
-
 export function delay(ms) {
   return new Promise((resolve) => {
     const timeout = setTimeout(resolve, ms);
@@ -35,26 +25,11 @@ export function delay(ms) {
   });
 }
 
-export async function waitForExitOrTimeout(exitPromise, timeoutMs) {
+async function waitForExitOrTimeout(exitPromise, timeoutMs) {
   return Promise.race([
     exitPromise.then((exit) => ({ exit })),
     delay(timeoutMs).then(() => ({ timeout: true })),
   ]);
-}
-
-export function readPositiveNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-export async function readPendingExit(exitPromise) {
-  const result = await Promise.race([
-    exitPromise.then((exit) => ({ exit })),
-    new Promise((resolve) => {
-      setImmediate(() => resolve({}));
-    }),
-  ]);
-  return result.exit;
 }
 
 export async function stopChild(

--- a/scripts/smoke-process-utils.mjs
+++ b/scripts/smoke-process-utils.mjs
@@ -47,10 +47,12 @@ function waitForExitEvent(child, rejectOnError) {
   });
 }
 
+/** Wait for process exit, rejecting if the child reports a process error. */
 export function waitForExit(child) {
   return waitForExitEvent(child, true);
 }
 
+/** Wait for actual process exit without treating an error event as exit. */
 export function waitForTermination(child) {
   return waitForExitEvent(child, false);
 }

--- a/scripts/smoke-process-utils.mjs
+++ b/scripts/smoke-process-utils.mjs
@@ -11,7 +11,7 @@ export function hasExited(child) {
   return child.exitCode !== null || child.signalCode !== null;
 }
 
-export function waitForExit(child) {
+function waitForExitEvent(child, rejectOnError) {
   if (hasExited(child)) {
     return Promise.resolve({
       code: child.exitCode,
@@ -19,17 +19,40 @@ export function waitForExit(child) {
     });
   }
 
-  return new Promise((resolve) => {
-    const onExit = (code, signal) => resolve({ code, signal });
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('exit', onExit);
+      if (onError) child.off('error', onError);
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    const onError = rejectOnError
+      ? (error) => {
+          cleanup();
+          reject(error);
+        }
+      : undefined;
+
     child.once('exit', onExit);
+    if (onError) child.once('error', onError);
     // Close the check/listener TOCTOU interval: an exit that happened between
     // the first check and listener registration has updated these fields even
     // if its event was missed.
     if (hasExited(child)) {
-      child.off('exit', onExit);
+      cleanup();
       resolve({ code: child.exitCode, signal: child.signalCode });
     }
   });
+}
+
+export function waitForExit(child) {
+  return waitForExitEvent(child, true);
+}
+
+export function waitForTermination(child) {
+  return waitForExitEvent(child, false);
 }
 
 export function delay(ms) {

--- a/scripts/smoke-process-utils.mjs
+++ b/scripts/smoke-process-utils.mjs
@@ -12,9 +12,23 @@ export function hasExited(child) {
 }
 
 export function waitForExit(child) {
-  return new Promise((resolve, reject) => {
-    child.once('error', reject);
-    child.once('exit', (code, signal) => resolve({ code, signal }));
+  if (hasExited(child)) {
+    return Promise.resolve({
+      code: child.exitCode,
+      signal: child.signalCode,
+    });
+  }
+
+  return new Promise((resolve) => {
+    const onExit = (code, signal) => resolve({ code, signal });
+    child.once('exit', onExit);
+    // Close the check/listener TOCTOU interval: an exit that happened between
+    // the first check and listener registration has updated these fields even
+    // if its event was missed.
+    if (hasExited(child)) {
+      child.off('exit', onExit);
+      resolve({ code: child.exitCode, signal: child.signalCode });
+    }
   });
 }
 

--- a/src/test-kernel/scripts/DesktopPackageSmoke.vitest.mts
+++ b/src/test-kernel/scripts/DesktopPackageSmoke.vitest.mts
@@ -9,6 +9,7 @@ import { buildDesktopSmokeEnvironment } from '../../../scripts/desktop-package-s
 import {
   stopChild,
   waitForExit,
+  waitForTermination,
 } from '../../../scripts/smoke-process-utils.mjs';
 
 describe('packaged desktop smoke environment', () => {
@@ -54,11 +55,23 @@ describe('packaged desktop smoke process observation', () => {
       },
     };
 
-    await expect(waitForExit(child)).resolves.toEqual({
+    await expect(waitForTermination(child)).resolves.toEqual({
       code: 0,
       signal: null,
     });
     expect(child.off).toHaveBeenCalledOnce();
+  });
+
+  it('reports a process error to callers that require launch success', async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+    });
+    const exit = waitForExit(child);
+
+    child.emit('error', new Error('spawn failed'));
+
+    await expect(exit).rejects.toThrow('spawn failed');
   });
 
   it('does not mistake a process error for an exit during forced teardown', async () => {
@@ -80,7 +93,7 @@ describe('packaged desktop smoke process observation', () => {
       return true;
     });
 
-    const exit = await stopChild(child, waitForExit(child), {
+    const exit = await stopChild(child, waitForTermination(child), {
       graceMs: 5,
       label: 'test child',
     });

--- a/src/test-kernel/scripts/DesktopPackageSmoke.vitest.mts
+++ b/src/test-kernel/scripts/DesktopPackageSmoke.vitest.mts
@@ -1,0 +1,94 @@
+// Node imports
+import { EventEmitter } from 'node:events';
+
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - packaged desktop smoke boundaries
+import { buildDesktopSmokeEnvironment } from '../../../scripts/desktop-package-smoke-environment.mjs';
+import {
+  stopChild,
+  waitForExit,
+} from '../../../scripts/smoke-process-utils.mjs';
+
+describe('packaged desktop smoke environment', () => {
+  it('passes only required system variables and isolated TeXRA paths', () => {
+    const environment = buildDesktopSmokeEnvironment(
+      {
+        DISPLAY: ':99',
+        LC_ALL: 'C.UTF-8',
+        PATH: '/usr/bin',
+        DESKTOP_FUTURE_LINUX_GPG_SIGNING_KEY: 'private key',
+        GITHUB_TOKEN: 'token',
+        UNRELATED_PARENT_VALUE: 'not required',
+      },
+      {
+        profile: '/isolation/profile',
+        userData: '/isolation/user-data',
+      },
+    );
+
+    expect(environment).toMatchObject({
+      DISPLAY: ':99',
+      LC_ALL: 'C.UTF-8',
+      PATH: '/usr/bin',
+      HOME: '/isolation/profile',
+      TEXRA_DESKTOP_E2E_USER_DATA_PATH: '/isolation/user-data',
+    });
+    expect(environment).not.toHaveProperty(
+      'DESKTOP_FUTURE_LINUX_GPG_SIGNING_KEY',
+    );
+    expect(environment).not.toHaveProperty('GITHUB_TOKEN');
+    expect(environment).not.toHaveProperty('UNRELATED_PARENT_VALUE');
+  });
+});
+
+describe('packaged desktop smoke process observation', () => {
+  it('observes an exit that races with listener registration', async () => {
+    const child = {
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      off: vi.fn(),
+      once(event: string): void {
+        if (event === 'exit') this.exitCode = 0;
+      },
+    };
+
+    await expect(waitForExit(child)).resolves.toEqual({
+      code: 0,
+      signal: null,
+    });
+    expect(child.off).toHaveBeenCalledOnce();
+  });
+
+  it('does not mistake a process error for an exit during forced teardown', async () => {
+    const child = Object.assign(new EventEmitter(), {
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      kill: vi.fn(),
+    });
+    child.on('error', () => {});
+    child.kill.mockImplementation((signal: NodeJS.Signals) => {
+      if (signal === 'SIGTERM') {
+        queueMicrotask(() => child.emit('error', new Error('kill failed')));
+      } else {
+        queueMicrotask(() => {
+          child.signalCode = 'SIGKILL';
+          child.emit('exit', null, 'SIGKILL');
+        });
+      }
+      return true;
+    });
+
+    const exit = await stopChild(child, waitForExit(child), {
+      graceMs: 5,
+      label: 'test child',
+    });
+
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      'SIGTERM',
+      'SIGKILL',
+    ]);
+    expect(exit).toEqual({ code: null, signal: 'SIGKILL' });
+  });
+});


### PR DESCRIPTION
## Summary

Replace the duration-based packaged-desktop probe with a Playwright Electron readiness gate and run it against the macOS, Linux, and Windows unpacked package outputs before artifact upload.

The smoke launches the packaged executable with an isolated profile and workspace. Its child environment is constructed from an explicit list of operating-system path, display, and locale variables, so signing credentials and future job-level secrets are excluded by default. Readiness requires:

- Electron main process reports `app.isPackaged`
- a visible `.desktop-shell`
- a rendered `main-app[data-desktop-view="main"]` shadow root
- a valid theme delivered through the `WEBVIEW_READY` to `desktopViewState` IPC path

An early process exit, renderer crash, page exception, main-process error, or 30-second readiness timeout fails with bounded diagnostics. All readiness-race branches settle as values, so a late losing branch cannot reject unhandled during cleanup. Existing script callers still fail immediately on spawn errors, while packaged teardown uses a distinct actual-termination observer so an error event cannot masquerade as exit or suppress forced stopping.

Electron Builder also receives the stable Linux executable name `texra`; deriving a name from the scoped package otherwise produces an AppImage-invalid `@texradesktop` executable.

## Issue acceptance gates

This addresses the release-path drift item in #7728:

- launch the unpacked macOS package before upload
- launch the unpacked Linux package under Xvfb before upload
- launch the unpacked Windows package before upload
- assert application readiness rather than process survival for a fixed duration
- fail on early exit, renderer crash, page exception, main-process error, and spawn error
- isolate profile and workspace state
- exclude credentials and unrelated parent variables with a finite child-environment policy
- configure a stable, AppImage-safe Linux executable name
- make readiness and teardown failures bounded and deterministic
- document what the gate does and does not verify

The broader #7728 tracker remains open for its separate CLI JSON deprecation item.

## Single source of truth

`scripts/smoke-desktop-package-launch.mjs` owns packaged executable discovery, readiness orchestration, diagnostics, and teardown. `desktop-package-smoke-environment.mjs` owns the finite child-environment policy. `smoke-process-utils.mjs` distinguishes error-aware launch waiting from actual process termination and owns bounded stopping. The workflow only selects the package produced by each operating-system job.

Five obsolete process-helper exports are removed. `electron-builder.yml` explicitly owns the Linux executable name `texra`.

## Duplication and abstraction budget

The former raw-spawn duration probe is replaced in place; no parallel smoke path remains. The environment helper isolates the security boundary without coupling it to workflow secret names. The process helper closes the check/listener race once while exposing names for the two materially different waiting contracts.

## Net elements (R6)

- Files changed: 9.
- Diffstat: 616 insertions, 175 deletions (net +441).
- New files: 4.
- Exported runtime functions: net -3.
- New runtime classes or enums: 0.
- Declaration-only interfaces: 5.

## Consumer counts (R8)

No event, IPC, public product API, or persistence contract changes.

- `desktop:package:smoke`: one package script, retained in place.
- Packaging workflow call sites: three, one per operating system.
- Environment builder: one launch call site and one direct regression-test boundary.
- Error-aware exit observer: two existing script consumers.
- Actual-termination observer: packaged readiness and teardown.
- Readiness selectors: two TeXRA-owned renderer boundaries plus one theme state.

## Host impact

Extension and CLI behavior are unchanged.

Desktop release CI gains a pre-upload launch gate on macOS, Linux, and Windows. Linux installs Playwright's Chromium system dependencies and launches the packaged Electron binary under Xvfb.

## Validation

Rebased on current `main` at `9938c9d7b`, including the atomic CLI fallback-session reservation from #8110 and persisted tool-use round outcomes from #8108.

- `npm run desktop:build`: passed
- unpacked macOS arm64 package and unchanged package verifier: passed
- real packaged-app smoke with the finite environment policy: reached TeXRA readiness with the `light` theme and shut down cleanly
- `npm test`: 5,599 passed, 4 skipped
- focused environment/exit regression tests: 4 passed
- `npm run typecheck`: passed
- `npm run lint`: passed with 0 errors
- `node --check` for the smoke scripts: passed
- Prettier and diff checks: passed
- first three-platform Desktop Package run [29161562088](https://github.com/LionSR/TeXRA/actions/runs/29161562088): passed on macOS, Linux, and Windows
- final post-review three-platform run [29162735086](https://github.com/LionSR/TeXRA/actions/runs/29162735086) at pre-rebase runtime head `a927dd7ee`: all three package jobs and all three launch-smoke steps passed
- declaration and JSDoc follow-up `c16033fcd`: focused tests and the test-kernel type check passed; runtime code is unchanged from the successful package run

## Residual risk

The gate has now run successfully twice on all three operating systems, including once after the finite environment and process-observation corrections.

This gate validates unpacked applications. It does not mount installers, perform installation or uninstallation, or traverse operating-system trust dialogs.

Refs #7728.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and release-script changes only; no product runtime, auth, or data paths. Residual risk is flaky GUI smoke or false negatives on readiness selectors, not user-facing behavior.
> 
> **Overview**
> Replaces the **duration-based raw-spawn** packaged-desktop probe with a **Playwright Electron readiness gate** that runs on macOS, Linux (under `xvfb-run`), and Windows **before installer artifacts upload** in the Desktop Package workflow.
> 
> The smoke launches unpacked binaries with an **isolated profile and workspace**, builds the child env from an **explicit OS/path/display/locale allowlist** (new `buildDesktopSmokeEnvironment`) so signing tokens and job secrets are not inherited, and passes when `app.isPackaged` is true plus visible `.desktop-shell`, a rendered `main-app` shadow root, and a valid theme—failing on early exit, crashes, main/renderer errors, or a **30s** readiness timeout with bounded diagnostics. Process helpers now split **error-aware launch wait** (`waitForExit`) from **termination-only teardown** (`waitForTermination`).
> 
> **electron-builder** sets Linux `executableName: texra` for AppImage-safe naming; docs describe the new gate scope (unpacked app only, not installers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16033fcdba0cf2e495d718ba8933f11357dccbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->