### PR TITLE
fix(model-handlers): make the live pre-flight count own OpenAI context decisions

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -416,12 +416,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private inFlight = false;
 
   /**
-   * One-shot guard for the live-count compaction retry in
-   * {@link createResponseImpl}: if a compaction attempt fails to shrink the
-   * transcript, the recursive attempt's recount would still be over the
-   * threshold and must not recurse again. Reset per public call.
+   * One-shot guard for the internal compact-and-retry recursions (the
+   * live-count threshold in {@link createResponseImpl} and the overflow
+   * recovery in {@link handleCreateResponseError}): if a compaction attempt
+   * fails to shrink the transcript, the recursive attempt would hit the same
+   * threshold/overflow again and must not recurse a second time. Reset per
+   * public call.
    */
-  private liveCountCompactionAttempted = false;
+  private compactionRetryAttempted = false;
 
   /** DIAGNOSTIC: Pre-flight token estimate for comparison with actual usage */
   private _diagPreFlightTokens: number | null = null;
@@ -682,6 +684,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     if (this.supportsTokenCounting) {
       // The live pre-flight count decides for counting-capable models.
+      // Deliberate tradeoff: if the count API soft-fails for a turn, that
+      // turn has no automatic compaction trigger at all (the stale cumulative
+      // figure is not consulted) — the API enforces the window, and an
+      // API-side overflow still recovers via handleCreateResponseError's
+      // compact-and-retry. Costs one extra round-trip in that rare failure
+      // mode; keeps the live count the single decision owner.
       return false;
     }
 
@@ -1461,7 +1469,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     this.inFlight = true;
-    this.liveCountCompactionAttempted = false;
+    this.compactionRetryAttempted = false;
     try {
       return await run();
     } finally {
@@ -1735,7 +1743,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (
       preFlightTokens !== undefined &&
       !compactedThisCall &&
-      !this.liveCountCompactionAttempted &&
+      !this.compactionRetryAttempted &&
       this.getCompactionThresholdPercent() > 0 &&
       preFlightTokens > this.getCompactionTokenThreshold() &&
       this.canCompactRoute()
@@ -1744,7 +1752,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.logger,
         `Compacting conversation (pre-flight count ${preFlightTokens} tokens exceeds ${this.getCompactionThresholdPercent()}% threshold of ${this.getCompactionTokenThreshold()} tokens)`,
       );
-      this.liveCountCompactionAttempted = true;
+      this.compactionRetryAttempted = true;
       this.compactionRequested = true;
       this._diagPreFlightTokens = null;
       return this.createResponseImpl(options);
@@ -2240,17 +2248,22 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.backgroundLifecycle.clearPending();
     } else if (
       isContextWindowError(error) &&
-      this.chainState.hasPreviousResponseId() &&
-      !compactedThisCall
+      !compactedThisCall &&
+      !this.compactionRetryAttempted &&
+      (this.chainState.hasPreviousResponseId() || this.canCompactRoute())
     ) {
-      // Recovery: When using previous_response_id, accumulated reasoning tokens
-      // from prior turns are stored server-side and count against the context
-      // window, but inputTokens.count() may not fully reflect them. This causes
-      // pre-flight validation to pass while the API rejects the request.
-      //
-      // Fix: Drop server-side state (clearing previous_response_id discards the
-      // hidden reasoning tokens) and compact client-side messages, then retry.
-      // The guard !compactedThisCall prevents infinite recursion.
+      // Recovery for a context-window overflow (API-side or pre-flight):
+      // - When chaining, accumulated reasoning tokens from prior turns are
+      //   stored server-side and count against the window even where
+      //   inputTokens.count() may not fully reflect them — drop the chain
+      //   (clearing previous_response_id discards the hidden reasoning
+      //   tokens) and compact client-side messages, then retry.
+      // - Without a chain (e.g. after invalidateChain(), or a non-chaining
+      //   route), a compactable transcript still recovers via compaction
+      //   alone.
+      // Termination: compactedThisCall blocks re-entry after a successful
+      // compaction, and compactionRetryAttempted blocks it when compaction
+      // failed to shrink the transcript.
       logProgressStatus(
         this.logger,
         'Context window exceeded — compacting conversation and retrying.',
@@ -2259,6 +2272,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Don't call resetConversationState() — it zeroes cumulativeInputTokens
       // which would prevent shouldCompact() from triggering on the retry.
       this.backgroundLifecycle.clearPending();
+      this.compactionRetryAttempted = true;
       this.compactionRequested = true;
       this._diagPreFlightTokens = null;
       // Retry internally: the recursive call will compact (shouldCompact()=true)

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -415,6 +415,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   private inFlight = false;
 
+  /**
+   * One-shot guard for the live-count compaction retry in
+   * {@link createResponseImpl}: if a compaction attempt fails to shrink the
+   * transcript, the recursive attempt's recount would still be over the
+   * threshold and must not recurse again. Reset per public call.
+   */
+  private liveCountCompactionAttempted = false;
+
   /** DIAGNOSTIC: Pre-flight token estimate for comparison with actual usage */
   private _diagPreFlightTokens: number | null = null;
 
@@ -635,11 +643,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * Check if the conversation should be compacted based on cumulative input tokens.
-   * Compaction is only triggered when:
-   * - Threshold percentage is greater than 0 (not disabled)
-   * - Cumulative input tokens exceed the calculated threshold (percentage of context window)
-   * - Not running through OpenRouter (which may not support compaction)
+   * Whether this route can compact at all: compaction is supported, not
+   * routed through OpenRouter (which may not support compaction), and there
+   * is prior conversation to compact. Shared by the manual/requested flag
+   * path and the live-count decision in {@link createResponseImpl}.
+   */
+  private canCompactRoute(): boolean {
+    return (
+      this.supportsManualCompaction &&
+      !this.isOpenRouterRoutingEnabled() &&
+      this.chainState.getCumulativeInputTokens() > 0
+    );
+  }
+
+  /**
+   * Check if the conversation should be compacted.
+   *
+   * Automatic compaction is decided by the live pre-flight token count in
+   * {@link createResponseImpl} — one measurement of the CURRENT request owns
+   * the decision (it sets {@link compactionRequested} and retries
+   * internally). The cumulative-usage threshold below is only the fallback
+   * decision for models that cannot count tokens pre-flight; the cumulative
+   * figure comes from the PREVIOUS successful response and goes stale the
+   * moment a single turn adds a large input.
    */
   private shouldCompact(): boolean {
     if (!this.supportsManualCompaction) {
@@ -647,15 +673,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return false;
     }
 
-    // Manual compaction request bypasses threshold checks.
+    // Manual/requested compaction bypasses threshold checks.
     // The flag is NOT cleared here - the caller clears it after compaction
     // is attempted to preserve the request across retries.
     if (this.compactionRequested) {
-      if (this.isOpenRouterRoutingEnabled()) {
-        return false;
-      }
-      // Only compact if there are tokens to compact
-      return this.chainState.getCumulativeInputTokens() > 0;
+      return this.canCompactRoute();
+    }
+
+    if (this.supportsTokenCounting) {
+      // The live pre-flight count decides for counting-capable models.
+      return false;
     }
 
     const thresholdPercent = this.getCompactionThresholdPercent();
@@ -1434,6 +1461,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     this.inFlight = true;
+    this.liveCountCompactionAttempted = false;
     try {
       return await run();
     } finally {
@@ -1545,9 +1573,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // For automatic compaction (threshold-based), this is a no-op since the flag is false.
       this.compactionRequested = false;
       if (wasManualRequest) {
+        // Requested compactions come from the manual command, the live-count
+        // threshold, or the overflow recovery — each already logged its
+        // trigger; this line records the execution.
         logProgressStatus(
           this.logger,
-          `Compacting conversation (manually requested, ${this.chainState.getCumulativeInputTokens()} input tokens)`,
+          `Compacting conversation (requested, ${this.chainState.getCumulativeInputTokens()} input tokens)`,
         );
       } else {
         const threshold = this.getCompactionTokenThreshold();
@@ -1624,66 +1655,99 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_output_tokens if needed
     //
-    // Two-layer protection against context overflow:
-    // 1. shouldCompact() uses cumulativeInputTokens (from PREVIOUS response) at 75% threshold
-    //    to proactively compact before trouble
-    // 2. This native count (CURRENT request) is the safety net at 100% threshold
-    //
-    // NOTE: When previous_response_id is set, the API includes server-side history
-    // (per OpenAI docs). However, there may be edge cases where token counting
-    // doesn't match actual context usage. See PRD Known Issues for investigation.
-    if (!this.supportsTokenCounting) {
-      maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
+    // The live count of the CURRENT request is the one accurate measurement
+    // (with previous_response_id set it includes server-side history, per
+    // OpenAI docs) and owns every context decision for counting-capable
+    // models: it reduces max_output_tokens, it triggers compaction at the
+    // threshold (below, after this block), and past 100% it throws — routed
+    // through handleCreateResponseError so a pre-flight overflow gets the
+    // same recovery as an API-side rejection (drop previous_response_id,
+    // compact, retry internally). Throwing it raw would dead-end: every
+    // external retry of the unchanged request overflows identically.
+    let preFlightTokens: number | undefined;
+    try {
+      if (!this.supportsTokenCounting) {
+        maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
+      }
+
+      await this.applyTokenCountLimit({
+        // Reuse built params for token counting (build once principle).
+        // IMPORTANT: Pass tools and systemPrompt for accurate count.
+        countTokens: () =>
+          this.estimateTokenCount(baseParams.input, {
+            client,
+            signal,
+            systemPrompt,
+            tools: convertedTools,
+          }),
+        currentMaxTokens: maxOutputTokens,
+        contextWindow: this.getEffectiveContextWindow(),
+        tokenBuffer: this.getTokenSafetyBuffer(),
+        detailLabel:
+          'OpenAI Response: max_output_tokens reduced to fit context window',
+        applyReduced: (adjusted) => {
+          maxOutputTokens = adjusted;
+        },
+        onCounted: (inputTokens) => {
+          preFlightTokens = inputTokens;
+          // DIAGNOSTIC: Log token count details for investigation.
+          // Compare pre-flight estimate with cumulative tokens from prev response.
+          const prevCumulative = this.chainState.getCumulativeInputTokens();
+          const utilizationEstimate =
+            (inputTokens / this.getEffectiveContextWindow()) * 100;
+          this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
+          this.logger.debug('[TOKEN_DIAG] Pre-flight count', {
+            data: {
+              preFlightTokens: inputTokens,
+              utilizationEstimate,
+              prevCumulativeTokens: prevCumulative,
+              delta: inputTokens - prevCumulative,
+              newMessagesCount: newMessages.length,
+              totalMessagesCount: effectiveMessages.length,
+              hasPreviousResponseId: !!this.chainState.getPreviousResponseId(),
+              hasTools: !!convertedTools?.length,
+              toolCount: convertedTools?.length ?? 0,
+              contextWindow: this.getEffectiveContextWindow(),
+              maxOutputTokens,
+            },
+          });
+        },
+        onCountFailure: (err) => {
+          this.logger.debug('Token counting failed; applying fallback cap', {
+            data: buildErrorLogData(err, { operation: 'token counting' }),
+          });
+          maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
+        },
+      });
+    } catch (error) {
+      return await this.handleCreateResponseError(
+        error,
+        options,
+        compactedThisCall,
+      );
     }
 
-    await this.applyTokenCountLimit({
-      // Reuse built params for token counting (build once principle).
-      // IMPORTANT: Pass tools and systemPrompt for accurate count.
-      countTokens: () =>
-        this.estimateTokenCount(baseParams.input, {
-          client,
-          signal,
-          systemPrompt,
-          tools: convertedTools,
-        }),
-      currentMaxTokens: maxOutputTokens,
-      contextWindow: this.getEffectiveContextWindow(),
-      tokenBuffer: this.getTokenSafetyBuffer(),
-      detailLabel:
-        'OpenAI Response: max_output_tokens reduced to fit context window',
-      applyReduced: (adjusted) => {
-        maxOutputTokens = adjusted;
-      },
-      onCounted: (inputTokens) => {
-        // DIAGNOSTIC: Log token count details for investigation.
-        // Compare pre-flight estimate with cumulative tokens from prev response.
-        const prevCumulative = this.chainState.getCumulativeInputTokens();
-        const utilizationEstimate =
-          (inputTokens / this.getEffectiveContextWindow()) * 100;
-        this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
-        this.logger.debug('[TOKEN_DIAG] Pre-flight count', {
-          data: {
-            preFlightTokens: inputTokens,
-            utilizationEstimate,
-            prevCumulativeTokens: prevCumulative,
-            delta: inputTokens - prevCumulative,
-            newMessagesCount: newMessages.length,
-            totalMessagesCount: effectiveMessages.length,
-            hasPreviousResponseId: !!this.chainState.getPreviousResponseId(),
-            hasTools: !!convertedTools?.length,
-            toolCount: convertedTools?.length ?? 0,
-            contextWindow: this.getEffectiveContextWindow(),
-            maxOutputTokens,
-          },
-        });
-      },
-      onCountFailure: (err) => {
-        this.logger.debug('Token counting failed; applying fallback cap', {
-          data: buildErrorLogData(err, { operation: 'token counting' }),
-        });
-        maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
-      },
-    });
+    // Threshold decision on the live count: compact and retry internally
+    // before sending, using the same requested-compaction mechanism as the
+    // overflow recovery. The one-shot guard keeps a compaction attempt that
+    // failed to shrink the transcript from recursing again on its recount.
+    if (
+      preFlightTokens !== undefined &&
+      !compactedThisCall &&
+      !this.liveCountCompactionAttempted &&
+      this.getCompactionThresholdPercent() > 0 &&
+      preFlightTokens > this.getCompactionTokenThreshold() &&
+      this.canCompactRoute()
+    ) {
+      logProgressStatus(
+        this.logger,
+        `Compacting conversation (pre-flight count ${preFlightTokens} tokens exceeds ${this.getCompactionThresholdPercent()}% threshold of ${this.getCompactionTokenThreshold()} tokens)`,
+      );
+      this.liveCountCompactionAttempted = true;
+      this.compactionRequested = true;
+      this._diagPreFlightTokens = null;
+      return this.createResponseImpl(options);
+    }
 
     // Phase 4: EXECUTE - Build final params and make the API call
     const parallelToolCalls = getConfig<boolean>(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1716,7 +1716,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           this.logger.debug('Token counting failed; applying fallback cap', {
             data: buildErrorLogData(err, { operation: 'token counting' }),
           });
-          maxOutputTokens = this.applyTokenCountFailureFallback(maxOutputTokens);
+          maxOutputTokens =
+            this.applyTokenCountFailureFallback(maxOutputTokens);
         },
       });
     } catch (error) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -415,15 +415,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   private inFlight = false;
 
-  /**
-   * One-shot guard for the internal compact-and-retry recursions (the
-   * live-count threshold in {@link createResponseImpl} and the overflow
-   * recovery in {@link handleCreateResponseError}): if a compaction attempt
-   * fails to shrink the transcript, the recursive attempt would hit the same
-   * threshold/overflow again and must not recurse a second time. Reset per
-   * public call.
-   */
-  private compactionRetryAttempted = false;
+  /** Internal compaction recovery already attempted during this public call. */
+  private compactionRetrySource: 'threshold' | 'overflow' | null = null;
 
   /** DIAGNOSTIC: Pre-flight token estimate for comparison with actual usage */
   private _diagPreFlightTokens: number | null = null;
@@ -1469,7 +1462,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     this.inFlight = true;
-    this.compactionRetryAttempted = false;
+    this.compactionRetrySource = null;
     try {
       return await run();
     } finally {
@@ -1743,7 +1736,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (
       preFlightTokens !== undefined &&
       !compactedThisCall &&
-      !this.compactionRetryAttempted &&
+      this.compactionRetrySource === null &&
       this.getCompactionThresholdPercent() > 0 &&
       preFlightTokens > this.getCompactionTokenThreshold() &&
       this.canCompactRoute()
@@ -1752,7 +1745,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.logger,
         `Compacting conversation (pre-flight count ${preFlightTokens} tokens exceeds ${this.getCompactionThresholdPercent()}% threshold of ${this.getCompactionTokenThreshold()} tokens)`,
       );
-      this.compactionRetryAttempted = true;
+      this.compactionRetrySource = 'threshold';
       this.compactionRequested = true;
       this._diagPreFlightTokens = null;
       return this.createResponseImpl(options);
@@ -2249,7 +2242,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } else if (
       isContextWindowError(error) &&
       !compactedThisCall &&
-      !this.compactionRetryAttempted &&
+      this.compactionRetrySource !== 'overflow' &&
       (this.chainState.hasPreviousResponseId() || this.canCompactRoute())
     ) {
       // Recovery for a context-window overflow (API-side or pre-flight):
@@ -2262,17 +2255,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       //   route), a compactable transcript still recovers via compaction
       //   alone.
       // Termination: compactedThisCall blocks re-entry after a successful
-      // compaction, and compactionRetryAttempted blocks it when compaction
-      // failed to shrink the transcript.
+      // compaction, and the overflow source blocks a second overflow recovery.
       logProgressStatus(
         this.logger,
         'Context window exceeded — compacting conversation and retrying.',
       );
-      this.chainState.setPreviousResponseId(null);
+      this.chainState.invalidateChain();
       // Don't call resetConversationState() — it zeroes cumulativeInputTokens
       // which would prevent shouldCompact() from triggering on the retry.
       this.backgroundLifecycle.clearPending();
-      this.compactionRetryAttempted = true;
+      this.compactionRetrySource = 'overflow';
       this.compactionRequested = true;
       this._diagPreFlightTokens = null;
       // Retry internally: the recursive call will compact (shouldCompact()=true)

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -217,7 +217,14 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Guarded on the status code because isContextWindowError also matches by
   // message wording, and a retryable provider error (e.g. a 429 mentioning
   // tokens) must keep its retry affordance.
-  const overflowStatusCode = detectStatusCode(err);
+  const detectedOverflowStatusCode = detectStatusCode(err);
+  const overflowStatusCode =
+    (detectedOverflowStatusCode !== undefined &&
+    detectedOverflowStatusCode >= 400
+      ? detectedOverflowStatusCode
+      : undefined) ??
+    inferStatusCodeFromBody(rawErrorBody) ??
+    detectedOverflowStatusCode;
   if (
     isContextWindowError(err) &&
     (overflowStatusCode === undefined ||

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -12,6 +12,7 @@ import {
   toErrorMessage,
 } from '@utils/errors/errorMessage';
 import { findInCauseChain, isDiskFullError } from '../errorPredicates';
+import { isContextWindowError } from './errorPatterns';
 import {
   detectPartialText,
   detectSdkErrorMetadata,
@@ -206,6 +207,26 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (isDiskFullError(err)) {
     return terminalError(
       'No space left on device. Free up disk space and try again.',
+    );
+  }
+
+  // Context-window overflow — deterministic: a retry resends the same
+  // oversized payload and fails again. Handler-level recovery (compaction,
+  // dropping previous_response_id) runs before the error reaches this
+  // classifier, so an overflow that arrives here is terminal for this turn.
+  // Guarded on the status code because isContextWindowError also matches by
+  // message wording, and a retryable provider error (e.g. a 429 mentioning
+  // tokens) must keep its retry affordance.
+  const overflowStatusCode = detectStatusCode(err);
+  if (
+    isContextWindowError(err) &&
+    (overflowStatusCode === undefined ||
+      !isRetryableStatusCode(overflowStatusCode))
+  ) {
+    return terminalError(
+      `${extractedMessage ?? 'Conversation exceeds the model context window.'} ` +
+        'Retrying would resend the same oversized request. Start a new ' +
+        'session, or reduce attached files and tool output.',
     );
   }
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -866,6 +866,140 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.equal(requests[2].max_output_tokens, 99990);
   });
 
+  it('compacts before sending when the live pre-flight count crosses the threshold', async () => {
+    const handler = createHandler({
+      openRouterOnly: false,
+      contextWindow: 200000,
+    });
+    const compactCalls: ResponseInputItem[][] = [];
+    const requests: any[] = [];
+    let tokenCountCalls = 0;
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            // Turn 2's live count lands between the 75% threshold (150k) and
+            // the 200k window: the stale cumulative from turn 1 (100k) would
+            // never have triggered, but the live count must.
+            return { input_tokens: tokenCountCalls === 2 ? 180000 : 1000 };
+          },
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          return createResponse(`resp-${requests.length}`, {
+            input_tokens: 100000,
+          });
+        },
+      },
+    };
+    (
+      handler as unknown as { compactConversation: unknown }
+    ).compactConversation = async (
+      _client: unknown,
+      msgs: ResponseInputItem[],
+    ) => {
+      compactCalls.push(msgs);
+      const compacted = msgs.slice(-1);
+      (handler as unknown as { compactionResult: unknown }).compactionResult =
+        {
+          sourceMessages: msgs,
+          compactedMessages: compacted,
+          tokensAfter: 1000,
+        };
+      return compacted;
+    };
+
+    await handler.createResponse({
+      client: client as any,
+      messages: createMessages(2),
+      temperature: 0,
+    });
+
+    const secondTurn = createMessages(4);
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: secondTurn,
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-2');
+    assert.equal(requests.length, 2);
+    assert.equal(compactCalls.length, 1);
+    assert.equal(tokenCountCalls, 3);
+    assert.deepEqual(requests[1].input, secondTurn.slice(-1));
+  });
+
+  it('recovers a pre-flight context-window overflow by dropping the chain and compacting', async () => {
+    const handler = createHandler({
+      openRouterOnly: false,
+      contextWindow: 200000,
+    });
+    const compactCalls: ResponseInputItem[][] = [];
+    const requests: any[] = [];
+    let tokenCountCalls = 0;
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            // Turn 2's pre-flight count overflows the 200k window (the count
+            // includes server-side chained history); the internal retry after
+            // dropping the chain and compacting fits again.
+            return { input_tokens: tokenCountCalls === 2 ? 300000 : 1000 };
+          },
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          return createResponse(`resp-${requests.length}`, {
+            input_tokens: 100000,
+          });
+        },
+      },
+    };
+    (
+      handler as unknown as {
+        compactConversation: unknown;
+        compactionResult: unknown;
+      }
+    ).compactConversation = async (
+      _client: unknown,
+      msgs: ResponseInputItem[],
+    ) => {
+      compactCalls.push(msgs);
+      const compacted = msgs.slice(-1);
+      (handler as unknown as { compactionResult: unknown }).compactionResult =
+        {
+          sourceMessages: msgs,
+          compactedMessages: compacted,
+        };
+      return compacted;
+    };
+
+    await handler.createResponse({
+      client: client as any,
+      messages: createMessages(2),
+      temperature: 0,
+    });
+
+    const secondTurn = createMessages(4);
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: secondTurn,
+      temperature: 0,
+    });
+
+    // The overflow never escaped to the caller: the oversized chained request
+    // was never sent, and the recovered attempt went out unchained with the
+    // compacted transcript.
+    assert.equal(result.response.id, 'resp-2');
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].previous_response_id, undefined);
+    assert.equal(compactCalls.length, 1);
+    assert.equal(tokenCountCalls, 3);
+    assert.deepEqual(requests[1].input, secondTurn.slice(-1));
+  });
+
   it('tags the fallback hard-failure throw with the context-window marker', () => {
     // Mirrors ModelHandler.validateTokenLimits (#8078, followed up in #8100):
     // isContextWindowError() must recognize this throw via its typed marker,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -1035,12 +1035,11 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     ) => {
       compactCalls.push(msgs);
       const compacted = msgs.slice(-1);
-      (handler as unknown as { compactionResult: unknown }).compactionResult =
-        {
-          sourceMessages: msgs,
-          compactedMessages: compacted,
-          tokensAfter: 1000,
-        };
+      (handler as unknown as { compactionResult: unknown }).compactionResult = {
+        sourceMessages: msgs,
+        compactedMessages: compacted,
+        tokensAfter: 1000,
+      };
       return compacted;
     };
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -30,6 +30,7 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 import {
+  attachContextWindowError,
   hasContextWindowErrorMarker,
   isContextWindowError,
 } from '@common/errors/sdkErrorUtils';
@@ -1063,7 +1064,7 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.deepEqual(requests[1].input, secondTurn.slice(-1));
   });
 
-  it('fails fast instead of recursing when compaction cannot shrink an overflowing transcript', async () => {
+  it('bounds failed compaction recovery and preserves unchained history', async () => {
     const handler = createHandler({
       openRouterOnly: false,
       contextWindow: 200000,
@@ -1076,21 +1077,25 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
         inputTokens: {
           count: async () => {
             tokenCountCalls += 1;
-            // Turn 2 overflows on every attempt — compaction doesn't help.
-            return { input_tokens: tokenCountCalls >= 2 ? 300000 : 1000 };
+            return {
+              input_tokens:
+                tokenCountCalls === 2 || tokenCountCalls === 3 ? 180000 : 1000,
+            };
           },
         },
         create: async (params: any) => {
           requests.push(params);
+          if (requests.length > 1) {
+            const error = new Error('maximum context length exceeded');
+            attachContextWindowError(error);
+            throw error;
+          }
           return createResponse(`resp-${requests.length}`, {
             input_tokens: 100000,
           });
         },
       },
     };
-    // A compaction that fails to produce a result (compactionResult stays
-    // unset), so compactedThisCall never becomes true — only the one-shot
-    // guard stands between this and infinite recursion.
     (
       handler as unknown as { compactConversation: unknown }
     ).compactConversation = async (
@@ -1107,19 +1112,21 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
       temperature: 0,
     });
 
+    const secondTurn = createMessages(4);
     await assert.rejects(
       handler.createResponse({
         client: client as any,
-        messages: createMessages(4),
+        messages: secondTurn,
         temperature: 0,
       }),
-      /exceeds context window/,
+      /maximum context length exceeded/,
     );
 
-    // Exactly one recovery attempt: the failed compaction did not recurse
-    // again, and no oversized request ever reached the API.
-    assert.equal(compactCalls.length, 1);
-    assert.equal(requests.length, 1);
+    assert.equal(compactCalls.length, 2);
+    assert.equal(requests.length, 3);
+    assert.equal(requests[1].previous_response_id, 'resp-1');
+    assert.equal(requests[2].previous_response_id, undefined);
+    assert.deepEqual(requests[2].input, secondTurn);
   });
 
   it('tags the fallback hard-failure throw with the context-window marker', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -901,12 +901,11 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     ) => {
       compactCalls.push(msgs);
       const compacted = msgs.slice(-1);
-      (handler as unknown as { compactionResult: unknown }).compactionResult =
-        {
-          sourceMessages: msgs,
-          compactedMessages: compacted,
-          tokensAfter: 1000,
-        };
+      (handler as unknown as { compactionResult: unknown }).compactionResult = {
+        sourceMessages: msgs,
+        compactedMessages: compacted,
+        tokensAfter: 1000,
+      };
       return compacted;
     };
 
@@ -968,11 +967,10 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     ) => {
       compactCalls.push(msgs);
       const compacted = msgs.slice(-1);
-      (handler as unknown as { compactionResult: unknown }).compactionResult =
-        {
-          sourceMessages: msgs,
-          compactedMessages: compacted,
-        };
+      (handler as unknown as { compactionResult: unknown }).compactionResult = {
+        sourceMessages: msgs,
+        compactedMessages: compacted,
+      };
       return compacted;
     };
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -998,6 +998,131 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.deepEqual(requests[1].input, secondTurn.slice(-1));
   });
 
+  it('recovers an unchained pre-flight overflow by compacting (no previous_response_id to drop)', async () => {
+    // cursor[bot]/claude[bot] review finding on this PR: recovery used to
+    // require hasPreviousResponseId(), so after invalidateChain() or on a
+    // non-chaining route an overflow failed hard without ever attempting
+    // compaction — a regression vs the old cumulative-threshold trigger.
+    const handler = setupHandler(
+      new NonChainingResponseHandler(
+        createConfig({ openRouterOnly: false, contextWindow: 200000 }),
+      ),
+    );
+    const compactCalls: ResponseInputItem[][] = [];
+    const requests: any[] = [];
+    let tokenCountCalls = 0;
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            return { input_tokens: tokenCountCalls === 2 ? 300000 : 1000 };
+          },
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          return createResponse(`resp-${requests.length}`, {
+            input_tokens: 100000,
+          });
+        },
+      },
+    };
+    (
+      handler as unknown as { compactConversation: unknown }
+    ).compactConversation = async (
+      _client: unknown,
+      msgs: ResponseInputItem[],
+    ) => {
+      compactCalls.push(msgs);
+      const compacted = msgs.slice(-1);
+      (handler as unknown as { compactionResult: unknown }).compactionResult =
+        {
+          sourceMessages: msgs,
+          compactedMessages: compacted,
+          tokensAfter: 1000,
+        };
+      return compacted;
+    };
+
+    await handler.createResponse({
+      client: client as any,
+      messages: createMessages(2),
+      temperature: 0,
+    });
+
+    const secondTurn = createMessages(4);
+    const result = await handler.createResponse({
+      client: client as any,
+      messages: secondTurn,
+      temperature: 0,
+    });
+
+    assert.equal(result.response.id, 'resp-2');
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].previous_response_id, undefined);
+    assert.equal(compactCalls.length, 1);
+    assert.deepEqual(requests[1].input, secondTurn.slice(-1));
+  });
+
+  it('fails fast instead of recursing when compaction cannot shrink an overflowing transcript', async () => {
+    const handler = createHandler({
+      openRouterOnly: false,
+      contextWindow: 200000,
+    });
+    const compactCalls: ResponseInputItem[][] = [];
+    const requests: any[] = [];
+    let tokenCountCalls = 0;
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            // Turn 2 overflows on every attempt — compaction doesn't help.
+            return { input_tokens: tokenCountCalls >= 2 ? 300000 : 1000 };
+          },
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          return createResponse(`resp-${requests.length}`, {
+            input_tokens: 100000,
+          });
+        },
+      },
+    };
+    // A compaction that fails to produce a result (compactionResult stays
+    // unset), so compactedThisCall never becomes true — only the one-shot
+    // guard stands between this and infinite recursion.
+    (
+      handler as unknown as { compactConversation: unknown }
+    ).compactConversation = async (
+      _client: unknown,
+      msgs: ResponseInputItem[],
+    ) => {
+      compactCalls.push(msgs);
+      return msgs;
+    };
+
+    await handler.createResponse({
+      client: client as any,
+      messages: createMessages(2),
+      temperature: 0,
+    });
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: createMessages(4),
+        temperature: 0,
+      }),
+      /exceeds context window/,
+    );
+
+    // Exactly one recovery attempt: the failed compaction did not recurse
+    // again, and no oversized request ever reached the API.
+    assert.equal(compactCalls.length, 1);
+    assert.equal(requests.length, 1);
+  });
+
   it('tags the fallback hard-failure throw with the context-window marker', () => {
     // Mirrors ModelHandler.validateTokenLimits (#8078, followed up in #8100):
     // isContextWindowError() must recognize this throw via its typed marker,

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -164,7 +164,7 @@ function createMessages(count: number): ResponseInputItem[] {
 }
 
 describe('ModelHandlerOpenAIResponse automatic compaction', () => {
-  it('compacts before the next response when prior usage crosses the threshold', async () => {
+  it('compacts before the next response when the live count crosses the threshold', async () => {
     const handler = createHandler();
     const requests: any[] = [];
     const compactRequests: any[] = [];
@@ -178,7 +178,10 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     const client = {
       responses: {
         inputTokens: {
-          count: async () => ({ input_tokens: 100 }),
+          // 800 > the 75% threshold (750) of the 1000-token window. Turn 1
+          // has nothing to compact (no prior response); turn 2 compacts off
+          // this live pre-flight count.
+          count: async () => ({ input_tokens: 800 }),
         },
         compact: async (params: any) => {
           compactRequests.push(params);
@@ -237,7 +240,9 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     const client = {
       responses: {
         inputTokens: {
-          count: async () => ({ input_tokens: 100 }),
+          // Over the 750-token threshold: turn 2's live count triggers the
+          // compaction whose payload the same-turn retry must then reuse.
+          count: async () => ({ input_tokens: 800 }),
         },
         compact: async (params: any) => {
           compactRequests.push(params);
@@ -315,10 +320,18 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
         content: [{ type: 'input_text', text: 'compacted state' }],
       },
     ] as unknown as ResponseInputItem[];
+    let tokenCountCalls = 0;
     const client = {
       responses: {
         inputTokens: {
-          count: async () => ({ input_tokens: 100 }),
+          count: async () => {
+            tokenCountCalls += 1;
+            // Turn 1 and turn 2's pre-compaction counts are over the 750
+            // threshold (turn 1 has no prior response, so only turn 2
+            // compacts); after compaction the transcript is small again, so
+            // turn 3 stays under and must NOT compact.
+            return { input_tokens: tokenCountCalls <= 2 ? 800 : 160 };
+          },
         },
         compact: async (params: any) => {
           compactRequests.push(params);
@@ -354,8 +367,8 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     const turn2NewMessage = { role: 'user', content: 'message 3' };
     sharedMessages.push(turn2NewMessage as ResponseInputItem);
 
-    // Turn 1's response crossed the compaction threshold (800 > 750), so
-    // turn 2 compacts.
+    // Turn 2's live pre-flight count crosses the compaction threshold
+    // (800 > 750), so turn 2 compacts.
     const turn2Result = await handler.createResponse({
       client: client as any,
       messages: sharedMessages,

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -12,6 +12,7 @@ import {
 
 // Local imports - common errors
 import {
+  attachContextWindowError,
   formatProviderHttpError,
   normalizeProviderError,
   requiresFlowAutoRetry,
@@ -86,6 +87,35 @@ describe('OpenAI Responses error normalization', () => {
     expect(normalized.requestId).toBe('req_poll');
     expect(normalized.userRetryable).toBe(true);
     expect(requiresFlowAutoRetry(wrapped)).toBe(true);
+  });
+
+  it('classifies internally tagged context-window overflows as non-retryable', () => {
+    // The pre-flight guard's throw has no status code; without an explicit
+    // context-window branch the classifier would fall to the "no status code
+    // → retry for safety" default — but retrying resends the same oversized
+    // payload and deterministically fails again.
+    const error = new Error(
+      'Token count of message exceeds context window: 2331803 > 1050000',
+    );
+    attachContextWindowError(error);
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.userRetryable).toBe(false);
+    expect(providerError.message).toContain('2331803 > 1050000');
+
+    const normalized = normalizeProviderError(error);
+    expect(normalized.userRetryable).toBe(false);
+  });
+
+  it('classifies provider-worded context-window errors as non-retryable', () => {
+    const error = new Error(
+      "This model's maximum context length is 1050000 tokens.",
+    );
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.userRetryable).toBe(false);
   });
 
   it('keeps terminal background statuses retryable without HTTP metadata', () => {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -118,6 +118,24 @@ describe('OpenAI Responses error normalization', () => {
     expect(providerError.userRetryable).toBe(false);
   });
 
+  it('keeps body-classified rate limits retryable when their message mentions context', () => {
+    const error = Object.assign(
+      new Error("This model's maximum context length is temporarily limited."),
+      {
+        error: {
+          type: 'rate_limit_error',
+          message:
+            "This model's maximum context length is temporarily limited.",
+        },
+      },
+    );
+
+    const providerError = formatProviderHttpError(error);
+
+    expect(providerError.statusCode).toBe(429);
+    expect(providerError.userRetryable).toBe(true);
+  });
+
   it('keeps terminal background statuses retryable without HTTP metadata', () => {
     const wrapped = createOpenAIBackgroundTerminalError(
       {


### PR DESCRIPTION
## Problem (user report)

A numerics tool-use subagent on GPT-5.6 hit `Token count of message exceeds context window: 2331803 > 1050000`, then looped failure→retry→failure indefinitely (Progress view banners at 22:28/22:30/22:31), hanging the parent orchestrator. Fable/Anthropic runs were fine (server-side `context_management` compaction).

## Root cause: two divergent owners of one decision

| owner | measurement | power |
|---|---|---|
| `shouldCompact()` | PREVIOUS turn's cumulative usage vs 75% threshold | compaction |
| pre-flight `applyTokenCountLimit` | live count of the CURRENT request | reduce max_output_tokens; throw at 100% |

A single turn that jumps from <75% straight past 100% is invisible to the first owner, and the second owner's throw escaped **outside** the recovery try/catch — so the existing drop-`previous_response_id`-and-compact recovery (`handleCreateResponseError`) was unreachable exactly when needed. The throw also carries no HTTP status, so `normalizeProviderError` fell to "no status → retry for safety" and kept offering retries that resent the identical oversized payload (`RetryState` waits on the prompt with no timeout → the 死循环).

## Fix: one measurement owns every context decision

- **Live-count compaction**: after the pre-flight count, crossing the threshold sets the requested-compaction flag and retries internally — the same mechanism the overflow recovery uses, with a one-shot guard against a compaction that fails to shrink. `shouldCompact()`'s stale-cumulative branch now decides **only** for models that cannot count pre-flight (Codex subscription profile keeps its existing behavior — its capability sets `supportsTokenCounting: false`).
- **Pre-flight overflow routes through `handleCreateResponseError`**: gets the drop-chain + compact + internal-retry recovery instead of dead-ending; the `!supportsTokenCounting` fallback throw (tagged in b5b008009) is covered too.
- **Non-retryable classification**: `formatProviderHttpError` now consults `isContextWindowError` (its doc comment always said "should not be retried" — nothing consumed it), guarded on status code so a retryable provider error that merely mentions tokens (e.g. a 429) keeps its retry affordance. An overflow that survives recovery fails fast with actionable guidance.

## Tests

- New: live-count threshold compaction; pre-flight overflow recovery (chain dropped, compacted transcript sent, no error escapes); tagged + provider-worded overflow classified non-retryable.
- Updated `OpenAIResponseCompaction.vitest.ts` to the live-count semantics (mocks previously returned a 100-token live count while relying on stale cumulative 800 to trigger).
- Full `npm run typecheck` + `npm test` green (5738 passed).

## Verified

Opened: `modelHandlerOpenAIResponse.ts` (compaction phase, count phase, recovery), `ModelHandler.ts` (`applyTokenCountLimit`/`validateTokenLimits`), `providerErrorFormat.ts`, `errorPatterns.ts`, `RetryState.ts`, `OpenAIResponseCompaction.vitest.ts`, `ModelHandlerOpenAIResponse.vitest.ts`, `OpenAIResponseErrors.vitest.ts`.

Related: progress-view focus-steal / banner UX tracked separately in #8246.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core model-turn context management and retry classification; mistakes could skip compaction, over-compact, or misclassify retryable provider errors.
> 
> **Overview**
> Fixes infinite retry loops when a single turn jumps past the context window without crossing the stale **previous-turn** cumulative threshold used for compaction.
> 
> **OpenAI Responses handler** now treats the **live pre-flight token count** as the single owner for counting-capable models: it still trims `max_output_tokens`, but also **compacts and retries internally** when the count crosses the configured threshold (with a one-shot `compactionRetrySource` guard). `shouldCompact()` no longer uses cumulative usage for those models; cumulative thresholds remain only when pre-flight counting is unavailable. Pre-flight overflow from `applyTokenCountLimit` is caught and routed through **`handleCreateResponseError`**, so drop-chain + compact + internal retry matches API-side overflow. Overflow recovery no longer requires `previous_response_id`—unchained routes can compact alone—and uses **`invalidateChain()`** instead of only clearing the anchor.
> 
> **Provider errors**: `formatProviderHttpError` marks context-window overflows **non-retryable** (with status-code guard so token-related 429s stay retryable) and surfaces guidance when handler recovery did not succeed.
> 
> Tests cover live-count threshold compaction, pre-flight overflow recovery, bounded failed compaction, and error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92a8c6d09ebe6269f9ecf156355b5d7d90a9126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->