### PR TITLE
fix(desktop): rebind interactions, children, and status across window recreation

### DIFF
--- a/host-agent-import-baseline.json
+++ b/host-agent-import-baseline.json
@@ -49,6 +49,7 @@
       "@agent/runtime/AgentRuntimeHost",
       "@agent/runtime/agentShutdown",
       "@agent/runtime/detachSubagentsOnStop",
+      "@agent/runtime/executionRegistry",
       "@agent/runtime/helperModelName",
       "@agent/runtime/hostInteractionResultMappers",
       "@agent/runtime/HostInteractions",

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -48,10 +48,8 @@ import type {
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
 import {
-  findActiveAgentExecutionHandle,
   getAllActiveExecutionIds,
   SessionHandle,
-  untrackActiveAgentExecution,
 } from '@agent/runtime/SessionHandle';
 import { setProgressViewBridge } from '@agent/runtime/ProgressViewBridge';
 import {
@@ -102,6 +100,7 @@ import {
   type DesktopToolEditApprovalController,
 } from './desktopToolEditApproval.js';
 import { createDesktopHostInteractions } from './desktopHostInteractions.js';
+import { DesktopExecutionRebinder } from './desktopExecutionRebinder.js';
 import { toLogData } from './desktopLogUtils.js';
 import {
   DesktopProgressFileActions,
@@ -242,6 +241,7 @@ export class DesktopProgressBridge {
   private readonly detachHostInteractions: () => void;
   /** Detaches the session→toast consumer; called on dispose. */
   private detachResultToast: (() => void) | undefined;
+  private readonly executionRebinder: DesktopExecutionRebinder;
 
   constructor(
     private readonly postToRenderer: (message: unknown) => boolean | void,
@@ -251,6 +251,10 @@ export class DesktopProgressBridge {
       emit: (event, payload) => this.handleInteractionEvent(event, payload),
     };
     this.session = new SessionHandle({ hostChannel });
+    this.executionRebinder = new DesktopExecutionRebinder(
+      this.session,
+      this.logger,
+    );
     this.runtimeHost = {
       ...hostChannel,
       interactions: this.session.interactions,
@@ -687,6 +691,7 @@ export class DesktopProgressBridge {
   dispose(): void {
     this.detachResultToast?.();
     this.detachHostInteractions();
+    this.executionRebinder.dispose();
     this.toolEditApprovals.dispose();
     this.unsubscribe();
     this.backend.dispose();
@@ -756,7 +761,11 @@ export class DesktopProgressBridge {
     // rail entry owner at all: the old window's bridge already stopped
     // forwarding events (disposed), and nothing else ever subscribed this
     // window to them. See #8148.
-    this.rebindActiveExecutions(activeExecutionIds, allExecutionIds);
+    this.executionRebinder.rebind(
+      activeExecutionIds,
+      allExecutionIds,
+      this.sessionProgress.restoredStreams,
+    );
     this.sessionProgress.forgetActiveRestoredStreams(
       activeExecutionIds,
       allExecutionIds,
@@ -765,57 +774,8 @@ export class DesktopProgressBridge {
   }
 
   /**
-   * Reattach every still-active execution a restored (ghost) stream points
-   * at to THIS window's session, so window recreation doesn't strand a
-   * headless-continuing run on its previous window's disposed bridge (#8148).
-   * Idempotent (guarded by `this.session.executions.getHandle`), since
-   * startup repair calls `refreshActiveExecutionIds` more than once.
-   */
-  private rebindActiveExecutions(
-    activeExecutionIds: ReadonlySet<string>,
-    allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>,
-  ): void {
-    for (const [streamId, snapshot] of this.sessionProgress.restoredStreams) {
-      const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
-      if (!executionId || !activeExecutionIds.has(executionId)) continue;
-      if (this.session.executions.getHandle(executionId)) continue;
-      const found = findActiveAgentExecutionHandle(executionId);
-      if (!found || found.handle.childStreamId !== streamId) continue;
-      const { handle, status } = found;
-      this.session.executions.track(handle);
-      // `hydrateRestoredStreams()` already seeded this window's status from
-      // the on-disk snapshot's `lastKnownStatus`, which goes stale the moment
-      // the run transitions while headless (nothing persists it, #8148).
-      // Overwrite with the live status the owning session actually has, so
-      // display and `terminateWaitingHandle`'s WAITING/RESUMING check both
-      // see the truth instead of a possibly-wrong RUNNING carried from disk.
-      if (status) {
-        this.session.status.transition(streamId, status, 'restart-repair', {
-          trace: handle.trace,
-        });
-      }
-      const detachTrace = handle.trace
-        ? this.session.attachRunTrace(handle.trace, streamId)
-        : undefined;
-      void handle.result.finally(() => {
-        detachTrace?.();
-        // Release from every live session that still owns this handle, not
-        // just this window's -- otherwise the session that originally
-        // launched it (retained post-dispose via `keepActiveExecutions`)
-        // never sees its own registry go idle and leaks in `liveSessions`.
-        untrackActiveAgentExecution(executionId);
-      });
-    }
-  }
-
-  /**
-   * Consults detectWaitingStreams() (the KV-store-backed, ground-truth
-   * persisted flow record check) and then re-fetches active execution ids
-   * to drop any stream that became active while that await was in flight --
-   * a narrow but real race (another window, or a headless run, could resume
-   * the stream mid-lookup). Shared by both the primary try path and the
-   * degraded catch-fallback path in repairOrphanedStreamsAfterRestart so the
-   * two can no longer silently diverge on this check the way they once did.
+   * Detect persisted waiting streams, then recheck live executions so both
+   * primary and degraded restart-repair paths reject resumes won mid-read.
    */
   private async detectRaceGuardedWaitingStreams(
     executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,

--- a/packages/desktop/src/main/desktopExecutionRebinder.ts
+++ b/packages/desktop/src/main/desktopExecutionRebinder.ts
@@ -1,0 +1,371 @@
+// Type imports - tracing
+import type { AgentTrace } from '@agent/trace';
+
+// Local imports - agent runtime
+import {
+  AgentExecutionHandle,
+  ProcessExecutionHandle,
+  type ExecutionHandle,
+} from '@agent/runtime/executionRegistry';
+import {
+  findActiveAgentExecutionHandle,
+  type SessionHandle,
+  untrackActiveAgentExecution,
+} from '@agent/runtime/SessionHandle';
+
+// Local imports - shared schemas
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type RestoredStreamSnapshot,
+  type StreamTabId,
+} from '@shared/schemas';
+
+interface ReboundAgentBinding {
+  readonly streamId: StreamTabId;
+  readonly ownerSession: SessionHandle;
+  dispose(): void;
+}
+
+interface ReboundProcessBinding {
+  readonly ownerSession: SessionHandle;
+  dispose(): void;
+}
+
+/**
+ * Bridges executions retained by a closed desktop window into a replacement
+ * window without migrating their run-context ownership.
+ */
+export class DesktopExecutionRebinder {
+  private readonly interactionForwards = new Map<SessionHandle, () => void>();
+  private readonly agentBindings = new Map<ExecutionId, ReboundAgentBinding>();
+  private readonly rootOwners = new Map<StreamTabId, SessionHandle>();
+  private readonly processBindings = new Map<
+    ExecutionId,
+    ReboundProcessBinding
+  >();
+  private readonly ownerRegistrationObservers = new Map<
+    SessionHandle,
+    () => void
+  >();
+
+  constructor(
+    private readonly targetSession: SessionHandle,
+    private readonly logger: Pick<AgentTrace, 'debug' | 'warn'>,
+  ) {}
+
+  rebind(
+    activeExecutionIds: ReadonlySet<string>,
+    allExecutionIds: ReadonlyMap<StreamTabId, ExecutionId>,
+    restoredStreams: ReadonlyMap<StreamTabId, RestoredStreamSnapshot>,
+  ): void {
+    const reboundRoots = new Map(this.rootOwners);
+    for (const [streamId, snapshot] of restoredStreams) {
+      const executionId = snapshot.executionId ?? allExecutionIds.get(streamId);
+      if (!executionId || !activeExecutionIds.has(executionId)) continue;
+      let binding = this.agentBindings.get(executionId);
+      if (!binding) {
+        const found = findActiveAgentExecutionHandle(executionId);
+        if (!found || found.handle.childStreamId !== streamId) continue;
+        this.bindAgent(executionId, streamId, found.session);
+        binding = this.agentBindings.get(executionId);
+      }
+      if (!binding) continue;
+      this.forwardInteractions(binding.ownerSession);
+      this.rootOwners.set(streamId, binding.ownerSession);
+      reboundRoots.set(streamId, binding.ownerSession);
+      this.observeOwnerRegistrations(binding.ownerSession);
+    }
+    for (const [streamId, ownerSession] of reboundRoots) {
+      this.bindDescendants(streamId, ownerSession);
+    }
+  }
+
+  /** Detach every bridge and remove mirrored handles from the closing window. */
+  dispose(): void {
+    for (const binding of [...this.agentBindings.values()]) binding.dispose();
+    for (const binding of [...this.processBindings.values()]) binding.dispose();
+    for (const detach of this.ownerRegistrationObservers.values()) detach();
+    this.ownerRegistrationObservers.clear();
+    for (const detach of this.interactionForwards.values()) detach();
+    this.interactionForwards.clear();
+  }
+
+  private forwardInteractions(ownerSession: SessionHandle): void {
+    if (
+      ownerSession === this.targetSession ||
+      this.interactionForwards.has(ownerSession)
+    ) {
+      return;
+    }
+    const target = this.targetSession.interactions;
+    this.interactionForwards.set(
+      ownerSession,
+      ownerSession.useHostInteractions({
+        requestToolEditApproval: (request, options) =>
+          target.requestToolEditApproval(request, options),
+        requestBashApproval: (request, options) =>
+          target.requestBashApproval(request, options),
+        requestPlanApproval: (request, options) =>
+          target.requestPlanApproval(request, options),
+        requestAgentProposal: (request, options) =>
+          target.requestAgentProposal(request, options),
+        requestRetry: (request, options) =>
+          target.requestRetry(request, options),
+        askUserQuestion: (request, options) =>
+          target.askUserQuestion(request, options),
+        openExternalInquiry: (request) => target.openExternalInquiry(request),
+        setApprovalBypassState: (update) =>
+          target.setApprovalBypassState(update),
+        resolve: (requestId, result) => target.resolve(requestId, result),
+        cancel: (selector) => target.cancel(selector),
+      }),
+    );
+  }
+
+  private bindAgent(
+    executionId: ExecutionId,
+    streamId: StreamTabId,
+    ownerSession: SessionHandle,
+  ): void {
+    if (this.agentBindings.has(executionId)) return;
+    let currentHandle: AgentExecutionHandle | undefined;
+    let detachTrace: (() => void) | undefined;
+    let detachTerminalMirror: (() => void) | undefined;
+    let detachOwnerHandle = (): void => undefined;
+    let detachOwnerStatus = (): void => undefined;
+    let detachTargetHandle = (): void => undefined;
+    let disposed = false;
+
+    const disposeBinding = (): void => {
+      if (disposed) return;
+      disposed = true;
+      detachOwnerHandle();
+      detachOwnerStatus();
+      detachTargetHandle();
+      detachTrace?.();
+      detachTerminalMirror?.();
+      if (this.agentBindings.get(executionId) === binding) {
+        this.agentBindings.delete(executionId);
+      }
+      if (this.rootOwners.get(streamId) === ownerSession) {
+        this.rootOwners.delete(streamId);
+        this.detachOwnerObserverIfUnused(ownerSession);
+      }
+    };
+    const releaseCurrent = (): void => {
+      const staleHandle = currentHandle;
+      currentHandle = undefined;
+      disposeBinding();
+      if (staleHandle) untrackActiveAgentExecution(staleHandle);
+    };
+    const seedStatus = (handle: AgentExecutionHandle): void => {
+      const status = ownerSession.status.get(streamId);
+      if (!status) return;
+      const emitOptions = { trace: handle.trace };
+      const seeded =
+        status === STREAM_PHASE.WAITING
+          ? this.targetSession.status.transitionToWaiting(
+              streamId,
+              'restart-repair',
+              emitOptions,
+            )
+          : this.targetSession.status.transition(
+              streamId,
+              status,
+              'restart-repair',
+              emitOptions,
+            ) ||
+            (status === STREAM_PHASE.RUNNING &&
+              this.targetSession.status.transition(
+                streamId,
+                STREAM_PHASE.RUNNING,
+                'resume',
+                emitOptions,
+              ));
+      if (!seeded) {
+        this.logger.warn('Failed to seed rebound stream status', {
+          data: {
+            streamId,
+            status,
+            hydrated: this.targetSession.status.get(streamId),
+          },
+        });
+      }
+    };
+    const bindOwnerHandle = (handle: ExecutionHandle | undefined): void => {
+      if (disposed) return;
+      if (
+        !(handle instanceof AgentExecutionHandle) ||
+        handle.childStreamId !== streamId
+      ) {
+        releaseCurrent();
+        return;
+      }
+      if (handle === currentHandle) return;
+      const staleHandle = currentHandle;
+      detachTrace?.();
+      detachTerminalMirror?.();
+      currentHandle = handle;
+      this.targetSession.executions.track(handle);
+      detachTrace = handle.trace
+        ? this.targetSession.attachRunTrace(handle.trace, streamId)
+        : undefined;
+      detachTerminalMirror = handle.trace?.subscribe((event) => {
+        if (event.type !== 'result' || event.streamId !== streamId) return;
+        if (
+          !this.targetSession.status.transitionToTerminal(
+            streamId,
+            event.outcome,
+          )
+        ) {
+          this.logger.warn('Failed to mirror rebound terminal status', {
+            data: { streamId, status: event.outcome },
+          });
+        }
+      });
+      seedStatus(handle);
+      if (staleHandle) untrackActiveAgentExecution(staleHandle);
+    };
+
+    const binding: ReboundAgentBinding = {
+      streamId,
+      ownerSession,
+      dispose: () => {
+        const mirroredHandle = currentHandle;
+        currentHandle = undefined;
+        disposeBinding();
+        if (mirroredHandle) {
+          this.targetSession.executions.untrackIfCurrent(mirroredHandle);
+        }
+      },
+    };
+    this.agentBindings.set(executionId, binding);
+    detachTargetHandle = this.targetSession.executions.addListener(
+      executionId,
+      (handle) => {
+        if (disposed || handle === currentHandle) return;
+        releaseCurrent();
+      },
+    );
+    detachOwnerStatus = ownerSession.status.onDidChange((change) => {
+      if (disposed || change.streamId !== streamId) return;
+      if (
+        !this.targetSession.status.transition(
+          streamId,
+          change.status,
+          change.cause,
+          change.substate ? { substate: change.substate } : {},
+        ) &&
+        this.targetSession.status.get(streamId) !== change.status
+      ) {
+        this.logger.debug('Rejected rebound stream status mirror', {
+          data: {
+            streamId,
+            status: change.status,
+            current: this.targetSession.status.get(streamId),
+          },
+        });
+      }
+    });
+    const ownerDetach = ownerSession.executions.observeHandle(
+      executionId,
+      bindOwnerHandle,
+    );
+    detachOwnerHandle = ownerDetach;
+    if (disposed) ownerDetach();
+  }
+
+  private bindDescendants(
+    rootStreamId: StreamTabId,
+    ownerSession: SessionHandle,
+  ): void {
+    const childStreams = new Set<StreamTabId>([rootStreamId]);
+    for (let grew = true; grew;) {
+      grew = false;
+      for (const executionId of ownerSession.executions.getActiveIds()) {
+        const child = ownerSession.executions.getHandle(executionId);
+        if (child instanceof AgentExecutionHandle) {
+          if (
+            !child.isChildExecution ||
+            !childStreams.has(child.parentStreamId)
+          ) {
+            continue;
+          }
+          if (!childStreams.has(child.childStreamId)) {
+            childStreams.add(child.childStreamId);
+            grew = true;
+          }
+          this.bindAgent(child.executionId, child.childStreamId, ownerSession);
+        } else if (
+          child instanceof ProcessExecutionHandle &&
+          childStreams.has(child.parentStreamId)
+        ) {
+          this.bindProcess(child.executionId, ownerSession);
+        }
+      }
+    }
+  }
+
+  private observeOwnerRegistrations(ownerSession: SessionHandle): void {
+    if (this.ownerRegistrationObservers.has(ownerSession)) return;
+    this.ownerRegistrationObservers.set(
+      ownerSession,
+      ownerSession.executions.addRegistrationListener(() => {
+        for (const [rootStreamId, owner] of this.rootOwners) {
+          if (owner === ownerSession) {
+            this.bindDescendants(rootStreamId, ownerSession);
+          }
+        }
+      }),
+    );
+  }
+
+  private detachOwnerObserverIfUnused(ownerSession: SessionHandle): void {
+    for (const owner of this.rootOwners.values()) {
+      if (owner === ownerSession) return;
+    }
+    this.ownerRegistrationObservers.get(ownerSession)?.();
+    this.ownerRegistrationObservers.delete(ownerSession);
+  }
+
+  private bindProcess(
+    executionId: ExecutionId,
+    ownerSession: SessionHandle,
+  ): void {
+    if (this.processBindings.has(executionId)) return;
+    let currentHandle: ProcessExecutionHandle | undefined;
+    let detachOwnerHandle = (): void => undefined;
+    let disposed = false;
+    const disposeBinding = (): void => {
+      if (disposed) return;
+      disposed = true;
+      detachOwnerHandle();
+      if (currentHandle) {
+        this.targetSession.executions.untrackIfCurrent(currentHandle);
+      }
+      if (this.processBindings.get(executionId) === binding) {
+        this.processBindings.delete(executionId);
+      }
+    };
+    const binding: ReboundProcessBinding = {
+      ownerSession,
+      dispose: disposeBinding,
+    };
+    this.processBindings.set(executionId, binding);
+    const ownerDetach = ownerSession.executions.observeHandle(
+      executionId,
+      (handle) => {
+        if (disposed) return;
+        if (!(handle instanceof ProcessExecutionHandle)) {
+          disposeBinding();
+          return;
+        }
+        currentHandle = handle;
+        this.targetSession.executions.track(handle);
+      },
+    );
+    detachOwnerHandle = ownerDetach;
+    if (disposed) ownerDetach();
+  }
+}

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -38,10 +38,14 @@ import {
 import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
-import type { StreamPhase, StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 
 import { getRunContextSession, tryUseRunContext } from './RunContext';
-import { AgentExecutionHandle, ExecutionRegistry } from './executionRegistry';
+import {
+  AgentExecutionHandle,
+  ExecutionRegistry,
+  type ExecutionHandle,
+} from './executionRegistry';
 import { ExecutionSubscriptionBinder } from './ExecutionSubscriptionBinder';
 import { StreamStatusMachine } from './StreamStatusService';
 import {
@@ -300,11 +304,13 @@ export function getAllActiveExecutionIds(): string[] {
 }
 
 /** A still-active execution found on some other live session, plus that
- * session's own live status for it — authoritative over any stale on-disk
- * snapshot a rebinding window may have separately hydrated. */
+ * owning session itself. The owner's `status`/`executions` are the run's live
+ * runtime spine — authoritative over any stale on-disk snapshot a rebinding
+ * window may have separately hydrated — so a rebinder reads live status,
+ * walks child handles, and forwards host interactions through it. */
 export interface ActiveAgentExecutionLookup {
   readonly handle: AgentExecutionHandle;
-  readonly status: StreamPhase | undefined;
+  readonly session: SessionHandle;
 }
 
 /**
@@ -321,28 +327,31 @@ export function findActiveAgentExecutionHandle(
   for (const session of liveSessions) {
     const handle = session.executions.getHandle(executionId);
     if (handle instanceof AgentExecutionHandle) {
-      return { handle, status: session.status.get(handle.childStreamId) };
+      return { handle, session };
     }
   }
   return undefined;
 }
 
 /**
- * Untrack an execution from every live session that still has it registered
- * — not just the one session that happens to finalize it. A cross-session
- * rebind (via {@link findActiveAgentExecutionHandle} above) tracks the same
- * handle into a second session's registry without removing it from the
- * first. Without this, whichever session finalizes the run (e.g. a user stop
- * issued from a newly recreated window) only clears its own registry,
- * leaving the original `keepActiveExecutions` session's registry non-idle
- * forever: its `disposeWhenIdle` wait loop never observes the change and
- * that session never leaves {@link liveSessions} (#8148).
+ * Untrack an execution handle from every live session that still has it
+ * registered — not just the one session that happens to finalize it. A
+ * cross-session rebind (via {@link findActiveAgentExecutionHandle} above)
+ * tracks the same handle into a second session's registry without removing
+ * it from the first. Without this, whichever session finalizes the run
+ * (e.g. a user stop issued from a newly recreated window) only clears its
+ * own registry, leaving the original `keepActiveExecutions` session's
+ * registry non-idle forever: its `disposeWhenIdle` wait loop never observes
+ * the change and that session never leaves {@link liveSessions} (#8148).
+ *
+ * Matches on the handle identity, not the execution id: a resume replaces a
+ * rebound WAITING handle with a *fresh* handle under the same execution id
+ * (#8229), and releasing the superseded handle by id alone would tear the
+ * fresh, live registration out of its session's registry too.
  */
-export function untrackActiveAgentExecution(executionId: string): void {
+export function untrackActiveAgentExecution(handle: ExecutionHandle): void {
   for (const session of liveSessions) {
-    if (session.executions.getHandle(executionId)) {
-      session.executions.untrack(executionId);
-    }
+    session.executions.untrackIfCurrent(handle);
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -155,6 +155,9 @@ export class ExecutionRegistry {
     string,
     Set<(handle: ExecutionHandle | undefined) => void>
   >();
+  private readonly registrationListeners = new Set<
+    (executionId: string, handle: ExecutionHandle | undefined) => void
+  >();
 
   constructor({
     processOutput = new ProcessOutputPoller(),
@@ -222,10 +225,12 @@ export class ExecutionRegistry {
     this.activeChildRunLoops.clear();
     this.processOutput.dispose();
     for (const executionId of executionIds) {
+      this.notifyRegistrationListeners(executionId, undefined);
       this.notifyWaiters(executionId);
     }
     this.changeCallbacks.clear();
     this.persistentListeners.clear();
+    this.registrationListeners.clear();
   }
 
   /** Register a live child-run loop and return its lifecycle disposer. */
@@ -256,6 +261,8 @@ export class ExecutionRegistry {
       this.processOutput.register(handle);
       this.emitChildActivity(handle.parentStreamId, 'processes');
     }
+    this.notifyRegistrationListeners(handle.executionId, handle);
+    this.notifyWaiters(handle.executionId);
   }
 
   /**
@@ -313,8 +320,16 @@ export class ExecutionRegistry {
     this.untrackHandle(handle);
   }
 
+  /** Remove `handle` only if it is still the current registration. */
+  untrackIfCurrent(handle: ExecutionHandle): boolean {
+    if (this.handles.get(handle.executionId) !== handle) return false;
+    this.untrackHandle(handle);
+    return true;
+  }
+
   private untrackHandle(handle: ExecutionHandle): void {
     this.handles.delete(handle.executionId);
+    this.notifyRegistrationListeners(handle.executionId, undefined);
     this.notifyWaiters(handle.executionId);
     if (handle instanceof AgentExecutionHandle && handle.isChildExecution) {
       this.emitChildActivity(handle.parentStreamId, 'subagents');
@@ -679,6 +694,29 @@ export class ExecutionRegistry {
     };
   }
 
+  /**
+   * Observe the current handle immediately, then every replacement or removal.
+   * Registering before the initial read closes the usual get/listen race.
+   */
+  observeHandle(
+    executionId: string,
+    cb: (handle: ExecutionHandle | undefined) => void,
+  ): () => void {
+    const detach = this.addListener(executionId, cb);
+    cb(this.handles.get(executionId));
+    return detach;
+  }
+
+  /** Observe handle registrations, replacements, and removals across all ids. */
+  addRegistrationListener(
+    cb: (executionId: string, handle: ExecutionHandle | undefined) => void,
+  ): () => void {
+    this.registrationListeners.add(cb);
+    return () => {
+      this.registrationListeners.delete(cb);
+    };
+  }
+
   private emitChildActivity(
     parentStreamId: StreamTabId,
     kind: 'subagents' | 'processes',
@@ -955,6 +993,15 @@ export class ExecutionRegistry {
     // any still-registered persistent listener is firing into the void.
     if (!this.handles.has(executionId)) {
       this.persistentListeners.delete(executionId);
+    }
+  }
+
+  private notifyRegistrationListeners(
+    executionId: string,
+    handle: ExecutionHandle | undefined,
+  ): void {
+    for (const listener of [...this.registrationListeners]) {
+      listener(executionId, handle);
     }
   }
 }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -37,6 +37,48 @@ import {
 setupPlatform({ workspacePath: '/workspace' });
 
 describe('executionRegistry', () => {
+  it('observes the current handle, replacements, and removal in order', () => {
+    const registry = new ExecutionRegistry();
+    const executionId = 'exec-observe-handle';
+    const streamId = 'stream-observe-handle' as StreamTabId;
+    const first = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      streamId,
+      'first',
+      'workflow',
+      createRecordingHost().host,
+    );
+    const second = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      streamId,
+      'second',
+      'workflow',
+      createRecordingHost().host,
+    );
+    const registrations: unknown[] = [];
+    const detachRegistrations = registry.addRegistrationListener(
+      (changedId, handle) => {
+        if (changedId === executionId) registrations.push(handle);
+      },
+    );
+    registry.track(first);
+    const seen: unknown[] = [];
+    const detach = registry.observeHandle(executionId, (handle) => {
+      seen.push(handle);
+    });
+
+    registry.track(second);
+    registry.untrack(executionId);
+
+    expect(seen).toEqual([first, second, undefined]);
+    expect(registrations).toEqual([first, second, undefined]);
+    detach();
+    detachRegistrations();
+    registry.dispose();
+  });
+
   it('owns process-output poller teardown', () => {
     const explicit = createRecordingHost();
     const processOutput = new ProcessOutputPoller();

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3317,51 +3317,111 @@ describe('DesktopProgressBridge', () => {
   // reattaching the run to the new window — so it kept running headless with
   // no rail entry, no live progress, no cancel, and a stale on-disk snapshot.
   describe('window recreation rebind (#8148)', () => {
-    it('reattaches a still-active execution to the newly created window instead of stranding it', async () => {
-      const streamId = 'rebound-stream' as StreamTabId;
-      const executionId = 'ec00cc' as ExecutionId;
+    async function createReboundOwner({
+      streamId,
+      executionId,
+      agentName = 'proofreader',
+      category = AgentCategory.Workflow,
+      messages = [],
+    }: {
+      streamId: StreamTabId;
+      executionId: ExecutionId;
+      agentName?: string;
+      category?: AgentCategory;
+      messages?: unknown[];
+    }) {
       let activeExecutionIds: readonly string[] = [];
       const { bridgeModule } = await loadBridgeModule({
         activeExecutionIds: () => activeExecutionIds,
       });
-      const { AgentExecutionHandle } =
+      const { AgentExecutionHandle, ProcessExecutionHandle } =
         await import('@agent/runtime/executionRegistry');
       const { noopAgentRuntimeHost } =
         await import('@agent/runtime/AgentRuntimeHost');
-
-      // Window A launches a real, still-running execution.
-      const messagesA: unknown[] = [];
       const bridgeA = new bridgeModule.DesktopProgressBridge((message) => {
-        messagesA.push(message);
+        messages.push(message);
       }) as unknown as TestableBridge & { session: SessionHandle };
       await settleProgressEvents();
-
-      const trace = makeFakeTrace();
-      const handle = new AgentExecutionHandle(
-        executionId,
-        streamId,
-        streamId,
-        'proofreader',
-        AgentCategory.Workflow,
-        noopAgentRuntimeHost,
-        trace as unknown as ConstructorParameters<
-          typeof AgentExecutionHandle
-        >[6],
-      );
+      const createHandle = (
+        options: {
+          executionId?: ExecutionId;
+          parentStreamId?: StreamTabId;
+          childStreamId?: StreamTabId;
+          agentName?: string;
+          category?: AgentCategory;
+        } = {},
+      ) => {
+        const nextTrace = makeFakeTrace();
+        const nextHandle = new AgentExecutionHandle(
+          options.executionId ?? executionId,
+          options.parentStreamId ?? streamId,
+          options.childStreamId ?? streamId,
+          options.agentName ?? agentName,
+          options.category ?? category,
+          noopAgentRuntimeHost,
+          nextTrace as unknown as ConstructorParameters<
+            typeof AgentExecutionHandle
+          >[6],
+        );
+        return { handle: nextHandle, trace: nextTrace };
+      };
+      const { handle, trace } = createHandle();
       bridgeA.session.executions.trackAgentExecution(handle, {
         status: STREAM_PHASE.RUNNING,
       });
-      activeExecutionIds = [executionId];
+      const close = (): void => {
+        activeExecutionIds = [executionId];
+        bridgeA.dispose();
+      };
 
-      // Window A closes. The bridge tears down its own UI consumers but
-      // keeps the execution registered (`keepActiveExecutions`) so
-      // process-wide guards still see it running headless.
-      bridgeA.dispose();
+      const reopen = (
+        lastKnownStatus: StreamPhase,
+        reopenedMessages: unknown[] = [],
+      ) => {
+        close();
+        const streamSnapshotStore = createStreamSnapshotStore([
+          restoredSnapshot({ streamId, executionId, lastKnownStatus }),
+        ]);
+        const bridgeB = new bridgeModule.DesktopProgressBridge(
+          (message) => {
+            reopenedMessages.push(message);
+          },
+          { streamSnapshotStore },
+        ) as unknown as TestableBridge & {
+          session: SessionHandle;
+        };
+        return { bridgeB, streamSnapshotStore };
+      };
 
-      // The run keeps emitting while no window exists at all -- this must
-      // not throw, and (correctly) has no live subscriber yet.
+      return {
+        ProcessExecutionHandle,
+        bridgeA,
+        close,
+        createHandle,
+        handle,
+        noopAgentRuntimeHost,
+        reopen,
+        trace,
+      };
+    }
+
+    it('reattaches a still-active execution to the newly created window instead of stranding it', async () => {
+      const streamId = 'rebound-stream' as StreamTabId;
+      const executionId = 'ec00cc' as ExecutionId;
+      // Window A launches a real, still-running execution.
+      const messagesA: unknown[] = [];
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+        messages: messagesA,
+      });
+
+      // Closing the window retains its active execution for global guards.
+      owner.close();
+
+      // Headless progress has no live subscriber but must remain safe.
       expect(() =>
-        trace.emit({
+        owner.trace.emit({
           type: 'status',
           streamId,
           phase: STREAM_PHASE.WAITING,
@@ -3369,35 +3429,23 @@ describe('DesktopProgressBridge', () => {
         }),
       ).not.toThrow();
 
-      // Window B reopens: a brand-new bridge/session, hydrating the ghost
-      // rail entry the closed window last wrote to disk.
+      // Window B reopens from the persisted ghost entry.
       const messagesB: unknown[] = [];
-      const streamSnapshotStoreB = createStreamSnapshotStore([
-        restoredSnapshot({
-          streamId,
-          executionId,
-          lastKnownStatus: STREAM_PHASE.RUNNING,
-        }),
-      ]);
-      const bridgeB = new bridgeModule.DesktopProgressBridge(
-        (message) => {
-          messagesB.push(message);
-        },
-        { streamSnapshotStore: streamSnapshotStoreB },
-      ) as unknown as TestableBridge & { session: SessionHandle };
+      const { bridgeB, streamSnapshotStore: streamSnapshotStoreB } =
+        owner.reopen(STREAM_PHASE.RUNNING, messagesB);
 
       try {
         await (bridgeB as unknown as { restartRepair: Promise<void> })
           .restartRepair;
 
-        // The still-active execution is now owned by window B's session --
-        // a rail entry, and a target `stopStream`/inspect can find.
-        expect(bridgeB.session.executions.getHandle(executionId)).toBe(handle);
+        // Window B can inspect and stop the still-active execution.
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          owner.handle,
+        );
         expect(
           bridgeB.session.executions.getAgentHandleByStream(streamId),
-        ).toBe(handle);
-        // Restored ghosts and the rebound live stream cannot coexist as two
-        // entries for the same stream.
+        ).toBe(owner.handle);
+        // The live binding replaces, rather than duplicates, the ghost.
         expect(
           (
             bridgeB as unknown as {
@@ -3406,10 +3454,8 @@ describe('DesktopProgressBridge', () => {
           ).sessionProgress.hasRestoredStream(streamId),
         ).toBe(false);
 
-        // Subsequent live progress reaches window B exactly once, and the
-        // on-disk snapshot is refreshed even though nothing was watching
-        // between windows.
-        trace.emit({
+        // Later progress reaches B and refreshes its snapshot.
+        owner.trace.emit({
           type: 'status',
           streamId,
           phase: STREAM_PHASE.WAITING,
@@ -3432,12 +3478,7 @@ describe('DesktopProgressBridge', () => {
           ),
         ).toBe(false);
 
-        // Terminal completion untracks the handle from window B's session --
-        // no execution stranded as "still active" once it actually finishes.
-        // Mirrors the real run lifecycle: the trace 'result' event and
-        // `handle.settleResult` are both fired by the run's own finalize
-        // step (settling `handle.result` is what our rebind's cleanup
-        // awaits to untrack).
+        // Mirror the real finalize order: result, settlement, then untrack.
         const resultEvent = {
           type: 'result' as const,
           outcome: RUN_OUTCOME.COMPLETED,
@@ -3447,23 +3488,21 @@ describe('DesktopProgressBridge', () => {
           category: 'workflow' as const,
           isSubagent: false,
         };
-        trace.emit(resultEvent);
-        handle.settleResult(
-          resultEvent as unknown as Parameters<typeof handle.settleResult>[0],
+        owner.trace.emit(resultEvent);
+        owner.handle.settleResult(
+          resultEvent as unknown as Parameters<
+            typeof owner.handle.settleResult
+          >[0],
         );
-        await handle.result;
+        owner.bridgeA.session.executions.untrack(executionId);
+        await owner.handle.result;
         await settleProgressEvents();
         expect(
           bridgeB.session.executions.getHandle(executionId),
         ).toBeUndefined();
-        // Codex P1 (#8207 review): releasing the handle must not stop at
-        // window B's own registry. Window A's session was retained post-
-        // dispose specifically so `keepActiveExecutions` guards keep seeing
-        // this execution until it truly settles -- if only window B's
-        // registry is cleared, window A's registry never goes idle and that
-        // session leaks in the cross-session `liveSessions` set forever.
+        // Both registries must go idle; otherwise retained window A leaks.
         expect(
-          bridgeA.session.executions.getHandle(executionId),
+          owner.bridgeA.session.executions.getHandle(executionId),
         ).toBeUndefined();
       } finally {
         bridgeB.dispose();
@@ -3473,72 +3512,380 @@ describe('DesktopProgressBridge', () => {
     it('seeds the rebound stream with the live owning session status, not a stale on-disk snapshot (codex P2)', async () => {
       const streamId = 'rebound-stream-2' as StreamTabId;
       const executionId = 'ec00dd' as ExecutionId;
-      let activeExecutionIds: readonly string[] = [];
-      const { bridgeModule } = await loadBridgeModule({
-        activeExecutionIds: () => activeExecutionIds,
-      });
-      const { AgentExecutionHandle } =
-        await import('@agent/runtime/executionRegistry');
-      const { noopAgentRuntimeHost } =
-        await import('@agent/runtime/AgentRuntimeHost');
-
-      const bridgeA = new bridgeModule.DesktopProgressBridge(
-        () => {},
-      ) as unknown as TestableBridge & { session: SessionHandle };
-      await settleProgressEvents();
-
-      const trace = makeFakeTrace();
-      const handle = new AgentExecutionHandle(
+      const owner = await createReboundOwner({
+        streamId,
         executionId,
-        streamId,
-        streamId,
-        'proofreader',
-        AgentCategory.Workflow,
-        noopAgentRuntimeHost,
-        trace as unknown as ConstructorParameters<
-          typeof AgentExecutionHandle
-        >[6],
-      );
-      bridgeA.session.executions.trackAgentExecution(handle, {
-        status: STREAM_PHASE.RUNNING,
       });
-      activeExecutionIds = [executionId];
-      bridgeA.dispose();
+      owner.close();
 
-      // The run transitions to WAITING while headless. This mirrors the real
-      // lifecycle path (`ToolUseWaitNode` calling `streamStatus.transitionToWaiting`
-      // directly on the owning session, independent of whether any window is
-      // subscribed) -- window A's own `session.status` stays live and correct
-      // even with no bridge attached, unlike the on-disk snapshot which
-      // nothing persists to while no window exists (#8148).
+      // Owner status stays live while the persisted snapshot remains stale.
       expect(
-        bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
-          trace: trace as unknown as AgentTrace,
+        owner.bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
+          trace: owner.trace as unknown as AgentTrace,
         }),
       ).toBe(true);
-      expect(bridgeA.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+      expect(owner.bridgeA.session.status.get(streamId)).toBe(
+        STREAM_PHASE.WAITING,
+      );
 
-      // Window B reopens with a STALE ghost snapshot still claiming RUNNING
-      // (nothing persisted the WAITING transition above to disk).
-      const streamSnapshotStoreB = createStreamSnapshotStore([
-        restoredSnapshot({
-          streamId,
-          executionId,
-          lastKnownStatus: STREAM_PHASE.RUNNING,
-        }),
-      ]);
-      const bridgeB = new bridgeModule.DesktopProgressBridge(() => {}, {
-        streamSnapshotStore: streamSnapshotStoreB,
-      }) as unknown as TestableBridge & { session: SessionHandle };
+      // Window B's stale ghost still claims RUNNING.
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING);
 
       try {
         await (bridgeB as unknown as { restartRepair: Promise<void> })
           .restartRepair;
 
-        expect(bridgeB.session.executions.getHandle(executionId)).toBe(handle);
-        // Must reflect the live WAITING status from window A's session, not
-        // the stale RUNNING the ghost snapshot hydrated onto window B.
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          owner.handle,
+        );
+        // The authoritative owner status wins over the ghost snapshot.
         expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('forwards the owner session host interactions to the reopened window (#8227)', async () => {
+      const streamId = 'rebound-stream-3' as StreamTabId;
+      const executionId = 'ec00ee' as ExecutionId;
+      const messagesA: unknown[] = [];
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+        messages: messagesA,
+      });
+      const messagesB: unknown[] = [];
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING, messagesB);
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        // The retained run still resolves interactions through window A.
+        const planPromise =
+          owner.bridgeA.runtimeHost.interactions?.requestPlanApproval?.({
+            approvalId: 'plan-rebound',
+            streamId,
+            plan: { objective: 'Prove approvals reach the new window.' },
+            goalEnabled: false,
+          });
+        expect(planPromise).toBeDefined();
+
+        // The forwarded prompt surfaces only in window B.
+        await vi.waitFor(() => {
+          expect(
+            progressMessages(
+              messagesB,
+              PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+            ),
+          ).toContainEqual(
+            expect.objectContaining({
+              action: 'show',
+              permission: expect.objectContaining({
+                kind: PERMISSION_KIND.PLAN_APPROVAL,
+                data: expect.objectContaining({ approvalId: 'plan-rebound' }),
+              }),
+            }),
+          );
+        });
+        expect(
+          progressMessages(messagesA, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toEqual([]);
+
+        // Window B resolves the retained run's pending interaction.
+        expect(
+          bridgeB.session.interactions.resolve('plan-rebound', {
+            kind: 'plan',
+            action: 'approve',
+          }),
+        ).toBe(true);
+        await expect(planPromise).resolves.toEqual({ action: 'approve' });
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('rebinds still-active child subagent and process handles so stops cascade from the new window (#8228)', async () => {
+      const streamId = 'rebound-stream-4' as StreamTabId;
+      const childStreamId = 'rebound-child-4' as StreamTabId;
+      const executionId = 'ec00f0' as ExecutionId;
+      const childExecutionId = 'ec00f1' as ExecutionId;
+      const processExecutionId = 'ec00f2' as ExecutionId;
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+      });
+      const { ProcessExecutionHandle } = owner;
+      const rootInterrupt = vi.fn();
+      owner.handle.attachInterruptHandler({ interrupt: rootInterrupt });
+
+      // Child handles have no persisted ghosts; only the owner knows them.
+      const { handle: childHandle } = owner.createHandle({
+        executionId: childExecutionId,
+        childStreamId,
+        agentName: 'searcher',
+        category: AgentCategory.ToolUse,
+      });
+      const killProcess = vi.fn(() => true);
+      const processHandle = new ProcessExecutionHandle(
+        processExecutionId,
+        streamId,
+        'bash',
+        killProcess,
+        owner.noopAgentRuntimeHost,
+      );
+      const childInterrupt = vi.fn();
+      childHandle.attachInterruptHandler({ interrupt: childInterrupt });
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING);
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        // Children launched after startup repair are observed for root life.
+        owner.bridgeA.session.executions.trackAgentExecution(childHandle, {
+          status: STREAM_PHASE.RUNNING,
+        });
+        owner.bridgeA.session.executions.track(processHandle);
+
+        // Both children and the child status are now visible in window B.
+        expect(bridgeB.session.executions.getHandle(childExecutionId)).toBe(
+          childHandle,
+        );
+        expect(bridgeB.session.executions.getHandle(processExecutionId)).toBe(
+          processHandle,
+        );
+        expect(bridgeB.session.status.get(childStreamId)).toBe(
+          STREAM_PHASE.RUNNING,
+        );
+
+        // Native child follow-ups replace the owner-side handle and trace.
+        const { handle: freshChildHandle } = owner.createHandle({
+          executionId: childExecutionId,
+          childStreamId,
+          agentName: 'searcher',
+          category: AgentCategory.ToolUse,
+        });
+        const freshChildInterrupt = vi.fn();
+        freshChildHandle.attachInterruptHandler({
+          interrupt: freshChildInterrupt,
+        });
+        owner.bridgeA.session.executions.track(freshChildHandle);
+        expect(bridgeB.session.executions.getHandle(childExecutionId)).toBe(
+          freshChildHandle,
+        );
+
+        // Stop cascades through root, current child turn, and process.
+        bridgeB.session.executions.stopAgentStream(streamId);
+        expect(rootInterrupt).toHaveBeenCalledTimes(1);
+        expect(childInterrupt).not.toHaveBeenCalled();
+        expect(freshChildInterrupt).toHaveBeenCalledTimes(1);
+        expect(killProcess).toHaveBeenCalledTimes(1);
+
+        // Owner-side process removal clears the mirrored entry too.
+        owner.bridgeA.session.executions.untrack(processExecutionId);
+        expect(
+          bridgeB.session.executions.getHandle(processExecutionId),
+        ).toBeUndefined();
+
+        // Owner-side child removal clears both registries.
+        freshChildHandle.settleResult({
+          type: 'result',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId: childExecutionId,
+          streamId: childStreamId,
+          agentName: 'searcher',
+          category: 'toolUse',
+          isSubagent: true,
+        } as unknown as Parameters<typeof freshChildHandle.settleResult>[0]);
+        owner.bridgeA.session.executions.untrack(childExecutionId);
+        await freshChildHandle.result;
+        await settleProgressEvents();
+        expect(
+          bridgeB.session.executions.getHandle(childExecutionId),
+        ).toBeUndefined();
+        expect(
+          owner.bridgeA.session.executions.getHandle(childExecutionId),
+        ).toBeUndefined();
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('overwrites a stale WAITING seed with live RUNNING and mirrors later transitions (#8230, #8231)', async () => {
+      const streamId = 'rebound-stream-5' as StreamTabId;
+      const executionId = 'ec00f3' as ExecutionId;
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+      });
+      // The owner is RUNNING while the persisted snapshot says WAITING.
+      const { bridgeB } = owner.reopen(STREAM_PHASE.WAITING);
+      const resultsSeenByB: unknown[] = [];
+      const detachResult = bridgeB.session.onResult((event) => {
+        resultsSeenByB.push(event);
+      });
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          owner.handle,
+        );
+        // Rebind replays the missed resume rather than preserving WAITING.
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+
+        // Later owner transitions continue mirroring into window B.
+        expect(
+          owner.bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
+            trace: owner.trace as unknown as AgentTrace,
+          }),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+        expect(
+          owner.bridgeA.session.status.transition(
+            streamId,
+            STREAM_PHASE.RUNNING,
+            'resume',
+            { trace: owner.trace as unknown as AgentTrace },
+          ),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+
+        // A later owner turn replaces both handle and trace.
+        const { handle: freshHandle, trace: freshTrace } = owner.createHandle();
+        owner.bridgeA.session.executions.track(freshHandle);
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          freshHandle,
+        );
+        expect(
+          owner.bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
+            trace: freshTrace as unknown as AgentTrace,
+          }),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+
+        const resultEvent = {
+          type: 'result' as const,
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+          agentName: 'proofreader',
+          category: 'workflow' as const,
+          isSubagent: false,
+        };
+        freshTrace.emit(resultEvent);
+        expect(resultsSeenByB).toContainEqual(resultEvent);
+        expect(bridgeB.session.status.get(streamId)).toBe(
+          STREAM_PHASE.COMPLETED,
+        );
+        owner.bridgeA.session.executions.untrack(executionId);
+        expect(
+          bridgeB.session.executions.getHandle(executionId),
+        ).toBeUndefined();
+      } finally {
+        detachResult();
+        bridgeB.dispose();
+      }
+    });
+
+    it('detaches agent and process mirrors when the reopened window closes', async () => {
+      const streamId = 'rebound-stream-dispose' as StreamTabId;
+      const executionId = 'ec00f5' as ExecutionId;
+      const processExecutionId = 'ec00f6' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING);
+      await (bridgeB as unknown as { restartRepair: Promise<void> })
+        .restartRepair;
+
+      const processHandle = new owner.ProcessExecutionHandle(
+        processExecutionId,
+        streamId,
+        'bash',
+        () => true,
+        owner.noopAgentRuntimeHost,
+      );
+      owner.bridgeA.session.executions.track(processHandle);
+      expect(bridgeB.session.executions.getHandle(processExecutionId)).toBe(
+        processHandle,
+      );
+
+      bridgeB.dispose();
+      expect(bridgeB.session.executions.getHandle(executionId)).toBeUndefined();
+      expect(
+        bridgeB.session.executions.getHandle(processExecutionId),
+      ).toBeUndefined();
+
+      const { handle: freshHandle } = owner.createHandle();
+      owner.bridgeA.session.executions.track(freshHandle);
+      owner.bridgeA.session.executions.untrack(processExecutionId);
+      expect(bridgeB.session.executions.getHandle(executionId)).toBeUndefined();
+      expect(
+        bridgeB.session.executions.getHandle(processExecutionId),
+      ).toBeUndefined();
+      owner.bridgeA.session.executions.untrack(executionId);
+    });
+
+    it('releases the original session registration when a resume supersedes the rebound handle (#8229)', async () => {
+      const streamId = 'rebound-stream-6' as StreamTabId;
+      const executionId = 'ec00f4' as ExecutionId;
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+        agentName: 'search',
+        category: AgentCategory.ToolUse,
+      });
+      owner.close();
+      // Suspend while headless before reopening.
+      expect(
+        owner.bridgeA.session.status.transitionToWaiting(streamId, 'wait', {
+          trace: owner.trace as unknown as AgentTrace,
+        }),
+      ).toBe(true);
+      const { bridgeB } = owner.reopen(STREAM_PHASE.WAITING);
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          owner.handle,
+        );
+
+        // Local resume replaces the rebound handle under the same id.
+        const { handle: freshHandle } = owner.createHandle();
+        bridgeB.session.executions.track(freshHandle);
+        expect(
+          bridgeB.session.status.transition(
+            streamId,
+            STREAM_PHASE.RUNNING,
+            'resume',
+          ),
+        ).toBe(true);
+
+        // The replacement releases window A's stale registration.
+        expect(
+          owner.bridgeA.session.executions.getHandle(executionId),
+        ).toBeUndefined();
+        // Identity-safe cleanup preserves the fresh local handle.
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          freshHandle,
+        );
+
+        // Even a late settle of the stale handle cannot clobber the fresh one.
+        owner.handle.settleResult({
+          type: 'result',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId,
+          streamId,
+          agentName: 'search',
+          category: 'toolUse',
+          isSubagent: false,
+        } as unknown as Parameters<typeof owner.handle.settleResult>[0]);
+        await owner.handle.result;
+        await settleProgressEvents();
+        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
+          freshHandle,
+        );
       } finally {
         bridgeB.dispose();
       }


### PR DESCRIPTION
Closes #8227
Closes #8228
Closes #8229
Closes #8230
Closes #8231

## Summary

Window recreation now uses one focused `DesktopExecutionRebinder` instead of one-shot handle wiring inside the 1,600-line desktop bridge. It keeps the retained owner session as the runtime spine while mirroring the current handle, trace, status, children, processes, and host interactions into the replacement window.

## Design

- `ExecutionRegistry.observeHandle()` registers first, emits the current handle synchronously, and then observes every `track` replacement and `untrack`. `track()` now notifies observers, and `untrackIfCurrent()` centralizes identity-safe removal.
- Each rebound agent binding watches both registries:
  - owner-side replacements rebind the new per-turn handle and trace into the target;
  - target-side replacements mean ownership moved to the reopened window, so only stale mirrored handles are removed from retained sessions.
- Status mirrors directly from the owner status machine for the binding lifetime. A fresh turn's trace is attached before events fire, and terminal `result` events project terminal status before owner untrack can detach the bridge.
- Rebound root ownership survives restored-ghost eviction. A registration-only owner observer discovers child agents/processes even after startup repair has completed, without rescanning on status changes.
- Process mirrors use synchronous `observeHandle()` initialization, closing the get/listen untrack race.
- `DesktopExecutionRebinder.dispose()` detaches registry/status/trace observers, removes only mirrored target handles, and leaves authoritative owner executions running for the next window.
- Owner host-interaction slots forward to the live replacement window and detach when that window closes.

## Test cleanup

The rebind scenarios now share a two-phase owner/reopen fixture and handle factory. Despite adding owner-turn replacement, repeated-child-rescan, synchronous-observer, terminal-trace, and window-dispose coverage, the desktop test delta is 87 lines smaller than the original PR version.

## Validation

- Focused Vitest: 3 files, 105 tests passed
- Root `tsc --noEmit`: passed
- Test-kernel `tsc --noEmit -p tsconfig.test-kernel.json`: passed
- ESLint and Prettier on all touched TypeScript files: passed
- `git diff --check`: passed
- Strengthened tests proven against the rebased pre-fix PR head: repeated child discovery, owner-side replacement, and synchronous observation all fail
- Independent final lifecycle review: no findings

`compile:fast` could not run in the isolated worktree because pnpm attempted to relink its shared `node_modules`; CI will validate a clean install, full suite, compile, and package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-session execution registry mirroring, status sync, and interaction forwarding—complex lifecycle edge cases (#8148, #8227–#8231) but heavily covered by new Vitest scenarios.
> 
> **Overview**
> **Desktop window recreation** no longer relies on one-shot handle wiring in the progress bridge. A new **`DesktopExecutionRebinder`** keeps the **retained owner session** as the runtime spine while **mirroring** handles, traces, status, child subagents, background processes, and **host interactions** (approvals, questions, etc.) into the replacement window.
> 
> **`ExecutionRegistry`** gains **`observeHandle`** (subscribe-then-emit-current to avoid races), **`addRegistrationListener`**, and **`untrackIfCurrent`** so superseded handles can be dropped without killing a fresh registration under the same execution id. **`findActiveAgentExecutionHandle`** now returns the **owning session**; **`untrackActiveAgentExecution`** untracks by **handle identity** across all live sessions.
> 
> Restart repair still calls rebind **before** forgetting ghost streams; the rebinder **disposes** cleanly when the new window closes, leaving authoritative runs on the owner session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d007eee34775e2d988f276833bbb813f7c9c8f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
