### PR TITLE
fix(cli): render cancelled subagents with the neutral status color

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -13,7 +13,9 @@ export function childStatusColor(status: string | undefined): string {
   if (isChildExecutionErrorStatus(status)) return COLOR_ERROR;
   // A user stop is neither success nor error — show it neutral, matching the
   // progress view / webview (gray), not green (which reads as completed).
-  if (status === 'stopped') return COLOR_BORDER;
+  // Stream slices carry the canonical `cancelled` phase (RUN_OUTCOME); roster
+  // summaries still spell it as the legacy `stopped`.
+  if (status === 'cancelled' || status === 'stopped') return COLOR_BORDER;
   return COLOR_SUCCESS;
 }
 

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -6,7 +6,7 @@
 import { memo } from 'react';
 import { Box, Text } from 'ink';
 
-import { COLOR_ERROR, COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
+import { COLOR_ERROR, COLOR_HINT } from '../ui/colors';
 import { Markdown } from '../render/Markdown';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -18,6 +18,7 @@ import {
   USER_ENTRY_PREFIX,
 } from '../ui/glyphs';
 import { isInquiryContinuationText } from './transcriptEntries';
+import { childStatusColor } from './SubagentListDisplay';
 import { ToolUseRow } from './ToolUseRow';
 import { toolUseDisplayLines } from './toolRenderers';
 import type {
@@ -194,7 +195,9 @@ function ProcessEntryRow({
     );
   }
 
-  const color = process.isError ? COLOR_ERROR : COLOR_SUCCESS;
+  // Same status→color owner as the live SubagentList rows, so a cancelled or
+  // stopped child finalizes with the neutral dot instead of a green one.
+  const color = childStatusColor(process.status);
   const [, ...tailLines] = completedProcessDisplayLines(process);
   return (
     <Box

--- a/packages/cli/src/chat/tui/ui/colors.ts
+++ b/packages/cli/src/chat/tui/ui/colors.ts
@@ -31,7 +31,8 @@ export const COLOR_ACCENT = 'magenta';
 export const COLOR_INFO = 'blue';
 
 /** Neutral chrome with no semantic weight: the idle input box border and
- *  the neutral "stopped" subagent status marker. */
+ *  the neutral cancelled/stopped subagent status marker (a user stop is
+ *  neither success nor failure — see TeXRA#8115/#8188). */
 export const COLOR_BORDER = 'gray';
 
 // Not migrated onto this palette — decided in TeXRA#8118:

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -28,6 +28,11 @@ describe('CLI SubagentList display model', () => {
     // A user stop is not an error: neutral (gray), not red, matching the
     // progress view / webview and the canonical RUN_OUTCOME (cancelled ≠ failed).
     expect(childStatusColor('stopped')).toBe('gray');
+    // The canonical `cancelled` phase (what stream slices actually carry —
+    // roster summaries alone use the legacy `stopped` spelling) must get the
+    // same neutral color, distinct from completed (green) and failed (red).
+    expect(childStatusColor(STREAM_PHASE.CANCELLED)).toBe('gray');
+    expect(childStatusColor(STREAM_PHASE.COMPLETED)).toBe('green');
   });
 
   it('uses a compact child row budget instead of clipping nested sections', () => {


### PR DESCRIPTION
Closes #8188

## Summary

Cancelled subagents rendered with the label `stopped` but kept the green success dot: stream slices carry the canonical `cancelled` phase (`StreamStatusService.StreamStatusChange.status: StreamPhase` → `childExecutions.ts#reconstruct`), while `childStatusColor()` only neutralized the legacy `stopped` spelling and let `cancelled` fall through to `COLOR_SUCCESS`.

Design choice: keep `childStatusColor()` (`panes/SubagentListDisplay.ts`) as the single status→color owner and route every renderer that colors child status through it, using the semantic palette from #8215:

- `childStatusColor()` now maps canonical `cancelled` **and** legacy `stopped` to the neutral `COLOR_BORDER` role — distinct from completed (green) and failed (red), the same cancelled ≠ completed ≠ failed distinction ruled for iconography in #8115. This fixes the live region (`SubagentList` full + compact rows).
- The static transcript's finalized process row (`TranscriptEntry.tsx`) previously colored `isError ? COLOR_ERROR : COLOR_SUCCESS`, so a killed process (roster spells `cancelled` as legacy `stopped`, `executionRegistry.ts:748`) finalized with a green dot. It now calls `childStatusColor(process.status)` — behavior for completed/failed is unchanged since `isError` is derived from the very same `isChildExecutionErrorStatus()` predicate at the entry's single constructor (`buildCompletedProcessTranscript`).
- The Ctrl-T transcript viewer (`TranscriptViewer.tsx`), `TaskDetailView`, and `ChildControlPicker` render status as plain/hint text with no status-semantic coloring, so they need no change.

Per the issue's acceptance gates, one focused color-semantic assertion was added to the existing suite (no PTY snapshot duplication): `childStatusColor(STREAM_PHASE.CANCELLED) === 'gray'`, plus a completed-stays-green pin.

## Verified

- Opened and traced: `packages/cli/src/chat/tui/panes/SubagentListDisplay.ts`, `panes/SubagentList.tsx`, `panes/TranscriptEntry.tsx`, `state/childExecutions.ts`, `state/childExecutionStatus.ts`, `state/completedProcessTranscript.ts`, `state/streamStatus.ts`, `state/subscribeRuntimeHost.ts`, `modals/TranscriptViewer.tsx`, `modals/TaskDetailView.tsx`, `modals/ChildControlPicker.tsx`, `panes/StreamTabsStrip.tsx`, `ui/colors.ts`, `src/agent/runtime/executionRegistry.ts` (cancelled emission + roster `stopped` mapping), `src/agent/runtime/StreamStatusService.ts`, `src/shared/schemas/stream.ts`, `src/shared/streams/streamStatusDisplay.ts`.
- `npm run typecheck` — clean (all six project configs).
- `npm test -- SubagentListDisplay ConversationPane TuiStateAndFocus` — 3 files, 164 tests passed.
- Headless parity: `grep -rln "SubagentListDisplay|panes/TranscriptEntry" packages/cli/src | grep -v chat/tui` → no hits; only Ink TUI renderers touched, nothing reaches `texra run` / `--print` / `--output-format` paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ink TUI display-only color mapping with regression tests; no auth, data, or non-TUI CLI paths touched.
> 
> **Overview**
> **Cancelled subagents no longer show a green success dot** in the Ink TUI. Stream slices use the canonical `cancelled` phase, but `childStatusColor()` only neutralized legacy `stopped`, so `cancelled` fell through to green.
> 
> `childStatusColor()` in `SubagentListDisplay.ts` now maps **`cancelled` and `stopped`** to neutral gray (`COLOR_BORDER`), matching completed (green) vs failed (red) semantics from prior design work. Live subagent rows already used this helper; **finalized process rows** in `TranscriptEntry.tsx` previously used `isError ? red : green`, which painted user-stopped children green—they now call **`childStatusColor(process.status)`** so cancelled/stopped finalize with a gray dot while real failures stay red via the existing `isError` tail styling.
> 
> Tests pin `STREAM_PHASE.CANCELLED` → gray and completed → green; palette comments in `colors.ts` note cancelled/stopped neutrality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 259b01a5f4e49cd324ce875486cd1f7f7a862aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->