### PR TITLE
refactor(workflowScript): use p-timeout instead of hand-rolled Promise.race

### DIFF
--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -1,5 +1,7 @@
 import * as vm from 'node:vm';
 
+import pTimeout from 'p-timeout';
+
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { WorkflowScriptParseError } from './parseScript';
@@ -431,31 +433,22 @@ async function withTimeout(
   promise: Promise<unknown>,
   options: SandboxOptions,
 ): Promise<unknown> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          try {
-            options.onTimeout?.();
-          } catch {
-            // The timeout rejection below must fire even if the abort
-            // callback throws; otherwise the race never settles.
-          }
-          // The script continuation is orphaned past this point; suppress
-          // its eventual settlement so it cannot surface as an unhandled
-          // rejection after the run already reported the timeout.
-          promise.catch(() => {});
-          reject(
-            new Error(
-              `Workflow script ${options.filename} timed out after ${options.timeoutMs}ms`,
-            ),
-          );
-        }, options.timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+  // p-timeout's `fallback` fires in place of the default TimeoutError
+  // rejection and its own promise.then(resolve, reject) attachment already
+  // absorbs the orphaned continuation's eventual settlement, so no separate
+  // promise.catch(() => {}) suppression is needed here.
+  return await pTimeout(promise, {
+    milliseconds: options.timeoutMs,
+    fallback: () => {
+      try {
+        options.onTimeout?.();
+      } catch {
+        // The timeout rejection below must fire even if the abort
+        // callback throws; otherwise the run never settles.
+      }
+      throw new Error(
+        `Workflow script ${options.filename} timed out after ${options.timeoutMs}ms`,
+      );
+    },
+  });
 }


### PR DESCRIPTION
## Issue

Closes #8162

`src/agent/workflowScript/sandbox.ts`'s `withTimeout` hand-rolled a timeout via `Promise.race` + `setTimeout` (~32 LOC), while `p-timeout` is already a root dependency (`^7.0.1`) used elsewhere in the codebase (`src/tools/lean/direct/leanSession.ts`, `src/latex/arxivProcessor.ts`).

## Evaluation (per issue's "consider" wording)

The issue flagged two caveats to check before converting:

1. **`onTimeout` side-effect callback** — p-timeout's `fallback` option is called in place of the default `TimeoutError` rejection. `fallback` can run the `onTimeout` callback (wrapped in the same try/catch so a throwing callback still lets the timeout error surface) and then `throw` the original custom `Error` message — matching the original semantics exactly, message and all.
2. **Orphan-promise rejection suppression (`promise.catch(() => {})`)** — verified against `node_modules/p-timeout/index.js`: p-timeout unconditionally does `promise.then(resolve, reject)` on the wrapped promise *before* the timer fires. That attachment alone is what prevents Node's "unhandled rejection" detector from firing on the orphaned continuation's eventual settlement (a rejection handler is already attached to it), regardless of whether `fallback` already settled the outer promise. So the explicit `promise.catch(() => {})` becomes redundant and was safely dropped.

Net: p-timeout is a genuine drop-in here — no semantics lost, and the manual timer (`let timer`, `try/finally { clearTimeout }`) is now owned internally by p-timeout too.

**Dependency decision**: no new dependency — `p-timeout` is already declared in root `package.json` (`^7.0.1`) and already used in this exact style (`fallback`-based custom rejection) elsewhere in the repo.

## Net elements (R6)

- `src/agent/workflowScript/sandbox.ts`: `withTimeout` rewritten to delegate to `pTimeout(...)`. Net **-7 lines** (20 insertions / 27 deletions): one new import, deleted manual `Promise.race`/timer/orphan-suppression plumbing.
- No new files, no new exports, no new dependency in the manifest.

## Consumer counts (R8)

- `withTimeout` has exactly one call site (`runSandbox` in the same file) — no other consumers to update.
- Existing regression coverage already exercises the exact semantics preserved here: `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts` → `'aborts new agent calls after the wall-clock timeout'` (asserts the `onTimeout` abort fires and the orphaned continuation's second `agent()` call never lands, i.e. it's suppressed without becoming an unhandled rejection). All 43 tests in that file pass unmodified against the new implementation.

## Testing

- `npx vitest run src/test-kernel/agent/WorkflowScriptEngine.vitest.ts` — 43/43 passed
- `npx vitest run src/test-kernel/agent` — 1279 passed / 4 skipped (164 files)
- `npm run typecheck` — clean across all workspaces
- `npx eslint src/agent/workflowScript/sandbox.ts` — clean

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wall-clock limits for workflow script execution in `node:vm`; intended as a drop-in with existing tests, but timeout/orphan-promise behavior is subtle.
> 
> **Overview**
> **`withTimeout` in the workflow script sandbox** no longer uses a manual `Promise.race` + `setTimeout` + `clearTimeout` path. It delegates to the existing **`p-timeout`** dependency with a **`fallback`** that still runs **`onTimeout`** (with the same try/catch) and throws the same custom timeout **`Error`** message.
> 
> The explicit **`promise.catch(() => {})`** on the script continuation is removed; comments note that **`p-timeout`**’s internal promise attachment is enough to avoid unhandled rejections when the wall-clock cap wins.
> 
> Behavior is unchanged at the **`runScriptInSandbox`** boundary—only the timeout implementation is simplified (~7 net lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c591878ffd5ccd347e6c23d8c7bcb3ae26ae333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->