### PR TITLE
fix(auth): serialize Codex session replacement with refresh storage writes

### DIFF
--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -79,7 +79,13 @@ export class CodexSessionCoordinator {
   private readonly log?: CodexLogger;
   private readonly now: () => number;
   private refreshInFlight: Promise<CodexSession> | null = null;
-  private refreshStoreInFlight: Promise<void> | null = null;
+  /**
+   * Single serialized owner of every session-storage write (login store,
+   * sign-out delete, refresh store, fatal-refresh delete). Serializing the
+   * writes means a write enqueued after a session replacement can never land
+   * before the replacement's own write.
+   */
+  private sessionMutations: Promise<void> = Promise.resolve();
   private sessionGeneration = 0;
 
   constructor(init: CodexSessionCoordinatorInit) {
@@ -114,15 +120,45 @@ export class CodexSessionCoordinator {
   }
 
   /**
+   * Chain `op` after every previously queued session-storage write so
+   * replacement (login/sign-out) and refresh-originated writes settle in the
+   * order they were requested. The chain link is established synchronously
+   * (before the first `await`), so ordering is captured at call time.
+   */
+  private mutateSession(op: () => Promise<void>): Promise<void> {
+    const mutation = this.sessionMutations.then(op);
+    this.sessionMutations = mutation.catch(() => undefined);
+    return mutation;
+  }
+
+  /**
+   * Read a session only when no replacement changed its generation while the
+   * queued writes or storage read were settling.
+   */
+  private async loadStableSession(): Promise<{
+    generation: number;
+    session: CodexSession | null;
+  }> {
+    while (true) {
+      const generation = this.sessionGeneration;
+      await this.sessionMutations;
+      const session = await this.loadSession();
+      if (generation === this.sessionGeneration) {
+        return { generation, session };
+      }
+    }
+  }
+
+  /**
    * Advance the session generation and abandon any in-flight refresh so its
    * result can no longer overwrite the session that supersedes it. Shared by
-   * sign-out and every successful login.
+   * sign-out and every successful login, which must enqueue their storage
+   * write via {@link mutateSession} in the same synchronous block — that way
+   * an observed generation implies its write is already in the queue.
    */
-  private async supersedeInFlightRefresh(): Promise<void> {
+  private supersedeInFlightRefresh(): void {
     this.sessionGeneration += 1;
-    const staleStore = this.refreshStoreInFlight;
     this.refreshInFlight = null;
-    await staleStore?.catch(() => undefined);
   }
 
   /**
@@ -140,8 +176,8 @@ export class CodexSessionCoordinator {
 
   /** Forget the session (sign out). */
   async signOut(): Promise<void> {
-    await this.supersedeInFlightRefresh();
-    await this.storage.delete();
+    this.supersedeInFlightRefresh();
+    await this.mutateSession(() => this.storage.delete());
   }
 
   /** Whether a session is currently signed in (no network). */
@@ -185,8 +221,8 @@ export class CodexSessionCoordinator {
   }): Promise<CodexSession> {
     const tokens = await this.client.exchangeAuthorizationCode(params);
     const session = this.buildSession(tokens);
-    await this.supersedeInFlightRefresh();
-    await this.storeSession(session);
+    this.supersedeInFlightRefresh();
+    await this.mutateSession(() => this.storeSession(session));
     return session;
   }
 
@@ -224,7 +260,7 @@ export class CodexSessionCoordinator {
 
   /** Refresh if needed and return the live session. */
   async getFreshSession(forceRefresh = false): Promise<CodexSession> {
-    const session = await this.loadSession();
+    const { generation, session } = await this.loadStableSession();
     if (!session) {
       throw new CodexAuthError(
         'Not signed in with ChatGPT. Run sign-in first.',
@@ -232,13 +268,15 @@ export class CodexSessionCoordinator {
       );
     }
     if (!forceRefresh && !this.isExpiringSoon(session)) return session;
-    return this.refresh(session);
+    return this.refresh(session, generation);
   }
 
-  private async refresh(previous: CodexSession): Promise<CodexSession> {
+  private async refresh(
+    previous: CodexSession,
+    generation: number,
+  ): Promise<CodexSession> {
     // Single-flight: concurrent callers await the same refresh.
     if (this.refreshInFlight) return this.refreshInFlight;
-    const generation = this.sessionGeneration;
     const task = this.performRefresh(previous, generation).finally(() => {
       if (this.refreshInFlight === task) this.refreshInFlight = null;
     });
@@ -255,26 +293,26 @@ export class CodexSessionCoordinator {
       tokens = await this.client.refreshTokens(previous.refreshToken);
     } catch (error) {
       if (error instanceof CodexAuthError && error.kind === 'fatal') {
-        // Revoked / invalid refresh token: drop the dead session only if no
-        // newer login/sign-out happened while this refresh was in flight.
-        if (generation === this.sessionGeneration) {
+        // Revoked / invalid refresh token: drop the dead session unless a
+        // newer login/sign-out supersedes it. The check runs inside the
+        // serialized mutation, so a slow delete can never erase a login
+        // whose store is queued behind it.
+        await this.mutateSession(async () => {
+          if (generation !== this.sessionGeneration) return;
           this.log?.warn?.('Codex token refresh was rejected; signing out.');
           await this.storage.delete();
-        }
+        });
       }
       throw error;
     }
     const session = this.buildSession(tokens, previous);
-    this.assertSameGeneration(generation);
-    const storeTask = this.storeSession(session);
-    this.refreshStoreInFlight = storeTask;
-    try {
-      await storeTask;
-    } finally {
-      if (this.refreshStoreInFlight === storeTask) {
-        this.refreshStoreInFlight = null;
-      }
-    }
+    await this.mutateSession(async () => {
+      this.assertSameGeneration(generation);
+      await this.storeSession(session);
+    });
+    // Superseded while the store settled: the superseding write is queued
+    // after ours (so storage converges), but this caller must not hand out
+    // a token from the replaced session.
     this.assertSameGeneration(generation);
     return session;
   }

--- a/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
+++ b/src/test-kernel/auth/CodexSessionCoordinator.vitest.ts
@@ -29,6 +29,49 @@ function memoryStorage(initial?: CodexSession): CodexSessionStorage & {
   };
 }
 
+/**
+ * In-memory storage whose first `store` or `delete` call blocks until the
+ * test calls `release()`, for deterministic race interleavings. `gateReached`
+ * resolves once the gated write has started (and is therefore blocked).
+ */
+function gatedStorage(
+  gateOn: 'get' | 'store' | 'delete',
+  initial?: CodexSession,
+): CodexSessionStorage & {
+  peek: () => CodexSession | undefined;
+  gateReached: Promise<void>;
+  release: () => void;
+} {
+  let value = initial ? JSON.stringify(initial) : undefined;
+  const reached = pDefer<void>();
+  const released = pDefer<void>();
+  let gated = true;
+  const gate = async () => {
+    if (!gated) return;
+    gated = false;
+    reached.resolve();
+    await released.promise;
+  };
+  return {
+    get: async () => {
+      const snapshot = value;
+      if (gateOn === 'get') await gate();
+      return snapshot;
+    },
+    store: async (v) => {
+      if (gateOn === 'store') await gate();
+      value = v;
+    },
+    delete: async () => {
+      if (gateOn === 'delete') await gate();
+      value = undefined;
+    },
+    peek: () => (value ? (JSON.parse(value) as CodexSession) : undefined),
+    gateReached: reached.promise,
+    release: () => released.resolve(),
+  };
+}
+
 function session(overrides: Partial<CodexSession> = {}): CodexSession {
   return {
     accessToken: 'access-0',
@@ -49,6 +92,23 @@ function tokenResponse(
     expires_in: 3600,
     ...overrides,
   };
+}
+
+function newLoginTokenResponse(): CodexTokenResponse {
+  return tokenResponse({
+    access_token: 'access-new',
+    refresh_token: 'refresh-new',
+  });
+}
+
+function completeLogin(
+  coordinator: CodexSessionCoordinator,
+): Promise<CodexSession> {
+  return coordinator.completeLoginWithCode({
+    code: 'new-code',
+    verifier: 'new-verifier',
+    redirectUri: 'http://localhost:1455/auth/callback',
+  });
 }
 
 function makeCoordinator(
@@ -141,38 +201,14 @@ describe('CodexSessionCoordinator', () => {
   });
 
   it('does not restore a session when sign-out races with refresh storage', async () => {
-    let value: string | undefined = JSON.stringify(
-      session({ expiresAtMs: NOW - 1 }),
-    );
-    let storeStarted!: () => void;
-    let releaseStore!: () => void;
-    const storeStartedPromise = new Promise<void>((resolve) => {
-      storeStarted = resolve;
-    });
-    const releaseStorePromise = new Promise<void>((resolve) => {
-      releaseStore = resolve;
-    });
-    const storage: CodexSessionStorage & {
-      peek: () => CodexSession | undefined;
-    } = {
-      get: async () => value,
-      store: async (v) => {
-        storeStarted();
-        await releaseStorePromise;
-        value = v;
-      },
-      delete: async () => {
-        value = undefined;
-      },
-      peek: () => (value ? (JSON.parse(value) as CodexSession) : undefined),
-    };
+    const storage = gatedStorage('store', session({ expiresAtMs: NOW - 1 }));
     const refreshTokens = vi.fn(async () => tokenResponse());
     const coordinator = makeCoordinator(storage, { refreshTokens });
 
     const token = coordinator.getFreshAccessToken();
-    await storeStartedPromise;
+    await storage.gateReached;
     const signOut = coordinator.signOut();
-    releaseStore();
+    storage.release();
 
     await expect(token).rejects.toMatchObject({
       kind: 'expired',
@@ -182,15 +218,101 @@ describe('CodexSessionCoordinator', () => {
     expect(storage.peek()).toBeUndefined();
   });
 
+  it('does not erase a newer login with a blocked fatal-refresh deletion', async () => {
+    const storage = gatedStorage('delete', session({ expiresAtMs: NOW - 1 }));
+    const refreshTokens = vi.fn(async () => {
+      throw new CodexAuthError('revoked', 'fatal', 401);
+    });
+    const exchangeAuthorizationCode = vi.fn(async () =>
+      newLoginTokenResponse(),
+    );
+    const coordinator = makeCoordinator(storage, {
+      exchangeAuthorizationCode,
+      refreshTokens,
+    });
+
+    const token = coordinator.getFreshAccessToken();
+    // The fatal refresh has started its delete (blocked); a login lands now.
+    await storage.gateReached;
+    const login = completeLogin(coordinator);
+    // Let the login run as far as it can before the delete unblocks, so an
+    // unserialized store would land first and be erased by the stale delete.
+    await new Promise((r) => setTimeout(r, 0));
+    storage.release();
+
+    await expect(token).rejects.toMatchObject({ kind: 'fatal' });
+    await login;
+    expect(storage.peek()?.accessToken).toBe('access-new');
+    expect(storage.peek()?.refreshToken).toBe('refresh-new');
+  });
+
+  it('does not start a stale refresh for a caller entering during sign-out', async () => {
+    const storage = gatedStorage('delete', session({ expiresAtMs: NOW - 1 }));
+    const refreshTokens = vi.fn(async () => tokenResponse());
+    const coordinator = makeCoordinator(storage, { refreshTokens });
+
+    const signOut = coordinator.signOut();
+    // The sign-out delete is blocked mid-write; a caller enters now.
+    await storage.gateReached;
+    const token = coordinator.getFreshAccessToken();
+    storage.release();
+
+    await expect(token).rejects.toMatchObject({
+      kind: 'expired',
+      needsReauth: true,
+    });
+    await signOut;
+    expect(refreshTokens).not.toHaveBeenCalled();
+    expect(storage.peek()).toBeUndefined();
+  });
+
+  it('does not overwrite a newer login for a caller entering during login', async () => {
+    const storage = gatedStorage('store', session({ expiresAtMs: NOW - 1 }));
+    const refreshTokens = vi.fn(async () => tokenResponse());
+    const exchangeAuthorizationCode = vi.fn(async () =>
+      newLoginTokenResponse(),
+    );
+    const coordinator = makeCoordinator(storage, {
+      exchangeAuthorizationCode,
+      refreshTokens,
+    });
+
+    const login = completeLogin(coordinator);
+    // The login store is blocked mid-write; a caller enters now.
+    await storage.gateReached;
+    const token = coordinator.getFreshAccessToken();
+    storage.release();
+
+    await login;
+    expect(await token).toBe('access-new');
+    expect(refreshTokens).not.toHaveBeenCalled();
+    expect(storage.peek()?.accessToken).toBe('access-new');
+  });
+
+  it('retries a session read superseded while storage is blocked', async () => {
+    const storage = gatedStorage('get', session());
+    const exchangeAuthorizationCode = vi.fn(async () =>
+      newLoginTokenResponse(),
+    );
+    const coordinator = makeCoordinator(storage, {
+      exchangeAuthorizationCode,
+    });
+
+    const token = coordinator.getFreshAccessToken();
+    await storage.gateReached;
+    await completeLogin(coordinator);
+    storage.release();
+
+    expect(await token).toBe('access-new');
+    expect(storage.peek()?.accessToken).toBe('access-new');
+  });
+
   it('does not clear a newer login when a stale refresh is rejected', async () => {
     const storage = memoryStorage(session({ expiresAtMs: NOW - 1 }));
     const { promise: pending, reject } = pDefer<CodexTokenResponse>();
     const refreshTokens = vi.fn(() => pending);
     const exchangeAuthorizationCode = vi.fn(async () =>
-      tokenResponse({
-        access_token: 'access-new',
-        refresh_token: 'refresh-new',
-      }),
+      newLoginTokenResponse(),
     );
     const coordinator = makeCoordinator(storage, {
       exchangeAuthorizationCode,
@@ -201,11 +323,7 @@ describe('CodexSessionCoordinator', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(refreshTokens).toHaveBeenCalledOnce();
 
-    await coordinator.completeLoginWithCode({
-      code: 'new-code',
-      verifier: 'new-verifier',
-      redirectUri: 'http://localhost:1455/auth/callback',
-    });
+    await completeLogin(coordinator);
     reject(new CodexAuthError('revoked', 'fatal', 401));
 
     await expect(token).rejects.toMatchObject({


### PR DESCRIPTION
Closes #8232

## Problem

`CodexSessionCoordinator` serialized refresh *requests* (single-flight), but session replacement and refresh-originated storage writes were separate, unordered async operations. Two confirmed interleavings could corrupt the stored credential:

1. A fatal refresh checked `sessionGeneration`, then started an untracked `storage.delete()`. A login landing while that delete was blocked stored its session first — and the stale delete then erased the newer login.
2. `supersedeInFlightRefresh()` cleared `refreshInFlight` before the sign-out delete / login store settled. A second caller could read pre-replacement storage, start a refresh under the *new* generation (so every generation check passed), and resurrect the signed-out session or overwrite the newer login.

## Ownership design

One serialized session-mutation owner inside the coordinator: a per-instance `sessionMutations` promise chain (`mutateSession()`, same idiom as `CliSecrets.mutate` in `packages/cli/src/runtime/cliSecrets.ts`). Every session-storage write flows through it — login store, sign-out delete, refresh store, fatal-refresh delete — so writes settle strictly in request order, and the generation check is fused with the write inside the same exclusive section (atomic check+write instead of check-then-act):

- **Fatal-refresh delete** re-checks the generation *inside* the queued mutation; a login enqueued after it always writes after the delete resolves, so a blocked delete can never erase it.
- **Replacement (login/sign-out)** bumps the generation and enqueues its write in the same synchronous block, so an observed generation implies its write is already queued.
- **Fresh-session reads** wait out queued writes, read storage, then re-check the generation in a retry loop. A replacement landing before or during `storage.get()` forces a reread, so even a non-expiring stale token cannot escape.

This *deletes* the `refreshStoreInFlight` tracking field and the await-the-stale-store dance entirely; the queue subsumes them. No guards, retries, or host-side coordination added; public API unchanged (all external consumers use only `getFreshAccessToken`/`signOut`/`completeLoginWithCode`/`getStatus`).

## Acceptance gates (from #8232)

- [x] A blocked fatal deletion cannot erase a login that starts after the rejection — new test, fails on old code
- [x] A caller entering during sign-out cannot start a second stale refresh or resurrect the session — new test, fails on old code (old code called `refreshTokens` and resolved with a token from the signed-out session)
- [x] A caller entering during login cannot overwrite the new session with the old refresh result — new test, fails on old code
- [x] A replacement landing while `storage.get()` is pending cannot leak the old non-expiring token — new test, fails on the prior PR head with `access-0`
- [x] Existing single-flight, sign-out, and newer-login race tests remain green (18/18 in the suite)
- [x] No host-specific coordination or duplicate session state outside `CodexSessionCoordinator`

The four regression tests use deterministic interleavings through one gated in-memory storage helper. It can block a captured `get` snapshot or the first `store`/`delete`; no timing sleeps are used for assertions.

## Verified

- Rebased onto origin/main HEAD `1e9da47b0` (post-#8251) and re-opened the coordinator, auth access boundary, and race suite before updating the fix
- Grepped all consumers of the coordinator's public API (extension, CLI, desktop) — none touch the changed private internals
- `npm run typecheck` — clean (all workspace tsconfigs)
- `npm test -- CodexSessionCoordinator` — 18/18 pass on the fix
- Regression proof: the added blocked-read test fails on the prior PR head with `access-0` instead of `access-new`; the original three interleaving tests also fail on unpatched main
- `npm test -- src/test-kernel/auth` — 110/110 across 13 files
- `npx eslint` and `npx prettier --check` on both touched files — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential persistence ordering in auth code; behavior is constrained to private coordinator logic with a full test suite, but mistakes could still affect sign-in state.
> 
> **Overview**
> Fixes race conditions where **login**, **sign-out**, and **token refresh** could interleave storage writes and corrupt the persisted ChatGPT/Codex session (e.g. a slow fatal-refresh delete wiping a newer login, or a caller starting a stale refresh during sign-out).
> 
> **`CodexSessionCoordinator`** now routes every session-storage mutation through a single **`sessionMutations`** promise chain (`mutateSession`), so login store, sign-out delete, refresh store, and fatal-refresh delete settle in request order. Generation checks for fatal deletes and refresh stores run **inside** that queue; **`loadStableSession`** waits on pending mutations and retries if the generation changed mid-read. **`refreshStoreInFlight`** and awaiting stale refresh stores are removed; **`supersedeInFlightRefresh`** is synchronous and pairs with enqueued writes.
> 
> Tests add **`gatedStorage`** for deterministic blocked `get`/`store`/`delete` interleavings, plus regressions for fatal-delete vs login, sign-out vs new refresh, login vs stale refresh, and superseded reads during blocked storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4dacf8b88db2e692e24c57309700bb04d292cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
