### PR TITLE
refactor(agent): delete the 5 default-session module singleton aliases

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -10,9 +10,7 @@ import { render } from 'ink';
 import React from 'react';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
@@ -40,7 +38,6 @@ import {
 } from '@shared/schemas';
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
 import { GoalStore } from '@tools/goal';
-import { getDefaultStreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
@@ -273,7 +270,7 @@ const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
 const QUEUED_FOLLOW_UPS = parseList(process.env.HARNESS_QUEUED_FOLLOWUPS);
-const HARNESS_FOLLOW_UP_QUEUE = ToolUseFollowUpQueue.acquire(STREAM_ID);
+const HARNESS_FOLLOW_UP_QUEUE = defaultSession().followUps.acquire(STREAM_ID);
 const HARNESS_CWD_INPUT = process.env.HARNESS_CWD?.trim();
 // Keep platform state writes out of the repository unless a scenario opts in.
 const HARNESS_CWD =
@@ -617,7 +614,7 @@ function makeAssistantToolPreambleEntries(): ConversationEntry[] {
 }
 
 function seedLiveToolOnlyTranscript(): void {
-  const store = getDefaultStreamLogStore();
+  const store = defaultSession().transcripts;
   const timestamp = Date.now();
   store.append(STREAM_ID, {
     id: 'live-tool-user',
@@ -696,7 +693,7 @@ function makeRejectedBashToolEntries(): ConversationEntry[] {
 }
 
 function seedSubagentFollowupTranscript(): void {
-  const store = getDefaultStreamLogStore();
+  const store = defaultSession().transcripts;
   const timestamp = Date.now();
   const followups = [
     '<subagent-progress id="child-a" agent="strategy" type="round" current="2" total="3" />',
@@ -1121,11 +1118,12 @@ function emitChildEventOrderAttachment(streamId: StreamTabId): void {
   });
 }
 
-// Real `StreamStatusService` transitions — `subscribeStreamStatus()` is what
-// projects these into `cliState` (see `seedChildEventOrderFixture`), exactly
-// as `runChatTui.tsx` wires it for a real session.
+// Real status-machine transitions on the default session —
+// `subscribeStreamStatus()` is what projects these into `cliState` (see
+// `seedChildEventOrderFixture`), exactly as `runChatTui.tsx` wires it for a
+// real session.
 function transitionChildEventOrderRunning(streamId: StreamTabId): void {
-  StreamStatusService.transition(
+  defaultSession().status.transition(
     streamId,
     STREAM_PHASE.RUNNING,
     STREAM_TRANSITION_CAUSE.LIFECYCLE,
@@ -1134,9 +1132,13 @@ function transitionChildEventOrderRunning(streamId: StreamTabId): void {
 }
 
 function transitionChildEventOrderTerminal(streamId: StreamTabId): void {
-  StreamStatusService.transitionToTerminal(streamId, STREAM_PHASE.COMPLETED, {
-    events: defaultSession().events,
-  });
+  defaultSession().status.transitionToTerminal(
+    streamId,
+    STREAM_PHASE.COMPLETED,
+    {
+      events: defaultSession().events,
+    },
+  );
 }
 
 // Late resume-transition attempt for an already-removed stream: unlike a
@@ -1146,7 +1148,7 @@ function transitionChildEventOrderTerminal(streamId: StreamTabId): void {
 // `setStreamStatusInCliState` and actually exercises that function's
 // `isChildStreamRemoved` tombstone guard (see `completion-remove` below).
 function attemptChildEventOrderLateResume(streamId: StreamTabId): void {
-  StreamStatusService.transition(
+  defaultSession().status.transition(
     streamId,
     STREAM_PHASE.RUNNING,
     STREAM_TRANSITION_CAUSE.RESUME,
@@ -1809,7 +1811,7 @@ function appendHarnessStatus(): void {
       approvalBypasses: slice?.bypass,
       status: slice?.status ?? 'not started',
       goal: GoalStore.getForStream(streamId),
-      queuedFollowUpMessages: ToolUseFollowUpQueue.getAll(streamId),
+      queuedFollowUpMessages: defaultSession().followUps.getAll(streamId),
     }),
   );
 }
@@ -1817,9 +1819,9 @@ function appendHarnessStatus(): void {
 function resetHarnessForClear(): void {
   const meta = sessionMeta.get();
   clearApprovals();
-  ToolUseFollowUpQueue.drain(STREAM_ID);
+  defaultSession().followUps.drain(STREAM_ID);
   void GoalStore.forget(STREAM_ID);
-  const store = getDefaultStreamLogStore();
+  const store = defaultSession().transcripts;
   for (const streamId of streams.get().keys()) {
     store.delete(streamId).catch(() => {
       // The harness reset is best-effort; visible cliState is reset below.

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -7,7 +7,7 @@
 
 import PQueue from 'p-queue';
 
-import { getDefaultStreamLogStore, StreamSnapshotStore } from '@transcript';
+import { StreamSnapshotStore } from '@transcript';
 import {
   getExecutionStore,
   registerExecution,
@@ -20,7 +20,6 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
   executeAgent,
   resumeToolUseFromSnapshot,
@@ -211,7 +210,7 @@ export function createChatSessionController(
   const interruptActiveRun = (): void => {
     clearApprovals();
     if (!session.streamId) return;
-    SharedExecutionRegistry.stopAgentStream(session.streamId, {
+    defaultSession().executions.stopAgentStream(session.streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: session.runtimeHost,
     });
@@ -373,7 +372,7 @@ export function createChatSessionController(
       canDelegate: chatAgentSupportsDelegation(resolution.config.agent),
     });
 
-    await getDefaultStreamLogStore().ensureLoaded(resolution.streamId);
+    await defaultSession().transcripts.ensureLoaded(resolution.streamId);
     await snapshotStore.load([resolution.streamId]);
     const restored = await snapshotStore.read(resolution.streamId);
     patchStream(resolution.streamId, (slice) => {

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,4 +1,3 @@
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { isCodexSubscriptionActive } from '@auth/codex';
@@ -217,7 +216,7 @@ export async function handleTuiSlashCommand(
       requestCliCompaction({
         streamId: activeStreamIdSignal.get(),
         requestManualCompaction: (streamId) =>
-          SharedExecutionRegistry.requestManualCompaction(streamId),
+          defaultSession().executions.requestManualCompaction(streamId),
         notifyFollowUpSent,
         appendTranscript: appendLocalAssistantTranscript,
       });

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { assertCliAgentLaunch } from '@cli/runtime/agents';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
@@ -105,7 +105,9 @@ export async function applyCliModelSelection(
   }
 
   const activeFlow = context.session.streamId
-    ? SharedExecutionRegistry.getToolUseFlowContext(context.session.streamId)
+    ? defaultSession().executions.getToolUseFlowContext(
+        context.session.streamId,
+      )
     : undefined;
   if (!activeFlow) {
     appendLocalAssistantTranscript(

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -13,17 +13,12 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { render, type Instance as InkInstance } from 'ink';
 import PQueue from 'p-queue';
 
-import {
-  flushPendingRunTraces,
-  getDefaultStreamLogStore,
-  StreamSnapshotStore,
-} from '@transcript';
+import { flushPendingRunTraces, StreamSnapshotStore } from '@transcript';
 import { platform, tryPlatform } from '@platform/platform';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   presentFollowUpWakeResult,
@@ -403,7 +398,7 @@ export async function runChat(
   // subscribeStreamLog wires the append→sync bridge below. Best-effort: a load
   // failure leaves persistence off (save() no-ops) rather than breaking chat.
   try {
-    await getDefaultStreamLogStore().load();
+    await defaultSession().transcripts.load();
   } catch {
     // Persistence stays disabled; the session still runs in-memory as before.
   }
@@ -451,7 +446,7 @@ export async function runChat(
   const hasActiveToolUseFlow = (): boolean =>
     Boolean(
       session.streamId &&
-      SharedExecutionRegistry.getToolUseFlowContext(session.streamId),
+      defaultSession().executions.getToolUseFlowContext(session.streamId),
     );
   const canSelectCurrentModel = (): boolean =>
     chatTuiCanSelectModel({
@@ -467,7 +462,7 @@ export async function runChat(
       return undefined;
     }
     const activeFlow = session.streamId
-      ? SharedExecutionRegistry.getToolUseFlowContext(session.streamId)
+      ? defaultSession().executions.getToolUseFlowContext(session.streamId)
       : undefined;
     return activeFlow?.modelSwitchDisabledReason(candidateModel);
   };
@@ -534,7 +529,7 @@ export async function runChat(
     // StreamLogStore entries outlive resetCliState (which only clears the
     // React/signal view). Drop them so transcript projection can't replay
     // the cleared conversation into the fresh `<Static>` scrollback.
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
     for (const streamId of streamsSignal.get().keys()) {
       store.delete(streamId).catch(() => {
         // Best-effort: a KV failure leaves the log on disk, but the run
@@ -778,7 +773,7 @@ export async function runChat(
       onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
-        SharedExecutionRegistry.kill(executionId, {
+        defaultSession().executions.kill(executionId, {
           detachActiveChildren: detachSubagentsOnStop(),
         });
       }}
@@ -865,7 +860,7 @@ export async function runChat(
     flushPendingRunTraces();
     detachSnapshotPersistence();
     await Promise.all([
-      getDefaultStreamLogStore().flush(),
+      defaultSession().transcripts.flush(),
       snapshotStore.flush(),
     ]);
   };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -244,8 +244,9 @@ function streamSliceWithStatus(
 /**
  * Apply a stream-status event once to the CLI state mirror.
  *
- * Runtime status still originates in StreamStatusService, but TUI renderers
- * should read only StreamSlice data. The child `StreamSlice` is the single
+ * Runtime status still originates in the default session's status machine
+ * (`defaultSession().status`), but TUI renderers should read only
+ * StreamSlice data. The child `StreamSlice` is the single
  * status owner for retained/active child rows too: `childExecutions.ts`'s
  * selectors read status from here directly, so no copy into another
  * collection is needed. A status for a stream tombstoned by `removeStream`

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -1,4 +1,4 @@
-import { getDefaultStreamLogStore } from '@transcript';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 
 import {
@@ -73,7 +73,7 @@ function buildCompletedProcessEntry(params: {
     synthetic: true,
     syntheticKind: 'process',
     syntheticAfterSeq:
-      getDefaultStreamLogStore().get(params.streamId)?.head ?? 0,
+      defaultSession().transcripts.get(params.streamId)?.head ?? 0,
   };
 }
 

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -1,7 +1,5 @@
-import {
-  StreamStatusService,
-  type StreamStatusChange,
-} from '@agent/runtime/StreamStatusService';
+import type { StreamStatusChange } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { setStreamStatusInCliState } from './cliState';
 
 export function applyStreamStatusChange(change: StreamStatusChange): void {
@@ -15,5 +13,5 @@ export function applyStreamStatusChange(change: StreamStatusChange): void {
 export function onStreamStatusChange(
   listener: (change: StreamStatusChange) => void,
 ): () => void {
-  return StreamStatusService.onDidChange(listener);
+  return defaultSession().status.onDidChange(listener);
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -5,7 +5,8 @@
 
 import { isDeepStrictEqual } from 'node:util';
 
-import { flushPendingRunTraces, getDefaultStreamLogStore } from '@transcript';
+import { flushPendingRunTraces } from '@transcript';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
 import {
   MESSAGE_TYPES,
@@ -338,7 +339,7 @@ function sortTranscriptCandidatesIfNeeded(
 }
 
 export function subscribeStreamLog(): () => void {
-  const store = getDefaultStreamLogStore();
+  const store = defaultSession().transcripts;
   const pendingStreams = new Set<StreamTabId>();
 
   // One trailing timer shared by every stream: during a multi-subagent burst
@@ -377,7 +378,7 @@ export function syncStreamLog(streamId: StreamTabId): void {
   // an in-memory buffer and never reaches the transcript. Force any
   // pending flushers to materialize before we read.
   flushPendingRunTraces();
-  const store = getDefaultStreamLogStore();
+  const store = defaultSession().transcripts;
   const log = store.get(streamId);
   if (!log) return;
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,4 +1,5 @@
-// Mirror `StreamStatusService.onDidChange` into the per-stream status signal.
+// Mirror the default session's status machine `onDidChange` into the
+// per-stream status signal.
 
 import { projectStreamTranscriptForStatus } from './transcriptProjection';
 import { applyStreamStatusChange, onStreamStatusChange } from './streamStatus';

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -1,4 +1,4 @@
-import { getDefaultStreamLogStore } from '@transcript';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { isTerminalStatus } from '@common/constants/streamStatus';
 import { type StreamLifecycleStatus, type StreamTabId } from '@shared/schemas';
 
@@ -60,7 +60,8 @@ function appendLocalTranscriptEntry(
 
   const streamId = explicitStreamId ?? defaultLocalTranscriptStreamId();
   if (!activeStreamId.get()) activeStreamId.set(streamId);
-  const syntheticAfterSeq = getDefaultStreamLogStore().get(streamId)?.head ?? 0;
+  const syntheticAfterSeq =
+    defaultSession().transcripts.get(streamId)?.head ?? 0;
 
   patchStream(streamId, (slice) => {
     const entry: ConversationEntry = {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,12 +1,7 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { tryPlatform } from '@platform/platform';
-import {
-  flushPendingRunTraces,
-  getDefaultStreamLogStore,
-  StreamSnapshotStore,
-} from '@transcript';
+import { flushPendingRunTraces, StreamSnapshotStore } from '@transcript';
 import { writeTerminalStatus } from '@agent/storage';
-import { AgentError } from '@common/errors';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -16,6 +11,7 @@ import {
 import { runAgent } from '@agent/runtime/runAgent';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
+import { AgentError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 
@@ -239,7 +235,7 @@ export async function executeCliRequest(
   // when the process exits. Mirrors runChatTui.tsx's best-effort load. Done
   // last (right before the run starts) so it can't delay the synchronous
   // shutdown-hook registration above.
-  const streamLogStore = getDefaultStreamLogStore();
+  const streamLogStore = defaultSession().transcripts;
   try {
     await streamLogStore.load();
   } catch {

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -3,20 +3,20 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 export function stopAgent(streamId: StreamTabId): void {
-  SharedExecutionRegistry.stopAgentStream(streamId, {
+  defaultSession().executions.stopAgentStream(streamId, {
     detachActiveChildren: detachSubagentsOnStop(),
     runtimeHost: extensionAgentRuntimeHost,
   });
 }
 
 export async function compactResponse(streamId: StreamTabId): Promise<void> {
-  const result = SharedExecutionRegistry.requestManualCompaction(streamId);
+  const result = defaultSession().executions.requestManualCompaction(streamId);
   switch (result.kind) {
     case 'no_active_tool_use':
       await vscode.window.showInformationMessage(

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -11,7 +11,6 @@ import {
 } from '@agent/followUp/ToolUseFollowUp';
 import { shouldProbePersistedFlowForFollowUp } from '@agent/runtime/followUpResumeDetection';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -35,7 +34,7 @@ function emitQueuedFollowUpsChanged(streamId: StreamTabId): void {
 async function lazyDetectWaitingStatus(
   streamId: StreamTabId,
 ): Promise<boolean> {
-  const currentStatus = StreamStatusService.get(streamId);
+  const currentStatus = defaultSession().status.get(streamId);
   if (currentStatus === STREAM_PHASE.WAITING) {
     return true;
   }
@@ -58,7 +57,7 @@ async function lazyDetectWaitingStatus(
   try {
     const resumability = await deriveResumability(executionId);
     if (resumability.resumable) {
-      const repaired = StreamStatusService.transitionToWaiting(
+      const repaired = defaultSession().status.transitionToWaiting(
         streamId,
         'restart-repair',
         {

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
@@ -64,7 +64,7 @@ export function registerResumeAgentCommand(
         if (!snapshot) {
           return { success: false };
         }
-        if (StreamStatusService.isActiveOrResuming(snapshot.streamId)) {
+        if (defaultSession().status.isActiveOrResuming(snapshot.streamId)) {
           return { success: false };
         }
 

--- a/packages/extension/src/commands/agent/resumeFromSnapshot.ts
+++ b/packages/extension/src/commands/agent/resumeFromSnapshot.ts
@@ -14,7 +14,7 @@ import {
   isResumeInFlight,
   resolveAndResumeStream,
 } from '@agent/runtime/resolveAndResumeStream';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { createChannelTrace } from '@logger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
@@ -30,9 +30,10 @@ export { isResumeInFlight };
 export function tryResumeFromSnapshot(streamId: StreamTabId): Promise<boolean> {
   return resolveAndResumeStream(streamId, {
     runtimeHost: extensionAgentRuntimeHost,
-    // The extension runs on the default session, whose machine IS the shared
-    // service instance (SessionHandle.defaultSession aliases it by identity).
-    streamStatus: StreamStatusService,
+    // The extension runs on the default session for this host-path caller
+    // (outside any run ALS), so its status plane is the same one every other
+    // unmigrated default-session caller reads through `defaultSession()`.
+    streamStatus: defaultSession().status,
     resolveResumeState: async (id) => {
       const progressState = ProgressViewProvider.getInstance()?.state;
       if (!progressState) {

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -12,7 +12,7 @@ import { loadAgents } from '@agent/index';
 import { registerExecution } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { showQuickPick } from '@commands/_shared/quickInputUtils';
@@ -198,9 +198,9 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     // installs and config writes. The launcher's manual Execute path is
     // deliberately not gated — an explicit user action wins.
     if (
-      SharedExecutionRegistry.getAgentHandles().some(
-        (handle) => agentName(handle.agentName) === SETUP_AGENT_NAME,
-      )
+      defaultSession()
+        .executions.getAgentHandles()
+        .some((handle) => agentName(handle.agentName) === SETUP_AGENT_NAME)
     ) {
       void vscode.window.showInformationMessage(
         'The setup assistant is already running — follow it in the Progress view.',

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import type { StreamTabId } from '@shared/schemas';
 import { cleanupAllApprovals, releaseStreamResources } from '@tools/approval';
@@ -30,7 +30,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   }
 
   isStreamInFlight(stream: StreamTabId): boolean {
-    return isInFlightStatus(StreamStatusService.get(stream));
+    return isInFlightStatus(defaultSession().status.get(stream));
   }
 
   async stopStream(

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -27,7 +27,7 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import { SharedExecutionRegistry } from '@agent/runtime/executionRegistry';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import {
@@ -99,7 +99,7 @@ export class HistoryHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT>,
   ): Promise<void> {
     try {
-      const activeIds = SharedExecutionRegistry.getActiveIds();
+      const activeIds = defaultSession().executions.getActiveIds();
       if (activeIds.includes(data.historyId)) {
         await vscode.window.showWarningMessage(
           'Cannot delete a running execution',
@@ -126,7 +126,7 @@ export class HistoryHandlers {
   async handleClearHistory(): Promise<void> {
     try {
       await deleteAllExecutions(
-        new Set(SharedExecutionRegistry.getActiveIds()),
+        new Set(defaultSession().executions.getActiveIds()),
       );
       await vscode.window.showInformationMessage('Agent history cleared');
       await this.ctx.withActiveWebview(async (w) => {

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -12,12 +12,12 @@ const logger = createChannelTrace('ToolUseFollowUpQueue');
 /**
  * Follow-up queue owner indexed by stream ID.
  *
- * Fresh instances are session-owned. Static methods proxy to the process
- * default instance so unmigrated default-session callers stay byte-identical.
+ * Every instance is session-owned — the process default lives at
+ * `defaultSession().followUps` (#7694); there is no separate static/module
+ * singleton to reach it through.
  */
 export class ToolUseFollowUpQueue {
   static readonly RELEASED_CAP = 500;
-  private static readonly defaultQueue = new ToolUseFollowUpQueue();
   private readonly queues = new Map<StreamTabId, FollowUpQueue>();
   /** Streams whose queues were explicitly released (orchestrator disposed). */
   private readonly released = new LRUCache<StreamTabId, true>({
@@ -121,41 +121,5 @@ export class ToolUseFollowUpQueue {
 
   private rememberReleased(streamId: StreamTabId): void {
     this.released.set(streamId, true);
-  }
-
-  static onRelease(observer: (streamId: StreamTabId) => void): () => void {
-    return this.defaultQueue.onRelease(observer);
-  }
-
-  static acquire(streamId: StreamTabId): FollowUpQueue {
-    return this.defaultQueue.acquire(streamId);
-  }
-
-  static release(streamId: StreamTabId): void {
-    this.defaultQueue.release(streamId);
-  }
-
-  static enqueue(
-    streamId: StreamTabId,
-    followUp: FollowUpQueueInput,
-    options?: { createIfMissing?: boolean; force?: boolean },
-  ): boolean {
-    return this.defaultQueue.enqueue(streamId, followUp, options);
-  }
-
-  static drain(streamId: StreamTabId): string[] {
-    return this.defaultQueue.drain(streamId);
-  }
-
-  static drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
-    return this.defaultQueue.drainItems(streamId);
-  }
-
-  static getAll(streamId: StreamTabId): string[] {
-    return this.defaultQueue.getAll(streamId);
-  }
-
-  static defaultInstance(): ToolUseFollowUpQueue {
-    return this.defaultQueue;
   }
 }

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -11,14 +11,12 @@
  * from the registry) and when the subscriber stream's queue is released.
  */
 
-import {
-  SharedExecutionRegistry,
-  type ExecutionHandle,
-  type ExecutionRegistry,
+import type {
+  ExecutionHandle,
+  ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { StreamTabId } from '@shared/schemas';
@@ -194,8 +192,13 @@ export class ExecutionSubscriptionBinder {
   private releaseHook: (() => void) | undefined;
 
   constructor(options: ExecutionSubscriptionBinderOptions = {}) {
-    this.registry = options.registry ?? SharedExecutionRegistry;
-    this.releaseSource = options.releaseSource ?? ToolUseFollowUpQueue;
+    // Unreachable in production: `SessionHandle` always passes both `registry`
+    // and `releaseSource` explicitly (its own owned `executions`/`followUps`).
+    // These fall back through `currentSession()` — never a standalone
+    // singleton import — so a bare `new ExecutionSubscriptionBinder()` still
+    // resolves to the caller's session instead of a hidden module export.
+    this.registry = options.registry ?? currentSession().executions;
+    this.releaseSource = options.releaseSource ?? currentSession().followUps;
     this.logger = options.logger ?? logger;
     this.session = options.session;
   }
@@ -297,6 +300,3 @@ export class ExecutionSubscriptionBinder {
     if (bound.size === 0) this.perStream.delete(streamId);
   }
 }
-
-export const SharedExecutionSubscriptionBinder =
-  new ExecutionSubscriptionBinder();

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -11,9 +11,12 @@
  *
  * A session is one per host context: extension activation (per VS Code window),
  * CLI process, or desktop `BrowserWindow`. The default instance,
- * {@link defaultSession}, wraps the existing process-global singletons
- * **by identity**, so every unmigrated call site keeps hitting the same objects
- * byte-for-byte while the 7d train migrates call sites incrementally.
+ * {@link defaultSession}, is the sanctioned single-session entry point —
+ * it lazily constructs its owners on first use (module-private, process-wide)
+ * exactly like any other fresh session. There is no other way to reach
+ * these owners: the invariant is "no session-scoped mutable module export"
+ * (#7694) — a run-scoped caller resolves through {@link currentSession} /
+ * {@link defaultSession}, never a standalone singleton import.
  *
  * Fresh construction is in FORCED dependency order with every cross-reference
  * explicit: no member is ever allowed to default to a neighboring module
@@ -29,7 +32,6 @@
 
 import {
   getActiveFlushers,
-  getDefaultStreamLogStore,
   StreamLogStore,
   unregisterFlushers,
 } from '@transcript';
@@ -39,18 +41,9 @@ import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
 import { getRunContextSession, tryUseRunContext } from './RunContext';
-import {
-  ExecutionRegistry,
-  SharedExecutionRegistry,
-} from './executionRegistry';
-import {
-  ExecutionSubscriptionBinder,
-  SharedExecutionSubscriptionBinder,
-} from './ExecutionSubscriptionBinder';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from './StreamStatusService';
+import { ExecutionRegistry } from './executionRegistry';
+import { ExecutionSubscriptionBinder } from './ExecutionSubscriptionBinder';
+import { StreamStatusMachine } from './StreamStatusService';
 import {
   SessionHostInteractions,
   type HostInteractions,
@@ -91,7 +84,7 @@ export class SessionHandle {
   readonly subscriptions: ExecutionSubscriptionBinder;
   /** Session-scoped one-way fact plane. */
   readonly events: SessionEventHub;
-  /** Session-scoped status plane; wraps shared status data during migration. */
+  /** Session-scoped status plane. */
   readonly status: StreamStatusMachine;
   /** Session-owned transcript store for run traces launched in this session. */
   readonly transcripts: StreamLogStore;
@@ -117,9 +110,9 @@ export class SessionHandle {
     const executions =
       init.executions ??
       new ExecutionRegistry({ streamStatus: status, events });
-    // Re-attaching on every `SessionHandle` construction — including for the
-    // shared/default-session `ExecutionRegistry` singleton, which predates any
-    // session — rebinds `publishResult` to *this* session's listeners.
+    // Re-attaching on every `SessionHandle` construction — even when
+    // `executions` is caller-injected rather than fresh-built here — rebinds
+    // `publishResult` to *this* session's listeners.
     executions.attachSessionEvents(events, (event, streamId) =>
       this.publishRunEvent(streamId, event),
     );
@@ -138,8 +131,9 @@ export class SessionHandle {
     this.transcripts = transcripts;
     this.followUps = followUps;
     this.interactions = init.interactions ?? new SessionHostInteractions();
-    // A fresh session owns its own flusher set; the default session aliases the
-    // process-module set so `createRunTrace`'s default writes still drain.
+    // A fresh session owns its own flusher set; the default session aliases
+    // the process-module set (`getActiveFlushers()`) so the process-wide
+    // shutdown drain (`flushPendingRunTraces()`) still reaches it.
     this.flushers = init.flushers ?? new Set<() => void>();
     this.hostChannel = init.hostChannel;
     liveSessions.add(this);
@@ -298,25 +292,20 @@ export function getAllActiveExecutionIds(): string[] {
 let cachedDefaultSession: SessionHandle | undefined;
 
 /**
- * The process-default session. Its members ARE the existing exported singletons
- * — identity is the behavior-neutral compatibility mechanism for the 7d train:
- * unmigrated call sites keep hitting the same objects, and per-call-site
- * migration is `SharedExecutionRegistry.x(...)` → `session.executions.x(...)`
- * against the identical instance.
+ * The process-default session — the sole owner of the process-wide runtime
+ * singletons (#7694). Every member the constructor doesn't receive is
+ * fresh-built in the same FORCED dependency order any other `SessionHandle`
+ * uses; there is no separate `Shared*`/`*Service` module export to alias
+ * anymore, so this construction *is* where those singletons now live.
  *
  * Constructed lazily on first use rather than at module evaluation: many
  * run-scoped modules import `currentSession`, which pulls this module into
- * their import cycle, and an eager construction here would read the
- * `SharedExecutionSubscriptionBinder` singleton before its own module finished
- * initializing (TDZ). Deferring to first call sidesteps that entirely.
+ * their import cycle, and an eager construction here would risk reading a
+ * cross-module singleton before its own module finished initializing (TDZ).
+ * Deferring to first call sidesteps that entirely.
  */
 export function defaultSession(): SessionHandle {
   return (cachedDefaultSession ??= new SessionHandle({
-    executions: SharedExecutionRegistry,
-    subscriptions: SharedExecutionSubscriptionBinder,
-    status: StreamStatusService,
-    transcripts: getDefaultStreamLogStore(),
-    followUps: ToolUseFollowUpQueue.defaultInstance(),
     flushers: getActiveFlushers(),
   }));
 }
@@ -325,9 +314,8 @@ export function defaultSession(): SessionHandle {
  * Resolve the session for the calling context: the active run's session when
  * called inside a run, otherwise the process {@link defaultSession}. This is
  * the single resolution point run-scoped code (flows, tools, formatters) uses
- * instead of touching the process singletons directly — behavior-neutral while
- * the default session aliases those singletons, and the seam that lets a host
- * inject an isolated session per run.
+ * to reach session-owned state — there is no other way to reach it (#7694) —
+ * and the seam that lets a host inject an isolated session per run.
  */
 export function currentSession(): SessionHandle {
   return getRunContextSession(tryUseRunContext()) ?? defaultSession();

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -320,5 +320,3 @@ export class StreamStatusMachine {
     }
   }
 }
-
-export const StreamStatusService = new StreamStatusMachine();

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -4,7 +4,7 @@ import {
   CodexThreads,
 } from '@tools/agentCliSessionStores';
 
-import { SharedExecutionRegistry } from './executionRegistry';
+import { defaultSession } from './SessionHandle';
 
 /**
  * Stops agent-spawned child processes and CLI-backed agent sessions before
@@ -13,7 +13,7 @@ import { SharedExecutionRegistry } from './executionRegistry';
  */
 export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    SharedExecutionRegistry.killBackgroundProcesses(),
+    defaultSession().executions.killBackgroundProcesses(),
   );
   // Interrupt CLI-backed sessions so their streams don't reload in a stale
   // WAITING state.

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -13,9 +13,8 @@ import type { ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
-  StreamStatusService,
+  StreamStatusMachine,
   type StreamStatusEmitOptions,
-  type StreamStatusMachine,
 } from '@agent/runtime/StreamStatusService';
 import {
   isInFlightStatus,
@@ -159,7 +158,7 @@ export class ExecutionRegistry {
 
   constructor({
     processOutput = new ProcessOutputPoller(),
-    streamStatus = StreamStatusService,
+    streamStatus = new StreamStatusMachine(),
     events = new SessionEventHub(),
     publishResult,
   }: {
@@ -949,5 +948,3 @@ export class ExecutionRegistry {
     }
   }
 }
-
-export const SharedExecutionRegistry = new ExecutionRegistry();

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -6,7 +6,7 @@ import { describe, it, beforeAll } from 'vitest';
 
 // Local imports
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { createRunTrace } from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { ToolUseDispatchNode } from '@agent/core/flows/toolUseRound/ToolUseDispatchNode';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -73,7 +73,10 @@ interface HarnessOptions {
 }
 
 function dispatchHarness(opts: HarnessOptions) {
-  const runTrace = createRunTrace('DispatchParallelTest' as StreamTabId);
+  const runTrace = createRunTrace(
+    'DispatchParallelTest' as StreamTabId,
+    new StreamLogStore(),
+  );
   const services = {
     config: AgentConfigSchema.parse({
       rootUserInstruction: opts.rootUserInstruction,

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -10,7 +10,6 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_PHASE,
   STREAM_STATUS,
@@ -91,7 +90,7 @@ describe('child stream progress events', () => {
       normalizedErrorChildStreamId,
       noProjectionAutoCloseChildStreamId,
     ]) {
-      clearStreamStatusForTest(StreamStatusService, streamId);
+      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
@@ -377,7 +376,7 @@ describe('child stream progress events', () => {
       STREAM_STATUS.RUNNING,
       STREAM_PHASE.FAILED,
     ]);
-    expect(StreamStatusService.get(loopChildStreamId)).toBe(
+    expect(defaultSession().status.get(loopChildStreamId)).toBe(
       STREAM_PHASE.FAILED,
     );
     expect(
@@ -409,7 +408,7 @@ describe('child stream progress events', () => {
       defaultSession().executions.getAgentHandleByStream(stoppedChildStreamId);
     expect(handle).toBeDefined();
     seedStreamStatusForTest(
-      StreamStatusService,
+      defaultSession().status,
       stoppedChildStreamId,
       STREAM_PHASE.CANCELLED,
     );
@@ -421,7 +420,7 @@ describe('child stream progress events', () => {
       childStream.failTurn();
       await childStream.finalize({ failed: true });
 
-      expect(StreamStatusService.get(stoppedChildStreamId)).toBe(
+      expect(defaultSession().status.get(stoppedChildStreamId)).toBe(
         STREAM_PHASE.CANCELLED,
       );
       expect(runEventsOfType(recorded.events, 'status')).toHaveLength(0);
@@ -516,7 +515,7 @@ describe('child stream progress events', () => {
       }),
     );
 
-    expect(StreamStatusService.get(normalizedErrorChildStreamId)).toBe(
+    expect(defaultSession().status.get(normalizedErrorChildStreamId)).toBe(
       STREAM_PHASE.FAILED,
     );
     await expect(handle?.result).resolves.toMatchObject({

--- a/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
@@ -1,12 +1,7 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 
 // Local imports - shared
@@ -36,16 +31,10 @@ async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
 async function runWithLoggerStore<T>(
   fn: (store: StreamLogStore, logger: AgentTrace) => Promise<T>,
 ): Promise<T> {
-  const previousStore = getDefaultStreamLogStore();
   const store = new StreamLogStore();
-  setDefaultStreamLogStore(store);
   await store.clear();
 
-  try {
-    return await fn(store, createRunTrace(streamId).trace);
-  } finally {
-    setDefaultStreamLogStore(previousStore);
-  }
+  return await fn(store, createRunTrace(streamId, store).trace);
 }
 
 function collectToolLogs(store: StreamLogStore): unknown[] {

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -2,12 +2,7 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - agent
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { TraceEmitter } from '@agent/trace';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 
@@ -93,12 +88,10 @@ describe('codex progress events', () => {
   });
 
   it('updates in-flight Codex command items in place', async () => {
-    const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
     await store.clear();
 
-    const logger = createRunTrace(streamId).trace;
+    const logger = createRunTrace(streamId, store).trace;
     const startedCommand: CommandExecutionItem = {
       id: 'cmd-1',
       type: 'command_execution',
@@ -143,32 +136,28 @@ describe('codex progress events', () => {
       }),
     } as unknown as Thread;
 
-    try {
-      const result = await runStreamedTurn(
-        thread,
-        'Build the project',
-        streamId,
-        logger,
-      );
+    const result = await runStreamedTurn(
+      thread,
+      'Build the project',
+      streamId,
+      logger,
+    );
 
-      expect(result.finalResponse).toBe('Build succeeded.');
+    expect(result.finalResponse).toBe('Build succeeded.');
 
-      const log = store.get(streamId);
-      const entries = log?.getRange(0, log.head) ?? [];
-      const toolEntries = entries.filter(
-        (entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE,
-      );
+    const log = store.get(streamId);
+    const entries = log?.getRange(0, log.head) ?? [];
+    const toolEntries = entries.filter(
+      (entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
 
-      expect(toolEntries).toHaveLength(1);
-      expect(toolEntries[0].data).toMatchObject({
-        toolName: 'bash',
-        summary: 'npm run build',
-        input: { command: 'npm run build' },
-        output: 'building...\ndone',
-        status: 'completed',
-      });
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    expect(toolEntries).toHaveLength(1);
+    expect(toolEntries[0].data).toMatchObject({
+      toolName: 'bash',
+      summary: 'npm run build',
+      input: { command: 'npm run build' },
+      output: 'building...\ndone',
+      status: 'completed',
+    });
   });
 });

--- a/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
@@ -215,57 +215,54 @@ describe('FollowUpQueue', () => {
   });
 
   it('does not create ghost queues for unknown streams', () => {
+    const queue = new ToolUseFollowUpQueue();
     const streamId = 'stream:unknown-followup' as StreamTabId;
 
     try {
-      expect(
-        ToolUseFollowUpQueue.enqueue(streamId, { text: 'late result' }),
-      ).toBe(false);
-      expect(ToolUseFollowUpQueue.getAll(streamId)).toEqual([]);
+      expect(queue.enqueue(streamId, { text: 'late result' })).toBe(false);
+      expect(queue.getAll(streamId)).toEqual([]);
     } finally {
-      ToolUseFollowUpQueue.release(streamId);
+      queue.release(streamId);
     }
   });
 
   it('creates queues only for explicitly admitted follow-ups', () => {
+    const queue = new ToolUseFollowUpQueue();
     const streamId = 'stream:admitted-followup' as StreamTabId;
 
     try {
       expect(
-        ToolUseFollowUpQueue.enqueue(
+        queue.enqueue(
           streamId,
           { text: 'admitted result' },
           { createIfMissing: true },
         ),
       ).toBe(true);
-      expect(ToolUseFollowUpQueue.getAll(streamId)).toEqual([
-        'admitted result',
-      ]);
+      expect(queue.getAll(streamId)).toEqual(['admitted result']);
     } finally {
-      ToolUseFollowUpQueue.release(streamId);
+      queue.release(streamId);
     }
   });
 
   it('does not forget every released stream when the release cap is exceeded', () => {
+    const queue = new ToolUseFollowUpQueue();
     const firstStream = 'stream:released-first' as StreamTabId;
     const retainedStream = 'stream:released-retained' as StreamTabId;
 
-    ToolUseFollowUpQueue.acquire(firstStream);
-    ToolUseFollowUpQueue.release(firstStream);
-    ToolUseFollowUpQueue.acquire(retainedStream);
-    ToolUseFollowUpQueue.release(retainedStream);
+    queue.acquire(firstStream);
+    queue.release(firstStream);
+    queue.acquire(retainedStream);
+    queue.release(retainedStream);
 
     for (let i = 0; i < ToolUseFollowUpQueue.RELEASED_CAP - 1; i += 1) {
-      ToolUseFollowUpQueue.release(`stream:released-extra-${i}` as StreamTabId);
+      queue.release(`stream:released-extra-${i}` as StreamTabId);
     }
 
     try {
+      expect(queue.enqueue(firstStream, { text: 'late first' })).toBe(false);
+      expect(queue.getAll(firstStream)).toEqual([]);
       expect(
-        ToolUseFollowUpQueue.enqueue(firstStream, { text: 'late first' }),
-      ).toBe(false);
-      expect(ToolUseFollowUpQueue.getAll(firstStream)).toEqual([]);
-      expect(
-        ToolUseFollowUpQueue.enqueue(
+        queue.enqueue(
           retainedStream,
           {
             text: 'late retained',
@@ -273,10 +270,10 @@ describe('FollowUpQueue', () => {
           { createIfMissing: true },
         ),
       ).toBe(false);
-      expect(ToolUseFollowUpQueue.getAll(retainedStream)).toEqual([]);
+      expect(queue.getAll(retainedStream)).toEqual([]);
     } finally {
-      ToolUseFollowUpQueue.release(firstStream);
-      ToolUseFollowUpQueue.release(retainedStream);
+      queue.release(firstStream);
+      queue.release(retainedStream);
     }
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent core
-import { createRunTrace } from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
@@ -84,7 +84,10 @@ describe('ToolUseDispatchNode interruption', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseDispatchInterruption').trace,
+      logger: createRunTrace(
+        'ToolUseDispatchInterruption',
+        new StreamLogStore(),
+      ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
@@ -254,7 +257,10 @@ describe('ToolUseDispatchNode interruption', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseDispatchInterruption').trace,
+      logger: createRunTrace(
+        'ToolUseDispatchInterruption',
+        new StreamLogStore(),
+      ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -15,14 +15,10 @@ import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
-  SharedExecutionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import {
@@ -31,7 +27,6 @@ import {
   wakeQueuedFollowUpStream,
   wakeOrReleaseQueuedStream,
 } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -58,7 +53,7 @@ function trackChildHandle(
     'toolUse',
     noopAgentRuntimeHost,
   );
-  SharedExecutionRegistry.track(handle);
+  defaultSession().executions.track(handle);
 }
 
 describe('ToolUseFollowUp', () => {
@@ -88,10 +83,10 @@ describe('ToolUseFollowUp', () => {
   };
 
   afterEach(() => {
-    for (const executionId of SharedExecutionRegistry.getActiveIds()) {
-      SharedExecutionRegistry.untrack(executionId);
+    for (const executionId of defaultSession().executions.getActiveIds()) {
+      defaultSession().executions.untrack(executionId);
     }
-    ToolUseFollowUpQueue.release(streamId);
+    defaultSession().followUps.release(streamId);
   });
 
   function trackToolUseFlow(
@@ -116,7 +111,7 @@ describe('ToolUseFollowUp', () => {
       switchModel: async () => {},
       interrupt: () => {},
     });
-    SharedExecutionRegistry.track(handle);
+    defaultSession().executions.track(handle);
     return executionId;
   }
 
@@ -183,7 +178,7 @@ describe('ToolUseFollowUp', () => {
     const waitingStreamId = 'stream-waiting-race-follow-up' as StreamTabId;
     const sessionLifecycle = new ToolUseSessionLifecycle(
       waitingStreamId,
-      ToolUseFollowUpQueue.defaultInstance(),
+      defaultSession().followUps,
     );
     const executionId = trackToolUseFlow(waitingStreamId, (followUp) =>
       sessionLifecycle.appendFollowUp(followUp),
@@ -199,7 +194,7 @@ describe('ToolUseFollowUp', () => {
       // runToolUseFlow's finally, on the WAITING branch, now skips
       // sessionLifecycle.dispose() -- the follow-up survives instead of
       // being dropped when the queue would otherwise have been released.
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(waitingStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(waitingStreamId), [
         'keep going',
       ]);
 
@@ -208,11 +203,11 @@ describe('ToolUseFollowUp', () => {
       // back the same live instance with the raced-in follow-up intact.
       const resumedSessionLifecycle = new ToolUseSessionLifecycle(
         waitingStreamId,
-        ToolUseFollowUpQueue.defaultInstance(),
+        defaultSession().followUps,
       );
       assert.equal(resumedSessionLifecycle.hasQueuedFollowUp(), true);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
       sessionLifecycle.dispose();
     }
   });
@@ -245,12 +240,12 @@ describe('ToolUseFollowUp', () => {
         status: 'queued',
         reason: 'children_running',
       });
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
         'hello while running',
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -262,7 +257,7 @@ describe('ToolUseFollowUp', () => {
     const executionId = 'exec-released';
 
     trackChildHandle(executionId, parentStreamId, childStreamId);
-    ToolUseFollowUpQueue.release(parentStreamId);
+    defaultSession().followUps.release(parentStreamId);
 
     try {
       const result = await sendFollowUp(parentStreamId, 'after release');
@@ -271,12 +266,12 @@ describe('ToolUseFollowUp', () => {
         status: 'queued',
         reason: 'children_running',
       });
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
         'after release',
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -286,7 +281,7 @@ describe('ToolUseFollowUp', () => {
     const executionId = 'exec-subagent-result';
 
     trackChildHandle(executionId, parentStreamId, childStreamId);
-    ToolUseFollowUpQueue.release(parentStreamId);
+    defaultSession().followUps.release(parentStreamId);
 
     try {
       const result = await sendFollowUp(parentStreamId, {
@@ -298,7 +293,7 @@ describe('ToolUseFollowUp', () => {
         status: 'queued',
         reason: 'children_running',
       });
-      assert.deepEqual(ToolUseFollowUpQueue.drainItems(parentStreamId), [
+      assert.deepEqual(defaultSession().followUps.drainItems(parentStreamId), [
         {
           text: 'child done',
           origin: 'subagent_result',
@@ -308,8 +303,8 @@ describe('ToolUseFollowUp', () => {
         },
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -351,13 +346,13 @@ describe('ToolUseFollowUp', () => {
 
       assert.deepEqual(await wakes, [true, true]);
       assert.equal(resumeCalls, 1);
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
         'result one',
         'result two',
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -380,10 +375,10 @@ describe('ToolUseFollowUp', () => {
       assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
         kind: 'dropped',
       });
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), []);
+      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), []);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -392,7 +387,7 @@ describe('ToolUseFollowUp', () => {
 
     await initResumePlatform({ tryResumeStream: async () => false });
     seedStreamStatusForTest(
-      StreamStatusService,
+      defaultSession().status,
       waitingStreamId,
       STREAM_STATUS.WAITING,
     );
@@ -411,12 +406,12 @@ describe('ToolUseFollowUp', () => {
         await wakeQueuedFollowUpStream(waitingStreamId, result),
         { kind: 'queued_resume_failed' },
       );
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(waitingStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(waitingStreamId), [
         'queued while waiting',
       ]);
     } finally {
-      clearStreamStatusForTest(StreamStatusService, waitingStreamId);
-      ToolUseFollowUpQueue.release(waitingStreamId);
+      clearStreamStatusForTest(defaultSession().status, waitingStreamId);
+      defaultSession().followUps.release(waitingStreamId);
     }
   });
 
@@ -443,12 +438,12 @@ describe('ToolUseFollowUp', () => {
         await wakeOrReleaseQueuedStream(parentStreamId, result),
         true,
       );
-      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
         'late result',
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 
@@ -485,16 +480,15 @@ describe('ToolUseFollowUp', () => {
       );
 
       // Without an explicit session, the decision falls back to
-      // currentSession() (the process default), whose StreamStatusService
-      // has no state for this stream — proving the two sessions are not
-      // conflated and the routed session's state actually drove the result
-      // above.
+      // currentSession() (the process default), whose status machine has no
+      // state for this stream — proving the two sessions are not conflated
+      // and the routed session's state actually drove the result above.
       assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
         kind: 'queued_resume_failed',
       });
     } finally {
       clearStreamStatusForTest(routedSession.status, parentStreamId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -13,17 +13,14 @@ import {
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import {
   AgentExecutionHandle,
-  SharedExecutionRegistry,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   notifyFollowUpSent,
   onFollowUpSent,
   sendFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -43,7 +40,7 @@ describe('tool-use follow-up progress events', () => {
       unsubscribe();
     }
     for (const executionId of trackedExecutionIds) {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
     }
     trackedExecutionIds.clear();
     for (const { session, executionId } of sessionTrackedExecutions.splice(0)) {
@@ -53,7 +50,7 @@ describe('tool-use follow-up progress events', () => {
       session.dispose({ keepActiveExecutions: true });
     }
     sessions.clear();
-    clearAllStreamStatusesForTest(StreamStatusService);
+    clearAllStreamStatusesForTest(defaultSession().status);
   });
 
   function trackToolUseFlow({
@@ -91,7 +88,7 @@ describe('tool-use follow-up progress events', () => {
       session.executions.track(handle);
       sessionTrackedExecutions.push({ session, executionId });
     } else {
-      SharedExecutionRegistry.track(handle);
+      defaultSession().executions.track(handle);
       trackedExecutionIds.add(executionId);
     }
   }
@@ -305,7 +302,7 @@ describe('tool-use follow-up progress events', () => {
     const appendFollowUp = vi.fn();
 
     seedStreamStatusForTest(
-      StreamStatusService,
+      defaultSession().status,
       streamId,
       STREAM_PHASE.COMPLETED,
     );
@@ -351,7 +348,7 @@ describe('tool-use follow-up progress events', () => {
     const resumingStreamId = 'stream:resuming-follow-up' as StreamTabId;
 
     seedStreamStatusForTest(
-      StreamStatusService,
+      defaultSession().status,
       resumingStreamId,
       STREAM_STATUS.RESUMING,
     );
@@ -366,11 +363,11 @@ describe('tool-use follow-up progress events', () => {
         status: 'queued',
         reason: 'resuming',
       });
-      expect(ToolUseFollowUpQueue.getAll(resumingStreamId)).toEqual([
+      expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
         'queued while resuming',
       ]);
     } finally {
-      ToolUseFollowUpQueue.release(resumingStreamId);
+      defaultSession().followUps.release(resumingStreamId);
     }
   });
 
@@ -388,11 +385,11 @@ describe('tool-use follow-up progress events', () => {
     );
 
     seedStreamStatusForTest(
-      StreamStatusService,
+      defaultSession().status,
       parentStreamId,
       STREAM_STATUS.STOPPED,
     );
-    SharedExecutionRegistry.track(handle);
+    defaultSession().executions.track(handle);
 
     try {
       const result = await sendFollowUp(parentStreamId, 'continue child');
@@ -401,12 +398,12 @@ describe('tool-use follow-up progress events', () => {
         status: 'queued',
         reason: 'children_running',
       });
-      expect(ToolUseFollowUpQueue.getAll(parentStreamId)).toEqual([
+      expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([
         'continue child',
       ]);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      ToolUseFollowUpQueue.release(parentStreamId);
+      defaultSession().executions.untrack(executionId);
+      defaultSession().followUps.release(parentStreamId);
     }
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent core
-import { createRunTrace } from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
@@ -34,7 +34,8 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseRoundFollowUpMedia').trace,
+      logger: createRunTrace('ToolUseRoundFollowUpMedia', new StreamLogStore())
+        .trace,
       modelHandler: {
         addMediaToUserMessage,
         capabilities: { supportsVision: true },
@@ -161,7 +162,10 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseRoundBlankToolResult').trace,
+      logger: createRunTrace(
+        'ToolUseRoundBlankToolResult',
+        new StreamLogStore(),
+      ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
@@ -347,7 +351,8 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseRoundSystemPrompt').trace,
+      logger: createRunTrace('ToolUseRoundSystemPrompt', new StreamLogStore())
+        .trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -17,10 +17,8 @@ import {
   type ToolUseRunShared,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import {
@@ -797,7 +795,7 @@ describe('ToolUseWaitNode', () => {
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
       seedStreamStatusForTest(
-        StreamStatusService,
+        defaultSession().status,
         streamId,
         STREAM_PHASE.CANCELLED,
       );
@@ -807,17 +805,21 @@ describe('ToolUseWaitNode', () => {
         node.exec(prep),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(defaultSession().status.get(streamId)).toBe(
+        STREAM_PHASE.CANCELLED,
+      );
 
       await withTestRunContext(runtimeHost, streamId, () =>
         node.post(shared, prep, exec),
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(defaultSession().status.get(streamId)).toBe(
+        STREAM_PHASE.CANCELLED,
+      );
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(StreamStatusService, streamId);
+      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -16,14 +16,8 @@ import {
   AgentPromptSchema,
   AgentSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
-import {
-  AgentExecutionHandle,
-  SharedExecutionRegistry,
-} from '@agent/runtime/executionRegistry';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { createRunScope } from '@agent/runtime/RunScope';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
@@ -396,7 +390,7 @@ describe('runFlowWithLifecycle', () => {
       'lifecycle-subagent-error-registered',
     );
     const onError = vi.fn(() => {
-      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
+      expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
     });
 
     try {
@@ -411,9 +405,11 @@ describe('runFlowWithLifecycle', () => {
       expect(result.outcome).toBe(RUN_OUTCOME.FAILED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
       expect(onError).toHaveBeenCalledOnce();
-      expect(SharedExecutionRegistry.getHandle(executionId)).toBeUndefined();
+      expect(
+        defaultSession().executions.getHandle(executionId),
+      ).toBeUndefined();
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -447,9 +443,9 @@ describe('runFlowWithLifecycle', () => {
       expect(storageMocks.writeTerminalStatus).not.toHaveBeenCalled();
       expect(onError).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
-      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
+      expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -487,7 +483,7 @@ describe('runFlowWithLifecycle', () => {
       expect(staleCleanup).not.toHaveBeenCalled();
       expect(captured?.runWaitingCleanup()).toBe(false);
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });
@@ -519,7 +515,7 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      expect(SharedExecutionRegistry.getHandle(executionId)).toBeDefined();
+      expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
       expect(followUpsRelease).not.toHaveBeenCalled();
       expect(storageMocks.deleteFlowRecord).not.toHaveBeenCalled();
       // The fixture's ctx.logger is noopTrace, and the run handle carries it
@@ -532,7 +528,7 @@ describe('runFlowWithLifecycle', () => {
       // fake runner returns the WAITING outcome directly but doesn't drive
       // the real transitionToWaiting() call, so seed it explicitly.
       seedStreamStatusForTest(
-        StreamStatusService,
+        defaultSession().status,
         streamId,
         STREAM_STATUS.WAITING,
       );
@@ -541,12 +537,12 @@ describe('runFlowWithLifecycle', () => {
       // (post #7286) preserves the follow-up queue for WAITING — it does not
       // dispose the session — by the time a native subagent suspends at
       // WAITING (not reproduced by this fake runner, but true in production —
-      // see runToolUseFlow.ts). Before the fix, SharedExecutionRegistry.kill()
+      // see runToolUseFlow.ts). Before the fix, `executions.kill()`
       // found no interrupt target for a suspended handle and silently
       // no-opped, leaving the handle stuck registered forever. It must now
       // fall back to the waiting-cleanup registered above and actually tear
       // the execution down.
-      expect(SharedExecutionRegistry.kill(executionId)).toBe(true);
+      expect(defaultSession().executions.kill(executionId)).toBe(true);
 
       // The bypassed runFlowWithLifecycle can't emit the terminal result, so
       // terminateWaitingHandle must — trace subscribers would otherwise miss
@@ -560,8 +556,12 @@ describe('runFlowWithLifecycle', () => {
       );
       traceEmit.mockRestore();
 
-      expect(SharedExecutionRegistry.getHandle(executionId)).toBeUndefined();
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(
+        defaultSession().executions.getHandle(executionId),
+      ).toBeUndefined();
+      expect(defaultSession().status.get(streamId)).toBe(
+        STREAM_PHASE.CANCELLED,
+      );
       expect(followUpsRelease).toHaveBeenCalledWith(streamId);
       expect(storageMocks.deleteFlowRecord).toHaveBeenCalledWith(
         `flow_${executionId}`,
@@ -581,8 +581,8 @@ describe('runFlowWithLifecycle', () => {
         }),
       );
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
-      clearStreamStatusForTest(StreamStatusService, streamId);
+      defaultSession().executions.untrack(executionId);
+      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
@@ -740,7 +740,7 @@ describe('runFlowWithLifecycle', () => {
         carriedResult,
       );
     } finally {
-      SharedExecutionRegistry.untrack(executionId);
+      defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -16,11 +16,8 @@ import type {
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
@@ -198,7 +195,7 @@ describe('RetryState', () => {
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
       seedStreamStatusForTest(
-        StreamStatusService,
+        defaultSession().status,
         streamId,
         STREAM_PHASE.CANCELLED,
       );
@@ -208,7 +205,9 @@ describe('RetryState', () => {
       );
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(StreamStatusService.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(defaultSession().status.get(streamId)).toBe(
+        STREAM_PHASE.CANCELLED,
+      );
       expect(requestRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           streamId,
@@ -217,7 +216,7 @@ describe('RetryState', () => {
       );
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(StreamStatusService, streamId);
+      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -2,20 +2,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { getActiveFlushers, getDefaultStreamLogStore } from '@transcript';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { getActiveFlushers } from '@transcript';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   SessionHandle,
   defaultSession,
   getAllActiveExecutionIds,
 } from '@agent/runtime/SessionHandle';
-import {
-  AgentExecutionHandle,
-  SharedExecutionRegistry,
-} from '@agent/runtime/executionRegistry';
-import { SharedExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
@@ -41,28 +35,34 @@ function trackAgent(
 }
 
 describe('SessionHandle', () => {
-  it('defaultSession wraps the process singletons by identity', () => {
-    expect(defaultSession().executions).toBe(SharedExecutionRegistry);
-    expect(defaultSession().subscriptions).toBe(
-      SharedExecutionSubscriptionBinder,
-    );
-    expect(defaultSession().status).toBe(StreamStatusService);
-    expect(defaultSession().events).toBeDefined();
-    expect(defaultSession().transcripts).toBe(getDefaultStreamLogStore());
-    expect(defaultSession().followUps).toBe(
-      ToolUseFollowUpQueue.defaultInstance(),
-    );
+  it('defaultSession is a stable process-wide singleton (#7694: no separate module export to alias)', () => {
+    // No `Shared*`/`*Service` module export exists anymore — the process
+    // default's owners are constructed inside `defaultSession()` itself.
+    // What's left to verify is that repeated calls return the identical
+    // session (and therefore identical members), and that the flushers
+    // member still aliases the process-wide flush registry by identity
+    // (that accessor is intentionally NOT one of the deleted aliases — see
+    // `runTrace.ts`'s `getActiveFlushers`).
+    const first = defaultSession();
+    const second = defaultSession();
+    expect(second).toBe(first);
+    expect(second.executions).toBe(first.executions);
+    expect(second.subscriptions).toBe(first.subscriptions);
+    expect(second.status).toBe(first.status);
+    expect(second.events).toBe(first.events);
+    expect(second.transcripts).toBe(first.transcripts);
+    expect(second.followUps).toBe(first.followUps);
     expect(defaultSession().flushers).toBe(getActiveFlushers());
     expect(defaultSession().hostChannel).toBeUndefined();
   });
 
-  it('a fresh session shares no member with the module singletons', () => {
+  it('a fresh session shares no member with the default session', () => {
     const fresh = new SessionHandle();
     try {
-      expect(fresh.executions).not.toBe(SharedExecutionRegistry);
-      expect(fresh.subscriptions).not.toBe(SharedExecutionSubscriptionBinder);
+      expect(fresh.executions).not.toBe(defaultSession().executions);
+      expect(fresh.subscriptions).not.toBe(defaultSession().subscriptions);
       expect(fresh.interactions).not.toBe(defaultSession().interactions);
-      expect(fresh.status).not.toBe(StreamStatusService);
+      expect(fresh.status).not.toBe(defaultSession().status);
       expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
       expect(fresh.followUps).not.toBe(defaultSession().followUps);
@@ -78,7 +78,7 @@ describe('SessionHandle', () => {
     const session = new SessionHandle({ hostChannel: host });
     try {
       expect(session.hostChannel).toBe(host);
-      expect(session.executions).not.toBe(SharedExecutionRegistry);
+      expect(session.executions).not.toBe(defaultSession().executions);
     } finally {
       session.dispose();
     }

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -6,12 +6,11 @@ import {
   createRunTrace,
   flushPendingRunTraces,
   getActiveFlushers,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import {
   SessionHandle,
+  defaultSession,
   getAllActiveExecutionIds,
 } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
@@ -63,9 +62,7 @@ describe('cross-session active executions (SDK Step 7d PR 4)', () => {
 
 describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
   it('registers the flush in the run session set, not the default set', () => {
-    const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
     const sessionB = new SessionHandle();
     try {
       const defaultBefore = getActiveFlushers().size;
@@ -84,42 +81,35 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
       handle.dispose();
       expect(sessionB.flushers.size).toBe(0);
     } finally {
-      setDefaultStreamLogStore(previousStore);
       sessionB.dispose();
     }
   });
 
   it("drops the disposed session's flusher set from the process-wide drain", () => {
-    const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
     const sessionB = new SessionHandle();
     let drained = 0;
 
-    try {
-      // Registers sessionB.flushers in the process-wide drain registry.
-      createRunTrace(
-        'stream:flusher-dispose' as StreamTabId,
-        store,
-        sessionB.flushers,
-      );
-      sessionB.flushers.add(() => {
-        drained += 1;
-      });
+    // Registers sessionB.flushers in the process-wide drain registry.
+    createRunTrace(
+      'stream:flusher-dispose' as StreamTabId,
+      store,
+      sessionB.flushers,
+    );
+    sessionB.flushers.add(() => {
+      drained += 1;
+    });
 
-      flushPendingRunTraces();
-      // While live, the session's set is reached by the process-wide drain.
-      expect(drained).toBeGreaterThan(0);
+    flushPendingRunTraces();
+    // While live, the session's set is reached by the process-wide drain.
+    expect(drained).toBeGreaterThan(0);
 
-      sessionB.dispose();
+    sessionB.dispose();
 
-      drained = 0;
-      flushPendingRunTraces();
-      // After dispose the set is unregistered — no longer iterated forever.
-      expect(drained).toBe(0);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    drained = 0;
+    flushPendingRunTraces();
+    // After dispose the set is unregistered — no longer iterated forever.
+    expect(drained).toBe(0);
   });
 });
 
@@ -146,7 +136,7 @@ describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
             .map((entry) => entry.text),
         ).toEqual(['owned by launching session']);
         expect(sibling.transcripts.get(streamId)).toBeUndefined();
-        expect(getDefaultStreamLogStore().get(streamId)).toBeUndefined();
+        expect(defaultSession().transcripts.get(streamId)).toBeUndefined();
       } finally {
         handle.dispose();
       }

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -15,10 +15,8 @@ import {
   resolveAndResumeStream,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
-import {
-  StreamStatusMachine,
-  StreamStatusService,
-} from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 const STREAM = 'stream:resume' as StreamTabId;
@@ -29,7 +27,7 @@ function basePorts(
 ): ResumeStreamPorts {
   return {
     runtimeHost,
-    streamStatus: StreamStatusService,
+    streamStatus: defaultSession().status,
     resolveResumeState: vi.fn(async () => ({
       runState: { agent: 'a', model: 'm' } as never,
       executionId: 'exec-1' as never,
@@ -49,7 +47,7 @@ describe('resolveAndResumeStream', () => {
   });
 
   afterEach(() => {
-    clearStreamStatusForTest(StreamStatusService, STREAM);
+    clearStreamStatusForTest(defaultSession().status, STREAM);
   });
 
   it('routes a tool-use snapshot to the resume port', async () => {
@@ -102,7 +100,7 @@ describe('resolveAndResumeStream', () => {
     let statusDuringLaunch: string | undefined;
     const ports = basePorts({
       executeWorkflow: vi.fn(async () => {
-        statusDuringLaunch = StreamStatusService.get(STREAM);
+        statusDuringLaunch = defaultSession().status.get(STREAM);
       }),
     });
 
@@ -121,7 +119,7 @@ describe('resolveAndResumeStream', () => {
     // re-check must bail before touching the resume ports.
     retrieveSessionResumeDataMock.mockImplementation(async () => {
       seedStreamStatusForTest(
-        StreamStatusService,
+        defaultSession().status,
         STREAM,
         STREAM_STATUS.RUNNING,
       );
@@ -135,7 +133,11 @@ describe('resolveAndResumeStream', () => {
   });
 
   it('skips resume without resolving when the stream is already active', async () => {
-    seedStreamStatusForTest(StreamStatusService, STREAM, STREAM_STATUS.RUNNING);
+    seedStreamStatusForTest(
+      defaultSession().status,
+      STREAM,
+      STREAM_STATUS.RUNNING,
+    );
     const ports = basePorts();
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
@@ -205,7 +207,11 @@ describe('resolveAndResumeStream', () => {
   it('ignores activity recorded only on a different session machine', async () => {
     // The inverse: activity on the process default must not block a resume in
     // a session whose own machine says the stream is idle.
-    seedStreamStatusForTest(StreamStatusService, STREAM, STREAM_STATUS.RUNNING);
+    seedStreamStatusForTest(
+      defaultSession().status,
+      STREAM,
+      STREAM_STATUS.RUNNING,
+    );
     retrieveSessionResumeDataMock.mockResolvedValue({
       type: 'toolUse',
       snapshot: { streamId: STREAM, executionId: 'exec-1' },

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -13,8 +13,6 @@ import {
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { recordSessionEvents, sessionFactPayloads } from '../progressTestUtils';
@@ -60,12 +58,12 @@ describe('resumeToolUseSnapshot', () => {
   afterEach(() => {
     recordedSession?.detach();
     recordedSession = undefined;
-    ToolUseFollowUpQueue.release(STREAM);
-    clearStreamStatusForTest(StreamStatusService, STREAM);
+    defaultSession().followUps.release(STREAM);
+    clearStreamStatusForTest(defaultSession().status, STREAM);
   });
 
   it('drains queued follow-ups, replays them, and notifies the UI', async () => {
-    ToolUseFollowUpQueue.enqueue(
+    defaultSession().followUps.enqueue(
       STREAM,
       { text: 'queued one' },
       { force: true },
@@ -90,7 +88,7 @@ describe('resumeToolUseSnapshot', () => {
   });
 
   it('seeds an explicit follow-up ahead of the queued items', async () => {
-    ToolUseFollowUpQueue.enqueue(
+    defaultSession().followUps.enqueue(
       STREAM,
       { text: 'queued one' },
       { force: true },
@@ -142,7 +140,7 @@ describe('resumeToolUseSnapshot', () => {
     const failure = new Error('resume blew up');
     resumeToolUseFromSnapshotMock.mockRejectedValue(failure);
     const reportFailure = vi.fn();
-    ToolUseFollowUpQueue.enqueue(
+    defaultSession().followUps.enqueue(
       STREAM,
       { text: 'queued one' },
       { force: true },
@@ -152,8 +150,8 @@ describe('resumeToolUseSnapshot', () => {
       resumeToolUseSnapshot(snapshot(), { runtimeHost, reportFailure }),
     ).resolves.toBe(false);
 
-    expect(ToolUseFollowUpQueue.getAll(STREAM)).toEqual(['queued one']);
-    expect(StreamStatusService.get(STREAM)).toBe(STREAM_STATUS.WAITING);
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
     expect(reportFailure).toHaveBeenCalledWith(failure);
     // The re-enqueue replays a queue update beyond the initial drain notification.
     expect(
@@ -179,7 +177,7 @@ describe('resumeToolUseSnapshot', () => {
       ).resolves.toBe(false);
 
       expect(session.status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-      expect(StreamStatusService.get(STREAM)).toBeUndefined();
+      expect(defaultSession().status.get(STREAM)).toBeUndefined();
     } finally {
       session.status.clearStream(STREAM);
       session.dispose();
@@ -207,7 +205,7 @@ describe('resumeToolUseSnapshot', () => {
       ).resolves.toBe(false);
 
       expect(session.followUps.getAll(STREAM)).toEqual(['session queued']);
-      expect(ToolUseFollowUpQueue.getAll(STREAM)).toEqual([]);
+      expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
     } finally {
       session.followUps.release(STREAM);
       session.status.clearStream(STREAM);
@@ -218,7 +216,7 @@ describe('resumeToolUseSnapshot', () => {
   it('leaves the status alone when the started run has taken it over', async () => {
     resumeToolUseFromSnapshotMock.mockImplementation(async () => {
       seedStreamStatusForTest(
-        StreamStatusService,
+        defaultSession().status,
         STREAM,
         STREAM_STATUS.RUNNING,
       );
@@ -227,6 +225,6 @@ describe('resumeToolUseSnapshot', () => {
     await expect(
       resumeToolUseSnapshot(snapshot(), { runtimeHost }),
     ).resolves.toBe(true);
-    expect(StreamStatusService.get(STREAM)).toBe(STREAM_STATUS.RUNNING);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.RUNNING);
   });
 });

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -1,7 +1,9 @@
 // Suites for src/agent/trace emit helpers (stage metadata, tool-use cards,
 // log-file categorization). RunTraceStream keeps its own suite.
 
+import { strict as assert } from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import {
   type AgentEvent,
   type AgentTrace,
@@ -10,13 +12,6 @@ import {
   type StageStartEvent,
   TraceEmitter,
 } from '@agent/trace';
-import { strict as assert } from 'node:assert';
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 // ---------------------------------------------------------------------------
@@ -167,12 +162,12 @@ describe('logFileCategory', () => {
   let logger: AgentTrace;
   let disposeTrace: () => void;
   let capturedMessages: any[];
+  let store: StreamLogStore;
 
   beforeEach(async () => {
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    store = new StreamLogStore();
     await store.clear();
-    const runTrace = createRunTrace('TestFileListLogger');
+    const runTrace = createRunTrace('TestFileListLogger', store);
     logger = runTrace.trace;
     disposeTrace = runTrace.dispose;
     capturedMessages = [];
@@ -185,7 +180,7 @@ describe('logFileCategory', () => {
   });
 
   const refreshCaptured = (): void => {
-    const log = getDefaultStreamLogStore().get('TestFileListLogger');
+    const log = store.get('TestFileListLogger');
     capturedMessages = (log?.getRange(0, log.head) ?? []).map((entry) => ({
       id: entry.id,
       text: entry.text ?? '',

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -3,8 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createRunTrace,
   flushPendingRunTraces,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import {
@@ -15,18 +13,12 @@ import {
 } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
-/** Swap in a fresh default store (restored afterwards) around `run`. */
+/** Run against a fresh, test-local store. */
 function withStore(
   run: (store: StreamLogStore, logger: AgentTrace) => void,
 ): void {
-  const previousStore = getDefaultStreamLogStore();
   const store = new StreamLogStore();
-  setDefaultStreamLogStore(store);
-  try {
-    run(store, createRunTrace('stream').trace);
-  } finally {
-    setDefaultStreamLogStore(previousStore);
-  }
+  run(store, createRunTrace('stream', store).trace);
 }
 
 describe('AgentTrace stream output', () => {
@@ -230,64 +222,51 @@ describe('tool-use card groupId resolution', () => {
   });
 
   it('reuses the captured groupId when endToolUseCard is called with no explicit stage', async () => {
-    const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    const logger = createRunTrace('stream', store).trace;
+    const outer = logger.openStage('outer');
+    const ref = await outer.within(async () =>
+      startToolUseCard(logger, 'demoTool', { arg: 1 }),
+    );
 
-    try {
-      const logger = createRunTrace('stream').trace;
-      const outer = logger.openStage('outer');
-      const ref = await outer.within(async () =>
-        startToolUseCard(logger, 'demoTool', { arg: 1 }),
-      );
+    expect(ref.groupId).toBeDefined();
 
-      expect(ref.groupId).toBeDefined();
+    // Mirrors the deferred-tool path: caller passes the captured ref so
+    // the end event lands under the same stage as the start.
+    endToolUseCard(logger, ref, {
+      toolName: 'demoTool',
+      input: { arg: 1 },
+      output: 'ok',
+    });
 
-      // Mirrors the deferred-tool path: caller passes the captured ref so
-      // the end event lands under the same stage as the start.
-      endToolUseCard(logger, ref, {
-        toolName: 'demoTool',
-        input: { arg: 1 },
-        output: 'ok',
-      });
-
-      const entries = store.get('stream')?.getRange(0) ?? [];
-      const toolEntry = entries.find((e) => e.id === ref.logId);
-      expect(toolEntry?.groupId).toBe(ref.groupId);
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = store.get('stream')?.getRange(0) ?? [];
+    const toolEntry = entries.find((e) => e.id === ref.logId);
+    expect(toolEntry?.groupId).toBe(ref.groupId);
   });
 });
 
 describe('per-trace stage scope (cross-trace isolation)', () => {
   it('a run stage opened on its own trace does not inherit an active stage from another trace', async () => {
-    const previousStore = getDefaultStreamLogStore();
     const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
 
-    try {
-      // Orchestrator trace with an active "Task:" stage — mirrors a subagent
-      // launched from inside a delegation tool's stage scope.
-      const orchestrator = createRunTrace('orchestrator').trace;
-      const taskStage = orchestrator.openStage('Task: orchestrator');
+    // Orchestrator trace with an active "Task:" stage — mirrors a subagent
+    // launched from inside a delegation tool's stage scope.
+    const orchestrator = createRunTrace('orchestrator', store).trace;
+    const taskStage = orchestrator.openStage('Task: orchestrator');
 
-      // Subagent run on a SEPARATE trace/stream, opened *inside* the
-      // orchestrator's stage scope. With a per-instance stage scope the
-      // orchestrator's active stage cannot leak across traces, so the
-      // subagent's run stage is a root on its own stream with no extra flag.
-      // (A module-level shared scope would orphan it under the cross-trace id.)
-      await taskStage.within(async () => {
-        const subagent = createRunTrace('subagent').trace;
-        subagent.openStage('Run: subagent');
-      });
+    // Subagent run on a SEPARATE trace/stream, opened *inside* the
+    // orchestrator's stage scope. With a per-instance stage scope the
+    // orchestrator's active stage cannot leak across traces, so the
+    // subagent's run stage is a root on its own stream with no extra flag.
+    // (A module-level shared scope would orphan it under the cross-trace id.)
+    await taskStage.within(async () => {
+      const subagent = createRunTrace('subagent', store).trace;
+      subagent.openStage('Run: subagent');
+    });
 
-      const entries = store.get('subagent')?.getRange(0) ?? [];
-      const runStage = entries.find((e) => e.text === 'Run: subagent');
-      expect(runStage).toBeDefined();
-      expect(runStage?.groupId).toBeUndefined();
-    } finally {
-      setDefaultStreamLogStore(previousStore);
-    }
+    const entries = store.get('subagent')?.getRange(0) ?? [];
+    const runStage = entries.find((e) => e.text === 'Run: subagent');
+    expect(runStage).toBeDefined();
+    expect(runStage?.groupId).toBeUndefined();
   });
 });

--- a/src/test-kernel/agent/trace/logUserMessage.vitest.ts
+++ b/src/test-kernel/agent/trace/logUserMessage.vitest.ts
@@ -3,12 +3,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { logUserMessage, type AgentTrace } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
@@ -19,12 +14,12 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 describe('logUserMessage', () => {
   let logger: AgentTrace;
   let disposeTrace: () => void;
+  let store: StreamLogStore;
 
   beforeEach(async () => {
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    store = new StreamLogStore();
     await store.clear();
-    const runTrace = createRunTrace('TestUserMessageLogger');
+    const runTrace = createRunTrace('TestUserMessageLogger', store);
     logger = runTrace.trace;
     disposeTrace = runTrace.dispose;
   });
@@ -34,7 +29,7 @@ describe('logUserMessage', () => {
   });
 
   const capturedEntries = () => {
-    const log = getDefaultStreamLogStore().get('TestUserMessageLogger');
+    const log = store.get('TestUserMessageLogger');
     return log?.getRange(0, log.head) ?? [];
   };
 

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   LIVE_TAIL_ROWS,
   boundedAssistantDisplayLines,
@@ -192,7 +192,7 @@ describe('CLI conversation transcript splitting', () => {
     const dispose = subscribeStreamStatus();
 
     try {
-      StreamStatusService.transition(
+      defaultSession().status.transition(
         STREAM_ID,
         STREAM_PHASE.COMPLETED,
         'restart-repair',
@@ -225,7 +225,11 @@ describe('CLI conversation transcript splitting', () => {
     const dispose = subscribeStreamStatus();
 
     try {
-      StreamStatusService.transition(STREAM_ID, STREAM_PHASE.RUNNING, 'resume');
+      defaultSession().status.transition(
+        STREAM_ID,
+        STREAM_PHASE.RUNNING,
+        'resume',
+      );
 
       expect(streams.get().get(STREAM_ID)?.status).toBe(STREAM_STATUS.RUNNING);
     } finally {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -425,9 +425,9 @@ describe('executeCliRequest', () => {
 
   it('loads the stream log store before the run and flushes it after, in order', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const { getDefaultStreamLogStore } = await import('@transcript');
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
     const callOrder: string[] = [];
     vi.spyOn(store, 'load').mockImplementation(async () => {
       callOrder.push('load');
@@ -455,9 +455,9 @@ describe('executeCliRequest', () => {
 
   it('flushes the stream log store even when the run throws', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const { getDefaultStreamLogStore } = await import('@transcript');
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
     const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     mocks.runAgent.mockRejectedValueOnce(new AgentError('boom'));
@@ -475,9 +475,9 @@ describe('executeCliRequest', () => {
 
   it('rethrows a non-AgentError rejection instead of swallowing it into an exit code', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
-    const { getDefaultStreamLogStore } = await import('@transcript');
+    const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
     const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     // An unclassified failure (e.g. registerExecution disk I/O,

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -305,16 +305,15 @@ describe('CLI session status formatter', () => {
   });
 
   it('reads queued follow-ups from the queue manager for status details', () => {
-    const queue = ToolUseFollowUpQueue.acquire(STREAM_ID);
-    ToolUseFollowUpQueue.drain(STREAM_ID);
+    const queueManager = new ToolUseFollowUpQueue();
+    const queue = queueManager.acquire(STREAM_ID);
+    queueManager.drain(STREAM_ID);
     try {
       queue.enqueue({ text: 'Fresh queue message' });
 
-      expect(ToolUseFollowUpQueue.getAll(STREAM_ID)).toEqual([
-        'Fresh queue message',
-      ]);
+      expect(queueManager.getAll(STREAM_ID)).toEqual(['Fresh queue message']);
     } finally {
-      ToolUseFollowUpQueue.drain(STREAM_ID);
+      queueManager.drain(STREAM_ID);
     }
   });
 });

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
@@ -4,11 +4,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import type { StreamLogStore } from '@transcript';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { subscribeStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { streams, resetCliState } from '@cli/chat/tui/state/cliState';
 import {
@@ -38,23 +35,22 @@ function appendUserMessage(
 }
 
 describe('subscribeStreamLog batching and dispose', () => {
-  let previousStore: StreamLogStore;
-
-  beforeEach(() => {
-    previousStore = getDefaultStreamLogStore();
-    setDefaultStreamLogStore(new StreamLogStore());
+  beforeEach(async () => {
+    // No separate default-store export to swap in anymore (#7694) —
+    // `subscribeStreamLog()` reads the default session's own `transcripts`
+    // store, so clear it in place instead.
+    await defaultSession().transcripts.clear();
     resetCliState();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    setDefaultStreamLogStore(previousStore);
   });
 
   it('coalesces multiple store changes within the batch window into a single sync pass', () => {
     const dispose = subscribeStreamLog();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
 
     appendUserMessage(store, streamA, 'a-1', 'hello');
     // A second change arriving inside the window must NOT restart the timer:
@@ -82,7 +78,7 @@ describe('subscribeStreamLog batching and dispose', () => {
 
   it('dispose cancels a pending batch instead of flushing it', () => {
     const dispose = subscribeStreamLog();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
 
     appendUserMessage(store, streamA, 'a-1', 'hello');
     // Dispose before the batch window elapses: the pending sync must be
@@ -98,7 +94,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     firstDispose();
 
     const secondDispose = subscribeStreamLog();
-    const store = getDefaultStreamLogStore();
+    const store = defaultSession().transcripts;
     appendUserMessage(store, streamA, 'a-1', 'hello again');
     vi.advanceTimersByTime(16);
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -4,16 +4,10 @@ import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace } from '@transcript';
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   activeStreamId,
   rootRunStartAvailable,
@@ -126,7 +120,7 @@ const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
 
 afterEach(() => {
-  clearAllStreamStatusesForTest(StreamStatusService);
+  clearAllStreamStatusesForTest(defaultSession().status);
   resetCliState();
 });
 
@@ -269,7 +263,7 @@ describe('cliState Phase 4 fields', () => {
       // survives and its status is read live from the child's own slice.
       applySubagentRoster(root, []);
 
-      StreamStatusService.transition(
+      defaultSession().status.transition(
         child1,
         STREAM_PHASE.FAILED,
         'restart-repair',
@@ -1626,7 +1620,7 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     try {
-      StreamStatusService.transition(
+      defaultSession().status.transition(
         child1,
         STREAM_PHASE.RUNNING,
         'restart-repair',
@@ -1666,7 +1660,7 @@ describe('CLI TUI row allocation', () => {
     setParentStream(child1, root);
 
     try {
-      StreamStatusService.transition(
+      defaultSession().status.transition(
         child1,
         STREAM_PHASE.CANCELLED,
         'restart-repair',
@@ -1797,18 +1791,12 @@ describe('finalizeSettledPrefix', () => {
 
 describe('CLI transcript state', () => {
   // Several tests below log through `createRunTrace`/`syncStreamLog`, which
-  // read and write the *default* stream log store. Give every test in this
-  // block a fresh store up front and restore the original afterward, so
-  // store-backed tests don't need to repeat that swap individually.
-  let previousStore: StreamLogStore;
-
-  beforeEach(() => {
-    previousStore = getDefaultStreamLogStore();
-    setDefaultStreamLogStore(new StreamLogStore());
-  });
-
-  afterEach(() => {
-    setDefaultStreamLogStore(previousStore);
+  // read and write the default session's `transcripts` store. No separate
+  // default-store export to swap in anymore (#7694) — clear it in place
+  // before every test instead, so store-backed tests don't need to repeat
+  // that reset individually.
+  beforeEach(async () => {
+    await defaultSession().transcripts.clear();
   });
 
   it('renders orchestrator follow-ups without protocol tags', () => {
@@ -1823,7 +1811,7 @@ describe('CLI transcript state', () => {
   });
 
   it('summarizes subagent protocol continuations in the visible transcript', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('Please solve the problem.', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -1842,7 +1830,7 @@ describe('CLI transcript state', () => {
   });
 
   it('summarizes embedded subagent progress blocks in assistant transcript text', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info(
       [
         'Waiting for the child.',
@@ -1868,7 +1856,7 @@ describe('CLI transcript state', () => {
   });
 
   it('normalizes common HTML before assistant text reaches the live transcript', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info(
       '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
       { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
@@ -1885,7 +1873,7 @@ describe('CLI transcript state', () => {
   });
 
   it('bounds long subagent result responses in the visible transcript', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     const response = Array.from(
       { length: 20 },
       (_, index) => `proof line ${index + 1}`,
@@ -1916,7 +1904,7 @@ describe('CLI transcript state', () => {
   });
 
   it('mirrors error log entries into the transcript', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
     });
@@ -1933,7 +1921,7 @@ describe('CLI transcript state', () => {
   });
 
   it('tracks hidden thinking activity without rendering thinking text', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
 
     // Opening the stream alone marks the phase — hidden reasoning (e.g.
@@ -1972,7 +1960,7 @@ describe('CLI transcript state', () => {
   });
 
   it('does not project empty assistant responses into transcript rows', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
 
     syncStreamLog(root);
@@ -1993,7 +1981,7 @@ describe('CLI transcript state', () => {
   });
 
   it('trims leading blank assistant rows at turn start', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('Why?', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     logger.info('\n\n  The answer starts here.', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
@@ -2015,7 +2003,7 @@ describe('CLI transcript state', () => {
   // `splitTranscriptEntries` once status flipped to WAITING and silently
   // disappear from the transcript.
   it('preserves the finalized flag through a post-finalize sync tick', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('streaming assistant chunk', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     });
@@ -2047,7 +2035,7 @@ describe('CLI transcript state', () => {
   // the recorder-level upsert-vs-append unit coverage); these tests confirm
   // the CLI's own state ends up with exactly one entry, never a synthetic one.
   it('reconciles a streamed response to the authoritative post-replacement text', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     // Raw provider text, as it would arrive before replacement rules run.
     output.append('Done ✓');
@@ -2067,7 +2055,7 @@ describe('CLI transcript state', () => {
   });
 
   it('appends the final response when the round produced no live stream', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.responseFinalized('The answer is 2.');
 
     syncStreamLog(root);
@@ -2082,7 +2070,7 @@ describe('CLI transcript state', () => {
   });
 
   it('does not let an earlier round leak its stream id into a later round', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     const round0 = logger.openStage('r0', { kind: 'round', index: 0 });
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     output.append('Let me check that.');
@@ -2106,7 +2094,7 @@ describe('CLI transcript state', () => {
   });
 
   it('projects a turn boundary from the store alone, with zero synthetic entries', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('What is 1 + 1?', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -2241,7 +2229,7 @@ describe('CLI transcript state', () => {
   });
 
   it('flushes pending model-response chunks before transcript sync', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     stream.append('A short final answer.');
 
@@ -2254,7 +2242,7 @@ describe('CLI transcript state', () => {
   });
 
   it('finalizes a delayed first model-response sync after the stream is idle', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('A delayed final answer.', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     });
@@ -2278,7 +2266,7 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps repeated local slash-command responses after stream-log syncs', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     activeStreamId.set(root);
@@ -2444,7 +2432,7 @@ describe('CLI transcript state', () => {
   });
 
   it('preserves the finalized response across later log syncs', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     logger.responseFinalized('The answer is 2.');
@@ -2461,7 +2449,7 @@ describe('CLI transcript state', () => {
   });
 
   it('orders multiple finalized responses relative to the turns around them', () => {
-    const logger = createRunTrace(root).trace;
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     logger.responseFinalized('first answer');
@@ -3050,7 +3038,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
     patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    const queue = ToolUseFollowUpQueue.acquire(root);
+    const queue = defaultSession().followUps.acquire(root);
 
     try {
       queue.enqueue({ text: 'Keep the proof under one page.' });
@@ -3082,7 +3070,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       expect(slice?.queuedFollowUpMessages).toEqual([]);
     } finally {
       detach();
-      ToolUseFollowUpQueue.release(root);
+      defaultSession().followUps.release(root);
     }
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -37,12 +37,6 @@ vi.mock('@agent/storage', () => ({
   writeTerminalStatus: vi.fn(),
 }));
 
-vi.mock('@agent/runtime/executionRegistry', () => ({
-  SharedExecutionRegistry: {
-    stopAgentStream: mocks.stopAgentStream,
-  },
-}));
-
 vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
   resolveAndResumeStream: mocks.resolveAndResumeStream,
 }));
@@ -267,6 +261,7 @@ describe('createChatSessionController', () => {
       interactions: {},
       events: {},
       status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
+      executions: { stopAgentStream: mocks.stopAgentStream },
     });
     mocks.resolveAndResumeStream.mockReset();
     mocks.resolveAndResumeStream.mockResolvedValue(true);

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -502,7 +502,6 @@ describe('createChatSessionController', () => {
 
     expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
     expect(session.runCompleted).toBe(true);
-
   });
 
   it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -109,7 +109,7 @@ vi.mock('@cli/runtime/sessionResume', () => ({
   ): string => `not resumable (${resolution.kind}): ${id}`,
 }));
 
-import { setDefaultStreamLogStore, StreamSnapshotStore } from '@transcript';
+import { StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
@@ -123,7 +123,6 @@ import {
 } from '@cli/chat/tui/state/sessionRunState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import type { StreamLogStore } from '@transcript';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -278,6 +277,7 @@ describe('createChatSessionController', () => {
       events: {},
       status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
       executions: { stopAgentStream: mocks.stopAgentStream },
+      transcripts: { ensureLoaded: vi.fn(async () => undefined) },
     });
     mocks.resolveAndResumeStream.mockReset();
     mocks.resolveAndResumeStream.mockResolvedValue(true);
@@ -460,9 +460,11 @@ describe('createChatSessionController', () => {
     // bail out instead of silently starting `resumeToolUseFromSnapshot()`
     // once the awaits finish.
     const ensureLoaded = deferred<void>();
-    setDefaultStreamLogStore({
-      ensureLoaded: () => ensureLoaded.promise,
-    } as unknown as StreamLogStore);
+    const base = mocks.defaultSession();
+    mocks.defaultSession.mockReturnValue({
+      ...base,
+      transcripts: { ensureLoaded: () => ensureLoaded.promise },
+    });
 
     const session = makeSession({ runCompleted: true });
     const snapshotStore = {
@@ -486,7 +488,7 @@ describe('createChatSessionController', () => {
 
     const resumed = ctrl.resume('aaaaaa' as ExecutionId, preResolved);
     // resume() has claimed the slot and is suspended inside
-    // getDefaultStreamLogStore().ensureLoaded(); session.streamId is
+    // defaultSession().transcripts.ensureLoaded(); session.streamId is
     // already set to the resumed stream.
     expect(session.runPromise).toBeDefined();
     expect(session.streamId).toBe('stream-resume');
@@ -501,7 +503,6 @@ describe('createChatSessionController', () => {
     expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
     expect(session.runCompleted).toBe(true);
 
-    setDefaultStreamLogStore(undefined as unknown as StreamLogStore);
   });
 
   it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -85,10 +85,18 @@ vi.mock('@frontend/secretManager', () => ({
   },
 }));
 
-vi.mock('@agent/runtime/executionRegistry', () => ({
-  SharedExecutionRegistry: {
-    getAgentHandles: () => agentHandles(),
-  },
+// The guard's sole touchpoint is `defaultSession().executions.getAgentHandles()`
+// — a full stub replacement (not `importOriginal`) keeps this suite's
+// isolation: the real module eagerly constructs a `createChannelTrace`
+// logger at import time (`ToolUseFollowUpQueueManager.ts`), which needs more
+// of `@logger/logUtils` than this suite's minimal mock provides. No other
+// module in this test's import graph (all deps otherwise mocked away, and
+// `apiKeyCommands`/`codexSubscriptionSignIn` don't import SessionHandle)
+// touches this module's other exports.
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  defaultSession: () => ({
+    executions: { getAgentHandles: () => agentHandles() },
+  }),
 }));
 
 vi.mock('@controllers/onboarding/setupLaunch', () => ({
@@ -235,7 +243,7 @@ vi.mock('@logger/logUtils', () => ({
 await import('vscode');
 await import('@utils/config/providerConfig');
 await import('@frontend/secretManager');
-await import('@agent/runtime/executionRegistry');
+await import('@agent/runtime/SessionHandle');
 await import('@controllers/onboarding/setupLaunch');
 await import('@auth/codex');
 await import('@auth/serverKeys');

--- a/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
@@ -10,11 +10,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { ChatExportController } from '@controllers/settingsView/ChatExportController';
-import {
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -85,16 +81,9 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 describe('ChatExportController.exportAsHtml', () => {
-  let previousStreamLogStore: StreamLogStore;
   const controller = new ChatExportController({ latexPreamble: '' });
 
-  beforeEach(() => {
-    previousStreamLogStore = getDefaultStreamLogStore();
-    setDefaultStreamLogStore(new StreamLogStore());
-  });
-
   afterEach(async () => {
-    setDefaultStreamLogStore(previousStreamLogStore);
     await Promise.all(
       tempDirs
         .splice(0)
@@ -138,7 +127,7 @@ describe('ChatExportController.exportAsHtml', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     store.append(streamId, {
       id: 'entry-1',
@@ -173,7 +162,7 @@ describe('ChatExportController.exportAsHtml', () => {
     await installStoragePlatform();
     const executionId = 'exec-missing-template' as ExecutionId;
     await getExecutionStore(executionId).writeConfig(config());
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     const streamId = getStreamTabId('orchestrator', 'deepseekT', {
       executionId,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -247,7 +247,6 @@ function mockLoggerModule(loggerErrorSpy?: ReturnType<typeof vi.fn>): void {
       warn: () => {},
       error: loggerErrorSpy ?? (() => {}),
     }),
-    setDefaultStreamLogStore: () => {},
   }));
 }
 
@@ -3468,10 +3467,14 @@ describe('DesktopProgressBridge', () => {
     type WindowPair = {
       windowA: WindowFixture;
       windowB: WindowFixture;
-      /** Same-registry runtime modules (the ones the bridges actually use). */
+      /**
+       * Same-registry `defaultSession` (the one the bridges actually use) —
+       * there is no separate `StreamStatusService`/`getDefaultStreamLogStore`
+       * module export anymore (#7694): the process-wide default session owns
+       * its `status`/`transcripts` members directly.
+       */
       registry: {
-        StreamStatusService: StreamStatusMachine;
-        getDefaultStreamLogStore: typeof import('@transcript').getDefaultStreamLogStore;
+        defaultSession: typeof import('@agent/runtime/SessionHandle').defaultSession;
       };
       dispose(): void;
     };
@@ -3479,12 +3482,9 @@ describe('DesktopProgressBridge', () => {
     async function createWindowPair(): Promise<WindowPair> {
       const { bridgeModule } = await loadBridgeModule();
       // Same registry as the bridge module graph — identity comparisons
-      // against process-wide defaults must use these instances, not the
-      // statically imported copies from the pre-reset registry.
-      const [{ StreamStatusService }, transcript] = await Promise.all([
-        import('@agent/runtime/StreamStatusService'),
-        import('@transcript'),
-      ]);
+      // against process-wide defaults must use this instance, not a
+      // statically imported copy from the pre-reset registry.
+      const { defaultSession } = await import('@agent/runtime/SessionHandle');
       const makeWindow = (): WindowFixture => {
         const messages: unknown[] = [];
         const snapshots = createStreamSnapshotStore([]);
@@ -3516,8 +3516,7 @@ describe('DesktopProgressBridge', () => {
         windowA,
         windowB,
         registry: {
-          StreamStatusService,
-          getDefaultStreamLogStore: transcript.getDefaultStreamLogStore,
+          defaultSession,
         },
         dispose: () => {
           windowA.bridge.dispose();
@@ -3793,10 +3792,10 @@ describe('DesktopProgressBridge', () => {
           windowB.session.transcripts,
         );
         expect(windowA.session.transcripts).not.toBe(
-          registry.getDefaultStreamLogStore(),
+          registry.defaultSession().transcripts,
         );
         expect(windowB.session.transcripts).not.toBe(
-          registry.getDefaultStreamLogStore(),
+          registry.defaultSession().transcripts,
         );
 
         for (const [window, streamId] of [
@@ -3820,8 +3819,8 @@ describe('DesktopProgressBridge', () => {
         expect(windowA.session.transcripts.has(streamB)).toBe(false);
         expect(windowB.bridge.streamLogs.get(streamA)).toBeUndefined();
         expect(windowA.bridge.streamLogs.get(streamB)).toBeUndefined();
-        expect(registry.getDefaultStreamLogStore().has(streamA)).toBe(false);
-        expect(registry.getDefaultStreamLogStore().has(streamB)).toBe(false);
+        expect(registry.defaultSession().transcripts.has(streamA)).toBe(false);
+        expect(registry.defaultSession().transcripts.has(streamB)).toBe(false);
       } finally {
         pair.dispose();
       }
@@ -3832,15 +3831,19 @@ describe('DesktopProgressBridge', () => {
       const { windowA, windowB, registry } = pair;
 
       try {
-        // Desktop windows own fresh status machines. The process-wide default
-        // machine (`StreamStatusService`) survives, but only as the
+        // Desktop windows own fresh status machines. The process-wide
+        // default session's status machine survives, but only as the
         // single-session default-session compatibility path (extension/CLI) —
         // a ledgered residue tracked on #6981 (D1 rows), not a desktop
         // multi-window sharing point. Assert the isolation that IS promised:
         // neither window aliases it, and neither window writes to it.
         expect(windowA.session.status).not.toBe(windowB.session.status);
-        expect(windowA.session.status).not.toBe(registry.StreamStatusService);
-        expect(windowB.session.status).not.toBe(registry.StreamStatusService);
+        expect(windowA.session.status).not.toBe(
+          registry.defaultSession().status,
+        );
+        expect(windowB.session.status).not.toBe(
+          registry.defaultSession().status,
+        );
 
         const changesSeenByB: unknown[] = [];
         windowB.session.status.onDidChange((change) =>
@@ -3878,8 +3881,8 @@ describe('DesktopProgressBridge', () => {
           ),
         ).toEqual([]);
         // Neither window's run leaked into the process-default machine.
-        expect(registry.StreamStatusService.get(streamA)).toBeUndefined();
-        expect(registry.StreamStatusService.get(streamB)).toBeUndefined();
+        expect(registry.defaultSession().status.get(streamA)).toBeUndefined();
+        expect(registry.defaultSession().status.get(streamB)).toBeUndefined();
 
         // One window's delete-all sweep (bridge path AND machine path) cannot
         // reset the sibling's streams — the exact L3 clearAll leak.

--- a/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
@@ -128,14 +128,6 @@ async function loadBridgeModule(): Promise<
   vi.resetModules();
   vi.doMock('@logger', () => ({
     createChannelTrace: () => makeLogger(),
-    setDefaultStreamLogStore: () => {},
-  }));
-  vi.doMock('@agent/runtime/StreamStatusService', () => ({
-    StreamStatusService: {
-      transition: vi.fn(),
-      get: vi.fn(() => STREAM_PHASE.CANCELLED),
-      isActiveOrResuming: vi.fn(() => false),
-    },
   }));
   vi.doMock('@tools/goal', () => ({
     GoalStore: {

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -3,30 +3,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createRunTrace,
   flushPendingRunTraces,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
   StreamLogStore,
 } from '@transcript';
 import { MESSAGE_TYPES } from '@shared/schemas';
 
 describe('createRunTrace dispose', () => {
-  let previousStore: StreamLogStore;
   let store: StreamLogStore;
 
   beforeEach(() => {
-    previousStore = getDefaultStreamLogStore();
     store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
   });
 
   afterEach(() => {
-    setDefaultStreamLogStore(previousStore);
     vi.useRealTimers();
   });
 
   it('removes the flusher from the global registry on dispose', () => {
     vi.useFakeTimers();
-    const handle = createRunTrace('disposed-stream');
+    const handle = createRunTrace('disposed-stream', store);
     const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
     stream.append('a');
@@ -51,7 +45,7 @@ describe('createRunTrace dispose', () => {
   });
 
   it('returns the same dispose function across the handle', () => {
-    const handle = createRunTrace('idempotent-stream');
+    const handle = createRunTrace('idempotent-stream', store);
     handle.dispose();
     // Calling dispose again should not throw and should be a no-op.
     expect(() => handle.dispose()).not.toThrow();

--- a/src/test-kernel/logger/errorData.vitest.ts
+++ b/src/test-kernel/logger/errorData.vitest.ts
@@ -1,25 +1,21 @@
 import { strict as assert } from 'node:assert';
 import { beforeEach, describe, it } from 'vitest';
 
-import {
-  createRunTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 
 describe('AgentTrace error data', () => {
+  let store: StreamLogStore;
+
   beforeEach(async () => {
-    const store = new StreamLogStore();
-    setDefaultStreamLogStore(store);
+    store = new StreamLogStore();
     await store.clear();
   });
 
   it('emits error data with stack', () => {
-    const logger = createRunTrace('TestErrorLogger').trace;
+    const logger = createRunTrace('TestErrorLogger', store).trace;
     const err = new Error('test failure');
     logger.error(`Error occurred: ${err.message}`, { data: err });
-    const log = getDefaultStreamLogStore().get('TestErrorLogger');
+    const log = store.get('TestErrorLogger');
     const captured = log?.getRange(0, log.head).at(-1) as
       { data: any } | undefined;
     assert.ok(captured);

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -11,7 +11,7 @@ import {
   type ModelConfig,
   ModelProvider,
 } from 'llm-zoo';
-import { createRunTrace } from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import type { AgentEvent } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type {
@@ -242,7 +242,7 @@ describe('BashTool', () => {
 
     const options = roundServices({
       toolName: 'bash',
-      logger: createRunTrace('BashToolTest').trace,
+      logger: createRunTrace('BashToolTest', new StreamLogStore()).trace,
       streamId: 'bash-tool' as StreamTabId,
       toolRegistry: new MapToolRegistry({ bash: bashTool }),
     });
@@ -274,7 +274,10 @@ describe('BashTool', () => {
   });
 
   it('keeps result status out of visible tool log output', async () => {
-    const runTrace = createRunTrace('ToolStatusLogTest' as StreamTabId);
+    const runTrace = createRunTrace(
+      'ToolStatusLogTest' as StreamTabId,
+      new StreamLogStore(),
+    );
     const events: AgentEvent[] = [];
     const unsubscribe = runTrace.trace.subscribe((event) => {
       events.push(event);
@@ -508,7 +511,10 @@ describe('BashTool', () => {
       },
     );
 
-    const runTrace = createRunTrace('BashToolAbortTest' as StreamTabId);
+    const runTrace = createRunTrace(
+      'BashToolAbortTest' as StreamTabId,
+      new StreamLogStore(),
+    );
     const events: AgentEvent[] = [];
     const unsubscribe = runTrace.trace.subscribe((event) => {
       events.push(event);

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -4,14 +4,10 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import {
-  AgentExecutionHandle,
-  SharedExecutionRegistry,
-} from '@agent/runtime/executionRegistry';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
 
@@ -145,11 +141,11 @@ describe('headless delegation', () => {
   });
 
   afterEach(() => {
-    for (const executionId of SharedExecutionRegistry.getActiveIds()) {
-      SharedExecutionRegistry.untrack(executionId);
+    for (const executionId of defaultSession().executions.getActiveIds()) {
+      defaultSession().executions.untrack(executionId);
     }
-    ToolUseFollowUpQueue.release('parent-stream' as StreamTabId);
-    ToolUseFollowUpQueue.release('child-stream' as StreamTabId);
+    defaultSession().followUps.release('parent-stream' as StreamTabId);
+    defaultSession().followUps.release('child-stream' as StreamTabId);
   });
 
   it('awaits child delegation during one-shot tool-use runs', async () => {
@@ -594,7 +590,7 @@ describe('headless delegation', () => {
           'toolUse',
           host,
         );
-        SharedExecutionRegistry.track(handle);
+        defaultSession().executions.track(handle);
         options.onStreamResolved?.(childStreamId);
         options.onRun?.(handle);
         return {
@@ -646,14 +642,14 @@ describe('headless delegation', () => {
           'toolUse',
           host,
         );
-        SharedExecutionRegistry.track(handle);
+        defaultSession().executions.track(handle);
         capturedHandle = handle;
         options.onStreamResolved?.(childStreamId);
         options.onRun?.(handle);
         // Detach happens between the loop capturing the handle (onRun, above)
         // and the loop delivering this turn's result (after this resolves) —
         // the same ordering a real stop-with-detach produces mid-turn.
-        SharedExecutionRegistry.detachActiveChildren(parentStreamId, host);
+        defaultSession().executions.detachActiveChildren(parentStreamId, host);
         return {
           category: 'toolUse',
           outcome: STREAM_PHASE.WAITING,
@@ -681,7 +677,7 @@ describe('headless delegation', () => {
       );
     });
     expect(capturedHandle?.deliveryTargetStreamId).toBeUndefined();
-    expect(ToolUseFollowUpQueue.getAll(parentStreamId)).toEqual([]);
-    expect(ToolUseFollowUpQueue.getAll(childStreamId)).toEqual([]);
+    expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([]);
+    expect(defaultSession().followUps.getAll(childStreamId)).toEqual([]);
   });
 });

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -10,12 +10,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import {
-  assembleTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { assembleTrace, StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -71,23 +66,9 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 describe('assembleTrace', () => {
-  let previousStreamLogStore: StreamLogStore;
-
   setupPlatform(buildStoragePlatform);
 
-  beforeEach(() => {
-    // A fresh store per test, not the process-wide singleton: StreamLogStore's
-    // underlying KVStore caches a "directory already ensured" flag for its own
-    // lifetime, which goes stale once a later test points the platform at a
-    // different temp storage root. Real hosts never switch storage roots
-    // mid-process, so this is a test-only concern — the sanctioned fix used
-    // throughout src/test-kernel is swapping in a fresh store per test.
-    previousStreamLogStore = getDefaultStreamLogStore();
-    setDefaultStreamLogStore(new StreamLogStore());
-  });
-
   afterEach(async () => {
-    setDefaultStreamLogStore(previousStreamLogStore);
     await Promise.all(
       tempDirs
         .splice(0)
@@ -106,7 +87,7 @@ describe('assembleTrace', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     store.append(streamId, {
       id: 'entry-1',
@@ -171,7 +152,7 @@ describe('assembleTrace', () => {
     const actualChildStreamId = `bash@tool#${executionId}`;
     expect(actualChildStreamId).not.toBe(derivedId);
 
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     store.append(actualChildStreamId as ReturnType<typeof getStreamTabId>, {
       id: 'entry-1',
@@ -204,7 +185,7 @@ describe('assembleTrace', () => {
       executionConfig.model,
       { executionId },
     );
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     store.append(streamId, {
       id: 'entry-1',

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -10,12 +10,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import {
-  assembleTrace,
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
-  StreamLogStore,
-} from '@transcript';
+import { assembleTrace, StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -75,17 +70,9 @@ function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 describe('trace-viewer TraceDataSchema', () => {
-  let previousStreamLogStore: StreamLogStore;
-
   setupPlatform(buildStoragePlatform);
 
-  beforeEach(() => {
-    previousStreamLogStore = getDefaultStreamLogStore();
-    setDefaultStreamLogStore(new StreamLogStore());
-  });
-
   afterEach(async () => {
-    setDefaultStreamLogStore(previousStreamLogStore);
     await Promise.all(
       tempDirs
         .splice(0)
@@ -104,7 +91,7 @@ describe('trace-viewer TraceDataSchema', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = getDefaultStreamLogStore();
+    const store = new StreamLogStore();
     await store.load();
     store.append(streamId, {
       id: 'entry-1',

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -943,14 +943,3 @@ export class StreamLogStore {
     }
   }
 }
-
-let defaultStore: StreamLogStore | undefined;
-
-export function getDefaultStreamLogStore(): StreamLogStore {
-  defaultStore ??= new StreamLogStore();
-  return defaultStore;
-}
-
-export function setDefaultStreamLogStore(store: StreamLogStore): void {
-  defaultStore = store;
-}

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -10,8 +10,6 @@
  * subscriber via `trace.subscribe(...)` and persist however they need.
  */
 export {
-  getDefaultStreamLogStore,
-  setDefaultStreamLogStore,
   StreamLogStore,
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -13,10 +13,7 @@ import { attachChannelSubscriber } from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
 
 import { attachTranscriptRecorder } from './TexraTranscriptRecorder';
-import {
-  getDefaultStreamLogStore,
-  type StreamLogStore,
-} from './StreamLogStore';
+import type { StreamLogStore } from './StreamLogStore';
 
 export interface RunTrace {
   readonly trace: AgentTrace;
@@ -27,11 +24,14 @@ export interface RunTrace {
  * Produce a trace wired with the standard agent-run subscribers: per-channel
  * channel output AND the transcript recorder.
  *
- * `store` defaults to the global stream-log store — tests can override.
+ * `store` is caller-supplied — production launch paths pass the owning
+ * session's `transcripts` store (`session.transcripts`); there is no
+ * process-wide default to fall back to (`@transcript` never imports
+ * `@agent/runtime`, so it cannot reach `defaultSession()` itself).
  */
 export function createRunTrace(
   streamId: StreamTabId,
-  store: StreamLogStore = getDefaultStreamLogStore(),
+  store: StreamLogStore,
   flushers: Set<() => void> = activeFlushers,
 ): RunTrace {
   const trace = new TraceEmitter();

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -51,11 +51,11 @@ export async function assembleTrace(
   executionId: ExecutionId,
 ): Promise<AssembleTraceResult> {
   const executionStore = getExecutionStore(executionId);
-  // A fresh instance, not the shared getDefaultStreamLogStore() singleton:
-  // .load() clears all of a store's in-memory state, which would wipe out a
-  // live host's in-flight session if this ran against the shared instance.
-  // Reads the same on-disk files regardless — StreamSnapshotStore below
-  // already follows this same call-scoped-instance pattern.
+  // A fresh instance, not the session's shared `transcripts` store: .load()
+  // clears all of a store's in-memory state, which would wipe out a live
+  // host's in-flight session if this ran against the shared instance. Reads
+  // the same on-disk files regardless — StreamSnapshotStore below already
+  // follows this same call-scoped-instance pattern.
   const streamLogStore = new StreamLogStore();
   const [config, meta] = await Promise.all([
     executionStore.readConfig(),


### PR DESCRIPTION
## Summary

Executes the recorded decision on #7694: `defaultSession()` is declared **permanent** (the sanctioned single-session entry point); the invariant of record is **"no session-scoped mutable module export."** Moves construction of the process-default session's owners inside `SessionHandle.defaultSession()` itself and deletes the five standalone module exports that used to alias them, retargeting every consumer through `defaultSession()` / `currentSession()`.

Rides the #6982 D1 sweep per the decision's sequencing note ("defaultSession() inversion... rides this step").

## Net elements (R6)

- **-5 module-level singleton exports, 0 new elements.**
  - `SharedExecutionRegistry` (`src/agent/runtime/executionRegistry.ts`)
  - `SharedExecutionSubscriptionBinder` (`src/agent/runtime/ExecutionSubscriptionBinder.ts`)
  - `StreamStatusService` module singleton (`src/agent/runtime/StreamStatusService.ts`)
  - `getDefaultStreamLogStore` / `setDefaultStreamLogStore` (`src/transcript/StreamLogStore.ts`)
  - `ToolUseFollowUpQueue`'s default-instance static family — `defaultInstance()` plus the `onRelease`/`acquire`/`release`/`enqueue`/`drain`/`drainItems`/`getAll` static proxies and the private `defaultQueue` field (`src/agent/followUp/ToolUseFollowUpQueueManager.ts`)
- `defaultSession()` itself is unchanged in shape — only its construction changed, from aliasing five external singletons by identity to fresh-building its owners internally in the same FORCED dependency order every other `SessionHandle` already uses.
- No new files, no new ports/facades, no new exports added anywhere.
- Net diff: **-194 lines** (555 insertions / 749 deletions across 64 files).

### Scope note: the `ToolUseFollowUpQueue` static family

The issue's decision comment names only `ToolUseFollowUpQueue.defaultInstance()` among the five aliases. I expanded the deletion to the *entire* static default-instance family (`onRelease`/`acquire`/`release`/`enqueue`/`drain`/`drainItems`/`getAll`), because those methods proxied to the exact same private `defaultQueue` singleton that `defaultInstance()` exposed. Deleting only `defaultInstance()` while leaving the other statics pointed at that private field, or leaving them as dead code after `defaultSession()` stopped reading it, would have split identity between "the queue static callers see" and "the queue `defaultSession().followUps` resolves to" — precisely the #7640 bug class (a guard reading one instance while runs write another) this issue exists to close. Full deletion keeps a single owner.

## Consumer counts (R8)

Grepped and retargeted every consumer across `src/` and `packages/` (including the `.mts` test-kernel suite, which a first grep pass missed and a full `npm run typecheck` caught):

| Alias | Production files | Test files |
|---|---|---|
| `SharedExecutionRegistry` | 10 (`SessionHandle.ts`, `ExecutionSubscriptionBinder.ts`, `executionRegistry.ts`, `agentShutdown.ts`, `setupAssistantCommand.ts`, `agentCommands.ts`, `historyHandlers.ts`, `chatSessionController.ts`, `runChatTui.tsx`, `handleSlashCommand.ts`, `agentModelCommands.ts`) | 7 |
| `SharedExecutionSubscriptionBinder` | 2 (definition + construction site only — no external production consumers) | 1 |
| `StreamStatusService` (module singleton) | 7 (`executionRegistry.ts`, `SessionHandle.ts`, `followUpCommand.ts`, `resumeCommand.ts`, `resumeFromSnapshot.ts`, `ProgressStreamLifecycleHost.ts`, CLI `streamStatus.ts`) | ~14 |
| `getDefaultStreamLogStore` / `setDefaultStreamLogStore` | 9 (`StreamLogStore.ts`, `transcript/index.ts`, `runTrace.ts`, `SessionHandle.ts`, `tui-harness.tsx`, `runChatTui.tsx`, `chatSessionController.ts`, `completedProcessTranscript.ts`, CLI `transcript.ts`, `subscribeStreamLog.ts`, `runExecution.ts`) | ~20 |
| `ToolUseFollowUpQueue` default-instance family | 3 (`SessionHandle.ts`, `ExecutionSubscriptionBinder.ts`, `tui-harness.tsx`) | 8 |

Every retargeted production call site is a command/UI/IPC handler outside any run ALS, so `defaultSession()` is identity-equal to what the deleted alias resolved to by construction — no behavior change. `ExecutionSubscriptionBinder`'s two constructor defaults (`registry`/`releaseSource`) now fall back through `currentSession()` instead of a standalone singleton; both remain unreachable in production since `SessionHandle` always passes both explicitly (confirmed dead code, same as before).

`createRunTrace()`'s `store` parameter is now **required** (no default): `@transcript` cannot import `@agent/runtime` to reach `defaultSession()` (existing layering rule, documented in `runTrace.ts`), and its two production callers (`childStream.ts`, `AgentLaunchContext.ts`) already passed `session.transcripts` explicitly. ~30 test call sites that relied on the old default now pass an explicit `StreamLogStore` — either a shared per-test instance or `defaultSession().transcripts` where the test's assertions specifically check default-session identity/isolation.

## Residuals

None. All five aliases are fully deleted with zero remaining references (verified via repo-wide grep across `.ts`/`.tsx`/`.mts` after every edit) — no consumer needed to stay on a standalone singleton import.

Closes #7694

## Test plan

- [x] `npm run typecheck` — clean across all workspaces (root, test-kernel, CLI, trace-viewer, desktop)
- [x] `npm test` — 623 test files passed, 1 pre-existing skip; 5498 tests passed, 4 pre-existing skips
- [x] Repo-wide grep confirms zero remaining references to any of the 5 deleted aliases

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical retarget across agent runtime, CLI, and extension with behavior intended to stay identical; any missed import or wrong session handle could split execution/status/transcript state between callers.
> 
> **Overview**
> Completes the **#7694** invariant: no session-scoped mutable module exports. The process-default runtime owners now live only inside lazy `defaultSession()` construction instead of being re-exported as standalone singletons.
> 
> **Removed aliases:** `SharedExecutionRegistry`, `SharedExecutionSubscriptionBinder`, `StreamStatusService` (module instance), `getDefaultStreamLogStore` / `setDefaultStreamLogStore`, and the full `ToolUseFollowUpQueue` static default-queue API (`acquire`, `enqueue`, `drain`, etc.).
> 
> **Call-site migration:** Production paths in the CLI TUI, headless CLI, VS Code extension, shutdown hooks, and TUI harness now use `defaultSession().executions`, `.status`, `.transcripts`, and `.followUps` (or `currentSession()` where run-scoped). `ExecutionSubscriptionBinder` constructor fallbacks resolve through `currentSession()` instead of hidden module exports.
> 
> **Tests / tracing:** Suites stop swapping a global default transcript store; they pass an explicit `StreamLogStore` to `createRunTrace` or clear `defaultSession().transcripts` in place. `SessionHandle` tests now assert stable `defaultSession()` identity rather than equality with deleted `Shared*` exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b99a4f6f07ab1232b1f6a2eff206f3cd1d7f867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->