### PR TITLE
fix(errors): decouple isContextWindowError from internal message wording

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -55,6 +55,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   getSdkErrorMessage,
   isContextWindowError,
+  attachContextWindowError,
 } from '@common/errors/sdkErrorUtils';
 
 // Local imports - platform
@@ -1598,9 +1599,14 @@ export abstract class ModelHandler<
   ): TokenValidationResult {
     // Hard fail if input already exceeds context window
     if (inputTokens > contextWindow) {
-      throw new Error(
+      const error = new Error(
         `Token count of message exceeds context window: ${inputTokens} > ${contextWindow}`,
       );
+      // Tag with a typed marker so isContextWindowError() recognizes this
+      // internal case without depending on the message wording above, which
+      // this method (not a third-party provider) owns and may reword freely.
+      attachContextWindowError(error);
+      throw error;
     }
 
     const utilizationPercent = computeUtilizationPercent(

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -87,6 +87,30 @@ export function requiresFlowAutoRetry(err: unknown): boolean {
   );
 }
 
+const contextWindowErrorMetadata = createErrorMetadata<boolean>(
+  'contextWindowError',
+  (v): v is boolean => v === true,
+);
+
+/**
+ * Marks an error as a TeXRA-internal context-window violation at the throw
+ * site (e.g. `ModelHandler.validateTokenLimits`). Lets `isContextWindowError`
+ * recognize the internal case without string-matching a message whose exact
+ * wording the thrower owns — third-party provider error text is still
+ * matched via `CONTEXT_WINDOW_PATTERNS`.
+ */
+export function attachContextWindowError(err: unknown): void {
+  contextWindowErrorMetadata.attach(err, true);
+}
+
+export function hasContextWindowErrorMarker(err: unknown): boolean {
+  return (
+    findInCauseChain(err, (current) =>
+      contextWindowErrorMetadata.detect(current) === true ? true : undefined,
+    ) ?? false
+  );
+}
+
 export const providerErrorMetadata =
   createErrorMetadata<ProviderError>('providerError');
 

--- a/src/common/errors/sdkError/errorPatterns.ts
+++ b/src/common/errors/sdkError/errorPatterns.ts
@@ -1,6 +1,9 @@
 import { isObject } from '@utils/core';
 
-import { detectSdkErrorMetadata } from './errorMetadata';
+import {
+  detectSdkErrorMetadata,
+  hasContextWindowErrorMarker,
+} from './errorMetadata';
 import { getErrorClassNames } from './errorInspection';
 
 /** Max tail size (chars) for partial text attached to streaming errors.
@@ -21,8 +24,12 @@ export function isUserAbort(err: unknown): boolean {
   return isObject(err) && (err as { name?: unknown }).name === 'AbortError';
 }
 
+// Third-party provider wordings only — do not add TeXRA-internal messages
+// here. Internal throws (e.g. ModelHandler.validateTokenLimits) are tagged
+// with attachContextWindowError() at the throw site instead, so this
+// function doesn't need to string-match a message it doesn't own.
 const CONTEXT_WINDOW_PATTERNS = [
-  'exceeds context window', // TeXRA internal, Anthropic
+  'exceeds context window', // Anthropic
   'exceeds the context window', // OpenAI Responses API
   'context length exceeded', // Google
   'maximum context length', // OpenAI
@@ -31,8 +38,14 @@ const CONTEXT_WINDOW_PATTERNS = [
   'input too long', // Google
 ] as const;
 
-/** Checks if an error is a context window violation (should not be retried). */
+/** Checks if an error is a context window violation (should not be retried).
+ *  Recognizes TeXRA-internal throws via their typed marker (attached with
+ *  `attachContextWindowError`) and third-party provider errors via message
+ *  pattern matching. */
 export function isContextWindowError(err: unknown): boolean {
+  if (hasContextWindowErrorMarker(err)) {
+    return true;
+  }
   if (!(err instanceof Error)) {
     return false;
   }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -19,6 +19,7 @@ export {
   attachFlowAutoRetryRequired,
   requiresFlowAutoRetry,
   attachProviderError,
+  attachContextWindowError,
 } from './sdkError/errorMetadata';
 
 export {

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -20,6 +20,7 @@ export {
   requiresFlowAutoRetry,
   attachProviderError,
   attachContextWindowError,
+  hasContextWindowErrorMarker,
 } from './sdkError/errorMetadata';
 
 export {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -546,6 +546,19 @@ describe('isContextWindowError', () => {
     ).toBe(true);
   });
 
+  it('recognizes the marker through a cause chain (rethrown/wrapped error)', () => {
+    // Errors are frequently rewrapped as they propagate (e.g. `new Error(msg,
+    // { cause })`). The marker must still be found via `findInCauseChain`,
+    // not just on the outermost error.
+    const inner = new Error(
+      'Token count of message exceeds context window: 5 > 3',
+    );
+    attachContextWindowError(inner);
+    const outer = new Error('request failed', { cause: inner });
+
+    expect(isContextWindowError(outer)).toBe(true);
+  });
+
   it('does not misclassify an unrelated error as a context-window violation', () => {
     expect(isContextWindowError(new Error('rate limit exceeded'))).toBe(false);
   });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -23,12 +23,14 @@ import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 
 // Local imports - common errors
 import {
+  attachContextWindowError,
   attachProviderError,
   attachSdkErrorMetadata,
   attachStreamDiagnostics,
   buildErrorLogData,
   formatProviderHttpError,
   getSdkErrorMessage,
+  isContextWindowError,
   isUserAbort,
   normalizeProviderError,
   sdkErrorKindFromStatusCode,
@@ -510,6 +512,42 @@ describe('formatProviderHttpError', () => {
     const after = normalizeProviderError(error);
     expect(after.streamDiagnostics).toEqual(diagnostics);
     expect(after.statusCode).toBe(500);
+  });
+});
+
+describe('isContextWindowError', () => {
+  it('recognizes a TeXRA-internal throw via its typed marker, independent of wording', () => {
+    // ModelHandler.validateTokenLimits tags its own throw with
+    // attachContextWindowError() instead of relying on isContextWindowError
+    // string-matching the exact message it owns.
+    const err = new Error(
+      'Token count of message exceeds context window: 5 > 3',
+    );
+    attachContextWindowError(err);
+
+    expect(isContextWindowError(err)).toBe(true);
+  });
+
+  it('still recognizes the marker after the internal message wording changes', () => {
+    // The marker decouples classification from message text: even if
+    // ModelHandler reworks its wording entirely, the marker still matches.
+    const err = new Error('Input is too large for this model to process.');
+    attachContextWindowError(err);
+
+    expect(isContextWindowError(err)).toBe(true);
+  });
+
+  it('still matches third-party provider wording without a marker (fenced patterns)', () => {
+    expect(isContextWindowError(new Error('context length exceeded'))).toBe(
+      true,
+    );
+    expect(
+      isContextWindowError(new Error('Maximum context length is 128000.')),
+    ).toBe(true);
+  });
+
+  it('does not misclassify an unrelated error as a context-window violation', () => {
+    expect(isContextWindowError(new Error('rate limit exceeded'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Finding (round-2 APoSD audit, adversarially verified)

MED leak: `isContextWindowError` string-matched a TeXRA-internal error
message whose exact wording `ModelHandler.ts` owns. The thrower
(`ModelHandler.validateTokenLimits`, `src/agent/modelHandlers/ModelHandler.ts:1601-1604`)
and the classifier (`isContextWindowError`,
`src/common/errors/sdkError/errorPatterns.ts:35-41`) were coupled only by an
exact substring match on `"Token count of message exceeds context window: N > M"`
— a fragile self-contract. Any rewording of that internal message (e.g. for
clarity or localisation) would silently break `isContextWindowError()` for
the internal case, causing `applyTokenCountLimit`
(`ModelHandler.ts:1715-1730`) to swallow the hard-fail validation error into
the soft-failure path instead of rethrowing it, and letting
`modelHandlerOpenAIResponse.ts`'s context-compaction recovery
(`isContextWindowError(error) && this.chainState.hasPreviousResponseId()`)
silently stop firing.

Pins (both at merge base `b235d14e5`, HEAD of `origin/main` at task start):
- Throw site: `src/agent/modelHandlers/ModelHandler.ts:1601-1604`
  (`validateTokenLimits`)
- Consumer #1: `src/agent/modelHandlers/ModelHandler.ts:1719`
  (`applyTokenCountLimit`)
- Consumer #2: `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts:2110`
  (context-window recovery/compaction)
- Classifier: `src/common/errors/sdkError/errorPatterns.ts:35-41`
  (`isContextWindowError`, `CONTEXT_WINDOW_PATTERNS`)

## Fix

Stop round-tripping the internal case through the thrown `Error`'s message.
`ModelHandler.validateTokenLimits` now tags its own throw with a typed
marker (`attachContextWindowError`) at the throw site, using the existing
symbol-keyed error-metadata factory (`createErrorMetadata` in
`src/common/errors/sdkError/errorMetadata.ts`) that already backs
`attachFlowAutoRetryRequired`/`requiresFlowAutoRetry`,
`attachPartialText`/`detectPartialText`, etc. — no new error class, no new
abstraction layer, just one more instance of the pattern this file already
uses.

`isContextWindowError` now checks the marker first
(`hasContextWindowErrorMarker`, cause-chain aware like its siblings), then
falls back to the existing `CONTEXT_WINDOW_PATTERNS` string match for
third-party provider wording (Anthropic, OpenAI Responses API, Google) —
those patterns are untouched per the fencing instruction; only the comment
on the shared `'exceeds context window'` pattern was corrected (it no longer
needs to carry the internal case, since Anthropic happens to use the same
wording).

## Net elements (R6)

- **+1 exported function pair** (`attachContextWindowError` /
  `hasContextWindowErrorMarker`) — both are one-line calls into the
  **existing** `createErrorMetadata` factory already instantiated 4x in the
  same file; no new factory, class, or port introduced.
- **0 new files.**
- **Net LOC**: +86 / −4 across 5 files, but the actual production-code delta
  is a ~24-line addition to `errorMetadata.ts` (mirroring an existing
  pattern) + a 4-line tag-at-throw-site change in `ModelHandler.ts` + an
  ~8-line marker-check addition in `errorPatterns.ts`. The bulk of the diff
  (38 lines) is the new regression test.

## Consumer counts (R8)

- `attachContextWindowError`: 1 caller (`ModelHandler.validateTokenLimits`)
  + 1 test call site. Not extracted for reuse across multiple callers —
  it's the single typed tag at the single TeXRA-internal throw site named in
  the finding. (The similarly-shaped `applyTokenCountFailureFallback` throw
  in `modelHandlerOpenAIResponse.ts:1338` is a distinct message/thrower not
  named by this finding and is left as-is — out of scope for a minimal fix.)
- `hasContextWindowErrorMarker`: 1 caller (`isContextWindowError`), mirrors
  `requiresFlowAutoRetry`'s existing single-caller shape in the same file.
- `isContextWindowError` itself: unchanged consumer count (2 call sites,
  both pinned above) — this PR only changes what feeds it, not who calls it.

## Regression tests

Extended `src/test-kernel/common/SdkErrorUtils.vitest.mts` with a new
`describe('isContextWindowError', …)` block (4 cases):
1. Marker attached to an error carrying the *current* internal wording →
   recognized.
2. Marker attached to an error with the internal wording *changed entirely*
   → still recognized (the actual regression story: proves detection no
   longer depends on the message text).
3. No marker, third-party provider wording (`'context length exceeded'`,
   `'Maximum context length is 128000.'`) → still recognized (fenced
   patterns untouched).
4. Unrelated error → not misclassified.

Proven to fail pre-fix: ran the test file against unmodified `origin/main`
(before adding `attachContextWindowError`/marker check) — cases 1 and 2
failed with `TypeError: attachContextWindowError is not a function` (2
failed / 45 passed). After the fix, all 4 new cases plus the full existing
47-case file pass.

## Verification

- `npx vitest run src/test-kernel/common/SdkErrorUtils.vitest.mts
  src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts` — 52
  passed.
- `npx vitest run src/test-kernel/agent/modelHandlers src/test-kernel/modelHandlers
  src/test-kernel/common` — 537 passed, 4 skipped (pre-existing skips,
  unrelated).
- `npm run typecheck` (root `tsc --noEmit`, test-kernel project, `texra`,
  `@texra-ai/cli`, `@texra/trace-viewer`, `@texra/desktop`) — clean, exit 0.
- `npx prettier --check` on all touched files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how context-window errors are classified on token-count and OpenAI Responses recovery paths; a bug could wrongly soft-fail oversized prompts or skip compaction recovery, though behavior is intended to stay the same with safer detection.
> 
> **Overview**
> **Decouples TeXRA-internal context-window detection from error message text.** `ModelHandler.validateTokenLimits` now calls `attachContextWindowError` on the hard-fail throw, and `isContextWindowError` checks that symbol-keyed marker (including wrapped `cause` chains) before falling back to existing third-party `CONTEXT_WINDOW_PATTERNS`.
> 
> New helpers `attachContextWindowError` / `hasContextWindowErrorMarker` follow the same `createErrorMetadata` pattern as flow-auto-retry and partial-text markers; they are re-exported from `sdkErrorUtils`. Regression tests cover marker detection, wording changes, provider patterns, cause chains, and negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7a1e0d2c5bad937a6a8dc00bf53a6c513494cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->