### PR TITLE
refactor(export): isolate attachment marker vocabulary

### DIFF
--- a/src/agent/export/attachmentMarkerVocabulary.ts
+++ b/src/agent/export/attachmentMarkerVocabulary.ts
@@ -1,0 +1,17 @@
+import type { MediaAttachmentKind } from '@shared/schemas';
+
+const ATTACHMENT_MARKER_TYPE_BY_KIND = {
+  image: 'image',
+  document: 'document',
+} as const satisfies Record<MediaAttachmentKind, string>;
+
+interface AttachmentMarkerContentBlock {
+  type: (typeof ATTACHMENT_MARKER_TYPE_BY_KIND)[MediaAttachmentKind];
+}
+
+/** Build the byte-free content block used to mark an archived attachment. */
+export function mediaAttachmentKindToContentBlock(
+  kind: MediaAttachmentKind,
+): AttachmentMarkerContentBlock {
+  return { type: ATTACHMENT_MARKER_TYPE_BY_KIND[kind] };
+}

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -23,8 +23,6 @@ import {
   isFunctionCallOutputItem,
 } from '@agent/modelHandlers/openai/openAIResponseContent';
 import { isResponseFunctionToolCallItem } from '@agent/modelHandlers/openai/responseStreamEvents';
-import type { MediaAttachmentKind } from '@shared/schemas';
-import { assertNever } from '@utils/core';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
@@ -154,38 +152,6 @@ function googlePartToBlocks(part: Part): ContentBlock[] {
     return [{ type: mimeType?.startsWith('image/') ? 'image' : 'document' }];
   }
   return [];
-}
-
-/**
- * Anthropic-shaped content block for a media-attachment marker (no bytes) —
- * the two-member vocabulary `blocksToUserParts` below recognizes as
- * `'image'` / `'document'`. This is the ONE place that vocabulary is
- * spelled out; callers that need to synthesize an attachment marker block
- * (e.g. reconstructing a conversation from transcript rows that only
- * recorded the attachment kind, never the bytes) call this constructor
- * instead of writing `{ type: kind }` themselves, so they carry no
- * independent knowledge of the literal strings.
- *
- * The switch is exhaustive over {@link MediaAttachmentKind}
- * (`src/shared/schemas/progressView/data.ts`): adding or renaming a kind
- * there fails to compile here via `assertNever` until this function (and
- * `blocksToUserParts`'s recognition of the same two literals) is updated —
- * the vocabulary can't drift silently out of sync again.
- */
-export function mediaAttachmentKindToContentBlock(
-  kind: MediaAttachmentKind,
-): ContentBlock {
-  switch (kind) {
-    case 'image':
-      return { type: 'image' };
-    case 'document':
-      return { type: 'document' };
-    default:
-      return assertNever(
-        kind,
-        `Unmapped media attachment kind: ${String(kind)}`,
-      );
-  }
 }
 
 function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {

--- a/src/test-kernel/commands/history/normalizeConversation.vitest.ts
+++ b/src/test-kernel/commands/history/normalizeConversation.vitest.ts
@@ -11,12 +11,18 @@
 
 import { describe, expect, it } from 'vitest';
 
-import {
-  mediaAttachmentKindToContentBlock,
-  normalizeConversationForExport,
-} from '@agent/export/normalizeConversation';
+import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
+import { normalizeConversationForExport } from '@agent/export/normalizeConversation';
 import type { ExportNode } from '@agent/export/schemas';
 import type { MediaAttachmentKind } from '@shared/schemas';
+
+const MEDIA_ATTACHMENT_KIND_COVERAGE: Record<MediaAttachmentKind, true> = {
+  image: true,
+  document: true,
+};
+const MEDIA_ATTACHMENT_KINDS = Object.keys(
+  MEDIA_ATTACHMENT_KIND_COVERAGE,
+) as MediaAttachmentKind[];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -646,25 +652,22 @@ describe('Edge cases', () => {
 // ---------------------------------------------------------------------------
 
 describe('mediaAttachmentKindToContentBlock', () => {
+  it('defines the marker block for every media attachment kind', () => {
+    for (const kind of MEDIA_ATTACHMENT_KINDS) {
+      expect(mediaAttachmentKindToContentBlock(kind)).toEqual({ type: kind });
+    }
+  });
+
   it('round-trips every MediaAttachmentKind through normalizeConversationForExport', () => {
     // Callers that only recorded the attachment *kind* (never the bytes —
     // see completedRunArchive's userMessageEntryToMessages) synthesize the
     // marker block via this constructor rather than writing `{ type: kind }`
     // themselves. Prove the round trip for every kind the schema defines, so
-    // the two stay in sync: this module's own switch (not the caller's) is
-    // what breaks the build if a kind is added or renamed.
+    // the two stay in sync: the vocabulary map and this coverage record both
+    // require an explicit update if a kind is added or renamed.
     //
-    // The `Record<MediaAttachmentKind, true>` (not a plain array literal)
-    // is what makes this exhaustive: adding a member to `MediaAttachmentKind`
-    // without adding it here fails to compile, so this test can't silently
-    // stop covering a kind the way a hand-maintained array could.
-    const KIND_COVERAGE: Record<MediaAttachmentKind, true> = {
-      image: true,
-      document: true,
-    };
-    const kinds = Object.keys(KIND_COVERAGE) as MediaAttachmentKind[];
-
-    for (const kind of kinds) {
+    // The coverage record above makes this exhaustive at typecheck time.
+    for (const kind of MEDIA_ATTACHMENT_KINDS) {
       const nodes = normalize([
         {
           role: 'user',

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -11,7 +11,7 @@
 import pMap from 'p-map';
 
 import { getExecutionStore, type TodoEntry } from '@agent/storage';
-import { mediaAttachmentKindToContentBlock } from '@agent/export/normalizeConversation';
+import { mediaAttachmentKindToContentBlock } from '@agent/export/attachmentMarkerVocabulary';
 import { stringifyConversationValue } from '@agent/storage/conversationFormat';
 import { isFileNotFoundError } from '@common/errors';
 import { KVStore } from '@common/storage/KVStore';
@@ -177,10 +177,9 @@ function toolResultText(tool: ToolUseLog): string | undefined {
  * `userMessage` rows may carry an attachment-kind/count payload (#7508) —
  * media that was sent to the model but only ever lived in the provider
  * message. When present, render `content` as Anthropic-shaped blocks (no
- * bytes) via `mediaAttachmentKindToContentBlock` — the constructor
- * `normalizeConversationForExport` exports for exactly this shape — so its
- * existing attachment-marker rendering (`[image attachment]` /
- * `[document attachment]`) picks them up; otherwise keep the plain-string
+ * bytes) via the attachment-marker vocabulary constructor, so
+ * `normalizeConversationForExport` renders them as `[image attachment]` or
+ * `[document attachment]`; otherwise keep the plain-string
  * `content` shape every other conversation consumer already expects. This
  * module holds no independent opinion on what those blocks look like.
  */


### PR DESCRIPTION
## Summary

Move the media-attachment marker constructor into a small provider-free module. `completedRunArchive.ts` now reconstructs image and document markers without loading the full conversation normalizer and its OpenAI runtime dependencies.

The former `normalizeConversation.ts` export had no remaining consumer after the archive import moved, so it is deleted rather than retained as an unowned compatibility re-export.

Closes #8029.

## Issue acceptance gates

- `completedRunArchive.ts` no longer imports `normalizeConversation.ts`.
- The attachment vocabulary has no provider SDK or model-handler imports.
- Every `MediaAttachmentKind` has an explicit marker mapping checked by TypeScript.
- Attachment markers still round-trip to the expected export nodes.
- The CLI eager archive graph reaches zero OpenAI SDK inputs.
- No compatibility re-export or second marker implementation remains.

## Single source of truth

`attachmentMarkerVocabulary.ts` is the sole owner of the mapping from persisted `MediaAttachmentKind` values to byte-free content blocks. Transcript reconstruction consumes it directly, and conversation normalization recognizes those marker values without owning their construction.

## Duplication and abstraction budget

The new module contains one mapping, one private structural type, and one constructor. It replaces the larger provider-coupled switch and removes more lines than it adds; no factory, class, compatibility wrapper, or second marker implementation is introduced.

## Net elements (R6)

- Files changed: 4.
- Diffstat: 41 insertions, 56 deletions (net -15).
- New files: 1, containing 17 lines.
- Semantic exported symbols: net 0; the constructor moves from the provider-coupled module to its canonical vocabulary module.
- Classes/enums: 0.
- Private interfaces: +1.

## Consumer counts (R8)

- Direct production consumer: `completedRunArchive.ts`.
- Focused test consumer: one test module covering direct construction and normalization round trips.
- Compatibility consumers: 0.

## Host impact

Extension: no behavior change.

Desktop: removes one eager provider-SDK path from the startup graph.

CLI: removes OpenAI SDK modules from the completed-run archive eager graph.

## Validation

- focused Vitest: 2 files, 44 tests passed
- root source typecheck
- test-kernel typecheck
- CLI typecheck
- targeted ESLint (0 errors, 0 warnings)
- Prettier and `git diff --check`
- CLI esbuild metafile: the archive eager graph contains the vocabulary, excludes `normalizeConversation`, and reaches zero OpenAI SDK inputs
- integration validation with #8066: full desktop build, unpacked macOS arm64 package, and unchanged `check:desktop-package` all pass; the desktop startup graph excludes OpenAI, Anthropic, and Google SDKs

## Residual risk

Provider-specific conversation normalization remains intentionally provider-coupled and is still loaded when an export actually needs it. This change only removes that graph from transcript archive reconstruction.
