### PR TITLE
fix: install dependencies before release version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"

--- a/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
+++ b/src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts
@@ -1,12 +1,14 @@
 import { spawnSync } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 
 const repoRoot = process.cwd();
 const scriptPath = path.join(repoRoot, 'scripts/bump-workspace-version.mjs');
+const workflowPath = path.join(repoRoot, '.github/workflows/version-bump.yml');
 const manifestPaths = [
   'package.json',
   'packages/cli/package.json',
@@ -66,5 +68,25 @@ describe('bump-workspace-version script', () => {
     expect(result.stderr).toContain(
       'Release tag must be MAJOR.MINOR.PATCH, with an optional leading v or cli-v prefix.',
     );
+  });
+});
+
+describe('version-bump workflow', () => {
+  it('installs frozen dependencies before running the version bump script', async () => {
+    const workflow = parseYaml(await readFile(workflowPath, 'utf8')) as {
+      jobs?: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+    };
+    const steps = workflow.jobs?.['bump-version']?.steps ?? [];
+    const installIndex = steps.findIndex(
+      (step) =>
+        step.name === 'Install dependencies' &&
+        step.run?.trim() === 'pnpm install --frozen-lockfile',
+    );
+    const bumpIndex = steps.findIndex((step) =>
+      step.run?.includes('node scripts/bump-workspace-version.mjs'),
+    );
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(bumpIndex).toBeGreaterThan(installIndex);
   });
 });


### PR DESCRIPTION
## Summary

- install workspace dependencies from the frozen lockfile before the release version-bump script runs
- add a parsed-workflow invariant requiring that install step to precede the script invocation
- leave the semver-based release-tag parser unchanged

## Root cause

`scripts/bump-workspace-version.mjs` imports `semver`, but the release workflow invoked it before installing dependencies. A fresh Actions checkout therefore had no `node_modules`, and the later lockfile-only refresh could not make the earlier invocation succeed.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/scripts/BumpWorkspaceVersion.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `actionlint -ignore 'SC2086' .github/workflows/version-bump.yml`

Closes #8117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow ordering and a regression test only; no runtime product or auth/data paths change.
> 
> **Overview**
> Fixes release **version-bump** workflow failures on a clean checkout by running **`pnpm install --frozen-lockfile`** after Node/pnpm setup and **before** `node scripts/bump-workspace-version.mjs`, so workspace packages like **`semver`** are available when the bump script runs (the later lockfile-only refresh could not fix an earlier failed invocation).
> 
> Adds a **Vitest** check that parses `.github/workflows/version-bump.yml` and asserts that install step precedes the bump script step, so the ordering does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32f720bfd3fdc401a57a745dc8fd0d8f63e4885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->