### PR TITLE
fix(cli): stamp the update-check throttle only after the whole attempt completes

### DIFF
--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -220,32 +220,54 @@ function parseHomebrewFormulaVersion(
   return entry?.versions?.stable ?? undefined;
 }
 
+/** Result of one fetch attempt against the package source. */
+export interface CliUpdateFetchResult {
+  /** Latest published version, when one could be read (possibly stale). */
+  version: string | undefined;
+  /**
+   * True when the version reflects a live consultation of the source — an npm
+   * registry response, or `brew info` after a successful tap refresh. False
+   * when only stale local metadata was readable (failed `brew update`): still
+   * usable for a prompt, but the attempt must retry next launch instead of
+   * being stamped for a full throttle window.
+   */
+  refreshed: boolean;
+}
+
 /**
  * Attempt to refresh Homebrew tap metadata and fetch the latest formula
- * version, or undefined. Without the explicit update, `brew info` can report
- * stale local metadata and hide an available upgrade until the user runs
- * `brew update` manually. If the refresh fails, still read `brew info`: local
- * metadata may already be fresh enough to offer the right prompt.
+ * version. Without the explicit update, `brew info` can report stale local
+ * metadata and hide an available upgrade until the user runs `brew update`
+ * manually. If the refresh fails, still read `brew info` — local metadata may
+ * already be fresh enough to offer the right prompt — but report
+ * `refreshed: false` so the caller knows the version may be stale.
  */
 export async function fetchLatestHomebrewFormulaVersion(options?: {
   formula?: string;
   timeoutMs?: number;
   cwd?: string;
   runCommand?: CommandRunner;
-}): Promise<string | undefined> {
+}): Promise<CliUpdateFetchResult> {
   const formula = options?.formula ?? CLI_HOMEBREW_FORMULA;
   const runCommand = options?.runCommand ?? readCommandStdout;
   const timeoutMs = options?.timeoutMs ?? HOMEBREW_COMMAND_TIMEOUT_MS;
-  await runCommand('brew', ['update', '--quiet'], timeoutMs, options?.cwd);
+  const refreshStdout = await runCommand(
+    'brew',
+    ['update', '--quiet'],
+    timeoutMs,
+    options?.cwd,
+  );
   const stdout = await runCommand(
     'brew',
     ['info', '--json=v2', formula],
     timeoutMs,
     options?.cwd,
   );
-  return stdout == null
-    ? undefined
-    : parseHomebrewFormulaVersion(stdout, formula);
+  return {
+    version:
+      stdout == null ? undefined : parseHomebrewFormulaVersion(stdout, formula),
+    refreshed: refreshStdout != null,
+  };
 }
 
 function runCliUpdate(method: InstallMethod): Promise<boolean> {
@@ -287,8 +309,16 @@ function announceUpdateInstalled(latest: string, style: CliStyle): never {
 export interface CheckCliUpdateAvailableOptions {
   currentVersion: string;
   globalState: StateStore;
-  /** Fetch the latest published version, or undefined on any failure. */
-  fetchLatest: () => Promise<string | undefined>;
+  /** Fetch the latest published version plus whether the source was live. */
+  fetchLatest: () => Promise<CliUpdateFetchResult>;
+  /**
+   * Present a newer version to the user (notice + prompt). Called only when a
+   * strictly newer version was fetched, and always before the daily stamp is
+   * persisted — a throw (e.g. stdin closing mid-prompt) aborts the attempt
+   * un-stamped so the next launch re-checks instead of going silent for the
+   * full throttle window.
+   */
+  notify: (latest: string) => Promise<void>;
   now?: () => number;
 }
 
@@ -296,14 +326,20 @@ export interface CheckCliUpdateAvailableOptions {
  * At most once per day (persisted in global state), fetch the latest
  * published version and report it when newer than `currentVersion`. Mirrors
  * the desktop update checker's throttle (see `checkForDesktopUpdate` in
- * `desktopUpdateChecker.ts`): the daily stamp is only persisted after a
- * successful fetch, so a failed check (offline, registry hiccup) retries on
- * the next launch instead of being suppressed for a full day.
+ * `desktopUpdateChecker.ts`), but this is the single owner of the daily
+ * stamp: it is written in exactly one place, only once every outcome of the
+ * attempt is known — the source was genuinely consulted (`refreshed`, not a
+ * stale brew cache behind a failed tap refresh) and, when an update was
+ * available, `notify` resolved (the user actually saw it). Any other outcome
+ * (offline, registry hiccup, failed tap refresh, killed prompt) leaves the
+ * stamp unwritten so the next launch retries instead of being suppressed for
+ * a full day.
  */
 export async function checkCliUpdateAvailable({
   currentVersion,
   globalState,
   fetchLatest,
+  notify,
   now = Date.now,
 }: CheckCliUpdateAvailableOptions): Promise<string | undefined> {
   const lastCheckedAt = globalState.get<number>(
@@ -313,13 +349,19 @@ export async function checkCliUpdateAvailable({
   const nowMs = now();
   if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return undefined;
 
-  const latest = await fetchLatest();
-  if (!latest) return undefined;
-  await globalState.update(
-    GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
-    nowMs,
-  );
-  return isNewerVersion(latest, currentVersion) ? latest : undefined;
+  const { version, refreshed } = await fetchLatest();
+  const latest =
+    version !== undefined && isNewerVersion(version, currentVersion)
+      ? version
+      : undefined;
+  if (latest !== undefined) await notify(latest);
+  if (version && refreshed) {
+    await globalState.update(
+      GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+      nowMs,
+    );
+  }
+  return latest;
 }
 
 let notified = false;
@@ -353,13 +395,16 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   if (!isPackageManagerInstall()) return;
 
   const method = detectInstallMethod();
+  const updateCmd = formatUpdateCommand(method);
+  const style = createCliStyle(context.colorEnabled);
   // Runs before `initInteractiveCliPlatform`, so `platform()` isn't up yet —
   // open the same global `state.json` that `createCliStateStores` opens later
   // directly (see `cliStateStores.ts`). Failures here (e.g. an unreadable or
-  // unwritable global-storage directory) must stay as silent as a network
-  // failure: this whole check is best-effort and must never block `chat` /
-  // `orchestrate` startup.
+  // unwritable global-storage directory, or stdin closing mid-prompt) must
+  // stay as silent as a network failure: this whole check is best-effort and
+  // must never block `chat` / `orchestrate` startup.
   let latest: string | undefined;
+  let confirmed = false;
   try {
     const globalState = await JsonStore.open(
       path.join(
@@ -370,31 +415,28 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
     latest = await checkCliUpdateAvailable({
       currentVersion: context.version,
       globalState,
-      fetchLatest: () =>
-        method === 'brew'
-          ? fetchLatestHomebrewFormulaVersion({ cwd: context.cwd })
-          : fetchLatestCliVersion(),
+      fetchLatest: async () => {
+        if (method === 'brew') {
+          return fetchLatestHomebrewFormulaVersion({ cwd: context.cwd });
+        }
+        const version = await fetchLatestCliVersion();
+        return { version, refreshed: version !== undefined };
+      },
+      notify: async (latestVersion) => {
+        writeTextStderr(
+          `A new version of texra is available: ${context.version} → ${style.emphasis(style.success(latestVersion))}`,
+        );
+        const answer = await askCliQuestion(
+          `Update now with \`${style.command(updateCmd)}\`? [Y/n] `,
+        );
+        confirmed = affirmative(answer);
+      },
     });
   } catch {
     return;
   }
   if (!latest) return;
-
-  const updateCmd = formatUpdateCommand(method);
-  const style = createCliStyle(context.colorEnabled);
-  writeTextStderr(
-    `A new version of texra is available: ${context.version} → ${style.emphasis(style.success(latest))}`,
-  );
-
-  let answer: string;
-  try {
-    answer = await askCliQuestion(
-      `Update now with \`${style.command(updateCmd)}\`? [Y/n] `,
-    );
-  } catch {
-    return;
-  }
-  if (!affirmative(answer)) {
+  if (!confirmed) {
     writeTextStderr(
       style.muted('Skipped. Update later with: ') + style.command(updateCmd),
     );

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -333,7 +333,8 @@ export interface CheckCliUpdateAvailableOptions {
  * available, `notify` resolved (the user actually saw it). Any other outcome
  * (offline, registry hiccup, failed tap refresh, killed prompt) leaves the
  * stamp unwritten so the next launch retries instead of being suppressed for
- * a full day.
+ * a full day. The stamp write itself is best-effort: a failed write never
+ * rejects the completed attempt (it only means an early re-check).
  */
 export async function checkCliUpdateAvailable({
   currentVersion,
@@ -355,11 +356,19 @@ export async function checkCliUpdateAvailable({
       ? version
       : undefined;
   if (latest !== undefined) await notify(latest);
-  if (version && refreshed) {
-    await globalState.update(
-      GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
-      nowMs,
-    );
+  if (version !== undefined && refreshed) {
+    try {
+      await globalState.update(
+        GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+        nowMs,
+      );
+    } catch {
+      // Best-effort: the stamp write can fail even when `JsonStore.open`
+      // succeeded (readable-but-unwritable global storage). By this point the
+      // whole attempt — including the notify prompt — has completed, so a
+      // failed stamp must not reject and cancel an update the user already
+      // accepted; worst case the next launch re-checks a day early.
+    }
   }
   return latest;
 }

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -226,23 +226,23 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
             ],
           }),
       }),
-    ).resolves.toBe('0.39.0');
+    ).resolves.toEqual({ version: '0.39.0', refreshed: true });
   });
 
-  it('returns undefined when brew info is unavailable or missing the formula', async () => {
+  it('returns no version when brew info is unavailable or missing the formula', async () => {
     await expect(
       fetchLatestHomebrewFormulaVersion({
         runCommand: async () => undefined,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ version: undefined, refreshed: false });
     await expect(
       fetchLatestHomebrewFormulaVersion({
         runCommand: async () => JSON.stringify({ formulae: [] }),
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ version: undefined, refreshed: true });
   });
 
-  it('still reads formula info when the Homebrew tap refresh fails', async () => {
+  it('still reads formula info when the Homebrew tap refresh fails, marked stale', async () => {
     const calls: Array<{ command: string; args: readonly string[] }> = [];
     await expect(
       fetchLatestHomebrewFormulaVersion({
@@ -254,7 +254,7 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
           });
         },
       }),
-    ).resolves.toBe('0.39.0');
+    ).resolves.toEqual({ version: '0.39.0', refreshed: false });
 
     expect(calls).toEqual([
       { command: 'brew', args: ['update', '--quiet'] },
@@ -301,34 +301,49 @@ describe('fetchLatestHomebrewFormulaVersion', () => {
 describe('checkCliUpdateAvailable', () => {
   const currentVersion = '0.39.3';
   const latestVersion = '0.40.0';
+  const noopNotify = async () => {};
 
   it('checks on a first launch (no prior lastCheckedAt) and reports a newer version', async () => {
     const globalState = new MemoryStateStore();
     let fetchCalls = 0;
+    const notified: string[] = [];
 
     const latest = await checkCliUpdateAvailable({
       currentVersion,
       globalState,
       fetchLatest: async () => {
         fetchCalls += 1;
-        return latestVersion;
+        return { version: latestVersion, refreshed: true };
+      },
+      notify: async (v) => {
+        notified.push(v);
       },
     });
 
     expect(fetchCalls).toBe(1);
     expect(latest).toBe(latestVersion);
+    expect(notified).toEqual([latestVersion]);
   });
 
-  it('returns undefined when the fetched version is not newer', async () => {
+  it('returns undefined and does not notify when the fetched version is not newer', async () => {
     const globalState = new MemoryStateStore();
+    const notified: string[] = [];
 
     const latest = await checkCliUpdateAvailable({
       currentVersion: latestVersion,
       globalState,
-      fetchLatest: async () => latestVersion,
+      fetchLatest: async () => ({ version: latestVersion, refreshed: true }),
+      notify: async (v) => {
+        notified.push(v);
+      },
     });
 
     expect(latest).toBeUndefined();
+    expect(notified).toEqual([]);
+    // The check itself completed, so the day's stamp is still persisted.
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBeDefined();
   });
 
   it('throttles repeated checks within the same day', async () => {
@@ -346,8 +361,9 @@ describe('checkCliUpdateAvailable', () => {
         now: () => nowMs,
         fetchLatest: async () => {
           fetchCalls += 1;
-          return latestVersion;
+          return { version: latestVersion, refreshed: true };
         },
+        notify: noopNotify,
       });
 
     await run();
@@ -375,8 +391,10 @@ describe('checkCliUpdateAvailable', () => {
       now: () => nowMs,
       fetchLatest: async () => {
         fetchCalls += 1;
-        return undefined; // simulates a network/registry failure
+        // simulates a network/registry failure
+        return { version: undefined, refreshed: false };
       },
+      notify: noopNotify,
     });
 
     expect(fetchCalls).toBe(1);
@@ -392,13 +410,86 @@ describe('checkCliUpdateAvailable', () => {
       now: () => nowMs + 1000,
       fetchLatest: async () => {
         fetchCalls += 1;
-        return latestVersion;
+        return { version: latestVersion, refreshed: true };
       },
+      notify: noopNotify,
     });
 
     expect(fetchCalls).toBe(2);
     expect(
       globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBe(nowMs + 1000);
+  });
+
+  it('does not persist the throttle stamp on a stale (unrefreshed) version, but still offers it', async () => {
+    // #8223: a failed `brew update` that still yields the locally cached
+    // formula version must not count as a completed check — the next launch
+    // retries the tap refresh instead of going silent for 24h.
+    const globalState = new MemoryStateStore();
+    const nowMs = Date.UTC(2026, 0, 1);
+    const notified: string[] = [];
+
+    const latest = await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      now: () => nowMs,
+      fetchLatest: async () => ({ version: latestVersion, refreshed: false }),
+      notify: async (v) => {
+        notified.push(v);
+      },
+    });
+
+    expect(latest).toBe(latestVersion);
+    expect(notified).toEqual([latestVersion]);
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBeUndefined();
+  });
+
+  it('does not persist the throttle stamp when the notify prompt throws', async () => {
+    // #8224: the stamp must be written only after the user actually saw the
+    // notice — a prompt killed mid-way (closed stdin) leaves the attempt
+    // un-stamped so the next launch re-checks.
+    const globalState = new MemoryStateStore();
+    const nowMs = Date.UTC(2026, 0, 1);
+
+    await expect(
+      checkCliUpdateAvailable({
+        currentVersion,
+        globalState,
+        now: () => nowMs,
+        fetchLatest: async () => ({ version: latestVersion, refreshed: true }),
+        notify: async () => {
+          throw new Error('stdin closed');
+        },
+      }),
+    ).rejects.toThrow('stdin closed');
+
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBeUndefined();
+  });
+
+  it('persists the throttle stamp only after notify completes', async () => {
+    const globalState = new MemoryStateStore();
+    const nowMs = Date.UTC(2026, 0, 1);
+    let stampAtNotifyTime: unknown = 'unread';
+
+    await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      now: () => nowMs,
+      fetchLatest: async () => ({ version: latestVersion, refreshed: true }),
+      notify: async () => {
+        stampAtNotifyTime = globalState.values.get(
+          GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+        );
+      },
+    });
+
+    expect(stampAtNotifyTime).toBeUndefined();
+    expect(
+      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+    ).toBe(nowMs);
   });
 });

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -470,6 +470,31 @@ describe('checkCliUpdateAvailable', () => {
     ).toBeUndefined();
   });
 
+  it('still reports the update when the throttle stamp write fails', async () => {
+    // A readable-but-unwritable global state file lets `JsonStore.open`
+    // succeed while `update` rejects. The stamp is best-effort: its failure
+    // must not reject the completed attempt (which would cancel an update the
+    // user already accepted via the notify prompt) — the next launch just
+    // re-checks a day early.
+    const globalState = new MemoryStateStore();
+    globalState.update = async () => {
+      throw new Error('EACCES: permission denied');
+    };
+    const notified: string[] = [];
+
+    const latest = await checkCliUpdateAvailable({
+      currentVersion,
+      globalState,
+      fetchLatest: async () => ({ version: latestVersion, refreshed: true }),
+      notify: async (v) => {
+        notified.push(v);
+      },
+    });
+
+    expect(latest).toBe(latestVersion);
+    expect(notified).toEqual([latestVersion]);
+  });
+
   it('persists the throttle stamp only after notify completes', async () => {
     const globalState = new MemoryStateStore();
     const nowMs = Date.UTC(2026, 0, 1);


### PR DESCRIPTION
Closes #8223
Closes #8224

Follow-up to #8203 (tracking #8221).

## Problem

The daily throttle stamp (`GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT`) was written as soon as `fetchLatest()` returned any version:

- **#8224** — the stamp landed before the interactive prompt ran. If `askCliQuestion` threw (closed stdin / TTY issue), `notifyCliUpdate` exited quietly with the throttle already set, so the user who never saw the notice got silently throttled for 24h.
- **#8223** — for Homebrew installs, `fetchLatestHomebrewFormulaVersion` discards the `brew update` result and returns the (possibly stale) local `brew info` version, so a failed tap refresh still counted as a "successful check" and stamped the throttle — contrary to #8203's stated retry-on-failure intent.

## Design

Single owner: `checkCliUpdateAvailable` keeps sole ownership of the throttle state (one read-gate, one stamp write), but the write moves to the end of the attempt, after every outcome is known:

- `fetchLatest` now returns `CliUpdateFetchResult = { version, refreshed }`. `fetchLatestHomebrewFormulaVersion` reports whether the tap refresh succeeded (it still reads `brew info` on a failed refresh — pre-existing intentional behavior — but marks the result stale); the npm path maps a successful registry fetch to `refreshed: true`.
- The notice + prompt run through a new required `notify(latest)` callback, invoked before the stamp. A throw propagates out (caught by `notifyCliUpdate`'s existing fail-silent catch) and leaves the stamp unwritten, so the next launch re-checks.
- The stamp is written iff a version was fetched **and** the source was genuinely consulted **and** (when an update was available) the notify flow completed. Declining the prompt still stamps — the interaction completed.

`notifyCliUpdate`'s external signature is unchanged (`chat.ts` / `orchestrate.ts` untouched), and the TTY/ndjson gates at its top are unchanged, so nothing leaks into the headless path.

## Verified

- Opened: `packages/cli/src/runtime/updateChecker.ts` (full file at origin/main HEAD to confirm both defects), `src/test-kernel/cli/UpdateChecker.vitest.mts`, `packages/cli/src/commands/chat.ts` / `orchestrate.ts` (only external consumers, via grep of `checkCliUpdateAvailable` / `fetchLatestHomebrewFormulaVersion` / `fetchLatestCliVersion` / `notifyCliUpdate`), plus the bot findings and author triage on #8203.
- `npm run typecheck` — clean across all workspace packages.
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/UpdateChecker.vitest.mts` — 27/27 pass, including three new regression tests: stale (unrefreshed) version is still offered but not stamped (#8223); a throwing notify leaves the stamp unwritten (#8224); the stamp is persisted only after notify completes.
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli` — 130 files / 1686 tests pass.
- `npx eslint` + `npx prettier --check` on both touched files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to optional CLI self-update checks and global-state throttling; behavior is covered by expanded unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes cases where the CLI’s **once-per-day update check** wrote `CLI_UPDATE_CHECK_LAST_CHECKED_AT` too early, so users could miss prompts or get throttled for 24h after a failed or half-finished check.
> 
> **Fetch results** now return `{ version, refreshed }` (`CliUpdateFetchResult`). Homebrew sets `refreshed` from whether `brew update` succeeded; npm treats a successful registry read as refreshed. A cached formula version after a failed tap refresh can still drive a prompt, but does **not** count as a completed check.
> 
> **`checkCliUpdateAvailable`** takes a required **`notify`** callback (notice + prompt) and is the only place that stamps the throttle. The stamp runs only after a fetched version with `refreshed: true`, and—when an update is available—after **`notify`** resolves. Failed fetches, stale brew metadata, or a throwing prompt leave the stamp unset so the next launch retries. Stamp persistence is best-effort (write failures do not reject the flow).
> 
> **`notifyCliUpdate`** wires `notify` for the interactive prompt and update confirmation; its public API and command entrypoints are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13410c6cbbad89beeab4a371c49cda3e520dbd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->