### PR TITLE
refactor(cli-tui): unify status-bar key hints with the KeyHints format

### DIFF
--- a/docs/prds/cli-tui-ink/10-architecture.md
+++ b/docs/prds/cli-tui-ink/10-architecture.md
@@ -234,6 +234,7 @@ Every modal, form, palette, and approval card carries the same set of affordance
 - **`›`** for the focused row in any `Select` (Ink `figures.pointer`).
 - **`✓`** for the currently-active value (Ink `figures.tick`).
 - **Footer `<KeyHints>`** strip with scope-specific keys first, navigation in the middle, and `Enter confirm · Esc cancel` last. Implemented as a single shared component (`tui/ui/KeyHints.tsx`); ad-hoc footer text is a review-blocker.
+- **One hint vocabulary everywhere**: the status-bar bindings row (`panes/statusBarDisplay.ts`) uses the same unbracketed `key action` pairs joined by `KEY_HINT_SEPARATOR` (` · `) as `<KeyHints>` — text-only surfaces build hints through `keyHintText`, and the legacy bracketed `[key]action` format must not reappear.
 - **Sub-state indicators** are inline (`● High effort  ← / → to adjust`), never in a separate dialog layer.
 - **Numbered options** (`1.`–`9.`) so digit shortcuts are direct jumps without arrow-key counting.
 

--- a/docs/prds/cli-tui-ink/10-architecture.md
+++ b/docs/prds/cli-tui-ink/10-architecture.md
@@ -234,7 +234,7 @@ Every modal, form, palette, and approval card carries the same set of affordance
 - **`›`** for the focused row in any `Select` (Ink `figures.pointer`).
 - **`✓`** for the currently-active value (Ink `figures.tick`).
 - **Footer `<KeyHints>`** strip with scope-specific keys first, navigation in the middle, and `Enter confirm · Esc cancel` last. Implemented as a single shared component (`tui/ui/KeyHints.tsx`); ad-hoc footer text is a review-blocker.
-- **One hint vocabulary everywhere**: the status-bar bindings row (`panes/statusBarDisplay.ts`) uses the same unbracketed `key action` pairs joined by `KEY_HINT_SEPARATOR` (` · `) as `<KeyHints>` — text-only surfaces build hints through `keyHintText`, and the legacy bracketed `[key]action` format must not reappear.
+- **One hint vocabulary everywhere**: the status-bar bindings row (`panes/statusBarDisplay.ts`) uses the same unbracketed `key action` pairs joined by `KEY_HINT_SEPARATOR` (`·`) as `<KeyHints>` — text-only surfaces build hints through `keyHintText`, and the legacy bracketed `[key]action` format must not reappear.
 - **Sub-state indicators** are inline (`● High effort  ← / → to adjust`), never in a separate dialog layer.
 - **Numbered options** (`1.`–`9.`) so digit shortcuts are direct jumps without arrow-key counting.
 

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -136,7 +136,7 @@ const SCENARIOS = [
       'agent: chat · model: harness-model',
       'chat history line to grow the transcript pane',
       '◆',
-      '[Ctrl-C]exit',
+      'Ctrl-C exit',
     ],
   },
   {
@@ -222,7 +222,7 @@ const SCENARIOS = [
       '1. First queued follow-up',
       '2. Second queued follow-up',
       'queued 2',
-      '[Ctrl-C]stop',
+      'Ctrl-C stop',
     ],
     unexpect: ['Tip: Ctrl-C exits idle chats', 'First queued follo…'],
   },
@@ -280,7 +280,7 @@ const SCENARIOS = [
       '2. Second queued follow-up',
       '│ ›',
       'queued 2',
-      '[Ctrl-C]stop',
+      'Ctrl-C stop',
     ],
     unexpect: ['Tip: Ctrl-C exits idle chats', 'agent: chat · model'],
   },
@@ -370,7 +370,7 @@ const SCENARIOS = [
       '1-9/a-z/Enter open',
       'Esc exit',
     ],
-    unexpect: ['[/model]models', 'Tip:', 'tool-use:', 'workflow:'],
+    unexpect: ['/model models', 'Tip:', 'tool-use:', 'workflow:'],
   },
   {
     name: 'orchestrate-delegated-history',
@@ -424,7 +424,7 @@ const SCENARIOS = [
     unexpect: [
       'texra multi-agent show <team-id>',
       'Researcher Access sign-in may unlock more remote team agents.',
-      '[/model]models',
+      '/model models',
       'Tip:',
       'tool-use:',
       'workflow:',
@@ -1016,22 +1016,22 @@ const SCENARIOS = [
       'Auto-approve',
       'Enter select highlighted',
       'Esc cancel',
-      '[Esc]cancel',
+      'Esc cancel',
     ],
   },
   {
     name: 'approval-policy-status-bar',
     frame: 'scrollback',
     env: { HARNESS_APPROVAL_POLICY: 'never', HARNESS_ENTRIES: '4' },
-    expect: ['personal', 'deny', '[/status]details'],
+    expect: ['personal', 'deny', '/status details'],
     unexpect: ['keys deny', 'approval: deny privileged actions'],
   },
   {
     name: 'uninterruptible-running-status-bar',
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
-    expect: ['◆ running', '[Ctrl-C]exit'],
-    unexpect: ['[Ctrl-C]stop'],
+    expect: ['◆ running', 'Ctrl-C exit'],
+    unexpect: ['Ctrl-C stop'],
   },
   {
     name: 'tools-form',
@@ -1172,7 +1172,7 @@ const SCENARIOS = [
       '↑/↓ navigate',
       '1-3/Enter select',
       'Esc cancel',
-      '[Esc]cancel',
+      'Esc cancel',
     ],
     unexpect: [
       'Choose when privileged actions prompt or auto-approve.',
@@ -1221,7 +1221,7 @@ const SCENARIOS = [
   {
     name: 'edit-approval',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: [
       'Apply edit to draft.tex?',
@@ -1230,14 +1230,14 @@ const SCENARIOS = [
       'approval',
       'Use foreground panel shortcuts',
     ],
-    unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    unexpect: ['Alt-p tasks', 'Option-p tasks', '/model models'],
   },
   {
     name: 'edit-approval-feedback',
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['e', 'needs direct proof'],
     frame: 'viewport',
     expect: [
@@ -1247,14 +1247,14 @@ const SCENARIOS = [
       'Esc back',
       '1 approval',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['/model models'],
   },
   {
     name: 'narrow-edit-approval',
     rows: 12,
     cols: 40,
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: [
       'Apply edit to draft.tex?',
@@ -1268,17 +1268,17 @@ const SCENARIOS = [
   {
     name: 'edit-approval-approve',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['y'],
     frame: 'viewport',
-    expect: ['[/status]details', '[/model]models'],
+    expect: ['/status details', '/model models'],
     unexpect: ['Apply edit to draft.tex?', '1 approval'],
   },
   {
     name: 'bash-approval',
     frame: 'scrollback',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     resizes: [{ cols: 120 }],
     expect: [
       'agent: chat · model: harness-model',
@@ -1289,7 +1289,7 @@ const SCENARIOS = [
       'a commands for session',
       'Use foreground panel shortcuts',
     ],
-    unexpect: ['[Alt-p]tasks', '[Option-p]tasks', '[/model]models'],
+    unexpect: ['Alt-p tasks', 'Option-p tasks', '/model models'],
     maxOccurrences: [{ text: '{ T } TeXRA', max: 1 }],
     ordered: [
       {
@@ -1310,7 +1310,7 @@ const SCENARIOS = [
     rows: 12,
     cols: 40,
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: [
       'Run command?',
@@ -1327,7 +1327,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['e', 'use portable python3 instead'],
     frame: 'viewport',
     expect: [
@@ -1337,7 +1337,7 @@ const SCENARIOS = [
       'Esc back',
       '1 approval',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['/model models'],
   },
   {
     name: 'long-bash-approval',
@@ -1348,7 +1348,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Run command?',
       'Directory:',
@@ -1358,7 +1358,7 @@ const SCENARIOS = [
       'y approve',
       'Use foreground panel shortcuts',
     ],
-    unexpect: ['╚═    print', '[Option-p]tasks'],
+    unexpect: ['╚═    print', 'Option-p tasks'],
   },
   {
     name: 'compact-long-bash-approval',
@@ -1368,7 +1368,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: [
       'Run command?',
@@ -1379,7 +1379,7 @@ const SCENARIOS = [
       'y approve',
       'Use foreground panel shortcuts',
     ],
-    unexpect: ['╚═    print', '[Option-p]tasks'],
+    unexpect: ['╚═    print', 'Option-p tasks'],
   },
   {
     name: 'compact-long-bash-approval-scroll',
@@ -1389,7 +1389,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [DOWN, DOWN, DOWN],
     frame: 'viewport',
     expect: [
@@ -1401,7 +1401,7 @@ const SCENARIOS = [
       'scroll command',
       'y approve',
     ],
-    unexpect: ["$ python3 << 'EOF'", '[Option-p]tasks'],
+    unexpect: ["$ python3 << 'EOF'", 'Option-p tasks'],
   },
   {
     name: 'compact-long-bash-approval-page',
@@ -1411,7 +1411,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [PAGE_DOWN],
     frame: 'viewport',
     expect: [
@@ -1422,7 +1422,7 @@ const SCENARIOS = [
       'more rows',
       'PgUp/PgDn page',
     ],
-    unexpect: ["$ python3 << 'EOF'", '[Option-p]tasks'],
+    unexpect: ["$ python3 << 'EOF'", 'Option-p tasks'],
   },
   {
     name: 'tiny-compact-long-bash-approval',
@@ -1432,18 +1432,18 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_COMMAND: LONG_BASH_APPROVAL_COMMAND,
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: ['Run command?', 'Directory:', 'rows hidden', 'y approve'],
-    unexpect: ['[Option-p]tasks'],
+    unexpect: ['Option-p tasks'],
   },
   {
     name: 'bash-approval-approve-session',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['a'],
     frame: 'viewport',
-    expect: ['AUTO-BASH', '[/status]details', '[/model]models'],
+    expect: ['AUTO-BASH', '/status details', '/model models'],
     unexpect: ['AUTO-APPROVE', 'Run command?', '1 approval'],
   },
   {
@@ -1453,17 +1453,17 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_REPEATED_BASH_APPROVAL: '1',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['y', { input: 'y', delayMs: 1000 }],
     settleMs: 6000,
     frame: 'viewport',
-    expect: ['SECOND-BASH-APPROVED', '[/status]details', '[/model]models'],
+    expect: ['SECOND-BASH-APPROVED', '/status details', '/model models'],
     unexpect: ['Run command?', '1 approval'],
   },
   {
     name: 'bash-approval-session-status',
     env: { HARNESS_ENTRIES: '4', HARNESS_BASH_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['a', '/status', '\r'],
     frame: 'viewport',
     expect: [
@@ -1481,11 +1481,11 @@ const SCENARIOS = [
       HARNESS_CAN_DELEGATE: '1',
       HARNESS_TEAM_NAME: 'Physicist',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['a', '/status', '\r'],
     frame: 'viewport',
     expect: ['team: Physicist', 'auto-approvals: commands', 'AUTO-BASH'],
-    unexpect: ['Run command?', '1 approval', ']subagents'],
+    unexpect: ['Run command?', '1 approval', 's subagents'],
   },
   {
     name: 'agent-proposal-long',
@@ -1493,7 +1493,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_AGENT_PROPOSAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Spawn review?',
       FULL_WIDTH_AGENT_PROPOSAL_BORDER_80,
@@ -1505,14 +1505,14 @@ const SCENARIOS = [
       'y approve',
       'n reject',
     ],
-    unexpect: ['confirmation of correctness', '[Option-p]tasks'],
+    unexpect: ['confirmation of correctness', 'Option-p tasks'],
   },
   {
     name: 'compact-agent-proposal-scroll',
     rows: 17,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_AGENT_PROPOSAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [PAGE_DOWN, PAGE_DOWN, PAGE_DOWN, PAGE_DOWN, PAGE_DOWN, PAGE_DOWN],
     frame: 'viewport',
     expect: [
@@ -1525,14 +1525,14 @@ const SCENARIOS = [
       'y approve',
       'n reject',
     ],
-    unexpect: ['prompt rows hidden', '[Option-p]tasks'],
+    unexpect: ['prompt rows hidden', 'Option-p tasks'],
     maxLineColumns: 80,
   },
   {
     name: 'external-inquiry-long',
     rows: 24,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER],
     frame: 'viewport',
     expect: [
@@ -1547,8 +1547,8 @@ const SCENARIOS = [
     ],
     unexpect: [
       '└─Degenerate triples',
-      '[/model]models',
-      '[Esc]panel',
+      '/model models',
+      'Esc panel',
       'Esc sk…',
       '1 approval',
     ],
@@ -1558,7 +1558,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER],
     frame: 'viewport',
     expect: [
@@ -1573,8 +1573,8 @@ const SCENARIOS = [
     ],
     unexpect: [
       '└─Degenerate triples',
-      '[/model]models',
-      '[Esc]panel',
+      '/model models',
+      'Esc panel',
       'Esc sk…',
       '1 approval',
     ],
@@ -1584,7 +1584,7 @@ const SCENARIOS = [
     rows: 24,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [EM],
     frame: 'viewport',
     fakeClipboard: {
@@ -1594,14 +1594,14 @@ const SCENARIOS = [
       ],
     },
     expect: ['Agent asks: copied to clipboard', 'Ctrl-Y copy', '1 question'],
-    unexpect: ['copy failed', '[/model]models', '1 approval'],
+    unexpect: ['copy failed', '/model models', '1 approval'],
   },
   {
     name: 'external-inquiry-submit-answer',
     rows: 24,
     cols: 120,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER, '\r'],
     frame: 'viewport',
     expect: [
@@ -1610,8 +1610,8 @@ const SCENARIOS = [
       'Full thread: ei_123456abcdef',
       'No other open inquiries on this stream.',
       'Proceed using the new answer.',
-      '[/status]details',
-      '[/model]models',
+      '/status details',
+      '/model models',
     ],
     unexpect: [
       'Agent asks:',
@@ -1625,7 +1625,7 @@ const SCENARIOS = [
     rows: 36,
     cols: 120,
     env: { HARNESS_ENTRIES: '4', HARNESS_EXTERNAL_INQUIRY: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [LONG_EXTERNAL_INQUIRY_ANSWER_FOR_TRUNCATION, '\r'],
     frame: 'viewport',
     expect: [
@@ -1649,7 +1649,7 @@ const SCENARIOS = [
     rows: 12,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_USER_QUESTION: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     frame: 'viewport',
     expect: [
       'Agent asks:',
@@ -1663,8 +1663,8 @@ const SCENARIOS = [
       '1 question',
     ],
     unexpect: [
-      '[/model]models',
-      '[Esc]panel',
+      '/model models',
+      'Esc panel',
       'Context detail: the candidate proof',
       '1 approval',
     ],
@@ -1674,7 +1674,7 @@ const SCENARIOS = [
     name: 'plan-approval',
     frame: 'scrollback',
     env: { HARNESS_ENTRIES: '4', HARNESS_PLAN_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -1684,7 +1684,7 @@ const SCENARIOS = [
     unexpect: [
       'r approve & run',
       'Approve & run only auto-approves bash',
-      '[/model]models',
+      '/model models',
     ],
     maxBlankLinesBetween: [
       { from: 'entry-4 chat history line', to: 'Approve plan?', max: 3 },
@@ -1698,7 +1698,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_GOAL: '1',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -1708,7 +1708,7 @@ const SCENARIOS = [
       'y approve',
       'n reject',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['/model models'],
   },
   {
     name: 'plan-approval-wrap-boundary',
@@ -1732,7 +1732,7 @@ const SCENARIOS = [
         '**Stopping condition:** A summary report of all observed friction has been written to a memory note under `/memories/dogfood-friction.md` (no file edits — use the `memory` tool).',
       ].join('\n'),
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Approve & run only auto-approves bash',
@@ -1772,7 +1772,7 @@ const SCENARIOS = [
         '- The `review` subagent has confirmed the reasoning is sound (or flagged issues).',
       ].join('\n'),
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Approve & run only auto-approves bash',
@@ -1790,7 +1790,7 @@ const SCENARIOS = [
     rows: 10,
     cols: 80,
     env: { HARNESS_ENTRIES: '4', HARNESS_PLAN_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -1802,7 +1802,7 @@ const SCENARIOS = [
     unexpect: [
       'Approve & run only auto-approves bash',
       'Run auto-approves bash; edits still ask',
-      '[/model]models',
+      '/model models',
     ],
   },
   {
@@ -1815,7 +1815,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_GOAL: '1',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Approve plan?',
       'Coordinate a short math proof through CLI chat.',
@@ -1827,7 +1827,7 @@ const SCENARIOS = [
       'e feedback',
       'Esc cancel',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['/model models'],
   },
   {
     name: 'plan-approval-approve-goal',
@@ -1836,7 +1836,7 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_GOAL: '1',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['r', '/status', '\r'],
     frame: 'viewport',
     expect: [
@@ -1845,8 +1845,8 @@ const SCENARIOS = [
       'status: running',
       'goal: active',
       'goal objective: Coordinate a short math proof through CLI chat.',
-      '[/status]details',
-      '[/model]models',
+      '/status details',
+      '/model models',
     ],
     unexpect: ['Approve plan?', '1 approval'],
   },
@@ -1857,18 +1857,18 @@ const SCENARIOS = [
       HARNESS_PLAN_APPROVAL: '1',
       HARNESS_PLAN_APPROVAL_GOAL: '1',
     },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: [DC2],
     frame: 'viewport',
     expect: ['Approve plan?', 'r approve & run', '1 approval'],
-    unexpect: ['PLAN-GOAL', '[/model]models'],
+    unexpect: ['PLAN-GOAL', '/model models'],
   },
   {
     name: 'retry-approval',
     frame: 'scrollback',
     cols: 120,
     env: { HARNESS_ENTRIES: '4', HARNESS_RETRY_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     expect: [
       'Retry the failed call?',
       'HTTP 429 Too Many Requests',
@@ -1878,25 +1878,25 @@ const SCENARIOS = [
       'use API key and retry',
       '1 approval',
     ],
-    unexpect: ['[/model]models'],
+    unexpect: ['/model models'],
   },
   {
     name: 'retry-approval-switch-api',
     cols: 120,
     env: { HARNESS_ENTRIES: '4', HARNESS_RETRY_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['k'],
     frame: 'viewport',
-    expect: ['RETRY-API-MODE personal', '[/status]details', '[/model]models'],
+    expect: ['RETRY-API-MODE personal', '/status details', '/model models'],
     unexpect: ['Retry the failed call?', '1 approval'],
   },
   {
     name: 'edit-approval-reject',
     env: { HARNESS_ENTRIES: '4', HARNESS_EDIT_APPROVAL: '1' },
-    bootExpect: '[Ctrl-C]',
+    bootExpect: '· Ctrl-C ',
     keys: ['n'],
     frame: 'viewport',
-    expect: ['[/status]details', '[/model]models'],
+    expect: ['/status details', '/model models'],
     unexpect: ['Apply edit to draft.tex?', '1 approval'],
   },
   {
@@ -1907,17 +1907,17 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     expect: [
       'strategy',
       'leanSolver',
       'reviewer',
       'main.tex: Proof sketch',
       '3 sub',
-      '[Tab]streams',
-      ']tasks',
+      'Tab streams',
+      'p tasks',
     ],
-    unexpect: ['[Option-p]tasks', '[Option-s]subagents'],
+    unexpect: ['Option-p tasks', 'Option-s subagents'],
   },
   // PTY ordering tests (issue #7972): the harness drives one child stream's
   // attachment/roster/edge/status/removal facts through the real
@@ -1947,11 +1947,11 @@ const SCENARIOS = [
     // Steps: A, S(running), R_P+, E_P+.
     checkpoints: [
       {
-        expect: ['[Tab]streams'],
+        expect: ['Tab streams'],
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
-        expect: ['[Tab]streams'],
+        expect: ['Tab streams'],
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
@@ -1961,7 +1961,7 @@ const SCENARIOS = [
         expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
       },
     ],
-    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+    expect: ['orderChecker', '1 sub', 'Tab streams'],
   },
   {
     name: 'child-event-order-roster-first',
@@ -1978,10 +1978,10 @@ const SCENARIOS = [
         // Active via the roster's retained-parent fallback, before the
         // child's own StreamSlice exists — not yet focusable.
         expect: ['1 sub', 'orderChecker · 1m 4s'],
-        unexpect: ['[Tab]streams', 'orderChecker running'],
+        unexpect: ['Tab streams', 'orderChecker running'],
       },
       {
-        expect: ['[Tab]streams', '1:orderChecker'],
+        expect: ['Tab streams', '1:orderChecker'],
         unexpect: ['1:orderChecker*', 'orderChecker running'],
       },
       {
@@ -1991,7 +1991,7 @@ const SCENARIOS = [
         expect: ['orderChecker running', '1:orderChecker*'],
       },
     ],
-    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+    expect: ['orderChecker', '1 sub', 'Tab streams'],
   },
   {
     name: 'child-event-order-edge-first',
@@ -2007,17 +2007,12 @@ const SCENARIOS = [
       {
         // An edge alone cannot be focused until the child's StreamSlice exists.
         expect: ['◆'],
-        unexpect: [
-          '[Tab]streams',
-          '1 sub',
-          'orderChecker',
-          'harness-child-eve',
-        ],
+        unexpect: ['Tab streams', '1 sub', 'orderChecker', 'harness-child-eve'],
       },
       {
         // Attachment creates the slice and makes the existing edge focusable;
         // the running marker still waits for the next status fact.
-        expect: ['[Tab]streams', 'harness-child-eve…'],
+        expect: ['Tab streams', 'harness-child-eve…'],
         unexpect: ['1 sub', 'orderChecker', 'harness-child-eve…*'],
       },
       {
@@ -2028,7 +2023,7 @@ const SCENARIOS = [
         expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
       },
     ],
-    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+    expect: ['orderChecker', '1 sub', 'Tab streams'],
   },
   {
     name: 'child-event-order-status-first',
@@ -2042,13 +2037,13 @@ const SCENARIOS = [
     // Steps: S(running), A, E_P+, R_P+.
     checkpoints: [
       {
-        expect: ['[Tab]streams'],
+        expect: ['Tab streams'],
         unexpect: ['1 sub', 'orderChecker', 'harness-child-eve'],
       },
       {
         // Attachment does not supply a parent edge, so the running slice is
         // registered but still absent from the root's focus strip.
-        expect: ['[Tab]streams'],
+        expect: ['Tab streams'],
         unexpect: ['1 sub', 'orderChecker', 'harness-child-eve'],
       },
       {
@@ -2059,7 +2054,7 @@ const SCENARIOS = [
         expect: ['1 sub', 'orderChecker running', '1:orderChecker*'],
       },
     ],
-    expect: ['orderChecker', '1 sub', '[Tab]streams'],
+    expect: ['orderChecker', '1 sub', 'Tab streams'],
   },
   // The remaining four orderings correct old ambiguous transients (promotion,
   // reattachment, parent removal, completion+removal) instead of being
@@ -2075,8 +2070,8 @@ const SCENARIOS = [
     // Steps: A, S(running), R_P+, E_P+, E0 (promote to top-level), R_P+ (late,
     // stale roster from the former parent).
     checkpoints: [
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
       { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
       { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
       {
@@ -2110,14 +2105,14 @@ const SCENARIOS = [
     // (root), R_P+ (root), R_other+ (late, stale — from the child's former,
     // never-displayed parent).
     checkpoints: [
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
       // Facts scoped to the never-displayed former parent must not leak into
       // root's own view at any point.
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
       {
         expect: ['harness-child-eve…*'],
         unexpect: ['1 sub', 'orderChecker'],
@@ -2151,7 +2146,7 @@ const SCENARIOS = [
     // that late facts naming a removed parent don't resurrect it anywhere or
     // wedge the TUI.
     checkpoints: [
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
       { unexpect: ['1 sub', 'orderChecker'] },
       { unexpect: ['1 sub', 'orderChecker'] },
       { unexpect: ['1 sub', 'orderChecker'] },
@@ -2177,8 +2172,8 @@ const SCENARIOS = [
     // Steps: A, S(running), R_P+, E_P+, R_P- (roster omission), S(terminal),
     // X(child), R_P+ (late), E_P+ (late), A (late), late resume attempt.
     checkpoints: [
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
-      { expect: ['[Tab]streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
+      { expect: ['Tab streams'], unexpect: ['1 sub', 'orderChecker'] },
       { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
       { expect: ['1 sub', 'orderChecker running', '1:orderChecker*'] },
       {
@@ -2193,17 +2188,17 @@ const SCENARIOS = [
       },
       {
         // Removal scrubs every trace, including the retained/historical row.
-        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', 'Tab streams'],
       },
       {
-        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', 'Tab streams'],
       },
       {
-        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', 'Tab streams'],
       },
       {
         // A late re-attachment attempt for the removed id must stay ignored.
-        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', 'Tab streams'],
       },
       {
         // A late resume-transition attempt is the one status fact that would
@@ -2211,7 +2206,7 @@ const SCENARIOS = [
         // transition is a same-value no-op the status machine drops before
         // it gets there) — it must still stay suppressed by the removal
         // tombstone.
-        unexpect: ['orderChecker', '1 sub', '1:orderChecker', '[Tab]streams'],
+        unexpect: ['orderChecker', '1 sub', '1:orderChecker', 'Tab streams'],
       },
     ],
     // Prove the TUI is still interactive after the removal + late facts:
@@ -2231,14 +2226,14 @@ const SCENARIOS = [
       HARNESS_FAILED_CHILD: 'reviewer',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     expect: [
       'strategy running',
       'leanSolver waiting for you',
       'reviewer error',
       '2 sub',
-      '[Tab]streams',
-      ']tasks',
+      'Tab streams',
+      'p tasks',
     ],
     unexpect: ['reviewer running', '3 sub'],
   },
@@ -2253,15 +2248,15 @@ const SCENARIOS = [
       HARNESS_TODOS: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     expect: [
       'Waiting for leanSolver',
       '3 sub',
       '1 proc',
-      '[Tab]streams',
-      ']subagents',
-      ']tasks',
-      '[Ctrl-C]stop',
+      'Tab streams',
+      's subagents',
+      'p tasks',
+      'Ctrl-C stop',
     ],
   },
   {
@@ -2275,9 +2270,9 @@ const SCENARIOS = [
       HARNESS_TODOS: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: ']tasks',
-    expect: ['Waiting for leanSolver', ']tasks', '[Ctrl-C]stop'],
-    unexpect: [']subagents', '[Option-p]tasks'],
+    bootExpect: 'p tasks',
+    expect: ['Waiting for leanSolver', 'p tasks', 'Ctrl-C stop'],
+    unexpect: ['s subagents', 'Option-p tasks'],
   },
   {
     name: 'subagent-picker',
@@ -2287,7 +2282,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's'], // Esc/Alt-s
     expect: [
       'Subagents',
@@ -2317,7 +2312,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', 'child follow-up on focused stream', '\r'],
     frame: 'viewport',
     expect: [
@@ -2340,7 +2335,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: ['\t'],
     expect: [
       'strategy is checking the harness-child-strategy details',
@@ -2366,7 +2361,7 @@ const SCENARIOS = [
       HARNESS_BASH_APPROVAL: '1',
       HARNESS_BASH_APPROVAL_AFTER_CHILD_FOCUS: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: ['\t', '\t', '\t', '\t'],
     expect: [
       'agent: chat · model: harness-model',
@@ -2394,7 +2389,7 @@ const SCENARIOS = [
       HARNESS_LONG_CHILD_OUTPUT: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: ['\t'],
     expect: [
       'strategy detail line 15',
@@ -2405,7 +2400,7 @@ const SCENARIOS = [
       'strategy detail line 01',
       'entry-1 chat history line',
       'entry-4 chat history line',
-      '[PgUp',
+      'PgUp',
       '[main]*',
       'signal read during notification phase',
       'ERROR',
@@ -2422,7 +2417,7 @@ const SCENARIOS = [
       HARNESS_LONG_CHILD_OUTPUT: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: ['\t', DC4, 'g'],
     expect: [
       'strategy\n› Please handle the harness-child-strategy sub-workflow.',
@@ -2446,7 +2441,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: ['\t', '/status', '\r'],
     frame: 'viewport',
     expect: [
@@ -2472,7 +2467,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', '\t', '\t', '\t'],
     expect: [
       'entry-1 chat history line',
@@ -2497,7 +2492,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', '\r'],
     expect: [
       'strategy',
@@ -2521,7 +2516,7 @@ const SCENARIOS = [
       HARNESS_NESTED_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', ESC + 's', '\r'],
     expect: [
       'localChecker',
@@ -2545,7 +2540,7 @@ const SCENARIOS = [
       HARNESS_NESTED_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', ESC + 's'],
     frame: 'viewport',
     expect: [
@@ -2569,7 +2564,7 @@ const SCENARIOS = [
       HARNESS_NESTED_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', ESC + 'p'],
     frame: 'viewport',
     expect: [
@@ -2596,7 +2591,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p'], // Esc/Alt-p
     expect: [
       'Tasks and sub-workflows',
@@ -2622,7 +2617,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'viewport',
     expect: [
@@ -2652,7 +2647,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p'], // Esc/Alt-p
     frame: 'viewport',
     expect: [
@@ -2682,7 +2677,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', DOWN, DOWN, DOWN], // Esc/Alt-p, select process row
     frame: 'viewport',
     expect: [
@@ -2702,7 +2697,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', '\r'],
     expect: [
       'Task details',
@@ -2779,7 +2774,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
     expect: [
       'Task details',
@@ -2799,7 +2794,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'viewport',
     expect: [
@@ -2828,7 +2823,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', DOWN], // Esc/Alt-s, select second subagent
     frame: 'viewport',
     expect: [
@@ -2857,7 +2852,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p'], // Esc/Alt-p
     frame: 'viewport',
     expect: [
@@ -2924,10 +2919,9 @@ const SCENARIOS = [
       'f focus',
       'Esc back',
       '[main]* 1:strategy*',
-      '[Esc]back',
-      '[Ctrl-C]stop',
+      'Ctrl-C stop',
     ],
-    unexpect: ['│ ›', 'Task details', 'Output:', '*    y*', '[Ctrl…'],
+    unexpect: ['│ ›', 'Task details', 'Output:', '*    y*', 'Ctrl…'],
   },
   {
     name: 'tiny-task-subworkflow-detail-wrapped-scroll',
@@ -2948,7 +2942,6 @@ const SCENARIOS = [
       'f focus',
       'Esc back',
       '[main]* 1:strategy*',
-      '[Esc]back',
     ],
     unexpect: ['│ ›', 'Task details', 'Output:', '*    y*'],
   },
@@ -2969,7 +2962,6 @@ const SCENARIOS = [
       'main.tex: Proof sketch needs one',
       'missing reference',
       'Esc back',
-      '[Esc]back',
     ],
     unexpect: ['│ ›', 'Task details', 'Output:', '*    y*'],
   },
@@ -2990,7 +2982,6 @@ const SCENARIOS = [
       'f focus',
       'k kill',
       'Esc back',
-      '[Esc]back',
     ],
     unexpect: ['Esc ba…'],
   },
@@ -3005,13 +2996,7 @@ const SCENARIOS = [
     },
     keys: [ESC + 'p', DOWN, DOWN, DOWN, '\r'],
     frame: 'viewport',
-    expect: [
-      'shell · latex build',
-      'reference',
-      'k kill',
-      'Esc back',
-      '[Esc]back',
-    ],
+    expect: ['shell · latex build', 'reference', 'k kill', 'Esc back'],
     unexpect: ['Esc ba…'],
   },
   {
@@ -3022,7 +3007,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 's'],
     expect: [
       'Subagents',
@@ -3045,7 +3030,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 'p'],
     expect: [
       'Tasks and sub-workflows',
@@ -3064,7 +3049,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 'p', '\r'],
     expect: [
       'Task details',
@@ -3082,7 +3067,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 's', 'f'],
     frame: 'viewport',
     expect: [
@@ -3090,7 +3075,7 @@ const SCENARIOS = [
       '◆ stopped',
       'root active',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
-      '[Ctrl-C]stop root',
+      'Ctrl-C stop root',
     ],
     expectCollapsed: [STOPPED_SUBAGENT_INPUT_MESSAGE],
     unexpect: ['◆ running', '2 sub 1 proc'],
@@ -3103,7 +3088,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 's', 'f', { input: ESC, delayMs: 40 }, 's'],
     frame: 'viewport',
     expect: ['Subagents', 'strategy', '1. strategy — stopped', 'root active'],
@@ -3117,7 +3102,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 's', 'f', { input: ESC, delayMs: 40 }, '\t'],
     frame: 'viewport',
     expect: ['[2:leanSolver]', '◆ waiting for you', 'root active'],
@@ -3135,7 +3120,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 'p', 'k', ESC + 's', 'f', 'can you still receive this?', '\r'],
     frame: 'viewport',
     expect: [
@@ -3159,11 +3144,11 @@ const SCENARIOS = [
     },
     keys: [ESC + 'p'],
     frame: 'viewport',
-    expect: ['entry-4 chat history line', '[/status]details', '[Ctrl-C]exit'],
+    expect: ['entry-4 chat history line', '/status details', 'Ctrl-C exit'],
     unexpect: [
-      '[Option-p]tasks',
-      '[Alt-p]tasks',
-      '[Esc p]tasks',
+      'Option-p tasks',
+      'Alt-p tasks',
+      'Esc p tasks',
       'Tasks and sub-workflows',
       'No active tasks or sub-workflows.',
       'Enter view',
@@ -3179,7 +3164,7 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ESC + 's', 'f', ESC + 'p'],
     expect: [
       'Tasks and sub-workflows',
@@ -3219,7 +3204,7 @@ const SCENARIOS = [
       HARNESS_TODOS_IDLE: '1',
     },
     frame: 'viewport',
-    expect: ['idle', '[Ctrl-C]exit'],
+    expect: ['idle', 'Ctrl-C exit'],
     unexpect: [
       'Split theorem into algebraic and analytic checks',
       'Coordinate a small math proof through nested CLI work.',
@@ -3239,16 +3224,16 @@ const SCENARIOS = [
       HARNESS_CHILDREN: '1',
       HARNESS_CAN_INTERRUPT: '1',
     },
-    bootExpect: '[Tab]streams',
+    bootExpect: 'Tab streams',
     keys: [ETX],
     frame: 'viewport',
     expect: [
       'Harness interrupt requested.',
       '[main](stopped)',
       '◆ stopped personal',
-      '[Ctrl-C]exit',
+      'Ctrl-C exit',
     ],
-    unexpect: ['[Ctrl-C]stop'],
+    unexpect: ['Ctrl-C stop'],
   },
 ];
 

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -56,7 +56,7 @@ export function appEscapeInterruptActive({
   );
 }
 
-// The footer advertises `[Esc s]subagents` / `[Esc p]tasks` any time these
+// The footer advertises `Esc s subagents` / `Esc p tasks` any time these
 // controls are available, regardless of which stream is currently focused
 // or whether it's still in-flight (e.g. WAITING). Bare Esc must therefore
 // give a chord a chance to resolve any time that binding is on screen —

--- a/packages/cli/src/chat/tui/modals/childControlPickerHints.ts
+++ b/packages/cli/src/chat/tui/modals/childControlPickerHints.ts
@@ -1,16 +1,10 @@
 // Local imports - CLI TUI
 import { textDisplayWidth } from '../render/terminalText';
-import { KEY_HINT_SEPARATOR, type KeyHint } from '../ui/KeyHints';
+import { KEY_HINT_SEPARATOR, keyHintText, type KeyHint } from '../ui/KeyHints';
 import type { ChildControlMode } from '../state/childControls';
 
-function keyHintDisplayText(hint: KeyHint): string {
-  return `${hint.key} ${hint.action}`;
-}
-
 function keyHintsDisplayWidth(hints: readonly KeyHint[]): number {
-  return textDisplayWidth(
-    hints.map(keyHintDisplayText).join(KEY_HINT_SEPARATOR),
-  );
+  return textDisplayWidth(hints.map(keyHintText).join(KEY_HINT_SEPARATOR));
 }
 
 function keyHintsFit(

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -30,6 +30,7 @@ import {
 import { formatCliStatusLabel } from '../sessionStatus';
 import { COLOR_ERROR, COLOR_HINT, COLOR_WARNING } from '../ui/colors';
 import { STATUS_DIAMOND } from '../ui/glyphs';
+import { KEY_HINT_SEPARATOR, keyHintText } from '../ui/KeyHints';
 import {
   STATUS_BAR_HORIZONTAL_PADDING,
   STATUS_BAR_RIGHT_PREVIEW_GAP,
@@ -377,16 +378,15 @@ function fitStatusBarLeftSegments(
   );
 }
 
-function metaShortcutLabel(modifierLabel: string, key: string): string {
-  return `[${metaChordLabel(modifierLabel, key)}]`;
-}
-
+// Bindings use the shared KeyHints vocabulary (`key action` joined with
+// KEY_HINT_SEPARATOR) so the status bar and modal footers read as one system
+// (docs/prds/cli-tui-ink/10-architecture.md § Intuitiveness conventions).
 function statusBarBindingRow(
   bindings: readonly (string | false | undefined)[],
 ): string {
-  return joinStatusBindings(
-    bindings.filter((binding): binding is string => !!binding),
-  );
+  return bindings
+    .filter((binding): binding is string => !!binding)
+    .join(KEY_HINT_SEPARATOR);
 }
 
 // Single-slot memo for the bindings cascade below: it eagerly builds ~13
@@ -420,25 +420,38 @@ function statusBarBindingsText(
     maxColumns,
   ].join('|');
   if (memoKey === lastBindingsKey) return lastBindingsText;
-  const focusBinding = metaShortcutLabel(modifierLabel, '1..9');
-  const tasksBinding = metaShortcutLabel(modifierLabel, 'p');
-  const subagentsBinding = metaShortcutLabel(modifierLabel, 's');
-  const transcriptBinding = '[Ctrl-T]transcript';
-  const streamTabs = hasMultipleStreams ? '[Tab]streams' : undefined;
-  const streamFocus = hasMultipleStreams ? `${focusBinding}focus` : undefined;
-  const transcript = transcriptAvailable ? transcriptBinding : undefined;
-  const tasks = taskControlsAvailable ? `${tasksBinding}tasks` : undefined;
-  const subagents = subagentControlsAvailable
-    ? `${subagentsBinding}subagents`
+  const streamTabs = hasMultipleStreams
+    ? keyHintText({ key: 'Tab', action: 'streams' })
     : undefined;
-  const agent = agentSelectionAvailable ? '[/agent]agents' : undefined;
-  const status = '[/status]details';
-  const model = '[/model]models';
-  const api = '[/api]api';
-  const newline = shiftEnterNewline
-    ? '[Shift-Enter]newline'
-    : '[Ctrl-J]newline';
-  const ctrlC = `[Ctrl-C]${ctrlCAction}`;
+  const streamFocus = hasMultipleStreams
+    ? keyHintText({
+        key: metaChordLabel(modifierLabel, '1..9'),
+        action: 'focus',
+      })
+    : undefined;
+  const transcript = transcriptAvailable
+    ? keyHintText({ key: 'Ctrl-T', action: 'transcript' })
+    : undefined;
+  const tasks = taskControlsAvailable
+    ? keyHintText({ key: metaChordLabel(modifierLabel, 'p'), action: 'tasks' })
+    : undefined;
+  const subagents = subagentControlsAvailable
+    ? keyHintText({
+        key: metaChordLabel(modifierLabel, 's'),
+        action: 'subagents',
+      })
+    : undefined;
+  const agent = agentSelectionAvailable
+    ? keyHintText({ key: '/agent', action: 'agents' })
+    : undefined;
+  const status = keyHintText({ key: '/status', action: 'details' });
+  const model = keyHintText({ key: '/model', action: 'models' });
+  const api = keyHintText({ key: '/api', action: 'api' });
+  const newline = keyHintText({
+    key: shiftEnterNewline ? 'Shift-Enter' : 'Ctrl-J',
+    action: 'newline',
+  });
+  const ctrlC = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
   const setupControlsOnly =
     agentSelectionAvailable &&
     !taskControlsAvailable &&
@@ -509,10 +522,6 @@ function statusBarBindingsText(
   return text;
 }
 
-function joinStatusBindings(bindings: readonly string[]): string {
-  return bindings.join('  ');
-}
-
 function fitsStatusBindings(text: string, maxColumns: number | undefined) {
   return maxColumns === undefined || textDisplayWidth(text) <= maxColumns;
 }
@@ -522,12 +531,16 @@ function foregroundBindingsText(
   maxColumns?: number,
   escapeAction = 'close',
 ): string {
-  const ctrlCBinding = `[Ctrl-C]${ctrlCAction}`;
-  const escBinding = `[Esc]${escapeAction}`;
-  const full = `Use foreground panel shortcuts  ${escBinding}  ${ctrlCBinding}`;
+  const ctrlCBinding = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
+  const escBinding = keyHintText({ key: 'Esc', action: escapeAction });
+  const full = [
+    'Use foreground panel shortcuts',
+    escBinding,
+    ctrlCBinding,
+  ].join(KEY_HINT_SEPARATOR);
   if (fitsStatusBindings(full, maxColumns)) return full;
 
-  const compact = `${escBinding}  ${ctrlCBinding}`;
+  const compact = [escBinding, ctrlCBinding].join(KEY_HINT_SEPARATOR);
   if (fitsStatusBindings(compact, maxColumns)) return compact;
 
   return ctrlCBinding;

--- a/packages/cli/src/chat/tui/ui/KeyHints.tsx
+++ b/packages/cli/src/chat/tui/ui/KeyHints.tsx
@@ -24,6 +24,13 @@ export interface KeyHintsProps {
 
 export const KEY_HINT_SEPARATOR = ' · ';
 
+/** Plain-text projection of one hint. Must stay in sync with the component's
+ *  rendered output below (`key action`) so width math and text-only surfaces
+ *  (status-bar bindings, picker hint fitting) measure exactly what renders. */
+export function keyHintText(hint: KeyHint): string {
+  return `${hint.key} ${hint.action}`;
+}
+
 const DEFAULT_TAIL: readonly KeyHint[] = [
   { key: 'Enter', action: 'confirm' },
   { key: 'Esc', action: 'cancel' },

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -10,6 +10,7 @@ import {
 } from '@cli/chat/tui/panes/statusBarDisplay';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
+import { KEY_HINT_SEPARATOR } from '@cli/chat/tui/ui/KeyHints';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
 import { STREAM_PHASE, STREAM_SUBSTATE } from '@shared/schemas';
 
@@ -168,20 +169,35 @@ describe('CLI StatusBar display model', () => {
       PERSONAL_API_MODE_LABEL,
     ]);
     expect(display.right).toBeUndefined();
-    expect(display.bindings).toContain('[/api]api');
-    expect(display.bindings).toContain('[/model]models');
-    expect(display.bindings).not.toContain('[/agent]agents');
-    // [Ctrl-J]newline must be visible — the binding exists in BaseTextInput
+    expect(display.bindings).toContain('/api api');
+    expect(display.bindings).toContain('/model models');
+    expect(display.bindings).not.toContain('/agent agents');
+    // Ctrl-J newline must be visible — the binding exists in BaseTextInput
     // (see #4399) but used to be discoverable only via source diving.
-    expect(display.bindings).toContain('[Ctrl-J]newline');
-    expect(display.bindings).not.toContain('[Shift-Enter]newline');
-    expect(display.bindings).toContain('[Ctrl-C]exit');
-    expect(display.bindings).not.toContain('[Ctrl-C]stop');
-    expect(display.bindings).not.toContain('[Alt-s]subagents');
+    expect(display.bindings).toContain('Ctrl-J newline');
+    expect(display.bindings).not.toContain('Shift-Enter newline');
+    expect(display.bindings).toContain('Ctrl-C exit');
+    expect(display.bindings).not.toContain('Ctrl-C stop');
+    expect(display.bindings).not.toContain('Alt-s subagents');
     // Stream-navigation hints stay hidden in a single-stream chat.
-    expect(display.bindings).not.toContain('[Tab]streams');
-    expect(display.bindings).not.toContain('[Alt-1..9]focus');
+    expect(display.bindings).not.toContain('Tab streams');
+    expect(display.bindings).not.toContain('Alt-1..9 focus');
     expect(display.left.map(statusBarSegmentText)).not.toContain('deepseekT');
+  });
+
+  it('renders bindings in the shared KeyHints hint format', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        subagentControlsAvailable: true,
+        hasMultipleStreams: true,
+        transcriptAvailable: true,
+      }),
+    );
+
+    // One hint vocabulary across the TUI: unbracketed `key action` pairs
+    // joined by the KeyHints separator, matching every modal footer (#8199).
+    expect(display.bindings).toContain(KEY_HINT_SEPARATOR);
+    expect(display.bindings).not.toMatch(/[[\]]/);
   });
 
   it('advertises the transcript viewer when the focused stream has history', () => {
@@ -194,9 +210,9 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Tab]streams');
-    expect(display.bindings).toContain('[Ctrl-T]transcript');
-    expect(display.bindings).toContain('[Alt-s]subagents');
+    expect(display.bindings).toContain('Tab streams');
+    expect(display.bindings).toContain('Ctrl-T transcript');
+    expect(display.bindings).toContain('Alt-s subagents');
   });
 
   it('keeps the transcript shortcut in narrow stream views', () => {
@@ -209,8 +225,8 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Ctrl-T]transcript');
-    expect(display.bindings).toContain('[Ctrl-C]exit');
+    expect(display.bindings).toContain('Ctrl-T transcript');
+    expect(display.bindings).toContain('Ctrl-C exit');
   });
 
   it('prefers transcript over stream cycling when the bar is very narrow', () => {
@@ -223,7 +239,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toBe('[Ctrl-T]transcript  [Ctrl-C]exit');
+    expect(display.bindings).toBe('Ctrl-T transcript · Ctrl-C exit');
   });
 
   it('advertises root agent selection while setup can still change it', () => {
@@ -237,7 +253,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      '[/agent]agents  [/model]models  [/api]api  [Ctrl-J]newline  [Ctrl-C]exit',
+      '/agent agents · /model models · /api api · Ctrl-J newline · Ctrl-C exit',
     );
   });
 
@@ -252,8 +268,8 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Ctrl-T]transcript');
-    expect(display.bindings).toContain('[/agent]agents');
+    expect(display.bindings).toContain('Ctrl-T transcript');
+    expect(display.bindings).toContain('/agent agents');
   });
 
   it('keeps model and API controls visible after local-command transcript rows', () => {
@@ -267,7 +283,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      '[/agent]agents  [/model]models  [/api]api  [Ctrl-C]exit',
+      '/agent agents · /model models · /api api · Ctrl-C exit',
     );
   });
 
@@ -283,11 +299,11 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Tab]streams');
-    expect(display.bindings).toContain('[Alt-p]tasks');
-    expect(display.bindings).toContain('[Alt-s]subagents');
-    expect(display.bindings).not.toContain('[/model]models');
-    expect(display.bindings).not.toContain('[/api]api');
+    expect(display.bindings).toContain('Tab streams');
+    expect(display.bindings).toContain('Alt-p tasks');
+    expect(display.bindings).toContain('Alt-s subagents');
+    expect(display.bindings).not.toContain('/model models');
+    expect(display.bindings).not.toContain('/api api');
   });
 
   it('keeps root agent selection visible when setup bindings get narrow', () => {
@@ -300,10 +316,10 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[/agent]agents');
-    expect(display.bindings).toContain('[Ctrl-C]exit');
-    expect(display.bindings).not.toContain('[/model]models');
-    expect(display.bindings).not.toContain('[/api]api');
+    expect(display.bindings).toContain('/agent agents');
+    expect(display.bindings).toContain('Ctrl-C exit');
+    expect(display.bindings).not.toContain('/model models');
+    expect(display.bindings).not.toContain('/api api');
   });
 
   it('hides task shortcuts when no task rows exist', () => {
@@ -318,9 +334,9 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[/status]details');
-    expect(display.bindings).toContain('[Ctrl-C]stop');
-    expect(display.bindings).not.toContain('[Option-p]tasks');
+    expect(display.bindings).toContain('/status details');
+    expect(display.bindings).toContain('Ctrl-C stop');
+    expect(display.bindings).not.toContain('Option-p tasks');
   });
 
   it('keeps subagent shortcuts grouped when task shortcuts are hidden', () => {
@@ -338,13 +354,13 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).not.toContain('[Option-p]tasks');
-    expect(display.bindings).toContain('[Option-s]subagents');
-    expect(display.bindings.indexOf('[Option-s]subagents')).toBeLessThan(
-      display.bindings.indexOf('[/status]details'),
+    expect(display.bindings).not.toContain('Option-p tasks');
+    expect(display.bindings).toContain('Option-s subagents');
+    expect(display.bindings.indexOf('Option-s subagents')).toBeLessThan(
+      display.bindings.indexOf('/status details'),
     );
-    expect(display.bindings.indexOf('[Option-s]subagents')).toBeLessThan(
-      display.bindings.indexOf('[Ctrl-C]stop'),
+    expect(display.bindings.indexOf('Option-s subagents')).toBeLessThan(
+      display.bindings.indexOf('Ctrl-C stop'),
     );
   });
 
@@ -365,8 +381,8 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.bindings).not.toContain('PgUp');
     expect(display.bindings).not.toContain('scroll');
-    expect(display.bindings).toContain('[Tab]streams');
-    expect(display.bindings).toContain('[Ctrl-C]stop root');
+    expect(display.bindings).toContain('Tab streams');
+    expect(display.bindings).toContain('Ctrl-C stop root');
   });
 
   it('advertises Shift-Enter for newline when the Kitty protocol is active', () => {
@@ -374,8 +390,8 @@ describe('CLI StatusBar display model', () => {
       statusInput({ shiftEnterNewline: true }),
     );
 
-    expect(display.bindings).toContain('[Shift-Enter]newline');
-    expect(display.bindings).not.toContain('[Ctrl-J]newline');
+    expect(display.bindings).toContain('Shift-Enter newline');
+    expect(display.bindings).not.toContain('Ctrl-J newline');
   });
 
   it('shows live running signals and approval depth', () => {
@@ -412,11 +428,11 @@ describe('CLI StatusBar display model', () => {
     expect(display.right).toBe(
       '1. Keep the proof und… · 2. Also mention the f…',
     );
-    expect(display.bindings).toContain('[Alt-s]subagents');
-    expect(display.bindings).toContain('[Ctrl-C]stop');
+    expect(display.bindings).toContain('Alt-s subagents');
+    expect(display.bindings).toContain('Ctrl-C stop');
     // Stream-navigation hints appear once more than one stream is live.
-    expect(display.bindings).toContain('[Tab]streams');
-    expect(display.bindings).toContain('[Alt-1..9]focus');
+    expect(display.bindings).toContain('Tab streams');
+    expect(display.bindings).toContain('Alt-1..9 focus');
   });
 
   it('keeps critical controls visible in narrow subagent sessions', () => {
@@ -435,9 +451,9 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.bindings).toBe(
-      '[Tab]streams  [Alt-p]tasks  [Alt-s]subagents  [Ctrl-C]stop',
+      'Tab streams · Alt-p tasks · Alt-s subagents · Ctrl-C stop',
     );
-    expect(display.bindings).toContain('[Ctrl-C]stop');
+    expect(display.bindings).toContain('Ctrl-C stop');
   });
 
   it('prefers the task picker when one child-control shortcut fits', () => {
@@ -456,8 +472,8 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toBe('[Option-p]tasks  [Ctrl-C]stop');
-    expect(display.bindings).not.toContain('[Option-s]subagents');
+    expect(display.bindings).toBe('Option-p tasks · Ctrl-C stop');
+    expect(display.bindings).not.toContain('Option-s subagents');
   });
 
   it('drops low-priority status details before narrow footers lose separators', () => {
@@ -598,7 +614,7 @@ describe('CLI StatusBar display model', () => {
       'root active',
       PERSONAL_API_MODE_LABEL,
     ]);
-    expect(display.bindings).toContain('[Ctrl-C]stop root');
+    expect(display.bindings).toContain('Ctrl-C stop root');
 
     const liveChildDisplay = buildStatusBarDisplay({
       ...baseDisplayInput,
@@ -932,7 +948,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(statusInput({ width: 50 }));
 
     expect(display.bindings).toBe(
-      '[Alt-p]tasks  [/status]details  [Ctrl-C]exit',
+      'Alt-p tasks · /status details · Ctrl-C exit',
     );
   });
 
@@ -952,7 +968,7 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.left.map(statusBarSegmentText)).toContain('1 approval');
     expect(display.bindings).toBe(
-      'Use foreground panel shortcuts  [Esc]close  [Ctrl-C]stop',
+      'Use foreground panel shortcuts · Esc close · Ctrl-C stop',
     );
   });
 
@@ -969,7 +985,7 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.left.map(statusBarSegmentText)).toContain('1 question');
     expect(display.left.map(statusBarSegmentText)).not.toContain('1 approval');
-    expect(display.bindings).toContain('[Esc]skip');
+    expect(display.bindings).toContain('Esc skip');
   });
 
   it('shows cancel for non-question approval foregrounds', () => {
@@ -982,7 +998,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Esc]cancel');
+    expect(display.bindings).toContain('Esc cancel');
   });
 
   it('keeps escape and Ctrl-C actions visible in narrow foreground panels', () => {
@@ -999,7 +1015,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toBe('[Esc]close  [Ctrl-C]stop');
+    expect(display.bindings).toBe('Esc close · Ctrl-C stop');
   });
 
   it('falls back to the bare Ctrl-C action in tiny foreground panels', () => {
@@ -1016,7 +1032,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toBe('[Ctrl-C]stop');
+    expect(display.bindings).toBe('Ctrl-C stop');
   });
 
   it('shows a live elapsed segment only while running', () => {
@@ -1120,7 +1136,7 @@ describe('CLI StatusBar display model', () => {
     );
 
     expect(display.right).toBe('Keep the proof…');
-    expect(display.bindings).toContain('[Ctrl-C]exit');
+    expect(display.bindings).toContain('Ctrl-C exit');
   });
 
   it('shows the resume command while exit confirmation is armed', () => {
@@ -1232,9 +1248,9 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.bindings).toContain('[Esc 1..9]focus');
-    expect(display.bindings).toContain('[Esc p]tasks');
-    expect(display.bindings).toContain('[Esc s]subagents');
-    expect(display.bindings).not.toContain('[Option-p]tasks');
+    expect(display.bindings).toContain('Esc 1..9 focus');
+    expect(display.bindings).toContain('Esc p tasks');
+    expect(display.bindings).toContain('Esc s subagents');
+    expect(display.bindings).not.toContain('Option-p tasks');
   });
 });


### PR DESCRIPTION
Closes #8199

## Summary

Unifies the CLI TUI's two key-hint formats by moving `StatusBar`'s bindings row to `KeyHints`' canonical style: unbracketed `key action` pairs joined with `KEY_HINT_SEPARATOR` (`' · '`), replacing the legacy `[key]action` + 2-space join.

**Why this direction:** `KeyHints` is the documented convention (PRD `docs/prds/cli-tui-ink/10-architecture.md` § Intuitiveness conventions — "ad-hoc footer text is a review-blocker") and every modal/form/picker footer already uses it; the status bar was the lone divergent surface.

**Why the width-fit cascade needs no recalibration** (the regression that forced the revert in #8184): unbracketing shrinks every binding by exactly 1 column (`[Ctrl-T]transcript` → `Ctrl-T transcript`), while the wider separator adds 1 column per gap, so every N-binding row is exactly `-N + (N-1) = -1` column — strictly narrower. Every candidate that fit before still fits, so no binding drops out at any width. The #8184 attempt regressed because it changed only the separator (+1 per gap with no offset). All 13 exact-width vitest expectations (`width: 42/44/50/60/80` etc.) select the same cascade candidate as before, just rendered in the new format.

Mechanics:
- `keyHintText()` is the single owner of the `key action` shape, exported from `ui/KeyHints.tsx` with two consumers: `statusBarDisplay.ts` (row building) and `childControlPickerHints.ts` (replacing its identical local `keyHintDisplayText`).
- `statusBarDisplay.ts` builds every binding (including `metaChordLabel` chords and the foreground `Use foreground panel shortcuts · Esc close · Ctrl-C stop` row) through `keyHintText` + `KEY_HINT_SEPARATOR`; deleted the now-unused `metaShortcutLabel` bracket wrapper and single-caller `joinStatusBindings`.
- `validate-tui.mjs`: updated all ~130 hint-string assertions to the new format. `bootExpect: '[Ctrl-C]'` became `'· Ctrl-C '` (separator-anchored so the rotating tip row `Tip: Ctrl-C exits idle chats…` can never satisfy it prematurely; the bindings row always has ≥2 hints at validator widths and Ctrl-C is always last). Deduped 5 `'Esc back'` expectations that collapsed into the child-banner hint string. Stream-tab labels (`[main]*`) are selection markers, not key hints, and stay bracketed.
- New regression test pins the format parity (`bindings` contains `KEY_HINT_SEPARATOR`, never `[`/`]`).
- Documented the ruling in the PRD § Intuitiveness conventions.

Headless parity: `statusBarDisplay.ts`/`KeyHints.tsx` are imported only by Ink TUI surfaces (verified by grep over `packages/cli/src`); `texra run` / `--print` / `--output-format` paths are untouched.

## Verified

- Opened at origin/main HEAD: `packages/cli/src/chat/tui/panes/statusBarDisplay.ts` (bracket format at 426–441, 2-space join at 512–514), `ui/KeyHints.tsx` (25, 43), `modals/childControlPickerHints.ts`, `panes/StatusBar.tsx`, `panes/TipRow.tsx` (tip-row collision check for the bootExpect anchor), `scripts/validate-tui.mjs`, `docs/prds/cli-tui-ink/10-architecture.md`, `.github/workflows/ci.yml` (CI runs the `edit-approval subagent-picker hidden-root-approval-tab-return` trio).
- `npm run typecheck` — clean (exit 0).
- `npm test -- StatusBar` — 57 passed; `npm test -- ChildControls ConfirmCardState ExternalInquiry TuiStateAndFocus Orchestration KeyHints` — 223 passed; full `npm test -- cli/` — 130 files / 1684 tests passed.
- `node scripts/validate-tui.mjs edit-approval subagent-picker hidden-root-approval-tab-return transcript` — all 4 passed (the CI set).
- Targeted validator batches covering every scenario that asserts on a changed string (98 scenarios total across three runs: narrow 40-col bootExpects, `Esc back` dedupes, `PgUp`/`Ctrl…` unexpects, `stop root`, `Esc panel`/`Esc cancel`, `/model models` unexpects, `Tab streams` boots, child-event-order byte-identical frame pairs) — all passed. The first batch caught one gap (the modifier-agnostic `']tasks'`/`']subagents'` fragments), fixed as `'p tasks'`/`'s subagents'` and re-verified.
- `npm run lint` — 0 errors; no warnings in touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only string formatting in the TUI status bar and harness expectations; no auth, runtime, or API behavior changes.
> 
> **Overview**
> **Unifies keyboard-hint copy** across the Ink TUI by moving the status-bar bindings row off the legacy `[key]action` strings (joined with double spaces) onto the same vocabulary as `<KeyHints>`: unbracketed `key action` pairs separated by `KEY_HINT_SEPARATOR` (`·`).
> 
> Exports **`keyHintText()`** from `KeyHints.tsx` as the single plain-text projection of a hint; **`statusBarDisplay.ts`** builds every binding (slash commands, meta chords, Ctrl-C, foreground “Use foreground panel shortcuts” rows) through that helper and drops the bracket wrapper helpers. **`childControlPickerHints.ts`** deletes its duplicate local formatter and imports `keyHintText` instead.
> 
> **Docs and tests** follow the format: the CLI TUI architecture PRD § Intuitiveness conventions now requires one hint vocabulary everywhere; **`validate-tui.mjs`** updates ~130 frame assertions (including separator-anchored `bootExpect` where tip text could collide); **`StatusBar.vitest.mts`** expectations and a new test assert bindings contain `·` and never `[`/`]`. A comment in **`appInteractionPolicy.ts`** is updated to match the new Esc-chord wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f6ba73f80ff79ac37cda18b9a92177d3a74d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->