### PR TITLE
refactor: dedupe synthetic tool results, open-turn locking, and view-command dispatch

### DIFF
--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -136,6 +136,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     return this.streamLifecycleController.deleteStream(streamId);
   }
 
+  /** Execute a VS Code command, routing failures through this view's error channel. */
+  private runViewCommand<T = void>(
+    command: string,
+    args: unknown[] = [],
+  ): Promise<T | undefined> {
+    return safeExecuteCommand<T>(command, args, this.viewName);
+  }
+
   /**
    * Create the typed handler registry.
    * Each handler receives typed data - no casts or validation needed.
@@ -146,7 +154,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     };
     const runCommand = (command: string, ...args: unknown[]) => {
       return async () => {
-        await safeExecuteCommand(command, args, this.viewName);
+        await this.runViewCommand(command, args);
       };
     };
 
@@ -168,11 +176,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       // Shared progress command groups
       ...this.progressHost.commandHandlers,
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) => {
-        await safeExecuteCommand(
-          'texra.compactResponse',
-          [data.stream],
-          this.viewName,
-        );
+        await this.runViewCommand('texra.compactResponse', [data.stream]);
       },
 
       // Actions
@@ -194,11 +198,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           data.stream,
         );
         if (taskState) {
-          await safeExecuteCommand(
-            'texra.restoreState',
-            [taskState],
-            this.viewName,
-          );
+          await this.runViewCommand('texra.restoreState', [taskState]);
         }
       },
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>
@@ -281,28 +281,24 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof COMMON_COMMANDS.SWITCH_VIEW>,
   ): Promise<void> {
     if (data.view === 'dashboard') {
-      await safeExecuteCommand('texra.showDashboard', [], this.viewName);
+      await this.runViewCommand('texra.showDashboard');
       return;
     }
     if (data.view === 'main') {
-      await safeExecuteCommand('texra.showMainView', [], this.viewName);
+      await this.runViewCommand('texra.showMainView');
       return;
     }
     if (data.openInEditor) {
       await this.provider.popOutToEditor();
       return;
     }
-    await safeExecuteCommand('texra.showProgressView', [], this.viewName);
+    await this.runViewCommand('texra.showProgressView');
   }
 
   private async runGettingStartedAction(
     action: GettingStartedAction,
   ): Promise<void> {
-    await safeExecuteCommand(
-      GETTING_STARTED_COMMANDS[action],
-      [],
-      this.viewName,
-    );
+    await this.runViewCommand(GETTING_STARTED_COMMANDS[action]);
     if (action === 'runSetup') {
       await this.provider.refreshOnboardingFunnel();
     }
@@ -351,18 +347,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           await this.executeValidated(request);
         },
         runDiff: async (request) => {
-          await safeExecuteCommand(
-            'texra.runLatexdiff',
-            [request],
-            this.viewName,
-          );
+          await this.runViewCommand('texra.runLatexdiff', [request]);
         },
         runFileOperation: async (operation, request) => {
-          await safeExecuteCommand(
-            `texra.${operation}`,
-            [request],
-            this.viewName,
-          );
+          await this.runViewCommand(`texra.${operation}`, [request]);
         },
       },
       workflowFileActions: {
@@ -385,56 +373,45 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         host: {
           compareFiles: async (baseFile, editedFile) => {
-            await safeExecuteCommand(
-              'texra.compare',
-              [
-                pathToLocation(''), // inputFile unused
-                pathToLocation(baseFile),
-                pathToLocation(editedFile),
-              ],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.compare', [
+              pathToLocation(''), // inputFile unused
+              pathToLocation(baseFile),
+              pathToLocation(editedFile),
+            ]);
           },
           acceptEditedFile: async (baseFile, editedFile, copyMeta) => {
-            return safeExecuteCommand<boolean>(
-              'texra.acceptEdited',
-              [
-                pathToLocation(''), // inputFile unused
-                pathToLocation(baseFile),
-                pathToLocation(editedFile),
-                copyMeta,
-              ],
-              this.viewName,
-            );
+            return this.runViewCommand<boolean>('texra.acceptEdited', [
+              pathToLocation(''), // inputFile unused
+              pathToLocation(baseFile),
+              pathToLocation(editedFile),
+              copyMeta,
+            ]);
           },
           mergeFile: async (baseFile, editedFile) => {
-            await safeExecuteCommand(
-              'texra.merge',
-              [undefined, baseFile, editedFile],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.merge', [
+              undefined,
+              baseFile,
+              editedFile,
+            ]);
           },
           latexdiffFile: async (baseFile, editedFile) => {
-            await safeExecuteCommand(
-              'texra.latexdiff',
-              [undefined, baseFile, editedFile],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.latexdiff', [
+              undefined,
+              baseFile,
+              editedFile,
+            ]);
           },
           openDirectory: async (directory) => {
-            await safeExecuteCommand(
-              'revealFileInOS',
-              [vscode.Uri.file(directory)],
-              this.viewName,
-            );
+            await this.runViewCommand('revealFileInOS', [
+              vscode.Uri.file(directory),
+            ]);
           },
           openLabel: async (label) => {
             return (
-              (await safeExecuteCommand<boolean>(
-                'texra.openLabel',
-                [label, { notifyNotFound: false }],
-                this.viewName,
-              )) ?? false
+              (await this.runViewCommand<boolean>('texra.openLabel', [
+                label,
+                { notifyNotFound: false },
+              ])) ?? false
             );
           },
           readFile: (file) => FlexibleFS.read(createExternalLocation(file)),
@@ -451,11 +428,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           },
         },
         sendFollowUp: async (stream, text) => {
-          await safeExecuteCommand(
-            'texra.sendFollowUp',
-            [{ stream, text }],
-            this.viewName,
-          );
+          await this.runViewCommand('texra.sendFollowUp', [{ stream, text }]);
         },
       },
       agentProposal: {
@@ -463,11 +436,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           this.provider.getPendingAgentProposal(proposalId),
         restoreTaskState: async (taskState) => {
           return (
-            (await safeExecuteCommand<boolean>(
-              'texra.restoreState',
-              [taskState],
-              this.viewName,
-            )) === true
+            (await this.runViewCommand<boolean>('texra.restoreState', [
+              taskState,
+            ])) === true
           );
         },
         settleProposal: (proposalId, result) => {
@@ -519,19 +490,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         followUp: {
           sendFollowUp: async ({ stream, text, mediaFiles }) => {
-            await safeExecuteCommand(
-              'texra.sendFollowUp',
-              [
-                {
-                  stream,
-                  text,
-                  ...(mediaFiles && mediaFiles.length > 0
-                    ? { mediaFiles }
-                    : {}),
-                },
-              ],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.sendFollowUp', [
+              {
+                stream,
+                text,
+                ...(mediaFiles && mediaFiles.length > 0 ? { mediaFiles } : {}),
+              },
+            ]);
           },
           reportImageSaveError: (_image, error) => {
             // Best-effort: a failed image save must not block the text, but log
@@ -548,18 +513,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         },
         file: {
           openFile: async (file, line) => {
-            await safeExecuteCommand(
-              'texra.openFile',
-              [file, line],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.openFile', [file, line]);
           },
           openFileCompile: async (file) => {
-            await safeExecuteCommand(
-              'texra.openFileCompile',
-              [file],
-              this.viewName,
-            );
+            await this.runViewCommand('texra.openFileCompile', [file]);
           },
         },
         approval: {
@@ -589,11 +546,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         SecretManager.get(SecretManager.getApiKeySecretName(provider)),
       hasUsableKey: (provider) => SecretManager.hasUsableApiKey(provider),
       promptForApiKey: async (provider) => {
-        await safeExecuteCommand(
-          apiKeyCommands.setApiKey,
-          [provider],
-          this.viewName,
-        );
+        await this.runViewCommand(apiKeyCommands.setApiKey, [provider]);
       },
       setUseIncludedModelAccess: (enabled) =>
         getServerSideKeyService().setUseIncludedModelAccess(enabled),
@@ -820,15 +773,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       this.logger.error(this.channel, validation.message);
       return false;
     }
-    await safeExecuteCommand(
-      'texra.execute',
-      [
-        options.preferHelperModel
-          ? { ...validation.request, preferHelperModel: true }
-          : validation.request,
-      ],
-      this.viewName,
-    );
+    await this.runViewCommand('texra.execute', [
+      options.preferHelperModel
+        ? { ...validation.request, preferHelperModel: true }
+        : validation.request,
+    ]);
     return true;
   }
 
@@ -874,11 +823,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await this.host.info(plan.message);
         return;
       case 'restoreState':
-        await safeExecuteCommand(
-          'texra.restoreState',
-          [plan.taskState, plan.executeImmediately],
-          this.viewName,
-        );
+        await this.runViewCommand('texra.restoreState', [
+          plan.taskState,
+          plan.executeImmediately,
+        ]);
         return;
       case 'execute':
         // Follow-up 'execute' plans are the compile fixer (latexFixer), so run

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -254,21 +254,32 @@ export class ToolUseDispatchNode<C> extends Node<
         status: 'error',
         error: UNSAFE_DUPLICATE_CALL_ERROR,
       };
-      results[index] = {
-        call,
-        result: duplicateResult,
-        parsedInput: call.input,
-        extracted: {
-          sanitizedResult: duplicateResult,
-          attachments: [],
-        },
-        editedFiles: [],
-        logRef: {
-          logId: undefined,
-          groupId: this.services.logger.activeStageId(),
-        },
-      };
+      results[index] = this.makeSyntheticResult(call, duplicateResult, call.input);
     }
+  }
+
+  /**
+   * Build a synthetic ToolExecutionResult for a call that never actually
+   * executed a tool (duplicate fan-out, rejected duplicate, or cancelled
+   * call) — always empty edits/attachments, and a fresh logRef.
+   */
+  private makeSyntheticResult(
+    call: SdkToolCall,
+    result: ToolResult,
+    parsedInput: unknown,
+    sanitizedResult: ToolResult = result,
+  ): ToolExecutionResult {
+    return {
+      call,
+      result,
+      parsedInput,
+      extracted: { sanitizedResult, attachments: [] },
+      editedFiles: [],
+      logRef: {
+        logId: undefined,
+        groupId: this.services.logger.activeStageId(),
+      },
+    };
   }
 
   /** A tool declares itself side-effect-free via ITool.parallelSafe. */
@@ -322,22 +333,14 @@ export class ToolUseDispatchNode<C> extends Node<
         lineChanges: _lineChanges,
         ...sharedResult
       } = primary.result;
-      results[index] = {
+      // The primary already injected any attachments into the follow-up;
+      // repeating them per duplicate would duplicate binary context.
+      results[index] = this.makeSyntheticResult(
         call,
-        result: sharedResult as ToolResult,
-        parsedInput: primary.parsedInput,
-        extracted: {
-          sanitizedResult: primary.extracted.sanitizedResult,
-          // The primary already injected any attachments into the follow-up;
-          // repeating them per duplicate would duplicate binary context.
-          attachments: [],
-        },
-        editedFiles: [],
-        logRef: {
-          logId: undefined,
-          groupId: this.services.logger.activeStageId(),
-        },
-      };
+        sharedResult as ToolResult,
+        primary.parsedInput,
+        primary.extracted.sanitizedResult,
+      );
     }
   }
 
@@ -557,20 +560,7 @@ export class ToolUseDispatchNode<C> extends Node<
       status: 'error',
       error: CANCELLED_CALL_ERROR,
     };
-    return {
-      call,
-      result: cancelledResult,
-      parsedInput: call.input,
-      extracted: {
-        sanitizedResult: cancelledResult,
-        attachments: [],
-      },
-      editedFiles: [],
-      logRef: {
-        logId: undefined,
-        groupId: this.services.logger.activeStageId(),
-      },
-    };
+    return this.makeSyntheticResult(call, cancelledResult, call.input);
   }
 
   private async logAndProcessMediaFiles(

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -254,7 +254,11 @@ export class ToolUseDispatchNode<C> extends Node<
         status: 'error',
         error: UNSAFE_DUPLICATE_CALL_ERROR,
       };
-      results[index] = this.makeSyntheticResult(call, duplicateResult, call.input);
+      results[index] = this.makeSyntheticResult(
+        call,
+        duplicateResult,
+        call.input,
+      );
     }
   }
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -498,6 +498,11 @@ function normalizeSessionLinks(links?: string[] | null): string[] | undefined {
  * thread is missing, not open, has no turns, or its last turn isn't open —
  * the shared guard behind `recordAnswerForOpenTurn` and
  * `persistOpenTurnDraft`.
+ *
+ * `afterWrite`, if returned by `update`, runs after the manifest write but
+ * still inside the thread lock — for side effects (e.g. mirroring the
+ * thread directory to an execution) that must not interleave with a
+ * concurrent mutation of the same thread.
  */
 async function withOpenTurnUpdate<T>(
   threadId: ExternalInquiryThreadId,
@@ -506,8 +511,16 @@ async function withOpenTurnUpdate<T>(
     lastTurn: OpenInquiryTurn,
     timestamp: string,
   ) =>
-    | Promise<{ manifest: ExternalInquiryThreadManifest; result: T } | null>
-    | { manifest: ExternalInquiryThreadManifest; result: T }
+    | Promise<{
+        manifest: ExternalInquiryThreadManifest;
+        result: T;
+        afterWrite?: () => Promise<void>;
+      } | null>
+    | {
+        manifest: ExternalInquiryThreadManifest;
+        result: T;
+        afterWrite?: () => Promise<void>;
+      }
     | null,
 ): Promise<{ manifest: ExternalInquiryThreadManifest; result: T } | null> {
   return withThreadLock(threadId, async () => {
@@ -523,7 +536,8 @@ async function withOpenTurnUpdate<T>(
     if (!outcome) return null;
 
     await writeThreadManifest(outcome.manifest);
-    return outcome;
+    await outcome.afterWrite?.();
+    return { manifest: outcome.manifest, result: outcome.result };
   });
 }
 
@@ -653,6 +667,8 @@ export async function recordAnswerForOpenTurn(params: {
   sessionLinks?: string[] | null;
   executionId?: ExecutionId;
 }): Promise<PersistedAnsweredTurn | null> {
+  let executionMirrorPaths: ExternalInquiryExecutionMirrorPaths | undefined;
+
   const outcome = await withOpenTurnUpdate(
     params.threadId,
     async (existing, lastTurn, timestamp) => {
@@ -689,19 +705,27 @@ export async function recordAnswerForOpenTurn(params: {
         turns: [...existing.turns.slice(0, -1), answeredTurn],
       };
 
-      return { manifest: nextManifest, result: answeredTurn };
+      return {
+        manifest: nextManifest,
+        result: answeredTurn,
+        // Mirroring copies the whole thread directory, so it must observe
+        // the manifest just written above and must not interleave with a
+        // concurrent mutation (e.g. a follow-up recordOpenQuestion) — both
+        // require staying inside the thread lock.
+        afterWrite: params.executionId
+          ? async () => {
+              executionMirrorPaths = await mirrorThreadToExecution({
+                executionId: params.executionId!,
+                threadId: params.threadId,
+                turn: answeredTurn,
+              });
+            }
+          : undefined,
+      };
     },
   );
 
   if (!outcome) return null;
-
-  const executionMirrorPaths = params.executionId
-    ? await mirrorThreadToExecution({
-        executionId: params.executionId,
-        threadId: params.threadId,
-        turn: outcome.result,
-      })
-    : undefined;
 
   return {
     threadId: params.threadId,
@@ -751,7 +775,7 @@ export async function persistOpenTurnDraft(params: {
   threadId: ExternalInquiryThreadId;
   draft: InquiryDraft | null;
 }): Promise<void> {
-  await withOpenTurnUpdate(params.threadId, (existing, lastTurn) => {
+  await withOpenTurnUpdate(params.threadId, (existing, lastTurn, timestamp) => {
     const nextTurn: OpenInquiryTurn = {
       ...lastTurn,
       draft: params.draft ?? undefined,
@@ -759,6 +783,7 @@ export async function persistOpenTurnDraft(params: {
 
     const nextManifest: ExternalInquiryThreadManifest = {
       ...existing,
+      updatedAt: timestamp,
       turns: [...existing.turns.slice(0, -1), nextTurn],
     };
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -775,15 +775,19 @@ export async function persistOpenTurnDraft(params: {
   threadId: ExternalInquiryThreadId;
   draft: InquiryDraft | null;
 }): Promise<void> {
-  await withOpenTurnUpdate(params.threadId, (existing, lastTurn, timestamp) => {
+  await withOpenTurnUpdate(params.threadId, (existing, lastTurn) => {
     const nextTurn: OpenInquiryTurn = {
       ...lastTurn,
       draft: params.draft ?? undefined,
     };
 
+    // Deliberately does not bump updatedAt: a draft autosave is not a state
+    // transition (unlike open/answer/drop), and updatedAt drives listing
+    // sort order, the `since` freshness filter, and the "Updated: ..." text
+    // shown to the model — none of which should react to the user still
+    // typing an unsent answer.
     const nextManifest: ExternalInquiryThreadManifest = {
       ...existing,
-      updatedAt: timestamp,
       turns: [...existing.turns.slice(0, -1), nextTurn],
     };
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -493,6 +493,41 @@ function normalizeSessionLinks(links?: string[] | null): string[] | undefined {
 // ============================================================================
 
 /**
+ * Read a thread manifest under its lock, require the last turn to be open,
+ * and replace it via `update`. Returns null without calling `update` if the
+ * thread is missing, not open, has no turns, or its last turn isn't open —
+ * the shared guard behind `recordAnswerForOpenTurn` and
+ * `persistOpenTurnDraft`.
+ */
+async function withOpenTurnUpdate<T>(
+  threadId: ExternalInquiryThreadId,
+  update: (
+    existing: ExternalInquiryThreadManifest,
+    lastTurn: OpenInquiryTurn,
+    timestamp: string,
+  ) =>
+    | Promise<{ manifest: ExternalInquiryThreadManifest; result: T } | null>
+    | { manifest: ExternalInquiryThreadManifest; result: T }
+    | null,
+): Promise<{ manifest: ExternalInquiryThreadManifest; result: T } | null> {
+  return withThreadLock(threadId, async () => {
+    const existing = await readThreadManifest(threadId);
+    if (!existing || existing.status !== 'open' || existing.turns.length === 0)
+      return null;
+
+    const lastTurn = existing.turns.at(-1)!;
+    if (lastTurn.kind !== 'open') return null;
+
+    const timestamp = new Date().toISOString();
+    const outcome = await update(existing, lastTurn, timestamp);
+    if (!outcome) return null;
+
+    await writeThreadManifest(outcome.manifest);
+    return outcome;
+  });
+}
+
+/**
  * Append a new open question to a thread. Creates the thread when no
  * thread_id is passed (or the existing thread is unknown). Updates the
  * thread's `parentStreamId` to the caller — continuations always flow
@@ -618,66 +653,64 @@ export async function recordAnswerForOpenTurn(params: {
   sessionLinks?: string[] | null;
   executionId?: ExecutionId;
 }): Promise<PersistedAnsweredTurn | null> {
-  return withThreadLock(params.threadId, async () => {
-    const existing = await readThreadManifest(params.threadId);
-    if (!existing) return null;
-    if (existing.status !== 'open') return null;
-    if (existing.turns.length === 0) return null;
+  const outcome = await withOpenTurnUpdate(
+    params.threadId,
+    async (existing, lastTurn, timestamp) => {
+      const turnPath = threadTurnDir(params.threadId, lastTurn.turnIndex);
+      const td = turnDir(lastTurn.turnIndex);
+      const answerRelativePath = normalizeFilePath(
+        path.join(td, 'answer.txt'),
+      );
+      const sessionLinks = normalizeSessionLinks(params.sessionLinks);
 
-    const lastTurn = existing.turns.at(-1)!;
-    if (lastTurn.kind !== 'open') return null;
+      await GlobalStorageFS.write(
+        path.join(turnPath, 'answer.txt'),
+        params.answer,
+      );
 
-    const timestamp = new Date().toISOString();
-    const turnPath = threadTurnDir(params.threadId, lastTurn.turnIndex);
-    const td = turnDir(lastTurn.turnIndex);
-    const answerRelativePath = normalizeFilePath(path.join(td, 'answer.txt'));
-    const sessionLinks = normalizeSessionLinks(params.sessionLinks);
+      const answeredTurn: AnsweredInquiryTurn = {
+        turnIndex: lastTurn.turnIndex,
+        timestamp: lastTurn.timestamp,
+        question: lastTurn.question,
+        context: lastTurn.context,
+        questionRelativePath: lastTurn.questionRelativePath,
+        contextRelativePath: lastTurn.contextRelativePath,
+        suggestSearch: lastTurn.suggestSearch,
+        attachFiles: lastTurn.attachFiles,
+        kind: 'answered',
+        answer: params.answer,
+        answeredAt: timestamp,
+        answerRelativePath,
+        sessionLinks,
+      };
 
-    await GlobalStorageFS.write(
-      path.join(turnPath, 'answer.txt'),
-      params.answer,
-    );
+      const nextManifest: ExternalInquiryThreadManifest = {
+        ...existing,
+        status: 'answered',
+        updatedAt: timestamp,
+        turns: [...existing.turns.slice(0, -1), answeredTurn],
+      };
 
-    const answeredTurn: AnsweredInquiryTurn = {
-      turnIndex: lastTurn.turnIndex,
-      timestamp: lastTurn.timestamp,
-      question: lastTurn.question,
-      context: lastTurn.context,
-      questionRelativePath: lastTurn.questionRelativePath,
-      contextRelativePath: lastTurn.contextRelativePath,
-      suggestSearch: lastTurn.suggestSearch,
-      attachFiles: lastTurn.attachFiles,
-      kind: 'answered',
-      answer: params.answer,
-      answeredAt: timestamp,
-      answerRelativePath,
-      sessionLinks,
-    };
+      return { manifest: nextManifest, result: answeredTurn };
+    },
+  );
 
-    const nextManifest: ExternalInquiryThreadManifest = {
-      ...existing,
-      status: 'answered',
-      updatedAt: timestamp,
-      turns: [...existing.turns.slice(0, -1), answeredTurn],
-    };
+  if (!outcome) return null;
 
-    await writeThreadManifest(nextManifest);
+  const executionMirrorPaths = params.executionId
+    ? await mirrorThreadToExecution({
+        executionId: params.executionId,
+        threadId: params.threadId,
+        turn: outcome.result,
+      })
+    : undefined;
 
-    const executionMirrorPaths = params.executionId
-      ? await mirrorThreadToExecution({
-          executionId: params.executionId,
-          threadId: params.threadId,
-          turn: answeredTurn,
-        })
-      : undefined;
-
-    return {
-      threadId: params.threadId,
-      manifest: nextManifest,
-      turn: answeredTurn,
-      executionMirrorPaths,
-    };
-  });
+  return {
+    threadId: params.threadId,
+    manifest: outcome.manifest,
+    turn: outcome.result,
+    executionMirrorPaths,
+  };
 }
 
 /**
@@ -720,14 +753,7 @@ export async function persistOpenTurnDraft(params: {
   threadId: ExternalInquiryThreadId;
   draft: InquiryDraft | null;
 }): Promise<void> {
-  await withThreadLock(params.threadId, async () => {
-    const existing = await readThreadManifest(params.threadId);
-    if (!existing || existing.status !== 'open' || existing.turns.length === 0)
-      return;
-
-    const lastTurn = existing.turns.at(-1)!;
-    if (lastTurn.kind !== 'open') return;
-
+  await withOpenTurnUpdate(params.threadId, (existing, lastTurn) => {
     const nextTurn: OpenInquiryTurn = {
       ...lastTurn,
       draft: params.draft ?? undefined,
@@ -738,7 +764,7 @@ export async function persistOpenTurnDraft(params: {
       turns: [...existing.turns.slice(0, -1), nextTurn],
     };
 
-    await writeThreadManifest(nextManifest);
+    return { manifest: nextManifest, result: undefined };
   });
 }
 

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -658,9 +658,7 @@ export async function recordAnswerForOpenTurn(params: {
     async (existing, lastTurn, timestamp) => {
       const turnPath = threadTurnDir(params.threadId, lastTurn.turnIndex);
       const td = turnDir(lastTurn.turnIndex);
-      const answerRelativePath = normalizeFilePath(
-        path.join(td, 'answer.txt'),
-      );
+      const answerRelativePath = normalizeFilePath(path.join(td, 'answer.txt'));
       const sessionLinks = normalizeSessionLinks(params.sessionLinks);
 
       await GlobalStorageFS.write(


### PR DESCRIPTION
## Summary

A codebase-wide refactoring audit (four parallel subsystem scans plus a follow-up webview-frontend scan) identified ~1,400–2,000 net LOC of addressable technical debt across six subsystems, several of them high-risk (transcript-store overlay reconciliation, model-handler chain/background-state mirroring, `ExecutionRegistry` decomposition). This PR ships only the safest, fully mechanical, single-subsystem de-duplications from that audit — no behavior changes, each verified against the existing test suite. The larger structural items are intentionally left for separate, incrementally-reviewed follow-up PRs.

Three changes:

1. **`ToolUseDispatchNode.ts`** — `rejectUnsafeDuplicates`, `fanOutDuplicateResults`, and `buildCancelledResult` each hand-built an identical `ToolExecutionResult` shape (`extracted.attachments: []`, `editedFiles: []`, fresh `logRef`). Collapsed into one `makeSyntheticResult` factory used by all three (3 real call sites — not a single-caller extraction).
2. **`externalInquiryStorage.ts`** — `recordAnswerForOpenTurn` and `persistOpenTurnDraft` both hand-rolled "lock thread → read manifest → require status `open` with a non-empty, `open`-kind last turn → replace it → write" under `withThreadLock`. Extracted into `withOpenTurnUpdate`, which owns the guard and the write, leaving each caller only its turn transform.
3. **`ProgressViewMessageHandler.ts`** — 22 call sites repeated `safeExecuteCommand(command, args, this.viewName)`. Added a bound `runViewCommand(command, args?)` helper (mirrors the existing but underused local `runCommand` closure) and migrated every call site to it.

## Issue acceptance gates

No linked issue — this is a proactive audit-driven cleanup. Acceptance gate: each change is a pure mechanical de-duplication with zero behavioral difference, confirmed by identical typecheck + full test-suite results before and after.

## Single source of truth

- `ToolUseDispatchNode.makeSyntheticResult` is now the one place that knows the shape of a synthetic (never-executed) `ToolExecutionResult`.
- `externalInquiryStorage.withOpenTurnUpdate` is now the one place that knows the "must have an open last turn" guard + lock + write envelope.
- `ProgressViewMessageHandler.runViewCommand` is now the one place that knows this view's `safeExecuteCommand` channel binding.

## Duplication and abstraction budget

Removed: 3x duplicated `ToolExecutionResult` literal (~25 LOC), 2x duplicated lock/read/guard/write envelope (~35 LOC), 22x duplicated `, this.viewName` argument + call shape (~35 LOC after reflow). No new exported symbols — all three helpers are private/module-private with 2–22 real call sites each, consistent with this repo's ban on single-caller extractions.

## Net elements (R6)

- Files changed: 3 (diffstat: `+191 / -227`, net **-36 LOC**)
- Exported symbols: `git diff HEAD~1 HEAD | grep -E '^[+-]export'` → **0 matches** (no exports added or removed)
- Classes/interfaces/enums: 0 added, 0 removed
- New private helpers: 3 (`makeSyntheticResult`, `withOpenTurnUpdate`, `runViewCommand`), each replacing 2–22 inline duplicates

## Consumer counts (R8)

n/a — no emit path, export, or public API was deleted or re-routed. All three refactors are internal call-site consolidation within their existing owning modules.

## Host impact

Extension: `ProgressViewMessageHandler.ts` is extension-host-only (VS Code `webviewView`/`webviewPanel`); no other host is affected.

Desktop: n/a — none of the three files are desktop-specific or imported by `packages/desktop`.

CLI: n/a — none of the three files are imported by `packages/cli`.

## Scheduled refactoring

None filed yet. The audit's larger findings (transcript-store two-truth-source overlay machinery, model-handler Google/OpenAI chain-state mirroring, `ExecutionRegistry` God-object decomposition, agent cycle-flow duplication, webview Lit-component scaffolding, `SettingsApp` god-container, CLI TUI scrollable-modal duplication) are documented but not yet tracked as issues — happy to file them if useful.

## Validation

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `corepack pnpm --filter texra typecheck` (extension package) — clean
- `npx vitest run src/test-kernel` — 5535/5536 passing, 7 skipped. The one failure (`SystemUtils.vitest.ts > executeCommand > aborts shell command process groups including children`) is a pre-existing flake confirmed to pass in isolation on `main` before this change (process-group-abort timing, unrelated to any touched file) — not a regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C96CuT5CFoateqGkrjLTHx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors are internal call-site consolidation with explicit intent to preserve behavior; the inquiry **`afterWrite`** hook only tightens lock ordering for execution mirroring without changing public APIs.
> 
> **Overview**
> Mechanical de-duplication across three subsystems with no intended behavior change.
> 
> **`ProgressViewMessageHandler`** adds private **`runViewCommand`**, binding **`safeExecuteCommand`** to this view’s error channel, and routes ~22 webview-driven **`texra.*`** / VS Code command invocations through it instead of repeating **`this.viewName`**.
> 
> **`ToolUseDispatchNode`** centralizes never-executed **`ToolExecutionResult`** construction in **`makeSyntheticResult`**, used for unsafe duplicate rejection, safe duplicate fan-out, and cancelled-call synthesis.
> 
> **`externalInquiryStorage`** extracts **`withOpenTurnUpdate`** (thread lock, open-last-turn guard, manifest write, optional **`afterWrite`** still under the lock). **`recordAnswerForOpenTurn`** and **`persistOpenTurnDraft`** use it; answer recording runs execution mirroring via **`afterWrite`** so it cannot interleave with concurrent thread mutations. Draft persistence documents that **`updatedAt`** is intentionally not bumped on autosave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7492aaa566b1ed8a9100d7321083f15c43b7a969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->