### PR TITLE
fix(desktop): index Codex payload budgets by platform

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -383,7 +383,11 @@ The monorepo now has a local unsigned package rehearsal for the Electron desktop
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
 packaged `app.asar` contains the expected runtime files. The package verifier also reads the
 desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
-provider SDKs that should remain behind lazy agent-execution imports.
+provider SDKs that should remain behind lazy agent-execution imports. Its Codex payload check
+rejects unexpected platform packages independently of size. Size ceilings use the audited npm
+unpacked size of each `@openai/codex` 0.144.1 platform package plus 16 MiB of headroom per retained
+package; a universal build receives the sum of its component ceilings. A future Codex update that
+exceeds this headroom requires a tarball-content review before the platform baseline is updated.
 
 From the repository root:
 

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -3,8 +3,16 @@ import { join, relative } from 'node:path';
 
 const MEBIBYTE = 1024 * 1024;
 
-const CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES = 325 * MEBIBYTE;
-const CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES = 625 * MEBIBYTE;
+const CODEX_PAYLOAD_HEADROOM_BYTES_PER_PLATFORM = 16 * MEBIBYTE;
+// npm dist.unpackedSize values audited for @openai/codex 0.144.1.
+export const codexPayloadBaselineBytesByPlatform = {
+  'darwin-arm64': 311_569_963,
+  'darwin-x64': 337_129_194,
+  'linux-arm64': 308_463_407,
+  'linux-x64': 351_529_018,
+  'win32-arm64': 356_454_041,
+  'win32-x64': 409_157_780,
+};
 
 export const codexPlatformInfoByKey = {
   'linux-x64': {
@@ -76,9 +84,17 @@ export function formatBytes(bytes) {
 }
 
 export function expectedCodexPayloadBudgetBytes(expectedPlatformKeys) {
-  return expectedPlatformKeys.length > 1
-    ? CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES
-    : CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES;
+  let budgetBytes = 0;
+  for (const platformKey of expectedPlatformKeys) {
+    const baselineBytes = codexPayloadBaselineBytesByPlatform[platformKey];
+    if (baselineBytes == null) {
+      throw new Error(
+        `Codex payload budget has no audited baseline for ${platformKey}.`,
+      );
+    }
+    budgetBytes += baselineBytes + CODEX_PAYLOAD_HEADROOM_BYTES_PER_PLATFORM;
+  }
+  return budgetBytes;
 }
 
 export function inferCodexPlatformKeys({ platform, arch, appPath } = {}) {

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -5,6 +5,8 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
+  truncateSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -46,9 +48,25 @@ const codexPlatforms = {
     triple: 'x86_64-apple-darwin',
     binaryName: 'codex',
   },
+  'linux-x64': {
+    packageName: '@openai/codex-linux-x64',
+    triple: 'x86_64-unknown-linux-musl',
+    binaryName: 'codex',
+  },
+  'win32-x64': {
+    packageName: '@openai/codex-win32-x64',
+    triple: 'x86_64-pc-windows-msvc',
+    binaryName: 'codex.exe',
+  },
 } as const;
 
+type CodexPlatform = keyof typeof codexPlatforms;
+type DesktopPackageTarget = CodexPlatform | 'darwin-universal';
+
+const MEBIBYTE = 1024 * 1024;
+
 interface CodexPayloadModule {
+  codexPayloadBaselineBytesByPlatform: Readonly<Record<CodexPlatform, number>>;
   inferCodexPlatformKeys(input: {
     appPath: string;
     arch?: number;
@@ -60,6 +78,9 @@ interface CodexPayloadModule {
 async function loadCodexPayload(): Promise<CodexPayloadModule> {
   return (await import(payloadUrl)) as CodexPayloadModule;
 }
+
+const { codexPayloadBaselineBytesByPlatform: auditedCodexPayloadSizeBytes } =
+  await loadCodexPayload();
 
 let tempRoots: string[] = [];
 
@@ -117,6 +138,61 @@ describe('desktop Codex package payload', () => {
     const output = runVerifier(packageRoot);
     expect(output).toContain('@openai/codex-darwin-arm64');
     expect(output).toContain('Codex CLI payload size');
+  });
+
+  it.each([
+    {
+      platform: 'linux-x64' as const,
+      payloadSize: '335.2 MiB',
+      budgetSize: '351.2 MiB',
+    },
+    {
+      platform: 'win32-x64' as const,
+      payloadSize: '390.2 MiB',
+      budgetSize: '406.2 MiB',
+    },
+  ])(
+    'accepts the audited Codex 0.144.1 $platform payload with bounded headroom',
+    ({ platform, payloadSize, budgetSize }) => {
+      const { packageRoot } = createFakeDesktopPackage([platform], {
+        codexPayloadSizeBytes: {
+          [platform]: auditedCodexPayloadSizeBytes[platform],
+        },
+        target: platform,
+      });
+
+      const output = runVerifier(packageRoot);
+      expect(output).toContain(
+        `Codex CLI payload size: ${payloadSize} / ${budgetSize}`,
+      );
+    },
+  );
+
+  it('sums platform-indexed payload budgets for universal packages', () => {
+    const { packageRoot } = createFakeDesktopPackage(
+      ['darwin-arm64', 'darwin-x64'],
+      {
+        codexPayloadSizeBytes: auditedCodexPayloadSizeBytes,
+        target: 'darwin-universal',
+      },
+    );
+
+    const output = runVerifier(packageRoot);
+    expect(output).toContain('Codex CLI payload size: 618.6 MiB / 650.6 MiB');
+  });
+
+  it('rejects payload growth beyond the audited platform headroom', () => {
+    const platform = 'linux-x64';
+    const { packageRoot } = createFakeDesktopPackage([platform], {
+      codexPayloadSizeBytes: {
+        [platform]: auditedCodexPayloadSizeBytes[platform] + 17 * MEBIBYTE,
+      },
+      target: platform,
+    });
+
+    const result = runVerifierResult(packageRoot);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('above the 351.2 MiB budget for linux-x64');
   });
 
   it('does not infer Windows from a darwin path segment', async () => {
@@ -182,6 +258,14 @@ describe('desktop Codex package payload', () => {
     );
 
     expect(universalBudget).toBeGreaterThan(singlePlatformBudget);
+  });
+
+  it('rejects a platform without an audited payload baseline', async () => {
+    const { expectedCodexPayloadBudgetBytes } = await loadCodexPayload();
+
+    expect(() => expectedCodexPayloadBudgetBytes(['linux-riscv64'])).toThrow(
+      'no audited baseline for linux-riscv64',
+    );
   });
 
   it('keeps both Darwin Codex packages during universal temp packaging', async () => {
@@ -251,10 +335,12 @@ describe('desktop Codex package payload', () => {
 });
 
 function createFakeDesktopPackage(
-  platforms: Array<keyof typeof codexPlatforms>,
+  platforms: CodexPlatform[],
   options: {
     bootstrapInputs?: Record<string, { bytesInOutput: number }>;
+    codexPayloadSizeBytes?: Partial<Record<CodexPlatform, number>>;
     startupImportPath?: string;
+    target?: DesktopPackageTarget;
   } = {},
 ): {
   appOutDir: string;
@@ -265,8 +351,21 @@ function createFakeDesktopPackage(
   tempRoots.push(tempRoot);
 
   const packageRoot = join(tempRoot, 'dist-packaged');
-  const appOutDir = join(packageRoot, 'mac-arm64');
-  const resourcesDir = join(appOutDir, 'TeXRA.app', 'Contents', 'Resources');
+  const target = options.target ?? 'darwin-arm64';
+  let targetDirName: string;
+  if (target === 'darwin-universal') {
+    targetDirName = 'mac-universal';
+  } else if (target.startsWith('darwin')) {
+    targetDirName = `mac-${target.slice('darwin-'.length)}`;
+  } else if (target.startsWith('linux')) {
+    targetDirName = 'linux-unpacked';
+  } else {
+    targetDirName = 'win-unpacked';
+  }
+  const appOutDir = join(packageRoot, targetDirName);
+  const resourcesDir = target.startsWith('darwin')
+    ? join(appOutDir, 'TeXRA.app', 'Contents', 'Resources')
+    : join(appOutDir, 'resources');
   const appRoot = join(resourcesDir, 'app');
 
   writeJson(join(appRoot, 'package.json'), {
@@ -333,7 +432,11 @@ function createFakeDesktopPackage(
   }
 
   for (const platform of platforms) {
-    writeCodexPlatformPackage(appRoot, platform);
+    writeCodexPlatformPackage(
+      appRoot,
+      platform,
+      options.codexPayloadSizeBytes?.[platform],
+    );
   }
 
   return { appOutDir, packageRoot, resourcesDir: appRoot };
@@ -341,7 +444,8 @@ function createFakeDesktopPackage(
 
 function writeCodexPlatformPackage(
   appRoot: string,
-  platform: keyof typeof codexPlatforms,
+  platform: CodexPlatform,
+  payloadSizeBytes?: number,
 ): void {
   const info = codexPlatforms[platform];
   const packageRoot = join(
@@ -351,19 +455,28 @@ function writeCodexPlatformPackage(
     ...info.packageName.split('/'),
   );
 
-  writeJson(join(packageRoot, 'package.json'), {
+  const packageJsonPath = join(packageRoot, 'package.json');
+  writeJson(packageJsonPath, {
     name: '@openai/codex',
     version: `0.128.0-${platform}`,
   });
-  writeText(
-    join(packageRoot, 'vendor', info.triple, 'codex', info.binaryName),
-    'fake codex binary\n',
+  const binaryPath = join(
+    packageRoot,
+    'vendor',
+    info.triple,
+    'codex',
+    info.binaryName,
   );
+  writeText(binaryPath, 'fake codex binary\n');
+
+  if (payloadSizeBytes != null) {
+    truncateSync(binaryPath, payloadSizeBytes - statSync(packageJsonPath).size);
+  }
 }
 
 function writePnpmCodexPlatformPackage(
   appRoot: string,
-  platform: keyof typeof codexPlatforms,
+  platform: CodexPlatform,
 ): void {
   const info = codexPlatforms[platform];
   const packageRoot = join(


### PR DESCRIPTION
## Summary

- replace the single 325/625 MiB Codex payload ceilings with audited per-platform baselines
- add 16 MiB of explicit headroom for each retained platform package and sum component budgets for universal builds
- fail loudly when a platform has no audited baseline or exceeds its allowance

## Evidence

Desktop Package run 29148884334 built and launched all three unpacked applications. Static verification then rejected the legitimate Codex 0.144.1 payloads on Linux and Windows:

- Linux x64: 351,529,018 bytes (335.2 MiB)
- Windows x64: 409,157,780 bytes (390.2 MiB)
- macOS universal: 648,699,157 bytes (618.6 MiB), the sum of both Darwin packages

Comparison with 0.142.5 tarballs shows genuine upstream growth. The principal new executable is `codex-code-mode-host` (about 44 MiB on Linux and 51 MiB on Windows); the main Codex executables also grew. The package contents are target-specific, and CI pruning removed the unused architecture packages correctly.

## Design

`desktop-codex-payload.mjs` remains the single owner of platform inference, pruning vocabulary, and payload budgets. Each known platform has the audited npm `dist.unpackedSize` for Codex 0.144.1 plus 16 MiB headroom. A universal package receives the sum of its component budgets. Updating Codex beyond that allowance requires a fresh tarball-content audit rather than silently widening a global threshold.

Unexpected bundled platforms are still rejected independently of the size check. No packaging, pruning, or launch-smoke behavior changes.

## Validation

- `DesktopCodexPayload.vitest.mts`: 17 tests passed
- source typecheck passed
- full lint passed with zero errors
- `node --check` for both payload scripts
- targeted Prettier check
- `git diff --check`
- existing macOS arm64 package passed at 297.1 / 313.1 MiB

A fresh cross-platform package run will follow after this prerequisite lands.

Closes #8103

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only desktop package verification budgets and tests; no packaging, pruning, or runtime behavior.
> 
> **Overview**
> Replaces the desktop package verifier’s **flat 325 / 625 MiB Codex payload ceilings** with **per-platform budgets** in `desktop-codex-payload.mjs`: audited npm unpacked sizes for `@openai/codex` **0.144.1** plus **16 MiB headroom** per retained platform package. **Universal macOS builds** use the **sum** of each Darwin component’s ceiling instead of a single global cap.
> 
> `expectedCodexPayloadBudgetBytes` now **throws** when a platform has no audited baseline, so oversized or unknown platforms cannot pass by widening a global threshold. **Unexpected bundled Codex platforms** remain a separate failure from the size check.
> 
> `docs/electron-migration-plan.md` documents the new policy (baseline + headroom, universal summing, tarball review before baseline updates). **`DesktopCodexPayload.vitest.mts`** gains Linux/Windows and universal budget cases, over-budget rejection, missing-baseline errors, and fake packages that can simulate audited payload sizes across **darwin / linux / win** layout paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8795829c2a6e7ebb1a86d316452b561ef8161ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->