### PR TITLE
fix(agent): restore resume compatibility key fallback

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -9,6 +9,7 @@ import {
   modelHandlerCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
+import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { type SessionHandle } from '@agent/runtime/SessionHandle';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -144,21 +145,24 @@ export function normalizeResumedWorkspaceSnapshot(
  * Build the canonical self-heal payload for a resumed flow record's `shared`
  * blob from the resume boundary's already-validated snapshot
  * (`SessionResumeRetrieval.retrieveToolUseResumeData` -- the single owner of
- * FlowRecord.shared's legacy-format migration and modelHandlerCompatibilityKey
- * backfill). `structuralBase` is the record's own `migrateSharedState` output
- * (structural unwrap only), which supplies any pass-through fields the
+ * FlowRecord.shared's legacy-format migration and persisted-format
+ * modelHandlerCompatibilityKey inference). The snapshot's key is authoritative
+ * when present; otherwise the active handler's key preserves the legacy
+ * self-heal fallback. `structuralBase` is the record's own `migrateSharedState`
+ * output (structural unwrap only), which supplies any pass-through fields the
  * snapshot's narrower resume contract doesn't carry (e.g. `systemPrompt`,
  * `lastError`) so they survive the write-back untouched.
  */
 export function buildResumedSharedFromSnapshot(
   structuralBase: ToolUseRunShared,
   snapshot: ToolUseSessionSnapshot,
+  activeCompatibilityKey: ModelHandlerCompatibilityKey | undefined,
 ): ToolUseRunShared {
   return {
     ...structuralBase,
     messages: snapshot.messages,
     modelHandlerCompatibilityKey:
-      snapshot.modelHandlerCompatibilityKey ?? undefined,
+      snapshot.modelHandlerCompatibilityKey ?? activeCompatibilityKey,
     stateSlices: {
       runStateSnapshot: snapshot.run,
       workspaceSnapshot: normalizeResumedWorkspaceSnapshot(snapshot.workspace),
@@ -390,16 +394,18 @@ export async function runToolUseFlow<C = unknown>(
         // already migrated this record's legacy shapes and strictly validated
         // the result into `input.resumeSnapshot` before this flow was ever
         // launched -- it is the single owner of FlowRecord.shared's
-        // legacy-format parsing and modelHandlerCompatibilityKey backfill (see
-        // its CurrentToolUseFlowRecordStateSchema). Consume its canonical
-        // fields directly here instead of re-deriving them; `migrateSharedState`
-        // above is only used for its structural unwrap so that pass-through
-        // fields the snapshot's narrower contract doesn't carry (systemPrompt,
-        // lastError, ...) survive this self-heal write of the KV blob that
-        // PersistedFlow.ensureRecord's unchecked raw read (below) depends on.
+        // legacy-format parsing and persisted-format compatibility-key
+        // inference (see its CurrentToolUseFlowRecordStateSchema). Consume its
+        // canonical fields directly here instead of re-deriving them;
+        // `migrateSharedState` above is only used for its structural unwrap so
+        // that pass-through fields the snapshot's narrower contract doesn't
+        // carry (systemPrompt, lastError, ...) survive this self-heal write of
+        // the KV blob that PersistedFlow.ensureRecord's unchecked raw read
+        // (below) depends on.
         flowRecord.shared = buildResumedSharedFromSnapshot(
           migrationResult.data,
           input.resumeSnapshot,
+          compatibilityKey,
         );
         await kv.write(
           flowKey(executionId),

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,23 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
+import { noopTrace } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
+import {
+  AgentCategory,
+  AgentPromptSchema,
+  AgentToolUseSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import {
   AgentWorkspaceState,
   type AgentWorkspaceSnapshot,
 } from '@agent/core/state/AgentWorkspaceState';
-import { flowKey } from '@agent/node/persistedFlow';
+import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
+import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import {
   buildResumedSharedFromSnapshot,
   normalizeResumedWorkspaceSnapshot,
+  runToolUseFlow,
+  type RunToolUseFlowInput,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import { migrateSharedState } from '@agent/implementations/flows/tooluse/nodes/types';
+import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const CONFIG: AgentConfig = {
@@ -42,6 +61,65 @@ const GOOGLE_WORKFLOW_CONFIG: AgentConfig = {
   ...GOOGLE_CONFIG,
   agentCategory: AgentCategory.Workflow,
 };
+const TOOL_USE_SETTING = AgentToolUseSettingSchema.parse({});
+const TOOL_USE_PROMPT = AgentPromptSchema.parse({});
+const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
+const WAIT_NODE_CURSOR = 'start/default/default';
+
+function createTaggedModelHandler(
+  compatibilityKey: ModelHandlerCompatibilityKey,
+): RunToolUseFlowInput['modelHandler'] {
+  const handler = { extractAssistantText: () => undefined };
+  // ModelFactory installs this non-enumerable tag on every active handler.
+  Object.defineProperty(handler, '__texraModelHandlerCompatibilityKey', {
+    value: compatibilityKey,
+  });
+  return handler as unknown as RunToolUseFlowInput['modelHandler'];
+}
+
+async function runResumedFlowToWaiting(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+  snapshot: ToolUseSessionSnapshot,
+): Promise<void> {
+  const session = new SessionHandle();
+  const context = createRunContext({
+    modelSource: 'live',
+    getModel: () => snapshot.agentConfig.model,
+    runScope: createRunScope({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId,
+      executionId,
+      agentName: snapshot.agentConfig.agent,
+      session,
+    }),
+  });
+
+  try {
+    const result = await withRunContext(context, () =>
+      runToolUseFlow(
+        {
+          config: snapshot.agentConfig,
+          setting: TOOL_USE_SETTING,
+          prompt: TOOL_USE_PROMPT,
+          logger: noopTrace,
+          userVarChannels: snapshot.user,
+          modelHandler: createTaggedModelHandler(ACTIVE_COMPATIBILITY_KEY),
+          streamStatus: session.status,
+          checkInterruption: () => false,
+          setAbortController: () => {},
+          resumeSnapshot: snapshot,
+          isSubagent: true,
+          toolInjections: new ToolInjectionRegistry(),
+        },
+        new MapToolRegistry({}),
+      ),
+    );
+    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+  } finally {
+    session.dispose();
+  }
+}
 
 describe('retrieveSessionResumeData', () => {
   setupPlatform({ workspacePath: '/workspace' });
@@ -390,12 +468,6 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   setupPlatform({ workspacePath: '/workspace' });
 
   it('hydrates a legacy-shaped flow record through the single boundary, then self-heals via its canonical fields', async () => {
-    // Regression for the SessionResumeRetrieval.ts / runToolUseFlow.ts
-    // duplicate-parse finding: a legacy nested-`state` record with a
-    // `conversation` key and no compatibility key must migrate/validate
-    // exactly once, at the resume boundary (retrieveSessionResumeData) --
-    // runToolUseFlow.ts's self-heal write must consume that result's fields
-    // rather than independently re-deriving them.
     const executionId = 'abc140' as ExecutionId;
     const streamId = 'chat@gpt54#abc140' as StreamTabId;
     const legacyShared = {
@@ -422,10 +494,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       params: {},
       shared: legacyShared,
       createdAt: new Date().toISOString(),
-      nodes: [],
+      cursor: { nextNodeId: WAIT_NODE_CURSOR },
+      nodes: [
+        { action: 'default', nodeId: 'start' },
+        { action: 'default', nodeId: 'start/default' },
+      ],
     });
 
-    // Single boundary parse: migrate + strictly validate the legacy record.
     const resume = await retrieveSessionResumeData(
       streamId,
       executionId,
@@ -433,33 +508,73 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     );
     expect(resume?.type).toBe('toolUse');
     if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.modelHandlerCompatibilityKey).toBeUndefined();
 
-    // runToolUseFlow.ts's own read of the same bytes: only the structural
-    // unwrap from migrateSharedState is still needed there (to recover
-    // pass-through fields the snapshot doesn't carry); the canonical
-    // messages/stateSlices/modelHandlerCompatibilityKey values must come
-    // from the boundary's snapshot, not from re-parsing `legacyShared` here.
-    const structuralBase = migrateSharedState(legacyShared);
-    expect(structuralBase).not.toBeNull();
-    if (!structuralBase) return;
+    await runResumedFlowToWaiting(executionId, streamId, resume.snapshot);
 
-    const healed = buildResumedSharedFromSnapshot(
-      structuralBase.data,
-      resume.snapshot,
+    const healedRecord = await getExecutionStore(executionId).read<FlowRecord>(
+      flowKey(executionId),
     );
 
-    // Canonical fields match the boundary's single validated read.
-    expect(healed.messages).toEqual(resume.snapshot.messages);
-    expect(healed.stateSlices).toEqual({
-      runStateSnapshot: resume.snapshot.run,
-      workspaceSnapshot: resume.snapshot.workspace,
-      userChannels: resume.snapshot.user,
+    expect(healedRecord?.shared).toMatchObject({
+      messages: resume.snapshot.messages,
+      modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
+      stateSlices: {
+        runStateSnapshot: resume.snapshot.run,
+        workspaceSnapshot: resume.snapshot.workspace,
+        userChannels: resume.snapshot.user,
+      },
+      systemPrompt: 'You are a helpful assistant.',
     });
-    expect(healed.modelHandlerCompatibilityKey).toBe(
-      resume.snapshot.modelHandlerCompatibilityKey,
+  });
+
+  it('keeps a persisted snapshot compatibility key authoritative over the active handler', async () => {
+    const executionId = 'abc142' as ExecutionId;
+    const streamId = 'chat@gpt54#abc142' as StreamTabId;
+    const persistedCompatibilityKey = 'ModelHandlerAnthropic';
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [{ role: 'user', content: 'Continue.' }],
+        modelHandlerCompatibilityKey: persistedCompatibilityKey,
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: {},
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: WAIT_NODE_CURSOR },
+      nodes: [
+        { action: 'default', nodeId: 'start' },
+        { action: 'default', nodeId: 'start/default' },
+      ],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(CONFIG),
     );
-    // Pass-through field outside the snapshot's contract survives.
-    expect(healed.systemPrompt).toBe('You are a helpful assistant.');
+    expect(resume?.type).toBe('toolUse');
+    if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.modelHandlerCompatibilityKey).toBe(
+      persistedCompatibilityKey,
+    );
+
+    await runResumedFlowToWaiting(executionId, streamId, resume.snapshot);
+
+    const healedRecord = await getExecutionStore(executionId).read<FlowRecord>(
+      flowKey(executionId),
+    );
+    expect(healedRecord?.shared).toMatchObject({
+      modelHandlerCompatibilityKey: persistedCompatibilityKey,
+    });
   });
 
   it('migrates a legacy top-level {todos, plan} workspace snapshot when the persisted cursor is already past ToolUsePrepareNode', async () => {
@@ -530,6 +645,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const healed = buildResumedSharedFromSnapshot(
       structuralBase.data,
       resume.snapshot,
+      undefined,
     );
 
     // This is exactly ToolUseCycleNode.prep()'s canonical-only re-derivation


### PR DESCRIPTION
## Summary

Restore the active model handler's compatibility key as the final fallback when a validated tool-use resume snapshot has no persisted or inferable key.

A key present in the snapshot remains authoritative. The active key is threaded explicitly into `buildResumedSharedFromSnapshot`; the resume branch does not infer the persisted format a second time.

Closes #8019.
Closes #8020.

## Root cause

Before #8009, the self-heal path used:

`persisted-format inference ?? active handler compatibility key`.

The single-owner snapshot migration correctly moved persisted-format inference into `SessionResumeRetrieval`, but the flow reconstruction then copied an absent snapshot key as `undefined`. Legacy non-Google records therefore remained keyless after self-heal. A later route or settings change could select a handler with a different conversation format and make the persisted session unusable.

## Design

`SessionResumeRetrieval` remains the sole owner of legacy parsing, strict validation, and persisted-format inference. `runToolUseFlow` supplies only the already-active handler key as an explicit final fallback:

`snapshot key ?? active handler key`.

No new resolver, facade, schema field, compatibility alias, or duplicate inference path is introduced.

## Test boundary

The regression test now executes `runToolUseFlow` at a persisted WAITING cursor and reads the self-healed flow record from storage. It verifies both:

- a keyless non-Google legacy snapshot receives the active handler key;
- a persisted snapshot key remains authoritative over a different active handler key.

This replaces the earlier helper-only assertion that reconstructed both sides of the behavior without exercising the production persistence path.

## Net elements

- Files changed: 2.
- Diffstat: 165 insertions, 43 deletions (net +122).
- Production code: 17 insertions, 11 deletions (net +6).
- New files: 0.
- New exported symbols: 0.
- New classes, interfaces, and enums: 0.
- Production event, status, storage, or IPC keys: 0.

## Host impact

Extension, desktop, and CLI resumes share this runtime path. Only keyless legacy records change; records with a validated compatibility key retain it unchanged.

## Validation

Rebased on current `main` at `05a864612`.

- `CI=true corepack pnpm exec vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts`: 1 file, 13 tests passed
- source typecheck: passed
- test-kernel typecheck: passed
- `npm run lint`: passed
- targeted Prettier check: passed
- `git diff --check`: passed
- mutation check: removing the fallback makes the new persisted-record assertion fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resume/self-heal persistence for conversation-format keys shared by extension, desktop, and CLI; behavior change is narrow (keyless legacy records only) but incorrect keys could still break model switches or transcript replay.
> 
> **Overview**
> Restores **model handler compatibility key** persistence on tool-use resume when the validated snapshot has no key (typical for legacy non-Google records). Self-heal now writes `snapshot.modelHandlerCompatibilityKey ?? active handler key` instead of leaving the field undefined after the single-owner migration in `SessionResumeRetrieval`.
> 
> `buildResumedSharedFromSnapshot` takes an explicit **active compatibility key** from `runToolUseFlow`; a key already on the snapshot is unchanged. No second inference path in the flow layer.
> 
> Tests run **`runToolUseFlow`** through a persisted **WAITING** cursor and assert the healed KV record: keyless legacy snapshots get the active handler tag, while a persisted key (e.g. Anthropic) wins over a different active handler (e.g. OpenAI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b7d542a0f3ed94c777a2446c4fc758d46bbad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->