### PR TITLE
refactor(cli): narrow interaction policy inputs

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -94,7 +94,6 @@ interface InputEventEmitterLike {
   off(event: 'input', listener: (data: string) => void): void;
 }
 
-// Keep bottom panels from crowding out conversation or input chrome.
 const BOTTOM_PANEL_MAX_ROWS = 10;
 const EMPTY_SUBAGENT_ROWS: readonly ActiveChildInfo[] = [];
 
@@ -313,9 +312,9 @@ export function App(props: AppProps): React.JSX.Element {
   const childControlHasItems = childControlTarget?.hasItems ?? false;
   const { foregroundRows, transcriptRows } = allocateMiddleRows({
     foregroundMaxRows: foregroundMaxRowsForKind({
+      approvalKind: activeApprovalVisible ? pending?.payload.kind : undefined,
       childControlHasItems,
       kind: foregroundKind,
-      pending,
     }),
     foregroundOpen,
     inputVisible: inputBarVisible,
@@ -643,9 +642,11 @@ export function App(props: AppProps): React.JSX.Element {
           commandName={props.commandName}
           foregroundEscapeAction={foregroundEscapeAction({
             activeFormEscapeAction: activeForm?.escapeAction,
+            approvalKind: activeApprovalVisible
+              ? pending?.payload.kind
+              : undefined,
             childControlEscapeAction,
             foregroundKind,
-            pending: activeApprovalVisible ? pending : undefined,
           })}
           queuedFollowUpPreview={!queuedFollowUpPanelVisible}
           shortcutsActive={focusShortcutsActive}

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -17,6 +17,7 @@ const FORM_FOREGROUND_MAX_ROWS = 18;
 // Match form sizing for approval modals that already budget or scroll their
 // content. Natural-height approvals stay uncapped until they grow row budgets.
 const APPROVAL_FOREGROUND_MAX_ROWS = 18;
+type ApprovalKind = PendingApproval['payload']['kind'];
 
 // A bare Esc and the second key of an `Esc s` / `Esc p` chord are two
 // separate keystrokes on terminals without true Meta-key detection (macOS
@@ -142,14 +143,14 @@ export function approvalVisibleForActiveStream({
 
 export function foregroundEscapeAction({
   activeFormEscapeAction,
+  approvalKind,
   childControlEscapeAction,
   foregroundKind,
-  pending,
 }: {
   readonly activeFormEscapeAction?: string;
+  readonly approvalKind?: ApprovalKind;
   readonly childControlEscapeAction?: string;
   readonly foregroundKind: ForegroundSurfaceKind | undefined;
-  readonly pending: PendingApproval | undefined;
 }): string | undefined {
   switch (foregroundKind) {
     case undefined:
@@ -160,16 +161,15 @@ export function foregroundEscapeAction({
       return childControlEscapeAction ?? 'close';
     case 'transcript':
       return 'close';
-    case 'approval': {
-      const kind = pending?.payload.kind;
-      return kind === 'externalInquiry' || kind === 'userQuestion'
+    case 'approval':
+      return approvalKind === 'externalInquiry' ||
+        approvalKind === 'userQuestion'
         ? 'skip'
         : 'cancel';
-    }
   }
 }
 
-export function childControlForegroundMaxRows({
+function childControlForegroundMaxRows({
   hasItems,
 }: {
   readonly hasItems: boolean;
@@ -179,12 +179,12 @@ export function childControlForegroundMaxRows({
     : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
 }
 
-export function approvalForegroundMaxRows(
-  pending: PendingApproval | undefined,
+function approvalForegroundMaxRows(
+  approvalKind: ApprovalKind | undefined,
 ): number | undefined {
-  if (pending === undefined) return undefined;
+  if (approvalKind === undefined) return undefined;
 
-  switch (pending.payload.kind) {
+  switch (approvalKind) {
     case 'bash':
     case 'toolEdit':
     case 'proposal':
@@ -195,18 +195,18 @@ export function approvalForegroundMaxRows(
     case 'userQuestion':
       return undefined;
     default:
-      return assertNever(pending.payload, 'Unhandled approval payload kind');
+      return assertNever(approvalKind, 'Unhandled approval payload kind');
   }
 }
 
 export function foregroundMaxRowsForKind({
+  approvalKind,
   childControlHasItems,
   kind,
-  pending,
 }: {
+  readonly approvalKind?: ApprovalKind;
   readonly childControlHasItems: boolean;
   readonly kind: ForegroundSurfaceKind | undefined;
-  readonly pending: PendingApproval | undefined;
 }): number | undefined {
   switch (kind) {
     case 'childControls':
@@ -214,7 +214,7 @@ export function foregroundMaxRowsForKind({
     case 'form':
       return FORM_FOREGROUND_MAX_ROWS;
     case 'approval':
-      return approvalForegroundMaxRows(pending);
+      return approvalForegroundMaxRows(approvalKind);
     case 'transcript':
     case undefined:
       return undefined;

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -5,11 +5,10 @@ import { describe, expect, it } from 'vitest';
 import {
   appEscapeInterruptActive,
   appFocusShortcutsActive,
-  approvalForegroundMaxRows,
   approvalVisibleForActiveStream,
-  childControlForegroundMaxRows,
   digitFromMetaShortcut,
   foregroundEscapeAction,
+  foregroundMaxRowsForKind,
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
   triggerEscapeInterrupt,
@@ -19,17 +18,16 @@ import {
 import type { PendingApproval } from '@cli/chat/tui/state/approvalQueue';
 import type { StreamTabId } from '@shared/schemas';
 
-type ApprovalKind = PendingApproval['payload']['kind'];
 type EscapeActiveState = Parameters<typeof appEscapeInterruptActive>[0];
 type FocusState = Parameters<typeof appFocusShortcutsActive>[0];
 type ForegroundSurfaceInput = Parameters<typeof foregroundSurfaceKind>[0];
 type ForegroundEscapeInput = Parameters<typeof foregroundEscapeAction>[0];
+type ForegroundRowsInput = Parameters<typeof foregroundMaxRowsForKind>[0];
+type ApprovalKind = NonNullable<ForegroundRowsInput['approvalKind']>;
 type MetaChordState = Parameters<
   typeof shouldDeferEscapeInterruptForMetaChord
 >[0];
 
-const root = 'root' as StreamTabId;
-const child = 'child-1' as StreamTabId;
 const focusEnabled = {
   foregroundOpen: false,
   reverseSearchOpen: false,
@@ -47,12 +45,17 @@ const escChordHidden = {
   taskControlsAvailable: false,
 } satisfies MetaChordState;
 
-function pendingApproval(
-  kind: ApprovalKind,
-  streamId?: StreamTabId,
-): PendingApproval {
+function bashApproval(streamId?: StreamTabId): PendingApproval {
   return {
-    payload: { kind, payload: { streamId } } as PendingApproval['payload'],
+    payload: {
+      kind: 'bash',
+      payload: {
+        requestId: 'bash-1',
+        command: 'echo ok',
+        allowBypass: true,
+        streamId: streamId ?? '',
+      },
+    },
     decide: () => undefined,
   };
 }
@@ -69,18 +72,13 @@ function foregroundInput(
 }
 
 describe('app interaction policy', () => {
-  it('uses a smaller row cap for empty child-control pickers', () => {
-    const cases = [
-      [false, 6],
-      [true, 12],
-    ] satisfies readonly (readonly [boolean, number])[];
-
-    for (const [hasItems, expected] of cases) {
-      expect(childControlForegroundMaxRows({ hasItems })).toBe(expected);
-    }
-  });
-
-  it('applies exhaustive approval row-cap policy', () => {
+  it('resolves exhaustive foreground row caps', () => {
+    const surfaceCases = [
+      [{ childControlHasItems: false, kind: 'childControls' }, 6],
+      [{ childControlHasItems: true, kind: 'childControls' }, 12],
+      [{ childControlHasItems: false, kind: 'form' }, 18],
+      [{ childControlHasItems: false, kind: 'transcript' }, undefined],
+    ] satisfies readonly (readonly [ForegroundRowsInput, number | undefined])[];
     const expectedByKind = {
       plan: undefined,
       retry: undefined,
@@ -91,10 +89,17 @@ describe('app interaction policy', () => {
       externalInquiry: 18,
     } satisfies Record<ApprovalKind, number | undefined>;
 
-    for (const kind of Object.keys(expectedByKind) as ApprovalKind[]) {
-      expect(approvalForegroundMaxRows(pendingApproval(kind))).toBe(
-        expectedByKind[kind],
-      );
+    for (const [input, expected] of surfaceCases) {
+      expect(foregroundMaxRowsForKind(input)).toBe(expected);
+    }
+    for (const approvalKind of Object.keys(expectedByKind) as ApprovalKind[]) {
+      expect(
+        foregroundMaxRowsForKind({
+          approvalKind,
+          childControlHasItems: false,
+          kind: 'approval',
+        }),
+      ).toBe(expectedByKind[approvalKind]);
     }
   });
 
@@ -204,15 +209,15 @@ describe('app interaction policy', () => {
   });
 
   it('shows stream-owned approvals only on their matching tab', () => {
-    const childApproval = pendingApproval('bash', child);
-    const globalApproval = pendingApproval('toolEdit');
+    const childApproval = bashApproval('child-1');
+    const globalApproval = bashApproval();
     const visible = (activeStreamId: StreamTabId, pending: PendingApproval) =>
       approvalVisibleForActiveStream({ activeStreamId, pending });
 
-    expect(visible(child, childApproval)).toBe(true);
-    const hiddenApprovalVisible = visible(root, childApproval);
+    expect(visible('child-1', childApproval)).toBe(true);
+    const hiddenApprovalVisible = visible('root', childApproval);
     expect(hiddenApprovalVisible).toBe(false);
-    expect(visible(root, globalApproval)).toBe(true);
+    expect(visible('root', globalApproval)).toBe(true);
     expect(
       appFocusShortcutsActive({
         ...focusEnabled,
@@ -233,25 +238,20 @@ describe('app interaction policy', () => {
       ],
       [{ foregroundKind: 'form' }, 'close'],
       [{ activeFormEscapeAction: 'cancel', foregroundKind: 'form' }, 'cancel'],
-    ] satisfies readonly (readonly [
-      Omit<ForegroundEscapeInput, 'pending'>,
-      string,
-    ])[];
+    ] satisfies readonly (readonly [ForegroundEscapeInput, string])[];
     const approvalCases = [
       ['externalInquiry', 'skip'],
       ['bash', 'cancel'],
     ] satisfies readonly (readonly [ApprovalKind, string])[];
 
     for (const [input, expected] of surfaceCases) {
-      expect(foregroundEscapeAction({ ...input, pending: undefined })).toBe(
-        expected,
-      );
+      expect(foregroundEscapeAction(input)).toBe(expected);
     }
     for (const [kind, expected] of approvalCases) {
       expect(
         foregroundEscapeAction({
+          approvalKind: kind,
           foregroundKind: 'approval',
-          pending: pendingApproval(kind),
         }),
       ).toBe(expected);
     }


### PR DESCRIPTION
## Summary

Land the two actionable review fixes filed on merged PR #8062:

- narrow row-cap and escape-label policy inputs to the approval kind they actually consume
- test the exported foreground row resolver exhaustively instead of exporting/testing its private helpers
- replace casted approval-union fixtures with a minimal valid Bash approval

This follow-up is one commit on top of the already-merged extraction because #8062 auto-merged before its review comments arrived.

Closes #8061.

## Issue acceptance gates

- `App.tsx`: 660 lines.
- `appInteractionPolicy.ts`: 222 lines with no React or Ink imports.
- `TuiStateAndFocus.vitest.mts`: 3,127 lines.
- `AppInteractionPolicy.vitest.mts`: 259 lines.
- The exported row resolver covers child-control, form, transcript, and every approval kind.
- Test fixtures now satisfy the real discriminated union without casts.
- Production behavior remains unchanged.

## Single source of truth

`appInteractionPolicy.ts` remains the single owner. Its public API now accepts only the approval kind for decisions that do not need the full approval payload.

## Duplication and abstraction budget

Two implementation helpers become private again. One exhaustive resolver table replaces direct helper tests, and a single valid Bash fixture covers global and stream-owned visibility.

## Net elements (R6)

- Files: 3 modified.
- Diffstat: 58 insertions, 57 deletions.
- Exported symbols: net -2; `childControlForegroundMaxRows` and `approvalForegroundMaxRows` become private.
- Classes/interfaces/enums: 0.
- Net LoC: +1 in this hardening follow-up; the combined #8061 change remains net -214 LoC.

## Consumer counts (R8)

- `appInteractionPolicy` consumers remain 2 files: `App.tsx` and its focused suite.
- No runtime event, emit path, or external package export changes.

## Host impact

Extension: none.

Desktop: none.

CLI: behavior-preserving type and test hardening.

## Scheduled refactoring

Continue parent #6680 after this review follow-up lands.

## Validation

- Focused Vitest (2 files, 120 tests)
- 11 affected PTY TUI scenarios
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 44 pre-existing warnings)
- `npm test` (626 files passed, 1 skipped; 5,535 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving API narrowing and test hardening in CLI TUI policy code with no auth, data, or external export changes.
> 
> **Overview**
> **Narrows** `appInteractionPolicy` so row caps and status-bar escape labels take **`approvalKind`** instead of a full `PendingApproval`, matching what those code paths actually read. **`App.tsx`** passes `pending?.payload.kind` when an approval is visible on the active stream.
> 
> **Makes** `childControlForegroundMaxRows` and `approvalForegroundMaxRows` **private** again; behavior stays on the exported **`foregroundMaxRowsForKind`** resolver.
> 
> **Tests** exercise that resolver exhaustively (child controls, form, transcript, every approval kind) and use a **minimal valid bash approval** fixture instead of casted union stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7ce26b5cb427ebf1aada7860f284eef61fc6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->