### PR TITLE
refactor(cli): migrate live status readers

### DIFF
--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -1,9 +1,9 @@
 /** Pure row allocation and visibility policy for the root CLI TUI layout. */
 
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import { isActivePhase } from '@common/constants/streamStatus';
 import {
   TODO_STATUS,
-  type StreamLifecycleStatus,
+  type StreamPhase,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -236,7 +236,7 @@ export function shouldShowTodosPlanPanel({
 }: {
   readonly foregroundOpen: boolean;
   readonly hasPlan: boolean;
-  readonly status: StreamLifecycleStatus | undefined;
+  readonly status: StreamPhase | undefined;
   readonly todos: readonly TodoItem[];
 }): boolean {
   if (foregroundOpen) return false;
@@ -248,5 +248,5 @@ export function shouldShowTodosPlanPanel({
   ) {
     return false;
   }
-  return isLiveElapsedStatus(status);
+  return isActivePhase(status);
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -6,7 +6,7 @@ import { Box } from 'ink';
 import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
-import { isActiveStatus } from '@common/constants/streamStatus';
+import { isActivePhase } from '@common/constants/streamStatus';
 import { type ActiveChildInfo, type StreamTabId } from '@shared/schemas';
 import { clamp } from '@utils/core';
 
@@ -122,7 +122,7 @@ export function ConversationRegion({
   const activeSlice = snapshot.activeStreamId
     ? snapshot.streams.get(snapshot.activeStreamId)
     : undefined;
-  const activeResponseRunning = isActiveStatus(activeSlice?.status);
+  const activeResponseRunning = isActivePhase(activeSlice?.status);
   const queuedFollowUpMessages = activeSlice?.queuedFollowUpMessages ?? [];
   const queuedFollowUpPanelWanted =
     !foregroundOpen && queuedFollowUpMessages.length > 0;

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { isCodexSubscriptionActive } from '@auth/codex';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
-import { STREAM_STATUS } from '@shared/schemas';
+import { isActivePhase } from '@common/constants/streamStatus';
 
 import { approvalQueueStatus } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
@@ -99,10 +99,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     };
   }, [sessionMeta.model, codexPreferenceVersion]);
 
-  const runStartedAt =
-    statusSlice?.status === STREAM_STATUS.RUNNING
-      ? statusSlice.runStartedAt
-      : undefined;
+  const runStartedAt = isActivePhase(statusSlice?.status)
+    ? statusSlice?.runStartedAt
+    : undefined;
   const now = useLiveNowMs(runStartedAt !== undefined, runStartedAt);
 
   const display = buildStatusBarDisplay({

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -1,10 +1,10 @@
 import { Box, Text } from 'ink';
 
 import {
-  isInFlightStatus,
-  isTerminalStatus,
+  isActivePhase,
+  isTerminalOutcomePhase,
 } from '@common/constants/streamStatus';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
 import { textDisplayWidth, truncateToWidth } from '../render/terminalText';
@@ -29,9 +29,9 @@ export interface StreamTabDisplayItem {
   readonly shortcutIndex?: number;
   readonly status?: string;
   /**
-   * Whether the run has ENDED (stopped/error/ready) — terminal but not
-   * in-flight. WAITING is terminal-but-in-flight and is intentionally excluded
-   * so an active waiting tab stays unsuffixed.
+   * Whether the run has ended with a canonical outcome. WAITING remains
+   * in-flight and is intentionally excluded so an active waiting tab stays
+   * unsuffixed.
    */
   readonly ended?: boolean;
 }
@@ -47,8 +47,8 @@ export function streamTabSegmentText(item: StreamTabDisplayItem): string {
   const label = item.active ? `[${labeled}]` : labeled;
   const running = item.running ? '*' : '';
   // Inactive tabs surface any non-running status; the active tab additionally
-  // surfaces an ended state (stopped/error/ready) so an active stream that
-  // errors or finishes isn't visually indistinguishable from one still running.
+  // surfaces a terminal outcome so a stream that ends is not visually
+  // indistinguishable from one still running.
   const status =
     item.status && item.status !== 'running' && (!item.active || item.ended)
       ? `(${item.status})`
@@ -210,11 +210,10 @@ export function streamTabsDisplayItems(init: {
       id: view.id,
       label: truncateToWidth(view.label, MAX_LABEL_WIDTH),
       active: view.active,
-      running: slice?.status === STREAM_STATUS.RUNNING,
+      running: isActivePhase(slice?.status),
       shortcutIndex: view.shortcutIndex,
       status,
-      ended:
-        isTerminalStatus(slice?.status) && !isInFlightStatus(slice?.status),
+      ended: isTerminalOutcomePhase(slice?.status),
     };
   });
   return collapseMiddle(items, init.width);

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -6,11 +6,10 @@ import {
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import { isActivePhase } from '@common/constants/streamStatus';
 import {
-  STREAM_STATUS,
   type RoundStage,
-  type StreamLifecycleStatus,
+  type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
   type TokenUsageStats,
@@ -63,7 +62,7 @@ interface StatusBarSegment {
 }
 
 export interface StatusBarDisplayInput {
-  readonly status: string | undefined;
+  readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Milliseconds since the running turn began. When set and `status` is
    *  `running`, the bar shows a live `Ns` segment so a long token-less
@@ -549,7 +548,7 @@ function hasPendingOrLiveStream(
   streams: ReadonlyMap<StreamTabId, StatusBarVisibleStream>,
 ): boolean {
   for (const stream of streams.values()) {
-    if (stream.status === undefined || isLiveElapsedStatus(stream.status)) {
+    if (stream.status === undefined || isActivePhase(stream.status)) {
       return true;
     }
   }
@@ -559,7 +558,7 @@ function hasPendingOrLiveStream(
 function rootActiveSegment(
   input: StatusBarDisplayInput,
 ): StatusBarSegment | undefined {
-  return input.ctrlCAction === 'stop root' && !isLiveElapsedStatus(input.status)
+  return input.ctrlCAction === 'stop root' && !isActivePhase(input.status)
     ? {
         text: 'root active',
         color: 'yellow',
@@ -593,7 +592,7 @@ function approvalPolicySegment(
 }
 
 interface StatusBarVisibleStream {
-  readonly status: StreamLifecycleStatus | undefined;
+  readonly status: StreamPhase | undefined;
 }
 
 interface StatusBarStreamTarget {
@@ -628,7 +627,7 @@ export function statusBarStreamTarget({
     activeStreamId,
     parentStream,
     values: streams,
-    canUseValue: (stream) => isLiveElapsedStatus(stream.status),
+    canUseValue: (stream) => isActivePhase(stream.status),
   });
   const canStopVisibleRun =
     canStopActiveRun &&
@@ -688,10 +687,7 @@ export function buildStatusBarDisplay(
       ),
       color: 'dim',
     });
-    if (
-      input.status === STREAM_STATUS.RUNNING &&
-      input.elapsedMs !== undefined
-    ) {
+    if (isActivePhase(input.status) && input.elapsedMs !== undefined) {
       left.push({
         text: formatCompactDuration(input.elapsedMs),
         color: 'dim',

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -1,8 +1,8 @@
 import stripAnsi from 'strip-ansi';
 
 import { ANSI_ESCAPE_START, ansiEscapeEnd } from '@cli/runtime/ansiEscapes';
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
-import { type StreamLifecycleStatus } from '@shared/schemas';
+import { isActivePhase } from '@common/constants/streamStatus';
+import { type StreamPhase } from '@shared/schemas';
 
 import type { ConversationEntry } from '../state/cliState';
 
@@ -84,14 +84,14 @@ export function nextRenderableTranscriptEntry(
 export function userPromptAwaitsLiveContinuation(
   entries: readonly ConversationEntry[],
   index: number,
-  status: StreamLifecycleStatus | undefined,
+  status: StreamPhase | undefined,
 ): boolean {
   const entry = entries[index];
   if (
     entry?.role !== 'user' ||
     isInquiryContinuationText(entry.text) ||
     !isRenderableTranscriptEntry(entry) ||
-    !isLiveElapsedStatus(status)
+    !isActivePhase(status)
   ) {
     return false;
   }
@@ -100,7 +100,7 @@ export function userPromptAwaitsLiveContinuation(
 
 export function splitTranscriptEntries(
   entries: readonly ConversationEntry[],
-  status: StreamLifecycleStatus | undefined,
+  status: StreamPhase | undefined,
 ): {
   readonly finalized: ConversationEntry[];
   /** Non-finalized entries in original stream order. The renderer must
@@ -113,7 +113,7 @@ export function splitTranscriptEntries(
    *  fixed. */
   readonly pending: ConversationEntry[];
 } {
-  const showLiveAssistant = isLiveElapsedStatus(status);
+  const showLiveAssistant = isActivePhase(status);
   const finalized: ConversationEntry[] = [];
   const pending: ConversationEntry[] = [];
   for (const [index, entry] of entries.entries()) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -57,11 +57,11 @@ import {
 } from '@cli/runtime/terminalRequirements';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import { isActivePhase } from '@common/constants/streamStatus';
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ExecutionId,
-  type StreamLifecycleStatus,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { escapeText } from '@shared/utils/xmlEscape';
@@ -450,7 +450,7 @@ export async function runChat(
   const followUpQueue = new PQueue({ concurrency: 1 });
   const pendingSkillActivations = new Map<string, string>();
   let pendingSkillActivationClearEpoch = 0;
-  const rootStreamStatus = (): StreamLifecycleStatus | undefined =>
+  const rootStreamStatus = (): StreamPhase | undefined =>
     session.streamId
       ? streamsSignal.get().get(session.streamId)?.status
       : undefined;
@@ -527,8 +527,8 @@ export async function runChat(
     const isRunPending = Boolean(session.runPromise && !session.runCompleted);
 
     if (
-      (isRunPending && activeStatus !== STREAM_STATUS.WAITING) ||
-      isLiveElapsedStatus(activeStatus)
+      (isRunPending && activeStatus !== STREAM_PHASE.WAITING) ||
+      isActivePhase(activeStatus)
     ) {
       appendLocalAssistantTranscript(
         'Wait for the active response to finish, or press Ctrl-C before /clear.',
@@ -1020,7 +1020,7 @@ export async function runChat(
     onStreamStatusChange((change) => {
       if (
         change.streamId === session.streamId &&
-        change.status === STREAM_STATUS.WAITING &&
+        change.status === STREAM_PHASE.WAITING &&
         !session.stopRequested
       ) {
         notify({ kind: 'agentFinished' });

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -1,10 +1,8 @@
 // Pure state helpers for App-level child execution shortcuts and pickers.
 
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
-
 // Local imports - shared schemas
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ActiveChildInfo,
   type StreamTabId,
   type SubagentChildInfo,
@@ -126,7 +124,7 @@ function hasLiveChildElapsed(
 ): boolean {
   return (
     child.startedAt !== undefined &&
-    isLiveElapsedStatus(child.status ?? STREAM_STATUS.RUNNING)
+    (child.status === undefined || child.status === STREAM_PHASE.RUNNING)
   );
 }
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -6,6 +6,7 @@
 import { signal, type Signal } from '@lit-labs/signals';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { isActivePhase } from '@common/constants/streamStatus';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
 import {
   type ActiveChildInfo,
@@ -15,8 +16,7 @@ import {
   type Plan,
   type ProcessOutputTail,
   type RoundStage,
-  STREAM_STATUS,
-  type StreamLifecycleStatus,
+  type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
   type TodoItem,
@@ -110,7 +110,7 @@ export interface StreamSlice {
    *  from `setTaskState` or `setActiveStream`. Lets the exit hint list only
    *  resumable tool-use subagents (workflows don't resume). */
   readonly category: AgentCategory | undefined;
-  readonly status: StreamLifecycleStatus | undefined;
+  readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
    *  status. Drives the StatusBar's live elapsed-time segment so a long
@@ -153,12 +153,13 @@ export interface StreamSlice {
  */
 export function thinkingIndicatorVisible(
   slice:
-    | { readonly status: string | undefined; readonly thinkingActive: boolean }
+    | {
+        readonly status: StreamPhase | undefined;
+        readonly thinkingActive: boolean;
+      }
     | undefined,
 ): boolean {
-  return (
-    slice?.thinkingActive === true && slice.status === STREAM_STATUS.RUNNING
-  );
+  return slice?.thinkingActive === true && isActivePhase(slice.status);
 }
 
 export const NO_BYPASS: BypassState = {
@@ -221,14 +222,13 @@ export function patchStream(
 
 function streamSliceWithStatus(
   slice: StreamSlice,
-  status: StreamLifecycleStatus,
+  status: StreamPhase,
   substate: StreamSubstate | undefined,
   nowMs: number,
 ): StreamSlice {
-  const runStartedAt =
-    status === STREAM_STATUS.RUNNING
-      ? (slice.runStartedAt ?? nowMs)
-      : undefined;
+  const runStartedAt = isActivePhase(status)
+    ? (slice.runStartedAt ?? nowMs)
+    : undefined;
   if (
     slice.status === status &&
     slice.substate === substate &&
@@ -257,7 +257,7 @@ export function setStreamStatusInCliState({
   streamId,
 }: {
   readonly nowMs?: number;
-  readonly status: StreamLifecycleStatus;
+  readonly status: StreamPhase;
   readonly substate?: StreamSubstate;
   readonly streamId: StreamTabId;
 }): void {

--- a/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
+++ b/packages/cli/src/chat/tui/state/focusedChildFollowUp.ts
@@ -2,8 +2,8 @@ import {
   defaultShortcutModifierLabel,
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
-import { isInFlightStatus } from '@common/constants/streamStatus';
-import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
+import { isInFlightPhase } from '@common/constants/streamStatus';
+import type { StreamPhase, StreamTabId } from '@shared/schemas';
 
 import { resolveChildControlDisplayTargets } from './childControls';
 import { activeStreamScope } from './streamViews';
@@ -31,7 +31,7 @@ export function focusedChildFollowUpRoute(init: {
   const status = init.streams.get(scope.streamId)?.status;
   // A focused child normally has a status. Keep the previous permissive
   // behavior during the brief edge where parent focus arrives first.
-  if (status !== undefined && !isInFlightStatus(status)) {
+  if (status !== undefined && !isInFlightPhase(status)) {
     return { kind: 'reject', streamId: scope.streamId };
   }
   return { kind: 'accept', streamId: scope.streamId };
@@ -41,7 +41,7 @@ export function focusedChildInputDisabledMessage(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly parentStream: ReadonlyMap<StreamTabId, StreamTabId>;
   readonly shortcutModifierLabel?: string;
-  readonly status: StreamLifecycleStatus | undefined;
+  readonly status: StreamPhase | undefined;
   readonly subagentControlsAvailable?: boolean;
   readonly taskControlsAvailable?: boolean;
 }): string | undefined {
@@ -52,7 +52,7 @@ export function focusedChildInputDisabledMessage(init: {
   if (
     scope.kind !== 'child' ||
     init.status === undefined ||
-    isInFlightStatus(init.status)
+    isInFlightPhase(init.status)
   ) {
     return undefined;
   }

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -1,9 +1,9 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { CliExitCode } from '@cli/runtime/exitCodes';
-import { isLiveElapsedStatus } from '@common/constants/streamStatus';
+import { isActivePhase } from '@common/constants/streamStatus';
 import {
-  STREAM_STATUS,
-  type StreamLifecycleStatus,
+  STREAM_PHASE,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -97,20 +97,20 @@ export function chatTuiCanInterruptActiveRun(
 
 export function chatTuiCanStopActiveRun(
   session: InterruptibleTuiSessionState,
-  status: StreamLifecycleStatus | undefined,
+  status: StreamPhase | undefined,
 ): boolean {
   if (!session.runPromise || session.runCompleted) return false;
   if (!session.streamId) return true;
-  return status === undefined || isLiveElapsedStatus(status);
+  return status === undefined || isActivePhase(status);
 }
 
 export function chatTuiCanStopVisibleRun(
   session: InterruptibleTuiSessionState,
-  status: StreamLifecycleStatus | undefined,
+  status: StreamPhase | undefined,
 ): boolean {
   return (
     chatTuiCanStopActiveRun(session, status) ||
-    Boolean(session.streamId && isLiveElapsedStatus(status))
+    Boolean(session.streamId && isActivePhase(status))
   );
 }
 
@@ -129,14 +129,14 @@ export function publishChatTuiRootRunStartAvailability(
 export function chatTuiCanSelectModel(input: {
   readonly canStartRootRun: boolean;
   readonly streamId: StreamTabId | undefined;
-  readonly status: StreamLifecycleStatus | undefined;
+  readonly status: StreamPhase | undefined;
   readonly hasActiveToolUseFlow: boolean;
 }): boolean {
   return (
     input.canStartRootRun ||
     Boolean(
       input.streamId &&
-      input.status === STREAM_STATUS.WAITING &&
+      input.status === STREAM_PHASE.WAITING &&
       input.hasActiveToolUseFlow,
     )
   );

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -1,6 +1,10 @@
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { isTerminalStatus } from '@common/constants/streamStatus';
-import { type StreamLifecycleStatus, type StreamTabId } from '@shared/schemas';
+import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
+import {
+  STREAM_PHASE,
+  type StreamPhase,
+  type StreamTabId,
+} from '@shared/schemas';
 
 import {
   activeStreamId,
@@ -17,16 +21,15 @@ import { activeStreamParentOrSelfId } from './streamViews';
 export const CLI_LOCAL_STREAM_ID = 'cli-local' as StreamTabId;
 
 /**
- * Stream statuses at which deferred-finalization entries (assistant text and
- * tool rows) are promoted into `<Static>` scrollback. This is exactly the
- * shared "execution ended" set ({@link isTerminalStatus}): a terminal status
- * means the current cycle is done, so its entries are safe to finalize. Aliased
- * (not re-declared) so the membership stays single-sourced across all hosts.
+ * Stream phases at which deferred-finalization entries (assistant text and
+ * tool rows) are promoted into `<Static>` scrollback. WAITING ends the current
+ * turn without ending the run; terminal outcomes end both. In either case the
+ * current entries are safe to finalize.
  */
 export function isFinalTranscriptStatus(
-  status: StreamLifecycleStatus | undefined,
+  status: StreamPhase | undefined,
 ): boolean {
-  return isTerminalStatus(status);
+  return status === STREAM_PHASE.WAITING || isTerminalOutcomePhase(status);
 }
 
 let localEntrySeq = 0;

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -1,4 +1,4 @@
-import type { StreamLifecycleStatus, StreamTabId } from '@shared/schemas';
+import type { StreamPhase, StreamTabId } from '@shared/schemas';
 
 import { syncStreamLog } from './subscribeStreamLog';
 import {
@@ -31,7 +31,7 @@ export function projectStreamTranscript(
 /** Project a stream after a status transition. Final statuses promote rows. */
 export function projectStreamTranscriptForStatus(
   streamId: StreamTabId,
-  status: StreamLifecycleStatus,
+  status: StreamPhase,
 ): void {
   projectStreamTranscript(streamId, {
     finalize: isFinalTranscriptStatus(status),

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -15,7 +15,6 @@ import type {
 import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
 import {
   STREAM_PHASE,
-  STREAM_STATUS,
   type ActiveChildInfo,
   type ConversationProgress,
   type RoundStage,
@@ -403,7 +402,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 function formatRunProgressStatus(status: StreamPhase): string {
   if (status === STREAM_PHASE.COMPLETED) return 'done';
   if (status === STREAM_PHASE.CANCELLED) return 'interrupted';
-  if (status === STREAM_PHASE.FAILED) return STREAM_STATUS.ERROR;
+  if (status === STREAM_PHASE.FAILED) return 'error';
   return status;
 }
 

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -58,7 +58,7 @@ import {
 
 // Local imports - shared schemas
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   TOOL_USE_STATUS,
   type NormalizedToolUse,
   type StreamTabId,
@@ -124,10 +124,8 @@ function childStatusStreams(
       row.childStreamId,
       slice({
         streamId: row.childStreamId,
-        // Test fixtures reuse the loosely-typed `ActiveChildInfo.status`
-        // strings (e.g. legacy 'stopped'/'initializing') that
-        // `StreamLifecycleStatusSchema` accepts and normalizes at runtime,
-        // but the static `StreamLifecycleStatus` type doesn't include them.
+        // ChildStreamEntryRow keeps process status text stringly typed, while
+        // subagent StreamSlice status is the canonical StreamPhase.
         status: row.status as StreamSlice['status'],
       }),
     ]),
@@ -306,7 +304,7 @@ describe('CLI child execution controls', () => {
           executionId: 'agent-2',
           agentName: 'reviewer',
           childStreamId: 'child-b',
-          status: 'stopped',
+          status: STREAM_PHASE.CANCELLED,
           elapsed: '20s',
           active: false,
         },
@@ -419,7 +417,7 @@ describe('CLI child execution controls', () => {
     expect(childElapsed(parentSlice.activeProcesses[0], 62_000)).toBe('1s');
     expect(
       childElapsed(
-        { startedAt: 0, status: STREAM_STATUS.RUNNING, elapsed: '1s' },
+        { startedAt: 0, status: STREAM_PHASE.RUNNING, elapsed: '1s' },
         7_501_234,
       ),
     ).toBe('2h 5m');
@@ -432,7 +430,7 @@ describe('CLI child execution controls', () => {
           kind: 'process',
           executionId: 'proc-1',
           agentName: 'bash',
-          status: STREAM_STATUS.WAITING,
+          status: STREAM_PHASE.WAITING,
           elapsed: '3s',
         },
       ],
@@ -446,7 +444,7 @@ describe('CLI child execution controls', () => {
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'child-a',
-          status: STREAM_STATUS.WAITING,
+          status: STREAM_PHASE.WAITING,
           elapsed: '20s',
         },
       ],
@@ -498,7 +496,7 @@ describe('CLI child execution controls', () => {
             childStreamId: 'agent-1-stream',
             executionId: 'agent-1',
             agentName: 'reviewer',
-            status: 'initializing',
+            status: STREAM_PHASE.RUNNING,
             startedAt: 1_000,
           },
         ],
@@ -512,7 +510,7 @@ describe('CLI child execution controls', () => {
           'agent-1-stream',
           slice({
             streamId: 'agent-1-stream',
-            status: 'initializing' as StreamSlice['status'],
+            status: STREAM_PHASE.RUNNING,
           }),
         ],
       ]),
@@ -760,7 +758,7 @@ describe('CLI child execution controls', () => {
           executionId: 'agent-1',
           agentName: 'critic',
           childStreamId: 'child-a',
-          status: 'stopped',
+          status: STREAM_PHASE.CANCELLED,
           active: false,
         },
         {
@@ -1057,7 +1055,7 @@ describe('CLI child execution controls', () => {
           executionId: 'agent-1',
           agentName: 'review',
           childStreamId: 'review-stream',
-          status: 'stopped',
+          status: STREAM_PHASE.CANCELLED,
           active: false,
         },
       ],

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -46,11 +46,12 @@ import {
   finalizeAssistantTranscriptEntries,
 } from '@cli/chat/tui/state/transcript';
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
-import { STREAM_PHASE } from '@shared/schemas';
 import {
-  STREAM_STATUS,
+  RUN_OUTCOME,
+  STREAM_PHASE,
   TOOL_USE_STATUS,
   type NormalizedToolUse,
+  type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -148,14 +149,14 @@ describe('CLI conversation transcript splitting', () => {
 
     const running = splitTranscriptEntries(
       [user, assistant],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
     expect(running.finalized).toEqual([user]);
     expect(running.pending).toEqual([assistant]);
 
     const waitingBeforeFinalize = splitTranscriptEntries(
       [user, assistant],
-      STREAM_STATUS.WAITING,
+      STREAM_PHASE.WAITING,
     );
     expect(waitingBeforeFinalize.finalized).toEqual([user]);
     expect(waitingBeforeFinalize.pending).toEqual([]);
@@ -177,40 +178,45 @@ describe('CLI conversation transcript splitting', () => {
     expect(slice?.entries.map((item) => item.finalized)).toEqual([true, true]);
     const split = splitTranscriptEntries(
       slice?.entries ?? [],
-      STREAM_STATUS.WAITING,
+      STREAM_PHASE.WAITING,
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1', 'a1']);
     expect(split.pending).toEqual([]);
   });
 
-  it('freezes assistant entries when a stream returns to ready', () => {
-    resetCliState();
-    patchStream(STREAM_ID, (slice) => ({
-      ...slice,
-      entries: [entry('a1', 'assistant', 'A final answer.', false)],
-    }));
-    const dispose = subscribeStreamStatus();
+  it.each(Object.values(RUN_OUTCOME) as RunOutcome[])(
+    'freezes assistant entries on the %s outcome',
+    (outcome) => {
+      defaultSession().status.clearStream(STREAM_ID);
+      resetCliState();
+      patchStream(STREAM_ID, (slice) => ({
+        ...slice,
+        entries: [entry('a1', 'assistant', 'A final answer.', false)],
+      }));
+      const dispose = subscribeStreamStatus();
 
-    try {
-      defaultSession().status.transition(
-        STREAM_ID,
-        STREAM_PHASE.COMPLETED,
-        'restart-repair',
-      );
+      try {
+        defaultSession().status.transition(
+          STREAM_ID,
+          outcome,
+          'restart-repair',
+        );
 
-      expect(
-        streams
-          .get()
-          .get(STREAM_ID)
-          ?.entries.map((item) => ({
-            id: item.id,
-            finalized: item.finalized,
-          })),
-      ).toEqual([{ id: 'a1', finalized: true }]);
-    } finally {
-      dispose();
-    }
-  });
+        expect(
+          streams
+            .get()
+            .get(STREAM_ID)
+            ?.entries.map((item) => ({
+              id: item.id,
+              finalized: item.finalized,
+            })),
+        ).toEqual([{ id: 'a1', finalized: true }]);
+      } finally {
+        dispose();
+        defaultSession().status.clearStream(STREAM_ID);
+      }
+    },
+  );
 
   // Regression: a stream reused for a new run still carries WAITING from
   // the prior turn. The status must flip to a non-final value before
@@ -220,7 +226,7 @@ describe('CLI conversation transcript splitting', () => {
     resetCliState();
     patchStream(STREAM_ID, (slice) => ({
       ...slice,
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     }));
     const dispose = subscribeStreamStatus();
 
@@ -231,7 +237,7 @@ describe('CLI conversation transcript splitting', () => {
         'resume',
       );
 
-      expect(streams.get().get(STREAM_ID)?.status).toBe(STREAM_STATUS.RUNNING);
+      expect(streams.get().get(STREAM_ID)?.status).toBe(STREAM_PHASE.RUNNING);
     } finally {
       dispose();
     }
@@ -249,7 +255,7 @@ describe('CLI conversation transcript splitting', () => {
 
     const split = splitTranscriptEntries(
       [user, assistant, tool],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
 
     expect(split.finalized.map((e) => e.id)).toEqual(['u1']);
@@ -272,7 +278,7 @@ describe('CLI conversation transcript splitting', () => {
 
     let split = splitTranscriptEntries(
       streams.get().get(STREAM_ID)?.entries ?? [],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
     expect(split.finalized).toHaveLength(0);
     expect(split.pending.map((e) => e.id)).toEqual(['a1', 't1']);
@@ -281,7 +287,7 @@ describe('CLI conversation transcript splitting', () => {
 
     split = splitTranscriptEntries(
       streams.get().get(STREAM_ID)?.entries ?? [],
-      STREAM_STATUS.WAITING,
+      STREAM_PHASE.WAITING,
     );
     expect(split.finalized.map((e) => e.id)).toEqual(['a1', 't1']);
     expect(split.pending).toHaveLength(0);
@@ -422,7 +428,7 @@ describe('CLI conversation transcript splitting', () => {
 
     const split = splitTranscriptEntries(
       [user, emptyAssistant, tool],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
     expect(split.pending.map((item) => item.id)).toEqual(['t1']);
@@ -465,12 +471,12 @@ describe('CLI conversation transcript splitting', () => {
       [
         STREAM_ID,
         sliceWithEntries(STREAM_ID, [user], {
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ],
     ]);
 
-    const split = splitTranscriptEntries([user], STREAM_STATUS.RUNNING);
+    const split = splitTranscriptEntries([user], STREAM_PHASE.RUNNING);
     expect(split.finalized).toEqual([]);
     expect(split.pending.map((item) => item.id)).toEqual(['u1']);
 
@@ -490,12 +496,12 @@ describe('CLI conversation transcript splitting', () => {
       [
         STREAM_ID,
         sliceWithEntries(STREAM_ID, [user, tool], {
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ],
     ]);
 
-    const split = splitTranscriptEntries([user, tool], STREAM_STATUS.RUNNING);
+    const split = splitTranscriptEntries([user, tool], STREAM_PHASE.RUNNING);
     expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
     expect(split.pending.map((item) => item.id)).toEqual(['t1']);
 
@@ -526,7 +532,7 @@ describe('CLI conversation transcript splitting', () => {
 
     const split = splitTranscriptEntries(
       [continuation, assistant],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
     expect(split.finalized.map((item) => item.id)).toEqual(['u1']);
     expect(split.pending.map((item) => item.id)).toEqual(['a1']);
@@ -553,7 +559,7 @@ describe('CLI conversation transcript splitting', () => {
     expect(
       splitTranscriptEntries(
         [user, invisibleAssistant, tool],
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       ).pending.map((item) => item.id),
     ).toEqual(['t1']);
     expect(
@@ -917,7 +923,7 @@ describe('CLI conversation transcript splitting', () => {
           executionId: 'ei_search',
           agentName: 'search',
           childStreamId: CHILD,
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         },
       ],
     });
@@ -1163,7 +1169,7 @@ describe('CLI conversation transcript splitting', () => {
       thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: true,
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ),
     ).toBe(true);
@@ -1173,7 +1179,7 @@ describe('CLI conversation transcript splitting', () => {
       thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: false,
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ),
     ).toBe(false);
@@ -1181,7 +1187,7 @@ describe('CLI conversation transcript splitting', () => {
       thinkingIndicatorVisible(
         sliceWithEntries(STREAM_ID, [], {
           thinkingActive: true,
-          status: STREAM_STATUS.WAITING,
+          status: STREAM_PHASE.WAITING,
         }),
       ),
     ).toBe(false);

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -5,7 +5,7 @@ import {
   formatCliStatusLabel,
   formatCliSessionStatus,
 } from '@cli/chat/tui/sessionStatus';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 
 const STREAM_ID = 'status-queued-followups-test-stream';
 
@@ -291,14 +291,14 @@ describe('CLI session status formatter', () => {
   });
 
   it('uses the footer label for an idle waiting stream', () => {
-    expect(formatCliStatusLabel(STREAM_STATUS.WAITING)).toBe('idle');
+    expect(formatCliStatusLabel(STREAM_PHASE.WAITING)).toBe('idle');
     expect(
       formatCliSessionStatus({
         agent: 'research',
         model: 'deepseekT',
         api: 'included relay',
         approval: 'ask before privileged actions',
-        status: STREAM_STATUS.WAITING,
+        status: STREAM_PHASE.WAITING,
         queuedFollowUpMessages: [],
       }),
     ).toContain('status: idle');

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -26,7 +26,7 @@ import type { TuiSession } from '@cli/chat/tui/state/sessionRunState';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -248,7 +248,7 @@ describe('handleTuiSlashCommand', () => {
     activeStreamId.set(streamId);
     patchStream(streamId, (slice) => ({
       ...slice,
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     }));
 
     const handled = await handleTuiSlashCommand(

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -11,7 +11,7 @@ import {
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
-import { STREAM_PHASE, STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE, STREAM_SUBSTATE } from '@shared/schemas';
 
 const PERSONAL_API_MODE_LABEL = shortCliApiMode('personal');
 const COMPLETED_REVIEW_FOLLOWUP =
@@ -24,7 +24,7 @@ function statusInput(
   overrides: Partial<StatusBarDisplayInput> = {},
 ): StatusBarDisplayInput {
   return {
-    status: STREAM_STATUS.WAITING,
+    status: STREAM_PHASE.WAITING,
     pendingExitHint: false,
     pendingExitResumeId: undefined,
     bypass: NO_BYPASS,
@@ -144,7 +144,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps queued follow-up counts in the durable left status segments', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         queuedFollowUpMessages: ['Keep the proof under one page.'],
       }),
     );
@@ -309,7 +309,7 @@ describe('CLI StatusBar display model', () => {
   it('hides task shortcuts when no task rows exist', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 12_000,
         taskControlsAvailable: false,
         apiMode: 'relay',
@@ -326,7 +326,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps subagent shortcuts grouped when task shortcuts are hidden', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 12_000,
         activeSubagents: 1,
         taskControlsAvailable: false,
@@ -351,7 +351,7 @@ describe('CLI StatusBar display model', () => {
   it('does not advertise in-pane paging for focused child streams', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         activeSubagents: 1,
         taskControlsAvailable: false,
         subagentControlsAvailable: true,
@@ -381,7 +381,7 @@ describe('CLI StatusBar display model', () => {
   it('shows live running signals and approval depth', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         queuedFollowUpMessages: [
           'Keep the proof under one page.',
           'Also mention the finite monoid argument.',
@@ -422,7 +422,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps critical controls visible in narrow subagent sessions', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 88_000,
         activeSubagents: 3,
         activeProcesses: 1,
@@ -443,7 +443,7 @@ describe('CLI StatusBar display model', () => {
   it('prefers the task picker when one child-control shortcut fits', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 88_000,
         activeSubagents: 3,
         activeProcesses: 1,
@@ -463,7 +463,7 @@ describe('CLI StatusBar display model', () => {
   it('drops low-priority status details before narrow footers lose separators', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 75_000,
         activeSubagents: 3,
         activeProcesses: 1,
@@ -490,7 +490,7 @@ describe('CLI StatusBar display model', () => {
   it('drops approval depth before returning an over-wide narrow status', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 75_000,
         approvalDepth: 3,
         ctrlCAction: 'stop',
@@ -509,7 +509,7 @@ describe('CLI StatusBar display model', () => {
   it('drops elapsed before returning an over-wide critical-only status', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 75_000,
         ctrlCAction: 'stop',
         width: 16,
@@ -526,7 +526,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps queued follow-up previews aligned with visible queued counts', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         elapsedMs: 75_000,
         queuedFollowUpMessages: ['Keep the proof under one page.'],
         approvalDepth: 3,
@@ -547,7 +547,7 @@ describe('CLI StatusBar display model', () => {
   it('can hide queued follow-up previews while keeping the durable count', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         queuedFollowUpMessages: ['Keep the proof under one page.'],
         queuedFollowUpPreview: false,
         ctrlCAction: 'stop',
@@ -602,7 +602,7 @@ describe('CLI StatusBar display model', () => {
 
     const liveChildDisplay = buildStatusBarDisplay({
       ...baseDisplayInput,
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
     });
     expect(liveChildDisplay.left.map(statusBarSegmentText)).not.toContain(
       'root active',
@@ -619,13 +619,13 @@ describe('CLI StatusBar display model', () => {
 
   it('labels a focused WAITING child distinctly from the root idle wording', () => {
     const rootDisplay = buildStatusBarDisplay(
-      statusInput({ status: STREAM_STATUS.WAITING, isChildStream: false }),
+      statusInput({ status: STREAM_PHASE.WAITING, isChildStream: false }),
     );
     expect(rootDisplay.left.map(statusBarSegmentText)).toContain('idle');
 
     const childDisplay = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.WAITING,
+        status: STREAM_PHASE.WAITING,
         isChildStream: true,
         subagentControlsAvailable: true,
         hasMultipleStreams: true,
@@ -643,7 +643,7 @@ describe('CLI StatusBar display model', () => {
     const child = 'child';
     const waitingChildSlice = {
       streamId: child,
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     } as StreamSlice;
     const streams = new Map<StreamSlice['streamId'], StreamSlice>([
       [child, waitingChildSlice],
@@ -680,7 +680,7 @@ describe('CLI StatusBar display model', () => {
     const grandchild = 'grandchild';
     const rootSlice = {
       streamId: root,
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
     } as StreamSlice;
     const childSlice = {
       streamId: child,
@@ -815,7 +815,7 @@ describe('CLI StatusBar display model', () => {
 
     const waitingRootSlice = {
       streamId: root,
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     } as StreamSlice;
     expect(
       statusBarStreamTarget({
@@ -876,25 +876,25 @@ describe('CLI StatusBar display model', () => {
         streams: new Map<StreamSlice['streamId'], StreamSlice>([
           [
             root,
-            { streamId: root, status: STREAM_STATUS.WAITING } as StreamSlice,
+            { streamId: root, status: STREAM_PHASE.WAITING } as StreamSlice,
           ],
         ]),
       }),
     ).toMatchObject({
       ctrlCAction: 'exit',
-      displaySlice: { streamId: root, status: STREAM_STATUS.WAITING },
+      displaySlice: { streamId: root, status: STREAM_PHASE.WAITING },
     });
   });
 
   it('uses focused stream status when a stopped child stream is focused', () => {
     const rootSlice = {
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
     } as StreamSlice;
     const childSlice = {
       status: STREAM_PHASE.CANCELLED,
     } as StreamSlice;
     const waitingChildSlice = {
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     } as StreamSlice;
     const streams = new Map<StreamSlice['streamId'], StreamSlice>([
       ['root', rootSlice],
@@ -939,7 +939,7 @@ describe('CLI StatusBar display model', () => {
   it('hides inactive global bindings while a foreground panel owns input', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         activeSubagents: 2,
         activeProcesses: 1,
         approvalDepth: 1,
@@ -959,7 +959,7 @@ describe('CLI StatusBar display model', () => {
   it('labels foreground user questions as questions instead of approvals', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         approvalDepth: 1,
         approvalKind: 'question',
         foregroundEscapeAction: 'skip',
@@ -975,7 +975,7 @@ describe('CLI StatusBar display model', () => {
   it('shows cancel for non-question approval foregrounds', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         approvalDepth: 1,
         foregroundEscapeAction: 'cancel',
         shortcutsActive: false,
@@ -988,7 +988,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps escape and Ctrl-C actions visible in narrow foreground panels', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         activeSubagents: 3,
         activeProcesses: 1,
         subagentControlsAvailable: true,
@@ -1005,7 +1005,7 @@ describe('CLI StatusBar display model', () => {
   it('falls back to the bare Ctrl-C action in tiny foreground panels', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         activeSubagents: 3,
         activeProcesses: 1,
         subagentControlsAvailable: true,
@@ -1021,7 +1021,7 @@ describe('CLI StatusBar display model', () => {
 
   it('shows a live elapsed segment only while running', () => {
     const runningInput = statusInput({
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       elapsedMs: 110_000,
     });
     const running = buildStatusBarDisplay(runningInput);
@@ -1029,6 +1029,17 @@ describe('CLI StatusBar display model', () => {
     expect(running.left.map(statusBarSegmentText)).toEqual([
       '◆',
       'running',
+      '1m 50s',
+      PERSONAL_API_MODE_LABEL,
+    ]);
+
+    const resuming = buildStatusBarDisplay({
+      ...runningInput,
+      substate: STREAM_SUBSTATE.RESUMING,
+    });
+    expect(resuming.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'resuming',
       '1m 50s',
       PERSONAL_API_MODE_LABEL,
     ]);
@@ -1071,7 +1082,7 @@ describe('CLI StatusBar display model', () => {
   it('preserves distinct YOLO, bash, and edit bypass badges', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         bypass: { bash: true, superYolo: true, toolEdit: true },
       }),
     );
@@ -1101,7 +1112,7 @@ describe('CLI StatusBar display model', () => {
   it('budgets queued follow-up previews with rendered badge padding', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         bypass: { bash: false, superYolo: true, toolEdit: true },
         queuedFollowUpMessages: ['Keep the proof under one page.'],
         width: 65,
@@ -1115,7 +1126,7 @@ describe('CLI StatusBar display model', () => {
   it('shows the resume command while exit confirmation is armed', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         pendingExitHint: true,
         pendingExitResumeId: 'abc123',
       }),
@@ -1134,7 +1145,7 @@ describe('CLI StatusBar display model', () => {
   it('uses the provided command name in the armed-exit resume command', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         pendingExitHint: true,
         pendingExitResumeId: 'abc123',
         commandName: 'texra-local',
@@ -1149,7 +1160,7 @@ describe('CLI StatusBar display model', () => {
   it('warns that queued follow-ups are discarded while exit is armed', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         pendingExitHint: true,
         pendingExitResumeId: 'abc123',
         queuedFollowUpMessages: [
@@ -1173,7 +1184,7 @@ describe('CLI StatusBar display model', () => {
 
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {
     const input = statusInput({
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
     });
 
@@ -1196,7 +1207,7 @@ describe('CLI StatusBar display model', () => {
   it('keeps the exit confirmation visible in very narrow footers', () => {
     const display = buildStatusBarDisplay(
       statusInput({
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         pendingExitHint: true,
         pendingExitResumeId: 'abc123',
         width: 29,

--- a/src/test-kernel/cli/StreamTabsStrip.vitest.mts
+++ b/src/test-kernel/cli/StreamTabsStrip.vitest.mts
@@ -18,7 +18,7 @@ import {
   streamTabsDisplayItems,
 } from '@cli/chat/tui/panes/StreamTabsStrip';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
-import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 
 function streamId(value: string): StreamTabId {
   return value as StreamTabId;
@@ -192,9 +192,9 @@ describe('CLI stream tabs strip', () => {
     const child1 = streamId('child-1');
     const child2 = streamId('child-2');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
-      [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
-      [child2, slice('child-2', { status: STREAM_STATUS.RUNNING })],
+      [root, slice('root', { status: STREAM_PHASE.RUNNING })],
+      [child1, slice('child-1', { status: STREAM_PHASE.WAITING })],
+      [child2, slice('child-2', { status: STREAM_PHASE.RUNNING })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
       parentStreamId: root,
@@ -261,8 +261,8 @@ describe('CLI stream tabs strip', () => {
     const child1 = streamId('child-1');
     const child2 = streamId('child-2');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
-      [child2, slice('child-2', { status: STREAM_STATUS.WAITING })],
+      [child1, slice('child-1', { status: STREAM_PHASE.WAITING })],
+      [child2, slice('child-2', { status: STREAM_PHASE.WAITING })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
       parentStreamId: root,
@@ -290,8 +290,8 @@ describe('CLI stream tabs strip', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [root, slice('root', { status: STREAM_STATUS.WAITING })],
-      [child1, slice('child-1', { status: STREAM_STATUS.WAITING })],
+      [root, slice('root', { status: STREAM_PHASE.WAITING })],
+      [child1, slice('child-1', { status: STREAM_PHASE.WAITING })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
       parentStreamId: root,
@@ -352,11 +352,11 @@ describe('CLI stream tabs strip', () => {
     ]);
   });
 
-  it('labels a focused error or ready stream like a focused stopped one', () => {
+  it('labels focused failed and completed streams as ended', () => {
     const root = streamId('root');
     const child1 = streamId('child-1');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [root, slice('root', { status: STREAM_STATUS.READY })],
+      [root, slice('root', { status: STREAM_PHASE.COMPLETED })],
       [child1, slice('child-1', { status: STREAM_PHASE.FAILED })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
@@ -379,10 +379,10 @@ describe('CLI stream tabs strip', () => {
       width: 80,
     });
 
-    // The focused (active) error tab surfaces its status, matching stopped;
-    // previously only 'stopped' was special-cased and error/ready showed bare.
+    // The focused failed tab surfaces its status, as every terminal outcome
+    // does; completed roots retain their canonical label too.
     expect(items.map(streamTabSegmentText)).toEqual([
-      'main(ready)',
+      'main(completed)',
       '[1:strategy](error)',
     ]);
   });
@@ -393,8 +393,8 @@ describe('CLI stream tabs strip', () => {
     const grandchild1 = streamId('grandchild-1');
     const streams = new Map<StreamTabId, StreamSlice>([
       [root, slice('root')],
-      [child1, slice('child-1', { status: STREAM_STATUS.RUNNING })],
-      [grandchild1, slice('grandchild-1', { status: STREAM_STATUS.RUNNING })],
+      [child1, slice('child-1', { status: STREAM_PHASE.RUNNING })],
+      [grandchild1, slice('grandchild-1', { status: STREAM_PHASE.RUNNING })],
     ]);
     const childStreamEntries = new Map([
       ...buildChildStreamEntries({
@@ -480,10 +480,10 @@ describe('CLI stream tabs strip', () => {
     const leanSolver = streamId('lean-stream');
     const reviewer = streamId('reviewer-stream');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
-      [strategy, slice('strategy-stream', { status: STREAM_STATUS.RUNNING })],
-      [leanSolver, slice('lean-stream', { status: STREAM_STATUS.WAITING })],
-      [reviewer, slice('reviewer-stream', { status: STREAM_STATUS.RUNNING })],
+      [root, slice('root', { status: STREAM_PHASE.RUNNING })],
+      [strategy, slice('strategy-stream', { status: STREAM_PHASE.RUNNING })],
+      [leanSolver, slice('lean-stream', { status: STREAM_PHASE.WAITING })],
+      [reviewer, slice('reviewer-stream', { status: STREAM_PHASE.RUNNING })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
       parentStreamId: root,
@@ -492,19 +492,19 @@ describe('CLI stream tabs strip', () => {
           executionId: 'strategy',
           childStreamId: strategy,
           agentName: 'strategy',
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
         child({
           executionId: 'lean',
           childStreamId: leanSolver,
           agentName: 'leanSolver',
-          status: STREAM_STATUS.WAITING,
+          status: STREAM_PHASE.WAITING,
         }),
         child({
           executionId: 'review',
           childStreamId: reviewer,
           agentName: 'reviewer',
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ],
     });
@@ -645,9 +645,9 @@ describe('CLI stream tabs strip', () => {
     const middle = streamId('middle-stream');
     const active = streamId('active-stream');
     const streams = new Map<StreamTabId, StreamSlice>([
-      [root, slice('root', { status: STREAM_STATUS.RUNNING })],
-      [middle, slice('middle-stream', { status: STREAM_STATUS.RUNNING })],
-      [active, slice('active-stream', { status: STREAM_STATUS.RUNNING })],
+      [root, slice('root', { status: STREAM_PHASE.RUNNING })],
+      [middle, slice('middle-stream', { status: STREAM_PHASE.RUNNING })],
+      [active, slice('active-stream', { status: STREAM_PHASE.RUNNING })],
     ]);
     const childStreamEntries = buildChildStreamEntries({
       parentStreamId: root,
@@ -656,13 +656,13 @@ describe('CLI stream tabs strip', () => {
           executionId: 'middle',
           childStreamId: middle,
           agentName: 'veryLongMiddleAgent',
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
         child({
           executionId: 'active',
           childStreamId: active,
           agentName: 'activeTarget',
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         }),
       ],
     });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -8,7 +8,7 @@ import {
   compactChildRowText,
   compactRows,
 } from '@cli/chat/tui/panes/SubagentList';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_PHASE } from '@shared/schemas';
 import type { ActiveChildInfo } from '@shared/schemas';
 
 describe('CLI SubagentList display model', () => {
@@ -161,7 +161,7 @@ describe('CLI SubagentList display model', () => {
           kind: 'process',
           executionId: 'review',
           agentName: 'review',
-          status: STREAM_STATUS.WAITING,
+          status: STREAM_PHASE.WAITING,
         },
         nowMs: Date.now(),
       }),

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -89,7 +89,6 @@ import {
   DEFAULT_TOOL_CONFIG,
   MESSAGE_TYPES,
   STREAM_PHASE,
-  STREAM_STATUS,
   TODO_STATUS,
   type ActiveChildInfo,
   type ExecutionId,
@@ -158,7 +157,7 @@ describe('cliState Phase 4 fields', () => {
         executionId: 'agent-1',
         agentName: 'critic',
         childStreamId: child1,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       },
     ]);
     setParentStream(child1, root);
@@ -171,11 +170,11 @@ describe('cliState Phase 4 fields', () => {
           kind: 'process',
           executionId: 'process-1',
           agentName: 'bash',
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         },
       ],
     }));
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
 
     expect(
       hasChildControlItems(
@@ -243,7 +242,7 @@ describe('cliState Phase 4 fields', () => {
           executionId: 'agent-1',
           agentName: 'codex',
           childStreamId: child1,
-          status: STREAM_STATUS.RUNNING,
+          status: STREAM_PHASE.RUNNING,
         },
       ]);
       // A later, empty roster clears active membership; the retained row
@@ -292,7 +291,7 @@ describe('cliState Phase 4 fields', () => {
       activeStreamId.set(root);
       patchStream(child1, (s) => ({
         ...s,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       }));
 
       hub.emit({
@@ -308,7 +307,7 @@ describe('cliState Phase 4 fields', () => {
               executionId: 'agent-1',
               agentName: 'critic',
               childStreamId: child1,
-              status: STREAM_STATUS.RUNNING,
+              status: STREAM_PHASE.RUNNING,
             },
           ],
         },
@@ -603,7 +602,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         todos: [openTodo],
       }),
     ).toBe(true);
@@ -619,7 +618,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        status: STREAM_STATUS.WAITING,
+        status: STREAM_PHASE.WAITING,
         todos: [openTodo],
       }),
     ).toBe(false);
@@ -635,7 +634,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: true,
         hasPlan: false,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         todos: [openTodo],
       }),
     ).toBe(false);
@@ -643,7 +642,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: false,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         todos: [],
       }),
     ).toBe(false);
@@ -651,7 +650,7 @@ describe('CLI TUI row allocation', () => {
       shouldShowTodosPlanPanel({
         foregroundOpen: false,
         hasPlan: true,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         todos: [
           {
             content: 'Finish the old goal',
@@ -773,7 +772,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiCanSelectModel({
         canStartRootRun: false,
         streamId: root,
-        status: STREAM_STATUS.WAITING,
+        status: STREAM_PHASE.WAITING,
         hasActiveToolUseFlow: true,
       }),
     ).toBe(true);
@@ -781,7 +780,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiCanSelectModel({
         canStartRootRun: false,
         streamId: root,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
         hasActiveToolUseFlow: true,
       }),
     ).toBe(false);
@@ -789,7 +788,7 @@ describe('CLI TUI row allocation', () => {
       chatTuiCanSelectModel({
         canStartRootRun: false,
         streamId: root,
-        status: STREAM_STATUS.WAITING,
+        status: STREAM_PHASE.WAITING,
         hasActiveToolUseFlow: false,
       }),
     ).toBe(false);
@@ -815,7 +814,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(true);
     expect(
@@ -835,7 +834,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.WAITING,
+        STREAM_PHASE.WAITING,
       ),
     ).toBe(false);
     expect(
@@ -865,7 +864,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.READY,
+        STREAM_PHASE.COMPLETED,
       ),
     ).toBe(false);
     expect(
@@ -875,7 +874,7 @@ describe('CLI TUI row allocation', () => {
           runPromise,
           streamId: root,
         },
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(false);
   });
@@ -888,7 +887,7 @@ describe('CLI TUI row allocation', () => {
           runPromise: undefined,
           streamId: root,
         },
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(true);
     expect(
@@ -908,7 +907,7 @@ describe('CLI TUI row allocation', () => {
           runPromise: undefined,
           streamId: undefined,
         },
-        STREAM_STATUS.RUNNING,
+        STREAM_PHASE.RUNNING,
       ),
     ).toBe(false);
     expect(
@@ -918,7 +917,7 @@ describe('CLI TUI row allocation', () => {
           runPromise: undefined,
           streamId: root,
         },
-        STREAM_STATUS.WAITING,
+        STREAM_PHASE.WAITING,
       ),
     ).toBe(false);
   });
@@ -960,8 +959,8 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('selects the focused child stream as a follow-up target', () => {
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     setParentStream(child1, root);
 
     activeStreamId.set(root);
@@ -975,7 +974,7 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('ignores stale child row status when routing focused child follow-ups', () => {
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     applySubagentRoster(root, [
       {
         kind: 'subagent',
@@ -985,7 +984,7 @@ describe('CLI TUI row allocation', () => {
         status: STREAM_PHASE.COMPLETED,
       },
     ]);
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     setParentStream(child1, root);
 
     activeStreamId.set(child1);
@@ -996,14 +995,14 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('uses child slice status as a fallback for focused child follow-ups', () => {
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     applySubagentRoster(root, [
       {
         kind: 'subagent',
         executionId: 'child-exec-1',
         agentName: 'critic',
         childStreamId: child1,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       },
     ]);
     patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.CANCELLED }));
@@ -1039,7 +1038,7 @@ describe('CLI TUI row allocation', () => {
       focusedChildInputDisabledMessage({
         activeStreamId: child1,
         parentStream: parentStream.get(),
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       }),
     ).toBeUndefined();
 
@@ -1105,7 +1104,7 @@ describe('CLI TUI row allocation', () => {
 
   it('mirrors running child status events into focused child routing', () => {
     const dispose = subscribeStreamStatus();
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     applySubagentRoster(root, [
       {
         kind: 'subagent',
@@ -1126,14 +1125,14 @@ describe('CLI TUI row allocation', () => {
       );
 
       activeStreamId.set(child1);
-      expect(streams.get().get(child1)?.status).toBe(STREAM_STATUS.RUNNING);
+      expect(streams.get().get(child1)?.status).toBe(STREAM_PHASE.RUNNING);
       expect(
         retainedChildStreamsFor(
           root,
           childStreamEntries.get(),
           streams.get(),
         )[0]?.status,
-      ).toBe(STREAM_STATUS.RUNNING);
+      ).toBe(STREAM_PHASE.RUNNING);
       expect(chatTuiFocusedChildFollowUpRoute()).toEqual({
         kind: 'accept',
         streamId: child1,
@@ -1145,17 +1144,17 @@ describe('CLI TUI row allocation', () => {
 
   it('mirrors stopped child status events into focused child routing', () => {
     const dispose = subscribeStreamStatus();
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     applySubagentRoster(root, [
       {
         kind: 'subagent',
         executionId: 'child-exec-1',
         agentName: 'critic',
         childStreamId: child1,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       },
     ]);
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     setParentStream(child1, root);
 
     try {
@@ -1747,7 +1746,7 @@ describe('CLI transcript state', () => {
     });
     patchStream(root, (slice) => ({
       ...slice,
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
     }));
 
     syncStreamLog(root);
@@ -1759,7 +1758,7 @@ describe('CLI transcript state', () => {
       text: 'A delayed final answer.',
       finalized: true,
     });
-    const split = splitTranscriptEntries(entries, STREAM_STATUS.WAITING);
+    const split = splitTranscriptEntries(entries, STREAM_PHASE.WAITING);
     expect(split.finalized.map((entry) => entry.id)).toEqual([entries[0]?.id]);
     expect(split.pending).toEqual([]);
   });
@@ -1806,7 +1805,7 @@ describe('CLI transcript state', () => {
           syntheticAfterSeq: 1,
         },
       ],
-      STREAM_STATUS.RUNNING,
+      STREAM_PHASE.RUNNING,
     );
 
     expect(pending.map((entry) => entry.id)).toEqual(['model-response']);
@@ -2131,13 +2130,13 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       executionId: 'agent-1',
       agentName: 'critic',
       childStreamId: child1,
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
     };
 
     try {
       // The child's own status is the single owner the roster selectors read
       // from (rule 8: the roster's copied status is discarded).
-      patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+      patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
       hub.emit({
         scope: 'run',
         streamId: root,
@@ -2536,7 +2535,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
   it('refreshes queued follow-up display when an active follow-up is sent', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     const queue = defaultSession().followUps.acquire(root);
 
     try {
@@ -2735,7 +2734,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 
       const split = splitTranscriptEntries(
         slice?.entries ?? [],
-        STREAM_STATUS.WAITING,
+        STREAM_PHASE.WAITING,
       );
       expect(split.finalized).toContain(processEntries[0]);
       expect(split.pending).not.toContain(processEntries[0]);
@@ -2815,8 +2814,8 @@ describe('focusCycle', () => {
     ]);
     setParentStream(child1, root);
     setParentStream(child2, root);
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    patchStream(child2, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    patchStream(child2, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     // root → first descendant.
     expect(nextFocusForward()).toBe(child1);
     // child1 → next sibling resolved through the parent's descendant list.
@@ -2830,8 +2829,8 @@ describe('focusCycle', () => {
   it('Ctrl-A can still focus an inactive child stream with retained history', () => {
     activeStreamId.set(root);
     setParentStream(child1, root);
-    patchStream(root, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
-    patchStream(child1, (s) => ({ ...s, status: STREAM_STATUS.WAITING }));
+    patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
+    patchStream(child1, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
 
     expect(nextFocusForward()).toBe(child1);
   });
@@ -2884,23 +2883,23 @@ describe('child-stream ordered transition matrix', () => {
 
   it('1. canonical order: A, S(running), R_P+, E_P+', () => {
     patchStream(kid, (s) => ({ ...s, status: undefined }));
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
 
     expect(parentStream.get().get(kid)).toBe(parentP);
     expect(activeRows(parentP)).toMatchObject([
-      { status: STREAM_STATUS.RUNNING },
+      { status: STREAM_PHASE.RUNNING },
     ]);
     expect(retainedRows(parentP)).toMatchObject([
-      { status: STREAM_STATUS.RUNNING },
+      { status: STREAM_PHASE.RUNNING },
     ]);
   });
 
   it('2. roster first: R_P+, A, S(running), E_P+', () => {
     applySubagentRoster(parentP, [rosterRow()]);
     patchStream(kid, (s) => ({ ...s, status: undefined }));
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     setParentStream(kid, parentP);
 
     expect(parentStream.get().get(kid)).toBe(parentP);
@@ -2916,7 +2915,7 @@ describe('child-stream ordered transition matrix', () => {
     patchStream(kid, (s) => ({ ...s, status: undefined }));
     expect(parentStream.get().get(kid)).toBe(parentP);
 
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
 
     expect(activeRows(parentP)).toHaveLength(1);
@@ -2924,18 +2923,18 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('4. status first: S(running), A, E_P+, R_P+', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     setParentStream(kid, parentP);
     applySubagentRoster(parentP, [rosterRow()]);
 
     expect(parentStream.get().get(kid)).toBe(parentP);
     expect(activeRows(parentP)).toMatchObject([
-      { status: STREAM_STATUS.RUNNING },
+      { status: STREAM_PHASE.RUNNING },
     ]);
   });
 
   it('5. completion: A, S(running), R_P+, E_P+, R_P-, S(terminal)', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
 
@@ -2953,8 +2952,8 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('6. promotion with stale roster: A, S(running), R_P+, E_P+, E0, R_P+', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
     setParentStream(kid, parentP);
 
     setParentStream(kid, null);
@@ -2962,7 +2961,7 @@ describe('child-stream ordered transition matrix', () => {
 
     // A stale roster from the former parent must not resurrect the edge or
     // active membership.
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
 
     expect(parentStream.get().has(kid)).toBe(false);
     expect(activeRows(parentP)).toEqual([]);
@@ -2971,17 +2970,17 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('7. explicit reattachment: (6) then E_Q+, R_Q+, R_P+', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
     setParentStream(kid, parentP);
     setParentStream(kid, null);
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
 
     setParentStream(kid, parentQ);
-    applySubagentRoster(parentQ, [rosterRow(STREAM_STATUS.RUNNING)]);
+    applySubagentRoster(parentQ, [rosterRow(STREAM_PHASE.RUNNING)]);
     // Late roster from the old parent must not erase active membership or
     // metadata under the new parent.
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
 
     expect(parentStream.get().get(kid)).toBe(parentQ);
     expect(activeRows(parentQ)).toMatchObject([{ executionId: 'kid-exec' }]);
@@ -2991,7 +2990,7 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('8. child removal with late facts: (5) then X(child), R_P+, E_P+, A, S(terminal)', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
     applySubagentRoster(parentP, []);
@@ -3010,7 +3009,7 @@ describe('child-stream ordered transition matrix', () => {
     // shortcut) intentionally has no such guard.
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
-    setStreamStatusInCliState({ status: STREAM_STATUS.RUNNING, streamId: kid });
+    setStreamStatusInCliState({ status: STREAM_PHASE.RUNNING, streamId: kid });
 
     expect(activeRows(parentP)).toEqual([]);
     expect(retainedRows(parentP)).toEqual([]);
@@ -3019,13 +3018,13 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('9. fresh activation after removal uses a distinct id, not the removed one', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
     removeStream(kid);
 
     const freshKid = 'kid-2' as StreamTabId;
-    patchStream(freshKid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(freshKid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     setParentStream(freshKid, parentP);
     applySubagentRoster(parentP, [
       {
@@ -3033,7 +3032,7 @@ describe('child-stream ordered transition matrix', () => {
         executionId: 'kid-2-exec',
         agentName: 'kid-agent',
         childStreamId: freshKid,
-        status: STREAM_STATUS.RUNNING,
+        status: STREAM_PHASE.RUNNING,
       },
     ]);
 
@@ -3059,8 +3058,8 @@ describe('child-stream ordered transition matrix', () => {
       childStreamId: kidB,
       status,
     });
-    patchStream(kidA, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    patchStream(kidB, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kidA, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    patchStream(kidB, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
 
     // First-seen order: A then B.
     applySubagentRoster(parentP, [rowA(), rowB()]);
@@ -3090,14 +3089,14 @@ describe('child-stream ordered transition matrix', () => {
       visibleSubagentRows(parentP, childStreamEntries.get(), streams.get()).map(
         (r) => r.status,
       ),
-    ).toEqual([STREAM_PHASE.COMPLETED, STREAM_STATUS.RUNNING]);
+    ).toEqual([STREAM_PHASE.COMPLETED, STREAM_PHASE.RUNNING]);
   });
 
   it('11. parent removal with late facts: P -> child, X(P), R_P+, E_P+', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow()]);
     setParentStream(kid, parentP);
-    patchStream(parentP, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
+    patchStream(parentP, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
 
     removeStream(parentP);
     expect(isChildStreamRemoved(parentP)).toBe(true);
@@ -3113,14 +3112,14 @@ describe('child-stream ordered transition matrix', () => {
   });
 
   it('12. identical roster snapshot applied twice is a no-op (no store write)', () => {
-    patchStream(kid, (s) => ({ ...s, status: STREAM_STATUS.RUNNING }));
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
     const entriesAfterFirst = childStreamEntries.get();
 
     // The runtime resends a fresh array/row object on every poll even when
     // nothing changed; `rosterRow` below is a distinct object with identical
     // field values, not `===` to the first call's row.
-    applySubagentRoster(parentP, [rosterRow(STREAM_STATUS.RUNNING)]);
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
 
     expect(childStreamEntries.get()).toBe(entriesAfterFirst);
   });

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -130,7 +130,7 @@ import {
 } from '@cli/chat/tui/state/sessionRunState';
 import {
   RUN_OUTCOME,
-  STREAM_STATUS,
+  STREAM_PHASE,
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
@@ -500,7 +500,7 @@ describe('createChatSessionController', () => {
     const canInterruptActiveRun = chatTuiCanInterruptActiveRun(session);
     const canStopActiveRun = chatTuiCanStopActiveRun(
       session,
-      STREAM_STATUS.WAITING,
+      STREAM_PHASE.WAITING,
     );
     const resumableIdle = chatTuiIsResumableIdleOnExit({
       canInterruptActiveRun,
@@ -651,7 +651,7 @@ describe('createChatSessionController', () => {
       ) => {
         options.onResult?.({
           category: 'toolUse',
-          outcome: STREAM_STATUS.WAITING,
+          outcome: STREAM_PHASE.WAITING,
           executionId: 'exec-1' as ExecutionId,
           streamId: 'stream-1' as StreamTabId,
         });


### PR DESCRIPTION
## Summary

- narrow the CLI live status mirror from `StreamLifecycleStatus` to canonical `StreamPhase`, retaining `StreamSubstate` as the display axis
- replace TUI, child-control, follow-up, transcript, elapsed-time, and headless renderer decisions with `isActivePhase`, `isInFlightPhase`, and `isTerminalOutcomePhase`
- migrate the nine CLI status fixture suites to canonical phase and outcome values

## Design

The CLI continues to read its existing `StreamSlice` state and does not add a status cache or translation layer. WAITING remains an explicit turn-finalization phase, while completed, cancelled, and failed terminalization is classified through the shared `RunOutcome` guard. Display-only projections remain at their existing boundaries.

## Census

| Scope | Before | After |
| --- | ---: | ---: |
| Direct `STREAM_STATUS` / `StreamStatus` occurrences in `packages/cli/src` | 18 across 8 files | 0 |
| Direct occurrences plus the four legacy trait readers | 46 across 13 files | 0 |
| Direct legacy occurrences in CLI status tests | 169 across 9 files | 0 |

This recount was made against the current main branch rather than carrying forward the issue's earlier 44-reference snapshot.

## Compatibility

- human-readable status labels and headless progress text retain their existing strings
- frozen JSON and NDJSON projection code is unchanged
- the JSON, NDJSON, and headless renderer contract suites pass without output expectation changes
- shared compatibility schemas and non-CLI readers remain untouched

## Validation

- `npm run format`
- 12 focused CLI status/output suites: 489 tests passed
- `npm run typecheck`
- `npm run lint` (0 errors; 45 existing warnings outside changed files)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli run bundle`
- `npm test`: 633 files and 5,616 tests passed; 1 file and 4 tests skipped
- `npm run check:dead-code-ratchet`
- `npm run check:cli-architecture`

Closes #8142

References #7993 and #6968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many TUI gates (transcript finalize, stop/Ctrl-C, tabs, follow-ups) where a phase misclassification would change UX; scope is CLI-only with broad test updates and no new translation layer.
> 
> **Overview**
> The CLI TUI and related runtime paths stop using **`StreamLifecycleStatus`** / **`STREAM_STATUS`** and the old trait helpers (`isLiveElapsedStatus`, `isInFlightStatus`, `isTerminalStatus`, etc.). **`StreamSlice.status`** and status-bar inputs are typed as canonical **`StreamPhase`**, with behavior driven by **`isActivePhase`**, **`isInFlightPhase`**, and **`isTerminalOutcomePhase`** from `@common/constants/streamStatus`.
> 
> **Live vs ended behavior** is re-centered on phases: elapsed time, “thinking” indicators, todos/plan chrome, Ctrl-C stop eligibility, stream-tab “running”/“ended” suffixes, and live transcript splitting all key off the new helpers instead of ad-hoc `RUNNING` / lifecycle checks. Stream tabs treat **terminal outcomes** (`completed` / `cancelled` / `failed`) as ended while **WAITING** stays in-flight for tab labeling.
> 
> **Transcript finalization** now promotes deferred assistant/tool rows on **`WAITING`** as well as terminal outcomes (`isFinalTranscriptStatus`), with tests expanded to cover every **`RunOutcome`**. Child elapsed display only treats **`RUNNING`** (plus `startedAt`) as live. Headless run progress maps **`FAILED`** to the string **`error`** without referencing legacy status constants.
> 
> CLI status test fixtures are updated from legacy strings (`stopped`, `ready`, `initializing`) to **`STREAM_PHASE`** / outcome values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6322f6852f26fcce28b296630585795c4a1ed962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->