### PR TITLE
fix(cli): reap wedged clipboard helpers on write timeout

### DIFF
--- a/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
+++ b/packages/cli/src/chat/tui/modals/ExternalInquiry.tsx
@@ -274,6 +274,10 @@ export function ExternalInquiry(
   }
 
   async function copyQuestion(): Promise<void> {
+    // One write in flight at a time: a second Ctrl-Y while a copy is pending
+    // would race the first write's timeout reap, which kills all direct-child
+    // copy helpers -- including the second attempt's.
+    if (copyStatus === 'copying') return;
     setCopyStatus('copying');
     const result = await writeClipboardText(props.payload.question);
     if (result.ok) {

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,20 +1,89 @@
+import { execFile } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
+import { basename } from 'node:path';
+import { promisify } from 'node:util';
 
 import clipboard from 'clipboardy';
-import pTimeout from 'p-timeout';
+import pTimeout, { TimeoutError } from 'p-timeout';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
+
+const execFileAsync = promisify(execFile);
 
 export type ClipboardTextWriteResult =
   { readonly ok: true } | { readonly ok: false; readonly reason: string };
 
 const CLIPBOARD_WRITE_TIMEOUT_MS = 5_000;
+const HELPER_REAP_TIMEOUT_MS = 2_000;
 
 interface ClipboardTextWriteOptions {
   readonly platform?: NodeJS.Platform;
 }
 
-function normalizeClipboardText(text: string, platform = osPlatform()): string {
+// clipboardy (5.3.1) exposes no cancellation hook — `write(text)` takes no
+// signal — so a timed-out await abandons the promise while the platform helper
+// clipboardy spawned lives on (#8219). On timeout we reap wedged helpers
+// out-of-band instead: kill direct children of this process whose executable
+// is one of clipboardy's copy commands. The parent-pid bound keeps this from
+// touching processes we didn't spawn — e.g. a daemonized `wl-copy` from an
+// earlier successful copy has been reparented away and must stay alive to
+// keep serving the clipboard.
+const POSIX_COPY_HELPERS: ReadonlySet<string> = new Set([
+  'pbcopy', // macOS
+  'wl-copy', // Linux (Wayland)
+  'xsel', // Linux (X11), including clipboardy's bundled fallback binary
+  'clip.exe', // WSL
+  'termux-clipboard-set', // Android (Termux)
+]);
+
+async function reapPosixCopyHelpers(): Promise<void> {
+  const { stdout } = await execFileAsync('ps', ['-Ao', 'pid=,ppid=,comm='], {
+    timeout: HELPER_REAP_TIMEOUT_MS,
+  });
+  for (const line of stdout.split('\n')) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.+)$/.exec(line);
+    if (!match) continue;
+    if (Number(match[2]) !== process.pid) continue;
+    if (!POSIX_COPY_HELPERS.has(basename(match[3].trim()))) continue;
+    try {
+      process.kill(Number(match[1]), 'SIGKILL');
+    } catch {
+      // The helper exited between listing and killing.
+    }
+  }
+}
+
+async function reapWindowsCopyHelpers(): Promise<void> {
+  // clipboardy copies via `powershell.exe -EncodedCommand …` (powershell-utils)
+  // or its bundled `clipboard_<arch>.exe` fallback; both are direct children.
+  const script =
+    `Get-CimInstance Win32_Process -Filter 'ParentProcessId=${process.pid}' | ` +
+    `Where-Object { $_.Name -like 'clipboard_*.exe' -or ` +
+    `($_.Name -eq 'powershell.exe' -and $_.CommandLine -match '-EncodedCommand') } | ` +
+    `ForEach-Object { Stop-Process -Id $_.ProcessId -Force }`;
+  await execFileAsync(
+    'powershell',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { timeout: HELPER_REAP_TIMEOUT_MS, windowsHide: true },
+  );
+}
+
+async function reapWedgedCopyHelpers(
+  platform: NodeJS.Platform,
+): Promise<void> {
+  try {
+    await (platform === 'win32'
+      ? reapWindowsCopyHelpers()
+      : reapPosixCopyHelpers());
+  } catch {
+    // Best effort: a reap failure must not mask the timeout result.
+  }
+}
+
+function normalizeClipboardText(
+  text: string,
+  platform: NodeJS.Platform,
+): string {
   const lf = text.replaceAll(/\r\n?/g, '\n');
   return platform === 'win32' ? lf.replaceAll('\n', '\r\n') : lf;
 }
@@ -23,10 +92,8 @@ export async function writeClipboardText(
   text: string,
   options: ClipboardTextWriteOptions = {},
 ): Promise<ClipboardTextWriteResult> {
-  const normalized = normalizeClipboardText(
-    text,
-    options.platform ?? osPlatform(),
-  );
+  const platform = options.platform ?? osPlatform();
+  const normalized = normalizeClipboardText(text, platform);
   try {
     await pTimeout(clipboard.write(normalized), {
       milliseconds: CLIPBOARD_WRITE_TIMEOUT_MS,
@@ -34,6 +101,11 @@ export async function writeClipboardText(
     });
     return { ok: true };
   } catch (error) {
+    if (error instanceof TimeoutError) {
+      // Reap before reporting failure so a wedged helper cannot land a stale
+      // write on the clipboard after the UI has already shown 'failed'.
+      await reapWedgedCopyHelpers(platform);
+    }
     return { ok: false, reason: toErrorMessage(error) };
   }
 }

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -68,9 +68,7 @@ async function reapWindowsCopyHelpers(): Promise<void> {
   );
 }
 
-async function reapWedgedCopyHelpers(
-  platform: NodeJS.Platform,
-): Promise<void> {
+async function reapWedgedCopyHelpers(platform: NodeJS.Platform): Promise<void> {
   try {
     await (platform === 'win32'
       ? reapWindowsCopyHelpers()

--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -34,6 +34,9 @@ const POSIX_COPY_HELPERS: ReadonlySet<string> = new Set([
   'xsel', // Linux (X11), including clipboardy's bundled fallback binary
   'clip.exe', // WSL
   'termux-clipboard-set', // Android (Termux)
+  // Linux `ps -o comm=` reports the kernel task name, which TASK_COMM_LEN
+  // truncates to 15 characters — `termux-clipboard-set` surfaces as this.
+  'termux-clipboar',
 ]);
 
 async function reapPosixCopyHelpers(): Promise<void> {
@@ -56,10 +59,15 @@ async function reapPosixCopyHelpers(): Promise<void> {
 async function reapWindowsCopyHelpers(): Promise<void> {
   // clipboardy copies via `powershell.exe -EncodedCommand …` (powershell-utils)
   // or its bundled `clipboard_<arch>.exe` fallback; both are direct children.
+  // This reap script is itself a direct-child powershell.exe, so it must not
+  // match its own filter: `$_.ProcessId -ne $PID` excludes it, and splitting
+  // the '-EncodedCommand' literal keeps this script's command line (and a
+  // concurrent reap's) from containing the very substring it greps for.
   const script =
     `Get-CimInstance Win32_Process -Filter 'ParentProcessId=${process.pid}' | ` +
-    `Where-Object { $_.Name -like 'clipboard_*.exe' -or ` +
-    `($_.Name -eq 'powershell.exe' -and $_.CommandLine -match '-EncodedCommand') } | ` +
+    `Where-Object { $_.ProcessId -ne $PID -and ` +
+    `($_.Name -like 'clipboard_*.exe' -or ` +
+    `($_.Name -eq 'powershell.exe' -and $_.CommandLine -match ('-Encoded' + 'Command'))) } | ` +
     `ForEach-Object { Stop-Process -Id $_.ProcessId -Force }`;
   await execFileAsync(
     'powershell',
@@ -68,13 +76,28 @@ async function reapWindowsCopyHelpers(): Promise<void> {
   );
 }
 
+// Killing a wedged helper makes clipboardy retry with its bundled fallback
+// binary (Windows `clipboard_<arch>.exe`, Linux bundled `xsel`) — a new direct
+// child spawned after the first sweep's process snapshot. A healthy fallback
+// finishes within milliseconds (landing the still-current text before the user
+// can copy anything else); one delayed second sweep catches a fallback that
+// wedges exactly like the helper it replaced.
+const FALLBACK_REAP_DELAY_MS = 300;
+
 async function reapWedgedCopyHelpers(platform: NodeJS.Platform): Promise<void> {
-  try {
-    await (platform === 'win32'
-      ? reapWindowsCopyHelpers()
-      : reapPosixCopyHelpers());
-  } catch {
-    // Best effort: a reap failure must not mask the timeout result.
+  for (let sweep = 0; sweep < 2; sweep += 1) {
+    if (sweep > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, FALLBACK_REAP_DELAY_MS),
+      );
+    }
+    try {
+      await (platform === 'win32'
+        ? reapWindowsCopyHelpers()
+        : reapPosixCopyHelpers());
+    } catch {
+      // Best effort: a reap failure must not mask the timeout result.
+    }
   }
 }
 

--- a/src/test-kernel/cli/ClipboardText.vitest.mts
+++ b/src/test-kernel/cli/ClipboardText.vitest.mts
@@ -77,7 +77,7 @@ describe('CLI clipboard text writer', () => {
       const resultPromise = writeClipboardText('question', {
         platform: 'darwin',
       });
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(6_000);
       const result = await resultPromise;
 
       expect(result).toEqual({
@@ -93,20 +93,22 @@ describe('CLI clipboard text writer', () => {
     vi.useFakeTimers();
     try {
       writeMock.mockReturnValue(new Promise<void>(() => {}));
-      execFileMock.mockResolvedValue({
+      execFileMock.mockResolvedValueOnce({
         stdout: [
           '  101      1 /usr/bin/pbcopy', // someone else's child
           `  202 ${process.pid} vim`, // our child, not a copy helper
           `  303 ${process.pid} /usr/bin/pbcopy`, // wedged helper
           `  404 ${process.pid} wl-copy`, // stray from an earlier attempt
+          `  505 ${process.pid} termux-clipboar`, // TASK_COMM_LEN-truncated
         ].join('\n'),
         stderr: '',
       });
+      execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
 
       const resultPromise = writeClipboardText('question', {
         platform: 'darwin',
       });
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(6_000);
       const result = await resultPromise;
 
       expect(result).toEqual({
@@ -118,9 +120,44 @@ describe('CLI clipboard text writer', () => {
         ['-Ao', 'pid=,ppid=,comm='],
         expect.objectContaining({ timeout: 2_000 }),
       );
-      expect(process.kill).toHaveBeenCalledTimes(2);
+      expect(process.kill).toHaveBeenCalledTimes(3);
       expect(process.kill).toHaveBeenCalledWith(303, 'SIGKILL');
       expect(process.kill).toHaveBeenCalledWith(404, 'SIGKILL');
+      expect(process.kill).toHaveBeenCalledWith(505, 'SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sweeps again after a delay to catch the fallback helper a kill can spawn', async () => {
+    vi.useFakeTimers();
+    try {
+      writeMock.mockReturnValue(new Promise<void>(() => {}));
+      execFileMock.mockResolvedValueOnce({
+        stdout: `  303 ${process.pid} xsel`, // wedged system helper
+        stderr: '',
+      });
+      // Killing the system helper makes clipboardy retry with its bundled
+      // fallback binary, which here wedges too.
+      execFileMock.mockResolvedValueOnce({
+        stdout: `  606 ${process.pid} /repo/node_modules/clipboardy/fallbacks/linux/xsel`,
+        stderr: '',
+      });
+
+      const resultPromise = writeClipboardText('question', {
+        platform: 'linux',
+      });
+      await vi.advanceTimersByTimeAsync(6_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Clipboard write timed out after 5000ms',
+      });
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      expect(process.kill).toHaveBeenCalledTimes(2);
+      expect(process.kill).toHaveBeenCalledWith(303, 'SIGKILL');
+      expect(process.kill).toHaveBeenCalledWith(606, 'SIGKILL');
     } finally {
       vi.useRealTimers();
     }
@@ -134,21 +171,27 @@ describe('CLI clipboard text writer', () => {
       const resultPromise = writeClipboardText('question', {
         platform: 'win32',
       });
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(6_000);
       const result = await resultPromise;
 
       expect(result).toEqual({
         ok: false,
         reason: 'Clipboard write timed out after 5000ms',
       });
-      expect(execFileMock).toHaveBeenCalledTimes(1);
+      // One sweep for the wedged helper, one for the fallback a kill spawns.
+      expect(execFileMock).toHaveBeenCalledTimes(2);
       const [command, args] = execFileMock.mock.calls[0] as [
         string,
         readonly string[],
       ];
       expect(command).toBe('powershell');
-      expect(args.at(-1)).toContain(`ParentProcessId=${process.pid}`);
-      expect(args.at(-1)).toContain('Stop-Process');
+      const script = args.at(-1) ?? '';
+      expect(script).toContain(`ParentProcessId=${process.pid}`);
+      expect(script).toContain('Stop-Process');
+      // The reap script must not match itself: it excludes its own PID and
+      // its command line never contains the literal it greps for.
+      expect(script).toContain('$_.ProcessId -ne $PID');
+      expect(script).not.toContain('-EncodedCommand');
       expect(process.kill).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
@@ -164,7 +207,7 @@ describe('CLI clipboard text writer', () => {
       const resultPromise = writeClipboardText('question', {
         platform: 'darwin',
       });
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(6_000);
       const result = await resultPromise;
 
       expect(result).toEqual({

--- a/src/test-kernel/cli/ClipboardText.vitest.mts
+++ b/src/test-kernel/cli/ClipboardText.vitest.mts
@@ -1,16 +1,37 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const writeMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock('clipboardy', () => ({
   default: { write: writeMock },
 }));
 
+// `clipboardText` reaps wedged clipboard helpers through
+// `promisify(execFile)`, so the mock must carry `promisify.custom` for the
+// promisified call to route here.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { promisify } = await import('node:util');
+  const execFile = Object.assign(
+    (...args: unknown[]) => execFileMock(...args),
+    { [promisify.custom]: (...args: unknown[]) => execFileMock(...args) },
+  );
+  return { ...actual, execFile };
+});
+
 import { writeClipboardText } from '@cli/runtime/clipboardText';
 
 describe('CLI clipboard text writer', () => {
+  beforeEach(() => {
+    execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+  });
+
   afterEach(() => {
     writeMock.mockReset();
+    execFileMock.mockReset();
+    vi.restoreAllMocks();
   });
 
   it('normalizes to CRLF line endings for Windows writes', async () => {
@@ -43,12 +64,102 @@ describe('CLI clipboard text writer', () => {
     });
 
     expect(result).toEqual({ ok: false, reason: 'pbcopy not found' });
+    // Only a timeout reaps helpers; an ordinary rejection means the helper
+    // already exited.
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it('reports failure instead of hanging when the write never settles', async () => {
     vi.useFakeTimers();
     try {
       writeMock.mockReturnValue(new Promise<void>(() => {}));
+
+      const resultPromise = writeClipboardText('question', {
+        platform: 'darwin',
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Clipboard write timed out after 5000ms',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('kills wedged copy helpers it spawned on timeout, and only those', async () => {
+    vi.useFakeTimers();
+    try {
+      writeMock.mockReturnValue(new Promise<void>(() => {}));
+      execFileMock.mockResolvedValue({
+        stdout: [
+          '  101      1 /usr/bin/pbcopy', // someone else's child
+          `  202 ${process.pid} vim`, // our child, not a copy helper
+          `  303 ${process.pid} /usr/bin/pbcopy`, // wedged helper
+          `  404 ${process.pid} wl-copy`, // stray from an earlier attempt
+        ].join('\n'),
+        stderr: '',
+      });
+
+      const resultPromise = writeClipboardText('question', {
+        platform: 'darwin',
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Clipboard write timed out after 5000ms',
+      });
+      expect(execFileMock).toHaveBeenCalledWith(
+        'ps',
+        ['-Ao', 'pid=,ppid=,comm='],
+        expect.objectContaining({ timeout: 2_000 }),
+      );
+      expect(process.kill).toHaveBeenCalledTimes(2);
+      expect(process.kill).toHaveBeenCalledWith(303, 'SIGKILL');
+      expect(process.kill).toHaveBeenCalledWith(404, 'SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reaps Windows copy helpers through a parent-pid-bounded Stop-Process', async () => {
+    vi.useFakeTimers();
+    try {
+      writeMock.mockReturnValue(new Promise<void>(() => {}));
+
+      const resultPromise = writeClipboardText('question', {
+        platform: 'win32',
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Clipboard write timed out after 5000ms',
+      });
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      const [command, args] = execFileMock.mock.calls[0] as [
+        string,
+        readonly string[],
+      ];
+      expect(command).toBe('powershell');
+      expect(args.at(-1)).toContain(`ParentProcessId=${process.pid}`);
+      expect(args.at(-1)).toContain('Stop-Process');
+      expect(process.kill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still reports the timeout when helper reaping itself fails', async () => {
+    vi.useFakeTimers();
+    try {
+      writeMock.mockReturnValue(new Promise<void>(() => {}));
+      execFileMock.mockRejectedValue(new Error('ps exploded'));
 
       const resultPromise = writeClipboardText('question', {
         platform: 'darwin',


### PR DESCRIPTION
## What

After #8206 adopted clipboardy, a clipboard write timeout only abandoned the await — `p-timeout` has no cancellation signal into clipboardy, so the wedged platform helper (`pbcopy`, `wl-copy`, `xsel`, PowerShell `Set-Clipboard`, …) lived on. Consequences (per #8219): repeated Ctrl-Y attempts accumulate stuck helpers, and a late write from an orphaned helper can land on the clipboard *after* the UI already reported `failed`, silently clobbering whatever the user copied next.

## Design

**Premise checked first**: clipboardy 5.3.1 (latest on npm as of this PR) exposes no cancellation hook — `write(text)` takes no signal, and internally calls `platformLib.copy({input: text})` with no way to thread execa's `cancelSignal`/`timeout` through. So per the maintainer ruling on this issue, the fix is a **bounded process-scoped cleanup**, not a clipboardy replacement:

- On `TimeoutError` (and only then — an ordinary rejection means the helper already exited), `writeClipboardText` reaps wedged copy helpers **before** returning `{ ok: false }`, so a wedged helper cannot land a stale write after the UI shows `failed`.
- **POSIX**: `ps -Ao pid=,ppid=,comm=`, kill (`SIGKILL`) direct children of `process.pid` whose executable basename is one of clipboardy's copy commands (`pbcopy`, `wl-copy`, `xsel` incl. the bundled fallback, `clip.exe` for WSL, `termux-clipboard-set`).
- **Windows**: one PowerShell `Get-CimInstance Win32_Process -Filter 'ParentProcessId=<pid>'` bounded to `clipboard_*.exe` or `powershell.exe` running `-EncodedCommand` (clipboardy copies via powershell-utils' encoded command; the CLI's only other PowerShell child, `clipboardImage.ts`, uses `-Command`, so it can't be hit).
- The parent-pid bound is load-bearing: a daemonized `wl-copy` from an earlier *successful* copy is reparented away and must stay alive to keep serving the Wayland clipboard — it is never touched.
- The reap itself is best-effort with its own 2s timeout; a reap failure never masks the timeout result.
- Each timeout reaps **all** matching direct children, so strays accumulated from earlier timed-out attempts are also cleaned up.

The write path stays 100% clipboardy — this does **not** reintroduce the hand-rolled per-platform command-table/fallthrough that #8206 deleted. No new dependencies (`p-timeout`'s `TimeoutError` named export, `node:child_process`).

Net: +190 / −7 across the module and its existing test suite (extended, not forked — R7).

## Verified

- Opened: `packages/cli/src/runtime/clipboardText.ts`, `src/test-kernel/cli/ClipboardText.vitest.mts`, `packages/cli/src/chat/tui/modals/ExternalInquiry.tsx` (sole consumer; `{ ok, reason }` contract unchanged), clipboardy 5.3.1 sources (`index.js`, `index.d.ts`, `lib/{macos,linux,wayland,windows,wsl,termux}.js`), `powershell-utils` (`-EncodedCommand` confirmed), `p-timeout` (TimeoutError export; inner promise gets a handler attached, so a post-kill execa rejection cannot become an unhandled rejection), `packages/cli/scripts/build-bundle.mjs` (clipboardy stays external).
- `npx vitest run src/test-kernel/cli/ClipboardText.vitest.mts` — 7/7 passed (3 new: POSIX kill-only-our-helpers, Windows parent-pid-bounded Stop-Process, reap-failure never masks the timeout result).
- `npx vitest run src/test-kernel/cli` — 130 files / 1686 tests passed.
- `npm run typecheck` — clean (root, test-kernel, texra, @texra-ai/cli, trace-viewer, desktop).
- `npx eslint` on both touched files — clean; `corepack pnpm --filter @texra-ai/cli check:architecture` — clean.
- Real-process E2E: spawned a child whose executable basename is `pbcopy` (symlink to `/bin/sleep`) plus an unrelated `sleep` bystander, ran the exact reap code — wedged child died with `SIGKILL`, bystander survived, and `ps -Ao pid=,ppid=,comm=` output format matched the parser on macOS.

Closes #8219

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Process termination on clipboard timeout is inherently sensitive (wrong PID filtering could affect unrelated children), though the design limits kills to direct children and known helper names; TUI copy is the main consumer.
> 
> **Overview**
> Fixes clipboard writes that time out leaving **clipboardy** platform helpers (`pbcopy`, `wl-copy`, `xsel`, PowerShell, etc.) running, which could pile up on repeated copy attempts and still write stale text after the UI shows **failed**.
> 
> **`writeClipboardText`** now runs a **best-effort, parent-PID–bounded cleanup** only on **`TimeoutError`**: POSIX uses `ps` + `SIGKILL` on direct children whose comm matches known copy helpers; Windows runs a bounded PowerShell `Stop-Process` script (with safeguards so the reap process does not kill itself). A **second sweep** after ~300ms catches fallback helpers clipboardy may spawn after the first kill. Reap failures do not change the timeout failure returned to callers.
> 
> **External inquiry** copy (Ctrl-Y) ignores a second trigger while **`copying`**, so concurrent copies do not race the timeout reap and kill the wrong helper.
> 
> Vitest coverage for timeout behavior, selective killing, Windows reap, double sweep, and reap errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2380ea5aafaf8e494a2ac153661418191f58b2dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->