### PR TITLE
fix: harden two IO boundaries found by the convergence audit

### DIFF
--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -4,8 +4,10 @@
 // (init/runInitWizard) and the command (commands/init) build on these; keeping
 // the logic here makes it unit-testable without a TTY.
 
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
+
+import writeFileAtomic from 'write-file-atomic';
 
 import { TEXRA_STORAGE_DIR_NAME } from '@platform/defaults/nodeStorage';
 import { isFileNotFoundError } from '@common/errors';
@@ -59,7 +61,7 @@ export async function writeInitConfig(
   config: InitConfigShape,
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, serializeInitConfig(config), 'utf8');
+  await writeFileAtomic(filePath, serializeInitConfig(config));
 }
 
 /**
@@ -98,6 +100,6 @@ export async function ensureTexraGitignored(
   }
   const next = gitignoreWithTexra(existing);
   if (next === null) return 'present';
-  await writeFile(gitignorePath, next, 'utf8');
+  await writeFileAtomic(gitignorePath, next);
   return existed ? 'added' : 'created';
 }

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import * as vscode from 'vscode';
 import * as yaml from 'yaml';
+import { z } from 'zod';
 
 import {
   type AgentCategory,
@@ -20,9 +21,13 @@ import { AbsoluteFS } from '@utils/files';
 const CHANNEL = 'AgentCreator';
 logger.initialize(CHANNEL);
 
-interface ParsedCreatorYaml {
-  prompts: { systemPrompt: string; userRequest: string; retryPrompt?: string };
-}
+const ParsedCreatorYamlSchema = z.object({
+  prompts: z.object({
+    systemPrompt: z.string(),
+    userRequest: z.string(),
+    retryPrompt: z.string().optional(),
+  }),
+});
 
 /** Cached after first load. Templates are bundled resources — stable for the session. */
 let creatorConfig: CreatorConfig | null = null;
@@ -45,8 +50,8 @@ async function loadCreatorConfig(
       ),
       AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
     ]);
-  const wf = yaml.parse(workflowYaml) as ParsedCreatorYaml;
-  const tu = yaml.parse(toolUseYaml) as ParsedCreatorYaml;
+  const wf = ParsedCreatorYamlSchema.parse(yaml.parse(workflowYaml));
+  const tu = ParsedCreatorYamlSchema.parse(yaml.parse(toolUseYaml));
   const defaultRetry =
     'The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.';
   creatorConfig = {


### PR DESCRIPTION
## Summary

Two small entry-point fixes from the IO-pipeline sweep of the convergence audit:

1. **`texra init` writes were not atomic** (`packages/cli/src/runtime/initConfig.ts`): both `.texra/config.json` and the created/appended `.gitignore` used plain `writeFile` — a crash mid-write leaves a truncated file. Both now use `write-file-atomic`, the same primitive as `JsonStore`, `nodeFilesystem`, `baseFS`, and (since #8167) the CLI secrets file. No wrapper added; `serializeInitConfig` and the read-side error discipline are untouched.
2. **Unvalidated `yaml.parse` cast** (`packages/extension/src/commands/agent/agentCreatorCommands.ts`): the agent-creator templates were parsed with `yaml.parse(...) as ParsedCreatorYaml` — the only zero-validation cast the sweep found on a serialization boundary. Now `ParsedCreatorYamlSchema.parse(...)` per the repo's schema-first convention (interface deleted, schema is the source of truth). Failure mode moves from a delayed `undefined`-property crash to a loud zod error naming the bad template field.

## Test plan

- [x] `InitConfig.vitest.mts` — 10/10 pass (covers config write and both `.gitignore` paths)
- [x] `tsc --noEmit` (root) + extension + CLI typechecks — clean

Part of the reinvented-wheel/convergence audit (2026-07-11).

https://claude.ai/code/session_01NbdkQXLVewvfNVnzNJdNB1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized IO and parse-boundary hardening with no changes to auth, secrets semantics, or broader init/agent flow logic.
> 
> **Overview**
> **`texra init`** now writes `.texra/config.json` and `.gitignore` updates through **`write-file-atomic`** instead of plain `fs.writeFile`, matching other CLI persistence (e.g. secrets) so a crash mid-write cannot leave truncated files.
> 
> The VS Code **agent creator** replaces `yaml.parse(...) as ParsedCreatorYaml` with **`ParsedCreatorYamlSchema.parse(...)`** (zod); the hand-rolled interface is removed so malformed bundled templates fail fast with a clear validation error instead of later undefined-property crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fac82f3b9eff4208e24c232678825cd7035a6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->