### PR TITLE
fix(agent): restore workflow outputs on resume

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -33,7 +33,6 @@ import {
   type CompileFailure,
   type CompileResult,
   type FileLocation,
-  type RoundOutput,
 } from '@shared/schemas';
 import { FlexibleFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -48,7 +47,6 @@ interface OutputPrepInput {
 }
 
 interface OutputExecResult {
-  roundOutput: RoundOutput;
   summary: RoundSummary;
   compileFailures: CompileFailure[];
   compileResult?: CompileResult;
@@ -178,15 +176,11 @@ export class OutputNode<C = unknown> extends Node<
     );
 
     // Get round output — critical, throw if it fails
-    const roundOutput = await getRoundOutput(
-      outputState,
-      diffBaseFiles,
-      currentRound,
-      { isRewrite: setting.isRewrite },
-    );
+    await getRoundOutput(outputState, diffBaseFiles, currentRound, {
+      isRewrite: setting.isRewrite,
+    });
 
     return {
-      roundOutput,
       summary,
       compileFailures,
       compileResult: compileRoundResult,
@@ -231,19 +225,20 @@ export class OutputNode<C = unknown> extends Node<
       };
     }
 
-    return {
-      roundOutput: {
-        round: currentRound,
-        rawOutput: null,
-        outputs: [],
-        compileFailures: [],
-        xmlSummary: {
-          tagContents: {},
-          documents: [],
-          singleOutputFile: null,
-          sourceLocation: null,
-        },
+    outputState.rounds[currentRound] = {
+      round: currentRound,
+      rawOutput: null,
+      outputs: [],
+      compileFailures: [],
+      xmlSummary: {
+        tagContents: {},
+        documents: [],
+        singleOutputFile: null,
+        sourceLocation: null,
       },
+    };
+
+    return {
       summary,
       compileFailures: [],
       compileResult: undefined,
@@ -261,7 +256,7 @@ export class OutputNode<C = unknown> extends Node<
     const outputDependencies = this.outputDependencies();
     const { runtimeHost, streamId } = outputDependencies;
     const { outputLocation, currentRound, endTurn } = prepRes;
-    const { summary, roundOutput } = execRes;
+    const { summary } = execRes;
 
     // Emit output files event
     emitRunFact(logger, 'addOutputFiles', {
@@ -324,8 +319,8 @@ export class OutputNode<C = unknown> extends Node<
       }, this.recoverWarn('Validate expected outputs'));
     }
 
-    // Store round output
-    shared.roundOutputs[currentRound] = roundOutput;
+    // Project the canonical live collection into PersistedFlow's cloned state.
+    shared.roundOutputs = outputState.rounds;
     if (execRes.compileResult) {
       shared.lastCompileResult = execRes.compileResult;
       const compileFailureContext = shouldUseCompileFailureRepairContext(

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -254,6 +254,9 @@ export async function runReflectionFlow<C = unknown>(
       };
     }
 
+    // Hydrate the canonical live collection from the persisted round snapshot.
+    outputState.rounds = shared.roundOutputs;
+
     const prepContextNode = new PrepareContextNode<C>();
     const texCountNode = new TeXCountNode<C>();
     const mediaNode = new MediaExtractionNode<C>();

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -100,9 +100,9 @@ export function traceFileLineage(
   baseFiles: FileLocation[],
   currRound: number,
 ): RoundFileMapping {
-  const currentOutputs = state.rounds.get(currRound)?.outputs ?? [];
+  const currentOutputs = state.rounds[currRound]?.outputs ?? [];
   const prevOutputs =
-    currRound > 0 ? (state.rounds.get(currRound - 1)?.outputs ?? []) : [];
+    currRound > 0 ? (state.rounds[currRound - 1]?.outputs ?? []) : [];
 
   const baseEntries = buildBaseEntries(baseFiles);
   const currentLocations = currentOutputs.map((entry) => entry.location);

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -4,10 +4,9 @@
  * Manages mutable state for output files across rounds, including
  * round data, storage keys, and workspace preparation.
  *
- * `OutputState.rounds` stores mutable `RoundOutput` objects — the same type
- * persisted in `ReflectionFlowShared.roundOutputs`. Each round's entry is
- * built up in-place during processing; `OutputNode.post()` then writes the
- * completed entry to shared state for persistence.
+ * `OutputState.rounds` is the canonical live collection. The reflection flow
+ * hydrates it from persisted `roundOutputs` on startup and projects the same
+ * array shape back before each round is persisted.
  */
 
 import type { AgentTrace, StageHandle } from '@agent/trace';
@@ -31,7 +30,7 @@ import {
 } from '@utils/files';
 
 export interface OutputState {
-  rounds: Map<number, RoundOutput>;
+  rounds: RoundOutput[];
   openedOutputs: Set<string>;
   storageKey: StorageKey | null;
   runPreparation: Promise<void> | null;
@@ -48,9 +47,9 @@ export interface OutputDependencies {
   runtimeHost: AgentRuntimeHost;
 }
 
-export function createOutputState(): OutputState {
+export function createOutputState(rounds: RoundOutput[] = []): OutputState {
   return {
-    rounds: new Map(),
+    rounds,
     openedOutputs: new Set(),
     storageKey: null,
     runPreparation: null,
@@ -78,7 +77,7 @@ export function ensureRoundData(
   state: OutputState,
   round: number,
 ): RoundOutput {
-  let data = state.rounds.get(round);
+  let data = state.rounds[round];
   if (!data) {
     data = {
       round,
@@ -87,24 +86,24 @@ export function ensureRoundData(
       compileFailures: [],
       xmlSummary: OutputXmlSummarySchema.parse({}),
     };
-    state.rounds.set(round, data);
+    state.rounds[round] = data;
   }
   return data;
 }
 
 export function hasRoundOutputs(state: OutputState, round: number): boolean {
-  return (state.rounds.get(round)?.outputs.length ?? 0) > 0;
+  return (state.rounds[round]?.outputs.length ?? 0) > 0;
 }
 
 export function hasCompileFailures(state: OutputState, round: number): boolean {
-  return (state.rounds.get(round)?.compileFailures.length ?? 0) > 0;
+  return (state.rounds[round]?.compileFailures.length ?? 0) > 0;
 }
 
 export function getOutputFilesByRound(
   state: OutputState,
 ): RoundIndexed<OutputFileInfo> {
   return Object.fromEntries(
-    [...state.rounds].map(([round, data]) => [round, data.outputs]),
+    state.rounds.flatMap((data) => [[data.round, data.outputs] as const]),
   );
 }
 

--- a/src/test-kernel/agent/output/LineageMapping.vitest.ts
+++ b/src/test-kernel/agent/output/LineageMapping.vitest.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { traceFileLineage } from '@agent/output/lineageMapping';
-import { OutputXmlSummarySchema, type ExecutionId } from '@shared/schemas';
+import { createOutputState, ensureRoundData } from '@agent/output/outputState';
+import type { ExecutionId } from '@shared/schemas';
 import { createRunStorageLocation, getComparablePath } from '@utils/files';
 
 describe('workflow output lineage mapping', () => {
@@ -21,42 +22,25 @@ describe('workflow output lineage mapping', () => {
     const chapter1Output = runStorageFile('r0/inputs/chapter1/lemma.tex');
     const chapter2Output = runStorageFile('r0/inputs/chapter2/lemma.tex');
 
-    const mapping = traceFileLineage(
+    const state = createOutputState();
+    ensureRoundData(state, 0).outputs = [
       {
-        rounds: new Map([
-          [
-            0,
-            {
-              round: 0,
-              rawOutput: null,
-              outputs: [
-                {
-                  source: 'inputs/chapter1/lemma.tex',
-                  round: 0,
-                  location: chapter1Output,
-                  lineage: null,
-                  diff: null,
-                },
-                {
-                  source: 'inputs/chapter2/lemma.tex',
-                  round: 0,
-                  location: chapter2Output,
-                  lineage: null,
-                  diff: null,
-                },
-              ],
-              compileFailures: [],
-              xmlSummary: OutputXmlSummarySchema.parse({}),
-            },
-          ],
-        ]),
-        openedOutputs: new Set(),
-        storageKey: null,
-        runPreparation: null,
+        source: 'inputs/chapter1/lemma.tex',
+        round: 0,
+        location: chapter1Output,
+        lineage: null,
+        diff: null,
       },
-      [chapter1, chapter2],
-      0,
-    );
+      {
+        source: 'inputs/chapter2/lemma.tex',
+        round: 0,
+        location: chapter2Output,
+        lineage: null,
+        diff: null,
+      },
+    ];
+
+    const mapping = traceFileLineage(state, [chapter1, chapter2], 0);
 
     expect(mapping.get(getComparablePath(chapter1Output))?.origin).toBe(
       chapter1,

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -6,7 +6,7 @@ import { noopTrace, TraceEmitter, type AgentTrace } from '@agent/trace';
 import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
 import type { ReflectionFlowShared } from '@agent/implementations/flows/reflection/ReflectionFlowState';
 import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
-import { createOutputState } from '@agent/output/outputState';
+import { createOutputState, ensureRoundData } from '@agent/output/outputState';
 import {
   OutputFileProcessor,
   type ProcessingContext,
@@ -64,13 +64,6 @@ function createCompileFailureFixture() {
     failures: [compileFailure],
     logExcerpt: '! Missing $ inserted.',
   };
-  const roundOutput: RoundOutput = {
-    round: 0,
-    rawOutput: outputLocation,
-    outputs: [],
-    compileFailures: [compileFailure],
-    xmlSummary: emptyXmlSummary,
-  };
   const summary = {
     storageKey: normalizeRunId('run:compile-context'),
     currRound: 0,
@@ -84,7 +77,6 @@ function createCompileFailureFixture() {
     outputLocation,
     compileFailure,
     compileResult,
-    roundOutput,
     summary,
   };
 }
@@ -121,11 +113,12 @@ function createOutputNode(
   host: ReturnType<typeof createRecordingHost>['host'],
   workflowOutputPolicy: typeof defaultWorkflowOutputPolicy = defaultWorkflowOutputPolicy,
   logger: AgentTrace = noopTrace,
+  outputState = createOutputState(),
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
     logger,
-    outputState: createOutputState(),
+    outputState,
     runtimeHost: host,
     workflowOutputPolicy,
   } as unknown as ReflectionServices);
@@ -153,15 +146,9 @@ function createRecordedRuntime(streamId: string) {
 }
 
 describe('output progress events', () => {
-  it('publishes reflection output-node events through the runtime host', async () => {
+  it('publishes output events and projects restored rounds', async () => {
     const projected = createRecordedRuntime('stream:output-node');
     const { events, host, hostEvents, logger } = projected;
-    const outputNode = createOutputNode(
-      'stream:output-node',
-      host,
-      defaultWorkflowOutputPolicy,
-      logger,
-    );
     const outputLocation = createAgentLocation('/tmp/output.xml');
     const openedLocation = createLocation('/tmp/rendered.tex');
     const fileInfo: OutputFileInfo = {
@@ -171,28 +158,31 @@ describe('output progress events', () => {
       lineage: null,
       diff: null,
     };
-    const roundOutput: RoundOutput = {
-      round: 2,
-      rawOutput: outputLocation,
-      outputs: [fileInfo],
-      compileFailures: [],
-      xmlSummary: emptyXmlSummary,
-    };
-
+    const restoredFileInfo = { ...fileInfo, round: 1 };
+    const persisted = createOutputState();
+    ensureRoundData(persisted, 1).outputs = [restoredFileInfo];
+    const outputState = createOutputState(persisted.rounds);
+    const outputNode = createOutputNode(
+      'stream:output-node',
+      host,
+      defaultWorkflowOutputPolicy,
+      logger,
+      outputState,
+    );
+    const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
     try {
       const transition = await withTestRunContext(
         host,
         'stream:output-node',
         () =>
           outputNode.post(
-            { roundOutputs: [] } as never,
+            shared,
             {
               outputLocation,
               currentRound: 2,
               endTurn: false,
             },
             {
-              roundOutput,
               summary: {
                 storageKey: normalizeRunId('run:output-node'),
                 currRound: 2,
@@ -221,6 +211,8 @@ describe('output progress events', () => {
           payload: { location: openedLocation, preserveFocus: true },
         },
       ]);
+      expect(shared.roundOutputs).toBe(outputState.rounds);
+      expect(shared.roundOutputs[1]?.outputs).toEqual([restoredFileInfo]);
     } finally {
       projected.dispose();
     }
@@ -229,13 +221,8 @@ describe('output progress events', () => {
   it('stores compile failure context for the next reflection round', async () => {
     const { host } = createRecordingHost();
     const outputNode = createOutputNode('stream:compile-context', host);
-    const {
-      outputLocation,
-      compileFailure,
-      compileResult,
-      roundOutput,
-      summary,
-    } = createCompileFailureFixture();
+    const { outputLocation, compileFailure, compileResult, summary } =
+      createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
     await withTestRunContext(host, 'stream:compile-context', () =>
@@ -247,7 +234,6 @@ describe('output progress events', () => {
           endTurn: false,
         },
         {
-          roundOutput,
           summary,
           compileFailures: [compileFailure],
           compileResult,
@@ -274,13 +260,8 @@ describe('output progress events', () => {
         shouldRejectOnCompileFailure: () => false,
       },
     );
-    const {
-      outputLocation,
-      compileFailure,
-      compileResult,
-      roundOutput,
-      summary,
-    } = createCompileFailureFixture();
+    const { outputLocation, compileFailure, compileResult, summary } =
+      createCompileFailureFixture();
     const shared = { roundOutputs: [] } as unknown as ReflectionFlowShared;
 
     await withTestRunContext(host, 'stream:compile-context-disabled', () =>
@@ -292,7 +273,6 @@ describe('output progress events', () => {
           endTurn: false,
         },
         {
-          roundOutput,
           summary,
           compileFailures: [compileFailure],
           compileResult,
@@ -309,8 +289,7 @@ describe('output progress events', () => {
   it('clears stale compile failure context after a successful compile result', async () => {
     const { host } = createRecordingHost();
     const outputNode = createOutputNode('stream:compile-context-ok', host);
-    const { outputLocation, roundOutput, summary } =
-      createCompileFailureFixture();
+    const { outputLocation, summary } = createCompileFailureFixture();
     const compileResult: CompileResult = { status: 'ok', round: 1 };
     const shared = {
       roundOutputs: [],
@@ -332,7 +311,6 @@ describe('output progress events', () => {
           endTurn: false,
         },
         {
-          roundOutput: { ...roundOutput, round: 1, compileFailures: [] },
           summary: { ...summary, currRound: 1 },
           compileFailures: [],
           compileResult,


### PR DESCRIPTION
## Summary

- replace the live `Map<number, RoundOutput>` with the same `RoundOutput[]` shape persisted by reflection flows
- hydrate the live output collection from persisted rounds on resume, then project the full collection across `PersistedFlow`'s clone boundary before saving
- remove the now-redundant `roundOutput` pass-through and shorten stale output test fixtures

## Issue acceptance gates

Closes #8121.

- resumed workflows can read prior-round outputs before processing the next round
- `OutputState.rounds` is the one live owner; persisted shared state is an explicit hydration/projection boundary
- the existing output-node regression test now restores a prior round and verifies it survives projection
- fresh-run, fallback, lineage, compile, and persisted schema behavior remain compatible

## Single source of truth

`OutputState.rounds` owns live mutable round output. `runReflectionFlow` hydrates it once from persisted shared state, and `OutputNode.post` projects the complete array back into the cloned state that `PersistedFlow` serializes.

## Duplication and abstraction budget

Removed the parallel map/array representations and the per-round `OutputExecResult.roundOutput` pass-through. No new facade, class, export, or generic abstraction was added.

## Net elements (R6)

- files: 6 modified, 0 added, 0 deleted
- exported symbols: 0 added, 0 deleted; `createOutputState` remains backward-compatible with an optional restored-rounds argument
- classes/interfaces/enums: 0 added, 0 deleted
- production diff: 35 additions, 38 deletions (net -3 LoC)
- test diff: 43 additions, 81 deletions (net -38 LoC)
- total diff: 78 additions, 119 deletions (net -41 LoC)

## Consumer counts (R8)

n/a — no export, event, route, or subscriber path is removed or rerouted. Existing `createOutputState()` callers remain valid.

## Host impact

Extension: workflow resumes recover prior-round output context.

Desktop: workflow resumes recover prior-round output context.

CLI: workflow resumes recover prior-round output context.

## Scheduled refactoring

None for this issue scope.

## Validation

- `vitest run src/test-kernel/agent/output src/test-kernel/utils/TextDiffCallers.vitest.ts` — 11 files, 118 tests passed
- `tsc --noEmit -p tsconfig.test-kernel.json`
- ESLint on all six changed files
- Prettier check on all six changed files
- `git diff --check`
- independent subagent review: no concrete correctness risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reflection output persistence and in-memory round indexing; behavior change is intentional for resume but affects all rounds’ lineage and persistence boundaries.
> 
> **Overview**
> **Fixes resumed reflection workflows losing prior-round output context** by making `OutputState.rounds` a `RoundOutput[]` (same shape as persisted `roundOutputs`) instead of a parallel `Map`.
> 
> On flow start, **`runReflectionFlow` hydrates** `outputState.rounds` from `shared.roundOutputs`. **`OutputNode.post` projects** the live array back with `shared.roundOutputs = outputState.rounds` so earlier rounds survive `PersistedFlow`’s clone boundary. The redundant **`roundOutput` pass-through** on `OutputExecResult` is removed; fallback writes the empty round directly into `outputState.rounds`.
> 
> **Lineage and tests** use array indexing (`state.rounds[currRound]`); the output-node regression test restores a prior round and asserts it remains after projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616d76185a81ffb2c1260ccc9aec4182ad39e329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->