### PR TITLE
fix(agent): persist reflection round outcomes

### DIFF
--- a/src/agent/node/roundPersistedFlow.ts
+++ b/src/agent/node/roundPersistedFlow.ts
@@ -143,7 +143,7 @@ export class RoundPersistedFlow<
    * Returns the canonical run outcome directly.
    */
   async run(shared: S): Promise<RunOutcome> {
-    let outcome: RunOutcome = RUN_OUTCOME.COMPLETED;
+    let outcome: RunOutcome = RUN_OUTCOME.FAILED;
 
     await this.ensureRecord(shared);
     let currentShared = shared;
@@ -164,7 +164,7 @@ export class RoundPersistedFlow<
       // Determine final outcome
       outcome = this.resolveOutcome(currentShared);
     } finally {
-      this.currentRoundStage?.end();
+      this.currentRoundStage?.end(outcome);
       this.currentRoundStage = null;
     }
 
@@ -211,7 +211,7 @@ export class RoundPersistedFlow<
     return this.callbacks.grantExtraRound?.(shared) ?? false;
   }
 
-  /** Derive the canonical RunOutcome from shared state after the round loop exits. */
+  /** Derive the canonical RunOutcome from the current round state. */
   private resolveOutcome(shared: S): RunOutcome {
     return deriveRunOutcome({
       failed: Boolean(shared.lastError),
@@ -225,7 +225,7 @@ export class RoundPersistedFlow<
    */
   private async transitionToNextRound(shared: S): Promise<void> {
     // End previous round stage
-    this.currentRoundStage?.end();
+    this.currentRoundStage?.end(this.resolveOutcome(shared));
     this.currentRoundStage = null;
 
     // Increment round (single source of truth)

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -163,7 +163,7 @@ describe('RoundPersistedFlow bounded compile-repair round (#7077)', () => {
 type OutcomeShared = RoundAwareState;
 
 interface OutcomeControl {
-  readonly terminalOutcome: RunOutcome;
+  readonly terminalOutcome: RunOutcome | 'throws';
   interrupted: boolean;
 }
 
@@ -175,7 +175,9 @@ class OutcomeRoundNode extends BaseNode<OutcomeShared> {
   async post(shared: OutcomeShared): Promise<undefined> {
     if (shared.currentRound + 1 !== shared.totalRounds) return undefined;
 
-    if (this.control.terminalOutcome === RUN_OUTCOME.FAILED) {
+    if (this.control.terminalOutcome === 'throws') {
+      throw new Error('reflection round threw');
+    } else if (this.control.terminalOutcome === RUN_OUTCOME.FAILED) {
       shared.lastError = {
         message: 'reflection round failed',
         userRetryable: false,
@@ -194,18 +196,26 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
     {
       name: 'completed',
       terminalOutcome: RUN_OUTCOME.COMPLETED,
+      persistedOutcome: RUN_OUTCOME.COMPLETED,
     },
     {
       name: 'failed',
       terminalOutcome: RUN_OUTCOME.FAILED,
+      persistedOutcome: RUN_OUTCOME.FAILED,
     },
     {
       name: 'cancelled',
       terminalOutcome: RUN_OUTCOME.CANCELLED,
+      persistedOutcome: RUN_OUTCOME.CANCELLED,
+    },
+    {
+      name: 'thrown failure',
+      terminalOutcome: 'throws' as const,
+      persistedOutcome: RUN_OUTCOME.FAILED,
     },
   ])(
     'persists completed transition and $name final-round GROUP_END outcomes',
-    async ({ name, terminalOutcome }) => {
+    async ({ name, terminalOutcome, persistedOutcome }) => {
       const kv = createFakeKv();
       const logger = new TraceEmitter();
       const streamId = `stream:reflection-round-${name}` as StreamTabId;
@@ -240,7 +250,12 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
       const recorder = attachTranscriptRecorder(logger, streamId, store);
 
       try {
-        await expect(flow.run(shared)).resolves.toBe(terminalOutcome);
+        const run = flow.run(shared);
+        if (terminalOutcome === 'throws') {
+          await expect(run).rejects.toThrow('reflection round threw');
+        } else {
+          await expect(run).resolves.toBe(terminalOutcome);
+        }
 
         const roundEndStatuses =
           store
@@ -259,7 +274,7 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
 
         expect(roundEndStatuses).toEqual([
           RUN_OUTCOME.COMPLETED,
-          terminalOutcome,
+          persistedOutcome,
         ]);
       } finally {
         recorder.unsubscribe();

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -3,12 +3,22 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - node/flow primitives under test
 import { createFakeKv } from '@test/support/FakeExecutionKVStore';
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
+import { TraceEmitter } from '@agent/trace';
 import { BaseNode } from '@agent/node';
 import {
   RoundPersistedFlow,
   type RoundAwareState,
 } from '@agent/node/roundPersistedFlow';
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import {
+  RUN_OUTCOME,
+  STREAM_LOG_ENTRY_TYPES,
+  type RunOutcome,
+  type StreamTabId,
+} from '@shared/schemas';
+import { isObject } from '@utils/core';
 
 /**
  * Regression coverage for #7077: a compile failure on what would have been
@@ -148,4 +158,112 @@ describe('RoundPersistedFlow bounded compile-repair round (#7077)', () => {
     expect(finalShared.roundsRun).toEqual([0, 1, 2]);
     expect(finalShared.compileRepairRoundGranted).toBe(true);
   });
+});
+
+type OutcomeShared = RoundAwareState;
+
+interface OutcomeControl {
+  readonly terminalOutcome: RunOutcome;
+  interrupted: boolean;
+}
+
+class OutcomeRoundNode extends BaseNode<OutcomeShared> {
+  constructor(private readonly control: OutcomeControl) {
+    super();
+  }
+
+  async post(shared: OutcomeShared): Promise<undefined> {
+    if (shared.currentRound + 1 !== shared.totalRounds) return undefined;
+
+    if (this.control.terminalOutcome === RUN_OUTCOME.FAILED) {
+      shared.lastError = {
+        message: 'reflection round failed',
+        userRetryable: false,
+      };
+      shared.continueRounds = false;
+    } else if (this.control.terminalOutcome === RUN_OUTCOME.CANCELLED) {
+      this.control.interrupted = true;
+    }
+
+    return undefined;
+  }
+}
+
+describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
+  it.each([
+    {
+      name: 'completed',
+      terminalOutcome: RUN_OUTCOME.COMPLETED,
+    },
+    {
+      name: 'failed',
+      terminalOutcome: RUN_OUTCOME.FAILED,
+    },
+    {
+      name: 'cancelled',
+      terminalOutcome: RUN_OUTCOME.CANCELLED,
+    },
+  ])(
+    'persists completed transition and $name final-round GROUP_END outcomes',
+    async ({ name, terminalOutcome }) => {
+      const kv = createFakeKv();
+      const logger = new TraceEmitter();
+      const streamId = `stream:reflection-round-${name}` as StreamTabId;
+      const store = new StreamLogStore();
+      const control: OutcomeControl = {
+        terminalOutcome,
+        interrupted: false,
+      };
+      const flow = new RoundPersistedFlow<OutcomeShared>(
+        new OutcomeRoundNode(control),
+        kv,
+        {
+          callbacks: {
+            createRoundStage: (roundIndex, parent, shared) =>
+              logger.openStage(`r${roundIndex}`, {
+                parent: parent ?? undefined,
+                kind: 'round',
+                index: roundIndex,
+                total: shared.totalRounds,
+              }),
+            checkInterruption: () => control.interrupted,
+          },
+        },
+      );
+      const shared: OutcomeShared = {
+        currentRound: 0,
+        totalRounds: 2,
+        continueRounds: true,
+      };
+
+      store.ensureStream(streamId);
+      const recorder = attachTranscriptRecorder(logger, streamId, store);
+
+      try {
+        await expect(flow.run(shared)).resolves.toBe(terminalOutcome);
+
+        const roundEndStatuses =
+          store
+            .get(streamId)
+            ?.getRange(0)
+            .flatMap((entry) => {
+              if (
+                entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END &&
+                isObject(entry.data) &&
+                entry.data.kind === 'round'
+              ) {
+                return [entry.data.status];
+              }
+              return [];
+            }) ?? [];
+
+        expect(roundEndStatuses).toEqual([
+          RUN_OUTCOME.COMPLETED,
+          terminalOutcome,
+        ]);
+      } finally {
+        recorder.unsubscribe();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- close every `RoundPersistedFlow` round stage with its canonical completed, failed, or cancelled `RunOutcome`
- preserve failed closure when round execution throws before outcome resolution
- verify both transition and final-round outcomes at the persisted `GROUP_END` boundary

## Root cause

`RoundPersistedFlow` classified the final flow correctly with `deriveRunOutcome`, but both per-round closure sites called `StageHandle.end()` without an outcome. The stage API therefore used its generic completed default, causing failed and cancelled reflection rounds to be persisted as completed.

## Design

The final round now closes with the already-resolved flow outcome. A non-final round derives its outcome from that round's current error and interruption state immediately before transition. The pending outcome starts as failed so an exception cannot emit a completed round. This reuses `deriveRunOutcome` and the existing stage API; it adds no reflection-specific vocabulary and changes no persistence schema.

The existing `RoundPersistedFlow` suite now runs two-round cases for completed, failed, and cancelled outcomes through `TraceEmitter`, `TexraTranscriptRecorder`, and `StreamLogStore`. The completed, failed, and cancelled cases assert the intermediate completed `GROUP_END` and the final canonical outcome. A fourth case throws before outcome resolution and pins the final round to failed.

## Scope

- Files changed: 2
- Persistence schemas and status vocabularies: unchanged
- CLI status migration, follow-up images, release workflows, desktop smoke, and web-fetch code: untouched

## Validation

- `npm run format`: passed
- focused `RoundPersistedFlowCompileRepair.vitest.ts`: 8 passed, including all three returned outcomes and a thrown round
- `npm run typecheck`: passed
- `npm run compile:fast`: passed
- `npm run lint`: 0 errors; 45 pre-existing warnings outside the changed files
- full suite except the load-sensitive CLI signal test: 5,609 passed, 4 skipped
- isolated `RunChatSignalOwnership.vitest.mts`: 1 passed
- default aggregate suite: the same unrelated CLI signal test timed out under full worker load; all other tests passed
- `npm run check:dead-code`: completed the census and reported only existing repository debt
- `npm run check:dead-code-ratchet`: passed
- Prettier check and `git diff --check`: passed

Closes #8137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized orchestration and logging persistence fix with no schema changes; behavior change is correcting incorrect completed defaults on round closure.
> 
> **Overview**
> **Round stages now close with the correct `RunOutcome` instead of always defaulting to completed** when `StageHandle.end()` was called with no status.
> 
> `RoundPersistedFlow` passes the resolved outcome into `currentRoundStage.end(outcome)` in the `finally` block after the round loop, and passes `resolveOutcome(shared)` when ending a round before transitioning to the next. The pending outcome is initialized to **failed** so an exception before resolution cannot emit a completed round closure.
> 
> Regression tests drive a two-round flow through `TraceEmitter` → transcript `GROUP_END` entries and assert the first round ends **completed** and the final round ends **completed**, **failed**, or **cancelled** as scripted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69add07e3f5ef469de96ac5372a5067b770e8db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->