### PR TITLE
test(desktop): split execution factory suite

### DIFF
--- a/host-agent-mock-baseline.json
+++ b/host-agent-mock-baseline.json
@@ -149,22 +149,7 @@
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
       "form": "doMock",
-      "specifier": "@agent/runtime/executeAgent"
-    },
-    {
-      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
-      "form": "doMock",
       "specifier": "@agent/runtime/ProgressViewBridge"
-    },
-    {
-      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
-      "form": "doMock",
-      "specifier": "@agent/runtime/ProgressViewBridge"
-    },
-    {
-      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
-      "form": "doMock",
-      "specifier": "@agent/runtime/runAgent"
     },
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
@@ -184,12 +169,27 @@
     {
       "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
       "form": "doMock",
-      "specifier": "@agent/runtime/SessionResumeRetrieval"
+      "specifier": "@agent/storage/detectWaitingStreams"
     },
     {
-      "file": "src/test-kernel/desktop/DesktopAgentExecution.vitest.mts",
+      "file": "src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts",
       "form": "doMock",
-      "specifier": "@agent/storage/detectWaitingStreams"
+      "specifier": "@agent/runtime/executeAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/ProgressViewBridge"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/runAgent"
+    },
+    {
+      "file": "src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts",
+      "form": "doMock",
+      "specifier": "@agent/runtime/SessionResumeRetrieval"
     },
     {
       "file": "src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts",

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - transcript
 import {
@@ -31,7 +31,6 @@ import {
   type EndGroupStatus,
   type ExecutionId,
   type RestoredStreamSnapshot,
-  type RunOutcome,
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
@@ -40,10 +39,15 @@ import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progres
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { assertSupported } from '@shared/utils/dispatcher';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
-import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 
-// Local imports - desktop test paths
+// Local imports - desktop test support
+import {
+  disposeAfterTest,
+  makeFakeTrace,
+  mockLoggerModule,
+  type DesktopAgentExecutionModule,
+  type RunExecutionRequest,
+} from './desktopAgentExecutionTestHarness.mjs';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 type Bridge = {
@@ -51,11 +55,6 @@ type Bridge = {
   flush(): Promise<void>;
   dispose(): void;
 };
-
-function disposeAfterTest<T extends { dispose(): void }>(value: T): T {
-  onTestFinished(() => value.dispose());
-  return value;
-}
 
 type TestableBridge = Bridge & {
   runtimeHost: {
@@ -144,37 +143,6 @@ function bridgeFollowUps(
   return (bridge as BridgeWithSession).session.followUps;
 }
 
-type DesktopExecution = {
-  handleExecute(message: unknown): Promise<void>;
-  progress: Bridge;
-  flush(): Promise<void>;
-  dispose(): void;
-};
-
-type RunExecutionRequest = (
-  request: unknown,
-  options: {
-    openWorkflowOutput(result: {
-      outcome: RunOutcome;
-      outputs: Array<{ absolutePath: string }>;
-    }): Promise<void>;
-    // This window's SessionHandle. The onboarding run-completion test drives a
-    // terminal `result` event through it via `attachRunTrace`.
-    session: {
-      attachRunTrace(
-        trace: {
-          subscribe(fn: (event: unknown) => void): unknown;
-        },
-        streamId: string,
-      ): () => void;
-    };
-    runtimeUnavailableTools?: readonly string[];
-  },
-) => Promise<void>;
-
-type DesktopAgentExecutionModule =
-  typeof import('@desktop/main/desktopAgentExecution');
-
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
@@ -219,18 +187,6 @@ const SEARCH_TOOL_USE_AGENT_CONFIG = {
   model: 'deepseekproT',
   agentCategory: AgentCategory.ToolUse,
 } as const;
-
-function mockLoggerModule(loggerErrorSpy?: ReturnType<typeof vi.fn>): void {
-  vi.doMock('@logger', () => ({
-    createChannelTrace: () => ({
-      emit: vi.fn(),
-      debug: () => {},
-      info: () => {},
-      warn: () => {},
-      error: loggerErrorSpy ?? (() => {}),
-    }),
-  }));
-}
 
 /**
  * Registers the desktop module mocks once and imports the bridge module.
@@ -432,73 +388,6 @@ async function createBridge(
   );
 }
 
-async function createExecution(options: {
-  postToRenderer?: (message: unknown) => void;
-  opener?: {
-    openPath(filePath: string): Promise<void>;
-    openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
-  };
-  showErrorMessage?: (message: string) => Promise<void> | void;
-  prepareMainViewExecutionRequest: (message: unknown) => unknown;
-  runAgent?: RunExecutionRequest;
-  onRunCompleted?: () => void;
-}): Promise<DesktopExecution> {
-  vi.resetModules();
-  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
-    import('@platform/platform'),
-    import('@test/support/FakePlatform'),
-  ]);
-  initPlatform(createFakePlatform());
-  vi.doMock('@agent/runtime/ProgressViewBridge', () => ({
-    setProgressViewBridge: vi.fn(),
-  }));
-  vi.doMock('@agent/runtime/SessionResumeRetrieval', () => ({
-    retrieveSessionResumeData: vi.fn(async () => null),
-  }));
-  vi.doMock('@agent/runtime/executeAgent', () => ({
-    resumeToolUseFromSnapshot: vi.fn(async () => {}),
-  }));
-  vi.doMock('@agent/runtime/runAgent', () => ({
-    runAgent: options.runAgent ?? vi.fn(async () => {}),
-  }));
-  vi.doMock('@common/storage/KVStore', () => ({
-    KVStore: class {
-      async read(): Promise<undefined> {
-        return undefined;
-      }
-
-      async write(): Promise<void> {}
-
-      async delete(): Promise<void> {}
-
-      async deleteDir(): Promise<void> {}
-
-      async exists(): Promise<boolean> {
-        return false;
-      }
-
-      async listKeys(): Promise<string[]> {
-        return [];
-      }
-    },
-  }));
-  vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
-    prepareMainViewExecutionRequest: options.prepareMainViewExecutionRequest,
-  }));
-  mockLoggerModule();
-  const { createDesktopAgentExecution } = (await import(
-    moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
-  )) as DesktopAgentExecutionModule;
-  return disposeAfterTest(
-    createDesktopAgentExecution({
-      postToRenderer: options.postToRenderer ?? vi.fn(),
-      opener: options.opener,
-      showErrorMessage: options.showErrorMessage,
-      onRunCompleted: options.onRunCompleted,
-    }),
-  );
-}
-
 function progressMessages(
   messages: unknown[],
   command: string,
@@ -654,7 +543,6 @@ describe('DesktopProgressBridge', () => {
     vi.doUnmock('@agent/runtime/runAgent');
     vi.doUnmock('@agent/storage/detectWaitingStreams');
     vi.doUnmock('@common/storage/KVStore');
-    vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger');
     vi.doUnmock('vscode');
     vi.restoreAllMocks();
@@ -2520,256 +2408,6 @@ describe('DesktopProgressBridge', () => {
       accepted: false,
       userMessage: 'Stream resources released.',
     });
-  });
-
-  it('surfaces invalid execution requests through the host error path', async () => {
-    const postToRenderer = vi.fn();
-    const showErrorMessage = vi.fn();
-    const runAgent = vi.fn(async () => {});
-    const execution = await createExecution({
-      postToRenderer,
-      showErrorMessage,
-      runAgent,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: false,
-        message: 'Select an input file first.',
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(showErrorMessage).toHaveBeenCalledWith(
-      'Select an input file first.',
-    );
-    expect(postToRenderer).not.toHaveBeenCalled();
-    expect(runAgent).not.toHaveBeenCalled();
-  });
-
-  it('lets runtime execution errors propagate to the IPC error handler', async () => {
-    const failure = new Error('execution failed');
-    const execution = await createExecution({
-      runAgent: vi.fn(async () => {
-        throw failure;
-      }),
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request: {
-          agentName: 'default',
-          filePath: 'main.tex',
-          prompt: 'run',
-        },
-      })),
-    });
-
-    await expect(
-      execution.handleExecute({ command: 'execute' }),
-    ).rejects.toThrow(failure);
-  });
-
-  it('passes remote agent launches to the shared runtime unchanged', async () => {
-    const request = {
-      agentName: 'remote:remoteWriter',
-      filePath: 'main.tex',
-      prompt: 'draft',
-    };
-    const runAgent = vi.fn(async () => {});
-    const execution = await createExecution({
-      runAgent,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request,
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(runAgent).toHaveBeenCalledWith(
-      request,
-      expect.objectContaining({
-        openWorkflowOutput: expect.any(Function),
-        runtimeUnavailableTools: [
-          ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
-          'inline_comment',
-          DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
-        ],
-      }),
-    );
-  });
-
-  it('opens workflow outputs through the desktop preview host', async () => {
-    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
-    const runAgent = vi.fn(async (_request, options) => {
-      await options.openWorkflowOutput({
-        outcome: RUN_OUTCOME.COMPLETED,
-        outputs: [{ absolutePath: '/tmp/result.pdf', round: 0 }],
-      });
-    });
-    const execution = await createExecution({
-      opener,
-      runAgent,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request: {
-          agentName: 'default',
-          filePath: 'main.tex',
-          prompt: 'run',
-        },
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(opener.openPath).toHaveBeenCalledWith('/tmp/result.pdf');
-  });
-
-  // Minimal AgentTrace stand-in: the desktop bridge bridges a run's trace into
-  // the window session's onResult channel via `session.attachRunTrace`, which
-  // only needs `subscribe`. `emit` fans an event out to subscribers, matching
-  // how the real lifecycle publishes the terminal `result` event.
-  function makeFakeTrace(): {
-    subscribe(fn: (event: unknown) => void): () => void;
-    emit(event: unknown): void;
-  } {
-    const subscribers = new Set<(event: unknown) => void>();
-    return {
-      subscribe(fn) {
-        subscribers.add(fn);
-        return () => subscribers.delete(fn);
-      },
-      emit(event) {
-        for (const fn of subscribers) fn(event);
-      },
-    };
-  }
-
-  it('fires onRunCompleted when a run reaches a completed terminal result', async () => {
-    const onRunCompleted = vi.fn();
-    // The mock run bridges a trace into the window session's onResult channel
-    // (mirroring AgentLaunchContext.attachRunTrace) and emits a completed
-    // result — exactly what the lifecycle does after persisting firstRunDone.
-    const runAgent = vi.fn(async (_request, options) => {
-      const trace = makeFakeTrace();
-      options.session.attachRunTrace(trace, 'stream-1');
-      trace.emit({
-        type: 'result',
-        outcome: RUN_OUTCOME.COMPLETED,
-        executionId: 'ec1001',
-        streamId: 'stream-1',
-        agentName: 'proofreader',
-        category: 'workflow',
-        isSubagent: false,
-      });
-    });
-    const execution = await createExecution({
-      runAgent,
-      onRunCompleted,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request: {
-          agentName: 'default',
-          filePath: 'main.tex',
-          prompt: 'run',
-        },
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(onRunCompleted).toHaveBeenCalledOnce();
-  });
-
-  it('does not fire onRunCompleted on a failed terminal result', async () => {
-    const onRunCompleted = vi.fn();
-    const runAgent = vi.fn(async (_request, options) => {
-      const trace = makeFakeTrace();
-      options.session.attachRunTrace(trace, 'stream-2');
-      trace.emit({
-        type: 'result',
-        outcome: RUN_OUTCOME.FAILED,
-        executionId: 'exec-2',
-        streamId: 'stream-2',
-        agentName: 'proofreader',
-        category: 'workflow',
-        isSubagent: false,
-      });
-    });
-    const execution = await createExecution({
-      runAgent,
-      onRunCompleted,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request: {
-          agentName: 'default',
-          filePath: 'main.tex',
-          prompt: 'run',
-        },
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(onRunCompleted).not.toHaveBeenCalled();
-  });
-
-  it('does not auto-open outputs of a non-completed workflow', async () => {
-    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
-    const runAgent = vi.fn(async (_request, options) => {
-      await options.openWorkflowOutput({
-        outcome: RUN_OUTCOME.CANCELLED,
-        outputs: [{ absolutePath: '/tmp/result.pdf' }],
-      });
-    });
-    const execution = await createExecution({
-      opener,
-      runAgent,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: true,
-        request: {
-          agentName: 'default',
-          filePath: 'main.tex',
-          prompt: 'run',
-        },
-      })),
-    });
-
-    await execution.handleExecute({ command: 'execute' });
-    expect(opener.openPath).not.toHaveBeenCalled();
-  });
-
-  it('opens compile-file actions through the desktop preview host', async () => {
-    const opener = {
-      openPath: vi.fn(async (_filePath: string) => {}),
-      openBuildDisplay: vi.fn(
-        async (_location: { absolutePath: string }) => {},
-      ),
-    };
-    const execution = await createExecution({
-      opener,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: false,
-        message: 'not used',
-      })),
-    });
-
-    await execution.progress.openFileCompile('/tmp/output.tex');
-    expect(opener.openBuildDisplay).toHaveBeenCalledWith(
-      expect.objectContaining({ absolutePath: '/tmp/output.tex' }),
-    );
-    expect(opener.openPath).not.toHaveBeenCalled();
-  });
-
-  it('does not fall back to plain file open for compile-file actions', async () => {
-    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
-    const showErrorMessage = vi.fn();
-    const execution = await createExecution({
-      opener,
-      showErrorMessage,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: false,
-        message: 'not used',
-      })),
-    });
-
-    await execution.progress.openFileCompile('/tmp/output.tex');
-    expect(opener.openPath).not.toHaveBeenCalled();
-    expect(showErrorMessage).toHaveBeenCalledWith(
-      'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
-    );
   });
 
   it('resumes workflow streams from persisted meta', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -543,6 +543,7 @@ describe('DesktopProgressBridge', () => {
     vi.doUnmock('@agent/runtime/runAgent');
     vi.doUnmock('@agent/storage/detectWaitingStreams');
     vi.doUnmock('@common/storage/KVStore');
+    vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger');
     vi.doUnmock('vscode');
     vi.restoreAllMocks();

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -272,7 +272,7 @@ describe('createDesktopAgentExecution', () => {
     const runAgent = vi.fn(async (_request, options) => {
       await options.openWorkflowOutput({
         outcome: RUN_OUTCOME.CANCELLED,
-        outputs: [{ absolutePath: '/tmp/result.pdf' }],
+        outputs: [{ absolutePath: '/tmp/result.pdf', round: 0 }],
       });
     });
     const execution = await createExecution({

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -1,0 +1,335 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared schemas and tools
+import { RUN_OUTCOME } from '@shared/schemas';
+import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
+
+// Local imports - desktop test support
+import {
+  disposeAfterTest,
+  makeFakeTrace,
+  mockLoggerModule,
+  type DesktopAgentExecutionModule,
+  type RunExecutionRequest,
+} from './desktopAgentExecutionTestHarness.mjs';
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+type DesktopExecution = {
+  handleExecute(message: unknown): Promise<void>;
+  progress: {
+    openFileCompile(filePath: string): Promise<void>;
+  };
+  dispose(): void;
+};
+
+async function createExecution(options: {
+  postToRenderer?: (message: unknown) => void;
+  opener?: {
+    openPath(filePath: string): Promise<void>;
+    openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
+  };
+  showErrorMessage?: (message: string) => Promise<void> | void;
+  prepareMainViewExecutionRequest: (message: unknown) => unknown;
+  runAgent?: RunExecutionRequest;
+  onRunCompleted?: () => void;
+}): Promise<DesktopExecution> {
+  vi.resetModules();
+  const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
+    import('@platform/platform'),
+    import('@test/support/FakePlatform'),
+  ]);
+  initPlatform(createFakePlatform());
+  vi.doMock('@agent/runtime/ProgressViewBridge', () => ({
+    setProgressViewBridge: vi.fn(),
+  }));
+  vi.doMock('@agent/runtime/SessionResumeRetrieval', () => ({
+    retrieveSessionResumeData: vi.fn(async () => null),
+  }));
+  vi.doMock('@agent/runtime/executeAgent', () => ({
+    resumeToolUseFromSnapshot: vi.fn(async () => {}),
+  }));
+  vi.doMock('@agent/runtime/runAgent', () => ({
+    runAgent: options.runAgent ?? vi.fn(async () => {}),
+  }));
+  vi.doMock('@common/storage/KVStore', () => ({
+    KVStore: class {
+      async read(): Promise<undefined> {
+        return undefined;
+      }
+
+      async write(): Promise<void> {}
+
+      async delete(): Promise<void> {}
+
+      async deleteDir(): Promise<void> {}
+
+      async exists(): Promise<boolean> {
+        return false;
+      }
+
+      async listKeys(): Promise<string[]> {
+        return [];
+      }
+    },
+  }));
+  vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
+    prepareMainViewExecutionRequest: options.prepareMainViewExecutionRequest,
+  }));
+  mockLoggerModule();
+  const { createDesktopAgentExecution } = (await import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
+  )) as DesktopAgentExecutionModule;
+  return disposeAfterTest(
+    createDesktopAgentExecution({
+      postToRenderer: options.postToRenderer ?? vi.fn(),
+      opener: options.opener,
+      showErrorMessage: options.showErrorMessage,
+      onRunCompleted: options.onRunCompleted,
+    }),
+  );
+}
+
+describe('createDesktopAgentExecution', () => {
+  afterEach(() => {
+    vi.doUnmock('@agent/runtime/ProgressViewBridge');
+    vi.doUnmock('@agent/runtime/SessionResumeRetrieval');
+    vi.doUnmock('@agent/runtime/executeAgent');
+    vi.doUnmock('@agent/runtime/runAgent');
+    vi.doUnmock('@common/storage/KVStore');
+    vi.doUnmock('@controllers/mainView/MainViewExecutionController');
+    vi.doUnmock('@logger');
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces invalid execution requests through the host error path', async () => {
+    const postToRenderer = vi.fn();
+    const showErrorMessage = vi.fn();
+    const runAgent = vi.fn(async () => {});
+    const execution = await createExecution({
+      postToRenderer,
+      showErrorMessage,
+      runAgent,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: false,
+        message: 'Select an input file first.',
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Select an input file first.',
+    );
+    expect(postToRenderer).not.toHaveBeenCalled();
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it('lets runtime execution errors propagate to the IPC error handler', async () => {
+    const failure = new Error('execution failed');
+    const execution = await createExecution({
+      runAgent: vi.fn(async () => {
+        throw failure;
+      }),
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    await expect(
+      execution.handleExecute({ command: 'execute' }),
+    ).rejects.toThrow(failure);
+  });
+
+  it('passes remote agent launches to the shared runtime unchanged', async () => {
+    const request = {
+      agentName: 'remote:remoteWriter',
+      filePath: 'main.tex',
+      prompt: 'draft',
+    };
+    const runAgent = vi.fn(async () => {});
+    const execution = await createExecution({
+      runAgent,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request,
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(runAgent).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        openWorkflowOutput: expect.any(Function),
+        runtimeUnavailableTools: [
+          ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
+          'inline_comment',
+          DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+        ],
+      }),
+    );
+  });
+
+  it('opens workflow outputs through the desktop preview host', async () => {
+    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
+    const runAgent = vi.fn(async (_request, options) => {
+      await options.openWorkflowOutput({
+        outcome: RUN_OUTCOME.COMPLETED,
+        outputs: [{ absolutePath: '/tmp/result.pdf', round: 0 }],
+      });
+    });
+    const execution = await createExecution({
+      opener,
+      runAgent,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(opener.openPath).toHaveBeenCalledWith('/tmp/result.pdf');
+  });
+
+  it('fires onRunCompleted when a run reaches a completed terminal result', async () => {
+    const onRunCompleted = vi.fn();
+    // The mock run bridges a trace into the window session's onResult channel
+    // (mirroring AgentLaunchContext.attachRunTrace) and emits a completed
+    // result — exactly what the lifecycle does after persisting firstRunDone.
+    const runAgent = vi.fn(async (_request, options) => {
+      const trace = makeFakeTrace();
+      options.session.attachRunTrace(trace, 'stream-1');
+      trace.emit({
+        type: 'result',
+        outcome: RUN_OUTCOME.COMPLETED,
+        executionId: 'ec1001',
+        streamId: 'stream-1',
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+      });
+    });
+    const execution = await createExecution({
+      runAgent,
+      onRunCompleted,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(onRunCompleted).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire onRunCompleted on a failed terminal result', async () => {
+    const onRunCompleted = vi.fn();
+    const runAgent = vi.fn(async (_request, options) => {
+      const trace = makeFakeTrace();
+      options.session.attachRunTrace(trace, 'stream-2');
+      trace.emit({
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+        executionId: 'exec-2',
+        streamId: 'stream-2',
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+      });
+    });
+    const execution = await createExecution({
+      runAgent,
+      onRunCompleted,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(onRunCompleted).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-open outputs of a non-completed workflow', async () => {
+    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
+    const runAgent = vi.fn(async (_request, options) => {
+      await options.openWorkflowOutput({
+        outcome: RUN_OUTCOME.CANCELLED,
+        outputs: [{ absolutePath: '/tmp/result.pdf' }],
+      });
+    });
+    const execution = await createExecution({
+      opener,
+      runAgent,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    await execution.handleExecute({ command: 'execute' });
+    expect(opener.openPath).not.toHaveBeenCalled();
+  });
+
+  it('opens compile-file actions through the desktop preview host', async () => {
+    const opener = {
+      openPath: vi.fn(async (_filePath: string) => {}),
+      openBuildDisplay: vi.fn(
+        async (_location: { absolutePath: string }) => {},
+      ),
+    };
+    const execution = await createExecution({
+      opener,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: false,
+        message: 'not used',
+      })),
+    });
+
+    await execution.progress.openFileCompile('/tmp/output.tex');
+    expect(opener.openBuildDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({ absolutePath: '/tmp/output.tex' }),
+    );
+    expect(opener.openPath).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to plain file open for compile-file actions', async () => {
+    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
+    const showErrorMessage = vi.fn();
+    const execution = await createExecution({
+      opener,
+      showErrorMessage,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: false,
+        message: 'not used',
+      })),
+    });
+
+    await execution.progress.openFileCompile('/tmp/output.tex');
+    expect(opener.openPath).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
+    );
+  });
+});

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
@@ -1,0 +1,67 @@
+// Third-party imports
+import { onTestFinished, vi } from 'vitest';
+
+// Local imports - shared schemas
+import type { RunOutcome } from '@shared/schemas';
+
+export type DesktopAgentExecutionModule =
+  typeof import('@desktop/main/desktopAgentExecution');
+
+export type RunExecutionRequest = (
+  request: unknown,
+  options: {
+    openWorkflowOutput(result: {
+      outcome: RunOutcome;
+      outputs: Array<{ absolutePath: string }>;
+    }): Promise<void>;
+    // This window's SessionHandle. The onboarding run-completion test drives a
+    // terminal `result` event through it via `attachRunTrace`.
+    session: {
+      attachRunTrace(
+        trace: {
+          subscribe(fn: (event: unknown) => void): unknown;
+        },
+        streamId: string,
+      ): () => void;
+    };
+    runtimeUnavailableTools?: readonly string[];
+  },
+) => Promise<void>;
+
+export function disposeAfterTest<T extends { dispose(): void }>(value: T): T {
+  onTestFinished(() => value.dispose());
+  return value;
+}
+
+export function mockLoggerModule(
+  loggerErrorSpy?: ReturnType<typeof vi.fn>,
+): void {
+  vi.doMock('@logger', () => ({
+    createChannelTrace: () => ({
+      emit: vi.fn(),
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: loggerErrorSpy ?? (() => {}),
+    }),
+  }));
+}
+
+/**
+ * Minimal AgentTrace stand-in for bridging terminal results into a session.
+ */
+export function makeFakeTrace(): {
+  subscribe(fn: (event: unknown) => void): () => void;
+  emit(event: unknown): void;
+} {
+  const subscribers = new Set<(event: unknown) => void>();
+  return {
+    subscribe(fn) {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+    emit(event) {
+      for (const fn of subscribers) fn(event);
+    },
+  };
+}

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
@@ -3,6 +3,7 @@ import { onTestFinished, vi } from 'vitest';
 
 // Local imports - shared schemas
 import type { RunOutcome } from '@shared/schemas';
+import type { OutputFileSummary } from '@shared/schemas/output';
 
 export type DesktopAgentExecutionModule =
   typeof import('@desktop/main/desktopAgentExecution');
@@ -12,7 +13,7 @@ export type RunExecutionRequest = (
   options: {
     openWorkflowOutput(result: {
       outcome: RunOutcome;
-      outputs: Array<{ absolutePath: string }>;
+      outputs: Array<Pick<OutputFileSummary, 'absolutePath' | 'round'>>;
     }): Promise<void>;
     // This window's SessionHandle. The onboarding run-completion test drives a
     // terminal `result` event through it via `attachRunTrace`.
@@ -47,9 +48,7 @@ export function mockLoggerModule(
   }));
 }
 
-/**
- * Minimal AgentTrace stand-in for bridging terminal results into a session.
- */
+/** Minimal AgentTrace stand-in for bridging terminal results into a session. */
 export function makeFakeTrace(): {
   subscribe(fn: (event: unknown) => void): () => void;
   emit(event: unknown): void;


### PR DESCRIPTION
## Summary

- Separate nine `createDesktopAgentExecution` factory/facade tests from the direct `DesktopProgressBridge` suite.
- Keep the factory loader and factory-only imports in a focused 335-line test module.
- Move only five genuine cross-suite primitives into a 66-line execution-specific harness.
- Repoint the host-agent mock inventory entries for the four mocks that moved with the factory loader.

The original god suite drops from 3,673 to 3,312 lines and from 72 to 63 tests. The new factory suite owns 9 tests, so all 72 tests and assertions remain.

## Issue acceptance gates

Fixes #8055.

- Original bridge suite: 3,312 LoC / 63 tests.
- New factory suite: 335 LoC / 9 tests.
- Shared harness: 66 LoC, limited to module typing, run typing, disposal, logger mocking, and fake trace construction.
- Total test LoC growth is exactly 40 lines, matching the stated cap.
- All focused and repository-wide gates pass.

## Single source of truth

`DesktopAgentExecution.vitest.mts` now owns direct bridge behavior. `DesktopAgentExecutionFactory.vitest.mts` owns the factory-created facade, request forwarding, output opening, completion callbacks, and factory-wired compile preview. `desktopAgentExecutionTestHarness.mts` owns only setup primitives required by both suites.

## Duplication and abstraction budget

No test setup was duplicated. The shared harness contains five existing cross-suite dependencies and no generic utility surface. The extra 40 lines are file-level imports, cleanup, and suite boundaries that remove 362 lines from the god file and make factory responsibility independently navigable.

## Net elements (R6)

- Files: +2 test modules, 0 deleted, 2 modified.
- Exported symbols: +5 test-only harness exports.
- Functions and type declarations: net 0; existing declarations moved.
- Test suites: +1 responsibility boundary; tests remain 72.
- Net LoC: +40 (411 additions, 371 deletions).

## Consumer counts (R8)

n/a — no production emit path or export is deleted or rerouted.

## Host impact

Extension: none.

Desktop: test organization only; runtime behavior and assertions are unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run check:test-loc-growth` (warn-only baseline remains stale by 5,584 lines; this PR contributes exactly +40 and intentionally does not absorb unrelated drift into the baseline)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 pre-existing warnings)
- `npm test` (624 files passed, 1 skipped; 5,539 tests passed, 4 skipped)
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts --maxWorkers=2` (2 files, 72 tests passed)
- `npx vitest run src/test-kernel/architecture/hostAgentMockRatchet.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts --maxWorkers=2` (3 files, 74 tests passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only reorganization with no production code changes; assertions and mock coverage are preserved per the PR description.
> 
> **Overview**
> **Splits the oversized `DesktopAgentExecution` vitest file** so bridge tests and factory tests live in separate modules, with shared setup extracted.
> 
> Nine tests that exercise **`createDesktopAgentExecution`** (invalid requests, `runAgent` forwarding, remote-agent tool exclusions, workflow output opening, `onRunCompleted`, compile/preview wiring) move from `DesktopAgentExecution.vitest.mts` into new **`DesktopAgentExecutionFactory.vitest.mts`**, which keeps the factory-only `createExecution` loader and mocks.
> 
> **`desktopAgentExecutionTestHarness.mts`** is added with cross-suite helpers: `disposeAfterTest`, `mockLoggerModule`, `makeFakeTrace`, and shared types (`DesktopAgentExecutionModule`, `RunExecutionRequest`). The bridge suite imports these instead of inlining them.
> 
> The remaining **`DesktopAgentExecution.vitest.mts`** stays focused on **`DesktopProgressBridge`** (63 tests). **`host-agent-mock-baseline.json`** is updated so `@agent/*` `doMock` sites are attributed to the bridge file vs. the new factory file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e126021c0cbfd26a631ddca4344317bb1b423e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


