### PR TITLE
fix(cli): restore update checker architecture boundary

### DIFF
--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -11,6 +11,7 @@ import {
   cliEnvValue,
   readCliAmbientState,
   readCliEntrypointPath,
+  resolveCliCwd,
   type CliContext,
 } from './cliContext';
 import { CliExitCode } from './exitCodes';
@@ -160,19 +161,21 @@ type CommandRunner = (
   command: string,
   args: readonly string[],
   timeoutMs: number,
+  cwd?: string,
 ) => Promise<string | undefined>;
 
 async function readCommandStdout(
   command: string,
   args: readonly string[],
   timeoutMs: number,
+  cwd?: string,
 ): Promise<string | undefined> {
   // Runs before platform init (chat/orchestrate startup), so pass an
   // explicit cwd — the wrapper's WorkspaceFS default would throw — and
   // quiet: true so wrapper debug lines can't leak to the console sink.
   const result = await executeCommand([command, ...args], {
     timeout: timeoutMs,
-    cwd: process.cwd(),
+    cwd: cwd ?? (await resolveCliCwd(undefined)),
     quiet: true,
   });
   return result.success ? (result.stdout ?? '') : undefined;
@@ -217,16 +220,18 @@ function parseHomebrewFormulaVersion(
 export async function fetchLatestHomebrewFormulaVersion(options?: {
   formula?: string;
   timeoutMs?: number;
+  cwd?: string;
   runCommand?: CommandRunner;
 }): Promise<string | undefined> {
   const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
   const runCommand = options?.runCommand ?? readCommandStdout;
   const timeoutMs = options?.timeoutMs ?? HOMEBREW_COMMAND_TIMEOUT_MS;
-  await runCommand('brew', ['update', '--quiet'], timeoutMs);
+  await runCommand('brew', ['update', '--quiet'], timeoutMs, options?.cwd);
   const stdout = await runCommand(
     'brew',
     ['info', '--json=v2', formula],
     timeoutMs,
+    options?.cwd,
   );
   return stdout == null
     ? undefined
@@ -301,7 +306,7 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   const method = detectInstallMethod();
   const latest =
     method === 'brew'
-      ? await fetchLatestHomebrewFormulaVersion()
+      ? await fetchLatestHomebrewFormulaVersion({ cwd: context.cwd })
       : await fetchLatestCliVersion();
   if (!latest || !isNewerVersion(latest, context.version)) return;
 

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -249,12 +249,14 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
       command: string;
       args: readonly string[];
       timeoutMs: number;
+      cwd?: string;
     }> = [];
     await fetchLatestHomebrewFormulaVersion({
       formula: 'custom',
       timeoutMs: 123,
-      runCommand: async (command, args, timeoutMs) => {
-        calls.push({ command, args, timeoutMs });
+      cwd: '/workspace',
+      runCommand: async (command, args, timeoutMs, cwd) => {
+        calls.push({ command, args, timeoutMs, cwd });
         return JSON.stringify({
           formulae: [{ name: 'custom', versions: { stable: '1.2.3' } }],
         });
@@ -266,11 +268,13 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
         command: 'brew',
         args: ['update', '--quiet'],
         timeoutMs: 123,
+        cwd: '/workspace',
       },
       {
         command: 'brew',
         args: ['info', '--json=v2', 'custom'],
         timeoutMs: 123,
+        cwd: '/workspace',
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Route the update checker's pre-platform working-directory lookup through the existing CLI context boundary instead of reading `process.cwd()` directly. The resolved `context.cwd` is carried into Homebrew probes, preserving `--cwd` decisions without re-reading process state.

## Issue acceptance gates

Closes #8189.

- `updateChecker` passes an explicit working directory to the canonical exec wrapper before platform initialization.
- Normal CLI invocations carry the already-resolved `context.cwd`; standalone helper calls fall back through `resolveCliCwd(undefined)`.
- `pnpm --filter @texra-ai/cli validate:run` passes locally.

## Single source of truth

`packages/cli/src/runtime/cliContext.ts` remains the sole owner of CLI process-input reads, and `CliContext.cwd` carries that resolved decision to the update checker.

## Duplication and abstraction budget

No new abstraction. The fix reuses `CliContext.cwd` and the existing `resolveCliCwd` fallback rather than duplicating process access or weakening the architecture checker.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted
- LoC: +14 / -5 (net +9)
- Exported symbols: 0 added, 0 removed
- Classes/interfaces/enums: 0 added, 0 removed

## Consumer counts (R8)

n/a — no emit path or export is deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Restores the required process-input boundary and carries the resolved workspace into Homebrew update probes.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm --filter @texra-ai/cli run check:architecture`
- `corepack pnpm exec vitest run src/test-kernel/cli/UpdateChecker.vitest.mts` (20 passed)
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/updateChecker.ts src/test-kernel/cli/UpdateChecker.vitest.mts`
- `corepack pnpm exec eslint packages/cli/src/runtime/updateChecker.ts src/test-kernel/cli/UpdateChecker.vitest.mts`
