### PR TITLE
fix(auth): make relay-token invalid status sticky against stale probes

### DIFF
--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -114,6 +114,15 @@ export async function fetchRelayTokenStatus(
   if (cached) return cached;
   const result = await probeRelayTokenStatus(token, fetchImpl);
   if (result.state !== 'unknown') {
+    // Re-read immediately before writing: a concurrent live 401
+    // (markRelayTokenRejected) may have landed while this probe was in
+    // flight, and is authoritative evidence fresher than whatever the probe
+    // observed. `invalid` is sticky — never let a stale probe result
+    // clobber it back to `valid`; only an explicit cache reset clears it.
+    const current = statusCache.get(token);
+    if (current?.state === 'invalid') {
+      return current;
+    }
     statusCache.set(token, result);
   }
   return result;

--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -113,16 +113,19 @@ export async function fetchRelayTokenStatus(
   const cached = statusCache.get(token);
   if (cached) return cached;
   const result = await probeRelayTokenStatus(token, fetchImpl);
+  // Re-read immediately before returning/writing: a concurrent live 401
+  // (markRelayTokenRejected) may have landed while this probe was in
+  // flight, and is authoritative evidence fresher than whatever the probe
+  // observed. `invalid` is sticky against a stale probe result — even an
+  // `unknown` one — until an explicit cache reset or TTL expiry clears it.
+  // Checking this ahead of the `result.state !== 'unknown'` cache-write
+  // guard (rather than inside it) keeps the *return value* consistent with
+  // the cache for every probe outcome, not just settled ones.
+  const current = statusCache.get(token);
+  if (current?.state === 'invalid') {
+    return current;
+  }
   if (result.state !== 'unknown') {
-    // Re-read immediately before writing: a concurrent live 401
-    // (markRelayTokenRejected) may have landed while this probe was in
-    // flight, and is authoritative evidence fresher than whatever the probe
-    // observed. `invalid` is sticky — never let a stale probe result
-    // clobber it back to `valid`; only an explicit cache reset clears it.
-    const current = statusCache.get(token);
-    if (current?.state === 'invalid') {
-      return current;
-    }
     statusCache.set(token, result);
   }
   return result;

--- a/src/test-kernel/cli/RelayTokens.vitest.mts
+++ b/src/test-kernel/cli/RelayTokens.vitest.mts
@@ -8,6 +8,7 @@ import {
   fetchRelayTokenStatus,
   getCachedRelayTokenState,
   getConfiguredRelayToken,
+  markRelayTokenRejected,
   resetRelayTokenTierCacheForTests,
 } from '@auth/relayToken';
 import {
@@ -149,6 +150,38 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
       state: 'invalid',
     });
     expect(calls).toHaveLength(1);
+    expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
+  });
+
+  it('keeps a live 401 rejection sticky against a slower in-flight probe', async () => {
+    // Interleaving: a probe for `token` is already in flight (e.g. kicked
+    // off by an earlier synchronous check) when a *later* relay call gets a
+    // live 401 and calls markRelayTokenRejected — evidence that is fresher
+    // than whatever the in-flight probe will report. The probe then resolves
+    // 'valid' from data fetched before the rejection. The stale 'valid' must
+    // not clobber the fresher 'invalid': invalid is sticky until an explicit
+    // refresh (cache reset).
+    let resolveFetch!: (response: Response) => void;
+    const fetchImpl = (() =>
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as unknown as typeof fetch;
+
+    const pending = fetchRelayTokenStatus(TOKEN, fetchImpl);
+
+    // The live 401 lands and marks the token invalid while the probe above
+    // is still in flight.
+    markRelayTokenRejected(TOKEN);
+    expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
+
+    // The in-flight probe now resolves with a stale 'valid' verdict.
+    resolveFetch(
+      jsonResponse({ userStatus: { tier: 'Ultra', isExpired: false } }),
+    );
+    await pending;
+
+    // The fresher rejection must survive: the cache must not be clobbered
+    // back to 'valid' by the stale probe result.
     expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
   });
 

--- a/src/test-kernel/cli/RelayTokens.vitest.mts
+++ b/src/test-kernel/cli/RelayTokens.vitest.mts
@@ -160,7 +160,7 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
     // than whatever the in-flight probe will report. The probe then resolves
     // 'valid' from data fetched before the rejection. The stale 'valid' must
     // not clobber the fresher 'invalid': invalid is sticky until an explicit
-    // refresh (cache reset).
+    // refresh (cache reset) or TTL expiry.
     let resolveFetch!: (response: Response) => void;
     const fetchImpl = (() =>
       new Promise<Response>((resolve) => {
@@ -178,10 +178,40 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
     resolveFetch(
       jsonResponse({ userStatus: { tier: 'Ultra', isExpired: false } }),
     );
-    await pending;
+
+    // The resolved value itself must agree with the cache — not just the
+    // cache in isolation — otherwise a caller that trusts the return value
+    // (getUserAuthContext, getCliAuthProfile) could still treat the
+    // just-rejected token as usable.
+    await expect(pending).resolves.toEqual({ state: 'invalid' });
 
     // The fresher rejection must survive: the cache must not be clobbered
     // back to 'valid' by the stale probe result.
+    expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
+  });
+
+  it('keeps a live 401 rejection sticky against a slower in-flight probe that resolves unknown', async () => {
+    // Same race as above, but the in-flight probe resolves 'unknown' (e.g. a
+    // transient 5xx) instead of a settled 'valid'/'invalid'. 'unknown'
+    // results are never cached, so a naive fix that only re-checks the
+    // sticky guard for settled results would return 'unknown' here even
+    // though the cache already holds the fresher 'invalid' — exactly the
+    // return-value/cache inconsistency this guard exists to prevent.
+    let resolveFetch!: (response: Response) => void;
+    const fetchImpl = (() =>
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as unknown as typeof fetch;
+
+    const pending = fetchRelayTokenStatus(TOKEN, fetchImpl);
+
+    markRelayTokenRejected(TOKEN);
+    expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
+
+    // The in-flight probe resolves with a transient failure response.
+    resolveFetch(new Response('boom', { status: 500 }));
+
+    await expect(pending).resolves.toEqual({ state: 'invalid' });
     expect(getCachedRelayTokenState(TOKEN)).toBe('invalid');
   });
 


### PR DESCRIPTION
## Finding

**MED race in the relay CI-token status cache** (`src/auth/relayToken.ts`,
`fetchRelayTokenStatus`): an async tier-config probe that started before a
live 401 rejection landed could resolve *after* `markRelayTokenRejected()`
had already marked the token `invalid`, and unconditionally overwrite the
cache back to `valid` — clobbering fresher, authoritative evidence with a
stale one.

Interleaving:

1. `fetchRelayTokenStatus(token)` misses the cache and kicks off a
   tier-config probe.
2. Before the probe resolves, a live relay call gets a real 401 and calls
   `markRelayTokenRejected(token)` — the cache is now `invalid`.
3. The in-flight probe (fetched from data that predates the rejection)
   resolves `valid` and `fetchRelayTokenStatus` writes it into the cache
   unconditionally, clobbering the fresher `invalid` entry.
4. Synchronous credential checks (`getCachedRelayTokenState`,
   `isAuthenticated`, relay-call fallback) now disagree with reality until
   the TTL happens to expire.

## Fix

Per the verified redesign, `fetchRelayTokenStatus`'s cache-write path is now
the single owner of the downgrade rule: it re-reads `statusCache.get(token)`
immediately before writing, and never overwrites an already-`invalid` entry
with a probe result. `invalid` is sticky until an explicit refresh (cache
reset) — a stale `valid`/`unknown` probe outcome can no longer undo a fresher
rejection recorded via `markRelayTokenRejected`.

```ts
const result = await probeRelayTokenStatus(token, fetchImpl);
if (result.state !== 'unknown') {
  const current = statusCache.get(token);
  if (current?.state === 'invalid') {
    return current;
  }
  statusCache.set(token, result);
}
return result;
```

Returning the sticky `current` (not just skipping the write) keeps the
function's return value consistent with what `getCachedRelayTokenState`
reports — callers of `fetchRelayTokenStatus` no longer see `valid` for a
token the cache already treats as rejected.

## Test

Extended `src/test-kernel/cli/RelayTokens.vitest.mts` with the exact
interleaving: kick off a probe with a controllable/deferred `fetch`, call
`markRelayTokenRejected` while it's still in flight, then resolve the probe
with a `valid` tier-config response. Asserts the cache stays `invalid`.

Proved the regression test fails pre-fix (reverted the `relayToken.ts` change
locally and reran):

```
AssertionError: expected 'valid' to be 'invalid' // Object.is equality
Expected: "invalid"
Received: "valid"
```

## Net elements (R6)

- 0 new files, 0 new exports, 0 new types/interfaces.
- +1 re-read + sticky-guard branch inside the existing single write site in
  `fetchRelayTokenStatus` — no new layer, no new cache, no new function.
- +1 regression test in the existing relay-token suite.

## Consumer counts (R8)

`fetchRelayTokenStatus` has 3 call sites, all unaffected in shape (still
`await fetchRelayTokenStatus(token)`), only benefiting from the corrected
sticky-invalid semantics:

- `src/tools/setup/platform.ts:143`
- `src/auth/SupabaseClient.ts:311` (same module also owns
  `markRelayTokenRejected` at `:238`, the source of the race)
- `packages/cli/src/runtime/supabaseAuth.ts:286`

## Verified

- `src/auth/relayToken.ts` — the cache-write path and its callers
  (`markRelayTokenRejected`, `getCachedRelayTokenState`,
  `resetRelayTokenTierCacheForTests`).
- `src/auth/SupabaseClient.ts` — confirmed `markRelayTokenRejected` is the
  live-401 caller that races the probe.
- `src/tools/setup/platform.ts`, `packages/cli/src/runtime/supabaseAuth.ts` —
  confirmed both other consumers only `await` the result, unaffected by the
  return-value change (which now can never return a stale `valid` where the
  cache holds `invalid`).
- `src/test-kernel/cli/RelayTokens.vitest.mts` — full suite (14 tests)
  passing post-fix; new test proven to fail pre-fix by temporarily reverting
  the `relayToken.ts` change.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay CI token auth caching used on model/relay paths; behavior change is narrowly scoped to not clobbering fresher rejections, but incorrect logic could still mis-report token validity.
> 
> **Overview**
> Fixes a race where an in-flight tier-config probe could **overwrite** or **return** a fresher `invalid` from `markRelayTokenRejected` (live relay 401) with a stale `valid` or `unknown`.
> 
> **`fetchRelayTokenStatus`** now re-reads `statusCache` after `probeRelayTokenStatus` completes. If the entry is already `invalid`, it returns that and skips writing the probe result—so return value and cache stay aligned for callers like auth profile checks.
> 
> Adds two regression tests in **`RelayTokens.vitest.mts`**: probe resolves `valid` or `unknown` after rejection while still in flight; both must keep `invalid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bccc508fda193402145799f98815c2a605da53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->