### PR TITLE
fix(agent): finalize child before waking resumed parent turn

### DIFF
--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -31,9 +31,11 @@ import type {
 } from '@shared/schemas';
 
 import {
-  deliverChildRunFollowUp,
+  enqueueChildRunFollowUp,
+  wakeChildRunFollowUp,
   persistChildRunReport,
   persistChildRunResultMeta,
+  type ChildRunEnqueueResult,
 } from '@tools/childRunDelivery';
 import { formatSubagentProgress } from '@tools/subagentResults';
 import type { ChildStream } from '@tools/childStream';
@@ -339,9 +341,26 @@ async function persistResultMetaBestEffort(
 }
 
 /**
- * Format, persist, and deliver one turn's outcome to the parent's follow-up
+ * A turn's parent-follow-up enqueue, still pending its wake step. Waking can
+ * await the resumed parent's entire turn (`agentResume.tryResumeStream` → …
+ * → `resumeToolUseFromSnapshot`), so callers that are about to finalize this
+ * child (terminal/failed turns) must resolve the wake only AFTER that
+ * finalize completes — otherwise a resumed parent that immediately waits on
+ * this still-RUNNING execution self-stalls (#8093). Callers that continue to
+ * another turn (no finalize pending) may wake immediately.
+ */
+interface PendingChildDelivery {
+  readonly targetStreamId: StreamTabId;
+  readonly enqueueResult: ChildRunEnqueueResult;
+}
+
+/**
+ * Format, persist, and enqueue one turn's outcome on the parent's follow-up
  * queue — the loop's single delivery site, shared by every interim and
- * terminal turn, every strategy.
+ * terminal turn, every strategy. Returns the pending delivery for the caller
+ * to wake via {@link wakePendingDelivery} once its own ordering allows it;
+ * `undefined` when there is nothing to wake (detached child, or delivery
+ * skipped by `prepareParentDelivery`).
  */
 async function deliverTurn<TTurn>(params: {
   strategy: ChildRunStrategy<TTurn>;
@@ -354,7 +373,7 @@ async function deliverTurn<TTurn>(params: {
   wallTimeMs: number;
   isError: boolean;
   prepareParentDelivery?: () => boolean;
-}): Promise<void> {
+}): Promise<PendingChildDelivery | undefined> {
   const {
     strategy,
     executionId,
@@ -395,30 +414,49 @@ async function deliverTurn<TTurn>(params: {
       'Turn result not delivered: child was detached from its orchestrator. The result remains in the execution report.',
       { data: { executionId } },
     );
-    return;
+    return undefined;
   }
-  if (prepareParentDelivery?.() === false) return;
-  const delivery = await deliverChildRunFollowUp({
+  if (prepareParentDelivery?.() === false) return undefined;
+  const enqueueResult = await enqueueChildRunFollowUp({
     targetStreamId,
     followUp: { text: msg, origin: 'subagent_result' },
     session,
-    wake: true,
   });
-  if (delivery.kind === 'no_session') {
+  if (enqueueResult.kind === 'no_session') {
     logger.warn(
       'Turn result not delivered: parent stream has no active session. The result remains in the execution report.',
       {
         data: {
           executionId,
           parentStreamId: targetStreamId,
-          streamStatus: delivery.streamStatus ?? 'unknown',
+          streamStatus: enqueueResult.streamStatus ?? 'unknown',
         },
       },
     );
-  } else if (delivery.kind === 'dropped') {
+  }
+  return { targetStreamId, enqueueResult };
+}
+
+/**
+ * Resolve a pending delivery's wake step (no-op when there is nothing to
+ * wake, or the enqueue itself found no session — already logged above).
+ */
+async function wakePendingDelivery(
+  pending: PendingChildDelivery | undefined,
+  session: SessionHandle,
+  executionId: ExecutionId,
+  logger: AgentTrace,
+): Promise<void> {
+  if (!pending || pending.enqueueResult.kind === 'no_session') return;
+  const delivery = await wakeChildRunFollowUp(
+    pending.targetStreamId,
+    pending.enqueueResult,
+    session,
+  );
+  if (delivery.kind === 'dropped') {
     logger.warn(
       'Turn result dropped: parent stream is gone and could not be resumed. The result remains in the execution report.',
-      { data: { executionId, parentStreamId: targetStreamId } },
+      { data: { executionId, parentStreamId: pending.targetStreamId } },
     );
   }
 }
@@ -493,11 +531,11 @@ export function startChildRunLoop<TTurn>(
         : parentStreamId;
       if (!targetStreamId) return; // Detached — see deliverTurn for the same guard.
       const msg = formatSubagentProgress(executionId, agentName, update);
-      // No `wake: true` — intentional. A live progress notification should
+      // Enqueue-only — intentional. A live progress notification should
       // never wake a WAITING/detached parent stream just to deliver an
       // interim update; only a turn's own delivery (deliverTurn, below)
       // wakes the parent.
-      void deliverChildRunFollowUp({
+      void enqueueChildRunFollowUp({
         targetStreamId,
         followUp: { text: msg, origin: 'subagent_result' },
         session: runSession,
@@ -510,6 +548,13 @@ export function startChildRunLoop<TTurn>(
 
   let sawTurnFailure = false;
   let lastTurnErr: unknown;
+  // A delivery whose wake is still pending. Set right before any `break` out
+  // of the loop below (terminal/failed turn) and resolved AFTER this child's
+  // own finalize in the `finally` block — never before — so a resumed parent
+  // that immediately waits on this execution always finds it terminal
+  // (#8093). Interim (non-terminal) turns wake inline, immediately, since no
+  // finalize is pending for them.
+  let pendingDelivery: PendingChildDelivery | undefined;
   void (async () => {
     let runner: (ac: AbortController) => Promise<TTurn> = (ac) =>
       strategy.launch(ports, ac);
@@ -539,7 +584,7 @@ export function startChildRunLoop<TTurn>(
           strategy.publishUsage?.(turn);
         }
 
-        await deliverTurn({
+        const delivery = await deliverTurn({
           strategy,
           executionId,
           parentStreamId,
@@ -571,6 +616,7 @@ export function startChildRunLoop<TTurn>(
               `${strategy.stageLabel} reported a failed turn without throwing.`,
             );
           childStream?.failTurn();
+          pendingDelivery = delivery;
           break;
         }
 
@@ -580,13 +626,16 @@ export function startChildRunLoop<TTurn>(
           // turn terminal via `isTerminal`; reaching here with one still
           // undeclared-terminal is a strategy bug, not a run outcome — stop
           // rather than call an absent `runTurn`.
+          pendingDelivery = delivery;
           break;
         }
 
-        // Interim turn continuing: the loop's interrupt handler is already
-        // attached (immediately above, the instant this turn settled) —
-        // just drain the next batch. A follow-up already raced into the
-        // queue resumes immediately instead of genuinely waiting.
+        // Interim turn continuing: no finalize is pending, so wake now — the
+        // loop's interrupt handler is already attached (immediately above,
+        // the instant this turn settled) — then just drain the next batch. A
+        // follow-up already raced into the queue resumes immediately instead
+        // of genuinely waiting.
+        await wakePendingDelivery(delivery, runSession, executionId, logger);
         childStream?.waitForInput();
         if (loop.isInterrupted()) break;
 
@@ -662,6 +711,16 @@ export function startChildRunLoop<TTurn>(
           }
         }
       }
+      // Wake the parent only now — after this child's own finalize above —
+      // so a resumed parent turn that immediately waits on this execution
+      // (e.g. `executions` tool with `action=wait`) always observes it
+      // terminal instead of racing its own wake (#8093).
+      await wakePendingDelivery(
+        pendingDelivery,
+        runSession,
+        executionId,
+        logger,
+      );
     }
   })();
 }

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -12,13 +12,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
-  deliverChildRunFollowUp: vi.fn(),
+  enqueueChildRunFollowUp: vi.fn(),
+  wakeChildRunFollowUp: vi.fn(),
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
   persistChildRunReport: mocks.persistChildRunReport,
   persistChildRunResultMeta: mocks.persistChildRunResultMeta,
-  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
+  enqueueChildRunFollowUp: mocks.enqueueChildRunFollowUp,
+  wakeChildRunFollowUp: mocks.wakeChildRunFollowUp,
 }));
 
 import {
@@ -136,7 +138,11 @@ beforeEach(() => {
     return { kind: 'persisted' as const, msg };
   });
   mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
-  mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+  mocks.enqueueChildRunFollowUp.mockResolvedValue({
+    kind: 'enqueued',
+    sendResult: { status: 'sent' },
+  });
+  mocks.wakeChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
 });
 
 afterEach(() => {
@@ -152,9 +158,9 @@ describe('childRunLoop E2E fixtures', () => {
     const parentStreamId = 'parent' as StreamTabId;
     const { strategy, rejectTurn } = createFakeStrategy();
     const releaseSessionOwnership = vi.fn();
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+    mocks.enqueueChildRunFollowUp.mockImplementation(async () => {
       expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-      return { kind: 'delivered' };
+      return { kind: 'enqueued', sendResult: { status: 'sent' } };
     });
 
     startChildRunLoop({
@@ -206,7 +212,8 @@ describe('childRunLoop E2E fixtures', () => {
     await vi.waitFor(() =>
       expect(isChildRunLoopActive(childStreamId)).toBe(false),
     );
-    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.wakeChildRunFollowUp).not.toHaveBeenCalled();
     expect(session.executions.getHandle(executionId)).toBeUndefined();
   });
 
@@ -216,7 +223,7 @@ describe('childRunLoop E2E fixtures', () => {
     const { strategy, resolveTurn } = createFakeStrategy();
     const onTurnSuccess = vi.fn();
     const parentWake = vi.fn();
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+    mocks.wakeChildRunFollowUp.mockImplementation(async () => {
       parentWake();
       return { kind: 'delivered' };
     });
@@ -235,14 +242,19 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'interim', value: 'first' });
 
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           targetStreamId: parentStreamId,
           followUp: expect.objectContaining({ text: 'delivered:first' }),
-          wake: true,
         }),
       );
     });
+    // An interim (non-terminal) turn wakes inline — no finalize is pending
+    // for it — so the wake for this delivery is expected right away, unlike
+    // the terminal delivery below (see the deferred-wake regression test).
+    await vi.waitFor(() =>
+      expect(mocks.wakeChildRunFollowUp).toHaveBeenCalled(),
+    );
     expect(onTurnSuccess).toHaveBeenCalledOnce();
     expect(onTurnSuccess.mock.invocationCallOrder[0]).toBeLessThan(
       parentWake.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
@@ -260,7 +272,7 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(2, { kind: 'terminal', value: 'final' });
 
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'delivered:final' }),
         }),
@@ -303,7 +315,8 @@ describe('childRunLoop E2E fixtures', () => {
       'delivered:late',
     );
     expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.wakeChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('kill during WAITING: interrupting the loop while it is blocked between turns ends the run without a hang', async () => {
@@ -327,7 +340,7 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'interim', value: 'first' });
 
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalled();
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalled();
     });
     // The loop is now blocked in queue.waitAndDrainAll; the loop's handler on
     // the run handle is the live stop target.
@@ -337,7 +350,7 @@ describe('childRunLoop E2E fixtures', () => {
       expect(isChildRunLoopActive(childStreamId)).toBe(false),
     );
     // Only the one interim delivery — the kill did not spawn another turn.
-    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1);
   });
 
   it('stop between turns (native, no ChildStream) settles and untracks the dangling handle — no ghost subagent', async () => {
@@ -384,7 +397,7 @@ describe('childRunLoop E2E fixtures', () => {
 
     await resolveTurn(1, { kind: 'interim', value: 'first' });
     await vi.waitFor(() =>
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
     );
 
     // Loop is now between turns. Interrupt it through the run handle.
@@ -415,10 +428,10 @@ describe('childRunLoop E2E fixtures', () => {
     const executionId = 'exec-reregister-before-delivery' as ExecutionId;
     const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
     let deliveryGate: DeferredPromise<void> | undefined;
-    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
+    mocks.enqueueChildRunFollowUp.mockImplementation(async () => {
       deliveryGate = pDefer<void>();
       await deliveryGate.promise;
-      return { kind: 'delivered' };
+      return { kind: 'enqueued', sendResult: { status: 'sent' } };
     });
 
     const strategy: ChildRunStrategy<FakeTurn> = {
@@ -451,6 +464,61 @@ describe('childRunLoop E2E fixtures', () => {
     );
   });
 
+  it('#8093 regression: a terminal turn finalizes this child before its wake step is even reached, so a resumed parent never self-stalls waiting on it', async () => {
+    // Regression: `wakeChildRunFollowUp` can await the ENTIRE resumed parent
+    // turn (`agentResume.tryResumeStream` → … → `resumeToolUseFromSnapshot`).
+    // Before #8093, the loop awaited enqueue-and-wake together, inline in the
+    // turn loop, and only finalized this child (untracking its execution
+    // handle) afterward in the outer `finally` — so a resumed parent that
+    // immediately calls `executions` with action=wait on this same execution
+    // could find it still RUNNING and block on itself for the whole wait
+    // budget. Prove the fixed ordering: by the moment the wake step is even
+    // reached, this execution is already untracked (terminal in the registry)
+    // — a resumed parent's wait would resolve immediately instead of racing
+    // its own wake.
+    const childStreamId = uniqueStreamId('finalize-before-wake');
+    const parentStreamId = 'parent' as StreamTabId;
+    const executionId = 'exec-finalize-before-wake' as ExecutionId;
+    trackChildHandle(executionId, parentStreamId, childStreamId);
+
+    let releaseWake: (() => void) | undefined;
+    let handleAtWakeTime: unknown;
+    mocks.wakeChildRunFollowUp.mockImplementation(async () => {
+      // Snapshot registry state the instant the wake step is reached — the
+      // same moment a resumed parent's own turn would begin running.
+      handleAtWakeTime = session.executions.getHandle(executionId);
+      await new Promise<void>((resolve) => {
+        releaseWake = resolve;
+      });
+      return { kind: 'delivered' };
+    });
+
+    const strategy: ChildRunStrategy<FakeTurn> = {
+      stageLabel: 'Finalize-before-wake test',
+      launch: async () => ({ kind: 'terminal', value: 'done' }),
+      isTerminal: () => true,
+      formatDelivery: (turn) => `delivered:${turn.value}`,
+      formatError: () => 'error',
+    };
+
+    startChildRunLoop({
+      childStreamId,
+      parentStreamId,
+      executionId,
+      agentName: 'fake',
+      strategy,
+    });
+
+    await vi.waitFor(() => expect(releaseWake).toBeDefined());
+    expect(handleAtWakeTime).toBeUndefined();
+    expect(session.executions.getHandle(executionId)).toBeUndefined();
+
+    releaseWake?.();
+    await vi.waitFor(() =>
+      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+    );
+  });
+
   it('preserves #7491: a failed runTurn (thrown, not a value) delivers formatError to the parent', async () => {
     const childStreamId = uniqueStreamId('failed-run-turn');
     const parentStreamId = 'parent' as StreamTabId;
@@ -469,7 +537,7 @@ describe('childRunLoop E2E fixtures', () => {
     );
     await resolveTurn(1, { kind: 'interim', value: 'first' });
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1);
     });
 
     session.followUps
@@ -480,7 +548,7 @@ describe('childRunLoop E2E fixtures', () => {
     await rejectTurn(2, resumeFailure);
 
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'error:thrown' }),
         }),
@@ -511,7 +579,7 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 
     await vi.waitFor(() => {
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'error:oops' }),
         }),
@@ -611,7 +679,7 @@ describe('childRunLoop E2E fixtures', () => {
     );
     launchResolve?.({ kind: 'interim', value: 'first' });
     await vi.waitFor(() =>
-      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
+      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
     );
 
     session.followUps

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -539,6 +539,96 @@ describe('BashTool', () => {
     }
   });
 
+  it('#8093 regression: finalizes the background execution before its wake step resolves, so a resumed parent never self-stalls waiting on it', async () => {
+    // Regression: waking a WAITING parent (`agentResume.tryResumeStream`) can
+    // await the ENTIRE resumed parent turn. If that wake were awaited before
+    // this execution's own finalize (as it used to be, delivering via a
+    // single wake-aware call before `finalizeBackground`), a resumed parent
+    // that immediately calls `executions` with action=wait on this same
+    // execution could find it still RUNNING and block on itself for the
+    // whole wait budget. Prove the ordering: hold the host resume port open
+    // and confirm the execution is already untracked (terminal) by the time
+    // that port is even invoked.
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: true,
+      stdout: 'done\n',
+      stderr: '',
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    const parentStreamId = 'bash-tool-bg-finalize-before-wake' as StreamTabId;
+    let releaseResume: (() => void) | undefined;
+    let handleAtResumeTime: unknown;
+    let executionId = '';
+    const tryResumeStream = vi.fn().mockImplementation(async () => {
+      handleAtResumeTime = defaultSession().executions.getHandle(executionId);
+      await new Promise<void>((resolve) => {
+        releaseResume = resolve;
+      });
+      return true;
+    });
+    await installPlatform(
+      {
+        workspacePath: '/workspace',
+        config: { 'texra.toolUse.requireBashApproval': false },
+      },
+      { agentResume: { tryResumeStream } },
+    );
+    seedStreamStatusForTest(
+      defaultSession().status,
+      parentStreamId,
+      STREAM_STATUS.WAITING,
+    );
+
+    const { host } = createRecordingHost();
+    const bashTool = new BashTool();
+    const recorded = recordSessionEvents(defaultSession().events);
+
+    try {
+      const launchResult = await withToolEnvironment(
+        {
+          run: { runtimeHost: host, streamId: parentStreamId },
+          call: { tracker: new FileInteractionState() },
+        },
+        () =>
+          bashTool.call({
+            command: 'make build',
+            run_in_background: true,
+          }),
+      );
+      assert.equal(launchResult.status, 'executed');
+      const executionIdMatch = /Execution ID: (\S+)/.exec(
+        String(launchResult.output ?? ''),
+      );
+      assert.ok(
+        executionIdMatch,
+        'Launch output should report an execution id',
+      );
+      executionId = executionIdMatch![1]!;
+
+      await vi.waitFor(() => {
+        assert.ok(
+          tryResumeStream.mock.calls.length > 0,
+          'Background bash completion should reach the wake step',
+        );
+      });
+      // The wake step was reached — this execution must already be untracked
+      // (finalized), never still RUNNING, so a resumed parent that waits on
+      // it right now resolves immediately instead of racing its own wake.
+      assert.equal(handleAtResumeTime, undefined);
+      assert.equal(
+        defaultSession().executions.getHandle(executionId),
+        undefined,
+      );
+    } finally {
+      releaseResume?.();
+      recorded.detach();
+      clearStreamStatusForTest(defaultSession().status, parentStreamId);
+      defaultSession().followUps.release(parentStreamId);
+    }
+  });
+
   it('accepts optional command descriptions without passing them to the shell', async () => {
     vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: true,

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -29,6 +29,8 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 // Local imports - tools
 import {
   deliverChildRunFollowUp,
+  enqueueChildRunFollowUp,
+  wakeChildRunFollowUp,
   persistChildRunReport,
   persistChildRunResultMeta,
 } from '@tools/childRunDelivery';
@@ -156,5 +158,121 @@ describe('child run delivery', () => {
         wake: true,
       }),
     ).resolves.toEqual({ kind: 'dropped' });
+  });
+
+  // #8093: enqueue and wake are split so a caller can finalize its own child
+  // between them, keeping the (potentially slow) wake off the critical path
+  // that must observe the child as terminal.
+  describe('enqueueChildRunFollowUp / wakeChildRunFollowUp split', () => {
+    it('enqueueChildRunFollowUp only sends — it never calls the wake port', async () => {
+      const session = { tag: 'owner-session' };
+      mocks.sendFollowUp.mockResolvedValue({ status: 'sent' });
+
+      await expect(
+        enqueueChildRunFollowUp({
+          targetStreamId: 'parent' as StreamTabId,
+          followUp: { text: 'done', origin: 'subagent_result' },
+          session: session as never,
+        }),
+      ).resolves.toEqual({
+        kind: 'enqueued',
+        sendResult: { status: 'sent' },
+      });
+      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
+    });
+
+    it('enqueueChildRunFollowUp classifies a missing parent session without waking', async () => {
+      const session = { tag: 'owner-session' };
+      mocks.sendFollowUp.mockResolvedValue({
+        status: 'no_session',
+        streamStatus: 'completed',
+      });
+
+      await expect(
+        enqueueChildRunFollowUp({
+          targetStreamId: 'parent' as StreamTabId,
+          followUp: { text: 'done', origin: 'subagent_result' },
+          session: session as never,
+        }),
+      ).resolves.toEqual({ kind: 'no_session', streamStatus: 'completed' });
+      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
+    });
+
+    it('wakeChildRunFollowUp resolves a no_session enqueue result without calling the wake port', async () => {
+      const session = { tag: 'owner-session' };
+
+      await expect(
+        wakeChildRunFollowUp(
+          'parent' as StreamTabId,
+          { kind: 'no_session', streamStatus: 'completed' },
+          session as never,
+        ),
+      ).resolves.toEqual({ kind: 'no_session', streamStatus: 'completed' });
+      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
+    });
+
+    it('wakeChildRunFollowUp wakes (or releases) using the enqueue result it was handed', async () => {
+      const session = { tag: 'owner-session' };
+      const sendResult = { status: 'queued', reason: 'children_running' };
+      mocks.wakeOrReleaseQueuedStream.mockResolvedValue(true);
+
+      await expect(
+        wakeChildRunFollowUp(
+          'parent' as StreamTabId,
+          { kind: 'enqueued', sendResult: sendResult as never },
+          session as never,
+        ),
+      ).resolves.toEqual({ kind: 'delivered' });
+      expect(mocks.wakeOrReleaseQueuedStream).toHaveBeenCalledWith(
+        'parent',
+        sendResult,
+        session,
+      );
+    });
+
+    it('the enqueue half settles before a slow wake half resolves', async () => {
+      // Regression shape for #8093: a caller must be able to observe the
+      // enqueue's completion (and act on it — e.g. finalize its own child)
+      // strictly before the wake half, which can hang for as long as the
+      // resumed parent's own turn takes.
+      const session = { tag: 'owner-session' };
+      mocks.sendFollowUp.mockResolvedValue({
+        status: 'queued',
+        reason: 'children_running',
+      });
+      let resolveWake: (() => void) | undefined;
+      mocks.wakeOrReleaseQueuedStream.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveWake = () => resolve(true);
+          }),
+      );
+
+      const enqueueResult = await enqueueChildRunFollowUp({
+        targetStreamId: 'parent' as StreamTabId,
+        followUp: { text: 'done', origin: 'subagent_result' },
+        session: session as never,
+      });
+      // Enqueue is fully settled — the wake port has not even been called
+      // yet, proving the caller can act on this result (e.g. finalize)
+      // before ever touching the wake step.
+      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
+
+      let woke = false;
+      const wakePromise = wakeChildRunFollowUp(
+        'parent' as StreamTabId,
+        enqueueResult,
+        session as never,
+      ).then((result) => {
+        woke = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(woke).toBe(false);
+
+      resolveWake?.();
+      await expect(wakePromise).resolves.toEqual({ kind: 'delivered' });
+      expect(woke).toBe(true);
+    });
   });
 });

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -18,7 +18,8 @@ import {
 } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
-  deliverChildRunFollowUp: vi.fn(),
+  enqueueChildRunFollowUp: vi.fn(),
+  wakeChildRunFollowUp: vi.fn(),
   executeAgent: vi.fn(),
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
@@ -45,7 +46,8 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
-  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
+  enqueueChildRunFollowUp: mocks.enqueueChildRunFollowUp,
+  wakeChildRunFollowUp: mocks.wakeChildRunFollowUp,
   persistChildRunReport: mocks.persistChildRunReport,
   persistChildRunResultMeta: mocks.persistChildRunResultMeta,
 }));
@@ -80,7 +82,11 @@ function baseParams(parentSession = new SessionHandle()) {
 describe('NativeToolUseStrategy', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    mocks.enqueueChildRunFollowUp.mockResolvedValue({
+      kind: 'enqueued',
+      sendResult: { status: 'sent' },
+    });
+    mocks.wakeChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
     mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
     mocks.synchronizeAgentResultOutcome.mockResolvedValue(undefined);
@@ -400,7 +406,7 @@ describe('NativeToolUseStrategy', () => {
         strategy,
       });
       await vi.waitFor(() =>
-        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
+        expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
       );
 
       session.followUps.acquire(childStreamId).enqueue({
@@ -412,7 +418,7 @@ describe('NativeToolUseStrategy', () => {
         expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledTimes(1),
       );
       await vi.waitFor(() =>
-        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(2),
+        expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(2),
       );
       // Give an accidentally re-enqueued batch enough time to start a second
       // immediate resume. The guarded mock above prevents an actual busy loop.
@@ -431,7 +437,7 @@ describe('NativeToolUseStrategy', () => {
       ]);
       expect(session.followUps.getAll(childStreamId)).toEqual([]);
       expect(session.status.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
-      const resumedDeliveries = mocks.deliverChildRunFollowUp.mock.calls.filter(
+      const resumedDeliveries = mocks.enqueueChildRunFollowUp.mock.calls.filter(
         ([delivery]) => delivery.followUp.text.includes('follow-up response'),
       );
       expect(resumedDeliveries).toHaveLength(1);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -34,7 +34,11 @@ import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/constants/toolDefaults';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import { requireRunStream } from '@tools/contextHelpers';
-import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
+import {
+  enqueueChildRunFollowUp,
+  wakeChildRunFollowUp,
+  type ChildRunEnqueueResult,
+} from '@tools/childRunDelivery';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -344,51 +348,75 @@ export class BashTool extends defineTool({
       return childStream.finalize(options);
     };
 
-    const deliverParentFollowUp = async (text: string): Promise<void> => {
-      // Route through the shared wake-aware delivery path — a parent
-      // suspended WAITING on this background job must be resumed, not left
-      // to sit until something else wakes it (see deliverChildRunFollowUp).
-      const delivery = await deliverChildRunFollowUp({
-        targetStreamId: parentStreamId,
-        followUp: { text, origin: 'subagent_result' },
-        session: runSession,
-        wake: true,
-      });
-      if (delivery.kind === 'no_session') {
-        logger.debug(
-          'Background bash follow-up dropped: parent stream has no active session.',
-          {
-            data: {
-              parentStreamId,
-              streamStatus: delivery.streamStatus ?? 'unknown',
-            },
-          },
-        );
-      } else if (delivery.kind === 'dropped') {
-        logger.warn(
-          'Background bash follow-up dropped: parent stream is gone and could not be resumed.',
-          { data: { parentStreamId } },
-        );
-      }
-    };
-
     const logBackgroundFailure = (action: string, err: unknown): void => {
       logger.error(`Failed to ${action} background bash result`, {
         data: err,
       });
     };
 
+    const enqueueParentFollowUp = async (
+      text: string,
+    ): Promise<ChildRunEnqueueResult | undefined> => {
+      try {
+        return await enqueueChildRunFollowUp({
+          targetStreamId: parentStreamId,
+          followUp: { text, origin: 'subagent_result' },
+          session: runSession,
+        });
+      } catch (err: unknown) {
+        logBackgroundFailure('enqueue', err);
+        return undefined;
+      }
+    };
+
+    // Wake the parent only after this child is finalized (see #8093): waking
+    // a WAITING parent can await its entire resumed turn
+    // (`agentResume.tryResumeStream` → … → `resumeToolUseFromSnapshot`), and
+    // that resumed turn may itself wait on this execution — so finalizing
+    // first keeps a self-stall impossible instead of merely unlikely.
+    const wakeParentFollowUp = async (
+      enqueueResult: ChildRunEnqueueResult | undefined,
+    ): Promise<void> => {
+      if (!enqueueResult) return;
+      if (enqueueResult.kind === 'no_session') {
+        logger.debug(
+          'Background bash follow-up dropped: parent stream has no active session.',
+          {
+            data: {
+              parentStreamId,
+              streamStatus: enqueueResult.streamStatus ?? 'unknown',
+            },
+          },
+        );
+        return;
+      }
+      try {
+        const delivery = await wakeChildRunFollowUp(
+          parentStreamId,
+          enqueueResult,
+          runSession,
+        );
+        if (delivery.kind === 'dropped') {
+          logger.warn(
+            'Background bash follow-up dropped: parent stream is gone and could not be resumed.',
+            { data: { parentStreamId } },
+          );
+        }
+      } catch (err: unknown) {
+        logBackgroundFailure('wake', err);
+      }
+    };
+
     const deliverAndFinalize = async (
       text: string,
       finalizeOptions: Parameters<typeof finalizeBackground>[0],
     ): Promise<void> => {
-      try {
-        await deliverParentFollowUp(text);
-      } catch (err: unknown) {
-        logBackgroundFailure('deliver', err);
-      } finally {
-        await finalizeBackground(finalizeOptions);
-      }
+      // Order matters (see #8093): enqueue the result (fast), finalize this
+      // child so its terminal state is visible in the in-memory execution
+      // registry, then wake the parent — never the other way around.
+      const enqueueResult = await enqueueParentFollowUp(text);
+      await finalizeBackground(finalizeOptions);
+      await wakeParentFollowUp(enqueueResult);
     };
 
     void (async () => {

--- a/src/tools/childRunDelivery.ts
+++ b/src/tools/childRunDelivery.ts
@@ -12,6 +12,7 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   sendFollowUp,
   wakeOrReleaseQueuedStream,
+  type SendFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 
@@ -22,6 +23,15 @@ export type ChildRunDeliveryResult =
   | { kind: 'delivered' }
   | { kind: 'no_session'; streamStatus: string | undefined }
   | { kind: 'dropped' };
+
+/**
+ * Outcome of the fast "enqueue" half of delivery — appending to (or queueing
+ * on) the parent stream's follow-up queue. Never waits on a resumed parent
+ * turn; safe to await before a caller finalizes its own child.
+ */
+export type ChildRunEnqueueResult =
+  | { kind: 'enqueued'; sendResult: SendFollowUpResult }
+  | { kind: 'no_session'; streamStatus: string | undefined };
 
 export type ChildRunReportResult =
   { kind: 'persisted' } | { kind: 'failed'; err: unknown };
@@ -58,12 +68,16 @@ export async function persistChildRunResultMeta(
   }
 }
 
-export async function deliverChildRunFollowUp(params: {
+/**
+ * Enqueue a child-run result on the parent stream's follow-up queue. Never
+ * awaits a resumed parent turn — callers that must finalize their own child
+ * before the wake step (see {@link wakeChildRunFollowUp}) call this first.
+ */
+export async function enqueueChildRunFollowUp(params: {
   readonly targetStreamId: StreamTabId;
   readonly followUp: FollowUpQueueInput;
   readonly session: SessionHandle;
-  readonly wake?: boolean;
-}): Promise<ChildRunDeliveryResult> {
+}): Promise<ChildRunEnqueueResult> {
   const result = await sendFollowUp(
     params.targetStreamId,
     params.followUp,
@@ -71,17 +85,59 @@ export async function deliverChildRunFollowUp(params: {
     undefined,
     params.session,
   );
-  if (result.status === 'no_session') {
-    return { kind: 'no_session', streamStatus: result.streamStatus };
+  return result.status === 'no_session'
+    ? { kind: 'no_session', streamStatus: result.streamStatus }
+    : { kind: 'enqueued', sendResult: result };
+}
+
+/**
+ * Wake (or release) the parent stream for a result already enqueued via
+ * {@link enqueueChildRunFollowUp}. This is the half that can await an entire
+ * resumed parent turn (`agentResume.tryResumeStream` → … →
+ * `resumeToolUseFromSnapshot`) — call it only after any of this child's own
+ * finalization work is done, so a resumed parent that immediately waits on
+ * this child's execution never races its own wake.
+ */
+export async function wakeChildRunFollowUp(
+  targetStreamId: StreamTabId,
+  enqueueResult: ChildRunEnqueueResult,
+  session: SessionHandle,
+): Promise<ChildRunDeliveryResult> {
+  if (enqueueResult.kind === 'no_session') {
+    return { kind: 'no_session', streamStatus: enqueueResult.streamStatus };
+  }
+  return (await wakeOrReleaseQueuedStream(
+    targetStreamId,
+    enqueueResult.sendResult,
+    session,
+  ))
+    ? { kind: 'delivered' }
+    : { kind: 'dropped' };
+}
+
+/**
+ * Enqueue-then-wake in one call, for callers with no finalization step to
+ * order the wake after (e.g. a live-progress notification, or a wake-failure
+ * error report). Callers that finalize their own child around delivery use
+ * {@link enqueueChildRunFollowUp} and {@link wakeChildRunFollowUp} directly,
+ * with the finalize sandwiched between them.
+ */
+export async function deliverChildRunFollowUp(params: {
+  readonly targetStreamId: StreamTabId;
+  readonly followUp: FollowUpQueueInput;
+  readonly session: SessionHandle;
+  readonly wake?: boolean;
+}): Promise<ChildRunDeliveryResult> {
+  const enqueueResult = await enqueueChildRunFollowUp(params);
+  if (enqueueResult.kind === 'no_session') {
+    return { kind: 'no_session', streamStatus: enqueueResult.streamStatus };
   }
   if (!params.wake) {
     return { kind: 'delivered' };
   }
-  return (await wakeOrReleaseQueuedStream(
+  return wakeChildRunFollowUp(
     params.targetStreamId,
-    result,
+    enqueueResult,
     params.session,
-  ))
-    ? { kind: 'delivered' }
-    : { kind: 'dropped' };
+  );
 }


### PR DESCRIPTION
## Context

Closes #8093 — follow-up from #8079's review discussion
(https://github.com/LionSR/TeXRA/pull/8079#discussion_r3563812234). The
PR author verified but deferred fixing a cross-cutting ordering issue in
`deliverChildRunFollowUp({ wake: true })`: waking a WAITING parent
(`agentResume.tryResumeStream` → `resolveAndResumeStream` →
`resumeQueuedToolUseSnapshot` → `resumeToolUseFromSnapshot`) awaits the
**entire resumed parent turn**, but every caller awaited that wake before
finalizing its own child (`finally { await finalizeBackground/childStream.finalize }`).

The 2026-07-11 re-verification on the issue upgraded this from "cosmetic
staleness" to a real bounded self-stall: the resumed parent can now call
`executions` with `action=wait` (default budget 300s) on the very
execution that woke it — which is still tracked as RUNNING until the
child's own `finally` runs, which can't run until the parent's turn
returns. Cyclic wait, bounded by the wait budget, repeatable on retry.

## Root cause / fix

`deliverChildRunFollowUp` mixed two phases with very different latency:
- **enqueue** — append to (or queue on) the parent's follow-up queue; fast,
  never awaits a resumed parent turn.
- **wake** — resume a WAITING/detached parent via the host port; can await
  the parent's entire next turn.

Split them in `src/tools/childRunDelivery.ts`:
- `enqueueChildRunFollowUp` — the fast half.
- `wakeChildRunFollowUp` — the slow half, taking the enqueue result.
- `deliverChildRunFollowUp` kept as a thin enqueue-then-wake composition,
  for callers with no finalize step to sandwich between them (the
  `notify` progress port stays enqueue-only now; the wake-failure error
  report in `DelegationTools.ts`'s `resumeAgent` is already
  fire-and-forget off the tool call's own return, so it's untouched).

Both call sites that finalize a child around delivery now sandwich the
finalize between enqueue and wake:
- **`src/tools/bash.ts`** (background bash): enqueue → `finalizeBackground`
  → wake.
- **`src/agent/runtime/childRunLoop.ts`** (shared driver for agent-CLI
  child streams *and* native delegated subagents — one loop, N
  strategies): a terminal/failed turn's delivery is enqueued inline, then
  the wake is deferred (`pendingDelivery`) until *after* the loop's own
  `finally` finalizes the child (`childStream.finalize` for agent-CLI,
  `finalizeRunTerminal` for the native dangling-handle fallback). Interim
  (non-terminal) turns still wake inline immediately — no finalize is
  pending for them, so there is nothing to reorder around.

This gives background bash, delegated subagents, and the child run loop
one ordering model: enqueue, finalize, wake — never wake before finalize.

## Net elements (R6)

- **+2 exports** in `childRunDelivery.ts`: `enqueueChildRunFollowUp`,
  `wakeChildRunFollowUp` (plus the `ChildRunEnqueueResult` type). No new
  files, no new layers — `deliverChildRunFollowUp` stays as a thin
  composition of the two for callers that don't need the split.
- **0 new dependencies.**
- `childRunLoop.ts`'s `deliverTurn` return type changes from `void` to
  `PendingChildDelivery | undefined`; a new small `wakePendingDelivery`
  helper resolves it. `bash.ts` splits its single `deliverParentFollowUp`
  into `enqueueParentFollowUp` + `wakeParentFollowUp`, sequenced around
  the existing `finalizeBackground` call — no new abstraction layer, just
  the existing delivery closure split at its natural seam.

## Consumer counts (R8)

`enqueueChildRunFollowUp` — 2 callers (`childRunLoop.ts`'s `deliverTurn`
and its `notify` progress port; `bash.ts`'s `enqueueParentFollowUp`, 3
call sites total across 2 files). `wakeChildRunFollowUp` — 2 call sites
(`childRunLoop.ts`'s `wakePendingDelivery`; `bash.ts`'s
`wakeParentFollowUp`). `deliverChildRunFollowUp` — unchanged, still used
by `DelegationTools.ts`'s `deliverResumeWakeFailure` (fire-and-forget,
not on a finalize-blocking path, left as-is).

## Tests

- `src/test-kernel/tools/ChildRunDelivery.vitest.ts`: new tests for the
  enqueue/wake split, including one proving the enqueue half settles
  (and is actionable by a caller) strictly before a slow wake half
  resolves.
- `src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts`: updated all
  existing fixtures to the new enqueue/wake mock shape, plus a new
  regression test (`#8093 regression: ...`) that gates the wake step and
  asserts the execution is already untracked (terminal) the instant the
  wake step is reached — **proven to fail** against the pre-fix ordering
  (verified locally by reverting only the ordering while keeping the
  enqueue/wake API: exactly this new test fails, the other 11 stay
  green).
- `src/test-kernel/tools/BashTool.vitest.ts`: new regression test
  mirroring the same proof for background bash — holds the host resume
  port (`agentResume.tryResumeStream`) open and asserts the execution is
  already untracked by the time that port is invoked. **Proven to fail**
  against the pre-fix `bash.ts` (verified locally against the pre-fix
  source: this test fails, the other 7 stay green).
- `src/test-kernel/tools/NativeToolUseStrategy.vitest.ts`: updated its
  `childRunDelivery` mock to the new enqueue/wake shape (it drives the
  real `childRunLoop.ts`).

## Test plan

- [x] `npx vitest run src/test-kernel/tools/BashTool.vitest.ts
      src/test-kernel/tools/ChildRunDelivery.vitest.ts
      src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
      src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
      src/test-kernel/tools/DelegationTools.vitest.ts` — 47/47 passed
- [x] `npx vitest run src/test-kernel/tools src/test-kernel/agent/runtime`
      — 743/743 passed
- [x] `npm run typecheck` — clean
- [x] `npx eslint` + `npx prettier --check` on all changed files — clean
- [x] New regression tests independently verified to fail against the
      pre-fix ordering (both `childRunLoop.ts` and `bash.ts`)

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering in core child-run and background-bash orchestration where parent resume can block for a full turn; mistakes could reintroduce deadlocks or missed parent wakes, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **#8093** by separating **fast enqueue** from **slow parent wake** in child-run delivery, so callers can **finalize the child** (untrack / terminal in the execution registry) **before** waking a WAITING parent.
> 
> **`childRunDelivery`** adds `enqueueChildRunFollowUp` and `wakeChildRunFollowUp` (plus `ChildRunEnqueueResult`); `deliverChildRunFollowUp` remains a thin enqueue-then-wake helper for paths that do not need ordering around finalize.
> 
> **`childRunLoop`** enqueues each turn’s result as before, but **defers wake** for terminal/failed turns until after the loop’s own finalize in `finally`; **interim** turns still wake immediately. Progress `notify` stays **enqueue-only** (no wake).
> 
> **Background `bash`** completion follows the same rule: **enqueue → `finalizeBackground` → wake**, instead of awaiting wake before finalize.
> 
> Regression tests assert the execution is already **untracked** when the wake/resume step runs (child loop and background bash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab42235d8fb2a7c01d4c1e855ef1aac7a054f45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->