### PR TITLE
fix(agent): add missing zotero_collections to agentCreator TOOL_GROUPS

### DIFF
--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -120,7 +120,12 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
   },
   'Citation Management': {
     description: 'Manage references with Zotero',
-    tools: ['zotero_add', 'zotero_search', 'zotero_export'],
+    tools: [
+      'zotero_add',
+      'zotero_search',
+      'zotero_export',
+      'zotero_collections',
+    ],
     keywords: ['zotero', 'citation', 'reference', 'bibliography', 'endnote'],
   },
   Computation: {

--- a/src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
+++ b/src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
@@ -60,9 +60,7 @@ function parseCatalogGroups(markdown: string): Map<string, Set<string>> {
 }
 
 describe('agent-creator TOOL_GROUPS vs tool_catalog.md', () => {
-  const catalogGroups = parseCatalogGroups(
-    readFileSync(CATALOG_PATH, 'utf8'),
-  );
+  const catalogGroups = parseCatalogGroups(readFileSync(CATALOG_PATH, 'utf8'));
 
   it('lists every TOOL_GROUPS category in the doc', () => {
     for (const label of Object.keys(TOOL_GROUPS)) {

--- a/src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
+++ b/src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
@@ -1,0 +1,81 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+import { TOOL_GROUPS } from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
+
+// TOOL_GROUPS (the code owner consulted by the agent-creator UI's tool
+// picker) and the human-facing tool catalog doc are two hand-maintained
+// copies of the same tool-to-category grouping. They must agree, or the
+// picker and the docs silently disagree about which tools live where.
+const REPO_ROOT = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+);
+const CATALOG_PATH = resolve(
+  REPO_ROOT,
+  'packages/extension/resources/docs/agent-creation/tool_catalog.md',
+);
+
+// Sections that describe per-tool "recommended combos" or prose guidance
+// rather than the canonical per-category tool lists — not compared.
+const IGNORED_SECTIONS = new Set([
+  'recommended tool groups by use case',
+  'system prompt best practices',
+]);
+
+/** Parses the `## Category` sections of tool_catalog.md into tool-name sets. */
+function parseCatalogGroups(markdown: string): Map<string, Set<string>> {
+  const groups = new Map<string, Set<string>>();
+  const sections = markdown.split(/^## /m).slice(1);
+
+  for (const section of sections) {
+    const newlineIndex = section.indexOf('\n');
+    const header = section.slice(0, newlineIndex).trim().toLowerCase();
+    if (IGNORED_SECTIONS.has(header)) continue;
+
+    // Bullets in the doc soft-wrap across lines (continuation lines are
+    // indented, not re-prefixed with "- "); rejoin them before splitting
+    // into logical bullet lines so wrapped tool names aren't dropped.
+    const body = section.slice(newlineIndex + 1).replace(/\n +(?=\S)/g, ' ');
+    const tools = new Set<string>();
+    for (const line of body.split('\n')) {
+      if (!line.trimStart().startsWith('- ')) continue;
+      // Only the tool-name list before the em-dash description counts —
+      // parameter names quoted later in the sentence (e.g. `agent`, `model`)
+      // are not tool names.
+      const [toolList] = line.split(' — ');
+      for (const match of toolList.matchAll(/`([a-z0-9_]+)`/g)) {
+        tools.add(match[1]);
+      }
+    }
+    groups.set(header, tools);
+  }
+
+  return groups;
+}
+
+describe('agent-creator TOOL_GROUPS vs tool_catalog.md', () => {
+  const catalogGroups = parseCatalogGroups(
+    readFileSync(CATALOG_PATH, 'utf8'),
+  );
+
+  it('lists every TOOL_GROUPS category in the doc', () => {
+    for (const label of Object.keys(TOOL_GROUPS)) {
+      expect(catalogGroups.has(label.toLowerCase())).toBe(true);
+    }
+  });
+
+  it.each(Object.entries(TOOL_GROUPS))(
+    '%s: TOOL_GROUPS tools match tool_catalog.md',
+    (label, group) => {
+      const docTools = catalogGroups.get(label.toLowerCase());
+      expect(docTools).toBeDefined();
+      expect(new Set(group.tools)).toEqual(docTools);
+    },
+  );
+});


### PR DESCRIPTION
## Finding

**MED — live correctness gap.** `TOOL_GROUPS` in
`src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` is the code
owner behind the agent-creator's "pick tools" quick-pick UI
(`packages/extension/src/commands/agent/agentCreatorCommands.ts`). Its
`'Citation Management'` entry was missing `zotero_collections` — the tool is
registered (`src/tools/registry.ts:110`, `ZoteroCollectionsTool`) and is
listed in the parallel, hand-maintained
`packages/extension/resources/docs/agent-creation/tool_catalog.md` doc (the
context the agent-creator's own LLM prompt reads via `creator.yaml` when
generating new tool-use agents). The two copies of the same
tool-to-category grouping had drifted: picking "Citation Management" from
the quick-pick UI could never select `zotero_collections`, while the LLM
path (reading the doc) could.

Pins: `agentCreatorFlow.ts:121-125` (code owner, pre-fix) vs
`tool_catalog.md:47-50` (doc copy, already correct).

## Fix

Deepened the code owner: added `zotero_collections` to `TOOL_GROUPS['Citation
Management'].tools` so the quick-pick UI offers the same tool set as the doc
and the tool registry.

Added a drift-guard regression test
(`src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts`) that
parses `tool_catalog.md`'s `## <Category>` sections and asserts each
`TOOL_GROUPS` entry's `tools` list matches the doc's tool set exactly (also
asserting every `TOOL_GROUPS` category has a matching doc section). This
encodes the failure story directly: reverting the one-line fix reproduces
exactly the `Citation Management` mismatch (`zotero_collections` present in
the doc, absent from `TOOL_GROUPS`) and nothing else — verified by applying
the fix as a patch, confirming red, then re-applying it and confirming
green (see Tests below).

I did not make one side consume the other at runtime: `tool_catalog.md` is
prose fed to an LLM prompt (via `creator.yaml`), not a structured data file,
so generating it from `TOOL_GROUPS` (or vice versa) would add a build step
for a 9-entry table that a parity test already keeps honest at PR time.

## Net elements (R6)

- `+6/-1` lines in `agentCreatorFlow.ts` (one missing array entry).
- `+1` new test file (`AgentCreatorToolCatalogParity.vitest.mts`), 10 assertions
  (1 "every category has a doc section" test + 9 per-category parity tests,
  `it.each` over `TOOL_GROUPS`).
- `0` new abstractions, ports, or indirection layers — this is a same-file
  data fix plus a same-owner regression test.

## Consumer counts (R8)

- `TOOL_GROUPS`: 2 non-test consumers —
  `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` (owner)
  and `packages/extension/src/commands/agent/agentCreatorCommands.ts` (quick-pick
  UI, 3 use sites).
- `tool_catalog.md`: 2 non-test references —
  `packages/extension/resources/tool_use_agents/creator.yaml` (agent-creator's
  own LLM prompt, tells it to always read this file) and
  `packages/extension/resources/docs/agent-creation/tooluse_schema.md`
  (cross-reference).

## Tests

Regression test proven to fail pre-fix (via `git apply -R`/`git apply` on the
one-line fix, not `git stash`):

```
$ git apply -R <fix.patch>   # revert just the TOOL_GROUPS fix
$ npx vitest run src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
 × Citation Management: TOOL_GROUPS tools match tool_catalog.md
   AssertionError: expected Set{ 'zotero_add', …(2) } to deeply equal Set{ 'zotero_search', …(3) }
 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)

$ git apply <fix.patch>      # re-apply the fix
$ npx vitest run src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Also ran, post-fix:

- `npx vitest run src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts src/test-kernel/tools/externalToolDefs.vitest.ts` — 2 files, 14 tests, all pass.
- `npx vitest run src/test-kernel/agent/ src/test-kernel/tools/` — 240 files, 1737 tests: 9 pre-existing failures, all in
  `src/test-kernel/tools/lean/LeanTools.vitest.ts` (`runLakeCommand` mutex
  timing budgets, e.g. `expected 945 to be less than 600`) and one flaky
  `ToolAvailabilityAppSignals` case — timing-sensitive tests unrelated to
  this change; this machine had ~7 concurrent sibling worktrees running
  `typecheck`/`vitest` simultaneously during this run. None touch
  `agentCreator`, `externalToolDefs`, or Zotero tooling.
- `npm run typecheck` (all workspaces) — clean.

## Verified

- `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` (TOOL_GROUPS, both before and after the fix)
- `packages/extension/src/commands/agent/agentCreatorCommands.ts` (TOOL_GROUPS consumer, quick-pick UI)
- `src/tools/registry.ts` (confirms `zotero_collections` is a registered tool)
- `packages/extension/resources/docs/agent-creation/tool_catalog.md` (the doc copy, already correct)
- `packages/extension/resources/tool_use_agents/creator.yaml` and `tooluse_schema.md` (confirms the doc is a live LLM-prompt consumer, not dead documentation)
- `src/test-kernel/agent/GoalPromptParity.vitest.mts` (pattern followed for reading repo resource files from a vitest suite)

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only fix in agent-creator metadata plus a read-only regression test; no runtime behavior beyond the tool picker listing one more tool.
> 
> **Overview**
> Adds **`zotero_collections`** to **`TOOL_GROUPS['Citation Management']`** so the agent-creator quick-pick UI offers the same Zotero tools as **`tool_catalog.md`** and the registry (the LLM path already saw it in the doc).
> 
> Introduces **`AgentCreatorToolCatalogParity.vitest.mts`**, which parses **`tool_catalog.md`** by category and asserts every **`TOOL_GROUPS`** entry’s tool list matches the doc exactly, so future drift fails at PR time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0f33f19b0bc349998ae8125c860aaf5bde77eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->