### PR TITLE
refactor(cli): make input history single-owner

### DIFF
--- a/packages/cli/src/chat/tui/history/inputHistory.ts
+++ b/packages/cli/src/chat/tui/history/inputHistory.ts
@@ -64,21 +64,18 @@ export async function loadInputHistory(): Promise<InputHistory> {
   }
   // Cap on load; older entries fall off when the ring is full.
   if (records.length > MAX_LINES) records = records.slice(-MAX_LINES);
-  const entries = records.map((r) => r.v);
 
   return {
     async push(line: string) {
       const trimmed = line.trim();
       if (!trimmed) return;
       const stored = trimmed.slice(0, MAX_LINE_CHARS);
-      if (entries.at(-1) === stored) return;
+      if (records.at(-1)?.v === stored) return;
       const record: HistoryRecord = { t: Date.now(), v: stored };
-      entries.push(stored);
       records.push(record);
       await GlobalStorageFS.ensureDir(HISTORY_DIR);
-      if (entries.length > MAX_LINES) {
-        const drop = entries.length - MAX_LINES;
-        entries.splice(0, drop);
+      if (records.length > MAX_LINES) {
+        const drop = records.length - MAX_LINES;
         records.splice(0, drop);
         await GlobalStorageFS.write(HISTORY_PATH, serializeRecords(records));
         return;
@@ -90,20 +87,20 @@ export async function loadInputHistory(): Promise<InputHistory> {
     },
     reverseFind(needle, from) {
       if (!needle) return undefined;
-      const start = from === undefined ? entries.length - 1 : from - 1;
+      const start = from === undefined ? records.length - 1 : from - 1;
       for (let i = start; i >= 0; i--) {
-        const value = entries[i];
-        if (value !== undefined && value.includes(needle)) {
-          return { value, index: i };
+        const record = records[i];
+        if (record?.v.includes(needle)) {
+          return { value: record.v, index: i };
         }
       }
       return undefined;
     },
     at(index) {
-      return entries[index];
+      return records[index]?.v;
     },
     length() {
-      return entries.length;
+      return records.length;
     },
   };
 }


### PR DESCRIPTION
## Summary

Keep the TUI input-history ring in one `HistoryRecord[]` instead of maintaining a parallel `string[]` projection.

## Issue acceptance gates

Closes #8112.

- removes the parallel `entries` collection and every paired mutation
- preserves the public `InputHistory` API and JSONL persistence format
- preserves adjacent-deduplication, indexed browsing, reverse search, load capping, and compaction behavior
- relies on the existing focused behavior suite rather than adding replacement tests

## Single source of truth

`HistoryRecord[]` in `inputHistory.ts` now owns entry values, timestamps, ordering, browsing indexes, persistence, and compaction.

## Duplication and abstraction budget

Removed one mirrored array and its push/splice bookkeeping. Added no abstraction, helper, state, or test.

## Net elements (R6)

- files: 1 changed, 0 added, 0 deleted
- exports: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- net LoC: -3 (9 additions, 12 deletions)

## Consumer counts (R8)

n/a — no exports, events, or routing paths changed; the public `InputHistory` interface is unchanged.

## Host impact

Extension: None.

Desktop: None.

CLI: Internal TUI history storage is simpler with unchanged behavior.

## Scheduled refactoring

None.

## Validation

- `vitest run src/test-kernel/cli/InputHistory.vitest.mts` — 3 tests passed
- `tsc --noEmit -p packages/cli/tsconfig.json`
- `eslint packages/cli/src/chat/tui/history/inputHistory.ts`
- `prettier --check packages/cli/src/chat/tui/history/inputHistory.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in one file with no API or persistence format changes; behavior is covered by existing tests.
> 
> **Overview**
> **`loadInputHistory`** no longer keeps a mirrored **`string[]`** alongside **`HistoryRecord[]`**. The in-memory ring is a single **`records`** array; **`push`**, compaction, **`reverseFind`**, **`at`**, and **`length`** read and mutate that list (values via **`record.v`**) instead of syncing two structures.
> 
> The public **`InputHistory`** contract, JSONL on disk, adjacent deduplication, caps, and compaction are unchanged—only internal bookkeeping is removed (~3 net lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4558579e0d1872e6c0f87e40105771a544854a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->