### PR TITLE
refactor(transcript): StreamPhase-native group-end production (#7993 step 2)

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -70,7 +70,7 @@ import { createChannelTrace } from '@logger';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_PHASE,
-  type EndGroupStatus,
+  type RunOutcome,
   type AgentCategoryFilter,
   type MainViewPersistedState,
   type ProgressViewOutboundMessage,
@@ -811,7 +811,7 @@ export class DesktopProgressBridge {
 
   private async closeRunningTaskGroupsForStreams(
     streamIds: readonly StreamTabId[],
-    status: EndGroupStatus,
+    status: RunOutcome,
     now: number = Date.now(),
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -1,33 +1,54 @@
 import { create } from 'mutative';
 
+import { legacyEndGroupStatusForOutcome } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   ContextStateDataSchema,
   MESSAGE_TYPES,
+  RunOutcomeSchema,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_STATUS,
   type ContextStateData,
   type LogMessageData,
   type StreamLogEntry,
   type StreamLogTextDelta,
+  type TaskGroupStatus,
 } from '@shared/schemas';
 
 import type { StreamLogs, StreamState } from '../store';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-function isTaskGroupStatus(
-  value: unknown,
-): value is
-  | typeof STREAM_STATUS.RUNNING
-  | typeof STREAM_STATUS.ERROR
-  | typeof STREAM_STATUS.STOPPED
-  | typeof STREAM_STATUS.READY {
+function isTaskGroupStatus(value: unknown): value is TaskGroupStatus {
   return (
     value === STREAM_STATUS.RUNNING ||
     value === STREAM_STATUS.ERROR ||
     value === STREAM_STATUS.STOPPED ||
     value === STREAM_STATUS.READY
   );
+}
+
+/**
+ * A `GROUP_END` row's `data.status` now carries either the legacy 2-value
+ * `EndGroupStatus` (rows the standalone trace-viewer forwards raw from an
+ * exported trace file — that replay path stays legacy-capable permanently,
+ * see docs/proposals/session-scoped-runtime-architecture.md §8.3) or the
+ * canonical `RunOutcome` every live/persisted producer now writes (§8.2).
+ * Fold a canonical value down to the same legacy bucket the pre-cutover
+ * writer used so `TaskGroup.status` — not yet retyped to `StreamPhase`/
+ * `RunOutcome` (that reader migration is #7993 goal item 3) — keeps
+ * rendering exactly as it does today; only the transcript row itself gains
+ * the completed/cancelled bit this step. A value that is neither vocabulary
+ * (malformed data) falls back to the caller-supplied default, as before.
+ */
+function taskGroupEndStatus(
+  value: unknown,
+  fallback: TaskGroupStatus,
+): TaskGroupStatus {
+  if (isTaskGroupStatus(value)) return value;
+  const outcome = RunOutcomeSchema.safeParse(value);
+  return outcome.success
+    ? legacyEndGroupStatusForOutcome(outcome.data)
+    : fallback;
 }
 
 function isStageKind(
@@ -106,9 +127,7 @@ function updateTaskGroups(
     return false;
   }
 
-  const status = isTaskGroupStatus(payload.status)
-    ? payload.status
-    : STREAM_STATUS.STOPPED;
+  const status = taskGroupEndStatus(payload.status, STREAM_STATUS.STOPPED);
   const endTime =
     typeof payload.endTime === 'number' ? payload.endTime : undefined;
 

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -4,7 +4,7 @@ import {
   executionStatusToRunOutcome,
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
-  StreamStatusSchema,
+  StreamLifecycleStatusSchema,
   streamStatusToLifecycleStatus,
   type StreamLifecycleStatus,
   type StreamTabInfo,
@@ -90,6 +90,20 @@ function findRootStageId(
  * older snapshot-status escape hatch. Only when neither source records a
  * terminal status does this default to `READY`, same as an unqualified
  * successful finish.
+ *
+ * The terminal group row's `data.status` is parsed with
+ * `StreamLifecycleStatusSchema` (StreamPhase-or-legacy-StreamStatus union,
+ * already shipped — §2), not the narrower legacy-only `StreamStatusSchema`:
+ * `assembleTrace()` (src/transcript/traceAssembler.ts) is a `StreamLogStore`
+ * client, so every `TraceDocument` it builds — including one assembled from
+ * pre-cutover on-disk history — carries the canonical `RunOutcome` values
+ * `StreamLogStore.parsePersistedEntries` normalizes to (#7993 step 2), not
+ * just the legacy 2-value `EndGroupStatus` strings a genuinely
+ * externally-authored, never-reassembled `trace.json` predating this cutover
+ * would still carry. `StreamLifecycleStatusSchema` accepts both, so this one
+ * parse call keeps working for freshly-`assembleTrace()`d documents and for
+ * historical exported files alike — no per-entry rewrite of `trace.entries`,
+ * which stays exactly the future work §8.3 scopes separately.
  */
 function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
   if (trace.terminalStatus !== null) {
@@ -113,8 +127,8 @@ function toStreamLifecycleStatus(trace: TraceDocument): StreamLifecycleStatus {
       // else sharing the "no parent" shape is a nested round/phase/session.
       continue;
     }
-    const status = StreamStatusSchema.safeParse(entry.data.status);
-    if (status.success) return streamStatusToLifecycleStatus(status.data);
+    const status = StreamLifecycleStatusSchema.safeParse(entry.data.status);
+    if (status.success) return status.data;
   }
   return trace.snapshot.status
     ? streamStatusToLifecycleStatus(trace.snapshot.status)

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -18,10 +18,7 @@ import {
   classifyAgentError,
   normalizeProviderError,
 } from '@common/errors';
-import {
-  legacyEndGroupStatusForOutcome,
-  projectRunOutcome,
-} from '@common/constants/streamStatus';
+import { projectRunOutcome } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   RUN_OUTCOME,
@@ -135,7 +132,7 @@ export async function finalizeRunTerminal(
   }
   if (params.stage) {
     try {
-      params.stage.end(legacyEndGroupStatusForOutcome(outcome));
+      params.stage.end(outcome);
     } catch (stageErr) {
       logger.warn('Failed to end parent stage', {
         data: { agentIdentifier: handle.agentName, error: stageErr },
@@ -366,7 +363,7 @@ export async function runFlowWithLifecycle(
           session.transcripts.update(streamId, parentStageId, {
             type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
             data: {
-              status: legacyEndGroupStatusForOutcome(RUN_OUTCOME.CANCELLED),
+              status: RUN_OUTCOME.CANCELLED,
               endTime: Date.now(),
               kind: 'run',
             },

--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -11,7 +11,7 @@
  * `toolUseHelpers.ts` that operate on this interface — there is no host
  * subtype. SDK consumers program directly against `AgentTrace`.
  */
-import type { EndGroupStatus } from '@shared/schemas';
+import type { RunOutcome } from '@shared/schemas';
 
 import type {
   AgentEvent,
@@ -39,10 +39,10 @@ export interface StageOptions {
   /** Planned total count, when known, currently used for workflow rounds. */
   readonly total?: number;
   /**
-   * Status to emit at stage.end when no explicit status is supplied.
-   * Defaults to `stopped`.
+   * Outcome to emit at stage.end when no explicit status is supplied.
+   * Defaults to `completed`.
    */
-  readonly defaultStatus?: EndGroupStatus;
+  readonly defaultStatus?: RunOutcome;
   /**
    * Skip stage creation but propagate parent context to nested calls.
    * `handle.id` is undefined; `handle.within(fn)` runs `fn` in the parent
@@ -57,8 +57,8 @@ export interface StageOptions {
 export interface StageHandle {
   /** Stage id; undefined for skipped (passthrough) stages. */
   readonly id: string | undefined;
-  /** Emit `stage.end` with the given status. Idempotent. */
-  end(status?: EndGroupStatus): void;
+  /** Emit `stage.end` with the given outcome. Idempotent. */
+  end(status?: RunOutcome): void;
   /** Run `fn` with this stage as the active stamp. */
   within<T>(fn: () => Promise<T> | T): Promise<T>;
   /** `within(fn)` + auto-end on success/failure with success/error status. */

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -15,7 +15,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { nanoid } from 'nanoid';
 
 import * as logger from '@logger/logUtils';
-import { END_GROUP_STATUS, type EndGroupStatus } from '@shared/schemas';
+import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type {
@@ -209,7 +209,7 @@ export class TraceEmitter implements AgentTrace {
   // ─── Stages ────────────────────────────────────────────────────────
 
   openStage(label: string, options: StageOptions = {}): StageHandle {
-    const defaultStatus = options.defaultStatus ?? END_GROUP_STATUS.STOPPED;
+    const defaultStatus = options.defaultStatus ?? RUN_OUTCOME.COMPLETED;
     const parentId =
       options.parent?.id ?? options.parentId ?? this.activeStageId();
 
@@ -274,10 +274,10 @@ class StageHandleImpl implements StageHandle {
   constructor(
     private readonly trace: TraceEmitter,
     readonly id: string,
-    private readonly defaultStatus: EndGroupStatus,
+    private readonly defaultStatus: RunOutcome,
   ) {}
 
-  end(status?: EndGroupStatus): void {
+  end(status?: RunOutcome): void {
     if (this.ended) return;
     this.ended = true;
     this.trace.emit({
@@ -297,7 +297,7 @@ class StageHandleImpl implements StageHandle {
       this.end(this.defaultStatus);
       return result;
     } catch (err) {
-      this.end(END_GROUP_STATUS.ERROR);
+      this.end(RUN_OUTCOME.FAILED);
       throw err;
     }
   }
@@ -318,7 +318,7 @@ class SkippedStageHandle implements StageHandle {
     this.id = undefined;
   }
 
-  end(_status?: EndGroupStatus): void {
+  end(_status?: RunOutcome): void {
     // Skipped stages never opened a group; nothing to end.
   }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -17,7 +17,6 @@ import type {
   AddOutputFilesPayload,
   ConversationProgress,
   GoalPausedPayload,
-  EndGroupStatus,
   ExecutionId,
   RetryErrorInfo,
   RunOutcome,
@@ -109,7 +108,7 @@ export interface RunConfigEvent extends StageStamp {
 export interface StageEndEvent extends StageStamp {
   readonly type: 'stage.end';
   readonly id: string;
-  readonly status: EndGroupStatus;
+  readonly status: RunOutcome;
 }
 
 /** Tool call started. `logId` is the subscriber-correlatable id. */

--- a/src/agent/trace/noopTrace.ts
+++ b/src/agent/trace/noopTrace.ts
@@ -4,7 +4,7 @@
  */
 import { nanoid } from 'nanoid';
 
-import type { EndGroupStatus } from '@shared/schemas';
+import type { RunOutcome } from '@shared/schemas';
 
 import type {
   AgentTrace,
@@ -17,7 +17,7 @@ const NOOP: () => void = () => undefined;
 
 class NoopStageHandle implements StageHandle {
   constructor(readonly id: string | undefined) {}
-  end(_status?: EndGroupStatus): void {}
+  end(_status?: RunOutcome): void {}
   async within<T>(fn: () => Promise<T> | T): Promise<T> {
     return Promise.resolve(fn());
   }

--- a/src/controllers/progressView/backend/restartRepair.ts
+++ b/src/controllers/progressView/backend/restartRepair.ts
@@ -11,10 +11,8 @@ import {
   STREAM_TRANSITION_CAUSE,
 } from '@common/constants/streamStatus';
 import {
-  END_GROUP_STATUS,
   RUN_OUTCOME,
   STREAM_PHASE,
-  type EndGroupStatus,
   type ExecutionId,
   type RunOutcome,
   type StreamPhase,
@@ -32,7 +30,7 @@ export interface RestartRepairOptions {
   executionIds: ReadonlyMap<StreamTabId, ExecutionId>;
   closeRunningGroups(
     streamIds: readonly StreamTabId[],
-    status: EndGroupStatus,
+    status: RunOutcome,
     now: number,
   ): Promise<readonly StreamTabId[]>;
   repairStreams?: Iterable<StreamTabId>;
@@ -268,11 +266,15 @@ export async function repairRestartedStreams(
 
   const now = options.now ?? Date.now();
   const failedGroupStreams = [...failedStreams, ...orphanedGroupStreams];
+  // Restart repair's own crash-vs-graceful-interrupt classification (§8.2):
+  // a stream repaired back to WAITING never crashed — it's a graceful
+  // interrupt — so its still-open transcript group closes as CANCELLED, not
+  // the unconditional error default a crash-classified stream gets below.
   const closedWaitingGroups =
     waitingGroupStreams.length > 0
       ? await options.closeRunningGroups(
           waitingGroupStreams,
-          END_GROUP_STATUS.STOPPED,
+          RUN_OUTCOME.CANCELLED,
           now,
         )
       : [];
@@ -280,7 +282,7 @@ export async function repairRestartedStreams(
     failedGroupStreams.length > 0
       ? await options.closeRunningGroups(
           failedGroupStreams,
-          END_GROUP_STATUS.ERROR,
+          RUN_OUTCOME.FAILED,
           now,
         )
       : [];

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -18,7 +18,7 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  type EndGroupStatus,
+  type RunOutcome,
   StreamTabInfoBaseSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
@@ -316,7 +316,7 @@ export class ProgressViewState {
   async endRunningTaskGroups(
     now: number = Date.now(),
     streamIds?: readonly StreamTabId[],
-    status?: EndGroupStatus,
+    status?: RunOutcome,
   ): Promise<StreamTabId[]> {
     const affectedFromLogs = streamIds
       ? await this.streamLogs.endRunningGroupsForStreams(streamIds, now, status)

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -571,13 +571,18 @@ describe('runFlowWithLifecycle', () => {
       // is already desubscribed by this point (disposeTrace ran in the
       // WAITING branch's own finally), so the fix writes the stage's
       // GROUP_END entry directly to the transcript store instead of calling
-      // the now-inert `ctx.parentStage.end()`.
+      // the now-inert `ctx.parentStage.end()`. The written status is the
+      // literal `RunOutcome.CANCELLED` (#7993 step 2) — no
+      // legacyEndGroupStatusForOutcome fold at this direct-write call site.
       expect(transcriptsUpdate).toHaveBeenCalledWith(
         streamId,
         expect.any(String),
         expect.objectContaining({
           type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-          data: expect.objectContaining({ kind: 'run' }),
+          data: expect.objectContaining({
+            status: RUN_OUTCOME.CANCELLED,
+            kind: 'run',
+          }),
         }),
       );
     } finally {
@@ -589,25 +594,25 @@ describe('runFlowWithLifecycle', () => {
   // The canonical outcome is decided once and projected three ways. This
   // matrix pins the projections for every terminal path — in particular that
   // a user stop (the no-throw `cancelled` exit, the dominant stop path)
-  // persists `interrupted` and ends the stage neutral, never as an error.
+  // persists `interrupted` and ends the stage with the literal `cancelled`
+  // outcome, distinct from `completed` (#7993 step 2: `stage.end()` writes
+  // the native `RunOutcome`, not the folded 2-value `EndGroupStatus` string —
+  // completed/cancelled/failed all end up distinct on the transcript row).
   it('projects returned outcomes to terminal status, stage end, and stream status', async () => {
     const cases = [
       {
         outcome: RUN_OUTCOME.COMPLETED,
         terminal: EXECUTION_STATUS.COMPLETED,
-        stageEnd: 'stopped',
         stream: STREAM_PHASE.COMPLETED,
       },
       {
         outcome: RUN_OUTCOME.CANCELLED,
         terminal: EXECUTION_STATUS.INTERRUPTED,
-        stageEnd: 'stopped',
         stream: STREAM_PHASE.CANCELLED,
       },
       {
         outcome: RUN_OUTCOME.FAILED,
         terminal: EXECUTION_STATUS.ERROR,
-        stageEnd: 'error',
         stream: STREAM_PHASE.FAILED,
       },
     ] as const;
@@ -632,7 +637,9 @@ describe('runFlowWithLifecycle', () => {
           executionId,
           expected.terminal,
         );
-        expect(stageEnd).toHaveBeenCalledWith(expected.stageEnd);
+        // The stage closes with the literal outcome — no
+        // legacyEndGroupStatusForOutcome fold at this production call site.
+        expect(stageEnd).toHaveBeenCalledWith(expected.outcome);
         expect(streamStatus.get(streamId)).toBe(expected.stream);
       } finally {
         clearStreamStatusForTest(streamStatus, streamId);
@@ -640,7 +647,7 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('projects a thrown abort as cancelled (interrupted, neutral stage)', async () => {
+  it('projects a thrown abort as cancelled (distinct stage outcome, not folded to stopped)', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'outcome-thrown-abort',
     );
@@ -657,7 +664,7 @@ describe('runFlowWithLifecycle', () => {
         executionId,
         EXECUTION_STATUS.INTERRUPTED,
       );
-      expect(stageEnd).toHaveBeenCalledWith('stopped');
+      expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.CANCELLED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
@@ -682,7 +689,7 @@ describe('runFlowWithLifecycle', () => {
         executionId,
         EXECUTION_STATUS.ERROR,
       );
-      expect(stageEnd).toHaveBeenCalledWith('error');
+      expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.FAILED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);

--- a/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
@@ -62,6 +62,14 @@ describe('run outcome algebra', () => {
     });
   });
 
+  // legacyEndGroupStatusForOutcome is no longer called from any production
+  // GROUP_END write site (#7993 step 2 retypes stage.end()/StreamLogStore's
+  // orphan sweep to write the literal RunOutcome). It survives as a
+  // Tier-4-only read-side derive helper for the frozen CLI headless JSON's
+  // `endGroupStatus` projection (packages/cli/src/runtime/terminalStatus.ts)
+  // and as the fold `logSlice.ts` reuses to keep TaskGroup.status rendering
+  // unchanged until its own reader migration (#7993 goal item 3) — the
+  // algebra itself is unchanged, so it still needs to stay correct.
   it('derives folded legacy group-end and stream-status projections from one helper', () => {
     expect(groupEndStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe('ok');
     expect(groupEndStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe('ok');

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -22,15 +22,14 @@ import { DESKTOP_SHELL_COMMANDS } from '@desktop/desktopShellMessages';
 import type { DesktopStreamSnapshotStore } from '@desktop/main/desktopStreamSnapshot';
 import {
   AgentCategory,
-  END_GROUP_STATUS,
   LOG_LEVELS,
   RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
   STREAM_PHASE,
   STREAM_STATUS,
-  type EndGroupStatus,
   type ExecutionId,
   type RestoredStreamSnapshot,
+  type RunOutcome,
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
@@ -1241,7 +1240,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
-        status?: EndGroupStatus,
+        status?: RunOutcome,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
@@ -1257,7 +1256,7 @@ describe('DesktopProgressBridge', () => {
       expect(closeSpy).toHaveBeenCalledWith(
         ['snapshot-waiting-stream'],
         expect.any(Number),
-        END_GROUP_STATUS.STOPPED,
+        RUN_OUTCOME.CANCELLED,
       );
     } finally {
       finishDetection(new Set());
@@ -1316,7 +1315,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
-        status?: EndGroupStatus,
+        status?: RunOutcome,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
@@ -1509,7 +1508,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
-        status?: EndGroupStatus,
+        status?: RunOutcome,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi.spyOn(streamLogs, 'endRunningGroupsForStreams');
@@ -1522,7 +1521,7 @@ describe('DesktopProgressBridge', () => {
         expect(closeSpy).toHaveBeenCalledWith(
           ['waiting-stream'],
           expect.any(Number),
-          END_GROUP_STATUS.STOPPED,
+          RUN_OUTCOME.CANCELLED,
         );
       });
     } finally {
@@ -1550,7 +1549,7 @@ describe('DesktopProgressBridge', () => {
       endRunningGroupsForStreams: (
         streamIds: readonly StreamTabId[],
         now?: number,
-        status?: EndGroupStatus,
+        status?: RunOutcome,
       ) => Promise<StreamTabId[]>;
     };
     const closeSpy = vi
@@ -1570,7 +1569,7 @@ describe('DesktopProgressBridge', () => {
         expect(closeSpy).toHaveBeenLastCalledWith(
           ['waiting-stream'],
           expect.any(Number),
-          END_GROUP_STATUS.STOPPED,
+          RUN_OUTCOME.CANCELLED,
         );
       });
     } finally {

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -18,6 +18,7 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_STATUS,
   createStreamState,
   type ProgressViewOutboundMessage,
   type StreamLogEntry,
@@ -159,4 +160,84 @@ describe('LOG_DELTA text deltas', () => {
     expect(finalizedLogs?.updatedMessageIndices).toEqual([0]);
     expect(finalized && isStreamingTextLogMessage(finalized)).toBe(false);
   });
+});
+
+// #7993 step 2: every GROUP_END row a live/persisted producer writes now
+// carries the literal RunOutcome ('completed'/'cancelled'/'failed'), not the
+// folded 2-value EndGroupStatus ('stopped'/'error') logSlice.ts's
+// isTaskGroupStatus type guard alone recognizes. Without the read-side fold
+// this suite pins, every GROUP_END row — including a failure — would fall
+// through to isTaskGroupStatus's STOPPED default, losing the error icon.
+// The standalone trace-viewer forwards raw legacy entries into this same
+// LOG_DELTA handler (replayTrace.ts, §8.3's second, permanent boundary), so
+// the legacy wire values must keep working identically alongside the new
+// canonical ones — logSlice.ts stays a tolerant reader of both, it does not
+// go canonical-only.
+describe('LOG_DELTA GROUP_END task-group status (#7993 step 2)', () => {
+  function groupStartEntry(id: string): StreamLogEntry {
+    return {
+      seqNo: 1,
+      id,
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      text: 'Run: agent',
+      data: { status: 'running' },
+    };
+  }
+
+  function groupEndEntry(id: string, status: unknown): StreamLogEntry {
+    return {
+      seqNo: 2,
+      id,
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      level: LOG_LEVELS.INFO,
+      timestamp: 200,
+      text: 'Run: agent',
+      data: { status, endTime: 200 },
+    };
+  }
+
+  it.each([
+    // Canonical values every StreamLogStore-sourced GROUP_END row now
+    // carries directly (live producers write RunOutcome; persisted legacy
+    // rows are normalized to it at StreamLogStore.parsePersistedEntries).
+    ['completed', STREAM_STATUS.STOPPED],
+    ['cancelled', STREAM_STATUS.STOPPED],
+    ['failed', STREAM_STATUS.ERROR],
+    // Legacy values the standalone trace-viewer still forwards raw from a
+    // pre-cutover exported trace file — never normalized, permanently.
+    ['stopped', STREAM_STATUS.STOPPED],
+    ['error', STREAM_STATUS.ERROR],
+  ] as const)(
+    'maps GROUP_END data.status %s to task-group status %s',
+    (wireStatus, expectedStatus) => {
+      const streamId = 'stream-a' as StreamTabId;
+      const state = createInitialState();
+      state.activeStreamId = streamId;
+      state.streamStates.set(
+        streamId,
+        createStreamState(AgentCategory.Workflow),
+      );
+      const { ctx, getState } = createContext(state);
+
+      dispatch(
+        logHandlers,
+        {
+          command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+          streamId,
+          entries: [
+            groupStartEntry('run-0'),
+            groupEndEntry('run-0', wireStatus),
+          ],
+          updates: [],
+          textDeltas: [],
+        },
+        ctx,
+      );
+
+      const taskGroups = getState().streamStates.get(streamId)?.taskGroups;
+      expect(taskGroups?.[0]?.status).toBe(expectedStatus);
+    },
+  );
 });

--- a/src/test-kernel/progressView/RestartRepair.vitest.ts
+++ b/src/test-kernel/progressView/RestartRepair.vitest.ts
@@ -6,12 +6,11 @@ import { getExecutionStore } from '@agent/storage';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
 import {
-  END_GROUP_STATUS,
   EXECUTION_STATUS,
   RUN_OUTCOME,
   STREAM_PHASE,
-  type EndGroupStatus,
   type ExecutionId,
+  type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -47,8 +46,8 @@ describe('repairRestartedStreams', () => {
     const streamStatus = new StreamStatusMachine();
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
     const writeTerminalStatus = vi.fn();
 
@@ -71,7 +70,7 @@ describe('repairRestartedStreams', () => {
     });
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.STOPPED,
+      RUN_OUTCOME.CANCELLED,
       123,
     );
     expect(writeTerminalStatus).not.toHaveBeenCalled();
@@ -82,8 +81,8 @@ describe('repairRestartedStreams', () => {
     const executionId = 'execution-waiting-without-phase' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
     const writeTerminalStatus = vi.fn();
 
@@ -101,7 +100,7 @@ describe('repairRestartedStreams', () => {
     expect(result.closedWaitingGroups).toEqual([streamId]);
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.STOPPED,
+      RUN_OUTCOME.CANCELLED,
       234,
     );
     expect(writeTerminalStatus).not.toHaveBeenCalled();
@@ -112,8 +111,8 @@ describe('repairRestartedStreams', () => {
     const executionId = 'execution-without-phase' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.FAILED ? [...streamIds] : [],
     );
     const writeTerminalStatus = vi.fn(async () => undefined);
 
@@ -137,7 +136,7 @@ describe('repairRestartedStreams', () => {
     });
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.ERROR,
+      RUN_OUTCOME.FAILED,
       345,
     );
     expect(writeTerminalStatus).not.toHaveBeenCalled();
@@ -154,8 +153,8 @@ describe('repairRestartedStreams', () => {
       STREAM_TRANSITION_CAUSE.LIFECYCLE,
     );
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.STOPPED ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
     const writeTerminalStatus = vi.fn(async () => undefined);
 
@@ -179,7 +178,7 @@ describe('repairRestartedStreams', () => {
     });
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.STOPPED,
+      RUN_OUTCOME.CANCELLED,
       456,
     );
     expect(writeTerminalStatus).not.toHaveBeenCalled();
@@ -191,8 +190,8 @@ describe('repairRestartedStreams', () => {
     const streamStatus = new StreamStatusMachine();
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.FAILED ? [...streamIds] : [],
     );
     const writeTerminalStatus = vi.fn(async () => undefined);
     const synchronizeResultOutcome = vi.fn(async () => undefined);
@@ -217,7 +216,7 @@ describe('repairRestartedStreams', () => {
     });
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.ERROR,
+      RUN_OUTCOME.FAILED,
       456,
     );
     expect(writeTerminalStatus).toHaveBeenCalledWith(
@@ -275,8 +274,8 @@ describe('repairRestartedStreams', () => {
     expect(writeTerminalStatus).not.toHaveBeenCalled();
 
     const closeRunningGroups = vi.fn(
-      async (streamIds: readonly StreamTabId[], status: EndGroupStatus) =>
-        status === END_GROUP_STATUS.ERROR ? [...streamIds] : [],
+      async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
+        status === RUN_OUTCOME.FAILED ? [...streamIds] : [],
     );
 
     const result = await repairRestartedStreams({
@@ -297,7 +296,7 @@ describe('repairRestartedStreams', () => {
     });
     expect(closeRunningGroups).toHaveBeenCalledWith(
       [streamId],
-      END_GROUP_STATUS.ERROR,
+      RUN_OUTCOME.FAILED,
       567,
     );
     expect(writeTerminalStatus).toHaveBeenCalledWith(

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -17,7 +17,9 @@ import {
   END_GROUP_STATUS,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
   type StreamLogEntry,
 } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
@@ -377,7 +379,10 @@ describe('StreamLogStore load', () => {
     expect(affected).toEqual(['alpha']);
     expect(storage.fullLogReads()).toBe(1);
     expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
-    expect(entry?.data).toEqual({ status: 'error', endTime: 300 });
+    // endRunningGroups() defaults to RUN_OUTCOME.FAILED (#7993 step 2) — the
+    // orphan sweep's caller-classified default, not the folded 'error'
+    // EndGroupStatus string.
+    expect(entry?.data).toEqual({ status: RUN_OUTCOME.FAILED, endTime: 300 });
     expect(
       storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
     ).toEqual({
@@ -473,7 +478,7 @@ describe('StreamLogStore load', () => {
     });
   });
 
-  it('can close selected running groups with a neutral stopped status', async () => {
+  it('can close selected running groups with a caller-supplied RunOutcome', async () => {
     const storage = mockStorage({
       logs: {
         alpha: [runningGroupEntry('alpha', 1, 100)],
@@ -490,19 +495,83 @@ describe('StreamLogStore load', () => {
     const store = new StreamLogStore();
     await store.load();
 
+    // A caller-supplied RunOutcome (e.g. restart repair's graceful-interrupt
+    // classification, #7993 step 2) reaches the row directly — no fold to
+    // the legacy 2-value EndGroupStatus.
     const affected = await store.endRunningGroupsForStreams(
       ['alpha'],
       300,
-      END_GROUP_STATUS.STOPPED,
+      RUN_OUTCOME.CANCELLED,
     );
     await store.flush();
 
     expect(affected).toEqual(['alpha']);
     expect(store.get('alpha')?.getRange(0).at(0)?.data).toEqual({
-      status: END_GROUP_STATUS.STOPPED,
+      status: RUN_OUTCOME.CANCELLED,
       endTime: 300,
     });
     expect(storage.fullLogReads()).toBe(1);
+  });
+
+  // §8.3 boundary normalization: the ONE app-side read boundary for legacy
+  // GROUP_START/GROUP_END `data.status` wire values a pre-cutover writer left
+  // on disk. Every live producer now writes canonical StreamPhase/RunOutcome
+  // values directly (#7993 step 2), so this is the backfill path for rows
+  // that were already persisted before the cutover.
+  it('normalizes legacy persisted GROUP_END status at the read boundary (#7993 step 2)', async () => {
+    const legacyStoppedEntry: StreamLogEntry = {
+      seqNo: 1,
+      id: 'delta-legacy-stopped',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      data: { status: END_GROUP_STATUS.STOPPED, endTime: 150 },
+    };
+    const legacyErrorEntry: StreamLogEntry = {
+      seqNo: 2,
+      id: 'delta-legacy-error',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+      level: LOG_LEVELS.INFO,
+      timestamp: 200,
+      data: { status: END_GROUP_STATUS.ERROR, endTime: 250 },
+    };
+    const legacyRunningStartEntry: StreamLogEntry = {
+      seqNo: 3,
+      id: 'delta-legacy-running',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: 300,
+      data: { status: 'running' },
+    };
+    mockStorage({
+      logs: {
+        delta: [legacyStoppedEntry, legacyErrorEntry, legacyRunningStartEntry],
+      },
+      summaries: {},
+    });
+
+    const store = new StreamLogStore();
+    await store.load();
+    await store.ensureLoaded('delta');
+
+    const entries = store.get('delta')?.getRange(0) ?? [];
+
+    // 'stopped' -> RunOutcome.COMPLETED: a documented lossy default. The
+    // pre-cutover 2-value fold already could not distinguish completed from
+    // cancelled, and COMPLETED matches today's neutral "Stopped" rendering.
+    expect(entries.find((e) => e.id === 'delta-legacy-stopped')?.data).toEqual(
+      { status: RUN_OUTCOME.COMPLETED, endTime: 150 },
+    );
+    // 'error' -> RunOutcome.FAILED: lossless 1:1.
+    expect(entries.find((e) => e.id === 'delta-legacy-error')?.data).toEqual({
+      status: RUN_OUTCOME.FAILED,
+      endTime: 250,
+    });
+    // 'running' is string-identical to StreamPhase.RUNNING (row 1, §8.2) —
+    // passes through unnormalized, retype-only.
+    expect(
+      entries.find((e) => e.id === 'delta-legacy-running')?.data,
+    ).toEqual({ status: STREAM_PHASE.RUNNING });
   });
 
   it('does not load selected streams whose summaries have no running group', async () => {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -559,9 +559,10 @@ describe('StreamLogStore load', () => {
     // 'stopped' -> RunOutcome.COMPLETED: a documented lossy default. The
     // pre-cutover 2-value fold already could not distinguish completed from
     // cancelled, and COMPLETED matches today's neutral "Stopped" rendering.
-    expect(entries.find((e) => e.id === 'delta-legacy-stopped')?.data).toEqual(
-      { status: RUN_OUTCOME.COMPLETED, endTime: 150 },
-    );
+    expect(entries.find((e) => e.id === 'delta-legacy-stopped')?.data).toEqual({
+      status: RUN_OUTCOME.COMPLETED,
+      endTime: 150,
+    });
     // 'error' -> RunOutcome.FAILED: lossless 1:1.
     expect(entries.find((e) => e.id === 'delta-legacy-error')?.data).toEqual({
       status: RUN_OUTCOME.FAILED,
@@ -569,9 +570,9 @@ describe('StreamLogStore load', () => {
     });
     // 'running' is string-identical to StreamPhase.RUNNING (row 1, §8.2) —
     // passes through unnormalized, retype-only.
-    expect(
-      entries.find((e) => e.id === 'delta-legacy-running')?.data,
-    ).toEqual({ status: STREAM_PHASE.RUNNING });
+    expect(entries.find((e) => e.id === 'delta-legacy-running')?.data).toEqual({
+      status: STREAM_PHASE.RUNNING,
+    });
   });
 
   it('does not load selected streams whose summaries have no running group', async () => {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -5,10 +5,91 @@ import { StreamLogStore } from '@transcript/StreamLogStore';
 import { TraceEmitter } from '@agent/trace';
 import {
   MESSAGE_TYPES,
+  RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
   type StreamTabId,
 } from '@shared/schemas';
 import { isObject } from '@utils/core';
+
+describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)', () => {
+  it("writes GROUP_START's data.status as StreamPhase.RUNNING", () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:group-start-native' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const stage = trace.openStage('r0', { kind: 'round' });
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const startEntry = entries.find((e) => e.id === stage.id);
+
+    expect(startEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_START);
+    expect(isObject(startEntry?.data) && startEntry.data.status).toBe(
+      STREAM_PHASE.RUNNING,
+    );
+  });
+
+  it('defaults GROUP_END to the literal RunOutcome.COMPLETED, not a folded EndGroupStatus', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:group-end-default-outcome' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const stage = trace.openStage('r0', { kind: 'round' });
+    stage.end();
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const endEntry = entries.find((e) => e.id === stage.id);
+
+    expect(endEntry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
+    expect(isObject(endEntry?.data) && endEntry.data.status).toBe(
+      RUN_OUTCOME.COMPLETED,
+    );
+  });
+
+  it('writes an explicit RunOutcome passed to stage.end() verbatim', () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:group-end-explicit-outcome' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const stage = trace.openStage('r0', { kind: 'round' });
+    stage.end(RUN_OUTCOME.CANCELLED);
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const endEntry = entries.find((e) => e.id === stage.id);
+
+    expect(isObject(endEntry?.data) && endEntry.data.status).toBe(
+      RUN_OUTCOME.CANCELLED,
+    );
+  });
+
+  it('defaults a stage.run() failure to RunOutcome.FAILED', async () => {
+    const trace = new TraceEmitter();
+    const store = new StreamLogStore();
+    const streamId = 'stream:group-end-run-failure' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, streamId, store);
+
+    const stage = trace.openStage('r0', { kind: 'round' });
+    await expect(
+      stage.run(() => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    const endEntry = entries.find((e) => e.id === stage.id);
+
+    expect(isObject(endEntry?.data) && endEntry.data.status).toBe(
+      RUN_OUTCOME.FAILED,
+    );
+  });
+});
 
 describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
   it("preserves a round stage's kind onto its persisted GROUP_END row", () => {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -6,8 +6,9 @@ import * as log from '@logger/logUtils';
 import {
   END_GROUP_STATUS,
   PersistedStreamLogEntrySchema,
+  RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
-  type EndGroupStatus,
+  type RunOutcome,
   type StreamLogEntry,
   type StreamTabId,
 } from '@shared/schemas';
@@ -56,6 +57,49 @@ function summaryOf(logInstance: StreamLog): StreamLogSummary {
     hasRunningGroup: logInstance.hasRunningGroup,
     hasRunningStreamingText: logInstance.hasRunningStreamingText,
   };
+}
+
+/**
+ * The ONE app-side read boundary for legacy `GROUP_START`/`GROUP_END`
+ * `data.status` wire values (see
+ * docs/proposals/session-scoped-runtime-architecture.md §8.3). Every live
+ * producer now writes canonical `StreamPhase`/`RunOutcome` values directly
+ * through `append()` (§8.2), so this only backfills rows that were already
+ * persisted to disk before the cutover — `'running'` (row 1) is
+ * string-identical to `StreamPhase.RUNNING`, so it passes through unchanged;
+ * `'stopped'`/`'error'` (the pre-cutover 2-value `EndGroupStatus`) are
+ * upgraded to the `RunOutcome` they folded. `'stopped'` -> `COMPLETED` is a
+ * documented lossy default: the old 2-value fold already could not
+ * distinguish completed from cancelled, and `COMPLETED` matches today's
+ * neutral "Stopped" rendering, so no historical transcript's displayed label
+ * changes — only its typed value does. `data` stays `z.unknown()` in
+ * `PersistedStreamLogEntrySchema` (Tier 3 — opaque, pattern-matched by
+ * display code), so this is a value transform layered on top of the existing
+ * parse, not a schema change, and needs no persisted format-version bump.
+ * Any other value (already-canonical post-cutover write, or malformed data)
+ * passes through unchanged.
+ */
+function normalizeGroupStatusEntry(entry: StreamLogEntry): StreamLogEntry {
+  if (
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END
+  ) {
+    return entry;
+  }
+  if (!isObject(entry.data) || typeof entry.data.status !== 'string') {
+    return entry;
+  }
+  switch (entry.data.status) {
+    case END_GROUP_STATUS.STOPPED:
+      return {
+        ...entry,
+        data: { ...entry.data, status: RUN_OUTCOME.COMPLETED },
+      };
+    case END_GROUP_STATUS.ERROR:
+      return { ...entry, data: { ...entry.data, status: RUN_OUTCOME.FAILED } };
+    default:
+      return entry;
+  }
 }
 
 /**
@@ -393,7 +437,7 @@ export class StreamLogStore {
   async endRunningGroups(
     now: number = Date.now(),
     streamIds: readonly StreamTabId[] = [],
-    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
+    status: RunOutcome = RUN_OUTCOME.FAILED,
   ): Promise<StreamTabId[]> {
     const streamsToLoad = new Set(streamIds);
     for (const [streamId, summary] of this.summaries) {
@@ -419,7 +463,7 @@ export class StreamLogStore {
   async endRunningGroupsForStreams(
     streamIds: readonly StreamTabId[],
     now: number = Date.now(),
-    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
+    status: RunOutcome = RUN_OUTCOME.FAILED,
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];
     const streamsToLoad = streamIds.filter(
@@ -446,7 +490,7 @@ export class StreamLogStore {
   private endRunningEntriesInLoadedLogs(
     now: number,
     streamIds?: ReadonlySet<StreamTabId>,
-    status: EndGroupStatus = END_GROUP_STATUS.ERROR,
+    status: RunOutcome = RUN_OUTCOME.FAILED,
   ): StreamTabId[] {
     const affected: StreamTabId[] = [];
     for (const [streamId, logInstance] of this.logs.entries()) {
@@ -822,7 +866,7 @@ export class StreamLogStore {
     for (const raw of rawEntries) {
       const result = PersistedStreamLogEntrySchema.safeParse(raw);
       if (result.success) {
-        parsed.entries.push(result.data);
+        parsed.entries.push(normalizeGroupStatusEntry(result.data));
       } else {
         parsed.preservedRawEntries.push({
           beforeTypedIndex: parsed.entries.length,

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -23,9 +23,10 @@ import type {
 import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import { isDebugModeEnabled } from '@logger/logUtils';
 import {
-  END_GROUP_STATUS,
   MESSAGE_TYPES,
+  RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
   type LogLevel,
   type MessageType,
   type StreamTabId,
@@ -232,7 +233,7 @@ export function attachTranscriptRecorder(
           messageType: MESSAGE_TYPES.DEFAULT,
           text: event.label,
           data: {
-            status: 'running',
+            status: STREAM_PHASE.RUNNING,
             ...(event.kind ? { kind: event.kind } : {}),
             ...(event.index !== undefined ? { index: event.index } : {}),
             ...(event.total !== undefined ? { total: event.total } : {}),
@@ -247,7 +248,7 @@ export function attachTranscriptRecorder(
         store.update(streamId, event.id, {
           type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
           data: {
-            status: event.status ?? END_GROUP_STATUS.STOPPED,
+            status: event.status ?? RUN_OUTCOME.COMPLETED,
             endTime: Date.now(),
             ...(kind ? { kind } : {}),
           },


### PR DESCRIPTION
## Summary

Design-gated production cutover per docs/proposals/session-scoped-runtime-architecture.md §8 (issue #7993 step 2, the design doc's own §8.4 "Step 1"). Retypes all four live `GROUP_END`/`GROUP_START` producers atomically from the legacy 2-value `EndGroupStatus` to the canonical `RunOutcome`/`StreamPhase` vocabulary, and lands the one app-side read-boundary normalization in the same PR (§8.3's own requirement — the boundary and the producer cutover must ship together).

### 1. Retyped producers (all four, atomic)

- `AgentRunLifecycle.ts:138` (`finalizeRunTerminal`'s `params.stage.end(outcome)`) — dropped the `legacyEndGroupStatusForOutcome` fold; the stage now closes with the literal `RunOutcome`.
- `AgentRunLifecycle.ts:369` (the WAITING/kill teardown's direct `session.transcripts.update(...)` write, which bypasses `TraceEmitter` because the trace's subscriber is already torn down) — writes `RUN_OUTCOME.CANCELLED` directly.
- `TraceEmitter.ts:212` (`openStage`'s `defaultStatus`) — now defaults to `RUN_OUTCOME.COMPLETED`; `:300` (`StageHandleImpl.run()`'s catch branch) — now ends with `RUN_OUTCOME.FAILED`. Covers every non-run stage (tool groupings, sub-phases).
- `StreamLogStore`'s orphan-sweep trio (`endRunningGroups`/`endRunningGroupsForStreams`/`endRunningEntriesInLoadedLogs`) — retyped `status: EndGroupStatus = END_GROUP_STATUS.ERROR` to `status: RunOutcome = RUN_OUTCOME.FAILED`. Callers now pass the actual classification instead of a folded 2-value string:
  - `restartRepair.ts`'s crash-vs-graceful-interrupt split (§8.2): a stream repaired back to WAITING (graceful interrupt) closes its group as `RUN_OUTCOME.CANCELLED`; a crash-classified stream closes as `RUN_OUTCOME.FAILED` — previously both used the same 2-value `EndGroupStatus.STOPPED`/`.ERROR` strings and this distinction was discarded at the boundary.
  - `TexraTranscriptRecorder.ts`'s `GROUP_START` write moves the bare `'running'` string literal to `STREAM_PHASE.RUNNING` (row 1, §8.2 — string-identical, retype only, no value change). Its `GROUP_END` handler's `event.status ?? END_GROUP_STATUS.STOPPED` default becomes `event.status ?? RUN_OUTCOME.COMPLETED`.

### 2. Read-boundary normalization (`StreamLogStore.parsePersistedEntries`)

Added `normalizeGroupStatusEntry` in `StreamLogStore.ts`, run on every successfully-parsed `GROUP_START`/`GROUP_END` entry before it enters the in-memory `StreamLog`: on-disk `'running'` passes through unchanged (string-identical to `StreamPhase.RUNNING`); `'stopped'` → `RUN_OUTCOME.COMPLETED` (documented lossy default — the old fold already couldn't distinguish completed from cancelled, and COMPLETED matches today's neutral "Stopped" rendering); `'error'` → `RUN_OUTCOME.FAILED` (lossless 1:1). `data` stays `z.unknown()` in `PersistedStreamLogEntrySchema` — this is a value transform layered on the existing parse, not a schema change, no format-version bump.

This is the **only** legacy parse added to the in-app path. Verified by grep: `legacyEndGroupStatusForOutcome(` now has exactly one production caller outside its own definition and this PR's one addition — `packages/cli/src/runtime/terminalStatus.ts:78` (the frozen Tier-4 CLI JSON projection, untouched, byte-identical).

### 3. Live-emission path needs no parse — verified

`StreamLogStore.append()`/`update()` never call `parsePersistedEntries` (only the disk-load paths — `ensureLoaded`/`load`/`loadStreamSummary` — do):

```
$ grep -n "parsePersistedEntries" src/transcript/StreamLogStore.ts
272:        const diskEntries = this.parsePersistedEntries(streamId, raw);
675:      const entries = this.parsePersistedEntries(streamId, raw);
842:  private parsePersistedEntries(
```

Both call sites (272, 675) are inside `ensureLoaded`/`loadStreamSummary`-style disk reads; `append()`/`update()` (used by every live producer via `TexraTranscriptRecorder`) write straight to the in-memory `StreamLog` with no parse step. Every entry a live run produces is canonical the instant it's created, because step 1's four producers now emit canonical values directly — there is no vocabulary-mixing window.

## A design-doc gap found and fixed: `assembleTrace()` is a third, uncatalogued `StreamLogStore` boundary participant

§8.3 states there are exactly two boundaries — `StreamLogStore.parsePersistedEntries` (in-app) and the standalone trace-viewer's own file-import parse (`replayTrace.ts`'s `toStreamLifecycleStatus`, asserted to stay legacy-only **forever**) — and that "`StreamLogStore.parsePersistedEntries` never runs in that call chain" for trace-viewer content.

That's true for the trace-viewer's own *loading* side (`packages/trace-viewer/src/main.ts`'s `loadTrace()`), but it misses the *producing* side: `assembleTrace()` (`src/transcript/traceAssembler.ts`) is the function that builds every `TraceDocument` — used by the CLI's single-file export, the extension's history browser, and the settings-view chat export (`ChatExportController`) — and it constructs a **fresh** `StreamLogStore` instance and calls `.load()`/`.ensureLoaded()` on it. That means `assembleTrace()` *does* run through `parsePersistedEntries`, so after this PR every `TraceDocument` it assembles — including one built from pre-cutover on-disk history — carries canonical `RunOutcome` values in `GROUP_END` rows, not the legacy 2-value strings §8.3 assumed would persist in exported files "forever."

`replayTrace.ts`'s `toStreamLifecycleStatus` parsed the terminal group row's `data.status` with the legacy-only `StreamStatusSchema`, which doesn't recognize `'completed'`/`'cancelled'`/`'failed'`. This was caught by the **existing, unmodified** `replayTrace.vitest.ts` suite (`derives failed status from a real exported legacy trace without snapshot.status`, issue #7188) going from pass to fail once the producers retyped — a concrete, reproduced regression, not a hypothetical.

**Fix** (packages/trace-viewer/src/replayTrace.ts, minimal, no new vocabulary): swapped `StreamStatusSchema.safeParse` for the already-shipped `StreamLifecycleStatusSchema` (`z.union([StreamPhaseSchema, z.literal('ready'), StreamStatusSchema.transform(streamStatusToLifecycleStatus)])`, §2) — it accepts both canonical `StreamPhase`/`RunOutcome` values and legacy `StreamStatus` values, so it keeps working for freshly-`assembleTrace()`d documents and genuinely pre-cutover, never-reassembled exported files alike. This does **not** touch the per-entry `GROUP_START`/`GROUP_END` normalization of `trace.entries` forwarded into `logSlice.ts` via `LOG_DELTA` — that stays exactly the future work §8.3 scopes separately (trace-viewer's own per-entry cutover).

`replayTrace.vitest.ts` itself is unmodified — every existing case (including the legacy-string fixtures) still passes with the swap, since the legacy arm of `StreamLifecycleStatusSchema` reproduces `streamStatusToLifecycleStatus(StreamStatusSchema.parse(...))` exactly.

**Recommend**: correct §8.3's boundary census in the design doc to name `assembleTrace()`/`traceAssembler.ts` as a third `StreamLogStore` client whose output the trace-viewer consumes, and note `replayTrace.ts`'s `toStreamLifecycleStatus` needed to read `StreamLifecycleStatusSchema` (not `StreamStatusSchema`) for this reason. Filing this as documentation feedback rather than blocking on it — the fix reuses existing, already-shipped vocabulary/schema (R4) and is covered by the pre-existing pinned suite.

## A second, necessary deviation from the task's compressed SCOPE paraphrase: `logSlice.ts` stays a tolerant reader, not canonical-only

The task description's SCOPE item 2 says to "delete the now-redundant scattered legacy handling" at `logSlice.ts`. Per the actual §8.3 text this is explicitly premature: `logSlice.ts`'s `isTaskGroupStatus` fallback is deletable only "once the boundary lands **and** `logSlice.ts` is retyped to expect `StreamPhase`/`RunOutcome`... conditioned on **both** of `logSlice.ts`'s callers going canonical, not just `StreamLogStore`'s" — the standalone trace-viewer's `replayTrace()` forwards `trace.entries` **raw** into the same `LOG_DELTA`/`logSlice.ts` pipeline (`replayTrace.ts:181-188`), so `logSlice.ts` still receives un-normalized legacy strings from that path. §4's Tier-3 table independently prescribes the same posture for this exact row: "Tolerant reader accepting both old and new literals; writer switches." Deleting the fallback in this PR would break trace-viewer replay of any pre-cutover exported file.

There's also a correctness reason this can't be a no-op: `TaskGroup.status` (`logSlice.ts`'s `updateTaskGroups`) is still typed `TaskGroupStatus` (the 4-value legacy union) — its own reader retyping to `StreamPhase`/`RunOutcome` is `TaskGroupSchema`/`TaskGroupList.ts`'s job, explicitly scoped to the **next** PR (§8.4 "Step 2" / issue goal item 3, not this one). Since `RUNNING`/`ERROR`/`STOPPED`/`READY` share no wire values with `completed`/`cancelled`/`failed` (§8.2 row 5/6: "Wire-value change? Yes"), leaving `isTaskGroupStatus` untouched would make it return `false` for every canonical `GROUP_END` row a live run now produces, and the existing fallback would fold **every** outcome — including failures — into `STREAM_STATUS.STOPPED`. That's a real UI regression (a failed run's task group would lose its error icon and show the same "check" icon as a success), not a neutral no-op.

**Fix**: extended `logSlice.ts`'s status derivation with `taskGroupEndStatus()`, which recognizes the legacy `TaskGroupStatus` values as before (unchanged, still needed for `replayTrace()`'s raw forwarding) and additionally folds a canonical `RunOutcome` value down to the *same* legacy bucket the pre-cutover writer would have produced (`completed`/`cancelled` → `STOPPED`, `failed` → `ERROR`), reusing the existing `legacyEndGroupStatusForOutcome` helper (no new vocabulary, R4). Net effect: `TaskGroup.status`'s rendered value is byte-identical to today's for every input — legacy or canonical — so there is no visible extension UI change in this PR. The "extension webview starts distinguishing completed/cancelled" improvement §5/§8.2 describe as intentional still lands, correctly, in the next PR when `TaskGroupSchema`/`TaskGroupList.ts` retype (goal item 3) — this PR only gets the transcript *row* to carry the extra bit, exactly as §8.2 states ("the transcript row does not need the machine to carry the extra bit").

Pinned by a new `LOG_DELTA GROUP_END task-group status (#7993 step 2)` case added to `LogDeltaTextDeltas.vitest.ts` (the suite §8.5 names for this), parametrized over both vocabularies landing on the same expected status.

## R6 / R8

- Production: **+128/-52** (12 files). Matches §8.4's own estimate ("net-negative at the three/four call sites... net-positive at the boundary... roughly flat to slightly positive, not a reduction — correctly so, since this step is a correctness/behavior improvement, not a dead-code deletion") — the boundary normalization (~45 lines incl. doc comment) plus the two regression-prevention reader extensions (`logSlice.ts` ~30 lines, `replayTrace.ts` ~15 lines doc+swap) the design's file census missed account for the difference from the doc's original "~15-25 new lines" estimate, which only anticipated the `StreamLogStore` boundary itself.
- Tests: **+287/-43** (7 files) extending eight of the nine named §8.5 suites in place (R7 — no new test files): `AgentRunLifecycle.vitest.ts`, `RunOutcomeAlgebra.vitest.ts`, `TexraTranscriptRecorder.vitest.ts`, `StreamLogStoreLoad.vitest.ts`, `RestartRepair.vitest.ts`, `DesktopAgentExecution.vitest.mts`, `LogDeltaTextDeltas.vitest.ts` (new GROUP_END case), plus `WorkflowOutputResolution.vitest.mts` (Tier-4 CLI projection, confirmed unaffected, no edit needed). `StreamLog.vitest.ts` needed no changes (only checks the `'running'` literal, unaffected by the retype). `replayTrace.vitest.ts` is genuinely unmodified — its existing fixtures are what caught the `assembleTrace()` gap and what confirm the fix.
- R8: grep confirms exactly two production callers of `legacyEndGroupStatusForOutcome` remain outside its own module — the frozen CLI Tier-4 projection (`terminalStatus.ts`) and `logSlice.ts`'s read-side fold (this PR's addition, itself scheduled for deletion once `logSlice.ts`'s own reader migration lands). `EndGroupStatusSchema`/`END_GROUP_STATUS` themselves are untouched (not deleted — still back the Tier-4 helper and the boundary's on-disk literal matchers, per §8.3/§8.4).

## Test plan

- Extended suites (all green): `AgentRunLifecycle.vitest.ts`, `RunOutcomeAlgebra.vitest.ts`, `TexraTranscriptRecorder.vitest.ts`, `StreamLog.vitest.ts` (unchanged), `StreamLogStoreLoad.vitest.ts`, `RestartRepair.vitest.ts`, `DesktopAgentExecution.vitest.mts`, `replayTrace.vitest.ts` (unchanged, now passing again post-fix), `LogDeltaTextDeltas.vitest.ts`, `TaskGroupListIndex.vitest.ts` (unchanged, still green — confirms no reader-migration bleed into this PR).
- Proved the boundary normalization is load-bearing: temporarily reverted `parsePersistedEntries`'s call to `normalizeGroupStatusEntry` (direct one-line edit, no stash/checkout), re-ran `StreamLogStoreLoad.vitest.ts`'s new boundary case, confirmed it fails (`expected { status: 'stopped', ... } to deeply equal { status: 'completed', ... }`), then restored.
- `npm run typecheck`: clean.
- `npm test` (full `src/test-kernel` suite, 5550 tests): all green except 2 pre-existing flakes unrelated to this change (`DesktopSettingsIpc.vitest.mts` hook timeout, `ToolAvailabilityAppSignals.vitest.ts` test timeout — both pass cleanly in isolation; neither file touches transcript/stream-status code).
- Full `src/test-kernel/transcript` (101 tests) and `src/test-kernel/agent` (1247 tests) directories: all green.

Claude-Session: https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript persistence, restart repair classification, and progress/trace replay paths; behavior is heavily tested but wrong folding would mislabel failed vs cancelled runs in the UI.
> 
> **Overview**
> **#7993 step 2** moves live and persisted transcript **group start/end** rows from the legacy two-value `EndGroupStatus` (`stopped`/`error`) to canonical **`RunOutcome`** (`completed`/`cancelled`/`failed`) and **`StreamPhase.RUNNING`** on starts.
> 
> **Production paths** now emit outcomes literally: `finalizeRunTerminal` / `stage.end(outcome)`, `TraceEmitter` defaults (`COMPLETED` on success, `FAILED` on `stage.run` errors), `TexraTranscriptRecorder`, direct WAITING-kill `GROUP_END` writes, and **`StreamLogStore`** orphan sweeps plus **restart repair** (`CANCELLED` for graceful WAITING repair, `FAILED` for crash-classified streams). Call sites that closed groups are retyped from `EndGroupStatus` to `RunOutcome` (desktop bridge, progress backend).
> 
> **On disk load**, `StreamLogStore.parsePersistedEntries` runs **`normalizeGroupStatusEntry`** so pre-cutover `stopped`/`error` rows upgrade to `COMPLETED`/`FAILED` in memory (documented lossy fold for `stopped`).
> 
> **Readers stay compatible:** `logSlice` adds **`taskGroupEndStatus`** to fold canonical `RunOutcome` back into legacy `TaskGroup.status` so UI icons stay unchanged until a later reader migration; trace replay **`toStreamLifecycleStatus`** parses terminal group status with **`StreamLifecycleStatusSchema`** so `assembleTrace()`-backed documents with canonical rows still derive lifecycle correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8f7c893dbd7a54ad000ed22f8862670222e679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->