### PR TITLE
refactor(cli): route CliSecrets through the shared JsonStore

### DIFF
--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -1,15 +1,9 @@
 // Standard library imports
-import { chmod, mkdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-// Third-party imports
-import writeFileAtomic from 'write-file-atomic';
-
 // Local imports - platform
+import { JsonStore } from '@platform/defaults/jsonStore';
 import { DEFAULT_NODE_STORAGE_ROOT } from '@platform/defaults/nodeStorage';
-
-// Local imports - common
-import { isFileNotFoundError } from '@common/errors';
 
 // Local imports - CLI runtime
 import { cliEnvValue } from './cliContext';
@@ -17,27 +11,25 @@ import { cliEnvValue } from './cliContext';
 // Type imports - platform
 import type { PlatformSecrets } from '@platform/secrets';
 
-type SecretFileData = Record<string, string>;
-
-function isSecretFileData(value: unknown): value is SecretFileData {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.values(value).every((entry) => typeof entry === 'string')
-  );
-}
+/** Secrets file is owner-only: `0o600` (containing dir gets `0o700`). */
+const SECRETS_FILE_MODE = 0o600;
 
 /**
  * CLI secret storage.
  *
  * Environment variables remain the highest-priority source so automation can
  * keep using ephemeral keys. Values written by CLI login are persisted under
- * the user's TeXRA state directory.
+ * the user's TeXRA state directory through the shared `JsonStore` (the same
+ * owner `ElectronSecrets` wraps for the desktop host), with `strict: true`
+ * so a corrupt secrets file aborts a write instead of silently wiping every
+ * other stored credential (see `JsonStoreOptions.strict`).
+ *
+ * Each operation opens its own `JsonStore` rather than caching one for the
+ * lifetime of this instance: separate `texra` invocations are separate
+ * processes, and a fresh open re-reads the file so a concurrently running
+ * CLI invocation's write isn't clobbered by a stale in-memory snapshot.
  */
 export class CliSecrets implements PlatformSecrets {
-  private mutationQueue: Promise<void> = Promise.resolve();
-
   constructor(private readonly filePath = cliSecretsPath()) {}
 
   async get(key: string): Promise<string | undefined> {
@@ -45,69 +37,33 @@ export class CliSecrets implements PlatformSecrets {
   }
 
   async getStored(key: string): Promise<string | undefined> {
-    return (await this.readSecrets())[key];
+    const store = await this.openStore();
+    return store.get<string | undefined>(key, undefined);
   }
 
   async set(key: string, value: string): Promise<void> {
-    await this.updateSecrets((data) => {
-      data[key] = value;
-    });
+    const store = await this.openStore();
+    await store.set(key, value);
   }
 
   async delete(key: string): Promise<void> {
-    await this.updateSecrets((data) => {
-      delete data[key];
-    });
+    const store = await this.openStore();
+    await store.set(key, undefined);
   }
 
   async listStoredKeys(): Promise<readonly string[]> {
-    return Object.keys(await this.readSecrets());
+    const store = await this.openStore();
+    return Object.keys(store.snapshot());
   }
 
   getEnv(name: string): string | undefined {
     return cliEnvValue(name);
   }
 
-  private async updateSecrets(
-    mutator: (data: SecretFileData) => void,
-  ): Promise<void> {
-    const mutation = this.mutationQueue.then(async () => {
-      const data = await this.readSecrets();
-      mutator(data);
-      await this.writeSecrets(data);
-    });
-    this.mutationQueue = mutation.catch(() => {});
-    await mutation;
-  }
-
-  /**
-   * Reads the secrets file. A missing file is the expected first-run state
-   * and defaults to `{}`. Any other read failure (permissions, corrupt
-   * JSON, etc.) is rethrown rather than swallowed: `updateSecrets()` does a
-   * read-mutate-write, so silently defaulting to `{}` here would make a
-   * transient read failure permanently wipe every other stored secret on
-   * the next write.
-   */
-  private async readSecrets(): Promise<SecretFileData> {
-    let raw: string;
-    try {
-      raw = await readFile(this.filePath, 'utf8');
-    } catch (error) {
-      if (isFileNotFoundError(error)) return {};
-      throw error;
-    }
-    const data = JSON.parse(raw) as unknown;
-    return isSecretFileData(data) ? data : {};
-  }
-
-  private async writeSecrets(data: SecretFileData): Promise<void> {
-    const secretsDir = path.dirname(this.filePath);
-    await mkdir(secretsDir, { recursive: true, mode: 0o700 });
-    await chmod(secretsDir, 0o700);
-    // write-file-atomic stages to a sibling temp, fsyncs, and renames over
-    // the target, so a crash mid-write can't leave a truncated secrets file.
-    await writeFileAtomic(this.filePath, `${JSON.stringify(data, null, 2)}\n`, {
-      mode: 0o600,
+  private openStore(): Promise<JsonStore> {
+    return JsonStore.open(this.filePath, {
+      mode: SECRETS_FILE_MODE,
+      strict: true,
     });
   }
 }

--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -28,8 +28,17 @@ const SECRETS_FILE_MODE = 0o600;
  * lifetime of this instance: separate `texra` invocations are separate
  * processes, and a fresh open re-reads the file so a concurrently running
  * CLI invocation's write isn't clobbered by a stale in-memory snapshot.
+ *
+ * `set()`/`delete()` are additionally serialized through {@link mutationQueue}
+ * so overlapping mutations *within this process* don't each open a store off
+ * the same on-disk snapshot and flush independently — the later flush would
+ * otherwise silently drop the key the earlier one just wrote. Reads
+ * (`get`/`getStored`/`listStoredKeys`) stay outside the queue and always open
+ * a fresh store, matching prior `readSecrets()` behavior.
  */
 export class CliSecrets implements PlatformSecrets {
+  private mutationQueue: Promise<void> = Promise.resolve();
+
   constructor(private readonly filePath = cliSecretsPath()) {}
 
   async get(key: string): Promise<string | undefined> {
@@ -38,17 +47,16 @@ export class CliSecrets implements PlatformSecrets {
 
   async getStored(key: string): Promise<string | undefined> {
     const store = await this.openStore();
-    return store.get<string | undefined>(key, undefined);
+    const value = store.get<unknown>(key, undefined);
+    return typeof value === 'string' ? value : undefined;
   }
 
   async set(key: string, value: string): Promise<void> {
-    const store = await this.openStore();
-    await store.set(key, value);
+    await this.mutate((store) => store.set(key, value));
   }
 
   async delete(key: string): Promise<void> {
-    const store = await this.openStore();
-    await store.set(key, undefined);
+    await this.mutate((store) => store.set(key, undefined));
   }
 
   async listStoredKeys(): Promise<readonly string[]> {
@@ -58,6 +66,22 @@ export class CliSecrets implements PlatformSecrets {
 
   getEnv(name: string): string | undefined {
     return cliEnvValue(name);
+  }
+
+  /**
+   * Runs `op` against a freshly opened store, chained after any mutation
+   * already queued on this instance so overlapping `set()`/`delete()` calls
+   * serialize instead of racing. The chain link is established synchronously
+   * (before the first `await`), so ordering is captured at call time, not at
+   * whatever point `openStore()`'s `mkdir`/read happens to settle.
+   */
+  private mutate(op: (store: JsonStore) => Promise<void>): Promise<void> {
+    const mutation = this.mutationQueue.then(async () => {
+      const store = await this.openStore();
+      await op(store);
+    });
+    this.mutationQueue = mutation.catch(() => {});
+    return mutation;
   }
 
   private openStore(): Promise<JsonStore> {

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import writeFileAtomic from 'write-file-atomic';
@@ -12,7 +12,36 @@ const CHANNEL = 'JsonStore';
 
 type JsonRecord = Record<string, unknown>;
 
-async function readJsonRecord(filePath: string): Promise<JsonRecord> {
+export interface JsonStoreOptions {
+  /**
+   * POSIX mode for the store file (e.g. `0o600` to restrict a secrets file
+   * to its owner). The containing directory is created/chmod'd with the
+   * same owner permissions plus execute — `0o600` -> `0o700` — so it stays
+   * traversable. Left unset, `mkdir`/`writeFileAtomic` use their platform
+   * defaults, matching prior `JsonStore` behavior.
+   */
+  mode?: number;
+  /**
+   * When true, malformed JSON is a hard failure (rethrown) instead of being
+   * silently treated as an empty store. Callers that overwrite the whole
+   * file on every write (read-mutate-write, e.g. `CliSecrets`) need this:
+   * defaulting a transient parse failure to `{}` would permanently wipe
+   * every other stored value on the very next write. Defaults to false,
+   * preserving the self-healing behavior existing state/config stores rely
+   * on.
+   */
+  strict?: boolean;
+}
+
+/** `0o600` -> `0o700`: adds owner-execute wherever owner-read is set. */
+function dirModeFor(fileMode: number): number {
+  return fileMode | ((fileMode & 0o444) >> 2);
+}
+
+async function readJsonRecord(
+  filePath: string,
+  strict: boolean,
+): Promise<JsonRecord> {
   try {
     const content = await readFile(filePath, 'utf8');
     const parsed: unknown = JSON.parse(content);
@@ -21,7 +50,7 @@ async function readJsonRecord(filePath: string): Promise<JsonRecord> {
       : {};
   } catch (error) {
     if (isFileNotFoundError(error)) return {};
-    if (error instanceof SyntaxError) {
+    if (error instanceof SyntaxError && !strict) {
       logger.warn(
         CHANNEL,
         `Discarding unreadable ${filePath}; treating as empty.`,
@@ -51,11 +80,19 @@ export class JsonStore implements StateStore {
   private constructor(
     private readonly filePath: string,
     private data: JsonRecord,
+    private readonly options: JsonStoreOptions,
   ) {}
 
-  static async open(filePath: string): Promise<JsonStore> {
-    await mkdir(dirname(filePath), { recursive: true });
-    return new JsonStore(filePath, await readJsonRecord(filePath));
+  static async open(
+    filePath: string,
+    options: JsonStoreOptions = {},
+  ): Promise<JsonStore> {
+    await ensureDir(dirname(filePath), options.mode);
+    return new JsonStore(
+      filePath,
+      await readJsonRecord(filePath, options.strict ?? false),
+      options,
+    );
   }
 
   get<T>(key: string, defaultValue?: T): T {
@@ -98,10 +135,26 @@ export class JsonStore implements StateStore {
   }
 
   private async flush(snapshot: JsonRecord): Promise<void> {
-    await mkdir(dirname(this.filePath), { recursive: true });
+    await ensureDir(dirname(this.filePath), this.options.mode);
     await writeFileAtomic(
       this.filePath,
       `${JSON.stringify(snapshot, null, 2)}\n`,
+      this.options.mode === undefined ? undefined : { mode: this.options.mode },
     );
   }
+}
+
+/**
+ * Creates `dir` if missing. When `fileMode` is set, also chmods the
+ * directory to {@link dirModeFor} — `mkdir`'s own `mode` only applies at
+ * creation time, so a pre-existing directory with looser permissions needs
+ * the explicit follow-up chmod too.
+ */
+async function ensureDir(
+  dir: string,
+  fileMode: number | undefined,
+): Promise<void> {
+  const dirMode = fileMode === undefined ? undefined : dirModeFor(fileMode);
+  await mkdir(dir, { recursive: true, mode: dirMode });
+  if (dirMode !== undefined) await chmod(dir, dirMode);
 }

--- a/src/test-kernel/cli/CliSecrets.vitest.mts
+++ b/src/test-kernel/cli/CliSecrets.vitest.mts
@@ -60,6 +60,25 @@ describe('CLI secrets', () => {
     }
   });
 
+  it('restricts the secrets file and its directory to the owner', async () => {
+    if (process.platform === 'win32') return; // POSIX modes don't apply.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const secretsPath = cliSecretsPath(storageRoot);
+
+    try {
+      const secrets = new CliSecrets(secretsPath);
+      await secrets.set('TEXRA_CLI_SECRETS_TEST_KEY', 'test-key');
+
+      const fileStat = await fs.stat(secretsPath);
+      const dirStat = await fs.stat(path.dirname(secretsPath));
+      expect(fileStat.mode & 0o777).toBe(0o600);
+      expect(dirStat.mode & 0o777).toBe(0o700);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps one process-wide secrets store after the first root is selected', async () => {
     vi.resetModules();
     const { getCliSecrets } = await import('@cli/runtime/cliSecrets');

--- a/src/test-kernel/cli/CliSecrets.vitest.mts
+++ b/src/test-kernel/cli/CliSecrets.vitest.mts
@@ -60,6 +60,51 @@ describe('CLI secrets', () => {
     }
   });
 
+  it('merges overlapping set() calls instead of one silently dropping the other', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const secretsPath = cliSecretsPath(storageRoot);
+
+    try {
+      const secrets = new CliSecrets(secretsPath);
+
+      // Two overlapping mutations on the same instance, started before
+      // either resolves. Without intra-process serialization, each opens
+      // its own JsonStore off the same on-disk snapshot and the later
+      // flush silently drops the other's key.
+      await Promise.all([
+        secrets.set('KEY_A', 'value-a'),
+        secrets.set('KEY_B', 'value-b'),
+      ]);
+
+      expect(await secrets.get('KEY_A')).toBe('value-a');
+      expect(await secrets.get('KEY_B')).toBe('value-b');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores a non-string stored value instead of returning it as a key', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));
+    const storageRoot = path.join(root, 'storage');
+    const secretsPath = cliSecretsPath(storageRoot);
+
+    try {
+      const secrets = new CliSecrets(secretsPath);
+      await secrets.set('GOOD_KEY', 'good-value');
+      await fs.writeFile(
+        secretsPath,
+        JSON.stringify({ GOOD_KEY: 'good-value', BAD_KEY: { nested: true } }),
+        'utf8',
+      );
+
+      expect(await secrets.getStored('GOOD_KEY')).toBe('good-value');
+      expect(await secrets.getStored('BAD_KEY')).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('restricts the secrets file and its directory to the owner', async () => {
     if (process.platform === 'win32') return; // POSIX modes don't apply.
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'texra-cli-secrets-'));

--- a/src/test-kernel/desktop/JsonStore.vitest.mts
+++ b/src/test-kernel/desktop/JsonStore.vitest.mts
@@ -1,7 +1,7 @@
 // Node imports
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it } from 'vitest';
@@ -10,13 +10,19 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { loadPlatformDefaultsModule } from './loadPlatformDefaultsModule.mjs';
 
 interface JsonStore {
+  get<T>(key: string, defaultValue?: T): T;
   set(key: string, value: unknown): Promise<void>;
   snapshot(): Record<string, unknown>;
 }
 
+interface JsonStoreOptions {
+  mode?: number;
+  strict?: boolean;
+}
+
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string): Promise<JsonStore>;
+    open(filePath: string, options?: JsonStoreOptions): Promise<JsonStore>;
   };
 }
 
@@ -58,5 +64,29 @@ describe('shared JsonStore', () => {
     expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
       ready: true,
     });
+  });
+
+  it('rethrows malformed JSON instead of discarding it when opened with strict: true', async () => {
+    const JsonStore = await loadJsonStore();
+    const filePath = await createTempFile('state.json', '{"truncated"');
+
+    await expect(
+      JsonStore.open(filePath, { strict: true }),
+    ).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  it('restricts the store file and its directory to the owner when a mode is set', async () => {
+    if (process.platform === 'win32') return; // POSIX modes don't apply.
+    const JsonStore = await loadJsonStore();
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
+    const filePath = join(tempDir, 'nested', 'secrets.json');
+
+    const store = await JsonStore.open(filePath, { mode: 0o600 });
+    await store.set('key', 'value');
+
+    const fileStat = await stat(filePath);
+    const dirStat = await stat(dirname(filePath));
+    expect(fileStat.mode & 0o777).toBe(0o600);
+    expect(dirStat.mode & 0o777).toBe(0o700);
   });
 });


### PR DESCRIPTION
## What

`packages/cli/src/runtime/cliSecrets.ts` hand-rolled a mutation queue, a tolerant read, and an atomic write that `JsonStore` (`src/platform/defaults/jsonStore.ts`) already owns and that `ElectronSecrets` already wraps for the desktop host. `CliSecrets` now goes through `JsonStore` the same way, and the ~55 duplicated store LOC (mutation queue, `isSecretFileData` guard, hand-rolled `mkdir`/`chmod`/`write-file-atomic`) are deleted.

## Decision: JsonStore grows two small options

The issue calls out the file-mode blocker explicitly; while wiring the convergence I found the read-tolerance semantics also needed a decision (see "Correctness note" below), so `JsonStore` grows **one options bag** (`JsonStoreOptions`) with two fields, both opt-in and defaulting to prior behavior for the other 5 existing `JsonStore.open()` call sites (unchanged, still compile/typecheck clean):

- `mode?: number` — POSIX mode for the store file (`0o600` for secrets); the containing directory is created/chmod'd to the same owner bits plus execute (`0o600` -> `0o700`), matching what `CliSecrets.writeSecrets()` did by hand.
- `strict?: boolean` — rethrow malformed JSON instead of `JsonStore`'s default self-healing "treat as empty" (see below).

## Correctness note: preserved, not regressed, #7478/#8167

`JsonStore`'s default read behavior (see `JsonStore.vitest.mts`, "recovers from malformed JSON stores and overwrites on the next write") silently discards corrupt JSON and starts the store from `{}`. That's the right default for state/config caches, but it is **exactly** the bug #7478 ("fix(cli): don't wipe CLI secrets on a transient read failure") fixed for secrets: a read-mutate-write store that silently defaults a parse failure to `{}` will happily overwrite the file with `{}` + one new key on the very next write, permanently destroying every other stored credential. `CliSecrets` opens its `JsonStore` with `strict: true` to keep rethrowing on corrupt JSON, so a subsequent `set()`/`delete()` aborts instead of wiping — same guarantee as before, now expressed as an owner option instead of duplicated logic. The existing regression test for that bug (`aborts a write instead of wiping the file when the read fails for a reason other than a missing file`) is untouched and still passes.

`CliSecrets` also keeps its per-call freshness: each `get`/`set`/`delete`/`listStoredKeys` opens its own `JsonStore` (rather than caching one for the instance's lifetime), so a fresh read happens on every operation — preserving safety across concurrently running `texra` invocations (separate processes), which is why `set()`/`delete()` originally did a full read before every write (see #8167's write-path hardening for the same file).

## Net elements (R6)

- `packages/cli/src/runtime/cliSecrets.ts`: 126 -> 82 lines (-44). Deleted: `mutationQueue`, `isSecretFileData`, `readSecrets()`, `writeSecrets()`.
- `src/platform/defaults/jsonStore.ts`: 107 -> 160 lines (+53). Added: `JsonStoreOptions` (2 fields, both documented), `dirModeFor()`, `ensureDir()` (shared by `open()`/`flush()`, 2 call sites).
- Net across the two production files: **+9 lines**, trading duplicated CLI-only logic for two small, documented, opt-in options on the shared owner that the desktop `ElectronSecrets` sibling and any future `JsonStore` consumer can also use.
- Tests: +49 lines (2 new tests: file/dir-mode regression in `CliSecrets.vitest.mts`; `strict: true` + `mode` regression in `JsonStore.vitest.mts`).

## Consumer counts (R8)

`JsonStore.open()` has 6 call sites across `electronSecrets.ts`, `cliSecrets.ts`, `desktopStreamSnapshot.ts`, `platform/index.ts` (x6 opens), `cliStateStores.ts` (x2), `initPlatform.ts` (x2). The new options are optional with defaults matching prior behavior — the other 5 call sites are untouched and unaffected (confirmed by a clean `npm run typecheck` across the whole workspace).

## Dependency decision

No new dependency. `write-file-atomic` was already a `JsonStore`/repo dependency (added via #8167); `CliSecrets` no longer imports it directly.

## Test plan

- `npx vitest run src/test-kernel/cli/CliSecrets.vitest.mts src/test-kernel/desktop/JsonStore.vitest.mts` — 7/7 pass (2 new: file/dir mode regression, `strict` regression).
- `npx vitest run src/test-kernel/cli/CliInitPlatform.vitest.mts src/test-kernel/cli/CliSecrets.vitest.mts src/test-kernel/cli/CliSupabaseAuth.vitest.mts src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts src/test-kernel/desktop/ElectronConfig.vitest.mts src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts src/test-kernel/desktop/JsonStore.vitest.mts src/test-kernel/desktop/ElectronSecretsBootstrap.vitest.mts src/test-kernel/desktop/ElectronSecretStorageWarningDialog.vitest.mts` — 63/63 pass (every suite touching `JsonStore`/`CliSecrets`/`ElectronSecrets`).
- `npm run typecheck` — clean across the whole workspace (root, test-kernel, extension, CLI, trace-viewer, desktop).
- `npx eslint` / `npx prettier --write` on all changed files — clean.

Closes #8182

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential persistence and read-failure semantics; behavior is intentionally preserved via strict mode and serialized mutations, with regression tests.
> 
> **Overview**
> **`CliSecrets`** no longer implements its own read-mutate-write, atomic flush, and directory `chmod` logic; it persists `secrets.json` via **`JsonStore`** with **`mode: 0o600`** and **`strict: true`**, aligned with desktop **`ElectronSecrets`**. Each operation still opens a fresh store for cross-process freshness; **`set()`/`delete()`** remain serialized through an instance **`mutationQueue`** so concurrent mutations in one process do not clobber each other. **`getStored`** only returns string values.
> 
> **`JsonStore`** gains optional **`JsonStoreOptions`**: **`mode`** applies owner-only file permissions and **`0o700`** on the parent directory (via **`ensureDir`** / **`dirModeFor`**); **`strict`** rethrows malformed JSON instead of self-healing to `{}`. Defaults preserve existing call sites.
> 
> Tests cover overlapping **`set()`** merges, non-string secret values, POSIX permissions, and **`strict: true`** parse failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0eff2bc948325f00183174c00413b01ff15d1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->