### PR TITLE
feat(cli): introduce a semantic color palette for the TUI

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -13,6 +13,7 @@ import {
 } from './slashRegistry';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
+import { COLOR_HINT } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
 import { nextWrappingHighlightIndex } from '../ui/Select';
@@ -183,7 +184,7 @@ export function SlashPalette(
   return (
     <Box
       borderStyle="single"
-      borderColor="cyan"
+      borderColor={COLOR_HINT}
       flexDirection="column"
       paddingX={1}
     >
@@ -195,7 +196,7 @@ export function SlashPalette(
         return (
           <Box key={cmd.name} flexDirection="row">
             <Box flexShrink={0} width={commandLabelWidth}>
-              <Text color={i === highlight ? 'cyan' : undefined}>
+              <Text color={i === highlight ? COLOR_HINT : undefined}>
                 {i === highlight ? POINTER : ' '} /{cmd.name}
               </Text>
             </Box>

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -201,7 +201,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
 
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/agent" showCloseHint={false}>
+      <FormFrame title="/agent" showCloseHint={false}>
         {currentAgentHint ? (
           <Text dimColor wrap="truncate-end">
             {currentAgentHint}
@@ -228,7 +228,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
   }
 
   return (
-    <FormFrame color="cyan" title="/agent" showCloseHint={false}>
+    <FormFrame title="/agent" showCloseHint={false}>
       <Text dimColor wrap="truncate-end">
         {props.selectable
           ? 'Choose the root agent for this chat.'

--- a/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiKeyEntryForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@shared/constants/providers';
 
 import { BaseTextInput } from '../input/BaseTextInput';
+import { COLOR_ERROR } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
 import { FormFrame } from './_shared/FormFrame';
@@ -43,11 +44,7 @@ export function ApiKeyEntryForm(
   });
 
   return (
-    <FormFrame
-      color="cyan"
-      title="Use my own provider API key"
-      showCloseHint={false}
-    >
+    <FormFrame title="Use my own provider API key" showCloseHint={false}>
       <Text dimColor>Provider: {label}</Text>
       {keyUrl ? <Text dimColor>Get a key: {keyUrl}</Text> : null}
       <Box marginTop={1}>
@@ -65,7 +62,7 @@ export function ApiKeyEntryForm(
       </Box>
       <Box marginTop={1} flexDirection="column">
         {props.error ? (
-          <Text color="red">{props.error}</Text>
+          <Text color={COLOR_ERROR}>{props.error}</Text>
         ) : (
           <Text dimColor>
             Stored in TeXRA secrets on Enter — or set{' '}

--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -51,7 +51,7 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
 
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/api" showCloseHint={false}>
+      <FormFrame title="/api" showCloseHint={false}>
         <Select
           items={items}
           activeValue={props.currentMode}
@@ -66,7 +66,7 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
   }
 
   return (
-    <FormFrame color="cyan" title="/api" showCloseHint={false}>
+    <FormFrame title="/api" showCloseHint={false}>
       <Text dimColor>
         Choose which credentials model calls should use. Press 1 for API keys.
       </Text>

--- a/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApprovalPolicyForm.tsx
@@ -38,7 +38,7 @@ export function ApprovalPolicyForm(
 ): React.JSX.Element {
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/approval" showCloseHint={false}>
+      <FormFrame title="/approval" showCloseHint={false}>
         <Select
           items={APPROVAL_POLICY_ITEMS}
           activeValue={props.currentPolicy}
@@ -56,7 +56,7 @@ export function ApprovalPolicyForm(
   }
 
   return (
-    <FormFrame color="cyan" title="/approval" showCloseHint={false}>
+    <FormFrame title="/approval" showCloseHint={false}>
       <Text dimColor>
         Choose when privileged actions prompt or auto-approve.
       </Text>

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -22,6 +22,7 @@ import {
 
 import { BaseTextInput } from '../input/BaseTextInput';
 import { isCtrlInput, type ReturnKeyInput } from '../input/inputKeys';
+import { COLOR_ERROR } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { POINTER } from '../ui/glyphs';
 import { Select, type SelectItem } from '../ui/Select';
@@ -189,7 +190,6 @@ function ConfigTextEditor(props: {
   });
   return (
     <FormFrame
-      color="cyan"
       title={`/config · ${settingDisplayName(props.entry)}`}
       showCloseHint={false}
     >
@@ -210,7 +210,7 @@ function ConfigTextEditor(props: {
       </Box>
       {error ? (
         <Box marginTop={1}>
-          <Text color="red">{error}</Text>
+          <Text color={COLOR_ERROR}>{error}</Text>
         </Box>
       ) : null}
       <Box marginTop={1}>
@@ -293,7 +293,6 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
     });
     return (
       <FormFrame
-        color="cyan"
         title={`/config · ${settingDisplayName(entry)}`}
         showCloseHint={false}
       >
@@ -358,7 +357,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
 
   if (items.length === 0) {
     return (
-      <FormFrame color="cyan" title="/config">
+      <FormFrame title="/config">
         <Text dimColor>No configurable settings are available here yet.</Text>
       </FormFrame>
     );
@@ -390,7 +389,7 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   };
 
   return (
-    <FormFrame color="cyan" title="/config" showCloseHint={false}>
+    <FormFrame title="/config" showCloseHint={false}>
       <Select
         items={items}
         maxVisibleItems={window.maxVisibleItems}

--- a/packages/cli/src/chat/tui/forms/LoginForm.tsx
+++ b/packages/cli/src/chat/tui/forms/LoginForm.tsx
@@ -40,7 +40,7 @@ export const LOGIN_FORM_ITEMS = [
 export function LoginForm(props: LoginFormProps): React.JSX.Element {
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/login" showCloseHint={false}>
+      <FormFrame title="/login" showCloseHint={false}>
         <Select
           items={LOGIN_FORM_ITEMS}
           maxVisibleItems={LOGIN_FORM_ITEMS.length}
@@ -57,7 +57,7 @@ export function LoginForm(props: LoginFormProps): React.JSX.Element {
   }
 
   return (
-    <FormFrame color="cyan" title="/login" showCloseHint={false}>
+    <FormFrame title="/login" showCloseHint={false}>
       <Text dimColor>Choose how TeXRA should authenticate model calls.</Text>
       <Box marginTop={1} flexDirection="column">
         <Select

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -10,6 +10,7 @@ import {
 import type { MemoryViewItem } from '@shared/schemas';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 
+import { COLOR_WARNING } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 import { FormFrame, renderAsyncListFormTransient } from './_shared/FormFrame';
@@ -50,7 +51,7 @@ export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
   const items = data ?? [];
   if (items.length === 0) {
     return (
-      <FormFrame color="yellow" title="/memory">
+      <FormFrame color={COLOR_WARNING} title="/memory">
         <Text>No memory files found.</Text>
       </FormFrame>
     );
@@ -67,7 +68,7 @@ export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
   }));
 
   return (
-    <FormFrame color="cyan" title="/memory" showCloseHint={false}>
+    <FormFrame title="/memory" showCloseHint={false}>
       <Text dimColor>Choose a memory to preview in the transcript.</Text>
       <Box marginTop={1}>
         <Select

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -158,7 +158,6 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
   if (isCompactFormRows(props.availableRows) && items.length > 0) {
     return (
       <FormFrame
-        color="cyan"
         title={`/model · ${formatCliApiMode(props.apiMode)}`}
         showCloseHint={false}
       >
@@ -218,7 +217,6 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
 
   return (
     <FormFrame
-      color="cyan"
       title={`/model · ${formatCliApiMode(props.apiMode)}`}
       showCloseHint={false}
     >

--- a/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ResumeListForm.tsx
@@ -11,6 +11,7 @@ import {
 import { formatCliHistoryResumeSummary } from '@cli/runtime/historyLabels';
 import type { ExecutionId } from '@shared/schemas';
 
+import { COLOR_WARNING } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { Select } from '../ui/Select';
 import { FormFrame, renderAsyncListFormTransient } from './_shared/FormFrame';
@@ -58,7 +59,7 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
   const entries = data ?? [];
   if (entries.length === 0) {
     return (
-      <FormFrame color="yellow" title="/resume">
+      <FormFrame color={COLOR_WARNING} title="/resume">
         <Text>No resumable sessions found.</Text>
       </FormFrame>
     );
@@ -75,7 +76,7 @@ export function ResumeListForm(props: ResumeListFormProps): React.JSX.Element {
   }));
 
   return (
-    <FormFrame color="cyan" title="/resume" showCloseHint={false}>
+    <FormFrame title="/resume" showCloseHint={false}>
       <Text dimColor>Choose a previous session to continue.</Text>
       <Box marginTop={1}>
         <Select

--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -8,6 +8,7 @@ import { formatRuntimeSkillActivation } from '@skills/runtimeSkills';
 import { readCliRuntimeSkills, skillListRecord } from '@cli/runtime/skills';
 import { escapeText } from '@shared/utils/xmlEscape';
 
+import { COLOR_WARNING } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { Select, type SelectItem } from '../ui/Select';
 import {
@@ -117,7 +118,7 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
 
   if (skills.length === 0) {
     return (
-      <FormFrame color="yellow" title="/skills" showCloseHint={false}>
+      <FormFrame color={COLOR_WARNING} title="/skills" showCloseHint={false}>
         <Text>No discoverable skills found.</Text>
         {issueSummary ? <Text dimColor>{issueSummary}</Text> : null}
       </FormFrame>
@@ -133,7 +134,7 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
 
   if (isCompactFormRows(props.availableRows)) {
     return (
-      <FormFrame color="cyan" title="/skills" showCloseHint={false}>
+      <FormFrame title="/skills" showCloseHint={false}>
         <Text dimColor wrap="truncate-end">
           Select a skill to activate.
         </Text>
@@ -153,7 +154,7 @@ export function SkillsListForm(props: SkillsListFormProps): React.JSX.Element {
   }
 
   return (
-    <FormFrame color="cyan" title="/skills" showCloseHint={false}>
+    <FormFrame title="/skills" showCloseHint={false}>
       <Text dimColor>Select a skill to activate it.</Text>
       {issueSummary ? <Text dimColor>{issueSummary}</Text> : null}
       <Select

--- a/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ToolsListForm.tsx
@@ -105,7 +105,6 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
   if (isCompactFormRows(props.availableRows)) {
     return (
       <FormFrame
-        color="cyan"
         title="/tools · Toggle available external integrations."
         showCloseHint={false}
       >
@@ -124,7 +123,7 @@ export function ToolsListForm(props: ToolsListFormProps): React.JSX.Element {
   }
 
   return (
-    <FormFrame color="cyan" title="/tools" showCloseHint={false}>
+    <FormFrame title="/tools" showCloseHint={false}>
       <Text dimColor>Toggle available external integrations.</Text>
       <Select
         items={items}

--- a/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/FormFrame.tsx
@@ -6,12 +6,16 @@ import { Text, useWindowSize } from 'ink';
 
 import { KeyHints, type KeyHint } from '@cli/chat/tui/ui/KeyHints';
 import { BorderedPanel } from '@cli/chat/tui/ui/BorderedPanel';
+import { COLOR_ERROR, COLOR_HINT } from '@cli/chat/tui/ui/colors';
 import { LoadingIndicator } from '@cli/chat/tui/ui/LoadingIndicator';
 import { FORM_FRAME_MAX_WIDTH } from '@cli/chat/tui/ui/theme';
 import { clamp } from '@utils/core';
 
 export interface FormFrameProps {
-  readonly color: string;
+  /** Border/title color. Defaults to the palette's informational hint —
+   *  pass an explicit color only for a non-default state (e.g. an
+   *  empty-results warning or an error transient). */
+  readonly color?: string;
   readonly title: string;
   readonly children: React.ReactNode;
   /**
@@ -34,7 +38,7 @@ export function FormFrame(props: FormFrameProps): React.JSX.Element {
 
   return (
     <BorderedPanel
-      color={props.color}
+      color={props.color ?? COLOR_HINT}
       title={props.title}
       width={formFrameWidth(columns)}
       footer={
@@ -69,11 +73,7 @@ export function renderAsyncListFormTransient(props: {
 }): React.JSX.Element | null {
   if (props.loading) {
     return (
-      <FormFrame
-        color="cyan"
-        title={props.title}
-        showCloseHint={props.showCloseHint}
-      >
+      <FormFrame title={props.title} showCloseHint={props.showCloseHint}>
         <LoadingIndicator label={props.loadingLabel} />
       </FormFrame>
     );
@@ -81,7 +81,7 @@ export function renderAsyncListFormTransient(props: {
   if (props.error !== undefined) {
     return (
       <FormFrame
-        color="red"
+        color={COLOR_ERROR}
         title={`${props.title} - error`}
         showCloseHint={props.showCloseHint}
       >

--- a/packages/cli/src/chat/tui/input/ReverseSearch.tsx
+++ b/packages/cli/src/chat/tui/input/ReverseSearch.tsx
@@ -7,6 +7,7 @@
 import { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 
+import { COLOR_ACCENT } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import { BaseTextInput } from './BaseTextInput';
 import { isCtrlInput, isEscapeInput } from './inputKeys';
@@ -50,12 +51,12 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
   return (
     <Box
       borderStyle="round"
-      borderColor="magenta"
+      borderColor={COLOR_ACCENT}
       flexDirection="column"
       paddingX={1}
     >
       <Box>
-        <Text color="magenta">(reverse-i-search)`</Text>
+        <Text color={COLOR_ACCENT}>(reverse-i-search)`</Text>
         <BaseTextInput
           value={query}
           onChange={(value) => {
@@ -67,7 +68,7 @@ export function ReverseSearch(props: ReverseSearchProps): React.JSX.Element {
             else props.onCancel();
           }}
         />
-        <Text color="magenta">`: </Text>
+        <Text color={COLOR_ACCENT}>`: </Text>
         <Text>{match?.value ?? ''}</Text>
       </Box>
       <Box marginTop={1}>

--- a/packages/cli/src/chat/tui/modals/AgentProposal.tsx
+++ b/packages/cli/src/chat/tui/modals/AgentProposal.tsx
@@ -8,6 +8,7 @@ import {
 } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
+import { COLOR_ACCENT } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -222,7 +223,7 @@ export function AgentProposal(props: AgentProposalProps): React.JSX.Element {
   return (
     <ConfirmCard
       borderStyle="double"
-      color="magenta"
+      color={COLOR_ACCENT}
       title={title}
       onDecide={props.onDecide}
     >

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { BashPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
+import { COLOR_WARNING } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -168,7 +169,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
   return (
     <ConfirmCard
       borderStyle="double"
-      color="yellow"
+      color={COLOR_WARNING}
       title={COMMAND_APPROVAL_TITLE}
       alwaysAllow={{ kind: 'bash', label: 'commands for session' }}
       onDecide={props.onDecide}

--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -23,6 +23,7 @@ import {
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { KeyHints } from '../ui/KeyHints';
 import { BorderedPanel } from '../ui/BorderedPanel';
+import { COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
 import {
   nextWrappingHighlightIndex,
@@ -93,7 +94,7 @@ function PickerItemHead({
   readonly index: number;
   readonly label: string;
 }): React.JSX.Element {
-  const color = highlighted ? 'cyan' : undefined;
+  const color = highlighted ? COLOR_HINT : undefined;
   return (
     <>
       <Box flexShrink={0}>
@@ -402,7 +403,7 @@ export function ChildControlPicker({
     ].filter((part): part is string => Boolean(part));
     return (
       <Box flexDirection="column" minWidth={0} width={availableColumns}>
-        <Text bold color="cyan" wrap="truncate-end">
+        <Text bold color={COLOR_HINT} wrap="truncate-end">
           {titleParts.join(' · ')}
         </Text>
         {selectedItem ? (
@@ -425,7 +426,7 @@ export function ChildControlPicker({
 
   return (
     <BorderedPanel
-      color="cyan"
+      color={COLOR_HINT}
       width={availableColumns}
       title={pickerTitle(mode)}
       footer={

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
 import { ConfirmCard } from './ConfirmCard';
+import { COLOR_HINT } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -146,7 +147,7 @@ export function EditApproval(props: EditApprovalProps): React.JSX.Element {
   return (
     <ConfirmCard
       borderStyle="double"
-      color="cyan"
+      color={COLOR_HINT}
       title={title}
       alwaysAllow={{ kind: 'toolEdit', label: 'approve edits for session' }}
       feedbackPlaceholder={EDIT_APPROVAL_FEEDBACK_PLACEHOLDER}

--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -5,6 +5,7 @@ import { writeClipboardText } from '@cli/runtime/clipboardText';
 import type { ExternalInquiryPermission } from '@shared/schemas';
 import { clamp } from '@utils/core';
 
+import { COLOR_SUCCESS, COLOR_WARNING } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -320,14 +321,14 @@ export function ExternalInquiry(
   return (
     <BorderedPanel
       borderStyle="single"
-      color="green"
+      color={COLOR_SUCCESS}
       width={columns}
       title={
         <>
           Agent asks:
           {copyStatus !== 'idle' ? (
             <Text
-              color={copyStatus === 'failed' ? 'yellow' : 'green'}
+              color={copyStatus === 'failed' ? COLOR_WARNING : COLOR_SUCCESS}
               dimColor={copyStatus === 'copying'}
             >
               {copyStatusLabel(copyStatus)}

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useWindowSize } from 'ink';
 import type { PlanApprovalPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
+import { COLOR_INFO } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -258,7 +259,7 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
   return (
     <ConfirmCard
       borderStyle="double"
-      color="blue"
+      color={COLOR_INFO}
       compact={compact}
       title={PLAN_APPROVAL_TITLE}
       extraActions={

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -7,6 +7,7 @@ import {
 import type { RetryPermission } from '@shared/schemas';
 
 import { ConfirmCard } from './ConfirmCard';
+import { COLOR_HINT, COLOR_WARNING } from '../ui/colors';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface RetryRequestProps {
@@ -30,7 +31,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   return (
     <ConfirmCard
       borderStyle="single"
-      color="yellow"
+      color={COLOR_WARNING}
       title="Retry the failed call?"
       approveLabel="retry"
       rejectLabel="give up"
@@ -50,7 +51,9 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
       <Box marginY={1}>
         <Text dimColor>{subject}</Text>
       </Box>
-      {canSwitchToPersonalKey ? <Text color="cyan">{switchHint}</Text> : null}
+      {canSwitchToPersonalKey ? (
+        <Text color={COLOR_HINT}>{switchHint}</Text>
+      ) : null}
     </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
+++ b/packages/cli/src/chat/tui/modals/TaskDetailView.tsx
@@ -30,6 +30,7 @@ import {
 } from '../state/taskDetailScroll';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { BorderedPanel } from '../ui/BorderedPanel';
+import { COLOR_HINT } from '../ui/colors';
 
 export const TASK_DETAIL_LABEL_WIDTH = 13;
 const ULTRA_COMPACT_TASK_DETAIL_MAX_ROWS = 4;
@@ -374,7 +375,7 @@ export function TaskDetailView({
   if (ultraCompact) {
     return (
       <Box flexDirection="column" minWidth={0} width={availableColumns}>
-        <Text bold color="cyan" wrap="truncate-end">
+        <Text bold color={COLOR_HINT} wrap="truncate-end">
           {`Task details · ${commandLabel}: ${item.command}`}
         </Text>
         <KeyHints hints={hints} confirmCancel={false} />
@@ -384,7 +385,7 @@ export function TaskDetailView({
 
   return (
     <BorderedPanel
-      color="cyan"
+      color={COLOR_HINT}
       width={availableColumns}
       title={layout.showTitle ? 'Task details' : undefined}
       footer={
@@ -404,7 +405,7 @@ export function TaskDetailView({
       ) : (
         <Text
           bold={!layout.showTitle}
-          color={!layout.showTitle ? 'cyan' : undefined}
+          color={!layout.showTitle ? COLOR_HINT : undefined}
           dimColor={layout.showTitle}
           wrap="truncate-end"
         >

--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -14,6 +14,7 @@ import {
   isJumpToBottomInput,
   isJumpToTopInput,
 } from '../input/inputKeys';
+import { COLOR_HINT } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
 import {
   initialTranscriptScrollState,
@@ -98,7 +99,7 @@ export function TranscriptViewer({
   return (
     <Box flexDirection="column" width={width}>
       {title ? (
-        <Text bold color="cyan" wrap="truncate-end">
+        <Text bold color={COLOR_HINT} wrap="truncate-end">
           {title}
         </Text>
       ) : null}

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -14,6 +14,7 @@ import {
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
+import { COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
@@ -294,7 +295,7 @@ function QuestionShell(props: QuestionShellProps): React.JSX.Element {
   return (
     <BorderedPanel
       borderStyle="single"
-      color="green"
+      color={COLOR_SUCCESS}
       width={columns}
       title="Agent asks:"
       footer={<KeyHints hints={props.hints} confirmCancel={false} />}
@@ -422,13 +423,16 @@ function MultiSelectQuestion(
         return (
           <Box key={option.label} minWidth={0}>
             <Box flexShrink={0}>
-              <Text color={focused ? 'cyan' : undefined}>
+              <Text color={focused ? COLOR_HINT : undefined}>
                 {focused ? POINTER : ' '} {checked ? TICK : ' '}{' '}
                 {optionIndex + 1}.{' '}
               </Text>
             </Box>
             <Box flexShrink={0} maxWidth={24}>
-              <Text color={focused ? 'cyan' : undefined} wrap="truncate-end">
+              <Text
+                color={focused ? COLOR_HINT : undefined}
+                wrap="truncate-end"
+              >
                 {option.label}
               </Text>
             </Box>

--- a/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
+++ b/packages/cli/src/chat/tui/panes/EntryErrorBoundary.tsx
@@ -18,6 +18,7 @@ import * as logUtils from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
+import { COLOR_ERROR } from '../ui/colors';
 import { WARNING } from '../ui/glyphs';
 
 interface EntryErrorBoundaryProps {
@@ -80,7 +81,7 @@ export class EntryErrorBoundary extends Component<
     const detail = formatRenderError(this.state.error);
     return (
       <Box paddingX={1}>
-        <Text color="red" dimColor>
+        <Text color={COLOR_ERROR} dimColor>
           {`${WARNING} failed to render ${this.props.label ?? 'entry'}${detail ? `: ${detail}` : ''}`}
         </Text>
       </Box>

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -14,6 +14,7 @@ import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { openRegisteredCliSlashForm } from '../commands/slashForms';
 import { SlashPalette } from '../commands/SlashPalette';
+import { COLOR_BORDER, COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
 import {
   matchSlashCommands,
@@ -347,11 +348,11 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       {attachNotice ? <Text dimColor>{attachNotice}</Text> : null}
       <Box
         borderStyle="round"
-        borderColor="gray"
+        borderColor={COLOR_BORDER}
         paddingX={1}
         aria-role="textbox"
       >
-        <Text aria-hidden color="cyan">
+        <Text aria-hidden color={COLOR_HINT}>
           {prompt ?? POINTER}{' '}
         </Text>
         {disabled && props.disabledMessage ? (

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'ink';
 
 import { numberedFollowUpPreview } from '../render/followUpPreview';
+import { COLOR_WARNING } from '../ui/colors';
 import { truncateSummaryToWidth } from '../render/terminalText';
 
 const QUEUED_FOLLOW_UP_PANEL_MAX_ROWS = 3;
@@ -85,7 +86,7 @@ export function QueuedFollowUpsPanel({
 
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Text color="yellow" wrap="truncate-end">
+      <Text color={COLOR_WARNING} wrap="truncate-end">
         {display.title}
       </Text>
       {display.rows.map((row, index) => (

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -28,6 +28,7 @@ import {
 import { streamViewForId } from '../state/streamViews';
 import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
+import { COLOR_HINT } from '../ui/colors';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
   isInquiryContinuationText,
@@ -122,7 +123,7 @@ function SessionHeaderBlock({
     return (
       <Box paddingX={1}>
         <Text wrap="truncate-end">
-          <Text bold color="cyan">
+          <Text bold color={COLOR_HINT}>
             {'{ T } TeXRA'}
           </Text>{' '}
           <Text dimColor>v{meta.version}</Text>{' '}
@@ -136,13 +137,13 @@ function SessionHeaderBlock({
   return (
     <Box flexDirection="column">
       <Box>
-        <Text aria-hidden color="cyan">
+        <Text aria-hidden color={COLOR_HINT}>
           {'─'.repeat(columns)}
         </Text>
       </Box>
       <Box flexDirection="column" paddingX={1}>
         <Box gap={2}>
-          <Text bold color="cyan">
+          <Text bold color={COLOR_HINT}>
             {'{ T } TeXRA'}
           </Text>
           <Text dimColor>v{meta.version}</Text>

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -23,6 +23,7 @@ import {
   parentStream as parentStreamSignal,
 } from '../state/childExecutions';
 import { useLiveNowMs } from '../state/useLiveNowMs';
+import { COLOR_ERROR } from '../ui/colors';
 import { useSignal } from '../state/useSignal';
 import {
   buildStatusBarDisplay,
@@ -153,7 +154,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
             segment.badge ? (
               <Badge
                 key={`${segment.text}-${index}`}
-                color={segment.badgeColor ?? 'red'}
+                color={segment.badgeColor ?? COLOR_ERROR}
               >
                 {segment.text}
               </Badge>

--- a/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
+++ b/packages/cli/src/chat/tui/panes/StreamTabsStrip.tsx
@@ -8,6 +8,7 @@ import type { StreamTabId } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 
 import { textDisplayWidth, truncateToWidth } from '../render/terminalText';
+import { COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import {
   activeStreamId as activeStreamIdSignal,
   streams as streamsSignal,
@@ -245,9 +246,9 @@ function StreamTabsStripView(props: {
           dimColor={!segment.item.active && !segment.item.running}
           color={
             segment.item.active
-              ? 'cyan'
+              ? COLOR_HINT
               : segment.item.running
-                ? 'green'
+                ? COLOR_SUCCESS
                 : undefined
           }
         >

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,14 +1,20 @@
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
+import {
+  COLOR_BORDER,
+  COLOR_ERROR,
+  COLOR_SUCCESS,
+  COLOR_WARNING,
+} from '../ui/colors';
 import { STATUS_DOT } from '../ui/glyphs';
 
 export function childStatusColor(status: string | undefined): string {
-  if (!status) return 'green';
-  if (status === 'waiting' || status === 'idle') return 'yellow';
-  if (isChildExecutionErrorStatus(status)) return 'red';
+  if (!status) return COLOR_SUCCESS;
+  if (status === 'waiting' || status === 'idle') return COLOR_WARNING;
+  if (isChildExecutionErrorStatus(status)) return COLOR_ERROR;
   // A user stop is neither success nor error — show it neutral, matching the
   // progress view / webview (gray), not green (which reads as completed).
-  if (status === 'stopped') return 'gray';
-  return 'green';
+  if (status === 'stopped') return COLOR_BORDER;
+  return COLOR_SUCCESS;
 }
 
 // A steady marker — intentionally NOT animated. A blinking dot forced the whole

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -16,6 +16,7 @@ import {
   streams as streamsSignal,
 } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
+import { COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { TODO_ACTIVE, TODO_DONE, TODO_PENDING } from '../ui/glyphs';
 
 // Marker glyph + color per todo status; statuses absent here (e.g. PENDING)
@@ -23,8 +24,8 @@ import { TODO_ACTIVE, TODO_DONE, TODO_PENDING } from '../ui/glyphs';
 const TODO_STATUS_DISPLAY: Partial<
   Record<TodoStatus, { marker: string; color: string }>
 > = {
-  [TODO_STATUS.COMPLETED]: { marker: TODO_DONE, color: 'green' },
-  [TODO_STATUS.IN_PROGRESS]: { marker: TODO_ACTIVE, color: 'cyan' },
+  [TODO_STATUS.COMPLETED]: { marker: TODO_DONE, color: COLOR_SUCCESS },
+  [TODO_STATUS.IN_PROGRESS]: { marker: TODO_ACTIVE, color: COLOR_HINT },
 };
 
 function todoMarker(status: TodoStatus): string {

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -6,6 +6,7 @@
 import { memo } from 'react';
 import { Box, Text } from 'ink';
 
+import { COLOR_ERROR, COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { Markdown } from '../render/Markdown';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -159,7 +160,7 @@ function InquiryContinuationRow({
       {displayLines.map((line, index) => (
         <Text
           key={index}
-          color={colorEnabled !== false && index === 0 ? 'cyan' : undefined}
+          color={colorEnabled !== false && index === 0 ? COLOR_HINT : undefined}
           dimColor={colorEnabled !== false && index > 0}
         >
           {line}
@@ -193,7 +194,7 @@ function ProcessEntryRow({
     );
   }
 
-  const color = process.isError ? 'red' : 'green';
+  const color = process.isError ? COLOR_ERROR : COLOR_SUCCESS;
   const [, ...tailLines] = completedProcessDisplayLines(process);
   return (
     <Box
@@ -208,14 +209,14 @@ function ProcessEntryRow({
         {process.elapsed ? (
           <Text dimColor>{` · ${process.elapsed}`}</Text>
         ) : null}
-        {process.isError ? <Text color="red"> · error</Text> : null}
+        {process.isError ? <Text color={COLOR_ERROR}> · error</Text> : null}
       </Box>
       {process.tailLines.length > 0 ? (
         <Box marginLeft={2} flexDirection="column">
           {tailLines.map((line, index) => (
             <Text
               key={index}
-              color={process.isError ? 'red' : undefined}
+              color={process.isError ? COLOR_ERROR : undefined}
               dimColor={!process.isError}
             >
               {line}
@@ -268,7 +269,7 @@ export const TranscriptEntry = memo(function TranscriptEntry({
       const cols = entryCols(width, 2);
       return (
         <Box paddingX={1}>
-          <Text color="red">
+          <Text color={COLOR_ERROR}>
             {compactPrefixedDisplayRows({
               fillWidth,
               prefix: ERROR_ENTRY_PREFIX,
@@ -455,7 +456,7 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
 
   const prefix =
     entry.role === 'error' ? ERROR_ENTRY_PREFIX : USER_ENTRY_PREFIX;
-  const color = entry.role === 'error' ? 'red' : undefined;
+  const color = entry.role === 'error' ? COLOR_ERROR : undefined;
   const cols = entryCols(width, 2);
   return (
     <Box paddingX={1}>

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -28,6 +28,7 @@ import {
   truncateSummaryToWidth,
 } from '../render/terminalText';
 import { formatCliStatusLabel } from '../sessionStatus';
+import { COLOR_ERROR, COLOR_HINT, COLOR_WARNING } from '../ui/colors';
 import { STATUS_DIAMOND } from '../ui/glyphs';
 import {
   STATUS_BAR_HORIZONTAL_PADDING,
@@ -45,14 +46,17 @@ import {
 } from '../state/streamViews';
 import type { ApprovalQueueStatusKind } from '../state/approvalQueue';
 
-type StatusBarColor = 'cyan' | 'yellow' | 'red' | 'dim';
+// 'dim' is not an Ink color name — it is a sentinel this file's own renderer
+// (`StatusBar.tsx`) reads to apply `dimColor` instead of an explicit `color`.
+type StatusBarColor =
+  typeof COLOR_HINT | typeof COLOR_WARNING | typeof COLOR_ERROR | 'dim';
 type CtrlCAction = 'exit' | 'stop' | 'stop root';
 
 interface StatusBarSegment {
   readonly text: string;
   readonly color?: StatusBarColor;
   readonly badge?: boolean;
-  readonly badgeColor?: 'red' | 'yellow';
+  readonly badgeColor?: typeof COLOR_ERROR | typeof COLOR_WARNING;
   readonly compactPriority?: number;
   /** Shorter replacement text tried (in priority order) before the segment
    *  is removed outright when the bar overflows the terminal width. */
@@ -147,8 +151,8 @@ function formatUsage(
     Math.round(computeUtilizationPercent(used, contextWindow)),
   );
   let color: StatusBarColor;
-  if (ratio >= 0.9) color = 'red';
-  else if (ratio >= 0.6) color = 'yellow';
+  if (ratio >= 0.9) color = COLOR_ERROR;
+  else if (ratio >= 0.6) color = COLOR_WARNING;
   else color = 'dim';
   return {
     ...base,
@@ -243,7 +247,7 @@ function queuedFollowUpsCountSegment(
   return messages.length > 0
     ? {
         text: `queued ${messages.length}`,
-        color: 'yellow',
+        color: COLOR_WARNING,
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.queuedFollowUp,
       }
     : undefined;
@@ -259,7 +263,7 @@ function pendingInteractionSegment({
   if (depth <= 0) return undefined;
   return {
     text: `${depth} ${kind}${depth === 1 ? '' : 's'}`,
-    color: 'yellow',
+    color: COLOR_WARNING,
     compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalDepth,
   };
 }
@@ -561,7 +565,7 @@ function rootActiveSegment(
   return input.ctrlCAction === 'stop root' && !isActivePhase(input.status)
     ? {
         text: 'root active',
-        color: 'yellow',
+        color: COLOR_WARNING,
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.rootActive,
       }
     : undefined;
@@ -577,13 +581,13 @@ function approvalPolicySegment(
     case 'never':
       return {
         text: 'deny',
-        color: 'yellow',
+        color: COLOR_WARNING,
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalPolicy,
       };
     case 'yolo':
       return {
         text: 'yolo',
-        color: 'red',
+        color: COLOR_ERROR,
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalPolicy,
       };
     default:
@@ -651,22 +655,22 @@ export function statusBarStreamTarget({
 const BYPASS_BADGES: ReadonlyArray<{
   readonly field: keyof BypassState;
   readonly text: string;
-  readonly badgeColor: 'red' | 'yellow';
+  readonly badgeColor: typeof COLOR_ERROR | typeof COLOR_WARNING;
 }> = [
-  { field: 'superYolo', text: 'YOLO', badgeColor: 'red' },
-  { field: 'bash', text: 'AUTO-BASH', badgeColor: 'yellow' },
-  { field: 'toolEdit', text: 'AUTO-EDIT', badgeColor: 'yellow' },
+  { field: 'superYolo', text: 'YOLO', badgeColor: COLOR_ERROR },
+  { field: 'bash', text: 'AUTO-BASH', badgeColor: COLOR_WARNING },
+  { field: 'toolEdit', text: 'AUTO-EDIT', badgeColor: COLOR_WARNING },
 ];
 
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
   const left: StatusBarSegment[] = [
-    { text: STATUS_DIAMOND, color: 'cyan', decorative: true },
+    { text: STATUS_DIAMOND, color: COLOR_HINT, decorative: true },
   ];
 
   if (input.pendingExitHint) {
-    left.push({ text: PENDING_EXIT_HINT_TEXT, color: 'yellow' });
+    left.push({ text: PENDING_EXIT_HINT_TEXT, color: COLOR_WARNING });
     const queuedCount = input.queuedFollowUpMessages.length;
     if (queuedCount > 0) {
       // Exiting drops queued follow-ups silently — warn before the user
@@ -675,7 +679,7 @@ export function buildStatusBarDisplay(
         text: `${queuedCount} queued follow-up${
           queuedCount === 1 ? '' : 's'
         } will be discarded`,
-        color: 'red',
+        color: COLOR_ERROR,
       });
     }
   } else {
@@ -702,7 +706,7 @@ export function buildStatusBarDisplay(
     ) {
       left.push({
         text: 'thinking...',
-        color: 'yellow',
+        color: COLOR_WARNING,
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
       });
     }
@@ -713,7 +717,7 @@ export function buildStatusBarDisplay(
 
   left.push(
     input.subscriptionActive
-      ? { text: 'subscription', color: 'cyan', compactText: 'sub' }
+      ? { text: 'subscription', color: COLOR_HINT, compactText: 'sub' }
       : { text: input.apiMode, color: 'dim' },
   );
   const policy = approvalPolicySegment(input.approvalPolicy);

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -23,6 +23,7 @@ import {
   textDisplayWidth,
   truncateSummaryToWidth,
 } from '../render/terminalText';
+import { COLOR_ERROR, COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { STATUS_DOT, TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;
@@ -141,9 +142,11 @@ function previewInput(input: unknown): string {
   }
 }
 
-function statusColor(toolUse: NormalizedToolUse): 'green' | 'red' | undefined {
-  if (toolUse.isError) return 'red';
-  if (toolUse.status === TOOL_USE_STATUS.COMPLETED) return 'green';
+function statusColor(
+  toolUse: NormalizedToolUse,
+): typeof COLOR_SUCCESS | typeof COLOR_ERROR | undefined {
+  if (toolUse.isError) return COLOR_ERROR;
+  if (toolUse.status === TOOL_USE_STATUS.COMPLETED) return COLOR_SUCCESS;
   return undefined;
 }
 
@@ -414,7 +417,7 @@ function CornerLine({
   color,
   children,
 }: {
-  readonly color?: 'red';
+  readonly color?: typeof COLOR_ERROR;
   readonly children: React.ReactNode;
 }): React.JSX.Element {
   return (
@@ -431,7 +434,7 @@ interface ToolRowProps {
   readonly toolUse: NormalizedToolUse;
   readonly displayName?: string;
   readonly fallbackName?: string;
-  readonly previewColor?: 'cyan';
+  readonly previewColor?: typeof COLOR_HINT;
   readonly showPatch?: boolean;
   readonly showOutput?: boolean;
   readonly showExitCode?: boolean;
@@ -497,10 +500,10 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
       <OutputBlock lines={visibleOutput} />
       {patchGroups ? <PatchPreview groups={patchGroups} /> : null}
       {toolUse.isError && exitCode !== undefined ? (
-        <CornerLine color="red">{`exit ${exitCode}`}</CornerLine>
+        <CornerLine color={COLOR_ERROR}>{`exit ${exitCode}`}</CornerLine>
       ) : null}
       {toolUse.isError ? (
-        <CornerLine color="red">
+        <CornerLine color={COLOR_ERROR}>
           {truncateWithEllipsis(
             collapseWhitespace(errorText),
             MAX_ERROR_PREVIEW,
@@ -557,7 +560,7 @@ const bashRenderer: ToolRenderer = {
     <ToolRow
       toolUse={toolUse}
       fallbackName="bash"
-      previewColor="cyan"
+      previewColor={COLOR_HINT}
       showOutput={true}
       showExitCode={true}
       preferInputPreview={true}

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -12,6 +12,7 @@ import { Box, Text, useInput } from 'ink';
 import { useEffect, useRef, useState } from 'react';
 
 import { clamp, clampIndex } from '@utils/core';
+import { COLOR_HINT } from './colors';
 import { POINTER, TICK } from './glyphs';
 
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
@@ -327,17 +328,17 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
                 option role + state above already announce focus/active. The
                 hotkey stays audible because it is actionable. */}
             <Box flexShrink={0}>
-              <Text aria-hidden color={focused ? 'cyan' : undefined}>
+              <Text aria-hidden color={focused ? COLOR_HINT : undefined}>
                 {pointer} {tick}{' '}
               </Text>
-              <Text color={focused ? 'cyan' : undefined}>{shortcut} </Text>
+              <Text color={focused ? COLOR_HINT : undefined}>{shortcut} </Text>
             </Box>
             <Box
               flexShrink={0}
               maxWidth={props.labelMaxCols ?? SELECT_LABEL_MAX_COLS}
             >
               <Text
-                color={focused ? 'cyan' : undefined}
+                color={focused ? COLOR_HINT : undefined}
                 dimColor={item.disabled}
                 wrap="truncate-end"
               >

--- a/packages/cli/src/chat/tui/ui/colors.ts
+++ b/packages/cli/src/chat/tui/ui/colors.ts
@@ -30,7 +30,8 @@ export const COLOR_ACCENT = 'magenta';
  *  set the plan-review card apart from the edit/bash approval cards). */
 export const COLOR_INFO = 'blue';
 
-/** Neutral chrome border with no semantic weight (the idle input box). */
+/** Neutral chrome with no semantic weight: the idle input box border and
+ *  the neutral "stopped" subagent status marker. */
 export const COLOR_BORDER = 'gray';
 
 // Not migrated onto this palette — decided in TeXRA#8118:

--- a/packages/cli/src/chat/tui/ui/colors.ts
+++ b/packages/cli/src/chat/tui/ui/colors.ts
@@ -1,0 +1,43 @@
+// Semantic color palette for the CLI TUI. Components say WHAT (semantic
+// color); this module says WHICH Ink/chalk color name backs it — so
+// re-theming or contrast-tuning happens in one owned place instead of at
+// each of the dozens of `color="cyan"` / `borderColor="yellow"` call sites
+// this replaces (see TeXRA#8118).
+//
+// Ink's `color`/`borderColor` props accept any chalk color name typed as
+// `LiteralUnion<ForegroundColorName, string>`. These constants are typed as
+// plain string literals (not chalk's own `ForegroundColorName`) to match the
+// existing `BorderedPanel`/`ConfirmCard`/`FormFrame` `color: string` props —
+// chalk is only a transitive dependency of `ink` here, not one the CLI
+// declares directly.
+
+/** Positive/affirmative state: completed tool runs, "agent asks" prompts. */
+export const COLOR_SUCCESS = 'green';
+
+/** Caution: retryable failures, bash/edit auto-approval, queued/empty states. */
+export const COLOR_WARNING = 'yellow';
+
+/** Failure/destructive state: errors, non-zero exit codes, the yolo policy. */
+export const COLOR_ERROR = 'red';
+
+/** Default informational emphasis: form/panel borders, headings, previews. */
+export const COLOR_HINT = 'cyan';
+
+/** Distinctive one-off highlight: reverse-search mode, agent-proposal review. */
+export const COLOR_ACCENT = 'magenta';
+
+/** Secondary informational callout, distinct from the default hint (used to
+ *  set the plan-review card apart from the edit/bash approval cards). */
+export const COLOR_INFO = 'blue';
+
+/** Neutral chrome border with no semantic weight (the idle input box). */
+export const COLOR_BORDER = 'gray';
+
+// Not migrated onto this palette — decided in TeXRA#8118:
+//  - `render/DiffView.tsx`'s hex constants are paired background+foreground
+//    bands tuned for WCAG contrast on both light and dark terminals, not
+//    single named colors; they stay a self-contained diff-band style.
+//  - `render/ansiMarkdown.ts`'s picocolors usage renders raw ANSI strings
+//    (not Ink `color` props) and is already centralized in one local
+//    `ansiMarkdownStyle()` factory; picocolors' `createColors(enabled)` gate
+//    doesn't compose with plain color-name constants.


### PR DESCRIPTION
## Summary

Follow-up from #8074 per #8118: introduces one owned semantic color-palette
module for the CLI TUI (`packages/cli/src/chat/tui/ui/colors.ts`) and
migrates every raw Ink color literal in `packages/cli/src/chat/tui/` onto it,
so components say WHAT (semantic color) and the palette says WHICH Ink color
backs it.

`colors.ts` exports:
- `COLOR_SUCCESS` = `'green'`, `COLOR_WARNING` = `'yellow'`, `COLOR_ERROR` =
  `'red'`, `COLOR_HINT` = `'cyan'`, `COLOR_ACCENT` = `'magenta'` — the five
  names the issue calls out — plus two outliers the audit surfaced that don't
  fit those five: `COLOR_INFO` = `'blue'` (sets the plan-review card apart
  from the edit/bash approval cards) and `COLOR_BORDER` = `'gray'` (the idle
  input box's neutral chrome border).
- Every constant keeps the exact literal value the migrated call site already
  used — this is a value-preserving rename, not a re-theme, so there is no
  visual/behavioral change.

**Existing typed color pipelines** (`StatusBarColor`/`badgeColor` in
`panes/statusBarDisplay.ts`, `statusColor()`/`CornerLine`/`previewColor` in
`panes/toolRenderers.tsx`) are migrated onto the palette's constants (via
`typeof COLOR_X` for their narrow literal unions). `StatusBarColor` keeps its
`'dim'` member as-is — it's a sentinel `StatusBar.tsx` reads to apply
`dimColor` instead of a real Ink color name, not a color the palette owns.

**Not migrated** (documented in `colors.ts`, per the issue's ask to "decide
... and act on that decision"):
- `render/DiffView.tsx`'s hex background/foreground band pairs are tuned for
  WCAG contrast on both light and dark terminals — a paired diff-band style,
  not a single named color — so they stay self-contained.
- `render/ansiMarkdown.ts`'s picocolors usage renders raw ANSI strings (not
  Ink `color` props) and is already centralized in one local
  `ansiMarkdownStyle()` factory; picocolors' `createColors(enabled)` gate
  doesn't compose with plain color-name constants.

**Small simplification found along the way**: `FormFrame`'s `color` prop was
required and 13 of its ~19 call sites only ever passed the default
(`"cyan"`). Made it optional with a default of `COLOR_HINT` and deleted those
13 redundant props — real deletion-beats-addition, not scope creep, since it
falls directly out of centralizing the same default color the palette now
owns.

## Net elements (R6)

- **+1 file**: `packages/cli/src/chat/tui/ui/colors.ts` (43 lines) — a
  genuine multi-caller owner (30 consumer files import it; see Consumer
  counts below), not a single-caller extraction.
- **36 consumer files edited**, net **+191/-113** lines. The net add is the
  cost of naming ~57 raw color-literal call sites (issue's own audit found
  "30+", a fuller re-survey here found more once narrow prop types like
  `previewColor?: 'cyan'` and ternary-assigned literals like
  `const color = process.isError ? 'red' : 'green'` are counted) plus a few
  multi-line reformats; it is offset by the 13-line FormFrame default
  deletion above.
- **0 new dependencies.**

## Consumer counts (R8)

`grep -rlE "from '[^']*\bcolors'" packages/cli/src/chat/tui` → **30 files**
import the new palette module before this PR had zero. Raw
`color="cyan"`/`'red'`/etc. literals in `packages/cli/src/chat/tui`: **57 →
0** (verified via
`grep -rnE '"(cyan|yellow|red|green|magenta|blue|gray|grey)"'` and the
single-quote/ternary variant, both now empty except the palette's own
definitions and one comment reference).

## Test plan

- No dedicated test file added: this codebase has no JSX/render-testing
  infrastructure for the TUI (props-in → JSX-out per CLAUDE.md; no
  `ink-testing-library`/`react-test-renderer` dependency anywhere in the
  workspace) — component color props aren't independently unit-testable here.
  The existing pure-function suites (`StatusBar.vitest.mts`,
  `SubagentListDisplay.vitest.mts`, `ToolRenderers.vitest.mts`, etc.) already
  assert the exact literal color strings these functions return, and I
  verified they're a real regression net for this change: temporarily
  changing `COLOR_WARNING` to `'blue'` in `colors.ts` made
  `StatusBar.vitest.mts`'s `'surfaces non-default approval policies...'` test
  fail immediately (`expected color: 'blue' to match { color: 'yellow' }`),
  then reverted.
- [x] `npx vitest run --config vitest.config.mjs src/test-kernel/cli` — 130
      files / 1673 tests passed (one unrelated flaky signal-handling test
      failed once under parallel load and passed both in isolation and on
      re-run of the full suite).
- [x] `corepack pnpm --filter @texra-ai/cli typecheck` — clean.
- [x] `npm run typecheck` (full workspace) — clean.
- [x] `npx eslint` on all 37 changed files — clean.
- [x] `npx prettier --write` on all 37 changed files — 2 files reformatted,
      re-verified tests/typecheck/lint after.

Closes #8118

https://claude.ai/code/session_01ACrdwMVd2zrKSYDbh28Jmn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor with preserved color values; no auth, data, or runtime logic changes.
> 
> **Overview**
> Adds **`packages/cli/src/chat/tui/ui/colors.ts`** with semantic tokens (`COLOR_HINT`, `COLOR_WARNING`, `COLOR_ERROR`, etc.) that still map to the same Ink/chalk names as before, so this is a **rename/centralization** rather than a visual re-theme.
> 
> **Migrates** slash forms, approval modals, status bar, transcript panes, `Select`, and related UI from inline `'cyan'` / `'red'` / … strings to those constants; typed color unions in `statusBarDisplay.ts` and `toolRenderers.tsx` now reference the palette via `typeof COLOR_*`.
> 
> **`FormFrame`** treats `color` as optional and defaults borders/titles to `COLOR_HINT`, dropping redundant `color="cyan"` on most slash forms; empty-list states still pass `COLOR_WARNING`, and async error transients use `COLOR_ERROR`.
> 
> **Explicitly leaves** `DiffView` hex band pairs and `ansiMarkdown` picocolors styling unchanged (documented in `colors.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db650349980132b0a50150fcd7d94478fa123661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->