### PR TITLE
test(desktop): cover Linux and Windows arm64 Codex payload budgets

### DIFF
--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -48,10 +48,20 @@ const codexPlatforms = {
     triple: 'x86_64-apple-darwin',
     binaryName: 'codex',
   },
+  'linux-arm64': {
+    packageName: '@openai/codex-linux-arm64',
+    triple: 'aarch64-unknown-linux-musl',
+    binaryName: 'codex',
+  },
   'linux-x64': {
     packageName: '@openai/codex-linux-x64',
     triple: 'x86_64-unknown-linux-musl',
     binaryName: 'codex',
+  },
+  'win32-arm64': {
+    packageName: '@openai/codex-win32-arm64',
+    triple: 'aarch64-pc-windows-msvc',
+    binaryName: 'codex.exe',
   },
   'win32-x64': {
     packageName: '@openai/codex-win32-x64',
@@ -142,9 +152,19 @@ describe('desktop Codex package payload', () => {
 
   it.each([
     {
+      platform: 'linux-arm64' as const,
+      payloadSize: '294.2 MiB',
+      budgetSize: '310.2 MiB',
+    },
+    {
       platform: 'linux-x64' as const,
       payloadSize: '335.2 MiB',
       budgetSize: '351.2 MiB',
+    },
+    {
+      platform: 'win32-arm64' as const,
+      payloadSize: '339.9 MiB',
+      budgetSize: '355.9 MiB',
     },
     {
       platform: 'win32-x64' as const,
@@ -193,6 +213,15 @@ describe('desktop Codex package payload', () => {
     const result = runVerifierResult(packageRoot);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('above the 351.2 MiB budget for linux-x64');
+  });
+
+  it('rejects a fake Codex payload smaller than its package metadata', () => {
+    expect(() =>
+      createFakeDesktopPackage(['linux-arm64'], {
+        codexPayloadSizeBytes: { 'linux-arm64': 1 },
+        target: 'linux-arm64',
+      }),
+    ).toThrow('smaller than its package metadata');
   });
 
   it('does not infer Windows from a darwin path segment', async () => {
@@ -357,8 +386,12 @@ function createFakeDesktopPackage(
     targetDirName = 'mac-universal';
   } else if (target.startsWith('darwin')) {
     targetDirName = `mac-${target.slice('darwin-'.length)}`;
+  } else if (target === 'linux-arm64') {
+    targetDirName = 'linux-arm64-unpacked';
   } else if (target.startsWith('linux')) {
     targetDirName = 'linux-unpacked';
+  } else if (target === 'win32-arm64') {
+    targetDirName = 'win-arm64-unpacked';
   } else {
     targetDirName = 'win-unpacked';
   }
@@ -458,7 +491,7 @@ function writeCodexPlatformPackage(
   const packageJsonPath = join(packageRoot, 'package.json');
   writeJson(packageJsonPath, {
     name: '@openai/codex',
-    version: `0.128.0-${platform}`,
+    version: `0.144.1-${platform}`,
   });
   const binaryPath = join(
     packageRoot,
@@ -470,7 +503,13 @@ function writeCodexPlatformPackage(
   writeText(binaryPath, 'fake codex binary\n');
 
   if (payloadSizeBytes != null) {
-    truncateSync(binaryPath, payloadSizeBytes - statSync(packageJsonPath).size);
+    const metadataSizeBytes = statSync(packageJsonPath).size;
+    if (payloadSizeBytes < metadataSizeBytes) {
+      throw new Error(
+        `Fake Codex payload for ${platform} requests ${payloadSizeBytes} bytes, smaller than its package metadata (${metadataSizeBytes} bytes).`,
+      );
+    }
+    truncateSync(binaryPath, payloadSizeBytes - metadataSizeBytes);
   }
 }
 
@@ -484,7 +523,7 @@ function writePnpmCodexPlatformPackage(
     'app.asar.unpacked',
     'node_modules',
     '.pnpm',
-    `@openai+codex@0.133.0-${platform}`,
+    `@openai+codex@0.144.1-${platform}`,
     'node_modules',
     '@openai',
     'codex',
@@ -492,7 +531,7 @@ function writePnpmCodexPlatformPackage(
 
   writeJson(join(packageRoot, 'package.json'), {
     name: '@openai/codex',
-    version: `0.133.0-${platform}`,
+    version: `0.144.1-${platform}`,
   });
   writeText(
     join(packageRoot, 'vendor', info.triple, 'bin', info.binaryName),


### PR DESCRIPTION
Closes #8138

Follow-up to #8104: the platform-indexed Codex payload budget table in `scripts/desktop-codex-payload.mjs` already carries audited `linux-arm64` and `win32-arm64` baselines, but the unit suite only exercised budget acceptance for Linux x64, Windows x64, and the macOS slices. This PR adds the missing arm64 coverage — test-only, no production script changes, fail-closed semantics unchanged.

## Changes

- Add `linux-arm64` and `win32-arm64` fixtures to `codexPlatforms` with the production package names, vendor triples, and binary names (mirroring `codexPlatformInfoByKey`).
- Map arm64 targets to the Electron Builder output directories `linux-arm64-unpacked` / `win-arm64-unpacked`, so arch inference from the packaged path is exercised end-to-end through the real verifier.
- Extend the budget-acceptance `it.each` with both arm64 targets against the audited 0.144.1 baselines: linux-arm64 `294.2 MiB / 310.2 MiB`, win32-arm64 `339.9 MiB / 355.9 MiB` (baseline + 16 MiB headroom, same formula as the existing rows).
- Guard `writeCodexPlatformPackage` against a requested fake payload smaller than its package metadata: previously the negative length reached `truncateSync`, which on Node silently zeroes the binary (a wrong fixture) instead of failing precisely; now it throws a diagnostic naming the platform and both sizes, with a regression test.
- Align fake Codex package versions (`0.128.0` / `0.133.0`) with the installed `0.144.1` used by the repo and by the audited baselines.

Scope note: the group follow-up mentioned workflow matrix rows, but `.github/workflows/desktop-package.yml` has no platform matrix and `packages/desktop/electron-builder.yml` currently only targets x64 (win/linux) + universal (mac) — CI never packages arm64 Linux/Windows, so the budget-check coverage gap is exactly this unit suite. Budget-table entries for arm64 already landed in #8104.

## Verified

- Opened: `src/test-kernel/desktop/DesktopCodexPayload.vitest.mts`, `scripts/desktop-codex-payload.mjs`, `scripts/verify-desktop-package.mjs` (checkCodexPayload + app.label derivation), `.github/workflows/desktop-package.yml`, `packages/desktop/electron-builder.yml`, PR #8104 file list.
- `npm test -- DesktopCodexPayload`: 20/20 passed (17 before; +2 arm64 budget rows, +1 fixture-guard test).
- `npm run typecheck`: clean.
- `eslint src/test-kernel/desktop/DesktopCodexPayload.vitest.mts`: clean; `prettier --check` on the file: clean.
- `npm run check:dead-code-ratchet`: OK (at/below baseline).
- Probed `truncateSync` with a negative length on Node 26: no throw, file silently truncated to 0 — confirming the guard is needed for a precise fixture error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to desktop Codex payload unit tests and test helpers; no production packaging or verifier logic is modified.
> 
> **Overview**
> Extends **desktop Codex payload** unit tests so **linux-arm64** and **win32-arm64** get the same budget acceptance coverage as the existing x64 rows, using the audited **0.144.1** baselines and headroom already defined in production scripts.
> 
> Test fixtures now include both arm64 platforms (package names, triples, binary names) and map them to **`linux-arm64-unpacked`** / **`win-arm64-unpacked`** so path-based platform inference runs through the real verifier. Fake package versions are bumped to **0.144.1** to match the repo.
> 
> **`writeCodexPlatformPackage`** throws when a requested fake payload is smaller than **`package.json`** metadata instead of calling **`truncateSync`** with a negative length (which could silently zero the binary); a regression test locks that in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c477c7c57088ed37a49891608cc807e5c08a7ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->