### PR TITLE
refactor(cli): adopt clipboardy for text clipboard writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/write-file-atomic": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
+    "clipboardy": "^5.3.1",
     "concurrently": "^10.0.3",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,8 @@
     "validate:tui": "node scripts/validate-tui.mjs"
   },
   "dependencies": {
-    "@inkjs/ui": "^2.0.0"
+    "@inkjs/ui": "^2.0.0",
+    "clipboardy": "^5.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/packages/cli/scripts/build-bundle.mjs
+++ b/packages/cli/scripts/build-bundle.mjs
@@ -29,7 +29,13 @@ try {
     platform: 'node',
     format: 'esm',
     target: 'node20',
-    external: ['fsevents'],
+    // clipboardy's Linux/Windows backends resolve their bundled fallback
+    // binaries (xsel / clipboard_*.exe) relative to `import.meta.url`, which
+    // esbuild rewrites to point at the *bundled* outfile instead of
+    // clipboardy's own package directory. Keeping it external preserves
+    // those file-relative lookups against the real `node_modules/clipboardy`
+    // install that ships alongside `dist` as a declared dependency.
+    external: ['fsevents', 'clipboardy'],
     define: {
       'process.env.TEXRA_CLI_INCLUDE_INTERNAL_VALIDATION_MODEL': JSON.stringify(
         includeInternalValidationModel ? '1' : '',

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -23,7 +23,9 @@ try {
     platform: 'node',
     format: 'esm',
     target: 'node20',
-    external: ['fsevents'],
+    // See build-bundle.mjs: clipboardy resolves its fallback binaries
+    // relative to `import.meta.url`, which esbuild bundling breaks.
+    external: ['fsevents', 'clipboardy'],
     jsx: 'automatic',
     loader: { '.tsx': 'tsx', '.ts': 'ts' },
     alias: { 'react-devtools-core': reactDevtoolsStub },

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,28 +1,14 @@
-// Not routed through executeCommand: this needs an injectable spawn seam
-// (`spawnCommand`) with per-candidate kill-on-timeout while falling through
-// multiple clipboard tools, which executeCommand's single-command timeout
-// model doesn't expose as a test seam.
-import { spawn } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
+
+import clipboard from 'clipboardy';
+
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import type { ChildProcess } from 'node:child_process';
 
 export type ClipboardTextWriteResult =
   { readonly ok: true } | { readonly ok: false; readonly reason: string };
 
-const DEFAULT_CLIPBOARD_WRITE_TIMEOUT_MS = 5_000;
-
-interface ClipboardCommand {
-  readonly command: string;
-  readonly args: readonly string[];
-}
-
-type SpawnCommand = typeof spawn;
-
 interface ClipboardTextWriteOptions {
   readonly platform?: NodeJS.Platform;
-  readonly spawnCommand?: SpawnCommand;
-  readonly timeoutMs?: number;
 }
 
 function normalizeClipboardText(text: string, platform = osPlatform()): string {
@@ -30,139 +16,15 @@ function normalizeClipboardText(text: string, platform = osPlatform()): string {
   return platform === 'win32' ? lf.replaceAll('\n', '\r\n') : lf;
 }
 
-function clipboardCommandsForPlatform(
-  platform = osPlatform(),
-): readonly ClipboardCommand[] {
-  switch (platform) {
-    case 'darwin':
-      return [{ command: 'pbcopy', args: [] }];
-    case 'linux':
-      return [
-        { command: 'wl-copy', args: [] },
-        { command: 'xclip', args: ['-selection', 'clipboard'] },
-        { command: 'xsel', args: ['--clipboard', '--input'] },
-      ];
-    case 'win32':
-      return [
-        {
-          command: 'powershell.exe',
-          args: [
-            '-NoProfile',
-            '-NonInteractive',
-            '-Command',
-            '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); Set-Clipboard -Value ([Console]::In.ReadToEnd())',
-          ],
-        },
-      ];
-    default:
-      return [];
-  }
-}
-
-function missingClipboardToolsMessage(platform = osPlatform()): string {
-  if (platform === 'linux') {
-    return 'Text clipboard copy needs wl-clipboard, xclip, or xsel.';
-  }
-  return `Text clipboard copy is not supported on ${platform}.`;
-}
-
-function writeWithCommand(
-  candidate: ClipboardCommand,
-  text: string,
-  {
-    spawnCommand = spawn,
-    timeoutMs = DEFAULT_CLIPBOARD_WRITE_TIMEOUT_MS,
-  }: Pick<ClipboardTextWriteOptions, 'spawnCommand' | 'timeoutMs'> = {},
-): Promise<ClipboardTextWriteResult> {
-  return new Promise((resolve) => {
-    let settled = false;
-    let stderr = '';
-    const deadlineMs = Math.max(1, Math.floor(timeoutMs));
-
-    let child: ChildProcess;
-    try {
-      child = spawnCommand(candidate.command, [...candidate.args], {
-        stdio: ['pipe', 'ignore', 'pipe'],
-        windowsHide: true,
-      });
-    } catch (error) {
-      resolve({
-        ok: false,
-        reason: toErrorMessage(error),
-      });
-      return;
-    }
-
-    const stdin = child.stdin;
-    if (!stdin) {
-      resolve({
-        ok: false,
-        reason: `${candidate.command} did not open stdin`,
-      });
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      try {
-        child.kill();
-      } catch {
-        // Best effort only; the result still needs to unblock the UI.
-      }
-      finish({
-        ok: false,
-        reason: `${candidate.command} timed out after ${deadlineMs}ms`,
-      });
-    }, deadlineMs);
-    const finish = (result: ClipboardTextWriteResult): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      resolve(result);
-    };
-
-    stdin.on('error', () => undefined);
-    child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', (error: NodeJS.ErrnoException) => {
-      const reason =
-        error.code === 'ENOENT'
-          ? `${candidate.command} not found`
-          : error.message;
-      finish({ ok: false, reason });
-    });
-    child.on('close', (code) => {
-      if (code === 0) {
-        finish({ ok: true });
-        return;
-      }
-      finish({
-        ok: false,
-        reason:
-          stderr.trim() || `${candidate.command} exited with code ${code}`,
-      });
-    });
-
-    stdin.end(text, 'utf8');
-  });
-}
-
 export async function writeClipboardText(
   text: string,
   options: ClipboardTextWriteOptions = {},
 ): Promise<ClipboardTextWriteResult> {
-  const platform = options.platform ?? osPlatform();
-  const normalized = normalizeClipboardText(text, platform);
-  const candidates = clipboardCommandsForPlatform(platform);
-  if (candidates.length === 0) {
-    return { ok: false, reason: missingClipboardToolsMessage(platform) };
+  const normalized = normalizeClipboardText(text, options.platform ?? osPlatform());
+  try {
+    await clipboard.write(normalized);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: toErrorMessage(error) };
   }
-
-  let lastFailure = missingClipboardToolsMessage(platform);
-  for (const candidate of candidates) {
-    const result = await writeWithCommand(candidate, normalized, options);
-    if (result.ok) return result;
-    lastFailure = result.reason;
-  }
-  return { ok: false, reason: lastFailure };
 }

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,11 +1,14 @@
 import { platform as osPlatform } from 'node:os';
 
 import clipboard from 'clipboardy';
+import pTimeout from 'p-timeout';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export type ClipboardTextWriteResult =
   { readonly ok: true } | { readonly ok: false; readonly reason: string };
+
+const CLIPBOARD_WRITE_TIMEOUT_MS = 5_000;
 
 interface ClipboardTextWriteOptions {
   readonly platform?: NodeJS.Platform;
@@ -25,7 +28,10 @@ export async function writeClipboardText(
     options.platform ?? osPlatform(),
   );
   try {
-    await clipboard.write(normalized);
+    await pTimeout(clipboard.write(normalized), {
+      milliseconds: CLIPBOARD_WRITE_TIMEOUT_MS,
+      message: `Clipboard write timed out after ${CLIPBOARD_WRITE_TIMEOUT_MS}ms`,
+    });
     return { ok: true };
   } catch (error) {
     return { ok: false, reason: toErrorMessage(error) };

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -20,7 +20,10 @@ export async function writeClipboardText(
   text: string,
   options: ClipboardTextWriteOptions = {},
 ): Promise<ClipboardTextWriteResult> {
-  const normalized = normalizeClipboardText(text, options.platform ?? osPlatform());
+  const normalized = normalizeClipboardText(
+    text,
+    options.platform ?? osPlatform(),
+  );
   try {
     await clipboard.write(normalized);
     return { ok: true };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  ink@7.1.0:
-    hash: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
-    path: patches/ink@7.1.0.patch
+  ink@7.1.0: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
 
 importers:
 
@@ -338,6 +336,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.63.0
         version: 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      clipboardy:
+        specifier: ^5.3.1
+        version: 5.3.1
       concurrently:
         specifier: ^10.0.3
         version: 10.0.3
@@ -395,6 +396,9 @@ importers:
       '@inkjs/ui':
         specifier: ^2.0.0
         version: 2.0.0(ink@7.1.0(patch_hash=db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6)(@types/react@19.2.17)(react@19.2.7))
+      clipboardy:
+        specifier: ^5.3.1
+        version: 5.3.1
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -3229,6 +3233,15 @@ packages:
     resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
     engines: {node: '>=22'}
 
+  clipboard-image@0.1.0:
+    resolution: {integrity: sha512-SWk7FgaXLNFld19peQ/rTe0n97lwR1WbkqxV6JKCAOh7U52AKV/PeMFCyt/8IhBdqyDA8rdyewQMKZqvWT5Akg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  clipboardy@5.3.1:
+    resolution: {integrity: sha512-fPWgBqpp9ctiOQCkE5yjYGzv11ZU55g6ahEgr3COiio6dXdt1mbchCPXQrSR2Y9sZqfi8L7QD3+UosgXVIuPdg==}
+    engines: {node: '>=20'}
+
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
@@ -3370,6 +3383,10 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -4327,9 +4344,17 @@ packages:
   is-unsafe@1.0.1:
     resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
+  is-wayland@0.1.0:
+    resolution: {integrity: sha512-QkbMsWkIfkrzOPxenwye0h56iAXirZYHG9eHVPb22fO9y+wPbaX/CHacOWBa/I++4ohTcByimhM1/nyCsH8KNA==}
+    engines: {node: '>=20'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  is64bit@2.0.0:
+    resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
+    engines: {node: '>=18'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -4627,6 +4652,10 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  macos-version@6.0.0:
+    resolution: {integrity: sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5166,6 +5195,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  powershell-utils@0.2.0:
+    resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
+    engines: {node: '>=20'}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -5378,6 +5411,10 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
+
+  run-jxa@3.0.0:
+    resolution: {integrity: sha512-4f2CrY7H+sXkKXJn/cE6qRA3z+NMVO7zvlZ/nUV0e62yWftpiLAfw5eV9ZdomzWd2TXWwEIiGjAT57+lWIzzvA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -5657,6 +5694,10 @@ packages:
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
 
+  subsume@4.0.0:
+    resolution: {integrity: sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -5679,6 +5720,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  system-architecture@0.1.0:
+    resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
+    engines: {node: '>=18'}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -5849,6 +5894,14 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -5921,6 +5974,10 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -8859,6 +8916,19 @@ snapshots:
       slice-ansi: 9.0.0
       string-width: 8.2.2
 
+  clipboard-image@0.1.0:
+    dependencies:
+      run-jxa: 3.0.0
+
+  clipboardy@5.3.1:
+    dependencies:
+      clipboard-image: 0.1.0
+      execa: 9.6.1
+      is-wayland: 0.1.0
+      is-wsl: 3.1.1
+      is64bit: 2.0.0
+      powershell-utils: 0.2.0
+
   cliui@7.0.4:
     dependencies:
       string-width: 4.2.3
@@ -8981,6 +9051,10 @@ snapshots:
       which: 2.0.2
 
   crypto-js@4.2.0: {}
+
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
 
   css-select@5.2.2:
     dependencies:
@@ -10075,9 +10149,15 @@ snapshots:
 
   is-unsafe@1.0.1: {}
 
+  is-wayland@0.1.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  is64bit@2.0.0:
+    dependencies:
+      system-architecture: 0.1.0
 
   isarray@1.0.0: {}
 
@@ -10368,6 +10448,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  macos-version@6.0.0:
+    dependencies:
+      semver: 7.8.5
 
   magic-string@0.30.21:
     dependencies:
@@ -10877,6 +10961,8 @@ snapshots:
       commander: 9.5.0
     optional: true
 
+  powershell-utils@0.2.0: {}
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -11131,6 +11217,13 @@ snapshots:
       - supports-color
 
   run-applescript@7.1.0: {}
+
+  run-jxa@3.0.0:
+    dependencies:
+      execa: 5.1.1
+      macos-version: 6.0.0
+      subsume: 4.0.0
+      type-fest: 2.19.0
 
   run-parallel@1.2.0:
     dependencies:
@@ -11425,6 +11518,11 @@ snapshots:
     dependencies:
       boundary: 2.0.0
 
+  subsume@4.0.0:
+    dependencies:
+      escape-string-regexp: 5.0.0
+      unique-string: 3.0.0
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -11449,6 +11547,8 @@ snapshots:
       supports-color: 7.2.0
 
   symbol-tree@3.2.4: {}
+
+  system-architecture@0.1.0: {}
 
   table@6.9.0:
     dependencies:
@@ -11623,6 +11723,10 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  type-fest@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
   type-fest@4.41.0: {}
 
   type-fest@5.6.0:
@@ -11681,6 +11785,10 @@ snapshots:
   unicorn-magic@0.1.0: {}
 
   unicorn-magic@0.3.0: {}
+
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
 
   universal-user-agent@7.0.3: {}
 

--- a/src/test-kernel/cli/ClipboardText.vitest.mts
+++ b/src/test-kernel/cli/ClipboardText.vitest.mts
@@ -44,4 +44,24 @@ describe('CLI clipboard text writer', () => {
 
     expect(result).toEqual({ ok: false, reason: 'pbcopy not found' });
   });
+
+  it('reports failure instead of hanging when the write never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      writeMock.mockReturnValue(new Promise<void>(() => {}));
+
+      const resultPromise = writeClipboardText('question', {
+        platform: 'darwin',
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Clipboard write timed out after 5000ms',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/test-kernel/cli/ClipboardText.vitest.mts
+++ b/src/test-kernel/cli/ClipboardText.vitest.mts
@@ -1,137 +1,47 @@
-import { EventEmitter } from 'node:events';
-
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const writeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('clipboardy', () => ({
+  default: { write: writeMock },
+}));
+
 import { writeClipboardText } from '@cli/runtime/clipboardText';
-import type { spawn } from 'node:child_process';
-
-type SpawnCommand = typeof spawn;
-
-interface ChildScenario {
-  readonly closeCode?: number;
-  readonly hang?: boolean;
-  readonly stderr?: string;
-}
-
-class FakeClipboardChild extends EventEmitter {
-  readonly stderr = new EventEmitter();
-  readonly stdin: EventEmitter & {
-    end: (chunk?: string | Buffer, encoding?: BufferEncoding) => void;
-  };
-  readonly kill = vi.fn(() => true);
-  input = '';
-  inputEncoding: BufferEncoding | undefined;
-
-  constructor(private readonly scenario: ChildScenario) {
-    super();
-    const stdin = new EventEmitter() as FakeClipboardChild['stdin'];
-    stdin.end = (chunk, encoding): void => {
-      this.input += Buffer.isBuffer(chunk)
-        ? chunk.toString('utf8')
-        : (chunk ?? '');
-      this.inputEncoding = encoding;
-      if (this.scenario.hang) return;
-      queueMicrotask(() => {
-        if (this.scenario.stderr) {
-          this.stderr.emit('data', this.scenario.stderr);
-        }
-        this.emit('close', this.scenario.closeCode ?? 0);
-      });
-    };
-    this.stdin = stdin;
-  }
-}
-
-interface SpawnCall {
-  readonly command: string;
-  readonly args: readonly string[];
-  readonly options: unknown;
-  readonly child: FakeClipboardChild;
-}
-
-function spawnStub(scenarios: readonly ChildScenario[]): {
-  readonly calls: readonly SpawnCall[];
-  readonly spawnCommand: SpawnCommand;
-} {
-  const calls: SpawnCall[] = [];
-  const spawnMock = vi.fn(
-    (command: string, args: readonly string[], options) => {
-      const child = new FakeClipboardChild(scenarios[calls.length] ?? {});
-      calls.push({ command, args, options, child });
-      return child;
-    },
-  );
-  return {
-    calls,
-    spawnCommand: spawnMock as unknown as SpawnCommand,
-  };
-}
 
 describe('CLI clipboard text writer', () => {
   afterEach(() => {
-    vi.useRealTimers();
+    writeMock.mockReset();
   });
 
-  it('uses a Unicode-safe PowerShell command for Windows text copies', async () => {
-    const { calls, spawnCommand } = spawnStub([{ closeCode: 0 }]);
+  it('normalizes to CRLF line endings for Windows writes', async () => {
+    writeMock.mockResolvedValue(undefined);
 
     const result = await writeClipboardText('alpha π\nbeta 🚀', {
       platform: 'win32',
-      spawnCommand,
     });
 
     expect(result).toEqual({ ok: true });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.command).toBe('powershell.exe');
-    expect(calls[0]?.command).not.toBe('clip.exe');
-    expect(calls[0]?.args).toEqual(
-      expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']),
-    );
-    expect(calls[0]?.args.join(' ')).toContain('InputEncoding');
-    expect(calls[0]?.args.join(' ')).toContain('Set-Clipboard');
-    expect(calls[0]?.child.input).toBe('alpha π\r\nbeta 🚀');
-    expect(calls[0]?.child.inputEncoding).toBe('utf8');
+    expect(writeMock).toHaveBeenCalledWith('alpha π\r\nbeta 🚀');
   });
 
-  it('kills a hung command and falls back to the next Linux clipboard tool', async () => {
-    vi.useFakeTimers();
-    const { calls, spawnCommand } = spawnStub([
-      { hang: true },
-      { closeCode: 0 },
-    ]);
+  it('normalizes to LF line endings on non-Windows platforms', async () => {
+    writeMock.mockResolvedValue(undefined);
 
-    const resultPromise = writeClipboardText('question', {
-      platform: 'linux',
-      spawnCommand,
-      timeoutMs: 25,
-    });
-
-    expect(calls.map((call) => call.command)).toEqual(['wl-copy']);
-    await vi.advanceTimersByTimeAsync(25);
-
-    await expect(resultPromise).resolves.toEqual({ ok: true });
-    expect(calls.map((call) => call.command)).toEqual(['wl-copy', 'xclip']);
-    expect(calls[0]?.child.kill).toHaveBeenCalledTimes(1);
-    expect(calls[1]?.child.kill).not.toHaveBeenCalled();
-  });
-
-  it('reports timeout failure when the platform clipboard command hangs', async () => {
-    vi.useFakeTimers();
-    const { calls, spawnCommand } = spawnStub([{ hang: true }]);
-
-    const resultPromise = writeClipboardText('question', {
+    const result = await writeClipboardText('alpha\r\nbeta\rgamma', {
       platform: 'darwin',
-      spawnCommand,
-      timeoutMs: 10,
     });
 
-    await vi.advanceTimersByTimeAsync(10);
+    expect(result).toEqual({ ok: true });
+    expect(writeMock).toHaveBeenCalledWith('alpha\nbeta\ngamma');
+  });
 
-    await expect(resultPromise).resolves.toEqual({
-      ok: false,
-      reason: 'pbcopy timed out after 10ms',
+  it('reports failure when the platform clipboard write rejects', async () => {
+    writeMock.mockRejectedValue(new Error('pbcopy not found'));
+
+    const result = await writeClipboardText('question', {
+      platform: 'darwin',
     });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.child.kill).toHaveBeenCalledTimes(1);
+
+    expect(result).toEqual({ ok: false, reason: 'pbcopy not found' });
   });
 });


### PR DESCRIPTION
## What

`packages/cli/src/runtime/clipboardText.ts` (168 LOC) hand-rolled a per-platform clipboard-writer command table (pbcopy / wl-copy / xclip / xsel / powershell) with fallthrough and a manual kill-on-timeout spawn loop — reimplementing exactly what `clipboardy` already does.

Fixes #8169, which asked to pick one of: (a) adopt `clipboardy` and accept module-level mocking in tests, or (b) close as justified divergence. The issue author's own follow-up comment on #8169 said "adapt" (adopt `clipboardy`), so this PR takes path (a).

`clipboardy` is arguably a *safer* implementation than the hand-rolled one: it deliberately avoids `xclip` ("does not properly close stdout/stderr when receiving input via stdin, causing hangs"), bundles fallback binaries for `xsel`/Windows, and already handles Wayland-vs-X11 detection — so the custom per-candidate timeout/kill machinery is no longer load-bearing.

`writeClipboardText()` keeps its `{ ok: true } | { ok: false, reason }` result contract and the Windows CRLF normalization (clipboardy writes raw text as given; the TUI's `ExternalInquiry.tsx` copy-status UI, which only checks `result.ok`, is unaffected). Companion `clipboardImage.ts` is out of scope, per the issue.

## Dependency decision (per repo rule: new deps allowed only if issue-named + small focused lib consistent with existing deps)

The issue itself names `clipboardy` as the library to evaluate. It is a small, focused, single-purpose lib (`execa`-based, from the same `sindresorhus` line as this repo's existing `p-*`/`execa`/`lru-cache`/`delay` dependencies) — consistent with the existing dependency class. Added to `packages/cli/package.json` `dependencies` (the runtime consumer) and to root `package.json` `devDependencies`, mirroring the existing pattern for CLI-only packages needed for module-mocking resolution from the shared root `vitest` test-kernel (e.g. `semver`, which is used only by `packages/cli`/`packages/desktop` but is listed at the workspace root for the same reason).

## Net elements (R6)

- `packages/cli/src/runtime/clipboardText.ts`: 168 → 25 LOC (deleted the per-platform command table, the injectable `spawnCommand` seam, and the manual timeout/kill/stderr-buffering spawn loop; kept CRLF normalization + the result contract).
- `src/test-kernel/cli/ClipboardText.vitest.mts`: rewritten from a `node:child_process` fake-spawn harness (137 LOC) to `vi.mock('clipboardy', ...)`-based module mocking (49 LOC), per the issue's accepted tradeoff.
- Net across touched non-lockfile files: **+31 / −257 (net −226 LOC)**.
- 1 new dependency (`clipboardy`, issue-named, per the dependency rule above).

## Consumer counts (R8)

- `writeClipboardText` has exactly one call site: `packages/cli/src/chat/tui/modals/ExternalInquiry.tsx` (Ctrl-Y "copy question" in the External Inquiry TUI modal). Its call signature (`writeClipboardText(text)`) and the `{ ok, reason }` contract are unchanged, so no caller-side changes were needed. TUI capability-gating semantics (graceful `{ ok: false, reason }` on failure instead of a thrown/crashing write) are preserved.

## Tests

- `src/test-kernel/cli/ClipboardText.vitest.mts` rewritten to mock `clipboardy` (module-level mocking, as the issue anticipated) and verify: Windows CRLF normalization, non-Windows LF normalization, and failure-reason propagation when the underlying write rejects.
- `npx vitest run src/test-kernel/cli` — 130 files / 1673 tests passed.
- `npm run typecheck` — clean (root + test-kernel + `texra` + `@texra-ai/cli` + trace-viewer + desktop).
- `corepack pnpm --filter @texra-ai/cli check:architecture` — clean.
- `npx eslint packages/cli/src/runtime/clipboardText.ts src/test-kernel/cli/ClipboardText.vitest.mts` — clean.

Closes #8169

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX helper change with unchanged public API; main packaging caveat is requiring `clipboardy` beside the CLI bundle at runtime.
> 
> **Overview**
> Replaces the hand-rolled, per-platform clipboard command loop in `writeClipboardText` with **`clipboardy`**, while keeping the same `{ ok, reason }` result shape and Windows CRLF line-ending normalization.
> 
> **`clipboardy`** is added as a runtime dependency of `@texra-ai/cli` and at the workspace root (for Vitest module resolution). CLI **esbuild** bundles mark **`clipboardy` as external** so bundled fallback binaries still resolve from the real `node_modules` install.
> 
> Tests drop the fake-`spawn` harness in favor of **`vi.mock('clipboardy')`**, still covering normalization, rejection handling, and the 5s write timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aac5c12239d9d29b8159665f9e6f78ad628dcfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->