### PR TITLE
Fix desktop update-check lifecycle races

### DIFF
--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -85,15 +85,40 @@ export interface CheckForDesktopUpdateOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+let desktopUpdateCheckInFlight: Promise<void> | undefined;
+let desktopUpdateCheckNotify:
+  CheckForDesktopUpdateOptions['notify'] | undefined;
+
 /**
  * At most once per day (persisted in global state), check for a newer
  * desktop release and notify at most once per release version. The daily
- * throttle stamp is only persisted after a successful fetch, so a failed
- * check (network hiccup, GitHub API hiccup, timeout) simply retries on the
- * next launch instead of being suppressed for a full day; failures never
- * interrupt startup.
+ * throttle stamp is only persisted after a successful fetch and any required
+ * notification, so a failed check retries on the next launch instead of being
+ * suppressed for a full day. Concurrent callers share one process-level check.
  */
-export async function checkForDesktopUpdate({
+export function checkForDesktopUpdate(
+  options: CheckForDesktopUpdateOptions,
+): Promise<void> {
+  // Window recreation may call again while the fetch is pending. Keep the
+  // newest callback so any eventual dialog is parented to the live window.
+  desktopUpdateCheckNotify = options.notify;
+  if (desktopUpdateCheckInFlight) return desktopUpdateCheckInFlight;
+
+  const check = runDesktopUpdateCheck({
+    ...options,
+    notify: (release) => desktopUpdateCheckNotify?.(release),
+  });
+  const tracked = check.finally(() => {
+    if (desktopUpdateCheckInFlight === tracked) {
+      desktopUpdateCheckInFlight = undefined;
+      desktopUpdateCheckNotify = undefined;
+    }
+  });
+  desktopUpdateCheckInFlight = tracked;
+  return tracked;
+}
+
+async function runDesktopUpdateCheck({
   currentVersion,
   globalState,
   isPackaged,
@@ -114,23 +139,32 @@ export async function checkForDesktopUpdate({
 
   const release = await fetchRelease();
   if (!release) return;
-  // Only persist the throttle stamp once the fetch actually succeeded.
-  await globalState.update(
-    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-    nowMs,
-  );
   if (!isNewerDesktopVersion(release.version, currentVersion)) {
+    await globalState.update(
+      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+      nowMs,
+    );
     return;
   }
 
   const lastNotifiedVersion = globalState.get<string>(
     GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
   );
-  if (lastNotifiedVersion === release.version) return;
+  if (lastNotifiedVersion === release.version) {
+    await globalState.update(
+      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+      nowMs,
+    );
+    return;
+  }
 
   await notify(release);
   await globalState.update(
     GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
     release.version,
+  );
+  await globalState.update(
+    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+    nowMs,
   );
 }

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -275,5 +275,85 @@ describe('desktop update checker', () => {
         ),
       ).toBe(nowMs + 1000);
     });
+
+    it('does not persist the throttle stamp when notification fails', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      const nowMs = Date.UTC(2026, 0, 1);
+      let notifyCalls = 0;
+
+      const run = (notify: () => void | Promise<void>) =>
+        checkForDesktopUpdate({
+          currentVersion: '0.39.3',
+          globalState,
+          isPackaged: true,
+          env: {},
+          notify,
+          now: () => nowMs,
+          fetchRelease: async () => release,
+        });
+
+      await expect(
+        run(() => {
+          notifyCalls += 1;
+          throw new Error('dialog failed');
+        }),
+      ).rejects.toThrow('dialog failed');
+      expect(
+        globalState.values.get(
+          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+        ),
+      ).toBeUndefined();
+
+      await run(() => {
+        notifyCalls += 1;
+      });
+      expect(notifyCalls).toBe(2);
+      expect(
+        globalState.values.get(
+          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+        ),
+      ).toBe(nowMs);
+    });
+
+    it('coalesces concurrent checks into one fetch and notification', async () => {
+      const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
+      const globalState = new MemoryStateStore();
+      let fetchCalls = 0;
+      let firstNotifyCalls = 0;
+      let secondNotifyCalls = 0;
+      let resolveFetch: ((value: DesktopLatestRelease) => void) | undefined;
+      const pendingRelease = new Promise<DesktopLatestRelease>((resolve) => {
+        resolveFetch = resolve;
+      });
+      const options = {
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: () => {
+          firstNotifyCalls += 1;
+        },
+        fetchRelease: async () => {
+          fetchCalls += 1;
+          return pendingRelease;
+        },
+      };
+
+      const first = checkForDesktopUpdate(options);
+      const second = checkForDesktopUpdate({
+        ...options,
+        notify: () => {
+          secondNotifyCalls += 1;
+        },
+      });
+      expect(fetchCalls).toBe(1);
+
+      resolveFetch?.(release);
+      await Promise.all([first, second]);
+      expect(fetchCalls).toBe(1);
+      expect(firstNotifyCalls).toBe(0);
+      expect(secondNotifyCalls).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- coalesce concurrent desktop update checks behind one process-owned promise
- persist the daily throttle only after any required notification succeeds
- retry on the next launch when the dialog or download-link action fails

Closes #7995.

## Root cause

The checker persisted `lastCheckedAt` immediately after fetching, so notification failure consumed the 24-hour throttle. Window creation also launched checks independently, allowing overlapping calls to pass the persisted throttle before either completed.

The checker now owns the in-flight operation and the persistence order. Callers remain fire-and-report and no host-level guard is duplicated.

## Validation

- focused regression suite: 12 passed (including notification failure and concurrent calls)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` (624 files; 5,505 passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop startup update polling and persisted throttle timing; behavior change is intentional bugfix with focused tests.
> 
> **Overview**
> Fixes **desktop update-check lifecycle races** where overlapping window creation could run multiple GitHub fetches, and where persisting the daily throttle right after fetch meant a **failed update dialog** still blocked retries for 24 hours.
> 
> `checkForDesktopUpdate` now **deduplicates concurrent callers** behind one in-process promise and keeps the **latest `notify` callback** so the dialog can attach to the current window after recreation. The real work lives in `runDesktopUpdateCheck`; **`DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT` is written only** when the check is fully “done” (no newer release, already notified for that version, or **after** `notify` succeeds and the notified version is saved)—not immediately after fetch.
> 
> Regression tests cover **notify failure** (no throttle stamp, retry works) and **concurrent calls** (one fetch, second caller’s notify wins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548bafef3c6ede0cae524f666db17f78b604e5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->