### PR TITLE
refactor(tools): centralize CLI session cleanup

### DIFF
--- a/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
@@ -1,3 +1,4 @@
+import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -48,20 +49,6 @@ function tokenResponse(
     expires_in: 3600,
     ...overrides,
   };
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
 }
 
 function makeCoordinator(
@@ -115,7 +102,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('single-flights concurrent refreshes', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW - 1 }));
-    const { promise: pending, resolve } = deferred<CodexTokenResponse>();
+    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
     const refreshTokens = vi.fn(() => pending);
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
@@ -135,7 +122,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not restore a session when sign-out races with refresh', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW - 1 }));
-    const { promise: pending, resolve } = deferred<CodexTokenResponse>();
+    const { promise: pending, resolve } = pDefer<CodexTokenResponse>();
     const refreshTokens = vi.fn(() => pending);
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
@@ -197,7 +184,7 @@ describe('CodexSessionCoordinator', () => {
 
   it('does not clear a newer login when a stale refresh is rejected', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW - 1 }));
-    const { promise: pending, reject } = deferred<CodexTokenResponse>();
+    const { promise: pending, reject } = pDefer<CodexTokenResponse>();
     const refreshTokens = vi.fn(() => pending);
     const exchangeAuthorizationCode = vi.fn(async () =>
       tokenResponse({

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -5,6 +5,7 @@
 // mutations that are safe to verify without a full agent harness.
 
 import PQueue from 'p-queue';
+import pDefer from 'p-defer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -180,20 +181,6 @@ function makeInit(
     snapshotStore: new StreamSnapshotStore(),
     ...overrides,
   };
-}
-
-function deferred<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (reason?: unknown) => void;
-} {
-  let resolve: (value: T | PromiseLike<T>) => void = () => {};
-  let reject: (reason?: unknown) => void = () => {};
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
 }
 
 function makeResumeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -404,7 +391,7 @@ describe('createChatSessionController', () => {
   });
 
   it('reserves the root-run slot before tryResumeStream awaits persisted state', async () => {
-    const preload = deferred();
+    const preload = pDefer<void>();
     const session = makeSession({ runCompleted: true });
     const snapshotStore = makeResumeSnapshotStore({
       preload: () => preload.promise,
@@ -426,7 +413,7 @@ describe('createChatSessionController', () => {
   });
 
   it('reserves the root-run slot before resume() awaits the resolved snapshot', async () => {
-    const snapshot = deferred<{ readonly kind: 'not-found' }>();
+    const snapshot = pDefer<{ readonly kind: 'not-found' }>();
     mocks.resolveCliResumeSnapshot.mockReturnValueOnce(snapshot.promise);
     const session = makeSession({ runCompleted: true });
     const ctrl = createChatSessionController(makeInit({ session }));
@@ -455,7 +442,7 @@ describe('createChatSessionController', () => {
     // and start doing real work — which resume(A) would then clobber when
     // it woke back up and unconditionally overwrote session.runPromise.
     // Post-fix, exactly one caller (A) ever holds the slot.
-    const snapshot = deferred<{ readonly kind: 'not-found' }>();
+    const snapshot = pDefer<{ readonly kind: 'not-found' }>();
     mocks.resolveCliResumeSnapshot.mockReturnValueOnce(snapshot.promise);
     const session = makeSession({ runCompleted: true });
     const snapshotStoreForB = makeResumeSnapshotStore({
@@ -490,7 +477,7 @@ describe('createChatSessionController', () => {
     // rehydration window, resume() must notice `session.stopRequested` and bail
     // out instead of silently starting `resumeToolUseFromSnapshot()` once the
     // awaits finish.
-    const ensureLoaded = deferred<void>();
+    const ensureLoaded = pDefer<void>();
     const base = mocks.defaultSession();
     mocks.defaultSession.mockReturnValue({
       ...base,
@@ -564,7 +551,7 @@ describe('createChatSessionController', () => {
   });
 
   it('forwards a stop issued during manual resume helper-model setup', async () => {
-    const helperModel = deferred();
+    const helperModel = pDefer<void>();
     mocks.setCliHelperModel.mockReturnValueOnce(helperModel.promise);
 
     const session = makeSession({ runCompleted: true });
@@ -711,7 +698,7 @@ describe('createChatSessionController', () => {
   });
 
   it('does not auto-resume after stop during helper-model setup', async () => {
-    const helperModel = deferred();
+    const helperModel = pDefer<void>();
     const session = makeSession({ runCompleted: true });
     const config = makeResumeConfig();
     const snapshotStore = makeResumeSnapshotStore({

--- a/src/test-kernel/support/agentCliResumeTestUtils.ts
+++ b/src/test-kernel/support/agentCliResumeTestUtils.ts
@@ -1,0 +1,20 @@
+// Local imports - transcript
+import { createRunTrace, StreamLogStore } from '@transcript';
+
+// Type imports
+import type { StreamTabId } from '@shared/schemas';
+import type { ChildStream } from '@tools/childStream';
+
+export function createFakeAgentCliChildStream(
+  childStreamId: StreamTabId,
+): ChildStream {
+  const logger = createRunTrace(childStreamId, new StreamLogStore()).trace;
+  return {
+    childStreamId,
+    logger,
+    waitForInput: () => {},
+    beginTurn: () => {},
+    failTurn: () => {},
+    finalize: async () => {},
+  };
+}

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -22,14 +22,12 @@ describe('AgentCliSessionRegistry', () => {
       const releaseInitialClaim = registry.claim('session-a');
       expect(releaseInitialClaim).toBeTypeOf('function');
       expect(registry.claim('session-a')).toBeUndefined();
-      expect(registry.isActive('session-a')).toBe(false);
       expect(registry.lookup('session-a')).toBeUndefined();
 
       const active = registry.waitForActive('session-a');
       registry.register('session-a', entry);
 
       await expect(active).resolves.toBe(entry);
-      expect(registry.isActive('session-a')).toBe(true);
       expect(registry.lookup('session-a')).toBe(entry);
       expect(registry.claim('session-a')).toBeUndefined();
 
@@ -40,7 +38,6 @@ describe('AgentCliSessionRegistry', () => {
       expect(registry.lookup('session-a')).toBe(entry);
 
       registry.release('session-a');
-      expect(registry.isActive('session-a')).toBe(false);
       const releaseNextClaim = registry.claim('session-a');
       expect(releaseNextClaim).toBeTypeOf('function');
       releaseInitialClaim?.();
@@ -62,12 +59,50 @@ describe('AgentCliSessionRegistry', () => {
     releaseClaim?.();
 
     await expect(active).resolves.toBeUndefined();
-    expect(registry.isActive('session-a')).toBe(false);
     const releaseNextClaim = registry.claim('session-a');
     expect(releaseNextClaim).toBeTypeOf('function');
 
     releaseNextClaim?.();
     await expect(registry.waitForActive('session-a')).resolves.toBeUndefined();
+  });
+
+  it('releases every active alias owned by one execution', () => {
+    const registry = new AgentCliSessionRegistry('test_session_id');
+    const executions = new ExecutionRegistry();
+    const executionA = 'execution-a' as ExecutionId;
+    const executionB = 'execution-b' as ExecutionId;
+    const entry = (executionId: ExecutionId, childStreamId: StreamTabId) => ({
+      childStreamId,
+      executionId,
+      executions,
+    });
+    const releasePending = registry.claim('pending-session');
+
+    try {
+      registry.register(
+        'session-a',
+        entry(executionA, 'child-a' as StreamTabId),
+      );
+      registry.register(
+        'session-a-alias',
+        entry(executionA, 'child-a' as StreamTabId),
+      );
+      registry.register(
+        'session-b',
+        entry(executionB, 'child-b' as StreamTabId),
+      );
+
+      registry.releaseByExecutionId(executionA);
+
+      expect(registry.lookup('session-a')).toBeUndefined();
+      expect(registry.lookup('session-a-alias')).toBeUndefined();
+      expect(registry.lookup('session-b')?.executionId).toBe(executionB);
+      expect(registry.claim('pending-session')).toBeUndefined();
+    } finally {
+      releasePending?.();
+      registry.releaseByExecutionId(executionB);
+      executions.dispose();
+    }
   });
 
   it('interrupts each child through the execution registry that owns the session', () => {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -1,22 +1,19 @@
 // Regression coverage for the claude_agent tool's resume fallback: when a
 // caller passes a session_id whose in-memory ClaudeAgentSessions registry
 // entry is gone (extension reload, host crash, or a stale id from an older
-// run), the tool must NOT throw a "not active" ToolError like a raw
-// resumeAgentCliSession() call would. The first fallback must claim the id
-// before asynchronous setup, while concurrent calls wait for that loop and
-// then enqueue through the ordinary follow-up path.
+// run). The first fallback must claim the id before asynchronous setup, while
+// concurrent calls wait for that loop and then enqueue through the ordinary
+// follow-up path.
 
+import pDefer from 'p-defer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createRunTrace, StreamLogStore } from '@transcript';
-import type { AgentTrace } from '@agent/trace';
 import type {
   ChildRunPorts,
   ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { ClaudeAgentSessions } from '@tools/agentCliSessionStores';
-import type { ChildStream } from '@tools/childStream';
 
 const mocks = vi.hoisted(() => ({
   requestBashApproval: vi.fn(),
@@ -88,6 +85,7 @@ vi.mock('@tools/claudeAgentImport', () => ({
 }));
 
 import { ClaudeAgentTool } from '@tools/claudeAgent';
+import { createFakeAgentCliChildStream } from '../support/agentCliResumeTestUtils';
 
 const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:claude-child' as StreamTabId;
@@ -99,45 +97,12 @@ async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
   }
 }
 
-function deferred<T>(): {
-  promise: Promise<T>;
-  reject: (reason?: unknown) => void;
-  resolve: (value: T) => void;
-} {
-  let settle: ((value: T) => void) | undefined;
-  let rejectPromise: ((reason?: unknown) => void) | undefined;
-  const promise = new Promise<T>((resolve, reject) => {
-    settle = resolve;
-    rejectPromise = reject;
-  });
-  return {
-    promise,
-    reject: (reason) => rejectPromise?.(reason),
-    resolve: (value) => settle?.(value),
-  };
-}
-
-function fakeLogger(): AgentTrace {
-  const store = new StreamLogStore();
-  return createRunTrace(childStreamId, store).trace;
-}
-
-function fakeChildStream(): ChildStream {
-  return {
-    childStreamId,
-    logger: fakeLogger(),
-    waitForInput: () => {},
-    beginTurn: () => {},
-    failTurn: () => {},
-    finalize: async () => {},
-  };
-}
-
 describe('claude_agent tool — resume fallback for a torn-down registry', () => {
   afterEach(() => {
     vi.clearAllMocks();
     // Clear anything a test registered into the real (module-level) registry.
-    ClaudeAgentSessions.releaseMany(['stale-session', 'sess-resumed']);
+    ClaudeAgentSessions.releaseByExecutionId(executionId);
+    ClaudeAgentSessions.release('stale-session');
   });
 
   function setupCommonMocks(): void {
@@ -157,30 +122,13 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
     mocks.ensureRunDir.mockResolvedValue(undefined);
     mocks.buildClaudeAgentEnv.mockResolvedValue({});
-    mocks.createChildStream.mockReturnValue(fakeChildStream());
+    mocks.createChildStream.mockReturnValue(
+      createFakeAgentCliChildStream(childStreamId),
+    );
     mocks.currentSession.mockReturnValue({
       followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
     });
   }
-
-  it('falls through to a fresh launch instead of throwing when session_id is not in the in-memory registry', async () => {
-    setupCommonMocks();
-    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
-
-    const tool = new ClaudeAgentTool();
-    const result = await tool.call({
-      prompt: 'continue the refactor',
-      session_id: 'stale-session',
-    });
-
-    // Pre-fix, execute() unconditionally called resumeAgentCliSession() for
-    // any session_id, which throws "... is not active ..." the moment the
-    // in-memory registry doesn't have the id — surfacing as a tool error
-    // instead of resuming. Post-fix it must launch a fresh session instead.
-    expect(result.status).toBe('executed');
-    expect(result.error).toBeUndefined();
-    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
-  });
 
   it('seeds the fallback launch with the stale session_id so the SDK resumes from disk', async () => {
     setupCommonMocks();
@@ -215,44 +163,10 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(callArgs.options.resume).toBe('stale-session');
   });
 
-  it('registers the fallback session_id up front via onSessionStart, ahead of the first turn completing', async () => {
-    setupCommonMocks();
-    mocks.query.mockReturnValue(
-      streamMessages([
-        {
-          type: 'result',
-          subtype: 'success',
-          session_id: 'stale-session',
-          result: 'Resumed and continued.',
-        },
-      ]),
-    );
-
-    const tool = new ClaudeAgentTool();
-    await tool.call({
-      prompt: 'continue the refactor',
-      session_id: 'stale-session',
-    });
-
-    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
-    const [loopParams] = mocks.startChildRunLoop.mock.calls[0] as [
-      { strategy: ChildRunStrategy<unknown> },
-    ];
-
-    // Pins reservation promotion itself: onSessionStart must make the stale
-    // session_id observably active synchronously, independent of whether the
-    // first turn has resolved yet.
-    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
-    loopParams.strategy.onSessionStart?.({
-      executions: { getAgentHandleByStream: () => undefined } as any,
-    } as any);
-    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(true);
-  });
-
   it('launches one fallback loop when concurrent calls use the same stale session_id', async () => {
     setupCommonMocks();
-    const envStarted = deferred<void>();
-    const envReady = deferred<NodeJS.ProcessEnv>();
+    const envStarted = pDefer<void>();
+    const envReady = pDefer<NodeJS.ProcessEnv>();
     const executions = { getAgentHandleByStream: () => undefined } as any;
     let strategy: ChildRunStrategy<unknown> | undefined;
     mocks.buildClaudeAgentEnv.mockImplementation(() => {
@@ -294,28 +208,13 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     });
 
     strategy?.onSessionCleanup?.();
-    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
-  });
-
-  it('releases the fallback claim when asynchronous launch setup fails', async () => {
-    setupCommonMocks();
-    mocks.buildClaudeAgentEnv.mockRejectedValue(new Error('env failed'));
-
-    const result = await new ClaudeAgentTool().call({
-      prompt: 'continue the refactor',
-      session_id: 'stale-session',
-    });
-
-    expect(result.status).toBe('error');
-    const releaseClaim = ClaudeAgentSessions.claim('stale-session');
-    expect(releaseClaim).toBeTypeOf('function');
-    releaseClaim?.();
+    expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();
   });
 
   it('lets a waiting caller own the fallback after the first launch fails', async () => {
     setupCommonMocks();
-    const firstEnvStarted = deferred<void>();
-    const firstEnv = deferred<NodeJS.ProcessEnv>();
+    const firstEnvStarted = pDefer<void>();
+    const firstEnv = pDefer<NodeJS.ProcessEnv>();
     const executions = { getAgentHandleByStream: () => undefined } as any;
     let strategy: ChildRunStrategy<unknown> | undefined;
     mocks.buildClaudeAgentEnv
@@ -353,7 +252,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
 
     strategy?.onSessionCleanup?.();
-    expect(ClaudeAgentSessions.isActive('stale-session')).toBe(false);
+    expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();
   });
 
   it('still enqueues a follow-up (no fresh launch) when session_id IS active in the registry', async () => {

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -3,14 +3,12 @@
 // owns asynchronous SDK setup, while later calls wait for registration and
 // enqueue through the ordinary follow-up path.
 
+import pDefer from 'p-defer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createRunTrace, StreamLogStore } from '@transcript';
-import type { AgentTrace } from '@agent/trace';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { CodexThreads } from '@tools/agentCliSessionStores';
-import type { ChildStream } from '@tools/childStream';
 
 const mocks = vi.hoisted(() => ({
   requestBashApproval: vi.fn(),
@@ -83,49 +81,17 @@ vi.mock('@tools/codexImport', () => ({
 }));
 
 import { CodexTool } from '@tools/codex';
+import { createFakeAgentCliChildStream } from '../support/agentCliResumeTestUtils';
 
 const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:codex-child' as StreamTabId;
 const executionId = 'parent-exec' as ExecutionId;
 
-function deferred<T>(): {
-  promise: Promise<T>;
-  reject: (reason?: unknown) => void;
-  resolve: (value: T) => void;
-} {
-  let settle: ((value: T) => void) | undefined;
-  let rejectPromise: ((reason?: unknown) => void) | undefined;
-  const promise = new Promise<T>((resolve, reject) => {
-    settle = resolve;
-    rejectPromise = reject;
-  });
-  return {
-    promise,
-    reject: (reason) => rejectPromise?.(reason),
-    resolve: (value) => settle?.(value),
-  };
-}
-
-function fakeLogger(): AgentTrace {
-  const store = new StreamLogStore();
-  return createRunTrace(childStreamId, store).trace;
-}
-
-function fakeChildStream(): ChildStream {
-  return {
-    childStreamId,
-    logger: fakeLogger(),
-    waitForInput: () => {},
-    beginTurn: () => {},
-    failTurn: () => {},
-    finalize: async () => {},
-  };
-}
-
 describe('codex tool - atomic resume fallback', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    CodexThreads.releaseMany(['stale-thread']);
+    CodexThreads.releaseByExecutionId(executionId);
+    CodexThreads.release('stale-thread');
   });
 
   function setupCommonMocks(): void {
@@ -146,7 +112,9 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
     mocks.ensureRunDir.mockResolvedValue(undefined);
     mocks.findCodexBinaryPath.mockResolvedValue(undefined);
-    mocks.createChildStream.mockReturnValue(fakeChildStream());
+    mocks.createChildStream.mockReturnValue(
+      createFakeAgentCliChildStream(childStreamId),
+    );
     mocks.currentSession.mockReturnValue({
       followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
     });
@@ -154,8 +122,8 @@ describe('codex tool - atomic resume fallback', () => {
 
   it('launches one fallback loop when concurrent calls use the same stale thread_id', async () => {
     setupCommonMocks();
-    const sdkImportStarted = deferred<void>();
-    const sdkReady = deferred<any>();
+    const sdkImportStarted = pDefer<void>();
+    const sdkReady = pDefer<any>();
     const thread = {
       id: 'stale-thread',
       runStreamed: vi.fn(),
@@ -213,29 +181,13 @@ describe('codex tool - atomic resume fallback', () => {
     });
 
     strategy?.onSessionCleanup?.();
-    expect(CodexThreads.isActive('stale-thread')).toBe(false);
-  });
-
-  it('releases the fallback claim when asynchronous SDK setup fails', async () => {
-    setupCommonMocks();
-    mocks.importCodexClass.mockRejectedValue(new Error('SDK import failed'));
-
-    const result = await new CodexTool().call({
-      prompt: 'continue the refactor',
-      sandbox_mode: 'workspace-write',
-      thread_id: 'stale-thread',
-    });
-
-    expect(result.status).toBe('error');
-    const releaseClaim = CodexThreads.claim('stale-thread');
-    expect(releaseClaim).toBeTypeOf('function');
-    releaseClaim?.();
+    expect(CodexThreads.lookup('stale-thread')).toBeUndefined();
   });
 
   it('lets a waiting caller own the fallback after the first launch fails', async () => {
     setupCommonMocks();
-    const firstImportStarted = deferred<void>();
-    const firstImport = deferred<any>();
+    const firstImportStarted = pDefer<void>();
+    const firstImport = pDefer<any>();
     const thread = { id: 'stale-thread', runStreamed: vi.fn() };
     const executions = { getAgentHandleByStream: () => undefined } as any;
     let strategy: ChildRunStrategy<unknown> | undefined;
@@ -282,6 +234,6 @@ describe('codex tool - atomic resume fallback', () => {
     expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
 
     strategy?.onSessionCleanup?.();
-    expect(CodexThreads.isActive('stale-thread')).toBe(false);
+    expect(CodexThreads.lookup('stale-thread')).toBeUndefined();
   });
 });

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -61,10 +61,6 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
       .catch(() => {});
   }
 
-  isActive(sessionId: string): boolean {
-    return this.sessions.get(sessionId)?.kind === 'active';
-  }
-
   lookup(sessionId: string): T | undefined {
     const state = this.sessions.get(sessionId);
     return state?.kind === 'active' ? state.entry : undefined;
@@ -83,9 +79,12 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
     if (state?.kind === 'reserved') state.resolve(undefined);
   }
 
-  releaseMany(sessionIds: Iterable<string>): void {
-    for (const sessionId of sessionIds) {
-      this.release(sessionId);
+  /** Release active aliases owned by one child execution without touching claims. */
+  releaseByExecutionId(executionId: ExecutionId): void {
+    for (const [sessionId, state] of this.sessions) {
+      if (state.kind === 'active' && state.entry.executionId === executionId) {
+        this.sessions.delete(sessionId);
+      }
     }
   }
 

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -422,7 +422,6 @@ function startClaudeAgentLoop(params: {
   // params.resumeSessionId when this launch is a disk-based fallback resume.
   let resumeSessionId: string | undefined = params.resumeSessionId;
   const fallbackSessionId = params.resumeSessionId;
-  const storedSessionIds = new Set<string>();
 
   const registerSession = (sessionId: string, session: SessionHandle): void => {
     if (ClaudeAgentSessions.lookup(sessionId)) return;
@@ -437,7 +436,6 @@ function startClaudeAgentLoop(params: {
       cwd: params.cwd,
       additionalDirectories: params.additionalDirectories,
     });
-    storedSessionIds.add(sessionId);
   };
   // The joined prompt text for whichever turn is currently in flight —
   // captured here (rather than threaded through the loop contract) since
@@ -510,9 +508,8 @@ function startClaudeAgentLoop(params: {
           ),
         },
       ),
-    onSessionCleanup: () => {
-      ClaudeAgentSessions.releaseMany(storedSessionIds);
-    },
+    onSessionCleanup: () =>
+      ClaudeAgentSessions.releaseByExecutionId(executionId),
   };
 
   startChildRunLoop({

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -377,7 +377,6 @@ function startCodexLoop(params: {
 
   // Fresh threads don't have thread.id yet; they're registered after the first
   // turn completes. A resumed thread's pre-launch claim is promoted up front.
-  const storedThreadIds = new Set<string>();
   const registerThread = (threadId: string, session: SessionHandle): void => {
     if (CodexThreads.lookup(threadId)) return;
     CodexThreads.register(threadId, {
@@ -387,7 +386,6 @@ function startCodexLoop(params: {
       executionId,
       executions: session.executions,
     });
-    storedThreadIds.add(threadId);
   };
 
   // The joined prompt text for whichever turn is currently in flight —
@@ -443,9 +441,7 @@ function startCodexLoop(params: {
         { tag: DELIVERY_TAG.codexError, executionId, prompt: lastPrompt },
         { message: toErrorMessage(err) },
       ),
-    onSessionCleanup: () => {
-      CodexThreads.releaseMany(storedThreadIds);
-    },
+    onSessionCleanup: () => CodexThreads.releaseByExecutionId(executionId),
   };
 
   startChildRunLoop({


### PR DESCRIPTION
## Summary

- make `AgentCliSessionRegistry` release every active alias by owning `executionId`
- remove duplicated `storedThreadIds` / `storedSessionIds` bookkeeping from Codex and Claude adapters
- remove the unused `isActive` query and redundant direct-claim tests
- replace four handwritten deferred helpers with the existing `p-defer` dependency
- share the exact fake child-stream fixture used by the two provider resume suites

## Design

The registry already stores `executionId` on every active session alias, but each provider maintained a second local `Set` solely for cleanup. Cleanup now queries the authoritative registry state, so adding another SDK id no longer requires synchronized writes to provider-local bookkeeping. Pending reservations are deliberately left untouched because they belong to an in-flight launch claimant, not the terminating execution.

## Test cleanup

The latest resume change added 488 test lines. This follow-up removes four weaker tests already subsumed by the concurrent-success and waiter-takeover cases, centralizes exact fixtures, and removes an implementation-only query. The PR is net **-128 lines** while preserving the meaningful race matrix.

## Validation

- live `texra-local` proof chat and persisted resume follow-up
- PTY TUI snapshot harness (17 frames)
- focused Vitest: 5 files, 44 tests
- full Vitest: 632 files passed, 5,600 tests passed, 4 skipped
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only baseline remains unchanged; this PR reduces LoC)

Closes #8136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how external-agent session aliases are released at loop end; a bug could leave stale registry entries or break concurrent resume/follow-up, though scope is limited to Codex/Claude CLI tooling with focused tests.
> 
> **Overview**
> Centralizes **Codex** and **Claude Code CLI** in-memory session teardown so providers no longer keep parallel `storedThreadIds` / `storedSessionIds` sets.
> 
> `AgentCliSessionRegistry` gains **`releaseByExecutionId`**, which drops every **active** SDK id alias for one child execution while leaving **pending claims** alone. **`onSessionCleanup`** in `codex.ts` and `claudeAgent.ts` now calls that instead of **`releaseMany`** over provider-local id sets. **`isActive`** and **`releaseMany`** are removed from the registry API.
> 
> Test-only churn: handwritten **`deferred`** helpers become **`p-defer`**, resume suites share **`createFakeAgentCliChildStream`**, assertions use **`lookup`** instead of **`isActive`**, and a few overlapping resume-fallback cases are dropped in favor of the concurrent-race matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0499c1ed13be54f2f01dc46220d80fbfeeda7404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->