### PR TITLE
refactor(tools): replace hand-rolled image-dimension sniffing with image-size

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "http-status-codes": "^2.3.0",
     "identifiers-arxiv": "^0.1.1",
     "ignore": "^7.0.6",
+    "image-size": "^2.0.2",
     "is-network-error": "^1.3.2",
     "is-wsl": "^3.1.1",
     "katex": "^0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       ignore:
         specifier: ^7.0.6
         version: 7.0.6
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
       is-network-error:
         specifier: ^1.3.2
         version: 1.3.2
@@ -4196,6 +4199,11 @@ packages:
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
+
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   import-in-the-middle@3.2.0:
     resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
@@ -9963,6 +9971,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
+
+  image-size@2.0.2: {}
 
   import-in-the-middle@3.2.0:
     dependencies:

--- a/src/test-kernel/tools/ImageUtils.vitest.ts
+++ b/src/test-kernel/tools/ImageUtils.vitest.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOversizedImage } from '@tools/imageUtils';
+
+/** Minimal PNG header (signature + IHDR) with the given dimensions. */
+function pngHeader(width: number, height: number): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr.set([8, 6, 0, 0, 0], 8);
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.from([0, 0, 0, 13]),
+    Buffer.from('IHDR'),
+    ihdr,
+  ]);
+}
+
+describe('isOversizedImage', () => {
+  it('flags images beyond the many-image dimension limit', () => {
+    expect(isOversizedImage(pngHeader(2001, 100))).toBe(true);
+    expect(isOversizedImage(pngHeader(100, 2001))).toBe(true);
+  });
+
+  it('accepts images within the limit', () => {
+    expect(isOversizedImage(pngHeader(2000, 2000))).toBe(false);
+  });
+
+  it('treats unrecognized data as not oversized', () => {
+    expect(isOversizedImage(Buffer.from('plain text, not an image'))).toBe(
+      false,
+    );
+    expect(isOversizedImage(Buffer.alloc(0))).toBe(false);
+  });
+});

--- a/src/tools/imageUtils.ts
+++ b/src/tools/imageUtils.ts
@@ -1,114 +1,20 @@
+import { imageSize } from 'image-size';
+
 /**
  * Max image dimension (px) for many-image API requests.
  * Anthropic returns a non-retryable 400 when any image exceeds this in a multi-image request.
  */
 export const MANY_IMAGE_MAX_DIMENSION = 2000;
 
-/** Max bytes to scan for JPEG SOF markers — all well-formed JPEGs have SOF within the first 64 KB. */
-const JPEG_MAX_SCAN_BYTES = 65536;
-
-/**
- * Parse image dimensions from buffer header bytes (PNG, JPEG, GIF, WebP).
- * Returns undefined if format is unrecognized or header is truncated.
- */
-function getImageDimensionsFromBuffer(
-  buffer: Buffer,
-): { width: number; height: number } | undefined {
-  if (buffer.length < 10) return undefined;
-
-  // PNG: width@16 and height@20 (4 bytes BE each)
-  if (
-    buffer[0] === 0x89 &&
-    buffer[1] === 0x50 &&
-    buffer[2] === 0x4e &&
-    buffer[3] === 0x47
-  ) {
-    if (buffer.length < 24) return undefined;
-    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
-  }
-
-  // GIF: width@6 and height@8 (2 bytes LE each)
-  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) {
-    return { width: buffer.readUInt16LE(6), height: buffer.readUInt16LE(8) };
-  }
-
-  // JPEG: scan for SOF markers (bounded to first 64 KB)
-  if (buffer[0] === 0xff && buffer[1] === 0xd8) {
-    const limit = Math.min(buffer.length, JPEG_MAX_SCAN_BYTES);
-    let offset = 2;
-    while (offset + 9 < limit) {
-      if (buffer[offset] !== 0xff) {
-        offset++;
-        continue;
-      }
-      const marker = buffer[offset + 1];
-      if (
-        (marker >= 0xc0 && marker <= 0xc3) ||
-        (marker >= 0xc5 && marker <= 0xc7) ||
-        (marker >= 0xc9 && marker <= 0xcb) ||
-        (marker >= 0xcd && marker <= 0xcf)
-      ) {
-        return {
-          height: buffer.readUInt16BE(offset + 5),
-          width: buffer.readUInt16BE(offset + 7),
-        };
-      }
-      if (offset + 3 >= limit) return undefined;
-      const segmentLength = buffer.readUInt16BE(offset + 2);
-      if (segmentLength < 2) return undefined;
-      offset += 2 + segmentLength;
-    }
-    return undefined;
-  }
-
-  // WebP: "RIFF" + 4 bytes + "WEBP", then a "VP8" + subtype-byte chunk tag.
-  if (
-    buffer.length >= 30 &&
-    buffer[0] === 0x52 &&
-    buffer[1] === 0x49 &&
-    buffer[2] === 0x46 &&
-    buffer[3] === 0x46 &&
-    buffer[8] === 0x57 &&
-    buffer[9] === 0x45 &&
-    buffer[10] === 0x42 &&
-    buffer[11] === 0x50 &&
-    buffer[12] === 0x56 &&
-    buffer[13] === 0x50 &&
-    buffer[14] === 0x38
-  ) {
-    switch (buffer[15]) {
-      case 0x20: // VP8 (lossy)
-        return {
-          width: buffer.readUInt16LE(26) & 0x3fff,
-          height: buffer.readUInt16LE(28) & 0x3fff,
-        };
-      case 0x4c: {
-        // VP8L (lossless)
-        if (buffer.length < 25) return undefined;
-        const bits = buffer.readUInt32LE(21);
-        return {
-          width: (bits & 0x3fff) + 1,
-          height: ((bits >> 14) & 0x3fff) + 1,
-        };
-      }
-      case 0x58: // VP8X (extended)
-        return {
-          width: (buffer[24] | (buffer[25] << 8) | (buffer[26] << 16)) + 1,
-          height: (buffer[27] | (buffer[28] << 8) | (buffer[29] << 16)) + 1,
-        };
-    }
-  }
-
-  return undefined;
-}
-
 /** Returns true if buffer is an image exceeding the many-image dimension limit. */
 export function isOversizedImage(buffer: Buffer | Uint8Array): boolean {
-  const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
-  const dims = getImageDimensionsFromBuffer(buf);
-  if (!dims) return false;
-  return (
-    dims.width > MANY_IMAGE_MAX_DIMENSION ||
-    dims.height > MANY_IMAGE_MAX_DIMENSION
-  );
+  let width: number;
+  let height: number;
+  try {
+    ({ width, height } = imageSize(buffer));
+  } catch {
+    // Unrecognized or truncated image data — nothing to measure.
+    return false;
+  }
+  return width > MANY_IMAGE_MAX_DIMENSION || height > MANY_IMAGE_MAX_DIMENSION;
 }


### PR DESCRIPTION
## Summary

`src/tools/imageUtils.ts` hand-parsed image headers — PNG offsets, GIF offsets, a JPEG SOF-marker scan loop, and WebP VP8/VP8L/VP8X bit arithmetic (~100 LOC) — purely to answer one question for `ReadTool`/`attachments`: *does this image exceed the 2000px many-image API limit?*

This swaps the parser for [`image-size`](https://www.npmjs.com/package/image-size) (v2.0.2, ~26M weekly downloads, actively maintained), keeping `isOversizedImage` as the single domain-level entry point (threshold + unrecognized→`false` contract unchanged — no pass-through wrapper added, the whole parser layer is deleted).

**Behavior improvement:** image-size recognizes more formats (BMP, TIFF, HEIF/AVIF, ICO, …), so oversized images in formats the hand parser didn't know are now correctly stripped instead of being sent through and drawing a non-retryable 400 from Anthropic (the exact failure the module documents guarding against). Callers are mime-gated (`image/*`), so non-image data never reaches this path in practice; the unrecognized→`false` fallback is preserved regardless.

`src/tools/` is a VS Code-free zone; image-size is pure JS with no platform deps. Net: −94 LOC prod code, +1 well-tested dependency, +1 regression test (the module previously had none).

## Test plan

- [x] New `src/test-kernel/tools/ImageUtils.vitest.ts` — oversized (both axes), boundary (2000px = not oversized), unrecognized/empty input — 3/3 pass
- [x] `tsc --noEmit` (root + test-kernel configs) — clean

Found in a reinvented-wheel audit (2026-07-11).

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor behind the same `isOversizedImage` API; behavior is preserved or improved for additional image formats with new unit tests.
> 
> **Overview**
> Replaces the in-house PNG/GIF/JPEG/WebP header parsing in `imageUtils.ts` with the **`image-size`** dependency while keeping **`isOversizedImage`** as the gate for the 2000px many-image API limit used by **`ReadTool`** and **`attachments`**.
> 
> **`MANY_IMAGE_MAX_DIMENSION`**, the oversized check semantics, and the **unrecognized/truncated → `false`** behavior stay the same; oversized images are still stripped before multi-image requests. **Broader format support** (e.g. BMP, TIFF, HEIF) means more oversized attachments are caught instead of slipping through and triggering Anthropic 400s.
> 
> Adds **`ImageUtils.vitest.ts`** for boundary, oversized, and non-image cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b695ebe95de39d30d33cdc42e103c56a558928b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->