### PR TITLE
fix(cli): repaint finalized transcript on resize

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -1,8 +1,8 @@
-// Print-once session header plus transcript entries. The header is the first
+// Session header plus finalized transcript entries. The header is the first
 // static row for the active scrollback owner; finalized entries append after it
-// in ordinary terminal scrollback through Ink `<Static>`. The Static key must
-// stay stable across resize because terminal scrollback is append-only: reflowing
-// old rows by remounting Static reprints the header and finalized history.
+// in ordinary terminal scrollback through Ink `<Static>`. On a width change,
+// the width-qualified Static identity remounts these same items so patched Ink
+// can replace its accumulated static output with the new geometry.
 
 import path from 'node:path';
 
@@ -345,6 +345,7 @@ export function StaticConversationTranscript({
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): React.JSX.Element {
+  const normalizedWidth = Math.max(1, Math.floor(width ?? 80));
   const streams = useSignal(streamsSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);
@@ -359,7 +360,7 @@ export function StaticConversationTranscript({
       maxRows,
       parentStream,
       scrollbackStreamId,
-      width,
+      width: normalizedWidth,
     }),
   }));
 
@@ -374,7 +375,7 @@ export function StaticConversationTranscript({
           maxRows,
           parentStream,
           scrollbackStreamId,
-          width,
+          width: normalizedWidth,
         });
 
   useEffect(() => {
@@ -394,7 +395,7 @@ export function StaticConversationTranscript({
         maxRows,
         parentStream,
         scrollbackStreamId,
-        width,
+        width: normalizedWidth,
       });
       if (current.ownerKey === ownerKey && current.items === nextItems) {
         return current;
@@ -409,7 +410,7 @@ export function StaticConversationTranscript({
     scrollbackStreamId,
     sessionMeta,
     streams,
-    width,
+    normalizedWidth,
   ]);
 
   // Keep our scrollback state readonly and adapt once at the Ink boundary.
@@ -419,7 +420,10 @@ export function StaticConversationTranscript({
   const staticItems = useMemo(() => [...items], [items]);
 
   return (
-    <Static key={`transcript:${ownerKey}`} items={staticItems}>
+    <Static
+      key={`transcript:${ownerKey}:${normalizedWidth}`}
+      items={staticItems}
+    >
       {(item: StaticTranscriptItem) => (
         <Box key={item.id} flexDirection="column">
           {item.kind === 'header' ? (
@@ -428,14 +432,14 @@ export function StaticConversationTranscript({
                 compact={item.compact}
                 identityLine={item.identityLine}
                 meta={item.meta}
-                width={width}
+                width={normalizedWidth}
               />
             </EntryErrorBoundary>
           ) : (
             <EntryErrorBoundary label={item.entry.role}>
               <TranscriptEntry
                 entry={item.entry}
-                width={width}
+                width={normalizedWidth}
                 colorEnabled={colorEnabled}
                 userBottomMarginRows={item.userBottomMarginRows}
               />

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -114,11 +114,11 @@ function UserEntryRow({
   // Mark a user turn with a reverse-video band (theme-adaptive via reverse
   // video), inset one column from each terminal edge — the same gutter the
   // error/tool/process rows get from their padded boxes — with a blank row
-  // above and below so the turn breathes. Static transcript rows are
-  // print-once terminal scrollback: a row keeps the width it had when it was
-  // appended, while later rows render at the latest width. The `› ` chevron
-  // is 2 cols; row estimators add the exported margin constants alongside
-  // their wrapped-line count.
+  // above and below so the turn breathes. Finalized transcript rows are
+  // normally print-once; a width change remounts the enclosing `<Static>` so
+  // patched Ink replaces the accumulated rows at the current width. The `› `
+  // chevron is 2 cols; row estimators add the exported margin constants
+  // alongside their wrapped-line count.
   const cols = entryCols(width, 2);
   return (
     <Box marginTop={marginTopRows} marginBottom={marginBottomRows} paddingX={1}>

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -1,32 +1,42 @@
-// Regression test for the patched Ink resize repaint path. Renders a minimal
-// Ink app with a deliberately remounted `<Static>` band to an in-memory fake
-// stdout, simulates a terminal resize by bumping `columns` and emitting
-// `resize`, and asserts the highlighted band reflows to the NEW width instead
-// of staying baked at the original width.
-//
-// This exercises the patched Ink resize full-repaint + the `<Static>` remount
-// (`handleStaticChange` regenerates `fullStaticOutput` at the new width) without
-// a pty (node-pty's posix_spawn is unavailable in sandboxed CI; the existing
-// InkResizePatch test uses a recording stream too). The main transcript does
-// not use this pattern for historical rows, because terminal scrollback is
-// append-only and remounting old rows duplicates finalized output.
+// Regression test for the production transcript's patched Ink resize path.
+// An in-memory stdout exposes the exact clear-and-repaint frame, which is the
+// reliable boundary for proving that Ink replaced its accumulated `<Static>`
+// output. A PTY adds emulator reflow but cannot reveal stale rows that the same
+// repaint subsequently clears.
 
-// Set before Ink/chalk load so reverse-video SGR (`ESC[7m`) is actually emitted
-// to the non-TTY fake stdout; otherwise chalk no-ops `inverse` and the band has
-// no styled fill to measure.
-process.env.FORCE_COLOR ??= '3';
+// Set before Ink/chalk load so reverse-video SGR (`ESC[7m`) is emitted to the
+// in-memory TTY; otherwise chalk no-ops `inverse` and the band has no styled
+// fill to measure.
+const ORIGINAL_COLOR_ENV = {
+  FORCE_COLOR: process.env.FORCE_COLOR,
+  NO_COLOR: process.env.NO_COLOR,
+};
+delete process.env.NO_COLOR;
+process.env.FORCE_COLOR = '3';
 
+// Node.js imports
 import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
 
-import { describe, expect, it } from 'vitest';
+// Third-party imports
+import stripAnsi from 'strip-ansi';
+import { afterAll, describe, expect, it } from 'vitest';
 
-import { fillRows } from '@cli/chat/tui/render/terminalText';
+// Local imports
+import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
+import type { StreamTabId } from '@shared/schemas';
 import { delay } from '@utils/core';
 
 const cliRequire = createRequire(
   new URL('../../../packages/cli/package.json', import.meta.url),
 );
+
+afterAll(() => {
+  for (const [name, value] of Object.entries(ORIGINAL_COLOR_ENV)) {
+    if (value == null) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
 
 class FakeStdout extends EventEmitter {
   isTTY = true;
@@ -56,9 +66,8 @@ class FakeStdin extends EventEmitter {
   }
 }
 
-/** Widest visible reverse-video (`ESC[7m…ESC[27m`) run that contains the band. */
-function bandWidth(output: string): number {
-  let widest = 0;
+function inverseBandWidths(output: string, text: string): readonly number[] {
+  const widths: number[] = [];
   // eslint-disable-next-line no-control-regex -- matching raw SGR escapes
   const run = /\x1b\[7m([\s\S]*?)\x1b\[(?:27|0)m/g;
   // eslint-disable-next-line no-control-regex -- stripping raw SGR escapes
@@ -66,9 +75,25 @@ function bandWidth(output: string): number {
   let match: RegExpExecArray | null;
   while ((match = run.exec(output))) {
     const visible = match[1].replaceAll(sgr, '');
-    if (visible.includes('hi')) widest = Math.max(widest, visible.length);
+    if (visible.includes(text)) widths.push(visible.length);
   }
-  return widest;
+  return widths;
+}
+
+function horizontalRuleWidths(output: string): readonly number[] {
+  return stripAnsi(output)
+    .split('\n')
+    .filter((line) => /^─+$/u.test(line))
+    .map((line) => line.length);
+}
+
+function latestRepaintFrame(output: string, clearTerminal: string): string {
+  const clearIndex = output.lastIndexOf(clearTerminal);
+  return clearIndex < 0 ? '' : output.slice(clearIndex + clearTerminal.length);
+}
+
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
 }
 
 async function waitFor(
@@ -84,52 +109,103 @@ async function waitFor(
 }
 
 describe('Static band resize', () => {
-  it('reflows the user band to the new width on resize', async () => {
+  it('replaces finalized transcript geometry at the new width', async () => {
     // Dynamic import so FORCE_COLOR is set first and the patched workspace Ink
     // (not a hoisted copy) is loaded.
     const ink = (await import(cliRequire.resolve('ink'))) as any;
     const React = ((await import(cliRequire.resolve('react'))) as any).default;
-    const { useState, useEffect, createElement } = React;
+    const { createElement } = React;
+    const { StaticConversationTranscript } =
+      await import('@cli/chat/tui/panes/StaticConversationTranscript');
+    const { patchStream, resetCliState } =
+      await import('@cli/chat/tui/state/cliState');
+    const inkRequire = createRequire(cliRequire.resolve('ink'));
+    const { clearTerminal } = inkRequire('ansi-escapes') as {
+      readonly clearTerminal: string;
+    };
+    const streamId = 'resize-static-stream' as StreamTabId;
+    const prompt = 'resize geometry prompt';
+    const finalizedUser: ConversationEntry = {
+      id: 'resize-user',
+      role: 'user',
+      text: prompt,
+      finalized: true,
+    };
+    const liveAssistant: ConversationEntry = {
+      id: 'live-assistant',
+      role: 'assistant',
+      text: 'working',
+      finalized: false,
+    };
+
+    resetCliState({
+      agent: 'research',
+      model: 'test-model',
+      modelSource: 'builtin-default',
+      cwd: '/tmp/resize-proof',
+      apiMode: 'personal',
+      approvalPolicy: 'ask',
+      canDelegate: false,
+      version: '0.0.0-test',
+    });
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      entries: [finalizedUser, liveAssistant],
+    }));
 
     function App(): unknown {
-      const { stdout } = ink.useStdout();
-      const [cols, setCols] = useState(stdout.columns || 80);
-      useEffect(() => {
-        const onResize = (): void => setCols(stdout.columns || 80);
-        stdout.on('resize', onResize);
-        return () => stdout.off('resize', onResize);
-      }, [stdout]);
-      return createElement(ink.Static, { key: cols, items: [0] }, () =>
-        createElement(
-          ink.Box,
-          { key: 'band' },
-          createElement(ink.Text, { inverse: true }, fillRows('> hi', cols)),
-        ),
-      );
+      const { columns } = ink.useWindowSize();
+      return createElement(StaticConversationTranscript, {
+        colorEnabled: true,
+        ownerKey: 'resize-owner',
+        scrollbackStreamId: streamId,
+        width: columns,
+      });
     }
 
     const out = new FakeStdout(40);
     const inst = ink.render(createElement(App), {
       stdout: out,
       stdin: new FakeStdin(),
+      interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
     });
 
     try {
-      expect(await waitFor(() => bandWidth(out.buf) >= 40, 5000)).toBe(true);
-      expect(bandWidth(out.buf)).toBe(40);
+      expect(
+        await waitFor(
+          () =>
+            horizontalRuleWidths(out.buf).includes(40) &&
+            inverseBandWidths(out.buf, prompt).includes(38),
+          5000,
+        ),
+      ).toBe(true);
 
       // Widen: bump columns and fire the resize the patched Ink handler listens
-      // for. Clear the buffer so we measure only the post-resize repaint.
+      // for. Clear the recording so the final frame cannot pass using initial
+      // output.
       out.buf = '';
       out.columns = 80;
       out.emit('resize');
 
-      expect(await waitFor(() => bandWidth(out.buf) >= 80, 5000)).toBe(true);
-      expect(bandWidth(out.buf)).toBe(80);
+      expect(await waitFor(() => out.buf.includes(clearTerminal), 5000)).toBe(
+        true,
+      );
+      const frame = latestRepaintFrame(out.buf, clearTerminal);
+      const ruleWidths = horizontalRuleWidths(frame);
+      const bandWidths = inverseBandWidths(frame, prompt);
+      const visibleFrame = stripAnsi(frame);
+
+      expect(ruleWidths).toEqual([80]);
+      expect(ruleWidths).not.toContain(40);
+      expect(bandWidths).toEqual([78]);
+      expect(bandWidths).not.toContain(38);
+      expect(occurrences(visibleFrame, '{ T } TeXRA')).toBe(1);
+      expect(occurrences(visibleFrame, `› ${prompt}`)).toBe(1);
     } finally {
       inst.unmount();
+      resetCliState();
     }
   });
 });


### PR DESCRIPTION
## Summary

- qualify the finalized transcript `<Static>` identity by normalized terminal width
- let the existing Ink full-repaint path regenerate the accumulated header and finalized rows at the new geometry
- replace the synthetic band test with a production `StaticConversationTranscript` regression

## Design

Finalized transcript rows previously leaked their original terminal geometry into Ink's accumulated static output. The component now normalizes its width once and treats width as part of the rendered Static identity. Ink's existing static-change handler rebuilds `fullStaticOutput`, while the patched resize repaint clears the former frame before writing the rebuilt one. Transcript state is not reset, and no second repaint mechanism is introduced.

The regression test examines the exact frame written after the terminal clear. This distinguishes replacement from accidental append behavior and verifies that neither the header nor the user prompt is duplicated. Its Ink render explicitly enables interactive mode because Ink defaults to noninteractive under CI; production chat is interactive.

## Regression proof

After widening from 40 to 80 columns:

- horizontal rule widths are exactly `[80]`, not `[40]`
- inverse user-band widths are exactly `[78]`, not `[38]`
- the session title occurs once
- the finalized user prompt occurs once

Before the fix, the same test reports the stale rule width `[40]`.

## Validation

- `CI=true` focused Vitest: `StaticBandResize`, `InkResizePatch`, and `TranscriptScroll` (13 tests)
- CLI typecheck
- test-kernel typecheck
- `npm run lint` (0 errors; pre-existing warnings only)
- targeted ESLint and Prettier checks
- freshly rebuilt PTY/xterm `bash-approval` scenario
- `git diff --check`

Closes #8095

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal scrollback rendering on every resize (remount + full static repaint); wrong keying could duplicate or drop history, but transcript item state is preserved and behavior is regression-tested.
> 
> **Overview**
> Fixes finalized CLI transcript layout staying at the old column count after a terminal resize by tying Ink `<Static>` to **normalized width**, not only scrollback owner.
> 
> `StaticConversationTranscript` now floors width once and uses `transcript:${ownerKey}:${normalizedWidth}` as the `<Static>` key so a column change remounts the same finalized items; patched Ink can clear and rebuild accumulated static output (header + finalized rows) at the new geometry without resetting transcript state. Header and entry renderers consistently use that normalized width.
> 
> Comments in `TranscriptEntry` describe this remount/repaint behavior instead of “print-once at original width forever.”
> 
> The `StaticBandResize` regression now renders real `StaticConversationTranscript` with CLI state, widens 40→80 columns, asserts a terminal-clear repaint, and checks rule/band widths plus no duplicate session title or user prompt (with `interactive: true` so CI matches production Ink).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d970911cd0ce6a669a6a8bb8799969f0c6328e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->