### PR TITLE
fix(agent): tag applyTokenCountFailureFallback's throw with attachContextWindowError

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -27,6 +27,7 @@ import type {
   TokenCountOptions,
 } from '@agent/types/IModelHandler';
 import {
+  attachContextWindowError,
   buildErrorLogData,
   getSdkErrorMessage,
   isContextWindowError,
@@ -1369,9 +1370,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         buffer,
       )
     ) {
-      throw new Error(
+      const error = new Error(
         `Token estimate (${inputEstimate}) + output budget (${maxOutputTokens}) + safety buffer (${buffer}) exceeds context window (${contextWindow}), and this route cannot enforce a reduced output budget locally.`,
       );
+      // Tag with a typed marker so isContextWindowError() recognizes this
+      // internal case without depending on the message wording above, which
+      // this method (not a third-party provider) owns and may reword freely.
+      attachContextWindowError(error);
+      throw error;
     }
 
     this.logger.debug('Fallback: adjusting max_output_tokens', {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -29,6 +29,10 @@ import {
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
+import {
+  hasContextWindowErrorMarker,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import { pathToLocation } from '@utils/files';
@@ -860,6 +864,56 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.deepEqual(requests[2].input, rebuiltMessages);
     assert.equal(tokenCountCalls, 3);
     assert.equal(requests[2].max_output_tokens, 99990);
+  });
+
+  it('tags the fallback hard-failure throw with the context-window marker', () => {
+    // Mirrors ModelHandler.validateTokenLimits (#8078, followed up in #8100):
+    // isContextWindowError() must recognize this throw via its typed marker,
+    // not by string-matching wording that this method owns and may reword
+    // freely. Without the marker, a future reword of "exceeds context
+    // window" would silently break the
+    // `isContextWindowError(error) && this.chainState.hasPreviousResponseId()`
+    // compaction-recovery check that reads this throw upstream.
+    class FailOnReducedBudgetHandler extends ModelHandlerOpenAIResponse {
+      protected override shouldFailWhenFallbackOutputBudgetIsReduced(): boolean {
+        return true;
+      }
+    }
+    const handler = setupHandler(
+      new FailOnReducedBudgetHandler(
+        createConfig({
+          openRouterOnly: false,
+          maxOutputTokens: 200,
+          contextWindow: 1000,
+        }),
+      ),
+    );
+    (
+      handler as unknown as {
+        chainState: { setCumulativeInputTokens: (tokens: number) => void };
+      }
+    ).chainState.setCumulativeInputTokens(900);
+
+    let caught: unknown;
+    try {
+      (
+        handler as unknown as {
+          applyTokenCountFailureFallback: (maxOutputTokens: number) => number;
+        }
+      ).applyTokenCountFailureFallback(200);
+    } catch (error) {
+      caught = error;
+    }
+
+    assert.ok(caught instanceof Error);
+    assert.match(caught.message, /exceeds context window/);
+    // Load-bearing assertion: the typed marker itself, independent of the
+    // fenced-string fallback that `isContextWindowError` also happens to
+    // match today (this exact message currently contains "exceeds context
+    // window"). The marker is what keeps classification correct if that
+    // wording is ever reworded on the assumption it's Anthropic-only.
+    assert.equal(hasContextWindowErrorMarker(caught), true);
+    assert.equal(isContextWindowError(caught), true);
   });
 });
 


### PR DESCRIPTION
## Context

Follow-up from #8078 (fix(errors): decouple isContextWindowError from internal message wording). That PR tagged `ModelHandler.validateTokenLimits`'s context-window throw with the typed `attachContextWindowError` marker so `isContextWindowError()` no longer depends on message wording it owns, but explicitly left a sibling throw site untouched: `applyTokenCountFailureFallback` in `modelHandlerOpenAIResponse.ts`, which still relies purely on the `'exceeds context window'` substring in `CONTEXT_WINDOW_PATTERNS` (now commented as belonging to Anthropic).

This PR closes that deferred follow-up: tag the throw with the same marker, mirroring the pattern already applied in `ModelHandler.validateTokenLimits`.

## Change

- `src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts`: `applyTokenCountFailureFallback` now calls `attachContextWindowError(error)` before throwing, with the same explanatory comment used at the `ModelHandler.validateTokenLimits` site.
- No new abstraction: reuses the existing `attachContextWindowError` export from `@common/errors/sdkErrorUtils` (already imported elsewhere in this file for `isContextWindowError`).

## Net elements (R6)

- +1 function call (`attachContextWindowError(error)`) and +1 import at the existing throw site; no new types, files, or abstractions.
- Net LOC: +7 production / +54 test (regression coverage), 0 deletions of behavior.

## Consumer counts (R8)

- `attachContextWindowError` now has 2 call sites (`ModelHandler.validateTokenLimits`, `ModelHandlerOpenAIResponse.applyTokenCountFailureFallback`) — both are the throw sites `isContextWindowError`'s marker-based path exists to serve; no new shared helper introduced.

## Tests

Extended `src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts` (R7) with a new case: `tags the fallback hard-failure throw with the context-window marker`. It drives the real `applyTokenCountFailureFallback` throw site (via a capability-overriding subclass + direct chain-state setup) and asserts `hasContextWindowErrorMarker(caught) === true` — the load-bearing assertion, independent of the fenced-string match that happens to also pass today. Verified this assertion fails without the fix (reverted the `attachContextWindowError` call locally, confirmed `AssertionError: false !== true`, then restored the fix) — proven-to-fail per repo convention, no `git stash`/`patch` used.

- `npx vitest run src/test-kernel/agent/modelHandlers/` — 434 passed, 4 skipped (pre-existing skips)
- `npm run typecheck` — clean
- `npx eslint` on touched files — clean

Closes #8100

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-classification change with regression tests; no auth, data, or wire-format changes.
> 
> **Overview**
> Completes the **#8078** follow-up by marking the hard-failure path in **`applyTokenCountFailureFallback`** (OpenAI Responses handler) with **`attachContextWindowError`** before throw, matching **`ModelHandler.validateTokenLimits`**.
> 
> That throw fires when token counting is unavailable, the estimated input + output budget overflows the context window, and the route cannot cap **`max_output_tokens`** locally (e.g. Codex-style profiles). **`isContextWindowError()`** can then classify it via the typed marker instead of relying on the **`exceeds context window`** substring in provider-oriented **`CONTEXT_WINDOW_PATTERNS`**, so upstream logic—especially **`handleCreateResponseError`**’s **`isContextWindowError(error) && hasPreviousResponseId()`** compaction retry—stays correct if the internal message is reworded.
> 
> Adds a kernel test that drives **`applyTokenCountFailureFallback`** through a subclass forcing **`shouldFailWhenFallbackOutputBudgetIsReduced`** and asserts **`hasContextWindowErrorMarker`** and **`isContextWindowError`** on the caught error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b0080093e615cbb0510f1ff4a3a33c7f9ab327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->