### PR TITLE
refactor(cli): centralize resume failure ownership

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -1010,14 +1010,7 @@ export async function runChat(
   // session.runPromise, and the normal first-input path stays available so the
   // user can keep chatting (follow-ups target session.streamId as usual).
   if (initialResume) {
-    // Guard the void: resumeAgentRun awaits snapshot resolution / ensureLoaded
-    // before installing its own .then/.catch, so an early throw there would
-    // otherwise surface as an unhandled rejection.
-    void chatController
-      .resume(initialResume.id, initialResume.resolution)
-      .catch((error: unknown) => {
-        appendLocalErrorTranscript(toErrorMessage(error));
-      });
+    void chatController.resume(initialResume.id, initialResume.resolution);
   }
 
   // Auto-prompt when the active stream goes WAITING so the UI clearly


### PR DESCRIPTION
## Summary

- remove the obsolete initial-resume `.catch()` from the Ink composition root
- keep `ChatSessionController.resume()` as the single transcript and exit-code owner
- delete the stale comment describing the pre-#8129 rejection behavior

This is the automated review follow-up requested on #8129 and reduces the call site by seven lines. No new test is added because #8129's focused controller regression already enforces the non-rejecting resume contract.

## Validation

- `corepack pnpm prettier --write packages/cli/src/chat/tui/runChatTui.tsx`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- targeted ESLint on `runChatTui.tsx`
- `corepack pnpm vitest run src/test-kernel/cli/chatSessionController.vitest.mts` (19 passed)

Closes #8130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deletion at one call site with no behavior change beyond avoiding duplicate error transcripts; resume failure contract is already covered by existing controller tests from #8129.
> 
> **Overview**
> Removes duplicate resume error handling at the Ink TUI entry (`runChatTui`): the `initialResume` path no longer wraps `chatController.resume()` in a `.catch()` that called `appendLocalErrorTranscript`, along with the comment about guarding against unhandled rejections before the controller settled its own promise chain.
> 
> **`ChatSessionController.resume()`** remains the single place that records resume failures to the transcript and manages run exit state; startup resume is now a plain fire-and-forget `void chatController.resume(...)`, consistent with slash-command and other resume call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d5d83fbe3d299a73bf80f70d1b9b165342cf14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->