### PR TITLE
fix(runtime): retarget terminal-outcome-phase checks to the shared helper

### DIFF
--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -12,6 +12,7 @@ import type {
 } from '@agent/runtime/SessionEventHub';
 
 // Local imports - shared schemas
+import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
 import {
   STREAM_PHASE,
   STREAM_STATUS,
@@ -302,7 +303,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
     this.rootStreamStatus = status;
     this.state.phase = formatRunProgressStatus(status);
-    this.rootStreamTerminal = isTerminalStreamStatus(status);
+    this.rootStreamTerminal = isTerminalOutcomePhase(status);
     if (this.rootStreamTerminal) {
       this.state.activeProcesses = undefined;
       this.state.activeSubagents = undefined;
@@ -397,14 +398,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     parts.push(formatElapsed(now - this.startedAt));
     return parts.join(' · ');
   }
-}
-
-function isTerminalStreamStatus(status: StreamPhase): boolean {
-  return (
-    status === STREAM_PHASE.COMPLETED ||
-    status === STREAM_PHASE.CANCELLED ||
-    status === STREAM_PHASE.FAILED
-  );
 }
 
 function formatRunProgressStatus(status: StreamPhase): string {

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -16,12 +16,9 @@ import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
+import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  STREAM_PHASE,
-  STREAM_STATUS,
-  type StreamLifecycleStatus,
-} from '@shared/schemas';
+import { STREAM_STATUS, type StreamLifecycleStatus } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { selectStyles } from '@shared/styles/selectStyles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
@@ -230,9 +227,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
       ) &&
       (this.status == null ||
         this.status === STREAM_STATUS.READY ||
-        this.status === STREAM_PHASE.FAILED ||
-        this.status === STREAM_PHASE.COMPLETED ||
-        this.status === STREAM_PHASE.CANCELLED)
+        isTerminalOutcomePhase(this.status))
     );
   }
 

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -117,7 +117,10 @@ export const STREAM_TRANSITION_CAUSE = {
 export type StreamTransitionCause =
   (typeof STREAM_TRANSITION_CAUSE)[keyof typeof STREAM_TRANSITION_CAUSE];
 
-function isTerminalOutcomePhase(
+/** Whether a `StreamPhase` is one of the three terminal outcome phases
+ *  (COMPLETED | CANCELLED | FAILED). This is the single enumeration of that
+ *  set — hosts must consume it rather than hand-rolling their own. */
+export function isTerminalOutcomePhase(
   phase: StreamPhase | undefined,
 ): phase is RunOutcome {
   return (

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -936,6 +936,43 @@ describe('CLI run progress renderer', () => {
     );
   });
 
+  it('freezes on a failed terminal stream stop, same as completed/cancelled', () => {
+    const output = outputBuffer();
+    const renderer = createRunProgressRenderer(
+      context({ colorEnabled: false }),
+      {
+        colorEnabled: false,
+        write: output.write,
+        minIntervalMs: 0,
+        nowMs: () => 0,
+      },
+    );
+
+    handleRunConfig(
+      renderer,
+      workflowTaskState({
+        streamId: 'root-stream',
+        agent: 'orchestrator',
+        inputFiles: [],
+      }),
+    );
+    handleStreamStatus(renderer, 'root-stream', STREAM_PHASE.FAILED);
+    // Post-terminal activity must not un-freeze the renderer (STREAM_PHASE.FAILED
+    // must be recognized as a terminal outcome phase, same as COMPLETED/CANCELLED).
+    handleConversationProgress(renderer, 'root-stream', { toolCallCount: 9 });
+    handleActiveProcesses(renderer, 'root-stream', [
+      {
+        kind: 'process',
+        executionId: 'tool-2',
+        agentName: 'late-tool',
+        toolName: 'LateTool',
+        status: 'running',
+      },
+    ]);
+
+    expect(output.text).toBe('orchestrator · 0s\norchestrator · error · 0s\n');
+  });
+
   it('uses a separate render flag from platform log suppression', () => {
     expect(
       createRunProgressRenderer(


### PR DESCRIPTION
## The leak

The terminal-run-outcome enumeration `COMPLETED | CANCELLED | FAILED` (as a
`StreamPhase` predicate) was hand-rolled independently in two hosts:

- `packages/cli/src/runtime/runProgressRenderer.ts` — a private
  `isTerminalStreamStatus(status)` function pinning the same three-way
  disjunction, used to freeze the root-stream renderer once a run reaches a
  terminal phase.
- `packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts`
  — the same three-way disjunction inlined directly into `shouldRender()`, to
  decide when the follow-up-chat panel may render.

Both re-derived a decision that `src/common/constants/streamStatus.ts`
already owned: a private `isTerminalOutcomePhase()` (used internally by
`isTerminalPhase()` and `canTransitionStreamPhase()`) that is the declared
single source of truth for the run-outcome algebra in that file ("hosts must
not hand-roll their own mappings").

## The owner it deepens

`src/common/constants/streamStatus.ts` — `isTerminalOutcomePhase` is
exported (name kept; already precise: "is this phase one of the terminal
outcome phases") with a doc comment stating it is the single enumeration of
that set. No new file, type, or table was added — the owner already held the
full knowledge; only its visibility changed from module-private to exported.

Both hosts now import and call `isTerminalOutcomePhase` from
`@common/constants/streamStatus` instead of enumerating `STREAM_PHASE.COMPLETED
| CANCELLED | FAILED` themselves. The extension's `shouldRender()` also drops
its now-redundant `STREAM_PHASE` import.

## Net elements (R6)

- 0 new files, types, or exported symbols beyond flipping one existing
  private function to exported.
- Production diff (excludes the extended test suite):
  `+9 / -18` = **-9 net lines**, across the 3 touched production files.
- Deleted: the CLI's `isTerminalStreamStatus` function body (2 call sites
  collapsed to 1 import + 1 call); the extension's inline 3-line disjunction
  (collapsed to 1 call).

## Consumer counts (R8)

Before: 2 consumers of the terminal-outcome-phase check, both **internal**
to `streamStatus.ts` (`isTerminalPhase`, `canTransitionStreamPhase`), plus 2
**independent re-derivations** in the CLI and the extension webview that had
no structural tie to the owner.

After: 4 consumers of the single exported `isTerminalOutcomePhase`, all
calling the same function — the 2 pre-existing internal call sites plus the
CLI's `applyStatus()` and the extension's `shouldRender()`. Both hosts lost
all independent knowledge of the COMPLETED/CANCELLED/FAILED enumeration.

## Verified

- `src/common/constants/streamStatus.ts` (owner; only the `export` keyword
  and a doc comment added — no behavior change)
- `packages/cli/src/runtime/runProgressRenderer.ts` (deleted
  `isTerminalStreamStatus`, retargeted `applyStatus()`)
- `packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts`
  (deleted inline disjunction, retargeted `shouldRender()`)
- `src/test-kernel/cli/RunProgressRenderer.vitest.mts` (existing suite;
  COMPLETED and CANCELLED terminal-freeze behavior were already covered —
  added a FAILED-phase case so all three outcome phases are exercised
  end-to-end through the renderer's freeze behavior, guarding the deletion)
- `src/test-kernel/common/RunOutcomeAlgebra.vitest.ts` (existing exhaustive
  transition-table tests already exercise `isTerminalOutcomePhase` via
  `canTransitionStreamPhase`/`canAcquireStreamReservation` for all three
  phases — confirmed still green, no new gaps from the export)
- Confirmed no other hand-rolled `STREAM_PHASE.COMPLETED/CANCELLED/FAILED`
  three-way enumeration remains outside `streamStatus.ts` (grepped
  `src/` and `packages/`)

## Tests

- `npx vitest run src/test-kernel/cli/RunProgressRenderer.vitest.mts
  src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
  src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
  src/test-kernel/progressView/ProgressBackend.vitest.ts
  src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
  src/test-kernel/progressView/RestartRepair.vitest.ts
  src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts` → 100 passed
- `npm run typecheck` (root, test-kernel, cli, trace-viewer, desktop) → clean
- `npx eslint` + `npx prettier --check` on all touched files → clean

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small consolidation of stream-phase predicates with no behavior change intended beyond aligning hosts with the shared helper; risk is low and localized to progress UI.
> 
> **Overview**
> **Terminal outcome phases** (`COMPLETED`, `CANCELLED`, `FAILED`) are no longer duplicated in hosts. `isTerminalOutcomePhase` is **exported** from `streamStatus.ts` as the single predicate for that set.
> 
> The CLI run progress renderer drops its private `isTerminalStreamStatus` and uses the helper to **freeze** the root stream line after any terminal outcome. The extension workflow follow-up section uses the same helper in `shouldRender()` so the panel still appears on ready and terminal outcomes, without an inline three-way `STREAM_PHASE` check.
> 
> A CLI test asserts **`FAILED`** freezes progress the same way as completed/cancelled (late tool/process updates are ignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3ac00de61c2f36e9ed56c8d4d8753e07b1d9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->