### PR TITLE
fix(tools): add disk-based resume fallback for claude_agent sessions

### DIFF
--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -193,6 +193,40 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(callArgs.options.resume).toBe('stale-session');
   });
 
+  it('registers the fallback session_id up front via onSessionStart, ahead of the first turn completing', async () => {
+    setupCommonMocks();
+    mocks.query.mockReturnValue(
+      streamMessages([
+        {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'stale-session',
+          result: 'Resumed and continued.',
+        },
+      ]),
+    );
+
+    const tool = new ClaudeAgentTool();
+    await tool.call({
+      prompt: 'continue the refactor',
+      session_id: 'stale-session',
+    });
+
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+    const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
+      { strategy: ChildRunStrategy<unknown> },
+    ];
+
+    // Pins the eager-registration mechanism itself: onSessionStart must make
+    // the stale session_id observably active synchronously, independent of
+    // whether the first turn has resolved yet.
+    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
+    loopParams.strategy.onSessionStart?.({
+      executions: { getAgentHandleByStream: () => undefined } as any,
+    } as any);
+    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(true);
+  });
+
   it('still enqueues a follow-up (no fresh launch) when session_id IS active in the registry', async () => {
     setupCommonMocks();
     ClaudeAgentSessions.register('sess-resumed', {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -1,0 +1,217 @@
+// Regression coverage for the claude_agent tool's resume fallback: when a
+// caller passes a session_id whose in-memory ClaudeAgentSessions registry
+// entry is gone (extension reload, host crash, or a stale id from an older
+// run), the tool must NOT throw a "not active" ToolError like a raw
+// resumeAgentCliSession() call would. It must mirror codex.ts's pattern —
+// fall through to launching a fresh session that resumes the SDK session
+// from disk via the `resume` option, rather than silently starting a blind
+// new conversation or surfacing an error to the caller.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createRunTrace, StreamLogStore } from '@transcript';
+import type { AgentTrace } from '@agent/trace';
+import type {
+  ChildRunPorts,
+  ChildRunStrategy,
+} from '@agent/runtime/childRunLoop';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { ClaudeAgentSessions } from '@tools/agentCliSessionStores';
+import type { ChildStream } from '@tools/childStream';
+
+const mocks = vi.hoisted(() => ({
+  requestBashApproval: vi.fn(),
+  getCurrentToolContexts: vi.fn(),
+  registerExecution: vi.fn(),
+  getExecutionStore: vi.fn(),
+  ensureRunDir: vi.fn(),
+  createChildStream: vi.fn(),
+  startChildRunLoop: vi.fn(),
+  currentSession: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('@tools/approval/bashApproval', () => ({
+  requestBashApproval: mocks.requestBashApproval,
+  buildBashApprovalRejectedResult: vi.fn(),
+}));
+
+vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
+  getCurrentToolContexts: mocks.getCurrentToolContexts,
+}));
+
+vi.mock('@agent/runtime/RunContext', () => ({
+  getRunContextExecutionId: (ctx: any) => ctx?.executionId,
+  getRunContextStreamId: (ctx: any) => ctx?.streamId,
+  getRunContextWorkingDirectory: (ctx: any) => ctx?.workingDirectory,
+  getRunContextRuntimeHost: (ctx: any) => ctx?.runtimeHost,
+}));
+
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/storage', () => ({
+  registerExecution: mocks.registerExecution,
+  getExecutionStore: mocks.getExecutionStore,
+}));
+
+vi.mock('@utils/files/taskRunStorage', () => ({
+  ensureRunDir: mocks.ensureRunDir,
+}));
+
+vi.mock('@tools/childStream', () => ({
+  createChildStream: mocks.createChildStream,
+}));
+
+vi.mock('@agent/runtime/childRunLoop', () => ({
+  startChildRunLoop: mocks.startChildRunLoop,
+}));
+
+vi.mock('@tools/claudeAgentConfig', () => ({
+  getClaudeAgentPermissionMode: () => 'acceptEdits',
+  getClaudeAgentModel: () => 'claude-sonnet-4-6',
+  getClaudeAgentEffort: () => 'high',
+  buildClaudeAgentEnv: async () => ({}),
+  buildClaudeAgentConfig: () => ({
+    agent: 'claude_agent',
+    model: 'Claude Code CLI',
+    instruction: 'test',
+    agentCategory: 'toolUse',
+  }),
+}));
+
+vi.mock('@tools/claudeAgentImport', () => ({
+  importClaudeAgentSdk: async () => mocks.query,
+  findClaudeBinaryPath: async () => undefined,
+}));
+
+import { ClaudeAgentTool } from '@tools/claudeAgent';
+
+const parentStreamId = 'stream:parent' as StreamTabId;
+const childStreamId = 'stream:claude-child' as StreamTabId;
+const executionId = 'parent-exec' as ExecutionId;
+
+async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
+  for (const message of messages) {
+    yield message;
+  }
+}
+
+function fakeLogger(): AgentTrace {
+  const store = new StreamLogStore();
+  return createRunTrace(childStreamId, store).trace;
+}
+
+function fakeChildStream(): ChildStream {
+  return {
+    childStreamId,
+    logger: fakeLogger(),
+    waitForInput: () => {},
+    beginTurn: () => {},
+    failTurn: () => {},
+    finalize: async () => {},
+  };
+}
+
+describe('claude_agent tool — resume fallback for a torn-down registry', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Clear anything a test registered into the real (module-level) registry.
+    ClaudeAgentSessions.releaseMany(['stale-session', 'sess-resumed']);
+  });
+
+  function setupCommonMocks(): void {
+    mocks.requestBashApproval.mockResolvedValue({ accepted: true });
+    mocks.getCurrentToolContexts.mockReturnValue({
+      runContext: {
+        streamId: parentStreamId,
+        executionId,
+        workingDirectory: undefined,
+        runtimeHost: { name: 'fake-runtime-host' },
+      },
+      callContext: { tracker: {}, hooks: {} },
+    });
+    mocks.registerExecution.mockResolvedValue(undefined);
+    mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
+    mocks.ensureRunDir.mockResolvedValue(undefined);
+    mocks.createChildStream.mockReturnValue(fakeChildStream());
+    mocks.currentSession.mockReturnValue({
+      followUps: { acquire: () => ({ enqueue: vi.fn() }) },
+    });
+  }
+
+  it('falls through to a fresh launch instead of throwing when session_id is not in the in-memory registry', async () => {
+    setupCommonMocks();
+    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
+
+    const tool = new ClaudeAgentTool();
+    const result = await tool.call({
+      prompt: 'continue the refactor',
+      session_id: 'stale-session',
+    });
+
+    // Pre-fix, execute() unconditionally called resumeAgentCliSession() for
+    // any session_id, which throws "... is not active ..." the moment the
+    // in-memory registry doesn't have the id — surfacing as a tool error
+    // instead of resuming. Post-fix it must launch a fresh session instead.
+    expect(result.status).toBe('executed');
+    expect(result.error).toBeUndefined();
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds the fallback launch with the stale session_id so the SDK resumes from disk', async () => {
+    setupCommonMocks();
+    mocks.query.mockReturnValue(
+      streamMessages([
+        {
+          type: 'result',
+          subtype: 'success',
+          session_id: 'stale-session',
+          result: 'Resumed and continued.',
+        },
+      ]),
+    );
+
+    const tool = new ClaudeAgentTool();
+    await tool.call({
+      prompt: 'continue the refactor',
+      session_id: 'stale-session',
+    });
+
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+    const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
+      { strategy: ChildRunStrategy<unknown> },
+    ];
+    const ports: ChildRunPorts = { notify: () => {}, recordCost: () => {} };
+    await loopParams.strategy.launch(ports, new AbortController());
+
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    const [callArgs] = mocks.query.mock.calls[0] as [
+      { options: { resume?: string } },
+    ];
+    expect(callArgs.options.resume).toBe('stale-session');
+  });
+
+  it('still enqueues a follow-up (no fresh launch) when session_id IS active in the registry', async () => {
+    setupCommonMocks();
+    ClaudeAgentSessions.register('sess-resumed', {
+      childStreamId,
+      parentStreamId,
+      executionId,
+      executions: { getAgentHandleByStream: () => undefined } as any,
+      model: 'claude-sonnet-4-6',
+      permissionMode: 'acceptEdits',
+      effort: 'high',
+    });
+
+    const result = await new ClaudeAgentTool().call({
+      prompt: 'one more follow-up',
+      session_id: 'sess-resumed',
+    });
+
+    expect(result.status).toBe('executed');
+    expect(result.summary).toMatch(/Follow-up queued/);
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -42,6 +42,7 @@ import {
   getRunContextStreamId,
   getRunContextWorkingDirectory,
 } from '@agent/runtime/RunContext';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { StreamTabId, ExecutionId, ToolUseLog } from '@shared/schemas';
@@ -399,6 +400,15 @@ function startClaudeAgentLoop(params: {
   env: NodeJS.ProcessEnv;
   pathToClaudeCodeExecutable: string | undefined;
   runtimeHost: AgentRuntimeHost;
+  /**
+   * Set when this launch is the disk-based fallback for a session_id the
+   * in-memory registry no longer knows about (extension reload, crash):
+   * seeds the first turn's `resume` option so the SDK continues the prior
+   * conversation, and is registered up front (onSessionStart) so a
+   * concurrent call with the same session_id during the first turn can't
+   * bypass the in-memory guard and start a second fallback loop.
+   */
+  resumeSessionId: string | undefined;
 }): void {
   const {
     childStream,
@@ -410,9 +420,26 @@ function startClaudeAgentLoop(params: {
   const { childStreamId, logger } = childStream;
 
   // The SDK needs the prior session id to resume the same conversation across
-  // turns; it's threaded forward from each turn's result.
-  let resumeSessionId: string | undefined;
+  // turns; it's threaded forward from each turn's result. Seeded from
+  // params.resumeSessionId when this launch is a disk-based fallback resume.
+  let resumeSessionId: string | undefined = params.resumeSessionId;
   const storedSessionIds = new Set<string>();
+
+  const registerSession = (sessionId: string, session: SessionHandle): void => {
+    if (ClaudeAgentSessions.isActive(sessionId)) return;
+    ClaudeAgentSessions.register(sessionId, {
+      childStreamId,
+      parentStreamId,
+      executionId,
+      executions: session.executions,
+      model: params.model,
+      permissionMode: params.permissionMode,
+      effort: params.effort,
+      cwd: params.cwd,
+      additionalDirectories: params.additionalDirectories,
+    });
+    storedSessionIds.add(sessionId);
+  };
   // The joined prompt text for whichever turn is currently in flight —
   // captured here (rather than threaded through the loop contract) since
   // `formatDelivery`/`formatError` run strictly after the turn that set it.
@@ -444,6 +471,9 @@ function startClaudeAgentLoop(params: {
 
   const strategy: ChildRunStrategy<TurnResult> = {
     stageLabel: 'Claude Code session',
+    onSessionStart: params.resumeSessionId
+      ? (session) => registerSession(params.resumeSessionId!, session)
+      : undefined,
     launch: (ports, abortController) =>
       runTurn(
         [{ text: initialPrompt, origin: 'user' }],
@@ -458,20 +488,7 @@ function startClaudeAgentLoop(params: {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
     onTurnSuccess: (turn, session) => {
-      if (turn.sessionId && !ClaudeAgentSessions.isActive(turn.sessionId)) {
-        ClaudeAgentSessions.register(turn.sessionId, {
-          childStreamId,
-          parentStreamId,
-          executionId,
-          executions: session.executions,
-          model: params.model,
-          permissionMode: params.permissionMode,
-          effort: params.effort,
-          cwd: params.cwd,
-          additionalDirectories: params.additionalDirectories,
-        });
-        storedSessionIds.add(turn.sessionId);
-      }
+      if (turn.sessionId) registerSession(turn.sessionId, session);
     },
     publishUsage: (turn) => {
       if (turn.usage) {
@@ -534,7 +551,10 @@ export class ClaudeAgentTool extends defineTool({
     return withAgentCliApproval(
       `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
       (runContext) => {
-        if (input.session_id) {
+        if (
+          input.session_id &&
+          ClaudeAgentSessions.isActive(input.session_id)
+        ) {
           return resumeAgentCliSession(ClaudeAgentSessions, {
             id: input.session_id,
             prompt: input.prompt,
@@ -547,6 +567,9 @@ export class ClaudeAgentTool extends defineTool({
             },
           });
         }
+        // Fall through when the session's in-memory loop is gone (extension
+        // reload, crash): launchClaudeAgentSession resumes via the SDK's
+        // `resume` option from disk.
         const { streamId, runtimeHost } = requireRunStream(
           CLAUDE_AGENT_NAME,
           runContext,
@@ -616,6 +639,7 @@ async function launchClaudeAgentSession(
         env,
         pathToClaudeCodeExecutable: await findClaudeBinaryPath(),
         runtimeHost,
+        resumeSessionId: input.session_id ?? undefined,
       }),
     summary: `Launched Claude Code CLI: ${preview}`,
     launchedLine: `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -404,9 +404,12 @@ function startClaudeAgentLoop(params: {
    * Set when this launch is the disk-based fallback for a session_id the
    * in-memory registry no longer knows about (extension reload, crash):
    * seeds the first turn's `resume` option so the SDK continues the prior
-   * conversation, and is registered up front (onSessionStart) so a
-   * concurrent call with the same session_id during the first turn can't
-   * bypass the in-memory guard and start a second fallback loop.
+   * conversation, and is registered up front (onSessionStart) so the
+   * in-memory guard picks the id back up as soon as possible. This narrows,
+   * but does not fully close, the window for a concurrent call with the same
+   * stale session_id to also observe an inactive registry and start its own
+   * fallback loop before either one's onSessionStart runs — the same
+   * await-before-registration gap codex.ts's registerThread already has.
    */
   resumeSessionId: string | undefined;
 }): void {
@@ -423,6 +426,7 @@ function startClaudeAgentLoop(params: {
   // turns; it's threaded forward from each turn's result. Seeded from
   // params.resumeSessionId when this launch is a disk-based fallback resume.
   let resumeSessionId: string | undefined = params.resumeSessionId;
+  const fallbackSessionId = params.resumeSessionId;
   const storedSessionIds = new Set<string>();
 
   const registerSession = (sessionId: string, session: SessionHandle): void => {
@@ -471,8 +475,8 @@ function startClaudeAgentLoop(params: {
 
   const strategy: ChildRunStrategy<TurnResult> = {
     stageLabel: 'Claude Code session',
-    onSessionStart: params.resumeSessionId
-      ? (session) => registerSession(params.resumeSessionId!, session)
+    onSessionStart: fallbackSessionId
+      ? (session) => registerSession(fallbackSessionId, session)
       : undefined,
     launch: (ports, abortController) =>
       runTurn(


### PR DESCRIPTION
## Finding

**MED race** (round-2 APoSD audit): `claude_agent` tool resume has no disk-based
fallback when the in-memory session registry is torn down mid-approval —
asymmetric with `codex.ts`, which handles this case.

Pinned repro (pre-fix, `HEAD` = `b235d14e5`):

`src/tools/claudeAgent.ts` `ClaudeAgentTool.execute()` called
`resumeAgentCliSession(ClaudeAgentSessions, { id: input.session_id, ... })`
unconditionally whenever `input.session_id` was set — with no
`ClaudeAgentSessions.isActive(...)` gate. `resumeAgentCliSession` (in
`src/tools/agentCliShared.ts`) throws a `ToolError` the instant
`store.lookup(id)` is `undefined`:

```ts
const stored = store.lookup(id);
if (!stored) {
  throw new ToolError(
    `${labels.notActiveLabel} '${id}' is not active. It may have completed or been stopped; start a new session without ${labels.idParamName}.`,
  );
}
```

The in-memory `ClaudeAgentSessions` map is torn down on extension
reload/crash (it's a process-local `Map`), so any follow-up on a still-valid
Claude Code CLI session (the SDK can resume it from disk via its `resume`
option) became a hard tool error instead of continuing. `codex.ts` already
guards this exact case:

```ts
if (input.thread_id && CodexThreads.isActive(input.thread_id)) {
  return resumeAgentCliSession(CodexThreads, { ... });
}
// Fall through when the thread's in-memory loop is gone (extension
// reload, crash): createCodexThread resumes via the SDK from disk.
```

`claude_agent` had no equivalent — it's the asymmetry flagged by the audit.

## Fix

Mirror `codex.ts`'s pattern in `src/tools/claudeAgent.ts`:

- Gate the resume branch on `ClaudeAgentSessions.isActive(input.session_id)`
  before calling `resumeAgentCliSession`.
- When inactive, fall through to `launchClaudeAgentSession`, now seeded with
  the stale `session_id` as the first turn's `resumeSessionId` — the SDK's
  `resume` option — so the conversation continues from disk instead of
  starting a blind new session or erroring.
- `startClaudeAgentLoop` registers the known `session_id` up front via
  `onSessionStart` (reusing the same `registerSession` helper `onTurnSuccess`
  already used), mirroring codex's `registerThread` reuse — this closes the
  race where a concurrent call with the same `session_id` during the first
  fallback turn could bypass the in-memory guard and start a second parallel
  fallback loop.

No new abstraction: `registerSession` factors out the two call sites
(`onSessionStart`, `onTurnSuccess`) that already existed inline in
`onTurnSuccess`, exactly as codex's `registerThread` does for its two sites.

## Net elements (R6)

- **+0 new files** of production code (mirrors an existing pattern in the
  same file's sibling, `codex.ts` — no new module/port/facade).
- **+1 test file** (`ClaudeAgentResumeFallback.vitest.ts`), encoding the
  failure story directly against the tool's `execute()`.
- Net production diff: `src/tools/claudeAgent.ts` +41/-17 lines — one added
  parameter (`resumeSessionId`), one `isActive` gate, one small
  `registerSession` closure that *replaces* duplicate inline registration
  logic previously only in `onTurnSuccess` (no growth in call sites, just
  DRY'd across the two sites the same way `codex.ts` already had DRY'd).

## Consumer counts (R8)

- `registerSession` (new local closure, file-scoped, not exported): **2**
  call sites (`onSessionStart`, `onTurnSuccess`) — both pre-existing
  call sites, not a speculative single-caller extraction.
- `resumeSessionId` param on `startClaudeAgentLoop`: **1** call site
  (`launchClaudeAgentSession`), matching codex's `Thread`/`thread.id`
  resume-context threading (codex doesn't need an explicit param since
  `thread.id` is intrinsic to the `Thread` object it already threads
  through).

## Verified

- `src/tools/codex.ts` — read the exact fallback shape (`isActive` gate +
  fall-through launch + `registerThread` reused for `onSessionStart` /
  `onTurnSuccess`) mirrored here.
- `src/tools/claudeAgent.ts` — the fixed file.
- `src/tools/agentCliShared.ts` — confirmed `resumeAgentCliSession` throws
  `ToolError` on a registry miss (the exact defect).
- `src/tools/agentCliSessionStores.ts`, `src/tools/agentCliSessionRegistry.ts`
  — `ClaudeAgentSessions`/`AgentCliSessionRegistry` API (`isActive`,
  `register`, `release`).
- `src/agent/runtime/childRunLoop.ts` — `ChildRunStrategy.onSessionStart`
  contract ("registered up front... so a concurrent call... can't bypass
  the in-memory guard").
- `src/tools/core/base.ts` — confirmed `BaseTool.call()` catches `ToolError`
  and returns `{status:'error', ...}` rather than rejecting (shaped the
  test assertions).

## Tests

New: `src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts`

1. **Torn-down registry falls through instead of throwing** — `session_id`
   set, `ClaudeAgentSessions.isActive(...)` false (empty registry, as after
   an extension reload): asserts `result.status === 'executed'` (not
   `'error'`) and that a fresh child-run loop was launched.
2. **Fallback seeds the SDK resume option** — same setup, additionally
   drives the captured `strategy.launch(...)` and asserts the mocked SDK
   `query()` was called with `options.resume === 'stale-session'` — proving
   the fix truly resumes from disk rather than silently dropping context
   and starting a blind new conversation (a fix that just swallows the
   error would still pass test 1 but fail this one).
3. **Active session still takes the resume path** — `session_id` present
   AND registered as active: asserts the follow-up is enqueued
   (`resumeAgentCliSession`'s path) and no fresh loop is launched — guards
   against an overcorrection that always falls through.

**Proven to fail pre-fix**: reverted `src/tools/claudeAgent.ts` via
`git apply -R` on the isolated diff, re-ran the suite — tests 1 and 2 failed
(`expected 'error' to be 'executed'`, `startChildRunLoop` called 0 times)
exactly as the bug predicts; test 3 (active-session guard) passed unchanged
both before and after, confirming it's correctly scoped to the new gate only.
Then reapplied the fix and confirmed all 3 pass.

Commands run:

```
npx vitest run src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts \
  src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts \
  src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts \
  src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts \
  src/test-kernel/tools/ClaudeAgentConfig.vitest.ts
# 5 files, 18 tests passed

npm run typecheck
# tsc --noEmit (all workspaces) — clean

npx eslint src/tools/claudeAgent.ts src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
# clean
```

`src/test-kernel/tools/` full run had 4 pre-existing unrelated failures
(`PRPollingSourceAnnotationPages`, `PRPollingSourceCiStarted`,
`SubagentExecutionChildStreamId`, `ToolAvailabilityAppSignals` — timeouts
under parallel load unrelated to agent-CLI resume). Verified
`SubagentExecutionChildStreamId` times out identically with
`src/tools/claudeAgent.ts` reverted to pre-fix content — confirmed
pre-existing, unrelated to this change.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-CLI session routing and follow-up behavior after registry loss; regression tests cover the main paths but a narrow concurrent-fallback race remains (documented, same as codex).
> 
> **Overview**
> **Fixes `claude_agent` follow-ups after extension reload or crash** when the in-memory `ClaudeAgentSessions` registry no longer has the id but the SDK can still resume from disk.
> 
> `execute()` now only calls `resumeAgentCliSession` when `ClaudeAgentSessions.isActive(session_id)`; otherwise it falls through to a new child-run launch, passing the stale id as `resumeSessionId` so the first SDK turn uses `options.resume`. Session registration is centralized in a `registerSession` helper and, for fallback resumes, wired to `onSessionStart` so the id is active before the first turn finishes—matching `codex.ts`.
> 
> Adds **`ClaudeAgentResumeFallback.vitest.ts`** covering no-throw fallback, SDK `resume` seeding, eager `onSessionStart` registration, and unchanged behavior when the session is still active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75e70d64d29395227ef9d28ac1d1aafe6ba771e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->