### PR TITLE
fix(webview): reset pasted-image state when follow-up-input's stream changes

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -174,7 +174,14 @@ export class FollowUpInput extends LitElement {
     // streams, so any image pasted while bound to the previous stream must
     // not ride along to whichever stream is active when send eventually
     // fires. In-flight pastes are invalidated via imagePasteRevision so
-    // their async completion is a no-op (see attachPastedImages).
+    // their async completion is a no-op (see attachPastedImages). Also drop
+    // any still-in-flight paste promises from the old stream: emitSend()
+    // gates on pendingImagePastes.size, so a stale entry left behind here
+    // would block (or, via flushPendingImagePasteSend, mis-time) a send
+    // issued in the newly-bound stream until the old-stream paste settles.
+    // Clearing the set is safe — attachPastedImages already no-ops on a
+    // revision mismatch, and the promise's own .finally() tolerates
+    // deleting an already-absent entry.
     if (
       changedProperties.has('streamId') &&
       changedProperties.get('streamId') !== undefined
@@ -182,6 +189,7 @@ export class FollowUpInput extends LitElement {
       this.imagePasteRevision += 1;
       this.pendingImages = [];
       this.sendAfterImagePastes = false;
+      this.pendingImagePastes.clear();
     }
 
     // React to shouldFocus property change

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -124,6 +124,16 @@ export class FollowUpInput extends LitElement {
   @property({ type: Boolean, reflect: true }) visible = false;
   @property({ attribute: false }) value = '';
   @property({ attribute: false }) queuedMessages: string[] = [];
+  /**
+   * Identity of the stream this instance is currently bound to (the same
+   * `streamInfo.name` TodoList/PlanView key off of as `collapseKey`). The
+   * progress view reuses a single `<follow-up-input>` instance across the
+   * active-stream context switch, so any pasted-image state pending here
+   * must be reset when the bound stream changes — otherwise an image
+   * attached while viewing one stream can be delivered to whichever stream
+   * is active when the user later hits send.
+   */
+  @property({ type: String }) streamId = '';
 
   @property({ attribute: false }) shouldFocus = false;
   @property({ attribute: false }) polishedText: string | null = null;
@@ -160,6 +170,20 @@ export class FollowUpInput extends LitElement {
   });
 
   protected override willUpdate(changedProperties: PropertyValues): void {
+    // React to streamId property change: this instance is reused across
+    // streams, so any image pasted while bound to the previous stream must
+    // not ride along to whichever stream is active when send eventually
+    // fires. In-flight pastes are invalidated via imagePasteRevision so
+    // their async completion is a no-op (see attachPastedImages).
+    if (
+      changedProperties.has('streamId') &&
+      changedProperties.get('streamId') !== undefined
+    ) {
+      this.imagePasteRevision += 1;
+      this.pendingImages = [];
+      this.sendAfterImagePastes = false;
+    }
+
     // React to shouldFocus property change
     if (changedProperties.has('shouldFocus') && this.shouldFocus) {
       this.focusInput({ scrollIntoView: true }).then(() => {

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -72,6 +72,7 @@ export class ToolUseStreamContent extends BaseStreamContent {
 
       <follow-up-input
         .visible=${true}
+        .streamId=${streamInfo.name}
         .value=${currentState.ui.followUpText}
         .queuedMessages=${currentState.queuedFollowUps}
         .shouldFocus=${currentState.ui.shouldFocusFollowUp}

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -27,6 +27,7 @@ type FollowUpInputInternals = HTMLElement & {
   streamId: string;
   updateComplete: Promise<boolean>;
   pendingImages: ExtractedClipboardImage[];
+  pendingImagePastes: Set<Promise<void>>;
   emitSend: () => void;
 };
 
@@ -71,6 +72,30 @@ describe('follow-up-input pasted-image state across stream switches', () => {
 
     // The progress view rebinds this SAME instance to stream B instead of
     // mounting a fresh one.
+    element.streamId = 'stream-b';
+    await element.updateComplete;
+
+    const getSentImages = captureSentImages(element);
+    element.emitSend();
+
+    expect(getSentImages()).toEqual([]);
+  });
+
+  it('drops a stale in-flight paste promise from the previous stream so send is not blocked', async () => {
+    // Regression coverage for the codex/Copilot review finding on this PR:
+    // emitSend() gates on pendingImagePastes.size > 0, so a paste promise
+    // still in flight from the previously-bound stream must not survive a
+    // streamId change — otherwise a send issued in the newly-bound stream
+    // silently queues behind (and its timing/target depends on) an
+    // unrelated old-stream paste completing.
+    const element = createFollowUpInput('stream-a');
+    await element.updateComplete;
+
+    // Stand in for a paste whose async base64 read hasn't resolved yet
+    // (attachPastedImages adds its own promise to this set in handlePaste,
+    // before the read completes).
+    element.pendingImagePastes.add(new Promise<void>(() => {}));
+
     element.streamId = 'stream-b';
     await element.updateComplete;
 

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -1,0 +1,105 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared types
+import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+/**
+ * Regression coverage for the round-2 APoSD audit finding: the progress
+ * view reuses a SINGLE `<follow-up-input>` Lit instance across the active
+ * stream — `ToolUseStreamContent.render()` binds `.streamId=${streamInfo.name}`
+ * (the same source TodoList/PlanView key off of for `collapseKey`) rather
+ * than mounting a fresh instance per stream. Without a reset keyed on that
+ * identity, an image pasted while viewing stream A and still un-sent when
+ * the user switches to stream B rides along on the next send and is
+ * delivered to stream B instead of stream A.
+ */
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/FollowUpInput'),
+);
+
+type FollowUpInputInternals = HTMLElement & {
+  visible: boolean;
+  value: string;
+  streamId: string;
+  updateComplete: Promise<boolean>;
+  pendingImages: ExtractedClipboardImage[];
+  emitSend: () => void;
+};
+
+function createFollowUpInput(streamId: string): FollowUpInputInternals {
+  const element = document.createElement(
+    'follow-up-input',
+  ) as unknown as FollowUpInputInternals;
+  element.visible = true;
+  element.streamId = streamId;
+  document.body.append(element);
+  return element;
+}
+
+function captureSentImages(
+  element: FollowUpInputInternals,
+): () => ExtractedClipboardImage[] | undefined {
+  let sentImages: ExtractedClipboardImage[] | undefined;
+  element.addEventListener('followup-send', (event) => {
+    sentImages = (
+      event as CustomEvent<{ images: ExtractedClipboardImage[] }>
+    ).detail.images;
+  });
+  return () => sentImages;
+}
+
+describe('follow-up-input pasted-image state across stream switches', () => {
+  it('drops a pending pasted image left over from the previously bound stream', async () => {
+    const element = createFollowUpInput('stream-a');
+    await element.updateComplete;
+
+    // Stand in for a completed image paste while bound to stream A.
+    // (attachPastedImages populates this after the async base64 read
+    // resolves; this harness's jsdom has no FileReader/ClipboardEvent
+    // wiring, so the post-paste state is set directly, matching what the
+    // real paste handler leaves behind.)
+    element.pendingImages = [
+      {
+        fileName: 'pasted-image-1.png',
+        base64: 'AAAA',
+        mediaType: 'image/png',
+      },
+    ];
+
+    // The progress view rebinds this SAME instance to stream B instead of
+    // mounting a fresh one.
+    element.streamId = 'stream-b';
+    await element.updateComplete;
+
+    const getSentImages = captureSentImages(element);
+    element.emitSend();
+
+    expect(getSentImages()).toEqual([]);
+  });
+
+  it('keeps a pending pasted image when the bound stream does not change', async () => {
+    const element = createFollowUpInput('stream-a');
+    await element.updateComplete;
+
+    const image: ExtractedClipboardImage = {
+      fileName: 'pasted-image-1.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+    element.pendingImages = [image];
+
+    // A re-render with the SAME streamId (e.g. more tokens streaming into
+    // the still-active run) must not drop the pending image.
+    element.value = 'follow-up text';
+    await element.updateComplete;
+
+    const getSentImages = captureSentImages(element);
+    element.emitSend();
+
+    expect(getSentImages()).toEqual([image]);
+  });
+});

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -45,9 +45,8 @@ function captureSentImages(
 ): () => ExtractedClipboardImage[] | undefined {
   let sentImages: ExtractedClipboardImage[] | undefined;
   element.addEventListener('followup-send', (event) => {
-    sentImages = (
-      event as CustomEvent<{ images: ExtractedClipboardImage[] }>
-    ).detail.images;
+    sentImages = (event as CustomEvent<{ images: ExtractedClipboardImage[] }>)
+      .detail.images;
   });
   return () => sentImages;
 }

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -53,6 +53,7 @@ const domGlobalKeys = [
   'requestAnimationFrame',
   'cancelAnimationFrame',
   'ResizeObserver',
+  'MutationObserver',
 ] as const;
 
 const DEFAULT_VALIDITY = {
@@ -272,6 +273,11 @@ export function useLitComponentTestDom(
       ) => void,
       // jsdom lacks ResizeObserver; Web Awesome's wa-textarea constructs one.
       ResizeObserver: ResizeObserverStub,
+      // jsdom implements MutationObserver on its own `window`, but the plain
+      // Node globalThis used in this Vitest environment doesn't have one;
+      // Web Awesome's wa-details (used by the "Followup"/panel-collapsible
+      // wrapper) constructs one in firstUpdated().
+      MutationObserver: dom.window.MutationObserver,
     } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
 
     for (const key of domGlobalKeys) {


### PR DESCRIPTION
## Finding

**HIGH race (webview):** the progress view reuses a **single** `<follow-up-input>` Lit instance across the active-stream context switch (`ToolUseStreamContent` consumes `streamStateContext`/`streamInfo` via `@consume`, per `BaseStreamContent`). `FollowUpInput` keeps its pasted-image attachment state (`pendingImages`, `imagePasteRevision`, `sendAfterImagePastes`) as private instance fields with no reset keyed on which stream it's currently bound to.

Failure story: paste an image into the follow-up box while viewing stream A, switch to stream B before hitting send, then hit send — the image (and the `[fileName]` token already inserted into the textarea, via `.value`) rides along and is attached to stream B's follow-up instead of stream A's.

## Fix

Deepen the owner (`FollowUpInput`) using the SAME stream-identity source `TodoList`/`PlanView` already key their `collapseKey` off of (`streamInfo.name`, wired in `ToolUseStreamContent.render()`):

- Added a `streamId` property to `FollowUpInput` (`packages/extension/src/progressView/frontend/components/FollowUpInput.ts`).
- In `willUpdate`, when `streamId` changes, reset `pendingImages`, `sendAfterImagePastes`, and bump `imagePasteRevision` (the same revision guard `attachPastedImages` already checks — `pasteRevision !== this.imagePasteRevision` — so any paste still in flight from the old stream becomes a no-op instead of leaking a late-resolving image into the new stream).
- Wired `.streamId=${streamInfo.name}` in `ToolUseStreamContent.render()` (`packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts`), mirroring the existing `.collapseKey=${streamInfo.name}` bindings on `<todo-list>`/`<plan-view>` two lines above.

View-level, stateless-renderer-compatible fix: no new bus emit, no new subscribe surface, no new port — one property + one `willUpdate` branch, following the exact pattern `TodoList.collapseKey` already established.

## Tests

No existing suite covered `FollowUpInput` specifically — `packages/extension` has zero `*.test.*`/`*.vitest.*` files; `npm test` only runs `src/test-kernel/**/*.vitest.{ts,mts}`. There IS existing shared Lit-component test infra (`src/test-kernel/settings/litComponentTestUtils.ts`'s `useLitComponentTestDom`, already reused by other progress-view component suites such as `TaskGroupListIndex.vitest.ts` and `TerminalOutput.vitest.ts`), so I added a new suite file in that same area rather than inventing new test plumbing:

- `src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts` — mounts a real `<follow-up-input>` custom element, seeds `pendingImages` (standing in for a completed paste — this harness's jsdom has no `FileReader`/`ClipboardEvent` wiring), then asserts:
  1. switching `streamId` drops the pending image before send (the regression case);
  2. a same-stream re-render (e.g. new `value` while streaming) does NOT drop it (guards against an over-eager reset).

Rendering `<follow-up-input>` for the first time in this harness surfaced a real gap in the shared jsdom setup: Web Awesome's `wa-details` (the "Followup" collapsible wrapper) constructs a `MutationObserver` in `firstUpdated()`, which wasn't in `useLitComponentTestDom`'s global allowlist (only `ResizeObserver` was, for `wa-textarea`). Extended that SAME allowlist/replacement list with `MutationObserver` (jsdom's own `window.MutationObserver`) rather than adding a parallel polyfill — same pattern as the existing `ResizeObserverStub`/dialog-polyfill entries in that file.

**Proven to fail pre-fix**: reverted the two source files to `origin/main` (`git checkout HEAD -- FollowUpInput.ts ToolUseStreamContent.ts`) with the new test file left in place — `drops a pending pasted image left over from the previously bound stream` failed with the stale image still attached (`AssertionError: expected [ { fileName: 'pasted-image-1.png', ... } ] to deeply equal []`); `git apply`'d the fix patch back and both tests passed. No `git stash` used.

## Net elements (R6)

- **+1 property** (`FollowUpInput.streamId`) — no new class, port, or abstraction layer.
- **+1 `willUpdate` branch** — same shape as the existing `polishRevision`/`recording` branches already in that method.
- **+1 template binding** (`ToolUseStreamContent.ts`, one line) — same shape as the two adjacent `collapseKey` bindings.
- **+1 test suite file** + **+1 allowlist entry** in the existing shared jsdom harness (no new harness, no new file for that harness).
- **0 deletions** — nothing pre-existing duplicated this reset logic to remove.

## Consumer counts (R8)

- `FollowUpInput` (`<follow-up-input>`) has exactly **one** call site: `ToolUseStreamContent.render()`. `streamId` is a single-purpose property read only in that component's own `willUpdate` — not a shared helper, so no multi-caller bar applies.
- `useLitComponentTestDom` (the harness touched for `MutationObserver`) already has 5 consumers before this PR (`SettingsReliabilityPlacement`, `ProviderKeyModal`, `ModelSelectionProviderKeys`, `TerminalOutput`, `TaskGroupListIndex`), now 6 with `FollowUpInputStreamSwitch` — extending its existing global allowlist is squarely in "called from multiple locations" territory, not a new single-caller abstraction.

## Verified

- `packages/extension/src/progressView/frontend/components/FollowUpInput.ts`
- `packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts`
- `packages/extension/src/progressView/frontend/components/BaseStreamContent.ts` (confirms the single shared `streamContext`-consuming instance, i.e. the race's root cause)
- `packages/extension/src/progressView/frontend/components/TodoList.ts` (the `collapseKey` precedent this fix mirrors)
- `src/test-kernel/settings/litComponentTestUtils.ts` (shared Lit jsdom harness)
- `src/test-kernel/progressView/TaskGroupListIndex.vitest.ts`, `TerminalOutput.vitest.ts` (existing usage precedent for the harness)
- Confirmed no pre-existing `FollowUpInput` test coverage exists anywhere in the repo (`packages/extension` has 0 `*.test.*`/`*.vitest.*` files).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which stream receives pasted follow-up attachments; fix is narrow and tested but touches the send path for multimodal follow-ups.
> 
> **Overview**
> Fixes a race where the progress view **reuses one** `<follow-up-input>` across active streams: pasted images (and in-flight paste work) from stream A could be sent on a follow-up after switching to stream B.
> 
> **`FollowUpInput`** now takes a **`streamId`** (same identity as `streamInfo.name` / existing `collapseKey` wiring). On **`streamId`** change in **`willUpdate`**, it clears **`pendingImages`**, **`sendAfterImagePastes`**, and **`pendingImagePastes`**, and bumps **`imagePasteRevision`** so late async pastes from the old stream are ignored. **`ToolUseStreamContent`** binds **`.streamId=${streamInfo.name}`**.
> 
> Adds **`FollowUpInputStreamSwitch.vitest.ts`** for stream-switch vs same-stream re-render behavior, and exposes **`MutationObserver`** on the shared Lit jsdom harness so **`follow-up-input`** ( **`wa-details`** ) can mount in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97dc0485fd5446e6b143dc0f80bf7ba61184634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->