### PR TITLE
Replace regex-based semver parsing in bump-workspace-version.mjs with semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "memfs": "^4.64.0",
     "nunjucks": "^3.2.4",
     "prettier": "^3.9.5",
+    "semver": "^7.8.5",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       prettier:
         specifier: ^3.9.5
         version: 3.9.5
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -83,7 +83,9 @@ function parseVersion(rawVersion, label) {
   // prerelease or build metadata, and semver.parse would otherwise accept
   // (and silently drop) suffixes like "-beta" or "+build".
   const isBareVersion =
-    parsed != null && parsed.prerelease.length === 0 && parsed.build.length === 0;
+    parsed != null &&
+    parsed.prerelease.length === 0 &&
+    parsed.build.length === 0;
   if (!isBareVersion) {
     fail(
       `${label} must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.`,

--- a/scripts/bump-workspace-version.mjs
+++ b/scripts/bump-workspace-version.mjs
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import process from 'node:process';
+import semver from 'semver';
 
 const MANIFEST_PATHS = [
   'package.json',
@@ -13,7 +14,7 @@ const MANIFEST_PATHS = [
 // Accept the canonical extension tag (`v0.38.9`), the CLI tag (`cli-v0.38.9`),
 // and a bare version (`0.38.9`). Release tags are cut in pairs off the same
 // commit, so either tag resolves to the same next version.
-const VERSION_PATTERN = /^(?:cli-v|v)?(\d+)\.(\d+)\.(\d+)$/;
+const RELEASE_TAG_PREFIX = /^(?:cli-v|v)/;
 
 // Release trains use patch values 0 through 10; after .10, development moves
 // to the next minor train.
@@ -76,19 +77,20 @@ function parseArgs(argv) {
 }
 
 function parseVersion(rawVersion, label) {
-  const match = VERSION_PATTERN.exec(rawVersion);
-  if (match == null) {
+  const stripped = rawVersion.replace(RELEASE_TAG_PREFIX, '');
+  const parsed = semver.parse(stripped);
+  // Reject anything beyond a bare MAJOR.MINOR.PATCH — manifests never carry
+  // prerelease or build metadata, and semver.parse would otherwise accept
+  // (and silently drop) suffixes like "-beta" or "+build".
+  const isBareVersion =
+    parsed != null && parsed.prerelease.length === 0 && parsed.build.length === 0;
+  if (!isBareVersion) {
     fail(
       `${label} must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.`,
     );
   }
 
-  const [, major, minor, patch] = match;
-  return {
-    major: Number(major),
-    minor: Number(minor),
-    patch: Number(patch),
-  };
+  return { major: parsed.major, minor: parsed.minor, patch: parsed.patch };
 }
 
 function formatVersion(version) {

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -346,8 +346,19 @@ export interface Semaphore {
  * batches, workflow-script agent() calls). A released slot is handed
  * directly to the next waiter (active count unchanged) so a synchronous
  * newcomer cannot steal it and overshoot the limit. Kept hand-rolled
- * deliberately: p-queue (the in-repo alternative) types `add()` as
- * `Promise<T | void>`, which would force assertions at every call site.
+ * deliberately:
+ *  - p-queue types `add()` as `Promise<T | void>`, which would force
+ *    assertions at every call site.
+ *  - p-limit's typing matches, but it always defers task launch by a
+ *    microtask (its `enqueue` routes even a free slot through
+ *    `new Promise().then(run)`) instead of calling `task()` synchronously
+ *    when one is available. Workflow-script call-cap abort
+ *    (`runWorkflowScript.ts`) relies on the synchronous fast path: sibling
+ *    agents already in flight must have registered their AbortSignal
+ *    listener before the cap-trip synchronously calls `runAbort.abort()`,
+ *    or they never observe the abort. Confirmed by reproducing the swap:
+ *    it broke "aborts in-flight agents when the call cap trips" in
+ *    WorkflowScriptEngine.vitest.ts.
  */
 export function createSemaphore(limit: number): Semaphore {
   if (!Number.isInteger(limit) || limit < 1) {


### PR DESCRIPTION
## Summary

Ran an npm-package audit for hand-rolled logic that a well-maintained library could replace. Found the codebase already unusually well-covered (`p-retry`, `p-map`, `p-throttle`, `lru-cache`, `semver`, `micromatch`, Zod, `nanoid`, `markdown-it` are all in place). Of the few remaining candidates, only one panned out after verification; two others were investigated and deliberately reverted because the swap would have broken real behavior.

- **Landed:** `scripts/bump-workspace-version.mjs` hand-rolled a `^(?:cli-v|v)?(\d+)\.(\d+)\.(\d+)$` regex to parse release-tag versions, even though the repo already depends on `semver` for the same purpose elsewhere (`packages/desktop/src/main/desktopUpdateChecker.ts`, `packages/cli/src/runtime/updateChecker.ts`). Swapped to `semver.parse`, with an explicit guard so prerelease/build-metadata suffixes (`-beta`, `+build`) that `semver.parse` would otherwise silently accept and drop are still rejected, matching the original regex's strictness exactly.
- **Investigated and reverted — `AnnotationFetchBudget`'s hand-rolled token bucket → `limiter`:** `limiter`'s `TokenBucket.drip()` calls `performance.now()` internally with no clock-injection hook. The existing tests rely on passing explicit fake `nowMs` values (`tryClaim(1000)`, `tryClaim(900)`, ...) for deterministic, instant assertions — `limiter` can't support that, so the hand-rolled version stays (its file comment already documents this rationale correctly).
- **Investigated and reverted — `createSemaphore` → `p-limit`:** `p-limit`'s call signature matches `Semaphore.run<T>` exactly, so it looked like a clean drop-in. But `p-limit` always defers task launch by a microtask (its `enqueue` routes even a free slot through `new Promise().then(run)`), while the hand-rolled semaphore launches synchronously when a slot is free. `runWorkflowScript.ts`'s call-cap abort relies on that synchronous fast path: in-flight sibling agents must already have their `AbortSignal` listener registered before the cap-trip synchronously calls `runAbort.abort()`. Swapping to `p-limit` broke `WorkflowScriptEngine.vitest.ts > "aborts in-flight agents when the call cap trips"`. Reverted, and expanded the code comment to document the verified reason instead of just the typing rationale.

## Issue acceptance gates

Ad hoc request ("refactor and make PR" following an npm-package audit) — no tracked issue. Acceptance gate: replace hand-rolled logic with a library only where the library is a verified behavioral match, not just a type-signature match.

## Single source of truth

Release-tag version parsing in `scripts/bump-workspace-version.mjs` now goes through the same `semver` package the desktop and CLI update checkers already use, instead of a separate regex.

## Duplication and abstraction budget

No new abstraction added. `createSemaphore` and `AnnotationFetchBudget` are unchanged in behavior; their code comments now record the specific, verified reasons a library replacement doesn't fit, so a future pass doesn't have to re-derive this.

## Net elements (R6)

n/a — no new exported symbols, classes, or files. One regex constant replaced by a `semver.parse` call plus a stricter prerelease/build-metadata guard.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed.

## Host impact

Extension: none.

Desktop: none.

CLI: none. `semver` was already a direct dependency of `packages/cli` and `packages/desktop`; it's now also a root `devDependency` since `scripts/bump-workspace-version.mjs` runs from the workspace root (same pattern as `yaml`/`prettier` already used by other root scripts).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — same 44 pre-existing warnings, 0 errors, nothing new.
- `npm test` (full suite, 5543 tests) — 1 pre-existing failure (`SystemUtils.vitest.ts > aborts shell command process groups including children`), confirmed via `git stash` to fail identically on the unmodified base branch (container process-group signaling, unrelated to this change). Everything else passes, including the semaphore- and rate-limiter-dependent suites (`WorkflowScriptEngine.vitest.ts`, `ToolUseDispatchParallel.vitest.ts`, `ToolUseDispatchInterruption.vitest.ts`, `PRPollingSourceAnnotationPages.vitest.ts`, `PRPollingSource.vitest.ts`).
- Manually exercised `scripts/bump-workspace-version.mjs --check` against valid tags (`v0.39.4`, `cli-v0.39.4`, bare `0.39.4`, patch-rollover at `.10`) and invalid input (`v0.39.9-beta`, `v0.39.9+build.1`, garbage) to confirm identical accept/reject behavior to the old regex.


---
_Generated by [Claude Code](https://claude.ai/code/session_011j4R6whxZTT4q2XGmo9ScW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is a root release script and a comment; runtime semaphore behavior is unchanged.
> 
> **Overview**
> **Release bump script** now parses `v` / `cli-v` / bare tags with the `semver` package instead of a hand-rolled regex, and **rejects** prerelease or build suffixes that `semver.parse` would otherwise strip so behavior stays aligned with manifest `MAJOR.MINOR.PATCH` only. **`semver`** is added as a **root devDependency** for that script.
> 
> **Documentation only:** the `createSemaphore` comment in `src/utils/core/index.ts` is expanded to record why **`p-limit`** was not adopted (microtask-deferred launch breaks synchronous call-cap abort in workflow scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bb1ef1601fdd30b19d1bc2cc67393b7ee4e725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->