### PR TITLE
fix(exec): add stream-teardown backstop for aborted array-form commands

### DIFF
--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -137,6 +137,43 @@ describe('executeCommand', () => {
     assert.equal(result.stderr, 'Command aborted by user');
     await waitForProcessExit(childPid!);
   });
+
+  it('unblocks aborted array-form await when a descendant holds stdio', async () => {
+    if (process.platform === 'win32') return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'texra-exec-abort-array-'));
+    tempDirs.push(dir);
+    const pidFile = join(dir, 'sleep.pid');
+    const controller = new AbortController();
+    // The backgrounded sleep inherits stdout/stderr; execa's cancelSignal
+    // only kills the tracked bash pid, so without the stream-teardown
+    // backstop this await would hang until the descendant exits.
+    const promise = executeCommand(
+      ['bash', '-c', 'sleep 60 & echo $! > "$PID_FILE"; wait'],
+      {
+        cwd: dir,
+        env: { PID_FILE: pidFile },
+        signal: controller.signal,
+        timeout: 60_000,
+      },
+    );
+
+    await waitForFile(pidFile);
+    const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+    assert.ok(Number.isInteger(childPid) && childPid > 0);
+
+    controller.abort();
+    const result = await promise;
+
+    assert.equal(result.success, false);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.exitCode, 130);
+    assert.equal(result.stderr, 'Command aborted by user');
+    // The array form intentionally has no process-group semantics: the
+    // descendant must survive the abort. Reap it so the test doesn't leak.
+    assert.doesNotThrow(() => process.kill(childPid, 0));
+    process.kill(childPid, 'SIGKILL');
+  }, 20_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -251,12 +251,8 @@ export async function executeCommand(
       }
     };
 
-    const installAbortListener = (): void => {
+    const installAbortListener = (onAbort: () => void): void => {
       if (!options.signal) return;
-      const onAbort = (): void => {
-        shellAborted = true;
-        terminateSubprocess('SIGTERM');
-      };
       options.signal.addEventListener('abort', onAbort, { once: true });
       removeAbortListener = () => {
         options.signal?.removeEventListener('abort', onAbort);
@@ -315,10 +311,27 @@ export async function executeCommand(
     }
 
     if (subprocess.pid && options.onPid) options.onPid(subprocess.pid);
-    // Array-form abort is handled by execa's own `cancelSignal` (passed
-    // above); only the shell/string form needs the process-group-aware
-    // hand-rolled listener.
-    if (!Array.isArray(command)) installAbortListener();
+    if (Array.isArray(command)) {
+      // Array-form abort/force-kill is execa's (`cancelSignal` /
+      // `forceKillAfterDelay` above), but execa only signals the tracked
+      // pid: a descendant that inherited stdio (e.g. `bash -c 'work &
+      // wait'`) can keep the pipes open after the tracked process dies,
+      // hanging `await subprocess` forever. Destroy the streams once
+      // execa's force-kill delay has elapsed so the await always unblocks.
+      // No signal is sent here — the array form intentionally keeps no
+      // process-group semantics, so the descendant itself is left alone.
+      installAbortListener(() => {
+        forceKillTimeoutId = setTimeout(() => {
+          subprocess.stdout?.destroy();
+          subprocess.stderr?.destroy();
+        }, FORCE_KILL_DELAY_MS);
+      });
+    } else {
+      installAbortListener(() => {
+        shellAborted = true;
+        terminateSubprocess('SIGTERM');
+      });
+    }
 
     if (shellTimeout) {
       shellTimeoutId = setTimeout(() => {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -232,8 +232,10 @@ export async function executeCommand(
     // Only the shell/string form needs this hand-rolled abort + force-kill
     // machinery: it terminates via `signalProcessGroup` (negative-PID /
     // tree-kill) so piped children don't outlive the shell. The array form
-    // spawns a single non-detached process, so it delegates straight to
-    // execa's own `cancelSignal` / `forceKillAfterDelay` natives below.
+    // spawns a single non-detached process and leaves all signalling to
+    // execa's own `cancelSignal` / `forceKillAfterDelay` natives below; its
+    // only hand-rolled piece is the signal-free stream-destroy backstop
+    // installed in its abort listener.
     const terminateSubprocess = (signal: NodeJS.Signals): void => {
       const pid = subprocess.pid;
       if (!pid) return;


### PR DESCRIPTION
Closes #8217

## Summary

Follow-up to #8202. execa's `cancelSignal`/`forceKillAfterDelay` only signal the single tracked pid, so an aborted array-form `executeCommand` whose command spawned a descendant inheriting stdout/stderr (e.g. `['bash', '-c', 'sleep 60 & wait']`) left `await subprocess` hanging indefinitely: the tracked parent dies, but the descendant keeps the inherited pipes open so the streams never end. Reproduced empirically against execa 9.6.1 at origin/main HEAD before writing the fix (await still pending 5s after abort with `forceKillAfterDelay: 500`).

**Design choice — no second kill site.** `installAbortListener` stays the single owner of abort-listener lifecycle (install, remove-in-`finally`, pre-aborted replay); it now takes the abort action as a parameter. The array form's action schedules only a stream-destroy backstop on `subprocess.stdout`/`stderr` after `FORCE_KILL_DELAY_MS` — the same last-resort `await`-unblocker the shell form's force-kill escalation already uses — reusing the existing `forceKillTimeoutId` slot so the existing `finally` clears it. No signal is sent from our code for the array form: execa remains the only killer (SIGTERM at abort, SIGKILL at +5s), and the array form intentionally keeps no process-group semantics — the descendant itself is left alone (asserted in the test).

Note: the issue's alternative ("enable execa's `killDescendants` where safe") is not viable — no such option exists in execa 9.6.1 (checked `node_modules/execa/types/arguments/options.d.ts`).

## Regression test

Extended the existing `src/test-kernel/utils/system/SystemUtils.vitest.ts` suite (per one-suite-per-module): array-form `bash -c 'sleep 60 & echo $! > "$PID_FILE"; wait'` aborted mid-flight must resolve within a bounded time (20s test timeout; actually resolves at ~5s = force-kill delay) with `exitCode` 130 / `"Command aborted by user"`, and the descendant must still be alive afterwards (no reintroduced group kill; the test then reaps it). Verified the test fails by timeout against unfixed `execUtils.ts` and passes with the fix.

## Verified

- Reproduced the hang at origin/main HEAD with a standalone execa 9.6.1 script (`bash -c 'sleep 60 & wait'`, cancelSignal aborted at 200ms, `forceKillAfterDelay: 500` → still awaiting at 5s), and verified the stream-destroy backstop resolves it in ~700ms with `isCanceled: true`, which is what `executeCommand` already maps to exitCode 130 / aborted stderr.
- Opened `src/utils/system/execUtils.ts`, `src/tools/bash.ts` (uses the shell/string form — unaffected), and `node_modules/execa/types/arguments/options.d.ts` (no `killDescendants` option exists).
- `npm run typecheck` — clean.
- `npm test -- SystemUtils` — 16/16 pass (including the new regression test); re-ran with the src fix reverted to origin/main: the new test fails by timeout, the other 15 pass.
- `npm test -- BashTool` — 12/12 pass (BashTool + BashToolErrorFeedback consumer suites).
- `npx prettier --check` on both touched files — clean.
- Shell/string form's `signalProcessGroup` teardown untouched; its existing "aborts shell command process groups including children" test still passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared subprocess abort/teardown in `execUtils`, which many tools rely on; behavior change is narrow (array + signal) and covered by new and existing abort tests.
> 
> **Overview**
> Fixes a hang when **array-form** `executeCommand` is aborted while a child process still holds inherited stdout/stderr (e.g. `bash -c 'sleep 60 & wait'`): execa kills only the tracked PID, so pipes stay open and `await subprocess` never completes.
> 
> On abort, the array path now schedules a **stream-destroy backstop** after `FORCE_KILL_DELAY_MS`, reusing the existing `forceKillTimeoutId` cleanup in `finally`. **No extra signals** are sent—execa still owns SIGTERM/SIGKILL—and **no process-group kill** is added for array commands (background children can outlive abort by design).
> 
> `installAbortListener` is refactored to accept the abort action as a callback; shell/string commands still use `terminateSubprocess` / `signalProcessGroup` unchanged.
> 
> Adds a non-Windows regression test in `SystemUtils.vitest.ts` that abort must resolve with exit 130 while the background descendant remains alive until the test reaps it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e9dcd845499b0962b2aafb26a57785a01c0521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->