### PR TITLE
fix(cli): avoid duplicate child wait notification

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -48,7 +48,7 @@ import {
 import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import {
   EXECUTION_STATUS,
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ExecutionId,
   type StreamTabId,
   sumUsageStats,
@@ -529,7 +529,7 @@ export function createChatSessionController(
                 allowWaitingResult: true,
                 isCancellationRequested: () => session.stopRequested,
                 onResult: (result) => {
-                  resumedToWaiting = result.outcome === STREAM_STATUS.WAITING;
+                  resumedToWaiting = result.outcome === STREAM_PHASE.WAITING;
                 },
                 onError: reportRunFailure,
               }),

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -48,6 +48,7 @@ import {
 import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import {
   EXECUTION_STATUS,
+  STREAM_STATUS,
   type ExecutionId,
   type StreamTabId,
   sumUsageStats,
@@ -509,6 +510,7 @@ export function createChatSessionController(
         session.runExitCode = CliExitCode.Success;
         publishChatTuiRootRunStartAvailability(session);
 
+        let resumedToWaiting = false;
         const resumed = await setCliHelperModel(currentModel).then(() =>
           resolveAndResumeStream(streamId, {
             runtimeHost,
@@ -526,6 +528,9 @@ export function createChatSessionController(
                 runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
                 allowWaitingResult: true,
                 isCancellationRequested: () => session.stopRequested,
+                onResult: (result) => {
+                  resumedToWaiting = result.outcome === STREAM_STATUS.WAITING;
+                },
                 onError: reportRunFailure,
               }),
             executeWorkflow: async () => {
@@ -548,7 +553,9 @@ export function createChatSessionController(
             projectStreamTranscript(session.streamId, { finalize: true });
           }
           session.runExitCode = CliExitCode.Success;
-          notify({ kind: 'agentFinished' });
+          if (!resumedToWaiting) {
+            notify({ kind: 'agentFinished' });
+          }
         } else if (session.stopRequested) {
           session.runExitCode = CliExitCode.Interrupted;
         }

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -707,6 +707,7 @@ describe('createChatSessionController', () => {
     await expect(ctrl.tryResumeStream(child)).resolves.toBe(true);
 
     expect(rootStreamId.get()).toBe(root);
+    expect(mocks.notify).toHaveBeenCalledWith({ kind: 'agentFinished' });
   });
 
   it('does not auto-resume after stop during helper-model setup', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -113,6 +113,7 @@ import { StreamSnapshotStore } from '@transcript';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
+import type { ResumeQueuedToolUseOptions } from '@agent/runtime/resumeQueuedToolUse';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
@@ -654,6 +655,22 @@ describe('createChatSessionController', () => {
         ports: { resumeToolUseSnapshot(snapshot: unknown): Promise<boolean> },
       ) => ports.resumeToolUseSnapshot({ version: 2 }),
     );
+    mocks.resumeQueuedToolUseSnapshot.mockImplementationOnce(
+      async (
+        _streamId: StreamTabId,
+        _snapshot: unknown,
+        _runtimeHost: unknown,
+        options: ResumeQueuedToolUseOptions,
+      ) => {
+        options.onResult?.({
+          category: 'toolUse',
+          outcome: STREAM_STATUS.WAITING,
+          executionId: 'exec-1' as ExecutionId,
+          streamId: 'stream-1' as StreamTabId,
+        });
+        return true;
+      },
+    );
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
     );
@@ -673,6 +690,7 @@ describe('createChatSessionController', () => {
       finalize: true,
     });
     expect(rootStreamId.get()).toBe('stream-1');
+    expect(mocks.notify).not.toHaveBeenCalledWith({ kind: 'agentFinished' });
   });
 
   it('preserves root ownership when auto-resuming a child stream', async () => {


### PR DESCRIPTION
## Summary

- make the mounted TUI stream-status subscription the sole owner of `WAITING` notifications
- preserve controller-owned completion notifications for terminal auto-resume outcomes
- extend the existing queued-resume test instead of adding another test case or file

## Root cause

A child auto-resume transitions the active stream to `WAITING`, which synchronously triggers the TUI notification subscriber. `ChatSessionController.tryResumeStream()` then emitted the same `agentFinished` notification after every successful resume, including the non-terminal `WAITING` outcome.

The controller now observes the raw result through the existing `onResult` hook and suppresses only its duplicate `WAITING` notification.

## Impact

Terminals receive one completion signal when a child yields for more input, while terminal resume outcomes continue to notify normally.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 pre-existing warnings)
- `npm test` (5,595 passed; 4 skipped)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-8134` (149 scenarios passed)

Closes #8134

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow notification-gating in CLI chat resume with test coverage; no auth, data, or API surface changes.
> 
> **Overview**
> **`tryResumeStream()`** no longer always fires **`agentFinished`** after a successful queued auto-resume. It records whether **`resumeQueuedToolUseSnapshot`** returned **`STREAM_PHASE.WAITING`** via the existing **`onResult`** hook and **skips** the controller notification in that case, so the TUI stream-status path remains the sole source for “waiting for input” signals.
> 
> Terminal auto-resume outcomes (e.g. child stream resume that is not **`WAITING`**) still call **`notify({ kind: 'agentFinished' })`**. Tests cover the **`WAITING`** path (no notification) and assert notifications still fire for non-waiting child resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f48b5d0f598044583b04b09b3da578b7f0f5f92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->