### PR TITLE
fix(shared): delete desktop streams.json legacy status union+transform

### DIFF
--- a/src/shared/schemas/streamRestoration.ts
+++ b/src/shared/schemas/streamRestoration.ts
@@ -17,18 +17,9 @@ import { z } from 'zod';
 
 import { AgentCategorySchema } from './agent';
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
-import {
-  StreamPhaseSchema,
-  StreamStatusSchema,
-  streamStatusToPhase,
-} from './stream';
+import { StreamPhaseSchema } from './stream';
 
 export const RESTORED_STREAM_FILE_VERSION = 1;
-
-const PersistedLastKnownStreamPhaseSchema = z.union([
-  StreamPhaseSchema,
-  StreamStatusSchema.transform(streamStatusToPhase),
-]);
 
 /**
  * Slim subset of `StreamTabInfo` + `StreamMetadata` that's safe to
@@ -49,7 +40,7 @@ export const RestoredStreamSnapshotSchema = z.object({
   /** Original instruction text — useful for "start fresh" fallback. */
   instruction: z.string().optional(),
   /** Last known phase before shutdown. Kept under the legacy on-disk key. */
-  lastKnownStatus: PersistedLastKnownStreamPhaseSchema,
+  lastKnownStatus: StreamPhaseSchema,
   /** AI-generated description, if any. */
   description: z.string().optional(),
   /** Execution id for storage lookup (powers resume / transcript view). */

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -7,11 +7,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas
-import {
-  STREAM_PHASE,
-  STREAM_STATUS,
-  StreamPhaseSchema,
-} from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -74,7 +70,7 @@ function makeSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
     agentCategory: 'workflow',
     inputFile: 'paper.tex',
     instruction: 'Polish the abstract',
-    lastKnownStatus: STREAM_STATUS.RUNNING,
+    lastKnownStatus: STREAM_PHASE.RUNNING,
     description: 'Polish the abstract section',
     executionId: 'abc-123',
     creationTimestamp: 1_700_000_000_000,
@@ -153,52 +149,34 @@ describe('DesktopStreamSnapshot', () => {
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
     await writer.upsert(
-      makeSnapshot({ lastKnownStatus: STREAM_STATUS.RUNNING }),
+      makeSnapshot({ lastKnownStatus: STREAM_PHASE.RUNNING }),
     );
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
     expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_PHASE.RUNNING);
   });
 
-  it.each([
-    [STREAM_STATUS.RESUMING, STREAM_PHASE.RUNNING],
-    [STREAM_STATUS.INITIALIZING, STREAM_PHASE.RUNNING],
-    [STREAM_STATUS.WAITING, STREAM_PHASE.WAITING],
-  ])('maps legacy %s to %s on hydrate', async (status, expectedPhase) => {
+  it('preserves WAITING phase on hydrate for startup repair', async () => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
-    await writer.upsert(makeSnapshot({ lastKnownStatus: status }));
+    await writer.upsert(
+      makeSnapshot({ lastKnownStatus: STREAM_PHASE.WAITING }),
+    );
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
-    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(expectedPhase);
+    expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_PHASE.WAITING);
   });
 
   it('normalises inactive phases to COMPLETED on hydrate', async () => {
     const filePath = await tempFilePath();
 
     const writer = await openDesktopStreamSnapshotStore(filePath);
-    await writer.upsert(makeSnapshot({ lastKnownStatus: STREAM_STATUS.ERROR }));
+    await writer.upsert(makeSnapshot({ lastKnownStatus: STREAM_PHASE.FAILED }));
 
     const reopened = await openDesktopStreamSnapshotStore(filePath);
     expect(reopened.hydrated[0]?.lastKnownStatus).toBe(STREAM_PHASE.COMPLETED);
   });
-
-  it.each(Object.values(STREAM_STATUS))(
-    'read-shims legacy on-disk %s to a defined phase',
-    async (status) => {
-      const filePath = await tempFilePath();
-
-      const writer = await openDesktopStreamSnapshotStore(filePath);
-      await writer.upsert(makeSnapshot({ lastKnownStatus: status }));
-
-      const reopened = await openDesktopStreamSnapshotStore(filePath);
-      expect(
-        StreamPhaseSchema.safeParse(reopened.hydrated[0]?.lastKnownStatus)
-          .success,
-      ).toBe(true);
-    },
-  );
 
   it('preserves parent stream links on hydrate', async () => {
     const filePath = await tempFilePath();


### PR DESCRIPTION
Deletes the desktop `streams.json` legacy-status union+transform — D1 (#6982) task-4, desktop half, per the 2026-07-11 re-scope comment on #6982 ("the desktop `streams.json` union+transform (streamRestoration.ts:28-30 + desktopStreamSnapshot.ts) is the one tier-3 shim with positive evidence that ONLY desktop ever wrote the format → deleting now"). Do not close #6982 — the other tier-3 shims in that tracker stay dated 2026-07-24.

## What changed

`PersistedLastKnownStreamPhaseSchema` in `src/shared/schemas/streamRestoration.ts` was `z.union([StreamPhaseSchema, StreamStatusSchema.transform(streamStatusToPhase)])` — the second arm existed only to read a `streams.json` written by an old desktop build under the 7-value `StreamStatus` vocabulary (`running`/`error`/`stopped`/`ready`/`waiting`/`resuming`/`initializing`) instead of the current 5-value `StreamPhase` vocabulary (`running`/`waiting`/`completed`/`cancelled`/`failed`). Desktop has never been released, so no on-disk file can actually be in that legacy shape. Collapsed `lastKnownStatus` straight to `StreamPhaseSchema` and deleted the now-dead intermediate const, dropping the `StreamStatusSchema` / `streamStatusToPhase` imports from this file.

`packages/desktop/src/main/desktopStreamSnapshot.ts` had no legacy-specific read-side code to delete — the union/transform lived entirely in the schema. Its `parseHydrated()` was already the generic malformed-file tolerance path (see Failure path below), unchanged here.

## Failure path for a stale dev-machine `streams.json`

Confirmed via `packages/desktop/src/main/desktopStreamSnapshot.ts`'s `parseHydrated()`: it calls `RestoredStreamsFileSchema.safeParse(raw)`. If a leftover local dev file still has an old `StreamStatus` value (e.g. `"resuming"`, `"initializing"`, `"error"`, `"stopped"`, `"ready"` — none of which are valid `StreamPhase` values), the whole `streams` array now fails to parse. On `!parsed.success` the function `log.warn`s (`'[texra-desktop] Discarding malformed stream snapshot file', ...`) and returns `[]` — the same tolerated "no snapshot, start fresh" path already used for genuinely corrupt files. It does not throw and does not block app launch; this is pre-existing behavior, exercised by the unchanged `'discards a malformed snapshot file without throwing'` test.

`STREAM_STATUS.RUNNING` ('running') and `STREAM_STATUS.WAITING` ('waiting') happen to share their string values with `StreamPhase`, so those two legacy values still parse fine post-change (not a compatibility shim, just literal overlap) — everything else in the old 7-value vocabulary fails.

## Consumer counts (R8)

- `streamStatusToPhase` — **not deleted**, still has 3 live consumer sites after removing the streamRestoration.ts import: `src/shared/schemas/stream.ts:225` (internal use inside `streamStatusToLifecycleStatus`), `src/shared/streams/streamStatusDisplay.ts:37`, `src/test-kernel/helpers/streamStatusTestUtils.ts:61`. Grep: `grep -rn streamStatusToPhase src packages` → 5 hits (1 definition + these 3 call sites + 1 import line already counted alongside streamStatusDisplay.ts).
- `StreamStatusSchema` — **not deleted**, still consumed by `src/shared/schemas/streamSnapshot.ts`, `src/shared/streams/streamStatusDisplay.ts`, `src/shared/schemas/stream.ts` (definition + `StreamLifecycleStatusSchema`), and `packages/trace-viewer/src/replayTrace.ts` — none of those are the desktop tier-3 shim this PR targets.
- `PersistedLastKnownStreamPhaseSchema` (the deleted union const) — 0 remaining references; it had exactly 1 use site (`lastKnownStatus` field), now inlined to `StreamPhaseSchema` directly.

## Net elements (R6)

- Deleted: 1 union schema const (`PersistedLastKnownStreamPhaseSchema`), 2 now-unused imports (`StreamStatusSchema`, `streamStatusToPhase`) from `streamRestoration.ts`.
- Deleted (tests, legacy-arm only): `it.each` "maps legacy %s to %s on hydrate" (3 cases: RESUMING, INITIALIZING, WAITING→RUNNING/WAITING) and `it.each(Object.values(STREAM_STATUS))` "read-shims legacy on-disk %s to a defined phase" (7 cases) in `DesktopStreamSnapshot.vitest.mts` — both existed solely to exercise the now-removed transform arm.
- Updated (current-arm, kept): `'normalises inactive phases to COMPLETED on hydrate'` now writes `STREAM_PHASE.FAILED` instead of the legacy `STREAM_STATUS.ERROR` — same normalization behavior (a terminal-but-not-RUNNING/WAITING phase collapses to `COMPLETED` on hydrate), just exercised with a real `StreamPhase` value instead of a legacy one.
- Added: `'preserves WAITING phase on hydrate for startup repair'` — the deleted legacy-mapping test was the only place covering the WAITING branch of `RESTART_REPAIR_PHASES`; replaced with a direct current-arm case so that coverage isn't lost.
- `makeSnapshot()`'s default `lastKnownStatus` and the RUNNING-preserve test switched from `STREAM_STATUS.RUNNING` to `STREAM_PHASE.RUNNING` (same string value, correct vocabulary for what's now being validated).
- No production/runtime files touched besides the schema; `desktopStreamSnapshot.ts` needed no edits (confirmed no legacy-specific logic lived there).

## Verified

- `src/shared/schemas/streamRestoration.ts`
- `src/shared/schemas/stream.ts` (STREAM_STATUS/STREAM_PHASE value tables, `streamStatusToPhase`, remaining consumers)
- `packages/desktop/src/main/desktopStreamSnapshot.ts` (`parseHydrated`, `RESTART_REPAIR_PHASES`, malformed-file tolerance)
- `packages/desktop/src/main/desktopAgentExecution.ts` (`RESTART_REPAIR_PHASES` usage — phase-generic, not legacy-specific)
- `src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts`
- Issue #6982 and its 2026-07-11 re-scope comment (binding spec for this PR)

## Tests

- `npx vitest run src/test-kernel/desktop` — 42 files / 427 tests pass (includes updated `DesktopStreamSnapshot.vitest.mts`, plus `DesktopSessionProgressBridge.vitest.mts` and `DesktopAgentExecution.vitest.mts` which reference `lastKnownStatus` but weren't otherwise touched).
- `npm run typecheck` — passes (root + test-kernel + cli + trace-viewer + desktop main/preload/renderer configs).
- `npx eslint src/shared/schemas/streamRestoration.ts src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts` — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only change for unreleased desktop; stale dev files with non-overlapping legacy status strings fail parse and are discarded like other malformed snapshots—no new runtime paths.
> 
> **Overview**
> Removes the **legacy read shim** for desktop `streams.json` by validating `lastKnownStatus` with **`StreamPhaseSchema` only**, instead of a union that accepted old **`StreamStatus`** values and transformed them via **`streamStatusToPhase`**.
> 
> **`PersistedLastKnownStreamPhaseSchema`** and its **`StreamStatusSchema` / `streamStatusToPhase`** imports are deleted from **`streamRestoration.ts`**. Desktop snapshot tests now use **`STREAM_PHASE`** values, drop the legacy mapping/`read-shims` cases, and add a direct **WAITING** preserve test while keeping inactive-phase normalization (e.g. **FAILED** → **COMPLETED** on hydrate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc86596e9f8e87ff5683ba07be5f7cef1138dea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->