### PR TITLE
fix(cli): throttle the CLI update check to once per day

### DIFF
--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'node:child_process';
+import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
+import { JsonStore } from '@platform/defaults/jsonStore';
+import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import { executeCommand } from '@utils/system/execUtils';
 
 import {
@@ -16,6 +20,7 @@ import {
 import { CliExitCode } from './exitCodes';
 import { askCliQuestion, writeTextStderr } from './logSinks';
 import { createCliStyle, type CliStyle } from './style';
+import type { StateStore } from '@platform/interfaces';
 
 /** Published package name on npm; the `texra` bin lives here. */
 const CLI_PACKAGE_NAME = '@texra-ai/cli';
@@ -30,6 +35,11 @@ const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
 const HOMEBREW_COMMAND_TIMEOUT_MS = 10000;
 const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
+/**
+ * Check for a new release at most once per day, matching the desktop update
+ * checker's cadence (see `desktopUpdateChecker.ts`'s `CHECK_INTERVAL_MS`).
+ */
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Package manager the running binary was installed with. */
 export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
@@ -269,14 +279,53 @@ function announceUpdateInstalled(latest: string, style: CliStyle): never {
   process.exit(CliExitCode.Success);
 }
 
+export interface CheckCliUpdateAvailableOptions {
+  currentVersion: string;
+  globalState: StateStore;
+  /** Fetch the latest published version, or undefined on any failure. */
+  fetchLatest: () => Promise<string | undefined>;
+  now?: () => number;
+}
+
+/**
+ * At most once per day (persisted in global state), fetch the latest
+ * published version and report it when newer than `currentVersion`. Mirrors
+ * the desktop update checker's throttle (see `checkForDesktopUpdate` in
+ * `desktopUpdateChecker.ts`): the daily stamp is only persisted after a
+ * successful fetch, so a failed check (offline, registry hiccup) retries on
+ * the next launch instead of being suppressed for a full day.
+ */
+export async function checkCliUpdateAvailable({
+  currentVersion,
+  globalState,
+  fetchLatest,
+  now = Date.now,
+}: CheckCliUpdateAvailableOptions): Promise<string | undefined> {
+  const lastCheckedAt = globalState.get<number>(
+    GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+    0,
+  );
+  const nowMs = now();
+  if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return undefined;
+
+  const latest = await fetchLatest();
+  if (!latest) return undefined;
+  await globalState.update(
+    GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+    nowMs,
+  );
+  return isNewerVersion(latest, currentVersion) ? latest : undefined;
+}
+
 let notified = false;
 
 /**
- * Once per process: check the package source for a newer release and, in an
- * interactive terminal, offer to run the matching global install. npm-like
- * installs read the npm registry; Homebrew installs refresh local tap metadata
- * before reading the formula version. Failures are silent so a flaky network
- * never gets between the user and their session.
+ * Once per process: check the package source for a newer release (at most
+ * once per day — see {@link checkCliUpdateAvailable}) and, in an interactive
+ * terminal, offer to run the matching global install. npm-like installs read
+ * the npm registry; Homebrew installs refresh local tap metadata before
+ * reading the formula version. Failures are silent so a flaky network never
+ * gets between the user and their session.
  *
  * Disable entirely with `TEXRA_NO_UPDATE_CHECK=1`.
  */
@@ -299,11 +348,21 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   if (!isPackageManagerInstall()) return;
 
   const method = detectInstallMethod();
-  const latest =
-    method === 'brew'
-      ? await fetchLatestHomebrewFormulaVersion()
-      : await fetchLatestCliVersion();
-  if (!latest || !isNewerVersion(latest, context.version)) return;
+  // Runs before `initInteractiveCliPlatform`, so `platform()` isn't up yet —
+  // open the same global `state.json` that `createCliStateStores` opens later
+  // directly (see `cliStateStores.ts`).
+  const globalState = await JsonStore.open(
+    path.join(createNodeStorageProvider().getGlobalStoragePath(), 'state.json'),
+  );
+  const latest = await checkCliUpdateAvailable({
+    currentVersion: context.version,
+    globalState,
+    fetchLatest: () =>
+      method === 'brew'
+        ? fetchLatestHomebrewFormulaVersion()
+        : fetchLatestCliVersion(),
+  });
+  if (!latest) return;
 
   const updateCmd = formatUpdateCommand(method);
   const style = createCliStyle(context.colorEnabled);

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -143,6 +143,9 @@ export enum GlobalStateKey {
   DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT = 'texra.desktop.updateCheck.lastCheckedAt',
   DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION = 'texra.desktop.updateCheck.lastNotifiedVersion',
 
+  // CLI-only lightweight update check throttle (see packages/cli's updateChecker.ts)
+  CLI_UPDATE_CHECK_LAST_CHECKED_AT = 'texra.cli.updateCheck.lastCheckedAt',
+
   // Experimental
   INLINE_CRITICISM_ENABLED = 'texra.inlineCriticism.enabled',
 

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildUpdateCommand,
+  checkCliUpdateAvailable,
   detectInstallMethod,
   fetchLatestCliVersion,
   fetchLatestHomebrewFormulaVersion,
@@ -9,6 +10,23 @@ import {
   isNewerVersion,
   isPackageManagerInstall,
 } from '@cli/runtime/updateChecker';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+class MemoryStateStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
 
 describe('isNewerVersion', () => {
   it('compares numerically across all components', () => {
@@ -273,5 +291,110 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
         timeoutMs: 123,
       },
     ]);
+  });
+});
+
+describe('checkCliUpdateAvailable', () => {
+  const currentVersion = '0.39.3';
+  const latestVersion = '0.40.0';
+
+  it('checks on a first launch (no prior lastCheckedAt) and reports a newer version', async () => {
+    const globalState = new MemoryStateStore();
+    let fetchCalls = 0;
+
+    const latest = await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      fetchLatest: async () => {
+        fetchCalls += 1;
+        return latestVersion;
+      },
+    });
+
+    expect(fetchCalls).toBe(1);
+    expect(latest).toBe(latestVersion);
+  });
+
+  it('returns undefined when the fetched version is not newer', async () => {
+    const globalState = new MemoryStateStore();
+
+    const latest = await checkCliUpdateAvailable({
+      currentVersion: latestVersion,
+      globalState,
+      fetchLatest: async () => latestVersion,
+    });
+
+    expect(latest).toBeUndefined();
+  });
+
+  it('throttles repeated checks within the same day', async () => {
+    const globalState = new MemoryStateStore();
+    let fetchCalls = 0;
+    // A realistic epoch timestamp: on the very first check ever,
+    // `lastCheckedAt` defaults to 0, and this must be far enough past that
+    // default to *not* be throttled (matching a real first launch).
+    let nowMs = Date.UTC(2026, 0, 1);
+
+    const run = () =>
+      checkCliUpdateAvailable({
+        currentVersion,
+        globalState,
+        now: () => nowMs,
+        fetchLatest: async () => {
+          fetchCalls += 1;
+          return latestVersion;
+        },
+      });
+
+    await run();
+    expect(fetchCalls).toBe(1);
+
+    // Same process/day, ten minutes later: still throttled — no network hit.
+    nowMs += 10 * 60 * 1000;
+    await run();
+    expect(fetchCalls).toBe(1);
+
+    // A full day later: throttle window has elapsed.
+    nowMs += 24 * 60 * 60 * 1000;
+    await run();
+    expect(fetchCalls).toBe(2);
+  });
+
+  it('does not persist the throttle stamp on a failed fetch, so the next launch retries', async () => {
+    const globalState = new MemoryStateStore();
+    let fetchCalls = 0;
+    const nowMs = Date.UTC(2026, 0, 1);
+
+    await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      now: () => nowMs,
+      fetchLatest: async () => {
+        fetchCalls += 1;
+        return undefined; // simulates a network/registry failure
+      },
+    });
+
+    expect(fetchCalls).toBe(1);
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBeUndefined();
+
+    // Immediately "relaunching" (same day) must retry rather than being
+    // throttled for a full 24h off the back of the earlier failure.
+    await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      now: () => nowMs + 1000,
+      fetchLatest: async () => {
+        fetchCalls += 1;
+        return latestVersion;
+      },
+    });
+
+    expect(fetchCalls).toBe(2);
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBe(nowMs + 1000);
   });
 });


### PR DESCRIPTION
## What

`packages/cli/src/runtime/updateChecker.ts`'s `notifyCliUpdate` hit the npm
registry (or refreshed the Homebrew tap + ran `brew info`) on every
interactive `texra chat`/`texra orchestrate` launch, with no caching — every
launch paid a network round-trip, or the full 2.5s timeout when offline.

The desktop update checker already solved this (#7964,
`checkForDesktopUpdate` in `desktopUpdateChecker.ts`): a daily throttle
persisted in global state, where the stamp is only written after a
*successful* fetch so a flaky/offline check retries on the very next launch
instead of being suppressed for a full day.

## Fix

Add `checkCliUpdateAvailable`, a small orchestration function that mirrors
`checkForDesktopUpdate`'s throttle/persist-on-success shape (same 24h
interval, same "only persist the timestamp after a successful fetch" rule),
gated on a new `GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT` key.

`notifyCliUpdate` runs before `initInteractiveCliPlatform` (so `platform()`
isn't available yet), so it opens the same global `state.json` that
`createCliStateStores` opens later, directly via `JsonStore.open` +
`createNodeStorageProvider().getGlobalStoragePath()` — same file, same shape,
no new storage layer.

Deliberately NOT ported: the desktop's concurrent-check coalescing (Electron
can re-invoke the checker on window recreation; the CLI only ever calls
`notifyCliUpdate` once per process, already guarded by the existing
`notified` flag) and the "don't re-notify the same version" dedup (the CLI's
prompt is already interactive/opt-in each time it fires, unlike the desktop's
passive native dialog — the issue's problem is the *network hit*, not
prompt-nagging).

## Net elements (R6)

- **Added**: 1 exported function (`checkCliUpdateAvailable`) + its options
  interface, 1 new `GlobalStateKey` enum member, 1 new `const
  CHECK_INTERVAL_MS`.
- **Removed**: the inline unconditional `fetchLatestHomebrewFormulaVersion()`
  / `fetchLatestCliVersion()` call in `notifyCliUpdate` is now routed through
  the throttled helper — no separate cleanup needed, it's a straight swap at
  the same call site.
- **No new dependency**: reuses the existing `JsonStore` /
  `createNodeStorageProvider` platform primitives already used by
  `cliStateStores.ts` for the same global `state.json` file.

## Consumer counts (R8)

- `checkCliUpdateAvailable` — 1 production caller (`notifyCliUpdate`) + a
  dedicated `describe` block in the existing
  `src/test-kernel/cli/UpdateChecker.vitest.mts` suite (4 new tests:
  first-launch check, not-newer no-op, same-day throttle, failed-fetch stamp
  is not persisted).
- `GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT` — 1 write site, 1 read
  site (both inside `checkCliUpdateAvailable`), asserted directly in the new
  tests (mirrors how the desktop suite asserts
  `DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT`).

## Testing

- `npx vitest run --config vitest.config.mjs src/test-kernel/cli` — 130 test
  files / 1677 tests pass, including the 4 new regression tests (which fail
  against the pre-fix code: before this change there is no throttle at all,
  so a test asserting "second call within the same day makes no additional
  fetch" fails).
- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts` — unaffected, still 12 tests passing (confirms the desktop checker's own shape/tests are untouched).
- `npm run typecheck` — clean across all workspace packages.
- `npx eslint` / `npx prettier --check` on the touched files — clean.

Closes #8168

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort startup path only; storage or network errors stay silent and do not change auth or session behavior.
> 
> **Overview**
> **Stops the CLI from hitting npm or Homebrew on every interactive launch** by throttling version lookups to at most once per 24 hours, aligned with the desktop update checker.
> 
> `notifyCliUpdate` no longer calls `fetchLatestCliVersion` / `fetchLatestHomebrewFormulaVersion` unconditionally. It opens global `state.json` early (before platform init) and routes through new **`checkCliUpdateAvailable`**, which reads/writes `GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT`. The last-check timestamp is **only saved after a successful fetch**, so offline or registry failures retry on the next launch instead of waiting a full day.
> 
> Four unit tests cover first launch, not-newer, same-day throttle, and failed-fetch without persisting the stamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465d2f32b0167d584a62fc9ef4d5f9171af0d5e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->