### PR TITLE
refactor(agent): validate persisted tool-use shared state

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from 'node:util';
+
 import { z } from 'zod';
 
 import {
@@ -5,6 +7,7 @@ import {
   type AgentRunStateSnapshot,
 } from '@agent/core/state/AgentState';
 import {
+  AgentWorkspaceCurrentSnapshotSchema,
   AgentWorkspaceStateSnapshotSchema,
   type AgentWorkspaceState,
 } from '@agent/core/state/AgentWorkspaceState';
@@ -16,9 +19,9 @@ import {
   ProviderMessageArraySchema,
   type ProviderMessage,
 } from '@agent/types/ProviderMessage';
-import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
+import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import type { RetryErrorInfo } from '@shared/schemas';
+import { RetryErrorInfoSchema } from '@shared/schemas';
 
 export const StateSlicesSchema = z.object({
   runStateSnapshot: AgentRunStateSnapshotSchema,
@@ -26,7 +29,35 @@ export const StateSlicesSchema = z.object({
   userChannels: UserVariableChannelsSchema,
 });
 
-export type StateSlicesSnapshot = z.infer<typeof StateSlicesSchema>;
+const StateSlicesCanonicalSchema = StateSlicesSchema.extend({
+  workspaceSnapshot: AgentWorkspaceCurrentSnapshotSchema,
+});
+
+export type StateSlicesSnapshot = z.output<typeof StateSlicesSchema>;
+
+/** Full persisted and live shared state for one tool-use flow. */
+export const ToolUseRunSharedSchema = z.looseObject({
+  messages: ProviderMessageArraySchema,
+  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullable()
+    .transform((key) => key ?? undefined)
+    .optional(),
+  shouldSkipCycle: z.boolean(),
+  stateSlices: StateSlicesSchema.nullable(),
+  /** Per-call system text for providers that do not embed it in messages. */
+  systemPrompt: z.string().optional(),
+  userCancelledRetry: z.boolean().optional(),
+  /** Distinguishes failure from cancellation during resume. */
+  lastError: RetryErrorInfoSchema.optional(),
+  /** Last assistant response without the full assembly buffers. */
+  lastResponse: z.string().optional(),
+});
+
+/** Per-step schema after the one-time legacy workspace migration. */
+export const ToolUseRunSharedCanonicalSchema = ToolUseRunSharedSchema.extend({
+  stateSlices: StateSlicesCanonicalSchema.nullable(),
+});
+
+export type ToolUseRunShared = z.output<typeof ToolUseRunSharedSchema>;
 
 /** Extract edited file paths from a workspace state snapshot. */
 export function extractTouchedFiles(
@@ -36,25 +67,6 @@ export function extractTouchedFiles(
     stateSlices?.workspaceSnapshot?.interactions?.edits?.map((e) => e.path) ??
     []
   );
-}
-
-export interface ToolUseRunShared {
-  messages: ProviderMessage[];
-  modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey;
-  shouldSkipCycle: boolean;
-  stateSlices: StateSlicesSnapshot | null;
-  /**
-   * System prompt for providers that pass `system` per-call (Anthropic,
-   * Google) instead of embedding it into `messages`. Set once by
-   * `ToolUsePrepareNode`; threaded into every `ToolUseRoundShared` by
-   * `ToolUseCycleNode` so it reaches `createResponse` on every round.
-   */
-  systemPrompt?: string;
-  userCancelledRetry?: boolean;
-  /** Distinguishes failure from cancellation during resume. */
-  lastError?: RetryErrorInfo;
-  /** Last assembled assistant response, retained without persisting full assembly strings. */
-  lastResponse?: string;
 }
 
 export type WaitExecResult =
@@ -110,15 +122,9 @@ export function assertPreparedShared(
   }
 }
 
-const MessagesSchema = z.looseObject({ messages: ProviderMessageArraySchema });
-const LegacyConversationSchema = z.looseObject({
-  conversation: ProviderMessageArraySchema,
-});
-
 /**
- * Migrate legacy shared state formats to current ToolUseRunShared.
- * Handles: flat with `messages`, flat with `conversation`, and nested `{ state: {...} }`.
- * Returns null if unparseable.
+ * Parse persisted shared state once, normalizing the legacy conversation key,
+ * outer state wrapper, and workspace snapshot before live flow code sees it.
  */
 export function migrateSharedState(
   shared: unknown,
@@ -131,15 +137,27 @@ export function migrateSharedState(
   const obj = nested ? (shared as Record<string, unknown>).state : shared;
   if (!obj || typeof obj !== 'object') return null;
 
-  if (MessagesSchema.safeParse(obj).success) {
-    return { data: obj as ToolUseRunShared, migrated: nested };
+  const record = obj as Record<string, unknown>;
+  const messages = ProviderMessageArraySchema.safeParse(record.messages);
+  const conversation = ProviderMessageArraySchema.safeParse(
+    record.conversation,
+  );
+  if (!messages.success && !conversation.success) return null;
+
+  const { conversation: _legacyConversation, ...candidate } = record;
+  let migrated = nested;
+  if (!messages.success) {
+    candidate.messages = conversation.data;
   }
-  if (LegacyConversationSchema.safeParse(obj).success) {
-    const { conversation, ...rest } = obj as Record<string, unknown>;
-    return {
-      data: { ...rest, messages: conversation } as ToolUseRunShared,
-      migrated: true,
-    };
+  if (Object.hasOwn(record, 'conversation')) {
+    migrated = true;
   }
-  return null;
+
+  const parsed = ToolUseRunSharedSchema.safeParse(candidate);
+  if (!parsed.success) return null;
+
+  return {
+    data: parsed.data,
+    migrated: migrated || !isDeepStrictEqual(candidate, parsed.data),
+  };
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -14,11 +14,6 @@ import { type SessionHandle } from '@agent/runtime/SessionHandle';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
-  AgentWorkspaceState,
-  AgentWorkspaceCurrentSnapshotSchema,
-  type AgentWorkspaceSnapshot,
-} from '@agent/core/state/AgentWorkspaceState';
-import {
   PersistedFlow,
   flowKey,
   stampFlowRecordSchemaVersion,
@@ -52,6 +47,7 @@ import {
   findLastAssistantText,
   extractTouchedFiles,
   migrateSharedState,
+  ToolUseRunSharedCanonicalSchema,
   type ToolUseRunShared,
 } from './nodes/types';
 import {
@@ -120,40 +116,18 @@ export function getToolUseFlowErrorResult(
 }
 
 /**
- * Normalize a resumed flow record's workspace snapshot through the
- * legacy-capable hydration boundary (`AgentWorkspaceState.fromSnapshot`).
- * When a persisted tool-use flow's cursor is already past
- * `ToolUsePrepareNode` (that node's own one-time hydration never runs on
- * resume), this is the only remaining opportunity to migrate a pre-refactor
- * top-level `{todos, plan}` workspace snapshot before per-cycle code
- * (`ToolUseCycleNode.prep()`) re-derives state via the canonical-only
- * `fromCanonicalSnapshot`, which has no legacy fallback and throws on that
- * shape. Cheap and idempotent: skips the round-trip when the snapshot is
- * already canonical.
- */
-export function normalizeResumedWorkspaceSnapshot(
-  workspaceSnapshot: unknown,
-): AgentWorkspaceSnapshot {
-  const canonical =
-    AgentWorkspaceCurrentSnapshotSchema.safeParse(workspaceSnapshot);
-  return canonical.success
-    ? canonical.data
-    : AgentWorkspaceState.fromSnapshot(workspaceSnapshot).toSnapshot();
-}
-
-/**
  * Build the canonical self-heal payload for a resumed flow record's `shared`
  * blob from the resume boundary's already-validated snapshot
  * (`SessionResumeRetrieval.retrieveToolUseResumeData` -- the single owner of
  * FlowRecord.shared's legacy-format migration and persisted-format
  * modelHandlerCompatibilityKey inference). The snapshot's key is authoritative
  * when present; otherwise the active handler's key preserves the legacy
- * self-heal fallback. `structuralBase` is the record's own `migrateSharedState`
- * output (structural unwrap only), which supplies any pass-through fields the
+ * self-heal fallback. `structuralBase` is the record's fully validated
+ * `migrateSharedState` output, which supplies any pass-through fields the
  * snapshot's narrower resume contract doesn't carry (e.g. `systemPrompt`,
  * `lastError`) so they survive the write-back untouched.
  */
-export function buildResumedSharedFromSnapshot(
+function buildResumedSharedFromSnapshot(
   structuralBase: ToolUseRunShared,
   snapshot: ToolUseSessionSnapshot,
   activeCompatibilityKey: ModelHandlerCompatibilityKey | undefined,
@@ -165,7 +139,7 @@ export function buildResumedSharedFromSnapshot(
       snapshot.modelHandlerCompatibilityKey ?? activeCompatibilityKey,
     stateSlices: {
       runStateSnapshot: snapshot.run,
-      workspaceSnapshot: normalizeResumedWorkspaceSnapshot(snapshot.workspace),
+      workspaceSnapshot: snapshot.workspace,
       userChannels: snapshot.user,
     },
   };
@@ -429,13 +403,10 @@ export async function runToolUseFlow<C = unknown>(
         // the result into `input.resumeSnapshot` before this flow was ever
         // launched -- it is the single owner of FlowRecord.shared's
         // legacy-format parsing and persisted-format compatibility-key
-        // inference (see its CurrentToolUseFlowRecordStateSchema). Consume its
-        // canonical fields directly here instead of re-deriving them;
-        // `migrateSharedState` above is only used for its structural unwrap so
-        // that pass-through fields the snapshot's narrower contract doesn't
-        // carry (systemPrompt, lastError, ...) survive this self-heal write of
-        // the KV blob that PersistedFlow.ensureRecord's unchecked raw read
-        // (below) depends on.
+        // inference. Consume its canonical fields directly here instead of
+        // re-deriving them; `migrateSharedState` preserves pass-through fields
+        // the snapshot's narrower contract doesn't carry (systemPrompt,
+        // lastError, ...) so they survive this self-heal write.
         flowRecord.shared = buildResumedSharedFromSnapshot(
           migrationResult.data,
           input.resumeSnapshot,
@@ -449,34 +420,10 @@ export async function runToolUseFlow<C = unknown>(
         // Defensive fallback only: no resumeSnapshot means the resume
         // boundary above was never consulted for this call (e.g. a fresh
         // launch that happens to find a leftover record for its execution
-        // id). Migrate/backfill here so PersistedFlow.ensureRecord's
-        // unchecked raw read never sees a stale legacy shape. `migrateSharedState`
-        // above only unwraps the outer structural wrapper -- it never touches
-        // the nested `stateSlices.workspaceSnapshot`, so a legacy top-level
-        // `{todos, plan}` workspace snapshot must be normalized here too
-        // (same reasoning as the resumeSnapshot branch above).
+        // id). Migrate/backfill here so PersistedFlow.ensureRecord never sees
+        // a stale legacy shape.
         let migratedData = migrationResult.data;
         let shouldWriteShared = migrationResult.migrated;
-        if (
-          migratedData.stateSlices &&
-          !AgentWorkspaceCurrentSnapshotSchema.safeParse(
-            migratedData.stateSlices.workspaceSnapshot,
-          ).success
-        ) {
-          logger.debug(
-            'Migrated legacy workspace snapshot in resumed flow record.',
-          );
-          migratedData = {
-            ...migratedData,
-            stateSlices: {
-              ...migratedData.stateSlices,
-              workspaceSnapshot: normalizeResumedWorkspaceSnapshot(
-                migratedData.stateSlices.workspaceSnapshot,
-              ),
-            },
-          };
-          shouldWriteShared = true;
-        }
         const sharedModel = migratedData.stateSlices
           ? (currentModelFromUserChannels(
               migratedData.stateSlices.userChannels,
@@ -520,7 +467,12 @@ export async function runToolUseFlow<C = unknown>(
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);
     waitNode.on(FlowTransition.WAITING, waitNode);
-    const pf: ToolUsePersistedFlow<C> = new PersistedFlow(prepareNode, kv);
+    const pf: ToolUsePersistedFlow<C> = new PersistedFlow(
+      prepareNode,
+      kv,
+      executionId,
+      ToolUseRunSharedCanonicalSchema,
+    );
     activePersistedFlow = pf;
     pf.setServices(services);
     // Note: the flow record is the resume SSOT and the transcript sidecar

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -47,6 +47,7 @@ import {
   findLastAssistantText,
   extractTouchedFiles,
   migrateSharedState,
+  ToolUseRunSharedSchema,
   ToolUseRunSharedCanonicalSchema,
   type ToolUseRunShared,
 } from './nodes/types';
@@ -132,7 +133,7 @@ function buildResumedSharedFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   activeCompatibilityKey: ModelHandlerCompatibilityKey | undefined,
 ): ToolUseRunShared {
-  return {
+  return ToolUseRunSharedSchema.parse({
     ...structuralBase,
     messages: snapshot.messages,
     modelHandlerCompatibilityKey:
@@ -142,7 +143,7 @@ function buildResumedSharedFromSnapshot(
       workspaceSnapshot: snapshot.workspace,
       userChannels: snapshot.user,
     },
-  };
+  });
 }
 
 interface ToolUseFlowContext {

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -21,10 +21,7 @@ import {
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import { ProviderMessageArraySchema } from '@agent/types/ProviderMessage';
-import {
-  migrateSharedState,
-  StateSlicesSchema,
-} from '@agent/implementations/flows/tooluse/nodes/types';
+import { migrateSharedState } from '@agent/implementations/flows/tooluse/nodes/types';
 import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,
@@ -65,16 +62,6 @@ export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 export interface SessionResumeRetrievalOptions {
   readonly parentStreamId?: StreamTabId;
 }
-
-const CurrentToolUseFlowRecordStateSchema = z.looseObject({
-  messages: ProviderMessageArraySchema,
-  modelHandlerCompatibilityKey: ModelHandlerCompatibilityKeySchema.nullish(),
-  stateSlices: StateSlicesSchema,
-});
-
-type NormalizedToolUseState = z.infer<
-  typeof CurrentToolUseFlowRecordStateSchema
->;
 
 function throwIfResumeStorageUnreadable(
   resumability: ResumabilityDecision,
@@ -179,17 +166,14 @@ async function retrieveToolUseResumeData(
       return null;
     }
 
-    const parseResult = CurrentToolUseFlowRecordStateSchema.safeParse(
-      migrationResult.data,
-    );
-    if (!parseResult.success) {
+    const { messages, stateSlices } = migrationResult.data;
+    if (stateSlices === null) {
       logger.warn(
         `Invalid flow record structure for execution: ${executionId}`,
       );
       return null;
     }
 
-    const { messages, stateSlices } = parseResult.data;
     const currentConfig = {
       ...agentConfig,
       model:
@@ -197,7 +181,7 @@ async function retrieveToolUseResumeData(
         agentConfig.model,
     };
     const modelHandlerCompatibilityKey =
-      parseResult.data.modelHandlerCompatibilityKey ??
+      migrationResult.data.modelHandlerCompatibilityKey ??
       inferPersistedModelHandlerCompatibilityKey(currentConfig.model, messages);
 
     // Construct and validate the complete snapshot.

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -185,26 +185,4 @@ describe('agent workspace work-plan state', () => {
     expect(rehydrated.workPlan.todos).toEqual([todo]);
     expect(rehydrated.workPlan.plan).toBeNull();
   });
-
-  it('normalizes a legacy top-level {todos, plan} snapshot for the tool-use resume boundary', () => {
-    // Regression for the codex P1 on #8005: when a persisted tool-use flow's
-    // cursor is already past ToolUsePrepareNode, that node's own one-time
-    // hydration never runs on resume (PersistedFlow.ensureRecord just reuses
-    // the existing record). ToolUseRunSharedSchema's one-time persistence
-    // boundary delegates to this legacy-capable workspace schema before
-    // per-cycle code's canonical-only fromCanonicalSnapshot
-    // (ToolUseCycleNode.prep()) ever sees it.
-    const legacyWorkspaceSnapshot = {
-      todos: [todo],
-      plan: objectivePlan,
-    };
-
-    const normalized = AgentWorkspaceState.fromSnapshot(
-      legacyWorkspaceSnapshot,
-    ).toSnapshot();
-
-    const rehydrated = AgentWorkspaceState.fromCanonicalSnapshot(normalized);
-    expect(rehydrated.workPlan.todos).toEqual([todo]);
-    expect(rehydrated.workPlan.plan).toEqual(objectivePlan);
-  });
 });

--- a/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
+++ b/src/test-kernel/agent/AgentWorkspaceWorkPlanState.vitest.ts
@@ -190,12 +190,10 @@ describe('agent workspace work-plan state', () => {
     // Regression for the codex P1 on #8005: when a persisted tool-use flow's
     // cursor is already past ToolUsePrepareNode, that node's own one-time
     // hydration never runs on resume (PersistedFlow.ensureRecord just reuses
-    // the existing record). runToolUseFlow's resume boundary is the only
-    // place left to migrate a legacy top-level {todos, plan} workspace
-    // snapshot -- it does so via this exact fromSnapshot(...).toSnapshot()
-    // round trip (see normalizeResumedWorkspaceSnapshot in
-    // runToolUseFlow.ts) before per-cycle code's canonical-only
-    // fromCanonicalSnapshot (ToolUseCycleNode.prep()) ever sees it.
+    // the existing record). ToolUseRunSharedSchema's one-time persistence
+    // boundary delegates to this legacy-capable workspace schema before
+    // per-cycle code's canonical-only fromCanonicalSnapshot
+    // (ToolUseCycleNode.prep()) ever sees it.
     const legacyWorkspaceSnapshot = {
       todos: [todo],
       plan: objectivePlan,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -26,7 +26,10 @@ import {
   type RunToolUseFlowInput,
   type ToolUseFlowSetupCallback,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
-import { migrateSharedState } from '@agent/implementations/flows/tooluse/nodes/types';
+import {
+  migrateSharedState,
+  ToolUseRunSharedCanonicalSchema,
+} from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import {
@@ -93,21 +96,26 @@ function buildToolUseSnapshot(
   };
 }
 
-async function runResumedFlow(
+async function runPersistedFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
-  snapshot: ToolUseSessionSnapshot,
+  snapshot: ToolUseSessionSnapshot | undefined,
   onSetup?: (context: ToolUseSetupContext) => void,
   session: SessionHandle = new SessionHandle(),
 ): Promise<RunToolUseFlowResult> {
+  const config = snapshot?.agentConfig ?? CONFIG;
+  const userVarChannels = snapshot?.user ?? {
+    input: Object.freeze({ MODEL: config.model }),
+    transient: {},
+  };
   const context = createRunContext({
     modelSource: 'live',
-    getModel: () => snapshot.agentConfig.model,
+    getModel: () => config.model,
     runScope: createRunScope({
       runtimeHost: noopAgentRuntimeHost,
       streamId,
       executionId,
-      agentName: snapshot.agentConfig.agent,
+      agentName: config.agent,
       session,
     }),
   });
@@ -117,11 +125,11 @@ async function runResumedFlow(
     return await withRunContext(context, () =>
       runToolUseFlow(
         {
-          config: snapshot.agentConfig,
+          config,
           setting: TOOL_USE_SETTING,
           prompt: TOOL_USE_PROMPT,
           logger: noopTrace,
-          userVarChannels: snapshot.user,
+          userVarChannels,
           modelHandler: createTaggedModelHandler(ACTIVE_COMPATIBILITY_KEY),
           streamStatus: session.status,
           checkInterruption: () => interrupted,
@@ -129,7 +137,7 @@ async function runResumedFlow(
             interrupted = true;
           },
           setAbortController: () => {},
-          resumeSnapshot: snapshot,
+          ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
           isSubagent: true,
           toolInjections: new ToolInjectionRegistry(),
         },
@@ -147,7 +155,7 @@ async function runResumedFlowToWaiting(
   streamId: StreamTabId,
   snapshot: ToolUseSessionSnapshot,
 ): Promise<void> {
-  const result = await runResumedFlow(executionId, streamId, snapshot);
+  const result = await runPersistedFlow(executionId, streamId, snapshot);
   expect(result.outcome).toBe(STREAM_PHASE.WAITING);
 }
 
@@ -518,7 +526,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
-      const result = await runResumedFlow(
+      const result = await runPersistedFlow(
         executionId,
         streamId,
         snapshot,
@@ -563,7 +571,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
-      const result = await runResumedFlow(
+      const result = await runPersistedFlow(
         executionId,
         streamId,
         snapshot,
@@ -614,7 +622,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
 
     try {
-      const result = await runResumedFlow(
+      const result = await runPersistedFlow(
         executionId,
         streamId,
         snapshot,
@@ -778,18 +786,19 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       nodes: [{ action: 'default', nodeId: 'start' }],
     });
 
-    const resume = await retrieveSessionResumeData(
-      streamId,
-      executionId,
-      agentConfigToTaskState(CONFIG),
+    const result = await runPersistedFlow(executionId, streamId, undefined);
+    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+
+    const healedRecord = await getExecutionStore(executionId).read<FlowRecord>(
+      flowKey(executionId),
     );
-    expect(resume?.type).toBe('toolUse');
-    if (resume?.type !== 'toolUse') return;
-
-    await runResumedFlowToWaiting(executionId, streamId, resume.snapshot);
-
+    const healedShared = ToolUseRunSharedCanonicalSchema.parse(
+      healedRecord?.shared,
+    );
+    expect(healedShared.stateSlices).not.toBeNull();
+    if (!healedShared.stateSlices) return;
     const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
-      resume.snapshot.workspace,
+      healedShared.stateSlices.workspaceSnapshot,
     );
     expect(workspaceState.workPlan.todos).toEqual(
       legacyWorkspaceSnapshot.todos,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -11,10 +11,7 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
-import {
-  AgentWorkspaceState,
-  type AgentWorkspaceSnapshot,
-} from '@agent/core/state/AgentWorkspaceState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -24,8 +21,6 @@ import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import {
-  buildResumedSharedFromSnapshot,
-  normalizeResumedWorkspaceSnapshot,
   runToolUseFlow,
   type RunToolUseFlowResult,
   type RunToolUseFlowInput,
@@ -158,6 +153,16 @@ async function runResumedFlowToWaiting(
 
 describe('retrieveSessionResumeData', () => {
   setupPlatform({ workspacePath: '/workspace' });
+
+  it('rejects malformed fields at the shared-state boundary', () => {
+    expect(
+      migrateSharedState({
+        messages: [],
+        shouldSkipCycle: 'false',
+        stateSlices: null,
+      }),
+    ).toBeNull();
+  });
 
   it('uses the persisted current model while preserving the original stream id', async () => {
     const executionId = 'abc123' as ExecutionId;
@@ -313,7 +318,7 @@ describe('retrieveSessionResumeData', () => {
     ]);
   });
 
-  it('normalizes a flat legacy conversation-keyed flow record for tool-use resume', async () => {
+  it('falls back to a flat legacy conversation when messages is invalid', async () => {
     // Distinct from the nested `{ state: { conversation } }` case above: this
     // is the flat (unwrapped) legacy shape -- `conversation` at the top level
     // of `shared`, never renamed to `messages`.
@@ -323,6 +328,7 @@ describe('retrieveSessionResumeData', () => {
       flowName: 'texra',
       params: {},
       shared: {
+        messages: null,
         conversation: [
           { role: 'user', content: 'Continue the flat legacy conversation.' },
         ],
@@ -739,17 +745,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
   });
 
-  it('migrates a legacy top-level {todos, plan} workspace snapshot when the persisted cursor is already past ToolUsePrepareNode', async () => {
-    // Regression for the codex P1 on #8005: ToolUsePrepareNode.exec() is the
-    // *other* legacy-migrating hydration boundary for workspaceSnapshot, but
-    // it only runs on session-init resume. A flow record whose persisted
-    // cursor has already advanced past ToolUsePrepareNode (e.g. suspended
-    // mid-cycle) skips that node entirely on resume -- PersistedFlow.
-    // ensureRecord just reuses the existing record -- so this resume
-    // boundary (SessionResumeRetrieval + runToolUseFlow's self-heal) is the
-    // only place left that can migrate a pre-refactor top-level
-    // `{todos, plan}` workspace snapshot before ToolUseCycleNode.prep()'s
-    // canonical-only `fromCanonicalSnapshot` sees it.
+  it('migrates a legacy workspace before strict per-step validation', async () => {
     const executionId = 'abc141' as ExecutionId;
     const streamId = 'chat@gpt54#abc141' as StreamTabId;
     const legacyWorkspaceSnapshot = {
@@ -767,7 +763,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       params: {},
       shared: {
         messages: [{ role: 'user', content: 'Continue.' }],
-        shouldSkipCycle: false,
+        shouldSkipCycle: true,
         stateSlices: {
           runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
           workspaceSnapshot: legacyWorkspaceSnapshot,
@@ -778,10 +774,8 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         },
       },
       createdAt: new Date().toISOString(),
-      // Cursor already past ToolUsePrepareNode -- resume replays from here,
-      // never touching ToolUsePrepareNode's own hydration.
-      cursor: { nextNodeId: 'ToolUseCycleNode' },
-      nodes: [{ action: 'default', nodeId: 'ToolUsePrepareNode' }],
+      cursor: { nextNodeId: 'start/default' },
+      nodes: [{ action: 'default', nodeId: 'start' }],
     });
 
     const resume = await retrieveSessionResumeData(
@@ -792,79 +786,14 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     expect(resume?.type).toBe('toolUse');
     if (resume?.type !== 'toolUse') return;
 
-    const structuralBase = migrateSharedState({
-      messages: [{ role: 'user', content: 'Continue.' }],
-      shouldSkipCycle: false,
-      stateSlices: {
-        runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-        workspaceSnapshot: legacyWorkspaceSnapshot,
-        userChannels: { input: { MODEL: 'gpt54' }, transient: {} },
-      },
-    });
-    expect(structuralBase).not.toBeNull();
-    if (!structuralBase) return;
+    await runResumedFlowToWaiting(executionId, streamId, resume.snapshot);
 
-    const healed = buildResumedSharedFromSnapshot(
-      structuralBase.data,
-      resume.snapshot,
-      undefined,
-    );
-
-    // This is exactly ToolUseCycleNode.prep()'s canonical-only re-derivation
-    // -- it must not throw, and the migrated todos/plan must survive.
     const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
-      healed.stateSlices!.workspaceSnapshot,
+      resume.snapshot.workspace,
     );
     expect(workspaceState.workPlan.todos).toEqual(
       legacyWorkspaceSnapshot.todos,
     );
     expect(workspaceState.workPlan.plan).toEqual(legacyWorkspaceSnapshot.plan);
-  });
-
-  it('normalizeResumedWorkspaceSnapshot migrates a raw legacy workspace snapshot for the no-resumeSnapshot defensive fallback', () => {
-    // Regression for the codex P1 on #8005, targeted at runToolUseFlow's
-    // *other* self-heal branch: a fresh launch that happens to find a
-    // leftover flow record (no resumeSnapshot -- the resume boundary above
-    // was never consulted) migrates/backfills locally via
-    // migrateSharedState, which only unwraps the outer structural wrapper
-    // and never touches the nested stateSlices.workspaceSnapshot. Without
-    // normalizeResumedWorkspaceSnapshot, a legacy top-level `{todos, plan}`
-    // workspace snapshot survives untouched into the self-healed record and
-    // later fails ToolUseCycleNode.prep()'s canonical-only
-    // fromCanonicalSnapshot, whereas the pre-#8005 fromSnapshot silently
-    // migrated it.
-    const legacyWorkspaceSnapshot = {
-      todos: [
-        {
-          content: 'Ship the fix',
-          status: 'in_progress',
-          activeForm: 'Shipping the fix',
-        },
-      ],
-      plan: { objective: 'Migrate legacy workspace snapshots on resume' },
-    };
-
-    // Documents the failure mode: the raw legacy shape (what
-    // migrateSharedState's untouched pass-through produces) has no
-    // `workPlan` field, so the canonical-only parse throws.
-    expect(() =>
-      AgentWorkspaceState.fromCanonicalSnapshot(
-        legacyWorkspaceSnapshot as unknown as AgentWorkspaceSnapshot,
-      ),
-    ).toThrow();
-
-    const normalized = normalizeResumedWorkspaceSnapshot(
-      legacyWorkspaceSnapshot,
-    );
-    const workspaceState =
-      AgentWorkspaceState.fromCanonicalSnapshot(normalized);
-    expect(workspaceState.workPlan.todos).toEqual(
-      legacyWorkspaceSnapshot.todos,
-    );
-    expect(workspaceState.workPlan.plan).toEqual(legacyWorkspaceSnapshot.plan);
-
-    // Idempotent: normalizing an already-canonical snapshot is a no-op pass-through.
-    const canonical = AgentWorkspaceState.create().toSnapshot();
-    expect(normalizeResumedWorkspaceSnapshot(canonical)).toEqual(canonical);
   });
 });

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -753,56 +753,72 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
   });
 
-  it('migrates a legacy workspace before strict per-step validation', async () => {
-    const executionId = 'abc141' as ExecutionId;
-    const streamId = 'chat@gpt54#abc141' as StreamTabId;
-    const legacyWorkspaceSnapshot = {
-      todos: [
-        {
-          content: 'Ship the fix',
-          status: 'in_progress',
-          activeForm: 'Shipping the fix',
-        },
-      ],
-      plan: { objective: 'Migrate legacy workspace snapshots on resume' },
-    };
-    await getExecutionStore(executionId).write(flowKey(executionId), {
-      flowName: 'texra',
-      params: {},
-      shared: {
-        messages: [{ role: 'user', content: 'Continue.' }],
-        shouldSkipCycle: true,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: legacyWorkspaceSnapshot,
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
+  it.each([
+    { name: 'direct stored-state recovery', withSnapshot: false },
+    { name: 'unvalidated resume snapshot', withSnapshot: true },
+  ])(
+    'migrates a legacy workspace before strict validation: $name',
+    async ({ withSnapshot }) => {
+      const suffix = withSnapshot ? 'snapshot' : 'stored';
+      const executionId = `abc141-${suffix}` as ExecutionId;
+      const streamId = `chat@gpt54#abc141-${suffix}` as StreamTabId;
+      const legacyWorkspaceSnapshot = {
+        todos: [
+          {
+            content: 'Ship the fix',
+            status: 'in_progress',
+            activeForm: 'Shipping the fix',
+          },
+        ],
+        plan: { objective: 'Migrate legacy workspace snapshots on resume' },
+      };
+      await getExecutionStore(executionId).write(flowKey(executionId), {
+        flowName: 'texra',
+        params: {},
+        shared: {
+          messages: [{ role: 'user', content: 'Continue.' }],
+          shouldSkipCycle: true,
+          stateSlices: {
+            runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+            workspaceSnapshot: legacyWorkspaceSnapshot,
+            userChannels: {
+              input: Object.freeze({ MODEL: 'gpt54' }),
+              transient: {},
+            },
           },
         },
-      },
-      createdAt: new Date().toISOString(),
-      cursor: { nextNodeId: 'start/default' },
-      nodes: [{ action: 'default', nodeId: 'start' }],
-    });
+        createdAt: new Date().toISOString(),
+        cursor: { nextNodeId: 'start/default' },
+        nodes: [{ action: 'default', nodeId: 'start' }],
+      });
 
-    const result = await runPersistedFlow(executionId, streamId, undefined);
-    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+      const snapshot = withSnapshot
+        ? buildToolUseSnapshot(executionId, streamId)
+        : undefined;
+      if (snapshot) {
+        // Simulate a typed external command payload that bypassed schema parsing.
+        Object.assign(snapshot, { workspace: legacyWorkspaceSnapshot });
+      }
+      const result = await runPersistedFlow(executionId, streamId, snapshot);
+      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
 
-    const healedRecord = await getExecutionStore(executionId).read<FlowRecord>(
-      flowKey(executionId),
-    );
-    const healedShared = ToolUseRunSharedCanonicalSchema.parse(
-      healedRecord?.shared,
-    );
-    expect(healedShared.stateSlices).not.toBeNull();
-    if (!healedShared.stateSlices) return;
-    const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
-      healedShared.stateSlices.workspaceSnapshot,
-    );
-    expect(workspaceState.workPlan.todos).toEqual(
-      legacyWorkspaceSnapshot.todos,
-    );
-    expect(workspaceState.workPlan.plan).toEqual(legacyWorkspaceSnapshot.plan);
-  });
+      const healedRecord = await getExecutionStore(
+        executionId,
+      ).read<FlowRecord>(flowKey(executionId));
+      const healedShared = ToolUseRunSharedCanonicalSchema.parse(
+        healedRecord?.shared,
+      );
+      expect(healedShared.stateSlices).not.toBeNull();
+      if (!healedShared.stateSlices) return;
+      const workspaceState = AgentWorkspaceState.fromCanonicalSnapshot(
+        healedShared.stateSlices.workspaceSnapshot,
+      );
+      expect(workspaceState.workPlan.todos).toEqual(
+        legacyWorkspaceSnapshot.todos,
+      );
+      expect(workspaceState.workPlan.plan).toEqual(
+        legacyWorkspaceSnapshot.plan,
+      );
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Define the full tool-use shared-state shape once with Zod and derive its TypeScript type from that schema.
- Normalize legacy wrappers, message aliases, retry fields, workspace snapshots, and typed external resume snapshots at one persistence boundary.
- Revalidate every persisted flow step with a canonical-only schema while removing duplicate parsing and helper-only tests.

Closes #8126.

## Issue acceptance gates

- [x] Add one canonical `ToolUseRunSharedSchema` covering every persisted field.
- [x] Normalize legacy `conversation` aliases and nested `{ state }` wrappers at one boundary.
- [x] Reuse the schema in `SessionResumeRetrieval` and `runToolUseFlow`.
- [x] Pass the canonical schema to `PersistedFlow` for every persisted read.
- [x] Remove whole-object `as ToolUseRunShared` assertions.
- [x] Refactor the existing resume tests instead of adding a broad parallel suite.

## Single source of truth

`src/agent/implementations/flows/tooluse/nodes/types.ts` now owns the persisted tool-use shared-state schema, legacy normalization, and the canonical per-step variant.

## Duplication and abstraction budget

Removed the duplicate resume schema, two shallow format-detection schemas, a separate workspace-normalization helper, and two redundant helper/schema tests. The two exported schemas own distinct invariants: one one-time legacy-capable hydration boundary and one canonical per-step persistence boundary.

## Net elements (R6)

- Files: 5 modified.
- Diff: +179 / -294 lines, net -115 LoC.
- Exported symbols: +2 schemas, -2 test-only helper functions; `ToolUseRunShared` remains one public symbol but is now schema-derived. Net 0 exports.
- Classes/interfaces/enums: -1 hand-maintained interface; no classes or enums added.
- Tests: parameterized the legacy-workspace recovery case across direct stored-state and unvalidated-snapshot modes, while deleting one duplicate workspace-schema test.

## Consumer counts (R8)

- `normalizeResumedWorkspaceSnapshot`: 1 external test-file consumer, 0 production consumers.
- `buildResumedSharedFromSnapshot`: 1 external test-file consumer, 0 production consumers.
- No event, command, or IPC subscriber paths changed.

## Host impact

Extension: Shared agent persistence becomes stricter and external resume snapshots self-heal before strict per-step reads; no UI API changes.

Desktop: Same shared runtime behavior; no desktop-specific changes.

CLI: Same shared runtime behavior; no CLI-specific changes.

## Scheduled refactoring

None for this focused issue.

## Validation

- `npm run lint` (0 errors; 45 existing warnings)
- `npm run compile:fast`
- `npm test` (631 files passed, 1 skipped; 5,593 tests passed, 4 skipped)
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- Focused persistence/resume suite after review updates: 3 files, 31 tests
- ESLint and Prettier checks on all touched files
- `git diff --check`
