### PR TITLE
fix(agent): gate resume-snapshot self-heal kv.write on actual change

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from 'node:util';
+
 // Third-party imports
 import { MODEL_CONFIGS } from 'llm-zoo';
 
@@ -408,15 +410,26 @@ export async function runToolUseFlow<C = unknown>(
         // re-deriving them; `migrateSharedState` preserves pass-through fields
         // the snapshot's narrower contract doesn't carry (systemPrompt,
         // lastError, ...) so they survive this self-heal write.
-        flowRecord.shared = buildResumedSharedFromSnapshot(
+        const resumedShared = buildResumedSharedFromSnapshot(
           migrationResult.data,
           input.resumeSnapshot,
           compatibilityKey,
         );
-        await kv.write(
-          flowKey(executionId),
-          stampFlowRecordSchemaVersion(flowRecord),
-        );
+        // `resumeToolUseFromSnapshot` passes `resumeSnapshot` on every
+        // native-subagent turn, so this self-heal write must skip whenever
+        // the record was already canonical: no legacy shape to migrate, and
+        // the snapshot-derived fields match what is already persisted.
+        // Otherwise this becomes a `StorageFSKVStore` disk write per turn.
+        const writeNeeded =
+          migrationResult.migrated ||
+          !isDeepStrictEqual(migrationResult.data, resumedShared);
+        flowRecord.shared = resumedShared;
+        if (writeNeeded) {
+          await kv.write(
+            flowKey(executionId),
+            stampFlowRecordSchemaVersion(flowRecord),
+          );
+        }
       } else {
         // Defensive fallback only: no resumeSnapshot means the resume
         // boundary above was never consulted for this call (e.g. a fresh

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -704,6 +704,73 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     });
   });
 
+  it('skips the resume self-heal write when the persisted record is already canonical (issue #8018)', async () => {
+    // `resumeToolUseFromSnapshot` passes `resumeSnapshot` on every
+    // native-subagent turn, so the resume-branch self-heal write must not
+    // fire when the persisted record already matches what would be
+    // written -- otherwise every turn costs a `StorageFSKVStore` disk
+    // write for a no-op overwrite of identical bytes.
+    const executionId = 'abc143' as ExecutionId;
+    const streamId = 'chat@gpt54#abc143' as StreamTabId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        messages: [{ role: 'user', content: 'Continue.' }],
+        modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
+        shouldSkipCycle: false,
+        stateSlices: {
+          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+          userChannels: {
+            input: Object.freeze({ MODEL: 'gpt54' }),
+            transient: {},
+          },
+        },
+      },
+      createdAt: new Date().toISOString(),
+      cursor: { nextNodeId: WAIT_NODE_CURSOR },
+      nodes: [
+        { action: 'default', nodeId: 'start' },
+        { action: 'default', nodeId: 'start/default' },
+      ],
+    });
+
+    const resume = await retrieveSessionResumeData(
+      streamId,
+      executionId,
+      agentConfigToTaskState(CONFIG),
+    );
+    expect(resume?.type).toBe('toolUse');
+    if (resume?.type !== 'toolUse') return;
+    expect(resume.snapshot.modelHandlerCompatibilityKey).toBe(
+      ACTIVE_COMPATIBILITY_KEY,
+    );
+
+    const store = getExecutionStore(executionId);
+    const writeSpy = vi.spyOn(store, 'write');
+    try {
+      await runResumedFlowToWaiting(executionId, streamId, resume.snapshot);
+
+      // `PersistedFlow` still legitimately persists its own node-cursor
+      // progress once as the flow steps through to WAITING -- that write is
+      // not under test here. What must NOT happen is a *second*, earlier
+      // write from the resume-branch self-heal repairing an already-
+      // canonical record. Every write the flow does make must already carry
+      // the final WAITING cursor, never the pre-step one the self-heal write
+      // would have produced.
+      expect(writeSpy.mock.calls.length).toBeGreaterThan(0);
+      for (const [, record] of writeSpy.mock.calls) {
+        expect((record as FlowRecord).cursor).toEqual({
+          lastAction: 'waiting',
+          nextNodeId: WAIT_NODE_CURSOR,
+        });
+      }
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
   it('keeps a persisted snapshot compatibility key authoritative over the active handler', async () => {
     const executionId = 'abc142' as ExecutionId;
     const streamId = 'chat@gpt54#abc142' as StreamTabId;


### PR DESCRIPTION
## Context

Closes #8018 (follow-up from #8009, review comments [r3562479725](https://github.com/LionSR/TeXRA/pull/8009#discussion_r3562479725) and [r3562486115](https://github.com/LionSR/TeXRA/pull/8009#discussion_r3562486115)).

In `runToolUseFlow.ts`'s `input.resumeSnapshot` branch, the self-heal `kv.write` was unconditional. `resumeToolUseFromSnapshot` passes `resumeSnapshot` on every native-subagent turn (`executeAgent.ts:541`, driven by `nativeToolUseStrategy.runTurn`), so this reintroduced a `StorageFSKVStore` filesystem write on every tool-use turn — even when the persisted record was already canonical (no migration needed, compatibility key already present) and the write was a no-op overwrite of identical bytes.

## Fix

Gate the write the same way the sibling fallback branch (no `resumeSnapshot`) already gates its own write on `shouldWriteShared`: write only when

- `migrationResult.migrated` (the on-disk shape needed structural repair), or
- the newly-built resumed shared state differs from the already-migrated on-disk form, compared via `isDeepStrictEqual` — the same node:util comparison `migrateSharedState` already uses internally to compute its own `migrated` flag, so this reuses an established in-repo pattern rather than introducing a new one.

When the write is skipped, `flowRecord.shared` is still updated in memory so downstream code in this call sees the healed value; only the disk write is elided. `PersistedFlow.ensureRecord` re-reads from `kv` regardless, so skipping is only safe (and only happens) when the skipped write would have been byte-for-byte the same as what's already on disk.

## Net elements (R6)

Not a refactor/simplify/consolidate/dedupe/extract PR (correctness fix gating an existing write), so R6 accounting doesn't strictly apply, but for reference: `git diff --stat origin/main` → 2 files changed, 85 insertions(+), 5 deletions(-). No new exported symbols, no new types/interfaces/classes. One new `node:util` import (`isDeepStrictEqual`, already used elsewhere in this same module's sibling file `nodes/types.ts`) — not a new dependency.

## Consumer counts (R8)

No emit path deleted or re-routed; N/A.

## Tests

Extended the existing `src/test-kernel/agent/SessionResumeRetrieval.vitest.ts` suite (R7) rather than adding a new test file — one new case: `skips the resume self-heal write when the persisted record is already canonical (issue #8018)`. It seeds an already-canonical persisted flow record, resumes it, and spies on the KV store's `write` to assert every write carries the flow's own final WAITING cursor (i.e. no earlier, separate self-heal write happened). Verified as a real regression test: reverting the production fix (`git stash` on the modified `runToolUseFlow.ts` only) makes this new test fail with the pre-fix self-heal write's cursor showing up before the flow's own step write; restored the fix and re-ran green.

- `npx vitest run src/test-kernel/agent/SessionResumeRetrieval.vitest.ts` — 18 passed
- `npx vitest run src/test-kernel/agent` — 164 files / 1280 tests passed (1 skipped file, 4 skipped tests, pre-existing)
- `npm run typecheck` — clean across all workspace packages
- `npx eslint` on both changed files — clean

Closes #8018

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized persistence gating with in-memory state unchanged; writes still occur when migration or content actually changes.
> 
> **Overview**
> Stops an unnecessary **filesystem write on every native subagent tool-use turn** when resuming from an already-canonical persisted flow record.
> 
> In `runToolUseFlow`, the `input.resumeSnapshot` branch still builds resumed shared state in memory, but **`kv.write` runs only** when migration repaired legacy shapes or when that state **differs** from what was on disk (`isDeepStrictEqual`, same pattern as `migrateSharedState`). A regression test in `SessionResumeRetrieval.vitest.ts` asserts no extra self-heal write before `PersistedFlow`’s normal WAITING cursor updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1409c2f62d4a3f6fcc6514be88139c445486011e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->