### PR TITLE
fix(exec): delegate array-form abort/force-kill to execa natives

### DIFF
--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -43,6 +43,14 @@ async function waitForProcessExit(pid: number): Promise<void> {
   throw new Error(`Process ${pid} was still running after abort`);
 }
 
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (condition()) return;
+    await sleep(20);
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
 describe('executeCommand', () => {
   const tempDirs: string[] = [];
 
@@ -101,6 +109,34 @@ describe('executeCommand', () => {
     assert.equal(result.timedOut, false);
     assert.equal(result.stderr, 'Command aborted by user');
     await waitForProcessExit(childPid);
+  });
+
+  it('aborts array-form commands via execa native cancelSignal', async () => {
+    if (process.platform === 'win32') return;
+
+    const controller = new AbortController();
+    let childPid: number | undefined;
+    const promise = executeCommand(
+      [process.execPath, '-e', 'setTimeout(() => {}, 60000)'],
+      {
+        signal: controller.signal,
+        timeout: 60_000,
+        onPid: (pid) => {
+          childPid = pid;
+        },
+      },
+    );
+
+    await waitForCondition(() => childPid !== undefined);
+    assert.ok(childPid && childPid > 0);
+
+    controller.abort();
+    const result = await promise;
+
+    assert.equal(result.success, false);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.stderr, 'Command aborted by user');
+    await waitForProcessExit(childPid!);
   });
 });
 

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -119,7 +119,11 @@ describe('executeCommand', () => {
       },
     );
 
-    for (let attempt = 0; attempt < 50 && childPid === undefined; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 50 && childPid === undefined;
+      attempt += 1
+    ) {
       await sleep(20);
     }
     assert.ok(childPid && childPid > 0);

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -43,14 +43,6 @@ async function waitForProcessExit(pid: number): Promise<void> {
   throw new Error(`Process ${pid} was still running after abort`);
 }
 
-async function waitForCondition(condition: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    if (condition()) return;
-    await sleep(20);
-  }
-  throw new Error('Timed out waiting for condition');
-}
-
 describe('executeCommand', () => {
   const tempDirs: string[] = [];
 
@@ -127,7 +119,9 @@ describe('executeCommand', () => {
       },
     );
 
-    await waitForCondition(() => childPid !== undefined);
+    for (let attempt = 0; attempt < 50 && childPid === undefined; attempt += 1) {
+      await sleep(20);
+    }
     assert.ok(childPid && childPid > 0);
 
     controller.abort();
@@ -135,6 +129,7 @@ describe('executeCommand', () => {
 
     assert.equal(result.success, false);
     assert.equal(result.timedOut, false);
+    assert.equal(result.exitCode, 130);
     assert.equal(result.stderr, 'Command aborted by user');
     await waitForProcessExit(childPid!);
   });

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -229,6 +229,11 @@ export async function executeCommand(
     let shellTimedOut = false;
     let shellAborted = false;
 
+    // Only the shell/string form needs this hand-rolled abort + force-kill
+    // machinery: it terminates via `signalProcessGroup` (negative-PID /
+    // tree-kill) so piped children don't outlive the shell. The array form
+    // spawns a single non-detached process, so it delegates straight to
+    // execa's own `cancelSignal` / `forceKillAfterDelay` natives below.
     const terminateSubprocess = (signal: NodeJS.Signals): void => {
       const pid = subprocess.pid;
       if (!pid) return;
@@ -268,7 +273,11 @@ export async function executeCommand(
           `Running command: ${shellQuote([cmd, ...args])}`,
         );
       }
-      subprocess = execa(cmd, args, execaOptions);
+      subprocess = execa(cmd, args, {
+        ...execaOptions,
+        cancelSignal: options.signal,
+        forceKillAfterDelay: FORCE_KILL_DELAY_MS,
+      });
     } else {
       if (!options.quiet) {
         logger.debug(logChannel, `Running command: ${command}`);
@@ -306,7 +315,10 @@ export async function executeCommand(
     }
 
     if (subprocess.pid && options.onPid) options.onPid(subprocess.pid);
-    installAbortListener();
+    // Array-form abort is handled by execa's own `cancelSignal` (passed
+    // above); only the shell/string form needs the process-group-aware
+    // hand-rolled listener.
+    if (!Array.isArray(command)) installAbortListener();
 
     if (shellTimeout) {
       shellTimeoutId = setTimeout(() => {
@@ -331,10 +343,13 @@ export async function executeCommand(
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
-    const exitCode = result.exitCode ?? (shellAborted ? 130 : 1);
+    // `shellAborted` covers the hand-rolled shell-form path; `isCanceled`
+    // covers the array-form path, aborted natively via execa's `cancelSignal`.
+    const aborted = shellAborted || (result.isCanceled ?? false);
+    const exitCode = result.exitCode ?? (aborted ? 130 : 1);
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
     const normalizedStderr =
-      shellAborted && !stderr ? 'Command aborted by user' : stderr;
+      aborted && !stderr ? 'Command aborted by user' : stderr;
 
     if (!options.quiet) {
       logCommandStderr(logChannel, normalizedStderr, options.truncate);


### PR DESCRIPTION
Fixes #8183.

## What

`executeCommand` in `src/utils/system/execUtils.ts` spawns via two shapes:

- **array form** (`execa(cmd, args, ...)`) — a single, non-detached child process.
- **shell/string form** (`execa(command, { shell: true, ... })`) — optionally `detached`, since it can front piped children (`find | head`) that need process-group teardown.

Previously *both* forms went through the same hand-rolled `installAbortListener` (a manual `AbortSignal` → `SIGTERM` listener) and `forceKillTimeoutId` (a manual SIGKILL-after-5s escalation), both driving termination through `signalProcessGroup` (negative-PID on POSIX / `tree-kill` on Windows).

The array form doesn't need any of that — there's no process group to reach, so `signalProcessGroup`'s negative-PID attempt there always failed and silently fell back to a plain `process.kill(pid, signal)`. It already delegated its `timeout` straight to execa's native option; this PR extends that same delegation to abort and force-kill by passing `cancelSignal`/`forceKillAfterDelay` into the array-form `execa()` call, and scopes `installAbortListener()`/`forceKillTimeoutId` to the shell/string form only, where they remain required exactly as documented in the issue ("What must NOT change").

Result interpretation (`exitCode`/`stderr` on abort) now merges the shell path's `shellAborted` flag with execa's own `result.isCanceled`, so `'Command aborted by user'` / exit code `130` are produced identically regardless of which path aborted the process.

## Net elements (R6)

- Deleted: the unconditional `installAbortListener()` call on the array-form path (now conditional on `!Array.isArray(command)`), and this path's implicit dependency on the hand-rolled `terminateSubprocess`/`forceKillTimeoutId` machinery — it now goes through execa's own `cancelSignal`/`forceKillAfterDelay` natives instead.
- Added: `cancelSignal`/`forceKillAfterDelay` passed into the array-form `execa()` call (2 lines); an `aborted` merge (`shellAborted || result.isCanceled`) replacing the old `shellAborted`-only check (1 line); explanatory comments.
- Kept unchanged, per the issue's own "What must NOT change": the shell/string form's hand-rolled `signalProcessGroup`-based abort listener, timeout, and force-kill timer — execa's native mechanisms only ever call `subprocess.kill()` on the single tracked child, not the process group, so they can't safely replace this path (piped children would be orphaned, reproducing the exact bug `signalProcessGroup` exists to avoid).
- Net diff: `src/utils/system/execUtils.ts` +19/-4 lines; no new dependency (execa is already a direct dependency, already imported in this file).

## Consumer counts (R8)

`executeCommand` has ~20 call sites across 15 files:

- **Array-form** (17 call sites, unaffected in practice except where noted): `applyPath.ts`, `githubSubscriptionTool.ts`, `isGitRepository.ts`, `workspaceInfo.ts` (×3), `img.ts` (×2), `worktreeInfo.ts` (×2), `toolUtils.ts`, `latexdiff.ts`, `diffCommandExecutor.ts` (×2), `updateChecker.ts` (CLI), `desktopSetupTerminal.ts`. Only `src/tools/grep.ts`'s `rg` call passes a live `signal` (agent-run cancellation) today — this is the one array-form site whose abort semantics actually changed underlying mechanism (from the degenerate hand-rolled fallback to execa's native `cancelSignal`), verified behavior-identical by the new regression test.
- **Shell/string-form** (3 call sites, byte-for-bit unchanged): `bash.ts` (×2, foreground + background — the primary abort/timeout consumer, covered by the existing `aborts shell command process groups including children` test) and `desktopTerminalRunner.ts` (desktop setup terminal).

## Tests

- Extended `src/test-kernel/utils/system/SystemUtils.vitest.ts` (existing `executeCommand` describe block, R7) with `aborts array-form commands via execa native cancelSignal`, which spawns a long-lived array-form Node subprocess, aborts it mid-flight, and asserts the same `exitCode`/`stderr`/process-teardown contract as the pre-existing shell-form abort test.
- Regression-proven: temporarily reverted just the `cancelSignal`/`forceKillAfterDelay` array-form delegation (keeping the new `!Array.isArray(command)` guard that skips the hand-rolled listener) — the new test then hung and failed with `Test timed out in 10000ms`, confirming it catches an incomplete delegation. Restored before committing.
- `npx vitest run src/test-kernel/utils/system/SystemUtils.vitest.ts` — 15/15 passed.
- `npx vitest run src/test-kernel/tools/BashTool.vitest.ts src/test-kernel/tools/BashToolErrorFeedback.vitest.ts src/test-kernel/tools/Wolfram.vitest.ts` — 16/16 passed (shell-form + array-form consumer suites).
- `npm run typecheck` — clean across the whole workspace.

Closes #8183

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared command execution and cancellation used by many tools; shell-form behavior is unchanged but array-form abort now relies on execa natives.
> 
> **Overview**
> **Array-form** `executeCommand` now passes `cancelSignal` and `forceKillAfterDelay` into execa instead of using the hand-rolled `AbortSignal` listener and process-group kill path. **Shell/string** commands still use `installAbortListener` and `signalProcessGroup` so piped children are not orphaned.
> 
> Aborted runs are normalized the same way for both shapes: `shellAborted` is combined with execa's `result.isCanceled` so callers still get exit code **130** and `'Command aborted by user'` when stderr is empty.
> 
> A regression test asserts array-form abort via execa's native cancel path (non-Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabb9a702de7399860597d2ecfe87d1d9e0f0fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->