### PR TITLE
fix(agent): avoid duplicate queued follow-up replay

### DIFF
--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -74,6 +74,7 @@ export async function resumeQueuedToolUseSnapshot(
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
   let cancelledBeforeSessionSetup = false;
+  let resumeReturned = false;
   let resumeError: { error: unknown } | undefined;
   const restoreFollowUps = (): void => {
     for (const item of followUps) {
@@ -124,13 +125,16 @@ export async function resumeQueuedToolUseSnapshot(
         }
       },
     });
-    options.onResult?.(result);
+    resumeReturned = true;
     if (cancelledBeforeSessionSetup) restoreFollowUps();
+    options.onResult?.(result);
   } catch (error) {
     resumeError = { error };
-    // Re-enqueue the drained follow-ups (explicit seed first) so a later
-    // resume replays them instead of dropping them.
-    restoreFollowUps();
+    // A rejected resume has not committed the drained batch's disposition,
+    // so a later resume must replay it. Once the resume returns, the flow has
+    // either consumed, disposed, or deliberately left the batch live; an
+    // observer failure must not enqueue it again.
+    if (!resumeReturned) restoreFollowUps();
   } finally {
     // Early failures leave the stream RESUMING. Startup cancellation can
     // instead reach lifecycle terminalization before the queue owner regains

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -13,6 +13,7 @@ import {
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { recordSessionEvents, sessionFactPayloads } from '../progressTestUtils';
@@ -28,20 +29,24 @@ function snapshot(parentStreamId?: StreamTabId): ToolUseSessionSnapshot {
 function capturedResumeOptions(): {
   parentStreamId?: StreamTabId;
   isCancellationRequested?: () => boolean;
-  setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
+  setupSession: (session: {
+    appendFollowUp(item: FollowUpQueueInput): void;
+  }) => void;
 } {
   const calls = resumeToolUseFromSnapshotMock.mock
     .calls as unknown as unknown[][];
   return calls.at(-1)?.[2] as {
     parentStreamId?: StreamTabId;
     isCancellationRequested?: () => boolean;
-    setupSession: (session: { appendFollowUp(item: unknown): void }) => void;
+    setupSession: (session: {
+      appendFollowUp(item: FollowUpQueueInput): void;
+    }) => void;
   };
 }
 
 /** Capture the `setupSession` replay callback handed to the leaf resume. */
 function capturedSetupSession(): (session: {
-  appendFollowUp(item: unknown): void;
+  appendFollowUp(item: FollowUpQueueInput): void;
 }) => void {
   const options = capturedResumeOptions();
   return options.setupSession;
@@ -212,6 +217,52 @@ describe('resumeToolUseSnapshot', () => {
         'updateQueuedFollowUps',
       ),
     ).toHaveLength(2);
+  });
+
+  it('does not duplicate a live batch when post-setup cancellation result handling throws', async () => {
+    const failure = new Error('result callback failed');
+    const reportFailure = vi.fn();
+    let cancellationRequested = false;
+    const isCancellationRequested = vi.fn(() => cancellationRequested);
+    defaultSession().followUps.enqueue(
+      STREAM,
+      { text: 'queued one' },
+      { force: true },
+    );
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        const liveQueue = defaultSession().followUps.acquire(STREAM);
+        options.setupSession({
+          appendFollowUp: (item) => liveQueue.enqueue(item),
+        });
+        cancellationRequested = true;
+        seedStreamStatusForTest(
+          defaultSession().status,
+          STREAM,
+          STREAM_PHASE.CANCELLED,
+        );
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        isCancellationRequested,
+        onResult: () => {
+          throw failure;
+        },
+        onError: reportFailure,
+      }),
+    ).resolves.toBe(false);
+
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(reportFailure).toHaveBeenCalledWith(failure);
+    expect(
+      sessionFactPayloads(
+        recordedSession?.events ?? [],
+        'updateQueuedFollowUps',
+      ),
+    ).toHaveLength(1);
   });
 
   it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {


### PR DESCRIPTION
## Summary

- treat a fulfilled resume as the commit point for the drained follow-up batch
- restore the batch only when the resume operation itself rejects
- prevent a throwing `onResult` observer from duplicating a batch that cancellation already left live

## Root cause

`resumeQueuedToolUseSnapshot` used one catch block for both the resume operation and the optional result observer. After post-setup cancellation, the resumed flow deliberately preserves the re-appended batch. If `onResult` then threw, the catch block restored that same batch again.

## Design

The helper records when `resumeToolUseFromSnapshot` fulfills. Before that point, a rejection means queue disposition was not committed and the drained batch must be restored. After that point, the flow has consumed, disposed, or preserved the batch, so observer failure is reported without changing queue ownership.

No schema or public callback signature changes.

## Validation

- focused resume suites: 12 tests passed
- `npm run format`
- `npm run typecheck`
- `npm run lint`: 0 errors; 45 existing warnings
- `npm run compile:fast`
- `git diff --check origin/main...HEAD`

Closes #8119
References #7946

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent resume queue ownership and cancellation handoff; wrong restore logic could drop or duplicate user follow-ups, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **duplicate queued follow-ups** when `resumeQueuedToolUseSnapshot` finishes the underlying resume but the optional **`onResult`** callback throws.
> 
> The helper now treats a **fulfilled** `resumeToolUseFromSnapshot` as the commit point for the drained batch: **`restoreFollowUps`** runs only if the resume **rejects** before it returns. **`onResult`** is invoked **after** that commit (and after the pre-setup cancellation restore), so observer failures are reported without re-enqueueing a batch cancellation already left live.
> 
> Adds a regression test for post-setup cancellation plus a throwing **`onResult`**, and tightens test typings to **`FollowUpQueueInput`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ef3ba0323008fb321d76095f3612775beccbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->