### PR TITLE
fix(settings): stop re-hardcoding retry defaults in Settings UI

### DIFF
--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -30,14 +30,15 @@ const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
     key: 'texra.model.retry.maxAttempts',
     label: 'Retry attempts',
     description:
-      'Flow-managed retry attempts (Google, OpenRouter rate limits, background transients). Anthropic/OpenAI retries are managed by their SDKs and unaffected.',
+      'Flow-managed retry attempts (Google, OpenRouter 429/408, background transients). Anthropic/OpenAI/OpenAIResponse retries are provider-managed by their SDKs (default 2); this setting does not affect them.',
     min: 0,
     defaultValue: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
   },
   {
     key: 'texra.model.retry.backoffMs',
     label: 'Retry backoff',
-    description: 'Base delay between retry attempts.',
+    description:
+      'Base backoff delay in milliseconds between retry attempts for model calls',
     min: 0,
     unit: 'ms',
     defaultValue: DEFAULT_CORE_SETTINGS.model.retry.backoffMs,

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -7,6 +7,7 @@ import type {
   UpdateProfileMessage,
 } from '@shared/schemas/profileViewMessages';
 import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
+import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { buildProfileMessage } from './ProfileMessageBuilder';
 import type { StateStore } from '@platform/interfaces';
 
@@ -31,7 +32,7 @@ const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
     description:
       'Flow-managed retry attempts (Google, OpenRouter rate limits, background transients). Anthropic/OpenAI retries are managed by their SDKs and unaffected.',
     min: 0,
-    defaultValue: 0,
+    defaultValue: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
   },
   {
     key: 'texra.model.retry.backoffMs',
@@ -39,7 +40,7 @@ const SETTINGS_RELIABILITY_SETTINGS: readonly SettingsReliabilitySetting[] = [
     description: 'Base delay between retry attempts.',
     min: 0,
     unit: 'ms',
-    defaultValue: 1000,
+    defaultValue: DEFAULT_CORE_SETTINGS.model.retry.backoffMs,
   },
 ];
 

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -211,15 +211,17 @@ describe('SettingsProfileController', () => {
 
     const reliabilitySettings = controller.getReliabilitySettings();
 
-    expect(
-      reliabilitySettings.find(
-        (setting) => setting.key === 'texra.model.retry.maxAttempts',
-      )?.value,
-    ).toBe(DEFAULT_CORE_SETTINGS.model.retry.maxAttempts);
-    expect(
-      reliabilitySettings.find(
-        (setting) => setting.key === 'texra.model.retry.backoffMs',
-      )?.value,
-    ).toBe(DEFAULT_CORE_SETTINGS.model.retry.backoffMs);
+    expect(reliabilitySettings).toContainEqual(
+      expect.objectContaining({
+        key: 'texra.model.retry.maxAttempts',
+        value: DEFAULT_CORE_SETTINGS.model.retry.maxAttempts,
+      }),
+    );
+    expect(reliabilitySettings).toContainEqual(
+      expect.objectContaining({
+        key: 'texra.model.retry.backoffMs',
+        value: DEFAULT_CORE_SETTINGS.model.retry.backoffMs,
+      }),
+    );
   });
 });

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -6,6 +6,7 @@ import {
 } from '@controllers/settingsView/SettingsProfileController';
 import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import type { StateStore } from '@platform/interfaces';
 
 const providerVscodeSettings = {
@@ -203,5 +204,22 @@ describe('SettingsProfileController', () => {
         value: 3,
       }),
     );
+  });
+
+  it('defaults reliability settings to DEFAULT_CORE_SETTINGS.model.retry (no drift from the catalog)', async () => {
+    const { controller } = createController();
+
+    const reliabilitySettings = controller.getReliabilitySettings();
+
+    expect(
+      reliabilitySettings.find(
+        (setting) => setting.key === 'texra.model.retry.maxAttempts',
+      )?.value,
+    ).toBe(DEFAULT_CORE_SETTINGS.model.retry.maxAttempts);
+    expect(
+      reliabilitySettings.find(
+        (setting) => setting.key === 'texra.model.retry.backoffMs',
+      )?.value,
+    ).toBe(DEFAULT_CORE_SETTINGS.model.retry.backoffMs);
   });
 });


### PR DESCRIPTION
## The leak

`SettingsProfileController.ts`'s `SETTINGS_RELIABILITY_SETTINGS` hardcoded
`defaultValue: 0` and `defaultValue: 1000` for the `texra.model.retry.maxAttempts`
/ `texra.model.retry.backoffMs` settings shown in the Settings UI. These are the
same two numbers `DEFAULT_CORE_SETTINGS.model.retry` already owns as the
canonical schema defaults (`src/shared/schemas/coreSettings.ts`). The #7784
reader-side fix (`src/agent/core/flows/RetryState.ts`) already reads
`DEFAULT_CORE_SETTINGS.model.retry.{maxAttempts,backoffMs}` instead of
re-pinning `0`/`1000`, but missed this UI-side catalog, leaving a second,
independent copy of the same design decision that could silently drift from
the schema default.

## The owner it deepens

`DEFAULT_CORE_SETTINGS.model.retry` (`src/shared/schemas/coreSettings.ts`)
already holds `maxAttempts: 0` / `backoffMs: 1000` as the canonical settings
defaults — the same constant `RetryState.ts` reads from. No new module or
layer; `SETTINGS_RELIABILITY_SETTINGS` now imports and reads the two fields
from that constant instead of re-deriving them as literals.

## Net elements (R6)

- 0 new files, 0 new exports, 0 new abstractions.
- 1 new import (`DEFAULT_CORE_SETTINGS` from `@shared/schemas/coreSettings`)
  in `SettingsProfileController.ts`, replacing two numeric literals with
  property reads on the existing catalog constant.
- 1 new regression test asserting `getReliabilitySettings()`'s UI defaults
  equal `DEFAULT_CORE_SETTINGS.model.retry.{maxAttempts,backoffMs}`, so a
  future edit to the catalog that isn't mirrored here fails the settings
  suite instead of silently drifting.

## Consumer counts (R8)

- `SETTINGS_RELIABILITY_SETTINGS` (`SettingsProfileController.ts`) — the only
  UI-side re-derivation of these two defaults; now reads the catalog instead
  of hardcoding.
- `getNodeRetryConfig()` (`RetryState.ts`) — already reads the catalog
  post-#7784; unchanged.
- No other consumer independently hardcodes these two values (verified via
  `grep -rn "texra.model.retry.(maxAttempts|backoffMs)"`).

## Verified

- Opened `src/controllers/settingsView/SettingsProfileController.ts`,
  `src/shared/schemas/coreSettings.ts`,
  `src/agent/core/flows/RetryState.ts`, and
  `src/test-kernel/controllers/SettingsProfileController.vitest.ts`.
- Grepped for other independent hardcodes of the two retry-setting keys —
  none found beyond the fixed UI catalog and the already-fixed reader.

## Tests

- `npx vitest run src/test-kernel/controllers/SettingsProfileController.vitest.ts` — 6 passed (new pinning test included).
- `npx vitest run src/test-kernel/controllers` — 35 files / 215 tests passed.
- `npm run typecheck` (all workspaces) — passed.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-source-of-truth for display defaults only; runtime retry behavior was already tied to the same catalog elsewhere, with no auth or data-path changes.
> 
> **Overview**
> **Settings reliability UI** no longer hardcodes `0` and `1000` for `texra.model.retry.maxAttempts` and `texra.model.retry.backoffMs`. Those catalog entries now take `defaultValue` from `DEFAULT_CORE_SETTINGS.model.retry`, matching the flow reader (`RetryState`) and schema catalog.
> 
> Copy for **retry attempts** and **retry backoff** is updated to spell out which retries are flow-managed vs provider-SDK-managed and to describe backoff in milliseconds.
> 
> A **regression test** asserts `getReliabilitySettings()` shows the same defaults as `DEFAULT_CORE_SETTINGS.model.retry` when config is unset, so a future catalog change cannot drift silently in the Settings profile UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b119e9a3544ec62bb0b71621f3c59961a6e9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->