### PR TITLE
test(agent): assert fresh system prompt on resume

### DIFF
--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -9,6 +9,8 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUsePrepareNode } from '@agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
+import { hasDelegationTool } from '@shared/constants/delegationTools';
+import { buildInitialToolUsePrompts } from '@utils/prompt';
 
 function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},
@@ -108,20 +110,34 @@ function buildSnapshot(
 }
 
 describe('ToolUsePrepareNode resume (prompt-cache preservation)', () => {
-  it('keeps the persisted messages byte-identical on resume, never rewriting messages[0]', async () => {
+  it('keeps the persisted message prefix while rebuilding the per-call system prompt', async () => {
     // Rewriting the persisted system message on every resume to reflect
     // current workspace/tool state would change the leading bytes of the
     // request and invalidate the provider's prefix-based prompt cache. Per
     // maintainer ruling, resume must use the snapshot's messages verbatim —
     // a mid-run agent-config edit does not propagate into an
-    // already-suspended run's prefix. This is the regression test for that
-    // contract: no local re-derivation, no port call, no mutation.
+    // already-suspended run's prefix. The separate per-call system prompt,
+    // however, must still be rebuilt from the current prompt configuration.
     const snapshot = buildSnapshot();
     const services = buildServices({ snapshot });
     const node = new ToolUsePrepareNode().setServices(services);
+    const resolvedToolNames = services.resolvedTools.map((tool) => tool.name);
+    const rebuiltPrompts = await buildInitialToolUsePrompts(
+      services.prompt,
+      services.userVarChannels.transient,
+      services.logger,
+      {
+        resolvedToolNames,
+        hasDelegationTools: hasDelegationTool(resolvedToolNames),
+        isSubagent: services.isSubagent,
+      },
+    );
 
     const result = await node.exec(undefined);
 
+    expect(result.result.systemPrompt).toBe(
+      `${rebuiltPrompts.systemPrompt}\n${rebuiltPrompts.instructionSuffix}`,
+    );
     expect(result.result.messages).toBe(snapshot.messages);
     expect(result.result.messages[0]).toEqual({
       role: 'system',


### PR DESCRIPTION
## Summary

- assert a resumed tool-use session rebuilds the current per-call system prompt
- retain the reference-identity and content assertions for the persisted provider-message prefix
- keep the fresh-session `initializeMessages` path excluded during resume

## Contract

Providers that embed the system text in persisted messages must retain that byte prefix across resume for prompt-cache stability. Providers that pass a separate system parameter still require the current prompt on every call. The regression now proves both halves of that contract in the same resume case.

No production behavior changes.

## Validation

- focused Vitest: 4 tests passed
- source typecheck passed
- test-kernel typecheck passed
- full lint passed with zero errors
- targeted ESLint and Prettier checks
- `git diff --check`

Closes #8037

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test assertions and comments change; no production code in the diff.
> 
> **Overview**
> **Test-only** update to the `ToolUsePrepareNode` resume regression: the case now documents and checks both sides of the prompt-cache contract.
> 
> On resume, **`result.messages`** must still be the snapshot array unchanged (including a stale embedded system message like `'stale system'`), **`shouldSkipCycle`** stays true, and **`initializeMessages`** is not invoked. **Additionally**, **`result.systemPrompt`** must match a fresh build from `buildInitialToolUsePrompts` (system + instruction suffix), mirroring how production rebuilds the per-call `system` parameter without rewriting the persisted message prefix.
> 
> The test name and comment are adjusted to reflect “persisted prefix + rebuilt per-call system prompt” rather than only byte-identical messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 999dc68644cf7b5edc1230e0f0cd6c8568df6f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->