### PR TITLE
refactor(progressView): delete dead native-<summary> branch in buildDetailsSummary

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -127,7 +127,6 @@ export class ContextManagement extends LitElement {
           iconName: this.config.icon,
           label: this.config.label,
           labelClass: 'context-title',
-          summarySlot: true,
         })}
         <div class="context-content" data-log-id=${this.logId}>
           ${repeat(

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -169,7 +169,6 @@ export class LatexdiffResults extends LitElement {
         ${buildDetailsSummary({
           iconName: 'diff',
           label: summaryText,
-          summarySlot: true,
         })}
         <ul class="latexdiff-content">
           ${repeat(

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.styles.ts
@@ -49,8 +49,6 @@ export const retryRequestPanelStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
-  /* Note: .toggle-icon rotation handled by commonViewStyles */
-
   .retry-request__error-body {
     margin-top: ${sp.tiny};
     padding: ${sp.small};

--- a/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/StatisticsPanel.ts
@@ -82,7 +82,6 @@ export class StatisticsPanel extends LitElement {
         ${buildDetailsSummary({
           iconName: 'graph',
           label: 'Statistics',
-          summarySlot: true,
         })}
         <div class="statistics-content">
           ${repeat(

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -98,9 +98,6 @@ export function wrapInPre(text: string, className = ''): TemplateResult {
   return html`<pre class=${ifDefined(className || undefined)}>${content}</pre>`;
 }
 
-// Note: Toggle icons now use CSS-only rotation via details[open] selector.
-// Always render the chevron-right icon and CSS will rotate when open.
-
 /**
  * Stop an Enter/Space keydown on a control slotted into a `<wa-details>`
  * summary from also toggling the details panel.
@@ -151,11 +148,6 @@ export interface DetailsSummaryOptions {
   iconName: string;
   label: string;
   labelClass?: string;
-  /**
-   * Render as `<wa-details>` summary-slot content instead of a native summary.
-   * The caller must register `<wa-details>` and rely on its built-in toggle icon.
-   */
-  summarySlot?: boolean;
   timestamp?: { display: string; tooltip: string };
   copyButton?: {
     title: string;
@@ -167,7 +159,11 @@ export interface DetailsSummaryOptions {
   extraContent?: TemplateResult;
 }
 
-/** Build a details summary element with icon, label, and optional extras. */
+/**
+ * Build a `<wa-details>` summary-slot header with icon, label, and optional
+ * extras. The caller must render it inside a `<wa-details>` and rely on its
+ * built-in toggle icon.
+ */
 export function buildDetailsSummary(
   options: DetailsSummaryOptions,
 ): TemplateResult {
@@ -175,7 +171,6 @@ export function buildDetailsSummary(
     iconName,
     label,
     labelClass = 'label',
-    summarySlot = false,
     timestamp,
     copyButton,
     extraContent,
@@ -192,13 +187,8 @@ export function buildDetailsSummary(
     ? buildCopyButton(copyButton.title, copyButton)
     : nothing;
   const extraTemplate = extraContent ?? nothing;
-  if (summarySlot) {
-    // prettier-ignore
-    return html`<div slot="summary" class="details-summary">${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</div>`;
-  }
-  // Native details toggle icon uses CSS rotation via details[open].
   // prettier-ignore
-  return html`<summary class="details-summary"><wa-icon library=${TEXRA_ICON_LIBRARY} name="chevron-right" class="toggle-icon" aria-hidden="true"></wa-icon> ${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</summary>`;
+  return html`<div slot="summary" class="details-summary">${iconTemplate} <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</div>`;
 }
 
 /** Build rendered templates for file list. */

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -85,7 +85,6 @@ export function formatBannerContentTemplate(
       content: trimmedContent,
       contentId: id ? `banner:${id}` : undefined,
     },
-    summarySlot: true,
   })}${contentTemplate}</wa-details>`;
 }
 
@@ -123,6 +122,5 @@ export function formatModelResponseTemplate(
       content: trimmedContent,
       contentId: id ? `model:${id}` : undefined,
     },
-    summarySlot: true,
   })}${contentTemplate}</wa-details>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -50,7 +50,6 @@ export function formatFileListTemplate(
       iconName: 'file',
       label: 'Files (raw)',
       labelClass: 'summary-text',
-      summarySlot: true,
     })}<ul class="file-list-content" data-log-id=${ifDefined(id)}><pre>${text ?? ''}</pre></ul></wa-details>`;
   }
 
@@ -60,7 +59,6 @@ export function formatFileListTemplate(
     iconName: 'file',
     label: renderData?.summary ?? 'Files',
     labelClass: 'summary-text',
-    summarySlot: true,
   })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${renderData?.items ?? ''}</ul></wa-details>`;
 }
 
@@ -102,7 +100,6 @@ export function formatMissingOutputsTemplate(
     iconName: 'warning',
     label: `Missing outputs (${missing.length})`,
     labelClass: 'summary-text',
-    summarySlot: true,
   })}<ul class="file-list-content" data-log-id=${ifDefined(id)}>${listItems}</ul>${xmlFile ? renderXmlLink(xmlFile) : ''}</wa-details>`;
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -216,6 +216,5 @@ export function formatToolUseTemplate(
     label: titleText,
     labelClass: 'tool-use-title',
     extraContent,
-    summarySlot: true,
   })}${bannerContentTemplate}</wa-details>`;
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -40,7 +40,7 @@ function buildToolUseDetails(opts: {
 }): TemplateResult {
   const bannerContentTemplate = buildBannerContent(opts.message, opts.content);
   // prettier-ignore
-  return html`<wa-details appearance="plain" class=${classMap({ 'banner-details': true, 'tool-use-details': true, 'tool-use-error': opts.isError })} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title', summarySlot: true })}${bannerContentTemplate}</wa-details>`;
+  return html`<wa-details appearance="plain" class=${classMap({ 'banner-details': true, 'tool-use-details': true, 'tool-use-error': opts.isError })} ?open=${opts.defaultOpen ?? false}>${buildDetailsSummary({ iconName: opts.iconName, label: opts.label, labelClass: 'tool-use-title' })}${bannerContentTemplate}</wa-details>`;
 }
 
 // Web search provider display names

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -162,7 +162,7 @@ export const logEntryStyles = css`
     gap: var(--wa-space-2xs);
   }
 
-  /* Note: .toggle-icon and .details-summary base styles are in commonViewStyles */
+  /* Note: .details-summary base styles are in commonViewStyles */
 
   /* File list details styling */
   .file-list-details {

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -322,18 +322,6 @@ export const commonViewStyles: CSSResult = css`
     border-radius: var(--border-radius-small);
   }
 
-  /* Toggle icon for collapsible native details summaries. */
-  .details-summary .toggle-icon {
-    opacity: var(--opacity-subtle);
-    font-size: var(--font-size-sm);
-    display: inline-block;
-    transition: transform var(--transition-fast);
-  }
-
-  details[open] > summary .toggle-icon {
-    transform: rotate(90deg);
-  }
-
   /* Compact banner variant used by progress-view custom-element panels. */
   wa-details.banner-details::part(base) {
     border: 0;


### PR DESCRIPTION
Closes #8195

## Summary

Follow-up to #8165, which migrated the last `buildDetailsSummary` callers to `wa-details` with `summarySlot: true`. That made the native-`<summary>` branch provably dead, so this PR deletes it (pure deletion, net −33 lines):

- `buildDetailsSummary` (`packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts`) now always emits the `<div slot="summary">` path; the `summarySlot` option, the native `<summary>`/chevron-right branch, and the stale "CSS-only rotation" note above `stopSummaryToggleKeydown` are gone. The summary-slot constraint from the option's doc comment moved onto the function docstring.
- Removed the orphaned `.details-summary .toggle-icon` and `details[open] > summary .toggle-icon` rules from `src/shared/styles/commonViewStyles.ts` — the deleted branch was the only emitter of `.toggle-icon` in the repo.
- Dropped `summarySlot: true` from all 10 call sites (dataFormatters ×3, bannerFormatters ×2, toolFormatters, webFormatters, StatisticsPanel, ContextManagement, LatexdiffResults).
- Removed the stale `.toggle-icon` comment in `RetryRequestPanel.styles.ts` (that panel renders `wa-details` with `slot="summary"`, never a `.toggle-icon`) and trimmed the `.toggle-icon` mention from the `logEntryStyles.ts` note (`.details-summary` base styles do still live in commonViewStyles).

Kept as-is: the `.details-summary` base rule in commonViewStyles (still used by the slot-div path and `messageFormatters.ts:149`), and the historical rationale comment in `toolUseStyles.ts:71` explaining why `banner-details--no-toggle` hides the wa-details icon.

## Verified

- Grepped every `buildDetailsSummary(` call site at origin/main HEAD (e3cc61844): 10 sites, all passing `summarySlot: true`, none passing `false` or omitting it — the native branch was unreachable.
- Grepped `toggle-icon` repo-wide after the change: only the historical comment in `toolUseStyles.ts` remains; no element emits the class and no CSS targets it.
- Grepped `details-summary` consumers to confirm the base rule stays live (messageFormatters slot div + per-view style extensions).
- `npm run typecheck` — clean across all workspace tsconfigs.
- `npm test -- ToolUseFormatter WebFormattersUrlSanitization RetryRequestPanel` — 3 files, 26 tests passed.
- `npx prettier --check` on all touched files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unreachable UI paths and unused CSS; collapsible behavior stays on wa-details’ built-in disclosure with no auth or data changes.
> 
> **Overview**
> **Removes unreachable collapsible-header code** after all progress-view panels already use `<wa-details>` with slotted summaries.
> 
> `buildDetailsSummary` now **only** emits `<div slot="summary" class="details-summary">` (icon, label, optional timestamp/copy/extras). The `summarySlot` option, the native `<summary>` + `chevron-right` toggle branch, and related comments are deleted; the function docstring documents the wa-details contract.
> 
> **Call sites** drop redundant `summarySlot: true` (banner/tool/data formatters, StatisticsPanel, ContextManagement, LatexdiffResults, web formatters).
> 
> **CSS cleanup:** orphaned `.toggle-icon` rules and `details[open]` rotation in `commonViewStyles`; stale `.toggle-icon` notes in `logEntryStyles` and `RetryRequestPanel.styles`. Shared `.details-summary` layout styles remain for the slot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228fbf7e2ace0e6b449e32e31d67aee82707b48e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->