### PR TITLE
test(desktop): simplify command surface coverage

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -95,6 +95,15 @@ export interface DesktopCommandMenuEntry {
   unavailableReason?: string;
 }
 
+/** Menu template shape produced before Electron materializes native menus. */
+export interface DesktopMenuTemplateItem extends Omit<
+  MenuItemConstructorOptions,
+  'click' | 'submenu'
+> {
+  click?: () => void;
+  submenu?: DesktopMenuTemplateItem[];
+}
+
 export interface DesktopCommandActions {
   showRoute(route: DesktopRoute): void;
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
@@ -368,14 +377,14 @@ export function buildDesktopMainViewResetMessage(): DesktopMainViewResetMessage 
 export function buildDesktopMenuTemplate(
   actions: DesktopCommandActions,
   platform: NodeJS.Platform = process.platform,
-): MenuItemConstructorOptions[] {
+): DesktopMenuTemplateItem[] {
   const entriesById = new Map(
     getDesktopCommandMenuEntries(DESKTOP_COMMAND_IDS, platform).map((entry) => [
       entry.id,
       entry,
     ]),
   );
-  const commandItem = (id: DesktopCommandId): MenuItemConstructorOptions => {
+  const commandItem = (id: DesktopCommandId): DesktopMenuTemplateItem => {
     const entry = entriesById.get(id);
     if (!entry) throw new Error(`Missing desktop menu entry: ${id}`);
     return {
@@ -389,7 +398,7 @@ export function buildDesktopMenuTemplate(
       },
     };
   };
-  const customMenu: MenuItemConstructorOptions = {
+  const customMenu: DesktopMenuTemplateItem = {
     label: 'TeXRA',
     submenu: [
       ...DESKTOP_MENU_GROUPS[0].map(commandItem),
@@ -397,7 +406,7 @@ export function buildDesktopMenuTemplate(
       ...DESKTOP_MENU_GROUPS[1].map(commandItem),
     ],
   };
-  const fileMenu: MenuItemConstructorOptions = {
+  const fileMenu: DesktopMenuTemplateItem = {
     label: 'File',
     submenu: [
       ...DESKTOP_FILE_COMMANDS.map(commandItem),
@@ -406,7 +415,7 @@ export function buildDesktopMenuTemplate(
     ],
   };
 
-  const leadingMenus: MenuItemConstructorOptions[] =
+  const leadingMenus: DesktopMenuTemplateItem[] =
     platform === 'darwin' ? [{ role: 'appMenu' }, fileMenu] : [fileMenu];
 
   return [

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -1,76 +1,15 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
-// Local imports - webview commands
-import type { DesktopCommandActions } from '@desktop/desktopCommandSurface';
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-
 // Local imports - command catalog and shared schemas
 import { commandCatalogById, type CommandId } from '@shared/commands/catalog';
-import { AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
-interface DesktopCommandSurfaceModule {
-  DESKTOP_LOCAL_COMMANDS: {
-    OPEN_DESKTOP_DOCS: string;
-    SHOW_LOGS: string;
-    OPEN_LOG_FOLDER: string;
-    OPEN_WORKSPACE_FOLDER: string;
-    OPEN_WORKSPACE_IN_NEW_WINDOW: string;
-    SHOW_FIRST_RUN_WALKTHROUGH: string;
-  };
-  DESKTOP_COMMAND_IDS: readonly string[];
-  buildDesktopMenuTemplate(
-    actions: DesktopCommandActions,
-    platform?: NodeJS.Platform,
-  ): Array<{
-    label?: string;
-    role?: string;
-    submenu?: DesktopMenuItem[];
-  }>;
-  dispatchDesktopCommand(id: string, actions: DesktopCommandActions): boolean;
-  getDesktopCommandMenuEntries(
-    ids?: readonly string[],
-    platform?: NodeJS.Platform,
-  ): Array<{
-    id: string;
-    label: string;
-    category: string;
-    accelerator?: string;
-    enabled: boolean;
-    unavailableReason?: string;
-  }>;
-  toElectronAccelerator(
-    keybinding: { key: string; mac?: string },
-    platform?: NodeJS.Platform,
-  ): string;
-  formatDesktopAccelerator(
-    accelerator: string | undefined,
-    platform?: NodeJS.Platform,
-  ): string | undefined;
-  buildDesktopSettingsTabMessage(
-    tabIndex: number,
-    agentSubTab?: string,
-  ): {
-    command: string;
-    tabIndex: number;
-    agentSubTab?: string;
-  };
-}
-
-interface DesktopMenuItem {
-  label?: string;
-  role?: string;
-  accelerator?: string;
-  enabled?: boolean;
-  toolTip?: string;
-  submenu?: DesktopMenuItem[];
-  type?: 'separator';
-  click?: () => void;
-}
+type DesktopCommandSurfaceModule =
+  typeof import('@desktop/desktopCommandSurface');
 
 async function loadDesktopCommandSurface(): Promise<DesktopCommandSurfaceModule> {
   return import(
@@ -98,9 +37,8 @@ describe('desktop command surface', () => {
         expect(['File', 'TeXRA', 'Help']).toContain(entry.category);
         continue;
       }
-      expect(catalogEntry).toBeDefined();
-      expect(entry.label).toBe(catalogEntry?.shortTitle ?? catalogEntry?.title);
-      expect(entry.category).toBe(catalogEntry?.category);
+      expect(entry.label).toBe(catalogEntry.shortTitle ?? catalogEntry.title);
+      expect(entry.category).toBe(catalogEntry.category);
     }
     expect(entries).toContainEqual({
       id: DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
@@ -279,32 +217,8 @@ describe('desktop command surface', () => {
     expect(actions.showSettings).not.toHaveBeenCalled();
   });
 
-  it('builds settings-tab messages from one shared helper', async () => {
-    const { buildDesktopSettingsTabMessage } =
-      await loadDesktopCommandSurface();
-
-    expect(buildDesktopSettingsTabMessage(SETTINGS_TAB.MODELS)).toEqual({
-      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex: SETTINGS_TAB.MODELS,
-    });
-    expect(
-      buildDesktopSettingsTabMessage(
-        SETTINGS_TAB.AGENTS,
-        AgentCategory.ToolUse,
-      ),
-    ).toEqual({
-      agentSubTab: AgentCategory.ToolUse,
-      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex: SETTINGS_TAB.AGENTS,
-    });
-  });
-
   it('wires menu clicks to the catalog-backed dispatcher', async () => {
-    const {
-      DESKTOP_LOCAL_COMMANDS,
-      buildDesktopMenuTemplate,
-      getDesktopCommandMenuEntries,
-    } = await loadDesktopCommandSurface();
+    const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
     const actions = {
       openDesktopDocs: vi.fn(),
       openWorkspaceFolder: vi.fn(),
@@ -359,21 +273,6 @@ describe('desktop command surface', () => {
       'Clean LLM Outputs',
       'Clean Build Files',
     ]);
-    expect(
-      submenu
-        .filter((item) => item.type !== 'separator')
-        .map((item) => item.label),
-    ).toEqual(
-      getDesktopCommandMenuEntries(undefined, 'darwin')
-        .filter(
-          (entry) =>
-            entry.category !== 'Help' &&
-            entry.id !== DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER &&
-            entry.id !== DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW,
-        )
-        .map((entry) => entry.label),
-    );
-
     const launcherItem = submenu.find((item) => item.label === 'Show Launcher');
     const executeItem = submenu.find((item) => item.label === 'Execute Agent');
     const modelsItem = submenu.find((item) => item.label === 'Show Models');
@@ -389,11 +288,11 @@ describe('desktop command surface', () => {
     });
 
     const helpMenu = menu.find((item) => item.label === 'Help');
-    expect(helpMenu?.submenu?.map((item) => item.label)).toEqual([
+    const helpSubmenu = helpMenu?.submenu ?? [];
+    expect(helpSubmenu.map((item) => item.label)).toEqual([
       'Show First-Run Walkthrough',
       'Desktop Documentation',
     ]);
-    const helpSubmenu = helpMenu?.submenu ?? [];
     helpSubmenu[0].click?.();
     expect(actions.showFirstRunWalkthrough).toHaveBeenCalledOnce();
     helpSubmenu[1].click?.();


### PR DESCRIPTION
## Summary

- Replace the desktop command-surface test's hand-written module and menu shadow types with the production module type.
- Give the desktop menu builder a precise recursive template contract for the arrays and zero-argument click closures it actually creates.
- Remove settings-message and derived submenu assertions already owned by canonical IPC/menu coverage.

The test file drops from 402 to 301 lines and from 7 to 6 tests while preserving unique command and menu behavior coverage.

## Issue acceptance gates

Fixes #8051.

- Uses `typeof import('@desktop/desktopCommandSurface')` instead of local module/menu shadows.
- Removes the settings-message test covered by `DesktopIpcAdapters.vitest.mts` and `ElectronMainViewIpc.vitest.mts`.
- Removes the derived submenu-label assertion subsumed by the exact label/order assertion.
- Removes the guarded tautological assertion and resulting unused imports.
- Passes focused tests, typecheck, compile, lint, and the full Vitest suite.

## Single source of truth

`packages/desktop/src/desktopCommandSurface.ts` now owns the precise menu-template shape returned by `buildDesktopMenuTemplate`. The desktop IPC suites remain the owners of renderer settings-message integration coverage.

## Duplication and abstraction budget

Removed a 58-line test-local shadow API, one duplicate test, and one duplicate derived assertion. Added one recursive interface that owns a real host boundary: the pre-materialization menu shape emitted by the desktop builder, narrower than Electron's native `MenuItemConstructorOptions` union.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: +1 `DesktopMenuTemplateItem`.
- Interfaces: +1 production interface, -2 test-local interfaces, net -1.
- Net LoC: -92 (21 additions, 113 deletions).

## Consumer counts (R8)

n/a — no emit path or existing export is deleted or rerouted.

## Host impact

Extension: none.

Desktop: compile-time menu-template contract is more precise; runtime behavior is unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 pre-existing warnings)
- `npm test` (623 files passed, 1 skipped; 5,539 tests passed, 4 skipped)
- `npx vitest run src/test-kernel/desktop/DesktopCommandSurface.vitest.mts --maxWorkers=2` (6 passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time typing and test refactors only; desktop menu runtime behavior is unchanged.
> 
> **Overview**
> Introduces **`DesktopMenuTemplateItem`** so `buildDesktopMenuTemplate` returns a typed pre-Electron menu tree (recursive `submenu`, zero-arg `click`) instead of raw `MenuItemConstructorOptions[]`.
> 
> **`DesktopCommandSurface.vitest.mts`** drops hand-written module/menu shadow types in favor of `typeof import('@desktop/desktopCommandSurface')`, and trims overlap: no dedicated `buildDesktopSettingsTabMessage` test (covered in IPC suites), no derived TeXRA submenu label check (explicit label/order assertions remain), and a simpler catalog-entry assertion loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd9579812d66a0d28faf87c6fdf257dd414795b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->