### PR TITLE
fix(agent): drain all live sessions on shutdown

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -289,6 +289,13 @@ export function getAllActiveExecutionIds(): string[] {
   return [...ids];
 }
 
+/** Stop background OS processes owned by every live runtime session. */
+export function killAllSessionBackgroundProcesses(): void {
+  for (const session of liveSessions) {
+    session.executions.killBackgroundProcesses();
+  }
+}
+
 let cachedDefaultSession: SessionHandle | undefined;
 
 /**

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -4,7 +4,7 @@ import {
   CodexThreads,
 } from '@tools/agentCliSessionStores';
 
-import { defaultSession } from './SessionHandle';
+import { killAllSessionBackgroundProcesses } from './SessionHandle';
 
 /**
  * Stops agent-spawned child processes and CLI-backed agent sessions before
@@ -13,7 +13,7 @@ import { defaultSession } from './SessionHandle';
  */
 export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    defaultSession().executions.killBackgroundProcesses(),
+    killAllSessionBackgroundProcesses(),
   );
   // Interrupt CLI-backed sessions so their streams don't reload in a stale
   // WAITING state.

--- a/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - platform
+import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
+// Local imports - runtime
+import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
+import { SessionHandle, defaultSession } from '@agent/runtime/SessionHandle';
+// Local imports - CLI session stores
+import {
+  ClaudeAgentSessions,
+  CodexThreads,
+} from '@tools/agentCliSessionStores';
+
+describe('agent shutdown', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drains every live session once and interrupts global CLI sessions', async () => {
+    const firstSession = new SessionHandle();
+    const secondSession = new SessionHandle();
+    const compatibilitySession = defaultSession();
+    const firstDrain = vi.spyOn(
+      firstSession.executions,
+      'killBackgroundProcesses',
+    );
+    const secondDrain = vi.spyOn(
+      secondSession.executions,
+      'killBackgroundProcesses',
+    );
+    const compatibilityDrain = vi.spyOn(
+      compatibilitySession.executions,
+      'killBackgroundProcesses',
+    );
+    const interruptCodex = vi
+      .spyOn(CodexThreads, 'interruptAll')
+      .mockImplementation(() => {});
+    const interruptClaude = vi
+      .spyOn(ClaudeAgentSessions, 'interruptAll')
+      .mockImplementation(() => {});
+
+    try {
+      const lifecycle = createLifecycleHost();
+      registerAgentShutdownHandlers(lifecycle);
+
+      await Promise.all([lifecycle.runShutdown(), lifecycle.runShutdown()]);
+      await lifecycle.runShutdown();
+
+      expect(firstDrain).toHaveBeenCalledOnce();
+      expect(secondDrain).toHaveBeenCalledOnce();
+      expect(compatibilityDrain).toHaveBeenCalledOnce();
+      expect(interruptCodex).toHaveBeenCalledOnce();
+      expect(interruptClaude).toHaveBeenCalledOnce();
+    } finally {
+      firstSession.dispose();
+      secondSession.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- drain background OS processes from every live runtime session during host shutdown
- replace the shutdown handler's `defaultSession()` assumption with a narrow process-wide runtime operation
- verify independent desktop-style sessions, the compatibility session, and repeated shutdown calls

## Root cause

Desktop windows construct independent `SessionHandle` instances, but the shared shutdown hook killed processes only through `defaultSession().executions`. Background processes owned by window sessions were therefore outside the shutdown sweep.

## Design

`SessionHandle` already owns a private process-wide set of live sessions for cross-session execution queries. A new action over that private set kills background processes in each session without exposing session enumeration or mutable ownership to hosts. The existing global Codex and Claude interruption handlers remain unchanged.

The operation does not eagerly construct the default session; it drains that session when it exists and treats it like every other live session.

## Validation

- focused shutdown and session suites: 2 files, 9 tests passed
- `npm run format`
- `npm run typecheck`
- `npm run lint`: 0 errors; 45 existing warnings
- `npm run compile:fast`
- targeted ESLint and Prettier checks
- `git diff --check origin/main...HEAD`

Closes #8149
References #8144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches host teardown for OS child processes across all sessions; scope is narrow but incorrect draining could leave zombies or over-kill during exit.
> 
> **Overview**
> Host shutdown previously killed background OS processes only through **`defaultSession()`**, so independent desktop **`SessionHandle`** instances could leave agent-spawned children running after the host exited.
> 
> Shutdown now calls **`killAllSessionBackgroundProcesses()`**, which walks the existing process-wide **`liveSessions`** set and invokes **`killBackgroundProcesses()`** on each session’s execution registry—without eagerly creating the default session or exposing session enumeration to hosts. Global Codex and Claude **`interruptAll`** handlers are unchanged.
> 
> A focused test registers the shutdown handlers, runs **`runShutdown`** concurrently and repeatedly (matching the lifecycle host’s single-flight shutdown promise), and asserts each live session—including **`defaultSession()`**—is drained once alongside the CLI session interrupts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c844fbd3d605c8c177dd3b2e0967616ad3a4c189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->