### PR TITLE
test(desktop): split history handler coverage

### DIFF
--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -1,0 +1,253 @@
+// Third-party imports
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - history dependencies
+import { setupPlatform } from '@test/support/setupPlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { AgentCategory } from '@shared/schemas/agent';
+import { assertSupported } from '@shared/utils/dispatcher';
+
+// Local imports - desktop test support
+import {
+  desktopSourcePath,
+  moduleFileUrl,
+  repoPath,
+} from './desktopTestPaths.mjs';
+
+// Local imports - controller types
+import type { ChatExportInput } from '@controllers/settingsView/ChatExportController';
+
+const chatExportMocks = vi.hoisted(() => ({
+  buildExportInput: vi.fn(),
+  exportAsMarkdown: vi.fn(),
+  exportAsLatex: vi.fn(),
+  exportAsHtml: vi.fn(),
+  constructorDeps: [] as unknown[],
+}));
+
+vi.mock('@controllers/settingsView/ChatExportController', () => ({
+  ChatExportController: class {
+    buildExportInput = chatExportMocks.buildExportInput;
+    exportAsMarkdown = chatExportMocks.exportAsMarkdown;
+    exportAsLatex = chatExportMocks.exportAsLatex;
+    exportAsHtml = chatExportMocks.exportAsHtml;
+
+    constructor(dependencies: unknown) {
+      chatExportMocks.constructorDeps.push(dependencies);
+    }
+  },
+}));
+
+type DesktopHistoryHandlersModule =
+  typeof import('@desktop/main/desktopHistoryHandlers');
+type DesktopHistoryDependencies = ConstructorParameters<
+  DesktopHistoryHandlersModule['DesktopHistoryHandlers']
+>[0];
+
+const RESOURCES_PATH = repoPath('packages', 'extension', 'resources');
+const HISTORY_ID = 'bbbb2222';
+const HISTORY_CONFIG = AgentConfigSchema.parse({
+  agent: 'chat',
+  model: 'deepseekT',
+  instruction: 'Check a proof.',
+  agentCategory: AgentCategory.ToolUse,
+});
+const EXPORT_INPUT: ChatExportInput = {
+  timestamp: '2026-01-01T00:00:00.000Z',
+  config: { agent: 'chat' },
+  messages: [],
+};
+
+let DesktopHistoryHandlers!: DesktopHistoryHandlersModule['DesktopHistoryHandlers'];
+
+setupPlatform();
+
+function createHistoryActions(
+  overrides: Partial<DesktopHistoryDependencies> = {},
+) {
+  return new DesktopHistoryHandlers({
+    postToRenderer: vi.fn(),
+    resourcesPath: RESOURCES_PATH,
+    onError: vi.fn(),
+    ...overrides,
+  }).actions;
+}
+
+async function writeHistoryConfig(): Promise<void> {
+  await getExecutionStore(HISTORY_ID).writeConfig(HISTORY_CONFIG);
+}
+
+describe('DesktopHistoryHandlers', () => {
+  beforeAll(async () => {
+    ({ DesktopHistoryHandlers } = (await import(
+      moduleFileUrl(desktopSourcePath('main', 'desktopHistoryHandlers.ts'))
+    )) as DesktopHistoryHandlersModule);
+  });
+
+  beforeEach(() => {
+    clearStoreCache();
+    chatExportMocks.constructorDeps.length = 0;
+    vi.resetAllMocks();
+  });
+
+  it("restores a history item's setup into the main view", async () => {
+    await writeHistoryConfig();
+    const showErrorMessage = vi.fn();
+    const restoreTaskState = vi.fn(async () => true);
+    const actions = createHistoryActions({
+      showErrorMessage,
+      restoreTaskState,
+    });
+
+    await assertSupported(actions.restoreAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+      historyId: HISTORY_ID,
+    });
+
+    expect(showErrorMessage).not.toHaveBeenCalled();
+    expect(restoreTaskState).toHaveBeenCalledWith({
+      agentConfig: HISTORY_CONFIG,
+    });
+  });
+
+  it('reports missing history items for rerun and restore instead of dropping them', async () => {
+    const showErrorMessage = vi.fn();
+    const actions = createHistoryActions({ showErrorMessage });
+    const historyId = 'ffff9999';
+
+    await assertSupported(actions.rerunAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId,
+    });
+    await assertSupported(actions.restoreAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
+      historyId,
+    });
+
+    expect(showErrorMessage).toHaveBeenCalledTimes(2);
+    expect(showErrorMessage).toHaveBeenNthCalledWith(
+      1,
+      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
+    );
+    expect(showErrorMessage).toHaveBeenNthCalledWith(
+      2,
+      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
+    );
+  });
+
+  it('errors instead of a false success when rerun has no runExecution dependency wired (Copilot #7827)', async () => {
+    await writeHistoryConfig();
+    const showInfoMessage = vi.fn();
+    const showErrorMessage = vi.fn();
+    const actions = createHistoryActions({
+      showInfoMessage,
+      showErrorMessage,
+    });
+
+    await assertSupported(actions.rerunAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId: HISTORY_ID,
+    });
+
+    expect(showInfoMessage).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Rerunning agents from history is not available in this build',
+    );
+  });
+
+  it('exports a history chat to Markdown via the shared ChatExportController', async () => {
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput: EXPORT_INPUT,
+    });
+    chatExportMocks.exportAsMarkdown.mockResolvedValue({
+      storagePath: 'executions/abc/chat.md',
+      absolutePath: '/tmp/executions/abc/chat.md',
+    });
+    const openPath = vi.fn();
+    const showInfoMessage = vi.fn();
+    const actions = createHistoryActions({ openPath, showInfoMessage });
+
+    await assertSupported(actions.exportChatMd)({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+      historyId: 'abc',
+    });
+
+    expect(chatExportMocks.buildExportInput).toHaveBeenCalledWith('abc');
+    expect(chatExportMocks.exportAsMarkdown).toHaveBeenCalledWith(
+      'abc',
+      EXPORT_INPUT,
+    );
+    expect(openPath).toHaveBeenCalledWith('/tmp/executions/abc/chat.md');
+    expect(showInfoMessage).toHaveBeenCalledWith('Chat exported: chat.md');
+    expect(chatExportMocks.constructorDeps.at(-1)).toMatchObject({
+      latexPreamble: expect.stringContaining('\\documentclass'),
+    });
+  });
+
+  it('falls back to opening the .tex source when LaTeX compilation fails', async () => {
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput: EXPORT_INPUT,
+    });
+    chatExportMocks.exportAsLatex.mockResolvedValue({
+      storagePath: 'executions/abc/chat.tex',
+      absolutePath: '/tmp/executions/abc/chat.tex',
+      pdfPath: undefined,
+      logTail: '! Undefined control sequence.',
+    });
+    const openPath = vi.fn();
+    const showInfoMessage = vi.fn();
+    const actions = createHistoryActions({ openPath, showInfoMessage });
+
+    await assertSupported(actions.exportChatTex)({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
+      historyId: 'abc',
+    });
+
+    expect(openPath).toHaveBeenCalledWith('/tmp/executions/abc/chat.tex');
+    expect(showInfoMessage).toHaveBeenCalledWith(
+      'LaTeX compilation failed. The .tex source file has been opened instead.',
+    );
+  });
+
+  it('exports a history chat to HTML via the shared trace-viewer template', async () => {
+    chatExportMocks.exportAsHtml.mockResolvedValue({
+      status: 'ok',
+      result: {
+        storagePath: 'executions/abc/chat.html',
+        absolutePath: '/tmp/executions/abc/chat.html',
+      },
+    });
+    const openPath = vi.fn();
+    const actions = createHistoryActions({ openPath });
+
+    await assertSupported(actions.exportChatHtml)({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
+      historyId: 'abc',
+    });
+
+    expect(chatExportMocks.exportAsHtml).toHaveBeenCalledWith(
+      'abc',
+      `${RESOURCES_PATH}/traceViewerStandalone/index.html`,
+    );
+    expect(openPath).toHaveBeenCalledWith('/tmp/executions/abc/chat.html');
+  });
+
+  it('reports a missing history item on export instead of throwing', async () => {
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'config_missing',
+    });
+    const showInfoMessage = vi.fn();
+    const actions = createHistoryActions({ showInfoMessage });
+
+    await assertSupported(actions.exportChatMd)({
+      command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+      historyId: 'missing',
+    });
+
+    expect(showInfoMessage).toHaveBeenCalledWith('History item not found');
+  });
+});

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -14,11 +14,7 @@ import {
 } from '@tools/worktreeConfig';
 import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
-import {
-  desktopSourcePath,
-  moduleFileUrl,
-  repoPath,
-} from './desktopTestPaths.mjs';
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 import type { StateStore } from '@platform/interfaces';
 
 const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
@@ -31,33 +27,6 @@ const computeModelOptionsData = vi.hoisted(() =>
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData,
   invalidateModelOptionsCache,
-}));
-
-// The export wiring tests below assert desktopSettingsIpc.ts's history
-// actions call through to ChatExportController with the right arguments and
-// react to its result — ChatExportController's own formatting/compile/write
-// behavior already has dedicated coverage (ChatExportController.vitest.ts,
-// ChatExportControllerHtml.vitest.ts), so it's mocked here rather than
-// re-exercised.
-const chatExportMocks = vi.hoisted(() => ({
-  buildExportInput: vi.fn(),
-  exportAsMarkdown: vi.fn(),
-  exportAsLatex: vi.fn(),
-  exportAsHtml: vi.fn(),
-  constructorDeps: [] as unknown[],
-}));
-
-vi.mock('@controllers/settingsView/ChatExportController', () => ({
-  ChatExportController: class {
-    buildExportInput = chatExportMocks.buildExportInput;
-    exportAsMarkdown = chatExportMocks.exportAsMarkdown;
-    exportAsLatex = chatExportMocks.exportAsLatex;
-    exportAsHtml = chatExportMocks.exportAsHtml;
-
-    constructor(deps: unknown) {
-      chatExportMocks.constructorDeps.push(deps);
-    }
-  },
 }));
 
 type DesktopSettingsIpcModule =
@@ -1625,10 +1594,15 @@ describe('desktop settings IPC', () => {
   });
 
   it('reruns an agent from history through the shared runAgent path', async () => {
-    const { getExecutionStore } = await import('@agent/storage');
+    const { clearStoreCache, getExecutionStore } =
+      await import('@agent/storage');
     const { AgentConfigSchema } =
       await import('@agent/core/definition/AgentConfig');
     const { AgentCategory } = await import('@shared/schemas/agent');
+    const { installPlatform } = await import('@test/support/setupPlatform');
+
+    clearStoreCache();
+    await installPlatform();
 
     const historyId = 'aaaa1111';
     const config = AgentConfigSchema.parse({
@@ -1660,259 +1634,6 @@ describe('desktop settings IPC', () => {
 
     expect(infos).toEqual(['Rerunning agent from history']);
     expect(runRequests).toEqual([{ config, executionId: undefined }]);
-  });
-
-  it("restores a history item's setup into the main view", async () => {
-    const { getExecutionStore } = await import('@agent/storage');
-    const { AgentConfigSchema } =
-      await import('@agent/core/definition/AgentConfig');
-    const { AgentCategory } = await import('@shared/schemas/agent');
-
-    const historyId = 'bbbb2222';
-    const config = AgentConfigSchema.parse({
-      agent: 'chat',
-      model: 'deepseekT',
-      instruction: 'Check a proof.',
-      agentCategory: AgentCategory.ToolUse,
-    });
-    await getExecutionStore(historyId).writeConfig(config);
-
-    const errors: string[] = [];
-    const restoredTaskStates: unknown[] = [];
-    const { settings } = createSettingsFixture({
-      showErrorMessage: async (message) => {
-        errors.push(message);
-      },
-      restoreTaskState: async (taskState) => {
-        restoredTaskStates.push(taskState);
-        return true;
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
-        historyId,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(errors).toEqual([]);
-    expect(restoredTaskStates).toEqual([{ agentConfig: config }]);
-  });
-
-  it('reports missing history items for rerun and restore instead of dropping them', async () => {
-    const shownErrors: string[] = [];
-    const { settings } = createSettingsFixture({
-      showErrorMessage: async (message) => {
-        shownErrors.push(message);
-      },
-    });
-
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-      historyId: 'ffff9999',
-    });
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
-      historyId: 'ffff9999',
-    });
-    await flushAsyncWork();
-
-    expect(shownErrors).toEqual([
-      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
-      'History item not found or unreadable (missing, corrupt, or from an incompatible version)',
-    ]);
-  });
-
-  it('errors instead of a false success when rerun has no runExecution dependency wired (Copilot #7827)', async () => {
-    const { getExecutionStore } = await import('@agent/storage');
-    const { AgentConfigSchema } =
-      await import('@agent/core/definition/AgentConfig');
-    const { AgentCategory } = await import('@shared/schemas/agent');
-
-    const historyId = 'cccc3333';
-    const config = AgentConfigSchema.parse({
-      agent: 'chat',
-      model: 'deepseekT',
-      instruction: 'Check a proof.',
-      agentCategory: AgentCategory.ToolUse,
-    });
-    await getExecutionStore(historyId).writeConfig(config);
-
-    const infos: string[] = [];
-    const errors: string[] = [];
-    // Deliberately omit `runExecution` — this is the desktop wiring gap the
-    // finding calls out: the IPC handler must not report success when the
-    // host never wired the execution bridge.
-    const { settings } = createSettingsFixture({
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-      showErrorMessage: async (message) => {
-        errors.push(message);
-      },
-    });
-
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-      historyId,
-    });
-    await flushAsyncWork();
-
-    expect(infos).toEqual([]);
-    expect(errors).toEqual([
-      'Rerunning agents from history is not available in this build',
-    ]);
-  });
-
-  it('exports a history chat to Markdown via the shared ChatExportController', async () => {
-    const exportInput = {
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: { agent: 'chat' },
-      conversation: [],
-    };
-    chatExportMocks.buildExportInput.mockResolvedValue({
-      status: 'ok',
-      exportInput,
-    });
-    chatExportMocks.exportAsMarkdown.mockResolvedValue({
-      storagePath: 'executions/abc/chat.md',
-      absolutePath: '/tmp/executions/abc/chat.md',
-    });
-
-    const opened: string[] = [];
-    const infos: string[] = [];
-    const { settings } = createSettingsFixture({
-      resourcesPath: repoPath('packages', 'extension', 'resources'),
-      openPath: async (filePath) => {
-        opened.push(filePath);
-      },
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
-        historyId: 'abc',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(chatExportMocks.buildExportInput).toHaveBeenCalledWith('abc');
-    expect(chatExportMocks.exportAsMarkdown).toHaveBeenCalledWith(
-      'abc',
-      exportInput,
-    );
-    expect(opened).toEqual(['/tmp/executions/abc/chat.md']);
-    expect(infos).toEqual(['Chat exported: chat.md']);
-    // Constructed from the real bundled `templates/chatExport.tex` (the
-    // LaTeX-export dependency), not a mocked/stubbed preamble.
-    expect(chatExportMocks.constructorDeps.at(-1)).toMatchObject({
-      latexPreamble: expect.stringContaining('\\documentclass'),
-    });
-  });
-
-  it('falls back to opening the .tex source when LaTeX compilation fails', async () => {
-    const exportInput = {
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: { agent: 'chat' },
-      conversation: [],
-    };
-    chatExportMocks.buildExportInput.mockResolvedValue({
-      status: 'ok',
-      exportInput,
-    });
-    chatExportMocks.exportAsLatex.mockResolvedValue({
-      storagePath: 'executions/abc/chat.tex',
-      absolutePath: '/tmp/executions/abc/chat.tex',
-      pdfPath: undefined,
-      logTail: '! Undefined control sequence.',
-    });
-
-    const opened: string[] = [];
-    const infos: string[] = [];
-    const { settings } = createSettingsFixture({
-      resourcesPath: repoPath('packages', 'extension', 'resources'),
-      openPath: async (filePath) => {
-        opened.push(filePath);
-      },
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
-        historyId: 'abc',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(opened).toEqual(['/tmp/executions/abc/chat.tex']);
-    expect(infos).toEqual([
-      'LaTeX compilation failed. The .tex source file has been opened instead.',
-    ]);
-  });
-
-  it('exports a history chat to HTML via the shared trace-viewer template', async () => {
-    chatExportMocks.exportAsHtml.mockResolvedValue({
-      status: 'ok',
-      result: {
-        storagePath: 'executions/abc/chat.html',
-        absolutePath: '/tmp/executions/abc/chat.html',
-      },
-    });
-
-    const opened: string[] = [];
-    const resourcesPath = repoPath('packages', 'extension', 'resources');
-    const { settings } = createSettingsFixture({
-      resourcesPath,
-      openPath: async (filePath) => {
-        opened.push(filePath);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_HTML,
-        historyId: 'abc',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(chatExportMocks.exportAsHtml).toHaveBeenCalledWith(
-      'abc',
-      `${resourcesPath}/traceViewerStandalone/index.html`,
-    );
-    expect(opened).toEqual(['/tmp/executions/abc/chat.html']);
-  });
-
-  it('reports a missing history item on export instead of throwing', async () => {
-    chatExportMocks.buildExportInput.mockResolvedValue({
-      status: 'config_missing',
-    });
-
-    const infos: string[] = [];
-    const { settings } = createSettingsFixture({
-      resourcesPath: repoPath('packages', 'extension', 'resources'),
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
-        historyId: 'missing',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(infos).toEqual(['History item not found']);
   });
 
   it('ignores unsupported or malformed settings messages', async () => {


### PR DESCRIPTION
## Summary

Split desktop history behavior coverage out of the broad settings IPC suite. The settings suite retains one end-to-end rerun dispatcher smoke, while the new handler suite directly awaits the seven history actions behind focused fixtures.

Closes #8057.

## Issue acceptance gates

- `DesktopSettingsIpc.vitest.mts`: 1,650 LoC / 34 tests.
- `DesktopHistoryHandlers.vitest.mts`: 253 LoC / 7 tests.
- Preserves all 41 tests and one settings-dispatcher integration path.
- Reduces total test LoC from 1,929 to 1,903 (net -26).
- Uses `setupPlatform()` plus `clearStoreCache()` for fresh execution storage per test.
- Keeps unique Markdown, LaTeX fallback, HTML template, restore, missing-history, and unavailable-rerun assertions.

## Single source of truth

`DesktopHistoryHandlers.actions` owns history behavior. `createDesktopSettingsIpc` is now tested only for constructing and dispatching that behavior.

## Duplication and abstraction budget

Removed repeated full settings fixtures, deferred event-loop flushes, persisted-config setup, resource paths, and export-input fixtures. Added no production abstraction; the focused test fixture mirrors only the handler constructor boundary.

## Net elements (R6)

- Files: +1 test file.
- Diffstat: 260 insertions, 286 deletions.
- Exported symbols: 0.
- Classes/interfaces/enums: net 0; the existing export-controller mock class moved unchanged in responsibility.
- Net test LoC: -26.

## Consumer counts (R8)

n/a — no production emit path or export changed.

## Host impact

Extension: none.

Desktop: test organization only; production behavior is unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 pre-existing import-order warnings)
- `npm test` (625 files passed, 1 skipped; 5,539 tests passed, 4 skipped)
- Focused suites: 2 files / 41 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production code changes; only test file moves and fixture simplification with the same behavioral assertions preserved.
> 
> **Overview**
> **Test-only refactor:** desktop history behavior is no longer exercised through the large `DesktopSettingsIpc` fixture; it lives in a new **`DesktopHistoryHandlers.vitest.mts`** suite that calls `DesktopHistoryHandlers.actions` directly.
> 
> Six history scenarios (restore, missing history on rerun/restore, rerun without `runExecution`, Markdown/LaTeX/HTML export wiring, missing export) move out of **`DesktopSettingsIpc.vitest.mts`**, along with the **`ChatExportController`** mock and **`repoPath`** usage there. The settings suite keeps **one** integration test that **`RERUN_AGENT`** still dispatches through **`createDesktopSettingsIpc`** into **`runExecution`**, with **`clearStoreCache`**, **`installPlatform`**, and related setup added for that path.
> 
> The new suite uses **`setupPlatform()`**, per-test **`clearStoreCache()`**, and a small **`createHistoryActions`** helper instead of full settings IPC fixtures and deferred **`flushAsyncWork`** loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3778ed4101de5247a591d52d6afa4ac127194cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->