### PR TITLE
fix(a11y): add keyboard activation to preset-card, parent-link, and proposal file-name spans

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.styles.ts
@@ -108,6 +108,12 @@ export const proposalRequestPanelStyles: CSSResult = css`
     color: var(--wa-color-text-link-active, var(--wa-color-text-link));
   }
 
+  .workflow-proposal__file-name:focus-visible {
+    outline: var(--border-thin) solid var(--wa-color-focus);
+    outline-offset: var(--border-thin);
+    border-radius: var(--border-radius-small);
+  }
+
   .workflow-proposal__file-name--readonly {
     color: var(--color-text-secondary);
     cursor: default;

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -50,6 +50,7 @@ import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { proposalRequestPanelStyles } from './ProposalRequestPanel.styles';
 import { APPROVE_SUPER_YOLO_ACTION } from '../events';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
+import { getComposedPathElement } from '../utils';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { PermissionState } from '../permissionState';
 
@@ -272,6 +273,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
       <div
         class="workflow-proposal__${label.toLowerCase()}-files"
         @click=${this.handleFileClick}
+        @keydown=${this.handleFileKey}
       >
         <span class="workflow-proposal__file-label">${label}:</span>
         ${repeat(
@@ -284,6 +286,8 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
                 }"
                 title=${file}
                 data-file=${ifDefined(clickable ? file : undefined)}
+                role=${ifDefined(clickable ? 'button' : undefined)}
+                tabindex=${ifDefined(clickable ? '0' : undefined)}
                 >${getBasename(file)}</span
               >`,
         )}
@@ -297,6 +301,22 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
 
   private handleFileClick = (event: MouseEvent): void => {
     const file = (event.target as HTMLElement).dataset.file;
+    if (file) {
+      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, { file });
+    }
+  };
+
+  // Keyboard activation parity for the clickable file-name spans (Enter/Space),
+  // mirroring FileList.ts's handleFileKey delegate for the same job.
+  private handleFileKey = (event: KeyboardEvent): void => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const fileEl = getComposedPathElement<HTMLElement>(
+      event,
+      '.workflow-proposal__file-name[data-file]',
+    );
+    if (!fileEl) return;
+    event.preventDefault();
+    const file = fileEl.dataset.file;
     if (file) {
       postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, { file });
     }

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -511,11 +511,21 @@ export class StreamHeader extends LitElement {
       <span
         class="parent-link"
         title="Go to parent: ${displayName}"
+        role="button"
+        tabindex="0"
         @click=${this.navigateToParent}
+        @keydown=${this.handleParentLinkKey}
       >
         ${waIcon('arrow-left')} ${displayName}
       </span>
     `;
+  }
+
+  private handleParentLinkKey(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.navigateToParent();
+    }
   }
 
   private navigateToParent(): void {

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -213,6 +213,13 @@ export class MultiAgentTab extends LitElement {
     );
   }
 
+  private handlePresetKey(event: KeyboardEvent, preset: AgentModePreset): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.handlePresetClick(preset);
+    }
+  }
+
   private handleDeletePreset(event: Event, preset: AgentModePreset): void {
     event.stopPropagation();
     this.dispatchEvent(
@@ -245,7 +252,10 @@ export class MultiAgentTab extends LitElement {
     return html`
       <div
         class=${classMap({ 'preset-card': true, active: isActive })}
+        role="button"
+        tabindex="0"
         @click=${() => this.handlePresetClick(preset)}
+        @keydown=${(e: KeyboardEvent) => this.handlePresetKey(e, preset)}
         title="Apply ${preset.name} team"
       >
         <div class="preset-card-header">

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
@@ -1,0 +1,143 @@
+// Third-party imports
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { ProposalRequestPanel } from '@progressView/frontend/components/ProposalRequestPanel';
+
+// Local imports - shared schemas
+import { AgentCategory } from '@shared/schemas';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { HOST_BRIDGE_API_KEY } from '@shared/hostBridgeTypes';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+type PostedMessage = { command: string; file?: string };
+let posted: PostedMessage[] = [];
+
+// Install the host-bridge stub at module scope, BEFORE the DOM harness
+// imports the panel module — `hostBridge` resolves this global at module
+// load (see MainAppPersistenceRestore.vitest.mts for the same pattern).
+(globalThis as Record<string, unknown>)[HOST_BRIDGE_API_KEY] = {
+  postMessage: (message: unknown) => {
+    posted.push(message as PostedMessage);
+  },
+  getState: () => undefined,
+  setState: () => undefined,
+};
+
+function createPermission(): ProposalRequestPanel['permission'] {
+  return {
+    kind: 'proposal',
+    data: {
+      proposalId: 'proposal-1',
+      streamId: 'stream-a',
+      agentCategory: AgentCategory.Workflow,
+      agent: 'writer',
+      agentSource: null,
+      model: 'sonnet',
+      instruction: 'Revise the introduction.',
+      memories: [],
+      workingDirectory: null,
+      inputFiles: ['/workspace/paper.tex'],
+      contextFiles: [],
+      mediaFiles: [],
+      outputFiles: ['/workspace/paper_revised.tex'],
+      toolConfig: { ...DEFAULT_TOOL_CONFIG },
+    },
+  };
+}
+
+async function mountPanel(
+  permission: ProposalRequestPanel['permission'] = createPermission(),
+): Promise<ProposalRequestPanel> {
+  const element = document.createElement(
+    'proposal-request-panel',
+  ) as ProposalRequestPanel;
+  element.permission = permission;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function dispatchKey(target: Element, key: string): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
+}
+
+/**
+ * Regression coverage for the a11y-clickables audit: clickable file-name
+ * spans relied on a container `@click` delegate with no role/tabindex/
+ * keydown, so keyboard users could never open a proposal's input/output
+ * files. Mirrors FileList.ts's `.file-path[data-command]` keyboard
+ * delegation for the same "click a file name to open it" job.
+ */
+describe('proposal-request-panel file-name keyboard activation', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/ProposalRequestPanel'),
+  );
+
+  beforeEach(() => {
+    posted = [];
+  });
+
+  it('exposes role=button and tabindex=0 on every clickable file-name span', async () => {
+    const element = await mountPanel();
+    const names = element.shadowRoot?.querySelectorAll(
+      '.workflow-proposal__file-name',
+    );
+    expect(names?.length).toBeGreaterThan(0);
+    for (const name of names ?? []) {
+      expect(name.getAttribute('role')).toBe('button');
+      expect(name.getAttribute('tabindex')).toBe('0');
+    }
+  });
+
+  it('opens the file on Enter and Space, not on other keys', async () => {
+    const element = await mountPanel();
+    const fileName = element.shadowRoot?.querySelector(
+      '.workflow-proposal__file-name',
+    );
+    expect(fileName).toBeInstanceOf(HTMLElement);
+
+    dispatchKey(fileName!, 'a');
+    expect(posted).toHaveLength(0);
+
+    dispatchKey(fileName!, 'Enter');
+    dispatchKey(fileName!, ' ');
+
+    expect(posted).toEqual([
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: '/workspace/paper.tex',
+      },
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: '/workspace/paper.tex',
+      },
+    ]);
+  });
+
+  it('does not add role/tabindex to read-only (non-clickable) file names', async () => {
+    const permission = createPermission();
+    permission.data.memories = ['/memories/notes.md'];
+    const element = await mountPanel(permission);
+
+    const readonlyName = element.shadowRoot?.querySelector(
+      '.workflow-proposal__file-name--readonly',
+    );
+    expect(readonlyName).toBeInstanceOf(HTMLElement);
+    expect(readonlyName?.hasAttribute('role')).toBe(false);
+    expect(readonlyName?.hasAttribute('tabindex')).toBe(false);
+
+    dispatchKey(readonlyName!, 'Enter');
+    expect(posted).toHaveLength(0);
+  });
+});

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -1,0 +1,97 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component type
+import type { StreamHeader } from '@progressView/frontend/components/StreamHeader';
+import type { StreamEventDetail } from '@progressView/frontend/events';
+
+// Local imports - shared schemas
+import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+function baseStream(overrides: Partial<StreamTabInfo> = {}): StreamTabInfo {
+  return {
+    kind: 'agent',
+    name: 'stream-a',
+    label: 'Stream A',
+    agentCategory: AgentCategory.Workflow,
+    creationTimestamp: 1,
+    ...overrides,
+  };
+}
+
+async function mount(props: Partial<StreamHeader> = {}): Promise<StreamHeader> {
+  const element = document.createElement('stream-header') as StreamHeader;
+  element.stream = baseStream();
+  Object.assign(element, props);
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function dispatchKey(target: Element, key: string): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
+}
+
+/**
+ * Regression coverage for the a11y-clickables audit: the "go to parent
+ * stream" label was a bare `<span @click>` with no role/tabindex/keydown, so
+ * keyboard users could never reach or activate it even though `.parent-link`
+ * already shipped a `:focus-visible` outline. Mirrors FileList.ts's
+ * file-path keyboard-activation coverage for the same "clickable label"
+ * job.
+ */
+describe('stream-header parent-link keyboard activation', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/StreamHeader'),
+  );
+
+  it('exposes role=button and tabindex=0 on the parent-link span', async () => {
+    const element = await mount({
+      stream: baseStream({ parentStreamId: 'assistant@123' }),
+    });
+
+    const link = element.shadowRoot?.querySelector('.parent-link');
+    expect(link).toBeInstanceOf(HTMLElement);
+    expect(link?.getAttribute('role')).toBe('button');
+    expect(link?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('switches to the parent stream on Enter and Space, not on other keys', async () => {
+    const element = await mount({
+      stream: baseStream({ parentStreamId: 'assistant@123' }),
+    });
+    const switches: StreamEventDetail[] = [];
+    element.addEventListener('stream-switch', (event) => {
+      switches.push((event as CustomEvent<StreamEventDetail>).detail);
+    });
+
+    const link = element.shadowRoot?.querySelector('.parent-link');
+    expect(link).toBeInstanceOf(HTMLElement);
+
+    dispatchKey(link!, 'a');
+    expect(switches).toHaveLength(0);
+
+    dispatchKey(link!, 'Enter');
+    dispatchKey(link!, ' ');
+
+    expect(switches).toEqual([
+      { streamId: 'assistant@123' },
+      { streamId: 'assistant@123' },
+    ]);
+  });
+
+  it('renders nothing when there is no parent stream', async () => {
+    const element = await mount({ stream: baseStream() });
+    expect(element.shadowRoot?.querySelector('.parent-link')).toBeFalsy();
+  });
+});

--- a/src/test-kernel/settings/MultiAgentTab.vitest.mts
+++ b/src/test-kernel/settings/MultiAgentTab.vitest.mts
@@ -1,0 +1,76 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component type
+import type { MultiAgentTab } from '@settingsView/frontend/tabs/MultiAgentTab';
+
+// Local imports - shared schemas
+import { AGENT_MODE_PRESETS } from '@shared/schemas/agentPresets';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+async function mount(): Promise<MultiAgentTab> {
+  const element = document.createElement('multi-agent-tab') as MultiAgentTab;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function dispatchKey(target: Element, key: string): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    }),
+  );
+}
+
+/**
+ * Regression coverage for the a11y-clickables audit: the team-preset card
+ * was a plain `<div @click>` with no role/tabindex/keydown, so keyboard
+ * users could never select a team even though `.preset-card:focus-visible`
+ * already shipped an outline. Mirrors GoalTab.ts's `.goal-row` and
+ * AgentSelectionPanel.ts's `.agent-list-item` keyboard-activation pattern.
+ */
+describe('multi-agent-tab preset card keyboard activation', () => {
+  useLitComponentTestDom(
+    () => import('@settingsView/frontend/tabs/MultiAgentTab'),
+  );
+
+  it('exposes role=button and tabindex=0 on every preset card', async () => {
+    const element = await mount();
+    const cards = element.shadowRoot?.querySelectorAll('.preset-card') ?? [];
+    expect(cards.length).toBe(AGENT_MODE_PRESETS.length);
+    for (const card of cards) {
+      expect(card.getAttribute('role')).toBe('button');
+      expect(card.getAttribute('tabindex')).toBe('0');
+    }
+  });
+
+  it('applies the preset on Enter and Space, not on other keys', async () => {
+    const element = await mount();
+    const applied: string[] = [];
+    element.addEventListener('apply-agent-mode-preset', (event) => {
+      applied.push(
+        (event as CustomEvent<{ presetId: string }>).detail.presetId,
+      );
+    });
+
+    const firstCard = element.shadowRoot?.querySelector('.preset-card');
+    expect(firstCard).toBeInstanceOf(HTMLElement);
+
+    dispatchKey(firstCard!, 'a');
+    expect(applied).toHaveLength(0);
+
+    dispatchKey(firstCard!, 'Enter');
+    dispatchKey(firstCard!, ' ');
+
+    expect(applied).toEqual([
+      AGENT_MODE_PRESETS[0]!.id,
+      AGENT_MODE_PRESETS[0]!.id,
+    ]);
+  });
+});

--- a/src/test-kernel/settings/MultiAgentTab.vitest.mts
+++ b/src/test-kernel/settings/MultiAgentTab.vitest.mts
@@ -104,9 +104,8 @@ describe('multi-agent-tab preset card keyboard activation', () => {
       );
     });
 
-    const deleteButton = element.shadowRoot?.querySelector(
-      '.preset-delete-btn',
-    );
+    const deleteButton =
+      element.shadowRoot?.querySelector('.preset-delete-btn');
     expect(deleteButton).toBeInstanceOf(HTMLElement);
 
     dispatchKey(deleteButton!, 'Enter');


### PR DESCRIPTION
## Summary

Fixes the three `a11y-clickables` findings from the adversarial UI-consistency audit: three click-only clickable divs/spans that had no `role`/`tabindex`/`@keydown`, so keyboard and screen-reader users could never reach or activate them. Two of the three (`preset-card`, `.parent-link`) already shipped dead `:focus-visible` CSS assuming this was wired up — that CSS is now live.

## Per-finding disposition

1. **`MultiAgentTab.ts` `.preset-card` (team-preset selection)** — Fixed. Added `role="button"`, `tabindex="0"`, and a `handlePresetKey` Enter/Space handler on the card `<div>`, mirroring `GoalTab.ts`'s `.goal-row` and `AgentSelectionPanel.ts`'s `.agent-list-item`. The nested `wa-button` delete control already calls `event.stopPropagation()` on click, so the card's new keydown handler doesn't interfere with it (native button semantics own its own Enter/Space activation when it has DOM focus).
2. **`StreamHeader.ts` `.parent-link` span (go-to-parent-stream nav)** — Fixed. Added `role="button"`, `tabindex="0"`, and a `handleParentLinkKey` Enter/Space handler, reusing the existing `.parent-link:focus-visible` CSS that was previously unreachable. Kept the bespoke `.parent-link` class (icon + chip styling) rather than swapping to `.clickable-link` — the finding's recommendation is the accessibility *behavior*, and the visual design here is deliberately different from a plain text link (icon, padding, muted color), so this is a like-for-like behavior fix, not a restyle.
3. **`ProposalRequestPanel.ts` `.workflow-proposal__file-name` spans (click a file name to open it)** — Fixed. Added conditional `role="button"`/`tabindex="0"` (only on `clickable` spans — the read-only `Memories` group still renders as inert text, matching prior behavior), a `handleFileKey` delegate on the container using the shared `getComposedPathElement` helper (same delegation shape as `FileList.ts`'s `handleFileKey`), and a new `.workflow-proposal__file-name:focus-visible` outline (this file had no pre-existing focus-visible CSS to reactivate, so one was added to match the outline used by `.clickable-link`/`.parent-link`).

All three: same visual appearance, same click behavior — purely additive keyboard-activation parity (Enter and Space only; other keys are no-ops, verified in tests).

## In-flight PR interaction

- **#8163** (model-option provider icons) — different file, no interaction.
- **#8164** (StreamHeader `title=` → `wa-tooltip` swap) — touches `StreamHeader.ts` and adds `src/test-kernel/progressView/StreamHeader.vitest.mts`. Diff'd via `gh pr diff 8164`: its changes are confined to `renderGoalChip`/`renderProgressBadge` (lines ~474-497), immediately *before* `renderParentLink` (line 500) — no line overlap with this PR's `renderParentLink`/`handleParentLinkKey` changes, so a normal merge should apply cleanly. **However, both PRs add a new file at the same path** (`src/test-kernel/progressView/StreamHeader.vitest.mts`) — whichever merges second will hit an add/add conflict and needs to fold the two `describe` blocks (their tooltip suite + this PR's parent-link keyboard suite) into one file.
- **#8165/#8166** (selectTemplates / TUI modals) — different files, no interaction.

## Net elements (R6)

- `MultiAgentTab.ts`: +1 handler method (`handlePresetKey`), +2 template attributes (`role`, `tabindex`), +1 `@keydown` binding. No new abstraction — direct call-site fix mirroring `GoalTab.ts`.
- `StreamHeader.ts`: +1 handler method (`handleParentLinkKey`), +2 template attributes, +1 `@keydown` binding.
- `ProposalRequestPanel.ts`: +1 handler method (`handleFileKey`), +2 conditional template attributes (`ifDefined`-gated), +1 `@keydown` binding on the container, +1 import (`getComposedPathElement` — already exported from `../utils`, reused not duplicated).
- `ProposalRequestPanel.styles.ts`: +1 CSS rule (`:focus-visible` outline), same shape/tokens as the two pre-existing `:focus-visible` rules this PR reactivates elsewhere.
- 3 new test files (one per finding); no existing test files for these three components existed yet, so each is a new suite using the `useLitComponentTestDom` harness — the same precedent `#8164` just established for `StreamHeader.vitest.mts` (noted above: files may need folding at merge time).
- No new dependencies, no new shared helpers beyond the already-shipped `getComposedPathElement` (reused, not reinvented).

## Consumer counts (R8)

- `getComposedPathElement` (`packages/extension/src/progressView/frontend/utils.ts`): pre-existing shared utility, already consumed by `StreamTabs.ts`, `StreamHeader.ts` (toolbar clicks), `LogList.ts` (3 call sites), `FileList.ts` (2 call sites) — this PR adds a 5th consumer file (`ProposalRequestPanel.ts`), no new export needed.
- `handlePresetKey` / `handleParentLinkKey` / `handleFileKey`: each is a single-file, single-call-site handler co-located with its own component, following the existing `handleRowKey` (`GoalTab.ts`) / inline-handler (`AgentSelectionPanel.ts`) / `handleFileKey` (`FileList.ts`) precedent — no cross-file sharing, no new abstraction layer.

## Testing

- New suites (one per finding), each asserting: (a) `role="button"`/`tabindex="0"` are present on the activatable element(s), (b) Enter and Space trigger the same action as click, (c) an unrelated key (`'a'`) does not, and (d) where relevant, the still-non-clickable case (readonly memories, no-parent-stream) gets neither the attributes nor an activation:
  - `src/test-kernel/progressView/StreamHeader.vitest.mts` (parent-link)
  - `src/test-kernel/settings/MultiAgentTab.vitest.mts` (preset-card)
  - `src/test-kernel/progressView/ProposalRequestPanel.vitest.mts` (file-name spans, using the `HOST_BRIDGE_API_KEY` module-scope stub pattern from `MainAppPersistenceRestore.vitest.mts` to observe the `postMessage` call)
- `npx vitest run --config vitest.config.mjs src/test-kernel/progressView src/test-kernel/settings` — 53 files / 265 tests passed.
- `npm run typecheck` — full workspace typecheck (root, test-kernel, extension, cli, trace-viewer, desktop) passed.
- `npx eslint` on all changed/added files — clean.
- `npx prettier --check` — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive accessibility and UI-only navigation (open file, switch stream, apply preset); click behavior unchanged and covered by new tests.
> 
> **Overview**
> Addresses **a11y-clickables** gaps where mouse-only controls had no keyboard path, including **`:focus-visible` styles that were already present but unreachable**.
> 
> **Multi-agent preset cards** (`MultiAgentTab`): cards get `role="button"`, `tabindex="0"`, and Enter/Space handling to apply a team; key events from the nested delete control are ignored so delete does not also select the preset.
> 
> **Stream header parent link** (`StreamHeader`): the go-to-parent control gets the same button semantics and Enter/Space activation, wiring up existing `.parent-link:focus-visible` styling.
> 
> **Proposal file names** (`ProposalRequestPanel`): clickable input/output file spans get conditional `role`/`tabindex`, container `@keydown` delegation via `getComposedPathElement` (same shape as `FileList`), and a new `:focus-visible` outline; read-only memory paths stay inert.
> 
> Vitest suites cover attributes, Enter/Space vs other keys, and the readonly / no-parent edge cases; `StreamHeader.vitest.mts` nests tooltip tests with the new parent-link suite under one `useLitComponentTestDom` registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe767da555224ca2bce78ad120cb7716a3779373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->