### PR TITLE
refactor(cli): make approval queue single-owner

### DIFF
--- a/docs/prds/cli-tui-ink/10-architecture.md
+++ b/docs/prds/cli-tui-ink/10-architecture.md
@@ -55,7 +55,7 @@ Every dependency is either already in the workspace, used by the dominant 2026 A
 | Concern                          | Package                                                                                                                      |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Serial follow-up queue           | `p-queue`                                                                                                                    |
-| Approval modal queue             | `p-queue` (`concurrency: 1`) with Promise-returning launchers — see § Approvals                                              |
+| Approval modal queue             | In-tree single-owner FIFO with Promise-returning launchers — see § Approvals                                                 |
 | Colors (legacy renderer only)    | `picocolors`                                                                                                                 |
 | Clipboard ("copy last response") | `clipboardy` (with OSC 52 fallback; tmux/screen DCS wrapping deferred — R9)                                                  |
 | Terminal notifications           | In-tree dispatcher emitting OSC 9 / OSC 99 / BEL (and OSC 9;4 for progress), capability-gated. See § Terminal notifications. |
@@ -77,10 +77,10 @@ StreamStatusService.onDidChange ┘  (@lit-labs/signals, same           │
                                     primitive as progressState)            ├── <Static> for finalized turns
                                                                             └── live <Box> for in-flight turn
 
-Approval payloads (intercepted in host.emit) ──► approvalQueue (p-queue, concurrency: 1)
-                                                       └──► launcher returns Promise<Decision>
-                                                            head of queue → cliState.currentApproval signal
-                                                            <ApprovalModal> dispatches to today's resolvers
+HostInteractions requests ──► createTuiHostInteractions ──► approvalQueue (single-owner FIFO)
+                                                                    └──► launcher returns Promise<Decision>
+                                                                         head → currentApproval signal
+                                                                         <ApprovalModal> dispatches by payload kind
 ```
 
 Same signal primitive (`@lit-labs/signals`) and same state shape as the webview's `progressState`; event sources differ — CLI subscribes to `runtimeHost`, `StreamLogStore`, `StreamStatusService` directly.
@@ -90,8 +90,10 @@ packages/cli/src/chat/tui/
 ├── App.tsx
 ├── state/
 │   ├── cliState.ts                 (@lit-labs/signals; mirrors progressState shape, activeStreamId: StreamTabId | null)
+│   ├── approvalQueue.ts            (single-owner approval/request FIFO; projects head and status signals)
+│   ├── subscribeApprovals.ts       (implements the TUI HostInteractions port and routes requests into the FIFO)
 │   ├── useSignal.ts                (≈10-line useSyncExternalStore bridge)
-│   ├── subscribeRuntimeHost.ts     (wraps runtimeHost.emit; routes payloads → signal patches and the approval p-queue)
+│   ├── subscribeRuntimeHost.ts     (wraps runtimeHost.emit; routes runtime events → signal patches)
 │   ├── subscribeStreamLog.ts       (StreamLogStore.onChange → signal patch)
 │   ├── subscribeStreamStatus.ts    (StreamStatusService.onDidChange → signal patch)
 │   └── terminalCapabilities.ts     (DA1-sentinel feature discovery; populates signal at startup)
@@ -264,26 +266,26 @@ The state shape (`streamById: Map<StreamTabId, StreamTabInfo>` + `activeStreamId
 - **Detach runtime patch.** `detachActiveChildren` (`executionRegistry.ts:253–269`) today calls `handle.detach()` and re-emits `updateActiveSubagents` only — it does **not** emit `setParentStream` to clear the child's `parentStreamId`. Phase 4 adds that emit so the TUI (and any future host that consumes the parent-link) promotes detached children to top-level streams.
 - **Why not `Ctrl-Shift-*`.** Many terminals collapse Shift on a letter to the unshifted Ctrl chord; Ink cannot distinguish them on the smoke-test matrix. Hence `Ctrl-A` cycles forward and `Ctrl-B` returns to parent (see [30-reference.md § Keymap](./30-reference.md#11-keymap)).
 
-## 9. Approvals: Promise-returning launchers with a concurrency-1 queue
+## 9. Approvals: Promise-returning launchers with a single-owner FIFO
 
-This replaces stderr prompts with a typed React dispatch. The implementation pattern is **Promise-returning launchers backed by a serial queue**, not a hand-rolled FIFO state machine.
+This replaces stderr prompts with a typed React dispatch. The implementation pattern is **Promise-returning launchers backed by one explicit FIFO**. The FIFO is the canonical pending-request store; reactive status and the foreground modal are projections of it.
 
 `CliContext.approvalPrompt` only carries `CliPromptRequest` (`kind`, `summary`, `prompt`) — that's enough for today's free-text approval but loses the typed payload the TUI needs (the bash command string, the tool-edit `originalContent`/`proposedContent`, the plan structure, the proposal's agent metadata).
 
 ### Mechanism
 
-- A new TUI-aware approval installer replaces `installCliApprovalHandlers`. It exposes one entrypoint per approval kind, each of which:
-  1. constructs the typed payload from the runtime-host event;
-  2. enqueues it on a `p-queue` instance with `concurrency: 1` (the approval queue);
+- `createTuiHostInteractions` implements the session-owned approval port. It exposes one entrypoint per request kind, each of which:
+  1. constructs the typed payload from the host-interaction request;
+  2. appends it to the approval queue's module-private FIFO;
   3. returns a `Promise<Decision>` that resolves when the user answers.
-- Inside the queue, the head item is pushed onto the `cliState.currentApproval` signal (a single-item view of the queue head, not a parallel queue). `<ApprovalModal>` reads the signal, dispatches by the payload's discriminant, and calls `resolve(decision)` on action. The p-queue then advances and writes the next head.
+- Inside the queue, the head item is pushed onto the `currentApproval` signal (a single-item view of the queue head, not a parallel queue). `<ApprovalModal>` reads the signal, dispatches by the payload's discriminant, and settles that item on action. Removing the head promotes the next surviving FIFO entry; bulk cancellation partitions the queue before presenting a survivor.
 
-This gives the simplicity of `await launchBashApproval(payload)` at the call site **without** losing the ability to serialize concurrent approvals from different subagent streams — which the original FIFO queue was designed to handle.
+This gives the simplicity of `await launchBashApproval(payload)` at the call site **without** losing the ability to serialize concurrent approvals from different subagent streams.
 
 ### Wiring per event
 
-- Tool-edit: `setToolEditApprovalHandler` still owns dispatch; the typed `ToolEditApprovalRequest` (with `originalContent` + `proposedContent`) is pushed from the handler.
-- Other approval events: interceptor inside the wrapped `runtimeHost.emit` constructs payloads and calls the matching `launchX`.
+- Tool-edit and other interactive requests enter through `createTuiHostInteractions`; policy decisions happen before typed requests reach the FIFO.
+- Stream-scoped cancellation uses the same host port to remove every matching queued request atomically.
 - On resolution, the modal calls today's resolvers — wiring unchanged (see § 10 event map for the per-event resolver list).
 - `--approval-policy never` and `yolo` short-circuit before the queue (unchanged `immediateDecision` logic).
 - `<EditApproval>` renders unified diffs via `diff` + `cli-highlight`. Keys: `y` approve, `n` reject, `e` reject-with-feedback. Long diffs paginate with a summary header and `Ctrl-O` expand — no silent truncation.

--- a/docs/prds/cli-tui-ink/20-implementation.md
+++ b/docs/prds/cli-tui-ink/20-implementation.md
@@ -86,8 +86,8 @@ Implements components per 10-architecture §§ Input component, Terminal capabil
 ### Phase 2 — Tool & approval rendering (3 d)
 
 - `<ToolUseCard>`.
-- Replace `installCliApprovalHandlers` with the typed TUI installer per [10-architecture § Approvals](./10-architecture.md#9-approvals-promise-returning-launchers-with-a-concurrency-1-queue). Each `launchX(payload)` returns `Promise<Decision>`; the approval `p-queue` (`concurrency: 1`) serializes them.
-- All six approval modals dispatched off the typed queue.
+- Replace `installCliApprovalHandlers` with the typed TUI installer per [10-architecture § Approvals](./10-architecture.md#9-approvals-promise-returning-launchers-with-a-single-owner-fifo). Each `launchX(payload)` returns `Promise<Decision>`; one explicit FIFO serializes them and projects its head into the modal signal.
+- All seven approval/request modals dispatched off the typed queue.
 - `<DiffView>` using `diff` + `cli-highlight`.
 - Resolver wiring unchanged.
 - **Audit** (prerequisite for closing the phase): confirm whether subagent and main-stream approvals can interleave; document the finding in the PR description. Either outcome leaves the API identical.

--- a/docs/prds/cli-tui-ink/mockups/03-approval-bash.md
+++ b/docs/prds/cli-tui-ink/mockups/03-approval-bash.md
@@ -58,4 +58,4 @@ The agent has produced a bash command and the approval policy isn't `yolo`. Moda
 1. Should the **reason** row appear at all? It's the model speaking from inside the approval payload — useful but extra height.
 2. Color: amber for read-ish commands, red for destructive — is that detectable enough, or should we add an explicit "destructive" badge?
 3. `ctrl-y yolo (this turn)` is risky as a hidden key. Should it require typing the full word `yolo` like dangerous CLI confirmations?
-4. When multiple approvals queue up (per the p-queue serializer), should the modal show `(1 of 3)` so users know more are pending?
+4. When multiple approvals queue up (through the approval FIFO), should the modal show `(1 of 3)` so users know more are pending?

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -92,17 +92,6 @@ const INTERRUPT: ApprovalDecision = {
   userMessage: 'Session interrupted.',
 };
 
-/**
- * Settle one queue item through the canonical FIFO. Removing the foreground
- * item clears its modal and schedules the next entry for presentation.
- */
-function settleItem(
-  item: ApprovalQueueItem,
-  decision: ApprovalDecision,
-): boolean {
-  return settleItems((candidate) => candidate === item, decision) === 1;
-}
-
 function presentForeground(): void {
   const item = pendingItems[0];
   if (!item || CURRENT.get()) return;
@@ -118,7 +107,7 @@ function presentForeground(): void {
   CURRENT.set({
     payload: item.payload,
     decide: (decision) => {
-      settleItem(item, decision);
+      settleItems((candidate) => candidate === item, decision);
     },
   });
 }

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -1,14 +1,12 @@
 // Typed approval pipeline per docs/prds/cli-tui-ink/10-architecture.md §9.
 //
-// Each enqueued approval or human-input prompt becomes a `p-queue` task.
-// When its turn comes up it publishes itself on the `currentApproval` signal
-// and waits for the modal to call `decide(decision)`. Both pending outer
-// Promises returned to callers and the currently-running task's `advance` are
-// settled by `clearApprovals` so a session interrupt never leaves the queue
-// blocked or the caller hanging.
+// One explicit FIFO owns every pending approval or human-input prompt. The
+// head is projected onto `currentApproval`; settling or removing it promotes
+// the next entry. `clearApprovals` resolves every caller promise directly, so
+// a session interrupt cannot leave a hidden scheduler task or queue slot
+// blocked.
 
 import { signal, type Signal } from '@lit-labs/signals';
-import PQueue from 'p-queue';
 
 import type { ApprovalBypassKind as HostApprovalBypassKind } from '@agent/runtime/HostInteractions';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
@@ -79,17 +77,15 @@ export const currentApproval = CURRENT as Signal.State<
 >;
 export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
 
-const queue = new PQueue({ concurrency: 1 });
 const clearListeners = new Set<() => void>();
 
 interface ApprovalQueueItem {
   readonly payload: ApprovalPayload;
   readonly resolve: (decision: ApprovalDecision) => void;
-  advance: (() => void) | undefined;
+  readonly onPresent?: () => void;
 }
 
-const pendingItems = new Set<ApprovalQueueItem>();
-let currentItem: ApprovalQueueItem | undefined;
+const pendingItems: ApprovalQueueItem[] = [];
 
 const INTERRUPT: ApprovalDecision = {
   accepted: false,
@@ -97,26 +93,60 @@ const INTERRUPT: ApprovalDecision = {
 };
 
 /**
- * Settle one queue item out of band (interrupt/timeout/stream-scoped cancel)
- * rather than through the modal's own `decide()` callback: remove it from
- * `pendingItems`, clear the foreground modal if it was the one showing, and
- * resume the queue's blocked task so the single concurrency slot is freed.
- * Returns false if the item was already settled.
+ * Settle one queue item through the canonical FIFO. Removing the foreground
+ * item clears its modal and schedules the next entry for presentation.
  */
 function settleItem(
   item: ApprovalQueueItem,
   decision: ApprovalDecision,
 ): boolean {
-  if (!pendingItems.delete(item)) return false;
-  if (currentItem === item) {
-    currentItem = undefined;
-    CURRENT.set(undefined);
+  return settleItems((candidate) => candidate === item, decision) === 1;
+}
+
+function presentForeground(): void {
+  const item = pendingItems[0];
+  if (!item || CURRENT.get()) return;
+
+  try {
+    item.onPresent?.();
+  } catch {
+    // Presentation hooks update surrounding TUI state only; approval
+    // resolution must remain available even if focus activation fails.
   }
-  const advance = item.advance;
-  item.advance = undefined;
-  item.resolve(decision);
-  advance?.();
-  return true;
+  if (pendingItems[0] !== item) return;
+
+  CURRENT.set({
+    payload: item.payload,
+    decide: (decision) => {
+      settleItem(item, decision);
+    },
+  });
+}
+
+/**
+ * Atomically remove and settle every matching item. The queue is partitioned
+ * before any promise resolves or survivor is presented, so a bulk cancellation
+ * cannot briefly foreground another item that the same operation removes.
+ */
+function settleItems(
+  predicate: (item: ApprovalQueueItem) => boolean,
+  decision: ApprovalDecision,
+): number {
+  const previousForeground = pendingItems[0];
+  const removed: ApprovalQueueItem[] = [];
+  const retained: ApprovalQueueItem[] = [];
+  for (const item of pendingItems) {
+    (predicate(item) ? removed : retained).push(item);
+  }
+  if (removed.length === 0) return 0;
+
+  pendingItems.splice(0, pendingItems.length, ...retained);
+  const foregroundChanged = previousForeground !== pendingItems[0];
+  if (foregroundChanged) CURRENT.set(undefined);
+  syncApprovalStatus();
+  for (const item of removed) item.resolve(decision);
+  if (foregroundChanged) presentForeground();
+  return removed.length;
 }
 
 export function onApprovalsCleared(listener: () => void): () => void {
@@ -180,7 +210,7 @@ export function approvalPayloadStreamId(
 }
 
 function syncApprovalStatus(): void {
-  const depth = pendingItems.size;
+  const depth = pendingItems.length;
   STATUS.set({
     depth,
     kind:
@@ -194,53 +224,18 @@ export function enqueueApproval(
   payload: ApprovalPayload,
   options: EnqueueApprovalOptions = {},
 ): Promise<ApprovalDecision> {
-  let item!: ApprovalQueueItem;
-  const outer = new Promise<ApprovalDecision>((resolve) => {
-    item = { payload, resolve, advance: undefined };
+  return new Promise<ApprovalDecision>((resolve) => {
+    const wasEmpty = pendingItems.length === 0;
+    pendingItems.push({ payload, resolve, onPresent: options.onPresent });
+    syncApprovalStatus();
+    if (wasEmpty) presentForeground();
   });
-  pendingItems.add(item);
-  syncApprovalStatus();
-
-  void queue
-    .add(async () => {
-      // Already cleared before scheduling: clearApprovals settled the caller.
-      if (!pendingItems.has(item)) return;
-      await new Promise<void>((advance) => {
-        item.advance = advance;
-        currentItem = item;
-        try {
-          options.onPresent?.();
-        } catch {
-          // Presentation hooks update the surrounding TUI only; approval
-          // resolution must remain available even if focus activation fails.
-        }
-        CURRENT.set({
-          payload,
-          decide: (decision) => {
-            // settleItem resolves item.advance (== this closure's `advance`),
-            // resuming the queue's blocked task; no separate call needed.
-            if (settleItem(item, decision)) syncApprovalStatus();
-          },
-        });
-      });
-    })
-    .catch(() => {
-      // p-queue rejects when `queue.clear()` drops the task. Settle the
-      // outer promise so the requester (e.g. ToolEditApprovalHandler)
-      // doesn't hang forever.
-      if (settleItem(item, INTERRUPT)) syncApprovalStatus();
-    });
-
-  return outer;
 }
 
 /**
- * Hard-cancel: settle every pending resolver AND unblock the
- * currently-running task so the queue's single concurrency slot doesn't
- * stay permanently occupied.
+ * Hard-cancel every pending resolver and clear the foreground projection.
  */
 export function clearApprovals(): void {
-  queue.clear();
   CURRENT.set(undefined);
   for (const listener of clearListeners) {
     try {
@@ -250,16 +245,10 @@ export function clearApprovals(): void {
       // interruption must continue even if a hook fails.
     }
   }
-  const items = [...pendingItems];
-  pendingItems.clear();
+  const items = pendingItems.splice(0);
   syncApprovalStatus();
-  const activeItem = currentItem;
-  currentItem = undefined;
   for (const item of items) {
-    const advance = item.advance;
-    item.advance = undefined;
     item.resolve(INTERRUPT);
-    if (item === activeItem) advance?.();
   }
 }
 
@@ -275,13 +264,7 @@ export function clearApprovalsWhere(
   predicate: (payload: ApprovalPayload) => boolean,
   decision: ApprovalDecision = INTERRUPT,
 ): number {
-  let cleared = 0;
-  for (const item of [...pendingItems]) {
-    if (!predicate(item.payload)) continue;
-    if (settleItem(item, decision)) cleared += 1;
-  }
-  if (cleared > 0) syncApprovalStatus();
-  return cleared;
+  return settleItems((item) => predicate(item.payload), decision);
 }
 
 /**

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -160,6 +160,13 @@ describe('CLI approval queue', () => {
 
     currentApproval.get()?.decide({ accepted: true });
     await expect(nextResult).resolves.toEqual({ accepted: true });
+
+    const cancelledDuringPresentation = enqueueApproval(
+      bashPayload('child-4'),
+      { onPresent: clearApprovals },
+    );
+    await expect(cancelledDuringPresentation).resolves.toEqual(interrupted);
+    expect(currentApproval.get()).toBeUndefined();
   });
 
   it('notifies only when a TUI approval becomes the foreground modal', async () => {
@@ -245,10 +252,17 @@ describe('CLI approval queue', () => {
     } as ApprovalPayload;
     const staleForStreamA = bashPayload('stream-a');
     const untouched = bashPayload('stream-b');
+    const presented: string[] = [];
 
-    const planResult = enqueueApproval(planPayload);
-    const staleResult = enqueueApproval(staleForStreamA);
-    const untouchedResult = enqueueApproval(untouched);
+    const planResult = enqueueApproval(planPayload, {
+      onPresent: () => presented.push('plan'),
+    });
+    const staleResult = enqueueApproval(staleForStreamA, {
+      onPresent: () => presented.push('stale'),
+    });
+    const untouchedResult = enqueueApproval(untouched, {
+      onPresent: () => presented.push('untouched'),
+    });
 
     await vi.waitFor(() => {
       expect(currentApproval.get()?.payload).toBe(planPayload);
@@ -267,6 +281,7 @@ describe('CLI approval queue', () => {
     await vi.waitFor(() => {
       expect(currentApproval.get()?.payload).toBe(untouched);
     });
+    expect(presented).toEqual(['plan', 'untouched']);
     currentApproval.get()?.decide({ accepted: true });
     await expect(untouchedResult).resolves.toEqual({ accepted: true });
   });


### PR DESCRIPTION
## Summary

- replace the approval queue's `PQueue`/`Set`/active-item layers with one explicit FIFO owner
- derive the foreground modal and queue status from that canonical list
- make selective cancellation atomic so removed requests never flash as foreground
- update the TUI architecture docs and strengthen existing cancellation coverage without adding another test case

## Issue acceptance gates

Closes #8092.

- foreground approvals remain FIFO and `onPresent` fires exactly once on promotion
- full and stream-scoped clears settle every matched caller promise
- removing the foreground item promotes the next unmatched request atomically
- queue depth and kind derive from the canonical FIFO
- focused queue, retry, host-cancel, and real PTY scenarios pass

## Single source of truth

`packages/cli/src/chat/tui/state/approvalQueue.ts` now owns pending requests in one module-private FIFO. `currentApproval` and `approvalQueueStatus` are projections of that list rather than parallel stores.

## Duplication and abstraction budget

Removed the approval queue's `PQueue`, pending `Set`, active-item pointer, and per-item advance callbacks. No generic queue abstraction was added; the module keeps a direct FIFO and one bulk-settlement transition that owns partition-before-resolve semantics.

## Net elements (R6)

- files: 5 modified, 0 added, 0 deleted
- exported symbols: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- net LoC: 94 insertions, 105 deletions (net -11)

## Consumer counts (R8)

n/a — no exports or emit paths were deleted or rerouted; the existing approval queue API and host-interaction consumers remain unchanged.

## Host impact

Extension: none.

Desktop: none.

CLI: approval/request ordering and behavior stay unchanged, while interruption and selective cancellation have one owner and no hidden scheduler promises.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 existing warnings)
- `npm test` (628 files passed, 1 skipped; 5,569 tests passed, 4 skipped)
- focused approval suite after review update (3 files; 35 tests)
- real PTY TUI harness (10 approval, inquiry, focus-return, retry, and interrupt scenarios)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive approval/interrupt paths in the CLI TUI where stuck or flashing modals would block agent runs; behavior is well-covered by expanded vitest cases but remains user-facing concurrency logic.
> 
> **Overview**
> **Replaces the CLI TUI approval serializer** so pending bash/tool-edit/plan/proposal/retry/inquiry prompts are owned by a single in-memory FIFO in `approvalQueue.ts`, not by `p-queue` plus a parallel `Set`, active-item pointer, and per-task `advance` callbacks.
> 
> **Enqueue and foreground behavior** append to that list, sync `approvalQueueStatus` from its length/kinds, and call `presentForeground()` so only the head is written to `currentApproval` (with optional `onPresent` hooks). User decisions and selective clears go through `settleItems`, which partitions the queue before resolving promises so bulk/stream-scoped cancellation cannot briefly show a modal for a request that is being removed in the same operation.
> 
> **Session interrupt** (`clearApprovals`) drains the FIFO and resolves every waiter with the interrupt decision without touching a hidden scheduler queue. **Docs** (architecture, implementation phase 2, bash mockup) now describe the single-owner FIFO and `createTuiHostInteractions` wiring instead of `p-queue` concurrency-1 for approvals. **Tests** add coverage for clear during `onPresent` and assert `onPresent` runs only for items that actually become foreground after `clearApprovalsForStream`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd8a6e56b8ef1f941a54ad50fd47a5e1e6f5ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->