### PR TITLE
fix(tools): preserve concurrent resume follow-ups

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -71,19 +71,15 @@ export interface ChildRunPorts {
  * the resumed flow's persisted WAITING boundary without re-enqueueing it).
  *
  * Per-turn call order: `launch`/`runTurn` → `getUsage` (turn summary) →
- * `isTurnError` → `onTurnError` (if true) → `onTurnSuccess` (only when the
- * turn did not fail) → `publishUsage` → `formatDelivery`/`formatError` →
- * `buildResultMeta`. `onSessionCleanup` runs once in the loop's `finally`.
+ * `isTurnError` → `onTurnError` (if true) → `publishUsage` →
+ * `formatDelivery`/`formatError` → `buildResultMeta` → `onTurnSuccess` (only
+ * while the loop remains active) → route/wake the parent.
+ * Failed turns release session ownership before routing/waking the parent;
+ * interrupted turns release ownership but skip parent delivery entirely.
  */
 export interface ChildRunStrategy<TTurn> {
   /** Stage label opened on the child trace (e.g. "Codex session"). */
   readonly stageLabel: string;
-
-  /**
-   * Called once before the loop starts. Agent-CLI strategies use this to
-   * promote a synchronously claimed fallback id to an active session entry.
-   */
-  onSessionStart?(session: SessionHandle): void;
 
   /** Produce the first turn's outcome. Throws on hard failure. */
   launch(
@@ -158,10 +154,10 @@ export interface ChildRunStrategy<TTurn> {
   resolveDeliveryTarget?(): StreamTabId | undefined;
 
   /**
-   * Called in the finally block to release provider-owned registry entries.
-   * Runs after this loop detaches its interrupt handler and follow-up queue state.
+   * Release provider-owned registry entries. The loop calls this exactly once,
+   * before failed/interrupted parent delivery or during finalization.
    */
-  onSessionCleanup?(): void;
+  releaseSessionOwnership?(): void;
 }
 
 export interface ChildRunLoopParams<TTurn> {
@@ -357,6 +353,7 @@ async function deliverTurn<TTurn>(params: {
   err: unknown;
   wallTimeMs: number;
   isError: boolean;
+  prepareParentDelivery?: () => boolean;
 }): Promise<void> {
   const {
     strategy,
@@ -368,6 +365,7 @@ async function deliverTurn<TTurn>(params: {
     err,
     wallTimeMs,
     isError,
+    prepareParentDelivery,
   } = params;
   const delivered = turn != null && !isError;
   const msg = await (delivered
@@ -399,6 +397,7 @@ async function deliverTurn<TTurn>(params: {
     );
     return;
   }
+  if (prepareParentDelivery?.() === false) return;
   const delivery = await deliverChildRunFollowUp({
     targetStreamId,
     followUp: { text: msg, origin: 'subagent_result' },
@@ -479,6 +478,12 @@ export function startChildRunLoop<TTurn>(
   const sessionStage = childStream
     ? logger.openStage(strategy.stageLabel)
     : undefined;
+  let sessionOwnershipReleased = false;
+  const releaseSessionOwnershipOnce = (): void => {
+    if (sessionOwnershipReleased) return;
+    sessionOwnershipReleased = true;
+    strategy.releaseSessionOwnership?.();
+  };
 
   let latestCostUsd: number | undefined;
   const ports: ChildRunPorts = {
@@ -509,14 +514,6 @@ export function startChildRunLoop<TTurn>(
     let runner: (ac: AbortController) => Promise<TTurn> = (ac) =>
       strategy.launch(ports, ac);
     try {
-      // Runs synchronously before this IIFE's first `await` — i.e. before
-      // `startChildRunLoop` itself returns to its caller — matching
-      // `onSessionStart`'s documented "before the loop starts" contract.
-      // Placed inside this `try` (rather than before the IIFE, as originally
-      // written) so a throw here is covered by the `finally` below and
-      // cannot leak the `activeChildRunLoops` entry or the interrupt/queue
-      // registrations already made above.
-      strategy.onSessionStart?.(runSession);
       while (!loop.isInterrupted()) {
         const startedAt = Date.now();
         const abortController = loop.startTurn();
@@ -538,9 +535,6 @@ export function startChildRunLoop<TTurn>(
         const wallTimeMs = Date.now() - startedAt;
         const turnFailed = err != null || turnIsError;
 
-        if (!turnFailed && turn != null) {
-          strategy.onTurnSuccess?.(turn, runSession);
-        }
         if (turn != null) {
           strategy.publishUsage?.(turn);
         }
@@ -555,6 +549,18 @@ export function startChildRunLoop<TTurn>(
           err,
           wallTimeMs,
           isError: turnFailed,
+          prepareParentDelivery: () => {
+            if (loop.isInterrupted()) {
+              releaseSessionOwnershipOnce();
+              return false;
+            }
+            if (turnFailed) {
+              releaseSessionOwnershipOnce();
+            } else if (turn != null) {
+              strategy.onTurnSuccess?.(turn, runSession);
+            }
+            return true;
+          },
         });
 
         if (turnFailed) {
@@ -595,7 +601,7 @@ export function startChildRunLoop<TTurn>(
       detachLoopInterrupt?.();
       unregisterChildRunLoop();
       runSession.followUps.release(childStreamId);
-      strategy.onSessionCleanup?.();
+      releaseSessionOwnershipOnce();
       params.recordCost?.(latestCostUsd);
       // The shared terminal finalizer owns the single outcome derivation and
       // its projections: persisted terminal status (before untrack notifies

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -147,6 +147,34 @@ afterEach(() => {
 });
 
 describe('childRunLoop E2E fixtures', () => {
+  it('releases session ownership before delivering a failed turn', async () => {
+    const childStreamId = uniqueStreamId('failed-turn-release');
+    const parentStreamId = 'parent' as StreamTabId;
+    const { strategy, rejectTurn } = createFakeStrategy();
+    const releaseSessionOwnership = vi.fn();
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+      expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+      return { kind: 'delivered' };
+    });
+
+    startChildRunLoop({
+      childStreamId,
+      parentStreamId,
+      executionId: 'exec-failed-turn-release' as ExecutionId,
+      agentName: 'fake-cli',
+      strategy: { ...strategy, releaseSessionOwnership },
+    });
+
+    await vi.waitFor(() =>
+      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+    );
+    await rejectTurn(1, new Error('initial turn failed'));
+    await vi.waitFor(() =>
+      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+    );
+    expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+  });
+
   it('delegate → interrupt mid-run: an interrupt during the first turn ends the run without a terminal delivery for that turn', async () => {
     const childStreamId = uniqueStreamId('interrupt-mid-run');
     const parentStreamId = 'parent' as StreamTabId;
@@ -186,13 +214,19 @@ describe('childRunLoop E2E fixtures', () => {
     const childStreamId = uniqueStreamId('complete-followup');
     const parentStreamId = 'parent' as StreamTabId;
     const { strategy, resolveTurn } = createFakeStrategy();
+    const onTurnSuccess = vi.fn();
+    const parentWake = vi.fn();
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+      parentWake();
+      return { kind: 'delivered' };
+    });
 
     startChildRunLoop({
       childStreamId,
       parentStreamId,
       executionId: 'exec-complete-followup' as ExecutionId,
       agentName: 'fake',
-      strategy,
+      strategy: { ...strategy, onTurnSuccess },
     });
 
     await vi.waitFor(() =>
@@ -209,6 +243,10 @@ describe('childRunLoop E2E fixtures', () => {
         }),
       );
     });
+    expect(onTurnSuccess).toHaveBeenCalledOnce();
+    expect(onTurnSuccess.mock.invocationCallOrder[0]).toBeLessThan(
+      parentWake.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
 
     // Enqueue a follow-up on the same queue the loop is now blocked on.
     session.followUps
@@ -233,24 +271,19 @@ describe('childRunLoop E2E fixtures', () => {
     );
   });
 
-  it('late result after parent stop: a turn that resolves after the loop already interrupted still attempts best-effort delivery and does not throw', async () => {
+  it('late result after parent stop: a turn that resolves after interruption is persisted but not delivered', async () => {
     const childStreamId = uniqueStreamId('late-result');
     const parentStreamId = 'parent' as StreamTabId;
     const executionId = 'exec-late-result' as ExecutionId;
     const { strategy, resolveTurn } = createFakeStrategy();
     const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
-    // The parent stream is gone by the time this late delivery lands.
-    mocks.deliverChildRunFollowUp.mockResolvedValue({
-      kind: 'no_session',
-      streamStatus: 'completed',
-    });
-
+    const releaseSessionOwnership = vi.fn();
     startChildRunLoop({
       childStreamId,
       parentStreamId,
       executionId,
       agentName: 'fake',
-      strategy,
+      strategy: { ...strategy, releaseSessionOwnership },
     });
 
     await vi.waitFor(() =>
@@ -262,16 +295,15 @@ describe('childRunLoop E2E fixtures', () => {
     expect(handle.interrupt()).toBe(true);
     await resolveTurn(1, { kind: 'terminal', value: 'late' });
 
-    await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
-        expect.objectContaining({
-          followUp: expect.objectContaining({ text: 'delivered:late' }),
-        }),
-      );
-    });
     await vi.waitFor(() =>
       expect(isChildRunLoopActive(childStreamId)).toBe(false),
     );
+    expect(mocks.persistChildRunReport).toHaveBeenCalledWith(
+      executionId,
+      'delivered:late',
+    );
+    expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('kill during WAITING: interrupting the loop while it is blocked between turns ends the run without a hang', async () => {

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -176,7 +176,6 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
-        params.strategy.onSessionStart?.({ executions } as any);
       },
     );
 
@@ -197,7 +196,11 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
 
     envReady.resolve({});
-    const [firstResult, secondResult] = await Promise.all([first, second]);
+    const firstResult = await first;
+    strategy?.onTurnSuccess?.({ sessionId: 'stale-session' }, {
+      executions,
+    } as any);
+    const secondResult = await second;
 
     expect(firstResult.status).toBe('executed');
     expect(secondResult.summary).toMatch(/Follow-up queued/);
@@ -207,7 +210,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
       text: 'also update the tests',
     });
 
-    strategy?.onSessionCleanup?.();
+    strategy?.releaseSessionOwnership?.();
     expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();
   });
 
@@ -226,7 +229,6 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
-        params.strategy.onSessionStart?.({ executions } as any);
       },
     );
 
@@ -251,7 +253,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(mocks.buildClaudeAgentEnv).toHaveBeenCalledTimes(2);
     expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
 
-    strategy?.onSessionCleanup?.();
+    strategy?.releaseSessionOwnership?.();
     expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();
   });
 

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -138,7 +138,6 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
-        params.strategy.onSessionStart?.({ executions } as any);
       },
     );
 
@@ -168,7 +167,9 @@ describe('codex tool - atomic resume fallback', () => {
         }
       },
     );
-    const [firstResult, secondResult] = await Promise.all([first, second]);
+    const firstResult = await first;
+    strategy?.onTurnSuccess?.({}, { executions } as any);
+    const secondResult = await second;
 
     expect(firstResult.status).toBe('executed');
     expect(secondResult.summary).toMatch(/Follow-up queued/);
@@ -180,7 +181,7 @@ describe('codex tool - atomic resume fallback', () => {
       text: 'also update the tests',
     });
 
-    strategy?.onSessionCleanup?.();
+    strategy?.releaseSessionOwnership?.();
     expect(CodexThreads.lookup('stale-thread')).toBeUndefined();
   });
 
@@ -206,7 +207,6 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
-        params.strategy.onSessionStart?.({ executions } as any);
       },
     );
 
@@ -233,7 +233,7 @@ describe('codex tool - atomic resume fallback', () => {
     expect(mocks.importCodexClass).toHaveBeenCalledTimes(2);
     expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
 
-    strategy?.onSessionCleanup?.();
+    strategy?.releaseSessionOwnership?.();
     expect(CodexThreads.lookup('stale-thread')).toBeUndefined();
   });
 });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -106,8 +106,10 @@ function queueAgentCliFollowUp(
  * Atomically choose between queueing onto an owned session id and launching a
  * disk-based fallback. A failed owner releases only its own claim; waiting
  * callers then compete for the released id, so one retries the fallback while
- * the others continue waiting. A started loop promotes and later releases the
- * claim itself.
+ * the others continue waiting. A successful launch transfers the claim to its
+ * loop, which promotes it after the first successful turn or releases it during
+ * cleanup so an acknowledged follow-up can never be stranded behind a failed
+ * initial turn.
  */
 export async function resumeOrLaunchAgentCliSession(
   store: ClaimableAgentCliStore,
@@ -116,7 +118,7 @@ export async function resumeOrLaunchAgentCliSession(
     prompt: string;
     callerStreamId: StreamTabId | undefined;
     labels: AgentCliResumeLabels;
-    launch: () => Promise<ToolResult>;
+    launch: (releaseClaim?: () => void) => Promise<ToolResult>;
   },
 ): Promise<ToolResult> {
   const { id } = params;
@@ -126,7 +128,7 @@ export async function resumeOrLaunchAgentCliSession(
     const releaseClaim = store.claim(id);
     if (releaseClaim) {
       try {
-        return await params.launch();
+        return await params.launch(releaseClaim);
       } catch (error) {
         releaseClaim();
         throw error;

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -404,9 +404,11 @@ function startClaudeAgentLoop(params: {
    * Set when this launch is the disk-based fallback for a session_id the
    * in-memory registry no longer knows about (extension reload or crash). The
    * id is claimed synchronously before fallback setup begins, seeds the first
-   * turn's `resume` option, and is promoted to an active entry onSessionStart.
+   * turn's `resume` option, and is promoted after that turn succeeds.
    */
   resumeSessionId: string | undefined;
+  /** Release the fallback claim if the loop exits before promoting it. */
+  releaseFallbackClaim: (() => void) | undefined;
 }): void {
   const {
     childStream,
@@ -468,9 +470,6 @@ function startClaudeAgentLoop(params: {
 
   const strategy: ChildRunStrategy<TurnResult> = {
     stageLabel: 'Claude Code session',
-    onSessionStart: fallbackSessionId
-      ? (session) => registerSession(fallbackSessionId, session)
-      : undefined,
     launch: (ports, abortController) =>
       runTurn(
         [{ text: initialPrompt, origin: 'user' }],
@@ -485,6 +484,7 @@ function startClaudeAgentLoop(params: {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
     onTurnSuccess: (turn, session) => {
+      if (fallbackSessionId) registerSession(fallbackSessionId, session);
       if (turn.sessionId) registerSession(turn.sessionId, session);
     },
     publishUsage: (turn) => {
@@ -508,8 +508,10 @@ function startClaudeAgentLoop(params: {
           ),
         },
       ),
-    onSessionCleanup: () =>
-      ClaudeAgentSessions.releaseByExecutionId(executionId),
+    releaseSessionOwnership: () => {
+      params.releaseFallbackClaim?.();
+      ClaudeAgentSessions.releaseByExecutionId(executionId);
+    },
   };
 
   startChildRunLoop({
@@ -557,7 +559,7 @@ export class ClaudeAgentTool extends defineTool({
             summaryLabel: 'Claude Code CLI',
             queuedLabel: 'Claude Code session',
           },
-          launch: () => {
+          launch: (releaseClaim) => {
             // A missing in-memory entry denotes a disk-based SDK fallback.
             const { streamId, runtimeHost } = requireRunStream(
               CLAUDE_AGENT_NAME,
@@ -572,6 +574,7 @@ export class ClaudeAgentTool extends defineTool({
               getRunContextExecutionId(runContext),
               getRunContextWorkingDirectory(runContext),
               runtimeHost,
+              releaseClaim,
             );
           },
         });
@@ -589,6 +592,7 @@ async function launchClaudeAgentSession(
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   runtimeHost: AgentRuntimeHost,
+  releaseFallbackClaim: (() => void) | undefined,
 ): Promise<ToolResult> {
   const config = await getClaudeAgentConfig();
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
@@ -631,6 +635,7 @@ async function launchClaudeAgentSession(
         pathToClaudeCodeExecutable: await findClaudeBinaryPath(),
         runtimeHost,
         resumeSessionId: input.session_id ?? undefined,
+        releaseFallbackClaim,
       }),
     summary: `Launched Claude Code CLI: ${preview}`,
     launchedLine: `Claude Code agent launched (model: ${model}, permission: ${permissionMode}).`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -360,9 +360,11 @@ function startCodexLoop(params: {
   runtimeHost: AgentRuntimeHost;
   /**
    * The disk-based fallback thread id claimed synchronously in execute(). The
-   * loop promotes that reservation before its first turn starts.
+   * loop promotes that reservation after its first turn succeeds.
    */
   resumeThreadId: string | undefined;
+  /** Release the fallback claim if the loop exits before promoting it. */
+  releaseFallbackClaim: (() => void) | undefined;
 }): void {
   const {
     thread,
@@ -375,8 +377,8 @@ function startCodexLoop(params: {
   const { childStreamId, logger } = childStream;
   const fallbackThreadId = params.resumeThreadId;
 
-  // Fresh threads don't have thread.id yet; they're registered after the first
-  // turn completes. A resumed thread's pre-launch claim is promoted up front.
+  // Fresh and resumed thread IDs are registered after the first successful
+  // turn is persisted, immediately before its result reaches the parent.
   const registerThread = (threadId: string, session: SessionHandle): void => {
     if (CodexThreads.lookup(threadId)) return;
     CodexThreads.register(threadId, {
@@ -409,9 +411,6 @@ function startCodexLoop(params: {
 
   const strategy: ChildRunStrategy<RunResult> = {
     stageLabel: 'Codex session',
-    onSessionStart: fallbackThreadId
-      ? (session) => registerThread(fallbackThreadId, session)
-      : undefined,
     launch: (ports, abortController) =>
       runTurn(
         [{ text: initialPrompt, origin: 'user' }],
@@ -422,6 +421,7 @@ function startCodexLoop(params: {
     isTerminal: () => false,
     getUsage: (turn) => turn.usage,
     onTurnSuccess: (_turn, session) => {
+      if (fallbackThreadId) registerThread(fallbackThreadId, session);
       if (thread.id) registerThread(thread.id, session);
     },
     publishUsage: (turn) => {
@@ -441,7 +441,10 @@ function startCodexLoop(params: {
         { tag: DELIVERY_TAG.codexError, executionId, prompt: lastPrompt },
         { message: toErrorMessage(err) },
       ),
-    onSessionCleanup: () => CodexThreads.releaseByExecutionId(executionId),
+    releaseSessionOwnership: () => {
+      params.releaseFallbackClaim?.();
+      CodexThreads.releaseByExecutionId(executionId);
+    },
   };
 
   startChildRunLoop({
@@ -520,7 +523,7 @@ export class CodexTool extends defineTool({
             summaryLabel: 'Codex',
             queuedLabel: 'Codex thread',
           },
-          launch: () => {
+          launch: (releaseClaim) => {
             // A missing in-memory entry denotes a disk-based SDK fallback.
             const { streamId, runtimeHost } = requireRunStream(
               'codex',
@@ -532,6 +535,7 @@ export class CodexTool extends defineTool({
               getRunContextExecutionId(runContext),
               getRunContextWorkingDirectory(runContext),
               runtimeHost,
+              releaseClaim,
             );
           },
         });
@@ -546,6 +550,7 @@ async function launchCodexSession(
   parentExecutionId: ExecutionId | undefined,
   parentWorkingDirectory: string | undefined,
   runtimeHost: AgentRuntimeHost,
+  releaseFallbackClaim: (() => void) | undefined,
 ): Promise<ToolResult> {
   const workingDir = parseWorkingDirectory(parentWorkingDirectory);
   const thread = await createCodexThread(input, workingDir);
@@ -570,6 +575,7 @@ async function launchCodexSession(
         initialPrompt: input.prompt,
         runtimeHost,
         resumeThreadId: input.thread_id ?? undefined,
+        releaseFallbackClaim,
       }),
     summary: `Launched Codex: ${preview}`,
     launchedLine: `Codex agent launched (sandbox: ${input.sandbox_mode}).`,


### PR DESCRIPTION
## Summary
- transfer fallback-claim cleanup to the child run loop
- publish resumed CLI-session readiness only after the first turn is formatted and persisted, immediately before parent delivery
- let concurrent waiters retry instead of acknowledging a follow-up that a failed or interrupted loop drops
- remove the shallow pre-turn `onSessionStart` lifecycle hook

## Root cause
The fallback reservation was promoted before the initial resumed turn ran. A concurrent waiter could therefore enqueue a follow-up and receive a successful acknowledgement even when that initial turn failed or resolved after interruption and immediately tore down the loop.

The loop now owns provider session ownership. A successful initial turn publishes readiness synchronously immediately before either an active parent append or a queued-parent wake can consume the delivered session id; failed turns release the reservation and active aliases before parent delivery, while interrupted turns persist their report but skip parent delivery entirely.

## Validation
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 45 existing warnings)
- `npm test` (633 files passed, 5,615 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only baseline report)
- regression test fails on the pre-fix `origin/main` with the queued-then-dropped acknowledgement

Closes #8140
