### PR TITLE
fix(ui): restore empty-state body sizing and tokenize ModelsTab gaps

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -50,7 +50,7 @@ export class ModelsTab extends LitElement {
       .chatgpt-subscription__header {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: var(--wa-space-xs);
       }
       .chatgpt-subscription__title {
         font-weight: var(--font-weight-semibold);
@@ -72,7 +72,7 @@ export class ModelsTab extends LitElement {
       .chatgpt-subscription__limit {
         display: flex;
         align-items: flex-start;
-        gap: 0.4rem;
+        gap: var(--wa-space-xs);
         margin: 0 0 var(--wa-space-xs);
         opacity: 0.85;
         font-size: var(--font-size-sm);
@@ -84,7 +84,7 @@ export class ModelsTab extends LitElement {
       .chatgpt-subscription__row {
         display: flex;
         align-items: center;
-        gap: 0.75rem;
+        gap: var(--wa-space-s);
         flex-wrap: wrap;
       }
       .chatgpt-subscription__setting {
@@ -93,7 +93,7 @@ export class ModelsTab extends LitElement {
       .chatgpt-subscription__account {
         display: inline-flex;
         align-items: center;
-        gap: 0.35rem;
+        gap: var(--wa-space-2xs);
       }
     `,
   ];

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -389,6 +389,10 @@ export const commonViewStyles: CSSResult = css`
 
   .empty-state .empty-state-body {
     margin: 0;
+    /* Body copy was <p class="text-secondary"> before the helper: keep the
+       smaller secondary sizing so it stays subordinate to the title (color
+       already cascades from .empty-state). */
+    font-size: var(--font-size-sm);
   }
 
   /* Agent icon indicators (remote, multiple outputs) - fixed width for consistent sizing */


### PR DESCRIPTION
Closes #8196
Closes #8198

Two small webview styling follow-ups from the UI-standardization night, per maintainer grouping.

## #8196 — restore secondary sizing for renderEmptyState() body text

When #8177 converged History/Memory empty states onto the shared `renderEmptyState()` helper, the body copy lost the `--font-size-sm` sizing it previously had via `<p class="text-secondary">`, so title and body rendered at the same size. Fix: add `font-size: var(--font-size-sm)` to the shared `.empty-state .empty-state-body` hook in `src/shared/styles/commonViewStyles.ts`. Color is deliberately not re-declared — `.empty-state` already sets `color: var(--color-text-secondary)`, which the old `text-secondary` class matched, so it cascades identically.

Call-site regression sweep (R8): the `.empty-state`-scoped rule reaches only the four `className: 'empty-state'` callers — `MemoryList.ts:93`, `HistoryList.ts:270`/`:289`, `GoalTab.ts:183`. GoalTab and the HistoryList no-search-match state pass no `body`, so they are no-ops; the progressView callers (`ProgressApp`, `StreamTabs`, `TaskGroupList`) use `.progress-empty-state`/`.log-placeholder` scoping with their own `.empty-state-body` rules in `logStyles.ts`, so they are untouched even though `logStyles` composes `commonViewStyles`.

## #8198 — converge remaining raw-rem gaps in ModelsTab.ts

Replaced the four remaining raw-rem `gap:` literals in the `.chatgpt-subscription` block with `--wa-space-*` tokens, verified against the real scale in `packages/desktop/src/renderer/themeTokens.css` (3xs=0.125 / 2xs=0.25 / xs=0.5 / s=0.75 / m=1rem):

- `__header` `0.5rem` → `var(--wa-space-xs)` (exact)
- `__row` `0.75rem` → `var(--wa-space-s)` (exact)
- `__account` `0.35rem` → `var(--wa-space-2xs)` (same snap #8172 used for the hint margin in this block)
- `__limit` `0.4rem` → `var(--wa-space-xs)` (nearest token; matches #8172's `0.6rem` → `xs` snapping precedent)

The `letter-spacing: 0.04em` / `padding: 0 0.4em` on `__badge` are typography-relative em values, not spacing-scale candidates, and were left alone.

## Verified

- Opened: `src/shared/styles/commonViewStyles.ts`, `src/shared/wa/emptyState.ts`, all six `renderEmptyState()` call sites (MemoryList, HistoryList x2, GoalTab, ProgressApp, StreamTabs, TaskGroupList), `packages/extension/src/progressView/frontend/styles/logStyles.ts`, `packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts`, `packages/desktop/src/renderer/themeTokens.css`; diffed pre-#8177 History/Memory markup and the #8172 merge diff for mapping precedent.
- `npm run typecheck` — clean (all six sub-project tsc passes).
- `npm test -- EmptyStateHelper SettingsReliabilityPlacement ModelSelectionProviderKeys` — 3 files, 12 tests, all pass.
- No markup or behavior change (CSS token/value edits only), so no new test; the existing `EmptyStateHelper.vitest.ts` suite pins the helper's class-hook contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS token and font-size tweaks only; no logic, markup, or API changes.
> 
> **Overview**
> Restores **visual hierarchy** for shared empty states and finishes **spacing-token** cleanup on the Models settings tab.
> 
> **Empty states:** Adds `font-size: var(--font-size-sm)` to `.empty-state .empty-state-body` in `commonViewStyles.ts` so body copy is smaller than the title again after History/Memory moved to `renderEmptyState()` (replacing the old `text-secondary` paragraph sizing). Secondary color still comes from `.empty-state`.
> 
> **Models tab:** Replaces four raw `rem` `gap` values in `.chatgpt-subscription` with `--wa-space-*` tokens (`xs`, `s`, `2xs`) in `ModelsTab.ts`. Badge `em`-based typography spacing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466e00d337922937e42481eea4c36159c5ef7aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->