### PR TITLE
test(cli): remove redundant interaction assertions

### DIFF
--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -215,15 +215,8 @@ describe('app interaction policy', () => {
       approvalVisibleForActiveStream({ activeStreamId, pending });
 
     expect(visible('child-1', childApproval)).toBe(true);
-    const hiddenApprovalVisible = visible('root', childApproval);
-    expect(hiddenApprovalVisible).toBe(false);
+    expect(visible('root', childApproval)).toBe(false);
     expect(visible('root', globalApproval)).toBe(true);
-    expect(
-      appFocusShortcutsActive({
-        ...focusEnabled,
-        foregroundOpen: hiddenApprovalVisible,
-      }),
-    ).toBe(true);
   });
 
   it('labels foreground escape actions from the owning surface', () => {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -1163,10 +1163,6 @@ describe('CLI child execution controls', () => {
       { key: 'k', action: 'kill' },
       { key: 'Esc', action: 'close' },
     ]);
-    expect(childPickerKeyAction({ input: '3' })).toEqual({
-      kind: 'jump',
-      index: 2,
-    });
     expect(pickerKeyHintsForColumns('tasks', 3)).toContainEqual({
       key: '1-9',
       action: 'jump',

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -954,9 +954,6 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toBe(
       'Use foreground panel shortcuts  [Esc]close  [Ctrl-C]stop',
     );
-    expect(display.bindings).not.toContain('[Tab]streams');
-    expect(display.bindings).not.toContain('[Alt-p]tasks');
-    expect(display.bindings).not.toContain('[/model]models');
   });
 
   it('labels foreground user questions as questions instead of approvals', () => {


### PR DESCRIPTION
## Summary
- keep the direct stream-approval visibility contract and remove its redundant focus recomposition
- keep numeric picker behavior in the key-action test instead of repeating it in hint coverage
- rely on exact foreground binding equality instead of implied substring absences

Net change: 14 test lines removed with no production-code changes.

## Validation
- `corepack pnpm exec prettier --check src/test-kernel/cli/AppInteractionPolicy.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `npm run lint` (0 errors; existing import-order warnings only)
- `corepack pnpm exec vitest run src/test-kernel/cli/AppInteractionPolicy.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/StatusBar.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli typecheck`

Closes #8089

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletions with no runtime changes; residual risk is only if a removed assertion was the sole guard for a regression.
> 
> **Overview**
> This PR trims **CLI Vitest** coverage in three kernel test files with **no production code changes** (~14 lines removed).
> 
> In **`AppInteractionPolicy.vitest.mts`**, the stream-tab approval visibility test still asserts child vs global approvals on the active tab, but drops the extra `appFocusShortcutsActive` check that duplicated the dedicated focus-shortcuts case table.
> 
> In **`ChildControls.vitest.mts`**, the picker hint test no longer re-asserts `childPickerKeyAction` for digit `3`; that jump behavior remains covered in **`keeps picker key handling independent of Ink rendering`**.
> 
> In **`StatusBar.vitest.mts`**, the foreground-panel bindings test relies on a single **exact** `display.bindings` string instead of separate `not.toContain` checks for global shortcuts already implied by that equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c84887c3a7bad75ac1851719caabb23a9cf9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->