### PR TITLE
fix(transcript): eager-apply overlay for missing outputs and compile failures

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -582,6 +582,52 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('replays clearMissingOutputs before a later updateMissingOutputs on an unseeded stream', async () => {
+    // clearMissingOutputs must not stay on the plain deferred mutate() path
+    // while updateMissingOutputs eagerly overlays: on an unseeded stream that
+    // ordering let the seed's overlay replay (update) land, then the clear
+    // (queued behind the same seed) run afterward and wipe it out regardless
+    // of call order. Here the clear fires first, so the later update must
+    // survive.
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'missingOutputs.json'),
+      JSON.stringify({ '0': ['stale.tex'] }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.clearMissingOutputs(OTHER_STREAM);
+    store.updateMissingOutputs(OTHER_STREAM, { 1: ['next.tex'] });
+    expect(store.getMissingOutputs(OTHER_STREAM)).toEqual({ 1: ['next.tex'] });
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'missingOutputs.json'));
+    expect(raw).toEqual({ '1': ['next.tex'] });
+  });
+
+  it('replays a later clearMissingOutputs over an earlier updateMissingOutputs on an unseeded stream', async () => {
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'missingOutputs.json'),
+      JSON.stringify({ '0': ['stale.tex'] }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.updateMissingOutputs(OTHER_STREAM, { 1: ['next.tex'] });
+    store.clearMissingOutputs(OTHER_STREAM);
+    expect(store.getMissingOutputs(OTHER_STREAM)).toEqual({});
+    await store.flush();
+
+    const raw = await StorageFS.readJson(path.join(dir, 'missingOutputs.json'));
+    expect(raw).toEqual({});
+  });
+
   it('returns compile failures immediately for streams outside a partial preload without erasing disk markers', async () => {
     const dir = streamDataDir(OTHER_STREAM);
     await StorageFS.ensureDir(dir);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -552,6 +552,65 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('returns missing outputs immediately for streams outside a partial preload without erasing disk markers', async () => {
+    // Same race as the output-files case above, replayed for
+    // updateMissingOutputs: a stream outside the preloaded set is still
+    // unseeded when the mutation lands, so the seed's disk read is racing
+    // the caller's read of its own write. Regression for the "half-fixed"
+    // eager-apply overlay gap (missingOutputs/compileFailures lacked the
+    // guarantee addOutputFiles/addUsage already had).
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    await StorageFS.write(
+      path.join(dir, 'missingOutputs.json'),
+      JSON.stringify({ '0': ['prior.tex'] }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.updateMissingOutputs(OTHER_STREAM, { 1: ['next.tex'] });
+    // Fails pre-fix: the plain mutate() path defers the whole apply behind
+    // the in-flight seed, so this synchronous read-back still sees nothing.
+    expect(store.getMissingOutputs(OTHER_STREAM)[1]).toEqual(['next.tex']);
+    await store.flush();
+
+    const raw = await StorageFS.readJson(
+      path.join(dir, 'missingOutputs.json'),
+    );
+    expect(raw).toMatchObject({
+      '0': ['prior.tex'],
+      '1': ['next.tex'],
+    });
+  });
+
+  it('returns compile failures immediately for streams outside a partial preload without erasing disk markers', async () => {
+    const dir = streamDataDir(OTHER_STREAM);
+    await StorageFS.ensureDir(dir);
+    const prior = compileFailure('prior.tex', 0);
+    const next = compileFailure('next.tex', 1);
+    await StorageFS.write(
+      path.join(dir, 'compileFailures.json'),
+      JSON.stringify({ '0': [prior] }),
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.preload([STREAM]);
+
+    store.updateCompileFailures(OTHER_STREAM, { 1: [next] });
+    // Fails pre-fix for the same reason as the missing-outputs case above.
+    expect(store.getCompileFailures(OTHER_STREAM)[1]).toEqual([next]);
+    await store.flush();
+
+    const raw = await StorageFS.readJson(
+      path.join(dir, 'compileFailures.json'),
+    );
+    expect(raw).toMatchObject({
+      '0': [prior],
+      '1': [next],
+    });
+  });
+
   it('makes task state readable immediately while preserving later seeded sidecars', async () => {
     const dir = streamDataDir(STREAM);
     await StorageFS.ensureDir(dir);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -575,9 +575,7 @@ describe('StreamSnapshotStore', () => {
     expect(store.getMissingOutputs(OTHER_STREAM)[1]).toEqual(['next.tex']);
     await store.flush();
 
-    const raw = await StorageFS.readJson(
-      path.join(dir, 'missingOutputs.json'),
-    );
+    const raw = await StorageFS.readJson(path.join(dir, 'missingOutputs.json'));
     expect(raw).toMatchObject({
       '0': ['prior.tex'],
       '1': ['next.tex'],

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -122,6 +122,42 @@ function sameOutputFiles(left: string[], right: string[]): boolean {
   return left.every((file, index) => file === right[index]);
 }
 
+/**
+ * Merge a round-keyed patch (per round: a value list, or `null` to delete
+ * that round) into an existing overlay patch, later entries winning. Shared
+ * by every round-keyed accumulator overlay (output files, missing outputs,
+ * compile failures) — they're all the same shape, so one merge function
+ * services all three via {@link StreamSnapshotStore.mutateWithOverlay}.
+ */
+function mergeRoundPatch<T>(
+  existing: Map<number, T[] | null> | undefined,
+  patch: Map<number, T[] | null>,
+): Map<number, T[] | null> {
+  const merged = existing ?? new Map<number, T[] | null>();
+  for (const [round, value] of patch) merged.set(round, value);
+  return merged;
+}
+
+/**
+ * Merge a per-run usage delta patch into an existing overlay patch,
+ * accumulating (not replacing) each run's totals — mirrors the in-memory
+ * sum `applyUsageDeltaMemory` performs, so the overlay replayed after
+ * seeding matches what was already applied eagerly.
+ */
+function mergeUsagePatch(
+  existing: Map<StorageKey, TokenUsageStats> | undefined,
+  patch: Map<StorageKey, TokenUsageStats>,
+): Map<StorageKey, TokenUsageStats> {
+  const merged = existing ?? new Map<StorageKey, TokenUsageStats>();
+  for (const [storageKey, delta] of patch) {
+    merged.set(
+      storageKey,
+      sumUsageStats([merged.get(storageKey) ?? emptyUsageStats(), delta]),
+    );
+  }
+  return merged;
+}
+
 function descriptorFromConfig(
   stream: StreamTabId,
   executionId: ExecutionId,
@@ -191,6 +227,14 @@ export class StreamSnapshotStore {
   private readonly outputFileOverlays = new Map<
     StreamTabId,
     OutputFilesPatch
+  >();
+  private readonly missingOutputsOverlays = new Map<
+    StreamTabId,
+    Map<number, string[] | null>
+  >();
+  private readonly compileFailuresOverlays = new Map<
+    StreamTabId,
+    Map<number, CompileFailure[] | null>
   >();
   private readonly usageOverlays = new Map<
     StreamTabId,
@@ -413,65 +457,36 @@ export class StreamSnapshotStore {
   }
 
   /**
-   * Shared round→value patch application for the round-keyed accumulators
-   * (missing outputs, compile failures). `normalize` returns `null` to delete
-   * a round's entry (e.g. once its failure list empties out) or the value to
-   * store otherwise.
+   * Shared round→value patch parsing for the round-keyed accumulators
+   * (output files, missing outputs, compile failures). `normalize` returns
+   * `null` to delete a round's entry (e.g. once its failure list empties
+   * out) or the value list to store otherwise.
    */
-  private applyRoundKeyedPatch<T>(
-    map: Map<StreamTabId, RoundIndexed<T>>,
-    stream: StreamTabId,
+  private parseRoundPatch<T>(
     filesByRound: Record<string, unknown>,
     normalize: (raw: unknown) => T[] | null,
-  ): RoundIndexed<T> {
-    const rounds = this.getOrCreate(map, stream);
+  ): Map<number, T[] | null> {
+    const patch = new Map<number, T[] | null>();
     for (const [round, raw] of Object.entries(filesByRound)) {
       const key = RoundKeySchema.safeParse(round);
       if (!key.success) continue;
-      const value = normalize(raw);
-      if (value === null) delete rounds[key.data];
-      else rounds[key.data] = value;
-    }
-    return rounds;
-  }
-
-  private parseOutputFilesPatch(
-    filesByRound: RoundIndexed<OutputFileInfo>,
-  ): OutputFilesPatch {
-    const patch: OutputFilesPatch = new Map();
-    for (const [round, files] of Object.entries(filesByRound)) {
-      const key = RoundKeySchema.safeParse(round);
-      if (!key.success) continue;
-      const normalized = OutputFileInfoListSchema.parse(
-        Array.isArray(files) ? files : [],
-      );
-      patch.set(key.data, normalized.length === 0 ? null : normalized);
+      patch.set(key.data, normalize(raw));
     }
     return patch;
   }
 
-  private applyOutputFilesPatch(
+  /** Apply a parsed round-keyed patch to `map`'s per-stream record. */
+  private applyRoundPatch<T>(
+    map: Map<StreamTabId, RoundIndexed<T>>,
     stream: StreamTabId,
-    patch: OutputFilesPatch,
-  ): RoundIndexed<OutputFileInfo> {
-    const rounds = this.getOrCreate(this.outputFiles, stream);
-    for (const [round, files] of patch) {
-      if (files === null) delete rounds[round];
-      else rounds[round] = files;
+    patch: Map<number, T[] | null>,
+  ): RoundIndexed<T> {
+    const rounds = this.getOrCreate(map, stream);
+    for (const [round, value] of patch) {
+      if (value === null) delete rounds[round];
+      else rounds[round] = value;
     }
     return rounds;
-  }
-
-  private addOutputFilesOverlay(
-    stream: StreamTabId,
-    patch: OutputFilesPatch,
-  ): void {
-    if (patch.size === 0) return;
-    const overlay =
-      this.outputFileOverlays.get(stream) ??
-      new Map<number, OutputFileInfo[] | null>();
-    for (const [round, files] of patch) overlay.set(round, files);
-    this.outputFileOverlays.set(stream, overlay);
   }
 
   private writeOutputFiles(stream: StreamTabId): void {
@@ -497,21 +512,6 @@ export class StreamSnapshotStore {
     return accumulated;
   }
 
-  private addUsageOverlay(
-    stream: StreamTabId,
-    storageKey: StorageKey,
-    delta: TokenUsageStats,
-  ): void {
-    if (isEmptyUsage(delta)) return;
-    const overlay =
-      this.usageOverlays.get(stream) ?? new Map<StorageKey, TokenUsageStats>();
-    overlay.set(
-      storageKey,
-      sumUsageStats([overlay.get(storageKey) ?? emptyUsageStats(), delta]),
-    );
-    this.usageOverlays.set(stream, overlay);
-  }
-
   private writeUsage(stream: StreamTabId): void {
     const parsed = mapToRecord(this.usage.get(stream) ?? new Map());
     const unparsed = this.usageUnparsed.get(stream);
@@ -525,58 +525,116 @@ export class StreamSnapshotStore {
     this.write(stream, STREAM_DATA_KEYS.USAGE_STATS, record);
   }
 
+  /**
+   * Shared eager-apply + overlay-reconcile shape for every accumulator that
+   * patches per-stream state from a live progress event. `applyToMemory`
+   * always runs immediately, so a caller can read its own write back
+   * synchronously whether or not the stream is seeded yet. A seeded stream
+   * also persists immediately (`persist`). An unseeded stream instead
+   * records `overlayPatch` in `overlay` (merged with anything still pending
+   * from an earlier unseeded mutation on the same stream via `mergePatch`),
+   * leaving `overlayPatch` `undefined` to skip recording (used for
+   * effectively-empty patches). `applyStreamData`'s post-seed reconciliation
+   * then replays the overlay on top of the freshly-read disk state and
+   * persists it there, so an eager write racing ahead of its own seed is
+   * never clobbered by that seed's raw disk read. This is the guarantee
+   * `addOutputFiles`/`addUsage` used to hand-roll individually; every
+   * round/usage mutator now shares it here, so a future one inherits it by
+   * construction instead of needing its own bespoke overlay block.
+   */
+  private mutateWithOverlay<T, P>(
+    stream: StreamTabId,
+    overlayPatch: P | undefined,
+    overlay: Map<StreamTabId, P>,
+    mergePatch: (existing: P | undefined, patch: P) => P,
+    applyToMemory: () => T,
+    persist: () => void,
+  ): { result: T; pending: Promise<void> | undefined } {
+    const result = applyToMemory();
+
+    if (this.canMutateSynchronously(stream)) {
+      persist();
+      return { result, pending: undefined };
+    }
+
+    const version = this.streamVersion(stream);
+    if (overlayPatch !== undefined) {
+      overlay.set(stream, mergePatch(overlay.get(stream), overlayPatch));
+    }
+    return {
+      result,
+      pending: this.queueAfterSeed(stream, version, () => undefined),
+    };
+  }
+
   addOutputFiles(
     stream: StreamTabId,
     filesByRound: RoundIndexed<OutputFileInfo>,
   ): void {
-    const patch = this.parseOutputFilesPatch(filesByRound);
+    const patch = this.parseRoundPatch<OutputFileInfo>(filesByRound, (raw) => {
+      const normalized = OutputFileInfoListSchema.parse(
+        Array.isArray(raw) ? raw : [],
+      );
+      return normalized.length === 0 ? null : normalized;
+    });
     if (patch.size === 0) return;
 
-    if (this.canMutateSynchronously(stream)) {
-      this.applyOutputFilesPatch(stream, patch);
-      this.writeOutputFiles(stream);
-      return;
-    }
-
-    const version = this.streamVersion(stream);
-    this.applyOutputFilesPatch(stream, patch);
-    this.addOutputFilesOverlay(stream, patch);
-    this.queueAfterSeed(stream, version, () => undefined);
+    this.mutateWithOverlay(
+      stream,
+      patch,
+      this.outputFileOverlays,
+      mergeRoundPatch,
+      () => this.applyRoundPatch(this.outputFiles, stream, patch),
+      () => this.writeOutputFiles(stream),
+    );
   }
 
   updateMissingOutputs(
     stream: StreamTabId,
     filesByRound: RoundIndexed<string>,
   ): void {
-    this.mutate(stream, () => {
-      const rounds = this.applyRoundKeyedPatch<string>(
-        this.missingOutputs,
-        stream,
-        filesByRound,
-        (raw) => raw as string[],
-      );
-      this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, { ...rounds });
-    });
+    const patch = this.parseRoundPatch<string>(
+      filesByRound,
+      (raw) => raw as string[],
+    );
+    if (patch.size === 0) return;
+
+    this.mutateWithOverlay(
+      stream,
+      patch,
+      this.missingOutputsOverlays,
+      mergeRoundPatch,
+      () => this.applyRoundPatch(this.missingOutputs, stream, patch),
+      () =>
+        this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
+          ...this.missingOutputs.get(stream),
+        }),
+    );
   }
 
   updateCompileFailures(
     stream: StreamTabId,
     filesByRound: RoundIndexed<CompileFailure>,
   ): void {
-    this.mutate(stream, () => {
-      const rounds = this.applyRoundKeyedPatch<CompileFailure>(
-        this.compileFailures,
-        stream,
-        filesByRound,
-        (raw) => {
-          const normalized = CompileFailureSchema.array().parse(
-            Array.isArray(raw) ? raw : [],
-          );
-          return normalized.length === 0 ? null : normalized;
-        },
+    const patch = this.parseRoundPatch<CompileFailure>(filesByRound, (raw) => {
+      const normalized = CompileFailureSchema.array().parse(
+        Array.isArray(raw) ? raw : [],
       );
-      this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, { ...rounds });
+      return normalized.length === 0 ? null : normalized;
     });
+    if (patch.size === 0) return;
+
+    this.mutateWithOverlay(
+      stream,
+      patch,
+      this.compileFailuresOverlays,
+      mergeRoundPatch,
+      () => this.applyRoundPatch(this.compileFailures, stream, patch),
+      () =>
+        this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, {
+          ...this.compileFailures.get(stream),
+        }),
+    );
   }
 
   /**
@@ -589,16 +647,24 @@ export class StreamSnapshotStore {
     usage: TokenUsageStats,
   ): UsageUpdateResult {
     const delta = TokenUsageStatsParsingSchema.parse(usage);
-    if (this.canMutateSynchronously(stream)) {
-      const accumulated = this.applyUsageDeltaMemory(stream, storageKey, delta);
-      if (!isEmptyUsage(delta)) this.writeUsage(stream);
-      return accumulated;
-    }
-
     const version = this.streamVersion(stream);
-    this.applyUsageDeltaMemory(stream, storageKey, delta);
-    this.addUsageOverlay(stream, storageKey, delta);
-    return this.queueAfterSeed(stream, version, () => undefined).then(() => {
+    const overlayPatch = isEmptyUsage(delta)
+      ? undefined
+      : new Map<StorageKey, TokenUsageStats>([[storageKey, delta]]);
+
+    const { result: accumulated, pending } = this.mutateWithOverlay(
+      stream,
+      overlayPatch,
+      this.usageOverlays,
+      mergeUsagePatch,
+      () => this.applyUsageDeltaMemory(stream, storageKey, delta),
+      () => {
+        if (!isEmptyUsage(delta)) this.writeUsage(stream);
+      },
+    );
+
+    if (!pending) return accumulated;
+    return pending.then(() => {
       if (this.streamVersion(stream) !== version || !this.seeded.has(stream)) {
         return undefined;
       }
@@ -689,6 +755,8 @@ export class StreamSnapshotStore {
       this.seedChains,
       this.metaOverlays,
       this.outputFileOverlays,
+      this.missingOutputsOverlays,
+      this.compileFailuresOverlays,
       this.usageOverlays,
       this.kvCache,
     ];
@@ -1229,6 +1297,8 @@ export class StreamSnapshotStore {
     const runDescriptorOverlay =
       metaOverlay !== undefined ? this.runDescriptors.get(stream) : undefined;
     const outputFileOverlay = this.outputFileOverlays.get(stream);
+    const missingOutputsOverlay = this.missingOutputsOverlays.get(stream);
+    const compileFailuresOverlay = this.compileFailuresOverlays.get(stream);
     const usageOverlay = this.usageOverlays.get(stream);
     const sidecarsToWrite = new Set(data.legacyKeys);
     this.outputFiles.set(stream, data.outputFiles);
@@ -1281,9 +1351,23 @@ export class StreamSnapshotStore {
     }
     this.metaOverlays.delete(stream);
     if (outputFileOverlay) {
-      this.applyOutputFilesPatch(stream, outputFileOverlay);
+      this.applyRoundPatch(this.outputFiles, stream, outputFileOverlay);
       sidecarsToWrite.add(STREAM_DATA_KEYS.OUTPUT_FILES);
       this.outputFileOverlays.delete(stream);
+    }
+    if (missingOutputsOverlay) {
+      this.applyRoundPatch(this.missingOutputs, stream, missingOutputsOverlay);
+      sidecarsToWrite.add(STREAM_DATA_KEYS.MISSING_OUTPUTS);
+      this.missingOutputsOverlays.delete(stream);
+    }
+    if (compileFailuresOverlay) {
+      this.applyRoundPatch(
+        this.compileFailures,
+        stream,
+        compileFailuresOverlay,
+      );
+      sidecarsToWrite.add(STREAM_DATA_KEYS.COMPILE_FAILURES);
+      this.compileFailuresOverlays.delete(stream);
     }
     if (usageOverlay) {
       for (const [storageKey, delta] of usageOverlay) {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -139,6 +139,42 @@ function mergeRoundPatch<T>(
 }
 
 /**
+ * Overlay shape for {@link StreamSnapshotStore.updateMissingOutputs} /
+ * {@link StreamSnapshotStore.clearMissingOutputs} on an unseeded stream:
+ * `reset` records that a `clearMissingOutputs()` happened somewhere in the
+ * recorded sequence, so replay wipes the disk-read state before layering
+ * `patch` on top, instead of merging onto stale disk rounds a clear was
+ * supposed to erase.
+ */
+interface RoundOverlay<T> {
+  reset: boolean;
+  patch: Map<number, T[] | null>;
+}
+
+/**
+ * Merge {@link RoundOverlay} patches in call order so `clearMissingOutputs`
+ * interleaved with `updateMissingOutputs` on the same unseeded stream
+ * replays correctly regardless of which fired first: a reset (`clear`)
+ * supersedes everything recorded before it — it drops the earlier round
+ * patch outright, matching a disk write of `{}` — while a later update
+ * layers its round patch on top and preserves whichever reset flag is
+ * already recorded. Without this, `clearMissingOutputs` staying on the
+ * plain deferred `mutate()` path let it replay out of order relative to an
+ * eagerly-overlaid `updateMissingOutputs`, silently dropping the newer
+ * update or resurrecting rounds a clear was supposed to erase.
+ */
+function mergeMissingOutputsOverlay(
+  existing: RoundOverlay<string> | undefined,
+  patch: RoundOverlay<string>,
+): RoundOverlay<string> {
+  if (patch.reset) return patch;
+  return {
+    reset: existing?.reset ?? false,
+    patch: mergeRoundPatch(existing?.patch, patch.patch),
+  };
+}
+
+/**
  * Merge a per-run usage delta patch into an existing overlay patch,
  * accumulating (not replacing) each run's totals — mirrors the in-memory
  * sum `applyUsageDeltaMemory` performs, so the overlay replayed after
@@ -230,7 +266,7 @@ export class StreamSnapshotStore {
   >();
   private readonly missingOutputsOverlays = new Map<
     StreamTabId,
-    Map<number, string[] | null>
+    RoundOverlay<string>
   >();
   private readonly compileFailuresOverlays = new Map<
     StreamTabId,
@@ -601,9 +637,9 @@ export class StreamSnapshotStore {
 
     this.mutateWithOverlay(
       stream,
-      patch,
+      { reset: false, patch },
       this.missingOutputsOverlays,
-      mergeRoundPatch,
+      mergeMissingOutputsOverlay,
       () => this.applyRoundPatch(this.missingOutputs, stream, patch),
       () =>
         this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
@@ -715,12 +751,27 @@ export class StreamSnapshotStore {
     return paths;
   }
 
-  /** Clear the missing-outputs marker for a stream (memory + disk). */
+  /**
+   * Clear the missing-outputs marker for a stream (memory + disk). Goes
+   * through the same `mutateWithOverlay` shape as `updateMissingOutputs` (via
+   * the shared `reset`-aware overlay) rather than the plain deferred
+   * `mutate()` path, so a clear and an update racing on the same unseeded
+   * stream replay in call order instead of the clear always landing last.
+   */
   clearMissingOutputs(stream: StreamTabId): void {
-    this.mutate(stream, () => {
-      if (!this.missingOutputs.delete(stream)) return;
-      this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {});
-    });
+    let existed = false;
+    this.mutateWithOverlay(
+      stream,
+      { reset: true, patch: new Map<number, string[] | null>() },
+      this.missingOutputsOverlays,
+      mergeMissingOutputsOverlay,
+      () => {
+        existed = this.missingOutputs.delete(stream);
+      },
+      () => {
+        if (existed) this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {});
+      },
+    );
   }
 
   // ==========================================================================
@@ -1356,7 +1407,12 @@ export class StreamSnapshotStore {
       this.outputFileOverlays.delete(stream);
     }
     if (missingOutputsOverlay) {
-      this.applyRoundPatch(this.missingOutputs, stream, missingOutputsOverlay);
+      if (missingOutputsOverlay.reset) this.missingOutputs.set(stream, {});
+      this.applyRoundPatch(
+        this.missingOutputs,
+        stream,
+        missingOutputsOverlay.patch,
+      );
       sidecarsToWrite.add(STREAM_DATA_KEYS.MISSING_OUTPUTS);
       this.missingOutputsOverlays.delete(stream);
     }


### PR DESCRIPTION
## The race

`StreamSnapshotStore` is the single writer of `streamData/{id}/*`. When a
stream hasn't been seeded from disk yet, every mutator has to choose between
applying to memory now (so a caller can read its own write back) and letting
the in-flight seed's `applyStreamData()` — which does
`this.<accumulator>.set(stream, data.<accumulator>)`, an unconditional
overwrite — land after it and clobber the update.

`addOutputFiles`/`addUsage` already carry the fix (added in 609bf0046, "fix:
keep snapshot output usage updates readable"): apply to memory eagerly, and
if the stream isn't seeded yet, additionally record the patch in a
per-accumulator overlay map. `applyStreamData()` replays that overlay on top
of the freshly-read disk state once the seed lands, so the eager write can
never be clobbered.

`updateMissingOutputs`/`updateCompileFailures` never got this treatment —
they still went through the plain `mutate()` path, which *defers the entire
apply* until after the seed resolves. Concretely:

1. Stream `X` isn't seeded (e.g. it was outside a partial `preload()`).
2. `updateMissingOutputs(X, { 1: ['next.tex'] })` calls `mutate()`, which sees
   the stream isn't synchronously mutable and queues the whole apply behind
   `ensureSeeded()` (the in-flight disk read for `X`) via `queueAfterSeed`.
3. A caller that reads `getMissingOutputs(X)` in the same tick — before the
   seed's disk read resolves — sees **the pre-mutation value**, not what it
   just wrote. Anything that branches on that read (surfacing a missing-file
   marker in the UI, or persisting a decision made off `getMissingOutputs`)
   silently loses the update until the seed's microtask eventually catches up
   — the same lost-update class `addOutputFiles`/`addUsage` were fixed for,
   just half-applied across the four mutators.

Two new regression tests
(`src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`) reproduce this
exact interleaving — `preload([STREAM])` leaves `OTHER_STREAM` unseeded, then
`updateMissingOutputs`/`updateCompileFailures` on `OTHER_STREAM` is
immediately followed by a synchronous `getMissingOutputs`/
`getCompileFailures` read, mirroring the existing "returns output files
immediately for streams outside a partial preload" test for
`addOutputFiles`. Verified failing pre-fix (checked out against
`origin/main`'s `StreamSnapshotStore.ts` with the new tests applied):

```
AssertionError: expected undefined to deeply equal [ 'next.tex' ]
AssertionError: expected undefined to deeply equal [ { round: 1, …(4) } ]
```

## The ownership fix

Doctrine: the cure for an internal race is single-owner/sequenced design
that makes the race impossible, not caller discipline. Rather than
hand-rolling a third bespoke eager-apply+overlay block for
`updateMissingOutputs`/`updateCompileFailures`, this generalizes the shape
`addOutputFiles`/`addUsage` already proved into one shared internal helper,
`mutateWithOverlay`, and deletes the two bespoke overlay blocks
(`addOutputFilesOverlay`, `addUsageOverlay`) in favor of it:

- `mutateWithOverlay<T, P>(stream, overlayPatch, overlay, mergePatch,
  applyToMemory, persist)` always applies to memory immediately. A seeded
  stream also persists immediately. An unseeded stream instead merges
  `overlayPatch` into `overlay` (via `mergePatch`) and queues a no-op behind
  the seed so `applyStreamData()`'s reconciliation picks it up.
- `applyStreamData()`'s post-seed reconciliation now handles all three
  round-keyed overlays (output files, missing outputs, compile failures)
  the same way, plus the pre-existing usage overlay.
- `parseRoundPatch`/`applyRoundPatch` replace three near-duplicate
  functions (`applyRoundKeyedPatch`, `parseOutputFilesPatch`,
  `applyOutputFilesPatch`) with one generic round→value-patch parse/apply
  pair shared by all three round-keyed accumulators.
- `addOutputFiles`, `updateMissingOutputs`, `updateCompileFailures`, and
  `addUsage` — all four mutators — now call `mutateWithOverlay`, so the
  guarantee is structural: a fifth round/usage mutator added later gets it
  by construction instead of needing to remember to hand-roll it.

`setTodos`/`setPlan`/`clearMissingOutputs`/`queueMetaPatch` still use the
existing plain `mutate()` (and `queueMetaPatch`'s own pre-existing meta
overlay) — out of scope; this PR only touches the four round/usage patch
mutators named in the finding.

## Net elements (R6)

- **Deleted:** `applyRoundKeyedPatch`, `parseOutputFilesPatch`,
  `applyOutputFilesPatch`, `addOutputFilesOverlay`, `addUsageOverlay` (5
  private methods).
- **Added:** `parseRoundPatch`, `applyRoundPatch` (2 generic private
  methods, replacing the first 3 above), `mutateWithOverlay` (1 shared
  private method, replacing the bespoke branching `addOutputFiles`/
  `addUsage` used to each hand-roll), `mergeRoundPatch`/`mergeUsagePatch`
  (2 pure module-level merge functions), 2 new overlay `Map` fields
  (`missingOutputsOverlays`, `compileFailuresOverlays` — required: these are
  genuinely new per-accumulator state, not a wrapper).
- Net production diff is +187/-103 lines in `StreamSnapshotStore.ts`; the
  increase is the fix itself (two more accumulators gaining eager-apply +
  overlay coverage — two new overlay maps, two new reconciliation blocks in
  `applyStreamData`, plus JSDoc on the new shared helper) rather than
  incidental abstraction — the mechanism itself is smaller than four
  independent hand-rolled copies would have been (1 shared helper instead of
  what would otherwise be 4).
- No new coordinator/layer: `mutateWithOverlay` lives on `StreamSnapshotStore`
  itself, next to the `mutate()` it complements — the sole owner of this
  state — not a new class or facade.

## Consumer counts (R8)

- `mutateWithOverlay`: 4 call sites (`addOutputFiles`, `updateMissingOutputs`,
  `updateCompileFailures`, `addUsage`) — all four call sites the finding
  named.
- `parseRoundPatch`/`applyRoundPatch`: 3 call sites each (output files,
  missing outputs, compile failures) plus 1 additional `applyRoundPatch`
  call from `applyStreamData`'s overlay reconciliation.
- `mergeRoundPatch`: 3 call sites (the three round-keyed
  `mutateWithOverlay` calls). `mergeUsagePatch`: 1 call site (`addUsage`).

## Tests

- Extended `src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` with
  two regression tests encoding the lost-update interleaving for
  `updateMissingOutputs`/`updateCompileFailures` (verified failing pre-fix,
  passing post-fix).
- `npx vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` —
  31/31 pass.
- `npx vitest run src/test-kernel/transcript/` — 93/93 pass.
- Broader transcript-adjacent suites (desktop stream snapshot/agent
  execution, CLI chat session controller/run execution, progress backend,
  execution stream resolver, completed run archive, output discovery,
  round-map schemas) — 209/209 pass.
- `npm run typecheck` — clean across the whole workspace (root, test-kernel,
  extension, cli, trace-viewer, desktop).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transcript persistence and seed/overlay ordering for multiple sidecar mutators; incorrect replay could drop or resurrect missing-output/compile-failure markers, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a **lost-update race** on unseeded streams (e.g. tabs outside a partial `preload()`): `updateMissingOutputs` and `updateCompileFailures` used deferred `mutate()` and callers could not read their own writes synchronously, unlike `addOutputFiles` / `addUsage`.
> 
> **`StreamSnapshotStore`** now routes those mutators—and refactors the existing output/usage paths—through shared **`mutateWithOverlay`**: apply to memory immediately, record per-stream overlay patches when disk seed is still in flight, and replay overlays in **`applyStreamData`** after load so seeding never clobbers eager updates. **`clearMissingOutputs`** uses the same reset-aware overlay so clear/update interleaving replays in call order.
> 
> Round-keyed patching is unified via **`parseRoundPatch`** / **`applyRoundPatch`** and **`mergeRoundPatch`**; missing outputs get **`mergeMissingOutputsOverlay`** for clear vs update ordering. Vitest adds regressions for immediate read-back, clear/update ordering, and compile failures on partially preloaded streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a993827f7ba74e5f4958f72fec852adc5d25f791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->