### PR TITLE
refactor(cli): extract child picker hint policy

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -21,8 +21,7 @@ import {
   type ChildControlMode,
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
-import { textDisplayWidth } from '../render/terminalText';
-import { KEY_HINT_SEPARATOR, KeyHints, type KeyHint } from '../ui/KeyHints';
+import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
 import {
   nextWrappingHighlightIndex,
@@ -33,6 +32,7 @@ import {
   type ChildStreamEntries,
 } from '../state/childExecutions';
 import { TaskDetailView } from './TaskDetailView';
+import { pickerKeyHintsForColumns } from './childControlPickerHints';
 import type { StreamSlice } from '../state/cliState';
 
 interface ChildControlPickerProps {
@@ -71,94 +71,6 @@ export function isUltraCompactPickerRows(
   return (
     availableRows !== undefined &&
     availableRows <= ULTRA_COMPACT_PICKER_MAX_ROWS
-  );
-}
-
-export function pickerKeyHints(
-  mode: ChildControlMode,
-  itemCount: number,
-  canKill = itemCount > 0,
-): readonly KeyHint[] {
-  return pickerKeyHintsForColumns(mode, itemCount, canKill);
-}
-
-function keyHintDisplayText(hint: KeyHint): string {
-  return `${hint.key} ${hint.action}`;
-}
-
-function keyHintsDisplayWidth(hints: readonly KeyHint[]): number {
-  return textDisplayWidth(
-    hints.map(keyHintDisplayText).join(KEY_HINT_SEPARATOR),
-  );
-}
-
-function keyHintsFit(
-  hints: readonly KeyHint[],
-  availableColumns: number | undefined,
-): boolean {
-  return (
-    availableColumns === undefined ||
-    keyHintsDisplayWidth(hints) <= availableColumns
-  );
-}
-
-type PickerOptionalHint = 'focus' | 'jump' | 'kill';
-
-function pickerHintsForOptionals(
-  mode: ChildControlMode,
-  itemCount: number,
-  canKill: boolean,
-  selected: ReadonlySet<PickerOptionalHint>,
-  availableColumns: number | undefined,
-): readonly KeyHint[] {
-  return [
-    {
-      key: '↑/↓',
-      action: availableColumns === undefined ? 'navigate' : 'nav',
-    },
-    ...(selected.has('jump') && itemCount > 1
-      ? [{ key: '1-9', action: 'jump' }]
-      : []),
-    { key: 'Enter', action: 'view' },
-    ...(selected.has('focus') && mode === 'subagents'
-      ? [{ key: 'f', action: 'focus' }]
-      : []),
-    ...(selected.has('kill') && canKill ? [{ key: 'k', action: 'kill' }] : []),
-    { key: 'Esc', action: 'close' },
-  ];
-}
-
-export function pickerKeyHintsForColumns(
-  mode: ChildControlMode,
-  itemCount: number,
-  canKill = itemCount > 0,
-  availableColumns?: number,
-): readonly KeyHint[] {
-  if (itemCount <= 0) return [{ key: 'Esc', action: 'close' }];
-
-  const selected = new Set<PickerOptionalHint>();
-  const priority: readonly PickerOptionalHint[] =
-    mode === 'subagents' ? ['focus', 'jump', 'kill'] : ['kill', 'jump'];
-
-  for (const option of priority) {
-    const nextSelected = new Set(selected);
-    nextSelected.add(option);
-    const nextHints = pickerHintsForOptionals(
-      mode,
-      itemCount,
-      canKill,
-      nextSelected,
-      availableColumns,
-    );
-    if (keyHintsFit(nextHints, availableColumns)) selected.add(option);
-  }
-
-  return pickerHintsForOptionals(
-    mode,
-    itemCount,
-    canKill,
-    selected,
-    availableColumns,
   );
 }
 

--- a/packages/cli/src/chat/tui/modals/childControlPickerHints.ts
+++ b/packages/cli/src/chat/tui/modals/childControlPickerHints.ts
@@ -1,0 +1,84 @@
+// Local imports - CLI TUI
+import { textDisplayWidth } from '../render/terminalText';
+import { KEY_HINT_SEPARATOR, type KeyHint } from '../ui/KeyHints';
+import type { ChildControlMode } from '../state/childControls';
+
+function keyHintDisplayText(hint: KeyHint): string {
+  return `${hint.key} ${hint.action}`;
+}
+
+function keyHintsDisplayWidth(hints: readonly KeyHint[]): number {
+  return textDisplayWidth(
+    hints.map(keyHintDisplayText).join(KEY_HINT_SEPARATOR),
+  );
+}
+
+function keyHintsFit(
+  hints: readonly KeyHint[],
+  availableColumns: number | undefined,
+): boolean {
+  return (
+    availableColumns === undefined ||
+    keyHintsDisplayWidth(hints) <= availableColumns
+  );
+}
+
+type PickerOptionalHint = 'focus' | 'jump' | 'kill';
+
+function pickerHintsForOptionals(
+  mode: ChildControlMode,
+  itemCount: number,
+  canKill: boolean,
+  selected: ReadonlySet<PickerOptionalHint>,
+  availableColumns: number | undefined,
+): readonly KeyHint[] {
+  return [
+    {
+      key: '↑/↓',
+      action: availableColumns === undefined ? 'navigate' : 'nav',
+    },
+    ...(selected.has('jump') && itemCount > 1
+      ? [{ key: '1-9', action: 'jump' }]
+      : []),
+    { key: 'Enter', action: 'view' },
+    ...(selected.has('focus') && mode === 'subagents'
+      ? [{ key: 'f', action: 'focus' }]
+      : []),
+    ...(selected.has('kill') && canKill ? [{ key: 'k', action: 'kill' }] : []),
+    { key: 'Esc', action: 'close' },
+  ];
+}
+
+export function pickerKeyHintsForColumns(
+  mode: ChildControlMode,
+  itemCount: number,
+  canKill = itemCount > 0,
+  availableColumns?: number,
+): readonly KeyHint[] {
+  if (itemCount <= 0) return [{ key: 'Esc', action: 'close' }];
+
+  const selected = new Set<PickerOptionalHint>();
+  const priority: readonly PickerOptionalHint[] =
+    mode === 'subagents' ? ['focus', 'jump', 'kill'] : ['kill', 'jump'];
+
+  for (const option of priority) {
+    const nextSelected = new Set(selected);
+    nextSelected.add(option);
+    const nextHints = pickerHintsForOptionals(
+      mode,
+      itemCount,
+      canKill,
+      nextSelected,
+      availableColumns,
+    );
+    if (keyHintsFit(nextHints, availableColumns)) selected.add(option);
+  }
+
+  return pickerHintsForOptionals(
+    mode,
+    itemCount,
+    canKill,
+    selected,
+    availableColumns,
+  );
+}

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -11,10 +11,9 @@ import {
   computePickerListLayout,
   emptyPickerText,
   isUltraCompactPickerRows,
-  pickerKeyHints,
-  pickerKeyHintsForColumns,
   pickerTitle,
 } from '@cli/chat/tui/modals/ChildControlPicker';
+import { pickerKeyHintsForColumns } from '@cli/chat/tui/modals/childControlPickerHints';
 import {
   computeTaskDetailLayout,
   isUltraCompactTaskDetailRows,
@@ -1155,10 +1154,10 @@ describe('CLI child execution controls', () => {
   });
 
   it('advertises only applicable keys for child pickers', () => {
-    expect(pickerKeyHints('tasks', 0)).toEqual([
+    expect(pickerKeyHintsForColumns('tasks', 0)).toEqual([
       { key: 'Esc', action: 'close' },
     ]);
-    expect(pickerKeyHints('tasks', 1)).toEqual([
+    expect(pickerKeyHintsForColumns('tasks', 1)).toEqual([
       { key: '↑/↓', action: 'navigate' },
       { key: 'Enter', action: 'view' },
       { key: 'k', action: 'kill' },
@@ -1168,19 +1167,19 @@ describe('CLI child execution controls', () => {
       kind: 'jump',
       index: 2,
     });
-    expect(pickerKeyHints('tasks', 3)).toContainEqual({
+    expect(pickerKeyHintsForColumns('tasks', 3)).toContainEqual({
       key: '1-9',
       action: 'jump',
     });
-    expect(pickerKeyHints('subagents', 1)).toContainEqual({
+    expect(pickerKeyHintsForColumns('subagents', 1)).toContainEqual({
       key: 'Enter',
       action: 'view',
     });
-    expect(pickerKeyHints('subagents', 1)).toContainEqual({
+    expect(pickerKeyHintsForColumns('subagents', 1)).toContainEqual({
       key: 'f',
       action: 'focus',
     });
-    expect(pickerKeyHints('subagents', 1, false)).not.toContainEqual({
+    expect(pickerKeyHintsForColumns('subagents', 1, false)).not.toContainEqual({
       key: 'k',
       action: 'kill',
     });


### PR DESCRIPTION
## Summary

- move child-picker display-width measurement and optional-key priority into a pure hint-policy module
- reduce `ChildControlPicker.tsx` from 583 to 495 lines while keeping Ink state and rendering in the component
- delete the shallow `pickerKeyHints` wrapper and point existing tests at the real width-aware API

## Issue acceptance gates

Advances #6680 with a behavior-preserving split of one cohesive responsibility from an oversized CLI TUI component.

- hint selection has one canonical owner
- production rendering remains unchanged at wide, compact, narrow, and tiny terminal sizes
- no new tests or fallback paths were added

## Single source of truth

`packages/cli/src/chat/tui/modals/childControlPickerHints.ts` now owns hint display-width measurement, optional-hint priority, empty-state hints, and killability-aware hint selection.

## Duplication and abstraction budget

The extracted policy has two production call sites in `ChildControlPicker`. It hides the full fitting algorithm rather than passing data through. The test-only `pickerKeyHints` forwarding export was removed, and all existing assertions use `pickerKeyHintsForColumns` directly.

## Net elements (R6)

- files: +1 / -0
- exported symbols: +0 / -1 (`pickerKeyHints` removed; `pickerKeyHintsForColumns` moved)
- classes/interfaces/enums: +0 / -0
- LoC: +93 / -98 (net -5)
- oversized component: `ChildControlPicker.tsx` 583 → 495 lines

## Consumer counts (R8)

- `pickerKeyHintsForColumns`: 2 production call sites, 9 existing test assertions
- removed `pickerKeyHints`: 0 production consumers; test-only forwarding wrapper

## Host impact

Extension: None.

Desktop: None.

CLI: No behavior change; child-picker hint rendering keeps the same responsive policy.

## Scheduled refactoring

#6680 remains open for additional independently scoped component decompositions.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 existing warnings)
- `npm test` (623 passed, 1 skipped; 5540 tests passed, 4 skipped)
- `npx vitest run src/test-kernel/cli/ChildControls.vitest.mts --maxWorkers=2` (44 passed)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-6680-picker subagent-picker task-picker compact-subagent-picker compact-task-picker narrow-subagent-picker narrow-task-picker tiny-subagent-picker`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving file split with no new runtime paths; CLI picker UX should match prior responsive hint policy.
> 
> **Overview**
> Moves **child-picker key-hint policy** out of `ChildControlPicker.tsx` into a new pure module `childControlPickerHints.ts`. That module now owns terminal **display-width** checks, optional-hint priority (`focus` / `jump` / `kill`), empty-state hints, and the width-aware `pickerKeyHintsForColumns` API.
> 
> The picker component keeps Ink state and rendering and still calls `pickerKeyHintsForColumns` at its two `KeyHints` sites; **hint text and narrow-terminal fitting behavior are unchanged**. The shallow **`pickerKeyHints` re-export is removed**; `ChildControls.vitest.mts` asserts against `pickerKeyHintsForColumns` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2294039aa1d5bc66a125b11a2fe0dac1a6d1ea2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->