### PR TITLE
test(cli): centralize temp directory cleanup

### DIFF
--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -121,6 +121,18 @@ async function initDefaultFakePlatform(): Promise<void> {
   initPlatform(createFakePlatform());
 }
 
+async function withTempDir<T>(
+  prefix: string,
+  run: (root: string) => Promise<T>,
+): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
 describe('CLI root argument routing', () => {
   it('routes top-level --logout to the logout subcommand', () => {
     expect(normalizeRootShortcuts(['--logout'])).toEqual(['logout']);
@@ -514,8 +526,7 @@ describe('CLI root argument routing', () => {
   });
 
   it('expands workflow input directories and globs relative to cwd', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-inputs-'));
-    try {
+    await withTempDir('texra-cli-inputs-', async (root) => {
       await fs.mkdir(path.join(root, 'paper', 'sections'), {
         recursive: true,
       });
@@ -539,28 +550,22 @@ describe('CLI root argument routing', () => {
           root,
         ),
       ).resolves.toEqual(['paper/sections/appendix.tex']);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects a literal --input file that does not exist', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-inputs-'));
-    try {
+    await withTempDir('texra-cli-inputs-', async (root) => {
       const missing = path.join(root, 'no-such.tex');
       // Pure path (no glob magic, not a directory) — previously this was
       // returned as-is and the workflow ran until the agent ENOENT'd.
       await expect(expandWorkflowInputSpecs([missing], root)).rejects.toThrow(
         /--input: file not found/,
       );
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('materializes stdin when --input - is passed', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       let readCount = 0;
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
@@ -591,14 +596,11 @@ describe('CLI root argument routing', () => {
       await expect(
         fs.stat(path.dirname(path.resolve(root, expanded[0]))),
       ).rejects.toThrow();
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('preserves stdin position when mixed with file inputs', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       await fs.writeFile(path.join(root, 'paper.tex'), 'paper');
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
@@ -618,14 +620,11 @@ describe('CLI root argument routing', () => {
       expect(path.basename(expanded[0])).toBe('stdin.tex');
       expect(isMaterializedStdinWorkflowInputPath(expanded[0])).toBe(true);
       expect(expanded[1]).toBe('paper.tex');
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects empty stdin input', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
         readStdinText: async () => ' \n\t ',
@@ -634,9 +633,7 @@ describe('CLI root argument routing', () => {
       await expect(
         expandWorkflowInputSpecs(['-'], root, '--input', { stdinInputFile }),
       ).rejects.toThrow(/stdin: no data on stdin/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('detects stdin mixed with other raw workflow input specs', () => {
@@ -659,8 +656,7 @@ describe('CLI root argument routing', () => {
   });
 
   it('does not read stdin before later --input validation errors', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       let readCount = 0;
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
@@ -676,14 +672,11 @@ describe('CLI root argument routing', () => {
         }),
       ).rejects.toThrow(/--input: file not found: missing\.tex/);
       expect(readCount).toBe(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('does not read stdin before --context validation errors', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       let readCount = 0;
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
@@ -699,14 +692,11 @@ describe('CLI root argument routing', () => {
         }),
       ).rejects.toThrow(/--context: file not found: missing-context\.tex/);
       expect(readCount).toBe(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('materializes stdin for --context - when input is a normal file', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       await fs.writeFile(path.join(root, 'main.tex'), 'main');
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
@@ -727,14 +717,11 @@ describe('CLI root argument routing', () => {
       await expect(
         fs.readFile(path.resolve(root, contextFiles[0]), 'utf8'),
       ).resolves.toBe('context body');
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects stdin across both input and context with a clear usage error', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-stdin-'));
-    try {
+    await withTempDir('texra-cli-stdin-', async (root) => {
       const stdinInputFile = createStdinWorkflowInputMaterializer({
         tempDir: root,
         readStdinText: async () => 'piped body',
@@ -742,9 +729,7 @@ describe('CLI root argument routing', () => {
       await expect(
         expandRunInputs(['-'], ['-'], root, { stdinInputFile }),
       ).rejects.toThrow(/Use `-` for either --input or --context/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('rejects external files when tool-use runs require workspace files', async () => {
@@ -807,15 +792,12 @@ describe('CLI root argument routing', () => {
     // The helper is shared between --input (texra run, multi-agent run input)
     // and --context (multi-agent run context). The error must name the flag
     // the user actually passed, not always say --input.
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-flag-'));
-    try {
+    await withTempDir('texra-cli-flag-', async (root) => {
       const missing = path.join(root, 'no-such-context.tex');
       await expect(
         expandWorkflowInputSpecs([missing], root, '--context'),
       ).rejects.toThrow(/--context: file not found/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('expands a glob --context spec the same way --input does', async () => {
@@ -823,16 +805,13 @@ describe('CLI root argument routing', () => {
     // the AgentConfig and failed late with raw ENOENT (exit 1). Routing
     // through expandWorkflowInputSpecs gives it the same expansion semantics
     // as `--input` (and surfaces missing-path errors as Usage / exit 2).
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-ctx-'));
-    try {
+    await withTempDir('texra-cli-ctx-', async (root) => {
       await fs.writeFile(path.join(root, 'a.bib'), 'a');
       await fs.writeFile(path.join(root, 'b.bib'), 'b');
       await expect(
         expandWorkflowInputSpecs([path.join(root, '*.bib')], root, '--context'),
       ).resolves.toEqual(['a.bib', 'b.bib']);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   // Skip on Windows (no POSIX chmod semantics) and when running as root, where
@@ -1680,8 +1659,7 @@ describe('runCli usage output stream routing', () => {
   });
 
   it('defaults bare history to list while accepting global flags', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-history-'));
-    try {
+    await withTempDir('texra-history-', async (root) => {
       const result = await runCli([
         'history',
         '--cwd',
@@ -1693,9 +1671,7 @@ describe('runCli usage output stream routing', () => {
       expect(result.exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual([]);
       expect(stderr).toBe('');
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it('forwards history globals before an explicit subcommand', async () => {


### PR DESCRIPTION
## Summary

- Add a file-local `withTempDir` helper for CLI root argument tests.
- Replace 12 identical single-directory `mkdtemp` / `try` / `finally` / `rm` lifecycles.
- Keep multi-directory, permission-sensitive, and suite-level storage cleanup explicit.

## Issue acceptance gates

Closes #8035.

- Migrates exactly the 12 bounded single-directory cases.
- Preserves all 109 tests and all 353 assertions.
- Preserves every temp prefix, test body, and explicit behavior-under-test cleanup assertion.
- Leaves the three dual-directory cases, chmod-sensitive case, and suite storage lifecycle unchanged.
- Passes focused and repository-wide validation.

## Single source of truth

The file-local `withTempDir` helper now owns the common invariant: create a fresh directory, await the test callback, and recursively remove the directory in `finally`.

## Duplication and abstraction budget

The helper replaces 12 exact cleanup lifecycles and has 12 consumers. It remains test-local, owns real resource-lifecycle behavior, and introduces no production abstraction or pass-through layer.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Diffstat: 36 insertions, 60 deletions.
- Net LoC: -24 (`1775 -> 1751`).
- Exported symbols: 0 added, 0 removed.
- Functions: 1 local helper added.
- Classes/interfaces/enums: no net change.
- Test cases/assertions: unchanged at 109/353.

## Consumer counts (R8)

n/a: no export, event, or emit path is deleted or rerouted.

## Host impact

Extension: none.

Desktop: none.

CLI: test-only cleanup; production behavior is unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 47 existing import-order warnings)
- `npm test` (623 files passed, 1 skipped; 5536 tests passed, 4 skipped)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/CliRootArgs.vitest.mts` (109/109)
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- Targeted ESLint (0 errors)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor in one vitest file; no production or CLI behavior changes.
> 
> **Overview**
> Introduces a file-local **`withTempDir`** helper in `CliRootArgs.vitest.mts` that creates a prefixed temp directory, runs an async callback, and always removes the directory in `finally`.
> 
> **Twelve** tests that previously inlined `mkdtemp` / `try` / `finally` / `fs.rm` now call `withTempDir` with the same temp prefixes and unchanged test bodies (workflow `--input`/`--context` expansion, stdin materialization, history list defaults, and related cases).
> 
> Tests that need **two** temp dirs, **chmod**-sensitive cleanup, or **suite-level** platform storage teardown are left as explicit lifecycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9fe2c530a0b301b606ef96d2e8ca3e4c5d3d157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->