### PR TITLE
refactor: converge extension-side raw exec sites on the canonical wrappers

### DIFF
--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -25,6 +25,7 @@ import {
   splitCommitLines,
 } from '@utils/git/commitLogFormat';
 import { isGitRepository } from '@utils/system/isGitRepository';
+import { extendEnvPath } from '@utils/system/platformPaths';
 
 const execFileAsync = promisify(execFile);
 
@@ -125,6 +126,9 @@ export function createDesktopGitHost(
             cwd: workspace,
             timeout: GIT_TIMEOUT_MS,
             maxBuffer: MAX_BUFFER_BYTES,
+            // Same extended PATH as the shared isGitRepository probe, so the
+            // gate can't report a repo the log call then fails to read.
+            env: { ...process.env, PATH: extendEnvPath() },
           },
         );
         return {

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { execa, execaSync } from 'execa';
+import { execa } from 'execa';
 import * as vscode from 'vscode';
 
 // Local imports - utilities
@@ -21,8 +21,8 @@ import {
   COMMIT_LABEL_FORMAT,
   splitCommitLines,
 } from '@utils/git/commitLogFormat';
+import { executeCommandSync } from '@utils/system/execUtils';
 import { isGitRepository as probeGitRepository } from '@utils/system/isGitRepository';
-import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'gitCommands';
 logger.initialize(CHANNEL);
@@ -83,20 +83,20 @@ async function getRecentCommits(rootPath?: string): Promise<string[] | null> {
     );
   }
 
-  const result = execaSync(
-    'git',
+  const result = executeCommandSync(
     [
+      'git',
       'log',
       '-n',
       String(numberOfCommits),
       `--pretty=format:${COMMIT_LABEL_FORMAT}`,
     ],
-    { cwd: workspacePath, reject: false },
+    { cwd: workspacePath },
   );
-  if (result.exitCode !== 0) {
+  if (!result.success) {
     return [];
   }
-  return splitCommitLines(result.stdout);
+  return splitCommitLines(result.stdout ?? '');
 }
 
 function findCommitInHistory(
@@ -117,28 +117,25 @@ function findCommitInHistory(
     return null;
   }
 
-  const verifyResult = execaSync(
-    'git',
-    ['rev-parse', '--verify', `${sanitizedCommit}^{commit}`],
-    { cwd: workspacePath, reject: false },
+  const verifyResult = executeCommandSync(
+    ['git', 'rev-parse', '--verify', `${sanitizedCommit}^{commit}`],
+    { cwd: workspacePath },
   );
 
-  if (verifyResult.exitCode !== 0) {
+  if (!verifyResult.success) {
     return null;
   }
 
-  const labelResult = execaSync(
-    'git',
-    ['show', '-s', `--format=${COMMIT_LABEL_FORMAT}`, sanitizedCommit],
-    { cwd: workspacePath, reject: false },
+  const labelResult = executeCommandSync(
+    ['git', 'show', '-s', `--format=${COMMIT_LABEL_FORMAT}`, sanitizedCommit],
+    { cwd: workspacePath },
   );
 
-  if (labelResult.exitCode !== 0) {
+  if (!labelResult.success) {
     return sanitizedCommit;
   }
 
-  const label = labelResult.stdout.trim();
-  return label || sanitizedCommit;
+  return labelResult.stdout ?? sanitizedCommit;
 }
 
 async function promptInput(
@@ -228,12 +225,7 @@ const GIT_INSTALL_OPTIONS: Partial<
 const GIT_DOWNLOAD_URL = 'https://git-scm.com/downloads';
 
 function isToolAvailable(tool: string): boolean {
-  return (
-    execaSync(tool, ['--version'], {
-      reject: false,
-      env: { ...process.env, PATH: extendEnvPath() },
-    }).exitCode === 0
-  );
+  return executeCommandSync([tool, '--version']).success;
 }
 
 async function promptGitMissing(): Promise<void> {
@@ -270,7 +262,7 @@ async function promptGitMissing(): Promise<void> {
 async function checkClonePreconditions(
   workspacePath: string,
 ): Promise<boolean> {
-  if (execaSync('git', ['--version'], { reject: false }).exitCode !== 0) {
+  if (!executeCommandSync(['git', '--version']).success) {
     await promptGitMissing();
     return false;
   }

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -22,6 +22,7 @@ import {
   splitCommitLines,
 } from '@utils/git/commitLogFormat';
 import { executeCommandSync } from '@utils/system/execUtils';
+import { extendEnvPath } from '@utils/system/platformPaths';
 import { isGitRepository as probeGitRepository } from '@utils/system/isGitRepository';
 
 const CHANNEL = 'gitCommands';
@@ -332,7 +333,9 @@ export async function cloneOverleafProject(
       () =>
         execa('git', ['clone', remote, '.'], {
           cwd: workspacePath,
-          env: { GIT_TERMINAL_PROMPT: '0' },
+          // Same extended PATH as the executeCommandSync preflight above, so
+          // the probe can't pass while the clone misses git (bot review).
+          env: { GIT_TERMINAL_PROMPT: '0', PATH: extendEnvPath() },
         }),
     );
     vscode.window.showInformationMessage(`${label} project cloned.`);

--- a/src/utils/system/isGitRepository.ts
+++ b/src/utils/system/isGitRepository.ts
@@ -2,29 +2,19 @@
  * Async probe for "is this path inside a git working tree?".
  *
  * VS Code-free: uses the injected WorkspaceFS provider for the default root
- * and shells out via `execFile` so availability checks (e.g. the GitHub
- * PR-subscription gate in EXTERNAL_TOOL_DEFS) can live outside the command
- * layer.
+ * so availability checks (e.g. the GitHub PR-subscription gate in
+ * EXTERNAL_TOOL_DEFS) can live outside the command layer.
  */
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-
 import { WorkspaceFS } from '@utils/files';
-
-const execFileAsync = promisify(execFile);
+import { executeCommand } from '@utils/system/execUtils';
 
 export async function isGitRepository(rootPath?: string): Promise<boolean> {
   const cwd = rootPath ?? WorkspaceFS.getPath();
   if (!cwd) return false;
-  try {
-    const { stdout } = await execFileAsync(
-      'git',
-      ['rev-parse', '--is-inside-work-tree'],
-      { cwd, timeout: 5_000 },
-    );
-    return stdout.trim() === 'true';
-  } catch {
-    return false;
-  }
+  const result = await executeCommand(
+    ['git', 'rev-parse', '--is-inside-work-tree'],
+    { cwd, timeout: 5_000 },
+  );
+  return result.success && result.stdout === 'true';
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { execa, execaSync } from 'execa';
+import { execa } from 'execa';
 import { parse as shellParse } from 'shell-quote';
 
 // Local imports
@@ -29,7 +29,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 // Local file imports
 import { IS_WINDOWS, extendEnvPath } from './platformPaths';
 import { BinaryResolver } from './binaryResolver';
-import { executeCommand } from './execUtils';
+import { executeCommand, executeCommandSync } from './execUtils';
 
 const CHANNEL = 'toolUtils';
 logger.initialize(CHANNEL);
@@ -435,12 +435,6 @@ let cachedPackageManager: 'brew' | 'apt' | 'scoop' | undefined;
 export function detectPackageManager(): 'brew' | 'apt' | 'scoop' | null {
   if (cachedPackageManager !== undefined) return cachedPackageManager;
 
-  const extendedPath = extendEnvPath();
-  const execOptions = {
-    env: { ...process.env, PATH: extendedPath },
-    reject: false,
-  };
-
   // Platform-aware order: check the platform's native PM first so that
   // cross-platform installs (e.g. Linuxbrew on Linux) don't shadow the
   // PM that DEPENDENCY_INSTALL_COMMANDS actually uses for that platform.
@@ -464,15 +458,10 @@ export function detectPackageManager(): 'brew' | 'apt' | 'scoop' | null {
     : allManagers;
 
   for (const { name, args } of managers) {
-    try {
-      const result = execaSync(name, args, execOptions);
-      if (result.exitCode === 0) {
-        logger.debug(CHANNEL, `Package manager detected: ${name}`);
-        cachedPackageManager = name;
-        return name;
-      }
-    } catch {
-      // Not available, try next
+    if (executeCommandSync([name, ...args]).success) {
+      logger.debug(CHANNEL, `Package manager detected: ${name}`);
+      cachedPackageManager = name;
+      return name;
     }
   }
 


### PR DESCRIPTION
## Summary

Companion to #8175 (same convergence axis, extension/shared side). The repo's canonical process primitives are `executeCommand`/`executeCommandSync`; these sites bypassed them and re-plumbed the same features by hand:

- **`gitCommands.ts`** (5 sites): `git log`/`rev-parse --verify`/`git show` in the commit pickers, plus two `--version` availability probes. Each carried its own `reject: false` + manual `exitCode` checks; `isToolAvailable` also hand-merged `PATH: extendEnvPath()` into env — which `executeCommandSync` already does via `commandEnv`. Now single-call delegations; the `extendEnvPath` import drops out.
- **`toolUtils.ts` `detectPackageManager`**: the brew/apt/scoop probe loop carried bespoke `execOptions` (PATH extension + `reject: false`) and a try/catch for spawn failures — all three concerns are the canonical wrapper's job. Loop body shrinks to one `.success` check.
- **`isGitRepository.ts`**: `promisify(execFile)` + try/catch + manual trim, replaced by one `executeCommand` call (same 5s timeout, same `=== 'true'` contract).

**Verified-and-left-raw** (each has a real reason the canonical wrapper can't express): `tryExeca` in toolUtils (its doc comment depends on execa's overload resolution, and callers distinguish spawn-failure `null` from non-zero exit — `ExecResult` folds both into `exitCode 127`); the `git clone` under `withProgress` (auth-failure detection regexes the thrown execa message); the macOS keychain probe in `claudeAgentConfig` (`stdio: 'ignore'`, zero LOC gain). The exec audit's remaining justified-raw list (pty, inherit-stdio, binary stdout, detached, maxBuffer) is unchanged.

Net: **−31 LOC**, no new abstractions, one env-extension behavior now consistent (`git`/PM probes see the same extended PATH everywhere).

## Test plan

- [x] `IsGitRepository.vitest.ts` + `LatexToolingController.vitest.ts` — 8/8 pass
- [x] `tsc --noEmit` (root) + `pnpm --filter texra typecheck` — clean
- [x] eslint on the three touched files — clean

Part of the reinvented-wheel/convergence audit (2026-07-11).

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only convergence on existing wrappers with intentional PATH consistency fixes; async git clone and desktop maxBuffer paths are unchanged in structure.
> 
> **Overview**
> Routes extension and shared git/tool probes through **`executeCommand`** / **`executeCommandSync`** instead of ad-hoc **`execaSync`** / **`execFile`** with hand-rolled **`reject: false`**, exit-code checks, and PATH merging.
> 
> **`gitCommands.ts`** uses the sync wrapper for commit history (`git log`, `rev-parse`, `show`) and availability checks (`git --version`, package-manager `--version`). **`git clone`** stays on **`execa`** for progress/auth handling but now sets **`PATH: extendEnvPath()`** so preflight and clone agree on where **`git`** lives.
> 
> **`isGitRepository`** becomes a single async **`executeCommand`** call (same 5s timeout and **`true`** stdout contract). **`detectPackageManager`** in **`toolUtils`** drops bespoke **`execOptions`** and probes brew/apt/scoop via **`.success`** only.
> 
> **Desktop** **`desktopGitHost`** still uses **`execFile`** for **`maxBuffer`**, but **`git log`** now gets the same extended **`PATH`** as the shared repo probe so a passing gate cannot be followed by a failed log spawn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da96e723567c4de8c974e85311f83dd157f12f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->