### PR TITLE
fix: guard agentLoad's inherits walk against circular chains

### DIFF
--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -155,8 +155,10 @@ export async function loadAgentSettingAndPrompts(
         `Unable to locate parent agent "${config.inherits}" in source "${entry.source}".`,
       );
     }
-    const [parentSettings, parentPrompts] =
-      await loadAgentSettingAndPrompts(parentResolution, nextSeen);
+    const [parentSettings, parentPrompts] = await loadAgentSettingAndPrompts(
+      parentResolution,
+      nextSeen,
+    );
 
     // Parent provides defaults, child overrides.
     // parentSettings has resolved ToolDefinition objects while

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -112,6 +112,7 @@ function resolveAgentSettingTools(settings: AgentSettingInput): object {
 
 export async function loadAgentSettingAndPrompts(
   resolution: ResolvedAgent,
+  seen: ReadonlySet<string> = new Set(),
 ): Promise<[AgentSetting, AgentPrompt]> {
   const { entry } = resolution;
 
@@ -124,6 +125,17 @@ export async function loadAgentSettingAndPrompts(
     // Remote agents are already fully processed (tools resolved, validated)
     return [remoteConfig.settings, remoteConfig.prompts];
   }
+
+  // Mirrors the cycle guard in agentYamlScanner.ts's inheritedDefinitionBlock:
+  // a self- or mutually-referential `inherits` chain must fail loudly here
+  // (this is the runtime load path) rather than recurse without bound.
+  const entryKey = agentKey(entry.source, entry.name);
+  if (seen.has(entryKey)) {
+    throw new Error(
+      `Circular "inherits" chain detected: ${[...seen, entryKey].join(' -> ')}.`,
+    );
+  }
+  const nextSeen = new Set([...seen, entryKey]);
 
   const rawConfig = await loadYaml(resolution.definitionPath);
   const config = AgentDefinitionSchema.parse(rawConfig);
@@ -144,7 +156,7 @@ export async function loadAgentSettingAndPrompts(
       );
     }
     const [parentSettings, parentPrompts] =
-      await loadAgentSettingAndPrompts(parentResolution);
+      await loadAgentSettingAndPrompts(parentResolution, nextSeen);
 
     // Parent provides defaults, child overrides.
     // parentSettings has resolved ToolDefinition objects while

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -3,16 +3,22 @@
 // Standard library imports
 import { strict as assert } from 'node:assert';
 import * as path from 'node:path';
-import { describe, it, beforeEach, afterEach } from 'vitest';
+import { describe, it, beforeEach, afterEach, vi } from 'vitest';
 
 // Local imports - agent runtime
-import type { ResolvedAgent } from '@agent/index';
+import { resolveAgent, type ResolvedAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   loadAgentSettingAndPrompts,
   validateAgentYamlContent,
 } from '@agent/runtime/agentLoad';
 import { AbsoluteFS } from '@utils/files';
+
+vi.mock('@agent/index', async () => {
+  const actual =
+    await vi.importActual<typeof import('@agent/index')>('@agent/index');
+  return { ...actual, resolveAgent: vi.fn(actual.resolveAgent) };
+});
 
 describe('validateAgentYamlContent', () => {
   it('rejects root settings that only satisfy the partial YAML schema', () => {
@@ -198,5 +204,53 @@ describe('loadAgentSettingAndPrompts', () => {
           `Failed to parse YAML at ${resolution.definitionPath}:`,
         ),
     );
+  });
+
+  it('rejects a circular "inherits" chain instead of recursing without bound', async () => {
+    const resolutionA = customResolution('agent_a', AgentCategory.Workflow);
+    const resolutionB = customResolution('agent_b', AgentCategory.Workflow);
+    const resolutionByName: Record<string, ResolvedAgent> = {
+      agent_a: resolutionA,
+      agent_b: resolutionB,
+    };
+
+    fileContents.set(
+      normalize(resolutionA.definitionPath),
+      [
+        'name: agent_a',
+        'inherits: agent_b',
+        'settings:',
+        '  agentCategory: workflow',
+        'prompts: {}',
+        '',
+      ].join('\n'),
+    );
+    fileContents.set(
+      normalize(resolutionB.definitionPath),
+      [
+        'name: agent_b',
+        'inherits: agent_a',
+        'settings:',
+        '  agentCategory: workflow',
+        'prompts: {}',
+        '',
+      ].join('\n'),
+    );
+
+    const resolveAgentMock = vi.mocked(resolveAgent);
+    resolveAgentMock.mockImplementation(
+      (identifier: string) => resolutionByName[identifier.split(':').pop()!],
+    );
+
+    try {
+      await assert.rejects(
+        () => loadAgentSettingAndPrompts(resolutionA),
+        (error: unknown) =>
+          error instanceof Error &&
+          error.message.startsWith('Circular "inherits" chain detected:'),
+      );
+    } finally {
+      resolveAgentMock.mockRestore();
+    }
   });
 });

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -237,6 +237,8 @@ describe('loadAgentSettingAndPrompts', () => {
       ].join('\n'),
     );
 
+    const actual =
+      await vi.importActual<typeof import('@agent/index')>('@agent/index');
     const resolveAgentMock = vi.mocked(resolveAgent);
     resolveAgentMock.mockImplementation(
       (identifier: string) => resolutionByName[identifier.split(':').pop()!],
@@ -250,7 +252,11 @@ describe('loadAgentSettingAndPrompts', () => {
           error.message.startsWith('Circular "inherits" chain detected:'),
       );
     } finally {
-      resolveAgentMock.mockRestore();
+      // mockRestore() only rehydrates vi.spyOn() mocks; this is a plain
+      // vi.fn(actual.resolveAgent), so restore the real implementation
+      // explicitly to avoid leaving `resolveAgent` returning undefined for
+      // any later test in this describe block.
+      resolveAgentMock.mockImplementation(actual.resolveAgent);
     }
   });
 });


### PR DESCRIPTION
## Summary

Found while auditing the codebase for overlapping/duplicated responsibilities: agent-YAML `inherits` resolution is implemented independently in two places — the runtime loader (`src/agent/runtime/agentLoad.ts::loadAgentSettingAndPrompts`) and the registry scanner (`src/agent/index/agentYamlScanner.ts::inheritedDefinitionBlock`). Both walk the same parent chain, but only the scanner guards against cycles (it threads a `seen: ReadonlySet<string>` and returns `complete: false` on a repeat). The runtime loader recursed through `resolveAgent()` with no visited-set tracking at all, so a self- or mutually-referential `inherits` chain in a custom agent YAML would recurse without bound and crash the process with a stack overflow instead of failing with a clear error.

This PR brings the runtime loader's cycle safety in line with the scanner's, using the same pattern: thread a `seen` set through the recursive calls and throw a clear "Circular inherits chain detected" error the first time an already-visited agent key is seen again.

## Issue acceptance gates

- A self-referential or mutually-referential `inherits` chain in an agent YAML now fails with a descriptive `Circular "inherits" chain detected: ...` error instead of recursing unboundedly. Covered by a new test (`rejects a circular "inherits" chain instead of recursing without bound`).
- No behavior change for any non-circular `inherits` chain (the new `seen` parameter defaults to an empty set and is purely additive).

## Single source of truth

No new shared module was introduced — the fix is local to `loadAgentSettingAndPrompts`, mirroring the guard pattern already established in `agentYamlScanner.ts::inheritedDefinitionBlock`. Full consolidation of the three agent-YAML loaders (runtime loader, registry scanner, `RemoteAgentLoader`) into one shared implementation is a larger, separate refactor — out of scope here to keep this change minimal and low-risk.

## Duplication and abstraction budget

No duplication removed (the two loaders remain independent); no new abstraction added. This closes a *drift* between two duplicate implementations (one had a safety invariant the other lacked), not the duplication itself.

## Net elements (R6)

n/a — no exported symbols added; `loadAgentSettingAndPrompts` gained one optional parameter (`seen`, defaulted, backward compatible with all existing call sites).

## Consumer counts (R8)

n/a — no emit path, export, or public signature removed/re-routed. `loadAgentSettingAndPrompts` is called from `packages/extension/src/commands/system/yamlCommands.ts` (2 call sites) and `src/agent/runtime/AgentLaunchContext.ts` (1 call site); all omit the new parameter and are unaffected.

## Host impact

Extension: none (command call sites unaffected; new parameter is optional).

Desktop: none (shares the same core loader).

CLI: none (shares the same core loader).

## Scheduled refactoring

None. If future work resolves the three-way loader duplication documented separately, this cycle guard's behavior should be preserved.

## Validation

- `npx vitest run src/test-kernel/agent/runtime/agentLoad.vitest.ts` — 9 passed (includes new cycle-detection test).
- `npx vitest run src/test-kernel/agent` — 1298 passed, 4 skipped (full agent test-kernel suite, no regressions).
- `npm run typecheck` — clean across all workspaces.
- `npx eslint src/agent/runtime/agentLoad.ts src/test-kernel/agent/runtime/agentLoad.vitest.ts` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_011dSbYh3TVUWqTrLRyX7jdR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive guard on an optional parameter; non-circular loads are unchanged and failure mode improves for bad YAML.
> 
> **Overview**
> **`loadAgentSettingAndPrompts`** now tracks visited agent keys while walking YAML `inherits` parents. On a repeat, it throws **`Circular "inherits" chain detected: ...`** with the path through the cycle instead of recursing until a stack overflow.
> 
> The optional **`seen`** parameter defaults to an empty set, so existing callers are unchanged for valid inheritance trees. Behavior aligns with the cycle guard already used in **`agentYamlScanner.ts`**.
> 
> A vitest case covers mutual **`agent_a` ↔ `agent_b`** inheritance with a mocked **`resolveAgent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16089f57874d640489a9f2c28d260e0f5fa7efbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->