### PR TITLE
chore(deps): remove unused axios dependency

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1982,7 +1982,6 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "arxiv-client": "^0.0.9",
-    "axios": "^1.18.1",
     "bibtex": "^0.9.0",
     "deepmerge": "^4.3.1",
     "diff-match-patch": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.0: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+  ink@7.1.0:
+    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+    path: patches/ink@7.1.0.patch
 
 importers:
 
@@ -569,9 +571,6 @@ importers:
       arxiv-client:
         specifier: ^0.0.9
         version: 0.0.9
-      axios:
-        specifier: ^1.18.1
-        version: 1.18.1
       bibtex:
         specifier: ^0.9.0
         version: 0.9.0
@@ -3019,9 +3018,6 @@ packages:
 
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
-
-  axios@1.18.1:
-    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -8597,16 +8593,6 @@ snapshots:
   aws4@1.13.2: {}
 
   axios@1.17.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6


### PR DESCRIPTION
## Summary

`axios` (^1.18.1, declared only in `packages/extension/package.json`) has **zero references** anywhere in the repo — no static imports, no `require()`, no dynamic imports, across all `src/`, `packages/*/src/`, and `scripts/`. The HTTP layer is fully on `ky` + native `fetch` (WebFetchTool, WebSearchTool, LoogleTool, Zotero clients, RemoteAgentLoader, UsageLogService, `src/tools/timeouts.ts`). The only textual mention is a tombstone comment in `src/latex/arxivProcessor.ts:32` describing the old axios behavior that was migrated away.

Verified `@modelcontextprotocol/sdk` (the other zero-import dep) must **stay** — it satisfies a `peerDependencies` requirement of `@anthropic-ai/claude-agent-sdk`, unlike axios which is nobody's peer.

Why knip didn't catch it: `knip.json` sets `"ignoreDependencies": [".*"]`, so dependency checks are fully disabled; only file/export dead-code is ratcheted.

## Test plan

- [x] `grep -rn axios` over all source/config/script file types — no hits outside the manifest and the tombstone comment
- [x] `pnpm install --lockfile-only` — lockfile updated cleanly
- [x] CI build will exercise the VSIX packaging path

Found in a reinvented-wheel audit (2026-07-11).

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and lockfile-only cleanup of an unreferenced dependency; no behavioral changes expected.
> 
> **Overview**
> Removes the unused **`axios`** (^1.18.1) direct dependency from `packages/extension/package.json` and drops the matching **`axios@1.18.1`** entries from **`pnpm-lock.yaml`**. No application code changes—HTTP in the extension already uses **`ky`** and native **`fetch`**.
> 
> The lockfile also normalizes **`patchedDependencies`** for **`ink@7.1.0`** to the expanded object form (`hash` + `path`), alongside the manifest cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d77b6bec69d26bc8731e0fd8a4afc98f5847eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->