### PR TITLE
fix(webview): preserve pasted images per stream

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -745,15 +745,13 @@ function wireConversation(): void {
     )) as EventListener);
   conversationView.addEventListener('followup-change', ((e: CustomEvent) =>
     handleFollowUpChange(e, ctx())) as EventListener);
-  conversationView.addEventListener('followup-send', () =>
-    handleFollowUpSend(ctx()),
-  );
+  conversationView.addEventListener('followup-send', ((e: CustomEvent) =>
+    handleFollowUpSend(e, ctx())) as EventListener);
   conversationView.addEventListener('followup-polish', () =>
     handleFollowUpPolish(ctx()),
   );
-  conversationView.addEventListener('followup-clear', () =>
-    handleFollowUpClear(ctx()),
-  );
+  conversationView.addEventListener('followup-clear', ((e: CustomEvent) =>
+    handleFollowUpClear(e, ctx())) as EventListener);
   // followup-focus-complete: clear the focus/polish/transcribe trigger flags.
   conversationView.addEventListener(
     'followup-focus-complete',

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -386,13 +386,13 @@ export class ProgressApp extends ProgressAppBase {
     handleFollowUpChange(e, this.getEventHandlerContext());
 
   private onFollowUpSend = (e: CustomEvent): void =>
-    handleFollowUpSend(this.getEventHandlerContext(), e.detail?.images ?? []);
+    handleFollowUpSend(e, this.getEventHandlerContext());
 
   private onFollowUpPolish = (): void =>
     handleFollowUpPolish(this.getEventHandlerContext());
 
-  private onFollowUpClear = (): void =>
-    handleFollowUpClear(this.getEventHandlerContext());
+  private onFollowUpClear = (e: CustomEvent): void =>
+    handleFollowUpClear(e, this.getEventHandlerContext());
 
   private onCompileFixerRun = (): void =>
     runCompileFixer(this.getEventHandlerContext());

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -28,6 +28,10 @@ import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { archivedContext } from '../contexts/streamContexts';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
+import {
+  resetFollowUpInputTransientState,
+  type FollowUpInputTransientState,
+} from '../followUpInputState';
 
 // Local imports - progress view components
 import './QueuedFollowUps';
@@ -124,16 +128,11 @@ export class FollowUpInput extends LitElement {
   @property({ type: Boolean, reflect: true }) visible = false;
   @property({ attribute: false }) value = '';
   @property({ attribute: false }) queuedMessages: string[] = [];
-  /**
-   * Identity of the stream this instance is currently bound to (the same
-   * `streamInfo.name` TodoList/PlanView key off of as `collapseKey`). The
-   * progress view reuses a single `<follow-up-input>` instance across the
-   * active-stream context switch, so any pasted-image state pending here
-   * must be reset when the bound stream changes — otherwise an image
-   * attached while viewing one stream can be delivered to whichever stream
-   * is active when the user later hits send.
-   */
+  /** Identity of the stream currently bound to this reused component. */
   @property({ type: String }) streamId = '';
+  /** Image draft selected upstream with the same stream key as `value`. */
+  @property({ attribute: false })
+  transientState: FollowUpInputTransientState | null = null;
 
   @property({ attribute: false }) shouldFocus = false;
   @property({ attribute: false }) polishedText: string | null = null;
@@ -153,12 +152,6 @@ export class FollowUpInput extends LitElement {
 
   @state() private polishing = false;
 
-  /** Images pasted into the follow-up box; attached to the message on send. */
-  private pendingImages: ExtractedClipboardImage[] = [];
-  private readonly pendingImagePastes = new Set<Promise<void>>();
-  private imagePasteRevision = 0;
-  private sendAfterImagePastes = false;
-
   @query(`#${ELEMENT_IDS.FOLLOW_UP_INPUT}`)
   declare private textAreaEl: HTMLElement | null;
 
@@ -170,28 +163,6 @@ export class FollowUpInput extends LitElement {
   });
 
   protected override willUpdate(changedProperties: PropertyValues): void {
-    // React to streamId property change: this instance is reused across
-    // streams, so any image pasted while bound to the previous stream must
-    // not ride along to whichever stream is active when send eventually
-    // fires. In-flight pastes are invalidated via imagePasteRevision so
-    // their async completion is a no-op (see attachPastedImages). Also drop
-    // any still-in-flight paste promises from the old stream: emitSend()
-    // gates on pendingImagePastes.size, so a stale entry left behind here
-    // would block (or, via flushPendingImagePasteSend, mis-time) a send
-    // issued in the newly-bound stream until the old-stream paste settles.
-    // Clearing the set is safe — attachPastedImages already no-ops on a
-    // revision mismatch, and the promise's own .finally() tolerates
-    // deleting an already-absent entry.
-    if (
-      changedProperties.has('streamId') &&
-      changedProperties.get('streamId') !== undefined
-    ) {
-      this.imagePasteRevision += 1;
-      this.pendingImages = [];
-      this.sendAfterImagePastes = false;
-      this.pendingImagePastes.clear();
-    }
-
     // React to shouldFocus property change
     if (changedProperties.has('shouldFocus') && this.shouldFocus) {
       this.focusInput({ scrollIntoView: true }).then(() => {
@@ -252,21 +223,28 @@ export class FollowUpInput extends LitElement {
   private handlePaste(event: ClipboardEvent): void {
     const files = clipboardImageFiles(event);
     if (files.length === 0) return;
+    const streamId = this.streamId;
+    const transientState = this.transientState;
+    if (!streamId || !transientState) return;
     // Suppress the default paste synchronously, before the async read below.
     event.preventDefault();
     const paste = this.attachPastedImages(
+      streamId,
+      transientState,
       event,
       files,
-      this.imagePasteRevision,
+      transientState.imagePasteRevision,
     );
-    this.pendingImagePastes.add(paste);
+    transientState.pendingImagePastes.add(paste);
     void paste.finally(() => {
-      this.pendingImagePastes.delete(paste);
-      this.flushPendingImagePasteSend();
+      transientState.pendingImagePastes.delete(paste);
+      this.flushPendingImagePasteSend(streamId, transientState);
     });
   }
 
   private async attachPastedImages(
+    streamId: string,
+    transientState: FollowUpInputTransientState,
     event: ClipboardEvent,
     files: Array<{ file: File; type: string }>,
     pasteRevision: number,
@@ -292,16 +270,27 @@ export class FollowUpInput extends LitElement {
         ),
       )
     ).filter((image): image is ExtractedClipboardImage => image !== undefined);
-    if (pasteRevision !== this.imagePasteRevision) return;
+    if (pasteRevision !== transientState.imagePasteRevision) return;
     if (added.length === 0) return;
     const chipText = added.map(({ fileName }) => `[${fileName}]`).join(' ');
     if (insertText && !insertText.endsWith(' ') && !insertText.endsWith('\n')) {
       insertText += ' ';
     }
     insertText += chipText;
-    this.pendingImages = [...this.pendingImages, ...added];
-    insertTextAtCursor(target, insertText);
-    this.updateValue(getTextareaValue(target));
+    transientState.pendingImages = [...transientState.pendingImages, ...added];
+    if (
+      this.streamId === streamId &&
+      this.transientState === transientState &&
+      this.textAreaEl === target
+    ) {
+      insertTextAtCursor(target, insertText);
+      this.updateValue(getTextareaValue(target), streamId);
+      return;
+    }
+
+    // The shared Lit instance may now display another stream. Preserve the
+    // completed paste in its source stream without touching the active box.
+    this.updateValue(insertText, streamId, 'append');
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -403,26 +392,45 @@ export class FollowUpInput extends LitElement {
   private handleInput(event: InputEvent): void {
     const target = event.currentTarget as HTMLTextAreaElement | null;
     const value = target?.value ?? '';
-    this.dispatchEvent(ProgressEvents.followupChange({ value }));
+    this.updateValue(value);
   }
 
   private emitSend(): void {
-    if (this.pendingImagePastes.size > 0) {
-      this.sendAfterImagePastes = true;
+    const streamId = this.streamId;
+    const transientState = this.transientState;
+    if (!streamId || !transientState) return;
+    this.emitSendForStream(streamId, transientState);
+  }
+
+  private emitSendForStream(
+    streamId: string,
+    transientState: FollowUpInputTransientState,
+  ): void {
+    if (transientState.pendingImagePastes.size > 0) {
+      transientState.sendAfterImagePastes = true;
       return;
     }
     this.dispatchEvent(
-      ProgressEvents.followupSend({ images: this.pendingImages }),
+      ProgressEvents.followupSend({
+        streamId,
+        images: transientState.pendingImages,
+      }),
     );
-    this.pendingImages = [];
-    this.sendAfterImagePastes = false;
+    transientState.pendingImages = [];
+    transientState.sendAfterImagePastes = false;
   }
 
-  private flushPendingImagePasteSend(): void {
-    if (!this.sendAfterImagePastes || this.pendingImagePastes.size > 0) {
+  private flushPendingImagePasteSend(
+    streamId: string,
+    transientState: FollowUpInputTransientState,
+  ): void {
+    if (
+      !transientState.sendAfterImagePastes ||
+      transientState.pendingImagePastes.size > 0
+    ) {
       return;
     }
-    this.emitSend();
+    this.emitSendForStream(streamId, transientState);
   }
 
   private emitPolish(): void {
@@ -434,13 +442,21 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitClear(): void {
-    this.imagePasteRevision += 1;
-    this.pendingImages = [];
-    this.sendAfterImagePastes = false;
-    this.dispatchEvent(ProgressEvents.followupClear());
+    const streamId = this.streamId;
+    const transientState = this.transientState;
+    if (!streamId || !transientState) return;
+    resetFollowUpInputTransientState(transientState);
+    this.dispatchEvent(ProgressEvents.followupClear({ streamId }));
   }
 
-  private updateValue(value: string): void {
-    this.dispatchEvent(ProgressEvents.followupChange({ value }));
+  private updateValue(
+    value: string,
+    streamId = this.streamId,
+    mode: 'replace' | 'append' = 'replace',
+  ): void {
+    if (!streamId) return;
+    this.dispatchEvent(
+      ProgressEvents.followupChange({ streamId, value, mode }),
+    );
   }
 }

--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -6,6 +6,7 @@ import { customElement } from 'lit/decorators.js';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
+import { getFollowUpInputTransientState } from '../followUpInputState';
 import { BaseStreamContent } from './BaseStreamContent';
 import { renderStreamHeader } from './streamHeaderView';
 import type { ToolUseStreamState } from '../store';
@@ -73,6 +74,7 @@ export class ToolUseStreamContent extends BaseStreamContent {
       <follow-up-input
         .visible=${true}
         .streamId=${streamInfo.name}
+        .transientState=${getFollowUpInputTransientState(streamInfo.name)}
         .value=${currentState.ui.followUpText}
         .queuedMessages=${currentState.queuedFollowUps}
         .shouldFocus=${currentState.ui.shouldFocusFollowUp}

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -171,7 +171,7 @@ export function handleFollowUpChange(
         return;
       }
       if (!value) return;
-      const current = prev.ui.followUpText;
+      const current = prev.ui.followUpText ?? '';
       const separator =
         current && !/\s$/.test(current) && !/^\s/.test(value) ? ' ' : '';
       draft.ui.followUpText = `${current}${separator}${value}`;
@@ -192,14 +192,6 @@ function getFollowUpText(
   if (!text) return null;
 
   return { streamId, text };
-}
-
-/** Resolve the active tool-use stream's trimmed follow-up text. */
-function getActiveFollowUpText(
-  ctx: FrontendEventHandlerContext,
-): { streamId: StreamTabId; text: string } | null {
-  const streamId = ctx.getState().activeStreamId;
-  return streamId ? getFollowUpText(ctx, streamId) : null;
 }
 
 export function handleFollowUpSend(
@@ -228,7 +220,8 @@ export function handleFollowUpSend(
 }
 
 export function handleFollowUpPolish(ctx: FrontendEventHandlerContext): void {
-  const result = getActiveFollowUpText(ctx);
+  const streamId = ctx.getState().activeStreamId;
+  const result = streamId ? getFollowUpText(ctx, streamId) : null;
   if (!result) return;
 
   postMessage(PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP, {

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -10,10 +10,10 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 
 // Local imports - progress view
-import { firstStreamId, getStreamState, isToolUseState } from './store';
+import { firstStreamId, isToolUseState } from './store';
+import { deleteFollowUpInputTransientState } from './followUpInputState';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
 import { clearInquiryDraft } from './components/ExternalInquiryPanel';
@@ -21,8 +21,10 @@ import {
   APPROVE_SESSION_ACTION,
   APPROVE_SUPER_YOLO_ACTION,
   type FilterEventDetail,
+  type FollowUpClearDetail,
   type FollowupCommandDetail,
   type FollowUpChangeDetail,
+  type FollowUpSendDetail,
   type PermissionActionDetail,
   type ProgressFileActionDetail,
   type StreamEventDetail,
@@ -89,6 +91,7 @@ export function handleStreamDelete(
   ctx: FrontendEventHandlerContext,
 ): void {
   const streamId = event.detail.streamId;
+  deleteFollowUpInputTransientState(streamId);
 
   // Optimistic removal: apply delete locally before notifying backend
   ctx.setState((prev) =>
@@ -159,30 +162,31 @@ export function handleFollowUpChange(
   event: CustomEvent<FollowUpChangeDetail>,
   ctx: FrontendEventHandlerContext,
 ): void {
-  const streamId = ctx.getState().activeStreamId;
-  if (!streamId) return;
+  const { mode = 'replace', streamId, value } = event.detail;
+  if (!ctx.getState().streamStates.has(streamId)) return;
   updateToolUseState(ctx, streamId, (prev) =>
     create(prev, (draft) => {
-      draft.ui.followUpText = event.detail.value;
+      if (mode === 'replace') {
+        draft.ui.followUpText = value;
+        return;
+      }
+      if (!value) return;
+      const current = prev.ui.followUpText;
+      const separator =
+        current && !/\s$/.test(current) && !/^\s/.test(value) ? ' ' : '';
+      draft.ui.followUpText = `${current}${separator}${value}`;
     }),
   );
 }
 
-/** Resolve the active tool-use stream's trimmed follow-up text, or null if unavailable. */
-function getActiveFollowUpText(
+/** Resolve one tool-use stream's trimmed follow-up text, or null if unavailable. */
+function getFollowUpText(
   ctx: FrontendEventHandlerContext,
+  streamId: StreamTabId,
 ): { streamId: StreamTabId; text: string } | null {
   const state = ctx.getState();
-  const streamId = state.activeStreamId;
-  if (!streamId) return null;
-
-  const streamInfo = state.streamById.get(streamId);
-  const streamState = getStreamState(
-    state,
-    streamId,
-    streamInfo?.agentCategory,
-  );
-  if (!isToolUseState(streamState)) return null;
+  const streamState = state.streamStates.get(streamId);
+  if (!streamState || !isToolUseState(streamState)) return null;
 
   const text = streamState.ui.followUpText?.trim() ?? '';
   if (!text) return null;
@@ -190,16 +194,24 @@ function getActiveFollowUpText(
   return { streamId, text };
 }
 
-export function handleFollowUpSend(
+/** Resolve the active tool-use stream's trimmed follow-up text. */
+function getActiveFollowUpText(
   ctx: FrontendEventHandlerContext,
-  images: readonly ExtractedClipboardImage[] = [],
+): { streamId: StreamTabId; text: string } | null {
+  const streamId = ctx.getState().activeStreamId;
+  return streamId ? getFollowUpText(ctx, streamId) : null;
+}
+
+export function handleFollowUpSend(
+  event: CustomEvent<FollowUpSendDetail>,
+  ctx: FrontendEventHandlerContext,
 ): void {
-  const result = getActiveFollowUpText(ctx);
+  const result = getFollowUpText(ctx, event.detail.streamId);
   if (!result) return;
 
   // Orphan gate: only attach images whose [fileName] token survives in the
   // submitted text (the user may have deleted a pasted chip before sending).
-  const attached = images.filter((img) =>
+  const attached = event.detail.images.filter((img) =>
     result.text.includes(`[${img.fileName}]`),
   );
 
@@ -225,9 +237,12 @@ export function handleFollowUpPolish(ctx: FrontendEventHandlerContext): void {
   });
 }
 
-export function handleFollowUpClear(ctx: FrontendEventHandlerContext): void {
-  const streamId = ctx.getState().activeStreamId;
-  if (!streamId) return;
+export function handleFollowUpClear(
+  event: CustomEvent<FollowUpClearDetail>,
+  ctx: FrontendEventHandlerContext,
+): void {
+  const streamId = event.detail.streamId;
+  if (!ctx.getState().streamStates.has(streamId)) return;
   updateToolUseState(ctx, streamId, (prev) =>
     create(prev, (draft) => {
       draft.ui.followUpText = '';

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -5,7 +5,6 @@
 
 import type {
   GettingStartedActionDetail,
-  StringValueDetail,
   UserQuestionAnswers,
 } from '@shared/schemas';
 import { createEvent } from '@shared/utils/events';
@@ -30,12 +29,21 @@ export interface ToolbarCommandDetail {
   command: string;
 }
 
-/** Alias for semantic clarity - uses shared StringValueDetail */
-export type FollowUpChangeDetail = StringValueDetail;
+export interface FollowUpChangeDetail {
+  readonly streamId: string;
+  readonly value: string;
+  /** Append is used when an async paste finishes after its stream is hidden. */
+  readonly mode?: 'replace' | 'append';
+}
 
 /** Images pasted into the follow-up box, carried with the send event. */
 export interface FollowUpSendDetail {
+  readonly streamId: string;
   readonly images: readonly ExtractedClipboardImage[];
+}
+
+export interface FollowUpClearDetail {
+  readonly streamId: string;
 }
 
 export interface FollowupCommandDetail {
@@ -121,7 +129,8 @@ export const ProgressEvents = {
 
   followupPolish: () => createEvent('followup-polish', undefined),
 
-  followupClear: () => createEvent('followup-clear', undefined),
+  followupClear: (detail: FollowUpClearDetail) =>
+    createEvent('followup-clear', detail),
 
   followupRequestOptions: () =>
     createEvent('followup-request-options', undefined),

--- a/packages/extension/src/progressView/frontend/followUpInputState.ts
+++ b/packages/extension/src/progressView/frontend/followUpInputState.ts
@@ -1,0 +1,63 @@
+// Local imports - shared types
+import type { StreamTabId } from '@shared/schemas';
+import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
+
+/**
+ * Non-persisted follow-up image state for one stream.
+ *
+ * Follow-up text remains in `ToolUseStreamState.ui.followUpText`, the
+ * canonical stream state used by both the extension and desktop renderers.
+ * Image bytes and promises cannot live in that Zod-backed state, so this
+ * module gives them the same stream-keyed ownership without serializing them.
+ */
+export interface FollowUpInputTransientState {
+  pendingImages: ExtractedClipboardImage[];
+  pendingImagePastes: Set<Promise<void>>;
+  imagePasteRevision: number;
+  sendAfterImagePastes: boolean;
+}
+
+const stateByStream = new Map<StreamTabId, FollowUpInputTransientState>();
+
+/** Return the stable transient-state object owned by `streamId`. */
+export function getFollowUpInputTransientState(
+  streamId: StreamTabId,
+): FollowUpInputTransientState {
+  const existing = stateByStream.get(streamId);
+  if (existing) return existing;
+
+  const created: FollowUpInputTransientState = {
+    pendingImages: [],
+    pendingImagePastes: new Set(),
+    imagePasteRevision: 0,
+    sendAfterImagePastes: false,
+  };
+  stateByStream.set(streamId, created);
+  return created;
+}
+
+/** Invalidate pending work and empty one stream's follow-up image draft. */
+export function resetFollowUpInputTransientState(
+  state: FollowUpInputTransientState,
+): void {
+  state.imagePasteRevision += 1;
+  state.pendingImages = [];
+  state.pendingImagePastes.clear();
+  state.sendAfterImagePastes = false;
+}
+
+/** Remove a deleted stream's image draft and invalidate late paste work. */
+export function deleteFollowUpInputTransientState(streamId: StreamTabId): void {
+  const state = stateByStream.get(streamId);
+  if (!state) return;
+  resetFollowUpInputTransientState(state);
+  stateByStream.delete(streamId);
+}
+
+/** Clear every image draft when the progress frontend is reset. */
+export function clearFollowUpInputTransientStateStore(): void {
+  for (const state of stateByStream.values()) {
+    resetFollowUpInputTransientState(state);
+  }
+  stateByStream.clear();
+}

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -27,6 +27,7 @@ import {
 import { toNewestFirstByTimestamp } from '@utils/core';
 
 import { setsEqual } from './utils';
+import { clearFollowUpInputTransientStateStore } from './followUpInputState';
 import {
   createInitialState,
   EMPTY_PROCESS_OUTPUTS,
@@ -175,6 +176,7 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
  */
 export function resetProgressState(): void {
   _prevApprovalIds = new Set();
+  clearFollowUpInputTransientStateStore();
   appState.set(createInitialState());
   placement.set('sidebar');
   narrowLayout.set(false);

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -26,6 +26,10 @@ import {
 import { clearCopyContentStore } from '../formatters/copyContentStore';
 import { clearProposalInputStore } from '../formatters/proposalInputStore';
 import {
+  clearFollowUpInputTransientStateStore,
+  deleteFollowUpInputTransientState,
+} from '../followUpInputState';
+import {
   removePermissionsForStream,
   updateParentStreamId,
 } from '../stateUtils';
@@ -77,7 +81,10 @@ function updateStreamInfo(
   // mutative draft callback so the side effect doesn't run if the draft
   // later throws.
   for (const key of state.streamStates.keys()) {
-    if (!newStreamById.has(key)) pendingDescriptions.delete(key);
+    if (!newStreamById.has(key)) {
+      pendingDescriptions.delete(key);
+      deleteFollowUpInputTransientState(key);
+    }
   }
 
   return create(state, (draft) => {
@@ -162,6 +169,7 @@ export const streamLifecycleHandlers = {
     clearResolvedProposalIds();
     clearCopyContentStore();
     clearProposalInputStore();
+    deleteFollowUpInputTransientState(streamId);
 
     // Remove permissions for the deleted stream to prevent orphaned entries
     const cleaned = removePermissionsForStream(ctx.getPermissions(), streamId);
@@ -186,6 +194,7 @@ export const streamLifecycleHandlers = {
     clearResolvedProposalIds();
     clearCopyContentStore();
     clearProposalInputStore();
+    clearFollowUpInputTransientStateStore();
     pendingDescriptions.clear();
 
     // Clear all permissions — no streams means no valid permissions

--- a/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpEventHandlers.vitest.ts
@@ -1,0 +1,146 @@
+// Third-party imports
+import { create } from 'mutative';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
+
+vi.mock('@progressView/frontend/components/ExternalInquiryPanel', () => ({
+  clearInquiryDraft: vi.fn(),
+}));
+
+// Local imports - progress view
+import {
+  handleFollowUpChange,
+  handleFollowUpSend,
+} from '@progressView/frontend/eventHandlers';
+import type { FrontendEventHandlerContext } from '@progressView/frontend/messageHandlerTypes';
+import {
+  createInitialState,
+  isToolUseState,
+  type ProgressState,
+  type StreamState,
+} from '@progressView/frontend/store';
+
+// Local imports - shared schemas
+import {
+  AgentCategory,
+  createStreamState,
+  type StreamTabId,
+} from '@shared/schemas';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+
+function createToolUseState(text: string): StreamState {
+  const state = createStreamState(AgentCategory.ToolUse);
+  if (!isToolUseState(state)) throw new Error('Expected tool-use state');
+  return create(state, (draft) => {
+    draft.ui.followUpText = text;
+  });
+}
+
+function createContext(): {
+  ctx: FrontendEventHandlerContext;
+  getState: () => ProgressState;
+} {
+  let state = createInitialState();
+  state.activeStreamId = 'stream-b';
+  state.streamStates.set('stream-a', createToolUseState('draft'));
+  state.streamStates.set('stream-b', createToolUseState('other'));
+
+  const ctx: FrontendEventHandlerContext = {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    },
+    setStreamState: (
+      streamId: StreamTabId,
+      updater: (prev: StreamState) => StreamState,
+    ) => {
+      const current = state.streamStates.get(streamId);
+      if (!current) return;
+      const updated = updater(current);
+      state = create(state, (draft) => {
+        draft.streamStates.set(streamId, updated);
+      });
+    },
+    setStreamLogs: () => {},
+  };
+
+  return { ctx, getState: () => state };
+}
+
+function followUpText(state: ProgressState, streamId: string): string {
+  const stream = state.streamStates.get(streamId);
+  if (!stream || !isToolUseState(stream)) {
+    throw new Error(`Expected tool-use state for ${streamId}`);
+  }
+  return stream.ui.followUpText;
+}
+
+describe('stream-scoped follow-up event handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('appends a late paste token to its source stream', () => {
+    const { ctx, getState } = createContext();
+
+    handleFollowUpChange(
+      {
+        detail: {
+          streamId: 'stream-a',
+          value: '[pasted-a.png]',
+          mode: 'append',
+        },
+      } as CustomEvent,
+      ctx,
+    );
+
+    expect(followUpText(getState(), 'stream-a')).toBe('draft [pasted-a.png]');
+    expect(followUpText(getState(), 'stream-b')).toBe('other');
+  });
+
+  it('sends stream A images while stream B is active', () => {
+    const { ctx, getState } = createContext();
+    handleFollowUpChange(
+      {
+        detail: {
+          streamId: 'stream-a',
+          value: 'draft [pasted-a.png]',
+        },
+      } as CustomEvent,
+      ctx,
+    );
+    const pastedImage = {
+      fileName: 'pasted-a.png',
+      base64: 'AAAA',
+      mediaType: 'image/png',
+    };
+
+    handleFollowUpSend(
+      {
+        detail: {
+          streamId: 'stream-a',
+          images: [pastedImage],
+        },
+      } as CustomEvent,
+      ctx,
+    );
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+      {
+        stream: 'stream-a',
+        text: 'draft [pasted-a.png]',
+        images: [pastedImage],
+      },
+    );
+    expect(followUpText(getState(), 'stream-a')).toBe('');
+    expect(followUpText(getState(), 'stream-b')).toBe('other');
+  });
+});

--- a/src/test-kernel/progressView/FollowUpInputState.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputState.vitest.ts
@@ -1,0 +1,59 @@
+// Third-party imports
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - progress view
+import {
+  clearFollowUpInputTransientStateStore,
+  deleteFollowUpInputTransientState,
+  getFollowUpInputTransientState,
+} from '@progressView/frontend/followUpInputState';
+
+describe('follow-up input transient state', () => {
+  beforeEach(() => {
+    clearFollowUpInputTransientStateStore();
+  });
+
+  it('returns stable, independent state for each stream', () => {
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const streamB = getFollowUpInputTransientState('stream-b');
+
+    streamA.pendingImages = [
+      {
+        fileName: 'pasted-a.png',
+        base64: 'AAAA',
+        mediaType: 'image/png',
+      },
+    ];
+
+    expect(getFollowUpInputTransientState('stream-a')).toBe(streamA);
+    expect(streamB.pendingImages).toEqual([]);
+  });
+
+  it('invalidates pending work before releasing a deleted stream', () => {
+    const deleted = getFollowUpInputTransientState('stream-a');
+    const pendingPaste = new Promise<void>(() => {});
+    deleted.pendingImagePastes.add(pendingPaste);
+    deleted.sendAfterImagePastes = true;
+
+    deleteFollowUpInputTransientState('stream-a');
+
+    expect(deleted.imagePasteRevision).toBe(1);
+    expect(deleted.pendingImagePastes.size).toBe(0);
+    expect(deleted.sendAfterImagePastes).toBe(false);
+    expect(getFollowUpInputTransientState('stream-a')).not.toBe(deleted);
+  });
+
+  it('invalidates every stream during a frontend reset', () => {
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const streamB = getFollowUpInputTransientState('stream-b');
+    streamA.sendAfterImagePastes = true;
+    streamB.sendAfterImagePastes = true;
+
+    clearFollowUpInputTransientStateStore();
+
+    expect(streamA.imagePasteRevision).toBe(1);
+    expect(streamB.imagePasteRevision).toBe(1);
+    expect(streamA.sendAfterImagePastes).toBe(false);
+    expect(streamB.sendAfterImagePastes).toBe(false);
+  });
+});

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -1,5 +1,12 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - progress view
+import {
+  clearFollowUpInputTransientStateStore,
+  getFollowUpInputTransientState,
+  type FollowUpInputTransientState,
+} from '@progressView/frontend/followUpInputState';
 
 // Local imports - shared types
 import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
@@ -7,123 +14,134 @@ import type { ExtractedClipboardImage } from '@shared/utils/clipboardImages';
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
-/**
- * Regression coverage for the round-2 APoSD audit finding: the progress
- * view reuses a SINGLE `<follow-up-input>` Lit instance across the active
- * stream — `ToolUseStreamContent.render()` binds `.streamId=${streamInfo.name}`
- * (the same source TodoList/PlanView key off of for `collapseKey`) rather
- * than mounting a fresh instance per stream. Without a reset keyed on that
- * identity, an image pasted while viewing stream A and still un-sent when
- * the user switches to stream B rides along on the next send and is
- * delivered to stream B instead of stream A.
- */
 useLitComponentTestDom(
   () => import('@progressView/frontend/components/FollowUpInput'),
 );
+
+interface FollowUpSendDetail {
+  streamId: string;
+  images: readonly ExtractedClipboardImage[];
+}
 
 type FollowUpInputInternals = HTMLElement & {
   visible: boolean;
   value: string;
   streamId: string;
+  transientState: FollowUpInputTransientState | null;
   updateComplete: Promise<boolean>;
-  pendingImages: ExtractedClipboardImage[];
-  pendingImagePastes: Set<Promise<void>>;
   emitSend: () => void;
+  flushPendingImagePasteSend: (
+    streamId: string,
+    transientState: FollowUpInputTransientState,
+  ) => void;
 };
+
+function bindStream(
+  element: FollowUpInputInternals,
+  streamId: string,
+): FollowUpInputTransientState {
+  const state = getFollowUpInputTransientState(streamId);
+  element.streamId = streamId;
+  element.transientState = state;
+  return state;
+}
 
 function createFollowUpInput(streamId: string): FollowUpInputInternals {
   const element = document.createElement(
     'follow-up-input',
   ) as unknown as FollowUpInputInternals;
   element.visible = true;
-  element.streamId = streamId;
+  bindStream(element, streamId);
   document.body.append(element);
   return element;
 }
 
-function captureSentImages(
+function captureSend(
   element: FollowUpInputInternals,
-): () => ExtractedClipboardImage[] | undefined {
-  let sentImages: ExtractedClipboardImage[] | undefined;
+): () => FollowUpSendDetail | undefined {
+  let sent: FollowUpSendDetail | undefined;
   element.addEventListener('followup-send', (event) => {
-    sentImages = (event as CustomEvent<{ images: ExtractedClipboardImage[] }>)
-      .detail.images;
+    sent = (event as CustomEvent<FollowUpSendDetail>).detail;
   });
-  return () => sentImages;
+  return () => sent;
+}
+
+function image(fileName: string): ExtractedClipboardImage {
+  return {
+    fileName,
+    base64: `base64-${fileName}`,
+    mediaType: 'image/png',
+  };
 }
 
 describe('follow-up-input pasted-image state across stream switches', () => {
-  it('drops a pending pasted image left over from the previously bound stream', async () => {
-    const element = createFollowUpInput('stream-a');
-    await element.updateComplete;
-
-    // Stand in for a completed image paste while bound to stream A.
-    // (attachPastedImages populates this after the async base64 read
-    // resolves; this harness's jsdom has no FileReader/ClipboardEvent
-    // wiring, so the post-paste state is set directly, matching what the
-    // real paste handler leaves behind.)
-    element.pendingImages = [
-      {
-        fileName: 'pasted-image-1.png',
-        base64: 'AAAA',
-        mediaType: 'image/png',
-      },
-    ];
-
-    // The progress view rebinds this SAME instance to stream B instead of
-    // mounting a fresh one.
-    element.streamId = 'stream-b';
-    await element.updateComplete;
-
-    const getSentImages = captureSentImages(element);
-    element.emitSend();
-
-    expect(getSentImages()).toEqual([]);
+  beforeEach(() => {
+    clearFollowUpInputTransientStateStore();
   });
 
-  it('drops a stale in-flight paste promise from the previous stream so send is not blocked', async () => {
-    // Regression coverage for the codex/Copilot review finding on this PR:
-    // emitSend() gates on pendingImagePastes.size > 0, so a paste promise
-    // still in flight from the previously-bound stream must not survive a
-    // streamId change — otherwise a send issued in the newly-bound stream
-    // silently queues behind (and its timing/target depends on) an
-    // unrelated old-stream paste completing.
+  it('restores stream A images after an A -> B -> A round trip', async () => {
     const element = createFollowUpInput('stream-a');
     await element.updateComplete;
 
-    // Stand in for a paste whose async base64 read hasn't resolved yet
-    // (attachPastedImages adds its own promise to this set in handlePaste,
-    // before the read completes).
-    element.pendingImagePastes.add(new Promise<void>(() => {}));
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const streamB = getFollowUpInputTransientState('stream-b');
+    const imageA = image('pasted-a.png');
+    const imageB = image('pasted-b.png');
+    streamA.pendingImages = [imageA];
 
-    element.streamId = 'stream-b';
+    bindStream(element, 'stream-b');
+    streamB.pendingImages = [imageB];
     await element.updateComplete;
 
-    const getSentImages = captureSentImages(element);
+    bindStream(element, 'stream-a');
+    await element.updateComplete;
+
+    const getSent = captureSend(element);
     element.emitSend();
 
-    expect(getSentImages()).toEqual([]);
+    expect(getSent()).toEqual({ streamId: 'stream-a', images: [imageA] });
+    expect(streamB.pendingImages).toEqual([imageB]);
   });
 
-  it('keeps a pending pasted image when the bound stream does not change', async () => {
+  it('finishes a deferred stream A send while stream B is active', async () => {
     const element = createFollowUpInput('stream-a');
     await element.updateComplete;
 
-    const image: ExtractedClipboardImage = {
-      fileName: 'pasted-image-1.png',
-      base64: 'AAAA',
-      mediaType: 'image/png',
-    };
-    element.pendingImages = [image];
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const imageA = image('pasted-a.png');
+    const pendingPaste = new Promise<void>(() => {});
+    streamA.pendingImages = [imageA];
+    streamA.pendingImagePastes.add(pendingPaste);
 
-    // A re-render with the SAME streamId (e.g. more tokens streaming into
-    // the still-active run) must not drop the pending image.
+    const getSent = captureSend(element);
+    element.emitSend();
+    expect(getSent()).toBeUndefined();
+    expect(streamA.sendAfterImagePastes).toBe(true);
+
+    bindStream(element, 'stream-b');
+    await element.updateComplete;
+
+    // Mirrors handlePaste's finally block after stream A's file read settles.
+    streamA.pendingImagePastes.delete(pendingPaste);
+    element.flushPendingImagePasteSend('stream-a', streamA);
+
+    expect(getSent()).toEqual({ streamId: 'stream-a', images: [imageA] });
+  });
+
+  it('keeps a pending image across a same-stream re-render', async () => {
+    const element = createFollowUpInput('stream-a');
+    await element.updateComplete;
+
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const imageA = image('pasted-a.png');
+    streamA.pendingImages = [imageA];
+
     element.value = 'follow-up text';
     await element.updateComplete;
 
-    const getSentImages = captureSentImages(element);
+    const getSent = captureSend(element);
     element.emitSend();
 
-    expect(getSentImages()).toEqual([image]);
+    expect(getSent()).toEqual({ streamId: 'stream-a', images: [imageA] });
   });
 });


### PR DESCRIPTION
## Summary

- Store pasted-image bytes, metadata, in-flight paste promises, and deferred-send state in a frontend-only map keyed by the same stream ID that owns `ui.followUpText`.
- Bind each stream's stable transient entry into the shared `FollowUpInput`, preserving A's draft across A -> B -> A while keeping A and B isolated.
- Carry the originating stream ID through asynchronous text, send, and clear events so late paste work cannot target the currently active stream.
- Invalidate transient entries when streams are deleted or the progress frontend is reset.
- Forward the same typed send and clear events through the desktop renderer, so extension and desktop use the common handler and retain image payloads.

## Root Cause

`followUpText` was already stored per stream, but `FollowUpInput` owned one component-local image array and one set of paste promises. PR #8076 cleared those fields on every stream switch to prevent cross-stream delivery. That removed stream A's backing image payload while leaving A's persisted chip text intact, producing an orphaned `[fileName]` token after an A -> B -> A round trip.

## Design

The canonical text draft remains in the existing Zod-backed stream state. Base64 image data and promises are intentionally kept outside persisted state, but receive the same stream-keyed lifetime. A paste captures its source stream and stable transient object; completion and deferred send continue against that source even if another stream is active. Deletion and reset paths invalidate revisions before releasing entries, making late completions inert.

## Scope

Rebased on current `main` at `d0a851b24`.

- Files changed: 12.
- Diffstat: 499 insertions, 162 deletions.
- Persistence schemas and host IPC payloads: unchanged.
- Extension and desktop share the same frontend event and transient-state implementation.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; existing repository warnings only)
- `npm run compile:fast`
- Focused Vitest: 3 files, 8 tests
- `npm test` on the final rebased tree: 5,618 passed and 4 skipped; the unrelated load-sensitive `RunChatSignalOwnership` test timed out while all other tests passed
- isolated `RunChatSignalOwnership.vitest.mts`: 1 passed

Closes #8097

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Frontend-only follow-up UX with async paste/send races; behavior is well-tested but wrong stream targeting could mis-attach images to agent messages.
> 
> **Overview**
> Fixes orphaned `[fileName]` chips after switching streams by moving pasted-image bytes, in-flight paste promises, and deferred-send flags out of the reused `FollowUpInput` into a new **stream-keyed** `followUpInputState` map (text stays in `ui.followUpText`).
> 
> `FollowUpInput` now takes `transientState` from `ToolUseStreamContent`; paste/send/clear/change events carry **`streamId`**, and late async pastes **append** to the source stream without touching the active textarea. Handlers update or send the named stream (not only `activeStreamId`). Transient entries are cleared on stream delete, `DELETE_ALL`, and progress reset.
> 
> Desktop wires the same typed `followup-send` / `followup-clear` events. Vitest covers transient state, stream-scoped handlers, and stream-switch image behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5e297ad727a374fc985be90bbe96b06d38d7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->