### PR TITLE
fix(auth): fall back from dead ChatGPT sessions

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -8,6 +8,7 @@ import { getExecutionStore } from '@agent/storage';
 import {
   activeModelHandlerCompatibilityKey,
   createModelHandler,
+  modelHandlersShareConversationFormat,
   modelHandlerCompatibilityKey,
 } from '@agent/runtime/ModelFactory';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
@@ -266,10 +267,9 @@ export async function runToolUseFlow<C = unknown>(
     const previousHandler = services.modelHandler;
     const nextHandler = (await createModelHandler(
       nextConfig,
+      setting.agentCategory,
     )) as ToolUseServices<C>['modelHandler'];
-    // Backstop for untagged/custom handlers and future route drift. This is a
-    // constructor-reference comparison, so CLI minification cannot affect it.
-    if (nextHandler.constructor !== previousHandler.constructor) {
+    if (!modelHandlersShareConversationFormat(previousHandler, nextHandler)) {
       nextHandler.dispose();
       throw new Error(MODEL_SWITCH_DIFFERENT_FORMAT_ERROR);
     }

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -38,6 +38,7 @@ import {
   CODEX_ORIGINATOR_HEADER,
   CodexAuthError,
   codexCoordinator,
+  formatCodexAuthUnavailableMessage,
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from '@auth/codex';
@@ -309,14 +310,10 @@ export class ModelHandlerCodex extends ModelHandlerOpenAIResponse {
       return await codexCoordinator().getFreshAccessToken();
     } catch (error) {
       if (error instanceof CodexAuthError) {
-        const action = error.needsReauth
-          ? 'Sign in with ChatGPT again, or turn off "Prefer ChatGPT subscription".'
-          : 'Try again in a moment, or turn off "Prefer ChatGPT subscription".';
         // Preserve the original CodexAuthError (kind/stack) as the cause.
-        throw new Error(
-          `ChatGPT subscription unavailable: ${error.message} ${action}`,
-          { cause: error },
-        );
+        throw new Error(formatCodexAuthUnavailableMessage(error), {
+          cause: error,
+        });
       }
       throw error;
     }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -312,8 +312,9 @@ async function assembleAgentLaunchContext(
     ? await createModelHandlerForCompatibilityKey(
         modelConfig,
         modelHandlerCompatibilityKey,
+        setting.agentCategory,
       )
-    : await createModelHandler(modelConfig);
+    : await createModelHandler(modelConfig, setting.agentCategory);
 
   const streamId =
     input.streamTabIdOverride ??

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -9,12 +9,16 @@ import {
   shouldUseInternalValidationModelHandler,
 } from '@agent/runtime/internalValidationOverride';
 import {
-  isCodexSignedIn,
-  resolveCodexSubscriptionCapabilities,
+  CodexAuthError,
+  formatCodexAuthUnavailableMessage,
+  isCodexSessionRoutable,
+  resolveCodexSubscriptionCapabilitiesForAgentCategory,
 } from '@auth/codex';
+import { AgentError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { isGpt5ModelName } from '@model/modelNames';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import type { AgentCategory } from '@shared/schemas/agent';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { getConfig } from '@utils/config/configUtils';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
@@ -301,6 +305,18 @@ export function activeModelHandlerCompatibilityKey(
   ];
 }
 
+/** Compare persisted format keys, falling back to class identity for untagged handlers. */
+export function modelHandlersShareConversationFormat(
+  first: object,
+  second: object,
+): boolean {
+  const firstKey = activeModelHandlerCompatibilityKey(first);
+  const secondKey = activeModelHandlerCompatibilityKey(second);
+  return firstKey !== undefined && secondKey !== undefined
+    ? firstKey === secondKey
+    : first.constructor === second.constructor;
+}
+
 function withModelHandlerCompatibilityKey<T extends ModelHandler>(
   handler: T,
   compatibilityKey: ModelHandlerCompatibilityKey,
@@ -379,6 +395,7 @@ function withCompatibilityRoutingMode(
  */
 export async function createModelHandler(
   originalConfig: ModelConfig,
+  agentCategory?: AgentCategory,
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
   const useOpenRouter = getUseOpenRouter();
@@ -395,7 +412,7 @@ export async function createModelHandler(
     config,
     compatibilityKey,
     useOpenRouter,
-    { allowCodexSubscriptionOverride: true },
+    { allowCodexSubscriptionOverride: true, agentCategory },
   );
 }
 
@@ -407,6 +424,7 @@ export async function createModelHandler(
 export async function createModelHandlerForCompatibilityKey(
   originalConfig: ModelConfig,
   compatibilityKey: ModelHandlerCompatibilityKey,
+  agentCategory?: AgentCategory,
 ): Promise<ModelHandler> {
   const routedConfig = withCompatibilityRoutingMode(
     withShortModelName(originalConfig),
@@ -420,6 +438,7 @@ export async function createModelHandlerForCompatibilityKey(
     {
       allowCodexSubscriptionOverride:
         compatibilityKey === 'ModelHandlerOpenAIResponse',
+      agentCategory,
     },
   );
 }
@@ -428,7 +447,10 @@ async function createModelHandlerForResolvedCompatibilityKey(
   config: ModelConfig,
   compatibilityKey: ModelHandlerCompatibilityKey | undefined,
   useOpenRouter: boolean,
-  options: { allowCodexSubscriptionOverride: boolean },
+  options: {
+    allowCodexSubscriptionOverride: boolean;
+    agentCategory: AgentCategory | undefined;
+  },
 ): Promise<ModelHandler> {
   // ChatGPT subscription (Codex backend via the user's OAuth session) — an
   // async, key-neutral override of the Responses path: these are OpenAI
@@ -438,8 +460,12 @@ async function createModelHandlerForResolvedCompatibilityKey(
   if (
     options.allowCodexSubscriptionOverride &&
     compatibilityKey !== 'ModelHandlerValidation' &&
-    resolveCodexSubscriptionCapabilities(config, useOpenRouter) &&
-    (await isCodexSignedIn())
+    resolveCodexSubscriptionCapabilitiesForAgentCategory(
+      config,
+      useOpenRouter,
+      options.agentCategory,
+    ) &&
+    (await isCodexSessionRoutableForAgent())
   ) {
     logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');
     const { ModelHandlerCodex } =
@@ -516,5 +542,19 @@ async function createModelHandlerForResolvedCompatibilityKey(
         route.compatibilityKey,
       );
     }
+  }
+}
+
+/** Classify retryable/config preflight failures for the agent lifecycle. */
+async function isCodexSessionRoutableForAgent(): Promise<boolean> {
+  try {
+    return await isCodexSessionRoutable();
+  } catch (error) {
+    if (error instanceof CodexAuthError) {
+      throw new AgentError(formatCodexAuthUnavailableMessage(error), {
+        cause: error,
+      });
+    }
+    throw error;
   }
 }

--- a/src/auth/codex/codexAuthAccess.ts
+++ b/src/auth/codex/codexAuthAccess.ts
@@ -15,6 +15,7 @@ import {
   type CodexSessionCoordinator,
   type CodexSessionStatus,
 } from './CodexSessionCoordinator';
+import { CodexAuthError } from './codexSessionTypes';
 import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
@@ -62,6 +63,55 @@ export async function getCodexStatus(): Promise<CodexSessionStatus> {
 /** Whether a Codex session is currently signed in (no network, no throw). */
 export async function isCodexSignedIn(): Promise<boolean> {
   return (await getCodexStatus()).signedIn;
+}
+
+/**
+ * Whether subscription routing should use the stored session. Expiring sessions
+ * are refreshed by the coordinator; absent/dead sessions return false after its
+ * re-auth path clears them. If a re-auth error leaves a session in storage, the
+ * refresh was superseded and the error propagates rather than misrouting the
+ * newer session. Retryable/config errors likewise propagate so callers do not
+ * silently spend fallback quota or immediately retry the same refresh.
+ */
+export async function isCodexSessionRoutable(): Promise<boolean> {
+  if (!tryPlatform()) return false;
+  const coordinator = codexCoordinator();
+  try {
+    await coordinator.getFreshAccessToken();
+    return true;
+  } catch (error) {
+    if (!(error instanceof CodexAuthError)) {
+      throw new CodexAuthError(
+        `Could not access ChatGPT session: ${toErrorMessage(error)}`,
+        'transient',
+        undefined,
+        { cause: error },
+      );
+    }
+    if (error.needsReauth) {
+      let storedSession;
+      try {
+        storedSession = await coordinator.loadSession();
+      } catch (readError) {
+        throw new CodexAuthError(
+          `Could not verify ChatGPT session: ${toErrorMessage(readError)}`,
+          'transient',
+          undefined,
+          { cause: readError },
+        );
+      }
+      if (storedSession) {
+        throw new CodexAuthError(
+          'ChatGPT session changed while refreshing.',
+          'transient',
+          error.status,
+          { cause: error },
+        );
+      }
+      return false;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -67,8 +67,13 @@ export class CodexAuthError extends Error {
   readonly kind: CodexAuthErrorKind;
   readonly status?: number;
 
-  constructor(message: string, kind: CodexAuthErrorKind, status?: number) {
-    super(message);
+  constructor(
+    message: string,
+    kind: CodexAuthErrorKind,
+    status?: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
     this.name = 'CodexAuthError';
     this.kind = kind;
     this.status = status;
@@ -78,4 +83,14 @@ export class CodexAuthError extends Error {
   get needsReauth(): boolean {
     return this.kind === 'fatal' || this.kind === 'expired';
   }
+}
+
+/** User-facing message shared by preflight and request-time auth failures. */
+export function formatCodexAuthUnavailableMessage(
+  error: CodexAuthError,
+): string {
+  const action = error.needsReauth
+    ? 'Sign in with ChatGPT again, or turn off "Prefer ChatGPT subscription".'
+    : 'Try again in a moment, or turn off "Prefer ChatGPT subscription".';
+  return `ChatGPT subscription unavailable: ${error.message} ${action}`;
 }

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -20,6 +20,7 @@ export {
 } from './codexJwt';
 export {
   CodexAuthError,
+  formatCodexAuthUnavailableMessage,
   CodexSessionSchema,
   type CodexSession,
   type CodexTokenResponse,
@@ -53,6 +54,7 @@ export {
   resetCodexCoordinator,
   getCodexStatus,
   getChatGptAuthStatus,
+  isCodexSessionRoutable,
   isCodexSignedIn,
 } from './codexAuthAccess';
 export {

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -24,15 +24,19 @@ import {
   createModelHandler,
   createModelHandlerForCompatibilityKey,
   modelHandlerCompatibilityKey,
+  modelHandlersShareConversationFormat,
   shouldUseResponsesAPI,
 } from '@agent/runtime/ModelFactory';
 import {
   CODEX_BACKEND_BASE_URL,
   CODEX_SESSION_SECRET_KEY,
+  CodexAuthError,
+  codexCoordinator,
   resetCodexCoordinator,
   type CodexSession,
 } from '@auth/codex';
 import { shouldRouteModelThroughOpenRouter } from '@model/openRouterRouting';
+import { AgentCategory } from '@shared/schemas/agent';
 import type { FakePlatformOptions } from '@test/support/FakePlatform';
 
 function modelConfig(
@@ -200,9 +204,37 @@ describe('OpenAI model handler routing', () => {
   const signedInCodexSession = (): CodexSession => ({
     accessToken: 'access-token',
     refreshToken: 'refresh-token',
-    expiresAtMs: Date.now() + 60_000,
+    expiresAtMs: Date.now() + 10 * 60_000,
     accountId: 'account-id',
   });
+
+  const initializePreferredCodexRelay = async (
+    extraConfig: Record<string, unknown> = {},
+  ): Promise<void> =>
+    initFakePlatform({
+      config: {
+        'texra.chatgptCodex.preferSubscription': true,
+        ...extraConfig,
+      },
+      globalState: { 'texra.useIncludedModelAccess': true },
+      secrets: {
+        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(signedInCodexSession()),
+      },
+    });
+
+  const createdHandlerName = async (
+    agentCategory?: AgentCategory,
+  ): Promise<string> => {
+    const handler = await createModelHandler(
+      codexEligibleConfig,
+      agentCategory,
+    );
+    try {
+      return handler.constructor.name;
+    } finally {
+      handler.dispose();
+    }
+  };
 
   it('keeps Codex-eligible subscription models on the Responses compatibility key', async () => {
     await initFakePlatform({
@@ -263,15 +295,83 @@ describe('OpenAI model handler routing', () => {
     }
   });
 
-  it('uses the Codex endpoint for a signed-in preferred subscription even when relay access is selected', async () => {
-    const codexSession = signedInCodexSession();
-    await initFakePlatform({
-      config: { 'texra.chatgptCodex.preferSubscription': true },
-      globalState: { 'texra.useIncludedModelAccess': true },
-      secrets: {
-        [CODEX_SESSION_SECRET_KEY]: JSON.stringify(codexSession),
+  it('falls back when subscription re-authentication is required', async () => {
+    await initializePreferredCodexRelay();
+    const coordinator = codexCoordinator();
+    vi.spyOn(coordinator, 'getFreshAccessToken').mockImplementation(
+      async () => {
+        await coordinator.signOut();
+        throw new CodexAuthError('revoked', 'fatal', 401);
       },
+    );
+
+    expect(await createdHandlerName()).toBe('ModelHandlerOpenAIResponse');
+  });
+
+  it('propagates a superseded re-auth failure without falling back', async () => {
+    await initializePreferredCodexRelay();
+    const error = new CodexAuthError('session changed', 'expired');
+    vi.spyOn(codexCoordinator(), 'getFreshAccessToken').mockRejectedValue(
+      error,
+    );
+
+    await expect(createModelHandler(codexEligibleConfig)).rejects.toMatchObject(
+      {
+        name: 'AgentError',
+        message: expect.stringContaining('Try again in a moment'),
+        cause: { kind: 'transient' },
+      },
+    );
+  });
+
+  it('propagates session verification read failures without falling back', async () => {
+    await initializePreferredCodexRelay();
+    const coordinator = codexCoordinator();
+    const readError = new Error('keychain unavailable');
+    vi.spyOn(coordinator, 'getFreshAccessToken').mockRejectedValue(
+      new CodexAuthError('session changed', 'expired'),
+    );
+    vi.spyOn(coordinator, 'loadSession').mockRejectedValue(readError);
+
+    await expect(createModelHandler(codexEligibleConfig)).rejects.toMatchObject(
+      {
+        name: 'AgentError',
+        cause: { kind: 'transient', cause: readError },
+      },
+    );
+  });
+
+  it('wraps raw token verification failures as transient auth errors', async () => {
+    await initializePreferredCodexRelay();
+    const rawError = new Error('keychain unavailable');
+    vi.spyOn(codexCoordinator(), 'getFreshAccessToken').mockRejectedValue(
+      rawError,
+    );
+
+    await expect(createModelHandler(codexEligibleConfig)).rejects.toMatchObject(
+      {
+        name: 'AgentError',
+        cause: { name: 'CodexAuthError', kind: 'transient', cause: rawError },
+      },
+    );
+  });
+
+  it('skips subscription preflight for workflows when subscription is tool-use-only', async () => {
+    await initializePreferredCodexRelay({
+      'texra.chatgptCodex.subscriptionToolUseOnly': true,
     });
+    const refreshSpy = vi
+      .spyOn(codexCoordinator(), 'getFreshAccessToken')
+      .mockRejectedValue(new CodexAuthError('temporary outage', 'transient'));
+
+    expect(await createdHandlerName(AgentCategory.Workflow)).toBe(
+      'ModelHandlerOpenAIResponse',
+    );
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the Codex endpoint for a signed-in preferred subscription even when relay access is selected', async () => {
+    await initializePreferredCodexRelay();
 
     const handler = await createModelHandler(codexEligibleConfig);
     try {
@@ -282,6 +382,23 @@ describe('OpenAI model handler routing', () => {
       );
     } finally {
       handler.dispose();
+    }
+  });
+
+  it('treats Codex and relay Responses handlers with the shared key as compatible', async () => {
+    await initializePreferredCodexRelay();
+    const codex = await createModelHandler(codexEligibleConfig);
+    await codexCoordinator().signOut();
+    const relay = await createModelHandler(codexEligibleConfig);
+    try {
+      expect(codex.constructor).not.toBe(relay.constructor);
+      expect(activeModelHandlerCompatibilityKey(codex)).toBe(
+        activeModelHandlerCompatibilityKey(relay),
+      );
+      expect(modelHandlersShareConversationFormat(codex, relay)).toBe(true);
+    } finally {
+      codex.dispose();
+      relay.dispose();
     }
   });
 


### PR DESCRIPTION
## Summary

- Preflight expiring ChatGPT subscription sessions before selecting the Codex model handler.
- Fall back to the normal compatible handler in the same launch only when refresh proves the stored session is gone.
- Propagate transient/config, superseded-session, and verification-read failures as classified `AgentError`s, avoiding silent relay spend, duplicate refresh, and crash-report prompts.
- Gate preflight by agent category so workflow/helper runs skip ChatGPT auth when the preference is tool-use-only.
- Share one user-facing Codex auth message formatter across preflight and request-time failures.

## Issue acceptance gates

Closes #8216.

- A stale ChatGPT session no longer blocks the first otherwise-available relay launch.
- Fatal/expired refresh failures that clear storage route the same launch to the compatible fallback handler.
- A re-auth error that leaves a session in storage is treated as superseded and surfaces retry guidance rather than misrouting the newer session.
- Transient and keychain-read failures surface once instead of consuming fallback quota.
- Tool-use-only subscription mode does not preflight ChatGPT auth for workflow runs.

## Single source of truth

`CodexSessionCoordinator` remains the sole owner of session validation, refresh classification, and stale-session deletion. `ModelFactory` owns handler routing, receives the resolved agent category from launch/switch callers, and classifies expected provider-auth failures for the agent lifecycle.

## Duplication and abstraction budget

The fix adds one narrow session-routability query that delegates to the existing coordinator; it adds no cache or duplicate auth state. `formatCodexAuthUnavailableMessage` removes duplicate user-facing classification text from the preflight and request-time paths. Routing tests share setup and handler-disposal helpers rather than repeating fixtures.

## Net elements (R6)

- Files: 0 added, 0 deleted, 8 modified.
- Exported symbols: 3 added (`isCodexSessionRoutable`, `formatCodexAuthUnavailableMessage`, `modelHandlersShareConversationFormat`), 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- LoC: +249 / -27, net +222.

## Consumer counts (R8)

- `isCodexSessionRoutable`: 1 runtime consumer (`ModelFactory`) plus its barrel export.
- `formatCodexAuthUnavailableMessage`: 2 runtime consumers (`ModelFactory`, `ModelHandlerCodex`) plus its barrel export.
- `modelHandlersShareConversationFormat`: 1 runtime consumer (`runToolUseFlow`) plus focused test coverage.
- No emit path or existing export was deleted; `isCodexSignedIn` retains its 2 read-only runtime consumers.

## Host impact

Extension: Shared model routing now recovers from dead ChatGPT sessions before invocation.

Desktop: Same shared routing behavior; no desktop-specific changes.

CLI: The first launch falls back through relay when refresh invalidates a stale session; retryable auth failures produce one classified message without a crash-report prompt.

## Scheduled refactoring

- #8232 tracks the separate coordinator storage-write/session-replacement races found during review; they are intentionally not folded into this routing fix.

## Validation

- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing warnings only)
- `npm test` / CI kernel suite (649 files passed, 1 skipped; 5,733 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- Focused auth/routing suite (16 files, 170 tests)
- `prettier --check` and `git diff --check`
- CLI PTY snapshot harness (149 scenarios)
- Live TTY math task with two approved subagents, rejected child-side commands, approved parent Python execution, and final synthesis
- Synthetic expired-session CLI smoke: same launch returned `OK` through relay and removed the stale session
- Independent subagent review of the final diff: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-handler selection and ChatGPT OAuth preflight at launch, switch, and first turn—auth misclassification could still misroute quota or block launches, though behavior is heavily tested.
> 
> **Overview**
> **ChatGPT subscription routing** now **preflights** the OAuth session via `isCodexSessionRoutable()` (token refresh through the coordinator) instead of treating “signed in” as enough. **Dead sessions** that clear storage after re-auth failure **fall back** to the normal Responses/relay handler on the same launch; **transient**, **config**, **superseded-session**, and **keychain read** failures surface as **`AgentError`** with shared copy from `formatCodexAuthUnavailableMessage` instead of silently burning relay quota or blocking the run.
> 
> **Agent category** is threaded through `createModelHandler` / launch and model switch so **tool-use-only** subscription mode **skips** ChatGPT preflight for **workflow** runs. **Mid-chat model switches** compare handlers with **`modelHandlersShareConversationFormat`** (compatibility key, with class fallback) so **Codex** and **API-key Responses** handlers sharing `ModelHandlerOpenAIResponse` stay switchable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4ee2bd32e39c6cdfa7ef1a3f217b1a489c1e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



