### PR TITLE
fix(shared): validate outbound webview/desktop IPC against existing schemas

### DIFF
--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -1,9 +1,4 @@
-import { MainViewMessageSchema } from '@shared/schemas/mainView';
-import { ProgressViewOutboundMessageSchema } from '@shared/schemas/progressView';
-import {
-  assertKnownOutboundMessage,
-  UnsupportedCommandError,
-} from '@shared/utils/dispatcher';
+import { UnsupportedCommandError } from '@shared/utils/dispatcher';
 
 export type DesktopCommandMessage = { command: string } & Record<
   string,
@@ -16,27 +11,6 @@ export interface DesktopMessageHandler {
 
 export interface DesktopRenderer {
   postToRenderer(message: unknown): void;
-}
-
-/**
- * Dev/test-only shape check for every message posted to the desktop
- * renderer through {@link DesktopRenderer.postToRenderer}. Desktop
- * multiplexes `MainViewMessage`s, `ProgressViewOutboundMessage`s, and
- * desktop-only overlay/settings commands (`desktop:showPdf`, git-author
- * settings, history, ...) onto the one renderer-push channel
- * (`installDesktopHostBridge` in `hostBridge.ts`, the sole caller of this
- * function); only the first two domains have an outbound Zod schema today —
- * a command belonging to neither passes through unchecked, per
- * `assertKnownOutboundMessage`. No-op outside dev/test: this channel also
- * carries high-frequency progress-stream chunks, so production keeps
- * sending the typed payload as-is with zero added parse cost (see
- * `assertKnownOutboundMessage` for the full rationale).
- */
-export function assertDesktopOutboundMessage(message: unknown): void {
-  assertKnownOutboundMessage(
-    [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
-    message,
-  );
 }
 
 export function isDesktopCommandMessage(

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -1,4 +1,9 @@
-import { UnsupportedCommandError } from '@shared/utils/dispatcher';
+import { MainViewMessageSchema } from '@shared/schemas/mainView';
+import { ProgressViewOutboundMessageSchema } from '@shared/schemas/progressView';
+import {
+  assertKnownOutboundMessage,
+  UnsupportedCommandError,
+} from '@shared/utils/dispatcher';
 
 export type DesktopCommandMessage = { command: string } & Record<
   string,
@@ -11,6 +16,27 @@ export interface DesktopMessageHandler {
 
 export interface DesktopRenderer {
   postToRenderer(message: unknown): void;
+}
+
+/**
+ * Dev/test-only shape check for every message posted to the desktop
+ * renderer through {@link DesktopRenderer.postToRenderer}. Desktop
+ * multiplexes `MainViewMessage`s, `ProgressViewOutboundMessage`s, and
+ * desktop-only overlay/settings commands (`desktop:showPdf`, git-author
+ * settings, history, ...) onto the one renderer-push channel
+ * (`installDesktopHostBridge` in `hostBridge.ts`, the sole caller of this
+ * function); only the first two domains have an outbound Zod schema today —
+ * a command belonging to neither passes through unchecked, per
+ * `assertKnownOutboundMessage`. No-op outside dev/test: this channel also
+ * carries high-frequency progress-stream chunks, so production keeps
+ * sending the typed payload as-is with zero added parse cost (see
+ * `assertKnownOutboundMessage` for the full rationale).
+ */
+export function assertDesktopOutboundMessage(message: unknown): void {
+  assertKnownOutboundMessage(
+    [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
+    message,
+  );
 }
 
 export function isDesktopCommandMessage(

--- a/packages/desktop/src/main/hostBridge.ts
+++ b/packages/desktop/src/main/hostBridge.ts
@@ -1,10 +1,13 @@
 import { ipcMain, type BrowserWindow, type IpcMainEvent } from 'electron';
 
+import { MainViewMessageSchema } from '@shared/schemas/mainView';
+import { ProgressViewOutboundMessageSchema } from '@shared/schemas/progressView';
+import { assertKnownOutboundMessage } from '@shared/utils/dispatcher';
+
 import {
   ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
   ELECTRON_WEBVIEW_PUSH_CHANNEL,
 } from '../hostBridgeChannels.js';
-import { assertDesktopOutboundMessage } from './desktopIpcTypes.js';
 
 export interface DesktopHostBridgeOptions {
   onRendererMessage?: (message: unknown, window: BrowserWindow) => void;
@@ -34,7 +37,17 @@ export function installDesktopHostBridge(
   window.once('closed', dispose);
   return {
     postToRenderer: (message) => {
-      assertDesktopOutboundMessage(message);
+      // Dev/test-only shape check (no-op in prod, see `isDevAssertionMode`
+      // in `assertKnownOutboundMessage`). Desktop multiplexes
+      // `MainViewMessage`s, `ProgressViewOutboundMessage`s, and
+      // desktop-only overlay/settings commands (`desktop:showPdf`,
+      // git-author settings, history, ...) onto this one renderer-push
+      // channel; only the first two domains have an outbound Zod schema
+      // today — a command belonging to neither passes through unchecked.
+      assertKnownOutboundMessage(
+        [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
+        message,
+      );
       if (window.isDestroyed() || window.webContents.isDestroyed()) return;
       window.webContents.send(ELECTRON_WEBVIEW_PUSH_CHANNEL, message);
     },

--- a/packages/desktop/src/main/hostBridge.ts
+++ b/packages/desktop/src/main/hostBridge.ts
@@ -4,6 +4,7 @@ import {
   ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
   ELECTRON_WEBVIEW_PUSH_CHANNEL,
 } from '../hostBridgeChannels.js';
+import { assertDesktopOutboundMessage } from './desktopIpcTypes.js';
 
 export interface DesktopHostBridgeOptions {
   onRendererMessage?: (message: unknown, window: BrowserWindow) => void;
@@ -33,6 +34,7 @@ export function installDesktopHostBridge(
   window.once('closed', dispose);
   return {
     postToRenderer: (message) => {
+      assertDesktopOutboundMessage(message);
       if (window.isDestroyed() || window.webContents.isDestroyed()) return;
       window.webContents.send(ELECTRON_WEBVIEW_PUSH_CHANNEL, message);
     },

--- a/packages/extension/src/webview/managers/BaseWebviewManager.ts
+++ b/packages/extension/src/webview/managers/BaseWebviewManager.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+import { MainViewMessageSchema } from '@shared/schemas/mainView';
+import { assertOutboundMessage } from '@shared/utils/dispatcher';
+
 /**
  * Base class for webview managers that need to post messages to the webview.
  * Provides common webview attachment and message posting patterns.
@@ -23,6 +26,11 @@ export abstract class BaseWebviewManager {
     command: string;
     [key: string]: unknown;
   }): void {
+    // Dev/test-only: every BaseWebviewManager subclass sends MainView
+    // outbound messages exclusively, so a shape mismatch here is always a
+    // real drift between the schema and the producer, not an out-of-scope
+    // command. See `assertOutboundMessage` for the prod no-op rationale.
+    assertOutboundMessage(MainViewMessageSchema, message);
     this.webview?.webview.postMessage(message);
   }
 }

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -10,6 +10,7 @@ import {
   createDispatcher,
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
+import { ThemeSchema } from '../commonViewMessages';
 import { GoalStatusSchema } from '../goal';
 
 import { StreamTabIdSchema } from '../identifiers';
@@ -338,9 +339,15 @@ const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
   objective: z.string().optional(),
 });
 
+// `theme` reuses the canonical `ThemeSchema` (`commonViewMessages.ts`) rather
+// than a locally re-declared enum — the actual desktop theme kind includes
+// `'high-contrast'` (see `DESKTOP_THEME_KIND`), which
+// `COMMON_COMMANDS.THEME_SET` messages already carry for both mainView and
+// progressView; a narrower local enum here previously just hadn't been
+// exercised against real payloads before outbound send validation (#8123).
 export const ProgressSetThemeMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.THEME_SET),
-  theme: z.enum(['dark', 'light']),
+  theme: ThemeSchema,
 });
 
 export const ProgressDeleteStreamMessageSchema = StreamScopedBaseSchema.extend({

--- a/src/shared/utils/dispatcher.ts
+++ b/src/shared/utils/dispatcher.ts
@@ -179,3 +179,96 @@ export function createDispatcher<TMessage extends CommandMessage>(
     return true;
   };
 }
+
+/**
+ * Dev/test-only outbound-message assertions. Mirrors `createDispatcher`'s
+ * inbound-side validation, but for the send side of the same schemas: a
+ * webview/desktop IPC boundary that already has an outbound Zod schema but
+ * never runs the payload through it before posting.
+ *
+ * Both `assertOutboundMessage` and `assertKnownOutboundMessage` are no-ops
+ * outside `isDevAssertionMode()` — zero `safeParse` cost in production. Some
+ * of these boundaries (desktop's single `postToRenderer` channel carries
+ * high-frequency progress-stream chunks, e.g. `LOG_DELTA`) are hot enough
+ * that even a cheap parse per message is worth avoiding outside dev/test;
+ * production keeps sending the TypeScript-typed payload as-is (a
+ * compile-time type-assert, not a runtime check) exactly as it did before
+ * this validation existed, so there is no prod behavior or wire-format
+ * change. Dev/test throws immediately on a mismatch — schema and producer
+ * have drifted — rather than logging, since these are the same runs where
+ * `npm test` / CI would otherwise treat drift as silently passing.
+ */
+function isDevAssertionMode(): boolean {
+  return (
+    process.env.NODE_ENV === 'test' || process.env.TEXRA_DEV_ASSERTIONS === '1'
+  );
+}
+
+/**
+ * True when a discriminated-union `safeParse` failure means "this message's
+ * `command` doesn't belong to this schema at all" (Zod's "no matching
+ * discriminator" case) rather than "the command matched but a field is
+ * wrong". Only the top-level `command` discriminator counts — a nested
+ * discriminated union inside a matched branch (e.g. `UpdatePermissionMessage
+ * Schema`'s `action` field) reports its own `invalid_union` issue at a
+ * different path, which is a real validation failure, not an unrecognized
+ * command.
+ */
+function isUnrecognizedCommand(error: z.ZodError): boolean {
+  const [issue, ...rest] = error.issues;
+  return (
+    rest.length === 0 &&
+    issue?.code === 'invalid_union' &&
+    issue.path.length === 1 &&
+    issue.path[0] === 'command'
+  );
+}
+
+/**
+ * Asserts (dev/test only) that `message` conforms to `schema` — for a send
+ * boundary where every message is known to belong to exactly one outbound
+ * domain (e.g. `BaseWebviewManager.postMessage`, which only ever sends
+ * `MainViewMessage`s). Throws on any mismatch, including a `command` the
+ * schema doesn't recognize at all.
+ */
+export function assertOutboundMessage<TMessage extends CommandMessage>(
+  schema: z.ZodType<TMessage>,
+  message: unknown,
+): void {
+  if (!isDevAssertionMode()) return;
+  const result = schema.safeParse(message);
+  if (!result.success) {
+    throw new Error(
+      `Outbound message failed schema validation: ${result.error.message}`,
+    );
+  }
+}
+
+/**
+ * Asserts (dev/test only) that `message` conforms to the outbound schema
+ * that recognizes its `command` — for a send boundary that multiplexes
+ * several outbound domains onto one channel (desktop's single
+ * `postToRenderer`, which carries `MainViewMessage`, `ProgressViewOutbound
+ * Message`, and desktop-only overlay/settings commands that don't have a
+ * schema here yet). `domains` is tried in order; a `command` none of them
+ * recognize is out of scope for this call and passes through unchecked —
+ * this only guards commands that already have a schema, per the "don't
+ * create new schemas" boundary for this change. A `command` a domain does
+ * recognize, but whose payload fails that domain's deeper validation, is a
+ * real mismatch and throws immediately.
+ */
+export function assertKnownOutboundMessage(
+  domains: readonly z.ZodType<CommandMessage>[],
+  message: unknown,
+): void {
+  if (!isDevAssertionMode()) return;
+  for (const schema of domains) {
+    const result = schema.safeParse(message);
+    if (result.success) return;
+    if (!isUnrecognizedCommand(result.error)) {
+      throw new Error(
+        `Outbound message failed schema validation: ${result.error.message}`,
+      );
+    }
+  }
+}

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
@@ -166,7 +166,7 @@ describe('desktop Electron host bridge', () => {
 
     // `theme` must be a real `ProgressSetThemeMessageSchema` value
     // ('dark' | 'light') — `postToRenderer` now runs every message through
-    // `assertDesktopOutboundMessage` (dev/test only), so an arbitrary
+    // `assertKnownOutboundMessage` (dev/test only), so an arbitrary
     // placeholder like the renderer-side test's `'vscode-dark'` would throw
     // here instead of exercising the channel-routing behavior under test.
     const hostMessage = { command: 'setTheme', theme: 'dark' };

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
@@ -164,7 +164,12 @@ describe('desktop Electron host bridge', () => {
     rendererListener?.({ sender: webContents }, { command: 'ready' });
     expect(rendererMessages).toEqual([{ command: 'ready' }]);
 
-    const hostMessage = { command: 'setTheme', theme: 'vscode-dark' };
+    // `theme` must be a real `ProgressSetThemeMessageSchema` value
+    // ('dark' | 'light') — `postToRenderer` now runs every message through
+    // `assertDesktopOutboundMessage` (dev/test only), so an arbitrary
+    // placeholder like the renderer-side test's `'vscode-dark'` would throw
+    // here instead of exercising the channel-routing behavior under test.
+    const hostMessage = { command: 'setTheme', theme: 'dark' };
     bridge.postToRenderer(hostMessage);
     expect(sends).toEqual([
       { channel: ELECTRON_WEBVIEW_PUSH_CHANNEL, message: hostMessage },
@@ -177,5 +182,65 @@ describe('desktop Electron host bridge', () => {
     );
     closedListeners[0]?.();
     expect(ipcMain.off).toHaveBeenCalledTimes(1);
+  });
+
+  // #8123: `postToRenderer` now routes every message through the existing
+  // MainView / ProgressView outbound Zod schemas (dev/test only) before
+  // handing it to `webContents.send`, instead of forwarding whatever shape
+  // the caller happened to build.
+  describe('outbound schema validation (#8123)', () => {
+    async function createBridge() {
+      const { ELECTRON_WEBVIEW_PUSH_CHANNEL } = await loadHostBridgeModule();
+      const ipcMain = { on: vi.fn(), off: vi.fn() };
+      const { installDesktopHostBridge } =
+        await loadMainHostBridgeModule(ipcMain);
+      const sends: Array<{ channel: string; message: unknown }> = [];
+      const window = {
+        isDestroyed: () => false,
+        once: vi.fn(),
+        webContents: {
+          isDestroyed: () => false,
+          send: vi.fn((channel, message) => sends.push({ channel, message })),
+        },
+      };
+      return {
+        bridge: installDesktopHostBridge(window),
+        sends,
+        pushChannel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+      };
+    }
+
+    it('throws on a ProgressView-domain message with a bad field (schema/producer drift)', async () => {
+      const { bridge } = await createBridge();
+      // Same fixture shape as the channel-routing test above, but with the
+      // invalid theme value restored — proves the assertion actually fires
+      // for a real MainView/ProgressView schema mismatch, not just that the
+      // production code compiles.
+      expect(() =>
+        bridge.postToRenderer({ command: 'setTheme', theme: 'vscode-dark' }),
+      ).toThrow(/Outbound message failed schema validation/);
+    });
+
+    it('forwards a well-formed MainView outbound message unchanged', async () => {
+      const { bridge, sends, pushChannel } = await createBridge();
+      const message = {
+        command: 'setCurrentFile',
+        filePath: 'paper.tex',
+        fileType: 'input',
+      };
+      expect(() => bridge.postToRenderer(message)).not.toThrow();
+      expect(sends).toEqual([{ channel: pushChannel, message }]);
+    });
+
+    it('passes a desktop-only command unrecognized by either outbound schema through unchecked', async () => {
+      const { bridge, sends, pushChannel } = await createBridge();
+      // `desktop:showPdf` (and settings/history/onboarding commands) aren't
+      // modeled by MainViewMessageSchema or ProgressViewOutboundMessageSchema
+      // — out of scope for this change, so no schema claims the command and
+      // it must not throw.
+      const message = { command: 'desktop:showPdf', title: 't' };
+      expect(() => bridge.postToRenderer(message)).not.toThrow();
+      expect(sends).toEqual([{ channel: pushChannel, message }]);
+    });
   });
 });

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -518,7 +518,12 @@ describe('desktop main-view IPC', () => {
       })),
     }));
     vi.doMock('@model/computeModelOptions', () => ({
-      computeModelOptionsData: vi.fn(async () => [{ value: 'fresh-model' }]),
+      // `label` is required by `ModelOptionDataSchema` (PickerOptionBaseSchema)
+      // — `postToRenderer` now runs the SET_MODEL_OPTIONS payload through it
+      // (dev/test only), so the stub must match the real shape.
+      computeModelOptionsData: vi.fn(async () => [
+        { value: 'fresh-model', label: 'Fresh Model' },
+      ]),
     }));
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =
       await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -23,13 +23,19 @@ import {
   createInitialState,
   type ProgressState,
 } from '@progressView/frontend/store';
-import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { MAIN_VIEW_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewOutbound,
+  MainViewMessageSchema,
   ProgressViewOutboundMessageSchema,
   type ProgressViewOutboundHandlerRegistry,
 } from '@shared/schemas';
-import { UnsupportedCommandError, unsupported } from '@shared/utils/dispatcher';
+import {
+  assertKnownOutboundMessage,
+  assertOutboundMessage,
+  UnsupportedCommandError,
+  unsupported,
+} from '@shared/utils/dispatcher';
 
 /** Every command in the real outbound schema, including nested unions (UPDATE_PERMISSION). */
 function outboundCommands(): string[] {
@@ -209,5 +215,60 @@ describe('dispatchProgressViewOutbound Unsupported-command gating (@shared/utils
       1,
     );
     expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+// #8123: outbound webview/desktop IPC (BaseWebviewManager.postMessage,
+// desktopIpcTypes.ts's postToRenderer) now runs payloads through these
+// existing outbound schemas before sending, mirroring the inbound-side
+// validation `createDispatcher` already performs. Vitest runs with
+// `NODE_ENV=test`, so `assertOutboundMessage`/`assertKnownOutboundMessage`
+// are always in their dev/test-assertion (throwing) mode here.
+describe('assertOutboundMessage / assertKnownOutboundMessage (#8123)', () => {
+  it('does not throw for a well-formed MainView outbound message', () => {
+    expect(() =>
+      assertOutboundMessage(MainViewMessageSchema, {
+        command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
+        filePath: 'paper.tex',
+        fileType: 'input',
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when a MainView outbound message drifts from its schema (single-domain boundary, e.g. BaseWebviewManager.postMessage)', () => {
+    expect(() =>
+      assertOutboundMessage(MainViewMessageSchema, {
+        command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
+        // Missing `fileType` — required by SetCurrentFileMessageSchema.
+        filePath: 'paper.tex',
+      }),
+    ).toThrow(/Outbound message failed schema validation/);
+  });
+
+  it('lets a command unrecognized by any listed domain pass through unchecked (desktop-only messages)', () => {
+    expect(() =>
+      assertKnownOutboundMessage(
+        [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
+        { command: 'desktop:showPdf', title: 'paper.pdf', pdfPath: '/x.pdf' },
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws when a command matches a known domain but fails that domain's own validation", () => {
+    expect(() =>
+      assertKnownOutboundMessage(
+        [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
+        { command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM }, // missing `activeStream`
+      ),
+    ).toThrow(/Outbound message failed schema validation/);
+  });
+
+  it('throws for a bad discriminator nested inside a matched command (UPDATE_PERMISSION.action), not just a top-level unknown command', () => {
+    expect(() =>
+      assertKnownOutboundMessage(
+        [MainViewMessageSchema, ProgressViewOutboundMessageSchema],
+        { command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION, action: 'bogus' },
+      ),
+    ).toThrow(/Outbound message failed schema validation/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up on #8069's deferred audit item — closes #8123.

`BaseWebviewManager.postMessage` (extension) and desktop's `postToRenderer`
(`DesktopRenderer.postToRenderer`, implemented once in
`installDesktopHostBridge`/`hostBridge.ts`, the sole funnel every desktop
`postToRenderer` call — 17+ call sites — ultimately reaches) sent payloads
straight to `webview.postMessage` / `webContents.send` without ever running
them through the outbound Zod schemas that already exist for the same
message domains (`MainViewMessageSchema`, `ProgressViewOutboundMessageSchema`
— these are only exercised today on the *receiving* side, via
`dispatchMainView`/`dispatchProgressViewOutbound` in the frontend). This adds
validate-on-send at both funnels, mirroring `createDispatcher`'s existing
inbound-side validation.

- `assertOutboundMessage(schema, message)` — strict, single-domain boundary.
  Used by `BaseWebviewManager.postMessage`, since its three subclasses
  (`FileManager`, `InstructionManager`, `DiffManager`) only ever send
  `MainViewMessage`s — any `command` this schema doesn't recognize is a real
  bug, not an out-of-scope message.
- `assertKnownOutboundMessage(domains, message)` — desktop's single
  `postToRenderer` multiplexes `MainViewMessage`, `ProgressViewOutboundMessage`,
  and several desktop-only overlay/settings commands (`desktop:showPdf`,
  git-author settings, history, onboarding, ...) onto one Electron channel.
  Tries each domain in order; a `command` none of them recognize is out of
  scope for this change (no schema exists for it yet) and passes through
  unchecked. A `command` a domain *does* recognize whose payload still fails
  validation throws immediately — including a mismatch nested one level
  down (e.g. `UPDATE_PERMISSION`'s `action` sub-discriminator), not just an
  unrecognized top-level `command`.

**Dev/test vs. prod**: both assertions are gated on `isDevAssertionMode()`
(`NODE_ENV=test` or `TEXRA_DEV_ASSERTIONS=1` — the existing pattern from
`SessionEventHub.ts`) and are a hard **no-op outside that mode** — zero
`safeParse` cost in production. Desktop's `postToRenderer` channel also
carries high-frequency progress-stream chunks (e.g. `LOG_DELTA`), so even a
cheap parse per message was worth avoiding there; production keeps sending
the TypeScript-typed payload exactly as before, so there's no wire-format or
runtime behavior change for real users — only CI/dev/test now catch a
schema/producer drift immediately instead of silently shipping it.

**Real bug the new validation caught**: `ProgressSetThemeMessageSchema`
locally re-declared `theme: z.enum(['dark', 'light'])`, but desktop's
`postTheme()` sends the real `DesktopThemeKind` (`'dark' | 'light' |
'high-contrast'`) for both mainView and progressView `THEME_SET` pushes.
`commonViewMessages.ts` already has the correct three-value `ThemeSchema` as
its documented "single source of truth for all theme schemas" — swapped the
local enum for it instead of widening it by hand (no new schema; reuses the
existing canonical one). Two test fixtures were also silently unrealistic
(`theme: 'vscode-dark'`, a `SET_MODEL_OPTIONS` stub missing the required
`label` field) — fixed to match the real schemas rather than relaxed.

## Net elements (R6)

New exports: `assertOutboundMessage`, `assertKnownOutboundMessage` in
`src/shared/utils/dispatcher.ts` (2 functions, ~50 LOC incl. docs), plus one
private helper `assertDesktopOutboundMessage` in `desktopIpcTypes.ts` that
composes them with the two known domains for desktop's funnel — not a new
schema, a thin composition of two already-exported ones. No new schema
types were created; `ProgressSetThemeMessageSchema`'s `theme` field now
reuses the existing `ThemeSchema` instead of a local duplicate (net: one
fewer independently-maintained enum). Two call sites gained one line each
(`assertOutboundMessage(...)` in `BaseWebviewManager.postMessage`,
`assertDesktopOutboundMessage(message)` in `hostBridge.ts`'s
`postToRenderer`) — this is the entire "17+ call sites" surface from the
audit; validating at these two funnels exercises every one of them without
touching their individual construction sites.

## Consumer counts (R8)

- `ProgressSetThemeMessageSchema`: grepped, used only within
  `progressView/outbound.ts` (as a `ProgressViewOutboundMessageSchema` union
  member) — safe to widen its `theme` field in place.
- `assertOutboundMessage` / `assertKnownOutboundMessage`: new, 1 and 1
  call site respectively (`BaseWebviewManager.ts`, `desktopIpcTypes.ts`).

## Dependency decision

None — no new npm dependency. Reuses `zod` (already a dependency) and the
existing `createDispatcher`/`z.discriminatedUnion` machinery in
`src/shared/utils/dispatcher.ts`.

## Host impact

- **Extension**: `BaseWebviewManager.postMessage` (used by `FileManager`,
  `InstructionManager`, `DiffManager`) now validates against
  `MainViewMessageSchema` in dev/test. No prod behavior change.
- **Desktop**: `installDesktopHostBridge`'s `postToRenderer` (the sole
  implementation behind `DesktopRenderer.postToRenderer` and every
  `installDesktopMainViewIpc`/`index.ts` wrapper around it) now validates
  against `[MainViewMessageSchema, ProgressViewOutboundMessageSchema]` in
  dev/test; desktop-only commands without a schema pass through unchanged.
  No prod behavior change. `ProgressSetThemeMessageSchema` widening also
  fixes a real (if latent, since nothing previously validated it) gap for
  desktop's `high-contrast` theme value.
- **CLI**: untouched — no `BaseWebviewManager`/`postToRenderer` coupling.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — clean (no errors in touched files or repo-wide).
- `npm test` (`src/test-kernel`) — 645 files / 5681 tests passed, 1
  file / 4 tests skipped (pre-existing), 0 failed. Includes new
  regression coverage:
  - `src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts`:
    direct unit tests for `assertOutboundMessage`/`assertKnownOutboundMessage`
    (valid message passes, single-domain drift throws, out-of-scope command
    passes through, known-domain field failure throws, nested-discriminator
    failure — e.g. `UPDATE_PERMISSION.action` — throws rather than being
    mistaken for an unrecognized top-level command).
  - `src/test-kernel/desktop/ElectronHostBridge.vitest.mts`: proves
    `installDesktopHostBridge.postToRenderer` throws on real
    schema/producer drift, forwards a well-formed `MainViewMessage`
    unchanged, and passes a desktop-only command (`desktop:showPdf`)
    through unchecked. The first of these is a genuine regression test —
    it fails against the pre-fix `postToRenderer` (confirmed while
    developing this PR: the original single existing test in this file
    used the same invalid `theme: 'vscode-dark'` fixture and only started
    failing once the funnel was wired up, which is what surfaced the
    `ProgressSetThemeMessageSchema` bug above).
  - `src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`: fixed a
    pre-existing test stub (`SET_MODEL_OPTIONS` mock missing the
    schema-required `label` field) that the new validation now catches.

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Assertions are no-ops in production; changes tighten dev/CI guarantees and fix a latent theme enum mismatch without altering prod wire behavior.
> 
> **Overview**
> Adds **dev/test-only** Zod validation on outbound IPC at the two shared send funnels—extension `BaseWebviewManager.postMessage` (strict `MainViewMessageSchema`) and desktop `installDesktopHostBridge`’s `postToRenderer` (`assertKnownOutboundMessage` over MainView + ProgressView schemas). Production stays a no-op (`NODE_ENV=test` or `TEXRA_DEV_ASSERTIONS=1` only), so high-frequency channels like `LOG_DELTA` are unchanged for users; CI/dev now throw when producers drift from schemas.
> 
> Desktop multiplexing still allows **desktop-only** commands without schemas (e.g. `desktop:showPdf`) to pass through; known commands with bad payloads fail validation, including nested discriminators like `UPDATE_PERMISSION.action`.
> 
> **Schema fix surfaced by the new checks:** `ProgressSetThemeMessageSchema.theme` now reuses canonical `ThemeSchema` (`dark` | `light` | `high-contrast`) instead of a local two-value enum, matching real desktop theme pushes. Test fixtures were aligned (`setTheme` theme values, `SET_MODEL_OPTIONS` stub `label`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5961023c73e468b81f295ec67d8882deb456ae0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->