### PR TITLE
refactor(progress-view): retype TaskGroup.status to native RunOutcome/StreamPhase (#7993 step 3)

### DIFF
--- a/docs/proposals/session-scoped-runtime-architecture.md
+++ b/docs/proposals/session-scoped-runtime-architecture.md
@@ -1079,6 +1079,32 @@ does not — validate `data.status`; the normalization is a _value_ transform
 on top of the existing parse, not a schema change, and needs no persisted
 format-version bump.
 
+**Census correction (found while landing #8087, folded in here per that PR's
+own recommendation):** the two live callers named above are not the only
+`StreamLogStore` clients — `assembleTrace()`
+(`src/transcript/traceAssembler.ts`) is a **third**, and it sits upstream of
+the trace-viewer's input rather than downstream of it. It constructs a fresh
+`StreamLogStore` instance and calls `.load()`/`.ensureLoaded()` on it to
+build every exported `TraceDocument` — used by the CLI's single-file export,
+the extension's history browser, and the settings-view chat export
+(`ChatExportController`) — so it runs through `parsePersistedEntries` like
+any other reader. Consequently, every `TraceDocument` `assembleTrace()`
+builds after this boundary lands carries canonical `RunOutcome`/`StreamPhase`
+values in its `GROUP_START`/`GROUP_END` rows, **including a re-export built
+from pre-cutover on-disk history** — a genuinely externally-authored
+`trace.json` that predates the cutover and is never reassembled keeps the
+legacy 2-value strings forever (per the trace-viewer boundary below), so
+`replayTrace.ts`'s `toStreamLifecycleStatus` has to read a
+`StreamLogStore`-derived `TraceDocument` right alongside a legacy one without
+knowing in advance which vocabulary it's holding. That consumer-side
+handling already landed in #8087: `toStreamLifecycleStatus` parses the
+terminal group's `data.status` with `StreamLifecycleStatusSchema` (the
+already-shipped `StreamPhase`-or-legacy-`StreamStatus` union, §2), not the
+narrower legacy-only `StreamStatusSchema` the original census described — see
+`replayTrace.ts:105-116`. This is a census fix only: `assembleTrace()` is a
+third _client_ of boundary 1, not a third _boundary_ — it does not change the
+two-boundary count in this section's heading.
+
 **Target:** extend `parsePersistedEntries` (or a transform run immediately
 after it, before entries reach callers) so that any `GROUP_START`/`GROUP_END`
 entry's `data.status` is normalized in place at load time:

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -9,7 +9,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared schemas
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   type GettingStartedAction,
   type LogMessageData,
   type TaskGroup,
@@ -55,15 +55,22 @@ const TIMELINE_ITEM_WINDOW_STEP = 120;
 const DEFAULT_GROUP_MESSAGE_WINDOW = 400;
 const GROUP_MESSAGE_WINDOW_STEP = 400;
 
-/** Maps group status to a wa-icon name; null indicates an animated spinner. */
+/**
+ * Maps group status to a wa-icon name; null indicates an animated spinner.
+ * `TaskGroup.status` is the native `StreamPhase`/`RunOutcome` vocabulary
+ * (#7993 step 3) — `CANCELLED` now renders distinctly from `COMPLETED`
+ * instead of folding into one neutral "stopped" icon.
+ */
 function getStatusIcon(status: string): string | null {
   switch (status) {
-    case STREAM_STATUS.RUNNING:
+    case STREAM_PHASE.RUNNING:
       return null;
-    case STREAM_STATUS.ERROR:
+    case STREAM_PHASE.FAILED:
       return 'error';
-    case STREAM_STATUS.STOPPED:
+    case STREAM_PHASE.COMPLETED:
       return 'check';
+    case STREAM_PHASE.CANCELLED:
+      return 'circle-stop';
     default:
       return 'circle-outline';
   }
@@ -288,7 +295,13 @@ export class TaskGroupList extends LitElement {
     );
   }
 
-  /** Play sound when a run group completes */
+  /**
+   * Play sound when a run group completes. `STREAM_STATUS.STOPPED` folded
+   * `completed`/`cancelled` into one neutral bucket; the native
+   * `TaskGroup.status` (#7993 step 3) keeps them apart, so this checks both
+   * terminal-but-not-failed phases to preserve the prior "stopped" trigger
+   * byte-for-byte — a failed round still does not play the sound.
+   */
   private checkForCompletedRuns(): void {
     const nextStatuses = new Map<string, string>();
     for (const group of this.groups) {
@@ -298,10 +311,10 @@ export class TaskGroupList extends LitElement {
         (group.kind === 'round' ||
           (group.kind === undefined &&
             parseWorkflowOutputRoundDir(group.name) !== null));
-      const wasRunning = prev === STREAM_STATUS.RUNNING;
+      const wasRunning = prev === STREAM_PHASE.RUNNING;
       const isNowComplete =
-        group.status === STREAM_STATUS.READY ||
-        group.status === STREAM_STATUS.STOPPED;
+        group.status === STREAM_PHASE.COMPLETED ||
+        group.status === STREAM_PHASE.CANCELLED;
 
       if (isRunGroup && wasRunning && isNowComplete) {
         playCompletionSound();

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -1,13 +1,12 @@
 import { create } from 'mutative';
 
-import { legacyEndGroupStatusForOutcome } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   ContextStateDataSchema,
+  END_GROUP_STATUS,
   MESSAGE_TYPES,
-  RunOutcomeSchema,
   STREAM_LOG_ENTRY_TYPES,
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ContextStateData,
   type LogMessageData,
   type StreamLogEntry,
@@ -20,35 +19,39 @@ import type { HandlerRegistry } from '../messageHandlerTypes';
 
 function isTaskGroupStatus(value: unknown): value is TaskGroupStatus {
   return (
-    value === STREAM_STATUS.RUNNING ||
-    value === STREAM_STATUS.ERROR ||
-    value === STREAM_STATUS.STOPPED ||
-    value === STREAM_STATUS.READY
+    value === STREAM_PHASE.RUNNING ||
+    value === STREAM_PHASE.COMPLETED ||
+    value === STREAM_PHASE.CANCELLED ||
+    value === STREAM_PHASE.FAILED
   );
 }
 
 /**
- * A `GROUP_END` row's `data.status` now carries either the legacy 2-value
- * `EndGroupStatus` (rows the standalone trace-viewer forwards raw from an
- * exported trace file — that replay path stays legacy-capable permanently,
- * see docs/proposals/session-scoped-runtime-architecture.md §8.3) or the
- * canonical `RunOutcome` every live/persisted producer now writes (§8.2).
- * Fold a canonical value down to the same legacy bucket the pre-cutover
- * writer used so `TaskGroup.status` — not yet retyped to `StreamPhase`/
- * `RunOutcome` (that reader migration is #7993 goal item 3) — keeps
- * rendering exactly as it does today; only the transcript row itself gains
- * the completed/cancelled bit this step. A value that is neither vocabulary
- * (malformed data) falls back to the caller-supplied default, as before.
+ * A `GROUP_END` row's `data.status` now carries the canonical `RunOutcome`
+ * every live/persisted producer writes (§8.2) — `TaskGroup.status` is
+ * retyped to that same native vocabulary (#7993 step 3), so the common case
+ * is a straight pass-through via `isTaskGroupStatus`. The one remaining
+ * legacy arm handles entries the standalone trace-viewer forwards raw from
+ * an exported trace file predating this cutover: that replay path stays
+ * legacy-capable permanently (docs/proposals/session-scoped-runtime-
+ * architecture.md §8.3 — the trace-viewer's own per-entry normalization is
+ * separate future work), so a legacy 2-value `EndGroupStatus` string can
+ * still reach this reader. Map it UP to the same native value
+ * `StreamLogStore.parsePersistedEntries` produces for the same on-disk
+ * string (`'stopped'` -> `completed`, the documented lossy default; `'error'`
+ * -> `failed`) so a task group renders identically whether it arrived live,
+ * from a rehydrated stream, or forwarded raw by the trace-viewer. A value
+ * that is neither vocabulary (malformed data) falls back to the
+ * caller-supplied default, as before.
  */
 function taskGroupEndStatus(
   value: unknown,
   fallback: TaskGroupStatus,
 ): TaskGroupStatus {
   if (isTaskGroupStatus(value)) return value;
-  const outcome = RunOutcomeSchema.safeParse(value);
-  return outcome.success
-    ? legacyEndGroupStatusForOutcome(outcome.data)
-    : fallback;
+  if (value === END_GROUP_STATUS.STOPPED) return STREAM_PHASE.COMPLETED;
+  if (value === END_GROUP_STATUS.ERROR) return STREAM_PHASE.FAILED;
+  return fallback;
 }
 
 function isStageKind(
@@ -102,7 +105,7 @@ function updateTaskGroups(
   if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
     const status = isTaskGroupStatus(payload.status)
       ? payload.status
-      : STREAM_STATUS.RUNNING;
+      : STREAM_PHASE.RUNNING;
     const nextGroup = {
       id: entry.id,
       name: entry.text ?? String(payload.name ?? entry.id),
@@ -127,7 +130,7 @@ function updateTaskGroups(
     return false;
   }
 
-  const status = taskGroupEndStatus(payload.status, STREAM_STATUS.STOPPED);
+  const status = taskGroupEndStatus(payload.status, STREAM_PHASE.COMPLETED);
   const endTime =
     typeof payload.endTime === 'number' ? payload.endTime : undefined;
 

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -19,11 +19,12 @@ export const groupStyles = css`
       border-left-color: var(--wa-color-status-warning-bg);
     }
 
-    &.is-error {
+    &.is-failed {
       border-left-color: var(--wa-color-danger-on-quiet);
     }
 
-    &.is-stopped {
+    &.is-completed,
+    &.is-cancelled {
       border-left-color: var(--wa-color-success-fill-loud);
     }
   }

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -112,13 +112,13 @@ const SAMPLE_TASK_GROUPS: TaskGroup[] = [
     name: 'Analyze manuscript structure',
     startTime: BASE_TIME + 1_000,
     endTime: BASE_TIME + 24_000,
-    status: STREAM_STATUS.STOPPED,
+    status: STREAM_PHASE.COMPLETED,
   },
   {
     id: 'rewrite',
     name: 'Polish abstract and introduction',
     startTime: BASE_TIME + 25_000,
-    status: STREAM_STATUS.RUNNING,
+    status: STREAM_PHASE.RUNNING,
   },
 ];
 

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-import type { TaskGroupStatus } from './stream';
-
 export const LOG_LEVELS = {
   ERROR: 'error',
   WARN: 'warn',
@@ -12,7 +10,20 @@ export const LOG_LEVELS = {
 export const LogLevelSchema = z.enum(LOG_LEVELS);
 export type LogLevel = z.infer<typeof LogLevelSchema>;
 
-/** Terminal states for finalizing log groups (subset of TaskGroupStatus) */
+/**
+ * Legacy 2-value terminal vocabulary a `GROUP_END` row's `data.status` used
+ * to carry (retired as a *production* type by #8087/§8.2 — every live writer
+ * now emits the literal `RunOutcome`). Kept as a read-side/derive type: the
+ * frozen Tier-4 CLI JSON projection
+ * (`packages/cli/src/runtime/terminalStatus.ts`) still derives it from
+ * `RunOutcome` via `legacyEndGroupStatusForOutcome`, and `StreamLogStore`'s
+ * `parsePersistedEntries` boundary (§8.3) still matches these two literals
+ * to normalize on-disk rows written before the cutover — this stays as the
+ * permanent legacy-transcript reader, not a temporary shim, since released
+ * transcripts are never rewritten. No longer asserted as a subset of
+ * `TaskGroupStatus`: that type is retyped to the native `StreamPhase`/
+ * `RunOutcome` vocabulary (#7993 step 3) and shares no values with this one.
+ */
 export const END_GROUP_STATUS = {
   ERROR: 'error',
   STOPPED: 'stopped',
@@ -20,10 +31,6 @@ export const END_GROUP_STATUS = {
 
 const EndGroupStatusSchema = z.enum(END_GROUP_STATUS);
 export type EndGroupStatus = z.infer<typeof EndGroupStatusSchema>;
-
-type _AssertEndGroupStatusSubset = EndGroupStatus extends TaskGroupStatus
-  ? true
-  : never;
 
 export const MESSAGE_TYPES = {
   THINKING: 'thinking',

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -108,15 +108,6 @@ export function streamStatusesWithTrait(
 export const LIVE_ELAPSED_STREAM_STATUSES: ReadonlySet<string> =
   streamStatusesWithTrait('liveElapsed');
 
-/** Subset of StreamStatus used for task groups */
-export const TaskGroupStatusSchema = z.enum([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.ERROR,
-  STREAM_STATUS.STOPPED,
-  STREAM_STATUS.READY,
-]);
-export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
-
 export const EXECUTION_STATUS = {
   COMPLETED: 'completed',
   INTERRUPTED: 'interrupted',
@@ -155,6 +146,25 @@ export const STREAM_PHASE = {
 
 export const StreamPhaseSchema = z.enum(STREAM_PHASE);
 export type StreamPhase = z.infer<typeof StreamPhaseSchema>;
+
+/**
+ * Subset of `StreamPhase` used for task groups (`TaskGroupSchema.status`,
+ * populated from `GROUP_START`/`GROUP_END` transcript rows — #7993 step 3).
+ * No `WAITING`: task groups have no waiting concept, only running and the
+ * three terminal `RunOutcome` values (§8.2's group-end mapping table,
+ * docs/proposals/session-scoped-runtime-architecture.md). Previously a
+ * 4-value subset of the legacy `StreamStatus` (`running`/`error`/`stopped`/
+ * `ready`); retyped to the native vocabulary in lockstep with its readers
+ * (`logSlice.ts`, `TaskGroupList.ts`) so the completed/cancelled distinction
+ * §8.2 already writes to the transcript row reaches the rendered value too.
+ */
+export const TaskGroupStatusSchema = z.enum([
+  STREAM_PHASE.RUNNING,
+  STREAM_PHASE.COMPLETED,
+  STREAM_PHASE.CANCELLED,
+  STREAM_PHASE.FAILED,
+]);
+export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
 
 export const STREAM_SUBSTATE = {
   STARTING: 'starting',

--- a/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/common/RunOutcomeAlgebra.vitest.ts
@@ -63,13 +63,14 @@ describe('run outcome algebra', () => {
   });
 
   // legacyEndGroupStatusForOutcome is no longer called from any production
-  // GROUP_END write site (#7993 step 2 retypes stage.end()/StreamLogStore's
-  // orphan sweep to write the literal RunOutcome). It survives as a
-  // Tier-4-only read-side derive helper for the frozen CLI headless JSON's
+  // GROUP_END write site (#8087 retypes stage.end()/StreamLogStore's orphan
+  // sweep to write the literal RunOutcome), nor from logSlice.ts's read side
+  // (#7993 step 3 retypes TaskGroup.status to the native StreamPhase/
+  // RunOutcome vocabulary, so that reader no longer needs to fold a
+  // canonical value down to a legacy bucket). It survives as a Tier-4-only
+  // read-side derive helper for the frozen CLI headless JSON's
   // `endGroupStatus` projection (packages/cli/src/runtime/terminalStatus.ts)
-  // and as the fold `logSlice.ts` reuses to keep TaskGroup.status rendering
-  // unchanged until its own reader migration (#7993 goal item 3) — the
-  // algebra itself is unchanged, so it still needs to stay correct.
+  // — the algebra itself is unchanged, so it still needs to stay correct.
   it('derives folded legacy group-end and stream-status projections from one helper', () => {
     expect(groupEndStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe('ok');
     expect(groupEndStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe('ok');

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -17,8 +17,9 @@ import {
   AgentCategory,
   LOG_LEVELS,
   MESSAGE_TYPES,
+  RUN_OUTCOME,
   STREAM_LOG_ENTRY_TYPES,
-  STREAM_STATUS,
+  STREAM_PHASE,
   createStreamState,
   type ProgressViewOutboundMessage,
   type StreamLogEntry,
@@ -162,18 +163,20 @@ describe('LOG_DELTA text deltas', () => {
   });
 });
 
-// #7993 step 2: every GROUP_END row a live/persisted producer writes now
-// carries the literal RunOutcome ('completed'/'cancelled'/'failed'), not the
-// folded 2-value EndGroupStatus ('stopped'/'error') logSlice.ts's
-// isTaskGroupStatus type guard alone recognizes. Without the read-side fold
-// this suite pins, every GROUP_END row — including a failure — would fall
-// through to isTaskGroupStatus's STOPPED default, losing the error icon.
-// The standalone trace-viewer forwards raw legacy entries into this same
-// LOG_DELTA handler (replayTrace.ts, §8.3's second, permanent boundary), so
-// the legacy wire values must keep working identically alongside the new
-// canonical ones — logSlice.ts stays a tolerant reader of both, it does not
-// go canonical-only.
-describe('LOG_DELTA GROUP_END task-group status (#7993 step 2)', () => {
+// #7993 step 3: TaskGroup.status is now the native StreamPhase/RunOutcome
+// vocabulary, not the legacy 2-value EndGroupStatus ('stopped'/'error')
+// folded down from it. Every GROUP_END row a live/persisted producer writes
+// carries the literal RunOutcome ('completed'/'cancelled'/'failed') and
+// logSlice.ts's isTaskGroupStatus type guard now recognizes those directly —
+// without that retyping, every canonical GROUP_END row (including a
+// failure) would fall through to the STOPPED default, losing the error icon
+// and folding completed/cancelled together. The standalone trace-viewer
+// still forwards raw legacy entries into this same LOG_DELTA handler
+// (replayTrace.ts, §8.3's second, permanent boundary), so logSlice.ts stays
+// a tolerant reader of the legacy wire values too — it maps them UP to the
+// same native value StreamLogStore.parsePersistedEntries would produce for
+// the same on-disk string, rather than going canonical-only.
+describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
   function groupStartEntry(id: string): StreamLogEntry {
     return {
       seqNo: 1,
@@ -201,14 +204,20 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 2)', () => {
   it.each([
     // Canonical values every StreamLogStore-sourced GROUP_END row now
     // carries directly (live producers write RunOutcome; persisted legacy
-    // rows are normalized to it at StreamLogStore.parsePersistedEntries).
-    ['completed', STREAM_STATUS.STOPPED],
-    ['cancelled', STREAM_STATUS.STOPPED],
-    ['failed', STREAM_STATUS.ERROR],
+    // rows are normalized to it at StreamLogStore.parsePersistedEntries) —
+    // completed/cancelled stay distinct instead of folding into one bucket,
+    // and a failure keeps its own value (the error icon's source).
+    ['completed', RUN_OUTCOME.COMPLETED],
+    ['cancelled', RUN_OUTCOME.CANCELLED],
+    ['failed', RUN_OUTCOME.FAILED],
     // Legacy values the standalone trace-viewer still forwards raw from a
-    // pre-cutover exported trace file — never normalized, permanently.
-    ['stopped', STREAM_STATUS.STOPPED],
-    ['error', STREAM_STATUS.ERROR],
+    // pre-cutover exported trace file — never normalized, permanently —
+    // map UP to the native value, matching parsePersistedEntries exactly.
+    ['stopped', RUN_OUTCOME.COMPLETED],
+    ['error', RUN_OUTCOME.FAILED],
+    // Malformed/unrecognized data.status falls back to the caller-supplied
+    // default, now STREAM_PHASE.COMPLETED (was STREAM_STATUS.STOPPED).
+    ['bogus', STREAM_PHASE.COMPLETED],
   ] as const)(
     'maps GROUP_END data.status %s to task-group status %s',
     (wireStatus, expectedStatus) => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - progressView frontend
+import { GROUP_DOM_IDS } from '@progressView/frontend/constants';
 import type {
   GroupTree,
   MessageIndex,
@@ -11,7 +12,7 @@ import type {
 // Local imports - shared schemas
 import {
   LOG_LEVELS,
-  STREAM_STATUS,
+  STREAM_PHASE,
   type LogMessageData,
   type TaskGroup,
 } from '@shared/schemas';
@@ -98,10 +99,10 @@ async function renderList(
 describe('task-group-list ungrouped message indexes', () => {
   it('plays round-completion sound for workflow rounds only', () => {
     const list = createList([]);
-    const running = createGroup('round-1', STREAM_STATUS.RUNNING, {
+    const running = createGroup('round-1', STREAM_PHASE.RUNNING, {
       kind: 'round',
     });
-    const stopped = createGroup('round-1', STREAM_STATUS.STOPPED, {
+    const stopped = createGroup('round-1', STREAM_PHASE.COMPLETED, {
       kind: 'round',
     });
 
@@ -125,10 +126,10 @@ describe('task-group-list ungrouped message indexes', () => {
 
   it('keeps legacy workflow r<N> groups eligible for completion sound', () => {
     const list = createList([]);
-    const running = createGroup('legacy-round', STREAM_STATUS.RUNNING, {
+    const running = createGroup('legacy-round', STREAM_PHASE.RUNNING, {
       name: 'r2',
     });
-    const stopped = createGroup('legacy-round', STREAM_STATUS.STOPPED, {
+    const stopped = createGroup('legacy-round', STREAM_PHASE.COMPLETED, {
       name: 'r2',
     });
 
@@ -168,7 +169,7 @@ describe('task-group-list ungrouped message indexes', () => {
   });
 
   it('patches stable group metadata without rebuilding the message tree', () => {
-    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const group = createGroup('g1', STREAM_PHASE.RUNNING);
     const message = createMessage('m1', 'grouped', 2, group.id);
     const list = createList([message]);
     list.groups = [group];
@@ -178,7 +179,7 @@ describe('task-group-list ungrouped message indexes', () => {
     const originalTree: GroupTree | undefined = list.index.tree[0];
     const stoppedGroup = {
       ...group,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       endTime: 3,
     };
     list.groups = [stoppedGroup];
@@ -225,7 +226,7 @@ describe('task-group-list ungrouped message indexes', () => {
   });
 
   it('bounds rendered message DOM inside large groups', async () => {
-    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const group = createGroup('g1', STREAM_PHASE.RUNNING);
     const messages = Array.from({ length: 450 }, (_, index) =>
       createMessage(`m${index}`, `group entry ${index}`, index, group.id),
     );
@@ -253,7 +254,7 @@ describe('task-group-list ungrouped message indexes', () => {
   });
 
   it('resets expanded render windows when leaving terminal mode', async () => {
-    const group = createGroup('g1', STREAM_STATUS.RUNNING);
+    const group = createGroup('g1', STREAM_PHASE.RUNNING);
     const messages = Array.from({ length: 450 }, (_, index) =>
       createMessage(`m${index}`, `group entry ${index}`, index, group.id),
     );
@@ -288,14 +289,14 @@ describe('task-group-list orphan re-rooting', () => {
       id: 'run',
       name: 'Run: subagent',
       startTime: 1,
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       parentGroupId: 'phantom-orchestrator-stage',
     };
     const init: TaskGroup = {
       id: 'init',
       name: 'Init',
       startTime: 2,
-      status: STREAM_STATUS.STOPPED,
+      status: STREAM_PHASE.COMPLETED,
       parentGroupId: 'run',
     };
     const scratchpad = createMessage('m1', 'scratchpad', 3, 'init');
@@ -322,7 +323,7 @@ describe('task-group-list orphan re-rooting', () => {
       id: 'run',
       name: 'Run: subagent',
       startTime: 1,
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       parentGroupId: 'phantom-orchestrator-stage',
     };
     const list = await renderList([run], []);
@@ -332,5 +333,59 @@ describe('task-group-list orphan re-rooting', () => {
     const rootEl = list.shadowRoot?.querySelector('[data-run-id="run"]');
     expect(rootEl).not.toBeNull();
     expect(rootEl?.classList.contains('log-run')).toBe(true);
+  });
+});
+
+// #7993 step 3: TaskGroup.status carries the native StreamPhase/RunOutcome
+// vocabulary end to end. Renders a canonical GROUP_END-derived group of each
+// terminal status and checks the icon distinguishes them — proving the
+// legacy-bucket-fold deletion in logSlice.ts (LogDeltaTextDeltas.vitest.ts
+// pins the mapping into TaskGroup.status) is safe all the way to the DOM:
+// a failed group keeps its own error icon instead of losing it to the old
+// STOPPED default, and a cancelled group no longer renders identically to a
+// completed one.
+describe('task-group-list status icon (#7993 step 3)', () => {
+  it('renders a distinct icon for completed, cancelled, and failed groups', async () => {
+    const parent: TaskGroup = {
+      id: 'run',
+      name: 'Run: workflow',
+      startTime: 1,
+      status: STREAM_PHASE.RUNNING,
+    };
+    const groups: TaskGroup[] = [
+      parent,
+      {
+        id: 'completed-phase',
+        name: 'Completed phase',
+        startTime: 2,
+        status: STREAM_PHASE.COMPLETED,
+        parentGroupId: 'run',
+      },
+      {
+        id: 'cancelled-phase',
+        name: 'Cancelled phase',
+        startTime: 3,
+        status: STREAM_PHASE.CANCELLED,
+        parentGroupId: 'run',
+      },
+      {
+        id: 'failed-phase',
+        name: 'Failed phase',
+        startTime: 4,
+        status: STREAM_PHASE.FAILED,
+        parentGroupId: 'run',
+      },
+    ];
+
+    const list = await renderList(groups, []);
+
+    const iconFor = (groupId: string): string | null =>
+      list.shadowRoot
+        ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}${groupId} wa-icon`)
+        ?.getAttribute('name') ?? null;
+
+    expect(iconFor('completed-phase')).toBe('check');
+    expect(iconFor('cancelled-phase')).toBe('circle-stop');
+    expect(iconFor('failed-phase')).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary

Design-gated per docs/proposals/session-scoped-runtime-architecture.md §8 (issue #7993 step 3, the design doc's own §8.4 "Step 2 — Migrate the live-status readers"). Step 2 (#8087, merged) retyped all four `GROUP_END`/`GROUP_START` producers to native `RunOutcome`/`StreamPhase` and landed the `StreamLogStore.parsePersistedEntries` read boundary, but kept `logSlice.ts` folding a canonical value back down to the legacy `TaskGroupStatus` bucket so `TaskGroup.status` itself stayed unretyped. This PR does that reader retyping.

### 1. `TaskGroupStatusSchema` retype (`src/shared/schemas/stream.ts`)

Was a 4-value subset of the legacy `StreamStatus` (`running`/`error`/`stopped`/`ready`). Now a subset of `StreamPhase` (`running`/`completed`/`cancelled`/`failed`) — task groups have no waiting concept, only running and the three terminal `RunOutcome` values (§8.2's mapping table). `taskGroup.ts` needs no edit; `TaskGroupSchema.status` already references the schema by name, so the retype is transparent to it.

`log.ts`'s `_AssertEndGroupStatusSubset` compile-time assertion is deleted: `EndGroupStatus` (`'error'|'stopped'`) is no longer a subset of the retyped `TaskGroupStatus` — that relationship only existed while `TaskGroupStatus` was itself legacy-typed. `EndGroupStatus`/`END_GROUP_STATUS` stay (Tier-4 CLI projection + `StreamLogStore`'s permanent boundary parse, per §8.3).

### 2. `logSlice.ts` — fold direction flips from down to up

`isTaskGroupStatus`/`taskGroupEndStatus` now recognize the native values directly (the common case, since every `StreamLogStore`-sourced entry is canonical post-#8087). The one remaining legacy arm handles entries the standalone trace-viewer still forwards **raw** from a pre-cutover exported trace file (`replayTrace()` dispatches `trace.entries` verbatim into the same `LOG_DELTA` pipeline, §8.3's second, permanent boundary) — that tolerant arm is **not deleted**, it now maps a legacy `EndGroupStatus` string **up** to the same native value `StreamLogStore.parsePersistedEntries` would produce for the same on-disk string (`'stopped'` → `completed`, `'error'` → `failed`), instead of folding a canonical value down.

### 3. `TaskGroupList.ts` — task-group consumers

- `getStatusIcon` distinguishes `cancelled` (`circle-stop`, an already-registered icon) from `completed` (`check`) instead of folding both into one "stopped" icon — the deliberate completed/cancelled UX distinction §5/§8.2 describe.
- `checkForCompletedRuns`'s completion-sound trigger is preserved **byte-for-byte**: it fires on `completed` or `cancelled` (not `failed`), matching the old `STOPPED`-vs-`ERROR` split exactly, just expressed in the native vocabulary.
- `groupStyles.ts`'s `.is-*` status classes follow: `.is-completed`/`.is-cancelled` share the old `.is-stopped` styling, `.is-failed` replaces `.is-error` — matching the `.is-completed`/`.is-cancelled`/`.is-failed` convention `statusIndicatorStyles.ts` already uses for the per-stream status dot.
- `ProgressBoardLayoutMock.ts`'s `TaskGroup` fixtures retype accordingly (its `StreamState.status` fixtures, a different field already on the canonical `StreamLifecycleStatusSchema`, are untouched).

### 4. No CLI-side reader to migrate

Grepped for a CLI-side `GROUP_END`/task-group consumer analogous to `logSlice.ts`: none exists. The CLI TUI's `STREAM_STATUS` readers (e.g. `TuiStateAndFocus.vitest.mts`, named in §8.5 for the general per-stream live-status census) cover a separate, already-canonical per-stream vocabulary (`sessionRunState.ts`'s live status), not task-group rows — the CLI TUI does not render transcript task groups the way the extension's progress view does. §8.4 Step 2's "any CLI-side reader §8.4 names" resolves to none for this specific migration; re-derived from code per the task's own instruction to say so when the spec and current code disagree.

### 5. §8.3 census correction (docs)

Folds in the correction #8087 recommended but didn't land: `assembleTrace()` (`src/transcript/traceAssembler.ts`) is a **third** `StreamLogStore` client (CLI single-file export, extension history browser, settings-view chat export) — not a third boundary. It constructs a fresh `StreamLogStore` and loads through `parsePersistedEntries`, so every `TraceDocument` it assembles carries canonical values even when built from pre-cutover on-disk history, including on re-export. That's why `replayTrace.ts`'s `toStreamLifecycleStatus` needed `StreamLifecycleStatusSchema` (not the narrower `StreamStatusSchema`) — already fixed in #8087's consumer-side change, now explained in the doc.

## A significant overlap found and flagged, not resolved here

**#8069** (open, not merged, same repo owner) independently touches `logSlice.ts`'s `isTaskGroupStatus`/`isStageKind`/`taskGroupEndStatus`/`updateTaskGroups` and adds `GroupLogPayloadSchema` to `taskGroup.ts` — but for an orthogonal concern (replacing hand-rolled type guards with Zod-schema parses, no vocabulary change). It branched after #8087 merged and still carries the **legacy** `TaskGroupStatusSchema`-based fold this PR retypes: its `GroupLogPayloadSchema.status` is `z.union([TaskGroupStatusSchema, RunOutcomeSchema])` and its `taskGroupEndStatus` still calls `legacyEndGroupStatusForOutcome` to fold a canonical value down.

Once this PR merges, `RunOutcomeSchema` becomes a strict subset of the retyped `TaskGroupStatusSchema`, so #8069's union becomes redundant, and `legacyEndGroupStatusForOutcome`'s `'error'|'stopped'` return type is no longer assignable to `TaskGroupStatus` — #8069 will need a small follow-up to drop the now-redundant union member and the down-fold (mirroring this PR's `taskGroupEndStatus`) whichever way the two PRs land relative to each other. Flagging explicitly per this task's instruction to name a residual precisely rather than silently building around unmerged, still-in-review code — this PR is correct and self-contained against current `main` either way.

## Verified

- `docs/proposals/session-scoped-runtime-architecture.md` §8 (full addendum), the two most recent #7993 comments (step-1/step-2 delivery notes), and #8087's own PR description (its recommended census correction + its "logSlice.ts stays tolerant" deviation note).
- `src/shared/schemas/{stream,log,taskGroup}.ts`, `packages/extension/src/progressView/frontend/{slices/logSlice.ts,components/TaskGroupList.ts,styles/groupStyles.ts}`, `src/common/constants/streamStatus.ts`, `src/transcript/{StreamLogStore.ts,traceAssembler.ts}`, `packages/trace-viewer/src/replayTrace.ts`.
- Grepped for every production/task-group `STREAM_STATUS`/`TaskGroupStatus` consumer across `src/` and `packages/*/src/` to confirm the migrated set is complete and the general 39-file per-stream live-status census (§8.4's separate, larger "Step 2" item) is correctly out of this PR's scope.
- `gh pr list --search "7993 in:body"` (none open) and read #8108 (tool-use round outcomes, unrelated files) and #8069 (see above) for overlap.

## R6/R8

- Production: +101/-46 across 6 files (schema retype, two reader migrations, one CSS follow, one mock fixture fix, one stale compile-assertion deletion).
- Tests: +115/-45 across 3 files, all extending suites §8.5 names in place (R7 — no new test files): `LogDeltaTextDeltas.vitest.ts` (GROUP_END mapping table extended to the native values + a malformed-fallback case), `TaskGroupListIndex.vitest.ts` (fixtures retyped + one new render-level icon-distinction test), `RunOutcomeAlgebra.vitest.ts` (stale comment only).
- R8: grep confirms `legacyEndGroupStatusForOutcome`'s only production caller outside its own module is now the frozen Tier-4 CLI projection (`terminalStatus.ts`) — `logSlice.ts`'s use is deleted, matching #8087's own note that its addition there was "scheduled for deletion once logSlice.ts's own reader migration lands."

## Test plan

- `npx vitest run src/test-kernel/common/RunOutcomeAlgebra.vitest.ts src/test-kernel/progressView src/test-kernel/transcript src/test-kernel/traceViewer/replayTrace.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — all pass.
- `npm test` — 631 files passed, 1 skipped; 5591 tests passed, 4 skipped.
- `npm run typecheck` — clean across all 5 workspace projects.
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files).
- `npx prettier --check` on every touched file — clean.
- Proved the legacy-bucket-fold deletion is safe: `LogDeltaTextDeltas.vitest.ts`'s `GROUP_END` table now asserts `completed`/`cancelled`/`failed` stay distinct (previously `completed`/`cancelled` both mapped to `STOPPED`) and a failed run keeps `failed` rather than falling to the old `STOPPED` default; `TaskGroupListIndex.vitest.ts`'s new render test confirms the DOM icon distinguishes all three terminal states end to end.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible progress-view status/icons and completion-sound logic change; scope is extension frontend and shared schemas with solid test coverage, not auth or persistence writes.
> 
> **Overview**
> **#7993 step 3** moves progress-view task groups off the legacy `StreamStatus` bucket (`running` / `error` / `stopped` / `ready`) onto native **`StreamPhase` / `RunOutcome`** (`running`, `completed`, `cancelled`, `failed`), so transcript group-end facts from step 2 show up in the UI instead of being folded back to “stopped.”
> 
> `TaskGroupStatusSchema` in `stream.ts` is redefined as that four-value native set (no `waiting`). `log.ts` drops the compile-time proof that `EndGroupStatus` ⊆ `TaskGroupStatus`; legacy `'stopped'` / `'error'` on `GROUP_END` rows are still accepted in `logSlice.ts` and mapped **up** to `completed` / `failed` (trace-viewer / pre-cutover traces), with canonical values passed through.
> 
> **`TaskGroupList`** and **`groupStyles`** now treat terminals separately: cancelled gets its own icon (`circle-stop`) and shares success styling with completed; failed replaces the old error class. Round completion sound still fires on **completed or cancelled**, not on failed.
> 
> Tests extend `GROUP_END` mapping and add a DOM icon test; the session-scoped runtime doc notes **`assembleTrace()`** as a third `StreamLogStore` client (census only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3db2cc8cad4a2ecc525df0f6aa2427b6a1e47b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->