### PR TITLE
fix(desktop): gate webviewReady paint on startup restart repair

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1066,6 +1066,26 @@ export class DesktopProgressBridge {
     replayApprovalRequestHandlers(this.approvalHandlers);
   }
 
+  /**
+   * Owns the Progress webview's readiness sequence. Restored streams are
+   * only folded into `streamLogs`/`session.status` once `restartRepair`
+   * settles (`repairOrphanedStreamsAfterRestart` awaits `streamLogs.load()`
+   * first), so painting the rail before that leaves restored streams
+   * missing from the first paint with nothing guaranteed to correct it —
+   * the same race class `revealStream` was fixed for (#7850). Gating the
+   * whole sequence here, instead of each `webviewReady` call site awaiting
+   * `restartRepair` inline, makes the ordering impossible to get wrong from
+   * a caller.
+   */
+  async completeWebviewReady(
+    onInquiryHydrationError?: (error: unknown) => void,
+  ): Promise<void> {
+    await this.restartRepair;
+    this.syncFullView();
+    void this.hydrateProgressViewInquiries().catch(onInquiryHydrationError);
+    this.replayPendingPrompts();
+  }
+
   setActiveStream(streamId: StreamTabId): void {
     if (!this.streamLogs.has(streamId)) {
       return;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1078,7 +1078,7 @@ export class DesktopProgressBridge {
    * a caller.
    */
   async completeWebviewReady(
-    onInquiryHydrationError?: (error: unknown) => void,
+    onInquiryHydrationError: (error: unknown) => void = () => {},
   ): Promise<void> {
     await this.restartRepair;
     this.syncFullView();

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -15,10 +15,7 @@ import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
 type DesktopProgressIpcBridge = Pick<
   DesktopProgressBridge,
-  | 'progressViewInboundHandlers'
-  | 'syncFullView'
-  | 'hydrateProgressViewInquiries'
-  | 'replayPendingPrompts'
+  'progressViewInboundHandlers' | 'completeWebviewReady'
 >;
 
 export interface DesktopProgressIpcOptions {
@@ -100,18 +97,12 @@ export function createDesktopProgressIpc(
         if (!isProgressWebviewReadyMessage(message)) return false;
         const progress = getProgress();
         if (progress) {
-          progress.syncFullView();
-          void progress.hydrateProgressViewInquiries().catch(reportAsyncError);
-          progress.replayPendingPrompts();
+          void progress
+            .completeWebviewReady(reportAsyncError)
+            .catch(reportAsyncError);
         } else if (ensureProgress) {
           void ensureProgress()
-            .then((loaded) => {
-              loaded.syncFullView();
-              void loaded
-                .hydrateProgressViewInquiries()
-                .catch(reportAsyncError);
-              loaded.replayPendingPrompts();
-            })
+            .then((loaded) => loaded.completeWebviewReady(reportAsyncError))
             .catch(reportAsyncError);
         }
         return false;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -73,6 +73,9 @@ type TestableBridge = Bridge & {
   };
   handleInteractionEvent(event: string, payload: unknown): void;
   syncFullView(): void;
+  completeWebviewReady(
+    onInquiryHydrationError?: (error: unknown) => void,
+  ): Promise<void>;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   setActiveStream(streamId: StreamTabId): void;
   revealStream(streamId: StreamTabId): Promise<void>;
@@ -1282,6 +1285,47 @@ describe('DesktopProgressBridge', () => {
       expect(runAgent).toHaveBeenCalledOnce();
     } finally {
       finishRepair(new Set());
+      bridge.dispose();
+    }
+  });
+
+  it('gates the Progress webview readiness paint on desktop startup repair', async () => {
+    // Regression test: the desktop webviewReady handler used to call
+    // syncFullView() / hydrateProgressViewInquiries() / replayPendingPrompts()
+    // directly, without awaiting `restartRepair` first. Restored streams are
+    // only folded into `streamLogs`/`session.status` once
+    // `repairOrphanedStreamsAfterRestart` (i.e. `restartRepair`) resolves --
+    // it awaits `state.streamLogs.load()` before anything else -- so a
+    // webviewReady race landing in that window paints the rail without the
+    // restored streams, with no guaranteed later repaint. Same race class as
+    // revealStream's #7850 fix. Gate the on-disk stream-log scan and assert
+    // `completeWebviewReady()` defers its entire paint sequence until
+    // `restartRepair` has actually settled.
+    let finishStreamLogsLoad!: () => void;
+    const streamLogsLoadGate = new Promise<void>((resolve) => {
+      finishStreamLogsLoad = resolve;
+    });
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages, { streamLogsLoadGate });
+
+    try {
+      const readyPromise = bridge.completeWebviewReady();
+
+      // streamLogs.load() is still gated, so restartRepair has not settled;
+      // completeWebviewReady() must not have painted anything yet.
+      await settleProgressEvents();
+      expect(messages).toEqual([]);
+
+      finishStreamLogsLoad();
+      await readyPromise;
+
+      // Once restartRepair settles, the deferred paint goes out.
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)
+          .length,
+      ).toBeGreaterThan(0);
+    } finally {
+      finishStreamLogsLoad();
       bridge.dispose();
     }
   });

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -30,33 +30,23 @@ function fillRegistry(
   return full as ProgressViewInboundHandlerRegistry;
 }
 
+interface DesktopProgressIpcBridgeStub {
+  completeWebviewReady(
+    onInquiryHydrationError?: (error: unknown) => void,
+  ): Promise<void>;
+  progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
+}
+
 interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
-    progress?: {
-      syncFullView(): void;
-      hydrateProgressViewInquiries(): Promise<void>;
-      replayPendingPrompts(): void;
-      progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
-    };
-    getProgress?: () =>
-      | {
-          syncFullView(): void;
-          hydrateProgressViewInquiries(): Promise<void>;
-          replayPendingPrompts(): void;
-          progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
-        }
-      | undefined;
+    progress?: DesktopProgressIpcBridgeStub;
+    getProgress?: () => DesktopProgressIpcBridgeStub | undefined;
     onUnsupportedCommand?: (
       message: { command: string },
       reason?: string,
     ) => void;
     onAsyncError?: (error: unknown) => void;
-    ensureProgress?: () => Promise<{
-      syncFullView(): void;
-      hydrateProgressViewInquiries(): Promise<void>;
-      replayPendingPrompts(): void;
-      progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
-    }>;
+    ensureProgress?: () => Promise<DesktopProgressIpcBridgeStub>;
   }): {
     handleMessage(
       message: { command: string } & Record<string, unknown>,
@@ -75,9 +65,7 @@ function createProgress(
   progressViewInboundHandlers: Partial<ProgressViewInboundHandlerRegistry> = {},
 ) {
   return {
-    syncFullView: vi.fn(),
-    hydrateProgressViewInquiries: vi.fn(async () => undefined),
-    replayPendingPrompts: vi.fn(),
+    completeWebviewReady: vi.fn(async () => undefined),
     progressViewInboundHandlers: fillRegistry(progressViewInboundHandlers),
   };
 }
@@ -100,9 +88,7 @@ describe('desktop Progress IPC', () => {
     ).toBe(false);
     await Promise.resolve();
 
-    expect(progress.syncFullView).toHaveBeenCalledTimes(1);
-    expect(progress.hydrateProgressViewInquiries).toHaveBeenCalledTimes(1);
-    expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
+    expect(progress.completeWebviewReady).toHaveBeenCalledTimes(1);
   });
 
   it('ignores main-view readiness broadcasts for Progress prompt replay', async () => {
@@ -116,8 +102,7 @@ describe('desktop Progress IPC', () => {
       }),
     ).toBe(false);
 
-    expect(progress.syncFullView).not.toHaveBeenCalled();
-    expect(progress.replayPendingPrompts).not.toHaveBeenCalled();
+    expect(progress.completeWebviewReady).not.toHaveBeenCalled();
   });
 
   it('replays pending prompts after lazy Progress readiness load', async () => {
@@ -134,9 +119,7 @@ describe('desktop Progress IPC', () => {
     ).toBe(false);
     await Promise.resolve();
 
-    expect(progress.syncFullView).toHaveBeenCalledTimes(1);
-    expect(progress.hydrateProgressViewInquiries).toHaveBeenCalledTimes(1);
-    expect(progress.replayPendingPrompts).toHaveBeenCalledTimes(1);
+    expect(progress.completeWebviewReady).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches recognized Progress commands through the bridge registry', async () => {
@@ -209,6 +192,26 @@ describe('desktop Progress IPC', () => {
         stream: 'run-1',
       }),
     ).toBe(true);
+    await Promise.resolve();
+    expect(onAsyncError).toHaveBeenCalledWith(error);
+  });
+
+  it('reports a failed webviewReady sequence through the desktop error path', async () => {
+    const error = new Error('restart repair failed');
+    const onAsyncError = vi.fn();
+    const progress = {
+      completeWebviewReady: vi.fn(() => Promise.reject(error)),
+      progressViewInboundHandlers: fillRegistry(),
+    };
+    const ipc = createDesktopProgressIpc({ progress, onAsyncError });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'progress',
+      }),
+    ).toBe(false);
+    await Promise.resolve();
     await Promise.resolve();
     expect(onAsyncError).toHaveBeenCalledWith(error);
   });


### PR DESCRIPTION
## The race story

Desktop's Progress webview sends `WEBVIEW_READY` (`view: 'progress'`) as
soon as its renderer mounts. `desktopProgressIpc.ts`'s handler for that
message called `progress.syncFullView()`, `progress.hydrateProgressViewInquiries()`,
and `progress.replayPendingPrompts()` directly — with no wait on
`DesktopProgressBridge.restartRepair`.

`restartRepair` is the promise `repairOrphanedStreamsAfterRestart()`
returns; it `await`s `state.streamLogs.load()` first, then hydrates
restored ("ghost") streams and reconciles their status against
persisted execution ids. Every *other* window-mutating desktop entry
point (`revealStream`, `tryResumeStream`, `sendFollowUp`, `runExecution`)
already awaits `this.restartRepair` before doing anything — `webviewReady`
was the one caller-discipline gap.

Interleaving that trips the bug:

1. Desktop process restarts after a crash mid-run. `DesktopProgressBridge`
   is constructed; `this.restartRepair = this.repairOrphanedStreamsAfterRestart()`
   starts and suspends at `await this.state.streamLogs.load()` (a disk
   scan).
2. The renderer mounts and immediately posts `WEBVIEW_READY` for the
   Progress view.
3. The old handler calls `syncFullView()` synchronously — it reads
   `session.status.getAllStreamStates()` *right now*, before
   `streamLogs.load()` has resolved and before restored streams have
   been folded into `state`/`session.status`. The rail paints without
   them.
4. `streamLogs.load()` resolves; repair continues and (conditionally)
   calls its own internal `syncFullView()` — but only if it detected
   waiting/failed streams or has restored-stream entries at that
   specific check. There is no unconditional "resync after repair"
   guaranteed to run for every restart, so a restored stream can stay
   missing from the rail with nothing to self-correct it. Same race
   class as the `revealStream` fix in #7850 (`streamLogs.has()` checked
   before the load it depends on had run).

## The ownership fix

Per the maintainer's doctrine for internal races: single-owner/sequenced
design that makes the race impossible, not caller discipline.

Deepened `DesktopProgressBridge` with one new owner method,
`completeWebviewReady()`:

```ts
async completeWebviewReady(
  onInquiryHydrationError?: (error: unknown) => void,
): Promise<void> {
  await this.restartRepair;
  this.syncFullView();
  void this.hydrateProgressViewInquiries().catch(onInquiryHydrationError);
  this.replayPendingPrompts();
}
```

`desktopProgressIpc.ts`'s `webviewReady` branch (both the immediate-`progress`
path and the lazy-`ensureProgress()` path — it previously duplicated the
three-call sequence in each) now just calls `progress.completeWebviewReady(reportAsyncError)`.
The `restartRepair` await lives inside the bridge that owns the promise;
no IPC call site can paint ahead of it because there is no longer an inline
sequence to get the ordering wrong on.

I grepped every other `await this.restartRepair` site in
`desktopAgentExecution.ts` (`revealStream`, `tryResumeStream`, `sendFollowUp`,
`runExecution`) — each is a single `await this.restartRepair;` guarding a
distinct action, not a duplicate of the `webviewReady` three-call sequence,
so they're left as-is (they already gate correctly and aren't the
duplicated logic this fix targets).

## Regression test

Extended `DesktopAgentExecution.vitest.mts` with
`'gates the Progress webview readiness paint on desktop startup repair'`,
reusing the `streamLogsLoadGate` hook (`CreateBridgeOptions`, also used by
the existing #7850 `revealStream` regression test) to suspend
`repairOrphanedStreamsAfterRestart()` at its `streamLogs.load()` await:

- Calls `bridge.completeWebviewReady()` while the gate is still pending,
  flushes microtasks, and asserts **zero** messages were posted to the
  renderer (proves the paint sequence doesn't run ahead of repair).
- Resolves the gate, awaits the promise, and asserts an `UPDATE_STREAMS`
  message was posted (proves the paint sequence still runs once repair
  settles — i.e. this isn't just "never paint").

**Proved it fails pre-fix**: I temporarily edited `completeWebviewReady()`
in place to restore the buggy ordering (`syncFullView()` /
`hydrateProgressViewInquiries()` / `replayPendingPrompts()` first, `await
this.restartRepair` last) and reran the new test — it failed, showing
`UPDATE_STREAMS` + `syncStreamContent` + `syncInquiryThreads` messages
went out *before* the gate resolved. Reverted back to the fix; test passes
again. (No `git stash` was used — the revert/re-apply was done with direct
in-place edits.)

Also updated `DesktopProgressIpc.vitest.mts`'s mock/interface shape from
the three separate `syncFullView`/`hydrateProgressViewInquiries`/`replayPendingPrompts`
spies to a single `completeWebviewReady` spy (matching the new
`DesktopProgressIpcBridge` `Pick<...>`), and added a case asserting a
rejected `completeWebviewReady()` still reaches `onAsyncError`.

## Net elements (R6)

- **+1 method**: `DesktopProgressBridge.completeWebviewReady()` — the new
  single owner of the webviewReady sequence.
- **0 new types/interfaces/layers.** `DesktopProgressIpcBridge`'s `Pick<>`
  swaps 4 picked members for 2 (net *fewer* picked members).
- **Net LOC**: +103/−45 across 4 files, but the two duplicated 3-line
  inline sequences in `desktopProgressIpc.ts` collapse to 2 one-line method
  calls (−~10 net there); the addition is almost entirely the new
  regression test (44 lines) and the mechanical mock-shape update in the
  ipc test (required because the `Pick<>` changed, not new machinery).
  No new coordinator/facade layer — the fix deepens the module (`DesktopProgressBridge`)
  that already owned `restartRepair`.

## Consumer counts (R8)

- `completeWebviewReady()` has **2 callers**, both in
  `desktopProgressIpc.ts`'s single `webviewReady` branch (the
  immediate-`progress` path and the lazy-`ensureProgress()` path) — both
  previously carried their own copy of the 3-call sequence; now both call
  the one owner method. Not a single-caller extraction.
- Grepped all 4 other `await this.restartRepair` sites in
  `desktopAgentExecution.ts` (`revealStream`, `tryResumeStream`,
  `sendFollowUp`, `runExecution`): none duplicate the `webviewReady`
  sequence (each guards different, single-purpose logic), so none were
  routed through the new method — routing them would be an unrelated,
  unjustified refactor.
- Grepped `syncFullView`/`hydrateProgressViewInquiries`/`replayPendingPrompts`
  usage outside `desktopAgentExecution.ts`/`desktopProgressIpc.ts`: only
  hits are in `packages/extension/src/progressView/*` (VS Code extension),
  which has no `restartRepair`-equivalent startup-recovery promise and is
  out of scope for this desktop-specific finding.

## Tests

- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts` — 81 passed
- `npx vitest run src/test-kernel/desktop/` (full desktop suite) — 431 passed
- `npm run typecheck` — clean (root + test-kernel + cli + trace-viewer + desktop main/preload/renderer)
- `npx eslint` + `npx prettier --check` on all touched files — clean

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop startup ordering for Progress view state; incorrect gating could delay or omit rail updates after restart, but scope is limited to desktop IPC/bridge sequencing with regression coverage.
> 
> **Overview**
> Fixes a **startup race** where the Progress webview’s `WEBVIEW_READY` handler could paint the stream rail before `restartRepair` finished loading stream logs and folding restored streams into state—same class of bug as the earlier `revealStream` fix (#7850).
> 
> **`DesktopProgressBridge.completeWebviewReady()`** now owns the full readiness sequence: `await this.restartRepair`, then `syncFullView()`, inquiry hydration, and `replayPendingPrompts()`. **`desktopProgressIpc`** calls that method (immediate and lazy `ensureProgress` paths) instead of inlining the three steps.
> 
> Tests assert painting stays deferred until repair settles and that IPC errors from a failed readiness sequence still reach `onAsyncError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbe1385cb3ae8e2ed18f54582b1b5d68b8c935f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->