### PR TITLE
refactor(cli-tui): route four modal panes through BorderedPanel

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -22,6 +22,7 @@ import {
 } from '../state/childControls';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { KeyHints } from '../ui/KeyHints';
+import { BorderedPanel } from '../ui/BorderedPanel';
 import { POINTER } from '../ui/glyphs';
 import {
   nextWrappingHighlightIndex,
@@ -423,16 +424,23 @@ export function ChildControlPicker({
   }
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
+    <BorderedPanel
+      color="cyan"
       width={availableColumns}
+      title={pickerTitle(mode)}
+      footer={
+        <KeyHints
+          hints={pickerKeyHintsForColumns(
+            mode,
+            items.length,
+            selectedItem?.killable ?? false,
+            hintColumns,
+          )}
+          confirmCancel={false}
+        />
+      }
+      footerMarginTop={stackSelectedSubagent || compactEmptyPicker ? 0 : 1}
     >
-      <Text bold color="cyan">
-        {pickerTitle(mode)}
-      </Text>
       {streamScopeText ? (
         <Text dimColor wrap="truncate-end">
           {streamScopeText}
@@ -464,17 +472,6 @@ export function ChildControlPicker({
           <Text dimColor>{emptyPickerText(mode)}</Text>
         )}
       </Box>
-      <Box marginTop={stackSelectedSubagent || compactEmptyPicker ? 0 : 1}>
-        <KeyHints
-          hints={pickerKeyHintsForColumns(
-            mode,
-            items.length,
-            selectedItem?.killable ?? false,
-            hintColumns,
-          )}
-          confirmCancel={false}
-        />
-      </Box>
-    </Box>
+    </BorderedPanel>
   );
 }

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -22,6 +22,7 @@ import {
   scrollBoundedRows,
 } from '../render/scrollBounds';
 import { KEY_HINT_SEPARATOR, KeyHints, type KeyHint } from '../ui/KeyHints';
+import { BorderedPanel } from '../ui/BorderedPanel';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface ExternalInquiryProps {
@@ -317,24 +318,25 @@ export function ExternalInquiry(
   });
 
   return (
-    <Box
+    <BorderedPanel
       borderStyle="single"
-      borderColor="green"
-      flexDirection="column"
-      paddingX={1}
+      color="green"
       width={columns}
+      title={
+        <>
+          Agent asks:
+          {copyStatus !== 'idle' ? (
+            <Text
+              color={copyStatus === 'failed' ? 'yellow' : 'green'}
+              dimColor={copyStatus === 'copying'}
+            >
+              {copyStatusLabel(copyStatus)}
+            </Text>
+          ) : null}
+        </>
+      }
+      footer={<KeyHints hints={keyHints} confirmCancel={false} />}
     >
-      <Text bold color="green">
-        Agent asks:
-        {copyStatus !== 'idle' ? (
-          <Text
-            color={copyStatus === 'failed' ? 'yellow' : 'green'}
-            dimColor={copyStatus === 'copying'}
-          >
-            {copyStatusLabel(copyStatus)}
-          </Text>
-        ) : null}
-      </Text>
       <Box flexDirection="column">
         {questionDisplayLines.map((line, index) => (
           <Text key={index} dimColor={line.kind === 'overflow'}>
@@ -361,9 +363,6 @@ export function ExternalInquiry(
           />
         </Box>
       </Box>
-      <Box marginTop={1}>
-        <KeyHints hints={keyHints} confirmCancel={false} />
-      </Box>
-    </Box>
+    </BorderedPanel>
   );
 }

--- a/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
+++ b/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
@@ -29,6 +29,7 @@ import {
   type TaskDetailScrollState,
 } from '../state/taskDetailScroll';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
+import { BorderedPanel } from '../ui/BorderedPanel';
 
 export const TASK_DETAIL_LABEL_WIDTH = 13;
 const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
@@ -382,18 +383,17 @@ export function TaskDetailView({
   }
 
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
+    <BorderedPanel
+      color="cyan"
       width={availableColumns}
+      title={layout.showTitle ? 'Task details' : undefined}
+      footer={
+        layout.showHints ? (
+          <KeyHints hints={hints} confirmCancel={false} />
+        ) : undefined
+      }
+      footerMarginTop={layout.compact ? 0 : 1}
     >
-      {layout.showTitle ? (
-        <Text bold color="cyan">
-          Task details
-        </Text>
-      ) : null}
       {layout.showExpandedMeta ? (
         <>
           {metaLine('Type', item.kind === 'process' ? 'shell' : 'stream')}
@@ -429,11 +429,6 @@ export function TaskDetailView({
           visibleLineCount={visibleLineCount}
         />
       </Box>
-      {layout.showHints ? (
-        <Box marginTop={layout.compact ? 0 : 1}>
-          <KeyHints hints={hints} confirmCancel={false} />
-        </Box>
-      ) : null}
-    </Box>
+    </BorderedPanel>
   );
 }

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -32,6 +32,7 @@ import {
   visibleSelectRange,
 } from '../ui/Select';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
+import { BorderedPanel } from '../ui/BorderedPanel';
 import { POINTER, TICK } from '../ui/glyphs';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
@@ -291,16 +292,14 @@ function QuestionShell(props: QuestionShellProps): React.JSX.Element {
     [contentWidth, promptRows, props.payload.context, questionText],
   );
   return (
-    <Box
+    <BorderedPanel
       borderStyle="single"
-      borderColor="green"
-      flexDirection="column"
-      paddingX={1}
+      color="green"
       width={columns}
+      title="Agent asks:"
+      footer={<KeyHints hints={props.hints} confirmCancel={false} />}
+      footerMarginTop={compact ? 0 : 1}
     >
-      <Text bold color="green">
-        Agent asks:
-      </Text>
       <Box marginTop={compact ? 0 : 1} flexDirection="column">
         {promptLines.map((line, lineIndex) => (
           <Text
@@ -314,10 +313,7 @@ function QuestionShell(props: QuestionShellProps): React.JSX.Element {
       <Box marginTop={compact ? 0 : 1} flexDirection="column">
         {props.children}
       </Box>
-      <Box marginTop={compact ? 0 : 1}>
-        <KeyHints hints={props.hints} confirmCancel={false} />
-      </Box>
-    </Box>
+    </BorderedPanel>
   );
 }
 

--- a/packages/cli/src/chat/tui/ui/BorderedPanel.tsx
+++ b/packages/cli/src/chat/tui/ui/BorderedPanel.tsx
@@ -1,18 +1,24 @@
 // Shared bordered-panel scaffold used by FormFrame (transient list-form
-// states) and ConfirmCard (y/n approval modals): a bordered box with a
-// colored bold title, a body slot, and an optional footer row.
+// states), ConfirmCard (y/n approval modals), ExternalInquiry, UserQuestion's
+// QuestionShell, ChildControlPicker, and TaskDetailView: a bordered box with
+// a colored bold title, a body slot, and an optional footer row.
 
 import { Box, Text, type BoxProps } from 'ink';
 
 export interface BorderedPanelProps {
   readonly borderStyle?: BoxProps['borderStyle'];
   readonly color: string;
-  readonly title: string;
+  /** Omit (or pass a falsy value) to render no title row — e.g. TaskDetailView
+   *  hides its title entirely once the viewport gets too short for it. */
+  readonly title?: React.ReactNode;
   readonly width?: number;
   readonly children: React.ReactNode;
-  /** Rendered inside its own `marginTop={1}` box (typically `<KeyHints>`).
+  /** Rendered inside its own margin box (typically `<KeyHints>`).
    *  Omit (or pass a falsy value) to render no footer row. */
   readonly footer?: React.ReactNode;
+  /** `marginTop` for the footer's wrapper box. Defaults to `1`; some callers
+   *  collapse it to `0` in their own compact layouts. */
+  readonly footerMarginTop?: number;
 }
 
 export function BorderedPanel({
@@ -22,6 +28,7 @@ export function BorderedPanel({
   width,
   children,
   footer,
+  footerMarginTop = 1,
 }: BorderedPanelProps): React.JSX.Element {
   return (
     <Box
@@ -31,11 +38,13 @@ export function BorderedPanel({
       paddingX={1}
       width={width}
     >
-      <Text bold color={color}>
-        {title}
-      </Text>
+      {title ? (
+        <Text bold color={color}>
+          {title}
+        </Text>
+      ) : null}
       {children}
-      {footer ? <Box marginTop={1}>{footer}</Box> : null}
+      {footer ? <Box marginTop={footerMarginTop}>{footer}</Box> : null}
     </Box>
   );
 }


### PR DESCRIPTION
Closes #8159

## Summary

`ExternalInquiry`, `UserQuestion`'s `QuestionShell`, `ChildControlPicker`'s full (non-ultra-compact) render, and `TaskDetailView`'s non-compact render each hand-rolled the same bordered-column `Box` shape (`borderStyle`/`borderColor`, `paddingX={1}`, bold-colored title `Text`, optional footer row) that `packages/cli/src/chat/tui/ui/BorderedPanel.tsx` already owns. This PR routes all four through `BorderedPanel` instead — mechanical reuse, no visual redesign.

## Net elements (R6)

- `BorderedPanel.tsx`: widened `title` from required `string` to optional `React.ReactNode` (falsy → no title row, needed by `TaskDetailView`, which hides its title below a row threshold; `ReactNode` needed by `ExternalInquiry`'s title, which embeds a conditional copy-status `<Text>`), and added `footerMarginTop?: number` (default `1`, matching the two existing callers unchanged; several of the new callers collapse their footer margin to `0` in their own compact layouts).
- 4 hand-rolled `<Box borderStyle... borderColor... paddingX={1}>` + title `<Text>` + footer-margin `<Box>` scaffolds deleted from `ExternalInquiry.tsx`, `UserQuestion.tsx`, `ChildControlPicker.tsx`, `TaskDetailView.tsx` — each now composes `BorderedPanel` with its existing `children`/`footer` content unchanged.
- No new files, no new dependencies. Net: −4 LOC across the 5 touched files (70 insertions / 74 deletions).

## Consumer counts (R8)

`BorderedPanel` goes from 2 callers to 6:
- `FormFrame.tsx` (pre-existing, unchanged — new `title`/`footerMarginTop` defaults preserve its exact output)
- `ConfirmCard.tsx` (pre-existing, unchanged, same reasoning)
- `ExternalInquiry.tsx` (new)
- `UserQuestion.tsx` → `QuestionShell` (new)
- `ChildControlPicker.tsx` (new)
- `TaskDetailView.tsx` (new)

## Verification

- `npm run typecheck` (root `tsc --noEmit` + `@texra-ai/cli` project) — clean.
- `eslint` on the 5 touched files — clean.
- `prettier --check` on the 5 touched files — clean.
- Targeted CLI vitest suites (`TuiStateAndFocus`, `ExternalInquiry`, `UserQuestion`, `UserQuestionState`, `ChildControls`, `ApprovalEvents`, `ApprovalAdapter`): 215/215 passed.
- Full `src/test-kernel/cli` suite: 1671/1672 (single unrelated pre-existing timeout flake on `RunChatSignalOwnership`, not touching any of the changed files — reran and got a different flaky timeout the first time, confirming it's load-related, not a regression).
- `node scripts/validate-tui.mjs` — ran the scenario subset covering all four panes (external-inquiry-*, compact-user-question, subagent/task-picker family, task-subworkflow/process-detail family, focused-stopped-subagent family): 31/33 passed byte-identical. The 2 failures (`focused-stopped-subagent`, `focused-stopped-subagent-submit`) reproduce identically on a clean `origin/main` checkout (verified via `git stash`) — pre-existing, unrelated to this change.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout refactor only; defaults preserve existing `FormFrame`/`ConfirmCard` output and modal content/behavior are intended to stay the same.
> 
> **Overview**
> **Refactors four CLI TUI modals** to use the shared `BorderedPanel` scaffold instead of duplicating bordered `Box` + bold title + footer `KeyHints` layout.
> 
> `BorderedPanel` now accepts an optional **`title`** (`React.ReactNode`, omitted when falsy) and **`footerMarginTop`** (default `1`) so callers like `TaskDetailView` and compact layouts can hide the title or tighten footer spacing. **`ExternalInquiry`**, **`UserQuestion`** (`QuestionShell`), **`ChildControlPicker`** (non–ultra-compact), and **`TaskDetailView`** (non–ultra-compact) pass their existing body content, borders (`single` vs default `round`), and footers through the component; ultra-compact paths are unchanged.
> 
> No new dependencies or intentional visual redesign—mechanical deduplication aligned with existing `FormFrame` / `ConfirmCard` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f108e187dfb934d17656b546848a75807fa55665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->