### PR TITLE
fix(cli): cancel resumes still rehydrating

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -407,11 +407,9 @@ export function createChatSessionController(
 
       // A Ctrl-C during the rehydration awaits above (`resolveCliResumeSnapshot`,
       // `ensureLoaded`, `snapshotStore.load`/`read`) lands here as
-      // `session.stopRequested`, since the early claim above already makes
-      // this run look stoppable to `chatTuiCanStopActiveRun`. Honor it before
-      // starting the real run chain — matching `tryResumeStream()`'s
-      // stop-check after its own preparatory awaits — instead of starting an
-      // agent the user already cancelled.
+      // `session.stopRequested`. Honor it before starting the real run chain —
+      // matching `tryResumeStream()`'s stop-check after its own preparatory
+      // awaits — instead of starting an agent the user already cancelled.
       if (session.stopRequested) {
         finalize();
         resolveRunPromise();

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -491,6 +491,12 @@ export async function runChat(
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
     chatTuiCanStopVisibleRun(session, rootStreamStatus());
+  const isResumableIdle = (): boolean =>
+    chatTuiIsResumableIdleOnExit({
+      canInterruptActiveRun: canInterruptActiveRun(),
+      canStopActiveRun: canStopActiveRun(),
+      hasActiveToolUseFlow: hasActiveToolUseFlow(),
+    });
   const canStopPendingRunWithoutStream = (): boolean =>
     Boolean(session.runPromise && !session.runCompleted && !session.streamId);
   // Chat-session controller: owns run start/resume/stop orchestration.
@@ -916,7 +922,7 @@ export async function runChat(
     const sigintAction = chatTuiSigintAction({
       exitArmed,
       canStopActiveRun: canStopActiveRun(),
-      canInterruptActiveRun: canInterruptActiveRun(),
+      resumableIdle: isResumableIdle(),
     });
     switch (sigintAction) {
       case 'clean-exit':
@@ -1045,12 +1051,9 @@ export async function runChat(
       await followUpQueue.onIdle();
       // A suspended (idle/WAITING) root session is resumable: its flow record
       // survives only if we DON'T interrupt the flow (interrupt clears it). See
-      // chatTuiIsResumableIdleOnExit for why "interruptible but not stoppable"
-      // is exactly the idle-but-suspended case we must leave untouched.
-      const resumableIdle = chatTuiIsResumableIdleOnExit({
-        canInterruptActiveRun: canInterruptActiveRun(),
-        canStopActiveRun: canStopActiveRun(),
-      });
+      // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
+      // this state from a resume slot that is still rehydrating.
+      const resumableIdle = isResumableIdle();
       if (session.runPromise && !session.runCompleted && !resumableIdle) {
         session.stopRequested = true;
         interruptActive();

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -148,24 +148,27 @@ export type ChatTuiSigintAction =
 export function chatTuiSigintAction(input: {
   readonly exitArmed: boolean;
   readonly canStopActiveRun: boolean;
-  readonly canInterruptActiveRun: boolean;
+  readonly resumableIdle: boolean;
 }): ChatTuiSigintAction {
   if (input.exitArmed) return 'force-exit';
   if (input.canStopActiveRun) return 'interrupt-and-arm-exit';
-  // Resumable-idle (interruptible, not actively running): exit WITHOUT
-  // interrupting so the suspended tool-use flow record survives for resume.
-  if (input.canInterruptActiveRun) return 'preserve-exit';
+  if (input.resumableIdle) return 'preserve-exit';
   return 'clean-exit';
 }
 
 /**
- * On exit, a tool-use session suspended at the WAIT node (idle/WAITING) must
- * NOT be interrupted: interrupting clears its per-execution flow record in
- * `runToolUseFlow`'s finally, destroying the only resumable state.
+ * On exit, a tool-use session suspended at the WAIT node (idle/WAITING) with a
+ * live flow must NOT be interrupted: interrupting clears its per-execution flow
+ * record in `runToolUseFlow`'s finally, destroying the only resumable state.
  */
 export function chatTuiIsResumableIdleOnExit(input: {
   readonly canInterruptActiveRun: boolean;
   readonly canStopActiveRun: boolean;
+  readonly hasActiveToolUseFlow: boolean;
 }): boolean {
-  return input.canInterruptActiveRun && !input.canStopActiveRun;
+  return (
+    input.canInterruptActiveRun &&
+    !input.canStopActiveRun &&
+    input.hasActiveToolUseFlow
+  );
 }

--- a/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts
@@ -2,37 +2,35 @@
 // suspended tool-use session is left untouched (so its flow record survives
 // for `texra resume`) or interrupted on shutdown. See the rationale on
 // chatTuiIsResumableIdleOnExit: interrupting clears the resumable state, so an
-// idle/WAITING session ("interruptible but not stoppable") must be preserved.
+// idle/WAITING session with a live flow must be preserved, while a claimed
+// resume slot that is still rehydrating must be interrupted.
 
 import { describe, expect, it } from 'vitest';
 
 import { chatTuiIsResumableIdleOnExit } from '@cli/chat/tui/state/sessionRunState';
 
 describe('chatTuiIsResumableIdleOnExit', () => {
-  it('preserves an idle/WAITING session (interruptible, not stoppable)', () => {
-    expect(
-      chatTuiIsResumableIdleOnExit({
-        canInterruptActiveRun: true,
-        canStopActiveRun: false,
-      }),
-    ).toBe(true);
-  });
-
-  it('does not preserve an actively-running turn (interrupt it on exit)', () => {
-    expect(
-      chatTuiIsResumableIdleOnExit({
-        canInterruptActiveRun: true,
-        canStopActiveRun: true,
-      }),
-    ).toBe(false);
-  });
-
-  it('does not preserve when there is no pending run at all', () => {
-    expect(
-      chatTuiIsResumableIdleOnExit({
-        canInterruptActiveRun: false,
-        canStopActiveRun: false,
-      }),
-    ).toBe(false);
-  });
+  it.each([
+    ['live idle flow', true, false, true, true],
+    ['pre-live rehydration', true, false, false, false],
+    ['actively running turn', true, true, true, false],
+    ['no pending run', false, false, false, false],
+  ] as const)(
+    '%s',
+    (
+      _name,
+      canInterruptActiveRun,
+      canStopActiveRun,
+      hasActiveToolUseFlow,
+      expected,
+    ) => {
+      expect(
+        chatTuiIsResumableIdleOnExit({
+          canInterruptActiveRun,
+          canStopActiveRun,
+          hasActiveToolUseFlow,
+        }),
+      ).toBe(expected);
+    },
+  );
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1326,16 +1326,6 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_PHASE.RUNNING,
-      ),
-    ).toBe(true);
-    expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
         STREAM_STATUS.WAITING,
       ),
     ).toBe(false);
@@ -1429,7 +1419,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiSigintAction({
         exitArmed: false,
         canStopActiveRun: false,
-        canInterruptActiveRun: false,
+        resumableIdle: false,
       }),
     ).toBe('clean-exit');
 
@@ -1439,7 +1429,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiSigintAction({
         exitArmed: false,
         canStopActiveRun: false,
-        canInterruptActiveRun: true,
+        resumableIdle: true,
       }),
     ).toBe('preserve-exit');
 
@@ -1447,7 +1437,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiSigintAction({
         exitArmed: false,
         canStopActiveRun: true,
-        canInterruptActiveRun: true,
+        resumableIdle: false,
       }),
     ).toBe('interrupt-and-arm-exit');
 
@@ -1455,7 +1445,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiSigintAction({
         exitArmed: true,
         canStopActiveRun: true,
-        canInterruptActiveRun: true,
+        resumableIdle: false,
       }),
     ).toBe('force-exit');
   });

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -118,10 +118,18 @@ import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
 import { createChatSessionController } from '@cli/chat/chatSessionController';
 import {
+  chatTuiCanInterruptActiveRun,
+  chatTuiCanStopActiveRun,
   chatTuiCanStartRootRun,
+  chatTuiIsResumableIdleOnExit,
+  chatTuiSigintAction,
   type TuiSession,
 } from '@cli/chat/tui/state/sessionRunState';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // ---------------------------------------------------------------------------
@@ -452,13 +460,11 @@ describe('createChatSessionController', () => {
   });
 
   it('honors a Ctrl-C issued while resume() is still rehydrating and never starts the resumed run', async () => {
-    // The early slot claim makes chatTuiCanStopActiveRun() report this
-    // resume() as stoppable (session.runPromise is set, session.streamId is
-    // still whatever resume() has set so far) well before the resumed agent
-    // actually starts running. If the user hits Ctrl-C during that
-    // rehydration window, resume() must notice `session.stopRequested` and
-    // bail out instead of silently starting `resumeToolUseFromSnapshot()`
-    // once the awaits finish.
+    // The early slot claim makes this resume() interruptible before the resumed
+    // agent actually starts running. If the user hits Ctrl-C during that
+    // rehydration window, resume() must notice `session.stopRequested` and bail
+    // out instead of silently starting `resumeToolUseFromSnapshot()` once the
+    // awaits finish.
     const ensureLoaded = deferred<void>();
     const base = mocks.defaultSession();
     mocks.defaultSession.mockReturnValue({
@@ -492,6 +498,24 @@ describe('createChatSessionController', () => {
     // already set to the resumed stream.
     expect(session.runPromise).toBeDefined();
     expect(session.streamId).toBe('stream-resume');
+
+    const canInterruptActiveRun = chatTuiCanInterruptActiveRun(session);
+    const canStopActiveRun = chatTuiCanStopActiveRun(
+      session,
+      STREAM_STATUS.WAITING,
+    );
+    const resumableIdle = chatTuiIsResumableIdleOnExit({
+      canInterruptActiveRun,
+      canStopActiveRun,
+      hasActiveToolUseFlow: false,
+    });
+    expect(
+      chatTuiSigintAction({
+        exitArmed: false,
+        canStopActiveRun,
+        resumableIdle,
+      }),
+    ).toBe('clean-exit');
 
     // Ctrl-C fires while resume() is still rehydrating.
     ctrl.stop();


### PR DESCRIPTION
## Summary

- distinguish a genuinely suspended idle tool-use flow from a root-run slot that is still rehydrating
- route Ctrl-C during resume rehydration through graceful cancellation while preserving real idle resumability
- tighten existing policy tests in place and remove one duplicate assertion

## Issue acceptance gates

Fixes #8038.

- `WAITING` plus no live tool-use flow now selects `clean-exit`, sets `stopRequested`, and lets `resume()` settle without starting the resumed agent
- `WAITING` plus a live suspended flow still selects `preserve-exit`
- SIGINT handling and final teardown consume the same resumable-idle decision

## Single source of truth

`chatTuiIsResumableIdleOnExit` in `packages/cli/src/chat/tui/state/sessionRunState.ts` owns the distinction between a resumable idle flow and pre-live rehydration.

## Duplication and abstraction budget

Reuses the existing `hasActiveToolUseFlow()` fact and a single exit predicate in both SIGINT handling and final teardown. No new pass-through module or process-level test harness was added. One duplicated `STREAM_PHASE.RUNNING` assertion was removed.

## Net elements (R6)

- files: +0 / -0 (6 modified)
- exported symbols: +0 / -0
- classes/interfaces/enums: +0 / -0
- LoC: +85 / -69 (net +16)

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Ctrl-C during resume rehydration now cancels gracefully instead of force-exiting; genuinely suspended idle sessions remain resumable.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 existing warnings)
- `npm test` (623 passed, 1 skipped; 5540 tests passed, 4 skipped)
- `npx vitest run src/test-kernel/cli/SessionResumeExitPolicy.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/chatSessionController.vitest.mts --maxWorkers=2`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-8038-tui ctrl-c-exit ctrl-c-interrupt-active`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI SIGINT and shutdown paths that affect resume persistence and cancellation; behavior is narrow but user-facing and regression-tested.
> 
> **Overview**
> **Ctrl-C during `texra resume` rehydration** no longer treats the session as “resumable idle.” `chatTuiIsResumableIdleOnExit` now requires **`hasActiveToolUseFlow`** in addition to interruptible and not stoppable, so a claimed root slot that is still loading snapshots/transcripts is distinguished from a real **WAITING** suspended tool-use flow.
> 
> SIGINT routing and graceful teardown both use a shared **`isResumableIdle()`** helper in `runChatTui` (wired to existing `hasActiveToolUseFlow()`). Rehydration gets **`clean-exit`** → `stopRequested` → `resume()` exits before **`resumeToolUseFromSnapshot`**; genuine idle suspension still gets **`preserve-exit`** so flow records survive for later resume.
> 
> Tests cover the four predicate cases and assert rehydrating resume maps to **`clean-exit`** and never starts the agent after Ctrl-C.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873d4fb5688b58d6e3c7c0f6f721e9e7e8e69463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->