### PR TITLE
test(desktop): use canonical execution types

### DIFF
--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -17,8 +17,9 @@ import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 
-// Local imports - progress schemas
+// Local imports - desktop and progress schemas
 import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
+import type { DesktopStreamSnapshotStore } from '@desktop/main/desktopStreamSnapshot';
 import {
   AgentCategory,
   END_GROUP_STATUS,
@@ -171,26 +172,8 @@ type RunExecutionRequest = (
   },
 ) => Promise<void>;
 
-interface DesktopAgentExecutionModule {
-  DesktopProgressBridge: new (
-    postToRenderer: (message: unknown) => void,
-    options?: {
-      streamSnapshotStore?: TestDesktopStreamSnapshotStore;
-      progressSnapshotStore?: ProgressSnapshotStore;
-      showErrorMessage?: (message: string) => Promise<void> | void;
-      openPath?: (filePath: string, line?: number) => Promise<void>;
-    },
-  ) => Bridge;
-  createDesktopAgentExecution(options: {
-    postToRenderer(message: unknown): void;
-    opener?: {
-      openPath(filePath: string): Promise<void>;
-      openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
-    };
-    showErrorMessage?: (message: string) => Promise<void> | void;
-    onRunCompleted?: () => void;
-  }): DesktopExecution;
-}
+type DesktopAgentExecutionModule =
+  typeof import('@desktop/main/desktopAgentExecution');
 
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
@@ -202,7 +185,7 @@ type CreateBridgeOptions = {
   retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
-  streamSnapshotStore?: TestDesktopStreamSnapshotStore;
+  streamSnapshotStore?: DesktopStreamSnapshotStore;
   configureProgressSnapshotStore?: (store: ProgressSnapshotStore) => void;
   detectWaitingStreams?: ReturnType<typeof vi.fn>;
   activeExecutionIds?: readonly string[] | (() => readonly string[]);
@@ -210,15 +193,6 @@ type CreateBridgeOptions = {
   openPath?: (filePath: string, line?: number) => Promise<void>;
   /** Captures `this.logger.error(...)` calls made by the bridge under test. */
   loggerErrorSpy?: ReturnType<typeof vi.fn>;
-};
-
-type TestDesktopStreamSnapshotStore = {
-  readonly hydrated: readonly RestoredStreamSnapshot[];
-  upsert(snapshot: RestoredStreamSnapshot): Promise<void>;
-  remove(streamId: StreamTabId): Promise<void>;
-  replaceAll(snapshots: RestoredStreamSnapshot[]): Promise<void>;
-  flush(): Promise<void>;
-  getAll(): RestoredStreamSnapshot[];
 };
 
 type ProgressMessage = {
@@ -445,14 +419,16 @@ async function createBridge(
     await loadBridgeModule(options);
   return disposeAfterTest(
     new bridgeModule.DesktopProgressBridge(
-      (message) => messages.push(message),
+      (message) => {
+        messages.push(message);
+      },
       {
         streamSnapshotStore: options.streamSnapshotStore,
         progressSnapshotStore,
         showErrorMessage: options.showErrorMessage,
         openPath: options.openPath,
       },
-    ) as TestableBridge,
+    ) as unknown as TestableBridge,
   );
 }
 
@@ -551,7 +527,7 @@ function restoredSnapshot(
 
 function createStreamSnapshotStore(
   hydrated: readonly RestoredStreamSnapshot[],
-): TestDesktopStreamSnapshotStore {
+): DesktopStreamSnapshotStore {
   const live = new Map(
     hydrated.map((snapshot) => [snapshot.streamId, snapshot]),
   );
@@ -3288,7 +3264,7 @@ describe('DesktopProgressBridge', () => {
       /** Loosely-typed runtime-host emit, as runs use it (`runtimeHost.emit`). */
       emit: (event: string, payload: unknown) => void;
       messages: unknown[];
-      snapshots: TestDesktopStreamSnapshotStore;
+      snapshots: DesktopStreamSnapshotStore;
     };
 
     type WindowPair = {
@@ -3316,9 +3292,11 @@ describe('DesktopProgressBridge', () => {
         const messages: unknown[] = [];
         const snapshots = createStreamSnapshotStore([]);
         const bridge = new bridgeModule.DesktopProgressBridge(
-          (message) => messages.push(message),
+          (message) => {
+            messages.push(message);
+          },
           { streamSnapshotStore: snapshots },
-        ) as TestableBridge;
+        ) as unknown as TestableBridge;
         const session = (bridge as unknown as { session: SessionHandle })
           .session;
         const { hostChannel } =


### PR DESCRIPTION
## Summary

- Replace the desktop agent-execution test's hand-written module interface with the production module type.
- Reuse the exported desktop stream snapshot-store contract instead of maintaining a test-local copy.
- Make intentional white-box bridge casts and renderer callbacks explicit while preserving every behavioral assertion.

The largest test file drops from 3,695 to 3,673 lines while retaining all 72 tests.

## Issue acceptance gates

Fixes #8053.

- Uses `typeof import('@desktop/main/desktopAgentExecution')` for the dynamically loaded module.
- Uses the exported `DesktopStreamSnapshotStore` contract.
- Preserves all 72 behavioral tests and adds no helpers or replacement tests.
- Passes focused tests, typecheck, compile, lint, and the full Vitest suite.

## Single source of truth

`packages/desktop/src/main/desktopAgentExecution.ts` owns the execution module API, and `packages/desktop/src/main/desktopStreamSnapshot.ts` owns the persisted snapshot-store contract.

## Duplication and abstraction budget

Removed one 20-line module shadow and one 8-line snapshot-store shadow. No new abstraction was added: one existing test-local module declaration now derives directly from production, and intentional private-state test access is marked with explicit `unknown` casts.

## Net elements (R6)

- Files: 0 added, 0 deleted, 1 modified.
- Exported symbols: no change.
- Type declarations: -1 net.
- Net LoC: -22 (15 additions, 37 deletions).

## Consumer counts (R8)

n/a — no emit path or export is deleted or rerouted.

## Host impact

Extension: none.

Desktop: test typing now follows production contracts; runtime behavior is unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 pre-existing warnings)
- `npm test` (623 files passed, 1 skipped; 5,539 tests passed, 4 skipped)
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts --maxWorkers=2` (72 passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only typing cleanup in one Vitest file; no production code paths or exports change.
> 
> **Overview**
> Refactors **desktop agent execution tests** so typings track production instead of parallel test-only definitions.
> 
> `DesktopAgentExecutionModule` is now `typeof import('@desktop/main/desktopAgentExecution')`, dropping a hand-written shadow of `DesktopProgressBridge` and `createDesktopAgentExecution`. The test-local `TestDesktopStreamSnapshotStore` is removed in favor of the exported **`DesktopStreamSnapshotStore`** from `desktopStreamSnapshot.ts`.
> 
> White-box access to the bridge still uses explicit **`as unknown as TestableBridge`** casts, and renderer `postToRenderer` callbacks are written as block bodies for clarity. **No runtime or production API changes** — all 72 behavioral tests are unchanged in intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709099a635d44441e3b09cf18b9877634ac882a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->