### PR TITLE
fix(desktop): unify desktop data root onto CLI's ~/.texra scheme

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -962,6 +962,7 @@ if (protocolLifecycle.shouldContinue) {
               sensitivePaths: [
                 platformInit.workspacePath,
                 app.getPath('userData'),
+                platformInit.dataRoot,
               ],
               log: console,
             });

--- a/packages/desktop/src/main/platform/dataRootMigration.ts
+++ b/packages/desktop/src/main/platform/dataRootMigration.ts
@@ -6,6 +6,9 @@ import { dirname, join } from 'node:path';
 // Local imports - utils
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+// Type imports - node
+import type { Dirent } from 'node:fs';
+
 export interface DesktopDataRootMigrationLogger {
   info(message: string): void;
   warn(message: string): void;
@@ -13,6 +16,15 @@ export interface DesktopDataRootMigrationLogger {
 
 const GLOBAL_STORAGE_DIR = 'global-storage';
 const WORKSPACE_STORAGE_DIR = 'workspace-storage';
+
+function errorCodeOf(error: unknown): string | undefined {
+  return typeof error === 'object' &&
+    error != null &&
+    'code' in error &&
+    typeof (error as { code?: unknown }).code === 'string'
+    ? (error as { code: string }).code
+    : undefined;
+}
 
 async function moveDirectoryIfAbsent(
   legacyPath: string,
@@ -23,7 +35,7 @@ async function moveDirectoryIfAbsent(
   if (!existsSync(legacyPath)) return;
   if (existsSync(targetPath)) {
     logger.warn(
-      `[desktop] Skipping legacy data migration for "${label}": a directory already exists at ${targetPath}.`,
+      `[desktop] Skipping legacy data migration for "${label}": a directory already exists at ${targetPath}. Legacy data is still at ${legacyPath}; move it manually if needed.`,
     );
     return;
   }
@@ -32,8 +44,13 @@ async function moveDirectoryIfAbsent(
     await rename(legacyPath, targetPath);
     logger.info(`[desktop] Migrated legacy "${label}" to ${targetPath}.`);
   } catch (error) {
+    // Surface the errno code (e.g. EXDEV on some Windows redirected-profile
+    // setups, EACCES on permission-restricted trees, ENOSPC when the target
+    // volume is full) so a failure is diagnosable from the log line alone —
+    // this stays non-throwing/best-effort either way.
+    const code = errorCodeOf(error);
     logger.warn(
-      `[desktop] Failed to migrate legacy "${label}" to ${targetPath}. Cause: ${toErrorMessage(error)}`,
+      `[desktop] Failed to migrate legacy "${label}" to ${targetPath}${code ? ` (${code})` : ''}. Legacy data is still at ${legacyPath}. Cause: ${toErrorMessage(error)}`,
     );
   }
 }
@@ -73,7 +90,19 @@ export async function migrateLegacyDesktopDataRoot(
   const legacyWorkspaceRoot = join(legacyRoot, WORKSPACE_STORAGE_DIR);
   if (!existsSync(legacyWorkspaceRoot)) return;
 
-  const entries = await readdir(legacyWorkspaceRoot, { withFileTypes: true });
+  // Best-effort here too: an unreadable legacy directory (EACCES, or
+  // ENOTDIR if something unexpected occupies that path) must not abort
+  // startup — it only means this run can't migrate workspace-storage.
+  let entries: Dirent[];
+  try {
+    entries = await readdir(legacyWorkspaceRoot, { withFileTypes: true });
+  } catch (error) {
+    const code = errorCodeOf(error);
+    logger.warn(
+      `[desktop] Failed to read legacy workspace-storage directory ${legacyWorkspaceRoot}${code ? ` (${code})` : ''}. Cause: ${toErrorMessage(error)}`,
+    );
+    return;
+  }
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     await moveDirectoryIfAbsent(

--- a/packages/desktop/src/main/platform/dataRootMigration.ts
+++ b/packages/desktop/src/main/platform/dataRootMigration.ts
@@ -1,0 +1,86 @@
+// Node imports
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+// Local imports - utils
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+export interface DesktopDataRootMigrationLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+const GLOBAL_STORAGE_DIR = 'global-storage';
+const WORKSPACE_STORAGE_DIR = 'workspace-storage';
+
+async function moveDirectoryIfAbsent(
+  legacyPath: string,
+  targetPath: string,
+  label: string,
+  logger: DesktopDataRootMigrationLogger,
+): Promise<void> {
+  if (!existsSync(legacyPath)) return;
+  if (existsSync(targetPath)) {
+    logger.warn(
+      `[desktop] Skipping legacy data migration for "${label}": a directory already exists at ${targetPath}.`,
+    );
+    return;
+  }
+  try {
+    await mkdir(dirname(targetPath), { recursive: true });
+    await rename(legacyPath, targetPath);
+    logger.info(`[desktop] Migrated legacy "${label}" to ${targetPath}.`);
+  } catch (error) {
+    logger.warn(
+      `[desktop] Failed to migrate legacy "${label}" to ${targetPath}. Cause: ${toErrorMessage(error)}`,
+    );
+  }
+}
+
+/**
+ * Best-effort, one-time move of a legacy Electron `userData`-rooted storage
+ * tree onto the shared `~/.texra` data root the CLI already uses (#7987).
+ *
+ * Desktop has never shipped a public release, so this is intentionally NOT a
+ * durable read-through fallback — it exists only to protect data already
+ * sitting on the maintainer's own dev machines. After this returns, only
+ * `targetRoot` is ever read; there is no ongoing legacy read path.
+ *
+ * Each top-level storage directory and each per-workspace-key directory
+ * under `workspace-storage` is moved independently so a partial legacy tree
+ * migrates as much as it safely can, and an existing target directory is
+ * never overwritten — it is skipped with a warning instead (mirrors the
+ * #5776 config-migration pattern: log per directory, never clobber).
+ *
+ * Idempotent: once a legacy directory has been moved, it no longer exists,
+ * so subsequent calls (e.g. on the next app launch) are cheap no-ops.
+ */
+export async function migrateLegacyDesktopDataRoot(
+  legacyRoot: string,
+  targetRoot: string,
+  logger: DesktopDataRootMigrationLogger = console,
+): Promise<void> {
+  if (legacyRoot === targetRoot) return;
+
+  await moveDirectoryIfAbsent(
+    join(legacyRoot, GLOBAL_STORAGE_DIR),
+    join(targetRoot, GLOBAL_STORAGE_DIR),
+    GLOBAL_STORAGE_DIR,
+    logger,
+  );
+
+  const legacyWorkspaceRoot = join(legacyRoot, WORKSPACE_STORAGE_DIR);
+  if (!existsSync(legacyWorkspaceRoot)) return;
+
+  const entries = await readdir(legacyWorkspaceRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    await moveDirectoryIfAbsent(
+      join(legacyWorkspaceRoot, entry.name),
+      join(targetRoot, WORKSPACE_STORAGE_DIR, entry.name),
+      `${WORKSPACE_STORAGE_DIR}/${entry.name}`,
+      logger,
+    );
+  }
+}

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -22,9 +22,14 @@ import { configKeyVariants } from '@shared/config/configKeys';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+import { migrateLegacyDesktopDataRoot } from './dataRootMigration.js';
 import { ElectronSecrets } from './electronSecrets.js';
 import { repairLaunchPath } from './pathFix.js';
-import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
+import {
+  resolveDesktopDataRoot,
+  resolveResourcesPath,
+  resolveWorkspacePath,
+} from './paths.js';
 import { showSecretStorageWarningDialog } from './secretStorageWarningDialog.js';
 import {
   isDesktopResumeInFlight,
@@ -76,7 +81,14 @@ export async function initializeElectronPlatform(
       DESKTOP_WORKSPACE_PATH_STATE_KEY,
     ),
   });
-  const storage = new WorkspaceStorageProvider(userDataPath, workspacePath);
+  // Desktop's memory/history/executions data root: shared with the CLI's
+  // `~/.texra` scheme in production so a workspace worked on from both hosts
+  // shows one history (#7987). A best-effort, one-time move of any legacy
+  // `userData`-rooted store protects the maintainer's own dev machines; there
+  // is no ongoing read fallback afterward — only `dataRoot` is ever read.
+  const dataRoot = resolveDesktopDataRoot(userDataPath);
+  await migrateLegacyDesktopDataRoot(userDataPath, dataRoot);
+  const storage = new WorkspaceStorageProvider(dataRoot, workspacePath);
   const workspaceStateStore = await JsonStore.open(
     join(storage.getStoragePath(), 'state.json'),
   );

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -44,6 +44,13 @@ export interface ElectronPlatformInitResult {
   lifecycle: LifecycleHost;
   progressSnapshotStore: StreamSnapshotStore;
   /**
+   * Desktop's memory/history/executions data root (`~/.texra` in
+   * production, see `resolveDesktopDataRoot()`). Threaded out so crash
+   * reporting can scrub it from event payloads the same way it already
+   * scrubs `userData` — this root no longer lives under `userData` (#7987).
+   */
+  dataRoot: string;
+  /**
    * Whether TeXRA had run on this machine before this session, captured from
    * `LAST_KNOWN_VERSION` BEFORE the bundled-agent directory sync writes that
    * key during this same init. Threaded out so the onboarding backfill can
@@ -218,6 +225,7 @@ export async function initializeElectronPlatform(
     workspacePath,
     lifecycle,
     progressSnapshotStore: snapshotStore,
+    dataRoot,
     hasPriorInstall,
     resourcesPath,
   };

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -4,12 +4,17 @@ import { join, resolve } from 'node:path';
 import { app } from 'electron';
 
 import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
+import { DEFAULT_NODE_STORAGE_ROOT } from '@platform/defaults/nodeStorage';
 import { getWorkspacePathInput } from '@desktop/workspacePath.js';
 
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;
   argv?: readonly string[];
   storedWorkspacePath?: string;
+}
+
+interface DataRootOptions {
+  env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_DESKTOP_E2E_USER_DATA_PATH'>>;
 }
 
 interface ResourcesPathOptions {
@@ -24,6 +29,27 @@ export function resolveWorkspacePath(
 ): string | undefined {
   const workspacePath = getWorkspacePathInput(options);
   return workspacePath == null ? undefined : resolve(workspacePath);
+}
+
+/**
+ * Root directory for desktop-persisted memory/history/executions data.
+ *
+ * Production desktop shares the CLI's `~/.texra` root ({@link
+ * DEFAULT_NODE_STORAGE_ROOT}) so a workspace worked on from both hosts shows
+ * one memory/history view (#7987). The e2e/dev harness isolates Electron's
+ * own `userData` profile via `TEXRA_DESKTOP_E2E_USER_DATA_PATH` (see
+ * `packages/desktop/src/main/index.ts`) so relaunches share one throwaway
+ * profile without ever touching a developer's real `~/.texra`; when that var
+ * is set, the data root stays colocated with that same isolated profile
+ * (`userDataPath` is already the isolated path by the time this runs).
+ */
+export function resolveDesktopDataRoot(
+  userDataPath: string,
+  options: DataRootOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  if (env.TEXRA_DESKTOP_E2E_USER_DATA_PATH?.trim()) return userDataPath;
+  return DEFAULT_NODE_STORAGE_ROOT;
 }
 
 export function resolveResourcesPath(

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -7,7 +7,7 @@ import {
   rm,
   writeFile,
 } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
 // Third-party imports
@@ -38,6 +38,10 @@ interface PathsModule {
   resolveWorkspacePath(options?: {
     env?: { TEXRA_WORKSPACE_PATH?: string };
   }): string | undefined;
+  resolveDesktopDataRoot(
+    userDataPath: string,
+    options?: { env?: { TEXRA_DESKTOP_E2E_USER_DATA_PATH?: string } },
+  ): string;
 }
 
 async function walkTypeScriptFiles(dir: string): Promise<string[]> {
@@ -144,6 +148,21 @@ describe('desktop composition root and launch environment', () => {
     expect(
       resolveWorkspacePath({ env: { TEXRA_WORKSPACE_PATH: '   ' } }),
     ).toBeUndefined();
+  });
+
+  it('shares the CLI ~/.texra data root by default, isolating only under the e2e override (#7987)', async () => {
+    const { resolveDesktopDataRoot } =
+      await loadDesktopPlatformModule<PathsModule>('paths.ts');
+    const userDataPath = '/tmp/some-electron-user-data';
+
+    expect(resolveDesktopDataRoot(userDataPath, { env: {} })).toBe(
+      join(homedir(), '.texra'),
+    );
+    expect(
+      resolveDesktopDataRoot(userDataPath, {
+        env: { TEXRA_DESKTOP_E2E_USER_DATA_PATH: userDataPath },
+      }),
+    ).toBe(userDataPath);
   });
 
   it('finds resources in configured, packaged, and monorepo development layouts', async () => {

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -1,5 +1,12 @@
 // Node imports
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -211,9 +218,9 @@ describe('desktop platform adapters', () => {
 
       await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
 
-      await expect(pathExists(join(targetRoot, 'global-storage'))).resolves.toBe(
-        false,
-      );
+      await expect(
+        pathExists(join(targetRoot, 'global-storage')),
+      ).resolves.toBe(false);
       await expect(
         pathExists(join(targetRoot, 'workspace-storage')),
       ).resolves.toBe(false);
@@ -242,9 +249,9 @@ describe('desktop platform adapters', () => {
 
       await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
 
-      await expect(pathExists(join(legacyRoot, 'global-storage'))).resolves.toBe(
-        false,
-      );
+      await expect(
+        pathExists(join(legacyRoot, 'global-storage')),
+      ).resolves.toBe(false);
       await expect(
         pathExists(join(legacyRoot, 'workspace-storage', 'proj-aaaa')),
       ).resolves.toBe(false);
@@ -308,14 +315,10 @@ describe('desktop platform adapters', () => {
 
       // The non-colliding workspace key still migrates.
       await expect(
-        pathExists(
-          join(legacyRoot, 'workspace-storage', 'proj-only-legacy'),
-        ),
+        pathExists(join(legacyRoot, 'workspace-storage', 'proj-only-legacy')),
       ).resolves.toBe(false);
       await expect(
-        pathExists(
-          join(targetRoot, 'workspace-storage', 'proj-only-legacy'),
-        ),
+        pathExists(join(targetRoot, 'workspace-storage', 'proj-only-legacy')),
       ).resolves.toBe(true);
 
       expect(logger.warnMessages).toHaveLength(2);

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -1,5 +1,5 @@
 // Node imports
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -38,6 +38,19 @@ interface ElectronSecrets {
   delete(key: string): Promise<void>;
   get(key: string): Promise<string | undefined>;
   set(key: string, value: string): Promise<void>;
+}
+
+interface DataRootMigrationLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+interface DataRootMigrationModule {
+  migrateLegacyDesktopDataRoot(
+    legacyRoot: string,
+    targetRoot: string,
+    logger?: DataRootMigrationLogger,
+  ): Promise<void>;
 }
 
 interface ElectronSecretsModule {
@@ -163,6 +176,186 @@ describe('desktop platform adapters', () => {
     await expect(pathExists(first.getGlobalStoragePath())).resolves.toBe(true);
     await expect(pathExists(first.getStoragePath())).resolves.toBe(true);
     await expect(pathExists(noWorkspace.getStoragePath())).resolves.toBe(true);
+  });
+
+  function fakeMigrationLogger(): DataRootMigrationLogger & {
+    infoMessages: string[];
+    warnMessages: string[];
+  } {
+    const infoMessages: string[] = [];
+    const warnMessages: string[] = [];
+    return {
+      infoMessages,
+      warnMessages,
+      info: (message) => infoMessages.push(message),
+      warn: (message) => warnMessages.push(message),
+    };
+  }
+
+  describe('legacy userData data-root migration (#7987)', () => {
+    async function loadMigration(): Promise<
+      DataRootMigrationModule['migrateLegacyDesktopDataRoot']
+    > {
+      const { migrateLegacyDesktopDataRoot } =
+        await loadDesktopPlatformModule<DataRootMigrationModule>(
+          'dataRootMigration.ts',
+        );
+      return migrateLegacyDesktopDataRoot;
+    }
+
+    it('is a no-op on a fresh install with no legacy userData store', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const legacyRoot = await makeTempDir('texra-migration-legacy-fresh-');
+      const targetRoot = await makeTempDir('texra-migration-target-fresh-');
+      const logger = fakeMigrationLogger();
+
+      await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
+
+      await expect(pathExists(join(targetRoot, 'global-storage'))).resolves.toBe(
+        false,
+      );
+      await expect(
+        pathExists(join(targetRoot, 'workspace-storage')),
+      ).resolves.toBe(false);
+      expect(logger.infoMessages).toEqual([]);
+      expect(logger.warnMessages).toEqual([]);
+    });
+
+    it('moves every legacy directory when the target root is empty', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const legacyRoot = await makeTempDir('texra-migration-legacy-present-');
+      const targetRoot = await makeTempDir('texra-migration-target-present-');
+      const logger = fakeMigrationLogger();
+
+      await mkdir(join(legacyRoot, 'global-storage'), { recursive: true });
+      await writeFile(
+        join(legacyRoot, 'global-storage', 'state.json'),
+        '{"legacy":true}',
+      );
+      await mkdir(join(legacyRoot, 'workspace-storage', 'proj-aaaa'), {
+        recursive: true,
+      });
+      await writeFile(
+        join(legacyRoot, 'workspace-storage', 'proj-aaaa', 'state.json'),
+        '{"workspace":"proj-aaaa"}',
+      );
+
+      await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
+
+      await expect(pathExists(join(legacyRoot, 'global-storage'))).resolves.toBe(
+        false,
+      );
+      await expect(
+        pathExists(join(legacyRoot, 'workspace-storage', 'proj-aaaa')),
+      ).resolves.toBe(false);
+      await expect(
+        pathExists(join(targetRoot, 'global-storage', 'state.json')),
+      ).resolves.toBe(true);
+      await expect(
+        pathExists(
+          join(targetRoot, 'workspace-storage', 'proj-aaaa', 'state.json'),
+        ),
+      ).resolves.toBe(true);
+      expect(logger.warnMessages).toEqual([]);
+      expect(logger.infoMessages).toHaveLength(2);
+    });
+
+    it('skips-and-warns per directory instead of overwriting an existing target', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const legacyRoot = await makeTempDir('texra-migration-legacy-both-');
+      const targetRoot = await makeTempDir('texra-migration-target-both-');
+      const logger = fakeMigrationLogger();
+
+      // global-storage collides at the target: must be skipped, never
+      // overwritten.
+      await mkdir(join(legacyRoot, 'global-storage'), { recursive: true });
+      await writeFile(
+        join(legacyRoot, 'global-storage', 'state.json'),
+        '{"legacy":true}',
+      );
+      await mkdir(join(targetRoot, 'global-storage'), { recursive: true });
+      await writeFile(
+        join(targetRoot, 'global-storage', 'state.json'),
+        '{"target":true}',
+      );
+
+      // Two workspace keys: one collides (must be skipped independently),
+      // the other is only in the legacy tree (must still migrate).
+      await mkdir(join(legacyRoot, 'workspace-storage', 'proj-collide'), {
+        recursive: true,
+      });
+      await mkdir(join(targetRoot, 'workspace-storage', 'proj-collide'), {
+        recursive: true,
+      });
+      await mkdir(join(legacyRoot, 'workspace-storage', 'proj-only-legacy'), {
+        recursive: true,
+      });
+
+      await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
+
+      // Collisions are left untouched on both sides, never clobbered.
+      await expect(
+        pathExists(join(legacyRoot, 'global-storage', 'state.json')),
+      ).resolves.toBe(true);
+      const targetGlobalState = await readFile(
+        join(targetRoot, 'global-storage', 'state.json'),
+        'utf8',
+      );
+      expect(JSON.parse(targetGlobalState)).toEqual({ target: true });
+      await expect(
+        pathExists(join(legacyRoot, 'workspace-storage', 'proj-collide')),
+      ).resolves.toBe(true);
+
+      // The non-colliding workspace key still migrates.
+      await expect(
+        pathExists(
+          join(legacyRoot, 'workspace-storage', 'proj-only-legacy'),
+        ),
+      ).resolves.toBe(false);
+      await expect(
+        pathExists(
+          join(targetRoot, 'workspace-storage', 'proj-only-legacy'),
+        ),
+      ).resolves.toBe(true);
+
+      expect(logger.warnMessages).toHaveLength(2);
+      expect(logger.warnMessages[0]).toContain('global-storage');
+      expect(logger.warnMessages[1]).toContain('proj-collide');
+      expect(logger.infoMessages).toEqual([
+        expect.stringContaining('proj-only-legacy'),
+      ]);
+    });
+
+    it('is idempotent once a legacy directory has already been moved', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const legacyRoot = await makeTempDir('texra-migration-legacy-idem-');
+      const targetRoot = await makeTempDir('texra-migration-target-idem-');
+      const logger = fakeMigrationLogger();
+
+      await mkdir(join(legacyRoot, 'global-storage'), { recursive: true });
+
+      await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
+      await migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger);
+
+      expect(logger.infoMessages).toHaveLength(1);
+      expect(logger.warnMessages).toEqual([]);
+    });
+
+    it('is a no-op when the legacy root and target root are the same path', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const root = await makeTempDir('texra-migration-same-root-');
+      const logger = fakeMigrationLogger();
+
+      await mkdir(join(root, 'global-storage'), { recursive: true });
+
+      await migrateLegacyDesktopDataRoot(root, root, logger);
+
+      expect(logger.infoMessages).toEqual([]);
+      expect(logger.warnMessages).toEqual([]);
+      await expect(pathExists(join(root, 'global-storage'))).resolves.toBe(
+        true,
+      );
+    });
   });
 
   it('stores encrypted secrets, supports env overrides, and deletes persisted values', async () => {

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -323,10 +323,44 @@ describe('desktop platform adapters', () => {
 
       expect(logger.warnMessages).toHaveLength(2);
       expect(logger.warnMessages[0]).toContain('global-storage');
+      expect(logger.warnMessages[0]).toContain(
+        join(legacyRoot, 'global-storage'),
+      );
       expect(logger.warnMessages[1]).toContain('proj-collide');
+      expect(logger.warnMessages[1]).toContain(
+        join(legacyRoot, 'workspace-storage', 'proj-collide'),
+      );
       expect(logger.infoMessages).toEqual([
         expect.stringContaining('proj-only-legacy'),
       ]);
+    });
+
+    it('does not abort startup when the legacy workspace-storage directory cannot be read', async () => {
+      const migrateLegacyDesktopDataRoot = await loadMigration();
+      const legacyRoot = await makeTempDir(
+        'texra-migration-legacy-unreadable-',
+      );
+      const targetRoot = await makeTempDir(
+        'texra-migration-target-unreadable-',
+      );
+      const logger = fakeMigrationLogger();
+
+      const legacyWorkspaceRoot = join(legacyRoot, 'workspace-storage');
+      // A file (not a directory) at the expected workspace-storage path
+      // makes readdir() reject with ENOTDIR, exercising the same
+      // best-effort catch path as a permission-denied (EACCES) directory
+      // without requiring platform-specific chmod tricks.
+      await writeFile(legacyWorkspaceRoot, 'not a directory');
+
+      await expect(
+        migrateLegacyDesktopDataRoot(legacyRoot, targetRoot, logger),
+      ).resolves.toBeUndefined();
+
+      expect(logger.warnMessages).toHaveLength(1);
+      expect(logger.warnMessages[0]).toContain(legacyWorkspaceRoot);
+      await expect(
+        pathExists(join(targetRoot, 'workspace-storage')),
+      ).resolves.toBe(false);
     });
 
     it('is idempotent once a legacy directory has already been moved', async () => {


### PR DESCRIPTION
Fixes #7987.

## Summary

Points desktop's storage provider at the same `~/.texra/global-storage` /
`~/.texra/workspace-storage` roots the CLI's `nodeStorage.ts` already
computes via `workspaceStorageId()`, instead of rooting under Electron's
`app.getPath('userData')`. This directly delivers the issue's outcome:
**Desktop and CLI now share the same workspace memory/history/executions
view** for a workspace worked on from both hosts.

The issue's sketch predates the maintainer's binding fact that desktop has
never shipped a public release, so this is simplified from the sketch:

- **No dated read-only fallback, no #6981 ledger row.** After the one-time
  migration attempt below, only the new `~/.texra` root is ever read. There
  is no ongoing legacy read path to delete later.
- **Migration is best-effort and one-time**, purely to protect the
  maintainer's own dev machines (which already have real `userData`-rooted
  stores): on startup, `migrateLegacyDesktopDataRoot()` moves each top-level
  storage directory (`global-storage`) and each per-workspace-key directory
  under `workspace-storage` independently from the legacy `userData` root
  into the new `~/.texra` root. It never overwrites an existing target
  directory — it skips that one directory and logs a warning instead
  (mirrors the #5776 config-migration pattern: log per directory, never
  clobber). Idempotent: once a legacy directory has moved, it no longer
  exists, so later launches are cheap no-ops.

## What changed

- `packages/desktop/src/main/platform/paths.ts` — new
  `resolveDesktopDataRoot()`: returns the CLI's `DEFAULT_NODE_STORAGE_ROOT`
  (`~/.texra`) by default; when the e2e/dev harness's
  `TEXRA_DESKTOP_E2E_USER_DATA_PATH` override is set (isolating Electron's
  own `userData` profile — see `packages/desktop/src/main/index.ts`), the
  data root stays colocated with that same isolated profile instead of
  diverging onto a developer's real `~/.texra`, so relaunch/e2e tests keep
  working unchanged.
- `packages/desktop/src/main/platform/dataRootMigration.ts` (new) —
  `migrateLegacyDesktopDataRoot()`, the best-effort one-time move described
  above.
- `packages/desktop/src/main/platform/index.ts` — wires the new data root
  and migration call in ahead of constructing `WorkspaceStorageProvider`;
  everything else in this file (global state/config stores, secrets) still
  reads directly from `userDataPath`, unchanged.

## Consumer counts (R8)

Grepped every `userData` reference under `packages/desktop/src` before and
after:

- `packages/desktop/src/main/desktopAppLog.ts` (logs dir) — unaffected,
  still under `app.getPath('userData')`.
- `packages/desktop/src/main/desktopStreamSnapshot.ts` /
  `packages/desktop/src/main/index.ts` (`streams.json` progress snapshot) —
  unaffected.
- `packages/desktop/src/main/platform/index.ts` — `state/global.json`,
  `config/global.json`, `secrets.json` all still open directly under
  `userDataPath`; only the `WorkspaceStorageProvider` root argument changed.
- `packages/desktop/src/main/desktopUpdateChecker.ts` — no `userData` or
  storage-root coupling at all; confirmed unaffected.

Only the one storage-provider root construction changes; every other
`userData` consumer keeps its existing path.

## Net elements (R6)

- **+1 file**: `dataRootMigration.ts` — a genuinely new one-time behavior
  (directory move with skip-and-warn semantics), not an extraction of
  existing logic, so it isn't a single-caller-helper anti-pattern; it has
  exactly one caller (`platform/index.ts`) by design, matching the #5776
  migration precedent.
- **+1 function** (`resolveDesktopDataRoot`) in the existing
  `paths.ts`, alongside `resolveWorkspacePath`/`resolveResourcesPath` — same
  options/env-override shape already used there.
- **No new abstraction layers, no ports, no ledger.** No wrapper functions
  added — `initializeElectronPlatform` calls `resolveDesktopDataRoot()` and
  `migrateLegacyDesktopDataRoot()` directly.

## Tests

- Extended `src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts`
  with a case proving `resolveDesktopDataRoot()` defaults to the CLI's
  `~/.texra` and only diverges under the e2e override.
- Extended `src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts`
  (the existing desktop storage suite) with the requested migration trio,
  plus two extra cases for idempotency and the same-root no-op:
  - **fresh** — no legacy store: no-op, nothing logged.
  - **legacy-present** — legacy `global-storage` and a workspace-key
    directory move cleanly into the empty target root.
  - **both-present-skip** — `global-storage` collides at the target (left
    untouched on both sides, warned) *and*, in the same run, one
    `workspace-storage` key collides (skipped+warned) while a second,
    non-colliding key still migrates — proving the per-directory (not
    whole-tree) granularity the issue asked for.
  - idempotency (second call after a successful move is a silent no-op) and
    same-root no-op (guards the e2e-override branch) round out the suite.

```
npx vitest run src/test-kernel/desktop src/test-kernel/platform/WorkspaceStorage.vitest.ts --no-file-parallelism
# 43 files, 447 tests passed
```

(`--no-file-parallelism` avoids cross-test-file timeout flakes under this
worktree's concurrent CI load; the same suites are green either way, just
occasionally slower under contention.)

`npx tsc --noEmit -p packages/desktop/tsconfig.main.json` — clean (covers
every file touched in this PR). The full `npm run typecheck` chain (root →
test-kernel → cli → trace-viewer → desktop, across all workspaces) was run
too; root and test-kernel stages passed before this PR body was written
(the chain uses `&&`, so reaching the CLI/desktop stages implies the earlier
stages were clean).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where desktop reads/writes execution and workspace history on disk at startup; migration is best-effort and non-throwing but wrong paths could split or hide data until manually fixed.
> 
> **Overview**
> **Desktop and CLI now share the same persisted memory/history/executions tree** by pointing `WorkspaceStorageProvider` at `~/.texra` (via `resolveDesktopDataRoot()` and `DEFAULT_NODE_STORAGE_ROOT`) instead of Electron `userData`. Global state, secrets, and config under `userData` are unchanged.
> 
> On startup, **`migrateLegacyDesktopDataRoot()`** best-effort moves `global-storage` and each `workspace-storage/<key>` from the old `userData` root into `~/.texra`, **per directory**, skipping targets that already exist (warn only). E2E/dev keeps the data root colocated with the isolated profile when `TEXRA_DESKTOP_E2E_USER_DATA_PATH` is set.
> 
> **Crash reporting** adds `platformInit.dataRoot` to `sensitivePaths` so payloads are scrubbed like `userData`. Vitest covers `resolveDesktopDataRoot` and migration (fresh, move, skip-on-collision, unreadable legacy, idempotent, same-root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1595aba1ca9c94c755c80d9b7650f949be7ab3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->