### PR TITLE
docs(relay): export SUPABASE_PROJECT_REF in redeploy snippet

### DIFF
--- a/docs/supabase/RELAY_SETUP.md
+++ b/docs/supabase/RELAY_SETUP.md
@@ -138,8 +138,12 @@ curl -X POST \
 To update the relay function after changes:
 
 ```bash
+export SUPABASE_PROJECT_REF="<your-project-ref>"
 node scripts/deploy-relay.mjs
 ```
+
+`scripts/deploy-relay.mjs` refuses to run without `SUPABASE_PROJECT_REF` (see
+step 1 above), so it must be exported in this shell too.
 
 Always pass `--no-verify-jwt` — the relay validates the JWT (and CI tokens)
 itself, so omitting the flag flips the gateway to `verify_jwt=true` and breaks


### PR DESCRIPTION
## Summary

Closes #8085.

Follow-up from #7998, which made `scripts/deploy-relay.mjs` hard-fail when `SUPABASE_PROJECT_REF` is unset and updated the initial-deploy instructions (step 1) in `docs/supabase/RELAY_SETUP.md` to match. Copilot's review on #7998 flagged that the doc's later `## Deployment` section (the redeploy-after-changes snippet near the end of the file) still showed only `node scripts/deploy-relay.mjs`, with no `export SUPABASE_PROJECT_REF=...` alongside it — a reader following just that section in a fresh shell now hits the new fail-fast error instead of deploying.

Fix: add the same `export SUPABASE_PROJECT_REF="<your-project-ref>"` line (and a one-line note pointing back to step 1) to the redeploy snippet, mirroring the wording already used in step 1.

## Net elements (R6)

- +4 lines, 0 files added/removed, docs-only. No new dependency (none named by the issue; none needed for a markdown edit).

## Consumer counts (R8)

- N/A — no code/API surface touched, so no callers to count. The change only affects a documentation snippet read by humans running the redeploy command manually.

## Verification

- `node docs/scripts/check-root-docs.mjs` — docs boundary gate: pass (file is under `docs/supabase/`, not root-level, so unaffected; ran per issue's "run docs gate" instruction).
- `npx prettier --check docs/supabase/RELAY_SETUP.md` — pass.
- Manual diff review: new snippet now matches step 1's existing wording/pattern exactly.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates the **`## Deployment`** redeploy instructions in `docs/supabase/RELAY_SETUP.md` so they match step 1: the bash block now includes **`export SUPABASE_PROJECT_REF="<your-project-ref>"`** before **`node scripts/deploy-relay.mjs`**.
> 
> Adds a short note that **`scripts/deploy-relay.mjs`** fails without that variable and points readers back to step 1, so someone redeploying from a fresh shell is not surprised by the fail-fast behavior introduced in #7998.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c7ec6a1e43e16a0781be5bd81826c0f3d07b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->