### PR TITLE
fix(model-handlers): commit compaction payload and chain-anchor clear together

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -675,10 +675,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Result from compactConversation including messages and state updates.
    * State updates are returned but not applied - caller is responsible for
    * applying them only after successful API call to prevent stale state on retry.
+   *
+   * `sourceMessages` is the exact `messages` array reference compaction ran
+   * against — it's how {@link createResponseImpl} recognizes a same-turn retry
+   * (PocketFlow's `Node._exec` reuses the same `prepRes`, hence the same
+   * `messages` reference, across retry attempts) and reuses this result
+   * instead of re-running compaction. That reuse is what keeps this payload's
+   * retry lifetime matched to {@link ResponseChainState.clearChainForCompaction}'s
+   * anchor clear, which already survives retries permanently — without it, the
+   * anchor clear alone would survive while this payload got wiped every
+   * attempt, forcing a redundant re-compaction on each retry.
    */
   private compactionResult?: {
     compactedMessages: ResponseInputItem[];
     tokensAfter: number;
+    sourceMessages: ResponseInputItem[];
   };
 
   /**
@@ -855,7 +866,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Store compacted messages for use in this request.
       // Mark as pending compaction - state will be finalized after successful API call.
       // This prevents stale state if API call fails and needs retry.
-      this.compactionResult = { compactedMessages, tokensAfter };
+      this.compactionResult = { compactedMessages, tokensAfter, sourceMessages: messages };
 
       return compactedMessages;
     } catch (err) {
@@ -1005,6 +1016,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // so an output-token underestimate could let through a request the backend
       // then rejects.
       tokensAfter: this.estimateResentInputTokens(compactedMessages),
+      sourceMessages: messages,
     };
     return compactedMessages;
   }
@@ -1429,9 +1441,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
     }
 
-    // Clear any stale compaction result from previous attempts. A retained
-    // pending response is handled above before this state can be discarded.
-    this.compactionResult = undefined;
+    // Clear any stale compaction result from a genuinely different input. A
+    // same-turn retry (PocketFlow's Node._exec reuses the same prepRes, hence
+    // the same `messages` reference, across retry attempts) keeps its cached
+    // result below instead — otherwise the chain anchor that compaction
+    // already cleared on chainState (which survives retries permanently)
+    // would outlive this payload, forcing a redundant re-compaction on every
+    // retry. A retained pending response is handled above before this state
+    // can be discarded.
+    if (this.compactionResult?.sourceMessages !== messages) {
+      this.compactionResult = undefined;
+    }
 
     // Route through isBackgroundModeActive() so provider-profile policy actually
     // gates the request, not just the predicate.
@@ -1471,7 +1491,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     let compactedThisCall = false;
     // Store compacted messages for return value (captured when compaction succeeds)
     let compactedMessages: ResponseInputItem[] | undefined;
-    if (this.shouldCompact()) {
+    if (this.compactionResult?.sourceMessages === messages) {
+      // Same-turn retry of an input that already compacted successfully on a
+      // prior attempt (see the cache check above): reuse it instead of
+      // hitting the compact endpoint again. Re-running compaction here would
+      // be a silent no-op from the caller's perspective but a real, wasted
+      // API round trip, since chainState's anchor clear already committed
+      // permanently and doesn't need redoing.
+      effectiveMessages = this.compactionResult.compactedMessages;
+      compactedThisCall = true;
+      compactedMessages = this.compactionResult.compactedMessages;
+    } else if (this.shouldCompact()) {
       // Capture whether this was a manual request before clearing the flag.
       const wasManualRequest = this.compactionRequested;
       // Clear manual compaction flag now that compaction is being attempted.

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -685,6 +685,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * anchor clear, which already survives retries permanently — without it, the
    * anchor clear alone would survive while this payload got wiped every
    * attempt, forcing a redundant re-compaction on each retry.
+   *
+   * Reference equality alone cannot distinguish a same-turn retry from the
+   * next turn, since `ModelInvocationNode.post()` mutates the shared messages
+   * array in place (same reference survives across turns too). The field is
+   * therefore also cleared unconditionally by {@link applyCompactionState} on
+   * every successful call, so it can never outlive the turn it was computed
+   * for; the `sourceMessages` check only ever matters while an attempt from
+   * this same turn is still retrying after a failure.
    */
   private compactionResult?: {
     compactedMessages: ResponseInputItem[];
@@ -1054,8 +1062,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Apply compaction state updates after successful API call.
-   * Updates conversation state flags. Does NOT clear compactionResult -
-   * it's needed for the return value and gets cleared on next createResponse() call.
+   * Updates conversation state flags.
    *
    * Note: cumulativeInputTokens is NOT updated here - it will be set from
    * response.usage.input_tokens after the API call to reflect actual usage.
@@ -1070,8 +1077,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Note: the chain anchor is already cleared immediately after compaction
     // (before API call) to avoid "No tool output found" errors.
 
-    // Note: compactionResult is NOT cleared here - it's read for the return value.
-    // It gets cleared at the start of the next createResponse() call.
+    // Clear compactionResult now that this successful call has consumed it.
+    // This runs only on success (finalizeResponse's success paths), never on
+    // a failed attempt that will be retried, so it can't be confused with the
+    // same-turn-retry cache check in createResponseImpl(). Clearing here
+    // (rather than relying on `sourceMessages !== messages` reference
+    // (in)equality) matters because PocketFlow's ModelInvocationNode.post()
+    // mutates `shared.messages` in place via replaceMessagesInPlace
+    // (length=0 + push), so the array reference is often IDENTICAL across
+    // turns, not just across retries of the same turn. Leaving compactionResult
+    // set here would make the next turn's genuinely different input look like
+    // a same-turn retry, resend this turn's stale compactedMessages, and
+    // silently drop everything appended since (tool outputs, new user turns).
+    this.compactionResult = undefined;
   }
 
   /** Creates a configured OpenAI client instance. */
@@ -1453,6 +1471,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // would outlive this payload, forcing a redundant re-compaction on every
     // retry. A retained pending response is handled above before this state
     // can be discarded.
+    //
+    // This reference check alone is NOT sufficient to distinguish a same-turn
+    // retry from the next turn, because PocketFlow's ModelInvocationNode.post()
+    // mutates `shared.messages` in place, so the reference is often identical
+    // across turns too. The primary guard against cross-turn reuse is
+    // applyCompactionState() clearing compactionResult on every successful
+    // call; this line only ever matters while a compaction from a still-in-
+    // flight (unsuccessful) attempt is pending.
     if (this.compactionResult?.sourceMessages !== messages) {
       this.compactionResult = undefined;
     }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -866,7 +866,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Store compacted messages for use in this request.
       // Mark as pending compaction - state will be finalized after successful API call.
       // This prevents stale state if API call fails and needs retry.
-      this.compactionResult = { compactedMessages, tokensAfter, sourceMessages: messages };
+      this.compactionResult = {
+        compactedMessages,
+        tokensAfter,
+        sourceMessages: messages,
+      };
 
       return compactedMessages;
     } catch (err) {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -294,6 +294,104 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     expect(result.updatedMessages).toEqual(compactedMessages);
   });
 
+  it('does not reuse a stale compaction across a genuinely new turn that keeps the same messages array reference', async () => {
+    // Unlike the two synthetic test helpers above (which pass a fresh array
+    // per turn), PocketFlow's ModelInvocationNode.post() mutates
+    // `shared.messages` IN PLACE (replaceMessagesInPlace: length=0 + push),
+    // so the array reference is typically IDENTICAL across turns, not just
+    // across retries of one turn. Keying compaction-result reuse on
+    // `sourceMessages === messages` alone would therefore also match the next
+    // turn and resend the stale post-compaction payload, silently dropping
+    // whatever was appended since (see cursor[bot]/codex[bot] review on this
+    // PR). This test drives the handler the way the real flow does: one
+    // array object, mutated across three turns.
+    const handler = createHandler();
+    const requests: any[] = [];
+    const compactRequests: any[] = [];
+    const compactedMessages = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'compacted state' }],
+      },
+    ] as unknown as ResponseInputItem[];
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => ({ input_tokens: 100 }),
+        },
+        compact: async (params: any) => {
+          compactRequests.push(params);
+          return {
+            output: compactedMessages,
+            usage: { output_tokens: 100 },
+          };
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          if (requests.length === 1) return createResponse('resp-turn1', 800);
+          if (requests.length === 2)
+            return createResponse('resp-turn2-compacted', 150);
+          return createResponse('resp-turn3', 160);
+        },
+      },
+    };
+
+    // One shared array, exactly as `shared.messages` is across the real
+    // PocketFlow cycle.
+    const sharedMessages = createMessages(2);
+
+    // Turn 1: below threshold, no compaction.
+    await handler.createResponse({
+      client: client as any,
+      messages: sharedMessages,
+      temperature: 0,
+    });
+
+    // Turn 2 begins: a new message arrives, appended onto the SAME array
+    // (mirrors ToolUseDispatchNode / a new user turn `.push()`-ing onto
+    // `shared.messages`).
+    const turn2NewMessage = { role: 'user', content: 'message 3' };
+    sharedMessages.push(turn2NewMessage as ResponseInputItem);
+
+    // Turn 1's response crossed the compaction threshold (800 > 750), so
+    // turn 2 compacts.
+    const turn2Result = await handler.createResponse({
+      client: client as any,
+      messages: sharedMessages,
+      temperature: 0,
+    });
+    expect(compactRequests).toHaveLength(1);
+    expect(turn2Result.updatedMessages).toEqual(compactedMessages);
+
+    // Mirror ModelInvocationNode.post(): replaceMessagesInPlace mutates the
+    // SAME array object to hold the compacted content instead of replacing
+    // the reference.
+    sharedMessages.length = 0;
+    sharedMessages.push(...(turn2Result.updatedMessages ?? []));
+
+    // Turn 3 begins: another message arrives, appended onto the SAME array
+    // object turn 1 and turn 2 both used.
+    const turn3NewMessage = { role: 'user', content: 'message 4' };
+    sharedMessages.push(turn3NewMessage as ResponseInputItem);
+
+    // Turn 2's response (150 tokens) is well under threshold, so turn 3 must
+    // NOT compact again and must send only what's new since the chain
+    // anchor (the single message appended after turn 2), not turn 2's stale
+    // compacted payload.
+    const turn3Result = await handler.createResponse({
+      client: client as any,
+      messages: sharedMessages,
+      temperature: 0,
+    });
+
+    expect(compactRequests).toHaveLength(1);
+    expect(requests).toHaveLength(3);
+    expect(requests[2].previous_response_id).toBe('resp-turn2-compacted');
+    expect(requests[2].input).toEqual([turn3NewMessage]);
+    expect(turn3Result.updatedMessages).toBeUndefined();
+  });
+
   it('does not call the Responses compact endpoint when compaction is unsupported', async () => {
     const handler = createUnsupportedCompactionHandler();
     const requests: any[] = [];
@@ -344,6 +442,12 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     const requests: any[] = [];
     const compactRequests: any[] = [];
     const streamRequests: any[] = [];
+    // compactionResult is only populated between the compaction call and this
+    // turn's own finalizeResponse() (which clears it on success so it can
+    // never leak into a later turn - see createResponseImpl). Snapshot it
+    // from inside the outer `create()` mock, the one point still inside that
+    // window, rather than reading it back after `createResponse()` resolves.
+    let tokensAfterDuringCall: number | undefined;
     const client = {
       responses: {
         compact: async (params: any) => {
@@ -368,6 +472,13 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
         },
         create: async (params: any) => {
           requests.push(params);
+          if (requests.length === 2) {
+            tokensAfterDuringCall = (
+              handler as unknown as {
+                compactionResult?: { tokensAfter: number };
+              }
+            ).compactionResult?.tokensAfter;
+          }
           return requests.length === 1
             ? createResponse('resp-before-threshold', 800)
             : createResponse('resp-after-client-side-compaction', 150);
@@ -419,15 +530,15 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     // back to a text-length estimate over exactly what gets resent.
     const resentText =
       '[Previous conversation summary]\n\nconcise summary of the prior turns';
-    const compactionResult = (
-      handler as unknown as {
-        compactionResult?: { tokensAfter: number };
-      }
-    ).compactionResult;
-    expect(compactionResult?.tokensAfter).toBe(
-      estimateTokensFromText(resentText),
-    );
-    expect(compactionResult?.tokensAfter).not.toBe(42);
+    expect(tokensAfterDuringCall).toBe(estimateTokensFromText(resentText));
+    expect(tokensAfterDuringCall).not.toBe(42);
+
+    // And after the successful call, compactionResult must NOT survive into
+    // a later turn (see the same-turn-retry-vs-next-turn regression test
+    // above) - applyCompactionState() clears it unconditionally on success.
+    expect(
+      (handler as unknown as { compactionResult?: unknown }).compactionResult,
+    ).toBeUndefined();
   });
 
   it('bounds the summary on Codex by aborting the stream once the client-side cap is reached (#7213)', async () => {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -217,6 +217,83 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     expect(result.updatedMessages).toEqual(compactedMessages);
   });
 
+  it('reuses a successful compaction across a same-turn retry instead of re-compacting (chain-anchor/payload commit race)', async () => {
+    // PocketFlow's Node._exec retries a failed exec() with the identical
+    // prepRes, so a same-turn retry resends the exact same `messages` array
+    // reference. Compaction's chain-anchor clear (on ResponseChainState)
+    // commits immediately and survives that retry permanently; its computed
+    // payload (compactionResult) must now survive the same retry too, or the
+    // retry silently redoes the compact() call for no reason.
+    const handler = createHandler();
+    const requests: any[] = [];
+    const compactRequests: any[] = [];
+    const compactedMessages = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'compacted state' }],
+      },
+    ] as unknown as ResponseInputItem[];
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => ({ input_tokens: 100 }),
+        },
+        compact: async (params: any) => {
+          compactRequests.push(params);
+          return {
+            output: compactedMessages,
+            usage: { output_tokens: 100 },
+          };
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          if (requests.length === 1) {
+            return createResponse('resp-before-threshold', 800);
+          }
+          if (requests.length === 2) {
+            // The request that follows a successful compaction fails once,
+            // forcing a same-turn retry with the same `messages` reference.
+            throw new Error('transient network failure');
+          }
+          return createResponse('resp-after-compaction', 150);
+        },
+      },
+    };
+    const firstTurnMessages = createMessages(2);
+    const secondTurnMessages = createMessages(3);
+
+    await handler.createResponse({
+      client: client as any,
+      messages: firstTurnMessages,
+      temperature: 0,
+    });
+
+    await expect(
+      handler.createResponse({
+        client: client as any,
+        messages: secondTurnMessages,
+        temperature: 0,
+      }),
+    ).rejects.toThrow('transient network failure');
+
+    // Same-turn retry: identical `messages` reference as the failed attempt.
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: secondTurnMessages,
+      temperature: 0,
+    });
+
+    // The /responses/compact endpoint must be hit only once across both
+    // attempts — the retry reuses the already-computed compaction instead of
+    // silently redoing it.
+    expect(compactRequests).toHaveLength(1);
+    expect(requests).toHaveLength(3);
+    expect(requests[2].previous_response_id).toBeUndefined();
+    expect(requests[2].input).toEqual(compactedMessages);
+    expect(result.updatedMessages).toEqual(compactedMessages);
+  });
+
   it('does not call the Responses compact endpoint when compaction is unsupported', async () => {
     const handler = createUnsupportedCompactionHandler();
     const requests: any[] = [];


### PR DESCRIPTION
## Problem

`ModelHandlerOpenAIResponse.compactConversation()` / `compactConversationClientSide()`
commit two things when compaction succeeds:

1. **The chain anchor** — `chainState.clearChainForCompaction()` nulls
   `previousResponseId` on `ResponseChainState` (`src/agent/modelHandlers/openai/ResponseChainState.ts`).
   This is a handler-lifetime field, so once cleared it stays cleared across
   any later retry within the same turn.
2. **The computed payload** — `this.compactionResult` (compacted messages +
   token estimate), a handler field the caller reads to build the outer
   `create()` request.

`createResponseImpl()` (`src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts:1444` pre-fix)
unconditionally wiped `this.compactionResult` at the top of every call:

```ts
// Clear any stale compaction result from previous attempts. ...
this.compactionResult = undefined;
```

PocketFlow's `Node._exec` (`src/agent/node/index.ts:172`) retries a failed
`exec()` with the *same* `prepRes`, so `ModelInvocationNode.exec()`
(`src/agent/core/flows/ModelInvocationNode.ts:128`) resends the identical
`messages` array reference on a same-turn retry. On that retry the anchor
clear (#1) had already committed permanently on `chainState`, but the payload
(#2) had just been thrown away — and `chainState.cumulativeInputTokens` is
only updated from a *successful* response (`finalizeResponse`, line ~555), so
`shouldCompact()` still reads the pre-compaction count and returns `true`
again. The handler silently redid the whole `/responses/compact` round trip
for input it had already compacted, purely because the payload's retry
lifetime didn't match the anchor mutation's.

## Fix

Key `compactionResult` to the exact `messages` reference it was computed
from (`sourceMessages`). `createResponseImpl()` now only discards a cached
result when the call's `messages` is a genuinely different reference (a new
turn), and reuses it directly — skipping the network round trip — when it's
the same reference (a same-turn retry). This makes the anchor clear and the
payload commit/survive together instead of diverging.

No new abstraction: `ResponseChainState` and `compactionResult` are the
existing owners: the payload is now trivially “this call's input” which is
already how PocketFlow's own retry model treats `prepRes.messages`.

## Regression test

`src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts` —
new case *"reuses a successful compaction across a same-turn retry instead of
re-compacting (chain-anchor/payload commit race)"*: turn 2 crosses the
compaction threshold, compacts successfully, then the outer `create()` call
fails once (simulating a transient error) forcing exactly the same
`messages` array to be retried. Asserts `/responses/compact` is invoked
exactly once across both attempts.

Verified failing pre-fix (`git checkout` on the production file only, test
kept): `compactRequests` had length 2 instead of 1. Re-applied the fix and
reran — passes.

## Net elements (R6)

- 0 new files, 0 new classes/functions.
- +1 field (`sourceMessages`) on the existing `compactionResult` object
  literal type in both `compactConversation()` and
  `compactConversationClientSide()`.
- 1 unconditional wipe → 1 conditional wipe (same call site).
- 1 new `if` branch in the existing `shouldCompact()` dispatch (reuse path),
  no new method.
- Net diff: +35/-5 in production code, +77 lines of test.

## Consumer counts (R8)

- `compactionResult` field: 2 producers (`compactConversation`,
  `compactConversationClientSide`), 5 pre-existing readers within the same
  class (`getBestInputTokenEstimate`, the background-resume context builder,
  `createResponseImpl`'s reuse/wipe logic, `applyCompactionState`) — all
  private to `ModelHandlerOpenAIResponse`; no other file reads this field, so
  widening its shape is confined to one class.
- `ResponseChainState.clearChainForCompaction()`: 2 callers, both in this
  same file — unchanged by this PR.

## Verified

- `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts` — the fix.
- `src/agent/modelHandlers/openai/ResponseChainState.ts` — confirmed
  `clearChainForCompaction()` is the permanent, cross-retry mutation this fix
  reconciles the payload's lifetime with.
- `src/agent/node/index.ts` — confirmed `Node._exec` retries `exec(prepRes)`
  with the same `prepRes` object across attempts.
- `src/agent/core/flows/ModelInvocationNode.ts` — confirmed `exec()` passes
  `prepRes.messages` straight through to `createResponse()`, so the retry
  reuses the identical array reference.
- `src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts` —
  existing coverage + new regression test.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conversation compaction and request input selection in the OpenAI Responses handler; incorrect cache logic could drop messages or skip compaction, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a **retry race** in OpenAI Responses compaction: after a successful compact, `clearChainForCompaction()` stayed committed across PocketFlow same-turn retries, but `createResponseImpl` **always cleared** `compactionResult`, so failed outer `create()` calls re-ran `/responses/compact` unnecessarily.
> 
> **`compactionResult`** now records **`sourceMessages`** (the `messages` array reference compaction used). At the start of `createResponseImpl`, the cache is dropped only when `sourceMessages !== messages`; when they match, the handler **reuses** the compacted payload instead of compacting again. **`applyCompactionState`** clears `compactionResult` on **every successful** response so a cache keyed only by reference cannot leak into the next turn when `shared.messages` is mutated in place.
> 
> Regression tests cover same-turn retry (one compact call), cross-turn reuse with a stable array reference (incremental send, no stale compaction), and client-side compaction bookkeeping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3407d5873501d8bd49e00f125610f275be305c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->