### PR TITLE
fix(cli): use write-file-atomic for the CLI secrets file

### DIFF
--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -1,6 +1,9 @@
 // Standard library imports
-import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
+
+// Third-party imports
+import writeFileAtomic from 'write-file-atomic';
 
 // Local imports - platform
 import { DEFAULT_NODE_STORAGE_ROOT } from '@platform/defaults/nodeStorage';
@@ -101,12 +104,11 @@ export class CliSecrets implements PlatformSecrets {
     const secretsDir = path.dirname(this.filePath);
     await mkdir(secretsDir, { recursive: true, mode: 0o700 });
     await chmod(secretsDir, 0o700);
-    const tempPath = `${this.filePath}.${process.pid}.tmp`;
-    await writeFile(tempPath, `${JSON.stringify(data, null, 2)}\n`, {
+    // write-file-atomic stages to a sibling temp, fsyncs, and renames over
+    // the target, so a crash mid-write can't leave a truncated secrets file.
+    await writeFileAtomic(this.filePath, `${JSON.stringify(data, null, 2)}\n`, {
       mode: 0o600,
     });
-    await rename(tempPath, this.filePath);
-    await chmod(this.filePath, 0o600);
   }
 }
 


### PR DESCRIPTION
## Summary

`CliSecrets.writeSecrets()` hand-rolled its atomic write: stage to `secrets.json.<pid>.tmp`, `rename`, `chmod`. Two gaps vs. the library the repo already uses elsewhere:

- **No fsync.** The rename can be durable before the data is, so a crash/power-loss right after a write can leave a truncated or empty `secrets.json`. Because `set()`/`delete()` do a full read-mutate-write of the whole file, that corruption silently wipes **all** stored secrets (the same failure family as #7463, which hardened the read side — this hardens the write side).
- **Collision-prone temp name.** `.${pid}.tmp` isn't unique across concurrent CLI invocations the way write-file-atomic's randomized temp names (murmurhex of pid+invocation) are.

The replacement is the exact idiom already used in `src/platform/defaults/jsonStore.ts`, `nodeFilesystem.ts`, and `src/utils/files/baseFS.ts`; `{ mode: 0o600 }` is passed through, and the directory `mkdir`/`chmod 0o700` hardening stays. Net −2 LOC, no new dependency, no wrapper added.

Bundling note: the historical `__filename` ESM-banner crash with bundled write-file-atomic (#5021/#5714) is fixed — the CLI bundle already ships write-file-atomic via the shared `JsonStore`.

## Test plan

- [x] `vitest run src/test-kernel/cli/CliSecrets.vitest.mts` — 3/3 pass (tests exercise a real temp dir, so the library path is executed for real)
- [x] `corepack pnpm --filter @texra-ai/cli typecheck` — clean

Found in a reinvented-wheel audit (2026-07-11).

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret persistence on disk; behavior should improve durability but any write-path change warrants careful review.
> 
> **Overview**
> **`CliSecrets.writeSecrets()`** no longer uses a manual temp file (`secrets.json.<pid>.tmp`), `writeFile`, `rename`, and a separate `chmod`. It now writes via **`write-file-atomic`**, matching the pattern used elsewhere in the repo.
> 
> The change adds **fsync-before-rename** durability so a crash or power loss is less likely to leave a truncated `secrets.json` (which, with read-mutate-write, could wipe all stored secrets). Temp filenames are also **less collision-prone** under concurrent CLI processes than PID-only suffixes. Directory **`mkdir`/`chmod 0o700`** is unchanged; file mode **`0o600`** is passed through the library options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a739c16512c9351475ac864e07a0b02b0b398d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->