### PR TITLE
refactor(cli): converge gitOps and updateChecker on the canonical exec wrappers

### DIFF
--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -105,7 +105,7 @@ function compareUrl(slug: GitHubSlug, base: string, branch: string): string {
 }
 
 function refExists(cwd: string, ref: string): boolean {
-  return git(cwd, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`).ok;
+  return git(cwd, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`).success;
 }
 
 function resolveBaseRef(cwd: string, base: string): string | null {
@@ -179,9 +179,9 @@ async function runInstallGithubAction(
   const checkout = branchExists
     ? git(root, 'checkout', branch)
     : git(root, 'checkout', '-b', branch, baseRef ?? base);
-  if (!checkout.ok) {
+  if (!checkout.success) {
     writeTextStderr(
-      `Failed to check out branch "${branch}": ${checkout.stderr}`,
+      `Failed to check out branch "${branch}": ${checkout.stderr ?? ''}`,
     );
     return CliExitCode.AgentError;
   }
@@ -198,8 +198,8 @@ async function runInstallGithubAction(
   }
 
   const add = git(root, 'add', '--', WORKFLOW_RELATIVE_PATH);
-  if (!add.ok) {
-    writeTextStderr(`Failed to stage the workflow: ${add.stderr}`);
+  if (!add.success) {
+    writeTextStderr(`Failed to stage the workflow: ${add.stderr ?? ''}`);
     restoreBranch(root, startBranch);
     return CliExitCode.AgentError;
   }
@@ -212,15 +212,15 @@ async function runInstallGithubAction(
     '--',
     WORKFLOW_RELATIVE_PATH,
   );
-  if (diff.status !== 0 && diff.status !== 1) {
+  if (diff.exitCode !== 0 && diff.exitCode !== 1) {
     writeTextStderr(
-      `Failed to inspect staged workflow changes: ${diff.stderr}`,
+      `Failed to inspect staged workflow changes: ${diff.stderr ?? ''}`,
     );
     restoreBranch(root, startBranch);
     return CliExitCode.AgentError;
   }
 
-  const hasWorkflowChanges = diff.status === 1;
+  const hasWorkflowChanges = diff.exitCode === 1;
   if (hasWorkflowChanges) {
     const commit = git(
       root,
@@ -230,8 +230,8 @@ async function runInstallGithubAction(
       '--',
       WORKFLOW_RELATIVE_PATH,
     );
-    if (!commit.ok) {
-      writeTextStderr(`Failed to commit the workflow: ${commit.stderr}`);
+    if (!commit.success) {
+      writeTextStderr(`Failed to commit the workflow: ${commit.stderr ?? ''}`);
       restoreBranch(root, startBranch);
       return CliExitCode.AgentError;
     }
@@ -267,8 +267,8 @@ async function runInstallGithubAction(
   }
 
   const push = git(root, 'push', '-u', 'origin', branch);
-  if (!push.ok) {
-    writeTextStderr(`Failed to push "${branch}": ${push.stderr}`);
+  if (!push.success) {
+    writeTextStderr(`Failed to push "${branch}": ${push.stderr ?? ''}`);
     writeTextStdout(
       `Once pushed, open ${compareUrl(slug, base, branch)} to propose the PR.`,
     );
@@ -297,9 +297,9 @@ async function runInstallGithubAction(
       '--body',
       PR_BODY,
     );
-    opened = pr.ok;
-    if (!pr.ok) {
-      const diagnostic = (pr.stderr || pr.stdout).trim();
+    opened = pr.success;
+    if (!pr.success) {
+      const diagnostic = pr.stderr ?? pr.stdout ?? '';
       writeTextStderr(
         diagnostic
           ? `gh pr create --web failed: ${diagnostic}`

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -105,7 +105,8 @@ function compareUrl(slug: GitHubSlug, base: string, branch: string): string {
 }
 
 function refExists(cwd: string, ref: string): boolean {
-  return git(cwd, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`).success;
+  return git(cwd, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`)
+    .success;
 }
 
 function resolveBaseRef(cwd: string, base: string): string | null {

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -1,65 +1,36 @@
 // Thin wrappers over `git` and `gh` for the `install-github-action` command.
-// Every call captures output and never throws — callers branch on `ok`.
-import { spawnSync } from 'node:child_process';
+// Every call captures output and never throws — callers branch on `success`.
+import { executeCommandSync } from '@utils/system/execUtils';
 
-export interface CommandResult {
-  readonly ok: boolean;
-  readonly status: number | null;
-  readonly stdout: string;
-  readonly stderr: string;
+import type { ExecResult } from '@shared/schemas/opResults';
+
+export function git(cwd: string, ...args: readonly string[]): ExecResult {
+  return executeCommandSync(['git', ...args], { cwd });
 }
 
-function run(
-  command: string,
-  args: readonly string[],
-  cwd: string,
-): CommandResult {
-  const result = spawnSync(command, [...args], {
-    cwd,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    return {
-      ok: false,
-      status: null,
-      stdout: '',
-      stderr: result.error.message,
-    };
-  }
-  return {
-    ok: result.status === 0,
-    status: result.status,
-    stdout: (result.stdout ?? '').trim(),
-    stderr: (result.stderr ?? '').trim(),
-  };
-}
-
-export function git(cwd: string, ...args: readonly string[]): CommandResult {
-  return run('git', args, cwd);
-}
-
-export function gh(cwd: string, ...args: readonly string[]): CommandResult {
-  return run('gh', args, cwd);
+export function gh(cwd: string, ...args: readonly string[]): ExecResult {
+  return executeCommandSync(['gh', ...args], { cwd });
 }
 
 export function isGitRepo(cwd: string): boolean {
-  return git(cwd, 'rev-parse', '--is-inside-work-tree').ok;
+  return git(cwd, 'rev-parse', '--is-inside-work-tree').success;
 }
 
 export function repoRoot(cwd: string): string | null {
   const result = git(cwd, 'rev-parse', '--show-toplevel');
-  return result.ok && result.stdout ? result.stdout : null;
+  return result.success && result.stdout ? result.stdout : null;
 }
 
 export function remoteUrl(cwd: string, remote = 'origin'): string | null {
   const result = git(cwd, 'remote', 'get-url', remote);
-  return result.ok && result.stdout ? result.stdout : null;
+  return result.success && result.stdout ? result.stdout : null;
 }
 
 export function currentBranch(cwd: string): string | null {
   const result = git(cwd, 'rev-parse', '--abbrev-ref', 'HEAD');
-  if (!result.ok || !result.stdout || result.stdout === 'HEAD') return null;
+  if (!result.success || !result.stdout || result.stdout === 'HEAD') {
+    return null;
+  }
   return result.stdout;
 }
 
@@ -71,7 +42,7 @@ export function defaultBranch(cwd: string): string | null {
     '--short',
     'refs/remotes/origin/HEAD',
   );
-  if (!result.ok || !result.stdout) return null;
+  if (!result.success || !result.stdout) return null;
   return result.stdout.startsWith('origin/')
     ? result.stdout.slice('origin/'.length)
     : result.stdout;
@@ -79,11 +50,11 @@ export function defaultBranch(cwd: string): string | null {
 
 export function localBranchExists(cwd: string, branch: string): boolean {
   return git(cwd, 'rev-parse', '--verify', '--quiet', `refs/heads/${branch}`)
-    .ok;
+    .success;
 }
 
 export function ghAvailable(cwd: string): boolean {
-  return gh(cwd, '--version').ok;
+  return gh(cwd, '--version').success;
 }
 
 export interface GitHubSlug {

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -5,11 +5,11 @@ import { executeCommandSync } from '@utils/system/execUtils';
 import type { ExecResult } from '@shared/schemas/opResults';
 
 export function git(cwd: string, ...args: readonly string[]): ExecResult {
-  return executeCommandSync(['git', ...args], { cwd });
+  return executeCommandSync(['git', ...args], { cwd, quiet: true });
 }
 
 export function gh(cwd: string, ...args: readonly string[]): ExecResult {
-  return executeCommandSync(['gh', ...args], { cwd });
+  return executeCommandSync(['gh', ...args], { cwd, quiet: true });
 }
 
 export function isGitRepo(cwd: string): boolean {

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -5,6 +5,7 @@ import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
 import { parseJsonWith } from '@common/parsing/safeParseJson';
+import { executeCommand } from '@utils/system/execUtils';
 
 import {
   cliEnvValue,
@@ -166,31 +167,10 @@ async function readCommandStdout(
   args: readonly string[],
   timeoutMs: number,
 ): Promise<string | undefined> {
-  return new Promise<string | undefined>((resolve) => {
-    const child = spawn(command, args, {
-      shell: false,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    let stdout = '';
-    let settled = false;
-    const finish = (value: string | undefined): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(value);
-    };
-    const timer = setTimeout(() => {
-      child.kill();
-      finish(undefined);
-    }, timeoutMs);
-
-    child.stdout?.setEncoding('utf8');
-    child.stdout?.on('data', (chunk: string) => {
-      stdout += chunk;
-    });
-    child.on('error', () => finish(undefined));
-    child.on('close', (code) => finish(code === 0 ? stdout : undefined));
+  const result = await executeCommand([command, ...args], {
+    timeout: timeoutMs,
   });
+  return result.success ? (result.stdout ?? '') : undefined;
 }
 
 /**

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -167,8 +167,13 @@ async function readCommandStdout(
   args: readonly string[],
   timeoutMs: number,
 ): Promise<string | undefined> {
+  // Runs before platform init (chat/orchestrate startup), so pass an
+  // explicit cwd — the wrapper's WorkspaceFS default would throw — and
+  // quiet: true so wrapper debug lines can't leak to the console sink.
   const result = await executeCommand([command, ...args], {
     timeout: timeoutMs,
+    cwd: process.cwd(),
+    quiet: true,
   });
   return result.success ? (result.stdout ?? '') : undefined;
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -185,6 +185,8 @@ export async function executeCommand(
     stderr?: Options['stderr'];
     /** Abort signal used to terminate the subprocess and any shell children. */
     signal?: AbortSignal;
+    /** Skip wrapper logging (pre-platform CLI callers whose sink is the console). */
+    quiet?: boolean;
   } = {},
 ): Promise<ExecResult> {
   // Hoisted so the finally block can clear them on both success and error paths.
@@ -260,13 +262,17 @@ export async function executeCommand(
     let shellTimeout: number | undefined;
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
-      logger.debug(
-        logChannel,
-        `Running command: ${shellQuote([cmd, ...args])}`,
-      );
+      if (!options.quiet) {
+        logger.debug(
+          logChannel,
+          `Running command: ${shellQuote([cmd, ...args])}`,
+        );
+      }
       subprocess = execa(cmd, args, execaOptions);
     } else {
-      logger.debug(logChannel, `Running command: ${command}`);
+      if (!options.quiet) {
+        logger.debug(logChannel, `Running command: ${command}`);
+      }
       // Shell commands with pipes (e.g. "find / | head -2") create child
       // processes that inherit stdout.  execa's built-in timeout only kills
       // the shell process; the piped children keep stdout open which causes
@@ -330,7 +336,9 @@ export async function executeCommand(
     const normalizedStderr =
       shellAborted && !stderr ? 'Command aborted by user' : stderr;
 
-    logCommandStderr(logChannel, normalizedStderr, options.truncate);
+    if (!options.quiet) {
+      logCommandStderr(logChannel, normalizedStderr, options.truncate);
+    }
 
     return resultFromProcessOutput(
       stdout,
@@ -367,6 +375,8 @@ export function executeCommandSync(
     env?: Record<string, string>;
     timeout?: number;
     cwd?: string;
+    /** Skip wrapper logging (pre-platform CLI callers whose sink is the console). */
+    quiet?: boolean;
   } = {},
 ): ExecResult {
   try {
@@ -380,14 +390,21 @@ export function executeCommandSync(
       reject: false,
     };
     const logChannel = options.channel ?? CHANNEL;
-    logger.debug(logChannel, `Running command: ${shellQuote([cmd, ...args])}`);
+    if (!options.quiet) {
+      logger.debug(
+        logChannel,
+        `Running command: ${shellQuote([cmd, ...args])}`,
+      );
+    }
     const result = execaSync(cmd, args, execaOptions);
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
     const exitCode = result.exitCode ?? 1;
     const timedOut = result.timedOut ?? false;
 
-    logCommandStderr(logChannel, stderr, options.truncate);
+    if (!options.quiet) {
+      logCommandStderr(logChannel, stderr, options.truncate);
+    }
 
     return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
   } catch (err) {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -347,10 +347,12 @@ export async function executeCommand(
       timedOut,
     );
   } catch (err) {
-    logger.error(
-      options.channel ?? CHANNEL,
-      `Error executing command: ${toErrorMessage(err)}`,
-    );
+    if (!options.quiet) {
+      logger.error(
+        options.channel ?? CHANNEL,
+        `Error executing command: ${toErrorMessage(err)}`,
+      );
+    }
 
     return resultFromExecutionError(err);
   } finally {
@@ -408,10 +410,12 @@ export function executeCommandSync(
 
     return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
   } catch (err) {
-    logger.error(
-      options.channel ?? CHANNEL,
-      `Error executing command: ${toErrorMessage(err)}`,
-    );
+    if (!options.quiet) {
+      logger.error(
+        options.channel ?? CHANNEL,
+        `Error executing command: ${toErrorMessage(err)}`,
+      );
+    }
 
     return resultFromExecutionError(err);
   }


### PR DESCRIPTION
## Summary

Unix-philosophy convergence pass on process execution: the repo's canonical primitives are `executeCommand` / `executeCommandSync` (`src/utils/system/execUtils.ts`, execa-backed, no-throw `ExecResult`, trimmed output, timeout + process-group kill). Two CLI files still shipped their own mini-runners:

- **`gitOps.ts`** — a bespoke `spawnSync` runner + its own `CommandResult {ok, status, stdout, stderr}` vocabulary (~35 LOC). Now: `git()`/`gh()` delegate to `executeCommandSync` and return the shared `ExecResult`; `installGithubAction.ts` call sites move `ok→success`, `status→exitCode` (the `exitCode 0/1` distinction for `git diff --cached --quiet` is preserved; spawn-failure maps to 127, which the `!== 0 && !== 1` error branch handles the same as the old `null`). Interpolated `stderr` gets `?? ''` guards since `ExecResult` null-normalizes empty output.
- **`updateChecker.ts` `readCommandStdout`** — a bespoke `spawn` + `setTimeout`-kill + stdout-accumulator promise (~28 LOC) that duplicated `executeCommand`'s timeout/buffer/no-throw handling. Now a 4-line delegation. The injectable `CommandRunner` test seam is unchanged. The `runCliUpdate` spawn (`stdio: 'inherit'`, may prompt interactively) stays raw — that's a documented, justified bypass.

**Deliberate behavior change, flagged for review:** `executeCommand*` merges `getGitAuthorEnv()` into the env — by that module's own doc, *"so that any `git commit` picks up the configured TeXRA author identity"*. `install-github-action`'s workflow commit was accidentally exempt via raw `spawnSync`; after this PR it follows the same convention as every other TeXRA-executed git commit. If that exemption was intentional, say so and I'll pin an empty env override instead.

Net: **−49 LOC**, two fewer result vocabularies, no new abstractions (both wrappers already existed with 20+ callers).

## Test plan

- [x] `UpdateChecker.vitest.mts` + `InstallGithubAction.vitest.mts` — 28/28 pass (the latter drives real git repos in a temp dir, so the converged runner is exercised end-to-end)
- [x] `corepack pnpm --filter @texra-ai/cli typecheck` — clean

Part of the reinvented-wheel/convergence audit (2026-07-11); exec-landscape map showed 2 canonical wrappers + ~23 bypasses, of which these 2 were the largest mechanical moves.

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git/gh orchestration for workflow install and changes commit author env for that path; logic is mostly mechanical but affects real repo mutations.
> 
> **Overview**
> CLI **git**/**gh** helpers and the update checker’s subprocess calls now go through shared **`executeCommand`** / **`executeCommandSync`** instead of local **`spawnSync`** / **`spawn`** runners and a separate **`CommandResult`** shape.
> 
> **`gitOps.ts`** delegates to **`executeCommandSync`** with **`quiet: true`** and returns **`ExecResult`**. **`install-github-action`** branches on **`success`** and **`exitCode`** (including **`git diff --cached --quiet`**’s 0/1 semantics) and uses **`?? ''`** when printing **`stderr`**.
> 
> **`updateChecker`** **`readCommandStdout`** is a thin **`executeCommand`** wrapper with explicit **`cwd`** and **`quiet`**. Interactive **`runCliUpdate`** still uses raw **`spawn`** with **`stdio: 'inherit'`**.
> 
> **`execUtils`** adds a **`quiet`** option to skip debug/error logging for pre-platform CLI callers.
> 
> **Behavior note:** workflow commits from **`install-github-action`** now inherit **`getGitAuthorEnv()`** like other TeXRA git commits, whereas raw **`spawnSync`** did not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926bb685a4577864dd759cee738e8be937a6528e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->