### PR TITLE
fix(ui): render model-option provider icons via wa-icon, not unicode glyphs

### DIFF
--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -1,56 +1,67 @@
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
+
 /**
  * Model provider decorator configuration - single source of truth for provider indicators.
  * Used in model dropdowns to visually distinguish different AI providers.
+ *
+ * Icon choices (FA-solid, via the texra wa-icon resolver — see #8157): free-solid
+ * ships no brand marks, so providers with a name-adjacent glyph get one
+ * (DeepSeek's mascot is a whale -> closest free-solid analog `fish`; Moonshot ->
+ * `moon`; OpenAI's mark is a hexagonal knot -> `hexagon`; Google's model line is
+ * "Gemini" -> `gem`; GitHub Copilot flies alongside you -> `plane`; Alibaba's
+ * prior glyph was a comet -> `meteor`). Everyone else (Anthropic, xAI, and the
+ * "other" fallback) gets a neutral glyph from the same set instead of a forced,
+ * unrelated metaphor.
  */
 export interface ProviderDecorator {
-  unicode: string;
+  icon: TeXRAIconName;
   label: string;
   hint: string;
 }
 
 const MODEL_PROVIDER_DECORATORS: Record<string, ProviderDecorator> = {
   anthropic: {
-    unicode: '\u{1D538}', // 𝔸 - Double-struck A
+    icon: 'brain',
     label: 'Anthropic',
     hint: 'Anthropic Claude models',
   },
   openai: {
-    unicode: '\u2B21', // ⬡ - Hexagon
+    icon: 'hexagon',
     label: 'OpenAI',
     hint: 'OpenAI GPT models',
   },
   google: {
-    unicode: '\u{1D53E}', // 𝔾 - Double-struck G
+    icon: 'gem',
     label: 'Google',
     hint: 'Google Gemini models',
   },
   xai: {
-    unicode: '\u{1D54F}', // 𝕏 - Double-struck X
+    icon: 'satellite',
     label: 'xAI',
     hint: 'xAI Grok models',
   },
   deepseek: {
-    unicode: '\u{1F433}', // 🐳 - Whale
+    icon: 'fish',
     label: 'DeepSeek',
     hint: 'DeepSeek models',
   },
   moonshot: {
-    unicode: '\u{1D542}', // 𝕂 - Double-struck K (for Kimi)
+    icon: 'moon',
     label: 'Moonshot',
     hint: 'Moonshot AI Kimi models',
   },
   dashscope: {
-    unicode: '\u2604', // ☄ - Comet (Alibaba Cloud)
+    icon: 'meteor',
     label: 'Qwen',
     hint: 'Alibaba Cloud Qwen models',
   },
   copilot: {
-    unicode: '\u2387', // ⎇ - Alternative key (GitHub)
+    icon: 'plane',
     label: 'Copilot',
     hint: 'GitHub Copilot models',
   },
   others: {
-    unicode: '\u25C7', // ◇ - Diamond
+    icon: 'robot',
     label: 'Other',
     hint: 'Other model providers',
   },

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -98,9 +98,6 @@ function defaultAvailability(opt: ModelOptionData): {
 
 function renderModelOption(opt: ModelOptionData): TemplateResult {
   const decorator = getModelProviderDecorator(opt.provider ?? '');
-  const display = decorator.unicode
-    ? `${decorator.unicode} ${opt.label}`
-    : opt.label;
   const fallback = defaultAvailability(opt);
   const availability = opt.availability ?? fallback.value;
   const availabilityLabel = opt.availabilityLabel ?? fallback.label;
@@ -125,7 +122,7 @@ function renderModelOption(opt: ModelOptionData): TemplateResult {
         availabilityLabel ? `${opt.label} (${availabilityLabel})` : opt.label
       }
     >
-      ${display}
+      <span class="agent-icon">${waIcon(decorator.icon)} </span>${opt.label}
       ${
         opt.disabled
           ? html`<span class="model-option-status">

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -13,6 +13,7 @@ import { faBook } from '@fortawesome/free-solid-svg-icons/faBook';
 import { faBookmark } from '@fortawesome/free-solid-svg-icons/faBookmark';
 import { faBox } from '@fortawesome/free-solid-svg-icons/faBox';
 import { faBoxArchive } from '@fortawesome/free-solid-svg-icons/faBoxArchive';
+import { faBrain } from '@fortawesome/free-solid-svg-icons/faBrain';
 import { faBuilding } from '@fortawesome/free-solid-svg-icons/faBuilding';
 import { faBullseye } from '@fortawesome/free-solid-svg-icons/faBullseye';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
@@ -60,6 +61,7 @@ import { faFileCode } from '@fortawesome/free-solid-svg-icons/faFileCode';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileLines } from '@fortawesome/free-solid-svg-icons/faFileLines';
 import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf';
+import { faFish } from '@fortawesome/free-solid-svg-icons/faFish';
 import { faFlask } from '@fortawesome/free-solid-svg-icons/faFlask';
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk';
 import { faFolder } from '@fortawesome/free-solid-svg-icons/faFolder';
@@ -67,10 +69,12 @@ import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
 import { faFolderTree } from '@fortawesome/free-solid-svg-icons/faFolderTree';
 import { faForwardStep } from '@fortawesome/free-solid-svg-icons/faForwardStep';
 import { faGear } from '@fortawesome/free-solid-svg-icons/faGear';
+import { faGem } from '@fortawesome/free-solid-svg-icons/faGem';
 import { faGlobe } from '@fortawesome/free-solid-svg-icons/faGlobe';
 import { faGraduationCap } from '@fortawesome/free-solid-svg-icons/faGraduationCap';
 import { faHashtag } from '@fortawesome/free-solid-svg-icons/faHashtag';
 import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart';
+import { faHexagon } from '@fortawesome/free-solid-svg-icons/faHexagon';
 import { faImage } from '@fortawesome/free-solid-svg-icons/faImage';
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faLightbulb } from '@fortawesome/free-solid-svg-icons/faLightbulb';
@@ -79,13 +83,16 @@ import { faListCheck } from '@fortawesome/free-solid-svg-icons/faListCheck';
 import { faListUl } from '@fortawesome/free-solid-svg-icons/faListUl';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
 import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlassChart';
+import { faMeteor } from '@fortawesome/free-solid-svg-icons/faMeteor';
 import { faMicrophone } from '@fortawesome/free-solid-svg-icons/faMicrophone';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
+import { faMoon } from '@fortawesome/free-solid-svg-icons/faMoon';
 import { faNoteSticky } from '@fortawesome/free-solid-svg-icons/faNoteSticky';
 import { faPalette } from '@fortawesome/free-solid-svg-icons/faPalette';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
+import { faPlane } from '@fortawesome/free-solid-svg-icons/faPlane';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faPlusMinus } from '@fortawesome/free-solid-svg-icons/faPlusMinus';
@@ -95,6 +102,7 @@ import { faRightToBracket } from '@fortawesome/free-solid-svg-icons/faRightToBra
 import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
 import { faRocket } from '@fortawesome/free-solid-svg-icons/faRocket';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
+import { faSatellite } from '@fortawesome/free-solid-svg-icons/faSatellite';
 import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons/faScrewdriverWrench';
 import { faServer } from '@fortawesome/free-solid-svg-icons/faServer';
 import { faShield } from '@fortawesome/free-solid-svg-icons/faShield';
@@ -156,6 +164,7 @@ const icons = {
   bookmark: faBookmark,
   box: faBox,
   'box-archive': faBoxArchive,
+  brain: faBrain,
   building: faBuilding,
   bullseye: faBullseye,
   'caret-down': faCaretDown,
@@ -203,6 +212,7 @@ const icons = {
   'file-export': faFileExport,
   'file-lines': faFileLines,
   'file-pdf': faFilePdf,
+  fish: faFish,
   flask: faFlask,
   'floppy-disk': faFloppyDisk,
   folder: faFolder,
@@ -210,10 +220,12 @@ const icons = {
   'folder-tree': faFolderTree,
   'forward-step': faForwardStep,
   gear: faGear,
+  gem: faGem,
   globe: faGlobe,
   'graduation-cap': faGraduationCap,
   hashtag: faHashtag,
   heart: faHeart,
+  hexagon: faHexagon,
   image: faImage,
   key: faKey,
   lightbulb: faLightbulb,
@@ -222,13 +234,16 @@ const icons = {
   'list-ul': faListUl,
   'magnifying-glass': faMagnifyingGlass,
   'magnifying-glass-chart': faMagnifyingGlassChart,
+  meteor: faMeteor,
   microphone: faMicrophone,
   minus: faMinus,
+  moon: faMoon,
   'note-sticky': faNoteSticky,
   palette: faPalette,
   'paper-plane': faPaperPlane,
   pencil: faPencil,
   'picture-in-picture': faPictureInPicture,
+  plane: faPlane,
   play: faPlay,
   plus: faPlus,
   'plus-minus': faPlusMinus,
@@ -238,6 +253,7 @@ const icons = {
   robot: faRobot,
   rocket: faRocket,
   'rotate-right': faRotateRight,
+  satellite: faSatellite,
   'screwdriver-wrench': faScrewdriverWrench,
   server: faServer,
   shield: faShield,

--- a/src/test-kernel/shared/SelectTemplatesModelProviderIcon.vitest.ts
+++ b/src/test-kernel/shared/SelectTemplatesModelProviderIcon.vitest.ts
@@ -1,0 +1,114 @@
+import { JSDOM } from 'jsdom';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ModelOptionData } from '@shared/schemas';
+
+/**
+ * Regression coverage for #8157: the model-option dropdown used to bake a
+ * raw unicode/emoji provider glyph into the option's text label
+ * (`MODEL_PROVIDER_DECORATORS[...].unicode`), while the sibling agent-option
+ * dropdown rendered its icons through `wa-icon` via the texra Font Awesome
+ * resolver. `renderModelOption` now uses the same `wa-icon` mechanism as
+ * `renderAgentOption` — never a unicode glyph baked into the label text.
+ */
+describe('renderModelOption uses wa-icon, matching renderAgentOption', () => {
+  let dom: JSDOM;
+
+  beforeAll(() => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>');
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      Node: dom.window.Node,
+      Element: dom.window.Element,
+      DocumentFragment: dom.window.DocumentFragment,
+      customElements: dom.window.customElements,
+      HTMLElement: dom.window.HTMLElement,
+    });
+  });
+
+  afterAll(() => {
+    dom.window.close();
+  });
+
+  it('renders a wa-icon for the provider, not a unicode glyph in the label text', async () => {
+    const { renderModelOptions } =
+      await import('@shared/utils/selectTemplates');
+    const { render } = await import('lit');
+
+    const options: ModelOptionData[] = [
+      { value: 'claude-x', label: 'Claude X', provider: 'anthropic' },
+    ];
+
+    const container = document.createElement('div');
+    render(renderModelOptions(options), container);
+
+    const option = container.querySelector('wa-option');
+    expect(option).not.toBeNull();
+
+    const icon = option?.querySelector('wa-icon');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('name')).toBe('brain');
+    expect(icon?.getAttribute('library')).toBe('texra');
+
+    // The label text itself carries no baked-in glyph — the old unicode
+    // decorators (𝔸, ⬡, 𝔾, 𝕏, 🐳, 𝕂, ☄, ⎇, ◇) are gone entirely.
+    expect(option?.textContent).toContain('Claude X');
+    expect(option?.textContent).not.toMatch(
+      /[\u{1D400}-\u{1D7FF}\u{1F300}-\u{1FAFF}⌀-⏿☀-➿]/u,
+    );
+  });
+
+  it('mirrors renderAgentOption: icon lives inside an .agent-icon span, not a slot', async () => {
+    const { renderModelOptions, renderAgentOptions } =
+      await import('@shared/utils/selectTemplates');
+    const { render } = await import('lit');
+
+    const modelContainer = document.createElement('div');
+    render(
+      renderModelOptions([
+        { value: 'gpt-x', label: 'GPT X', provider: 'openai' },
+      ]),
+      modelContainer,
+    );
+    const modelIconSpan = modelContainer.querySelector(
+      'wa-option .agent-icon wa-icon',
+    );
+    expect(modelIconSpan).not.toBeNull();
+    expect(modelIconSpan?.getAttribute('slot')).toBeNull();
+
+    const agentContainer = document.createElement('div');
+    render(
+      renderAgentOptions([
+        { value: 'orchestrator', label: 'Orchestrator', isOrchestrator: true },
+      ]),
+      agentContainer,
+    );
+    const agentIconSpan = agentContainer.querySelector(
+      'wa-option .agent-icon wa-icon',
+    );
+    expect(agentIconSpan).not.toBeNull();
+    expect(agentIconSpan?.getAttribute('slot')).toBeNull();
+  });
+
+  it('falls back to the neutral "robot" icon for an unmapped provider', async () => {
+    const { renderModelOptions } =
+      await import('@shared/utils/selectTemplates');
+    const { render } = await import('lit');
+
+    const container = document.createElement('div');
+    render(
+      renderModelOptions([
+        {
+          value: 'mystery',
+          label: 'Mystery Model',
+          provider: 'some-unknown-provider',
+        },
+      ]),
+      container,
+    );
+
+    const icon = container.querySelector('wa-option wa-icon');
+    expect(icon?.getAttribute('name')).toBe('robot');
+  });
+});


### PR DESCRIPTION
Closes #8157

## Summary

`renderModelOption()` in `src/shared/utils/selectTemplates.ts` baked a raw
unicode/emoji provider glyph (from `MODEL_PROVIDER_DECORATORS` in
`src/shared/utils/icons.ts`) into the option's label text, while its sibling
`renderAgentOption()` rendered icons through the standard `waIcon(...)` → FA-solid
`wa-icon` mechanism. This PR converts `renderModelOption` to the same
mechanism, mirroring `renderAgentOption`'s exact markup: `<span
class="agent-icon">${waIcon(name)} </span>` before the label text — same slot
(none — inline, light-DOM), same wrapper class, same spacing convention.

### Icon choices (FA-solid, via the existing texra wa-icon resolver)

Free-solid ships no brand marks, so providers with a name-adjacent glyph get one:

| Provider | Icon | Why |
|---|---|---|
| Anthropic | `brain` | Neutral AI/reasoning glyph (no obvious brand analog) |
| OpenAI | `hexagon` | OpenAI's mark is a hexagonal knot |
| Google | `gem` | Google's model line is literally "Gemini" |
| xAI | `satellite` | Space-adjacent (xAI/Grok ↔ Musk's space ventures); avoids reusing `xmark` (already "close") for the letter X |
| DeepSeek | `fish` | DeepSeek's mascot is a whale — `fish` is the closest free-solid analog (no whale icon in free-solid) |
| Moonshot | `moon` | Literally the company name |
| Qwen (dashscope) | `meteor` | Closest free-solid analog to the previous comet glyph |
| Copilot | `plane` | "Co-pilot" — flies alongside you |
| Other (fallback) | `robot` | Neutral generic-AI glyph, distinct from every mapped provider above |

Where no obvious brand-adjacent glyph exists (Anthropic, the "other" fallback),
a neutral glyph from the same consistent icon family is used rather than
forcing an unrelated metaphor, per the issue's guidance.

All 9 icons are visually distinct at option size (single bold FA-solid
silhouette each), so the row stays scannable exactly like the agent dropdown.

### Mechanism check (per issue's callout)

Checked how `renderAgentOption` embeds its icon before implementing:
it's an inline `<span class="agent-icon">${waIcon(...)}</span>` in the
light DOM — not a WA `slot`. `renderModelOption` now uses the identical
pattern (`.agent-icon` class reused as-is; no new CSS needed).

## Net elements (R6)

- **+8 icon imports** in `src/shared/wa/webAwesomeIcons.ts` (`faBrain`,
  `faFish`, `faGem`, `faHexagon`, `faMeteor`, `faMoon`, `faPlane`,
  `faSatellite`) — all from the already-shipped `@fortawesome/free-solid-svg-icons`
  package (zero new dependencies), registered into the existing `icons` map.
- **`ProviderDecorator.unicode: string` → `ProviderDecorator.icon: TeXRAIconName`**
  in `src/shared/utils/icons.ts` — one field renamed/retyped, not added; the
  9 provider entries swap their `unicode` value for an `icon` name.
- **`renderModelOption`**: removed the `display` unicode-concatenation local
  (net −1 helper expression), added one inline `waIcon(...)` call — net
  roughly flat, mechanism now matches the sibling function exactly.
- **+1 new test file** (`src/test-kernel/shared/SelectTemplatesModelProviderIcon.vitest.ts`,
  3 tests) — no existing suite covered `selectTemplates.ts` rendering output
  to extend (`grep`-verified below), so this follows the established
  JSDOM + `lit` render pattern from
  `src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts`.
- **No new abstractions, wrappers, or ports.** No files deleted (the
  `unicode` field is renamed in place since it's the sole reason
  `ProviderDecorator` exists — R8 grep below confirms no other consumer).

## Consumer counts (R8)

```
$ grep -rn "getModelProviderDecorator\|MODEL_PROVIDER_DECORATORS\|ProviderDecorator\|\.unicode\b" --include="*.ts" --include="*.tsx" src packages
src/shared/utils/selectTemplates.ts:12:import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
src/shared/utils/icons.ts:5:export interface ProviderDecorator {
src/shared/utils/icons.ts:11:const MODEL_PROVIDER_DECORATORS: Record<string, ProviderDecorator> = {
src/shared/utils/icons.ts:59:export function getModelProviderDecorator(provider: string): ProviderDecorator {
```

Only consumer is `selectTemplates.ts` — safe to change the field shape in place.

```
$ grep -rln "renderModelOptions" src packages
src/shared/utils/selectTemplates.ts
packages/extension/src/webview/frontend/components/InstructionPanel.ts
packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
```

All three consumers call `renderModelOptions(...)` opaquely (pass `ModelOptionData[]`,
get back a `TemplateResult`) — verified none of them reach into `ProviderDecorator`
or the old `.unicode` field directly, so **zero changes** needed to any of them.

## Tests

- New: `src/test-kernel/shared/SelectTemplatesModelProviderIcon.vitest.ts` (3 tests) —
  asserts a `wa-icon[library="texra"]` renders inside the option (not a baked-in
  unicode glyph in the text), that it lives in the same `.agent-icon` inline span
  as `renderAgentOption` (not a `slot`), and that the unmapped-provider fallback
  resolves to `robot`.
- `npm run typecheck` — clean across all workspaces (root, test-kernel, cli, trace-viewer, desktop).
- `npx eslint` on all 4 changed/added files — clean.
- `npx vitest run src/test-kernel/shared/ src/test-kernel/progressView/` — 50 files / 344 tests passed.
- `npx vitest run src/test-kernel/controllers/SettingsViewHost.vitest.ts src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts` — 9 tests passed (model-selection controller consumer, unaffected as expected).
- Full-repo `vitest run` was also kicked off; it hit unrelated pre-existing
  failures in `RunChatSignalOwnership` and `PRPollingSource*` (CLI signal
  wiring / GitHub PR-polling suites — network/timing sensitive, verified they
  don't import any of the changed files) before the run was cut off by a
  time budget. Not related to this change.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in shared select templates; `getModelProviderDecorator` has a single consumer and callers of `renderModelOptions` stay unchanged.
> 
> **Overview**
> Model dropdown options now show provider indicators with **texra `wa-icon`** (Font Awesome solid) instead of unicode/emoji baked into the label text, matching how agent options already render icons.
> 
> `ProviderDecorator` switches from `unicode` to typed `icon: TeXRAIconName`, with per-provider names such as `brain`, `hexagon`, `gem`, `fish`, `moon`, `meteor`, `plane`, `satellite`, and `robot` for the fallback. **`renderModelOption`** uses `<span class="agent-icon">${waIcon(decorator.icon)}</span>` ahead of the model name; eight new glyphs are registered in **`webAwesomeIcons.ts`**. A small **Vitest** suite locks in `wa-icon` markup, `.agent-icon` parity with agents, and the unknown-provider fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6155e72a59da9cb4dfcdae96e1566b442bd11554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->