### PR TITLE
fix(cli): preserve root ownership on child resume

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -484,6 +484,7 @@ export function createChatSessionController(
           (await getExecutionStore(executionId).readConfig());
         if (!config) return false;
         if (session.stopRequested) return false;
+        const parentStreamId = snapshotStore.getParentStreamId(streamId);
 
         const currentModel = config.model;
         const sessionContext = getSessionContext(currentModel);
@@ -500,7 +501,9 @@ export function createChatSessionController(
         session.runtimeHost = runtimeHost;
         session.streamId = streamId;
         session.executionId = executionId;
-        rootStreamId.set(streamId);
+        if (!parentStreamId) {
+          rootStreamId.set(streamId);
+        }
         activeStreamId.set(streamId);
         session.runCompleted = false;
         session.runExitCode = CliExitCode.Success;
@@ -514,7 +517,7 @@ export function createChatSessionController(
             resolveResumeState: async () => ({
               runState: config,
               executionId,
-              parentStreamId: snapshotStore.getParentStreamId(streamId),
+              parentStreamId,
             }),
             resumeToolUseSnapshot: (snapshot) =>
               resumeQueuedToolUseSnapshot(streamId, snapshot, runtimeHost, {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -117,6 +117,7 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
 import { createChatSessionController } from '@cli/chat/chatSessionController';
+import { rootStreamId } from '@cli/chat/tui/state/cliState';
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanStopActiveRun,
@@ -323,6 +324,7 @@ describe('createChatSessionController', () => {
       executionId: 'exec-resume',
       streamId: 'stream-resume',
     });
+    rootStreamId.set(undefined);
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -670,6 +672,23 @@ describe('createChatSessionController', () => {
     expect(mocks.projectStreamTranscript).toHaveBeenCalledWith('stream-1', {
       finalize: true,
     });
+    expect(rootStreamId.get()).toBe('stream-1');
+  });
+
+  it('preserves root ownership when auto-resuming a child stream', async () => {
+    const root = 'root-stream' as StreamTabId;
+    const child = 'child-stream' as StreamTabId;
+    rootStreamId.set(root);
+    const snapshotStore = makeResumeSnapshotStore({
+      executionId: 'exec-1',
+      config: makeResumeConfig(),
+      parentStreamId: root,
+    });
+    const ctrl = createChatSessionController(makeInit({ snapshotStore }));
+
+    await expect(ctrl.tryResumeStream(child)).resolves.toBe(true);
+
+    expect(rootStreamId.get()).toBe(root);
   });
 
   it('does not auto-resume after stop during helper-model setup', async () => {


### PR DESCRIPTION
## Summary

- read persisted `parentStreamId` once during queued stream auto-resume
- establish `rootStreamId` only for parentless streams
- keep the resumed child as `session.streamId` / `activeStreamId` without promoting it to root
- cover both parentless-root and persisted-child ownership

## Reproduction

The new child ownership test failed on current main before the fix:

```text
Expected: "root-stream"
Received: "child-stream"
```

This mattered because root-owned local notices and unscoped static scrollback prefer `rootStreamId`, while resume state still identified the stream as a child.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` (5,595 passed, 4 skipped)
- `npm run check:test-loc-growth` (existing warn-only baseline drift)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-8132` (149 scenarios)

Closes #8132

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI resume ownership fix with new unit tests; no auth, data, or broad architectural changes.
> 
> **Overview**
> **Queued follow-up auto-resume** no longer treats every resumed stream as the root. In `tryResumeStream`, persisted `parentStreamId` is read once; `rootStreamId` is updated only when that parent is absent, while the resumed stream still becomes `session.streamId` and `activeStreamId`.
> 
> That keeps root-owned local notices and unscoped scrollback on the real root when a **child** stream wakes from the queue, instead of promoting the child to root.
> 
> Tests assert parentless auto-resume still sets `rootStreamId`, and add coverage that resuming a child with an existing root leaves `rootStreamId` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f507e3b3b69a99352b5091de564cc18b0cd8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->