### PR TITLE
fix(ui): standardize forms/toggles on wa-* components

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.styles.ts
@@ -214,27 +214,14 @@ export const externalInquiryPanelStyles: CSSResult = css`
 
   .external-inquiry-request__session-links-input {
     width: 100%;
+  }
+
+  .external-inquiry-request__session-links-input::part(textarea) {
     min-height: 2.75rem;
     max-height: min(12vh, 5rem);
-    resize: vertical;
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
-    padding: ${sp.small} ${sp.medium};
-    background: var(--wa-form-control-background-color);
-    color: var(--wa-form-control-text-color);
-    border: var(--border-thin) solid var(--wa-form-control-border-color);
-    border-radius: var(--border-radius);
-    outline: none;
-    transition: border-color var(--transition-fast);
-  }
-
-  .external-inquiry-request__session-links-input:focus {
-    border-color: var(--wa-color-focus);
-  }
-
-  .external-inquiry-request__session-links-input::placeholder {
-    color: var(--wa-color-text-placeholder);
   }
 
   .external-inquiry-request__session-links-hint {
@@ -264,27 +251,14 @@ export const externalInquiryPanelStyles: CSSResult = css`
 
   .external-inquiry-request__answer-input {
     width: 100%;
+  }
+
+  .external-inquiry-request__answer-input::part(textarea) {
     min-height: 96px;
     max-height: min(24vh, 12rem);
-    resize: vertical;
     font-family: var(--wa-font-family-mono);
     font-size: var(--font-size);
     line-height: var(--line-height-normal);
-    padding: ${sp.medium};
-    background: var(--wa-form-control-background-color);
-    color: var(--wa-form-control-text-color);
-    border: var(--border-thin) solid var(--wa-form-control-border-color);
-    border-radius: var(--border-radius);
-    outline: none;
-    transition: border-color var(--transition-fast);
-  }
-
-  .external-inquiry-request__answer-input:focus {
-    border-color: var(--wa-color-focus);
-  }
-
-  .external-inquiry-request__answer-input::placeholder {
-    color: var(--wa-color-text-placeholder);
   }
 
   .external-inquiry-request__answer-hint {
@@ -300,12 +274,12 @@ export const externalInquiryPanelStyles: CSSResult = css`
       max-height: min(18vh, 10rem);
     }
 
-    .external-inquiry-request__answer-input {
+    .external-inquiry-request__answer-input::part(textarea) {
       min-height: 80px;
       max-height: min(20vh, 10rem);
     }
 
-    .external-inquiry-request__session-links-input {
+    .external-inquiry-request__session-links-input::part(textarea) {
       min-height: 2.5rem;
       max-height: min(10vh, 4.5rem);
     }

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -534,7 +534,8 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   // ── Event Handlers ──
 
   private handleAnswerInput(e: Event): void {
-    this.answerText = (e.target as HTMLElement & { value?: string }).value ?? '';
+    this.answerText =
+      (e.target as HTMLElement & { value?: string }).value ?? '';
     this.scheduleDraftSave();
   }
 

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -24,6 +24,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
@@ -421,13 +422,15 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
         <div class="external-inquiry-request__answer-label">
           Paste the answer from the external model:
         </div>
-        <textarea
+        <wa-textarea
           class="external-inquiry-request__answer-input"
           placeholder="Paste the answer here..."
+          rows="4"
+          resize="vertical"
           .value=${live(this.answerText)}
           @input=${this.handleAnswerInput}
           @keydown=${this.handleKeyDown}
-        ></textarea>
+        ></wa-textarea>
         <div class="external-inquiry-request__answer-hint">
           If the external model returns files, save them into the workspace and
           tell the agent the paths.
@@ -477,12 +480,14 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
               >Gemini Deep Think</a
             >
           </div>
-          <textarea
+          <wa-textarea
             class="external-inquiry-request__session-links-input"
             placeholder="Paste one external session link per line..."
+            rows="2"
+            resize="vertical"
             .value=${live(this.sessionLinksText)}
             @input=${this.handleSessionLinksInput}
-          ></textarea>
+          ></wa-textarea>
           <div class="external-inquiry-request__session-links-hint">
             Add the chat URL you used after pasting the answer.
           </div>
@@ -529,12 +534,13 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   // ── Event Handlers ──
 
   private handleAnswerInput(e: Event): void {
-    this.answerText = (e.target as HTMLTextAreaElement).value;
+    this.answerText = (e.target as HTMLElement & { value?: string }).value ?? '';
     this.scheduleDraftSave();
   }
 
   private handleSessionLinksInput(e: Event): void {
-    this.sessionLinksText = (e.target as HTMLTextAreaElement).value;
+    this.sessionLinksText =
+      (e.target as HTMLElement & { value?: string }).value ?? '';
     this.scheduleDraftSave();
   }
 

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -52,11 +52,11 @@ export const userQuestionPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
+  /* wa-radio-group has no exposed "radios" CSS part in the pinned
+     @awesome.me/webawesome build (only form-control/form-control-label/
+     form-control-input/hint are rendered) — style the host directly, same
+     technique as ApiAccessSection.styles.ts's wa-radio-group.api-access-options. */
   wa-radio-group {
-    display: flex;
-  }
-
-  wa-radio-group::part(radios) {
     display: flex;
     flex-direction: column;
     gap: ${sp.small};

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.styles.ts
@@ -52,22 +52,23 @@ export const userQuestionPanelStyles: CSSResult = css`
     gap: ${sp.small};
   }
 
-  .user-question-request__option {
-    display: grid;
-    grid-template-columns: auto 1fr;
+  wa-radio-group {
+    display: flex;
+  }
+
+  wa-radio-group::part(radios) {
+    display: flex;
+    flex-direction: column;
     gap: ${sp.small};
-    align-items: start;
+  }
+
+  .user-question-request__option {
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
     color: var(--wa-color-text-normal);
-    cursor: pointer;
   }
 
-  .user-question-request__option input {
-    margin-top: 0.2rem;
-  }
-
-  .user-question-request__option span {
+  .user-question-request__option::part(label) {
     display: flex;
     flex-direction: column;
     gap: ${sp.tiny};

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -4,6 +4,9 @@ import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Side-effect imports - register Web Awesome components
+import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/radio/radio.js';
+import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 // Local imports - shared styles
@@ -61,7 +64,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
           ${repeat(
             data.questions,
             (question) => question.question,
-            (question, index) => this.renderQuestion(question, index),
+            (question) => this.renderQuestion(question),
           )}
         </div>
         <div class="user-question-request__actions">
@@ -98,13 +101,8 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     return super.handleKeyboardShortcut(key);
   }
 
-  private renderQuestion(
-    question: UserQuestionPrompt,
-    index: number,
-  ): TemplateResult {
+  private renderQuestion(question: UserQuestionPrompt): TemplateResult {
     const current = this.selections[question.question] ?? [];
-    const inputType = question.multiSelect ? 'checkbox' : 'radio';
-    const name = `user-question-${index}`;
 
     return html`
       <section class="user-question-request__question">
@@ -119,29 +117,29 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
           <span>${question.question}</span>
         </div>
         <div class="user-question-request__options">
-          ${repeat(
-            question.options,
-            (option) => option.label,
-            (option) => html`
-              <label class="user-question-request__option">
-                <input
-                  type=${inputType}
-                  name=${name}
-                  .checked=${current.includes(option.label)}
-                  @change=${(event: Event) =>
-                    this.updateSelection(question, option.label, event)}
-                />
-                <span>
-                  <strong>${option.label}</strong>
-                  ${
-                    option.description
-                      ? html`<small>${option.description}</small>`
-                      : nothing
-                  }
-                </span>
-              </label>
-            `,
-          )}
+          ${
+            question.multiSelect
+              ? repeat(
+                  question.options,
+                  (option) => option.label,
+                  (option) =>
+                    this.renderCheckboxOption(question, option, current),
+                )
+              : html`
+                  <wa-radio-group
+                    aria-label=${question.question}
+                    .value=${current[0] ?? ''}
+                    @change=${(event: Event) =>
+                      this.updateSingleSelection(question, event)}
+                  >
+                    ${repeat(
+                      question.options,
+                      (option) => option.label,
+                      (option) => this.renderRadioOption(option),
+                    )}
+                  </wa-radio-group>
+                `
+          }
         </div>
         ${
           question.allowFreeText
@@ -159,21 +157,70 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
     `;
   }
 
+  private renderOptionLabel(
+    option: UserQuestionPrompt['options'][number],
+  ): TemplateResult {
+    return html`
+      <strong>${option.label}</strong>
+      ${
+        option.description
+          ? html`<small>${option.description}</small>`
+          : nothing
+      }
+    `;
+  }
+
+  private renderCheckboxOption(
+    question: UserQuestionPrompt,
+    option: UserQuestionPrompt['options'][number],
+    current: string[],
+  ): TemplateResult {
+    return html`
+      <wa-checkbox
+        class="user-question-request__option"
+        ?checked=${current.includes(option.label)}
+        @change=${(event: Event) =>
+          this.updateSelection(question, option.label, event)}
+      >
+        ${this.renderOptionLabel(option)}
+      </wa-checkbox>
+    `;
+  }
+
+  private renderRadioOption(
+    option: UserQuestionPrompt['options'][number],
+  ): TemplateResult {
+    return html`
+      <wa-radio class="user-question-request__option" value=${option.label}>
+        ${this.renderOptionLabel(option)}
+      </wa-radio>
+    `;
+  }
+
   private updateSelection(
     question: UserQuestionPrompt,
     label: string,
     event: Event,
   ): void {
-    const checked = (event.currentTarget as HTMLInputElement).checked;
+    const checked = (event.target as HTMLElement & { checked?: boolean })
+      .checked;
     const current = this.selections[question.question] ?? [];
-    const next = question.multiSelect
-      ? checked
-        ? [...current, label]
-        : current.filter((item) => item !== label)
-      : checked
-        ? [label]
-        : [];
+    const next = checked
+      ? [...current, label]
+      : current.filter((item) => item !== label);
     this.selections = { ...this.selections, [question.question]: next };
+  }
+
+  private updateSingleSelection(
+    question: UserQuestionPrompt,
+    event: Event,
+  ): void {
+    const value =
+      (event.target as HTMLElement & { value?: string }).value ?? '';
+    this.selections = {
+      ...this.selections,
+      [question.question]: value ? [value] : [],
+    };
   }
 
   private updateFreeText(question: string, event: Event): void {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -109,7 +109,7 @@ export const agentSelectionPanelStyles: CSSResult = css`
     opacity: var(--opacity-full);
   }
 
-  .agent-list-item-checkbox {
+  .agent-list-item-toggle {
     flex-shrink: 0;
   }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -1,7 +1,7 @@
 /** Master-detail panel of agents for a single category (workflow or tool-use). */
 
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
+import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import {
   LitElement,
@@ -264,8 +264,8 @@ export class AgentSelectionPanel extends LitElement {
         }}
         title=${agent.description ?? agent.name}
       >
-        <wa-checkbox
-          class="agent-list-item-checkbox"
+        <wa-switch
+          class="agent-list-item-toggle"
           ?checked=${agent.enabled}
           @click=${(e: Event) => {
             e.stopPropagation();
@@ -276,7 +276,7 @@ export class AgentSelectionPanel extends LitElement {
               ? 'Hide from agent selector'
               : 'Show in agent selector'
           }
-        ></wa-checkbox>
+        ></wa-switch>
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -157,7 +157,7 @@ export const modelSelectionListStyles: CSSResult = css`
     gap: var(--wa-space-xs);
   }
 
-  .model-row wa-checkbox {
+  .model-row wa-switch {
     flex: 1;
     min-width: 0;
     font-size: var(--font-size-sm);

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -16,7 +16,6 @@ import {
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 
@@ -42,7 +41,6 @@ import { modelSelectionListStyles } from './ModelSelectionList.styles';
 import { ModelSelectionEvents } from './events';
 import { resolveProviderKeyRows } from './providerKeyRows';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
-import type WaCheckbox from '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 interface ProviderGroup {
@@ -223,11 +221,11 @@ export class ModelSelectionList extends LitElement {
 
     return html`
       <div class="model-row${unavailableClass}">
-        <wa-checkbox
+        <wa-switch
           ?checked=${model.enabled}
           ?disabled=${!available && !model.enabled}
           @change=${(e: Event) => {
-            const checked = (e.target as WaCheckbox).checked;
+            const checked = (e.target as WaSwitch).checked;
             this.dispatchEvent(
               ModelSelectionEvents.setModelEnabled({
                 modelName: model.name,
@@ -247,7 +245,7 @@ export class ModelSelectionList extends LitElement {
                 })
               : nothing
           }
-        </wa-checkbox>
+        </wa-switch>
         ${this.renderReasoningDropdown(model)}
         <span class="model-metadata">
           ${

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -323,11 +323,6 @@ export class InstructionPanel extends LitElement {
         <div class="instruction-header">
           <div class="instruction-header-leading">
             <div class="instruction-session-toggle">
-              <input
-                type="hidden"
-                id="sessionType"
-                .value=${session.sessionType}
-              />
               <wa-radio-group
                 id="sessionTypeToggle"
                 aria-label="Choose the session type"

--- a/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
+++ b/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
@@ -63,18 +63,18 @@ describe('external-inquiry-panel answer/session-link inputs', () => {
     const element = await mountPanel();
 
     expect(element.shadowRoot!.querySelector('textarea')).toBeNull();
+    expect(element.shadowRoot!.querySelectorAll('wa-textarea').length).toBe(2);
     expect(
-      element.shadowRoot!.querySelectorAll('wa-textarea').length,
-    ).toBe(2);
-    expect(
-      element.shadowRoot!.querySelector(
-        '.external-inquiry-request__answer-input',
-      )?.tagName.toLowerCase(),
+      element
+        .shadowRoot!.querySelector('.external-inquiry-request__answer-input')
+        ?.tagName.toLowerCase(),
     ).toBe('wa-textarea');
     expect(
-      element.shadowRoot!.querySelector(
-        '.external-inquiry-request__session-links-input',
-      )?.tagName.toLowerCase(),
+      element
+        .shadowRoot!.querySelector(
+          '.external-inquiry-request__session-links-input',
+        )
+        ?.tagName.toLowerCase(),
     ).toBe('wa-textarea');
   });
 

--- a/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
+++ b/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
@@ -1,0 +1,119 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { ExternalInquiryPanel } from '@progressView/frontend/components/ExternalInquiryPanel';
+
+// Local imports - shared schemas
+import type { ExternalInquiryPermission } from '@shared/schemas';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+function createPermission(
+  overrides: Partial<ExternalInquiryPermission> = {},
+): ExternalInquiryPanel['permission'] {
+  return {
+    kind: 'externalInquiry',
+    data: {
+      requestId: 'inquiry-1',
+      allowBypass: false,
+      streamId: 'stream-1',
+      threadId: 'ei_000000000000',
+      question: 'What is the answer?',
+      mode: 'new',
+      ...overrides,
+    },
+  };
+}
+
+async function mountPanel(
+  permission: ExternalInquiryPanel['permission'] = createPermission(),
+): Promise<ExternalInquiryPanel> {
+  const element = document.createElement(
+    'external-inquiry-panel',
+  ) as ExternalInquiryPanel;
+  element.permission = permission;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+function recordPermissionActions(
+  element: ExternalInquiryPanel,
+): Record<string, unknown>[] {
+  const actions: Record<string, unknown>[] = [];
+  element.addEventListener('permission-action', (event) => {
+    actions.push((event as CustomEvent<Record<string, unknown>>).detail);
+  });
+  return actions;
+}
+
+function setTextareaValue(textarea: HTMLElement, value: string): void {
+  (textarea as HTMLElement & { value: string }).value = value;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('external-inquiry-panel answer/session-link inputs', () => {
+  useLitComponentTestDom(
+    () => import('@progressView/frontend/components/ExternalInquiryPanel'),
+  );
+
+  it('renders wa-textarea for the answer and session-link inputs, never a native textarea', async () => {
+    const element = await mountPanel();
+
+    expect(element.shadowRoot!.querySelector('textarea')).toBeNull();
+    expect(
+      element.shadowRoot!.querySelectorAll('wa-textarea').length,
+    ).toBe(2);
+    expect(
+      element.shadowRoot!.querySelector(
+        '.external-inquiry-request__answer-input',
+      )?.tagName.toLowerCase(),
+    ).toBe('wa-textarea');
+    expect(
+      element.shadowRoot!.querySelector(
+        '.external-inquiry-request__session-links-input',
+      )?.tagName.toLowerCase(),
+    ).toBe('wa-textarea');
+  });
+
+  it('reads the wa-textarea shadow-DOM value on input and submits it as the answer', async () => {
+    const element = await mountPanel();
+    const actions = recordPermissionActions(element);
+
+    const answerInput = element.shadowRoot!.querySelector(
+      '.external-inquiry-request__answer-input',
+    ) as HTMLElement;
+    const submitButton = element.shadowRoot!.querySelector(
+      'wa-button[data-action="submit"]',
+    ) as HTMLElement & { disabled?: boolean };
+
+    expect(submitButton.disabled).toBe(true);
+
+    setTextareaValue(answerInput, '  the answer  ');
+    await element.updateComplete;
+
+    expect(submitButton.disabled).toBe(false);
+
+    const sessionLinksInput = element.shadowRoot!.querySelector(
+      '.external-inquiry-request__session-links-input',
+    ) as HTMLElement;
+    setTextareaValue(
+      sessionLinksInput,
+      'https://chatgpt.com/c/abc\nhttps://chatgpt.com/c/abc\n',
+    );
+    await element.updateComplete;
+
+    submitButton.click();
+
+    expect(actions).toEqual([
+      {
+        permission: element.permission,
+        action: 'submit',
+        answer: 'the answer',
+        sessionLinks: ['https://chatgpt.com/c/abc'],
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
@@ -176,9 +176,7 @@ describe('user-question-panel', () => {
     red.checked = true;
     red.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     blue.checked = true;
-    blue.dispatchEvent(
-      new Event('change', { bubbles: true, composed: true }),
-    );
+    blue.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     await element.updateComplete;
 
     const button = element.shadowRoot?.querySelector(
@@ -202,13 +200,9 @@ describe('user-question-panel', () => {
       ]),
     );
 
-    expect(element.shadowRoot?.querySelector('wa-radio-group')).not.toBe(
-      null,
-    );
+    expect(element.shadowRoot?.querySelector('wa-radio-group')).not.toBe(null);
     expect(element.shadowRoot?.querySelectorAll('wa-radio').length).toBe(2);
-    expect(element.shadowRoot?.querySelector('input[type="radio"]')).toBe(
-      null,
-    );
+    expect(element.shadowRoot?.querySelector('input[type="radio"]')).toBe(null);
 
     const radioGroup = element.shadowRoot?.querySelector(
       'wa-radio-group',

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { UserQuestionPanel } from '@progressView/frontend/components/UserQuestionPanel';
 
 // Local imports - shared constants
+import type { UserQuestionPrompt } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - test utilities
@@ -75,29 +76,33 @@ function restoreDom(): void {
   }
 }
 
-function createPermission(): UserQuestionPanel['permission'] {
+function createPermission(
+  questions: UserQuestionPrompt[] = [
+    {
+      question: 'Choose an answer',
+      options: [{ label: 'A' }, { label: 'B' }],
+      allowFreeText: true,
+    },
+  ],
+): UserQuestionPanel['permission'] {
   return {
     kind: PERMISSION_KIND.USER_QUESTION,
     data: {
       requestId: 'question-1',
       allowBypass: false,
       streamId: 'stream-1',
-      questions: [
-        {
-          question: 'Choose an answer',
-          options: [{ label: 'A' }, { label: 'B' }],
-          allowFreeText: true,
-        },
-      ],
+      questions,
     },
   };
 }
 
-async function mountPanel(): Promise<UserQuestionPanel> {
+async function mountPanel(
+  permission: UserQuestionPanel['permission'] = createPermission(),
+): Promise<UserQuestionPanel> {
   const element = document.createElement(
     'user-question-panel',
   ) as UserQuestionPanel;
-  element.permission = createPermission();
+  element.permission = permission;
   document.body.append(element);
   await element.updateComplete;
   return element;
@@ -146,5 +151,76 @@ describe('user-question-panel', () => {
     expect(button?.disabled).toBe(true);
     expect(element.handleKeyboardShortcut('y')).toBe(true);
     expect(actions).toEqual([]);
+  });
+
+  it('renders multi-select options as wa-checkbox and accumulates checked labels', async () => {
+    const element = await mountPanel(
+      createPermission([
+        {
+          question: 'Pick any',
+          options: [{ label: 'Red' }, { label: 'Blue' }],
+          multiSelect: true,
+        },
+      ]),
+    );
+
+    const checkboxes = element.shadowRoot?.querySelectorAll('wa-checkbox');
+    expect(checkboxes?.length).toBe(2);
+    expect(element.shadowRoot?.querySelector('input[type="checkbox"]')).toBe(
+      null,
+    );
+
+    const [red, blue] = [...(checkboxes ?? [])] as (HTMLElement & {
+      checked?: boolean;
+    })[];
+    red.checked = true;
+    red.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    blue.checked = true;
+    blue.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+    await element.updateComplete;
+
+    const button = element.shadowRoot?.querySelector(
+      'wa-button[data-action="submit"]',
+    ) as HTMLElement & { disabled?: boolean };
+    expect(button?.disabled).toBe(false);
+
+    const actions = collectActions(element);
+    element.handleKeyboardShortcut('y');
+    expect(actions).toEqual(['submit']);
+  });
+
+  it('renders single-select options as wa-radio-group/wa-radio with no native inputs', async () => {
+    const element = await mountPanel(
+      createPermission([
+        {
+          question: 'Pick one',
+          options: [{ label: 'Yes' }, { label: 'No' }],
+          multiSelect: false,
+        },
+      ]),
+    );
+
+    expect(element.shadowRoot?.querySelector('wa-radio-group')).not.toBe(
+      null,
+    );
+    expect(element.shadowRoot?.querySelectorAll('wa-radio').length).toBe(2);
+    expect(element.shadowRoot?.querySelector('input[type="radio"]')).toBe(
+      null,
+    );
+
+    const radioGroup = element.shadowRoot?.querySelector(
+      'wa-radio-group',
+    ) as HTMLElement & { value?: string };
+    radioGroup.value = 'No';
+    radioGroup.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+    await element.updateComplete;
+
+    const actions = collectActions(element);
+    element.handleKeyboardShortcut('y');
+    expect(actions).toEqual(['submit']);
   });
 });

--- a/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
+++ b/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { AGENT_SOURCE } from '@shared/schemas/agent';
+import type { AgentSelectionItem } from '@shared/schemas/settingsView/data';
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+type AgentSelectionPanelElement = HTMLElement & {
+  agents: AgentSelectionItem[];
+  category: 'workflow' | 'toolUse';
+  updateComplete: Promise<boolean>;
+};
+
+type AgentEnabledSetDetail = {
+  agentName: string;
+  agentSource: string;
+  category: string;
+  enabled: boolean;
+};
+
+const workflowAgent: AgentSelectionItem = {
+  name: 'summarize',
+  category: 'workflow',
+  source: AGENT_SOURCE.BUILT_IN_WORKFLOW,
+  hasPath: true,
+  enabled: true,
+};
+
+async function renderAgentSelectionPanel(): Promise<AgentSelectionPanelElement> {
+  const panel = document.createElement(
+    'agent-selection-panel',
+  ) as AgentSelectionPanelElement;
+  panel.agents = [workflowAgent];
+  panel.category = 'workflow';
+  document.body.append(panel);
+  await panel.updateComplete;
+  return panel;
+}
+
+describe('AgentSelectionPanel enabled toggle', () => {
+  useLitComponentTestDom(
+    () =>
+      import(
+        '@settingsView/frontend/components/profile/AgentSelectionPanel'
+      ),
+  );
+
+  it('renders the per-agent enabled toggle as wa-switch, not wa-checkbox', async () => {
+    const panel = await renderAgentSelectionPanel();
+
+    expect(panel.shadowRoot!.querySelector('wa-checkbox')).toBeNull();
+    const toggle = panel.shadowRoot!.querySelector(
+      '.agent-list-item-toggle',
+    ) as HTMLElement & { checked?: boolean };
+
+    expect(toggle).not.toBeNull();
+    expect(toggle.tagName.toLowerCase()).toBe('wa-switch');
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('dispatches agent-enabled-set (not a click on the row) when the toggle is clicked', async () => {
+    const panel = await renderAgentSelectionPanel();
+
+    let detail: AgentEnabledSetDetail | undefined;
+    let rowClicked = false;
+    panel.addEventListener('agent-enabled-set', (event) => {
+      detail = (event as CustomEvent<AgentEnabledSetDetail>).detail;
+    });
+    panel
+      .shadowRoot!.querySelector('.agent-list-item')
+      ?.addEventListener('click', () => {
+        rowClicked = true;
+      });
+
+    const toggle = panel.shadowRoot!.querySelector(
+      '.agent-list-item-toggle',
+    ) as HTMLElement;
+    toggle.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true }),
+    );
+
+    expect(detail).toEqual({
+      agentName: 'summarize',
+      agentSource: AGENT_SOURCE.BUILT_IN_WORKFLOW,
+      category: 'workflow',
+      enabled: false,
+    });
+    // The toggle's click handler stops propagation, so the row's own
+    // click-to-select handler must not also fire.
+    expect(rowClicked).toBe(false);
+  });
+});

--- a/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
+++ b/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
@@ -39,9 +39,7 @@ async function renderAgentSelectionPanel(): Promise<AgentSelectionPanelElement> 
 describe('AgentSelectionPanel enabled toggle', () => {
   useLitComponentTestDom(
     () =>
-      import(
-        '@settingsView/frontend/components/profile/AgentSelectionPanel'
-      ),
+      import('@settingsView/frontend/components/profile/AgentSelectionPanel'),
   );
 
   it('renders the per-agent enabled toggle as wa-switch, not wa-checkbox', async () => {

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -13,6 +13,8 @@ type ModelSelectionListElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
+type ModelSelectionEventDetail = { modelName: string; enabled: boolean };
+
 const deepseekModel: ModelSelectionItem = {
   name: 'deepseek',
   label: 'DeepSeek V4 Flash',
@@ -76,5 +78,36 @@ describe('ModelSelectionList provider key status', () => {
     expect(helperOption?.textContent?.trim()).toBe(
       'DeepSeek V4 Flash (deepseek)',
     );
+  });
+
+  it('renders the per-model enabled toggle as wa-switch and emits model-enabled-set on change', async () => {
+    const list = await renderModelSelectionList(() => {});
+
+    const providerToggle = list.shadowRoot!.querySelector<HTMLElement>(
+      '.provider-group-toggle',
+    );
+    providerToggle?.click();
+    await list.updateComplete;
+
+    expect(list.shadowRoot!.querySelector('.model-row wa-checkbox')).toBe(
+      null,
+    );
+    const modelSwitch = list.shadowRoot!.querySelector(
+      '.model-row wa-switch',
+    ) as HTMLElement & { checked?: boolean };
+    expect(modelSwitch).not.toBeNull();
+    expect(modelSwitch.checked).toBe(true);
+
+    let detail: ModelSelectionEventDetail | undefined;
+    list.addEventListener('model-enabled-set', (event) => {
+      detail = (event as CustomEvent<ModelSelectionEventDetail>).detail;
+    });
+
+    modelSwitch.checked = false;
+    modelSwitch.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+
+    expect(detail).toEqual({ modelName: 'deepseek', enabled: false });
   });
 });

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -89,9 +89,7 @@ describe('ModelSelectionList provider key status', () => {
     providerToggle?.click();
     await list.updateComplete;
 
-    expect(list.shadowRoot!.querySelector('.model-row wa-checkbox')).toBe(
-      null,
-    );
+    expect(list.shadowRoot!.querySelector('.model-row wa-checkbox')).toBe(null);
     const modelSwitch = list.shadowRoot!.querySelector(
       '.model-row wa-switch',
     ) as HTMLElement & { checked?: boolean };


### PR DESCRIPTION
## Summary

Fixes the 4 adversarially-verified `forms` findings from the UI-consistency audit.

### 1. ExternalInquiryPanel native `<textarea>` → wa-textarea (med)
`ExternalInquiryPanel` rendered its answer and session-links inputs as raw
native `<textarea>` elements with ~90 lines of hand-rolled focus/placeholder/
border CSS, while every sibling multiline input in progressView — including
this same component's inherited rejection-feedback box (`BaseFeedbackPanel`),
`FollowUpInput`, and `WorkflowToolUseFollowupSection` — uses `wa-textarea`.
Swapped both textareas to `wa-textarea` (`rows`/`resize="vertical"`, same
`.value=${live(...)}` + `@input` pattern already used by `FollowUpInput`),
deleted the now-dead focus/placeholder/border/background CSS, and re-pointed
the remaining min/max-height rules at `::part(textarea)` (same technique
`FollowUpInput` already uses for its own sizing). Event handlers now read
`.value` off the host element (same shape `UserQuestionPanel.updateFreeText`
already uses) instead of casting to `HTMLTextAreaElement`.

### 2. UserQuestionPanel native checkbox/radio → wa-checkbox/wa-radio (low)
Swapped the hand-rolled `<input type="checkbox"/"radio">` option list for
`wa-checkbox` (multiSelect questions) and `wa-radio-group` + `wa-radio`
(single-select questions), matching `AgentSelectionPanel` (wa-checkbox) and
`InstructionPanel` (wa-radio-group/wa-radio) elsewhere in the same webview
bundle. `commonViewStyles`' existing `wa-checkbox`/`wa-radio` compaction rules
now apply automatically. Behavior is unchanged: single-select semantics were
already "exactly one radio checked" even with native inputs, and
`wa-radio-group`'s built-in arrow-key navigation is a strict a11y upgrade over
the old plain `<label>` list, not a regression.

### 3. InstructionPanel vestigial hidden input → deleted (low)
Deleted `<input type="hidden" id="sessionType" .value=${session.sessionType}>`
sitting next to the `<wa-radio-group>` that already owns the same state.
Re-grepped the whole repo (`src/`, `packages/`) for
`getElementById('sessionType')` / `querySelector('#sessionType')` before
deleting — zero readers, confirming the finding.

### 4. wa-checkbox vs wa-switch for catalog-row "enabled" toggles (med)
`ModelSelectionList` (per-model row) and `AgentSelectionPanel` (per-agent row)
used `wa-checkbox` for an "enable/disable this catalog item" toggle, while
every structurally-identical row toggle elsewhere in SettingsView uses
`wa-switch` — counted **13** existing call sites (`ToolCard`, `ProviderKeyList`
×3, `ModelsTab` ×2, `MultiAgentTab` ×3, `ToolsTab` ×2, `GitTab`, `LaTeXTab` ×2,
`MemoryToggle`, plus `ModelSelectionList`'s own sibling
`preferShortModelNames` switch) vs. these 2 checkbox call sites. Standardized
both on `wa-switch` per the majority convention; the swap was mechanical since
`wa-switch` exposes the same `checked`/`change`/`disabled` shape already used
by the neighboring switches, so the `@change` handlers port unchanged (only
`WaCheckbox` → `WaSwitch` type-import and the `.agent-list-item-checkbox` →
`.agent-list-item-toggle` CSS class rename). `wa-checkbox` now has exactly one
remaining call site in the whole app: `UserQuestionPanel`'s real multi-select
list (finding #2), which is legitimately its job — bulk/indeterminate-style
selection, not a boolean row toggle.

## Net elements (R6)
- **Deleted**: `.agent-list-item-checkbox` CSS selector (renamed to
  `.agent-list-item-toggle`), `.model-row wa-checkbox` CSS selector (renamed
  to `.model-row wa-switch`), `WaCheckbox` type import ×2, the vestigial
  hidden `<input id="sessionType">`, ~35 lines of hand-rolled
  focus/placeholder/border/background CSS for the two ExternalInquiryPanel
  textareas, the `inputType`/`name` native-radio plumbing in
  `UserQuestionPanel`.
- **Added**: `wa-checkbox`/`wa-radio`/`wa-radio-group` side-effect imports in
  `UserQuestionPanel`, `wa-textarea` side-effect import in
  `ExternalInquiryPanel`, `wa-switch` side-effect import in
  `AgentSelectionPanel`, small `renderCheckboxOption`/`renderRadioOption`/
  `renderOptionLabel` helpers in `UserQuestionPanel` (each has 2+ call sites —
  not single-caller extractions), `::part(textarea)`/`::part(label)`/
  `::part(radios)` CSS rules to carry over sizing that `wa-textarea`/
  `wa-checkbox`/`wa-radio-group` don't expose as plain classes.
- No new dependencies — every component used here (`wa-textarea`,
  `wa-checkbox`, `wa-radio`, `wa-radio-group`, `wa-switch`) is already shipped
  and imported elsewhere in the same webview bundle.

## Consumer counts (R8)
- `wa-checkbox`: was 2 call sites (`ModelSelectionList`, `AgentSelectionPanel`,
  both wrong job) + 0 correct-job sites → now 1 call site
  (`UserQuestionPanel`, correct job — the only place in the app doing
  multi-select-from-a-list).
- `wa-switch`: was ~13 call sites → now 15 (adds `ModelSelectionList`,
  `AgentSelectionPanel`).
- `wa-textarea`: was 3 call sites in progressView (`BaseFeedbackPanel`,
  `FollowUpInput`, `WorkflowToolUseFollowupSection`) + 1 already in
  `UserQuestionPanel` → now +2 in `ExternalInquiryPanel` (both of its
  multiline inputs).
- `wa-radio-group`/`wa-radio`: was 1 call site (`InstructionPanel`'s
  session-type toggle) → now 2 (adds `UserQuestionPanel`'s single-select
  questions).
- Native `<textarea>`/`<input type=checkbox/radio>` in progressView/webview
  form surfaces: 0 remaining (grepped after the change).

## In-flight PR interaction check
Checked the four in-flight UI PRs (#8163–#8166) via `gh pr diff <n> --name-only`:
none touch `ExternalInquiryPanel.ts`, `ExternalInquiryPanel.styles.ts`,
`UserQuestionPanel.ts`, `UserQuestionPanel.styles.ts`, `InstructionPanel.ts`,
`ModelSelectionList.ts`, `ModelSelectionList.styles.ts`,
`AgentSelectionPanel.ts`, or `AgentSelectionPanel.styles.ts`. No merge
interaction expected.

## Verified
- `packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts` / `.styles.ts`
- `packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts`, `FollowUpInput.ts`, `WorkflowToolUseFollowupSection.ts` (wa-textarea reference patterns)
- `packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts` / `.styles.ts`
- `packages/extension/src/webview/frontend/components/InstructionPanel.ts` (wa-radio-group reference pattern + hidden-input deletion)
- `packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts` / `.styles.ts`
- `packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts` / `.styles.ts`
- `packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts` (wa-switch reference pattern)
- `src/shared/styles/commonViewStyles.ts` (shared wa-checkbox/wa-radio compaction rules)
- WA component `.d.ts` sources for `textarea`, `checkbox`, `radio`, `radio-group`, `switch` (slot/event/part contracts) and the compiled `:host`/`[part=base]` CSS for checkbox/radio (confirms `align-items: flex-start` is already the default, no override needed)
- Repo-wide grep for `getElementById('sessionType')` / `#sessionType` (zero readers, confirms finding #3)
- Repo-wide grep confirming `wa-checkbox` now has exactly 1 call site, matching the finding's "isn't used anywhere for bulk/indeterminate selection" premise

## Tests
- Extended `src/test-kernel/progressView/UserQuestionPanel.vitest.mts` with
  multi-select (`wa-checkbox`) and single-select (`wa-radio-group`/`wa-radio`)
  coverage: renders the right tag, no native inputs remain, `change` events
  update selections and gate the submit button.
- Extended `src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts`
  with a test that expands a provider group, asserts `wa-switch` (not
  `wa-checkbox`) renders the row toggle, and asserts the `change` event still
  dispatches `model-enabled-set` with the right payload.
- New `src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts` (no prior
  suite existed for this component — follows the `useLitComponentTestDom`
  precedent from `ModelSelectionProviderKeys.vitest.ts`/`BashRequestPanel.vitest.mts`):
  asserts `wa-switch` renders instead of `wa-checkbox`, and that clicking the
  toggle dispatches `agent-enabled-set` with `stopPropagation` intact (the
  row's own click-to-select handler must not also fire).
- New `src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts`
  (no prior suite existed for this component — same `useLitComponentTestDom`
  precedent): asserts no native `<textarea>` renders, both inputs are
  `wa-textarea`, and typing into the wa-textarea (reading its shadow-DOM
  `.value` on `input`) correctly gates the submit button and flows through to
  the submitted `answer`/`sessionLinks` payload — directly pins the shadow-DOM
  value-read concern the finding flagged.
- `npm run typecheck` — clean.
- `npx eslint <changed files>` — 0 errors, 0 warnings.
- `npx vitest run src/test-kernel/progressView src/test-kernel/settings src/test-kernel/webview` — 55 files / 281 tests passed.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactors with preserved event payloads and new tests; no auth, data, or backend logic changes.
> 
> **Overview**
> Aligns progress and settings UI with the rest of the app by using **Web Awesome** form primitives instead of native elements and ad hoc styling.
> 
> **External inquiry** answer and session-link fields are now `wa-textarea` (with sizing via `::part(textarea)`); custom textarea CSS is removed and input handlers read `.value` from the component host.
> 
> **User question** panels use `wa-checkbox` for multi-select and `wa-radio-group`/`wa-radio` for single-select, replacing native checkbox/radio markup.
> 
> **Settings** per-model and per-agent “enabled” row controls switch from `wa-checkbox` to **`wa-switch`**, matching other catalog toggles.
> 
> **Instruction panel** drops an unused hidden `sessionType` input next to the existing radio group.
> 
> Vitest coverage is added or extended for these behaviors (including shadow-DOM value handling for external inquiry textareas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d06b46c8bf0c50f4939c306ccf2f4a3e510bfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->