### PR TITLE
fix(cli): honor cancellation during resume startup

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -546,6 +546,8 @@ export function createChatSessionController(
           }
           session.runExitCode = CliExitCode.Success;
           notify({ kind: 'agentFinished' });
+        } else if (session.stopRequested) {
+          session.runExitCode = CliExitCode.Interrupted;
         }
         return resumed;
       } catch (error: unknown) {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -424,11 +424,14 @@ export function createChatSessionController(
             isCancellationRequested: () => session.stopRequested,
           }),
         )
-        .then(() => {
+        .then((result) => {
           if (session.streamId) {
             projectStreamTranscript(session.streamId, { finalize: true });
           }
-          session.runExitCode = CliExitCode.Success;
+          session.runExitCode = terminalStatusExitCode(
+            cliTerminalStatus(result),
+            sessionContext,
+          );
           notify({ kind: 'agentFinished' });
         })
         .catch(reportRunFailure)

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -519,6 +519,7 @@ export function createChatSessionController(
                 approvalPromptsUnavailable: approvalsUnavailable,
                 runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
                 allowWaitingResult: true,
+                isCancellationRequested: () => session.stopRequested,
                 onError: reportRunFailure,
               }),
             executeWorkflow: async () => {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -421,6 +421,7 @@ export function createChatSessionController(
           resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {
             approvalPromptsUnavailable: approvalsUnavailable,
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+            isCancellationRequested: () => session.stopRequested,
           }),
         )
         .then(() => {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -358,6 +358,7 @@ export async function runToolUseFlow<C = unknown>(
   let touchedFiles: string[] | undefined;
   let totalCostUsd: number | undefined;
   let teardownSetup: (() => void) | undefined;
+  let preserveResumeRecord = false;
   const compatibilityKey = activeModelHandlerCompatibilityKey(
     services.modelHandler,
   );
@@ -373,7 +374,10 @@ export async function runToolUseFlow<C = unknown>(
     teardownSetup = onSetup?.(flowContext) ?? undefined;
     // A host can hand off a cancellation synchronously during setup. Observe
     // it before touching the persisted resume record.
-    if (input.checkInterruption()) return { outcome };
+    if (input.checkInterruption()) {
+      preserveResumeRecord = input.resumeSnapshot !== undefined;
+      return { outcome };
+    }
 
     let flowRecord: FlowRecord | null = null;
     try {
@@ -388,7 +392,10 @@ export async function runToolUseFlow<C = unknown>(
     }
     // Cancellation can also arrive while the recovery read is pending. Do not
     // start a migration or repair write after that handoff.
-    if (input.checkInterruption()) return { outcome };
+    if (input.checkInterruption()) {
+      preserveResumeRecord = input.resumeSnapshot !== undefined;
+      return { outcome };
+    }
 
     if (flowRecord?.shared) {
       logger.debug('Resuming tool-use flow from persistence');
@@ -558,7 +565,9 @@ export async function runToolUseFlow<C = unknown>(
     activePersistedFlow = undefined;
     teardownSetup?.();
     teardownSetup = undefined;
-    if (outcome === STREAM_PHASE.WAITING) {
+    if (preserveResumeRecord) {
+      logger.debug('Flow record preserved after resume startup cancellation');
+    } else if (outcome === STREAM_PHASE.WAITING) {
       logger.debug('Flow record preserved for native subagent WAITING');
     } else if (shared.userCancelledRetry) {
       logger.debug('Flow record preserved for resume after retry cancellation');

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -371,6 +371,10 @@ export async function runToolUseFlow<C = unknown>(
 
   try {
     teardownSetup = onSetup?.(flowContext) ?? undefined;
+    // A host can hand off a cancellation synchronously during setup. Observe
+    // it before touching the persisted resume record.
+    if (input.checkInterruption()) return { outcome };
+
     let flowRecord: FlowRecord | null = null;
     try {
       flowRecord = (await kv.read<FlowRecord>(flowKey(executionId))) ?? null;
@@ -382,6 +386,10 @@ export async function runToolUseFlow<C = unknown>(
         data: { executionId, error: toErrorMessage(error) },
       });
     }
+    // Cancellation can also arrive while the recovery read is pending. Do not
+    // start a migration or repair write after that handoff.
+    if (input.checkInterruption()) return { outcome };
+
     if (flowRecord?.shared) {
       logger.debug('Resuming tool-use flow from persistence');
       const migrationResult = migrateSharedState(flowRecord.shared);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -471,6 +471,7 @@ export async function executeAgent(
 }
 
 export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
+  /** Initialize the rebuilt session immediately after its flow is attached. */
   readonly setupSession?: (session: IToolUseSession) => void;
   /** Query caller-owned cancellation once the resumed flow is interruptible. */
   readonly isCancellationRequested?: () => boolean;
@@ -574,10 +575,10 @@ export async function resumeToolUseFromSnapshot(
           undefined,
           (flowContext) => {
             handle.attachToolUseFlow(flowContext);
+            options.setupSession?.(flowContext.session);
             if (options.isCancellationRequested?.()) {
               flowContext.interrupt();
             }
-            options.setupSession?.(flowContext.session);
             return () => handle.detachToolUseFlow(flowContext);
           },
         );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -482,6 +482,24 @@ export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly drainedFollowUps?: readonly FollowUpQueueBatchItem[];
 }
 
+export function resumeToolUseFromSnapshot(
+  snapshot: ToolUseSessionSnapshot,
+  runtimeHost: AgentRuntimeHost,
+  options: ResumeToolUseFromSnapshotOptions & { allowWaitingResult: true },
+): Promise<AgentFlowResult | WaitingToolUseFlowResult>;
+export function resumeToolUseFromSnapshot(
+  snapshot: ToolUseSessionSnapshot,
+  runtimeHost: AgentRuntimeHost,
+  options?: ResumeToolUseFromSnapshotOptions & {
+    allowWaitingResult?: false | undefined;
+  },
+): Promise<AgentFlowResult>;
+export function resumeToolUseFromSnapshot(
+  snapshot: ToolUseSessionSnapshot,
+  runtimeHost: AgentRuntimeHost,
+  options: ResumeToolUseFromSnapshotOptions,
+): Promise<AgentRuntimeFlowResult>;
+
 export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   runtimeHost: AgentRuntimeHost,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -472,6 +472,8 @@ export async function executeAgent(
 
 export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly setupSession?: (session: IToolUseSession) => void;
+  /** Query caller-owned cancellation once the resumed flow is interruptible. */
+  readonly isCancellationRequested?: () => boolean;
   /**
    * Follow-ups already drained by an external turn owner. The resumed flow
    * consumes this batch once at its persisted WAITING cursor; it must never
@@ -554,6 +556,9 @@ export async function resumeToolUseFromSnapshot(
           undefined,
           (flowContext) => {
             handle.attachToolUseFlow(flowContext);
+            if (options.isCancellationRequested?.()) {
+              flowContext.interrupt();
+            }
             options.setupSession?.(flowContext.session);
             return () => handle.detachToolUseFlow(flowContext);
           },

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -114,6 +114,9 @@ export async function resumeQueuedToolUseSnapshot(
       setupSession: (session) => {
         if (options.isCancellationRequested?.()) {
           cancelledBeforeSessionSetup = true;
+          // Capture messages accepted after the initial drain before the
+          // cancellation handoff disposes the shared stream queue.
+          followUps = [...followUps, ...followUpsQueue.drainItems(streamId)];
           return;
         }
         for (const item of followUps) {

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -52,7 +52,8 @@ export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
  *
  * Hosts stay thin adapters: they supply only what differs (`session`,
  * `runtimeUnavailableTools`, an optional seed follow-up, and the `onError`
- * toast). Returns `true` when the resume completed and `false` when it failed.
+ * toast). Returns `true` when the resume completed and `false` when it failed
+ * or was cancelled before the rebuilt session accepted its follow-ups.
  */
 export async function resumeQueuedToolUseSnapshot(
   streamId: StreamTabId,
@@ -120,19 +121,22 @@ export async function resumeQueuedToolUseSnapshot(
         }
       },
     });
-    if (cancelledBeforeSessionSetup) restoreFollowUps();
     options.onResult?.(result);
+    if (cancelledBeforeSessionSetup) restoreFollowUps();
   } catch (error) {
     resumeError = { error };
     // Re-enqueue the drained follow-ups (explicit seed first) so a later
     // resume replays them instead of dropping them.
     restoreFollowUps();
   } finally {
-    // Only the early-failure path leaves the stream RESUMING (a started run
-    // owns its own status); settle it back to WAITING before surfacing the
-    // error so a blocking host dialog cannot hold the stream in RESUMING.
-    if (streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING) {
-      streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
+    // Early failures leave the stream RESUMING. Startup cancellation can
+    // instead reach lifecycle terminalization before the queue owner regains
+    // control. In both cases, restored input makes WAITING the durable state.
+    if (
+      cancelledBeforeSessionSetup ||
+      streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING
+    ) {
+      streamStatus.transitionToWaiting(streamId, 'wait', {
         events: session.events,
       });
     }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -15,6 +15,8 @@ import { defaultSession } from './SessionHandle';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
+  /** Query a caller-owned stop request at the resumed flow attachment boundary. */
+  readonly isCancellationRequested?: () => boolean;
   /**
    * Fires with the resumed run's raw outcome — terminal or WAITING — right
    * after the call returns successfully. Additive to `onRunError`, which only
@@ -70,7 +72,22 @@ export async function resumeQueuedToolUseSnapshot(
 
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
+  let cancelledBeforeSessionSetup = false;
   let resumeError: { error: unknown } | undefined;
+  const restoreFollowUps = (): void => {
+    for (const item of followUps) {
+      followUpsQueue.enqueue(streamId, item, { force: true });
+    }
+    if (followUps.length > 0) {
+      session.events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId },
+        },
+      });
+    }
+  };
   try {
     followUps = [...seed, ...followUpsQueue.drainItems(streamId)];
     session.events.emit({
@@ -92,29 +109,24 @@ export async function resumeQueuedToolUseSnapshot(
       onProgress: options.onProgress,
       onRunError: options.onRunError,
       onRun: options.onRun,
+      isCancellationRequested: options.isCancellationRequested,
       setupSession: (session) => {
+        if (options.isCancellationRequested?.()) {
+          cancelledBeforeSessionSetup = true;
+          return;
+        }
         for (const item of followUps) {
           session.appendFollowUp(item);
         }
       },
     });
+    if (cancelledBeforeSessionSetup) restoreFollowUps();
     options.onResult?.(result);
   } catch (error) {
     resumeError = { error };
     // Re-enqueue the drained follow-ups (explicit seed first) so a later
     // resume replays them instead of dropping them.
-    for (const item of followUps) {
-      followUpsQueue.enqueue(streamId, item, { force: true });
-    }
-    if (followUps.length > 0) {
-      session.events.emit({
-        scope: 'session',
-        event: {
-          type: 'updateQueuedFollowUps',
-          payload: { streamId },
-        },
-      });
-    }
+    restoreFollowUps();
   } finally {
     // Only the early-failure path leaves the stream RESUMING (a started run
     // owns its own status); settle it back to WAITING before surfacing the
@@ -127,7 +139,7 @@ export async function resumeQueuedToolUseSnapshot(
   }
 
   if (!resumeError) {
-    return true;
+    return !cancelledBeforeSessionSetup;
   }
   try {
     await options.onError(resumeError.error);

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -27,12 +27,15 @@ import {
   buildResumedSharedFromSnapshot,
   normalizeResumedWorkspaceSnapshot,
   runToolUseFlow,
+  type RunToolUseFlowResult,
   type RunToolUseFlowInput,
+  type ToolUseFlowSetupCallback,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import { migrateSharedState } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import {
+  RUN_OUTCOME,
   STREAM_PHASE,
   type ExecutionId,
   type StreamTabId,
@@ -65,6 +68,7 @@ const TOOL_USE_SETTING = AgentToolUseSettingSchema.parse({});
 const TOOL_USE_PROMPT = AgentPromptSchema.parse({});
 const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
 const WAIT_NODE_CURSOR = 'start/default/default';
+type ToolUseSetupContext = Parameters<ToolUseFlowSetupCallback>[0];
 
 function createTaggedModelHandler(
   compatibilityKey: ModelHandlerCompatibilityKey,
@@ -77,11 +81,29 @@ function createTaggedModelHandler(
   return handler as unknown as RunToolUseFlowInput['modelHandler'];
 }
 
-async function runResumedFlowToWaiting(
+function buildToolUseSnapshot(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): ToolUseSessionSnapshot {
+  return {
+    version: 2,
+    executionId,
+    streamId,
+    agentConfig: CONFIG,
+    messages: [],
+    run: AgentRunStateSnapshotSchema.parse({}),
+    workspace: AgentWorkspaceState.create().toSnapshot(),
+    user: { input: {}, transient: {} },
+    lastUpdated: 0,
+  };
+}
+
+async function runResumedFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
   snapshot: ToolUseSessionSnapshot,
-): Promise<void> {
+  onSetup?: (context: ToolUseSetupContext) => void,
+): Promise<RunToolUseFlowResult> {
   const session = new SessionHandle();
   const context = createRunContext({
     modelSource: 'live',
@@ -94,9 +116,10 @@ async function runResumedFlowToWaiting(
       session,
     }),
   });
+  let interrupted = false;
 
   try {
-    const result = await withRunContext(context, () =>
+    return await withRunContext(context, () =>
       runToolUseFlow(
         {
           config: snapshot.agentConfig,
@@ -106,19 +129,31 @@ async function runResumedFlowToWaiting(
           userVarChannels: snapshot.user,
           modelHandler: createTaggedModelHandler(ACTIVE_COMPATIBILITY_KEY),
           streamStatus: session.status,
-          checkInterruption: () => false,
+          checkInterruption: () => interrupted,
+          onInterrupt: () => {
+            interrupted = true;
+          },
           setAbortController: () => {},
           resumeSnapshot: snapshot,
           isSubagent: true,
           toolInjections: new ToolInjectionRegistry(),
         },
         new MapToolRegistry({}),
+        onSetup,
       ),
     );
-    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
   } finally {
     session.dispose();
   }
+}
+
+async function runResumedFlowToWaiting(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+  snapshot: ToolUseSessionSnapshot,
+): Promise<void> {
+  const result = await runResumedFlow(executionId, streamId, snapshot);
+  expect(result.outcome).toBe(STREAM_PHASE.WAITING);
 }
 
 describe('retrieveSessionResumeData', () => {
@@ -466,6 +501,75 @@ describe('retrieveSessionResumeData', () => {
 
 describe('runToolUseFlow consumes the resume boundary instead of re-parsing', () => {
   setupPlatform({ workspacePath: '/workspace' });
+
+  it('skips persistence recovery when setup hands off a cancellation', async () => {
+    const executionId = 'abc-cancel-setup' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-cancel-setup' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    const readSpy = vi.spyOn(store, 'read');
+    const writeSpy = vi.spyOn(store, 'write');
+
+    try {
+      const result = await runResumedFlow(
+        executionId,
+        streamId,
+        snapshot,
+        (flowContext) => flowContext.interrupt(),
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('skips repair writes when cancellation arrives during the recovery read', async () => {
+    const executionId = 'abc-cancel-read' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-cancel-read' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    let flowContext: ToolUseSetupContext | undefined;
+    const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
+      flowContext?.interrupt();
+      return {
+        flowName: 'texra',
+        params: {},
+        shared: {
+          messages: [],
+          shouldSkipCycle: true,
+          stateSlices: {
+            runStateSnapshot: snapshot.run,
+            workspaceSnapshot: snapshot.workspace,
+            userChannels: snapshot.user,
+          },
+        },
+        createdAt: new Date().toISOString(),
+      };
+    });
+    const writeSpy = vi.spyOn(store, 'write');
+
+    try {
+      const result = await runResumedFlow(
+        executionId,
+        streamId,
+        snapshot,
+        (context) => {
+          flowContext = context;
+        },
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(readSpy).toHaveBeenCalledWith(flowKey(executionId));
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      writeSpy.mockRestore();
+    }
+  });
 
   it('hydrates a legacy-shaped flow record through the single boundary, then self-heals via its canonical fields', async () => {
     const executionId = 'abc140' as ExecutionId;

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -509,6 +509,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const store = getExecutionStore(executionId);
     const readSpy = vi.spyOn(store, 'read');
     const writeSpy = vi.spyOn(store, 'write');
+    const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
       const result = await runResumedFlow(
@@ -521,9 +522,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(readSpy).not.toHaveBeenCalled();
       expect(writeSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
     } finally {
       readSpy.mockRestore();
       writeSpy.mockRestore();
+      deleteSpy.mockRestore();
     }
   });
 
@@ -551,6 +554,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       };
     });
     const writeSpy = vi.spyOn(store, 'write');
+    const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
       const result = await runResumedFlow(
@@ -565,9 +569,11 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(readSpy).toHaveBeenCalledWith(flowKey(executionId));
       expect(writeSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
     } finally {
       readSpy.mockRestore();
       writeSpy.mockRestore();
+      deleteSpy.mockRestore();
     }
   });
 

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -1,0 +1,140 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  buildAgentLaunchContext: vi.fn(),
+  computeDelegationDepthFromStorage: vi.fn(),
+  invokeModelOrTool: vi.fn(),
+  runFlowWithLifecycle: vi.fn(),
+  runToolUseFlow: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/AgentLaunchContext', () => ({
+  buildAgentLaunchContext: mocks.buildAgentLaunchContext,
+  withExecutionRunContext: async (
+    _context: unknown,
+    _options: unknown,
+    run: () => Promise<unknown>,
+  ) => run(),
+}));
+
+vi.mock('@agent/runtime/AgentRunLifecycle', () => ({
+  runFlowWithLifecycle: mocks.runFlowWithLifecycle,
+}));
+
+vi.mock('@agent/runtime/delegationPolicy', () => ({
+  computeDelegationDepthFromStorage: mocks.computeDelegationDepthFromStorage,
+}));
+
+vi.mock('@agent/implementations/flows/reflection/runReflectionFlow', () => ({
+  runReflectionFlow: vi.fn(),
+}));
+
+vi.mock('@agent/implementations/flows/tooluse/runToolUseFlow', () => ({
+  getToolUseFlowErrorResult: () => undefined,
+  runToolUseFlow: mocks.runToolUseFlow,
+}));
+
+// Local imports - agent runtime
+import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+
+interface InterruptibleFlowInput {
+  checkInterruption(): boolean;
+  onInterrupt?: () => void;
+}
+
+interface TestFlowContext {
+  readonly session: { appendFollowUp(item: unknown): void };
+  interrupt(): void;
+}
+
+describe('resumeToolUseFromSnapshot cancellation handoff', () => {
+  it('interrupts at flow attachment before substantive work starts', async () => {
+    const executionId = 'e8049' as ExecutionId;
+    const streamId = 'stream-8049' as StreamTabId;
+    const runtimeHost = { emit: vi.fn() } as unknown as AgentRuntimeHost;
+    const context = {
+      setting: { agentCategory: AgentCategory.ToolUse },
+      runScope: {
+        executionId,
+        streamId,
+        session: { status: {} },
+      },
+      config: { agent: 'test-agent', model: 'test-model' },
+      attachedMemoryMisses: [],
+      usageMonitor: { recordUsage: vi.fn() },
+    } as unknown as AgentLaunchContext;
+    const order: string[] = [];
+    let attachedContext: TestFlowContext | undefined;
+    const handle = {
+      attachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
+        order.push('attach');
+        attachedContext = flowContext;
+      }),
+      detachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
+        order.push('detach');
+        if (attachedContext === flowContext) attachedContext = undefined;
+      }),
+    };
+
+    mocks.buildAgentLaunchContext.mockResolvedValueOnce(context);
+    mocks.computeDelegationDepthFromStorage.mockResolvedValueOnce(0);
+    mocks.runFlowWithLifecycle.mockImplementationOnce(
+      async (
+        _context: unknown,
+        run: (liveHandle: typeof handle) => Promise<unknown>,
+      ) => run(handle),
+    );
+    mocks.runToolUseFlow.mockImplementationOnce(
+      async (
+        input: InterruptibleFlowInput,
+        _registry: unknown,
+        onSetup: (flowContext: TestFlowContext) => void | (() => void),
+      ) => {
+        const flowContext: TestFlowContext = {
+          session: { appendFollowUp: vi.fn() },
+          interrupt: () => {
+            order.push('interrupt');
+            input.onInterrupt?.();
+          },
+        };
+        const teardown = onSetup(flowContext);
+        if (!input.checkInterruption()) mocks.invokeModelOrTool();
+        teardown?.();
+        return {
+          outcome: input.checkInterruption()
+            ? RUN_OUTCOME.CANCELLED
+            : RUN_OUTCOME.COMPLETED,
+        };
+      },
+    );
+
+    const snapshot = {
+      executionId,
+      streamId,
+      agentConfig: { agent: 'test-agent', model: 'test-model' },
+      messages: [],
+    } as unknown as ToolUseSessionSnapshot;
+
+    const result = await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
+      isCancellationRequested: () => {
+        order.push('query');
+        expect(attachedContext).toBeDefined();
+        return true;
+      },
+    });
+
+    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+    expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
+    expect(order).toEqual(['attach', 'query', 'interrupt', 'detach']);
+  });
+});

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -126,6 +126,7 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
     } as unknown as ToolUseSessionSnapshot;
 
     const result = await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
+      setupSession: () => order.push('setup'),
       isCancellationRequested: () => {
         order.push('query');
         expect(attachedContext).toBeDefined();
@@ -135,6 +136,6 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
-    expect(order).toEqual(['attach', 'query', 'interrupt', 'detach']);
+    expect(order).toEqual(['attach', 'setup', 'query', 'interrupt', 'detach']);
   });
 });

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -14,7 +14,7 @@ import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { recordSessionEvents, sessionFactPayloads } from '../progressTestUtils';
 
 const STREAM = 'stream:tooluse-resume' as StreamTabId;
@@ -151,6 +151,11 @@ describe('resumeToolUseSnapshot', () => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
         expect(options.isCancellationRequested).toBe(isCancellationRequested);
         options.setupSession({ appendFollowUp });
+        seedStreamStatusForTest(
+          defaultSession().status,
+          STREAM,
+          STREAM_PHASE.CANCELLED,
+        );
       },
     );
 
@@ -163,6 +168,42 @@ describe('resumeToolUseSnapshot', () => {
 
     expect(appendFollowUp).not.toHaveBeenCalled();
     expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
+  });
+
+  it('restores drained follow-ups once when cancellation result handling throws', async () => {
+    const failure = new Error('result callback failed');
+    const reportFailure = vi.fn();
+    defaultSession().followUps.enqueue(
+      STREAM,
+      { text: 'queued one' },
+      { force: true },
+    );
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        options.setupSession({ appendFollowUp: vi.fn() });
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        isCancellationRequested: () => true,
+        onResult: () => {
+          throw failure;
+        },
+        onError: reportFailure,
+      }),
+    ).resolves.toBe(false);
+
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(reportFailure).toHaveBeenCalledWith(failure);
+    expect(
+      sessionFactPayloads(
+        recordedSession?.events ?? [],
+        'updateQueuedFollowUps',
+      ),
+    ).toHaveLength(2);
   });
 
   it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -27,12 +27,14 @@ function snapshot(parentStreamId?: StreamTabId): ToolUseSessionSnapshot {
 
 function capturedResumeOptions(): {
   parentStreamId?: StreamTabId;
+  isCancellationRequested?: () => boolean;
   setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
 } {
   const calls = resumeToolUseFromSnapshotMock.mock
     .calls as unknown as unknown[][];
   return calls.at(-1)?.[2] as {
     parentStreamId?: StreamTabId;
+    isCancellationRequested?: () => boolean;
     setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
   };
 }
@@ -134,6 +136,33 @@ describe('resumeToolUseSnapshot', () => {
     );
 
     expect(capturedResumeOptions().parentStreamId).toBe(explicitParent);
+  });
+
+  it('restores drained follow-ups when cancellation reaches flow setup', async () => {
+    defaultSession().followUps.enqueue(
+      STREAM,
+      { text: 'queued one' },
+      { force: true },
+    );
+    const isCancellationRequested = vi.fn(() => true);
+    const appendFollowUp = vi.fn();
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        expect(options.isCancellationRequested).toBe(isCancellationRequested);
+        options.setupSession({ appendFollowUp });
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        isCancellationRequested,
+        onError: vi.fn(),
+      }),
+    ).resolves.toBe(false);
+
+    expect(appendFollowUp).not.toHaveBeenCalled();
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
   });
 
   it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -150,6 +150,11 @@ describe('resumeToolUseSnapshot', () => {
       async (...args: unknown[]) => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
         expect(options.isCancellationRequested).toBe(isCancellationRequested);
+        defaultSession().followUps.enqueue(
+          STREAM,
+          { text: 'queued during resume' },
+          { force: true },
+        );
         options.setupSession({ appendFollowUp });
         seedStreamStatusForTest(
           defaultSession().status,
@@ -167,7 +172,10 @@ describe('resumeToolUseSnapshot', () => {
     ).resolves.toBe(false);
 
     expect(appendFollowUp).not.toHaveBeenCalled();
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual([
+      'queued one',
+      'queued during resume',
+    ]);
     expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -686,6 +686,7 @@ describe('createChatSessionController', () => {
       finalize: true,
     });
     expect(mocks.notify).not.toHaveBeenCalledWith({ kind: 'agentFinished' });
+    expect(session.runExitCode).toBe(CliExitCode.Interrupted);
   });
 
   it('does not finalize the stream transcript when auto-resume returns false', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -126,6 +126,7 @@ import {
   type TuiSession,
 } from '@cli/chat/tui/state/sessionRunState';
 import {
+  RUN_OUTCOME,
   STREAM_STATUS,
   type ExecutionId,
   type StreamTabId,
@@ -300,7 +301,12 @@ describe('createChatSessionController', () => {
     mocks.moveLocalTranscriptToStream.mockReset();
     mocks.resolveCliResumeSnapshot.mockReset();
     mocks.resumeToolUseFromSnapshot.mockReset();
-    mocks.resumeToolUseFromSnapshot.mockResolvedValue(undefined);
+    mocks.resumeToolUseFromSnapshot.mockResolvedValue({
+      category: 'toolUse',
+      outcome: RUN_OUTCOME.COMPLETED,
+      executionId: 'exec-resume',
+      streamId: 'stream-resume',
+    });
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -551,6 +557,20 @@ describe('createChatSessionController', () => {
       snapshot,
       config: makeResumeConfig(),
     };
+    mocks.resumeToolUseFromSnapshot.mockImplementationOnce(
+      async (
+        _snapshot: unknown,
+        _runtimeHost: unknown,
+        options: { readonly isCancellationRequested?: () => boolean },
+      ) => ({
+        category: 'toolUse',
+        outcome: options.isCancellationRequested?.()
+          ? RUN_OUTCOME.CANCELLED
+          : RUN_OUTCOME.COMPLETED,
+        executionId: 'exec-resume',
+        streamId: 'stream-resume',
+      }),
+    );
 
     const resumeStarted = ctrl.resume('aaaaaa' as ExecutionId, preResolved);
     await vi.waitFor(() =>
@@ -574,6 +594,7 @@ describe('createChatSessionController', () => {
       { readonly isCancellationRequested?: () => boolean } | undefined;
     expect(resumeOptions?.isCancellationRequested?.()).toBe(true);
     await session.runPromise;
+    expect(session.runExitCode).toBe(CliExitCode.Interrupted);
   });
 
   it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -620,7 +620,10 @@ describe('createChatSessionController', () => {
       'stream-1',
       { version: 2 },
       expect.any(Object),
-      expect.objectContaining({ allowWaitingResult: true }),
+      expect.objectContaining({
+        allowWaitingResult: true,
+        isCancellationRequested: expect.any(Function),
+      }),
     );
     expect(mocks.projectStreamTranscript).toHaveBeenCalledWith('stream-1', {
       finalize: true,

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -528,6 +528,54 @@ describe('createChatSessionController', () => {
     expect(session.runCompleted).toBe(true);
   });
 
+  it('forwards a stop issued during manual resume helper-model setup', async () => {
+    const helperModel = deferred();
+    mocks.setCliHelperModel.mockReturnValueOnce(helperModel.promise);
+
+    const session = makeSession({ runCompleted: true });
+    const snapshotStore = {
+      load: vi.fn(async () => undefined),
+      read: vi.fn(async () => ({
+        runUsage: {},
+        todos: [],
+        plan: undefined,
+      })),
+    } as unknown as StreamSnapshotStore;
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+    const snapshot = { executionId: 'exec-resume' } as never;
+    const preResolved = {
+      kind: 'toolUse' as const,
+      streamId: 'stream-resume' as StreamTabId,
+      snapshot,
+      config: makeResumeConfig(),
+    };
+
+    const resumeStarted = ctrl.resume('aaaaaa' as ExecutionId, preResolved);
+    await vi.waitFor(() =>
+      expect(mocks.setCliHelperModel).toHaveBeenCalledWith('demo-model'),
+    );
+
+    ctrl.stop();
+    helperModel.resolve(undefined);
+
+    await resumeStarted;
+    await vi.waitFor(() =>
+      expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledWith(
+        snapshot,
+        expect.any(Object),
+        expect.objectContaining({
+          isCancellationRequested: expect.any(Function),
+        }),
+      ),
+    );
+    const resumeOptions = mocks.resumeToolUseFromSnapshot.mock.calls[0]?.[2] as
+      { readonly isCancellationRequested?: () => boolean } | undefined;
+    expect(resumeOptions?.isCancellationRequested?.()).toBe(true);
+    await session.runPromise;
+  });
+
   it('reports a failed persisted-child wake while the CLI root slot is busy', async () => {
     const session = makeSession({
       runPromise: new Promise(() => {}),


### PR DESCRIPTION
## Summary

Honor a CLI stop request that arrives after resume has passed its preparatory guards but before the resumed tool-use flow becomes live.

Both CLI resume paths now pass a narrow cancellation query to `resumeToolUseFromSnapshot`. As soon as the runtime attaches the new flow context to its execution handle, it reads that query and invokes the existing flow interruption path before model invocation, tool dispatch, or workspace file writes can begin. `runToolUseFlow` checks interruption before reading the resume record and again after an in-flight read, so cancellation during recovery cannot start migration or repair writes.

For queued resume, cancellation at this boundary preserves both the initially drained follow-ups and messages accepted while the stream is `RESUMING`: session setup captures late arrivals before interruption disposes the shared queue, restores the full batch after the leaf settles, and reports `false`.

Closes #8049.

## Root cause

During manual resume, `setCliHelperModel`, launch-context construction, and delegation-depth recovery all occur after the controller's first `session.stopRequested` check. A Ctrl-C in that interval set the pending stop flag, but `stopAgentStream` could not interrupt anything because the resumed flow had not yet registered its live context. The flow could then attach and continue after the user's cancellation.

The queued `tryResumeStream` path had the same final interval after `resolveAndResumeStream` performed its last cancellation check and entered the leaf resume.

## Design

The CLI retains ownership of `session.stopRequested`; core runtime receives only `() => boolean`. The query is consumed synchronously immediately after `attachToolUseFlow`, closing the interval between "no live flow exists" and "the execution registry can interrupt the live flow." Cancellation uses `flowContext.interrupt()`, preserving the established cancellation, session-wakeup, and interaction-cleanup behavior.

Queued resume threads the same query through its existing options. Its session-setup callback records startup cancellation and restores drained follow-ups after the interrupted leaf settles, so honoring Ctrl-C cannot discard pending user input.

Other hosts remain unchanged because the option is optional. Early cancellation also marks the resumed flow record for preservation so terminal cleanup cannot delete the snapshot that a restored WAITING session needs for its next resume.

## Net elements

- Files changed: 8.
- Diffstat: 499 insertions, 30 deletions (net +469).
- Production code: 89 insertions, 22 deletions.
- New test files: 1.
- New exported symbols: 0.
- New classes, interfaces, and enums: 0.

## Consumer counts

- `isCancellationRequested`: two CLI producers, manual and queued resume.
- Runtime query site: one, at resumed flow attachment.
- Queued startup-cancellation restoration path: one.
- Production event, status, storage, or IPC keys: 0.

## Host impact

CLI: Ctrl-C during late manual or queued-resume startup now cancels the flow before substantive work. Queued follow-ups remain available after cancellation, and a lifecycle-terminalized stream is repaired to WAITING. Manual and queued startup cancellation are reported with the interrupted CLI exit code.

Desktop and extension: no API change. An existing host interruption that lands during flow setup or recovery is now observed before migration or repair work, preserving the same cancellation contract at an earlier point.

## Validation

- Five focused suites: 5 files, 52 tests passed
  - CLI session controller
  - direct resume cancellation handoff
  - queued snapshot resume and follow-up restoration
  - persisted resume-recovery cancellation boundaries
  - native tool-use strategy
- latest follow-up rerun: 4 affected suites, 44 tests passedn- source typecheck: passed
- CLI typecheck: passed
- test-kernel typecheck: passed
- `npm run lint`: passed
- targeted Prettier check: passed
- `git diff --check`: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resume lifecycle, follow-up queue restoration, and persisted flow-record cleanup on cancel—behavioral changes in timing-sensitive paths, though scoped to optional cancellation plumbing and CLI producers.
> 
> **Overview**
> Fixes a gap where **Ctrl-C during CLI resume** could be ignored after early guards passed but before a live tool-use flow existed, so the agent could still start.
> 
> **CLI** manual and queued resume now pass `isCancellationRequested: () => session.stopRequested` into the runtime. **Manual resume** maps the resumed run outcome to the interrupted exit code when cancelled. **Queued auto-resume** sets `CliExitCode.Interrupted` when stop wins and resume reports false.
> 
> **Runtime:** `resumeToolUseFromSnapshot` reads that callback right after `attachToolUseFlow` and calls `flowContext.interrupt()` before substantive work. **`runToolUseFlow`** checks interruption before and after the persisted flow-record read; on early cancel it **keeps** the resume KV record instead of deleting it. **`resumeQueuedToolUseSnapshot`** skips appending drained follow-ups on startup cancel, **restores** them to the queue, returns `false`, and forces the stream back to **WAITING**.
> 
> Optional for other hosts; covered by new/extended tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c3d358a6097316713d9433c92bb2a3bcb01fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->