### PR TITLE
fix(cli): finish interaction policy review

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -94,6 +94,7 @@ interface InputEventEmitterLike {
   off(event: 'input', listener: (data: string) => void): void;
 }
 
+// Keep bottom panels from crowding out conversation or input chrome.
 const BOTTOM_PANEL_MAX_ROWS = 10;
 const EMPTY_SUBAGENT_ROWS: readonly ActiveChildInfo[] = [];
 
@@ -300,6 +301,8 @@ export function App(props: AppProps): React.JSX.Element {
     pendingApproval: activeApprovalVisible,
     transcriptViewerOpen,
   });
+  const approvalKind =
+    foregroundKind === 'approval' ? pending?.payload.kind : undefined;
   const childControlTarget =
     childControlMode !== undefined
       ? childControlTargets[childControlMode]
@@ -312,7 +315,7 @@ export function App(props: AppProps): React.JSX.Element {
   const childControlHasItems = childControlTarget?.hasItems ?? false;
   const { foregroundRows, transcriptRows } = allocateMiddleRows({
     foregroundMaxRows: foregroundMaxRowsForKind({
-      approvalKind: activeApprovalVisible ? pending?.payload.kind : undefined,
+      approvalKind,
       childControlHasItems,
       kind: foregroundKind,
     }),
@@ -642,9 +645,7 @@ export function App(props: AppProps): React.JSX.Element {
           commandName={props.commandName}
           foregroundEscapeAction={foregroundEscapeAction({
             activeFormEscapeAction: activeForm?.escapeAction,
-            approvalKind: activeApprovalVisible
-              ? pending?.payload.kind
-              : undefined,
+            approvalKind,
             childControlEscapeAction,
             foregroundKind,
           })}


### PR DESCRIPTION
## Summary
- derive `approvalKind` only when the approval surface owns the foreground
- reuse that narrowed value for row allocation and Escape routing
- restore the rationale comment for the bottom-panel row cap

## Validation
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm exec vitest run src/test-kernel/cli/AppInteractionPolicy.vitest.mts src/test-kernel/cli/TuiValidatorArgs.vitest.mts`

Closes #8061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small TUI layout and status-hint logic change with targeted tests; no auth, data, or runtime execution paths affected.
> 
> **Overview**
> Tightens TUI **interaction policy** so approval payload kind is only considered when the **approval modal actually owns the foreground**, not merely when a pending approval is visible for the active stream.
> 
> `App` now derives a shared `approvalKind` from `foregroundKind === 'approval'` and reuses it for **middle-row allocation** (`foregroundMaxRowsForKind`) and **StatusBar Escape hints** (`foregroundEscapeAction`), replacing inline checks tied to `activeApprovalVisible`. That avoids applying approval-specific row caps or skip/cancel Escape copy while a form, transcript viewer, or child-control picker is on top.
> 
> Also restores the comment documenting why `BOTTOM_PANEL_MAX_ROWS` caps bottom panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb638ac27a6b04108aebc5e5ebef5d99817f711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->