### PR TITLE
fix(desktop): rebind still-active executions across window recreation

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -48,6 +48,7 @@ import type {
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import {
+  findActiveAgentExecutionHandle,
   getAllActiveExecutionIds,
   SessionHandle,
 } from '@agent/runtime/SessionHandle';
@@ -744,11 +745,48 @@ export class DesktopProgressBridge {
   } {
     const activeExecutionIds = new Set(getAllActiveExecutionIds());
     const allExecutionIds = this.getRestartRepairExecutionIdMap();
+    // Rebind BEFORE forgetting the ghost: a restored stream's executionId
+    // being "active" only means some live session still owns it -- possibly
+    // a previous window's session, retained post-dispose so headless runs
+    // stay visible to process-wide guards (`keepActiveExecutions`, #6329).
+    // Without this, forgetting the ghost here (below) leaves the run with no
+    // rail entry owner at all: the old window's bridge already stopped
+    // forwarding events (disposed), and nothing else ever subscribed this
+    // window to them. See #8148.
+    this.rebindActiveExecutions(activeExecutionIds, allExecutionIds);
     this.sessionProgress.forgetActiveRestoredStreams(
       activeExecutionIds,
       allExecutionIds,
     );
     return { activeExecutionIds, allExecutionIds };
+  }
+
+  /**
+   * Reattach every still-active execution a restored (ghost) stream points
+   * at to THIS window's session, so window recreation doesn't strand a
+   * headless-continuing run on its previous window's disposed bridge (#8148).
+   * Idempotent (guarded by `this.session.executions.getHandle`), since
+   * startup repair calls `refreshActiveExecutionIds` more than once.
+   */
+  private rebindActiveExecutions(
+    activeExecutionIds: ReadonlySet<string>,
+    allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>,
+  ): void {
+    for (const [streamId, snapshot] of this.sessionProgress.restoredStreams) {
+      const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
+      if (!executionId || !activeExecutionIds.has(executionId)) continue;
+      if (this.session.executions.getHandle(executionId)) continue;
+      const handle = findActiveAgentExecutionHandle(executionId);
+      if (!handle || handle.childStreamId !== streamId) continue;
+      this.session.executions.track(handle);
+      const detachTrace = handle.trace
+        ? this.session.attachRunTrace(handle.trace, streamId)
+        : undefined;
+      void handle.result.finally(() => {
+        detachTrace?.();
+        this.session.executions.untrack(executionId);
+      });
+    }
   }
 
   /**

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -51,6 +51,7 @@ import {
   findActiveAgentExecutionHandle,
   getAllActiveExecutionIds,
   SessionHandle,
+  untrackActiveAgentExecution,
 } from '@agent/runtime/SessionHandle';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import {
@@ -776,15 +777,31 @@ export class DesktopProgressBridge {
       const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
       if (!executionId || !activeExecutionIds.has(executionId)) continue;
       if (this.session.executions.getHandle(executionId)) continue;
-      const handle = findActiveAgentExecutionHandle(executionId);
-      if (!handle || handle.childStreamId !== streamId) continue;
+      const found = findActiveAgentExecutionHandle(executionId);
+      if (!found || found.handle.childStreamId !== streamId) continue;
+      const { handle, status } = found;
       this.session.executions.track(handle);
+      // `hydrateRestoredStreams()` already seeded this window's status from
+      // the on-disk snapshot's `lastKnownStatus`, which goes stale the moment
+      // the run transitions while headless (nothing persists it, #8148).
+      // Overwrite with the live status the owning session actually has, so
+      // display and `terminateWaitingHandle`'s WAITING/RESUMING check both
+      // see the truth instead of a possibly-wrong RUNNING carried from disk.
+      if (status) {
+        this.session.status.transition(streamId, status, 'restart-repair', {
+          trace: handle.trace,
+        });
+      }
       const detachTrace = handle.trace
         ? this.session.attachRunTrace(handle.trace, streamId)
         : undefined;
       void handle.result.finally(() => {
         detachTrace?.();
-        this.session.executions.untrack(executionId);
+        // Release from every live session that still owns this handle, not
+        // just this window's -- otherwise the session that originally
+        // launched it (retained post-dispose via `keepActiveExecutions`)
+        // never sees its own registry go idle and leaks in `liveSessions`.
+        untrackActiveAgentExecution(executionId);
       });
     }
   }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -41,7 +41,7 @@ import { createChannelTrace } from '@logger';
 import type { StreamTabId } from '@shared/schemas';
 
 import { getRunContextSession, tryUseRunContext } from './RunContext';
-import { ExecutionRegistry } from './executionRegistry';
+import { AgentExecutionHandle, ExecutionRegistry } from './executionRegistry';
 import { ExecutionSubscriptionBinder } from './ExecutionSubscriptionBinder';
 import { StreamStatusMachine } from './StreamStatusService';
 import {
@@ -287,6 +287,24 @@ export function getAllActiveExecutionIds(): string[] {
     for (const id of session.executions.getActiveIds()) ids.add(id);
   }
   return [...ids];
+}
+
+/**
+ * Look up a still-active {@link AgentExecutionHandle} by id across every live
+ * session, not just one. A desktop window's own session is fresh per
+ * `BrowserWindow` (see the class doc), so a run kept alive across window
+ * recreation (`SessionHandle.dispose({ keepActiveExecutions: true })`) lives
+ * on in its *previous* window's retained session — invisible to a newly
+ * created window's session unless explicitly rebound onto it.
+ */
+export function findActiveAgentExecutionHandle(
+  executionId: string,
+): AgentExecutionHandle | undefined {
+  for (const session of liveSessions) {
+    const handle = session.executions.getHandle(executionId);
+    if (handle instanceof AgentExecutionHandle) return handle;
+  }
+  return undefined;
 }
 
 /** Stop background OS processes owned by every live runtime session. */

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -38,7 +38,7 @@ import {
 import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
-import type { StreamTabId } from '@shared/schemas';
+import type { StreamPhase, StreamTabId } from '@shared/schemas';
 
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { AgentExecutionHandle, ExecutionRegistry } from './executionRegistry';
@@ -289,6 +289,14 @@ export function getAllActiveExecutionIds(): string[] {
   return [...ids];
 }
 
+/** A still-active execution found on some other live session, plus that
+ * session's own live status for it — authoritative over any stale on-disk
+ * snapshot a rebinding window may have separately hydrated. */
+export interface ActiveAgentExecutionLookup {
+  readonly handle: AgentExecutionHandle;
+  readonly status: StreamPhase | undefined;
+}
+
 /**
  * Look up a still-active {@link AgentExecutionHandle} by id across every live
  * session, not just one. A desktop window's own session is fresh per
@@ -299,12 +307,33 @@ export function getAllActiveExecutionIds(): string[] {
  */
 export function findActiveAgentExecutionHandle(
   executionId: string,
-): AgentExecutionHandle | undefined {
+): ActiveAgentExecutionLookup | undefined {
   for (const session of liveSessions) {
     const handle = session.executions.getHandle(executionId);
-    if (handle instanceof AgentExecutionHandle) return handle;
+    if (handle instanceof AgentExecutionHandle) {
+      return { handle, status: session.status.get(handle.childStreamId) };
+    }
   }
   return undefined;
+}
+
+/**
+ * Untrack an execution from every live session that still has it registered
+ * — not just the one session that happens to finalize it. A cross-session
+ * rebind (via {@link findActiveAgentExecutionHandle} above) tracks the same
+ * handle into a second session's registry without removing it from the
+ * first. Without this, whichever session finalizes the run (e.g. a user stop
+ * issued from a newly recreated window) only clears its own registry,
+ * leaving the original `keepActiveExecutions` session's registry non-idle
+ * forever: its `disposeWhenIdle` wait loop never observes the change and
+ * that session never leaves {@link liveSessions} (#8148).
+ */
+export function untrackActiveAgentExecution(executionId: string): void {
+  for (const session of liveSessions) {
+    if (session.executions.getHandle(executionId)) {
+      session.executions.untrack(executionId);
+    }
+  }
 }
 
 /** Stop background OS processes owned by every live runtime session. */

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3308,4 +3308,159 @@ describe('DesktopProgressBridge', () => {
       expect(windowB.session.status.get(streamB)).toBeUndefined();
     });
   });
+
+  // #8148: closing a desktop window deliberately keeps its active executions
+  // alive (`session.dispose({ keepActiveExecutions: true })`), but the old
+  // bridge's UI consumers are torn down at the same time. A newly created
+  // window's bridge used to just forget the ghost once it saw the execution
+  // id was still active (`forgetActiveRestoredStreams`), with nothing ever
+  // reattaching the run to the new window — so it kept running headless with
+  // no rail entry, no live progress, no cancel, and a stale on-disk snapshot.
+  describe('window recreation rebind (#8148)', () => {
+    it('reattaches a still-active execution to the newly created window instead of stranding it', async () => {
+      const streamId = 'rebound-stream' as StreamTabId;
+      const executionId = 'ec00cc' as ExecutionId;
+      let activeExecutionIds: readonly string[] = [];
+      const { bridgeModule } = await loadBridgeModule({
+        activeExecutionIds: () => activeExecutionIds,
+      });
+      const { AgentExecutionHandle } =
+        await import('@agent/runtime/executionRegistry');
+      const { noopAgentRuntimeHost } =
+        await import('@agent/runtime/AgentRuntimeHost');
+
+      // Window A launches a real, still-running execution.
+      const messagesA: unknown[] = [];
+      const bridgeA = new bridgeModule.DesktopProgressBridge((message) => {
+        messagesA.push(message);
+      }) as unknown as TestableBridge & { session: SessionHandle };
+      await settleProgressEvents();
+
+      const trace = makeFakeTrace();
+      const handle = new AgentExecutionHandle(
+        executionId,
+        streamId,
+        streamId,
+        'proofreader',
+        AgentCategory.Workflow,
+        noopAgentRuntimeHost,
+        trace as unknown as ConstructorParameters<
+          typeof AgentExecutionHandle
+        >[6],
+      );
+      bridgeA.session.executions.trackAgentExecution(handle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      activeExecutionIds = [executionId];
+
+      // Window A closes. The bridge tears down its own UI consumers but
+      // keeps the execution registered (`keepActiveExecutions`) so
+      // process-wide guards still see it running headless.
+      bridgeA.dispose();
+
+      // The run keeps emitting while no window exists at all -- this must
+      // not throw, and (correctly) has no live subscriber yet.
+      expect(() =>
+        trace.emit({
+          type: 'status',
+          streamId,
+          phase: STREAM_PHASE.WAITING,
+          cause: 'wait',
+        }),
+      ).not.toThrow();
+
+      // Window B reopens: a brand-new bridge/session, hydrating the ghost
+      // rail entry the closed window last wrote to disk.
+      const messagesB: unknown[] = [];
+      const streamSnapshotStoreB = createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId,
+          executionId,
+          lastKnownStatus: STREAM_PHASE.RUNNING,
+        }),
+      ]);
+      const bridgeB = new bridgeModule.DesktopProgressBridge(
+        (message) => {
+          messagesB.push(message);
+        },
+        { streamSnapshotStore: streamSnapshotStoreB },
+      ) as unknown as TestableBridge & { session: SessionHandle };
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        // The still-active execution is now owned by window B's session --
+        // a rail entry, and a target `stopStream`/inspect can find.
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(handle);
+        expect(
+          bridgeB.session.executions.getAgentHandleByStream(streamId),
+        ).toBe(handle);
+        // Restored ghosts and the rebound live stream cannot coexist as two
+        // entries for the same stream.
+        expect(
+          (
+            bridgeB as unknown as {
+              sessionProgress: { hasRestoredStream(id: string): boolean };
+            }
+          ).sessionProgress.hasRestoredStream(streamId),
+        ).toBe(false);
+
+        // Subsequent live progress reaches window B exactly once, and the
+        // on-disk snapshot is refreshed even though nothing was watching
+        // between windows.
+        trace.emit({
+          type: 'status',
+          streamId,
+          phase: STREAM_PHASE.WAITING,
+          cause: 'wait',
+          previousPhase: STREAM_PHASE.RUNNING,
+        });
+        await settleProgressEvents();
+        expect(streamSnapshotStoreB.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId,
+            lastKnownStatus: STREAM_PHASE.WAITING,
+          }),
+        );
+        expect(messagesA).toEqual(
+          messagesA.filter(
+            (message) =>
+              !(
+                message &&
+                typeof message === 'object' &&
+                JSON.stringify(message).includes(STREAM_PHASE.WAITING)
+              ),
+          ),
+        );
+
+        // Terminal completion untracks the handle from window B's session --
+        // no execution stranded as "still active" once it actually finishes.
+        // Mirrors the real run lifecycle: the trace 'result' event and
+        // `handle.settleResult` are both fired by the run's own finalize
+        // step (settling `handle.result` is what our rebind's cleanup
+        // awaits to untrack).
+        const resultEvent = {
+          type: 'result' as const,
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+          agentName: 'proofreader',
+          category: 'workflow' as const,
+          isSubagent: false,
+        };
+        trace.emit(resultEvent);
+        handle.settleResult(
+          resultEvent as unknown as Parameters<typeof handle.settleResult>[0],
+        );
+        await handle.result;
+        await settleProgressEvents();
+        expect(
+          bridgeB.session.executions.getHandle(executionId),
+        ).toBeUndefined();
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+  });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -9,7 +9,7 @@ import {
 
 // Local imports - agent state
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
-import type { AgentEvent } from '@agent/trace';
+import type { AgentEvent, AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { TaskStateSchema } from '@agent/core/state/TaskState';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -3423,16 +3423,14 @@ describe('DesktopProgressBridge', () => {
             lastKnownStatus: STREAM_PHASE.WAITING,
           }),
         );
-        expect(messagesA).toEqual(
-          messagesA.filter(
+        expect(
+          messagesA.some(
             (message) =>
-              !(
-                message &&
-                typeof message === 'object' &&
-                JSON.stringify(message).includes(STREAM_PHASE.WAITING)
-              ),
+              message &&
+              typeof message === 'object' &&
+              JSON.stringify(message).includes(STREAM_PHASE.WAITING),
           ),
-        );
+        ).toBe(false);
 
         // Terminal completion untracks the handle from window B's session --
         // no execution stranded as "still active" once it actually finishes.
@@ -3458,6 +3456,89 @@ describe('DesktopProgressBridge', () => {
         expect(
           bridgeB.session.executions.getHandle(executionId),
         ).toBeUndefined();
+        // Codex P1 (#8207 review): releasing the handle must not stop at
+        // window B's own registry. Window A's session was retained post-
+        // dispose specifically so `keepActiveExecutions` guards keep seeing
+        // this execution until it truly settles -- if only window B's
+        // registry is cleared, window A's registry never goes idle and that
+        // session leaks in the cross-session `liveSessions` set forever.
+        expect(
+          bridgeA.session.executions.getHandle(executionId),
+        ).toBeUndefined();
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('seeds the rebound stream with the live owning session status, not a stale on-disk snapshot (codex P2)', async () => {
+      const streamId = 'rebound-stream-2' as StreamTabId;
+      const executionId = 'ec00dd' as ExecutionId;
+      let activeExecutionIds: readonly string[] = [];
+      const { bridgeModule } = await loadBridgeModule({
+        activeExecutionIds: () => activeExecutionIds,
+      });
+      const { AgentExecutionHandle } =
+        await import('@agent/runtime/executionRegistry');
+      const { noopAgentRuntimeHost } =
+        await import('@agent/runtime/AgentRuntimeHost');
+
+      const bridgeA = new bridgeModule.DesktopProgressBridge(
+        () => {},
+      ) as unknown as TestableBridge & { session: SessionHandle };
+      await settleProgressEvents();
+
+      const trace = makeFakeTrace();
+      const handle = new AgentExecutionHandle(
+        executionId,
+        streamId,
+        streamId,
+        'proofreader',
+        AgentCategory.Workflow,
+        noopAgentRuntimeHost,
+        trace as unknown as ConstructorParameters<
+          typeof AgentExecutionHandle
+        >[6],
+      );
+      bridgeA.session.executions.trackAgentExecution(handle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      activeExecutionIds = [executionId];
+      bridgeA.dispose();
+
+      // The run transitions to WAITING while headless. This mirrors the real
+      // lifecycle path (`ToolUseWaitNode` calling `streamStatus.transitionToWaiting`
+      // directly on the owning session, independent of whether any window is
+      // subscribed) -- window A's own `session.status` stays live and correct
+      // even with no bridge attached, unlike the on-disk snapshot which
+      // nothing persists to while no window exists (#8148).
+      expect(
+        bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
+          trace: trace as unknown as AgentTrace,
+        }),
+      ).toBe(true);
+      expect(bridgeA.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+
+      // Window B reopens with a STALE ghost snapshot still claiming RUNNING
+      // (nothing persisted the WAITING transition above to disk).
+      const streamSnapshotStoreB = createStreamSnapshotStore([
+        restoredSnapshot({
+          streamId,
+          executionId,
+          lastKnownStatus: STREAM_PHASE.RUNNING,
+        }),
+      ]);
+      const bridgeB = new bridgeModule.DesktopProgressBridge(() => {}, {
+        streamSnapshotStore: streamSnapshotStoreB,
+      }) as unknown as TestableBridge & { session: SessionHandle };
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(handle);
+        // Must reflect the live WAITING status from window A's session, not
+        // the stale RUNNING the ghost snapshot hydrated onto window B.
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
       } finally {
         bridgeB.dispose();
       }


### PR DESCRIPTION
## Summary

Closes #8148.

Closing a desktop window deliberately keeps its executions running
headless (`SessionHandle.dispose({ keepActiveExecutions: true })`,
#6329), but it also disposes every window-owned progress consumer for
that window (`this.unsubscribe()`, backend listeners, `sessionProgress`).
The `keepActiveExecutions` retained session stays in `liveSessions` (so
`getAllActiveExecutionIds()` still sees the run), but nothing in the
newly created window's session ever subscribes to it.

Concretely: a newly created `DesktopProgressBridge`'s startup repair
(`repairOrphanedStreamsAfterRestart` → `refreshActiveExecutionIds` →
`forgetActiveRestoredStreams`) saw the restored ghost's `executionId`
was still active and simply *forgot the ghost bookkeeping* — it never
attached anything new. The run kept executing with no rail owner: no
live progress, no cancellation/inspection route (`stopAgentStream`
looks up the handle via the *new* window's own `session.executions`,
which never had it), and a stale on-disk snapshot (nothing called
`streamSnapshotStore.upsert` again).

## Fix

- `src/agent/runtime/SessionHandle.ts`: add
  `findActiveAgentExecutionHandle(executionId)`, a cross-session lookup
  sibling to the existing `getAllActiveExecutionIds()` — both are the
  only sanctioned way to reach the private `liveSessions` set (the
  "no session-scoped mutable module export" invariant, #7694).
- `packages/desktop/src/main/desktopAgentExecution.ts`: add
  `rebindActiveExecutions`, called at the start of
  `refreshActiveExecutionIds` (before the ghost is forgotten). For each
  restored stream whose `executionId` is active but not yet tracked in
  *this* window's `session.executions`, it looks up the handle
  cross-session, `track()`s it in the new session's registry (so
  `stopAgentStream`/`getAgentHandleByStream` can find it — cancel and
  inspect), and reattaches its live trace via the existing
  `session.attachRunTrace(handle.trace, streamId)` — the exact hookup a
  normal launch already uses (`AgentLaunchContext.ts`), just pointed at
  the new window's session instead of the old one. `handle.result`
  settling untracks it again, so a finished run isn't stranded as
  "still active" in the new window's registry.

No new dependency, no new layer — the desktop bridge already had a
`forgetActiveRestoredStreams` path for exactly this "restored ghost
whose execution is active" case; this fix inserts the missing rebind
step ahead of it and reuses `SessionHandle.attachRunTrace`, an existing
public method.

## Net elements (R6)

- **Net production LOC**: +58 (`desktopAgentExecution.ts` +38,
  `SessionHandle.ts` +20). No files added or deleted.
- **New exports**: 1 — `findActiveAgentExecutionHandle`. Justified by
  module encapsulation, not caller count: `liveSessions` is a private
  module-scoped `Set` in `SessionHandle.ts`; the only way code outside
  that module can query it is through an exported accessor, exactly
  like the existing `getAllActiveExecutionIds` /
  `killAllSessionBackgroundProcesses` siblings in the same file.
- **New private methods**: 1 — `DesktopProgressBridge.rebindActiveExecutions`,
  a decomposition of the existing `refreshActiveExecutionIds` (not a
  new abstraction layer).
- **No new session/registry sharing**: verified against the Stage-5
  multi-window isolation gate (#6968) — the fix forwards a *specific*
  handle's trace into the new session's existing `events` hub (the same
  mechanism a normal launch uses); it never shares an `events`,
  `executions`, or `status` instance across sessions. The full
  `multi-window session isolation` suite in
  `DesktopAgentExecution.vitest.mts` still passes unchanged.

## Consumer counts (R8)

- `findActiveAgentExecutionHandle`: 1 production caller
  (`desktopAgentExecution.ts`'s `rebindActiveExecutions`), mirroring the
  2-caller `getAllActiveExecutionIds` it sits next to — both exist
  solely to cross the `liveSessions` encapsulation boundary, not as a
  general-purpose "shared" utility.
- `rebindActiveExecutions`: 1 caller (`refreshActiveExecutionIds`),
  extracted for readability from an already-multi-step repair method,
  not introduced as a standalone shared helper.

## Tests

New regression test in `src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
(`window recreation rebind (#8148) > reattaches a still-active
execution to the newly created window instead of stranding it`):
constructs a real `AgentExecutionHandle` + trace, tracks it in window
A's session, disposes window A (`keepActiveExecutions` path), emits a
trace event while no window exists (must not throw), then constructs
window B with a matching on-disk ghost snapshot and asserts:

- the handle is now tracked in window B's `session.executions` and
  reachable via `getAgentHandleByStream` (cancel/inspect target),
- the ghost bookkeeping (`sessionProgress.hasRestoredStream`) is
  cleared — no duplicate ghost + live entry,
- a subsequent live `status` event reaches window B and refreshes the
  on-disk snapshot store (`streamSnapshotStore.upsert`),
- window A's messages are unaffected (no cross-window leak — same
  invariant the existing multi-window isolation suite locks),
- terminal completion (`handle.settleResult` + trace `result`) untracks
  the handle from window B's registry.

Proven-to-fail: reverted the two production files to `origin/main` and
reran this test — it fails at the very first rebind assertion
(`expected undefined to be AgentExecutionHandle{…}`), confirming the
regression and that the test actually exercises the fix.

Ran:
- `npx vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/agent/runtime/SessionHandle.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts` — all passing (including the full `src/test-kernel/desktop/` suite, 458/458).
- `npx tsc --noEmit`, `tsc --noEmit -p tsconfig.test-kernel.json`, `pnpm --filter @texra/desktop typecheck` — clean.
- `npx eslint` + `npx prettier --check` on the three touched files — clean.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop multi-window execution ownership and cross-session registry tracking; behavior is narrow and well-tested but mistakes could affect cancel/stop paths or session lifecycle leaks.
> 
> **Overview**
> Fixes **#8148**: when a desktop window closes with `keepActiveExecutions`, runs can keep going headless while the new window only dropped the restored ghost and never subscribed to the live handle—no rail, progress, cancel, or fresh snapshots.
> 
> **Desktop startup repair** now calls **`rebindActiveExecutions`** before **`forgetActiveRestoredStreams`**. For each restored stream whose `executionId` is still process-active but not tracked on *this* window, it looks up the handle on another live session, **`track()`s** it locally, overwrites status from the **live** owning session (not stale disk), **`attachRunTrace`** for UI updates, and on completion **`untrackActiveAgentExecution`** so the retained pre-close session does not leak in `liveSessions`.
> 
> **`SessionHandle`** adds cross-session **`findActiveAgentExecutionHandle`** and **`untrackActiveAgentExecution`**, mirroring **`getAllActiveExecutionIds`** as the sanctioned way past private `liveSessions`.
> 
> Regression tests cover rebind after window A dispose → window B open, live progress/snapshot refresh, dual-session untrack on settle, and stale **RUNNING** ghost vs live **WAITING**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea8fddbca7a63f1b81a4dfd20593b876497cbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->