### PR TITLE
docs(supabase): avoid shell-redirection footgun in auth-bridge deploy comment

### DIFF
--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -32,7 +32,7 @@
  *   The one-time code is scrubbed from history after the deep link is built.
  *
  * Deployment:
- *   supabase functions deploy auth-bridge --no-verify-jwt --project-ref <project-ref>
+ *   supabase functions deploy auth-bridge --no-verify-jwt --project-ref YOUR_PROJECT_REF
  * The function URL must be on the Supabase Auth "Redirect URLs" allow-list
  * (Dashboard > Authentication > URL Configuration) as a globstar so it spans the
  * /<ext>/<id> path and the '.' in the id (a single '*' cannot):


### PR DESCRIPTION
## Context

Follow-up from #7998. That PR replaced the hardcoded production project ref in `supabase/functions/auth-bridge/index.ts`'s deploy comment with a bare `<project-ref>` placeholder. `<...>` is parsed by shells as input/output redirection, so a reader who copy-pastes the deploy command literally gets a broken (or silently wrong) command instead of a helpful shell error.

Fixes #8084: replace the angle-bracket placeholder with the `--flag VALUE`-style convention (`YOUR_PROJECT_REF`) already used for similar placeholders elsewhere in the codebase (e.g. `docs/supabase/SUPABASE_SETUP.md`).

## Net elements (R6)

- 1 file changed, 1 line modified (comment only). No new files, functions, types, or dependencies.

## Consumer counts (R8)

- N/A — no new shared abstraction, symbol, or dependency introduced; this is a comment-string edit with a single call site (the deploy instructions comment itself).

## Dependency decision

None. No new dependency added or needed.

## Tests

Comment-only change (the file lives under `supabase/` which is excluded from the main `tsconfig.json`, so it isn't covered by an existing test suite). Verified:
- `npx prettier --check supabase/functions/auth-bridge/index.ts` passes.
- `npm run typecheck` passes clean.
- Grepped the repo to confirm no test or tooling parses this comment string.

Closes #8084

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation comment change with no effect on the edge function or deployment tooling.
> 
> **Overview**
> Updates the **auth-bridge** deploy comment so copy-paste into a shell does not break on `<project-ref>` being treated as redirection.
> 
> The deployment line now uses `YOUR_PROJECT_REF` instead of angle-bracket placeholders, matching the intent described in the PR (same style as other Supabase docs). **No runtime or deploy behavior changes**—comment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bbaa99a9c98339599d4994773104c0f1352bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->