### PR TITLE
fix(tools): stop re-deriving KV filename vocabulary in executionKvFiles

### DIFF
--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -10,9 +10,12 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { BaseNode, Flow, type Action } from '.';
 import type { z } from 'zod';
 
+/** Prefix for a flow record's KV key. Single source of truth for callers deriving it. */
+export const FLOW_KEY_PREFIX = 'flow_';
+
 /** KV key for a flow record. Single source of truth for the prefix. */
 export function flowKey(runId: string): string {
-  return `flow_${runId}`;
+  return `${FLOW_KEY_PREFIX}${runId}`;
 }
 
 const CHANNEL = 'PersistedFlow';

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -59,7 +59,7 @@ const KEYS = {
   child: (id: string) => `${CHILD_KEY_PREFIX}${id}`,
 } as const;
 
-/** Single-value keys, derived from KEYS so the reserved-name check below never drifts. */
+/** Single-value keys, derived from SINGLE_VALUE_KEYS so the reserved-name check below never drifts. */
 const RESERVED_KEY_NAMES = new Set<string>(Object.values(SINGLE_VALUE_KEYS));
 
 /**

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -41,7 +41,10 @@ import {
 // Key constants (implementation detail — not exported)
 // ============================================================================
 
-const KEYS = {
+/** Prefix for a per-child execution record's KV key. */
+const CHILD_KEY_PREFIX = 'child-';
+
+const SINGLE_VALUE_KEYS = {
   META: 'meta',
   CONFIG: 'config',
   REPORT: 'report',
@@ -49,8 +52,27 @@ const KEYS = {
   CONVERSATION: 'conversation',
   WORKSPACE_FILES: 'workspace-files',
   RESULT_META: 'result-meta',
-  child: (id: string) => `child-${id}`,
 } as const;
+
+const KEYS = {
+  ...SINGLE_VALUE_KEYS,
+  child: (id: string) => `${CHILD_KEY_PREFIX}${id}`,
+} as const;
+
+/** Single-value keys, derived from KEYS so the reserved-name check below never drifts. */
+const RESERVED_KEY_NAMES = new Set<string>(Object.values(SINGLE_VALUE_KEYS));
+
+/**
+ * True when `key` is one of ExecutionKVStore's reserved keys — a single-value
+ * key (meta, config, report, todos, conversation, workspace-files,
+ * result-meta) or a per-child record key (`child-{id}`). Exported so callers
+ * that walk an execution's storage directory (e.g.
+ * `src/tools/executions/executionKvFiles.ts`) can recognize internal KV
+ * entries without re-deriving this vocabulary themselves.
+ */
+export function isReservedKvKeyName(key: string): boolean {
+  return RESERVED_KEY_NAMES.has(key) || key.startsWith(CHILD_KEY_PREFIX);
+}
 
 const CHANNEL = 'ExecutionKVStore';
 export const EXECUTION_META_SCHEMA_VERSION = 1;
@@ -274,13 +296,13 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
 
   /** Read children: per-child KV keys with schema validation. */
   async readChildren(): Promise<ChildRecord[]> {
-    const childKeys = await this.listKeys('child-');
+    const childKeys = await this.listKeys(CHILD_KEY_PREFIX);
 
     if (childKeys.length === 0) return [];
 
     const entries = await Promise.all(
       childKeys.map(async (key) => {
-        const id = key.replace('child-', '') as ExecutionId;
+        const id = key.replace(CHILD_KEY_PREFIX, '') as ExecutionId;
         const raw = await this.read(key);
         const result = ChildRecordDataSchema.safeParse(raw);
         return result.success ? { id, ...result.data } : null;

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -12,6 +12,7 @@ export {
   type ChildRecord,
   getExecutionStore,
   clearStoreCache,
+  isReservedKvKeyName,
 } from './ExecutionKVStore';
 export {
   buildCliWorkflowResultMeta,

--- a/src/test-kernel/agent/PersistedFlow.vitest.ts
+++ b/src/test-kernel/agent/PersistedFlow.vitest.ts
@@ -5,6 +5,7 @@ import { getExecutionStore } from '@agent/storage';
 import { BaseNode } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
+  FLOW_KEY_PREFIX,
   FLOW_RECORD_SCHEMA_VERSION,
   flowKey,
   PersistedFlow,
@@ -36,6 +37,14 @@ class SuspendNode extends BaseNode<{ count: number }> {
 }
 
 describe('PersistedFlow', () => {
+  // Regression for the executionKvFiles leak fix: consumers that recognize a
+  // flow record's KV filename (e.g. `isKVFile`) now import FLOW_KEY_PREFIX
+  // instead of hard-coding 'flow_', so pin that flowKey() is still built from it.
+  it('builds the flow key from the exported FLOW_KEY_PREFIX', () => {
+    const executionId = 'abc125' as ExecutionId;
+    expect(flowKey(executionId)).toBe(`${FLOW_KEY_PREFIX}${executionId}`);
+  });
+
   it('writes the current schema version into new flow records', async () => {
     const executionId = 'abc126' as ExecutionId;
     const store = getExecutionStore(executionId);

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -5,6 +5,7 @@ import {
   clearStoreCache,
   EXECUTION_META_SCHEMA_VERSION,
   getExecutionStore,
+  isReservedKvKeyName,
 } from '@agent/storage';
 import * as logger from '@logger/logUtils';
 import {
@@ -22,6 +23,35 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+// Regression for the executionKvFiles leak fix: isReservedKvKeyName is now
+// the single owner of the reserved single-value-key + `child-` prefix
+// vocabulary, exported so callers walking a run directory (e.g.
+// `src/tools/executions/executionKvFiles.ts`) recognize it without
+// re-deriving their own copy.
+describe('isReservedKvKeyName', () => {
+  it.each([
+    'meta',
+    'config',
+    'report',
+    'todos',
+    'conversation',
+    'workspace-files',
+    'result-meta',
+  ])('recognizes the reserved single-value key %s', (key) => {
+    expect(isReservedKvKeyName(key)).toBe(true);
+  });
+
+  it('recognizes any child- prefixed key', () => {
+    expect(isReservedKvKeyName('child-abc123')).toBe(true);
+  });
+
+  it('rejects keys outside the reserved vocabulary', () => {
+    expect(isReservedKvKeyName('flow_abc123')).toBe(false);
+    expect(isReservedKvKeyName('childish')).toBe(false);
+    expect(isReservedKvKeyName('report-draft')).toBe(false);
+  });
 });
 
 describe('ExecutionKVStore meta read shims', () => {

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -572,6 +572,31 @@ describe('ExecutionsTool', () => {
     });
   });
 
+  // Regression for a bug caught in review of the leak fix above: every real
+  // KV entry is written as `{key}.json` (KVStore.keyToPath always appends
+  // the suffix), so a generated file whose *basename* happens to collide
+  // with a reserved key name — but has no `.json` extension — must not be
+  // swept up by isKVFile.
+  it('keeps extensionless generated files named like reserved KV keys', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const runDir = resolveRunStoragePath(executionId);
+      await StorageFS.ensureDir(runDir);
+      const bareNames = ['meta', 'config', 'report', 'child-def456'];
+      for (const name of bareNames) {
+        await StorageFS.write(path.join(runDir, name), 'generated');
+      }
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}/files`,
+      });
+
+      for (const name of bareNames) {
+        expect(result.output).toContain(name);
+      }
+    });
+  });
+
   it('reads recorded files inside a top-level workspace directory', async () => {
     await withTempWorkspace(async (workspace) => {
       await mkdir(path.join(workspace, 'workspace'));

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -5,9 +5,11 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
+import { flowKey } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
@@ -530,6 +532,43 @@ describe('ExecutionsTool', () => {
 
       expect(result.status).toBe('error');
       expect(result.error).toContain('Workspace file not found');
+    });
+  });
+
+  // Regression for the executionKvFiles leak fix: isKVFile now derives its
+  // vocabulary from ExecutionKVStore's reserved keys and persistedFlow's
+  // FLOW_KEY_PREFIX instead of a hand-copied literal set, so exercise the
+  // real /executions/{id}/files listing to prove every reserved KV filename
+  // (including the child- and flow_ prefixes) is still filtered out.
+  it('filters internal KV metadata files out of /executions/{id}/files', async () => {
+    await withTempStorage(async () => {
+      const executionId = 'abc123' as ExecutionId;
+      const runDir = resolveRunStoragePath(executionId);
+      await StorageFS.ensureDir(runDir);
+      const kvFiles = [
+        'meta.json',
+        'config.json',
+        'conversation.json',
+        'todos.json',
+        'report.json',
+        'workspace-files.json',
+        'result-meta.json',
+        'child-def456.json',
+        `${flowKey(executionId)}.json`,
+      ];
+      for (const name of kvFiles) {
+        await StorageFS.write(path.join(runDir, name), '{}');
+      }
+      await StorageFS.write(path.join(runDir, 'output.tex'), 'generated');
+
+      const result = await new ExecutionsTool().call({
+        path: `/executions/${executionId}/files`,
+      });
+
+      expect(result.output).toContain('output.tex');
+      for (const name of kvFiles) {
+        expect(result.output).not.toContain(name);
+      }
     });
   });
 

--- a/src/tools/executions/executionKvFiles.ts
+++ b/src/tools/executions/executionKvFiles.ts
@@ -3,19 +3,17 @@
  * output. Shared by run-directory listing (`runDirectoryFiles.ts`) and the
  * CLI's history file listing (`packages/cli/src/runtime/history/generatedFiles.ts`)
  * so the two stay in sync on what counts as internal metadata.
+ *
+ * The reserved-key vocabulary itself (meta, config, todos, `child-*`, …) is
+ * owned by `ExecutionKVStore`; the `flow_*` prefix is owned by
+ * `persistedFlow`. This module only strips the on-disk `.json` suffix and
+ * defers to those owners rather than re-deriving the vocabulary.
  */
-const KV_FILES = new Set([
-  'meta.json',
-  'config.json',
-  'conversation.json',
-  'todos.json',
-  'report.json',
-  'workspace-files.json',
-  'result-meta.json',
-]);
+
+import { isReservedKvKeyName } from '@agent/storage';
+import { FLOW_KEY_PREFIX } from '@agent/node/persistedFlow';
 
 export function isKVFile(name: string): boolean {
-  return (
-    KV_FILES.has(name) || name.startsWith('child-') || name.startsWith('flow_')
-  );
+  const key = name.replace(/\.json$/, '');
+  return isReservedKvKeyName(key) || key.startsWith(FLOW_KEY_PREFIX);
 }

--- a/src/tools/executions/executionKvFiles.ts
+++ b/src/tools/executions/executionKvFiles.ts
@@ -8,12 +8,20 @@
  * owned by `ExecutionKVStore`; the `flow_*` prefix is owned by
  * `persistedFlow`. This module only strips the on-disk `.json` suffix and
  * defers to those owners rather than re-deriving the vocabulary.
+ *
+ * Every real KV entry is written through `KVStore.keyToPath`, which always
+ * appends `.json` — so a name without that suffix can never be an internal
+ * KV file. Requiring the suffix here (before checking the reserved-name
+ * vocabulary) keeps a generated file that happens to be named exactly
+ * `meta`, `config`, etc. from being wrongly hidden.
  */
 
 import { isReservedKvKeyName } from '@agent/storage';
 import { FLOW_KEY_PREFIX } from '@agent/node/persistedFlow';
 
 export function isKVFile(name: string): boolean {
-  const key = name.replace(/\.json$/, '');
+  const match = /^(.+)\.json$/.exec(name);
+  if (!match) return false;
+  const key = match[1];
   return isReservedKvKeyName(key) || key.startsWith(FLOW_KEY_PREFIX);
 }


### PR DESCRIPTION
## The leak

`src/tools/executions/executionKvFiles.ts` hand-copied the KV filename
vocabulary its two owners already hold privately:

- `ExecutionKVStore.ts:44-53`'s private `KEYS` map (explicitly commented
  "implementation detail — not exported"), including the `child-` prefix
  used for per-child execution records.
- `persistedFlow.ts:13-16`'s `flowKey()`, whose doc comment already claims
  to be the "single source of truth" for the `flow_` prefix — a claim that
  `executionKvFiles.ts` quietly violated by re-deriving `'flow_'` itself.

Both owners could drift a key/prefix and `isKVFile` would silently stop
filtering it out of `/executions/{id}/files` and the CLI's history file
listing (`packages/cli/src/runtime/history/generatedFiles.ts`), leaking
internal KV blobs into user-facing file listings.

## The fix — owners deepen, leak is deleted

- `ExecutionKVStore.ts` now exports `isReservedKvKeyName(key)`, derived
  directly from its `KEYS` map (a new `SINGLE_VALUE_KEYS` object feeds both
  `KEYS` and the reserved-name `Set`), covering the seven single-value keys
  plus the `child-` prefix.
- `persistedFlow.ts` now exports `FLOW_KEY_PREFIX`; `flowKey()` is rewritten
  to build off it instead of the inline `'flow_'` literal.
- `executionKvFiles.isKVFile` is rewritten to strip the on-disk `.json`
  suffix and defer to `isReservedKvKeyName` + `FLOW_KEY_PREFIX` — the
  hand-copied `KV_FILES` literal `Set` is **deleted**.
- Same-owner cleanup while in `ExecutionKVStore.ts`: its own two internal
  `'child-'` re-derivations (`readChildren`'s `listKeys('child-')` and
  `key.replace('child-', '')`) now route through the same
  `CHILD_KEY_PREFIX` constant instead of repeating the literal.

`src/tools/` already depends on `@agent/storage` elsewhere, so this adds no
new import-boundary exception (`src/tools` and `src/agent/*` are both
VS Code-free zones).

## Net elements (R6)

- **+2 exports**: `isReservedKvKeyName` (ExecutionKVStore), `FLOW_KEY_PREFIX`
  (persistedFlow) — both are the owning modules deepening their existing
  public surface, not new abstractions.
- **-1 hand-copied literal set** (`KV_FILES`) and **-2 inline `'child-'`
  literals** in `ExecutionKVStore.ts`.
- **0 new files, 0 new layers/facades.**
- Net: `+119 / -17` lines across 7 files, but the production-code delta is
  `+41 / -17` (the rest is regression test coverage); the only production
  file that shrinks in independent knowledge is `executionKvFiles.ts`
  (22 lines touched, net -0, but it no longer owns any vocabulary of its
  own — every reserved name/prefix it recognizes now traces to exactly one
  owning module).

## Consumer counts (R8)

- `isKVFile` (the leaking function) has exactly 2 call sites, both already
  existing: `src/tools/executions/runDirectoryFiles.ts` and
  `packages/cli/src/runtime/history/generatedFiles.ts` (aliased as
  `isHistoryKvFile`). Both now transitively depend on the two real owners
  instead of a third, independently-drifting copy — this PR does not add a
  new consumer, it collapses the vocabulary the existing 2 consumers see
  down to 1 owner each (`ExecutionKVStore`, `persistedFlow`).
- `isReservedKvKeyName` has 1 caller today (`executionKvFiles.ts`) — no new
  single-caller helper was invented for its own sake; it is an export of an
  already-private map that a second module needed to stop re-deriving.

## Tests

- `src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts`: new
  `describe('isReservedKvKeyName', …)` block pinning all 7 single-value
  keys, the `child-` prefix, and rejected non-reserved keys.
- `src/test-kernel/agent/PersistedFlow.vitest.ts`: new test pinning
  `flowKey()` is built from the exported `FLOW_KEY_PREFIX`.
- `src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts`: new
  end-to-end regression test that writes every reserved KV filename
  (including `child-*.json` and `flow_*.json`) plus a generated file into a
  real run directory and asserts `/executions/{id}/files` still filters all
  of them out through the real `ExecutionsTool` → `listRunDirectoryFiles` →
  `isKVFile` chain.

Ran: `npx tsc --noEmit` (root), full `npm run typecheck` (all workspaces),
targeted vitest suites above plus the broader `src/test-kernel/tools`,
`src/test-kernel/agent/storage`, and `PersistedFlow`/`RoundPersistedFlow`
suites (82 files / 532 tests, all green), and `eslint` on every changed
file (clean after one auto-fixed import-order warning).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to file-list filtering logic with explicit regression tests; no auth, persistence format, or runtime execution path changes.
> 
> **Overview**
> **Stops `executionKvFiles` from maintaining a duplicate list of internal KV filenames**, so `/executions/{id}/files` and CLI history listings stay aligned when storage keys change.
> 
> `ExecutionKVStore` now exports **`isReservedKvKeyName`** (derived from its key map plus `child-` prefix) and **`persistedFlow`** exports **`FLOW_KEY_PREFIX`**; `flowKey()` builds on that constant. **`isKVFile`** drops the hand-copied `KV_FILES` set, requires a **`.json`** suffix before classifying a name, then delegates to those owners. **`readChildren`** uses the same `CHILD_KEY_PREFIX` instead of inline `'child-'` literals.
> 
> Regression tests cover reserved-key recognition, end-to-end filtering via `ExecutionsTool`, and **extensionless** files named like reserved keys (must remain visible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1a9fbb659f6d1204dba3271de494c75093105e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->