### PR TITLE
fix(agent): preserve queued follow-ups on post-setup resume cancellation

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -44,6 +44,23 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
     this.followUps.dispose();
   }
 
+  /**
+   * Same wake-up as `interrupt()` (unblock any in-progress `waitForFollowUp`)
+   * but, unlike it, does not drop already-queued items. For the narrow window
+   * during resume startup where a caller (`resumeQueuedToolUseSnapshot`'s
+   * `setupSession`) has just re-appended its drained follow-up batch into
+   * this queue before the flow is interruptible: an async cancellation
+   * landing in that window must not erase that batch, since the flow's own
+   * early-cancel branch preserves the resume record for a later replay (see
+   * `runToolUseFlow`'s `preserveResumeRecord` finally guard, which also
+   * skips releasing this queue in that case). Every other cancellation path
+   * keeps using `interrupt()`'s destructive clear.
+   */
+  interruptPreservingQueue(): void {
+    this.syntheticFollowUpPending = false;
+    this.followUps.cancelWait();
+  }
+
   dispose(): void {
     this.queue.release(this.streamTabId);
   }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -326,6 +326,17 @@ export async function runToolUseFlow<C = unknown>(
     input.onModelChanged?.(nextHandler, model);
   };
 
+  // A resume's setupSession (see `resumeQueuedToolUseSnapshot`) re-appends
+  // its drained follow-up batch into `sessionLifecycle` from inside
+  // `onSetup` below, before the flow is interruptible. An async
+  // cancellation racing in during that window (through the recovery read,
+  // see the `checkInterruption()` guards below) must not erase that batch
+  // -- `flowContext.interrupt()` uses the queue-preserving variant for
+  // exactly this window, matching `preserveResumeRecord`'s finally guard.
+  // Cleared once the flow has passed both guards and moved into real work,
+  // so a later mid-run cancellation keeps the normal destructive clear.
+  let inResumeStartupWindow = input.resumeSnapshot !== undefined;
+
   const flowContext: ToolUseFlowContext = {
     ownerSession: runSession,
     session: sessionLifecycle,
@@ -339,7 +350,11 @@ export async function runToolUseFlow<C = unknown>(
     interrupt(): void {
       onInterrupt?.();
       runSession.interactions.cancel({ streamId, cause: 'Run interrupted.' });
-      sessionLifecycle.interrupt();
+      if (inResumeStartupWindow) {
+        sessionLifecycle.interruptPreservingQueue();
+      } else {
+        sessionLifecycle.interrupt();
+      }
     },
     requestImmediateCompaction(): void {
       services.modelHandler.requestCompaction();
@@ -396,6 +411,10 @@ export async function runToolUseFlow<C = unknown>(
       preserveResumeRecord = input.resumeSnapshot !== undefined;
       return { outcome };
     }
+    // Past both startup cancellation guards: any later interrupt() is a
+    // genuine mid-run cancellation, so go back to the normal destructive
+    // queue clear instead of the resume-startup rescue above.
+    inResumeStartupWindow = false;
 
     if (flowRecord?.shared) {
       logger.debug('Resuming tool-use flow from persistence');
@@ -587,7 +606,18 @@ export async function runToolUseFlow<C = unknown>(
     // live queue instance is what a genuine kill (see ExecutionRegistry.
     // terminate's waiting-cleanup path) or resume drains instead of a
     // `dispose()` here silently discarding it.
-    if (outcome !== STREAM_PHASE.WAITING) {
+    //
+    // Resume-startup cancellation (preserveResumeRecord): a resume's
+    // setupSession re-appends its drained follow-up batch into this same
+    // live queue before the flow is interruptible. `flowContext.interrupt()`
+    // uses `sessionLifecycle.interruptPreservingQueue()` instead of
+    // `interrupt()` for exactly this window (see its call site above), so
+    // that batch survives a cancellation landing while the recovery read is
+    // pending. Skipping `dispose()`/release here too keeps it intact for the
+    // next `resumeQueuedToolUseSnapshot` call's `drainItems()` instead of
+    // discarding the user's queued input alongside the preserved flow
+    // record.
+    if (outcome !== STREAM_PHASE.WAITING && !preserveResumeRecord) {
       sessionLifecycle.dispose();
     }
     runSession.interactions.cancel({ streamId, cause: 'Run ended.' });

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -103,8 +103,8 @@ async function runResumedFlow(
   streamId: StreamTabId,
   snapshot: ToolUseSessionSnapshot,
   onSetup?: (context: ToolUseSetupContext) => void,
+  session: SessionHandle = new SessionHandle(),
 ): Promise<RunToolUseFlowResult> {
-  const session = new SessionHandle();
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => snapshot.agentConfig.model,
@@ -574,6 +574,58 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       readSpy.mockRestore();
       writeSpy.mockRestore();
       deleteSpy.mockRestore();
+    }
+  });
+
+  it('preserves a follow-up appended during setup when cancellation arrives during the recovery read (issue #8049 P2)', async () => {
+    // Regression: resumeQueuedToolUseSnapshot's setupSession re-appends its
+    // drained follow-up batch into the live session queue *before* the flow
+    // is interruptible. If an external cancellation then lands while the
+    // recovery read is pending -- this same "cancellation during read"
+    // window as the sibling test above -- the early return here reports
+    // CANCELLED with the resume record preserved, but previously
+    // `ToolUseSessionLifecycle.interrupt()` unconditionally disposed the
+    // queue (dropping the just-appended follow-up) and the finally below
+    // unconditionally released it again, so neither the caller
+    // (`resumeQueuedToolUseSnapshot`, which never restores follow-ups on
+    // this success path) nor a later resume could ever recover the user's
+    // queued input. Fixed by routing this window's cancellation through
+    // `ToolUseSessionLifecycle.interruptPreservingQueue()` (cancels the
+    // pending wait without dropping queued items) and by skipping the queue
+    // release in `runToolUseFlow`'s finally whenever the flow record itself
+    // is preserved.
+    const executionId = 'abc-cancel-followup' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-cancel-followup' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    const session = new SessionHandle();
+    let flowContext: ToolUseSetupContext | undefined;
+    const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
+      // Cancellation arrives while the recovery read is pending -- after
+      // setupSession already appended the drained follow-up below.
+      flowContext?.interrupt();
+      return null;
+    });
+
+    try {
+      const result = await runResumedFlow(
+        executionId,
+        streamId,
+        snapshot,
+        (context) => {
+          flowContext = context;
+          context.session.appendFollowUp({ text: 'queued during resume' });
+        },
+        session,
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(session.followUps.getAll(streamId)).toEqual([
+        'queued during resume',
+      ]);
+    } finally {
+      readSpy.mockRestore();
+      session.followUps.release(streamId);
     }
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #8088 (merged before this fix landed): addresses the P2 bugbot finding at `runToolUseFlow.ts:397` that was verified real and unresolved on that PR.

- `resumeQueuedToolUseSnapshot`'s `setupSession` re-appends its drained follow-up batch into the live per-stream follow-up queue *before* the resumed flow becomes interruptible.
- If an async cancellation lands while the recovery `kv.read()` is pending, `runToolUseFlow`'s early return reports `CANCELLED` with the resume record preserved (`preserveResumeRecord`) — but `ToolUseSessionLifecycle.interrupt()` unconditionally disposed the follow-up queue, and the `finally` block released it again, so the user's just-queued follow-up was silently dropped even though the flow record itself survived for a later resume.
- `resumeQueuedToolUseSnapshot` never restores follow-ups on this success path (`cancelledBeforeSessionSetup` is only set for the earlier, pre-setup cancellation window), so nothing downstream could recover the lost input either.

## Fix

- Add `ToolUseSessionLifecycle.interruptPreservingQueue()`: cancels any in-progress `waitForFollowUp` (unblocking the flow) without dropping already-queued items. Used only for the narrow resume-startup window — before the flow passes both `checkInterruption()` guards — so every other cancellation path (mid-run, compaction, etc.) keeps `interrupt()`'s normal destructive clear.
- `runToolUseFlow`'s `finally` now also skips releasing the follow-up queue whenever `preserveResumeRecord` is set (mirroring the existing `WAITING` guard from issue #7286), so the preserved batch is there for the next `resumeQueuedToolUseSnapshot` call's `drainItems()`.

## Test plan

- [x] Added a regression test (`SessionResumeRetrieval.vitest.ts`) that appends a follow-up during `onSetup` and fires `flowContext.interrupt()` mid-`kv.read()`, then asserts the queue still has it. Verified it fails on the pre-fix code (`git checkout` the two source files, run test, confirm red) and passes after re-applying the fix.
- [x] `npx vitest run` on the tool-use flow, followUp, resume, execution-registry, and CLI `chatSessionController` suites (235 tests, all green).
- [x] `npm run typecheck` (full workspace) — clean.
- [x] `eslint` + `prettier --check` on changed files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tool-use resume/cancellation teardown and follow-up queue lifecycle; scope is narrow (resume startup window + preserveResumeRecord) but incorrect routing could leave stale queues or drop user input.
> 
> **Overview**
> Fixes a race where **cancelling a resumed tool-use flow while the recovery `kv.read()` is still pending** could keep the resume record but **silently drop follow-ups** re-appended during `setupSession`.
> 
> Adds **`ToolUseSessionLifecycle.interruptPreservingQueue()`**, which unblocks `waitForFollowUp` via `cancelWait()` without clearing queued items (unlike `interrupt()`’s `dispose()`). **`runToolUseFlow`** uses it only during the narrow **resume startup window** (`inResumeStartupWindow`, cleared after both early `checkInterruption()` guards); later cancellations still use destructive `interrupt()`.
> 
> The **`finally`** block now **skips `sessionLifecycle.dispose()`** when `preserveResumeRecord` is set (alongside the existing `WAITING` guard), so preserved follow-ups remain for the next `resumeQueuedToolUseSnapshot` `drainItems()`.
> 
> Adds a regression test that appends a follow-up in `onSetup`, interrupts mid-read, and asserts the queue still holds the text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d90c9d3d607a53d86ee8c90c53dc77654a3a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->