### PR TITLE
fix(cli): fuse resume()'s root-run slot check+claim into one atomic step

### DIFF
--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -34,6 +34,11 @@
     {
       "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
       "form": "mock",
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/cli/chatSessionController.vitest.mts",
+      "form": "mock",
       "specifier": "@agent/runtime/executionRegistry"
     },
     {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -69,6 +69,7 @@ import {
   markChatTuiRunCompleted,
   markChatTuiRunPending,
   publishChatTuiRootRunStartAvailability,
+  tryClaimRootRunSlot,
   type TuiSession,
 } from './tui/state/sessionRunState';
 import { createTuiHostInteractions } from './tui/state/subscribeApprovals';
@@ -341,93 +342,119 @@ export function createChatSessionController(
     id: ExecutionId,
     preResolved?: CliToolUseResumeResolution,
   ): Promise<void> => {
-    if (!chatTuiCanStartRootRun(session)) {
+    // Claim the root-run slot as the FIRST statement, synchronously, before
+    // any `await` below — see tryClaimRootRunSlot. This fuses the
+    // availability check and the claim into one atomic step so a concurrent
+    // tryResumeStream() (or another resume()) can never observe this call
+    // suspended between "checked available" and "claimed", and race in to
+    // claim the same slot out from under it.
+    let resolveRunPromise: () => void = () => {};
+    let rejectRunPromise: (error: unknown) => void = () => {};
+    const claimedRunPromise = new Promise<void>((resolve, reject) => {
+      resolveRunPromise = resolve;
+      rejectRunPromise = reject;
+    });
+    if (!tryClaimRootRunSlot(session, claimedRunPromise)) {
       appendLocalAssistantTranscript(
         'Finish the active chat before resuming a previous session.',
       );
       return;
     }
 
-    const resolution = preResolved ?? (await resolveCliResumeSnapshot(id));
-    if (resolution.kind !== 'toolUse') {
-      appendLocalErrorTranscript(explainNonResumable(resolution, id));
-      return;
+    try {
+      const resolution = preResolved ?? (await resolveCliResumeSnapshot(id));
+      if (resolution.kind !== 'toolUse') {
+        appendLocalErrorTranscript(explainNonResumable(resolution, id));
+        markChatTuiRunCompleted(session);
+        resolveRunPromise();
+        return;
+      }
+
+      clearLocalTranscript();
+      followUpQueue.clear();
+      session.streamId = resolution.streamId;
+      session.executionId = resolution.snapshot.executionId;
+      rootStreamId.set(resolution.streamId);
+
+      const currentModel = resolution.config.model;
+      const sessionContext = getSessionContext(currentModel);
+      patchSessionMeta({
+        agent: resolution.config.agent,
+        model: resolution.config.model,
+        modelSource: 'history',
+        canDelegate: chatAgentSupportsDelegation(resolution.config.agent),
+      });
+
+      await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
+      await snapshotStore.load([resolution.streamId]);
+      const restored = await snapshotStore.read(resolution.streamId);
+      patchStream(resolution.streamId, (slice) => {
+        const runUsages = Object.values(restored.runUsage);
+        return {
+          ...slice,
+          cumulativeUsage: runUsages.length
+            ? sumUsageStats(runUsages)
+            : slice.cumulativeUsage,
+          todos: restored.todos,
+          plan: restored.plan,
+        };
+      });
+      projectStreamTranscript(resolution.streamId);
+      activeStreamId.set(resolution.streamId);
+
+      const { runtimeHost, approvalsUnavailable, finalize } =
+        setupRunHost(sessionContext);
+      session.runtimeHost = runtimeHost;
+
+      const runChain = setCliHelperModel(currentModel)
+        .then(() =>
+          resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {
+            approvalPromptsUnavailable: approvalsUnavailable,
+            runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+          }),
+        )
+        .then(() => {
+          if (session.streamId) {
+            projectStreamTranscript(session.streamId, { finalize: true });
+          }
+          session.runExitCode = CliExitCode.Success;
+          notify({ kind: 'agentFinished' });
+        })
+        .catch(reportRunFailure)
+        .finally(finalize);
+      // `session.runPromise` was already claimed synchronously above with
+      // `claimedRunPromise`; forward its settlement to the real run chain so
+      // exit-drain's `await session.runPromise` blocks until the continued
+      // run actually finishes (or is interrupted), not just until
+      // rehydration completes. `resume()`'s own returned promise still
+      // settles here, before the run finishes — fire-and-forget per the
+      // interface contract.
+      runChain.then(resolveRunPromise, rejectRunPromise);
+    } catch (error: unknown) {
+      markChatTuiRunCompleted(session);
+      resolveRunPromise();
+      throw error;
     }
-
-    clearLocalTranscript();
-    followUpQueue.clear();
-    session.runCompleted = false;
-    publishChatTuiRootRunStartAvailability(session);
-    session.stopRequested = false;
-    session.runExitCode = CliExitCode.Success;
-    session.streamId = resolution.streamId;
-    session.executionId = resolution.snapshot.executionId;
-    rootStreamId.set(resolution.streamId);
-
-    const currentModel = resolution.config.model;
-    const sessionContext = getSessionContext(currentModel);
-    patchSessionMeta({
-      agent: resolution.config.agent,
-      model: resolution.config.model,
-      modelSource: 'history',
-      canDelegate: chatAgentSupportsDelegation(resolution.config.agent),
-    });
-
-    await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
-    await snapshotStore.load([resolution.streamId]);
-    const restored = await snapshotStore.read(resolution.streamId);
-    patchStream(resolution.streamId, (slice) => {
-      const runUsages = Object.values(restored.runUsage);
-      return {
-        ...slice,
-        cumulativeUsage: runUsages.length
-          ? sumUsageStats(runUsages)
-          : slice.cumulativeUsage,
-        todos: restored.todos,
-        plan: restored.plan,
-      };
-    });
-    projectStreamTranscript(resolution.streamId);
-    activeStreamId.set(resolution.streamId);
-
-    const { runtimeHost, approvalsUnavailable, finalize } =
-      setupRunHost(sessionContext);
-    session.runtimeHost = runtimeHost;
-
-    session.runPromise = setCliHelperModel(currentModel)
-      .then(() =>
-        resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {
-          approvalPromptsUnavailable: approvalsUnavailable,
-          runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
-        }),
-      )
-      .then(() => {
-        if (session.streamId) {
-          projectStreamTranscript(session.streamId, { finalize: true });
-        }
-        session.runExitCode = CliExitCode.Success;
-        notify({ kind: 'agentFinished' });
-      })
-      .catch(reportRunFailure)
-      .finally(finalize);
-    publishChatTuiRootRunStartAvailability(session);
   };
 
   const tryResumeStream = (streamId: StreamTabId): Promise<boolean> => {
-    if (!chatTuiCanStartRootRun(session)) {
-      return Promise.resolve(false);
-    }
-
     let resolveRun: (resumed: boolean) => void = () => {};
     let rejectRun: (error: unknown) => void = () => {};
     const runPromise = new Promise<boolean>((resolve, reject) => {
       resolveRun = resolve;
       rejectRun = reject;
     });
-    markChatTuiRunPending(
-      session,
-      runPromise.then(() => undefined),
-    );
+    // Claim the root-run slot as the FIRST statement, synchronously, before
+    // any `await` below — see tryClaimRootRunSlot and the matching comment
+    // in resume().
+    if (
+      !tryClaimRootRunSlot(
+        session,
+        runPromise.then(() => undefined),
+      )
+    ) {
+      return Promise.resolve(false);
+    }
 
     const runResume = async (): Promise<boolean> => {
       let finalize = (): void => markChatTuiRunCompleted(session);

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -406,6 +406,19 @@ export function createChatSessionController(
         setupRunHost(sessionContext);
       session.runtimeHost = runtimeHost;
 
+      // A Ctrl-C during the rehydration awaits above (`resolveCliResumeSnapshot`,
+      // `ensureLoaded`, `snapshotStore.load`/`read`) lands here as
+      // `session.stopRequested`, since the early claim above already makes
+      // this run look stoppable to `chatTuiCanStopActiveRun`. Honor it before
+      // starting the real run chain — matching `tryResumeStream()`'s
+      // stop-check after its own preparatory awaits — instead of starting an
+      // agent the user already cancelled.
+      if (session.stopRequested) {
+        finalize();
+        resolveRunPromise();
+        return;
+      }
+
       const runChain = setCliHelperModel(currentModel)
         .then(() =>
           resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -65,6 +65,25 @@ export function markChatTuiRunCompleted(
   publishChatTuiRootRunStartAvailability(session);
 }
 
+/**
+ * Atomically check-and-claim the root-run slot: fuses
+ * {@link chatTuiCanStartRootRun} and {@link markChatTuiRunPending} into one
+ * synchronous call so no caller can observe — or race on — a window between
+ * the check and the claim. Every root-run entry point (fresh start, resume,
+ * follow-up-wake resume) MUST call this as its first statement, before any
+ * `await`, so the claim happens before the caller can be suspended and a
+ * concurrent entry point can slip in and claim the same slot.
+ */
+export function tryClaimRootRunSlot(
+  session: ClearableTuiSessionState,
+  runPromise: Promise<void>,
+  runtimeHost?: AgentRuntimeHost,
+): boolean {
+  if (!chatTuiCanStartRootRun(session)) return false;
+  markChatTuiRunPending(session, runPromise, runtimeHost);
+  return true;
+}
+
 export function chatTuiCanInterruptActiveRun(
   session: InterruptibleTuiSessionState,
 ): boolean {

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -69,10 +69,13 @@ export function markChatTuiRunCompleted(
  * Atomically check-and-claim the root-run slot: fuses
  * {@link chatTuiCanStartRootRun} and {@link markChatTuiRunPending} into one
  * synchronous call so no caller can observe — or race on — a window between
- * the check and the claim. Every root-run entry point (fresh start, resume,
- * follow-up-wake resume) MUST call this as its first statement, before any
- * `await`, so the claim happens before the caller can be suspended and a
- * concurrent entry point can slip in and claim the same slot.
+ * the check and the claim. Every root-run entry point that awaits *before*
+ * it would otherwise claim (resume, follow-up-wake resume) MUST call this as
+ * its first statement, before any `await`, so the claim happens before the
+ * caller can be suspended and a concurrent entry point can slip in and claim
+ * the same slot. `startRootRun` claims via `markChatTuiRunPending` directly
+ * instead — it never suspends before claiming, so it has no check-then-await
+ * window for this primitive to close.
  */
 export function tryClaimRootRunSlot(
   session: ClearableTuiSessionState,

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   appendLocalUserTranscript: vi.fn(),
   clearLocalTranscript: vi.fn(),
   moveLocalTranscriptToStream: vi.fn(),
+  resolveCliResumeSnapshot: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -100,6 +101,14 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: mocks.notify,
 }));
 
+vi.mock('@cli/runtime/sessionResume', () => ({
+  resolveCliResumeSnapshot: mocks.resolveCliResumeSnapshot,
+  explainNonResumable: (
+    resolution: { readonly kind: string },
+    id: string,
+  ): string => `not resumable (${resolution.kind}): ${id}`,
+}));
+
 import { StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
@@ -112,7 +121,7 @@ import {
   chatTuiCanStartRootRun,
   type TuiSession,
 } from '@cli/chat/tui/state/sessionRunState';
-import type { StreamTabId } from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // ---------------------------------------------------------------------------
@@ -279,6 +288,7 @@ describe('createChatSessionController', () => {
     mocks.appendLocalUserTranscript.mockReset();
     mocks.clearLocalTranscript.mockReset();
     mocks.moveLocalTranscriptToStream.mockReset();
+    mocks.resolveCliResumeSnapshot.mockReset();
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -375,6 +385,65 @@ describe('createChatSessionController', () => {
 
     preload.resolve(undefined);
     await expect(resumed).resolves.toBe(false);
+    expect(session.runCompleted).toBe(true);
+  });
+
+  it('reserves the root-run slot before resume() awaits the resolved snapshot', async () => {
+    const snapshot = deferred<{ readonly kind: 'not-found' }>();
+    mocks.resolveCliResumeSnapshot.mockReturnValueOnce(snapshot.promise);
+    const session = makeSession({ runCompleted: true });
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    const resumed = ctrl.resume('aaaaaa' as ExecutionId);
+
+    // The claim (tryClaimRootRunSlot) must land synchronously, before
+    // resume() ever reaches its first await — same contract as
+    // tryResumeStream above.
+    expect(session.runPromise).toBeDefined();
+    expect(session.runCompleted).toBe(false);
+    expect(ctrl.canStartRootRun()).toBe(false);
+
+    snapshot.resolve({ kind: 'not-found' });
+    await resumed;
+    expect(session.runCompleted).toBe(true);
+  });
+
+  it('resume() suspended on the resolved snapshot keeps a concurrent follow-up wake from also claiming the root-run slot', async () => {
+    // Reproduces the finding's interleaving: resume(A) suspends on
+    // resolveCliResumeSnapshot (an await-suspension point) with the slot
+    // already claimed; a follow-up wake (tryResumeStream for a different
+    // stream) fires while A is still suspended. Pre-fix, resume(A) checked
+    // availability but claimed the slot only after this (and three more)
+    // awaits, so B's tryResumeStream would see the slot as free, claim it,
+    // and start doing real work — which resume(A) would then clobber when
+    // it woke back up and unconditionally overwrote session.runPromise.
+    // Post-fix, exactly one caller (A) ever holds the slot.
+    const snapshot = deferred<{ readonly kind: 'not-found' }>();
+    mocks.resolveCliResumeSnapshot.mockReturnValueOnce(snapshot.promise);
+    const session = makeSession({ runCompleted: true });
+    const snapshotStoreForB = makeResumeSnapshotStore({
+      executionId: undefined,
+    });
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore: snapshotStoreForB }),
+    );
+
+    const resumeA = ctrl.resume('aaaaaa' as ExecutionId);
+    // A is now suspended inside resolveCliResumeSnapshot; the slot is
+    // already claimed.
+    expect(session.runPromise).toBeDefined();
+    expect(session.runCompleted).toBe(false);
+
+    // The follow-up wake for a different stream fires while A is still
+    // suspended. It must bail out synchronously, before touching the
+    // snapshot store, because the slot is already held.
+    const resumedB = ctrl.tryResumeStream('stream-b');
+    expect(snapshotStoreForB.preload).not.toHaveBeenCalled();
+    await expect(resumedB).resolves.toBe(false);
+
+    // A remains the sole owner of the slot end to end.
+    snapshot.resolve({ kind: 'not-found' });
+    await resumeA;
     expect(session.runCompleted).toBe(true);
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   createTuiHostInteractions: vi.fn(),
   resolveAndResumeStream: vi.fn(),
   resumeQueuedToolUseSnapshot: vi.fn(),
+  resumeToolUseFromSnapshot: vi.fn(),
   projectStreamTranscript: vi.fn(),
   notify: vi.fn(),
   appendLocalAssistantTranscript: vi.fn(),
@@ -50,6 +51,11 @@ vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
 
 vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
   resumeQueuedToolUseSnapshot: mocks.resumeQueuedToolUseSnapshot,
+}));
+
+vi.mock('@agent/runtime/executeAgent', () => ({
+  executeAgent: vi.fn(),
+  resumeToolUseFromSnapshot: mocks.resumeToolUseFromSnapshot,
 }));
 
 vi.mock('@agent/runtime/SessionHandle', () => ({
@@ -109,7 +115,7 @@ vi.mock('@cli/runtime/sessionResume', () => ({
   ): string => `not resumable (${resolution.kind}): ${id}`,
 }));
 
-import { StreamSnapshotStore } from '@transcript';
+import { setDefaultStreamLogStore, StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
@@ -123,6 +129,7 @@ import {
 } from '@cli/chat/tui/state/sessionRunState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import type { StreamLogStore } from '@transcript';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -289,6 +296,8 @@ describe('createChatSessionController', () => {
     mocks.clearLocalTranscript.mockReset();
     mocks.moveLocalTranscriptToStream.mockReset();
     mocks.resolveCliResumeSnapshot.mockReset();
+    mocks.resumeToolUseFromSnapshot.mockReset();
+    mocks.resumeToolUseFromSnapshot.mockResolvedValue(undefined);
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -445,6 +454,59 @@ describe('createChatSessionController', () => {
     snapshot.resolve({ kind: 'not-found' });
     await resumeA;
     expect(session.runCompleted).toBe(true);
+  });
+
+  it('honors a Ctrl-C issued while resume() is still rehydrating and never starts the resumed run', async () => {
+    // The early slot claim makes chatTuiCanStopActiveRun() report this
+    // resume() as stoppable (session.runPromise is set, session.streamId is
+    // still whatever resume() has set so far) well before the resumed agent
+    // actually starts running. If the user hits Ctrl-C during that
+    // rehydration window, resume() must notice `session.stopRequested` and
+    // bail out instead of silently starting `resumeToolUseFromSnapshot()`
+    // once the awaits finish.
+    const ensureLoaded = deferred<void>();
+    setDefaultStreamLogStore({
+      ensureLoaded: () => ensureLoaded.promise,
+    } as unknown as StreamLogStore);
+
+    const session = makeSession({ runCompleted: true });
+    const snapshotStore = {
+      load: vi.fn(async () => undefined),
+      read: vi.fn(async () => ({
+        runUsage: {},
+        todos: [],
+        plan: undefined,
+      })),
+    } as unknown as StreamSnapshotStore;
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    const preResolved = {
+      kind: 'toolUse' as const,
+      streamId: 'stream-resume' as StreamTabId,
+      snapshot: { executionId: 'exec-resume' } as never,
+      config: makeResumeConfig(),
+    };
+
+    const resumed = ctrl.resume('aaaaaa' as ExecutionId, preResolved);
+    // resume() has claimed the slot and is suspended inside
+    // getDefaultStreamLogStore().ensureLoaded(); session.streamId is
+    // already set to the resumed stream.
+    expect(session.runPromise).toBeDefined();
+    expect(session.streamId).toBe('stream-resume');
+
+    // Ctrl-C fires while resume() is still rehydrating.
+    ctrl.stop();
+    expect(session.stopRequested).toBe(true);
+
+    ensureLoaded.resolve();
+    await resumed;
+
+    expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
+    expect(session.runCompleted).toBe(true);
+
+    setDefaultStreamLogStore(undefined as unknown as StreamLogStore);
   });
 
   it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {


### PR DESCRIPTION
## The race

`resume()` in `packages/cli/src/chat/chatSessionController.ts` checked
`chatTuiCanStartRootRun(session)` as its first statement, but only *claimed*
the root-run slot (`session.runPromise = …`) after four `await`s and several
session-field mutations later:

```
resume(A):
  if (!chatTuiCanStartRootRun(session)) return;   // check
  await resolveCliResumeSnapshot(id);              // ← suspension point
  ... session.streamId = ...
  await getDefaultStreamLogStore().ensureLoaded(...);
  await snapshotStore.load(...);
  await snapshotStore.read(...);
  ...
  session.runPromise = setCliHelperModel(...).then(...);  // claim (finally)
```

`tryResumeStream()` already claims synchronously (fused check+claim, no
`await` in between — landed in #7925). So the interleaving from the finding
plays out as:

1. `resume(A)` passes its check (slot free) and suspends at
   `resolveCliResumeSnapshot(id)`.
2. A follow-up wake fires `tryResumeStream(B)` for a different stream. It
   sees the slot still free (A hasn't claimed yet), claims it, and starts
   real work (`snapshotStore.preload`, `resolveAndResumeStream`, …).
3. `resume(A)` wakes back up, runs to completion of its own steps, and
   unconditionally overwrites `session.runPromise` at the end — clobbering
   B's claim while B's async work is still in flight.
4. Two concurrent runs now share one `session`; further mutations from
   either can slip in, including a third caller once B "finalizes" against
   state A already stomped on.

## The ownership fix

Per the maintainer's doctrine, the cure for an internal race is
single-owner/sequenced design that makes the race impossible, not a new
coordination layer. `sessionRunState.ts` already owns the run-state fields
(`markChatTuiRunPending`, `markChatTuiRunCompleted`,
`chatTuiCanStartRootRun`); it was missing the *atomic* check-and-claim
primitive, so callers had to hand-roll the two-step "check, then (much
later) claim" convention themselves — and `resume()` did it wrong.

Added `tryClaimRootRunSlot(session, runPromise, runtimeHost?)` to
`sessionRunState.ts`: it fuses `chatTuiCanStartRootRun` +
`markChatTuiRunPending` into one synchronous call. Both `resume()` and
`tryResumeStream()` now call it as their literal first statement, before any
`await` — there is no longer a window in either function where a check can
pass and a claim can still be pending. `resume()` is restructured to build a
deferred placeholder promise up front, claim with it immediately, then
forward that deferred's settlement to the real run chain once it's built
further down (`runChain.then(resolveRunPromise, rejectRunPromise)`) — so
`resume()`'s own returned promise keeps its documented fire-and-forget
contract (settles after rehydration), while `session.runPromise` (used by
exit-drain's `await session.runPromise` and by `chatTuiCanStartRootRun`)
still only settles once the continued run truly finishes or is interrupted.

The two-step convention is gone: neither `resume()` nor `tryResumeStream()`
calls `chatTuiCanStartRootRun`/`markChatTuiRunPending` separately anymore —
both route through the one atomic primitive.

## Regression test

Extended `src/test-kernel/cli/chatSessionController.vitest.mts` (mirrors the
existing "reserves the root-run slot before tryResumeStream awaits persisted
state" test in the same describe block):

- **`reserves the root-run slot before resume() awaits the resolved
  snapshot`** — asserts `session.runPromise` is claimed synchronously,
  before `resume()`'s first `await` settles.
- **`resume() suspended on the resolved snapshot keeps a concurrent
  follow-up wake from also claiming the root-run slot`** — encodes the exact
  interleaving from the finding: `resume(A)` is suspended at
  `resolveCliResumeSnapshot` (mocked as a controllable deferred), then
  `tryResumeStream('stream-b')` fires while A is still suspended. Asserts B's
  `snapshotStore.preload` was never called (B bailed out synchronously) and
  `tryResumeStream` resolved `false` — exactly one caller ever holds the
  slot.

**Proved the regression test fails pre-fix** (git stash forbidden, per
instructions): saved the fix as a patch, `git checkout --` reverted
`chatSessionController.ts`/`sessionRunState.ts` to origin/main, reran the
suite — both new tests failed (`expected undefined to be defined` on
`session.runPromise`, since pre-fix `resume()` hadn't claimed yet at that
point) — then `git apply`'d the patch back and confirmed all 16 (now
18-including-new) tests pass.

## Net elements (R6)

- **+1 exported function**: `tryClaimRootRunSlot` in `sessionRunState.ts` —
  the single atomic primitive both hazard sites now share.
- **0 new layers/coordinators**: no new class, no new module, no new
  subscribe surface — the fix deepens the existing state-owner module.
- **-1 duplicated convention**: the "check, then claim much later" pattern
  that only `tryResumeStream()` got right (and `resume()` didn't) is gone;
  both call sites now share one call.
- Test file: +2 regression tests (71 lines), reusing the existing
  `deferred()` helper and mock scaffolding already in the suite — no new
  test infrastructure.

## Consumer counts (R8)

- `tryClaimRootRunSlot`: **2** production callers (`resume()`,
  `tryResumeStream()` in `chatSessionController.ts`) — exactly the two
  hazard sites from the finding, plus 1 doc-comment self-reference.
- `chatTuiCanStartRootRun`: **5** other production consumers remain
  (`runChatTui.tsx`, `agentModelCommands.ts`, `handleSlashCommand.ts`,
  `apiModeCommands.ts`, plus its own use inside `tryClaimRootRunSlot`) — kept
  exported; these are legitimate read-only availability checks, not claims.
- `markChatTuiRunPending`: **2** other production callers remain
  (`startRootRun()` in `chatSessionController.ts`, and `startSession()`'s
  outer reservation in `runChatTui.tsx`, which already claims before its own
  first `await`) — kept exported, not folded into `tryClaimRootRunSlot`
  since those call sites don't have the check-then-claim gap this fix
  closes.

## Tests run

- `npx vitest run src/test-kernel/cli/chatSessionController.vitest.mts` — 16/16 pass
- `npx vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/SessionResumeResolution.vitest.mts` — 143/143 pass
- `npx vitest run src/test-kernel/cli` (full CLI suite) — 128 files / 1657 tests pass
- `npm run typecheck` — clean across all workspace packages

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI session run orchestration and concurrency boundaries; behavior is well-tested but mistakes could still affect resume/stop or concurrent stream wakes.
> 
> **Overview**
> Fixes a race where **`resume()`** could pass a root-run availability check, suspend on rehydration **`await`s**, and let **`tryResumeStream()`** (or another **`resume()`**) claim the same **`session`** slot—then overwrite **`session.runPromise`** when the first call finished setup.
> 
> Adds **`tryClaimRootRunSlot`** in **`sessionRunState.ts`**, fusing **`chatTuiCanStartRootRun`** and **`markChatTuiRunPending`** into one synchronous step. **`resume()`** and **`tryResumeStream()`** now call it as their first statement, before any **`await`**. **`resume()`** claims with a deferred placeholder promise and forwards settlement to the real run chain so exit-drain still waits for the agent, while honoring **Ctrl-C** during rehydration (no **`resumeToolUseFromSnapshot`** after **`stop()`**).
> 
> Regression coverage in **`chatSessionController.vitest.mts`** plus a host mock baseline entry for **`@agent/runtime/executeAgent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d023dd48ee11c74d46440ba373a3ce81934d1993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->