### PR TITLE
fix(agent): reach background-bash AgentExecutionHandles in shutdown drain

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -43,6 +43,15 @@ export interface ExecutionHandle {
 /** Live run-owned capability that can receive a user stop request. */
 export interface ExecutionInterruptHandler {
   interrupt(): void;
+  /**
+   * True when `interrupt()` tears down a live background OS process (e.g. a
+   * background bash child), as opposed to merely cancelling an in-flight
+   * agent turn or a resumable native-subagent loop. Shutdown drain reads this
+   * to reach a leaked background process (see
+   * `ExecutionRegistry.killBackgroundProcesses`) without disturbing agent
+   * executions that are intentionally left running for restart recovery.
+   */
+  readonly ownsBackgroundProcess?: boolean;
 }
 
 export interface LiveToolUseFlowContext {
@@ -185,6 +194,21 @@ export class AgentExecutionHandle implements ExecutionHandle {
     const context = this.toolUseFlowContext;
     if (!context) return false;
     context.interrupt();
+    return true;
+  }
+
+  /**
+   * Interrupt this handle's attached background OS process, if any — the
+   * case shutdown drain needs, distinct from `interrupt()`'s general stop
+   * (which also covers a loop-level or in-flight-turn interrupt handler that
+   * must stay untouched on shutdown so restart recovery can find it). A
+   * background bash run (`BashBackgroundSession`, see `tools/bash.ts`) is the
+   * only handler that currently sets `ownsBackgroundProcess`. Returns whether
+   * a background-process interrupt handler was attached and interrupted.
+   */
+  interruptBackgroundProcess(): boolean {
+    if (this.interruptHandler?.ownsBackgroundProcess !== true) return false;
+    this.interruptHandler.interrupt();
     return true;
   }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -474,11 +474,21 @@ export class ExecutionRegistry {
    * Kill only background OS processes (bash, codex) without touching agent
    * stream status. Agent executions are left in RUNNING so restart recovery can
    * restore them to WAITING (resumable) if a flow record exists.
+   *
+   * A background `bash` run is also an `AgentExecutionHandle` (see
+   * `createChildStream` in `tools/bash.ts`), not a `ProcessExecutionHandle` —
+   * killing its underlying OS process requires `interruptBackgroundProcess()`,
+   * which only fires for a handle whose attached interrupt handler declares
+   * itself as owning a live background process, leaving every other
+   * `AgentExecutionHandle` (root/native-subagent runs, loop-level interrupts)
+   * untouched (#8155).
    */
   killBackgroundProcesses(): void {
     for (const [executionId, handle] of this.handles) {
       if (handle instanceof ProcessExecutionHandle) {
         this.kill(executionId);
+      } else if (handle instanceof AgentExecutionHandle) {
+        handle.interruptBackgroundProcess();
       }
     }
   }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -58,6 +58,96 @@ describe('executionRegistry', () => {
     expect(flush).not.toHaveBeenCalled();
   });
 
+  it('drains a background-bash AgentExecutionHandle on shutdown without disturbing a resumable agent execution (issue #8155)', () => {
+    // Regression for #8155: killBackgroundProcesses() previously only walked
+    // ProcessExecutionHandles, missing a background `bash` run — which is
+    // registered as an AgentExecutionHandle (see createChildStream in
+    // tools/bash.ts) with its OS-process kill reachable only via the
+    // interrupt handler BashBackgroundSession attaches. The two AgentExecutionHandles
+    // below are tracked concurrently, mirroring the real interleaving at
+    // shutdown: a background bash child stream alongside an ordinary
+    // resumable agent execution (e.g. a native subagent loop, whose own
+    // loop-level interrupt handler must stay untouched so restart recovery
+    // can resume it). Drain must reach only the former.
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const bashExecutionId = 'exec-background-bash-drain-test';
+    const bashParentStreamId =
+      'parent-background-bash-drain-test' as StreamTabId;
+    const bashChildStreamId = 'child-background-bash-drain-test' as StreamTabId;
+    const agentExecutionId = 'exec-resumable-agent-drain-test';
+    const agentParentStreamId =
+      'parent-resumable-agent-drain-test' as StreamTabId;
+    const agentChildStreamId =
+      'child-resumable-agent-drain-test' as StreamTabId;
+    const bashInterrupt = vi.fn();
+    const agentInterrupt = vi.fn();
+    const processKillFn = vi.fn(() => true);
+
+    try {
+      // Background bash: an AgentExecutionHandle whose attached interrupt
+      // handler owns a live OS process (mirrors BashBackgroundSession).
+      const bashHandle = new AgentExecutionHandle(
+        bashExecutionId,
+        bashParentStreamId,
+        bashChildStreamId,
+        'bash',
+        'toolUse',
+        explicit.host,
+      );
+      bashHandle.attachInterruptHandler({
+        interrupt: bashInterrupt,
+        ownsBackgroundProcess: true,
+      });
+      registry.trackAgentExecution(bashHandle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+
+      // Ordinary agent execution (e.g. a native-subagent loop's own
+      // loop-level interrupt handler): no ownsBackgroundProcess flag, so
+      // shutdown drain must leave it alone for restart recovery.
+      const agentHandle = new AgentExecutionHandle(
+        agentExecutionId,
+        agentParentStreamId,
+        agentChildStreamId,
+        'test-subagent',
+        'toolUse',
+        explicit.host,
+      );
+      agentHandle.attachInterruptHandler({ interrupt: agentInterrupt });
+      registry.trackAgentExecution(agentHandle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+
+      // A genuine background process handle keeps working exactly as before.
+      const processHandle = new ProcessExecutionHandle(
+        'exec-process-drain-test',
+        bashParentStreamId,
+        'bash',
+        processKillFn,
+        explicit.host,
+      );
+      registry.track(processHandle);
+
+      registry.killBackgroundProcesses();
+
+      expect(bashInterrupt).toHaveBeenCalledOnce();
+      expect(processKillFn).toHaveBeenCalledOnce();
+      expect(agentInterrupt).not.toHaveBeenCalled();
+      // Neither AgentExecutionHandle's tracked status changes: killing a
+      // background OS process bypasses the generic terminate()/kill() path
+      // (and its cancelStreamStatus side effect) so restart recovery still
+      // finds both handles exactly as it would have before shutdown.
+      expect(streamStatus.get(bashChildStreamId)).toBe(STREAM_PHASE.RUNNING);
+      expect(streamStatus.get(agentChildStreamId)).toBe(STREAM_PHASE.RUNNING);
+      expect(registry.getHandle(bashExecutionId)).toBe(bashHandle);
+      expect(registry.getHandle(agentExecutionId)).toBe(agentHandle);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('uses the handle interrupt target when terminating agent handles', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusMachine();

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -109,6 +109,8 @@ function usesShellLevelBackgrounding(command: string): boolean {
 }
 
 class BashBackgroundSession implements ExecutionInterruptHandler {
+  /** Shutdown drain reaches this handler via `interruptBackgroundProcess()`. */
+  readonly ownsBackgroundProcess = true;
   private pid: number | undefined;
   private interrupted = false;
 


### PR DESCRIPTION
## Context

Follow-up from #8152 (fix(agent): drain all live sessions on shutdown), filed from a `chatgpt-codex-connector[bot]` P1 review comment that was left unaddressed when #8152 merged: https://github.com/LionSR/TeXRA/pull/8152#discussion_r3564996689

`killAllSessionBackgroundProcesses()` walks every live session's `ExecutionRegistry.killBackgroundProcesses()`, but that method only killed handles that were `instanceof ProcessExecutionHandle`. A background `bash` run (`bash.ts`'s `executeBackground`) is registered as an `AgentExecutionHandle` via `createChildStream`, with its underlying OS process reachable only through a `BashBackgroundSession` attached via `attachInterruptHandler`. Shutdown drain never called `handle.interrupt()` on that handle, so the background bash process outlived host shutdown.

## Fix

Trace: drain path is `killAllSessionBackgroundProcesses()` → `session.executions.killBackgroundProcesses()`. Attach path is `bash.ts`'s `executeBackground()` → `createChildStream()` (creates an `AgentExecutionHandle`) → `attachInterruptHandler(new BashBackgroundSession())`.

The owner that already knows about every child of a session is `ExecutionRegistry` (it owns both the `ProcessExecutionHandle` and `AgentExecutionHandle` maps that `killBackgroundProcesses()` walks), so the fix stays there:

- `ExecutionInterruptHandler` (in `ExecutionHandle.ts`) gains an optional `readonly ownsBackgroundProcess?: boolean` marker, distinguishing a handler that tears down a live background OS process from one that merely interrupts an in-flight turn or a resumable native-subagent loop (`childRunLoop.ts`'s `ChildRunInterruptible`, `executeAgent.ts`'s reflection-turn handler — both also implement `ExecutionInterruptHandler` but must stay untouched by shutdown drain so restart recovery can find them).
- `AgentExecutionHandle.interruptBackgroundProcess()` interrupts only when the currently attached handler sets that marker, bypassing the generic `terminate()`/`kill()` path (and its `cancelStreamStatus` side effect) — the tracked execution stays exactly as it was (RUNNING), matching the existing doc comment on `killBackgroundProcesses()` ("Agent executions are left in RUNNING so restart recovery can restore them").
- `BashBackgroundSession` (`bash.ts`) sets `ownsBackgroundProcess = true`.
- `killBackgroundProcesses()` now also calls `handle.interruptBackgroundProcess()` for every tracked `AgentExecutionHandle`, which no-ops for anything that isn't a background-bash handle.

## Net elements (R6)

- **Added**: 1 optional interface property (`ownsBackgroundProcess`), 1 method (`AgentExecutionHandle.interruptBackgroundProcess()`), 1 field assignment (`BashBackgroundSession.ownsBackgroundProcess = true`), 1 branch in `killBackgroundProcesses()`.
- **Removed**: nothing — this closes a real drain gap, not a refactor.
- No new files, no new layers/wrappers/factories.

## Consumer counts (R8)

- `interruptBackgroundProcess()`: 1 caller (`ExecutionRegistry.killBackgroundProcesses()`) — justified because it must encapsulate the private `interruptHandler` field on `AgentExecutionHandle`, matching the existing single-caller pattern already used by `runWaitingCleanup()` / `clearWaitingCleanup()` on the same class.
- `ownsBackgroundProcess`: 1 implementor today (`BashBackgroundSession`); the other two `ExecutionInterruptHandler` implementations (`ChildRunInterruptible`, the inline reflection-turn handler in `executeAgent.ts`) intentionally leave it unset (`undefined`), which is the correct "not a background process" default.

## Tests

- Extended `src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts` (R7) with a regression test that tracks a background-bash-style `AgentExecutionHandle` (interrupt handler with `ownsBackgroundProcess: true`) alongside an ordinary resumable-agent `AgentExecutionHandle` (plain interrupt handler, mirroring `childRunLoop`'s loop-level interrupt) and a `ProcessExecutionHandle`, all live at the same time — mirrors the real interleaving at shutdown. Confirmed **proven-to-fail on pre-fix code** by stashing the three source-file changes and re-running just that test: it fails (`bashInterrupt` never called) on the old `killBackgroundProcesses()`, and passes after the fix, while leaving the ordinary agent handle's status/interrupt untouched in both cases.
- `npx vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/AgentShutdown.vitest.ts` — 27 passed.
- `npx vitest run src/test-kernel/agent/runtime` (full runtime suite) — 242 passed.
- `npx vitest run src/test-kernel/tools` — included in the 522-test run below.
- `npx vitest run src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/AgentShutdown.vitest.ts src/test-kernel/tools` — 522 passed, 0 failed.
- `npm run typecheck` — clean across all workspace packages.
- `npx eslint` on all four changed files — clean.

Closes #8155

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches host shutdown and process lifecycle; behavior is narrowly scoped via ownsBackgroundProcess and covered by regression tests, but wrong classification could disturb restart recovery or leave processes running.
> 
> **Overview**
> Fixes a shutdown drain gap where **background `bash`** (`run_in_background`) could keep its OS process alive after host shutdown. Those runs register as **`AgentExecutionHandle`** child streams, not `ProcessExecutionHandle`, so `killBackgroundProcesses()` previously only killed process handles and never reached the bash interrupt path.
> 
> **`ExecutionInterruptHandler`** gains optional **`ownsBackgroundProcess`**. **`BashBackgroundSession`** sets it so shutdown can tell OS teardown apart from loop-level or in-flight-turn interrupts that must stay untouched for restart recovery.
> 
> **`AgentExecutionHandle.interruptBackgroundProcess()`** calls `interrupt()` only when the attached handler has that flag—avoiding generic `terminate()`/`kill()` and **`cancelStreamStatus`**, so agent executions stay **RUNNING** as documented for recovery.
> 
> **`ExecutionRegistry.killBackgroundProcesses()`** now also invokes **`interruptBackgroundProcess()`** on tracked agent handles. Regression test covers concurrent background bash, resumable agent, and process handles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9995386242972b0e5c96ba050ac4dc45d454544a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->