### PR TITLE
fix(runtime): clean up failed launch resources

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -66,6 +66,7 @@ import {
 } from './mediaVisionWarning';
 import { getStreamTabId } from './streamTab';
 import { currentSession, type SessionHandle } from './SessionHandle';
+import { AgentLaunchResources } from './AgentLaunchResources';
 import type { StreamStatusMachine } from './StreamStatusService';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
@@ -234,8 +235,7 @@ async function assembleAgentLaunchContext(
   executionId: ExecutionId,
   runtimeHost: AgentRuntimeHost,
   reservedStreamId: StreamTabId | undefined,
-  onActivated: (streamId: StreamTabId) => void,
-  onRunTraceCreated: (runTrace: RunTrace) => void,
+  resources: AgentLaunchResources,
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
   const fullConfig = AgentConfigSchema.parse(configPayload);
@@ -289,13 +289,15 @@ async function assembleAgentLaunchContext(
   const modelHandlerCompatibilityKey =
     input.modelHandlerCompatibilityKey ??
     (await inferLaunchModelHandlerCompatibilityKey(executionId, config.model));
-  const modelHandler = modelHandlerCompatibilityKey
-    ? await createModelHandlerForCompatibilityKey(
-        modelConfig,
-        modelHandlerCompatibilityKey,
-        setting.agentCategory,
-      )
-    : await createModelHandler(modelConfig, setting.agentCategory);
+  const modelHandler = resources.ownModelHandler(
+    modelHandlerCompatibilityKey
+      ? await createModelHandlerForCompatibilityKey(
+          modelConfig,
+          modelHandlerCompatibilityKey,
+          setting.agentCategory,
+        )
+      : await createModelHandler(modelConfig, setting.agentCategory),
+  );
 
   const streamId =
     input.streamTabIdOverride ??
@@ -312,18 +314,9 @@ async function assembleAgentLaunchContext(
     session.transcripts,
     session.flushers,
   );
-  const detachSessionTrace = session.attachRunTrace(
-    rawRunTrace.trace,
-    streamId,
+  const runTrace = resources.ownRunTrace(rawRunTrace, () =>
+    session.attachRunTrace(rawRunTrace.trace, streamId),
   );
-  const runTrace: RunTrace = {
-    trace: rawRunTrace.trace,
-    dispose: () => {
-      detachSessionTrace();
-      rawRunTrace.dispose();
-    },
-  };
-  onRunTraceCreated(runTrace);
   const agentLogger = runTrace.trace;
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
@@ -342,7 +335,7 @@ async function assembleAgentLaunchContext(
       },
     },
   });
-  onActivated(streamId);
+  resources.markActivated(streamId);
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
@@ -360,10 +353,12 @@ async function assembleAgentLaunchContext(
         modelHandler.capabilities.supportsNativeAudio
       : modelHandler.capabilities.supportsVision);
 
-  const parentStage = await beginRunStage(
-    agentLogger,
-    `Run: ${config.agent}`,
-    initialMediaMayBeInserted ? undefined : initialInstruction,
+  const parentStage = resources.ownParentStage(
+    await beginRunStage(
+      agentLogger,
+      `Run: ${config.agent}`,
+      initialMediaMayBeInserted ? undefined : initialInstruction,
+    ),
   );
   const storageKey: StorageKey = parentStage.id
     ? normalizeRunId(parentStage.id)
@@ -582,36 +577,29 @@ export async function buildAgentLaunchContext(
     );
   }
 
-  let activatedStreamId: StreamTabId | undefined;
-  // Captured so the outer catch can dispose the trace and let
-  // `compensateFailedActivation` reuse it for the failure log. Released to the
-  // returned context on the success path (cleaned up by runFlowWithLifecycle).
-  let runTrace: RunTrace | undefined;
+  const resources = new AgentLaunchResources();
   try {
     const ctx = await assembleAgentLaunchContext(
       { ...input, session: launchSession },
       executionId,
       runtimeHost,
       reservedStreamId,
-      (streamId) => {
-        activatedStreamId = streamId;
-      },
-      (rt) => {
-        runTrace = rt;
-      },
+      resources,
     );
+    resources.transfer();
     return ctx;
   } catch (err) {
-    compensateFailedActivation({
-      configPayload,
-      reservedStreamId,
-      activatedStreamId,
-      streamStatus,
-      session: launchSession,
-      err,
-      runTrace,
+    resources.fail((activatedStreamId, runTrace) => {
+      compensateFailedActivation({
+        configPayload,
+        reservedStreamId,
+        activatedStreamId,
+        streamStatus,
+        session: launchSession,
+        err,
+        runTrace,
+      });
     });
-    runTrace?.dispose();
     if (!input.suppressErrorNotification && !(err instanceof ZodError)) {
       runtimeHost.emit('requestShowError', {
         message: toErrorMessage(err),

--- a/src/agent/runtime/AgentLaunchResources.ts
+++ b/src/agent/runtime/AgentLaunchResources.ts
@@ -1,0 +1,98 @@
+// Local imports - launch resources
+import type { StageHandle } from '@agent/trace';
+import { createChannelTrace } from '@logger';
+import { RUN_OUTCOME, type StreamTabId } from '@shared/schemas';
+import type { RunTrace } from '@transcript';
+
+const logger = createChannelTrace('AgentLaunchResources');
+
+type DisposableModelHandler = {
+  dispose(): void;
+};
+
+/** Owns partially assembled launch resources until the runtime accepts them. */
+export class AgentLaunchResources {
+  private modelHandler?: DisposableModelHandler;
+  private runTrace?: RunTrace;
+  private parentStage?: StageHandle;
+  private activatedStreamId?: StreamTabId;
+
+  ownModelHandler<T extends DisposableModelHandler>(modelHandler: T): T {
+    this.modelHandler = modelHandler;
+    return modelHandler;
+  }
+
+  ownRunTrace(rawRunTrace: RunTrace, attach: () => () => void): RunTrace {
+    const attachment: { detach?: () => void } = {};
+    const runTrace: RunTrace = {
+      trace: rawRunTrace.trace,
+      dispose: () => {
+        try {
+          attachment.detach?.();
+        } finally {
+          rawRunTrace.dispose();
+        }
+      },
+    };
+    this.runTrace = runTrace;
+    attachment.detach = attach();
+    return runTrace;
+  }
+
+  ownParentStage(parentStage: StageHandle): StageHandle {
+    this.parentStage = parentStage;
+    return parentStage;
+  }
+
+  markActivated(streamId: StreamTabId): void {
+    this.activatedStreamId = streamId;
+  }
+
+  transfer(): void {
+    this.clear();
+  }
+
+  fail(
+    compensate: (
+      activatedStreamId: StreamTabId | undefined,
+      runTrace: RunTrace | undefined,
+    ) => void,
+  ): void {
+    const { modelHandler, runTrace, parentStage, activatedStreamId } = this;
+    this.clear();
+
+    this.runCleanup(runTrace, 'end failed launch stage', () => {
+      parentStage?.end(RUN_OUTCOME.FAILED);
+    });
+    this.runCleanup(runTrace, 'dispose failed launch model handler', () => {
+      modelHandler?.dispose();
+    });
+    this.runCleanup(runTrace, 'compensate failed launch activation', () => {
+      compensate(activatedStreamId, runTrace);
+    });
+    this.runCleanup(undefined, 'dispose failed launch trace', () => {
+      runTrace?.dispose();
+    });
+  }
+
+  private clear(): void {
+    this.modelHandler = undefined;
+    this.runTrace = undefined;
+    this.parentStage = undefined;
+    this.activatedStreamId = undefined;
+  }
+
+  private runCleanup(
+    runTrace: RunTrace | undefined,
+    operation: string,
+    cleanup: () => void,
+  ): void {
+    try {
+      cleanup();
+    } catch (error) {
+      (runTrace?.trace ?? logger).warn(`Failed to ${operation}`, {
+        data: { error },
+      });
+    }
+  }
+}

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -1,17 +1,44 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolve: vi.fn(),
+  load: vi.fn(),
+  createHandler: vi.fn(),
+  createTrace: vi.fn(),
+  buildVars: vi.fn(),
+}));
+
+vi.mock('@agent/index', () => ({
+  isRemoteAgent: () => false,
+  resolveAgentForLaunch: mocks.resolve,
+}));
+vi.mock('@agent/runtime/agentLoad', () => ({
+  loadAgentSettingAndPrompts: mocks.load,
+}));
+vi.mock('@agent/runtime/ModelFactory', () => ({
+  createModelHandler: mocks.createHandler,
+  createModelHandlerForCompatibilityKey: mocks.createHandler,
+}));
+vi.mock('@transcript', async (importActual) => ({
+  ...(await importActual<typeof import('@transcript')>()),
+  createRunTrace: mocks.createTrace,
+}));
+vi.mock('@agent/utils/userVars', () => ({ buildUserVars: mocks.buildVars }));
 
 // Local imports
 import { noopTrace } from '@agent/trace';
 import {
+  buildAgentLaunchContext,
   getAgentPath,
   withExecutionRunContext,
   type AgentLaunchContext,
 } from '@agent/runtime/AgentLaunchContext';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { useRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
+import { RUN_OUTCOME, STREAM_PHASE } from '@shared/schemas';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -82,5 +109,75 @@ describe('AgentLaunchContext', () => {
         expect(useRunContext().model).toBe('sonnet46T');
       },
     );
+  });
+
+  it('compensates a late launch-assembly failure before trace disposal', async () => {
+    const order: string[] = [];
+    const failure = new Error('user vars unavailable');
+    const session = new SessionHandle();
+    const detachEvents = session.events.subscribe(() => undefined);
+    const detachStatus = session.status.onDidChange(({ status }) => {
+      if (status === STREAM_PHASE.FAILED) order.push('terminal');
+    });
+    const stage = noopTrace.openStage('Run');
+    const endStage = vi.spyOn(stage, 'end').mockImplementation(() => {
+      order.push('stage');
+    });
+    const detachTrace = vi.fn(() => order.push('detach'));
+    const rawDispose = vi.fn(() => order.push('raw-trace'));
+    const trace = { ...noopTrace, subscribe: vi.fn(() => detachTrace) };
+    trace.openStage = vi.fn(() => stage);
+    const handler = {
+      capabilities: { supportsVision: false, supportsNativeAudio: false },
+      config: { provider: 'openai' },
+      setAgentCategory: vi.fn(),
+      setLogger: vi.fn(),
+      dispose: vi.fn(() => order.push('handler')),
+    };
+
+    mocks.resolve.mockReturnValueOnce({ definitionPath: '/agents/chat.yaml' });
+    mocks.load.mockResolvedValueOnce([
+      { agentCategory: AgentCategory.ToolUse },
+      {},
+    ]);
+    mocks.createHandler.mockResolvedValueOnce(handler);
+    mocks.createTrace.mockReturnValueOnce({ trace, dispose: rawDispose });
+    mocks.buildVars.mockRejectedValueOnce(failure);
+
+    try {
+      await expect(
+        buildAgentLaunchContext({
+          configPayload: {
+            agent: 'chat',
+            model: 'gpt55',
+            agentCategory: AgentCategory.ToolUse,
+          },
+          runtimeHost: createRecordingHost().host,
+          session,
+          streamTabIdOverride: 'late-assembly-stream',
+          suppressErrorNotification: true,
+          modelHandlerCompatibilityKey: 'ModelHandlerOpenAIResponse',
+        }),
+      ).rejects.toBe(failure);
+
+      expect(endStage).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.FAILED);
+      expect(handler.dispose).toHaveBeenCalledOnce();
+      expect(session.status.get('late-assembly-stream')).toBe(
+        STREAM_PHASE.FAILED,
+      );
+      expect(detachTrace).toHaveBeenCalledOnce();
+      expect(rawDispose).toHaveBeenCalledOnce();
+      expect(order).toEqual([
+        'stage',
+        'handler',
+        'terminal',
+        'detach',
+        'raw-trace',
+      ]);
+    } finally {
+      detachEvents();
+      detachStatus();
+      session.dispose();
+    }
   });
 });

--- a/src/test-kernel/agent/runtime/AgentLaunchResources.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchResources.vitest.ts
@@ -1,0 +1,20 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { noopTrace } from '@agent/trace';
+import { AgentLaunchResources } from '@agent/runtime/AgentLaunchResources';
+
+describe('AgentLaunchResources', () => {
+  it('retains raw-trace ownership when session attachment throws', () => {
+    const resources = new AgentLaunchResources();
+    const unattachedTrace = { trace: noopTrace, dispose: vi.fn() };
+    expect(() =>
+      resources.ownRunTrace(unattachedTrace, () => {
+        throw new Error('attach failed');
+      }),
+    ).toThrow('attach failed');
+    resources.fail(() => undefined);
+    expect(unattachedTrace.dispose).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Move partially assembled launch resources behind one internal ownership module.
- Transfer handler, stage, and trace ownership to `AgentRunLifecycle` only after context assembly succeeds.
- On failure, end the parent stage as failed, dispose the handler, compensate stream activation, then detach and dispose the trace without masking the original error.
- Register raw-trace ownership before session attachment, so an attachment exception cannot leak the trace.

Closes #8234.

## Design

`AgentLaunchResources` hides the temporary invalid states that exist while a launch is assembled. `AgentLaunchContext` now has four narrow operations—own handler, own trace, own stage, mark activation—plus one success transfer and one failure unwind, instead of independent optional rollback variables and callbacks.

Cleanup failures are isolated and logged; they cannot prevent later cleanup or replace the launch error.

## Net elements

- Files: 2 added, 0 deleted, 2 modified.
- Runtime modules: 1 internal module added; no barrel or public SDK export.
- Tests: 1 focused helper-boundary test and 1 late-assembly integration test.
- LoC: +250 / -47, net +203; `AgentLaunchContext.ts` itself shrinks while ownership logic moves behind the new module.

## Host impact

Extension, desktop, and CLI share the same launch assembly and receive the same leak-free failure behavior. No host-specific API changes.

## Validation

- Clean isolated root TypeScript check
- Clean isolated test-kernel TypeScript check
- ESLint on all four changed files
- `prettier --check` and `git diff --check`
- Focused Vitest: `AgentLaunchContext.vitest.ts` + `AgentLaunchResources.vitest.ts` (4 tests)
- Exact-commit CI kernel suite: 650 files passed, 1 skipped; 5,736 tests passed, 4 skipped
- Independent subagent review: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent launch and stream activation rollback paths; behavior is well-tested but mistakes could leak handlers/traces or leave streams stuck in STARTING.
> 
> **Overview**
> Introduces **`AgentLaunchResources`** to own model handler, run trace, parent stage, and activation state while `buildAgentLaunchContext` assembles a launch, replacing ad-hoc callbacks and optional rollback locals in **`AgentLaunchContext`**.
> 
> On **success**, `transfer()` drops internal ownership so the returned context and lifecycle keep the resources. On **failure**, `fail()` runs a fixed unwind: end the parent stage as failed, dispose the handler, run stream activation compensation, then detach and dispose the trace—with per-step error isolation so cleanup cannot mask the original launch error.
> 
> **`ownRunTrace`** registers the wrapped trace before session attach runs, so a thrown attach still leaves the raw trace owned and disposable. Tests lock in late-assembly failure ordering and attach-throw behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1577557967d2f43dbaa1f1926253cad45dbfc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
