### PR TITLE
fix(progressView): migrate log formatters from native <details> to wa-details

### DIFF
--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -283,20 +283,20 @@ export class LogList extends LitElement {
 
   /**
    * Keyboard activation (Enter/Space) for the focusable transcript link spans
-   * (file-link / latex-ref / proposal-restore-link). Copy buttons are native
-   * <wa-button>s and already keyboard-activatable via the click handler, so
-   * they are intentionally excluded here to avoid double-firing.
+   * (file-link / latex-ref). Copy buttons and the proposal-restore-link
+   * ("Setup") control are real `<wa-button>`/`<button>` elements and are
+   * already keyboard-activatable via native click synthesis (handled by the
+   * click handler below), so they are intentionally excluded here to avoid
+   * double-firing. proposal-restore-link additionally stops its own keydown
+   * from propagating this far — see stopSummaryToggleKeydown — since it sits
+   * inside a `<wa-details>` summary and would otherwise also toggle the
+   * panel.
    */
   private handleKeyEvent(event: Event): void {
     if (!(event instanceof KeyboardEvent)) return;
     if (event.key !== 'Enter' && event.key !== ' ') return;
     if (event.defaultPrevented) return;
-    if (
-      !getComposedPathElement<Element>(
-        event,
-        '.file-link, .latex-ref, .proposal-restore-link',
-      )
-    ) {
+    if (!getComposedPathElement<Element>(event, '.file-link, .latex-ref')) {
       return;
     }
     event.preventDefault();
@@ -327,7 +327,11 @@ export class LogList extends LitElement {
       return true;
     }
 
-    // Handle proposal restore links (may be inside <summary>, so prevent toggle)
+    // Handle proposal restore links. The wa-details toggle is suppressed
+    // separately: WA's own click handler already excludes this real
+    // <button>, and stopSummaryToggleKeydown stops its keydown from
+    // reaching wa-details' summary at all — this preventDefault only
+    // guards against any other native default action on the click.
     const proposalLink = getComposedPathElement<HTMLElement>(
       event,
       '.proposal-restore-link',

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -37,6 +37,28 @@ const MIN_SCROLLBACK = 4_000;
 /** Maximum visible rows before terminal scrolls internally. */
 const MAX_VISIBLE_ROWS = 20;
 
+/**
+ * Events that signal an ancestor disclosure container revealed this terminal,
+ * so it should refit to its now-visible container. Covers both the legacy
+ * native `<details>` `toggle` event (still emitted by any un-migrated
+ * surface) and Web Awesome's `<wa-details>`, which is not a `<details>` and
+ * never fires `toggle` — it dispatches `wa-show` synchronously when it starts
+ * opening and `wa-after-show` once its reveal animation finishes. Listening
+ * to both wa-details events covers the immediate-open case (matching the old
+ * un-animated native-toggle timing) and the post-animation case (accurate
+ * final layout for the fit-addon column/row calculation).
+ */
+export const TERMINAL_REFIT_EVENTS = [
+  'toggle',
+  'wa-show',
+  'wa-after-show',
+] as const;
+
+/** Ancestor selector for the ancestor disclosure container, matching both
+ * the Web Awesome `<wa-details>` custom element and any un-migrated native
+ * `<details>` surface. */
+const DETAILS_ANCESTOR_SELECTOR = 'wa-details, details';
+
 export interface TerminalTextUpdatePlan {
   reset: boolean;
   textToWrite: string;
@@ -104,7 +126,7 @@ export class TerminalOutput extends LitElement {
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private resizeObserver: ResizeObserver | null = null;
-  private detailsElement: HTMLDetailsElement | null = null;
+  private detailsElement: Element | null = null;
   private isFlushingText = false;
   private needsFlush = false;
   private pendingText = '';
@@ -148,10 +170,12 @@ export class TerminalOutput extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    this.detailsElement?.removeEventListener(
-      'toggle',
-      this.handleDetailsToggle,
-    );
+    for (const eventName of TERMINAL_REFIT_EVENTS) {
+      this.detailsElement?.removeEventListener(
+        eventName,
+        this.handleDetailsToggle,
+      );
+    }
     this.detailsElement = null;
     window.removeEventListener('resize', this.handleWindowResize);
 
@@ -164,8 +188,13 @@ export class TerminalOutput extends LitElement {
   }
 
   private attachResizeHooks(): void {
-    this.detailsElement = this.closest('details');
-    this.detailsElement?.addEventListener('toggle', this.handleDetailsToggle);
+    this.detailsElement = this.closest(DETAILS_ANCESTOR_SELECTOR);
+    for (const eventName of TERMINAL_REFIT_EVENTS) {
+      this.detailsElement?.addEventListener(
+        eventName,
+        this.handleDetailsToggle,
+      );
+    }
     window.addEventListener('resize', this.handleWindowResize);
 
     this.resizeObserver = new ResizeObserver(() => {

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -101,6 +101,33 @@ export function wrapInPre(text: string, className = ''): TemplateResult {
 // Note: Toggle icons now use CSS-only rotation via details[open] selector.
 // Always render the chevron-right icon and CSS will rotate when open.
 
+/**
+ * Stop an Enter/Space keydown on a control slotted into a `<wa-details>`
+ * summary from also toggling the details panel.
+ *
+ * `<wa-details>`'s own `handleSummaryClick` excludes interactive descendants
+ * (`<a>`, `<button>`, form-associated custom elements like `<wa-button>`)
+ * from triggering its toggle, but its `handleSummaryKeyDown` has no such
+ * check — every Enter/Space keydown that bubbles up to the `<summary>` calls
+ * `preventDefault()` and toggles, regardless of where it originated. Left
+ * unhandled, that ancestor `preventDefault()` also suppresses the focused
+ * control's own native keyboard activation (a button's Enter/Space normally
+ * synthesizes a `click`), so the control silently stops responding to the
+ * keyboard entirely — it only toggles the panel.
+ *
+ * Calling `stopPropagation()` here, on a listener bound directly to the
+ * control, runs before the event can reach `<summary>` and prevents both the
+ * unwanted toggle and the swallowed activation. It intentionally does not
+ * call `preventDefault()`, so the control's own native click synthesis for
+ * Enter/Space (and the click event that produces) is unaffected and still
+ * bubbles normally to any delegated click handler further up the tree.
+ */
+export function stopSummaryToggleKeydown(event: Event): void {
+  if (!(event instanceof KeyboardEvent)) return;
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.stopPropagation();
+}
+
 /** Build a copy button for banner content. */
 function buildCopyButton(
   title: string,
@@ -109,7 +136,7 @@ function buildCopyButton(
   const { hidden = false, content, contentId } = options;
   const copyId = content != null ? registerCopyContent(content, contentId) : '';
   // prettier-ignore
-  return html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden}>${waIcon('copy')}</wa-button>`;
+  return html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden} @keydown=${stopSummaryToggleKeydown}>${waIcon('copy')}</wa-button>`;
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -7,6 +7,9 @@
  * templates with `// prettier-ignore` to prevent whitespace issues.
  */
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 // Local imports - Lit utilities
 import type { LogMessageData } from '@shared/schemas';
 import {
@@ -74,7 +77,7 @@ export function formatBannerContentTemplate(
     : html`<div class="banner-content markdown-content log-entry-content ${config.contentClass}">${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
 
   // prettier-ignore
-  return html`<details class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
     iconName: config.iconName,
     label: config.labelText,
     copyButton: {
@@ -82,7 +85,8 @@ export function formatBannerContentTemplate(
       content: trimmedContent,
       contentId: id ? `banner:${id}` : undefined,
     },
-  })}${contentTemplate}</details>`;
+    summarySlot: true,
+  })}${contentTemplate}</wa-details>`;
 }
 
 /** Format a model response as TemplateResult. */
@@ -108,7 +112,7 @@ export function formatModelResponseTemplate(
     : html`<div class="banner-content markdown-content log-entry-content banner-content--model message-${level}">${unsafeHTML(processMarkdownContent(trimmedContent))}</div>`;
 
   // prettier-ignore
-  return html`<details class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" class="banner-details" ?open=${shouldOpen} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${buildDetailsSummary({
     iconName: 'sparkle',
     label: 'Assistant',
     timestamp: verbose
@@ -119,5 +123,6 @@ export function formatModelResponseTemplate(
       content: trimmedContent,
       contentId: id ? `model:${id}` : undefined,
     },
-  })}${contentTemplate}</details>`;
+    summarySlot: true,
+  })}${contentTemplate}</wa-details>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -10,6 +10,9 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 // Local imports - shared utilities
 import {
   ExtendedTokenUsageStatsSchema,
@@ -43,20 +46,22 @@ export function formatFileListTemplate(
   // Raw fallback when parsing fails
   if (!parseResult.success) {
     // prettier-ignore
-    return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
+    return html`<wa-details appearance="plain" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
       iconName: 'file',
       label: 'Files (raw)',
       labelClass: 'summary-text',
-    })}<ul class="file-list-content" data-log-id=${ifDefined(id)}><pre>${text ?? ''}</pre></ul></details>`;
+      summarySlot: true,
+    })}<ul class="file-list-content" data-log-id=${ifDefined(id)}><pre>${text ?? ''}</pre></ul></wa-details>`;
   }
 
   const renderData = buildFileListRender(parseResult.data);
   // prettier-ignore
-  return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
     iconName: 'file',
     label: renderData?.summary ?? 'Files',
     labelClass: 'summary-text',
-  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${renderData?.items ?? ''}</ul></details>`;
+    summarySlot: true,
+  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${renderData?.items ?? ''}</ul></wa-details>`;
 }
 
 /** Render XML link template. */
@@ -93,11 +98,12 @@ export function formatMissingOutputsTemplate(
     return html`<li class="detail-item" title=${filePath}><wa-icon library=${TEXRA_ICON_LIBRARY} name="warning" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${basename}</span></li>`;
   });
   // prettier-ignore
-  return html`<details class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
+  return html`<wa-details appearance="plain" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
     iconName: 'warning',
     label: `Missing outputs (${missing.length})`,
     labelClass: 'summary-text',
-  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile) : ''}</details>`;
+    summarySlot: true,
+  })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile) : ''}</wa-details>`;
 }
 
 // =============================================================================

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -36,6 +36,7 @@ import { stringifyWithLanguage } from '../parseUtils';
 import { formatDisplayTimestamp } from '../timestampUtils';
 import { ICON_BY_LEVEL } from '../constants';
 import { registerCopyContent } from '../copyContentStore';
+import { stopSummaryToggleKeydown } from '../htmlBuilders';
 
 /** Format user message entry as TemplateResult. */
 export function formatUserMessageTemplate(
@@ -140,7 +141,7 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // prettier-ignore
   const labelSpan = html`<span class="label" title=${tooltipTimestamp}>[${timeDisplay}] ${summaryText}</span>`;
   // prettier-ignore
-  const copyButton = html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails}>${waIcon('copy')}</wa-button>`;
+  const copyButton = html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails} @keydown=${stopSummaryToggleKeydown}>${waIcon('copy')}</wa-button>`;
   // Toggle chevron now comes from <wa-details>'s built-in disclosure icon
   // (::part(icon)); banner-details--no-toggle hides that part when there's
   // nothing to expand, replacing the old inline visibility:hidden style.

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -9,6 +9,9 @@
  * templates with `// prettier-ignore` to prevent whitespace issues.
  */
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 // Local imports - shared schemas
 import {
   ErrorLogDataSchema,
@@ -25,7 +28,6 @@ import {
   when,
   classMap,
   ifDefined,
-  styleMap,
   type FormatResult,
 } from '../litTemplates';
 
@@ -136,19 +138,21 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // prettier-ignore
   const contentTemplate = html`<div class="banner-content log-entry-content banner-content--error">${detailTemplate}</div>`;
   // prettier-ignore
-  const toggleIcon = html`<wa-icon library=${TEXRA_ICON_LIBRARY} name="chevron-right" class="toggle-icon" aria-hidden="true" style=${styleMap({ visibility: hasDetails ? '' : 'hidden' })}></wa-icon>`;
-  // prettier-ignore
   const labelSpan = html`<span class="label" title=${tooltipTimestamp}>[${timeDisplay}] ${summaryText}</span>`;
   // prettier-ignore
   const copyButton = html`<wa-button class="action-icon-button banner-content-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy error details" aria-label="Copy error details" data-default-title="Copy error details" data-success-title="Copied!" data-copy-id=${copyId} data-copy-type="banner" ?hidden=${!hasDetails}>${waIcon('copy')}</wa-button>`;
+  // Toggle chevron now comes from <wa-details>'s built-in disclosure icon
+  // (::part(icon)); banner-details--no-toggle hides that part when there's
+  // nothing to expand, replacing the old inline visibility:hidden style.
   // prettier-ignore
-  const summaryTemplate = html`<summary class="details-summary">${toggleIcon}<wa-icon library=${TEXRA_ICON_LIBRARY} name="error" class="icon" aria-hidden="true"></wa-icon>${labelSpan}${copyButton}</summary>`;
+  const summaryTemplate = html`<div slot="summary" class="details-summary"><wa-icon library=${TEXRA_ICON_LIBRARY} name="error" class="icon" aria-hidden="true"></wa-icon>${labelSpan}${copyButton}</div>`;
   // prettier-ignore
-  return html`<details class=${classMap({
+  return html`<wa-details appearance="plain" class=${classMap({
     'banner-details': true,
     'banner-details--error': true,
     'banner-details--relay-error': isRelayError,
-  })} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${summaryTemplate}${contentTemplate}</details>`;
+    'banner-details--no-toggle': !hasDetails,
+  })} data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${summaryTemplate}${contentTemplate}</wa-details>`;
 }
 
 /** Format default log message as TemplateResult. */

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -11,6 +11,9 @@
  * public entry point so existing import paths keep working.
  */
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 // Local imports - shared utilities
 import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
@@ -197,7 +200,7 @@ export function formatToolUseTemplate(
   const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" role="button" tabindex="0"><wa-icon library=${TEXRA_ICON_LIBRARY} name="reply" aria-hidden="true"></wa-icon> Setup</span>` : nothing}`;
 
   // prettier-ignore
-  return html`<details class=${classMap({
+  return html`<wa-details appearance="plain" class=${classMap({
     'banner-details': true,
     'tool-use-details': true,
     'tool-use-error': showAsError,
@@ -208,5 +211,6 @@ export function formatToolUseTemplate(
     label: titleText,
     labelClass: 'tool-use-title',
     extraContent,
-  })}${bannerContentTemplate}</details>`;
+    summarySlot: true,
+  })}${bannerContentTemplate}</wa-details>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -39,6 +39,7 @@ import {
   getToolIconName,
   buildCodeBlock,
   buildDetailsSummary,
+  stopSummaryToggleKeydown,
   SPINNER_ICON_NAME,
 } from '../htmlBuilders';
 import { registerProposalInput } from '../proposalInputStore';
@@ -196,8 +197,12 @@ export function formatToolUseTemplate(
       ? registerProposalInput(input, toolName)
       : null;
 
+  // A real <button> (not a role="button" span) so wa-details' own summary
+  // click handler recognizes it as interactive and skips its toggle — see
+  // stopSummaryToggleKeydown for why the keydown path additionally needs an
+  // explicit stopPropagation.
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" role="button" tabindex="0"><wa-icon library=${TEXRA_ICON_LIBRARY} name="reply" aria-hidden="true"></wa-icon> Setup</span>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" @keydown=${stopSummaryToggleKeydown}><wa-icon library=${TEXRA_ICON_LIBRARY} name="reply" aria-hidden="true"></wa-icon> Setup</button>` : nothing}`;
 
   // prettier-ignore
   return html`<wa-details appearance="plain" class=${classMap({

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -5,6 +5,9 @@
  * single-line templates with `// prettier-ignore` to prevent whitespace issues.
  */
 
+// Side-effect imports - register WA components
+import '@awesome.me/webawesome/dist/components/details/details.js';
+
 import {
   html,
   classMap,
@@ -37,7 +40,7 @@ function buildToolUseDetails(opts: {
 }): TemplateResult {
   const bannerContentTemplate = buildBannerContent(opts.message, opts.content);
   // prettier-ignore
-  return html`<details class=${classMap({ 'banner-details': true, 'tool-use-details': true, 'tool-use-error': opts.isError })} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title' })}${bannerContentTemplate}</details>`;
+  return html`<wa-details appearance="plain" class=${classMap({ 'banner-details': true, 'tool-use-details': true, 'tool-use-error': opts.isError })} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', summarySlot: true })}${bannerContentTemplate}</wa-details>`;
 }
 
 // Web search provider display names

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -124,8 +124,17 @@ export const toolUseStyles = css`
     border: var(--border-thin) solid var(--color-border);
   }
 
-  /* Proposal restore link */
+  /* Proposal restore link — a real <button> (not a role="button" span) so
+   * wa-details' own summary click handler recognizes it as interactive and
+   * skips its toggle; reset native button chrome to keep the prior
+   * link-like appearance. */
   .proposal-restore-link {
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    text-align: left;
     color: var(--color-text-link);
     cursor: pointer;
     font-size: var(--font-size-sm);

--- a/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/toolUseStyles.ts
@@ -67,6 +67,12 @@ export const toolUseStyles = css`
     color: var(--color-warning);
   }
 
+  /* Hide <wa-details>'s built-in disclosure icon when there's nothing to
+     expand (mirrors the old native-details toggle-icon visibility:hidden). */
+  wa-details.banner-details--no-toggle::part(icon) {
+    visibility: hidden;
+  }
+
   .tool-use-user-feedback > .details-summary :is(.tool-use-title, wa-icon) {
     color: var(--color-text-link);
   }

--- a/src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts
+++ b/src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts
@@ -49,7 +49,7 @@ describe('thinking block renders as a banner while streaming', () => {
     const container = document.createElement('div');
     render(formatLogEntry(message), container);
 
-    const details = container.querySelector('details.banner-details');
+    const details = container.querySelector('wa-details.banner-details');
     expect(details).not.toBeNull();
     expect(container.querySelector('.log-line')).toBeNull();
     // Auto-expanded while streaming, so the growing text is actually visible.
@@ -101,7 +101,7 @@ describe('thinking block renders as a banner while streaming', () => {
     const container = document.createElement('div');
     render(formatLogEntry(message), container);
 
-    const details = container.querySelector('details.banner-details');
+    const details = container.querySelector('wa-details.banner-details');
     expect(details).not.toBeNull();
     expect(container.querySelector('strong')?.textContent).toBe('bold');
     // No caller-supplied defaultOpen/preservedOpen here, so a finalized
@@ -127,7 +127,7 @@ describe('thinking block renders as a banner while streaming', () => {
     render(formatLogEntry(runningMessage), runningContainer);
 
     const runningDetails = runningContainer.querySelector(
-      'details.banner-details',
+      'wa-details.banner-details',
     );
     expect(runningDetails).not.toBeNull();
     expect(runningContainer.querySelector('.log-line')).toBeNull();
@@ -152,7 +152,7 @@ describe('thinking block renders as a banner while streaming', () => {
     const container = document.createElement('div');
     render(formatLogEntry(message), container);
 
-    const details = container.querySelector('details.banner-details');
+    const details = container.querySelector('wa-details.banner-details');
     expect(details).not.toBeNull();
     expect(details?.hasAttribute('open')).toBe(true);
     expect(container.textContent).toContain('Scratchpad');

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -11,6 +11,7 @@ useLitComponentTestDom(() =>
   Promise.all([
     import('@progressView/frontend/formatters/logFormatters/toolFormatters'),
     import('@progressView/frontend/formatters/logFormatters/bannerFormatters'),
+    import('@progressView/frontend/formatters/logFormatters/messageFormatters'),
   ]),
 );
 
@@ -253,6 +254,44 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
 
       const waDetails = container.querySelector(
         'wa-details.banner-details',
+      ) as WaDetailsElement | null;
+      expect(waDetails).not.toBeNull();
+      await waDetails!.updateComplete;
+
+      const copyButton = container.querySelector(
+        'wa-button.banner-content-copy',
+      ) as (HTMLElement & { updateComplete?: Promise<boolean> }) | null;
+      expect(copyButton).not.toBeNull();
+      if (copyButton!.updateComplete) await copyButton!.updateComplete;
+
+      expect(waDetails!.open).toBe(false);
+      dispatchActivationKeydown(copyButton!, key);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(waDetails!.open).toBe(false);
+    },
+  );
+
+  it.each(['Enter', ' '] as const)(
+    'keydown %j on the error banner copy button does not toggle the panel',
+    async (key) => {
+      const { formatErrorTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/messageFormatters');
+      const { render } = await import('lit');
+      const message: LogMessageData = {
+        id: 'error-1',
+        text: 'something failed',
+        level: LOG_LEVELS.ERROR,
+        timestamp: 1,
+        messageType: 'error',
+        data: { operation: 'test-op' },
+      };
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      render(formatErrorTemplate(message), container);
+
+      const waDetails = container.querySelector(
+        'wa-details.banner-details--error',
       ) as WaDetailsElement | null;
       expect(waDetails).not.toBeNull();
       await waDetails!.updateComplete;

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -149,9 +149,8 @@ function dispatchActivationKeydown(target: EventTarget, key: 'Enter' | ' ') {
 
 describe('wa-details summary controls: activation does not toggle the panel', () => {
   it('clicking the proposal-restore-link ("Setup") button does not toggle the panel, and the click still bubbles to an outer delegated handler', async () => {
-    const { formatToolUseTemplate } = await import(
-      '@progressView/frontend/formatters/logFormatters/toolFormatters'
-    );
+    const { formatToolUseTemplate } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
     const { render } = await import('lit');
     const message: LogMessageData = {
       id: 'proposal-1',
@@ -197,9 +196,8 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
   it.each(['Enter', ' '] as const)(
     'keydown %j on the proposal-restore-link does not toggle the panel',
     async (key) => {
-      const { formatToolUseTemplate } = await import(
-        '@progressView/frontend/formatters/logFormatters/toolFormatters'
-      );
+      const { formatToolUseTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
       const { render } = await import('lit');
       const message: LogMessageData = {
         id: 'proposal-2',
@@ -237,9 +235,8 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
   it.each(['Enter', ' '] as const)(
     'keydown %j on the copy button does not toggle the panel',
     async (key) => {
-      const { formatBannerContentTemplate } = await import(
-        '@progressView/frontend/formatters/logFormatters/bannerFormatters'
-      );
+      const { formatBannerContentTemplate } =
+        await import('@progressView/frontend/formatters/logFormatters/bannerFormatters');
       const { render } = await import('lit');
       const message: LogMessageData = {
         id: 'thinking-1',

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -47,6 +47,14 @@ describe('tool-use formatter', () => {
     );
     expect(title?.textContent).not.toContain('Built Mathlib');
     expect(body?.textContent).toContain('Built Mathlib.Example.Module19');
+
+    // Element-name pin (#8156): tool-use banners render through <wa-details>,
+    // matching the wa-details convention used elsewhere on this surface —
+    // never the native <details> element.
+    expect(
+      container.querySelector('wa-details.tool-use-details'),
+    ).not.toBeNull();
+    expect(container.querySelector('details')).toBeNull();
   });
 
   it('renders write_file cards even when compact logs omit content', async () => {

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -7,9 +7,11 @@ import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
-useLitComponentTestDom(
-  () =>
+useLitComponentTestDom(() =>
+  Promise.all([
     import('@progressView/frontend/formatters/logFormatters/toolFormatters'),
+    import('@progressView/frontend/formatters/logFormatters/bannerFormatters'),
+  ]),
 );
 
 describe('tool-use formatter', () => {
@@ -116,4 +118,158 @@ describe('tool-use formatter', () => {
     expect(container.textContent).toContain('wait (timeout: 1800s)');
     expect(container.textContent).not.toContain('3600s');
   });
+});
+
+/**
+ * Regression coverage for PR #8165 review findings: controls slotted into a
+ * `<wa-details>` summary (the "Setup" proposal-restore-link and the copy
+ * button) must not toggle the panel when activated, via mouse or keyboard.
+ *
+ * `<wa-details>`'s own summary click handler already excludes real
+ * `<button>`/`<wa-button>` elements from its toggle, but its keydown handler
+ * has no such check — every Enter/Space keydown that bubbles to the summary
+ * toggles regardless of origin. `stopSummaryToggleKeydown` (htmlBuilders.ts)
+ * stops those keydowns from reaching wa-details' summary at all.
+ */
+type WaDetailsElement = HTMLElement & {
+  open: boolean;
+  updateComplete: Promise<boolean>;
+};
+
+function dispatchActivationKeydown(target: EventTarget, key: 'Enter' | ' ') {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
+}
+
+describe('wa-details summary controls: activation does not toggle the panel', () => {
+  it('clicking the proposal-restore-link ("Setup") button does not toggle the panel, and the click still bubbles to an outer delegated handler', async () => {
+    const { formatToolUseTemplate } = await import(
+      '@progressView/frontend/formatters/logFormatters/toolFormatters'
+    );
+    const { render } = await import('lit');
+    const message: LogMessageData = {
+      id: 'proposal-1',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'propose_agent',
+        input: { agent: 'assistant', instruction: 'do the thing' },
+        output: 'proposed',
+      },
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(formatToolUseTemplate(message), container);
+
+    const waDetails = container.querySelector(
+      'wa-details.tool-use-details',
+    ) as WaDetailsElement | null;
+    expect(waDetails).not.toBeNull();
+    await waDetails!.updateComplete;
+
+    const setupButton = container.querySelector(
+      'button.proposal-restore-link',
+    ) as HTMLButtonElement | null;
+    expect(setupButton).not.toBeNull();
+
+    let ancestorSawClick = false;
+    container.addEventListener('click', () => {
+      ancestorSawClick = true;
+    });
+
+    expect(waDetails!.open).toBe(false);
+    setupButton!.click();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(waDetails!.open).toBe(false);
+    expect(ancestorSawClick).toBe(true);
+  });
+
+  it.each(['Enter', ' '] as const)(
+    'keydown %j on the proposal-restore-link does not toggle the panel',
+    async (key) => {
+      const { formatToolUseTemplate } = await import(
+        '@progressView/frontend/formatters/logFormatters/toolFormatters'
+      );
+      const { render } = await import('lit');
+      const message: LogMessageData = {
+        id: 'proposal-2',
+        text: '',
+        level: LOG_LEVELS.INFO,
+        timestamp: 1,
+        messageType: 'toolUse',
+        data: {
+          toolName: 'propose_agent',
+          input: { agent: 'assistant', instruction: 'do the thing' },
+          output: 'proposed',
+        },
+      };
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      render(formatToolUseTemplate(message), container);
+
+      const waDetails = container.querySelector(
+        'wa-details.tool-use-details',
+      ) as WaDetailsElement | null;
+      await waDetails!.updateComplete;
+      const setupButton = container.querySelector(
+        'button.proposal-restore-link',
+      ) as HTMLButtonElement | null;
+      expect(setupButton).not.toBeNull();
+
+      expect(waDetails!.open).toBe(false);
+      dispatchActivationKeydown(setupButton!, key);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(waDetails!.open).toBe(false);
+    },
+  );
+
+  it.each(['Enter', ' '] as const)(
+    'keydown %j on the copy button does not toggle the panel',
+    async (key) => {
+      const { formatBannerContentTemplate } = await import(
+        '@progressView/frontend/formatters/logFormatters/bannerFormatters'
+      );
+      const { render } = await import('lit');
+      const message: LogMessageData = {
+        id: 'thinking-1',
+        text: 'some thinking content',
+        level: LOG_LEVELS.INFO,
+        timestamp: 1,
+        messageType: 'thinking',
+        data: {},
+      };
+
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      render(formatBannerContentTemplate(message), container);
+
+      const waDetails = container.querySelector(
+        'wa-details.banner-details',
+      ) as WaDetailsElement | null;
+      expect(waDetails).not.toBeNull();
+      await waDetails!.updateComplete;
+
+      const copyButton = container.querySelector(
+        'wa-button.banner-content-copy',
+      ) as (HTMLElement & { updateComplete?: Promise<boolean> }) | null;
+      expect(copyButton).not.toBeNull();
+      if (copyButton!.updateComplete) await copyButton!.updateComplete;
+
+      expect(waDetails!.open).toBe(false);
+      dispatchActivationKeydown(copyButton!, key);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(waDetails!.open).toBe(false);
+    },
+  );
 });

--- a/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
+++ b/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
@@ -91,6 +91,14 @@ describe('web-search/web-fetch formatters: URL scheme sanitization', () => {
       expect(anchor).not.toBeNull();
       expect(anchor?.getAttribute('href')).toBe(url);
       expect(anchor?.textContent).toContain('Click me');
+
+      // Element-name pin (#8156): web-search banners render through
+      // <wa-details>, matching the wa-details convention used elsewhere on
+      // this surface — never the native <details> element.
+      expect(
+        container.querySelector('wa-details.tool-use-details'),
+      ).not.toBeNull();
+      expect(container.querySelector('details')).toBeNull();
     });
 
     it('renders a mailto URL as a real clickable href', async () => {

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -76,8 +76,7 @@ function installAnimationPolyfill(window: JSDOM['window']): void {
   // resolve immediately. Returning [] means "no animations" — animateWithClass
   // resolves on the next raf, which matches the visible behavior in tests.
   const proto = window.Element?.prototype as
-    | (Element & { getAnimations?: () => unknown[] })
-    | undefined;
+    (Element & { getAnimations?: () => unknown[] }) | undefined;
   if (!proto) return;
   if (typeof proto.getAnimations !== 'function') {
     proto.getAnimations = () => [];

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -76,10 +76,24 @@ function installAnimationPolyfill(window: JSDOM['window']): void {
   // resolve immediately. Returning [] means "no animations" — animateWithClass
   // resolves on the next raf, which matches the visible behavior in tests.
   const proto = window.Element?.prototype as
-    (Element & { getAnimations?: () => unknown[] }) | undefined;
+    | (Element & { getAnimations?: () => unknown[] })
+    | undefined;
   if (!proto) return;
   if (typeof proto.getAnimations !== 'function') {
     proto.getAnimations = () => [];
+  }
+  // jsdom also doesn't implement the Web Animations API (Element.animate).
+  // wa-details' internal animate() helper (used to drive its open/close
+  // transition) calls `el.animate(keyframes, options).finished` directly —
+  // without this, toggling a <wa-details> open/closed throws. Resolve
+  // immediately so the open/close state settles synchronously enough for
+  // tests to observe without waiting on a real animation. The stub's shape
+  // intentionally doesn't match the real `Animation` return type — only
+  // `.finished` is ever read by the code under test.
+  if (typeof proto.animate !== 'function') {
+    proto.animate = (() => ({
+      finished: Promise.resolve(),
+    })) as unknown as Element['animate'];
   }
 }
 


### PR DESCRIPTION
Closes #8156

progressView log formatters rendered native `<details>` while `wa-details` is the registered majority convention on the same surface (used by `ContextManagement`, `StatisticsPanel`, `LatexdiffResults`, `TaskGroupList`, `BackgroundTasksPanel`, `TodoList`, `PlanView`, etc.), so log entries diverged in theme/behavior (open/close animation, dark-mode styling, focus states) from the rest of the progress view.

## What changed

Swapped all 8 native `<details>` sites under `packages/extension/src/progressView/frontend/formatters/logFormatters/` to `<wa-details appearance="plain">`, using the existing `buildDetailsSummary({ summarySlot: true })` path that's already used by every other wa-details caller on this surface (no new abstraction):

- `toolFormatters.ts:200` — `formatToolUseTemplate`
- `messageFormatters.ts:147` — `formatErrorTemplate` (hand-rolled `<summary>`, not `buildDetailsSummary`; see below)
- `bannerFormatters.ts:77,111` — `formatBannerContentTemplate`, `formatModelResponseTemplate`
- `dataFormatters.ts:46,55,96` — `formatFileListTemplate` (×2), `formatMissingOutputsTemplate`
- `toolFormatters/webFormatters.ts:40` — `buildToolUseDetails` (shared by web-search/web-fetch formatters)

Each file also picked up the same side-effect import (`@awesome.me/webawesome/dist/components/details/details.js`) the existing wa-details callers already use to register the component.

### Behavior deltas handled

- **`formatErrorTemplate`'s hand-built toggle icon.** This formatter didn't go through `buildDetailsSummary` — it hand-rolled a `<summary>` with a `chevron-right` icon whose `visibility` was inline-toggled to `hidden` when there were no expandable error-detail fields (still-clickable summary, just no visible affordance). `wa-details` supplies its own built-in disclosure icon via `::part(icon)`, so the hand-rolled toggle icon is gone and a new `banner-details--no-toggle` modifier class hides `::part(icon)` instead — same visual outcome (no more inline `styleMap`/`toggle-icon` markup, which let `styleMap` drop out as an unused import).
- **CSS retargeting.** Grepped every selector under `progressView/frontend/styles/*.ts` and the shared `src/shared/styles/commonViewStyles.ts` for `details`/`summary`. All existing `.banner-details` / `.details-summary` rules are class-based (not element-tag-based) so they continue to match the slotted `<div slot="summary" class="details-summary">` produced by `summarySlot: true` — no changes needed there. The one truly native-tag selector (`details[open] > summary .toggle-icon` in `commonViewStyles.ts`) still has live callers outside this PR's scope (`TaskGroupList`/`BackgroundTasksPanel` use `wa-details` exclusively — an earlier grep hit there was a comment, not a live selector — so nothing to retarget for this rule). Added one new rule: `wa-details.banner-details--no-toggle::part(icon) { visibility: hidden; }` in `toolUseStyles.ts`, next to the sibling `.banner-details--error`/`.banner-details--relay-error` rules.
- **`open` attribute semantics.** `?open=${bool}` dynamic binding on `wa-details` is already a shipped pattern in this exact codebase (`BackgroundTasksPanel.ts`, `PlanView.ts`, `QueuedFollowUps.ts`, `TodoList.ts`, `TaskGroupList.ts`), and `wa-details`' `open` is a reflected boolean attribute/property with the same semantics as native `<details open>` (per Web Awesome's own docs) — no behavior change.

## Net elements (R6)

- Removed: 8 native `<details>`/`<summary>` element templates, 1 hand-rolled toggle-icon (`styleMap`-driven inline style).
- Added: 0 new abstractions — reused the existing `buildDetailsSummary(summarySlot: true)` path (15+ existing callers) and existing `wa-details` registration side-effect import pattern (already used by 15+ other files). 1 new CSS modifier class (`banner-details--no-toggle`) mirroring the existing `--error`/`--relay-error` modifier convention on the same selector.
- Net: mechanical element-name swap, no new components/helpers/wrappers.

## Consumer counts (R8)

```
$ grep -rn "<details" packages/extension/src/progressView/frontend/formatters/
(no matches)
```

All 8 pinned sites (and every sibling `<details` under `formatters/logFormatters/`) are converted. `TaskGroupList.ts`/`BackgroundTasksPanel.ts` (outside this pin's scope) were already fully on `wa-details`; the earlier `<details` grep hits there were comment text (`` `<details>` ``), not live elements.

## Tests

- Extended `src/test-kernel/progressView/ThinkingBlockStreamingRender.vitest.ts` (4 assertions): `details.banner-details` → `wa-details.banner-details` selectors.
- Extended `src/test-kernel/progressView/ToolUseFormatter.vitest.mts`: added an explicit `wa-details.tool-use-details` presence check + `details` absence check.
- Extended `src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts`: same element-name pin for the web-search banner path.
- `npx vitest run src/test-kernel/progressView/` — 38 files / 219 tests passed.
- `npm run typecheck` — clean (full workspace, including `tsconfig.test-kernel.json`).
- `npx eslint` + `npx prettier --check` on all changed files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad UI migration across log rendering plus keyboard/event fixes for interactive summary controls; risk is mostly regressions in expand/collapse, copy/setup actions, and terminal sizing when panels open—not auth or data paths.
> 
> **Overview**
> Progress view log banners (thinking, errors, tool use, file lists, web search/fetch, etc.) now use **`<wa-details appearance="plain">`** with **`buildDetailsSummary({ summarySlot: true })`** instead of native **`<details>`**, aligning log entries with the rest of the progress view.
> 
> **Keyboard and summary controls:** **`stopSummaryToggleKeydown`** stops Enter/Space on copy buttons and the proposal **Setup** control from bubbling to **`wa-details`**’s summary (which would toggle the panel and swallow native activation). **Setup** is a real **`<button>`** with link-like CSS; **`LogList`** no longer treats **Setup** as a keyboard-activated span.
> 
> **Error banners** use **`wa-details`**’ built-in chevron via **`banner-details--no-toggle::part(icon)`** when there is nothing to expand.
> 
> **Terminals** inside collapsed panels refit on **`toggle`**, **`wa-show`**, and **`wa-after-show`** from ancestor **`wa-details`** or **`details`**.
> 
> Tests add **`wa-details`** element pins, summary-control regression cases, and a jsdom **`Element.animate`** stub for **`wa-details`** toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8969b812c3012885bfda093f2f849e91cd5a1777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->