### PR TITLE
refactor(desktop): extract history IPC handlers

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -1,0 +1,276 @@
+// Node.js imports
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+// Local imports - history domain
+import {
+  ChatExportController,
+  type ExportInputStatus,
+} from '@controllers/settingsView/ChatExportController';
+import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
+import {
+  deleteAllExecutions,
+  deleteExecution,
+  getExecutionStore,
+} from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import {
+  validateExecutionRequest,
+  type ValidatedExecutionRequest,
+} from '@agent/core/state/executionRequests';
+import type { TaskState } from '@agent/core/state/TaskState';
+import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
+
+// Local imports - IPC contracts
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { ExecutionId } from '@shared/schemas';
+import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
+
+type HistoryExportFormat = 'md' | 'tex' | 'html';
+
+/** History-specific capabilities supplied by the desktop host. */
+export interface DesktopHistoryOptions {
+  /** Resolved extension resources used by chat export templates. */
+  resourcesPath?: string;
+  /** Run a validated request created from a persisted history entry. */
+  runExecution?: (request: ValidatedExecutionRequest) => Promise<void>;
+  /** Restore a persisted agent configuration into the main view. */
+  restoreTaskState?: (taskState: TaskState) => Promise<boolean>;
+}
+
+interface DesktopHistoryHandlerDependencies extends DesktopHistoryOptions {
+  postToRenderer(message: unknown): void;
+  openPath?: (filePath: string) => Promise<void>;
+  showInfoMessage?: (message: string) => Promise<void>;
+  showErrorMessage?: (message: string) => Promise<void>;
+  onError(error: unknown): void;
+}
+
+const HISTORY_CONFIG_UNREADABLE_MESSAGE =
+  'History item not found or unreadable (missing, corrupt, or from an incompatible version)';
+
+type HistoryConfigResult =
+  { status: 'ok'; config: AgentConfig } | { status: 'unreadable' };
+
+/** Own desktop history settings actions behind the dispatcher contract. */
+export class DesktopHistoryHandlers {
+  readonly actions: SettingsViewCommandActions['history'];
+
+  private chatExportController: ChatExportController | undefined;
+
+  constructor(
+    private readonly dependencies: DesktopHistoryHandlerDependencies,
+  ) {
+    this.actions = {
+      deleteAgent: (historyId) => this.deleteItem(historyId),
+      clear: () => this.clear(),
+      rerunAgent: (data) => this.rerun(data.historyId),
+      restoreAgent: (data) => this.restore(data.historyId),
+      exportChatMd: (data) => this.exportChat(data.historyId, 'md'),
+      exportChatTex: (data) => this.exportChat(data.historyId, 'tex'),
+      exportChatHtml: (data) => this.exportChat(data.historyId, 'html'),
+    };
+  }
+
+  async postHistoryData(): Promise<void> {
+    this.dependencies.postToRenderer(await buildHistoryMessage());
+  }
+
+  private async deleteItem(historyId: string): Promise<void> {
+    if (getAllActiveExecutionIds().includes(historyId)) {
+      await this.dependencies.showInfoMessage?.(
+        'Cannot delete a running execution',
+      );
+      return;
+    }
+
+    const deleted = await deleteExecution(historyId as ExecutionId);
+    if (!deleted) {
+      await this.dependencies.showInfoMessage?.(
+        `History item not found: ${historyId}`,
+      );
+      return;
+    }
+    await this.postHistoryData();
+  }
+
+  private async clear(): Promise<void> {
+    await deleteAllExecutions(new Set(getAllActiveExecutionIds()));
+    this.dependencies.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
+    });
+  }
+
+  // readConfig() validates and returns null for missing and corrupt configs;
+  // distinguishing them must happen in the storage layer, not here.
+  private async readHistoryConfig(
+    historyId: string,
+  ): Promise<HistoryConfigResult> {
+    const config = await getExecutionStore(
+      historyId as ExecutionId,
+    ).readConfig();
+    if (!config) return { status: 'unreadable' };
+    return { status: 'ok', config };
+  }
+
+  private async rerun(historyId: string): Promise<void> {
+    const result = await this.readHistoryConfig(historyId);
+    if (result.status === 'unreadable') {
+      await this.dependencies.showErrorMessage?.(
+        HISTORY_CONFIG_UNREADABLE_MESSAGE,
+      );
+      return;
+    }
+    const validated = validateExecutionRequest({ config: result.config });
+    if (!validated.valid) {
+      await this.dependencies.showErrorMessage?.(validated.message);
+      return;
+    }
+    if (!this.dependencies.runExecution) {
+      await this.dependencies.showErrorMessage?.(
+        'Rerunning agents from history is not available in this build',
+      );
+      return;
+    }
+    await this.dependencies.showInfoMessage?.('Rerunning agent from history');
+    await this.dependencies.runExecution(validated.request);
+  }
+
+  private async restore(historyId: string): Promise<void> {
+    const result = await this.readHistoryConfig(historyId);
+    if (result.status === 'unreadable') {
+      await this.dependencies.showErrorMessage?.(
+        HISTORY_CONFIG_UNREADABLE_MESSAGE,
+      );
+      return;
+    }
+    const restored =
+      (await this.dependencies.restoreTaskState?.(
+        agentConfigToTaskState(result.config),
+      )) ?? false;
+    if (!restored) {
+      await this.dependencies.showErrorMessage?.(
+        'Failed to restore configuration',
+      );
+    }
+  }
+
+  private getResourcesPath(): string {
+    if (!this.dependencies.resourcesPath) {
+      throw new Error(
+        'Desktop settings IPC missing resourcesPath; cannot export chat.',
+      );
+    }
+    return this.dependencies.resourcesPath;
+  }
+
+  private getChatExportController(): ChatExportController {
+    if (!this.chatExportController) {
+      const latexPreamble = readFileSync(
+        path.join(this.getResourcesPath(), 'templates', 'chatExport.tex'),
+        'utf8',
+      );
+      this.chatExportController = new ChatExportController({ latexPreamble });
+    }
+    return this.chatExportController;
+  }
+
+  private async reportExportInputError(
+    status: Exclude<ExportInputStatus, 'ok'>,
+  ): Promise<void> {
+    switch (status) {
+      case 'config_missing':
+        await this.dependencies.showInfoMessage?.('History item not found');
+        return;
+      case 'conversation_missing':
+        await this.dependencies.showInfoMessage?.(
+          'No conversation data available for this execution',
+        );
+        return;
+    }
+  }
+
+  private async reportHtmlExportError(
+    status: 'config_missing' | 'streamLogs_missing',
+  ): Promise<void> {
+    switch (status) {
+      case 'config_missing':
+        await this.dependencies.showInfoMessage?.('History item not found');
+        return;
+      case 'streamLogs_missing':
+        await this.dependencies.showInfoMessage?.(
+          'No stored transcript available for this execution — it may predate transcript persistence.',
+        );
+        return;
+    }
+  }
+
+  private async exportChatHtml(historyId: string): Promise<void> {
+    const controller = this.getChatExportController();
+    const outcome = await controller.exportAsHtml(
+      historyId,
+      path.join(this.getResourcesPath(), 'traceViewerStandalone', 'index.html'),
+    );
+    if (outcome.status !== 'ok') {
+      await this.reportHtmlExportError(outcome.status);
+      return;
+    }
+    const { absolutePath, storagePath } = outcome.result;
+    await this.dependencies.openPath?.(absolutePath);
+    await this.dependencies.showInfoMessage?.(
+      `Chat exported: ${path.basename(storagePath)}`,
+    );
+  }
+
+  private async exportChat(
+    historyId: string,
+    format: HistoryExportFormat,
+  ): Promise<void> {
+    if (format === 'html') {
+      await this.exportChatHtml(historyId);
+      return;
+    }
+
+    const controller = this.getChatExportController();
+    const result = await controller.buildExportInput(historyId);
+    if (result.status !== 'ok') {
+      await this.reportExportInputError(result.status);
+      return;
+    }
+    const { exportInput } = result;
+
+    if (format === 'md') {
+      const { absolutePath, storagePath } = await controller.exportAsMarkdown(
+        historyId,
+        exportInput,
+      );
+      await this.dependencies.openPath?.(absolutePath);
+      await this.dependencies.showInfoMessage?.(
+        `Chat exported: ${path.basename(storagePath)}`,
+      );
+      return;
+    }
+
+    const { absolutePath, storagePath, pdfPath, logTail } =
+      await controller.exportAsLatex(historyId, exportInput);
+    if (pdfPath) {
+      await this.dependencies.openPath?.(pdfPath);
+      await this.dependencies.showInfoMessage?.(
+        `Chat exported and compiled: ${path.basename(storagePath).replace('.tex', '.pdf')}`,
+      );
+      return;
+    }
+    if (logTail) {
+      this.dependencies.onError(
+        new Error(
+          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
+        ),
+      );
+    }
+    await this.dependencies.openPath?.(absolutePath);
+    await this.dependencies.showInfoMessage?.(
+      'LaTeX compilation failed. The .tex source file has been opened instead.',
+    );
+  }
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'node:fs';
-import * as path from 'node:path';
-
 import { platform, tryPlatform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
@@ -9,11 +6,6 @@ import {
   isAllowedLatexInstallCommand,
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
-import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
-import {
-  ChatExportController,
-  type ExportInputStatus,
-} from '@controllers/settingsView/ChatExportController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import {
@@ -22,25 +14,12 @@ import {
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import {
-  deleteAllExecutions,
-  deleteExecution,
-  getExecutionStore,
-} from '@agent/storage';
-import {
   computeAgentOptionsData,
   getAgentsByCategory,
   getVisibleAgents as getVisibleRegistryAgents,
   loadAgents,
   type AgentEntry,
 } from '@agent/index/agentRegistry';
-import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
-import { type AgentConfig } from '@agent/core/definition/AgentConfig';
-import {
-  validateExecutionRequest,
-  type ValidatedExecutionRequest,
-} from '@agent/core/state/executionRequests';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import type { TaskState } from '@agent/core/state/TaskState';
 import {
   codexCoordinator,
   getChatGptAuthStatus,
@@ -59,7 +38,6 @@ import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
-import type { ExecutionId } from '@shared/schemas';
 import { SETTINGS_VIEW_COMMANDS, MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
@@ -137,6 +115,10 @@ import {
   type DesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
+import {
+  DesktopHistoryHandlers,
+  type DesktopHistoryOptions,
+} from './desktopHistoryHandlers.js';
 import type { ConfigProvider, StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
 
@@ -144,7 +126,7 @@ type ToolDashboardBuilder = (
   cachedResults?: ExternalToolCheckResult[],
 ) => Promise<ToolDashboardItem[]>;
 
-export interface DesktopSettingsIpcOptions {
+export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   postToRenderer(message: unknown): void;
   sendStartupCatalogData?: boolean;
   loadAgents?: typeof loadAgents;
@@ -163,27 +145,6 @@ export interface DesktopSettingsIpcOptions {
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
   openExternalUrl?: (url: string) => Promise<void>;
-  /**
-   * Resolved `packages/extension/resources` tree (ElectronPlatformInitResult
-   * .resourcesPath). Used to locate the chat-export LaTeX preamble and the
-   * bundled trace-viewer standalone template — the same assets the
-   * extension's `HistoryHandlers` loads, reached here via `fs` instead of an
-   * esbuild text import.
-   */
-  resourcesPath?: string;
-  /**
-   * Run an agent (history "Rerun"). Delegates to the same host-neutral
-   * `runAgent` the extension's `runExecuteCommand` calls, via the desktop
-   * agent-execution bridge's `DesktopProgressBridge.runExecution`.
-   */
-  runExecution?: (request: ValidatedExecutionRequest) => Promise<void>;
-  /**
-   * Restore a task's setup into the main view (history "Setup"). Delegates to
-   * `DesktopProgressBridge.restoreTaskState`, the desktop equivalent of the
-   * extension's `texra.restoreState` command. Returns `false` when the config
-   * failed to convert to a persisted main-view state.
-   */
-  restoreTaskState?: (taskState: TaskState) => Promise<boolean>;
   /**
    * Offer the ChatGPT sign-in URL as a copyable link. `openExternalUrl` only
    * targets the system default browser; this lets a user whose ChatGPT
@@ -239,6 +200,16 @@ export function createDesktopSettingsIpc(
       void options.showInfoMessage?.(error.reason);
     },
   );
+  const historyHandlers = new DesktopHistoryHandlers({
+    postToRenderer: options.postToRenderer,
+    resourcesPath: options.resourcesPath,
+    runExecution: options.runExecution,
+    restoreTaskState: options.restoreTaskState,
+    openPath: options.openPath,
+    showInfoMessage: options.showInfoMessage,
+    showErrorMessage: options.showErrorMessage,
+    onError,
+  });
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
@@ -511,211 +482,6 @@ export function createDesktopSettingsIpc(
     await options.openPath?.(StorageFS.fullPath(resolveMemoryStoragePath()));
   }
 
-  async function postHistoryData(): Promise<void> {
-    options.postToRenderer(await buildHistoryMessage());
-  }
-
-  async function deleteHistoryItem(historyId: string): Promise<void> {
-    if (getAllActiveExecutionIds().includes(historyId)) {
-      await options.showInfoMessage?.('Cannot delete a running execution');
-      return;
-    }
-
-    const deleted = await deleteExecution(historyId as ExecutionId);
-    if (!deleted) {
-      await options.showInfoMessage?.(`History item not found: ${historyId}`);
-      return;
-    }
-    await postHistoryData();
-  }
-
-  async function clearHistory(): Promise<void> {
-    await deleteAllExecutions(new Set(getAllActiveExecutionIds()));
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
-    });
-  }
-
-  // readConfig() already validates via readValidated and returns null for
-  // BOTH missing and corrupt/legacy configs (the storage layer's silent-null
-  // read — distinguishing the two needs the loud-reads policy at the store,
-  // not a re-parse here, which can never see invalid data).
-  const HISTORY_CONFIG_UNREADABLE_MESSAGE =
-    'History item not found or unreadable (missing, corrupt, or from an incompatible version)';
-
-  type HistoryConfigResult =
-    { status: 'ok'; config: AgentConfig } | { status: 'unreadable' };
-
-  async function readHistoryConfig(
-    historyId: string,
-  ): Promise<HistoryConfigResult> {
-    const config = await getExecutionStore(
-      historyId as ExecutionId,
-    ).readConfig();
-    if (!config) return { status: 'unreadable' };
-    return { status: 'ok', config };
-  }
-
-  async function rerunHistoryAgent(historyId: string): Promise<void> {
-    const result = await readHistoryConfig(historyId);
-    if (result.status === 'unreadable') {
-      await options.showErrorMessage?.(HISTORY_CONFIG_UNREADABLE_MESSAGE);
-      return;
-    }
-    const validated = validateExecutionRequest({ config: result.config });
-    if (!validated.valid) {
-      await options.showErrorMessage?.(validated.message);
-      return;
-    }
-    if (!options.runExecution) {
-      await options.showErrorMessage?.(
-        'Rerunning agents from history is not available in this build',
-      );
-      return;
-    }
-    await options.showInfoMessage?.('Rerunning agent from history');
-    await options.runExecution(validated.request);
-  }
-
-  async function restoreHistoryAgent(historyId: string): Promise<void> {
-    const result = await readHistoryConfig(historyId);
-    if (result.status === 'unreadable') {
-      await options.showErrorMessage?.(HISTORY_CONFIG_UNREADABLE_MESSAGE);
-      return;
-    }
-    const restored =
-      (await options.restoreTaskState?.(
-        agentConfigToTaskState(result.config),
-      )) ?? false;
-    if (!restored) {
-      await options.showErrorMessage?.('Failed to restore configuration');
-    }
-  }
-
-  /**
-   * Resolved `resources/` tree, throwing if the host wired the IPC without
-   * one — export is only reachable when `resourcesPath` is supplied (see
-   * `DesktopSettingsIpcOptions.resourcesPath`).
-   */
-  function getResourcesPath(): string {
-    if (!options.resourcesPath) {
-      throw new Error(
-        'Desktop settings IPC missing resourcesPath; cannot export chat.',
-      );
-    }
-    return options.resourcesPath;
-  }
-
-  let chatExportController: ChatExportController | undefined;
-  function getChatExportController(): ChatExportController {
-    if (!chatExportController) {
-      const latexPreamble = readFileSync(
-        path.join(getResourcesPath(), 'templates', 'chatExport.tex'),
-        'utf8',
-      );
-      chatExportController = new ChatExportController({ latexPreamble });
-    }
-    return chatExportController;
-  }
-
-  async function reportExportInputError(
-    status: Exclude<ExportInputStatus, 'ok'>,
-  ): Promise<void> {
-    switch (status) {
-      case 'config_missing':
-        await options.showInfoMessage?.('History item not found');
-        return;
-      case 'conversation_missing':
-        await options.showInfoMessage?.(
-          'No conversation data available for this execution',
-        );
-        return;
-    }
-  }
-
-  async function reportHtmlExportError(
-    status: 'config_missing' | 'streamLogs_missing',
-  ): Promise<void> {
-    switch (status) {
-      case 'config_missing':
-        await options.showInfoMessage?.('History item not found');
-        return;
-      case 'streamLogs_missing':
-        await options.showInfoMessage?.(
-          'No stored transcript available for this execution — it may predate transcript persistence.',
-        );
-        return;
-    }
-  }
-
-  async function exportHistoryChatHtml(historyId: string): Promise<void> {
-    const controller = getChatExportController();
-    const outcome = await controller.exportAsHtml(
-      historyId,
-      path.join(getResourcesPath(), 'traceViewerStandalone', 'index.html'),
-    );
-    if (outcome.status !== 'ok') {
-      await reportHtmlExportError(outcome.status);
-      return;
-    }
-    const { absolutePath, storagePath } = outcome.result;
-    await options.openPath?.(absolutePath);
-    await options.showInfoMessage?.(
-      `Chat exported: ${path.basename(storagePath)}`,
-    );
-  }
-
-  async function exportHistoryChat(
-    historyId: string,
-    format: 'md' | 'tex' | 'html',
-  ): Promise<void> {
-    if (format === 'html') {
-      await exportHistoryChatHtml(historyId);
-      return;
-    }
-
-    const controller = getChatExportController();
-    const result = await controller.buildExportInput(historyId);
-    if (result.status !== 'ok') {
-      await reportExportInputError(result.status);
-      return;
-    }
-    const { exportInput } = result;
-
-    if (format === 'md') {
-      const { absolutePath, storagePath } = await controller.exportAsMarkdown(
-        historyId,
-        exportInput,
-      );
-      await options.openPath?.(absolutePath);
-      await options.showInfoMessage?.(
-        `Chat exported: ${path.basename(storagePath)}`,
-      );
-      return;
-    }
-
-    const { absolutePath, storagePath, pdfPath, logTail } =
-      await controller.exportAsLatex(historyId, exportInput);
-    if (pdfPath) {
-      await options.openPath?.(pdfPath);
-      await options.showInfoMessage?.(
-        `Chat exported and compiled: ${path.basename(storagePath).replace('.tex', '.pdf')}`,
-      );
-      return;
-    }
-    if (logTail) {
-      onError(
-        new Error(
-          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
-        ),
-      );
-    }
-    await options.openPath?.(absolutePath);
-    await options.showInfoMessage?.(
-      'LaTeX compilation failed. The .tex source file has been opened instead.',
-    );
-  }
-
   async function postToolDashboardData(postOptions?: {
     skipChecks?: boolean;
   }): Promise<void> {
@@ -816,7 +582,7 @@ export function createDesktopSettingsIpc(
     await Promise.all([
       memoryEnabledPosted,
       postMemoryData(),
-      postHistoryData(),
+      historyHandlers.postHistoryData(),
       modelSelectionDataPosted,
       postProfileData(),
       postChatGptAuthStatus(),
@@ -1309,15 +1075,7 @@ export function createDesktopSettingsIpc(
       pin: (storagePath) => setMemoryPinned(storagePath, true),
       unpin: (storagePath) => setMemoryPinned(storagePath, false),
     },
-    history: {
-      deleteAgent: (historyId) => deleteHistoryItem(historyId),
-      clear: () => clearHistory(),
-      rerunAgent: (data) => rerunHistoryAgent(data.historyId),
-      restoreAgent: (data) => restoreHistoryAgent(data.historyId),
-      exportChatMd: (data) => exportHistoryChat(data.historyId, 'md'),
-      exportChatTex: (data) => exportHistoryChat(data.historyId, 'tex'),
-      exportChatHtml: (data) => exportHistoryChat(data.historyId, 'html'),
-    },
+    history: historyHandlers.actions,
     profile: {
       signIn: () => signIn(),
       signOut: () => signOut(),

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -3,8 +3,9 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
-import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { LatexSettingsStatus } from '@shared/schemas/settingsViewMessages';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/constants/git';
 import { HOMEBREW_INSTALL_COMMAND } from '@shared/constants/latex';
 import {
@@ -18,6 +19,7 @@ import {
   moduleFileUrl,
   repoPath,
 } from './desktopTestPaths.mjs';
+import type { StateStore } from '@platform/interfaces';
 
 const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
 const computeModelOptionsData = vi.hoisted(() =>
@@ -58,105 +60,8 @@ vi.mock('@controllers/settingsView/ChatExportController', () => ({
   },
 }));
 
-interface StateStore {
-  get<T>(key: string, defaultValue?: T): T;
-  update(key: string, value: unknown): PromiseLike<void>;
-}
-
-interface DesktopSettingsIpcModule {
-  createDesktopSettingsIpc(options: {
-    postToRenderer(message: unknown): void;
-    sendStartupCatalogData?: boolean;
-    globalState?: StateStore;
-    workspaceState?: StateStore;
-    config?: {
-      get<T>(key: string, defaultValue?: T): T;
-      update<T>(
-        key: string,
-        value: T,
-        target?: 'global' | 'workspace',
-      ): Promise<void>;
-      inspect<T = unknown>(key: string): { effectiveValue?: T } | undefined;
-      isExplicitlySet(key: string): boolean;
-      watch(
-        key: string | readonly string[] | RegExp,
-        listener: () => void,
-      ): { dispose(): void };
-    };
-    loadAgents?: () => Promise<void>;
-    loadAgentOptionsData?: () => Promise<{
-      workflow: unknown[];
-      toolUse: unknown[];
-    }>;
-    getAgents?: (category: 'workflow' | 'toolUse') => Array<{
-      name: string;
-      source: 'builtInWorkflow' | 'builtInToolUse' | 'custom' | 'remote';
-      category: 'workflow' | 'toolUse';
-      description?: string;
-      path?: string;
-      multiplePath?: string;
-      isMultiple?: boolean;
-      tools?: string[];
-    }>;
-    getVisibleAgents?: (category: 'workflow' | 'toolUse') => Array<{
-      name: string;
-      source: 'builtInWorkflow' | 'builtInToolUse' | 'custom' | 'remote';
-      category: 'workflow' | 'toolUse';
-      description?: string;
-      path?: string;
-      multiplePath?: string;
-      isMultiple?: boolean;
-      tools?: string[];
-    }>;
-    buildToolDashboardItems?: (cachedResults?: unknown[]) => Promise<unknown[]>;
-    refreshToolAvailability?: () => Promise<void>;
-    getCustomAgentDirectory?: () => Promise<string>;
-    selectCustomAgentDirectory?: () => Promise<string | undefined>;
-    openPath?: (filePath: string) => Promise<void>;
-    openExternalUrl?: (url: string) => Promise<void>;
-    resourcesPath?: string;
-    runExecution?: (request: {
-      config: Record<string, unknown>;
-      executionId?: string;
-    }) => Promise<void>;
-    restoreTaskState?: (taskState: unknown) => Promise<boolean>;
-    installToolExtension?: (extensionId: string) => Promise<void>;
-    promptSecret?: (input: {
-      title: string;
-      prompt: string;
-    }) => Promise<string | undefined>;
-    promptText?: (input: {
-      title: string;
-      prompt: string;
-    }) => Promise<string | undefined>;
-    showInfoMessage?: (message: string) => Promise<void>;
-    showErrorMessage?: (message: string) => Promise<void>;
-    confirmAction?: (
-      message: string,
-      confirmLabel?: string,
-    ) => Promise<boolean>;
-    signIn?: () => Promise<void>;
-    signOut?: () => Promise<void>;
-    getAuthProfileData?: () => Promise<Record<string, unknown>>;
-    setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
-    initializeCrashReporting?: () => Promise<void>;
-    secrets?: {
-      get(key: string): Promise<string | undefined>;
-      set(key: string, value: string): Promise<void>;
-      delete(key: string): Promise<void>;
-    };
-    detectLatexSettingsStatus?: () => Promise<unknown>;
-    runInstallCommand?: (command: string) => Promise<void>;
-    onError?: (error: unknown) => void;
-    modelListRefresh?: PromiseLike<void>;
-    revealStream?: (streamId: string) => Promise<void>;
-  }): {
-    refreshAuthDependentData(): Promise<void>;
-    handleMessage(
-      message: { command: string } & Record<string, unknown>,
-    ): boolean;
-  };
-}
+type DesktopSettingsIpcModule =
+  typeof import('@desktop/main/desktopSettingsIpc');
 
 type DesktopSettingsIpcOptions = Parameters<
   DesktopSettingsIpcModule['createDesktopSettingsIpc']
@@ -168,11 +73,9 @@ type RendererMessage = Parameters<
 
 type SettingsFixtureOverrides = Omit<
   DesktopSettingsIpcOptions,
-  'globalState' | 'postToRenderer' | 'workspaceState'
+  'postToRenderer'
 > & {
-  globalState?: DesktopSettingsIpcOptions['globalState'];
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
-  workspaceState?: DesktopSettingsIpcOptions['workspaceState'];
 };
 
 type CapturedSettingsFixtureOverrides = Omit<
@@ -245,12 +148,20 @@ class MemorySecrets {
     return this.values.get(key);
   }
 
+  async getStored(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
   async set(key: string, value: string): Promise<void> {
     this.values.set(key, value);
   }
 
   async delete(key: string): Promise<void> {
     this.values.delete(key);
+  }
+
+  async listStoredKeys(): Promise<readonly string[]> {
+    return [...this.values.keys()];
   }
 
   getEnv(): string | undefined {
@@ -310,7 +221,7 @@ function commandOf(message: unknown): string | undefined {
   return (message as { command?: string }).command;
 }
 
-function inactiveLatexSettingsStatus(): unknown {
+function inactiveLatexSettingsStatus(): LatexSettingsStatus {
   return {
     outDir: true,
     autoRevealExclude: true,
@@ -1212,11 +1123,13 @@ describe('desktop settings IPC', () => {
         {
           source: 'builtInWorkflow' as const,
           name: 'correct',
+          path: '/agents/correct.yaml',
           category: 'workflow' as const,
         },
         {
           source: 'builtInWorkflow' as const,
           name: 'polish',
+          path: '/agents/polish.yaml',
           category: 'workflow' as const,
         },
       ],
@@ -1224,32 +1137,38 @@ describe('desktop settings IPC', () => {
         {
           source: 'builtInToolUse' as const,
           name: 'orchestrator',
+          path: '/agents/orchestrator.yaml',
           category: 'toolUse' as const,
           tools: ['delegate'],
         },
         {
           source: 'custom' as const,
           name: 'research',
+          path: '/agents/research.yaml',
           category: 'toolUse' as const,
         },
         {
           source: 'builtInToolUse' as const,
           name: 'numerics',
+          path: '/agents/numerics.yaml',
           category: 'toolUse' as const,
         },
         {
           source: 'builtInToolUse' as const,
           name: 'review',
+          path: '/agents/review.yaml',
           category: 'toolUse' as const,
         },
         {
           source: 'builtInToolUse' as const,
           name: 'presenter',
+          path: '/agents/presenter.yaml',
           category: 'toolUse' as const,
         },
         {
           source: 'builtInToolUse' as const,
           name: 'latexFixer',
+          path: '/agents/latexFixer.yaml',
           category: 'toolUse' as const,
         },
       ],
@@ -1357,11 +1276,13 @@ describe('desktop settings IPC', () => {
         {
           source: 'builtInWorkflow' as const,
           name: 'correct',
+          path: '/agents/correct.yaml',
           category: 'workflow' as const,
         },
         {
           source: 'builtInWorkflow' as const,
           name: 'polish',
+          path: '/agents/polish.yaml',
           category: 'workflow' as const,
         },
       ],
@@ -1369,11 +1290,13 @@ describe('desktop settings IPC', () => {
         {
           source: 'builtInToolUse' as const,
           name: 'review',
+          path: '/agents/review.yaml',
           category: 'toolUse' as const,
         },
         {
           source: 'builtInToolUse' as const,
           name: 'latexFixer',
+          path: '/agents/latexFixer.yaml',
           category: 'toolUse' as const,
         },
       ],
@@ -1511,15 +1434,6 @@ describe('desktop settings IPC', () => {
       setApiAccessMode: async (mode) => {
         persistedModes.push(mode);
       },
-      getAuthProfileData: async () => ({
-        authenticated: false,
-        user: null,
-        tier: 'free',
-        permissions: [],
-        remoteAgents: [],
-        apiAccessMode: 'personal',
-        accessExpiresAt: null,
-      }),
     });
 
     expect(
@@ -1556,15 +1470,6 @@ describe('desktop settings IPC', () => {
       setApiAccessMode: async (mode) => {
         persistedModes.push(mode);
       },
-      getAuthProfileData: async () => ({
-        authenticated: false,
-        user: null,
-        tier: 'free',
-        permissions: [],
-        remoteAgents: [],
-        apiAccessMode: 'personal',
-        accessExpiresAt: null,
-      }),
     });
 
     expect(
@@ -1588,17 +1493,10 @@ describe('desktop settings IPC', () => {
         loadCount += 1;
       },
       loadAgentOptionsData: async () => ({
-        workflow: [{ name: 'remote-workflow' }],
-        toolUse: [{ name: 'remote-tool' }],
-      }),
-      getAuthProfileData: async () => ({
-        authenticated: true,
-        user: { email: 'user@example.com', id: 'user-1' },
-        tier: 'free',
-        permissions: [],
-        remoteAgents: [],
-        apiAccessMode: 'included',
-        accessExpiresAt: null,
+        workflow: [
+          { value: 'remote:remote-workflow', label: 'remote-workflow' },
+        ],
+        toolUse: [{ value: 'remote:remote-tool', label: 'remote-tool' }],
       }),
     });
 
@@ -1688,15 +1586,6 @@ describe('desktop settings IPC', () => {
       signOut: async () => {
         signOutCalls += 1;
       },
-      getAuthProfileData: async () => ({
-        authenticated: false,
-        user: null,
-        tier: 'free',
-        permissions: [],
-        remoteAgents: [],
-        apiAccessMode: 'personal',
-        accessExpiresAt: null,
-      }),
     });
 
     expect(
@@ -1874,54 +1763,6 @@ describe('desktop settings IPC', () => {
     expect(infos).toEqual([]);
     expect(errors).toEqual([
       'Rerunning agents from history is not available in this build',
-    ]);
-  });
-
-  it('surfaces a friendly error instead of throwing on a corrupted history config (Copilot/texra-review #7827)', async () => {
-    const { getExecutionStore } = await import('@agent/storage');
-
-    const historyId = 'dddd4444';
-    // Bypass writeConfig's AgentConfig contract to simulate a corrupt/legacy
-    // on-disk record — a wrong-typed `agent` field fails AgentConfigSchema
-    // outright (unlike a merely-missing field, which prefaults), the same
-    // "malformed stored config" scenario the review comments describe for
-    // AgentConfigSchema.parse(raw).
-    await getExecutionStore(historyId).write('config', {
-      agent: 42,
-    });
-
-    const infos: string[] = [];
-    const errors: string[] = [];
-    const { settings } = createSettingsFixture({
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-      showErrorMessage: async (message) => {
-        errors.push(message);
-      },
-      runExecution: async () => {},
-      restoreTaskState: async () => true,
-    });
-
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-      historyId,
-    });
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
-      historyId,
-    });
-    await flushAsyncWork();
-
-    // Neither handler throws an unhandled ZodError; both report a graceful,
-    // user-visible message instead (the corrupt record fails schema
-    // validation at the storage layer already — readValidated returns null —
-    // so it surfaces as the unified "unreadable" error, not a raw parse
-    // exception).
-    expect(infos).toEqual([]);
-    expect(errors).toEqual([
-      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
-      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Extract desktop history list/delete/clear, rerun/restore, and chat-export behavior into `DesktopHistoryHandlers`.
- Keep `desktopSettingsIpc.ts` as the composition root with only the dispatcher action bundle and startup post method exposed.
- Replace a 95-line hand-maintained test module interface with the production type and remove one redundant corrupt-config integration case.

Closes #8042

## Issue acceptance gates

- History channel names, return values, messages, lazy export setup, and async rejection routing are unchanged.
- `desktopSettingsIpc.ts` shrinks from 1,521 to 1,279 lines.
- The desktop IPC suite shrinks from 2,088 to 1,929 lines without adding tests.
- Existing history, export, storage, dispatcher, typecheck, compile, lint, and full-suite gates pass.

## Single source of truth

`packages/desktop/src/main/desktopHistoryHandlers.ts` now owns desktop history orchestration. The parent only constructs it, posts startup history data, and supplies its typed `actions` bundle to the settings dispatcher.

## Duplication and abstraction budget

The change moves existing behavior rather than duplicating it. The new module exposes two concepts—`actions` and `postHistoryData()`—while storage, validation, controller lifecycle, paths, and user messages remain private.

The test fixture now derives its contract from `typeof import('@desktop/main/desktopSettingsIpc')` instead of shadowing production types.

## Net elements (R6)

- Adds one focused module and one class.
- Removes twelve history-local functions and their state from the 1,521-line composition root.
- Diff: 324 insertions, 449 deletions; net -125 lines.
- Production modules net +34 lines due to the explicit boundary; the affected test suite drops 159 lines.

## Consumer counts (R8)

`DesktopHistoryHandlers` has one production consumer: `createDesktopSettingsIpc`. Its action bundle is consumed directly by the existing exhaustive settings dispatcher.

## Host impact

Desktop-only refactor. Shared controllers, VS Code extension behavior, CLI behavior, IPC schemas, and channel names are unchanged.

## Scheduled refactoring

None. The VS Code `HistoryHandlers` remains separate because it owns VS Code-specific host behavior; merging those modules would widen this change without reducing current complexity.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` — 0 errors; touched files also lint with 0 warnings
- `npm test` — 623 files passed, 1 skipped; 5,540 tests passed, 4 skipped
- Focused history/export/storage suite — 7 files, 92 tests passed
- Independent subagent review — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only structural refactor with behavior preserved; remaining history tests still cover rerun, restore, and export paths.
> 
> **Overview**
> Moves desktop settings **history** behavior out of `desktopSettingsIpc.ts` into a dedicated **`DesktopHistoryHandlers`** module so the composition root only constructs the handler and plugs its `actions` into the settings dispatcher.
> 
> The new class owns the same orchestration as before: refreshing history in the renderer, delete/clear with guards for active runs, rerun/restore from persisted configs, and md/tex/html chat export (lazy `ChatExportController`, resource paths, user-visible errors). **`DesktopSettingsIpcOptions`** now extends **`DesktopHistoryOptions`** for `resourcesPath`, `runExecution`, and `restoreTaskState` instead of duplicating those fields on the IPC options type.
> 
> Tests drop a hand-written IPC options interface in favor of **`typeof import('@desktop/main/desktopSettingsIpc')`**, trim redundant auth profile stubs, add agent `path` fields where the catalog needs them, and remove one corrupt-history integration case while keeping rerun/restore/export coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d6be05885312b06c4116c9b1bbc40aee355954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->