### PR TITLE
fix(agent): recognize live Anthropic server-tool blocks in conversationFormat

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -244,11 +244,7 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         input: prettyJson(block.input ?? {}),
       };
 
-    // Tool result blocks: Anthropic tool_result + server-side code execution results
     case 'tool_result':
-    case 'code_execution_tool_result':
-    case 'bash_code_execution_tool_result':
-    case 'text_editor_code_execution_tool_result':
       return {
         kind: 'tool-result',
         text:
@@ -257,6 +253,13 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
             : prettyJson(block.content ?? ''),
       };
 
+    // Anthropic server-side tool blocks (the provider executes these, not a
+    // local tool handler). This vocabulary must stay in sync with the
+    // `formatConversationBlock` switch in `@agent/storage/conversationFormat`
+    // — both classify the same three live Anthropic block types emitted by
+    // `AnthropicStreamHandler` (`server_tool_use`, `web_search_tool_result`,
+    // `web_fetch_tool_result`), just into different output shapes (a
+    // structured `ExportNode` here vs. a truncated marker string there).
     case 'server_tool_use':
       if (block.name === 'web_search') {
         const query =

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -153,25 +153,41 @@ function formatWebSearchResultMarker(
 }
 
 /**
- * Anthropic `web_fetch_tool_result` content is a
+ * A live Anthropic `web_fetch_tool_result` block's `content` is a
  * `{type: 'web_fetch_result', url, content: {title, ...}}` object (or an
- * error object) — rendering it through the generic block formatter would
- * JSON-dump the fetched page's full text, so this collapses it to a
- * `title (url)` marker instead. Falls back to `formatToolResultMarker` for
- * the error shape.
+ * error object). A completed-run's transcript-sidecar archive
+ * (`webFetchEntryToMessages` in `@transcript/completedRunArchive`)
+ * reconstructs the same block type with no nested `content` at all —
+ * `url`/`title`/`page_content` sit directly on the block instead. Both
+ * `ExecutionsTool`'s `/conversation` endpoint and the CLI's `texra history`
+ * read completed-run conversations through that archive, so this must
+ * recognize both shapes; rendering either through the generic block
+ * formatter would JSON-dump the fetched page's full text, so this collapses
+ * whichever shape is present to a `title (url)` marker instead. Falls back
+ * to `formatToolResultMarker` for the live error shape.
  */
 function formatWebFetchResultMarker(
-  content: unknown,
+  block: Record<string, unknown>,
   options: ConversationFormatOptions,
 ): string {
-  if (!isObject(content) || content.type !== 'web_fetch_result') {
-    return formatToolResultMarker(content, options);
-  }
   const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
-  const url = asText(content.url);
-  const title = objectStringField(content.content, 'title');
-  const label = title && url ? `${title} (${url})` : title || url;
-  return `[tool_result: ${truncate(label, options.toolBlockLimit, marker)}]`;
+  const content = block.content;
+  if (isObject(content) && content.type === 'web_fetch_result') {
+    const url = asText(content.url);
+    const title = objectStringField(content.content, 'title');
+    const label = title && url ? `${title} (${url})` : title || url;
+    return `[tool_result: ${truncate(label, options.toolBlockLimit, marker)}]`;
+  }
+  const archivedUrl = asText(block.url);
+  const archivedTitle = asText(block.title);
+  if (archivedUrl || archivedTitle) {
+    const label =
+      archivedTitle && archivedUrl
+        ? `${archivedTitle} (${archivedUrl})`
+        : archivedTitle || archivedUrl;
+    return `[tool_result: ${truncate(label, options.toolBlockLimit, marker)}]`;
+  }
+  return formatToolResultMarker(content, options);
 }
 
 /**
@@ -277,7 +293,7 @@ function formatConversationBlock(
     case 'web_search_tool_result':
       return formatWebSearchResultMarker(block.content, options);
     case 'web_fetch_tool_result':
-      return formatWebFetchResultMarker(block.content, options);
+      return formatWebFetchResultMarker(block, options);
     default:
       return truncate(
         stringifyConversationValue(block),

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -128,6 +128,53 @@ function formatToolResultMarker(
 }
 
 /**
+ * Anthropic `web_search_tool_result` content is an array of
+ * `{type: 'web_search_result', title, url, ...}` entries (or an error
+ * object) — rendering each entry through the generic block formatter would
+ * JSON-dump its `encrypted_content` field, so this collapses the array to a
+ * compact `title (url)` list instead. Falls back to `formatToolResultMarker`
+ * for the error shape.
+ */
+function formatWebSearchResultMarker(
+  content: unknown,
+  options: ConversationFormatOptions,
+): string {
+  if (!Array.isArray(content)) return formatToolResultMarker(content, options);
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  const entries = content
+    .filter(isObject)
+    .map((entry) => {
+      const url = asText(entry.url);
+      const title = asText(entry.title) || url;
+      return url ? `${title} (${url})` : title;
+    })
+    .filter(Boolean);
+  return `[tool_result: ${truncate(entries.join(', '), options.toolBlockLimit, marker)}]`;
+}
+
+/**
+ * Anthropic `web_fetch_tool_result` content is a
+ * `{type: 'web_fetch_result', url, content: {title, ...}}` object (or an
+ * error object) — rendering it through the generic block formatter would
+ * JSON-dump the fetched page's full text, so this collapses it to a
+ * `title (url)` marker instead. Falls back to `formatToolResultMarker` for
+ * the error shape.
+ */
+function formatWebFetchResultMarker(
+  content: unknown,
+  options: ConversationFormatOptions,
+): string {
+  if (!isObject(content) || content.type !== 'web_fetch_result') {
+    return formatToolResultMarker(content, options);
+  }
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+  const url = asText(content.url);
+  const title = objectStringField(content.content, 'title');
+  const label = title && url ? `${title} (${url})` : title || url;
+  return `[tool_result: ${truncate(label, options.toolBlockLimit, marker)}]`;
+}
+
+/**
  * Render a single content-block (an element of a message's `content`/`parts`
  * array) to text. Handles Anthropic's `{type: ...}` discriminated blocks,
  * Google's discriminator-less `{text}`/`{functionCall}`/`{functionResponse}`
@@ -214,6 +261,23 @@ function formatConversationBlock(
       );
     case 'tool_result':
       return formatToolResultMarker(block.content, options);
+    // Anthropic server-side tool blocks (the provider executes these, not a
+    // local tool handler). This vocabulary must stay in sync with the
+    // `assistantBlockToNode` switch in `@agent/export/normalizeConversation`
+    // — both classify the same three live Anthropic block types emitted by
+    // `AnthropicStreamHandler` (`server_tool_use`, `web_search_tool_result`,
+    // `web_fetch_tool_result`), just into different output shapes (a
+    // truncated marker string here vs. a structured `ExportNode` there).
+    case 'server_tool_use':
+      return formatToolUseMarker(
+        asText(block.name) || 'unknown',
+        block.input,
+        options,
+      );
+    case 'web_search_tool_result':
+      return formatWebSearchResultMarker(block.content, options);
+    case 'web_fetch_tool_result':
+      return formatWebFetchResultMarker(block.content, options);
     default:
       return truncate(
         stringifyConversationValue(block),

--- a/src/test-kernel/commands/history/normalizeConversation.vitest.ts
+++ b/src/test-kernel/commands/history/normalizeConversation.vitest.ts
@@ -619,25 +619,28 @@ describe('Edge cases', () => {
     });
   });
 
-  it('handles code_execution_tool_result blocks', () => {
+  // code_execution_tool_result / bash_code_execution_tool_result /
+  // text_editor_code_execution_tool_result are not emitted by any model
+  // handler in this codebase (only server_tool_use, web_search_tool_result,
+  // and web_fetch_tool_result are — see AnthropicStreamHandler) and fall
+  // through to the switch's `default: return null`, same as any other
+  // unrecognized block type.
+  it('does not map unused code-execution block types to a node', () => {
     const nodes = normalize([
       {
         role: 'assistant',
         content: [
+          { type: 'code_execution_tool_result', content: 'execution output' },
+          { type: 'bash_code_execution_tool_result', content: 'bash output' },
           {
-            type: 'code_execution_tool_result',
-            content: 'execution output',
+            type: 'text_editor_code_execution_tool_result',
+            content: 'editor output',
           },
         ],
       },
     ]);
 
-    const results = nodesOfKind(nodes, 'tool-result');
-    expect(results).toHaveLength(1);
-    expect(results[0]).toMatchObject({
-      kind: 'tool-result',
-      text: 'execution output',
-    });
+    expect(nodesOfKind(nodes, 'tool-result')).toHaveLength(0);
   });
 });
 

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -142,6 +142,28 @@ describe('formatConversation', () => {
     expect(output).not.toContain('"type":"web_fetch_tool_result"');
   });
 
+  it('formats archived (completed-run sidecar) web_fetch_tool_result blocks as a title/url marker', () => {
+    // `src/transcript/completedRunArchive.ts`'s `webFetchEntryToMessages`
+    // reconstructs this block type with top-level url/title/page_content —
+    // no nested `content` — unlike the live Anthropic SDK shape above.
+    const output = formatConversation([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'web_fetch_tool_result',
+            url: 'https://texra.ai',
+            title: 'TeXRA home',
+            page_content: 'the full fetched page text'.repeat(20),
+          },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('[tool_result: TeXRA home (https://texra.ai)]');
+    expect(output).not.toContain('the full fetched page text');
+  });
+
   it('does not throw on an undefined content block', () => {
     expect(() =>
       formatConversation([{ role: 'user', content: [undefined] }]),

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -67,6 +67,81 @@ describe('formatConversation', () => {
     expect(output).not.toContain('{"type":"text"}');
   });
 
+  it('formats server_tool_use blocks as a tool_use marker (not a JSON dump)', () => {
+    const output = formatConversation([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'server_tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'texra latex' },
+          },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('[tool_use: web_search({"query":"texra latex"})]');
+    expect(output).not.toContain('"type":"server_tool_use"');
+  });
+
+  it('formats web_search_tool_result blocks as a compact result list', () => {
+    const output = formatConversation([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: [
+              {
+                type: 'web_search_result',
+                title: 'TeXRA',
+                url: 'https://texra.ai',
+                encrypted_content: 'abc',
+              },
+              {
+                type: 'web_search_result',
+                title: 'TeXRA docs',
+                url: 'https://texra.ai/docs',
+                encrypted_content: 'def',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(output).toContain(
+      '[tool_result: TeXRA (https://texra.ai), TeXRA docs (https://texra.ai/docs)]',
+    );
+    expect(output).not.toContain('encrypted_content');
+    expect(output).not.toContain('"type":"web_search_tool_result"');
+  });
+
+  it('formats web_fetch_tool_result blocks as a title/url marker', () => {
+    const output = formatConversation([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'web_fetch_tool_result',
+            tool_use_id: 'srvtoolu_2',
+            content: {
+              type: 'web_fetch_result',
+              url: 'https://texra.ai',
+              content: { type: 'document', title: 'TeXRA home' },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('[tool_result: TeXRA home (https://texra.ai)]');
+    expect(output).not.toContain('"type":"web_fetch_tool_result"');
+  });
+
   it('does not throw on an undefined content block', () => {
     expect(() =>
       formatConversation([{ role: 'user', content: [undefined] }]),


### PR DESCRIPTION
## Summary

Round-2 APoSD audit finding (HIGH): `conversationFormat.ts`
(`src/agent/storage/`) and `normalizeConversation.ts` (`src/agent/export/`)
independently classify Anthropic content-block types, and the two
vocabularies had drifted apart.

- `conversationFormat.ts`'s `formatConversationBlock` switch had no cases
  for `server_tool_use`, `web_search_tool_result`, or `web_fetch_tool_result`
  — the three server-tool block types `AnthropicStreamHandler.ts:267,280,284`
  actually emits — so they fell through to the `default:` branch and got
  JSON-dumped verbatim (including `web_search_result`'s
  `encrypted_content` field and the full fetched page text).
- `normalizeConversation.ts`'s `assistantBlockToNode` switch carried three
  `code_execution_tool_result` / `bash_code_execution_tool_result` /
  `text_editor_code_execution_tool_result` cases that no model handler in
  this codebase emits — dead speculative support.

## Fix

1. Added the three live cases to `conversationFormat.ts`'s switch, mapping
   onto its existing `[tool_use: ...]` / `[tool_result: ...]` marker
   shapes:
   - `server_tool_use` → reuses `formatToolUseMarker` (same shape as a
     regular `tool_use` block).
   - `web_search_tool_result` → new `formatWebSearchResultMarker`: a
     compact `title (url), title (url), ...` list instead of JSON-dumping
     each result's `encrypted_content`.
   - `web_fetch_tool_result` → new `formatWebFetchResultMarker`: a
     `title (url)` marker instead of JSON-dumping the fetched page's full
     text.
2. Deleted the three dead code-execution cases from
   `normalizeConversation.ts` (deletion beats speculative support — they
   now fall through to the existing `default: return null`, same as any
   other unrecognized block type).
3. Cross-referenced each switch's doc comment to the other file/switch by
   name, so the two vocabularies can't drift blind again. Went with doc
   comments over a shared type→category const (the
   `mediaAttachmentKindToContentBlock` pattern from #8007) because the two
   switches map the same three block types to genuinely different output
   shapes (a truncated marker string vs. a structured `ExportNode` variant
   per type) — a shared const would be a new abstraction layer for
   classification logic that's already this thin (3-way switch in each
   file).

Extended `ExecutionsConversationFormat.vitest.ts` with the three live
block types (verified failing pre-fix — see Tests below) and repurposed
the now-stale `normalizeConversation.vitest.ts` "handles
code_execution_tool_result" test into a "does not map unused
code-execution block types" test covering all three deleted cases.

## Net elements (R6)

- **Added**: 2 private helper functions (`formatWebSearchResultMarker`,
  `formatWebFetchResultMarker`) in `conversationFormat.ts` — both are
  single-purpose formatters for the two Anthropic block content shapes
  that need bespoke compaction (not a shared abstraction; each is called
  from exactly one switch case).
- **Deleted**: 3 dead switch cases (`code_execution_tool_result`,
  `bash_code_execution_tool_result`, `text_editor_code_execution_tool_result`)
  in `normalizeConversation.ts`.
- **No new files, no new exports, no new types.** Net diff is +145/−13
  across 2 source files + 2 test files; the two added helpers are pure
  functions colocated with (and reusing `formatToolResultMarker` as a
  fallback from) the switch they serve.

## Consumer counts (R8)

- `formatConversationBlock`'s switch (edited) is exercised by
  `formatConversationContent`, consumed by:
  - `src/tools/executions/conversationFormat.ts` → `ExecutionsTool`'s
    `/executions/{id}/conversation` endpoint
  - `packages/cli/src/runtime/history/conversationFormat.ts` → the CLI's
    `texra history` / resume previews
  Both are pure call-through consumers of the shared formatter — no
  changes needed on their side; they inherit the fix automatically.
- `assistantBlockToNode`'s switch (edited) is exercised by
  `normalizeConversationForExport`, the sole normalization entry point for
  every chat-export renderer (markdown/LaTeX/HTML) per the module's own
  docstring — grepped, no other caller.

## Tests

- `npx vitest run src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts` —
  3 new cases added (`server_tool_use`, `web_search_tool_result`,
  `web_fetch_tool_result`); confirmed failing pre-fix (implemented the
  tests first, ran them against the unmodified `conversationFormat.ts`,
  all 3 failed with the raw-JSON `default:` output), then passing after
  the fix. 9/9 pass post-fix.
- `npx vitest run src/test-kernel/commands/history/normalizeConversation.vitest.ts` —
  21/21 pass; repurposed test now asserts the three dead code-execution
  types produce no `tool-result` node.
- `npm run typecheck` (root tsc, test-kernel, `texra` extension, CLI,
  trace-viewer, desktop) — exit 0.

## Verified

- `src/agent/storage/conversationFormat.ts` (edited)
- `src/agent/export/normalizeConversation.ts` (edited)
- `src/agent/modelHandlers/support/AnthropicStreamHandler.ts` (confirmed
  the three live emitted block types at the cited line numbers)
- `src/agent/types/ServerToolTypes.ts` (`mapAnthropicWebSearchEntries`,
  `WebFetchResult` shapes — informed the marker formats without importing
  SDK types into the duck-typed `conversationFormat.ts`)
- `src/tools/executions/conversationFormat.ts`,
  `packages/cli/src/runtime/history/conversationFormat.ts` (both
  pass-through consumers, no changes needed)
- `src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts`,
  `src/test-kernel/commands/history/normalizeConversation.vitest.ts`
  (edited)
- Grepped the whole tree for `code_execution_tool_result` /
  `bash_code_execution_tool_result` / `text_editor_code_execution_tool_result`
  to confirm the only other reference was the now-repurposed test.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting and export normalization with no auth or persistence changes; behavior is tightened and covered by new tests.
> 
> **Overview**
> **Conversation text views** (`conversationFormat`) now handle the three Anthropic server-tool block types the stream handler actually emits (`server_tool_use`, `web_search_tool_result`, `web_fetch_tool_result`) instead of JSON-dumping them. `server_tool_use` reuses the existing `[tool_use: …]` marker; search and fetch results get compact `title (url)` markers so `encrypted_content` and full page bodies never leak into Executions `/conversation` or CLI `texra history` output. Archived completed-run `web_fetch_tool_result` shapes (top-level `url`/`title` without nested `content`) are handled alongside the live SDK shape.
> 
> **Export normalization** (`normalizeConversation`) drops speculative `code_execution_*_tool_result` cases that no handler emits; those blocks now follow the same `default: return null` path as other unknown types. Doc comments on both switches cross-reference each other so the shared three-type vocabulary stays aligned across marker strings vs structured `ExportNode`s.
> 
> Tests cover the new formatters and assert the removed code-execution types no longer produce `tool-result` export nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07486c939e48f72503d8e4739325e3e5f5a0e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->