### PR TITLE
fix(transcript): replay overlays after hydration

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -118,6 +118,24 @@ function toolUseTaskState(agent = 'search', model = 'deepseekproT'): TaskState {
   });
 }
 
+function injectDuringExecutionConfigHydration(
+  executionId: ExecutionId,
+  inject: () => void,
+) {
+  const originalRead = StorageFS.read.bind(StorageFS);
+  const configPath = path.join(
+    resolveRunStoragePath(executionId),
+    'config.json',
+  );
+  const injected = vi.fn(inject);
+  vi.spyOn(StorageFS, 'read').mockImplementation(async (target: string) => {
+    const raw = await originalRead(target);
+    if (target === configPath && injected.mock.calls.length === 0) injected();
+    return raw;
+  });
+  return injected;
+}
+
 describe('StreamSnapshotStore', () => {
   setupPlatform(buildSnapshotPlatform);
 
@@ -788,23 +806,13 @@ describe('StreamSnapshotStore', () => {
     );
 
     const store = new StreamSnapshotStore();
-    const originalRead = StorageFS.read.bind(StorageFS);
-    const configPath = path.join(
-      resolveRunStoragePath(oldExecutionId),
-      'config.json',
+    const wasRuntimeUpdateInjected = injectDuringExecutionConfigHydration(
+      oldExecutionId,
+      () => store.setTaskState(STREAM, newTaskState, newExecutionId),
     );
-    let injectedRuntimeUpdate = false;
-    vi.spyOn(StorageFS, 'read').mockImplementation(async (target: string) => {
-      const raw = await originalRead(target);
-      if (!injectedRuntimeUpdate && target === configPath) {
-        injectedRuntimeUpdate = true;
-        store.setTaskState(STREAM, newTaskState, newExecutionId);
-      }
-      return raw;
-    });
 
     await store.load([STREAM]);
-    expect(injectedRuntimeUpdate).toBe(true);
+    expect(wasRuntimeUpdateInjected).toHaveBeenCalledOnce();
     expect(store.getTaskState(STREAM)).toEqual(newTaskState);
     expect(store.getExecutionId(STREAM)).toBe(newExecutionId);
 
@@ -818,6 +826,52 @@ describe('StreamSnapshotStore', () => {
       executionId: newExecutionId,
       agent: 'new-search',
     });
+  });
+
+  it('persists a late reset and round patch that arrive during async hydration', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const executionId = 'c0ffee' as ExecutionId;
+    await StorageFS.ensureDir(dir);
+    await Promise.all([
+      StorageFS.write(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({
+          schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+          executionId,
+        }),
+      ),
+      StorageFS.write(
+        path.join(dir, 'missingOutputs.json'),
+        JSON.stringify({ '0': ['stale.tex'] }),
+      ),
+      getExecutionStore(executionId).writeConfig(
+        toolUseTaskState().agentConfig,
+      ),
+    ]);
+
+    const store = new StreamSnapshotStore();
+    const wereLateOverlaysInjected = injectDuringExecutionConfigHydration(
+      executionId,
+      () => {
+        store.clearMissingOutputs(STREAM);
+        store.updateMissingOutputs(STREAM, { 1: ['late.tex'] });
+        void store.addUsage(STREAM, RUN, usage(10, 2, 0.1));
+      },
+    );
+
+    await store.load([STREAM]);
+    expect(wereLateOverlaysInjected).toHaveBeenCalledOnce();
+    expect(store.getMissingOutputs(STREAM)).toEqual({ 1: ['late.tex'] });
+    expect(store.getRunUsage(STREAM).get(RUN)).toMatchObject(usage(10, 2, 0.1));
+    await store.flush();
+
+    const [missingOutputs, usageStats] = await Promise.all([
+      StorageFS.readJson(path.join(dir, 'missingOutputs.json')),
+      StorageFS.readJson(path.join(dir, 'usageStats.json')),
+    ]);
+    expect(missingOutputs).toEqual({ '1': ['late.tex'] });
+    expect(usageStats).toMatchObject({ [RUN]: usage(10, 2, 0.1) });
   });
 
   it('load refreshes already-seeded streams from disk instead of keeping stale memory', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1347,10 +1347,7 @@ export class StreamSnapshotStore {
       metaOverlay !== undefined ? this.runConfigs.get(stream) : undefined;
     const runDescriptorOverlay =
       metaOverlay !== undefined ? this.runDescriptors.get(stream) : undefined;
-    const outputFileOverlay = this.outputFileOverlays.get(stream);
-    const missingOutputsOverlay = this.missingOutputsOverlays.get(stream);
-    const compileFailuresOverlay = this.compileFailuresOverlays.get(stream);
-    const usageOverlay = this.usageOverlays.get(stream);
+    const usageOverlayToReplay = new Map(this.usageOverlays.get(stream));
     const sidecarsToWrite = new Set(data.legacyKeys);
     this.outputFiles.set(stream, data.outputFiles);
     this.missingOutputs.set(stream, data.missingOutputs);
@@ -1401,6 +1398,10 @@ export class StreamSnapshotStore {
       this.runDescriptors.set(stream, runDescriptor);
     }
     this.metaOverlays.delete(stream);
+    const outputFileOverlay = this.outputFileOverlays.get(stream);
+    const missingOutputsOverlay = this.missingOutputsOverlays.get(stream);
+    const compileFailuresOverlay = this.compileFailuresOverlays.get(stream);
+    const usageOverlay = this.usageOverlays.get(stream);
     if (outputFileOverlay) {
       this.applyRoundPatch(this.outputFiles, stream, outputFileOverlay);
       sidecarsToWrite.add(STREAM_DATA_KEYS.OUTPUT_FILES);
@@ -1426,7 +1427,7 @@ export class StreamSnapshotStore {
       this.compileFailuresOverlays.delete(stream);
     }
     if (usageOverlay) {
-      for (const [storageKey, delta] of usageOverlay) {
+      for (const [storageKey, delta] of usageOverlayToReplay) {
         this.applyUsageDeltaMemory(stream, storageKey, delta);
       }
       sidecarsToWrite.add(STREAM_DATA_KEYS.USAGE_STATS);


### PR DESCRIPTION
## Summary

- Re-read output-file, missing-output, compile-failure, and usage overlays after async run-state hydration completes.
- Replay round overlays at the final synchronous reconciliation point.
- Replay only pre-hydration usage deltas while using the latest usage overlay to trigger persistence, avoiding double-counting eager late deltas.
- Add one combined regression for a late reset, round patch, and additive usage delta.

## Issue acceptance gates

Closes #8033.

- Captures all four latest overlay maps after `hydrateRunStateFromMeta(...)`'s await window.
- Preserves overlays that existed before hydration and includes overlays created or replaced during hydration.
- Persists a late `clearMissingOutputs` reset plus later round patch to disk after `flush()`.
- Persists a late usage delta exactly once.
- The regression fails on the parent commit with stale disk data and passes with this fix.
- Passes focused and repository-wide validation.

## Single source of truth

`StreamSnapshotStore.applyStreamData` owns post-hydration overlay reconciliation. Round patches are idempotently replayed from the latest overlays. Additive usage snapshots only the pre-hydration deltas that the disk baseline overwrites; late deltas remain in memory and are persisted without being added twice.

## Duplication and abstraction budget

The production fix adds no abstraction. The tests reuse one local, once-only async-hydration injection helper across the existing run-config race test and the new overlay race test instead of duplicating the storage-read seam.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Diffstat: 74 insertions, 19 deletions.
- Net LoC: +55.
- Exported symbols: 0 added, 0 removed.
- Functions: 1 local test helper added.
- Classes/interfaces/enums: no net change.
- Tests: +1; assertions: +5.

## Consumer counts (R8)

n/a: no export, event, or emit path is deleted or rerouted.

## Host impact

Extension: prevents late snapshot overlays from remaining memory-only during hydration.

Desktop: same host-neutral snapshot persistence fix.

CLI: same host-neutral snapshot persistence fix.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` (34/34)
- `npm test` (623 files passed, 1 skipped; 5,541 tests passed, 4 skipped)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 existing import-order warnings)
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- Targeted ESLint (0 errors)
- `git diff --check`
- Independent race review confirmed the regression fails on the parent commit and the replay has no post-read interleaving window.
- Review follow-up now guards the injection seam to run once and asserts late usage is persisted without double-counting.