### PR TITLE
fix(agent): persist tool-use round outcomes

### DIFF
--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -926,9 +926,14 @@ transcript row:**
 3. **`TraceEmitter.ts:212` and `:300`** — `openStage()`'s
    `defaultStatus = options.defaultStatus ?? END_GROUP_STATUS.STOPPED` and
    `StageHandleImpl.run()`'s catch branch `this.end(END_GROUP_STATUS.ERROR)`.
-   These cover every **non-run** stage (tool groupings, sub-phases) that
-   never carries a `RunOutcome` — success/failure only, no cancellation
-   concept.
+   These defaults are correct for genuinely generic stages (tool groupings
+   and sub-phases), whose local execution is binary: success or failure.
+   They are not an outcome source for cancellable round stages. At the audit
+   baseline, `ToolUseCycleNode.ts` called `roundStage.run()` and only then
+   classified the returned round as completed, failed, or cancelled. Since
+   `run()` closed the stage before that classification, a returned failure or
+   cancellation was mislabelled as `STOPPED` there (and as `completed` after
+   the native-vocabulary cutover).
 
 **A fourth, previously uncatalogued producer** (found in this recount, not in
 the #6982 pins — the two-pin list in the issue body undercounts the surface):
@@ -1025,10 +1030,16 @@ Every real call site already has (or can trivially be given) the actual
   `legacyEndGroupStatusForOutcome` call entirely, no behavior decision needed.
 - `AgentRunLifecycle.ts:369` passes `RUN_OUTCOME.CANCELLED` directly — same
   deletion.
-- `TraceEmitter.ts`'s generic (non-run) stage default becomes
+- `TraceEmitter.ts`'s genuinely generic stage default becomes
   `RunOutcome.COMPLETED` on success, `RunOutcome.FAILED` on the `run()` catch
-  branch. Generic stages have no cancellation concept, so they only ever use
-  2 of the 3 `RunOutcome` members — that is a narrowing, not a new value.
+  branch. These stages have no local cancellation concept, so they only ever
+  use 2 of the 3 `RunOutcome` members — that is a narrowing, not a new value.
+- Cancellable round stages use the existing outcome-aware path: run their
+  body under `StageHandle.within()`, derive the round's `RunOutcome`, and pass
+  it explicitly to `StageHandle.end()` in a `finally` block. In particular,
+  `ToolUseCycleNode` preserves completed, failed, and cancelled as three
+  distinct `GROUP_END` values. `TraceEmitter` remains generic; it does not
+  gain a round-specific callback or a second `run()` interface.
 - `StreamLogStore`'s orphan-sweep default flips from unconditional `ERROR` to
   a caller-supplied `RunOutcome`; `ProgressViewState.endRunningTaskGroups`
   and desktop's `closeRunningTaskGroupsForStreams` already classify
@@ -1298,6 +1309,10 @@ parent issue's own estimate.
 Existing suites already pin group-end/transcript-boundary behavior and are
 the ones step 1 extends (R7 — no new suites):
 
+- `src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts` — pins
+  `ToolUseCycleNode`'s round-stage closure for completed, failed, and
+  cancelled classifications, including the corresponding literal
+  `RunOutcome` in each persisted `GROUP_END` row.
 - `src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts` — pins the two
   `stage.end`/direct-transcript-write call sites (§8.1 items 1-2); extend
   with cases asserting the `GROUP_END` row's `data.status` is the literal

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -10,8 +10,13 @@ import {
 import { withModelClient } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { buildFailedRetryInfo } from '@common/errors';
-import { MESSAGE_TYPES } from '@shared/schemas';
-import type { RetryErrorInfo } from '@shared/schemas';
+import { deriveRunOutcome } from '@common/constants/streamStatus';
+import {
+  MESSAGE_TYPES,
+  RUN_OUTCOME,
+  type RetryErrorInfo,
+  type RunOutcome,
+} from '@shared/schemas';
 
 import {
   type ToolUseRunShared,
@@ -128,22 +133,32 @@ export class ToolUseCycleNode<C> extends Node<
       },
     );
 
+    let roundOutcome: RunOutcome = RUN_OUTCOME.FAILED;
     try {
-      await roundStage.run(() => flow.run(roundShared));
+      await roundStage.within(() => flow.run(roundShared));
 
-      if (roundShared.shouldStop && roundShared.lastError) {
+      const lastError = roundShared.shouldStop
+        ? roundShared.lastError
+        : undefined;
+      roundOutcome = deriveRunOutcome({
+        failed: lastError !== undefined,
+        cancelled: roundShared.shouldStop && !roundShared.endTurn,
+      });
+
+      if (lastError) {
         return {
           outcome: 'failed',
-          message: roundShared.lastError.message,
-          userRetryable: roundShared.lastError.userRetryable,
-          lastError: roundShared.lastError,
+          message: lastError.message,
+          userRetryable: lastError.userRetryable,
+          lastError,
         };
       }
-      if (roundShared.shouldStop && !roundShared.endTurn) {
+      if (roundOutcome === RUN_OUTCOME.CANCELLED) {
         return { outcome: 'cancelled' };
       }
       return { outcome: 'completed', messages: roundShared.messages };
     } finally {
+      roundStage.end(roundOutcome);
       if (roundShared.currentUserInstruction !== undefined) {
         prepRes.userChannels.transient.INSTRUCTION =
           roundShared.currentUserInstruction;

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -1,7 +1,35 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+const roundFlowState = vi.hoisted(() => ({
+  shouldStop: false,
+  endTurn: false,
+  lastError: undefined as
+    { message: string; userRetryable: boolean } | undefined,
+}));
+
+vi.mock('@agent/core/flows/ToolUseRoundFlow', () => ({
+  createToolUseRoundFlow: () => ({
+    setServices() {},
+    async run(shared: {
+      shouldStop: boolean;
+      endTurn: boolean;
+      lastError?: { message: string; userRetryable: boolean };
+    }) {
+      shared.shouldStop = roundFlowState.shouldStop;
+      shared.endTurn = roundFlowState.endTurn;
+      shared.lastError = roundFlowState.lastError;
+    },
+  }),
+}));
+
+vi.mock('@agent/core/flows/CycleServices', () => ({
+  withModelClient: async (services: unknown) => services,
+}));
+
 // Local imports
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
@@ -14,10 +42,13 @@ import type {
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import {
   MESSAGE_TYPES,
+  RUN_OUTCOME,
+  STREAM_LOG_ENTRY_TYPES,
   type Plan,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
+import { isObject } from '@utils/core';
 import {
   createRecordingHost,
   recordSessionEvents,
@@ -39,13 +70,14 @@ const plan: Plan = {
 
 function createPrepResult(
   workspaceState: AgentWorkspaceState,
+  shouldSkipCycle = true,
 ): CyclePrepResult {
   return {
-    shouldSkipCycle: true,
+    shouldSkipCycle,
     messages: [],
     runState: { totalRounds: 0 } as CyclePrepResult['runState'],
     workspaceState,
-    userChannels: {} as CyclePrepResult['userChannels'],
+    userChannels: { input: {}, transient: {} },
   };
 }
 
@@ -115,4 +147,88 @@ describe('tool-use progress events', () => {
       messageType: MESSAGE_TYPES.ERROR,
     });
   });
+});
+
+describe('tool-use round outcome persistence (#8023)', () => {
+  it.each([
+    {
+      name: 'completed',
+      shouldStop: false,
+      endTurn: false,
+      lastError: undefined,
+      expectedOutcome: 'completed',
+      expectedStatus: RUN_OUTCOME.COMPLETED,
+    },
+    {
+      name: 'failed',
+      shouldStop: true,
+      endTurn: false,
+      lastError: { message: 'round failed', userRetryable: false },
+      expectedOutcome: 'failed',
+      expectedStatus: RUN_OUTCOME.FAILED,
+    },
+    {
+      name: 'cancelled',
+      shouldStop: true,
+      endTurn: false,
+      lastError: undefined,
+      expectedOutcome: 'cancelled',
+      expectedStatus: RUN_OUTCOME.CANCELLED,
+    },
+  ])(
+    'persists a $name round with its canonical RunOutcome',
+    async ({
+      name,
+      shouldStop,
+      endTurn,
+      lastError,
+      expectedOutcome,
+      expectedStatus,
+    }) => {
+      roundFlowState.shouldStop = shouldStop;
+      roundFlowState.endTurn = endTurn;
+      roundFlowState.lastError = lastError;
+
+      const { host } = createRecordingHost();
+      const logger = new TraceEmitter();
+      const streamId = `stream:tool-use-round-${name}` as StreamTabId;
+      const store = new StreamLogStore();
+      store.ensureStream(streamId);
+      const recorder = attachTranscriptRecorder(logger, streamId, store);
+      const node = new ToolUseCycleNode().setServices({
+        streamId,
+        runtimeHost: host,
+        logger,
+        modelHandler: { getClient: vi.fn() },
+        config: { model: 'test-model', agent: 'test-agent' },
+        setting: { tools: [] },
+        resolvedTools: [],
+      } as unknown as ToolUseServices);
+
+      try {
+        const result = await withTestRunContext(host, streamId, () =>
+          node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
+        );
+
+        expect(result.outcome).toBe(expectedOutcome);
+        const roundEndStatuses =
+          store
+            .get(streamId)
+            ?.getRange(0)
+            .flatMap((entry) => {
+              if (
+                entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END &&
+                isObject(entry.data) &&
+                entry.data.kind === 'round'
+              ) {
+                return [entry.data.status];
+              }
+              return [];
+            }) ?? [];
+        expect(roundEndStatuses).toEqual([expectedStatus]);
+      } finally {
+        recorder.unsubscribe();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- close tool-use round stages with their derived completed, failed, or cancelled `RunOutcome`
- preserve `TraceEmitter`'s generic success/failure stage interface
- distinguish generic stages from cancellable round stages in the runtime design
- cover all three round outcomes at the persisted `GROUP_END` boundary

## Root cause

The StreamPhase-native cutover correctly retyped `TraceEmitter` and transcript persistence to `RunOutcome`, but `ToolUseCycleNode` still used `roundStage.run()`. That helper ended the stage as completed immediately after the inner flow returned, before the node classified `shouldStop`, `endTurn`, and `lastError`. Returned failures and cancellations were therefore persisted as completed rounds.

## Design

`ToolUseCycleNode` now runs the inner flow under `StageHandle.within()`, derives the round outcome through the canonical `deriveRunOutcome` rule, and passes that outcome to `StageHandle.end()` in `finally`. A thrown inner flow remains failed by default. No round-specific API or callback is added to `TraceEmitter`.

The architecture document now records both the historical audit finding and the corrected invariant, so it does not describe the former behavior as current.

## Scope

- Files changed: 3.
- Diffstat: 162 insertions, 16 deletions.
- Persistence schema and public API changes: none.
- Hosts affected: shared agent runtime only; extension, desktop, and CLI receive the corrected persisted outcome through their existing trace path.

## Validation

Rebased on current `main` at `81c58534f`, including the atomic CLI fallback-session reservation from #8110.

- focused `ToolUseProgressEvents.vitest.ts`: 5 passed
- `npm test`: 5,598 passed, 4 skipped
- `npm run typecheck`: passed
- `npm run compile:fast`: passed
- `npm run lint`: passed with 0 errors
- dead-code ratchet: passed
- formatting and `git diff --check`: passed

Closes #8023