### PR TITLE
fix(transcript): guard writeMergedSidecars against stream eviction during hydration

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -121,7 +121,7 @@ function toolUseTaskState(agent = 'search', model = 'deepseekproT'): TaskState {
 
 function injectDuringExecutionConfigHydration(
   executionId: ExecutionId,
-  inject: () => void,
+  inject: () => void | Promise<void>,
 ) {
   const originalRead = StorageFS.read.bind(StorageFS);
   const configPath = path.join(
@@ -131,7 +131,9 @@ function injectDuringExecutionConfigHydration(
   const injected = vi.fn(inject);
   vi.spyOn(StorageFS, 'read').mockImplementation(async (target: string) => {
     const raw = await originalRead(target);
-    if (target === configPath && injected.mock.calls.length === 0) injected();
+    if (target === configPath && injected.mock.calls.length === 0) {
+      await injected();
+    }
     return raw;
   });
   return injected;
@@ -968,6 +970,51 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
 
     expect(await StorageFS.exists(dir)).toBe(false);
+  });
+
+  it('does not resurrect a deleted sidecar dir when deleteStream lands during hydration', async () => {
+    // Regression for #8226: applyStreamData awaits execution-config hydration
+    // mid-seed. If the stream is deleted during that await, the continuation
+    // must not re-resolve a record for the evicted stream and flush merged
+    // sidecars — pre-fix, the legacy-shaped file below queued an unconditional
+    // rewrite that recreated `streamData/{id}/` after deleteDir() removed it.
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const executionId = 'dead01' as ExecutionId;
+    await StorageFS.ensureDir(dir);
+    await Promise.all([
+      StorageFS.write(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({
+          schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+          executionId,
+        }),
+      ),
+      // Legacy nested shape → `missingOutputs` lands in `data.legacyKeys`,
+      // arming the merged-sidecar rewrite regardless of overlays.
+      StorageFS.write(
+        path.join(dir, 'missingOutputs.json'),
+        JSON.stringify({ 'run-1': { '0': ['stale.tex'] } }),
+      ),
+      getExecutionStore(executionId).writeConfig(
+        toolUseTaskState().agentConfig,
+      ),
+    ]);
+
+    const store = new StreamSnapshotStore();
+    // Await the delete so evict + deleteDir fully complete before hydration
+    // resumes — only the post-await continuation can recreate the dir.
+    const wasDeleteInjected = injectDuringExecutionConfigHydration(
+      executionId,
+      () => store.deleteStream(STREAM),
+    );
+
+    await store.load([STREAM]);
+    expect(wasDeleteInjected).toHaveBeenCalledOnce();
+    await store.flush();
+
+    expect(await StorageFS.exists(dir)).toBe(false);
+    expect(await store.listPersistedStreams()).not.toContain(STREAM);
   });
 
   it('serializes same-key writes so a slow first write finishes before a queued second write starts', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -539,14 +539,17 @@ export class StreamSnapshotStore {
    * Apply a parsed round-keyed patch to one round-keyed field of a stream's
    * record. `field` selects which field (output files / missing outputs /
    * compile failures) — always present on the record (defaulted at
-   * creation), so no separate lazy-init step is needed here.
+   * creation), so no separate lazy-init step is needed here. Takes the
+   * record, not the stream id, so `applyStreamData`'s post-hydration replay
+   * can't re-resolve (and thereby resurrect) a record for a stream that was
+   * evicted mid-hydration (#8226).
    */
   private applyRoundPatch<T>(
     field: (record: StreamRecord) => RoundIndexed<T>,
-    stream: StreamTabId,
+    record: StreamRecord,
     patch: Map<number, T[] | null>,
   ): RoundIndexed<T> {
-    const rounds = field(this.getOrCreateRecord(stream));
+    const rounds = field(record);
     for (const [round, value] of patch) {
       if (value === null) delete rounds[round];
       else rounds[round] = value;
@@ -563,11 +566,10 @@ export class StreamSnapshotStore {
   }
 
   private applyUsageDeltaMemory(
-    stream: StreamTabId,
+    record: StreamRecord,
     storageKey: StorageKey,
     delta: TokenUsageStats,
   ): TokenUsageStats | undefined {
-    const record = this.getOrCreateRecord(stream);
     if (isEmptyUsage(delta)) return record.usage.get(storageKey);
     const existing = record.usage.get(storageKey) ?? emptyUsageStats();
     const accumulated = sumUsageStats([existing, delta]);
@@ -653,7 +655,12 @@ export class StreamSnapshotStore {
         record.outputFileOverlay = value;
       },
       mergeRoundPatch,
-      () => this.applyRoundPatch((record) => record.outputFiles, stream, patch),
+      () =>
+        this.applyRoundPatch(
+          (record) => record.outputFiles,
+          this.getOrCreateRecord(stream),
+          patch,
+        ),
       () => this.writeOutputFiles(stream),
     );
   }
@@ -676,7 +683,11 @@ export class StreamSnapshotStore {
       },
       mergeMissingOutputsOverlay,
       () =>
-        this.applyRoundPatch((record) => record.missingOutputs, stream, patch),
+        this.applyRoundPatch(
+          (record) => record.missingOutputs,
+          this.getOrCreateRecord(stream),
+          patch,
+        ),
       () =>
         this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
           ...this.records.get(stream)?.missingOutputs,
@@ -705,7 +716,11 @@ export class StreamSnapshotStore {
       },
       mergeRoundPatch,
       () =>
-        this.applyRoundPatch((record) => record.compileFailures, stream, patch),
+        this.applyRoundPatch(
+          (record) => record.compileFailures,
+          this.getOrCreateRecord(stream),
+          patch,
+        ),
       () =>
         this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, {
           ...this.records.get(stream)?.compileFailures,
@@ -736,7 +751,12 @@ export class StreamSnapshotStore {
         record.usageOverlay = value;
       },
       mergeUsagePatch,
-      () => this.applyUsageDeltaMemory(stream, storageKey, delta),
+      () =>
+        this.applyUsageDeltaMemory(
+          this.getOrCreateRecord(stream),
+          storageKey,
+          delta,
+        ),
       () => {
         if (!isEmptyUsage(delta)) this.writeUsage(stream);
       },
@@ -1413,22 +1433,23 @@ export class StreamSnapshotStore {
       record.meta = undefined;
     }
 
-    // Re-fetch the record after the hydration await above (same object
-    // reference as `record` — records are mutated in place, not replaced —
-    // so this doesn't read from a different source): a concurrent eager
-    // mutation may have landed on this stream's overlay fields while
-    // hydration was in flight (the exact race #8014 fixed), and it must not
-    // be clobbered by what was read before that await.
-    const after = this.getOrCreateRecord(stream);
-    const latestMetaOverlay = after.metaOverlay ? after.meta : undefined;
+    // `record` rides across the hydration await above: records are mutated
+    // in place, never replaced, so re-reading its overlay fields here picks
+    // up any concurrent eager mutation that landed while hydration was in
+    // flight (the exact race #8014 fixed). Never re-resolve the record via
+    // `getOrCreateRecord` here — if the stream was evicted during the await,
+    // that would resurrect a record for a deleted stream and defeat
+    // `writeMergedSidecars`' eviction check (#8226); an orphaned `record` is
+    // mutated harmlessly and never written.
+    const latestMetaOverlay = record.metaOverlay ? record.meta : undefined;
     if (latestMetaOverlay) {
       meta = { ...(data.meta ?? {}), ...latestMetaOverlay };
-      after.meta = meta;
+      record.meta = meta;
     }
     const latestRunConfigOverlay =
-      latestMetaOverlay !== undefined ? after.runConfig : undefined;
+      latestMetaOverlay !== undefined ? record.runConfig : undefined;
     const latestRunDescriptorOverlay =
-      latestMetaOverlay !== undefined ? after.runDescriptor : undefined;
+      latestMetaOverlay !== undefined ? record.runDescriptor : undefined;
     const runConfig =
       latestRunConfigOverlay ?? runConfigOverlay ?? hydrated.config;
     const executionId = executionIdFromMeta(meta);
@@ -1439,56 +1460,62 @@ export class StreamSnapshotStore {
       (runConfig && executionId
         ? descriptorFromConfig(stream, executionId, runConfig)
         : undefined);
-    if (runConfig) after.runConfig = runConfig;
-    if (runDescriptor) after.runDescriptor = runDescriptor;
-    after.metaOverlay = false;
+    if (runConfig) record.runConfig = runConfig;
+    if (runDescriptor) record.runDescriptor = runDescriptor;
+    record.metaOverlay = false;
 
-    const outputFileOverlay = after.outputFileOverlay;
-    const missingOutputsOverlay = after.missingOutputsOverlay;
-    const compileFailuresOverlay = after.compileFailuresOverlay;
-    const usageOverlay = after.usageOverlay;
+    const outputFileOverlay = record.outputFileOverlay;
+    const missingOutputsOverlay = record.missingOutputsOverlay;
+    const compileFailuresOverlay = record.compileFailuresOverlay;
+    const usageOverlay = record.usageOverlay;
     if (outputFileOverlay) {
-      this.applyRoundPatch((r) => r.outputFiles, stream, outputFileOverlay);
+      this.applyRoundPatch((r) => r.outputFiles, record, outputFileOverlay);
       sidecarsToWrite.add(STREAM_DATA_KEYS.OUTPUT_FILES);
-      after.outputFileOverlay = undefined;
+      record.outputFileOverlay = undefined;
     }
     if (missingOutputsOverlay) {
-      if (missingOutputsOverlay.reset) after.missingOutputs = {};
+      if (missingOutputsOverlay.reset) record.missingOutputs = {};
       this.applyRoundPatch(
         (r) => r.missingOutputs,
-        stream,
+        record,
         missingOutputsOverlay.patch,
       );
       sidecarsToWrite.add(STREAM_DATA_KEYS.MISSING_OUTPUTS);
-      after.missingOutputsOverlay = undefined;
+      record.missingOutputsOverlay = undefined;
     }
     if (compileFailuresOverlay) {
       this.applyRoundPatch(
         (r) => r.compileFailures,
-        stream,
+        record,
         compileFailuresOverlay,
       );
       sidecarsToWrite.add(STREAM_DATA_KEYS.COMPILE_FAILURES);
-      after.compileFailuresOverlay = undefined;
+      record.compileFailuresOverlay = undefined;
     }
     if (usageOverlay) {
       for (const [storageKey, delta] of usageOverlayToReplay) {
-        this.applyUsageDeltaMemory(stream, storageKey, delta);
+        this.applyUsageDeltaMemory(record, storageKey, delta);
       }
       sidecarsToWrite.add(STREAM_DATA_KEYS.USAGE_STATS);
-      after.usageOverlay = undefined;
+      record.usageOverlay = undefined;
     }
-    after.seeded = true;
-    this.writeMergedSidecars(stream, sidecarsToWrite);
+    record.seeded = true;
+    this.writeMergedSidecars(stream, record, sidecarsToWrite);
   }
 
   /** Persist sidecars from merged memory after seeding and overlays converge. */
   private writeMergedSidecars(
     stream: StreamTabId,
+    record: StreamRecord,
     keys: Iterable<string>,
   ): void {
-    const record = this.records.get(stream);
-    if (!record) return;
+    // `record` rode across `applyStreamData`'s hydration await. Identity —
+    // not mere presence — against the live map entry: eviction during the
+    // await orphans `record`, and `deleteStream()`'s own post-evict `kv()`
+    // call (or a concurrent eager mutation) can already have re-created a
+    // fresh entry, so a presence check would still let orphaned seed state
+    // resurrect the deleted `streamData/{id}/` dir on disk (#8226).
+    if (this.records.get(stream) !== record) return;
     for (const key of keys) {
       switch (key) {
         case STREAM_DATA_KEYS.OUTPUT_FILES:


### PR DESCRIPTION
Closes #8226

## Summary

`applyStreamData()` awaits `hydrateRunStateFromMeta()` mid-seed, then re-resolved its record via `this.getOrCreateRecord(stream)`. If the stream was evicted during that await (e.g. `deleteStream()`), the re-resolve recreated an empty record, so `writeMergedSidecars`' `if (!record) return` presence guard never fired and legacy-keyed sidecars were rewritten as `{}` after `deleteDir()` had removed `streamData/{id}/` — silently resurrecting the deleted stream via `listPersistedStreams()`.

## Design choice

Per the maintainer ruling on #8226, the fix rides the consolidated `StreamRecord` (#8214) instead of adding a lock or version guard:

- **Hold the record reference across the async gap.** Records are mutated in place and never replaced, so the pre-hydration `record` reference is the live record whenever the stream wasn't evicted — re-reading its overlay fields through the held reference still picks up concurrent eager mutations (the #8014 race stays fixed). An orphaned (evicted) record is mutated harmlessly and never written.
- **No `getOrCreateRecord` anywhere in the post-await path.** `applyRoundPatch` and `applyUsageDeltaMemory` now take the `StreamRecord` instead of re-resolving by stream id; live mutators pass `this.getOrCreateRecord(stream)` at their own entry, the replay block passes the held record.
- **Fused check-and-use in `writeMergedSidecars`.** It now receives the record and identity-checks it against the live map entry (`this.records.get(stream) !== record`). Identity — not presence — is required: `deleteStream()`'s own post-evict `kv()` call recreates a fresh map entry, so a presence check would still let orphaned seed state resurrect the deleted dir.

The regression test drives the real flow: a legacy-shaped `missingOutputs.json` (arming the unconditional merged-sidecar rewrite) plus `deleteStream()` injected — and fully awaited — inside the execution-config hydration read. It fails on `origin/main` (dir resurrected) and passes with the fix.

## Verified

- Opened: `src/transcript/StreamSnapshotStore.ts` (full file at origin/main HEAD to confirm the premise), `src/transcript/streamSnapshotRead.ts` (legacyKeys production), `src/transcript/streamDataPaths.ts` (`STREAM_DATA_KEYS`), `src/test-kernel/transcript/StreamSnapshotStore.vitest.ts`.
- `pnpm run typecheck` — exit 0 (all packages).
- `npx vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` — 37/37 pass.
- New regression test run against origin/main's `StreamSnapshotStore.ts` — fails as expected (`StorageFS.exists(dir)` true), passes post-fix.
- All 17 suites referencing `StreamSnapshotStore` (transcript, desktop, progressView, cli, latex, schemas, tools) — 300/300 pass.
- `npx prettier --check` clean on both touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets a subtle async race in stream sidecar persistence; wrong behavior could resurrect deleted streams or write stale disk state, though the change is localized and regression-tested.
> 
> **Overview**
> Fixes **#8226**, where `deleteStream()` during `applyStreamData()`’s async execution-config hydration could **recreate** `streamData/{id}/` after `deleteDir()` removed it.
> 
> **`applyStreamData`** keeps the pre-await **`StreamRecord`** and no longer calls **`getOrCreateRecord`** after hydration. Overlay replay and **`applyRoundPatch`** / **`applyUsageDeltaMemory`** mutate that held record so eviction mid-await cannot spawn a fresh map entry from orphaned seed work.
> 
> **`writeMergedSidecars`** takes the same record and bails unless **`this.records.get(stream) === record`** (identity, not mere presence), so a post-delete **`kv()`** or concurrent mutation cannot let stale merged sidecars hit disk.
> 
> Adds a regression test that **`await`s `deleteStream`** inside the hydration read hook (legacy **`missingOutputs.json`** shape), plus async support in the test **`injectDuringExecutionConfigHydration`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da004bc0c39a9e9eb39e5aeea30b1a9c00ed202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->