### PR TITLE
fix(progressView): swap StreamHeader title= tooltips for wa-tooltip

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -474,27 +474,36 @@ export class StreamHeader extends LitElement {
       ? `${label}: ${this.goalObjective}`
       : label;
     return html`<wa-badge
-      class="goal-chip"
-      variant=${isPaused ? 'warning' : 'brand'}
-      appearance="filled"
-      title=${tooltip}
-      aria-label=${tooltip}
-    >
-      ${waIcon('compass')} ${label}
-    </wa-badge>`;
+        id=${ELEMENT_IDS.GOAL_CHIP}
+        class="goal-chip"
+        variant=${isPaused ? 'warning' : 'brand'}
+        appearance="filled"
+        aria-label=${tooltip}
+      >
+        ${waIcon('compass')} ${label}
+      </wa-badge>
+      <wa-tooltip for=${ELEMENT_IDS.GOAL_CHIP}>${tooltip}</wa-tooltip>`;
   }
 
   private renderProgressBadge(): TemplateResult | typeof nothing {
     if (!this.roundStage && !this.progress?.toolCallCount) return nothing;
+    const progressTitle = getProgressBadgeTitle(this.progress, this.roundStage);
     return html`<wa-tag
-      class="progress-badge"
-      variant="neutral"
-      size="small"
-      title=${ifDefined(getProgressBadgeTitle(this.progress, this.roundStage))}
-    >
-      ${waIcon('pulse')}
-      ${renderProgressBadgeContent(this.progress, this.roundStage)}
-    </wa-tag>`;
+        id=${ELEMENT_IDS.PROGRESS_BADGE}
+        class="progress-badge"
+        variant="neutral"
+        size="small"
+      >
+        ${waIcon('pulse')}
+        ${renderProgressBadgeContent(this.progress, this.roundStage)}
+      </wa-tag>
+      ${
+        progressTitle
+          ? html`<wa-tooltip for=${ELEMENT_IDS.PROGRESS_BADGE}
+              >${progressTitle}</wa-tooltip
+            >`
+          : nothing
+      }`;
   }
 
   private renderParentLink(): TemplateResult | typeof nothing {

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -12,6 +12,8 @@ export const ELEMENT_IDS = {
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
   STATUS_INDICATOR: 'statusIndicator',
+  GOAL_CHIP: 'goalChip',
+  PROGRESS_BADGE: 'progressBadge',
   RUN_SUMMARY: 'runSummary',
   CONTEXT_STATE: 'contextState',
   TODO_LIST_CONTAINER: 'todoListContainer',

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -20,9 +20,7 @@ function baseStream(): StreamTabInfo {
   };
 }
 
-async function mount(
-  props: Partial<StreamHeader> = {},
-): Promise<StreamHeader> {
+async function mount(props: Partial<StreamHeader> = {}): Promise<StreamHeader> {
   const element = document.createElement('stream-header') as StreamHeader;
   element.stream = baseStream();
   Object.assign(element, props);

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -1,0 +1,89 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component type
+import type { StreamHeader } from '@progressView/frontend/components/StreamHeader';
+
+// Local imports - shared schemas
+import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+function baseStream(): StreamTabInfo {
+  return {
+    kind: 'agent',
+    name: 'stream-a',
+    label: 'Stream A',
+    agentCategory: AgentCategory.Workflow,
+    creationTimestamp: 1,
+  };
+}
+
+async function mount(
+  props: Partial<StreamHeader> = {},
+): Promise<StreamHeader> {
+  const element = document.createElement('stream-header') as StreamHeader;
+  element.stream = baseStream();
+  Object.assign(element, props);
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+/**
+ * Regression coverage for #8158: the goal chip (`wa-badge`) and progress
+ * badge (`wa-tag`) used native `title=` hover labels while the rest of the
+ * header (e.g. the status indicator, id `statusIndicator`) already uses the
+ * themed `wa-tooltip[for=]` mechanism. Both anchors must expose an id with a
+ * sibling `<wa-tooltip for=id>` and no native `title` attribute, matching the
+ * status-indicator pattern.
+ */
+describe('stream-header tooltips', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/StreamHeader'),
+  );
+
+  it('anchors the goal chip tooltip via wa-tooltip[for], not a native title', async () => {
+    const element = await mount({
+      goalActive: true,
+      goalStatus: 'active',
+      goalObjective: 'ship the fix',
+    });
+
+    const chip = element.shadowRoot?.querySelector('#goalChip');
+    expect(chip).toBeTruthy();
+    expect(chip?.hasAttribute('title')).toBe(false);
+
+    const tooltip = element.shadowRoot?.querySelector(
+      'wa-tooltip[for="goalChip"]',
+    );
+    expect(tooltip).toBeTruthy();
+    expect(tooltip?.textContent?.trim()).toBe('Goal: ship the fix');
+  });
+
+  it('anchors the progress badge tooltip via wa-tooltip[for], not a native title', async () => {
+    const element = await mount({
+      roundStage: { index: 0, total: 2 },
+    });
+
+    const badge = element.shadowRoot?.querySelector('#progressBadge');
+    expect(badge).toBeTruthy();
+    expect(badge?.hasAttribute('title')).toBe(false);
+
+    const tooltip = element.shadowRoot?.querySelector(
+      'wa-tooltip[for="progressBadge"]',
+    );
+    expect(tooltip).toBeTruthy();
+    expect(tooltip?.textContent?.trim()).toBe('Round 1 of 2');
+  });
+
+  it('omits the progress badge tooltip entirely when there is no title text', async () => {
+    const element = await mount({});
+
+    expect(element.shadowRoot?.querySelector('#progressBadge')).toBeFalsy();
+    expect(
+      element.shadowRoot?.querySelector('wa-tooltip[for="progressBadge"]'),
+    ).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Closes #8158

The goal chip (`wa-badge`) and progress badge (`wa-tag`) in `StreamHeader.ts` used native `title=` hover labels while the status indicator in the same header already uses the themed `wa-tooltip[for=]` mechanism (at what was line :403). This left unthemed browser tooltips sitting next to themed ones in one header.

## What changed

Two swap sites only, mirroring the existing `:403` status-indicator pattern exactly (id on the anchor, sibling `<wa-tooltip for=id>` with the same content, placed immediately after the anchor):

- **Goal chip** (`wa-badge`): added `id=${ELEMENT_IDS.GOAL_CHIP}` ("goalChip"), dropped `title=`, added `<wa-tooltip for="goalChip">${tooltip}</wa-tooltip>`. `aria-label` is left untouched (out of scope — only `title=` is in the issue's fix).
- **Progress badge** (`wa-tag`): added `id=${ELEMENT_IDS.PROGRESS_BADGE}` ("progressBadge"), dropped `title=`, added a conditionally-rendered `<wa-tooltip for="progressBadge">` (only when `getProgressBadgeTitle(...)` returns a non-empty string, matching the previous `ifDefined(title)` behavior of never emitting an empty title).

No visual redesign — this is a like-for-like mechanism swap using components already registered/imported in the file (`wa-tooltip` is already side-effect-imported and used at the status-indicator site). Zero new dependencies.

## Net elements (R6)

- +2 `ELEMENT_IDS` string constants (`GOAL_CHIP`, `PROGRESS_BADGE`) — required so the new `wa-tooltip[for=]` elements can anchor to their targets, exactly mirroring the existing `STATUS_INDICATOR` id used by the `:403` tooltip.
- +2 `<wa-tooltip>` template nodes (one per swap site) — direct replacements for the removed `title=` attributes.
- −2 `title=` attributes (and the now-unused `ifDefined(...)` wrapper around the progress-badge title).
- No new files besides the test; no new helper functions, wrapper layers, or abstractions — call-site fix only, per the issue's sketch.

## Consumer counts (R8)

- `ELEMENT_IDS.GOAL_CHIP` / `ELEMENT_IDS.PROGRESS_BADGE`: 1 producer (the new `id=` binding) + 1 consumer (the new `wa-tooltip for=`) each, inside the same component file — same shape as the existing `STATUS_INDICATOR` id (1 producer/1 consumer pair) it mirrors. No shared/exported helper was introduced.

## Testing

- New suite `src/test-kernel/progressView/StreamHeader.vitest.mts` mounts the real `<stream-header>` custom element (via the existing `useLitComponentTestDom` helper already used by sibling progress-view component suites, e.g. `ApproveSplitButton.vitest.mts`) and asserts, for both swap sites: the anchor has no `title` attribute, and a sibling `wa-tooltip[for=...]` exists with the expected text. A third test confirms the progress-badge tooltip is omitted entirely when there's no title text (parity with the old `ifDefined` no-title behavior).
- `npx vitest run --config vitest.config.mjs src/test-kernel/progressView` — 39 files / 222 tests passed.
- `npm run typecheck` — full workspace typecheck (root, test-kernel, extension, cli, trace-viewer, desktop) passed.
- `npx eslint` on the three changed/added files — clean.
- `npx prettier --check` — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only tooltip mechanism swap in the progress view header; no auth, data, or behavioral logic changes.
> 
> **Overview**
> **StreamHeader** goal and progress badges now use themed **`wa-tooltip[for=]`** siblings (with **`GOAL_CHIP`** / **`PROGRESS_BADGE`** ids in **`ELEMENT_IDS`**) instead of native **`title=`** hover text, matching the status indicator and toolbar pattern (#8158).
> 
> The goal chip always gets a tooltip with the same copy as before; the progress badge tooltip is rendered only when **`getProgressBadgeTitle`** returns text, preserving the old **`ifDefined`** behavior. **`aria-label`** on the goal chip is unchanged.
> 
> Regression tests in **`StreamHeader.vitest.mts`** assert no **`title`** on the anchors and correct **`wa-tooltip`** wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824099aa0978271bd55d84c8c659fe8c9adf8430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->