### PR TITLE
fix(cli): preserve read-only init targets

### DIFF
--- a/packages/cli/src/runtime/initConfig.ts
+++ b/packages/cli/src/runtime/initConfig.ts
@@ -4,7 +4,8 @@
 // (init/runInitWizard) and the command (commands/init) build on these; keeping
 // the logic here makes it unit-testable without a TTY.
 
-import { access, mkdir, readFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdir, open, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import writeFileAtomic from 'write-file-atomic';
@@ -56,12 +57,25 @@ export async function configFileExists(filePath: string): Promise<boolean> {
   }
 }
 
+async function writeInitFileAtomic(
+  filePath: string,
+  data: string,
+): Promise<void> {
+  try {
+    const target = await open(filePath, fsConstants.O_WRONLY);
+    await target.close();
+  } catch (error: unknown) {
+    if (!isFileNotFoundError(error)) throw error;
+  }
+  await writeFileAtomic(filePath, data);
+}
+
 export async function writeInitConfig(
   filePath: string,
   config: InitConfigShape,
 ): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFileAtomic(filePath, serializeInitConfig(config));
+  await writeInitFileAtomic(filePath, serializeInitConfig(config));
 }
 
 /**
@@ -100,6 +114,6 @@ export async function ensureTexraGitignored(
   }
   const next = gitignoreWithTexra(existing);
   if (next === null) return 'present';
-  await writeFileAtomic(gitignorePath, next);
+  await writeInitFileAtomic(gitignorePath, next);
   return existed ? 'added' : 'created';
 }

--- a/src/test-kernel/cli/InitConfig.vitest.mts
+++ b/src/test-kernel/cli/InitConfig.vitest.mts
@@ -1,4 +1,9 @@
-import { mkdtemp, readFile as nodeReadFile, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdtemp,
+  readFile as nodeReadFile,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path, { join } from 'node:path';
 
@@ -10,6 +15,7 @@ import {
   ensureTexraGitignored,
   gitignoreWithTexra,
   serializeInitConfig,
+  writeInitConfig,
   type InitAnswers,
 } from '@cli/runtime/initConfig';
 
@@ -60,44 +66,85 @@ describe('workspaceTexraConfigPath', () => {
 });
 
 describe('gitignoreWithTexra', () => {
-  it('appends .texra/ to a non-empty file', () => {
-    expect(gitignoreWithTexra('node_modules\ndist\n')).toBe(
+  it.each([
+    [
+      'appends to content',
+      'node_modules\ndist\n',
       'node_modules\ndist\n.texra/\n',
-    );
-  });
-
-  it('creates content from an empty file', () => {
-    expect(gitignoreWithTexra('')).toBe('.texra/\n');
-  });
-
-  it('returns null when .texra/ is already ignored', () => {
-    expect(gitignoreWithTexra('node_modules\n.texra/\n')).toBeNull();
-  });
-
-  it('treats a bare .texra entry as already ignored', () => {
-    expect(gitignoreWithTexra('.texra\n')).toBeNull();
+    ],
+    ['creates content', '', '.texra/\n'],
+    ['recognizes .texra/', 'node_modules\n.texra/\n', null],
+    ['recognizes bare .texra', '.texra\n', null],
+  ])('%s', (_case, existing, expected) => {
+    expect(gitignoreWithTexra(existing)).toBe(expected);
   });
 });
 
 describe('ensureTexraGitignored', () => {
-  it('creates .gitignore when absent', async () => {
+  it.each([
+    ['creates an absent file', undefined, 'created', '.texra/\n'],
+    [
+      'appends to existing content',
+      'node_modules\n',
+      'added',
+      'node_modules\n.texra/\n',
+    ],
+  ] as const)('%s', async (_case, existing, outcome, expected) => {
     const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
+    const gitignorePath = join(workspace, '.gitignore');
+    if (existing !== undefined)
+      await writeFile(gitignorePath, existing, 'utf8');
 
-    await expect(ensureTexraGitignored(workspace)).resolves.toBe('created');
-    await expect(
-      nodeReadFile(join(workspace, '.gitignore'), 'utf8'),
-    ).resolves.toBe('.texra/\n');
+    await expect(ensureTexraGitignored(workspace)).resolves.toBe(outcome);
+    await expect(nodeReadFile(gitignorePath, 'utf8')).resolves.toBe(expected);
   });
 
-  it('appends to an existing .gitignore that does not yet ignore .texra', async () => {
-    const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
-    await writeFile(join(workspace, '.gitignore'), 'node_modules\n', 'utf8');
+  const skipPermissionTest =
+    process.platform === 'win32' ||
+    (typeof process.getuid === 'function' && process.getuid() === 0);
+  (skipPermissionTest ? it.skip : it)(
+    'does not atomically replace a read-only .gitignore',
+    async () => {
+      const workspace = await mkdtemp(join(tmpdir(), 'texra-gitignore-'));
+      const gitignorePath = join(workspace, '.gitignore');
+      await writeFile(gitignorePath, 'node_modules\n', 'utf8');
+      await chmod(gitignorePath, 0o444);
 
-    await expect(ensureTexraGitignored(workspace)).resolves.toBe('added');
-    await expect(
-      nodeReadFile(join(workspace, '.gitignore'), 'utf8'),
-    ).resolves.toBe('node_modules\n.texra/\n');
-  });
+      try {
+        await expect(ensureTexraGitignored(workspace)).rejects.toThrow(
+          /(EACCES|permission)/i,
+        );
+        await expect(nodeReadFile(gitignorePath, 'utf8')).resolves.toBe(
+          'node_modules\n',
+        );
+      } finally {
+        await chmod(gitignorePath, 0o644);
+      }
+    },
+  );
+
+  (skipPermissionTest ? it.skip : it)(
+    'still atomically replaces a write-only config',
+    async () => {
+      const workspace = await mkdtemp(join(tmpdir(), 'texra-config-'));
+      const configPath = workspaceTexraConfigPath(workspace);
+      await writeInitConfig(configPath, buildInitConfig(ANSWERS));
+      await chmod(configPath, 0o200);
+
+      try {
+        const updated = buildInitConfig({ ...ANSWERS, model: 'gemini35f' });
+        await expect(
+          writeInitConfig(configPath, updated),
+        ).resolves.toBeUndefined();
+        await chmod(configPath, 0o600);
+        await expect(nodeReadFile(configPath, 'utf8')).resolves.toContain(
+          '"model": "gemini35f"',
+        );
+      } finally {
+        await chmod(configPath, 0o600);
+      }
+    },
+  );
 
   it('does not overwrite .gitignore on a non-ENOENT read failure', async () => {
     // Reproduces #7470: a transient EACCES (or any non-missing-file error)


### PR DESCRIPTION
## Summary

Preserve `texra init`'s established POSIX permission semantics while retaining atomic replacement. Existing targets are probed with `O_WRONLY` before `write-file-atomic`; missing files continue directly to the atomic writer.

The focused init suite is also consolidated into table-driven cases so the two new permission regressions do not multiply setup boilerplate.

Closes #8186.

## Issue acceptance gates

- Existing non-writable `.gitignore` and `.texra/config.json` targets fail before replacement and retain their contents.
- Missing and writable targets still use `write-file-atomic`.
- Focused POSIX coverage verifies read-only rejection and write-only replacement in the existing init suite.

## Single source of truth

`writeInitFileAtomic` in `packages/cli/src/runtime/initConfig.ts` owns the permission-preserving atomic-write policy for both config and `.gitignore` writes.

## Duplication and abstraction budget

One internal helper replaces two raw atomic-write call sites and owns a concrete invariant: atomic replacement must not bypass an existing target's write permission. Existing `.gitignore` examples are table-driven instead of adding parallel setup paths.

## Net elements (R6)

- Files: 2 modified
- LoC: +94 / -33, net +61
- Exports: 0 added / 0 removed
- Classes/interfaces/enums: 0 added / 0 removed
- Internal functions: 1 added

## Consumer counts (R8)

n/a — no exports or event paths are deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: `texra init` now rejects existing read-only targets instead of replacing them through a writable parent directory.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/cli/InitConfig.vitest.mts` (12 passed)
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `corepack pnpm --filter @texra-ai/cli run check:architecture`
- `corepack pnpm exec eslint packages/cli/src/runtime/initConfig.ts src/test-kernel/cli/InitConfig.vitest.mts`
- `corepack pnpm exec prettier --check packages/cli/src/runtime/initConfig.ts src/test-kernel/cli/InitConfig.vitest.mts`
- Full `npm test`, `npm run lint`, `npm run compile:fast`, and `npm run check:dead-code-ratchet` passed before rebasing the unchanged patch onto current `main`.
- Real CLI reproduction exits with `EACCES` and leaves the read-only file unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI init I/O behavior with clearer failure modes; no auth, security, or API surface changes.
> 
> **Overview**
> **`texra init`** no longer replaces existing **read-only** `.gitignore` or `.texra/config.json` via a writable parent directory. A shared **`writeInitFileAtomic`** helper opens existing paths with **`O_WRONLY`** first so **`EACCES`** fails before **`write-file-atomic`**; missing files still go straight to the atomic writer.
> 
> Init tests are refactored to **table-driven** cases for `.gitignore` behavior, plus POSIX-only checks that read-only `.gitignore` is rejected with unchanged content and write-only config can still be updated atomically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842ac8402d142ed222e6e3c6275d759111421fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->