### PR TITLE
fix(webview): deliver pasted images after input unmount

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -25,7 +25,11 @@ import {
 } from '@shared/utils/clipboardImages';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import { archivedContext } from '../contexts/streamContexts';
+import {
+  archivedContext,
+  followUpEventSinkContext,
+  type FollowUpEventSink,
+} from '../contexts/streamContexts';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 import {
@@ -124,6 +128,14 @@ export class FollowUpInput extends LitElement {
    */
   @consume({ context: archivedContext, subscribe: true })
   private archived = false;
+
+  private readonly inputEventSink: FollowUpEventSink = (event) => {
+    this.dispatchEvent(event);
+  };
+
+  /** Stable conversation-owned sink retained across this element's unmount. */
+  @consume({ context: followUpEventSinkContext })
+  private followUpEventSink: FollowUpEventSink = this.inputEventSink;
 
   @property({ type: Boolean, reflect: true }) visible = false;
   @property({ attribute: false }) value = '';
@@ -226,6 +238,7 @@ export class FollowUpInput extends LitElement {
     const streamId = this.streamId;
     const transientState = this.transientState;
     if (!streamId || !transientState) return;
+    const eventSink = this.followUpEventSink;
     // Suppress the default paste synchronously, before the async read below.
     event.preventDefault();
     const paste = this.attachPastedImages(
@@ -234,11 +247,12 @@ export class FollowUpInput extends LitElement {
       event,
       files,
       transientState.imagePasteRevision,
+      eventSink,
     );
     transientState.pendingImagePastes.add(paste);
     void paste.finally(() => {
       transientState.pendingImagePastes.delete(paste);
-      this.flushPendingImagePasteSend(streamId, transientState);
+      this.flushPendingImagePasteSend(streamId, transientState, eventSink);
     });
   }
 
@@ -248,6 +262,7 @@ export class FollowUpInput extends LitElement {
     event: ClipboardEvent,
     files: Array<{ file: File; type: string }>,
     pasteRevision: number,
+    eventSink: FollowUpEventSink,
   ): Promise<void> {
     const target = this.textAreaEl;
     if (!target) return;
@@ -279,18 +294,24 @@ export class FollowUpInput extends LitElement {
     insertText += chipText;
     transientState.pendingImages = [...transientState.pendingImages, ...added];
     if (
+      this.isConnected &&
       this.streamId === streamId &&
       this.transientState === transientState &&
       this.textAreaEl === target
     ) {
       insertTextAtCursor(target, insertText);
-      this.updateValue(getTextareaValue(target), streamId);
+      this.updateValue(
+        getTextareaValue(target),
+        streamId,
+        'replace',
+        eventSink,
+      );
       return;
     }
 
-    // The shared Lit instance may now display another stream. Preserve the
-    // completed paste in its source stream without touching the active box.
-    this.updateValue(insertText, streamId, 'append');
+    // The input may now be disconnected or display another stream. Preserve
+    // the completed paste in its source stream without touching stale DOM.
+    this.updateValue(insertText, streamId, 'append', eventSink);
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -405,12 +426,13 @@ export class FollowUpInput extends LitElement {
   private emitSendForStream(
     streamId: string,
     transientState: FollowUpInputTransientState,
+    eventSink: FollowUpEventSink = this.inputEventSink,
   ): void {
     if (transientState.pendingImagePastes.size > 0) {
       transientState.sendAfterImagePastes = true;
       return;
     }
-    this.dispatchEvent(
+    eventSink(
       ProgressEvents.followupSend({
         streamId,
         images: transientState.pendingImages,
@@ -423,6 +445,7 @@ export class FollowUpInput extends LitElement {
   private flushPendingImagePasteSend(
     streamId: string,
     transientState: FollowUpInputTransientState,
+    eventSink: FollowUpEventSink = this.inputEventSink,
   ): void {
     if (
       !transientState.sendAfterImagePastes ||
@@ -430,7 +453,7 @@ export class FollowUpInput extends LitElement {
     ) {
       return;
     }
-    this.emitSendForStream(streamId, transientState);
+    this.emitSendForStream(streamId, transientState, eventSink);
   }
 
   private emitPolish(): void {
@@ -453,10 +476,9 @@ export class FollowUpInput extends LitElement {
     value: string,
     streamId = this.streamId,
     mode: 'replace' | 'append' = 'replace',
+    eventSink: FollowUpEventSink = this.inputEventSink,
   ): void {
     if (!streamId) return;
-    this.dispatchEvent(
-      ProgressEvents.followupChange({ streamId, value, mode }),
-    );
+    eventSink(ProgressEvents.followupChange({ streamId, value, mode }));
   }
 }

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -24,12 +24,14 @@ import {
   EMPTY_LOG_CONTEXT,
   EMPTY_STREAM_BY_ID,
   EMPTY_STREAM_CONTEXT,
+  followUpEventSinkContext,
   inquiryThreadsContext,
   permissionsContext,
   processOutputContext,
   streamByIdContext,
   streamLogContext,
   streamStateContext,
+  type FollowUpEventSink,
   type StreamByIdMap,
   type StreamContextValue,
   type StreamLogContextValue,
@@ -86,6 +88,11 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   @state()
   private inquiryThreadsContextValue: InquiryThreadUpdatedEvent[] =
     EMPTY_INQUIRY_THREADS;
+
+  @provide({ context: followUpEventSinkContext })
+  private readonly followUpEventSink: FollowUpEventSink = (event) => {
+    this.dispatchEvent(event);
+  };
 
   /**
    * Externally settable (unlike the signal-derived contexts above): every

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -133,6 +133,17 @@ export const streamByIdContext = createContext<StreamByIdMap>(
 );
 
 /**
+ * Durable delivery boundary for follow-up events. The conversation element
+ * outlives whichever stream-specific input is currently rendered, so async
+ * paste work can still reach host handlers after that input disconnects.
+ */
+export type FollowUpEventSink = (event: CustomEvent) => void;
+
+export const followUpEventSinkContext = createContext<FollowUpEventSink>(
+  'progress-follow-up-event-sink',
+);
+
+/**
  * Whether request panels render in a read-only, archived mode — true for a
  * static trace-viewer export (`packages/trace-viewer/`) replaying a finished
  * run with no live backend to send actions to. Defaults to `false` for every

--- a/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
+++ b/src/test-kernel/progressView/FollowUpInputStreamSwitch.vitest.ts
@@ -1,5 +1,25 @@
 // Third-party imports
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clipboardImageFiles: vi.fn(),
+  generatePastedImageName: vi.fn(),
+  readFileAsBase64: vi.fn(),
+}));
+
+vi.mock('@shared/files/pastedImageConstants', () => ({
+  generatePastedImageName: mocks.generatePastedImageName,
+}));
+
+vi.mock('@shared/utils/clipboardImages', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@shared/utils/clipboardImages')>();
+  return {
+    ...actual,
+    clipboardImageFiles: mocks.clipboardImageFiles,
+    readFileAsBase64: mocks.readFileAsBase64,
+  };
+});
 
 // Local imports - progress view
 import {
@@ -23,12 +43,20 @@ interface FollowUpSendDetail {
   images: readonly ExtractedClipboardImage[];
 }
 
+interface FollowUpChangeDetail {
+  streamId: string;
+  value: string;
+  mode: 'replace' | 'append';
+}
+
 type FollowUpInputInternals = HTMLElement & {
   visible: boolean;
   value: string;
   streamId: string;
   transientState: FollowUpInputTransientState | null;
+  followUpEventSink: (event: CustomEvent) => void;
   updateComplete: Promise<boolean>;
+  handlePaste: (event: ClipboardEvent) => void;
   emitSend: () => void;
   flushPendingImagePasteSend: (
     streamId: string,
@@ -76,7 +104,9 @@ function image(fileName: string): ExtractedClipboardImage {
 
 describe('follow-up-input pasted-image state across stream switches', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     clearFollowUpInputTransientStateStore();
+    mocks.generatePastedImageName.mockReturnValue('pasted-test.png');
   });
 
   it('restores stream A images after an A -> B -> A round trip', async () => {
@@ -143,5 +173,66 @@ describe('follow-up-input pasted-image state across stream switches', () => {
     element.emitSend();
 
     expect(getSent()).toEqual({ streamId: 'stream-a', images: [imageA] });
+  });
+
+  it('delivers a completed paste and deferred send after unmount', async () => {
+    let resolveRead: (value: string) => void = () => {};
+    mocks.readFileAsBase64.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+    mocks.clipboardImageFiles.mockReturnValue([
+      { file: {} as File, type: 'image/png' },
+    ]);
+
+    const element = createFollowUpInput('stream-a');
+    await element.updateComplete;
+    const streamA = getFollowUpInputTransientState('stream-a');
+    const durableTarget = document.createElement('div');
+    element.followUpEventSink = (event) => {
+      durableTarget.dispatchEvent(event);
+    };
+
+    let changed: FollowUpChangeDetail | undefined;
+    let sent: FollowUpSendDetail | undefined;
+    durableTarget.addEventListener('followup-change', (event) => {
+      changed = (event as CustomEvent<FollowUpChangeDetail>).detail;
+    });
+    durableTarget.addEventListener('followup-send', (event) => {
+      sent = (event as CustomEvent<FollowUpSendDetail>).detail;
+    });
+
+    const pasteEvent = {
+      clipboardData: { getData: () => '' },
+      preventDefault: vi.fn(),
+    } as unknown as ClipboardEvent;
+    element.handlePaste(pasteEvent);
+    const pendingPaste = [...streamA.pendingImagePastes][0];
+    if (!pendingPaste) throw new Error('Expected an in-flight image paste');
+
+    element.emitSend();
+    element.remove();
+    resolveRead('encoded-image');
+    await pendingPaste;
+    await Promise.resolve();
+
+    expect(pasteEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(changed).toEqual({
+      streamId: 'stream-a',
+      value: '[pasted-test.png]',
+      mode: 'append',
+    });
+    expect(sent).toEqual({
+      streamId: 'stream-a',
+      images: [
+        {
+          fileName: 'pasted-test.png',
+          base64: 'encoded-image',
+          mediaType: 'image/png',
+        },
+      ],
+    });
+    expect(streamA.pendingImages).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- provide a durable follow-up event sink from the stable `stream-conversation` owner
- capture that sink when an asynchronous image paste starts
- deliver late chip updates and deferred sends after the stream-specific input unmounts
- avoid writing into detached textarea DOM

## Root cause

Pasted-image bytes and deferred-send state became stream-scoped in #8143, but their completion channel remained component-scoped. If `follow-up-input` disconnected before its file read settled, dispatching a bubbling event on that detached element could not reach the extension or desktop host handlers. The component then cleared image state as though delivery had succeeded.

## Design

`StreamConversation` now provides a narrow `FollowUpEventSink` through the existing Lit context layer. It outlives tool-use, workflow, and process content swaps. `FollowUpInput` captures that sink at paste start and threads it only through the asynchronous completion and deferred-send path.

Ordinary typing, send, clear, and polish actions keep the existing component-local event contract. When the input is detached, paste completion appends to the source stream rather than mutating stale DOM.

## Validation

- focused follow-up suites: 3 files, 9 tests passed
- regression test covers paste start, deferred send, input unmount, read completion, chip update, and image delivery
- `npm run format`
- `npm run typecheck`
- `npm run lint`: 0 errors; 45 existing warnings
- `npm run compile:fast`
- `git diff --check`

Closes #8151
Follow-up to #8143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets async follow-up delivery and stream-switch edge cases; scope is narrow but affects user-visible follow-up/image behavior in the progress webview.
> 
> **Overview**
> Fixes a bug where **async clipboard image pastes** could finish after `follow-up-input` unmounts (e.g. stream switch), so `followup-change` / `followup-send` never reached the host and pasted image state was cleared incorrectly.
> 
> **`stream-conversation`** now provides a stable **`FollowUpEventSink`** via Lit context. **`FollowUpInput`** consumes it and threads that sink through the paste → read → chip update → deferred-send path, while normal typing/send/clear/polish still dispatch on the component. When the input is disconnected or bound to another stream, completion **appends** the `[filename]` chips to the source stream through the sink instead of touching a detached textarea.
> 
> Adds a regression test for paste start, deferred send, unmount, and late delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4d42ac5560dc6e6441f14502f3d872f59be2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->