### PR TITLE
refactor(cli): extract conversation region

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -468,7 +468,6 @@ export function App(props: AppProps): React.JSX.Element {
       snapshot={{
         activeStreamId,
         childStreamEntries,
-        childExecutionPanelTarget: childControlTargets.tasks,
         foregroundMaxRows,
         foregroundKind,
         parentStream,
@@ -477,6 +476,7 @@ export function App(props: AppProps): React.JSX.Element {
         slashPaletteOpen,
         streamTabsVisible,
         streams,
+        childExecutionPanelTarget: childControlTargets.tasks,
         transcriptViewerStreamId,
       }}
     />

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -1,21 +1,9 @@
 // Ink root: conversation and optional panels above stable status, approval, and input chrome.
 
-import { Box, useApp, useInput, useStdin, useWindowSize } from 'ink';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useApp, useInput, useStdin, useWindowSize } from 'ink';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import { isActiveStatus } from '@common/constants/streamStatus';
-import { type ActiveChildInfo } from '@shared/schemas';
-import { clamp } from '@utils/core';
-import {
-  allocateMiddleRows,
-  allocateSidePanelRows,
-  PINNED_CHROME_ROWS,
-  shouldShowTipRow,
-  shouldShowTodosPlanPanel,
-  staticScrollbackTarget,
-  staticTranscriptRowBudget,
-} from './appLayout';
 import {
   appEscapeInterruptActive,
   appFocusShortcutsActive,
@@ -29,25 +17,16 @@ import {
   triggerEscapeInterrupt,
   type EscapeInterruptState,
 } from './appInteractionPolicy';
-import { clampModalWidth } from './ui/theme';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ChildControlPicker } from './modals/ChildControlPicker';
 import { TranscriptViewer } from './modals/TranscriptViewer';
-import { ConversationPane } from './panes/ConversationPane';
-import { StaticConversationTranscript } from './panes/StaticConversationTranscript';
 import { InputBar } from './panes/InputBar';
-import {
-  QueuedFollowUpsPanel,
-  queuedFollowUpPanelRowCount,
-} from './panes/QueuedFollowUpsPanel';
+import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
 import {
   StreamTabsStrip,
   streamTabsDisplayItems,
 } from './panes/StreamTabsStrip';
-import { SubagentList, subagentPanelRowCount } from './panes/SubagentList';
-import { TipRow } from './panes/TipRow';
-import { TodosPlanPanel, todosPlanPanelRowCount } from './panes/TodosPlanPanel';
 import { currentApproval } from './state/approvalQueue';
 import {
   isEscapeInput,
@@ -73,18 +52,12 @@ import {
 import {
   childStreamEntries as childStreamEntriesSignal,
   parentStream as parentStreamSignal,
-  visibleSubagentRows,
 } from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
 import { nextFocusBack, nextFocusForward } from './state/focusCycle';
 import { streamDisplayLabel } from './state/streamViews';
-import {
-  isScopedTranscriptViewport,
-  transcriptViewportChange,
-  transcriptViewportKey,
-  type TranscriptViewportChange,
-} from './state/transcriptViewportMode';
 import { useSignal } from './state/useSignal';
+import type { TranscriptViewportChange } from './state/transcriptViewportMode';
 import type { InputHistory } from './history/inputHistory';
 
 // Narrow subset of Ink's internal stdin emitter used to synthesize Enter.
@@ -93,10 +66,6 @@ interface InputEventEmitterLike {
   on(event: 'input', listener: (data: string) => void): void;
   off(event: 'input', listener: (data: string) => void): void;
 }
-
-// Keep bottom panels from crowding out conversation or input chrome.
-const BOTTOM_PANEL_MAX_ROWS = 10;
-const EMPTY_SUBAGENT_ROWS: readonly ActiveChildInfo[] = [];
 
 export interface AppProps {
   readonly onSubmit: (line: string, mediaFiles?: readonly string[]) => void;
@@ -137,7 +106,6 @@ export function App(props: AppProps): React.JSX.Element {
   const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
-  const [tipHour] = useState(() => new Date().getHours());
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
   const canStopPendingRunWithoutStream =
@@ -195,19 +163,6 @@ export function App(props: AppProps): React.JSX.Element {
     slashPaletteOpen,
   ]);
   const inputBarVisible = !foregroundOpen;
-  const viewportKey = transcriptViewportKey({
-    activeStreamId,
-    parentStream,
-    transcriptViewerStreamId,
-  });
-  const scopedTranscript = isScopedTranscriptViewport(viewportKey);
-  const scrollbackTarget = staticScrollbackTarget({
-    activeStreamId,
-    rootStreamId,
-    scopedTranscript,
-  });
-  const previousViewportKey = useRef<string | undefined>(undefined);
-  const onTranscriptViewportChange = props.onTranscriptViewportChange;
 
   // Under the Kitty disambiguate flag (enabled in runChatTui for Shift+Enter),
   // some Enter variants arrive as CSI-u sequences that Ink parses incompletely.
@@ -230,21 +185,7 @@ export function App(props: AppProps): React.JSX.Element {
     return () => emitter.off('input', onInput);
   }, [inputDisabled, stdin]);
 
-  useLayoutEffect(() => {
-    const previous = previousViewportKey.current;
-    previousViewportKey.current = viewportKey;
-    const change = transcriptViewportChange({
-      previousViewportKey: previous,
-      nextViewportKey: viewportKey,
-    });
-    if (change) onTranscriptViewportChange?.(change);
-  }, [onTranscriptViewportChange, viewportKey]);
-
   const activeSlice = activeStreamId ? streams.get(activeStreamId) : undefined;
-  const activeResponseRunning = isActiveStatus(activeSlice?.status);
-  const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
-  const queuedFollowUpPanelWanted =
-    !foregroundOpen && queuedFollowUpMessages.length > 0;
   const streamTabItems = streamTabsDisplayItems({
     activeStreamId,
     childStreamEntries,
@@ -253,48 +194,6 @@ export function App(props: AppProps): React.JSX.Element {
     width: columns,
   });
   const streamTabsVisible = streamTabItems.length > 0;
-  const footerRows =
-    PINNED_CHROME_ROWS.status +
-    (inputBarVisible ? PINNED_CHROME_ROWS.input : 0) +
-    (streamTabsVisible ? PINNED_CHROME_ROWS.streamTabsWorstCase : 0);
-  const requestedQueuedFollowUpPanelRows = queuedFollowUpPanelWanted
-    ? queuedFollowUpPanelRowCount(queuedFollowUpMessages)
-    : 0;
-  const queuedFollowUpPanelRows = queuedFollowUpPanelWanted
-    ? clamp(rows - footerRows, 0, requestedQueuedFollowUpPanelRows)
-    : 0;
-  const queuedFollowUpPanelVisible = queuedFollowUpPanelRows > 0;
-  const tipRowVisible =
-    !scopedTranscript &&
-    shouldShowTipRow({
-      foregroundOpen,
-      hasQueuedFollowUps: queuedFollowUpPanelWanted,
-    });
-  const staticTranscriptRows = scopedTranscript
-    ? undefined
-    : staticTranscriptRowBudget({
-        footerRows,
-        foregroundOpen,
-        queuedFollowUpPanelRows,
-        rows,
-        tipVisible: tipRowVisible,
-      });
-  const subagentPanelTarget = childControlTargets.tasks;
-  const subagentPanelRows = subagentPanelTarget.streamId
-    ? visibleSubagentRows(
-        subagentPanelTarget.streamId,
-        childStreamEntries,
-        streams,
-      )
-    : EMPTY_SUBAGENT_ROWS;
-  const hasSubagentPanel = !foregroundOpen && subagentPanelTarget.hasItems;
-  const hasTodosPlanPanel = shouldShowTodosPlanPanel({
-    foregroundOpen,
-    hasPlan: activeSlice?.plan != null,
-    status: activeSlice?.status,
-    todos: activeSlice?.todos ?? [],
-  });
-  const transcriptWidth = clampModalWidth(columns);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
     childControlMode,
@@ -312,53 +211,15 @@ export function App(props: AppProps): React.JSX.Element {
       childControlEscapeActionSignal.set('close');
     }
   }, [childControlMode]);
-  const childControlHasItems = childControlTarget?.hasItems ?? false;
-  const { foregroundRows, transcriptRows } = allocateMiddleRows({
-    foregroundMaxRows: foregroundMaxRowsForKind({
-      approvalKind,
-      childControlHasItems,
-      kind: foregroundKind,
-    }),
-    foregroundOpen,
-    inputVisible: inputBarVisible,
-    queuedFollowUpPanelRows,
-    reverseSearchOpen,
-    reserveTranscriptRows: foregroundKind !== 'transcript',
-    rows,
-    slashPaletteOpen,
-    streamTabsVisible,
-    staticTranscriptRows: staticTranscriptRows ?? 0,
-    tipVisible: tipRowVisible,
+  const foregroundMaxRows = foregroundMaxRowsForKind({
+    approvalKind,
+    childControlHasItems: childControlTarget?.hasItems ?? false,
+    kind: foregroundKind,
   });
-  // The subagent/todos panels live at the bottom of the same vertical column.
-  // Reserve only as many rows as the panels actually need — capped so they
-  // never take more than half the transcript or push the input off-screen —
-  // and let the conversation reclaim whatever the panels don't use. A fixed
-  // reservation would leave a dead gap above the input whenever the lists are
-  // shorter than the cap.
-  const subagentContentRows =
-    hasSubagentPanel && subagentPanelTarget.slice
-      ? subagentPanelRowCount(
-          subagentPanelRows,
-          subagentPanelTarget.slice.activeProcesses,
-        )
-      : 0;
-  const todosPlanContentRows =
-    hasTodosPlanPanel && activeSlice
-      ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
-      : 0;
-  const bottomPanelBudget = Math.min(
-    BOTTOM_PANEL_MAX_ROWS,
-    subagentContentRows + todosPlanContentRows,
-    Math.floor(transcriptRows / 2),
-  );
-  const conversationRows = transcriptRows - bottomPanelBudget;
-  const { subagentRows, todosPlanRows } = allocateSidePanelRows({
-    subagentContentRows,
-    todosPlanContentRows,
-    rows: bottomPanelBudget,
-  });
-  function renderForegroundSurface(): React.ReactNode {
+  function renderForegroundSurface(
+    availableRows: number,
+    transcriptWidth: number,
+  ): React.ReactNode {
     switch (foregroundKind) {
       case 'transcript': {
         // foregroundKind is 'transcript' only while transcriptViewerOpen, so
@@ -366,7 +227,7 @@ export function App(props: AppProps): React.JSX.Element {
         if (!transcriptViewerStreamId) return null;
         return (
           <TranscriptViewer
-            availableRows={foregroundRows}
+            availableRows={availableRows}
             onClose={() => transcriptViewerStreamIdSignal.set(undefined)}
             slice={streams.get(transcriptViewerStreamId)}
             title={streamDisplayLabel({
@@ -388,7 +249,7 @@ export function App(props: AppProps): React.JSX.Element {
             availableColumns={columns}
             streamLabel={target.streamLabel}
             activeStreamId={target.streamId}
-            availableRows={foregroundRows}
+            availableRows={availableRows}
             mode={childControlMode}
             onClose={() => childControlModeSignal.set(undefined)}
             onEscapeActionChange={(action) =>
@@ -409,17 +270,16 @@ export function App(props: AppProps): React.JSX.Element {
       case 'form':
         return activeForm?.render(
           () => activeFormSignal.set(undefined),
-          foregroundRows,
+          availableRows,
         );
       case 'approval':
         return activeApprovalVisible && pending ? (
-          <ApprovalModal pending={pending} availableRows={foregroundRows} />
+          <ApprovalModal pending={pending} availableRows={availableRows} />
         ) : null;
       case undefined:
         return null;
     }
   }
-  const foregroundSurface = renderForegroundSurface();
 
   const focusShortcutsActive = appFocusShortcutsActive({
     foregroundOpen,
@@ -569,93 +429,56 @@ export function App(props: AppProps): React.JSX.Element {
   });
 
   return (
-    <>
-      {transcriptViewerOpen ? null : (
-        <StaticConversationTranscript
-          colorEnabled={props.colorEnabled}
-          maxRows={staticTranscriptRows}
-          ownerKey={scrollbackTarget.ownerKey}
-          scrollbackStreamId={scrollbackTarget.streamId}
-          width={transcriptWidth}
-        />
-      )}
-      <Box flexDirection="column">
-        <Box flexDirection="column" overflowY="hidden">
-          {!transcriptViewerOpen && conversationRows > 0 ? (
-            <ConversationPane
-              colorEnabled={props.colorEnabled}
-              width={transcriptWidth}
-              maxRows={conversationRows}
-            />
-          ) : null}
-          {foregroundSurface ? (
-            // Cap the modal area at its row budget but size to the surface's
-            // actual content: every foreground surface (forms, approvals,
-            // transcript viewer, child controls) already windows itself to the
-            // `foregroundRows` budget it is handed, so a fixed height only ever
-            // leaves dead rows below a short form/approval. maxHeight keeps the
-            // budget as a safety clip without reserving it.
-            <Box
-              flexDirection="column"
-              maxHeight={foregroundRows}
-              alignItems="flex-start"
-              overflowY="hidden"
-            >
-              {foregroundSurface}
-            </Box>
-          ) : null}
-        </Box>
-        {bottomPanelBudget > 0 ? (
-          <Box flexDirection="column" overflowY="hidden">
-            <SubagentList
-              maxRows={subagentRows}
-              subagents={subagentPanelRows}
-              activeProcesses={subagentPanelTarget.slice?.activeProcesses}
-              processOutput={subagentPanelTarget.slice?.processOutput}
-            />
-            <TodosPlanPanel maxRows={todosPlanRows} />
-          </Box>
-        ) : null}
-        {tipRowVisible ? (
-          <TipRow
+    <ConversationRegion
+      agentSelectionAvailable={agentSelectionAvailable}
+      colorEnabled={props.colorEnabled}
+      columns={columns}
+      onTranscriptViewportChange={props.onTranscriptViewportChange}
+      renderFooterChrome={(queuedFollowUpPanelVisible) => (
+        <>
+          <InputBar
+            onSubmit={props.onSubmit}
+            collapseWhenDisabled={!inputBarVisible}
+            disabledMessage={childInputDisabledMessage}
+            disabled={inputDisabled}
+            history={props.history}
+          />
+          <StreamTabsStrip items={streamTabItems} width={columns} />
+          <StatusBar
             agentSelectionAvailable={agentSelectionAvailable}
-            hour={tipHour}
-            responseRunning={activeResponseRunning}
+            canStopActiveRun={canStopActiveRun}
+            canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
+            commandName={props.commandName}
+            foregroundEscapeAction={foregroundEscapeAction({
+              activeFormEscapeAction: activeForm?.escapeAction,
+              approvalKind,
+              childControlEscapeAction,
+              foregroundKind,
+            })}
+            queuedFollowUpPreview={!queuedFollowUpPanelVisible}
+            shortcutsActive={focusShortcutsActive}
+            subagentControlsAvailable={subagentControlsAvailable}
+            taskControlsAvailable={taskControlsAvailable}
+            transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
           />
-        ) : null}
-        {queuedFollowUpPanelVisible ? (
-          <QueuedFollowUpsPanel
-            maxRows={queuedFollowUpPanelRows}
-            messages={queuedFollowUpMessages}
-            width={columns}
-          />
-        ) : null}
-        <InputBar
-          onSubmit={props.onSubmit}
-          collapseWhenDisabled={!inputBarVisible}
-          disabledMessage={childInputDisabledMessage}
-          disabled={inputDisabled}
-          history={props.history}
-        />
-        <StreamTabsStrip items={streamTabItems} width={columns} />
-        <StatusBar
-          agentSelectionAvailable={agentSelectionAvailable}
-          canStopActiveRun={canStopActiveRun}
-          canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
-          commandName={props.commandName}
-          foregroundEscapeAction={foregroundEscapeAction({
-            activeFormEscapeAction: activeForm?.escapeAction,
-            approvalKind,
-            childControlEscapeAction,
-            foregroundKind,
-          })}
-          queuedFollowUpPreview={!queuedFollowUpPanelVisible}
-          shortcutsActive={focusShortcutsActive}
-          subagentControlsAvailable={subagentControlsAvailable}
-          taskControlsAvailable={taskControlsAvailable}
-          transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
-        />
-      </Box>
-    </>
+        </>
+      )}
+      renderForegroundSurface={renderForegroundSurface}
+      rows={rows}
+      snapshot={{
+        activeStreamId,
+        childStreamEntries,
+        childExecutionPanelTarget: childControlTargets.tasks,
+        foregroundMaxRows,
+        foregroundKind,
+        parentStream,
+        reverseSearchOpen,
+        rootStreamId,
+        slashPaletteOpen,
+        streamTabsVisible,
+        streams,
+        transcriptViewerStreamId,
+      }}
+    />
   );
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -1,0 +1,275 @@
+// Conversation render boundary: static scrollback, live transcript, foreground
+// surfaces, compact side panels, tips, and queued follow-ups above the footer.
+
+// Third-party imports
+import { Box } from 'ink';
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+
+// Local imports - shared constants and schemas
+import { isActiveStatus } from '@common/constants/streamStatus';
+import { type ActiveChildInfo, type StreamTabId } from '@shared/schemas';
+import { clamp } from '@utils/core';
+
+// Local imports - conversation panes and layout
+import {
+  allocateMiddleRows,
+  allocateSidePanelRows,
+  PINNED_CHROME_ROWS,
+  shouldShowTipRow,
+  shouldShowTodosPlanPanel,
+  staticScrollbackTarget,
+  staticTranscriptRowBudget,
+} from '../appLayout';
+import {
+  visibleSubagentRows,
+  type ChildStreamEntries,
+} from '../state/childExecutions';
+import {
+  isScopedTranscriptViewport,
+  transcriptViewportChange,
+  transcriptViewportKey,
+  type TranscriptViewportChange,
+} from '../state/transcriptViewportMode';
+import { clampModalWidth } from '../ui/theme';
+import { ConversationPane } from './ConversationPane';
+import {
+  QueuedFollowUpsPanel,
+  queuedFollowUpPanelRowCount,
+} from './QueuedFollowUpsPanel';
+import { StaticConversationTranscript } from './StaticConversationTranscript';
+import { SubagentList, subagentPanelRowCount } from './SubagentList';
+import { TipRow } from './TipRow';
+import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
+import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
+import type { ChildControlStreamTarget } from '../state/childControls';
+import type { StreamSlice } from '../state/cliState';
+
+// Cap the bottom subagent/todos panels so they never crowd out the
+// conversation or push the input bar off-screen.
+const BOTTOM_PANEL_MAX_ROWS = 10;
+const EMPTY_SUBAGENT_ROWS: readonly ActiveChildInfo[] = [];
+
+interface ConversationRegionSnapshot {
+  readonly activeStreamId: StreamTabId | undefined;
+  readonly childStreamEntries: ChildStreamEntries;
+  readonly foregroundMaxRows: number | undefined;
+  readonly foregroundKind: ForegroundSurfaceKind | undefined;
+  readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
+  readonly reverseSearchOpen: boolean;
+  readonly rootStreamId: StreamTabId | undefined;
+  readonly slashPaletteOpen: boolean;
+  readonly streamTabsVisible: boolean;
+  readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly subagentPanelTarget: ChildControlStreamTarget;
+  readonly transcriptViewerStreamId: StreamTabId | undefined;
+}
+
+interface ConversationRegionProps {
+  readonly agentSelectionAvailable: boolean;
+  readonly children: (queuedFollowUpPanelVisible: boolean) => ReactNode;
+  readonly colorEnabled?: boolean;
+  readonly columns: number;
+  readonly onTranscriptViewportChange?: (
+    change: TranscriptViewportChange,
+  ) => void;
+  readonly renderForegroundSurface: (
+    availableRows: number,
+    transcriptWidth: number,
+  ) => ReactNode;
+  readonly rows: number;
+  readonly snapshot: ConversationRegionSnapshot;
+}
+
+export function ConversationRegion({
+  agentSelectionAvailable,
+  children,
+  colorEnabled,
+  columns,
+  onTranscriptViewportChange,
+  renderForegroundSurface,
+  rows,
+  snapshot,
+}: ConversationRegionProps): React.JSX.Element {
+  const [tipHour] = useState(() => new Date().getHours());
+  const transcriptViewerOpen = snapshot.transcriptViewerStreamId !== undefined;
+  const foregroundOpen = snapshot.foregroundKind !== undefined;
+  const inputBarVisible = !foregroundOpen;
+  const viewportKey = transcriptViewportKey({
+    activeStreamId: snapshot.activeStreamId,
+    parentStream: snapshot.parentStream,
+    transcriptViewerStreamId: snapshot.transcriptViewerStreamId,
+  });
+  const scopedTranscript = isScopedTranscriptViewport(viewportKey);
+  const scrollbackTarget = staticScrollbackTarget({
+    activeStreamId: snapshot.activeStreamId,
+    rootStreamId: snapshot.rootStreamId,
+    scopedTranscript,
+  });
+  const previousViewportKey = useRef<string | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    const previous = previousViewportKey.current;
+    previousViewportKey.current = viewportKey;
+    const change = transcriptViewportChange({
+      previousViewportKey: previous,
+      nextViewportKey: viewportKey,
+    });
+    if (change) onTranscriptViewportChange?.(change);
+  }, [onTranscriptViewportChange, viewportKey]);
+
+  const activeSlice = snapshot.activeStreamId
+    ? snapshot.streams.get(snapshot.activeStreamId)
+    : undefined;
+  const activeResponseRunning = isActiveStatus(activeSlice?.status);
+  const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
+  const queuedFollowUpPanelWanted =
+    !foregroundOpen && queuedFollowUpMessages.length > 0;
+  const footerRows =
+    PINNED_CHROME_ROWS.status +
+    (inputBarVisible ? PINNED_CHROME_ROWS.input : 0) +
+    (snapshot.streamTabsVisible ? PINNED_CHROME_ROWS.streamTabsWorstCase : 0);
+  const requestedQueuedFollowUpPanelRows = queuedFollowUpPanelWanted
+    ? queuedFollowUpPanelRowCount(queuedFollowUpMessages)
+    : 0;
+  const queuedFollowUpPanelRows = queuedFollowUpPanelWanted
+    ? clamp(rows - footerRows, 0, requestedQueuedFollowUpPanelRows)
+    : 0;
+  const queuedFollowUpPanelVisible = queuedFollowUpPanelRows > 0;
+  const tipRowVisible =
+    !scopedTranscript &&
+    shouldShowTipRow({
+      foregroundOpen,
+      hasQueuedFollowUps: queuedFollowUpPanelWanted,
+    });
+  const staticTranscriptRows = scopedTranscript
+    ? undefined
+    : staticTranscriptRowBudget({
+        footerRows,
+        foregroundOpen,
+        queuedFollowUpPanelRows,
+        rows,
+        tipVisible: tipRowVisible,
+      });
+  const subagentPanelTarget = snapshot.subagentPanelTarget;
+  const subagentPanelRows = subagentPanelTarget.streamId
+    ? visibleSubagentRows(
+        subagentPanelTarget.streamId,
+        snapshot.childStreamEntries,
+        snapshot.streams,
+      )
+    : EMPTY_SUBAGENT_ROWS;
+  const hasSubagentPanel = !foregroundOpen && subagentPanelTarget.hasItems;
+  const hasTodosPlanPanel = shouldShowTodosPlanPanel({
+    foregroundOpen,
+    hasPlan: activeSlice?.plan != null,
+    status: activeSlice?.status,
+    todos: activeSlice?.todos ?? [],
+  });
+  const transcriptWidth = clampModalWidth(columns);
+  const { foregroundRows, transcriptRows } = allocateMiddleRows({
+    foregroundMaxRows: snapshot.foregroundMaxRows,
+    foregroundOpen,
+    inputVisible: inputBarVisible,
+    queuedFollowUpPanelRows,
+    reverseSearchOpen: snapshot.reverseSearchOpen,
+    reserveTranscriptRows: snapshot.foregroundKind !== 'transcript',
+    rows,
+    slashPaletteOpen: snapshot.slashPaletteOpen,
+    streamTabsVisible: snapshot.streamTabsVisible,
+    staticTranscriptRows: staticTranscriptRows ?? 0,
+    tipVisible: tipRowVisible,
+  });
+  // The subagent/todos panels live at the bottom of the same vertical column.
+  // Reserve only as many rows as the panels actually need, capped so they
+  // never take more than half the transcript or push the input off-screen.
+  const subagentContentRows =
+    hasSubagentPanel && subagentPanelTarget.slice
+      ? subagentPanelRowCount(
+          subagentPanelRows,
+          subagentPanelTarget.slice.activeProcesses,
+        )
+      : 0;
+  const todosPlanContentRows =
+    hasTodosPlanPanel && activeSlice
+      ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
+      : 0;
+  const bottomPanelBudget = Math.min(
+    BOTTOM_PANEL_MAX_ROWS,
+    subagentContentRows + todosPlanContentRows,
+    Math.floor(transcriptRows / 2),
+  );
+  const conversationRows = transcriptRows - bottomPanelBudget;
+  const { subagentRows, todosPlanRows } = allocateSidePanelRows({
+    subagentContentRows,
+    todosPlanContentRows,
+    rows: bottomPanelBudget,
+  });
+  const foregroundSurface = renderForegroundSurface(
+    foregroundRows,
+    transcriptWidth,
+  );
+
+  return (
+    <>
+      {transcriptViewerOpen ? null : (
+        <StaticConversationTranscript
+          colorEnabled={colorEnabled}
+          maxRows={staticTranscriptRows}
+          ownerKey={scrollbackTarget.ownerKey}
+          scrollbackStreamId={scrollbackTarget.streamId}
+          width={transcriptWidth}
+        />
+      )}
+      <Box flexDirection="column">
+        <Box flexDirection="column" overflowY="hidden">
+          {!transcriptViewerOpen && conversationRows > 0 ? (
+            <ConversationPane
+              colorEnabled={colorEnabled}
+              width={transcriptWidth}
+              maxRows={conversationRows}
+            />
+          ) : null}
+          {foregroundSurface ? (
+            // Cap the modal area at its row budget but size to the surface's
+            // actual content. Each foreground surface already windows itself
+            // to the budget, so a fixed height leaves dead rows below it.
+            <Box
+              flexDirection="column"
+              maxHeight={foregroundRows}
+              alignItems="flex-start"
+              overflowY="hidden"
+            >
+              {foregroundSurface}
+            </Box>
+          ) : null}
+        </Box>
+        {bottomPanelBudget > 0 ? (
+          <Box flexDirection="column" overflowY="hidden">
+            <SubagentList
+              maxRows={subagentRows}
+              subagents={subagentPanelRows}
+              activeProcesses={subagentPanelTarget.slice?.activeProcesses}
+              processOutput={subagentPanelTarget.slice?.processOutput}
+            />
+            <TodosPlanPanel maxRows={todosPlanRows} />
+          </Box>
+        ) : null}
+        {tipRowVisible ? (
+          <TipRow
+            agentSelectionAvailable={agentSelectionAvailable}
+            hour={tipHour}
+            responseRunning={activeResponseRunning}
+          />
+        ) : null}
+        {queuedFollowUpPanelVisible ? (
+          <QueuedFollowUpsPanel
+            maxRows={queuedFollowUpPanelRows}
+            messages={queuedFollowUpMessages}
+            width={columns}
+          />
+        ) : null}
+        {children(queuedFollowUpPanelVisible)}
+      </Box>
+    </>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -60,13 +60,12 @@ interface ConversationRegionSnapshot {
   readonly slashPaletteOpen: boolean;
   readonly streamTabsVisible: boolean;
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
-  readonly subagentPanelTarget: ChildControlStreamTarget;
+  readonly childExecutionPanelTarget: ChildControlStreamTarget;
   readonly transcriptViewerStreamId: StreamTabId | undefined;
 }
 
 interface ConversationRegionProps {
   readonly agentSelectionAvailable: boolean;
-  readonly children: (queuedFollowUpPanelVisible: boolean) => ReactNode;
   readonly colorEnabled?: boolean;
   readonly columns: number;
   readonly onTranscriptViewportChange?: (
@@ -76,16 +75,19 @@ interface ConversationRegionProps {
     availableRows: number,
     transcriptWidth: number,
   ) => ReactNode;
+  readonly renderFooterChrome: (
+    queuedFollowUpPanelVisible: boolean,
+  ) => ReactNode;
   readonly rows: number;
   readonly snapshot: ConversationRegionSnapshot;
 }
 
 export function ConversationRegion({
   agentSelectionAvailable,
-  children,
   colorEnabled,
   columns,
   onTranscriptViewportChange,
+  renderFooterChrome,
   renderForegroundSurface,
   rows,
   snapshot,
@@ -150,15 +152,16 @@ export function ConversationRegion({
         rows,
         tipVisible: tipRowVisible,
       });
-  const subagentPanelTarget = snapshot.subagentPanelTarget;
-  const subagentPanelRows = subagentPanelTarget.streamId
+  const childExecutionPanelTarget = snapshot.childExecutionPanelTarget;
+  const childExecutionPanelRows = childExecutionPanelTarget.streamId
     ? visibleSubagentRows(
-        subagentPanelTarget.streamId,
+        childExecutionPanelTarget.streamId,
         snapshot.childStreamEntries,
         snapshot.streams,
       )
     : EMPTY_SUBAGENT_ROWS;
-  const hasSubagentPanel = !foregroundOpen && subagentPanelTarget.hasItems;
+  const hasChildExecutionPanel =
+    !foregroundOpen && childExecutionPanelTarget.hasItems;
   const hasTodosPlanPanel = shouldShowTodosPlanPanel({
     foregroundOpen,
     hasPlan: activeSlice?.plan != null,
@@ -183,10 +186,10 @@ export function ConversationRegion({
   // Reserve only as many rows as the panels actually need, capped so they
   // never take more than half the transcript or push the input off-screen.
   const subagentContentRows =
-    hasSubagentPanel && subagentPanelTarget.slice
+    hasChildExecutionPanel && childExecutionPanelTarget.slice
       ? subagentPanelRowCount(
-          subagentPanelRows,
-          subagentPanelTarget.slice.activeProcesses,
+          childExecutionPanelRows,
+          childExecutionPanelTarget.slice.activeProcesses,
         )
       : 0;
   const todosPlanContentRows =
@@ -247,9 +250,9 @@ export function ConversationRegion({
           <Box flexDirection="column" overflowY="hidden">
             <SubagentList
               maxRows={subagentRows}
-              subagents={subagentPanelRows}
-              activeProcesses={subagentPanelTarget.slice?.activeProcesses}
-              processOutput={subagentPanelTarget.slice?.processOutput}
+              subagents={childExecutionPanelRows}
+              activeProcesses={childExecutionPanelTarget.slice?.activeProcesses}
+              processOutput={childExecutionPanelTarget.slice?.processOutput}
             />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
@@ -268,7 +271,7 @@ export function ConversationRegion({
             width={columns}
           />
         ) : null}
-        {children(queuedFollowUpPanelVisible)}
+        {renderFooterChrome(queuedFollowUpPanelVisible)}
       </Box>
     </>
   );


### PR DESCRIPTION
## Summary

Extract the mounted conversation and transcript render boundary from the CLI TUI root.

`ConversationRegion.tsx` now owns static-scrollback identity, viewport transition notification, static/live/transcript-viewer exclusion, compact row budgeting, foreground transcript reservation, subagent and todo/plan panel allocation, tip and queued-follow-up placement, and the complete above-footer Ink tree.

`App.tsx` retains the stateful application boundary: signal subscriptions, approval selection, keyboard and process controls, foreground surface construction, stream-tab projection, `InputBar`, `StreamTabsStrip`, and `StatusBar`. Pure layout policy remains in `appLayout.ts`, and foreground/keyboard policy remains in `appInteractionPolicy.ts`.

Closes #6680.

## Issue acceptance gates

This is the final oversized-component slice in #6680:

- reduce `App.tsx` from 660 to 484 lines
- create one coherent mounted render-tree component rather than a single-purpose helper
- keep all signal subscriptions and the single `currentApproval` read in `App`
- keep App-level Kitty Enter handling, Escape timing, focus shortcuts, and process controls unchanged
- preserve root/scoped static-scrollback owner identity and viewport repaint notification
- preserve compact-terminal row allocation and render ordering
- preserve `appLayout.ts` and `appInteractionPolicy.ts` as the respective pure-policy owners
- add no compatibility re-export or duplicate state model

The task-detail and status-display extractions landed separately in #7985 and #7986.

## Single source of truth

`ConversationRegion` owns mounted conversation layout and above-footer rendering. It receives immutable render facts and one foreground renderer from `App`; it does not subscribe to signals or derive runtime policy.

`App` remains the sole owner of runtime subscriptions, keyboard/process behavior, modal construction, and footer facts. `appLayout.ts` and `appInteractionPolicy.ts` remain the pure functions used by those mounted owners.

## Duplication and abstraction budget

This change moves existing policy application and JSX without duplicating it. The new component owns a viewport ref, row allocation, scrollback identity, and a complete render tree. It does not add a reducer, hook, factory, service, barrel, compatibility export, or auxiliary helper module.

## Net elements (R6)

- Files changed: 2.
- Diffstat: 343 insertions, 242 deletions (net +101).
- New files: 1.
- `App.tsx`: 660 -> 484 lines.
- `ConversationRegion.tsx`: 0 -> 278 lines.
- Exported symbols: +1 (`ConversationRegion`).
- Private interfaces: +2 (`ConversationRegionProps`, `ConversationRegionSnapshot`).
- Classes/enums: 0.

## Consumer counts (R8)

No event, signal, command, persistence field, or input key changes.

- `ConversationRegion`: one production consumer, `App`.
- Foreground renderer callback: one producer, `App`, and one consumer, `ConversationRegion`.
- Footer render callback: one producer, `App`, and one consumer, `ConversationRegion`.
- Compatibility re-exports: 0.

## Host impact

Extension: none.

Desktop: none.

CLI: internal TUI ownership only. Input behavior, visible frames, focus semantics, and controls are unchanged.

## Validation

Rebased and revalidated on current `main` at `a0f22d2cf`.

- full CLI Vitest directory: 129 files, 1,663 tests passed
- PTY validation: 24 selected scenarios passed, covering transcript rendering, compact forms and approvals, queued follow-ups, side panels, stream focus, transcript viewing and return, task detail, and all eight `child-event-order-*` scenarios
- CLI typecheck
- test-kernel typecheck
- targeted ESLint: 0 errors and 0 warnings
- Prettier and commit-hook formatting
- `git diff --check origin/main...HEAD`

## Residual risk

Ink `<Static>` remains the first fragment child, and `ConversationRegion` remains mounted without a viewport key, preserving append-only scrollback identity. The PTY set covers compact layouts, focus changes, transcript viewing, side panels, and child-event ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural move of existing layout JSX and effects with no API or policy changes; PTY validation covers transcript, compact layouts, and panels.
> 
> **Overview**
> **Moves** the CLI TUI’s mounted conversation/transcript Ink tree out of `App.tsx` into a new `ConversationRegion` component, shrinking `App` while keeping behavior the same.
> 
> `ConversationRegion` now owns static scrollback identity, transcript viewport transition notification (`useLayoutEffect`), row budgeting via `appLayout`, and rendering of static/live transcript, foreground surface slot, subagent/todo panels, tips, and queued follow-ups. It takes an immutable `snapshot` of stream/layout facts plus `renderForegroundSurface` and `renderFooterChrome` callbacks instead of subscribing to signals.
> 
> `App` stays the runtime boundary: signal subscriptions, Kitty Enter rewriting, Escape/focus keyboard handling, foreground modal construction (approvals, forms, child controls, transcript viewer), and footer chrome (`InputBar`, `StreamTabsStrip`, `StatusBar`) passed through the footer render prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae10324d17d2b9c833a282f6c863ea16a65d7bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->