### PR TITLE
ci: run kernel tests with two workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: pnpm run check:tsconfig-paths
 
       - name: Kernel tests
-        run: pnpm run test
+        run: pnpm run test --maxWorkers=2
 
       - name: Validate CLI TUI smoke frames
         run: |


### PR DESCRIPTION
## Summary

- Run the existing Linux kernel test suite with at most two Vitest workers.
- Preserve every test, file, isolation boundary, and pass/fail condition.
- Make runner concurrency explicit where the 2-vCPU GitHub host otherwise defaults Vitest to one worker.

## Issue acceptance gates

Closes #8039.

- Keeps the same `pnpm run test` suite and adds only `--maxWorkers=2`.
- Preserves all 624 files and 5,544 test entries.
- Changes no test, coverage, or production source.
- Local and hosted two-worker executions pass without flakes or OOMs.
- Hosted kernel duration is 657.60 seconds versus the 791-second recent median.

## Single source of truth

The `Kernel tests` step in `.github/workflows/ci.yml` owns hosted-runner worker concurrency. The package test script remains host-neutral and unchanged.

## Duplication and abstraction budget

No abstraction or duplicate path is added. This makes one scheduler decision explicit at the CI boundary instead of changing local defaults or test behavior.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Diffstat: 1 insertion, 1 deletion.
- Net LoC: 0.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums/functions: no net change.

## Consumer counts (R8)

n/a: no export, event, or emit path is deleted or rerouted.

## Host impact

Extension: none.

Desktop: none.

CLI: none; CI scheduling only.

## Scheduled refactoring

None. Revert the worker cap if later hosted samples introduce instability.

## Validation

- Hosted PR CI: 623 files passed, 1 skipped; 5,540 tests passed, 4 skipped.
- Hosted Vitest duration: 657.60 seconds.
- Recent hosted single-worker baseline: 19 completed PR runs, 605–830 seconds, 791-second median.
- Improvement versus median: 133.40 seconds (16.9%).
- Improvement versus PR #8036: 129.21 seconds (16.4%).
- Full Linux validation job: 16m48s versus 18m42s on PR #8036.
- Local `corepack pnpm run test --maxWorkers=2`: same file/test counts in 194.69 seconds.
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 47 existing import-order warnings)
- `corepack pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`