### PR TITLE
fix(transcript): validate missing-output patches

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -23,6 +23,7 @@ import type {
   ExecutionId,
   OutputFileInfo,
   Plan,
+  RoundIndexed,
   StorageKey,
   StreamTabId,
   TodoItem,
@@ -595,6 +596,40 @@ describe('StreamSnapshotStore', () => {
 
     const raw = await StorageFS.readJson(path.join(dir, 'missingOutputs.json'));
     expect(raw).toMatchObject({
+      '0': ['prior.tex'],
+      '1': ['next.tex'],
+    });
+  });
+
+  it('rejects malformed missing-output patches before mutating memory or persisted state', async () => {
+    const dir = streamDataDir(STREAM);
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+
+    store.updateMissingOutputs(STREAM, { 0: ['prior.tex'] });
+    await store.flush();
+
+    const malformedPatch = {
+      0: ['replacement.tex'],
+      1: ['invalid.tex', 42],
+    } as unknown as RoundIndexed<string>;
+    expect(() => store.updateMissingOutputs(STREAM, malformedPatch)).toThrow();
+
+    expect(store.getMissingOutputs(STREAM)).toEqual({ 0: ['prior.tex'] });
+    await store.flush();
+    expect(
+      await StorageFS.readJson(path.join(dir, 'missingOutputs.json')),
+    ).toEqual({ '0': ['prior.tex'] });
+
+    store.updateMissingOutputs(STREAM, { 1: ['next.tex'] });
+    expect(store.getMissingOutputs(STREAM)).toEqual({
+      0: ['prior.tex'],
+      1: ['next.tex'],
+    });
+    await store.flush();
+    expect(
+      await StorageFS.readJson(path.join(dir, 'missingOutputs.json')),
+    ).toEqual({
       '0': ['prior.tex'],
       '1': ['next.tex'],
     });

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -629,9 +629,8 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     filesByRound: RoundIndexed<string>,
   ): void {
-    const patch = this.parseRoundPatch<string>(
-      filesByRound,
-      (raw) => raw as string[],
+    const patch = this.parseRoundPatch<string>(filesByRound, (raw) =>
+      z.array(z.string()).parse(Array.isArray(raw) ? raw : []),
     );
     if (patch.size === 0) return;
 


### PR DESCRIPTION
## Summary

- validate every missing-output round value with a Zod string-array schema before applying the patch
- preserve the existing non-array normalization used by the other round-keyed accumulators
- prove a partly malformed patch cannot change either in-memory or persisted state

## Design

The previous unchecked assertion leaked the caller input shape into `StreamSnapshotStore`. Validation now occurs while constructing the complete patch, before `applyRoundPatch` can mutate the store. This keeps the mutation boundary atomic and gives the persistence facade one normalized representation.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` (35 tests)
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `npm run lint` (0 errors; pre-existing warnings only)
- targeted ESLint and Prettier checks
- `git diff --check`

Closes #8034

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized hardening of transcript sidecar input validation with a regression test; no auth or broad behavior changes beyond rejecting bad patches.
> 
> **Overview**
> **`updateMissingOutputs`** now validates each round’s value as a string array via **`z.array(z.string())`** during patch construction, replacing an unchecked cast. Non-array round values still normalize to **`[]`**, consistent with the other round-keyed accumulators.
> 
> A new test asserts that a partly malformed patch (e.g. a non-string in a round list) **throws** before **`applyRoundPatch`** or disk writes run, so in-memory state and **`missingOutputs.json`** stay unchanged; valid follow-up patches still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc8968bbe341d10ac754e69484f829286bfd805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->