### PR TITLE
refactor(progress): reuse inquiry action schema

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -570,9 +570,7 @@ export class DesktopProgressBridge {
           },
         },
         externalInquiry: {
-          logWarn: (message, context) =>
-            this.logger.warn(message, { data: context }),
-          sessionContext: { session: this.session },
+          session: this.session,
         },
       },
     });

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -531,10 +531,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           handleUserQuestionAction: (message) =>
             this.handleUserQuestionAction(message),
         },
-        externalInquiry: {
-          logWarn: (message, context) =>
-            this.logger.warn(this.channel, message, { data: context }),
-        },
+        externalInquiry: {},
       },
     });
   }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -2,11 +2,7 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type {
-  AgentCategoryFilter,
-  ExternalInquiryThreadId,
-  StreamTabId,
-} from '@shared/schemas';
+import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
@@ -116,19 +112,10 @@ export interface ProgressViewApprovalCommandActions {
 
 export interface ProgressViewExternalInquiryCommandActions {
   /**
-   * Host log sink for the empty-answer guard. The guard policy and message
-   * live in the shared handler; hosts differ only in whether their logger
-   * carries a channel, so they pass just the transport here.
-   */
-  logWarn(
-    message: string,
-    context: { threadId: ExternalInquiryThreadId },
-  ): void;
-  /**
    * Forwarded to the inquiry submit/drop settle path. Desktop scopes it to its
    * window session; the extension omits it so the module default applies.
    */
-  sessionContext?: { session?: SessionHandle };
+  session?: SessionHandle;
 }
 
 export interface ProgressViewCommandActions {
@@ -311,44 +298,16 @@ export function createProgressViewCommandHandlers(
       await approval.handleAgentProposalAction(data);
     },
 
-    // External inquiry settle path: draft persists the open turn, submit/drop
-    // settle the durable thread. The empty-answer guard and warning message are
-    // shared; hosts supply only the log transport and (desktop) the session.
+    // Draft persists the open turn; the canonical submit/drop union settles it.
     [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: async (data) => {
       if (data.action === 'draft') {
         await persistOpenTurnDraft({
           threadId: data.threadId,
-          draft: data.draft ?? null,
+          draft: data.draft,
         });
         return;
       }
-      if (data.action === 'submit') {
-        if (data.answer == null || data.answer.length === 0) {
-          externalInquiry.logWarn(
-            'Ignoring external inquiry submit without an answer',
-            { threadId: data.threadId },
-          );
-          return;
-        }
-        await handleExternalInquiryAction(
-          {
-            action: 'submit',
-            threadId: data.threadId,
-            answer: data.answer,
-            sessionLinks: data.sessionLinks,
-          },
-          externalInquiry.sessionContext,
-        );
-        return;
-      }
-      await handleExternalInquiryAction(
-        {
-          action: 'drop',
-          threadId: data.threadId,
-          feedback: data.feedback,
-        },
-        externalInquiry.sessionContext,
-      );
+      await handleExternalInquiryAction(data, externalInquiry);
     },
   } satisfies Partial<ProgressViewInboundHandlerRegistry>;
 }

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -69,18 +69,22 @@ export type InquiryThreadUpdatedEvent = z.infer<
 // Action payloads — sent from inquiry panel to the host (keyed by threadId)
 // ============================================================================
 
+export const InquirySubmitActionSchema = z.object({
+  action: z.literal('submit'),
+  threadId: ExternalInquiryThreadIdSchema,
+  answer: z.string().min(1),
+  sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
+});
+
+export const InquiryDropActionSchema = z.object({
+  action: z.literal('drop'),
+  threadId: ExternalInquiryThreadIdSchema,
+  feedback: z.string().optional(),
+});
+
 const InquiryActionMessageSchema = z.discriminatedUnion('action', [
-  z.object({
-    action: z.literal('submit'),
-    threadId: ExternalInquiryThreadIdSchema,
-    answer: z.string().min(1),
-    sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
-  }),
-  z.object({
-    action: z.literal('drop'),
-    threadId: ExternalInquiryThreadIdSchema,
-    feedback: z.string().optional(),
-  }),
+  InquirySubmitActionSchema,
+  InquiryDropActionSchema,
 ]);
 export type InquiryActionMessage = z.infer<typeof InquiryActionMessageSchema>;
 

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -14,9 +14,10 @@ import {
 import { SwitchViewMessageSchema } from '../commonViewMessages';
 import { commandOnly } from '../messageFactories';
 import {
-  ExternalInquirySessionLinksSchema,
   ExternalInquiryThreadIdSchema,
   InquiryDraftSchema,
+  InquiryDropActionSchema,
+  InquirySubmitActionSchema,
 } from '../inquiry';
 import {
   AgentProposalSchema,
@@ -150,32 +151,20 @@ const PlanApprovalActionMessageSchema = z.object({
   feedback: z.string().optional(),
 });
 
-const ExternalInquiryActionMessageSchema = z
-  .object({
+const ExternalInquiryActionMessageSchema = z.discriminatedUnion('action', [
+  InquirySubmitActionSchema.extend({
     command: z.literal(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION),
-    action: z.enum(['submit', 'drop', 'draft']),
+  }),
+  InquiryDropActionSchema.extend({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION),
+  }),
+  z.object({
+    command: z.literal(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION),
+    action: z.literal('draft'),
     threadId: ExternalInquiryThreadIdSchema,
-    answer: z.string().min(1).optional(),
-    sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
-    feedback: z.string().optional(),
-    draft: InquiryDraftSchema.nullish(),
-  })
-  .superRefine((message, ctx) => {
-    if (message.action === 'submit' && !message.answer) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['answer'],
-        message: 'Submit actions require an answer.',
-      });
-    }
-    if (message.action === 'draft' && message.draft === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['draft'],
-        message: 'Draft actions require a draft value.',
-      });
-    }
-  });
+    draft: InquiryDraftSchema.nullable(),
+  }),
+]);
 
 const UserQuestionActionMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION),

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -92,9 +92,7 @@ function createActions(
       handleUserQuestionAction: vi.fn(),
       handleAgentProposalAction: vi.fn(),
     },
-    externalInquiry: {
-      logWarn: vi.fn(),
-    },
+    externalInquiry: {},
     ...overrides,
   };
 }
@@ -709,5 +707,24 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     expect(
       actions.approval.onUnsupportedToolEditApproval,
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('external inquiry action schema', () => {
+  const command = PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION;
+  const threadId = 'ei_123456789abc';
+
+  it("requires each action variant's own fields", () => {
+    const results = [
+      { command, action: 'submit', threadId, answer: 'Confirmed' },
+      { command, action: 'drop', threadId },
+      { command, action: 'draft', threadId, draft: null },
+      { command, action: 'submit', threadId },
+      { command, action: 'draft', threadId },
+    ].map(
+      (message) => ProgressViewInboundMessageSchema.safeParse(message).success,
+    );
+
+    expect(results).toEqual([true, true, true, false, false]);
   });
 });

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -95,9 +95,7 @@ describe('ProgressViewHost', () => {
           handlePlanApprovalAction: vi.fn(),
           handleUserQuestionAction: vi.fn(),
         },
-        externalInquiry: {
-          logWarn: vi.fn(),
-        },
+        externalInquiry: {},
       },
     });
 


### PR DESCRIPTION
Closes #8174

## Summary

- Reuse the canonical submit/drop inquiry variants in progress-view IPC.
- Replace the optional-field bag and `superRefine` checks with a discriminated union.
- Forward validated actions directly instead of rebuilding payloads in the controller.
- Remove redundant host logging adapters and keep one schema-invariant test.

## Issue acceptance gates

- Progress IPC composes the canonical inquiry submit/drop variants.
- Submit-without-answer and draft-without-draft fail at the parse boundary.
- Desktop retains its window session; extension retains the default session.
- Redundant controller payload reconstruction and logging adapters are removed.

## Single source of truth

`src/shared/schemas/inquiry.ts` owns submit/drop action fields and validation. The progress-view inbound schema adds only its IPC command and the progress-only draft variant.

## Duplication and abstraction budget

Removes the duplicate optional-field action model, two manual refinements, controller-side revalidation, payload rebuilding, and host log adapters. No pass-through abstraction is added; two existing action variants become exported for direct composition.

## Net elements (R6)

- Files: 7 modified, 0 added, 0 deleted.
- Exported symbols: +2 schemas (`InquirySubmitActionSchema`, `InquiryDropActionSchema`), 0 removed.
- Classes/interfaces/enums: 0 added or removed; one interface is narrowed by deleting the log callback and flattening the optional session field.
- LoC: +57 / -95, net -38.

## Consumer counts (R8)

n/a — no emit/subscribe path or existing export is deleted or rerouted. Each newly exported action schema has one new consumer in the progress-view inbound union.

## Host impact

Extension: Removes an unused warning adapter; submit/drop still use the default session.

Desktop: Flattens `sessionContext.session` to `session`; inquiry actions remain scoped to the window session.

CLI: No runtime behavior change; shared schema validation is covered by the same inbound boundary.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; 45 existing warnings)
- `npm test` (639 files passed, 1 skipped; 5638 tests passed, 4 skipped)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only baseline report)