### PR TITLE
refactor(agent): scope approval queues and pending state per session

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -49,7 +49,7 @@ import {
 } from '@model/apiProviders';
 import { isUpstreamCreditDepletedError } from '@shared/schemas';
 import {
-  proposalApprovalState,
+  proposalApprovals,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
@@ -489,7 +489,7 @@ async function requestProposalInteraction(
     decision.bypass === 'superYolo' &&
     request.streamId
   ) {
-    proposalApprovalState.setBypass(request.streamId, true, host);
+    proposalApprovals().setBypass(request.streamId, true, host);
     setTuiApprovalBypassState({
       streamId: request.streamId,
       kind: 'superYolo',

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -272,7 +272,8 @@ export class DesktopProgressBridge {
         return this.postToRenderer(message) !== false;
       },
       hasTarget: () => true,
-      getStreamControls: getProgressStreamControls,
+      getStreamControls: (stream) =>
+        getProgressStreamControls(stream, this.session),
       deleteStream: (stream) => this.deleteStream(stream),
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
@@ -528,6 +529,7 @@ export class DesktopProgressBridge {
         },
         bypass: {
           runtimeHost: this.runtimeHost,
+          session: this.session,
         },
         file: {
           openFile: async (file, line) => {
@@ -1213,19 +1215,18 @@ export class DesktopProgressBridge {
       ...this.sessionProgress.restoredStreams.keys(),
     ]);
     // Approval cleanup (incl. retry/proposal/plan pending state) is scoped
-    // to THIS window's streams via the per-stream helper, NOT the process-wide
-    // `cleanupAllApprovals` reset — so one window's "delete all" can't wipe
-    // another window's pending approvals (the approval controllers are
-    // process-global and streamId-keyed; the interaction half is session-owned).
+    // to THIS window's streams via the per-stream helper. Approval state is
+    // session-owned, so none of this can touch another window's pending
+    // approvals or bypass flags.
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
       releaseStreamResources(streamId, this.session);
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not
-    // equal any StreamTabId. Scope this to THIS window's runtime host so a
-    // sibling window's streamless approval is not rejected.
-    cleanupUnscopedApprovals(this.runtimeHost, this.session);
+    // equal any StreamTabId. Session-scoped, so a sibling window's streamless
+    // approval is not rejected.
+    cleanupUnscopedApprovals(this.session);
     // Child/subagent interaction requests may be session-owned without a local
     // desktop stream entry, so cancel the owning window's remaining pending
     // interactions after the visible per-stream sweep. This is session-scoped

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -76,9 +76,7 @@ class DesktopHostInteractions implements HostInteractions {
   requestToolEditApproval(
     request: ToolEditApprovalRequest,
   ): Promise<ToolEditApprovalResult> {
-    return this.options
-      .getToolEditApprovals()
-      .requestApproval(request, this.options.session);
+    return this.options.getToolEditApprovals().requestApproval(request);
   }
 
   requestBashApproval(

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -47,7 +47,6 @@ export interface DesktopToolEditApprovalController {
   }): boolean;
   requestApproval(
     request: ToolEditApprovalRequest,
-    session?: SessionHandle,
   ): Promise<ToolEditApprovalResult>;
   dispose(): void;
 }
@@ -71,7 +70,6 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
 
   async requestApproval(
     request: ToolEditApprovalRequest,
-    session: SessionHandle = this.options.session,
   ): Promise<ToolEditApprovalResult> {
     if (this.disposed) {
       throw new Error('Desktop tool edit approval controller is disposed.');
@@ -93,16 +91,24 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
       };
       entry.isSettled = () => settled;
       this.pending.set(requestId, entry);
-      registerPendingApproval(requestId, {
-        // `streamId` is `.nullish()` on the tool schema (string | null |
-        // undefined); the approval registry expects `string | undefined`, so
-        // collapse null → undefined (matches nativeToolEditApproval).
-        streamId: request.streamId ?? undefined,
-        runtimeHost: this.options.runtimeHost,
-        isSettled: () => settled,
-        settle: (value) => this.settle(requestId, value),
-      });
-      this.showProgressPermission(session, requestId, request, lineChanges);
+      registerPendingApproval(
+        requestId,
+        {
+          // `streamId` is `.nullish()` on the tool schema (string | null |
+          // undefined); the approval registry expects `string | undefined`, so
+          // collapse null → undefined (matches nativeToolEditApproval).
+          streamId: request.streamId ?? undefined,
+          isSettled: () => settled,
+          settle: (value) => this.settle(requestId, value),
+        },
+        this.options.session,
+      );
+      this.showProgressPermission(
+        this.options.session,
+        requestId,
+        request,
+        lineChanges,
+      );
     });
 
     if (result.accepted && result.appliedContent != null) return result;
@@ -217,7 +223,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     if (!entry || entry.isSettled()) return;
 
     this.pending.delete(requestId);
-    unregisterPendingApproval(requestId);
+    unregisterPendingApproval(requestId, this.options.session);
     entry.settle(result);
     this.options.runtimeHost.emit('resolveToolEditPermission', { requestId });
     this.cleanupEntry(entry);

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -216,13 +216,16 @@ export async function nativeRequestApproval(
       };
 
       pendingApprovals.set(requestId, entry);
-      // Register with the pure module for rejection tracking
-      registerPendingApproval(requestId, {
-        streamId: streamId ?? undefined,
-        runtimeHost: getRuntimeHost(),
-        isSettled: () => approvalSettled,
-        settle,
-      });
+      // Register with the owning session's registry for rejection tracking
+      registerPendingApproval(
+        requestId,
+        {
+          streamId: streamId ?? undefined,
+          isSettled: () => approvalSettled,
+          settle,
+        },
+        options.session,
+      );
 
       // Closing the proposed diff tab (e.g. Ctrl+W) must resolve the approval
       // as a rejection. Without this the approval Promise would never settle
@@ -307,7 +310,7 @@ export async function nativeRequestApproval(
     // Get entry before deleting to access workspace temp cleanup functions
     const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);
-    unregisterPendingApproval(requestId);
+    unregisterPendingApproval(requestId, options.session);
     if (diffSession) {
       await diffViewHost.closeDiff(diffSession);
     }

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -57,9 +57,9 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   }
 
   cleanupDeletedStreams(streams: StreamTabId[]): void {
-    // Process-wide approval reset for the single-session extension host.
-    // Queues are session-owned, so they are released per stream after the
-    // approval sweep through the same helper used by single-stream deletes.
+    // Default-session approval reset for the single-session extension host.
+    // Follow-up queues are released per stream after the approval sweep
+    // through the same helper used by single-stream deletes.
     cleanupAllApprovals();
     for (const stream of streams) {
       releaseStreamResources(stream);

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -49,6 +49,10 @@ import {
   type HostInteractions,
 } from './HostInteractions';
 import { SessionEventHub } from './SessionEventHub';
+import {
+  createSessionApprovals,
+  type SessionApprovals,
+} from './streamApprovalQueue';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('sessionHandle');
@@ -94,6 +98,8 @@ export class SessionHandle {
   readonly flushers: Set<() => void>;
   /** Session-scoped host interaction owner. */
   readonly interactions: SessionHostInteractions;
+  /** Session-owned approval queues, pending registries, and bypass state. */
+  readonly approvals: SessionApprovals;
   /**
    * Optional session-scoped emit surface for the non-run-scoped host-path
    * emissions (SDK Step 7d follow-on F-1). Unset ⇒ those stay on the bus.
@@ -131,6 +137,7 @@ export class SessionHandle {
     this.transcripts = transcripts;
     this.followUps = followUps;
     this.interactions = init.interactions ?? new SessionHostInteractions();
+    this.approvals = createSessionApprovals();
     // A fresh session owns its own flusher set; the default session aliases
     // the process-module set (`getActiveFlushers()`) so the process-wide
     // shutdown drain (`flushPendingRunTraces()`) still reaches it.
@@ -256,6 +263,9 @@ export class SessionHandle {
   private teardownOwners(): void {
     this.subscriptions.dispose();
     this.executions.dispose();
+    // Settle any approval still pending in this session (rejected) and drop
+    // its bypass state before the interaction slot itself is torn down.
+    this.approvals.rejectAndClearAll();
     this.interactions.dispose();
     this.resultListeners.clear();
   }

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -1,20 +1,27 @@
 /**
- * Generic stream-scoped approval controller.
+ * Generic stream-scoped approval controller, owned per session.
  *
  * Encapsulates the shared concerns of bash and tool-edit approvals:
- *   - serialized request queue (one prompt at a time)
+ *   - serialized request queue (one prompt at a time within a session)
  *   - registry of in-flight pending approvals keyed by request id
  *   - per-stream bypass state announced over a bound progress event
  *   - rejection on stream cleanup
  *
  * Parameterized by the approval result type so each controller can carry
  * domain-specific result fields (e.g. tool-edit appliedContent / userPatch).
+ *
+ * Controller instances live on {@link SessionApprovals}, one per
+ * `SessionHandle` (#8144) — there is no process-global controller, so two
+ * sessions queue, resolve, and clean up approvals independently.
  */
 
 import PQueue from 'p-queue';
 
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
+import type { ToolEditApprovalResult } from '@platform/interfaces';
+
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type { HostBashApprovalResult } from './HostInteractions';
 
 /** Progress events that announce per-stream approval-bypass changes. */
 export type ApprovalBypassEvent =
@@ -86,7 +93,6 @@ export function createStreamApprovalBypass(
 
 export interface PendingApproval<R extends { accepted: boolean }> {
   streamId?: StreamTabId;
-  runtimeHost?: AgentRuntimeHost;
   isSettled: () => boolean;
   settle: (result: R) => void;
 }
@@ -94,15 +100,15 @@ export interface PendingApproval<R extends { accepted: boolean }> {
 export interface StreamApprovalController<R extends { accepted: boolean }> {
   registerPending(id: string, entry: PendingApproval<R>): void;
   unregisterPending(id: string): void;
-  getPending(id: string): PendingApproval<R> | undefined;
   bypass: StreamApprovalBypass;
   enqueue<T>(run: () => Promise<T>): Promise<T>;
   rejectPendingForStream(streamId: StreamTabId): void;
   /**
-   * Reject pending entries with no concrete stream context. When `runtimeHost`
-   * is provided, only rejects entries owned by that host.
+   * Reject pending entries with no concrete stream context (streamId is
+   * undefined or empty). The controller is session-owned, so this never
+   * reaches another session's streamless approvals.
    */
-  rejectUnscopedPending(runtimeHost?: AgentRuntimeHost): void;
+  rejectUnscopedPending(): void;
   rejectAllPending(): void;
 }
 
@@ -137,9 +143,6 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     unregisterPending(id) {
       pending.delete(id);
     },
-    getPending(id) {
-      return pending.get(id);
-    },
     bypass: createStreamApprovalBypass(options.bypassEvent),
     enqueue<T>(run: () => Promise<T>): Promise<T> {
       // `add` widens to `T | void` to cover abort via signal/timeout; we pass
@@ -149,15 +152,58 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     rejectPendingForStream(streamId) {
       rejectWhere((entry) => entry.streamId === streamId);
     },
-    rejectUnscopedPending(runtimeHost) {
-      rejectWhere(
-        (entry) =>
-          !entry.streamId &&
-          (runtimeHost === undefined || entry.runtimeHost === runtimeHost),
-      );
+    rejectUnscopedPending() {
+      rejectWhere((entry) => !entry.streamId);
     },
     rejectAllPending() {
       rejectWhere(() => true);
+    },
+  };
+}
+
+/**
+ * Session-owned approval state: the tool-edit and bash controllers plus the
+ * delegation-proposal (super-YOLO) bypass. One instance per `SessionHandle`
+ * (`session.approvals`); run-scoped code resolves it through
+ * `currentSession()`, host code passes its own session explicitly.
+ */
+export interface SessionApprovals {
+  readonly toolEdit: StreamApprovalController<ToolEditApprovalResult>;
+  readonly bash: StreamApprovalController<HostBashApprovalResult>;
+  /**
+   * Per-stream bypass for agent delegation proposals (super-YOLO). Proposals
+   * settle through the run coordinators rather than a stream approval queue,
+   * so unlike bash / tool-edit there is no controller — only bypass state.
+   */
+  readonly proposal: StreamApprovalBypass;
+  /**
+   * Reject every pending approval and clear all bypass + proposal state for
+   * this session. Used by session teardown and the session-wide
+   * `cleanupAllApprovals` sweep.
+   */
+  rejectAndClearAll(): void;
+}
+
+export function createSessionApprovals(): SessionApprovals {
+  const toolEdit = createStreamApprovalController<ToolEditApprovalResult>({
+    rejectionResult: () => ({ accepted: false }),
+    bypassEvent: 'updateToolEditApprovalBypassState',
+  });
+  const bash = createStreamApprovalController<HostBashApprovalResult>({
+    rejectionResult: () => ({ accepted: false }),
+    bypassEvent: 'updateBashApprovalBypassState',
+  });
+  const proposal = createStreamApprovalBypass('updateSuperYoloBypassState');
+  return {
+    toolEdit,
+    bash,
+    proposal,
+    rejectAndClearAll() {
+      toolEdit.rejectAllPending();
+      bash.rejectAllPending();
+      toolEdit.bypass.clearAll();
+      bash.bypass.clearAll();
+      proposal.clearAll();
     },
   };
 }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -9,7 +9,7 @@ import type {
 } from '@shared/schemas/progressView';
 import {
   isApprovalBypassedForStream,
-  proposalApprovalState,
+  proposalApprovals,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
@@ -74,6 +74,11 @@ export interface ProgressViewFollowUpCommandActions {
 
 export interface ProgressViewBypassCommandOptions {
   runtimeHost: AgentRuntimeHost;
+  /**
+   * Session that owns the approval bypass state. Desktop scopes it to its
+   * window session; the extension omits it so the default session applies.
+   */
+  session?: SessionHandle;
   showInfo?(message: string): void | PromiseLike<unknown>;
 }
 
@@ -149,7 +154,7 @@ export function createProgressViewCommandHandlers(
   actions: ProgressViewCommandActions,
 ) {
   const { lifecycle, run, file, followUp, approval, externalInquiry } = actions;
-  const { runtimeHost, showInfo } = actions.bypass;
+  const { runtimeHost, session, showInfo } = actions.bypass;
 
   // Single source of truth for the coupled edit + bash session bypass behind
   // the one Yolo concept. The shield toolbar button flips it; the inline "Yolo
@@ -159,9 +164,10 @@ export function createProgressViewCommandHandlers(
     stream: StreamTabId,
     enabled: boolean,
   ): Promise<void> => {
-    setToolEditApprovalSessionBypass(stream, enabled, runtimeHost);
+    setToolEditApprovalSessionBypass(stream, enabled, runtimeHost, { session });
     setBashApprovalSessionBypass(stream, enabled, runtimeHost, {
       silent: true,
+      session,
     });
     await showInfo?.(
       enabled
@@ -180,14 +186,17 @@ export function createProgressViewCommandHandlers(
     enabled: boolean,
   ): Promise<void> => {
     if (enabled) {
-      if (!isApprovalBypassedForStream(stream)) {
-        setToolEditApprovalSessionBypass(stream, true, runtimeHost);
+      if (!isApprovalBypassedForStream(stream, session)) {
+        setToolEditApprovalSessionBypass(stream, true, runtimeHost, {
+          session,
+        });
       }
     } else {
-      setToolEditApprovalSessionBypass(stream, false, runtimeHost);
+      setToolEditApprovalSessionBypass(stream, false, runtimeHost, { session });
     }
     setBashApprovalSessionBypass(stream, enabled, runtimeHost, {
       silent: true,
+      session,
     });
     await showInfo?.(
       enabled
@@ -246,7 +255,7 @@ export function createProgressViewCommandHandlers(
     [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: (data) =>
       applyCoupledBypass(
         data.stream,
-        !isApprovalBypassedForStream(data.stream),
+        !isApprovalBypassedForStream(data.stream, session),
       ),
     // Inline "Yolo (this session)" prompt button: force bypass ON. Unlike the
     // shield toggle this is idempotent, so it can never invert an already-on
@@ -257,7 +266,7 @@ export function createProgressViewCommandHandlers(
     [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: (data) =>
       applySuperYoloBypass(
         data.stream,
-        proposalApprovalState.toggleBypass(data.stream, runtimeHost),
+        proposalApprovals(session).toggleBypass(data.stream, runtimeHost),
       ),
     // Inline "Super Yolo (this session)" proposal button: force the
     // delegated-task auto-approval bypass ON. Idempotent like
@@ -268,7 +277,7 @@ export function createProgressViewCommandHandlers(
     // enabled branch: edit bypass rides along only if not already on, bash
     // silently.
     [PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS]: (data) => {
-      proposalApprovalState.setBypass(data.stream, true, runtimeHost);
+      proposalApprovals(session).setBypass(data.stream, true, runtimeHost);
       return applySuperYoloBypass(data.stream, true);
     },
 

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -1,20 +1,22 @@
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import { isGoalInFlight } from '@shared/schemas/goal';
 import {
   isApprovalBypassedForStream,
-  proposalApprovalState,
+  proposalApprovals,
 } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 import type { ProgressStreamControls } from '@controllers/progressView/backend/events/ProgressFactApplier';
 
 export function getProgressStreamControls(
   streamId: StreamTabId,
+  session?: SessionHandle,
 ): ProgressStreamControls {
   const goal = GoalStore.getForStream(streamId);
   const goalActive = isGoalInFlight(goal);
   return {
-    toolEditBypass: isApprovalBypassedForStream(streamId),
-    superYoloBypass: proposalApprovalState.isBypassed(streamId),
+    toolEditBypass: isApprovalBypassedForStream(streamId, session),
+    superYoloBypass: proposalApprovals(session).isBypassed(streamId),
     goalActive,
     ...(goalActive && goal
       ? { goalStatus: goal.status, goalObjective: goal.objective }

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -12,7 +12,7 @@ import type { StreamTabId } from '@shared/schemas';
 import { AskUserQuestionTool } from '@tools/userQuestion';
 import {
   cleanupAllApprovals,
-  proposalApprovalState,
+  proposalApprovals,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
@@ -286,7 +286,7 @@ describe('human prompt progress events', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:proposal-bypass' as StreamTabId;
 
-    const enabled = proposalApprovalState.toggleBypass(streamId, explicit.host);
+    const enabled = proposalApprovals().toggleBypass(streamId, explicit.host);
 
     expect(enabled).toBe(true);
     expect(explicit.events).toEqual([

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -21,6 +21,7 @@ import type {
   SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /**
@@ -322,14 +323,19 @@ export function createRecordingHost(): {
 }
 
 /**
- * Minimal session stand-in exposing only `interactions` — enough for
- * run-scoped code that resolves `currentSession().interactions` (plan
- * approvals, proposals, retries) to reach the given port implementation.
+ * Minimal session stand-in exposing `interactions` plus fresh session-owned
+ * approval state — enough for run-scoped code that resolves
+ * `currentSession().interactions` (plan approvals, proposals, retries) or
+ * `currentSession().approvals` (bypass state, queues) to reach isolated
+ * instances.
  */
 export function sessionWithInteractions(
   interactions: HostInteractions | undefined,
 ): SessionHandle {
-  return { interactions } as unknown as SessionHandle;
+  return {
+    interactions,
+    approvals: createSessionApprovals(),
+  } as unknown as SessionHandle;
 }
 
 /**

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -66,6 +66,7 @@ describe('SessionHandle', () => {
       expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
       expect(fresh.followUps).not.toBe(defaultSession().followUps);
+      expect(fresh.approvals).not.toBe(defaultSession().approvals);
       expect(fresh.flushers).not.toBe(getActiveFlushers());
       expect(fresh.hostChannel).toBeUndefined();
     } finally {

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -19,7 +19,7 @@ import {
   cleanupAllApprovals,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
-  proposalApprovalState,
+  proposalApprovals,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
@@ -488,7 +488,7 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     ).toBe(true);
     await Promise.resolve();
 
-    expect(proposalApprovalState.isBypassed(stream)).toBe(true);
+    expect(proposalApprovals().isBypassed(stream)).toBe(true);
     expect(isApprovalBypassedForStream(stream)).toBe(true);
     expect(isBashApprovalBypassedForStream(stream)).toBe(true);
     expect(events).toEqual([
@@ -516,7 +516,7 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     ).toBe(true);
     await Promise.resolve();
 
-    expect(proposalApprovalState.isBypassed(stream)).toBe(false);
+    expect(proposalApprovals().isBypassed(stream)).toBe(false);
     expect(isApprovalBypassedForStream(stream)).toBe(false);
     expect(isBashApprovalBypassedForStream(stream)).toBe(false);
     expect(events.slice(-2)).toEqual([

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -111,9 +111,8 @@ async function createInteractions(handlers = createHandlers()) {
 }
 
 describe('createDesktopHostInteractions', () => {
-  it('delegates tool edit approvals with this window session', async () => {
-    const { interactions, session, toolEditApprovals } =
-      await createInteractions();
+  it('delegates tool edit approvals to the window controller', async () => {
+    const { interactions, toolEditApprovals } = await createInteractions();
     const request = {
       path: '/workspace/paper.tex',
       originalContent: 'old',
@@ -125,10 +124,9 @@ describe('createDesktopHostInteractions', () => {
     await expect(
       interactions.requestToolEditApproval(request),
     ).resolves.toEqual({ accepted: true });
-    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(
-      request,
-      session,
-    );
+    // The controller owns its window session (options.session), so the call
+    // carries only the request.
+    expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(request);
   });
 
   it('rejects a resolution whose kind does not match the pending request', async () => {

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -46,7 +46,6 @@ interface DesktopToolEditApprovalModule {
     }): boolean;
     requestApproval(
       request: ToolEditApprovalRequest,
-      session?: SessionHandle,
     ): Promise<ToolEditApprovalResult>;
     dispose(): void;
   };
@@ -156,12 +155,18 @@ async function loadApprovalModules(workspacePath = '/workspace') {
     const actual = await vi.importActual<
       typeof import('@agent/runtime/RunContext')
     >('@agent/runtime/RunContext');
+    const { createSessionApprovals } = await vi.importActual<
+      typeof import('@agent/runtime/streamApprovalQueue')
+    >('@agent/runtime/streamApprovalQueue');
+    // Session-owned approval state (bypass reads) for the fake run session.
+    const approvals = createSessionApprovals();
     return {
       ...actual,
       tryUseRunContext: vi.fn(() =>
         activeToolEditApproval
           ? {
               session: {
+                approvals,
                 interactions: {
                   requestToolEditApproval: activeToolEditApproval,
                 },
@@ -516,9 +521,10 @@ describe('desktop tool edit approval', () => {
         desktopModule,
       } = await loadApprovalModules();
       const runtimeHost = createRecordingRuntimeHost();
+      const session = createTestSession();
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
-        session: createTestSession(),
+        session,
         tempRoot,
       });
       useControllerApproval(controller);
@@ -535,7 +541,8 @@ describe('desktop tool edit approval', () => {
         });
         await vi.waitFor(() => expect(shown).toHaveLength(1));
 
-        cleanupApprovalsForStream('stream-cleanup');
+        // Pending registries are session-owned: sweep the owning session.
+        cleanupApprovalsForStream('stream-cleanup', session);
 
         await expect(resultPromise).resolves.toMatchObject({ accepted: false });
         expect(resolved).toEqual([{ requestId: shown[0].requestId }]);

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -2,10 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import {
-  noopAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import {
@@ -14,14 +11,24 @@ import {
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
 } from '@tools/approval';
-import { bashApprovalController } from '@tools/approval/bashApproval';
 import {
   registerPendingApproval,
   unregisterPendingApproval,
 } from '@tools/approval/toolEditApproval';
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
-const host = (): AgentRuntimeHost => ({ emit: () => {} });
+
+function createPending(id: string, settled: Set<string>, streamId = '') {
+  let isSettled = false;
+  return {
+    streamId: streamId as StreamTabId,
+    isSettled: () => isSettled,
+    settle: () => {
+      isSettled = true;
+      settled.add(id);
+    },
+  };
+}
 
 describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
   it("per-stream cleanup leaves another stream's approval state intact", () => {
@@ -36,8 +43,7 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
 
     try {
       // A desktop window deleting its own stream `a` scopes the sweep to `a`
-      // (this is what `deleteAllStreams` loops, instead of the process-wide
-      // `cleanupAllApprovals` reset) — so a sibling window's stream `b` keeps
+      // (this is what `deleteAllStreams` loops), so a sibling stream `b` keeps
       // its pending approval / bypass state.
       cleanupApprovalsForStream(a);
       expect(isBashApprovalBypassedForStream(a)).toBe(false);
@@ -47,60 +53,119 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
     }
   });
 
-  it('scopes streamless cleanup to the owning runtime host', () => {
-    const hostA = host();
-    const hostB = host();
-    const session = new SessionHandle();
-    const cancel = vi.fn();
-    const detach = session.useHostInteractions({
-      resolve: () => false,
-      cancel,
-    });
+  it('scopes streamless cleanup to the owning session', () => {
+    const sessionA = new SessionHandle();
+    const sessionB = new SessionHandle();
+    const cancelA = vi.fn();
+    sessionA.useHostInteractions({ resolve: () => false, cancel: cancelA });
     const settled = new Set<string>();
-    const createPending = (id: string, runtimeHost: AgentRuntimeHost) => {
-      let isSettled = false;
-      return {
-        streamId: '' as StreamTabId,
-        runtimeHost,
-        isSettled: () => isSettled,
-        settle: () => {
-          isSettled = true;
-          settled.add(id);
-        },
-      };
-    };
 
     try {
-      registerPendingApproval('tool-a', createPending('tool-a', hostA));
-      registerPendingApproval('tool-b', createPending('tool-b', hostB));
-      bashApprovalController.registerPending(
+      registerPendingApproval(
+        'tool-a',
+        createPending('tool-a', settled),
+        sessionA,
+      );
+      registerPendingApproval(
+        'tool-b',
+        createPending('tool-b', settled),
+        sessionB,
+      );
+      sessionA.approvals.bash.registerPending(
         'bash-a',
-        createPending('bash-a', hostA),
+        createPending('bash-a', settled),
       );
-      bashApprovalController.registerPending(
+      sessionB.approvals.bash.registerPending(
         'bash-b',
-        createPending('bash-b', hostB),
+        createPending('bash-b', settled),
       );
 
-      cleanupUnscopedApprovals(hostA, session);
+      cleanupUnscopedApprovals(sessionA);
 
+      // Only session A's streamless approvals are rejected; session B's stay
+      // pending even though they are equally streamless.
       expect(settled).toEqual(new Set(['tool-a', 'bash-a']));
-      expect(cancel).toHaveBeenCalledWith({
+      expect(cancelA).toHaveBeenCalledWith({
         streamId: null,
         cause: 'Streamless approval cleanup.',
       });
 
-      cleanupUnscopedApprovals();
+      cleanupUnscopedApprovals(sessionB);
 
       expect(settled).toEqual(
         new Set(['tool-a', 'bash-a', 'tool-b', 'bash-b']),
       );
     } finally {
-      unregisterPendingApproval('tool-a');
-      unregisterPendingApproval('tool-b');
-      bashApprovalController.unregisterPending('bash-a');
-      bashApprovalController.unregisterPending('bash-b');
-      detach();
+      unregisterPendingApproval('tool-a', sessionA);
+      unregisterPendingApproval('tool-b', sessionB);
+      sessionA.approvals.bash.unregisterPending('bash-a');
+      sessionB.approvals.bash.unregisterPending('bash-b');
+      sessionA.dispose();
+      sessionB.dispose();
     }
+  });
+});
+
+describe('session-owned approval state (#8144)', () => {
+  it('keeps bypass state for equal stream ids isolated between sessions', () => {
+    const sessionA = new SessionHandle();
+    const sessionB = new SessionHandle();
+    const streamId = sid('s:appr-same-id');
+
+    try {
+      setBashApprovalSessionBypass(streamId, true, noopAgentRuntimeHost, {
+        silent: true,
+        session: sessionA,
+      });
+
+      expect(isBashApprovalBypassedForStream(streamId, sessionA)).toBe(true);
+      // The same stream identifier in a sibling session stays gated.
+      expect(isBashApprovalBypassedForStream(streamId, sessionB)).toBe(false);
+      // And the process default session is untouched as well.
+      expect(isBashApprovalBypassedForStream(streamId)).toBe(false);
+    } finally {
+      sessionA.dispose();
+      sessionB.dispose();
+    }
+  });
+
+  it("an unanswered approval in one session does not delay another session's queue", async () => {
+    const sessionA = new SessionHandle();
+    const sessionB = new SessionHandle();
+
+    try {
+      // Session A's prompt slot is occupied by a never-answered approval.
+      void sessionA.approvals.bash.enqueue(() => new Promise(() => {}));
+
+      const ranInB = sessionB.approvals.bash.enqueue(() =>
+        Promise.resolve('answered'),
+      );
+
+      await expect(ranInB).resolves.toBe('answered');
+    } finally {
+      sessionA.dispose();
+      sessionB.dispose();
+    }
+  });
+
+  it('session disposal rejects its remaining pending approvals and clears bypass state', () => {
+    const session = new SessionHandle();
+    const streamId = sid('s:appr-dispose');
+    const settled = new Set<string>();
+
+    registerPendingApproval(
+      'tool-dispose',
+      createPending('tool-dispose', settled, streamId),
+      session,
+    );
+    setBashApprovalSessionBypass(streamId, true, noopAgentRuntimeHost, {
+      silent: true,
+      session,
+    });
+
+    session.dispose();
+
+    expect(settled).toEqual(new Set(['tool-dispose']));
+    expect(isBashApprovalBypassedForStream(streamId, session)).toBe(false);
   });
 });

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -47,9 +47,9 @@ vi.mock('@tools/approval', () => ({
   enableYoloOnChildStream: mocks.enableYoloOnChildStream,
   inheritBashBypassOnChildStream: mocks.inheritBashBypassOnChildStream,
   isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
-  proposalApprovalState: {
+  proposalApprovals: () => ({
     isBypassed: mocks.isProposalBypassed,
-  },
+  }),
 }));
 
 function runtimeHost(): AgentRuntimeHost {

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -49,6 +49,7 @@ async function installPlatform(flagOn: boolean): Promise<Platform> {
 
 function startPlanUpdate(streamId: StreamTabId, objective: string) {
   const { events, host, interactions } = createRecordingHost();
+  const session = sessionWithInteractions(interactions);
   const workPlanState = new WorkPlanState();
   const tool = new PlanTool();
 
@@ -57,7 +58,7 @@ function startPlanUpdate(streamId: StreamTabId, objective: string) {
       run: {
         runtimeHost: host,
         streamId,
-        session: sessionWithInteractions(interactions),
+        session,
       },
       call: {
         tracker: new FileInteractionState(),
@@ -67,7 +68,7 @@ function startPlanUpdate(streamId: StreamTabId, objective: string) {
     () => tool.call({ command: 'update', objective }),
   );
 
-  return { resultPromise, events, host, workPlanState };
+  return { resultPromise, events, host, session, workPlanState };
 }
 
 function findPlanApproval(
@@ -127,12 +128,11 @@ describe('PlanTool — update (plan approval)', () => {
     const streamId = 'stream:plan-goal' as StreamTabId;
     await installPlatform(true);
 
+    const { resultPromise, events, host, session } = startPlanUpdate(
+      streamId,
+      plan.objective,
+    );
     try {
-      const { resultPromise, events, host } = startPlanUpdate(
-        streamId,
-        plan.objective,
-      );
-
       const approval = findPlanApproval(events);
       expect((approval.payload as { goalEnabled: boolean }).goalEnabled).toBe(
         true,
@@ -152,11 +152,11 @@ describe('PlanTool — update (plan approval)', () => {
       expect(goal!.status).toBe('active');
       // The approved plan document seeds the goal verbatim.
       expect(goal!.objective).toBe(plan.objective);
-      expect(isBashApprovalBypassedForStream(streamId)).toBe(true);
-      expect(isApprovalBypassedForStream(streamId)).toBe(false);
+      expect(isBashApprovalBypassedForStream(streamId, session)).toBe(true);
+      expect(isApprovalBypassedForStream(streamId, session)).toBe(false);
     } finally {
       await GoalStore.forget(streamId);
-      cleanupApprovalsForStream(streamId);
+      cleanupApprovalsForStream(streamId, session);
     }
   });
 
@@ -164,13 +164,12 @@ describe('PlanTool — update (plan approval)', () => {
     const streamId = 'stream:plan-goal-retarget' as StreamTabId;
     await installPlatform(true);
 
+    const existing = await GoalStore.start(streamId, 'Old objective');
+    const { resultPromise, events, host, session } = startPlanUpdate(
+      streamId,
+      followUpPlan.objective,
+    );
     try {
-      const existing = await GoalStore.start(streamId, 'Old objective');
-      const { resultPromise, events, host } = startPlanUpdate(
-        streamId,
-        followUpPlan.objective,
-      );
-
       const approval = findPlanApproval(events);
       expect(
         host.interactions?.resolve(
@@ -189,11 +188,11 @@ describe('PlanTool — update (plan approval)', () => {
       expect(goal!.status).toBe('active');
       expect(goal!.objective).toBe(followUpPlan.objective);
       expect(goal!.objective).not.toContain('Old objective');
-      expect(isBashApprovalBypassedForStream(streamId)).toBe(true);
-      expect(isApprovalBypassedForStream(streamId)).toBe(false);
+      expect(isBashApprovalBypassedForStream(streamId, session)).toBe(true);
+      expect(isApprovalBypassedForStream(streamId, session)).toBe(false);
     } finally {
       await GoalStore.forget(streamId);
-      cleanupApprovalsForStream(streamId);
+      cleanupApprovalsForStream(streamId, session);
     }
   });
 

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -2,17 +2,21 @@ import { z } from 'zod';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
+  getRunContextSession,
   getRunContextStreamId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
+import {
+  currentSession,
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireRuntimeHost } from '@tools/contextHelpers';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
-
-import { createStreamApprovalController } from './streamApprovalQueue';
 
 const BashApprovalRequestSchema = z.object({
   command: z.string(),
@@ -38,19 +42,13 @@ const DEFAULT_BASH_TIMEOUT_INSTRUCTION =
   'rejection. You may retry the command later if it is still needed, use a ' +
   'non-shell method, or continue without it.';
 
-export const bashApprovalController =
-  createStreamApprovalController<BashApprovalResult>({
-    rejectionResult: () => ({ accepted: false }),
-    bypassEvent: 'updateBashApprovalBypassState',
-  });
-
 export function setBashApprovalSessionBypass(
   streamId: StreamTabId,
   enabled: boolean,
   runtimeHost: AgentRuntimeHost,
-  options?: { silent?: boolean },
+  options?: { silent?: boolean; session?: SessionHandle },
 ): void {
-  bashApprovalController.bypass.setBypass(
+  (options?.session ?? currentSession()).approvals.bash.bypass.setBypass(
     streamId,
     enabled,
     runtimeHost,
@@ -61,14 +59,16 @@ export function setBashApprovalSessionBypass(
 export function toggleBashApprovalSessionBypass(
   streamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
+  session: SessionHandle = currentSession(),
 ): boolean {
-  return bashApprovalController.bypass.toggleBypass(streamId, runtimeHost);
+  return session.approvals.bash.bypass.toggleBypass(streamId, runtimeHost);
 }
 
 export function isBashApprovalBypassedForStream(
   streamId: StreamTabId,
+  session: SessionHandle = currentSession(),
 ): boolean {
-  return bashApprovalController.bypass.isBypassed(streamId);
+  return session.approvals.bash.bypass.isBypassed(streamId);
 }
 
 export async function requestBashApproval(
@@ -77,19 +77,20 @@ export async function requestBashApproval(
   const approvalsEnabled = getConfig<boolean>(BASH_APPROVAL_CONFIG_KEY, true);
 
   const context = tryUseRunContext();
+  const session = getRunContextSession(context) ?? defaultSession();
   const streamId = request.streamId ?? getRunContextStreamId(context);
 
   if (
     !approvalsEnabled ||
-    (streamId && isBashApprovalBypassedForStream(streamId))
+    (streamId && session.approvals.bash.bypass.isBypassed(streamId))
   ) {
     return { accepted: true };
   }
 
   const runtimeHost = requireRuntimeHost('bash approval', context);
 
-  return bashApprovalController.enqueue(() =>
-    showApprovalPrompt(request, streamId, runtimeHost),
+  return session.approvals.bash.enqueue(() =>
+    showApprovalPrompt(request, streamId, runtimeHost, session),
   );
 }
 
@@ -97,8 +98,9 @@ async function showApprovalPrompt(
   request: BashApprovalRequest,
   streamId: StreamTabId | undefined,
   runtimeHost: AgentRuntimeHost,
+  session: SessionHandle,
 ): Promise<BashApprovalResult> {
-  if (streamId && isBashApprovalBypassedForStream(streamId)) {
+  if (streamId && session.approvals.bash.bypass.isBypassed(streamId)) {
     return { accepted: true };
   }
 

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -1,40 +1,37 @@
 /**
  * Unified approval system exports.
  *
- * This module is the coordination point for approval cleanup so that
- * bash and tool-edit modules don't form a circular dependency.
- *
- * Import cleanup helpers from here, not from individual modules.
+ * Approval queues, pending registries, and bypass state are owned per session
+ * (`session.approvals`, #8144). The cleanup helpers here sweep exactly one
+ * session's state; hosts pass their own session (desktop windows), while the
+ * single-session hosts (extension, CLI) rely on the default session.
  */
 
 import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
-import { bashApprovalController } from './bashApproval';
-import { proposalApprovalState } from './proposalApproval';
-import {
-  toolEditApprovalController,
+export {
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from './toolEditApproval';
 
 /**
- * Clean up all approval state for a deleted stream.
+ * Clean up all approval state for a deleted stream in the owning session.
  * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
  */
 export function cleanupApprovalsForStream(
   streamId: StreamTabId,
   session: SessionHandle = defaultSession(),
 ): void {
-  toolEditApprovalController.rejectPendingForStream(streamId);
-  bashApprovalController.rejectPendingForStream(streamId);
-  toolEditApprovalController.bypass.clearForStream(streamId);
-  bashApprovalController.bypass.clearForStream(streamId);
-  proposalApprovalState.clearForStream(streamId);
+  const { toolEdit, bash, proposal } = session.approvals;
+  toolEdit.rejectPendingForStream(streamId);
+  bash.rejectPendingForStream(streamId);
+  toolEdit.bypass.clearForStream(streamId);
+  bash.bypass.clearForStream(streamId);
+  proposal.clearForStream(streamId);
   session.interactions.cancel({
     streamId,
     cause: 'Stream resources released.',
@@ -61,24 +58,23 @@ export function releaseStreamResources(
 }
 
 /**
- * Reject pending tool-edit, bash, and user-question approvals that have no
- * concrete stream context (streamId is undefined or empty). These would
- * otherwise survive a per-stream {@link cleanupApprovalsForStream} loop
- * because they do not equal any concrete StreamTabId, only
- * {@link cleanupAllApprovals} catches them. Bypass and proposal state are
- * always streamId-keyed and are not affected here.
+ * Reject pending tool-edit, bash, and user-question approvals in `session`
+ * that have no concrete stream context (streamId is undefined or empty).
+ * These would otherwise survive a per-stream
+ * {@link cleanupApprovalsForStream} loop because they do not equal any
+ * concrete StreamTabId. Bypass and proposal state are always streamId-keyed
+ * and are not affected here.
  *
  * Desktop `deleteAllStreams` calls this after the per-stream sweep so that
  * an approval emitted without a concrete stream is rejected rather than left
- * pending with no UI prompt to answer. Multi-session hosts pass their own
- * `runtimeHost` so sibling windows' streamless approvals stay intact.
+ * pending with no UI prompt to answer. Approval registries are session-owned,
+ * so sibling windows' streamless approvals stay intact.
  */
 export function cleanupUnscopedApprovals(
-  runtimeHost?: AgentRuntimeHost,
   session: SessionHandle = defaultSession(),
 ): void {
-  toolEditApprovalController.rejectUnscopedPending(runtimeHost);
-  bashApprovalController.rejectUnscopedPending(runtimeHost);
+  session.approvals.toolEdit.rejectUnscopedPending();
+  session.approvals.bash.rejectUnscopedPending();
   session.interactions.cancel({
     streamId: null,
     cause: 'Streamless approval cleanup.',
@@ -86,29 +82,21 @@ export function cleanupUnscopedApprovals(
 }
 
 /**
- * PROCESS-WIDE reset of all approval state — rejects every pending tool-edit /
- * bash / user-question approval, clears all bypass + proposal state, and
- * cancels `session`'s pending host interactions.
+ * Session-wide reset of approval state — rejects every pending tool-edit /
+ * bash / user-question approval in `session`, clears all of its bypass +
+ * proposal state, and cancels its pending host interactions.
  *
- * The tool/bypass controllers are process-global and streamId-keyed, so this
- * `clearAll` touches EVERY session's streams. Safe only for single-session
- * hosts (the extension's default session), test reset, and process shutdown.
- * A MULTI-SESSION host (e.g. a desktop window) must NOT use this to delete its
- * own streams — it would wipe sibling windows' pending approvals; it scopes the
- * sweep to its own streams by looping {@link cleanupApprovalsForStream} instead.
+ * Approval state is session-owned, so this never touches another session:
+ * one desktop window's reset cannot wipe a sibling window's pending
+ * approvals. For the extension and CLI the default session covers the whole
+ * process.
  */
 export function cleanupAllApprovals(
   session: SessionHandle = defaultSession(),
 ): void {
-  toolEditApprovalController.rejectAllPending();
-  bashApprovalController.rejectAllPending();
-  toolEditApprovalController.bypass.clearAll();
-  bashApprovalController.bypass.clearAll();
-  proposalApprovalState.clearAll();
+  session.approvals.rejectAndClearAll();
   session.interactions.cancel({ cause: 'All approvals cleared.' });
 }
-
-export { enableYoloOnChildStream, inheritBashBypassOnChildStream };
 
 // Re-export commonly used functions from individual modules
 export {
@@ -122,7 +110,7 @@ export {
 
 export {
   // Proposal approval
-  proposalApprovalState,
+  proposalApprovals,
 } from './proposalApproval';
 
 export {

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -1,12 +1,21 @@
-import { createStreamApprovalBypass } from './streamApprovalQueue';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import type { StreamApprovalBypass } from '@agent/runtime/streamApprovalQueue';
 
 /**
- * Per-stream bypass state for agent delegation proposals (super-YOLO).
+ * Per-stream bypass state for agent delegation proposals (super-YOLO), owned
+ * by the session (`session.approvals.proposal`).
  *
  * Proposals settle through the run coordinators rather than a stream approval
  * queue, so unlike bash / tool-edit there is no controller here — only the
- * shared bypass state bound to its progress event.
+ * session's bypass state. Resolves the calling context's session by default
+ * (run session inside a run, otherwise the process default session);
+ * multi-session hosts pass their own session explicitly.
  */
-export const proposalApprovalState = createStreamApprovalBypass(
-  'updateSuperYoloBypassState',
-);
+export function proposalApprovals(
+  session: SessionHandle = currentSession(),
+): StreamApprovalBypass {
+  return session.approvals.proposal;
+}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -5,6 +5,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import {
+  currentSession,
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
@@ -27,8 +28,6 @@ import {
 } from '@utils/text/diff';
 import { countLines } from '@utils/text/stringUtils';
 
-import { bashApprovalController } from './bashApproval';
-import { createStreamApprovalController } from './streamApprovalQueue';
 import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
@@ -40,37 +39,34 @@ const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
 export const REVEAL_TIMEOUT_MS = 1500;
 
-export const toolEditApprovalController =
-  createStreamApprovalController<ToolEditApprovalResult>({
-    rejectionResult: () => ({ accepted: false }),
-    bypassEvent: 'updateToolEditApprovalBypassState',
-  });
-
 /** Register a pending approval entry for rejection tracking. */
 export function registerPendingApproval(
   id: string,
   entry: {
     streamId?: StreamTabId;
-    runtimeHost?: AgentRuntimeHost;
     isSettled: () => boolean;
     settle: (result: ToolEditApprovalResult) => void;
   },
+  session: SessionHandle = currentSession(),
 ): void {
-  toolEditApprovalController.registerPending(id, entry);
+  session.approvals.toolEdit.registerPending(id, entry);
 }
 
 /** Unregister a pending approval entry after it has been resolved. */
-export function unregisterPendingApproval(id: string): void {
-  toolEditApprovalController.unregisterPending(id);
+export function unregisterPendingApproval(
+  id: string,
+  session: SessionHandle = currentSession(),
+): void {
+  session.approvals.toolEdit.unregisterPending(id);
 }
 
 export function setToolEditApprovalSessionBypass(
   streamId: StreamTabId,
   enabled: boolean,
   runtimeHost: AgentRuntimeHost,
-  options?: { silent?: boolean },
+  options?: { silent?: boolean; session?: SessionHandle },
 ): void {
-  toolEditApprovalController.bypass.setBypass(
+  (options?.session ?? currentSession()).approvals.toolEdit.bypass.setBypass(
     streamId,
     enabled,
     runtimeHost,
@@ -88,12 +84,16 @@ export function setToolEditApprovalSessionBypass(
 export function toggleToolEditApprovalSessionBypass(
   streamId: StreamTabId,
   runtimeHost: AgentRuntimeHost,
+  session: SessionHandle = currentSession(),
 ): boolean {
-  return toolEditApprovalController.bypass.toggleBypass(streamId, runtimeHost);
+  return session.approvals.toolEdit.bypass.toggleBypass(streamId, runtimeHost);
 }
 
-export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
-  return toolEditApprovalController.bypass.isBypassed(streamId);
+export function isApprovalBypassedForStream(
+  streamId: StreamTabId,
+  session: SessionHandle = currentSession(),
+): boolean {
+  return session.approvals.toolEdit.bypass.isBypassed(streamId);
 }
 
 /**
@@ -124,7 +124,9 @@ export function emitToolEditApprovalPrompt(
       event: { type: 'setActiveStream', payload: { streamId } },
     });
   }
-  const isBypassed = streamId ? isApprovalBypassedForStream(streamId) : false;
+  const isBypassed = streamId
+    ? session.approvals.toolEdit.bypass.isBypassed(streamId)
+    : false;
   runtimeHost.emit('showToolEditPermission', {
     requestId,
     path: request.path,
@@ -227,6 +229,7 @@ export async function requestToolEditApproval(
   );
 
   const context = tryUseRunContext();
+  const session = getRunContextSession(context) ?? defaultSession();
   const contextStreamId = getRunContextStreamId(context);
   const preparedRequest =
     request.streamId || !contextStreamId
@@ -235,14 +238,13 @@ export async function requestToolEditApproval(
 
   const streamId = preparedRequest.streamId;
   const isStreamBypassed =
-    streamId && toolEditApprovalController.bypass.isBypassed(streamId);
+    streamId && session.approvals.toolEdit.bypass.isBypassed(streamId);
   if (!approvalsEnabled || isStreamBypassed) {
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
 
-  const hostInteraction = (
-    getRunContextSession(context) ?? defaultSession()
-  ).interactions.requestToolEditApproval(preparedRequest);
+  const hostInteraction =
+    session.interactions.requestToolEditApproval(preparedRequest);
   if (hostInteraction) {
     return finalizeApprovalResult(await hostInteraction, preparedRequest);
   }
@@ -499,12 +501,11 @@ export async function requestAndWriteApprovedEdit(request: {
 export function inheritBashBypassOnChildStream(
   childStreamId: StreamTabId,
   parentStreamId?: StreamTabId,
+  session: SessionHandle = currentSession(),
 ): void {
-  if (
-    parentStreamId &&
-    bashApprovalController.bypass.isBypassed(parentStreamId)
-  ) {
-    bashApprovalController.bypass.setBypass(childStreamId, true);
+  const bashBypass = session.approvals.bash.bypass;
+  if (parentStreamId && bashBypass.isBypassed(parentStreamId)) {
+    bashBypass.setBypass(childStreamId, true);
   }
 }
 
@@ -517,6 +518,9 @@ export function inheritBashBypassOnChildStream(
  * Bash bypass is handled separately by `inheritBashBypassOnChildStream` so it
  * follows the parent regardless of the tool-edit flag.
  */
-export function enableYoloOnChildStream(childStreamId: StreamTabId): void {
-  toolEditApprovalController.bypass.setBypass(childStreamId, true);
+export function enableYoloOnChildStream(
+  childStreamId: StreamTabId,
+  session: SessionHandle = currentSession(),
+): void {
+  session.approvals.toolEdit.bypass.setBypass(childStreamId, true);
 }

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -30,7 +30,7 @@ import {
 import type { ToolResult } from '@shared/schemas/toolResult';
 import {
   isApprovalBypassedForStream,
-  proposalApprovalState,
+  proposalApprovals,
 } from '@tools/approval';
 import {
   availableModelNamesFromOptions,
@@ -147,7 +147,7 @@ export async function proposeAndExecute(
   agentName: string,
   streamId: StreamTabId,
 ): Promise<ToolResult> {
-  if (proposalApprovalState.isBypassed(streamId)) {
+  if (proposalApprovals().isBypassed(streamId)) {
     return executeSubagent(proposal, agentName, streamId, {
       enableYoloOnChild: true,
       approvalMeta: { autoApproved: true },

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -38,7 +38,7 @@ import {
   type Goal,
 } from '@shared/schemas/goal';
 import { type ToolResult } from '@shared/schemas/toolResult';
-import { proposalApprovalState } from '@tools/approval';
+import { proposalApprovals } from '@tools/approval';
 import { requireStreamId } from '@tools/contextHelpers';
 import {
   GoalStore,
@@ -162,7 +162,7 @@ Best practices:
       logger.warn('Plan created without streamId — skipping approval gate');
       return this.buildApprovedResult({ autoApproved: false });
     }
-    if (proposalApprovalState.isBypassed(streamId)) {
+    if (proposalApprovals().isBypassed(streamId)) {
       logger.info('Plan auto-approved via delegated-task auto-approval');
       return this.buildApprovedResult({ autoApproved: true });
     }


### PR DESCRIPTION
Closes #8144

## Summary

Approval serialization, pending-request registries, and per-stream bypass state were process-global (`bashApprovalController` / `toolEditApprovalController` / `proposalApprovalState` module singletons), so an unanswered approval in one desktop window delayed unrelated approvals in another, and equal stream ids could cross-talk between sessions. This PR moves that state onto the session owner, per the Stage 4 (#6967) follow-up ruling.

**Design: single owner, resolve-once-at-boundary.**

- `SessionHandle` gains `readonly approvals: SessionApprovals` (tool-edit controller, bash controller, super-YOLO proposal bypass), constructed fresh per session in `src/agent/runtime/streamApprovalQueue.ts` (moved from `src/tools/approval/`). No module-level mutable approval state remains anywhere.
- Run-scoped code (`requestBashApproval`, `requestToolEditApproval`, delegation child-stream bypass inheritance, PlanTool/proposal bypass checks) resolves the owning session once from the run context (`getRunContextSession(...) ?? defaultSession()` / `currentSession()`), so each run queues on its own session's `PQueue` — one prompt at a time **within** a session, sessions never blocking each other.
- Host-UI paths keep the existing helper vocabulary (`set/toggle/is*Bypass`, `registerPendingApproval`, cleanup helpers) with an explicit `session` parameter: desktop passes its window session (progress-view bypass handlers, `getProgressStreamControls`, `desktopToolEditApproval`, `cleanupUnscopedApprovals`); extension and CLI stay on the default session. Same pattern already used for `externalInquiry.session`.
- `SessionHandle.dispose()` now rejects all remaining pending approvals and clears bypass/proposal state for that session (`SessionApprovals.rejectAndClearAll()`), shared with the session-scoped `cleanupAllApprovals`.
- Deletions enabled by single ownership: `PendingApproval.runtimeHost` + the `rejectUnscopedPending(runtimeHost)` disambiguator (only existed because the registry was global), dead `StreamApprovalController.getPending` (zero consumers), and the `proposalApprovalState` singleton (replaced by `proposalApprovals(session?)` accessor over `session.approvals.proposal`).

**Behavior kept:** rich tool-edit results, timeout/rejection semantics, one-at-a-time display per session, no new `bus.emit`, no process show/resolve pairs — interactions still flow through `SessionHostInteractions` (Stage 4 surface).

## Tests

`ApprovalCleanupScope.vitest.ts` extended for the acceptance criteria: bypass isolation for equal stream ids in two sessions, an unanswered approval in session A not delaying session B's queue, streamless cleanup scoped to the owning session, and disposal rejecting pending approvals + clearing bypass. `SessionHandle.vitest.ts` fresh-ctor test asserts `approvals` is not shared with the default session. `PlanToolWorkPlanState` / desktop suites updated to the session-owned semantics.

## Verified

- Opened at origin/main HEAD (7ec2876b9): `src/tools/approval/{bashApproval,toolEditApproval,proposalApproval,streamApprovalQueue,index}.ts`, `src/agent/runtime/{SessionHandle,HostInteractions,RunContext,RunScope}.ts`, `src/controllers/progressView/{ProgressViewCommandHandlers,progressStreamControls,ProgressViewHost}.ts`, `packages/desktop/src/main/{desktopAgentExecution,desktopHostInteractions,desktopToolEditApproval}.ts`, `packages/extension/src/{frontend/approval/nativeToolEditApproval,progressView/extensionHostInteractions,progressView/managers/ProgressStreamLifecycleHost}.ts`, `packages/cli/src/chat/tui/state/subscribeApprovals.ts` — confirmed the module-global controllers were still live and grep-verified every consumer of the removed exports.
- `npm run typecheck` — clean across all six workspace tsconfigs.
- Full `npm test` — 648 files / 5736 tests passed; sole failure `RunChatSignalOwnership.vitest.mts` is a load-induced 10s timeout, passes in isolation, and does not touch approval state.
- Targeted suites re-run green: ApprovalCleanupScope, ToolEditApprovalGate, ConcurrentToolEditApprovalHandlers, PlanToolWorkPlanState, SessionHandle, SessionScope, HumanPromptProgressEvents, ChildStreamYoloInheritance, ProgressViewCommandHandlers, DesktopToolEditApproval, DesktopHostInteractions, DesktopAgentExecution, DelegationHeadless, ToolUseWaitNode, Wolfram, RetryState.
- `npx eslint` on all changed production files — clean; prettier applied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent approval gating and multi-window isolation; behavior is intended to stay the same within a session, but incorrect session resolution could mis-route bypass or cleanup.
> 
> **Overview**
> Moves **bash/tool-edit approval queues**, **pending registries**, and **per-stream bypass** (including super-YOLO proposals) off process-global module singletons onto **`SessionHandle.approvals`**, so each desktop window / session serializes and cleans up approvals independently.
> 
> Run-scoped paths resolve the owning session via **`currentSession()`** / run context; hosts pass **`session` explicitly** (desktop progress bypass, stream controls, tool-edit register/unregister). **`proposalApprovalState`** becomes **`proposalApprovals(session?)`**; cleanup helpers (`cleanupApprovalsForStream`, `cleanupUnscopedApprovals`, `cleanupAllApprovals`) only touch the given session—**`PendingApproval.runtimeHost`** and host-scoped streamless rejection are removed. **`SessionHandle.dispose()`** rejects pending approvals and clears bypass via **`rejectAndClearAll()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de022e50573e4ab7772d1ffef4406f3139d6888c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->