### PR TITLE
fix(tools): reserve CLI fallback sessions

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -80,8 +80,8 @@ export interface ChildRunStrategy<TTurn> {
   readonly stageLabel: string;
 
   /**
-   * Called once before the loop starts. Used to register a resumed session id
-   * immediately so a concurrent call with the same id can't start a second loop.
+   * Called once before the loop starts. Agent-CLI strategies use this to
+   * promote a synchronously claimed fallback id to an active session entry.
    */
   onSessionStart?(session: SessionHandle): void;
 

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -9,6 +9,67 @@ import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
 import { createRecordingHost } from '../agent/progressTestUtils';
 
 describe('AgentCliSessionRegistry', () => {
+  it('atomically claims a session id and wakes waiters when it becomes active', async () => {
+    const registry = new AgentCliSessionRegistry('test_session_id');
+    const executions = new ExecutionRegistry();
+    const entry = {
+      childStreamId: 'child-a' as StreamTabId,
+      executionId: 'execution-a' as ExecutionId,
+      executions,
+    };
+
+    try {
+      const releaseInitialClaim = registry.claim('session-a');
+      expect(releaseInitialClaim).toBeTypeOf('function');
+      expect(registry.claim('session-a')).toBeUndefined();
+      expect(registry.isActive('session-a')).toBe(false);
+      expect(registry.lookup('session-a')).toBeUndefined();
+
+      const active = registry.waitForActive('session-a');
+      registry.register('session-a', entry);
+
+      await expect(active).resolves.toBe(entry);
+      expect(registry.isActive('session-a')).toBe(true);
+      expect(registry.lookup('session-a')).toBe(entry);
+      expect(registry.claim('session-a')).toBeUndefined();
+
+      // The original release handle owns only the reservation. Promotion to
+      // active makes it harmless, so a late launch failure cannot strand the
+      // running loop by deleting its registry entry.
+      releaseInitialClaim?.();
+      expect(registry.lookup('session-a')).toBe(entry);
+
+      registry.release('session-a');
+      expect(registry.isActive('session-a')).toBe(false);
+      const releaseNextClaim = registry.claim('session-a');
+      expect(releaseNextClaim).toBeTypeOf('function');
+      releaseInitialClaim?.();
+      expect(registry.claim('session-a')).toBeUndefined();
+      releaseNextClaim?.();
+    } finally {
+      registry.release('session-a');
+      executions.dispose();
+    }
+  });
+
+  it('releases pending waiters and permits a new claim after cleanup', async () => {
+    const registry = new AgentCliSessionRegistry('test_session_id');
+
+    const releaseClaim = registry.claim('session-a');
+    expect(releaseClaim).toBeTypeOf('function');
+    const active = registry.waitForActive('session-a');
+
+    releaseClaim?.();
+
+    await expect(active).resolves.toBeUndefined();
+    expect(registry.isActive('session-a')).toBe(false);
+    const releaseNextClaim = registry.claim('session-a');
+    expect(releaseNextClaim).toBeTypeOf('function');
+
+    releaseNextClaim?.();
+    await expect(registry.waitForActive('session-a')).resolves.toBeUndefined();
+  });
+
   it('interrupts each child through the execution registry that owns the session', () => {
     const registry = new AgentCliSessionRegistry('test_session_id');
     const ownerA = new ExecutionRegistry();
@@ -39,6 +100,7 @@ describe('AgentCliSessionRegistry', () => {
     ownerB.track(handleB);
 
     try {
+      registry.claim('pending-session');
       registry.register('session-a', {
         childStreamId: 'child-a' as StreamTabId,
         executionId: 'execution-a' as ExecutionId,
@@ -55,6 +117,7 @@ describe('AgentCliSessionRegistry', () => {
       expect(interruptA).toHaveBeenCalledOnce();
       expect(interruptB).toHaveBeenCalledOnce();
     } finally {
+      registry.release('pending-session');
       ownerA.dispose();
       ownerB.dispose();
     }

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -2,10 +2,9 @@
 // caller passes a session_id whose in-memory ClaudeAgentSessions registry
 // entry is gone (extension reload, host crash, or a stale id from an older
 // run), the tool must NOT throw a "not active" ToolError like a raw
-// resumeAgentCliSession() call would. It must mirror codex.ts's pattern —
-// fall through to launching a fresh session that resumes the SDK session
-// from disk via the `resume` option, rather than silently starting a blind
-// new conversation or surfacing an error to the caller.
+// resumeAgentCliSession() call would. The first fallback must claim the id
+// before asynchronous setup, while concurrent calls wait for that loop and
+// then enqueue through the ordinary follow-up path.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -29,6 +28,8 @@ const mocks = vi.hoisted(() => ({
   startChildRunLoop: vi.fn(),
   currentSession: vi.fn(),
   query: vi.fn(),
+  buildClaudeAgentEnv: vi.fn(),
+  enqueueFollowUp: vi.fn(),
 }));
 
 vi.mock('@tools/approval/bashApproval', () => ({
@@ -72,7 +73,7 @@ vi.mock('@tools/claudeAgentConfig', () => ({
   getClaudeAgentPermissionMode: () => 'acceptEdits',
   getClaudeAgentModel: () => 'claude-sonnet-4-6',
   getClaudeAgentEffort: () => 'high',
-  buildClaudeAgentEnv: async () => ({}),
+  buildClaudeAgentEnv: mocks.buildClaudeAgentEnv,
   buildClaudeAgentConfig: () => ({
     agent: 'claude_agent',
     model: 'Claude Code CLI',
@@ -96,6 +97,24 @@ async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
   for (const message of messages) {
     yield message;
   }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T) => void;
+} {
+  let settle: ((value: T) => void) | undefined;
+  let rejectPromise: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    settle = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    reject: (reason) => rejectPromise?.(reason),
+    resolve: (value) => settle?.(value),
+  };
 }
 
 function fakeLogger(): AgentTrace {
@@ -122,6 +141,8 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
   });
 
   function setupCommonMocks(): void {
+    mocks.startChildRunLoop.mockReset();
+    mocks.buildClaudeAgentEnv.mockReset();
     mocks.requestBashApproval.mockResolvedValue({ accepted: true });
     mocks.getCurrentToolContexts.mockReturnValue({
       runContext: {
@@ -135,9 +156,10 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
     mocks.ensureRunDir.mockResolvedValue(undefined);
+    mocks.buildClaudeAgentEnv.mockResolvedValue({});
     mocks.createChildStream.mockReturnValue(fakeChildStream());
     mocks.currentSession.mockReturnValue({
-      followUps: { acquire: () => ({ enqueue: vi.fn() }) },
+      followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
     });
   }
 
@@ -217,14 +239,121 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
       { strategy: ChildRunStrategy<unknown> },
     ];
 
-    // Pins the eager-registration mechanism itself: onSessionStart must make
-    // the stale session_id observably active synchronously, independent of
-    // whether the first turn has resolved yet.
+    // Pins reservation promotion itself: onSessionStart must make the stale
+    // session_id observably active synchronously, independent of whether the
+    // first turn has resolved yet.
     expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
     loopParams.strategy.onSessionStart?.({
       executions: { getAgentHandleByStream: () => undefined } as any,
     } as any);
     expect(ClaudeAgentSessions.isActive('stale-session')).toBe(true);
+  });
+
+  it('launches one fallback loop when concurrent calls use the same stale session_id', async () => {
+    setupCommonMocks();
+    const envStarted = deferred<void>();
+    const envReady = deferred<NodeJS.ProcessEnv>();
+    const executions = { getAgentHandleByStream: () => undefined } as any;
+    let strategy: ChildRunStrategy<unknown> | undefined;
+    mocks.buildClaudeAgentEnv.mockImplementation(() => {
+      envStarted.resolve(undefined);
+      return envReady.promise;
+    });
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+        params.strategy.onSessionStart?.({ executions } as any);
+      },
+    );
+
+    const tool = new ClaudeAgentTool();
+    const first = tool.call({
+      prompt: 'continue the refactor',
+      session_id: 'stale-session',
+    });
+    await envStarted.promise;
+
+    const second = tool.call({
+      prompt: 'also update the tests',
+      session_id: 'stale-session',
+    });
+    await Promise.resolve();
+
+    expect(mocks.buildClaudeAgentEnv).toHaveBeenCalledTimes(1);
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+
+    envReady.resolve({});
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.status).toBe('executed');
+    expect(secondResult.summary).toMatch(/Follow-up queued/);
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.enqueueFollowUp).toHaveBeenCalledWith({
+      text: 'also update the tests',
+    });
+
+    strategy?.onSessionCleanup?.();
+    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
+  });
+
+  it('releases the fallback claim when asynchronous launch setup fails', async () => {
+    setupCommonMocks();
+    mocks.buildClaudeAgentEnv.mockRejectedValue(new Error('env failed'));
+
+    const result = await new ClaudeAgentTool().call({
+      prompt: 'continue the refactor',
+      session_id: 'stale-session',
+    });
+
+    expect(result.status).toBe('error');
+    const releaseClaim = ClaudeAgentSessions.claim('stale-session');
+    expect(releaseClaim).toBeTypeOf('function');
+    releaseClaim?.();
+  });
+
+  it('lets a waiting caller own the fallback after the first launch fails', async () => {
+    setupCommonMocks();
+    const firstEnvStarted = deferred<void>();
+    const firstEnv = deferred<NodeJS.ProcessEnv>();
+    const executions = { getAgentHandleByStream: () => undefined } as any;
+    let strategy: ChildRunStrategy<unknown> | undefined;
+    mocks.buildClaudeAgentEnv
+      .mockImplementationOnce(() => {
+        firstEnvStarted.resolve(undefined);
+        return firstEnv.promise;
+      })
+      .mockResolvedValueOnce({});
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+        params.strategy.onSessionStart?.({ executions } as any);
+      },
+    );
+
+    const tool = new ClaudeAgentTool();
+    const first = tool.call({
+      prompt: 'first attempt',
+      session_id: 'stale-session',
+    });
+    await firstEnvStarted.promise;
+    const second = tool.call({
+      prompt: 'retry from the waiter',
+      session_id: 'stale-session',
+    });
+    await Promise.resolve();
+
+    firstEnv.reject(new Error('first environment failed'));
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.status).toBe('error');
+    expect(secondResult.status).toBe('executed');
+    expect(secondResult.summary).toMatch(/Launched Claude Code CLI/);
+    expect(mocks.buildClaudeAgentEnv).toHaveBeenCalledTimes(2);
+    expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
+
+    strategy?.onSessionCleanup?.();
+    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
   });
 
   it('still enqueues a follow-up (no fresh launch) when session_id IS active in the registry', async () => {

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -1,0 +1,287 @@
+// Regression coverage for atomic Codex disk-resume claims. Concurrent calls
+// with the same stale thread_id must share one fallback loop: the first call
+// owns asynchronous SDK setup, while later calls wait for registration and
+// enqueue through the ordinary follow-up path.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createRunTrace, StreamLogStore } from '@transcript';
+import type { AgentTrace } from '@agent/trace';
+import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { CodexThreads } from '@tools/agentCliSessionStores';
+import type { ChildStream } from '@tools/childStream';
+
+const mocks = vi.hoisted(() => ({
+  requestBashApproval: vi.fn(),
+  getCurrentToolContexts: vi.fn(),
+  registerExecution: vi.fn(),
+  getExecutionStore: vi.fn(),
+  ensureRunDir: vi.fn(),
+  createChildStream: vi.fn(),
+  startChildRunLoop: vi.fn(),
+  currentSession: vi.fn(),
+  importCodexClass: vi.fn(),
+  findCodexBinaryPath: vi.fn(),
+  resumeThread: vi.fn(),
+  enqueueFollowUp: vi.fn(),
+}));
+
+vi.mock('@tools/approval/bashApproval', () => ({
+  requestBashApproval: mocks.requestBashApproval,
+  buildBashApprovalRejectedResult: vi.fn(),
+}));
+
+vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
+  getCurrentToolContexts: mocks.getCurrentToolContexts,
+}));
+
+vi.mock('@agent/runtime/RunContext', () => ({
+  getRunContextExecutionId: (ctx: any) => ctx?.executionId,
+  getRunContextStreamId: (ctx: any) => ctx?.streamId,
+  getRunContextWorkingDirectory: (ctx: any) => ctx?.workingDirectory,
+  getRunContextRuntimeHost: (ctx: any) => ctx?.runtimeHost,
+}));
+
+vi.mock('@agent/runtime/SessionHandle', () => ({
+  currentSession: mocks.currentSession,
+}));
+
+vi.mock('@agent/storage', () => ({
+  registerExecution: mocks.registerExecution,
+  getExecutionStore: mocks.getExecutionStore,
+}));
+
+vi.mock('@utils/files/taskRunStorage', () => ({
+  ensureRunDir: mocks.ensureRunDir,
+}));
+
+vi.mock('@tools/childStream', () => ({
+  createChildStream: mocks.createChildStream,
+}));
+
+vi.mock('@agent/runtime/childRunLoop', () => ({
+  startChildRunLoop: mocks.startChildRunLoop,
+}));
+
+vi.mock('@tools/codexConfig', () => ({
+  getCodexSandboxMode: () => 'workspace-write',
+  getCodexApprovalPolicy: () => 'on-request',
+  getCodexCliReasoningEffort: () => 'high',
+  CODEX_CLI_MODEL: 'gpt-5.2-codex',
+  buildCodexConfig: () => ({
+    agent: 'codex',
+    model: 'Codex CLI',
+    instruction: 'test',
+    agentCategory: 'toolUse',
+  }),
+}));
+
+vi.mock('@tools/codexImport', () => ({
+  importCodexClass: mocks.importCodexClass,
+  findCodexBinaryPath: mocks.findCodexBinaryPath,
+}));
+
+import { CodexTool } from '@tools/codex';
+
+const parentStreamId = 'stream:parent' as StreamTabId;
+const childStreamId = 'stream:codex-child' as StreamTabId;
+const executionId = 'parent-exec' as ExecutionId;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T) => void;
+} {
+  let settle: ((value: T) => void) | undefined;
+  let rejectPromise: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    settle = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    reject: (reason) => rejectPromise?.(reason),
+    resolve: (value) => settle?.(value),
+  };
+}
+
+function fakeLogger(): AgentTrace {
+  const store = new StreamLogStore();
+  return createRunTrace(childStreamId, store).trace;
+}
+
+function fakeChildStream(): ChildStream {
+  return {
+    childStreamId,
+    logger: fakeLogger(),
+    waitForInput: () => {},
+    beginTurn: () => {},
+    failTurn: () => {},
+    finalize: async () => {},
+  };
+}
+
+describe('codex tool - atomic resume fallback', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    CodexThreads.releaseMany(['stale-thread']);
+  });
+
+  function setupCommonMocks(): void {
+    mocks.startChildRunLoop.mockReset();
+    mocks.importCodexClass.mockReset();
+    mocks.findCodexBinaryPath.mockReset();
+    mocks.requestBashApproval.mockResolvedValue({ accepted: true });
+    mocks.getCurrentToolContexts.mockReturnValue({
+      runContext: {
+        streamId: parentStreamId,
+        executionId,
+        workingDirectory: undefined,
+        runtimeHost: { name: 'fake-runtime-host' },
+      },
+      callContext: { tracker: {}, hooks: {} },
+    });
+    mocks.registerExecution.mockResolvedValue(undefined);
+    mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
+    mocks.ensureRunDir.mockResolvedValue(undefined);
+    mocks.findCodexBinaryPath.mockResolvedValue(undefined);
+    mocks.createChildStream.mockReturnValue(fakeChildStream());
+    mocks.currentSession.mockReturnValue({
+      followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
+    });
+  }
+
+  it('launches one fallback loop when concurrent calls use the same stale thread_id', async () => {
+    setupCommonMocks();
+    const sdkImportStarted = deferred<void>();
+    const sdkReady = deferred<any>();
+    const thread = {
+      id: 'stale-thread',
+      runStreamed: vi.fn(),
+    };
+    const executions = { getAgentHandleByStream: () => undefined } as any;
+    let strategy: ChildRunStrategy<unknown> | undefined;
+
+    mocks.importCodexClass.mockImplementation(() => {
+      sdkImportStarted.resolve(undefined);
+      return sdkReady.promise;
+    });
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+        params.strategy.onSessionStart?.({ executions } as any);
+      },
+    );
+
+    const tool = new CodexTool();
+    const first = tool.call({
+      prompt: 'continue the refactor',
+      sandbox_mode: 'workspace-write',
+      thread_id: 'stale-thread',
+    });
+    await sdkImportStarted.promise;
+
+    const second = tool.call({
+      prompt: 'also update the tests',
+      sandbox_mode: 'workspace-write',
+      thread_id: 'stale-thread',
+    });
+    await Promise.resolve();
+
+    expect(mocks.importCodexClass).toHaveBeenCalledTimes(1);
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+
+    sdkReady.resolve(
+      class MockCodex {
+        resumeThread(threadId: string): typeof thread {
+          mocks.resumeThread(threadId);
+          return thread;
+        }
+      },
+    );
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.status).toBe('executed');
+    expect(secondResult.summary).toMatch(/Follow-up queued/);
+    expect(mocks.resumeThread).toHaveBeenCalledOnce();
+    expect(mocks.resumeThread).toHaveBeenCalledWith('stale-thread');
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.enqueueFollowUp).toHaveBeenCalledWith({
+      text: 'also update the tests',
+    });
+
+    strategy?.onSessionCleanup?.();
+    expect(CodexThreads.isActive('stale-thread')).toBe(false);
+  });
+
+  it('releases the fallback claim when asynchronous SDK setup fails', async () => {
+    setupCommonMocks();
+    mocks.importCodexClass.mockRejectedValue(new Error('SDK import failed'));
+
+    const result = await new CodexTool().call({
+      prompt: 'continue the refactor',
+      sandbox_mode: 'workspace-write',
+      thread_id: 'stale-thread',
+    });
+
+    expect(result.status).toBe('error');
+    const releaseClaim = CodexThreads.claim('stale-thread');
+    expect(releaseClaim).toBeTypeOf('function');
+    releaseClaim?.();
+  });
+
+  it('lets a waiting caller own the fallback after the first launch fails', async () => {
+    setupCommonMocks();
+    const firstImportStarted = deferred<void>();
+    const firstImport = deferred<any>();
+    const thread = { id: 'stale-thread', runStreamed: vi.fn() };
+    const executions = { getAgentHandleByStream: () => undefined } as any;
+    let strategy: ChildRunStrategy<unknown> | undefined;
+    mocks.importCodexClass
+      .mockImplementationOnce(() => {
+        firstImportStarted.resolve(undefined);
+        return firstImport.promise;
+      })
+      .mockResolvedValueOnce(
+        class MockCodex {
+          resumeThread(): typeof thread {
+            return thread;
+          }
+        },
+      );
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+        params.strategy.onSessionStart?.({ executions } as any);
+      },
+    );
+
+    const tool = new CodexTool();
+    const first = tool.call({
+      prompt: 'first attempt',
+      sandbox_mode: 'workspace-write',
+      thread_id: 'stale-thread',
+    });
+    await firstImportStarted.promise;
+    const second = tool.call({
+      prompt: 'retry from the waiter',
+      sandbox_mode: 'workspace-write',
+      thread_id: 'stale-thread',
+    });
+    await Promise.resolve();
+
+    firstImport.reject(new Error('first SDK import failed'));
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.status).toBe('error');
+    expect(secondResult.status).toBe('executed');
+    expect(secondResult.summary).toMatch(/Launched Codex/);
+    expect(mocks.importCodexClass).toHaveBeenCalledTimes(2);
+    expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
+
+    strategy?.onSessionCleanup?.();
+    expect(CodexThreads.isActive('stale-thread')).toBe(false);
+  });
+});

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -8,32 +8,79 @@ export interface AgentCliSessionEntry {
   executions: ExecutionRegistry;
 }
 
+type AgentCliSessionState<T> =
+  | {
+      kind: 'reserved';
+      ready: Promise<T | undefined>;
+      resolve: (entry: T | undefined) => void;
+    }
+  | { kind: 'active'; entry: T };
+
 export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
-  private readonly sessions = new Map<string, T>();
+  private readonly sessions = new Map<string, AgentCliSessionState<T>>();
 
   constructor(private readonly persistedSessionKey: string) {}
 
   /**
+   * Atomically reserve an unowned SDK session id. Returns a release handle
+   * bound to this exact reservation, or undefined when another owner exists.
+   * Registration promotes the reservation and makes that handle a no-op.
+   */
+  claim(sessionId: string): (() => void) | undefined {
+    if (this.sessions.has(sessionId)) return undefined;
+
+    let settleReservation: ((entry: T | undefined) => void) | undefined;
+    const ready = new Promise<T | undefined>((settle) => {
+      settleReservation = settle;
+    });
+    const reservation: AgentCliSessionState<T> = {
+      kind: 'reserved',
+      ready,
+      resolve: (entry) => settleReservation?.(entry),
+    };
+    this.sessions.set(sessionId, reservation);
+    return () => {
+      if (this.sessions.get(sessionId) !== reservation) return;
+      this.sessions.delete(sessionId);
+      reservation.resolve(undefined);
+    };
+  }
+
+  /**
    * Register an active external-agent session and persist its SDK id for later
-   * display or cross-reference after an extension reload clears memory.
+   * display or cross-reference after an extension reload clears memory. When
+   * the id was reserved, registration also wakes callers waiting to enqueue a
+   * follow-up on the new loop.
    */
   register(sessionId: string, entry: T): void {
-    this.sessions.set(sessionId, entry);
+    const previous = this.sessions.get(sessionId);
+    this.sessions.set(sessionId, { kind: 'active', entry });
+    if (previous?.kind === 'reserved') previous.resolve(entry);
     void getExecutionStore(entry.executionId)
       .write(this.persistedSessionKey, sessionId)
       .catch(() => {});
   }
 
   isActive(sessionId: string): boolean {
-    return this.sessions.has(sessionId);
+    return this.sessions.get(sessionId)?.kind === 'active';
   }
 
   lookup(sessionId: string): T | undefined {
-    return this.sessions.get(sessionId);
+    const state = this.sessions.get(sessionId);
+    return state?.kind === 'active' ? state.entry : undefined;
+  }
+
+  /** Wait for a reserved id to become active, or for its owner to release it. */
+  async waitForActive(sessionId: string): Promise<T | undefined> {
+    const state = this.sessions.get(sessionId);
+    if (state?.kind === 'active') return state.entry;
+    return state?.ready;
   }
 
   release(sessionId: string): void {
+    const state = this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
+    if (state?.kind === 'reserved') state.resolve(undefined);
   }
 
   releaseMany(sessionIds: Iterable<string>): void {
@@ -43,7 +90,9 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
   }
 
   interruptAll(): void {
-    for (const { childStreamId, executions } of [...this.sessions.values()]) {
+    for (const state of [...this.sessions.values()]) {
+      if (state.kind === 'reserved') continue;
+      const { childStreamId, executions } = state.entry;
       executions.getAgentHandleByStream(childStreamId)?.interrupt();
     }
   }

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -50,14 +50,18 @@ export function publishAgentCliStreamUsage(
   });
 }
 
+interface ResumableAgentCliSession {
+  parentStreamId: StreamTabId;
+  childStreamId: StreamTabId;
+  executionId: ExecutionId;
+}
+
 interface ResumableAgentCliStore {
-  lookup(id: string):
-    | {
-        parentStreamId: StreamTabId;
-        childStreamId: StreamTabId;
-        executionId: ExecutionId;
-      }
-    | undefined;
+  waitForActive(id: string): Promise<ResumableAgentCliSession | undefined>;
+}
+
+interface ClaimableAgentCliStore extends ResumableAgentCliStore {
+  claim(id: string): (() => void) | undefined;
 }
 
 export interface AgentCliResumeLabels {
@@ -67,13 +71,8 @@ export interface AgentCliResumeLabels {
   queuedLabel: string;
 }
 
-/**
- * Enqueue a follow-up prompt onto an already-running agent-CLI session.
- * Refuse callers from a different parent stream because the turn result is
- * delivered back to the stored parent stream.
- */
-export function resumeAgentCliSession(
-  store: ResumableAgentCliStore,
+function queueAgentCliFollowUp(
+  stored: ResumableAgentCliSession,
   params: {
     id: string;
     prompt: string;
@@ -82,12 +81,6 @@ export function resumeAgentCliSession(
   },
 ): ToolResult {
   const { id, prompt, callerStreamId, labels } = params;
-  const stored = store.lookup(id);
-  if (!stored) {
-    throw new ToolError(
-      `${labels.notActiveLabel} '${id}' is not active. It may have completed or been stopped; start a new session without ${labels.idParamName}.`,
-    );
-  }
   if (callerStreamId && stored.parentStreamId !== callerStreamId) {
     throw new ToolError(
       `${labels.notActiveLabel} '${id}' is owned by a different session; start a new session without ${labels.idParamName} to run in this context.`,
@@ -107,6 +100,48 @@ export function resumeAgentCliSession(
       `Execution ID: ${stored.executionId}`,
     ].join('\n'),
   };
+}
+
+/**
+ * Atomically choose between queueing onto an owned session id and launching a
+ * disk-based fallback. A failed owner releases only its own claim; waiting
+ * callers then compete for the released id, so one retries the fallback while
+ * the others continue waiting. A started loop promotes and later releases the
+ * claim itself.
+ */
+export async function resumeOrLaunchAgentCliSession(
+  store: ClaimableAgentCliStore,
+  params: {
+    id: string | undefined;
+    prompt: string;
+    callerStreamId: StreamTabId | undefined;
+    labels: AgentCliResumeLabels;
+    launch: () => Promise<ToolResult>;
+  },
+): Promise<ToolResult> {
+  const { id } = params;
+  if (!id) return params.launch();
+
+  while (true) {
+    const releaseClaim = store.claim(id);
+    if (releaseClaim) {
+      try {
+        return await params.launch();
+      } catch (error) {
+        releaseClaim();
+        throw error;
+      }
+    }
+
+    const stored = await store.waitForActive(id);
+    if (!stored) continue;
+    return queueAgentCliFollowUp(stored, {
+      id,
+      prompt: params.prompt,
+      callerStreamId: params.callerStreamId,
+      labels: params.labels,
+    });
+  }
 }
 
 export interface AgentCliLaunchParams {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -66,7 +66,7 @@ import { ClaudeAgentSessions } from './agentCliSessionStores';
 import {
   publishAgentCliStreamUsage,
   launchAgentCliSession,
-  resumeAgentCliSession,
+  resumeOrLaunchAgentCliSession,
   withAgentCliApproval,
 } from './agentCliShared';
 import {
@@ -402,14 +402,9 @@ function startClaudeAgentLoop(params: {
   runtimeHost: AgentRuntimeHost;
   /**
    * Set when this launch is the disk-based fallback for a session_id the
-   * in-memory registry no longer knows about (extension reload, crash):
-   * seeds the first turn's `resume` option so the SDK continues the prior
-   * conversation, and is registered up front (onSessionStart) so the
-   * in-memory guard picks the id back up as soon as possible. This narrows,
-   * but does not fully close, the window for a concurrent call with the same
-   * stale session_id to also observe an inactive registry and start its own
-   * fallback loop before either one's onSessionStart runs — the same
-   * await-before-registration gap codex.ts's registerThread already has.
+   * in-memory registry no longer knows about (extension reload or crash). The
+   * id is claimed synchronously before fallback setup begins, seeds the first
+   * turn's `resume` option, and is promoted to an active entry onSessionStart.
    */
   resumeSessionId: string | undefined;
 }): void {
@@ -430,7 +425,7 @@ function startClaudeAgentLoop(params: {
   const storedSessionIds = new Set<string>();
 
   const registerSession = (sessionId: string, session: SessionHandle): void => {
-    if (ClaudeAgentSessions.isActive(sessionId)) return;
+    if (ClaudeAgentSessions.lookup(sessionId)) return;
     ClaudeAgentSessions.register(sessionId, {
       childStreamId,
       parentStreamId,
@@ -555,39 +550,34 @@ export class ClaudeAgentTool extends defineTool({
     return withAgentCliApproval(
       `[${CLAUDE_AGENT_NAME} ${permissionMode}] ${input.prompt}`,
       (runContext) => {
-        if (
-          input.session_id &&
-          ClaudeAgentSessions.isActive(input.session_id)
-        ) {
-          return resumeAgentCliSession(ClaudeAgentSessions, {
-            id: input.session_id,
-            prompt: input.prompt,
-            callerStreamId: getRunContextStreamId(runContext),
-            labels: {
-              notActiveLabel: 'Claude Code CLI session',
-              idParamName: 'session_id',
-              summaryLabel: 'Claude Code CLI',
-              queuedLabel: 'Claude Code session',
-            },
-          });
-        }
-        // Fall through when the session's in-memory loop is gone (extension
-        // reload, crash): launchClaudeAgentSession resumes via the SDK's
-        // `resume` option from disk.
-        const { streamId, runtimeHost } = requireRunStream(
-          CLAUDE_AGENT_NAME,
-          runContext,
-        );
-        return launchClaudeAgentSession(
-          input,
-          permissionMode,
-          model,
-          effort,
-          streamId,
-          getRunContextExecutionId(runContext),
-          getRunContextWorkingDirectory(runContext),
-          runtimeHost,
-        );
+        return resumeOrLaunchAgentCliSession(ClaudeAgentSessions, {
+          id: input.session_id ?? undefined,
+          prompt: input.prompt,
+          callerStreamId: getRunContextStreamId(runContext),
+          labels: {
+            notActiveLabel: 'Claude Code CLI session',
+            idParamName: 'session_id',
+            summaryLabel: 'Claude Code CLI',
+            queuedLabel: 'Claude Code session',
+          },
+          launch: () => {
+            // A missing in-memory entry denotes a disk-based SDK fallback.
+            const { streamId, runtimeHost } = requireRunStream(
+              CLAUDE_AGENT_NAME,
+              runContext,
+            );
+            return launchClaudeAgentSession(
+              input,
+              permissionMode,
+              model,
+              effort,
+              streamId,
+              getRunContextExecutionId(runContext),
+              getRunContextWorkingDirectory(runContext),
+              runtimeHost,
+            );
+          },
+        });
       },
     );
   }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -67,7 +67,7 @@ import { CodexThreads } from './agentCliSessionStores';
 import {
   publishAgentCliStreamUsage,
   launchAgentCliSession,
-  resumeAgentCliSession,
+  resumeOrLaunchAgentCliSession,
   withAgentCliApproval,
 } from './agentCliShared';
 import {
@@ -358,6 +358,11 @@ function startCodexLoop(params: {
   executionId: ExecutionId;
   initialPrompt: string;
   runtimeHost: AgentRuntimeHost;
+  /**
+   * The disk-based fallback thread id claimed synchronously in execute(). The
+   * loop promotes that reservation before its first turn starts.
+   */
+  resumeThreadId: string | undefined;
 }): void {
   const {
     thread,
@@ -368,22 +373,21 @@ function startCodexLoop(params: {
     runtimeHost,
   } = params;
   const { childStreamId, logger } = childStream;
+  const fallbackThreadId = params.resumeThreadId;
 
   // Fresh threads don't have thread.id yet; they're registered after the first
-  // turn completes. Resumed threads are registered up front (onSessionStart) so
-  // a second codex call with the same thread_id during the first turn can't
-  // bypass the in-memory guard and start a concurrent loop.
-  const registerThread = (session: SessionHandle): void => {
-    const threadId = thread.id;
-    if (threadId && !CodexThreads.isActive(threadId)) {
-      CodexThreads.register(threadId, {
-        thread,
-        childStreamId,
-        parentStreamId,
-        executionId,
-        executions: session.executions,
-      });
-    }
+  // turn completes. A resumed thread's pre-launch claim is promoted up front.
+  const storedThreadIds = new Set<string>();
+  const registerThread = (threadId: string, session: SessionHandle): void => {
+    if (CodexThreads.lookup(threadId)) return;
+    CodexThreads.register(threadId, {
+      thread,
+      childStreamId,
+      parentStreamId,
+      executionId,
+      executions: session.executions,
+    });
+    storedThreadIds.add(threadId);
   };
 
   // The joined prompt text for whichever turn is currently in flight —
@@ -407,7 +411,9 @@ function startCodexLoop(params: {
 
   const strategy: ChildRunStrategy<RunResult> = {
     stageLabel: 'Codex session',
-    onSessionStart: registerThread,
+    onSessionStart: fallbackThreadId
+      ? (session) => registerThread(fallbackThreadId, session)
+      : undefined,
     launch: (ports, abortController) =>
       runTurn(
         [{ text: initialPrompt, origin: 'user' }],
@@ -417,7 +423,9 @@ function startCodexLoop(params: {
     runTurn,
     isTerminal: () => false,
     getUsage: (turn) => turn.usage,
-    onTurnSuccess: (_turn, session) => registerThread(session),
+    onTurnSuccess: (_turn, session) => {
+      if (thread.id) registerThread(thread.id, session);
+    },
     publishUsage: (turn) => {
       if (turn.usage) {
         publishAgentCliStreamUsage(
@@ -436,8 +444,7 @@ function startCodexLoop(params: {
         { message: toErrorMessage(err) },
       ),
     onSessionCleanup: () => {
-      const threadId = thread.id;
-      if (threadId) CodexThreads.release(threadId);
+      CodexThreads.releaseMany(storedThreadIds);
     },
   };
 
@@ -507,29 +514,31 @@ export class CodexTool extends defineTool({
     return withAgentCliApproval(
       `[codex ${input.sandbox_mode}] ${input.prompt}`,
       (runContext) => {
-        if (input.thread_id && CodexThreads.isActive(input.thread_id)) {
-          return resumeAgentCliSession(CodexThreads, {
-            id: input.thread_id,
-            prompt: input.prompt,
-            callerStreamId: getRunContextStreamId(runContext),
-            labels: {
-              notActiveLabel: 'Codex thread',
-              idParamName: 'thread_id',
-              summaryLabel: 'Codex',
-              queuedLabel: 'Codex thread',
-            },
-          });
-        }
-        // Fall through when the thread's in-memory loop is gone (extension
-        // reload, crash): createCodexThread resumes via the SDK from disk.
-        const { streamId, runtimeHost } = requireRunStream('codex', runContext);
-        return launchCodexSession(
-          input,
-          streamId,
-          getRunContextExecutionId(runContext),
-          getRunContextWorkingDirectory(runContext),
-          runtimeHost,
-        );
+        return resumeOrLaunchAgentCliSession(CodexThreads, {
+          id: input.thread_id ?? undefined,
+          prompt: input.prompt,
+          callerStreamId: getRunContextStreamId(runContext),
+          labels: {
+            notActiveLabel: 'Codex thread',
+            idParamName: 'thread_id',
+            summaryLabel: 'Codex',
+            queuedLabel: 'Codex thread',
+          },
+          launch: () => {
+            // A missing in-memory entry denotes a disk-based SDK fallback.
+            const { streamId, runtimeHost } = requireRunStream(
+              'codex',
+              runContext,
+            );
+            return launchCodexSession(
+              input,
+              streamId,
+              getRunContextExecutionId(runContext),
+              getRunContextWorkingDirectory(runContext),
+              runtimeHost,
+            );
+          },
+        });
       },
     );
   }
@@ -564,6 +573,7 @@ async function launchCodexSession(
         executionId,
         initialPrompt: input.prompt,
         runtimeHost,
+        resumeThreadId: input.thread_id ?? undefined,
       }),
     summary: `Launched Codex: ${preview}`,
     launchedLine: `Codex agent launched (sandbox: ${input.sandbox_mode}).`,


### PR DESCRIPTION
## Summary

- add an atomic reserved state to `AgentCliSessionRegistry`, with activation waiting and ownership-bound cleanup
- route both `claude_agent` and Codex disk fallbacks through one claim-or-resume path
- promote claimed IDs on `onSessionStart` and release all owned IDs during normal loop cleanup
- add deterministic concurrency regressions for both adapters, including owner-failure handoff, and registry reservation lifecycle tests

## Root cause

The adapters previously checked whether a stale SDK session ID was active and only registered the fallback loop after several asynchronous setup operations. Two calls could therefore both observe a registry miss and launch external loops against the same on-disk session.

The new claim is synchronous and atomic. A concurrent caller waits for the owner to publish its active routing entry, then enqueues through the existing child follow-up queue. The claim returns a release handle bound to that exact reservation, so promotion or later ownership cannot be deleted by a stale catch path. If setup fails before the loop starts, exactly one waiter acquires the released ID and retries the disk fallback while the others continue waiting.

## Validation

- `corepack pnpm vitest run src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts src/test-kernel/tools/CodexResumeFallback.vitest.ts` (13 tests)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 pre-existing warnings in unrelated files)
- `npm test` (632 files passed, 5,603 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- rebased on `main` at `5f260fd2b`

## Net elements

- Files changed: 8.
- Diffstat: 685 insertions, 122 deletions (net +563).
- Production code: 197 insertions, 113 deletions.
- New test files: 1.
- Exported helper symbols: net 0 (`resumeOrLaunchAgentCliSession` replaces the now-internal direct resume helper).

Closes #8099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and session ownership for agent-CLI tools; behavior is well-tested but affects follow-up routing and fallback launch timing for Codex and Claude.
> 
> **Overview**
> Fixes a race where two **Codex** or **claude_agent** calls with the same stale `thread_id` / `session_id` could both miss the in-memory registry and start duplicate disk-resume loops.
> 
> **`AgentCliSessionRegistry`** now tracks **reserved** vs **active** ids: synchronous **`claim`**, **`waitForActive`** for waiters, and promotion on **`register`**. A claim release only affects that reservation (promotion makes the release handle harmless so a late launch failure cannot delete an active loop).
> 
> **`resumeOrLaunchAgentCliSession`** replaces the old lookup-or-throw resume path: the winner **`claim`**s and **`launch`**es; losers wait, then **enqueue follow-ups** on the active entry, or retry after a failed setup releases the claim. **Codex** and **Claude** both route through this helper.
> 
> Disk-fallback loops promote the claimed id in **`onSessionStart`** and **`releaseMany`** all owned ids on cleanup. **`ChildRunStrategy.onSessionStart`** docs are updated to match.
> 
> New regression tests cover registry lifecycle, Claude concurrency/failure handoff, and Codex parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71670f6363061d8cc5e4a78f28813fb32f3e8227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->