### PR TITLE
fix(cli): contain resume rehydration failures

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -445,9 +445,9 @@ export function createChatSessionController(
       // interface contract.
       runChain.then(resolveRunPromise, rejectRunPromise);
     } catch (error: unknown) {
+      reportRunFailure(error);
       markChatTuiRunCompleted(session);
       resolveRunPromise();
-      throw error;
     }
   };
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -205,6 +205,7 @@ function makeResumeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
 
 function makeResumeSnapshotStore(options: {
   readonly preload?: () => Promise<void>;
+  readonly load?: () => Promise<void>;
   readonly executionId?: string | undefined;
   readonly persistedExecutionId?: string | undefined;
   readonly config?: AgentConfig | undefined;
@@ -212,11 +213,26 @@ function makeResumeSnapshotStore(options: {
 }): StreamSnapshotStore {
   return {
     preload: vi.fn(options.preload ?? (async () => undefined)),
+    load: vi.fn(options.load ?? (async () => undefined)),
+    read: vi.fn(async () => ({
+      runUsage: {},
+      todos: [],
+      plan: undefined,
+    })),
     getExecutionId: vi.fn(() => options.executionId),
     readPersistedExecutionId: vi.fn(async () => options.persistedExecutionId),
     getRunConfig: vi.fn(() => options.config),
     getParentStreamId: vi.fn(() => options.parentStreamId),
   } as unknown as StreamSnapshotStore;
+}
+
+function makeResolvedResume() {
+  return {
+    kind: 'toolUse' as const,
+    streamId: 'stream-resume' as StreamTabId,
+    snapshot: { executionId: 'exec-resume' } as never,
+    config: makeResumeConfig(),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -479,26 +495,12 @@ describe('createChatSessionController', () => {
     });
 
     const session = makeSession({ runCompleted: true });
-    const snapshotStore = {
-      load: vi.fn(async () => undefined),
-      read: vi.fn(async () => ({
-        runUsage: {},
-        todos: [],
-        plan: undefined,
-      })),
-    } as unknown as StreamSnapshotStore;
+    const snapshotStore = makeResumeSnapshotStore({});
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
     );
 
-    const preResolved = {
-      kind: 'toolUse' as const,
-      streamId: 'stream-resume' as StreamTabId,
-      snapshot: { executionId: 'exec-resume' } as never,
-      config: makeResumeConfig(),
-    };
-
-    const resumed = ctrl.resume('aaaaaa' as ExecutionId, preResolved);
+    const resumed = ctrl.resume('aaaaaa' as ExecutionId, makeResolvedResume());
     // resume() has claimed the slot and is suspended inside
     // defaultSession().transcripts.ensureLoaded(); session.streamId is
     // already set to the resumed stream.
@@ -534,6 +536,30 @@ describe('createChatSessionController', () => {
     expect(session.runCompleted).toBe(true);
   });
 
+  it('reports resume rehydration failures without rejecting the TUI submit path', async () => {
+    const session = makeSession({ runCompleted: true });
+    const snapshotStore = makeResumeSnapshotStore({
+      load: async () => {
+        throw new Error('snapshot load failed');
+      },
+    });
+    const ctrl = createChatSessionController(
+      makeInit({ session, snapshotStore }),
+    );
+
+    await expect(
+      ctrl.resume('aaaaaa' as ExecutionId, makeResolvedResume()),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
+      'snapshot load failed',
+    );
+    expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
+    expect(session.runExitCode).toBe(CliExitCode.AgentError);
+    expect(session.runCompleted).toBe(true);
+    expect(ctrl.canStartRootRun()).toBe(true);
+  });
+
   it('forwards a stop issued during manual resume helper-model setup', async () => {
     const helperModel = deferred();
     mocks.setCliHelperModel.mockReturnValueOnce(helperModel.promise);
@@ -550,13 +576,8 @@ describe('createChatSessionController', () => {
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
     );
-    const snapshot = { executionId: 'exec-resume' } as never;
-    const preResolved = {
-      kind: 'toolUse' as const,
-      streamId: 'stream-resume' as StreamTabId,
-      snapshot,
-      config: makeResumeConfig(),
-    };
+    const preResolved = makeResolvedResume();
+    const { snapshot } = preResolved;
     mocks.resumeToolUseFromSnapshot.mockImplementationOnce(
       async (
         _snapshot: unknown,


### PR DESCRIPTION
## Summary

- keep manual resume rehydration failures inside `ChatSessionController`
- surface the error through the existing transcript/exit-code owner instead of rethrowing into the TUI's fire-and-forget submit callback
- reuse the resume snapshot fixture and cover slot release after a rejected snapshot load

## Design

The controller already owns start/resume lifecycle state and the single `reportRunFailure()` path. Reusing that path hides persistence failures behind the controller's narrow API, prevents an unhandled rejection from escaping into Ink, and avoids adding another UI-layer error wrapper.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` (5,594 passed, 4 skipped)
- `npm run check:test-loc-growth` (existing warn-only baseline drift)
- `corepack pnpm vitest run src/test-kernel/cli/chatSessionController.vitest.mts`
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-20260711` (149 scenarios)

Closes #8128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle/error-handling change in the CLI chat controller with dedicated unit coverage; no auth, persistence schema, or agent-runtime behavior changes beyond surfacing failures in-session.
> 
> **Overview**
> Manual **`resume()`** rehydration errors (snapshot load, transcript load, etc.) now go through **`reportRunFailure()`** instead of being rethrown from the controller’s `catch` block.
> 
> That keeps the Ink/TUI fire-and-forget submit path from seeing an unhandled rejection while still writing the error to the local transcript, setting **`CliExitCode.AgentError`**, completing the run slot, and resolving **`resume()`** so a new root run can start again.
> 
> Tests add **`makeResolvedResume()`** / richer **`makeResumeSnapshotStore`** fixtures and assert snapshot load failures resolve cleanly without calling **`resumeToolUseFromSnapshot`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5df3eacbd5ea860ae42fbf19dc267a7a34bb05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->