### PR TITLE
fix(desktop): load history export controller lazily

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -3,10 +3,6 @@ import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 // Local imports - history domain
-import {
-  ChatExportController,
-  type ExportInputStatus,
-} from '@controllers/settingsView/ChatExportController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
   deleteAllExecutions,
@@ -25,6 +21,12 @@ import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 // Local imports - IPC contracts
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ExecutionId } from '@shared/schemas';
+
+// Local imports - controller types
+import type {
+  ChatExportController,
+  ExportInputStatus,
+} from '@controllers/settingsView/ChatExportController';
 import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
 
 type HistoryExportFormat = 'md' | 'tex' | 'html';
@@ -57,7 +59,7 @@ type HistoryConfigResult =
 export class DesktopHistoryHandlers {
   readonly actions: SettingsViewCommandActions['history'];
 
-  private chatExportController: ChatExportController | undefined;
+  private chatExportControllerLoad: Promise<ChatExportController> | undefined;
 
   constructor(
     private readonly dependencies: DesktopHistoryHandlerDependencies,
@@ -165,15 +167,21 @@ export class DesktopHistoryHandlers {
     return this.dependencies.resourcesPath;
   }
 
-  private getChatExportController(): ChatExportController {
-    if (!this.chatExportController) {
-      const latexPreamble = readFileSync(
-        path.join(this.getResourcesPath(), 'templates', 'chatExport.tex'),
-        'utf8',
-      );
-      this.chatExportController = new ChatExportController({ latexPreamble });
-    }
-    return this.chatExportController;
+  private getChatExportController(): Promise<ChatExportController> {
+    this.chatExportControllerLoad ??=
+      import('@controllers/settingsView/ChatExportController')
+        .then(({ ChatExportController }) => {
+          const latexPreamble = readFileSync(
+            path.join(this.getResourcesPath(), 'templates', 'chatExport.tex'),
+            'utf8',
+          );
+          return new ChatExportController({ latexPreamble });
+        })
+        .catch((error: unknown) => {
+          this.chatExportControllerLoad = undefined;
+          throw error;
+        });
+    return this.chatExportControllerLoad;
   }
 
   private async reportExportInputError(
@@ -207,7 +215,7 @@ export class DesktopHistoryHandlers {
   }
 
   private async exportChatHtml(historyId: string): Promise<void> {
-    const controller = this.getChatExportController();
+    const controller = await this.getChatExportController();
     const outcome = await controller.exportAsHtml(
       historyId,
       path.join(this.getResourcesPath(), 'traceViewerStandalone', 'index.html'),
@@ -232,7 +240,7 @@ export class DesktopHistoryHandlers {
       return;
     }
 
-    const controller = this.getChatExportController();
+    const controller = await this.getChatExportController();
     const result = await controller.buildExportInput(historyId);
     if (result.status !== 'ok') {
       await this.reportExportInputError(result.status);

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -25,6 +25,7 @@ const chatExportMocks = vi.hoisted(() => ({
   exportAsLatex: vi.fn(),
   exportAsHtml: vi.fn(),
   constructorDeps: [] as unknown[],
+  constructorError: undefined as Error | undefined,
 }));
 
 vi.mock('@controllers/settingsView/ChatExportController', () => ({
@@ -36,6 +37,9 @@ vi.mock('@controllers/settingsView/ChatExportController', () => ({
 
     constructor(dependencies: unknown) {
       chatExportMocks.constructorDeps.push(dependencies);
+      const error = chatExportMocks.constructorError;
+      chatExportMocks.constructorError = undefined;
+      if (error) throw error;
     }
   },
 }));
@@ -89,6 +93,7 @@ describe('DesktopHistoryHandlers', () => {
   beforeEach(() => {
     clearStoreCache();
     chatExportMocks.constructorDeps.length = 0;
+    chatExportMocks.constructorError = undefined;
     vi.resetAllMocks();
   });
 
@@ -211,6 +216,37 @@ describe('DesktopHistoryHandlers', () => {
 
     expect(chatExportMocks.constructorDeps).toHaveLength(1);
     expect(chatExportMocks.buildExportInput).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries controller construction after the first load fails', async () => {
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput: EXPORT_INPUT,
+    });
+    chatExportMocks.exportAsMarkdown.mockResolvedValue({
+      storagePath: 'executions/def/chat.md',
+      absolutePath: '/tmp/executions/def/chat.md',
+    });
+    chatExportMocks.constructorError = new Error('controller setup failed');
+    const actions = createHistoryActions();
+    const exportChatMd = assertSupported(actions.exportChatMd);
+
+    await expect(
+      exportChatMd({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'abc',
+      }),
+    ).rejects.toThrow('controller setup failed');
+    await expect(
+      exportChatMd({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'def',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(chatExportMocks.constructorDeps).toHaveLength(2);
+    expect(chatExportMocks.buildExportInput).toHaveBeenCalledOnce();
+    expect(chatExportMocks.buildExportInput).toHaveBeenCalledWith('def');
   });
 
   it('falls back to opening the .tex source when LaTeX compilation fails', async () => {

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -187,6 +187,32 @@ describe('DesktopHistoryHandlers', () => {
     });
   });
 
+  it('shares the controller load across concurrent first exports', async () => {
+    chatExportMocks.buildExportInput.mockResolvedValue({
+      status: 'ok',
+      exportInput: EXPORT_INPUT,
+    });
+    chatExportMocks.exportAsMarkdown.mockResolvedValue({
+      storagePath: 'executions/abc/chat.md',
+      absolutePath: '/tmp/executions/abc/chat.md',
+    });
+    const actions = createHistoryActions();
+
+    await Promise.all([
+      assertSupported(actions.exportChatMd)({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'abc',
+      }),
+      assertSupported(actions.exportChatMd)({
+        command: SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
+        historyId: 'def',
+      }),
+    ]);
+
+    expect(chatExportMocks.constructorDeps).toHaveLength(1);
+    expect(chatExportMocks.buildExportInput).toHaveBeenCalledTimes(2);
+  });
+
   it('falls back to opening the .tex source when LaTeX compilation fails', async () => {
     chatExportMocks.buildExportInput.mockResolvedValue({
       status: 'ok',


### PR DESCRIPTION
## Summary

Defer loading `ChatExportController` until a desktop history export is requested. The desktop settings startup module retains only a type import, while one cached promise loads and constructs the controller for Markdown, LaTeX, or HTML export.

Concurrent first export requests share the same load and construction. A failed dynamic import or template read clears the cache so a later request may retry.

Closes #8063.

## Issue acceptance gates

- [x] use a type-only controller import from the desktop startup module
- [x] emit `ChatExportController` as a dynamic esbuild entry
- [x] cache one `Promise<ChatExportController>` across concurrent first exports
- [x] preserve Markdown, LaTeX, and HTML export paths
- [x] leave the verifier and esbuild configuration unchanged
- [x] pass focused history tests, lint, desktop and test-kernel type checks, build, unpacked packaging, and `check:desktop-package`

## Design

`DesktopHistoryHandlers.getChatExportController()` owns controller loading and construction. The two export dispatch paths await that one promise; no second controller cache, loader class, factory module, verifier exception, or host-specific export implementation is introduced.

## Net elements

- Files changed: 2.
- Diffstat: 86 insertions, 16 deletions (net +70).
- New files: 0.
- Exported symbols: 0.
- Classes, interfaces, and enums: net 0.

## Consumer counts

- Cached controller loader: two internal call sites covering three export commands.
- Dynamic controller entry: one desktop history handler consumer.
- Production event or IPC keys: 0.

## Host impact

Extension: none.

Desktop: the first history export loads one dynamic chunk; startup no longer loads the export controller through this handler.

CLI: none.

## Validation

Rebased on `main` at `98080d306`, which includes the provider-free attachment-marker vocabulary from #8068.

- `CI=true corepack pnpm exec vitest run src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts`: 1 file, 9 tests passed
- desktop typecheck: passed
- test-kernel typecheck: passed
- `npm run lint`: passed
- targeted Prettier check: passed
- `npm run desktop:build`: passed
- unpacked macOS arm64 package: passed
- unchanged `npm run check:desktop-package`: passed
- packaged desktop startup graph excludes provider SDKs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop history export loading; export behavior is unchanged aside from deferring and caching controller initialization, with focused tests.
> 
> **Overview**
> **Desktop history chat export** no longer pulls in `ChatExportController` at settings/handler startup. The handler keeps a **type-only** import and loads the controller with a **dynamic `import()`** the first time Markdown, LaTeX, or HTML export runs, still reading `chatExport.tex` from `resourcesPath` when constructing it.
> 
> A **single cached promise** backs `getChatExportController()`, so concurrent first exports share one load/construct path. If that promise rejects (import or setup), the cache is **cleared** so a later export can retry. Export dispatch now **awaits** the controller before calling the same export methods as before.
> 
> Tests add coverage for **shared load under concurrency** and **retry after a failed construction**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad5cb1206979524281a3e35f5a2fcbc8c9b0b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->