### PR TITLE
fix(agent-creator): reject empty or misspelled bundled template prompt fields

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -21,13 +21,33 @@ import { AbsoluteFS } from '@utils/files';
 const CHANNEL = 'AgentCreator';
 logger.initialize(CHANNEL);
 
-const ParsedCreatorYamlSchema = z.object({
-  prompts: z.object({
-    systemPrompt: z.string(),
-    userRequest: z.string(),
-    retryPrompt: z.string().optional(),
+// Validation only — no .trim() transform, so multiline block-scalar prompts
+// (including their trailing newline) pass through verbatim.
+const PromptStringSchema = z.string().refine((value) => value.trim() !== '', {
+  error: 'prompt must not be empty',
+});
+
+// Top level stays non-strict: templates carry metadata (name, description,
+// settings) that this loader does not consume. The prompts block is strict so
+// a misspelled key (e.g. `retryPromt`) fails the load instead of being
+// stripped and silently replaced by the built-in fallback.
+export const ParsedCreatorYamlSchema = z.object({
+  prompts: z.strictObject({
+    systemPrompt: PromptStringSchema,
+    userRequest: PromptStringSchema,
+    retryPrompt: PromptStringSchema.optional(),
   }),
 });
+
+function parseCreatorTemplate(fileName: string, raw: string) {
+  const parsed = ParsedCreatorYamlSchema.safeParse(yaml.parse(raw));
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid bundled agent-creator template ${fileName}: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+  return parsed.data;
+}
 
 /** Cached after first load. Templates are bundled resources — stable for the session. */
 let creatorConfig: CreatorConfig | null = null;
@@ -50,8 +70,8 @@ async function loadCreatorConfig(
       ),
       AbsoluteFS.read(path.join(templatesDir, 'agentTemplate-toolUse.yaml')),
     ]);
-  const wf = ParsedCreatorYamlSchema.parse(yaml.parse(workflowYaml));
-  const tu = ParsedCreatorYamlSchema.parse(yaml.parse(toolUseYaml));
+  const wf = parseCreatorTemplate('agentCreatorWorkflow.yaml', workflowYaml);
+  const tu = parseCreatorTemplate('agentCreatorToolUse.yaml', toolUseYaml);
   const defaultRetry =
     'The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.';
   creatorConfig = {

--- a/src/test-kernel/commands/AgentCreatorTemplateSchema.vitest.ts
+++ b/src/test-kernel/commands/AgentCreatorTemplateSchema.vitest.ts
@@ -1,0 +1,79 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+import * as yaml from 'yaml';
+
+import { ParsedCreatorYamlSchema } from '@commands/agent/agentCreatorCommands';
+
+// Schema-boundary contract for the bundled agent-creator templates (#8187):
+// malformed prompt blocks must fail loudly at load instead of silently
+// stripping misspelled keys or handing empty prompts to the helper model.
+const TEMPLATES_DIR = resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../..',
+  'packages/extension/resources/templates',
+);
+
+const VALID = {
+  name: 'example',
+  description: 'Example template metadata.',
+  settings: { agentCategory: 'internal' },
+  prompts: {
+    systemPrompt: 'You are a system prompt.\n',
+    userRequest: 'Generate the thing.\n',
+    retryPrompt: 'Try again: {{ VALIDATION_ERROR }}\n',
+  },
+};
+
+describe('bundled agent-creator template schema', () => {
+  it.each(['agentCreatorWorkflow.yaml', 'agentCreatorToolUse.yaml'])(
+    '%s parses with prompt content preserved verbatim',
+    (fileName) => {
+      const raw = yaml.parse(
+        readFileSync(resolve(TEMPLATES_DIR, fileName), 'utf8'),
+      );
+      const parsed = ParsedCreatorYamlSchema.parse(raw);
+      // No trimming or other rewriting of multiline block-scalar prompts.
+      expect(parsed.prompts).toEqual(raw.prompts);
+      expect(parsed.prompts.systemPrompt.endsWith('\n')).toBe(true);
+    },
+  );
+
+  it('accepts top-level metadata keys without prompts-level leniency', () => {
+    expect(ParsedCreatorYamlSchema.parse(VALID).prompts).toEqual(VALID.prompts);
+  });
+
+  it.each(['systemPrompt', 'userRequest', 'retryPrompt'])(
+    'rejects empty or whitespace-only %s',
+    (field) => {
+      for (const blank of ['', '  \n']) {
+        const result = ParsedCreatorYamlSchema.safeParse({
+          ...VALID,
+          prompts: { ...VALID.prompts, [field]: blank },
+        });
+        expect(result.success).toBe(false);
+      }
+    },
+  );
+
+  it('rejects misspelled keys inside prompts instead of stripping them', () => {
+    const { retryPrompt, ...rest } = VALID.prompts;
+    const result = ParsedCreatorYamlSchema.safeParse({
+      ...VALID,
+      prompts: { ...rest, retryPromt: retryPrompt },
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toContain('retryPromt');
+  });
+
+  it('rejects a missing required prompt field', () => {
+    const { userRequest: _omitted, ...rest } = VALID.prompts;
+    expect(
+      ParsedCreatorYamlSchema.safeParse({ ...VALID, prompts: rest }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #8187

## Summary

PR #8179 replaced the bundled agent-creator template cast with a Zod parse, but the schema still accepted malformed prompt blocks: empty `systemPrompt`/`userRequest` strings parsed fine, and a misspelled key inside `prompts` (e.g. `retryPromt`) was silently stripped so the built-in retry fallback masked the typo.

This PR tightens `ParsedCreatorYamlSchema` at the single load boundary in `packages/extension/src/commands/agent/agentCreatorCommands.ts`:

- `prompts` is now a `z.strictObject`, so unknown/misspelled keys inside the prompts block fail the load loudly.
- Prompt values must be non-blank via a validation-only `.refine` — no `.trim()` transform, so multiline block-scalar prompts (including trailing newlines) pass through verbatim.
- Parse failures now name the offending template file and use `z.prettifyError` (repo idiom), instead of an anonymous ZodError that can't distinguish the two bundled templates.
- Scope is deliberately narrow per the issue: the top level stays non-strict so legitimate template metadata (`name`, `description`, `settings`) remains accepted, and no other agent schemas were touched.

One focused schema-boundary suite (`src/test-kernel/commands/AgentCreatorTemplateSchema.vitest.ts`) covers the acceptance gates: both real bundled templates parse with prompt content preserved verbatim, empty/whitespace-only prompts are rejected, misspelled prompts keys are rejected, and missing required prompt fields are rejected.

## Verified

- Opened `packages/extension/src/commands/agent/agentCreatorCommands.ts`, `src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts` (CreatorConfig consumer), and both bundled templates (`packages/extension/resources/templates/agentCreatorWorkflow.yaml`, `agentCreatorToolUse.yaml`) to confirm the defect at origin/main HEAD (e3cc61844) and the exact key set a stricter schema must keep accepting.
- `npm run typecheck` — clean across all workspace projects.
- `npm test -- AgentCreator` — 2 files, 18 tests passed (new schema suite + existing tool-catalog parity suite).
- `npm test -- src/test-kernel/commands` — 9 files, 134 tests passed.
- `npx eslint` on both touched files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change at template load time with clearer failures; bundled templates are validated by new tests and behavior only affects the AI agent creation wizard.
> 
> **Overview**
> Tightens validation when loading bundled agent-creator YAML templates so bad `prompts` blocks fail at startup instead of slipping through to the helper model.
> 
> **`ParsedCreatorYamlSchema`** now uses **`z.strictObject`** on `prompts` (unknown keys like `retryPromt` error), requires non-blank **`systemPrompt`** / **`userRequest`** / optional **`retryPrompt`** via a refine (no `.trim()` so block-scalar newlines stay intact), and keeps the top-level object non-strict for unused metadata. Loading goes through **`parseCreatorTemplate`**, which throws an error naming the template file and **`z.prettifyError`** output.
> 
> Adds **`AgentCreatorTemplateSchema.vitest.ts`** to lock the contract: real bundled files parse verbatim, blanks and typos reject, missing required fields reject.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3beaa933b8972e8b32d6c91e0fd805dee344b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->