### PR TITLE
fix(tools): wake WAITING parent on background bash delivery

### DIFF
--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -3,7 +3,11 @@ import { strict as assert } from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
 
 // Local imports - tests
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
+import {
+  clearStreamStatusForTest,
+  seedStreamStatusForTest,
+} from '@test/helpers/streamStatusTestUtils';
 
 // Local imports - agent core
 import {
@@ -46,7 +50,7 @@ import type { SdkToolCall } from '@agent/types/IModelHandler';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import type { StreamTabId } from '@shared/schemas';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { BashTool } from '@tools/bash';
 import { TaskRunFileService } from '@utils/files';
@@ -469,6 +473,70 @@ describe('BashTool', () => {
       /<output-elided>[\d,]+ characters elided<\/output-elided>/,
       'Delivered follow-up should note how many characters sit between head and tail',
     );
+  });
+
+  it('wakes a WAITING parent stream when a background bash run completes', async () => {
+    // Regression: background bash delivery used a bespoke sendFollowUp call
+    // with no wake step, so a parent suspended WAITING on the job never
+    // resumed — every other child-run type routes through the shared
+    // wake-aware deliverChildRunFollowUp path. Prove the wake actually fires
+    // by asserting the host resume port gets invoked once the run completes.
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: true,
+      stdout: 'done\n',
+      stderr: '',
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    const parentStreamId = 'bash-tool-bg-wake-parent' as StreamTabId;
+    const tryResumeStream = vi.fn().mockResolvedValue(true);
+    await installPlatform(
+      {
+        workspacePath: '/workspace',
+        config: { 'texra.toolUse.requireBashApproval': false },
+      },
+      { agentResume: { tryResumeStream } },
+    );
+    seedStreamStatusForTest(
+      defaultSession().status,
+      parentStreamId,
+      STREAM_STATUS.WAITING,
+    );
+
+    const { host } = createRecordingHost();
+    const bashTool = new BashTool();
+    const recorded = recordSessionEvents(defaultSession().events);
+
+    try {
+      const launchResult = await withToolEnvironment(
+        {
+          run: { runtimeHost: host, streamId: parentStreamId },
+          call: { tracker: new FileInteractionState() },
+        },
+        () =>
+          bashTool.call({
+            command: 'make build',
+            run_in_background: true,
+          }),
+      );
+      assert.equal(launchResult.status, 'executed');
+
+      // The background run's completion must queue the follow-up AND wake
+      // the WAITING parent through the host resume port — not just queue it
+      // for the parent to notice on its own.
+      await vi.waitFor(() => {
+        assert.ok(
+          tryResumeStream.mock.calls.length > 0,
+          'Background bash completion should wake the WAITING parent stream',
+        );
+      });
+      assert.equal(tryResumeStream.mock.calls[0]?.[0], parentStreamId);
+    } finally {
+      recorded.detach();
+      clearStreamStatusForTest(defaultSession().status, parentStreamId);
+      defaultSession().followUps.release(parentStreamId);
+    }
   });
 
   it('accepts optional command descriptions without passing them to the shell', async () => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,7 +23,6 @@ import {
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import {
   deriveRunOutcome,
   projectRunOutcome,
@@ -35,6 +34,7 @@ import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import { requireRunStream } from '@tools/contextHelpers';
+import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -345,25 +345,29 @@ export class BashTool extends defineTool({
     };
 
     const deliverParentFollowUp = async (text: string): Promise<void> => {
-      const result = await sendFollowUp(
-        parentStreamId,
-        {
-          text,
-          origin: 'subagent_result',
-        },
-        undefined,
-        undefined,
-        runSession,
-      );
-      if (result.status === 'no_session') {
+      // Route through the shared wake-aware delivery path — a parent
+      // suspended WAITING on this background job must be resumed, not left
+      // to sit until something else wakes it (see deliverChildRunFollowUp).
+      const delivery = await deliverChildRunFollowUp({
+        targetStreamId: parentStreamId,
+        followUp: { text, origin: 'subagent_result' },
+        session: runSession,
+        wake: true,
+      });
+      if (delivery.kind === 'no_session') {
         logger.debug(
           'Background bash follow-up dropped: parent stream has no active session.',
           {
             data: {
               parentStreamId,
-              streamStatus: result.streamStatus ?? 'unknown',
+              streamStatus: delivery.streamStatus ?? 'unknown',
             },
           },
+        );
+      } else if (delivery.kind === 'dropped') {
+        logger.warn(
+          'Background bash follow-up dropped: parent stream is gone and could not be resumed.',
+          { data: { parentStreamId } },
         );
       }
     };


### PR DESCRIPTION
## Problem

`src/tools/bash.ts` delivered background bash results to the parent stream
through a bespoke `deliverParentFollowUp` helper that called `sendFollowUp`
directly and never followed up with a wake. Every other child-run type
(`delegate_agent`/`delegate_workflow` via `DelegationTools.ts`,
`subagentExecution.ts`, and the native/agent-CLI `childRunLoop.ts` turn
delivery) routes through the shared `deliverChildRunFollowUp` helper in
`src/tools/childRunDelivery.ts`, which enqueues the follow-up **and**, when
`wake: true`, calls `wakeOrReleaseQueuedStream` → the host `agentResume` port
to resume a parent that's suspended `WAITING` (or has gone `children_running`)
so the queued item is actually drained.

Background bash skipped that second step. A parent stream suspended `WAITING`
on a `run_in_background: true` bash job got its result silently queued but
was never resumed — it would sit until something unrelated happened to poke
the stream (a user action, another child's wake, etc.), which for a
long-running background build is exactly the case a parent is most likely to
suspend waiting for.

## Fix

Deepen the existing owner instead of adding a new path: route background
bash's parent delivery through `deliverChildRunFollowUp({ ..., wake: true })`,
the same helper `DelegationTools.ts`/`subagentExecution.ts`/`childRunLoop.ts`
already use. Deleted the bespoke `sendFollowUp` call and its now-redundant
`no_session` handling in favor of the shared helper's `no_session`/`dropped`
outcomes (mirroring the logging pattern in `childRunLoop.ts`'s `deliverTurn`).

The bash **child** lifecycle itself (process spawn/exit handling,
stdout/stderr buffering, `BashBackgroundSession` interrupt wiring) is
untouched — this only changes how the *result* reaches the parent.

```ts
// before
const result = await sendFollowUp(parentStreamId, { text, origin: 'subagent_result' }, undefined, undefined, runSession);
if (result.status === 'no_session') { logger.debug(...); }

// after
const delivery = await deliverChildRunFollowUp({
  targetStreamId: parentStreamId,
  followUp: { text, origin: 'subagent_result' },
  session: runSession,
  wake: true,
});
if (delivery.kind === 'no_session') { logger.debug(...); }
else if (delivery.kind === 'dropped') { logger.warn(...); }
```

## Regression test

Added `wakes a WAITING parent stream when a background bash run completes` to
`src/test-kernel/tools/BashTool.vitest.ts`: seeds the parent stream status to
`WAITING`, installs a fake `agentResume.tryResumeStream` spy, launches a
`run_in_background: true` bash call, and asserts `tryResumeStream` is invoked
for the parent stream once the (mocked) process completes.

Verified failing pre-fix by reverting only `src/tools/bash.ts` via
`git diff > patch; git checkout -- src/tools/bash.ts` (no `git stash`), rerunning:

```
AssertionError: Background bash completion should wake the WAITING parent stream
- Expected: true
+ Received: false
```

then restoring the fix with `git apply patch` and confirming green.

## Net elements (R6)

- 0 new files, 0 new exported symbols, 0 new abstractions.
- `-1` bespoke delivery path (bash.ts's inline `sendFollowUp` call + its
  partial `no_session`-only handling) deleted from `bash.ts`.
- `bash.ts` now imports `deliverChildRunFollowUp` (already-existing shared
  helper) instead of `sendFollowUp` directly — net import count in the file
  unchanged (swap, not addition).
- Net diff: `+15/-11` in `src/tools/bash.ts` (mostly the added `dropped`
  branch that mirrors `childRunLoop.ts`'s existing handling — no new
  behavior invented, just parity with the sibling delivery site).

## Consumer counts (R8)

`deliverChildRunFollowUp` (`src/tools/childRunDelivery.ts`) callers, before → after:

- Before: `DelegationTools.ts`, `delegation/subagentExecution.ts`,
  `agent/runtime/childRunLoop.ts` (3 callers).
- After: + `tools/bash.ts` (4 callers).

This is deepening an existing multi-caller owner, not introducing a
single-caller extraction — `deliverChildRunFollowUp` already had 3 call
sites before this change.

## Verified

- Read `src/tools/bash.ts` (full file, both foreground/background paths).
- Read `src/tools/childRunDelivery.ts` (the shared helper, its
  `no_session`/`dropped`/`delivered` outcomes).
- Read `src/agent/runtime/childRunLoop.ts`'s `deliverTurn` (the closest
  sibling wake-aware delivery site) to mirror its `no_session`/`dropped`
  logging.
- Read `src/tools/DelegationTools.ts`'s existing `deliverChildRunFollowUp`
  callers for the parameter shape (`targetStreamId`/`followUp`/`session`/`wake`).
- Read `src/agent/followUp/ToolUseFollowUp.ts` (`sendFollowUp`,
  `wakeQueuedFollowUpStream`, `wakeOrReleaseQueuedStream`) to confirm the wake
  mechanics (`agentResume.tryResumeStream`) that were missing pre-fix.
- Read `src/test-kernel/tools/BashTool.vitest.ts` (existing background-bash
  test using `sendFollowUp` spy) and
  `src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts` (WAITING-parent
  wake test patterns) to model the new regression test on established
  conventions (`seedStreamStatusForTest`, `installPlatform` with
  `agentResume` override).
- Confirmed no other production call site in `src/tools` still calls
  `sendFollowUp` directly for a background-style child delivery that should
  route through `deliverChildRunFollowUp` (the remaining direct
  `sendFollowUp` callers — `DelegationTools.ts`'s resumed-instruction framing,
  `childRunDelivery.ts` itself, `inquiryContinuation.ts`, and
  `StreamSubscriptionRegistry.ts` — are pre-existing, non-child-result paths
  outside this finding's scope).

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent stream resume and follow-up delivery for background bash; behavior change is narrow but affects long-running parent waits.
> 
> **Overview**
> Background bash completion now delivers parent follow-ups through **`deliverChildRunFollowUp`** with **`wake: true`**, matching delegation, subagent, and child-run-loop paths. That enqueues the result and resumes a parent stream stuck in **`WAITING`** via the host **`agentResume`** port instead of only queuing the message.
> 
> **`deliverParentFollowUp`** in `bash.ts` drops the direct **`sendFollowUp`** call and handles shared **`no_session`** / **`dropped`** outcomes (including a warn on dropped), without changing spawn, buffering, or child-stream lifecycle.
> 
> A regression test seeds the parent as **`WAITING`**, runs **`run_in_background: true`**, and asserts **`tryResumeStream`** is called for the parent when the mocked job finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 581f9e7b7ca4b7c01f47da4927708ea703bdcda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->