### PR TITLE
refactor: consolidate duplicated path-containment, data-URL, and effect-cancellation logic

### DIFF
--- a/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ApiModeForm.tsx
@@ -1,8 +1,9 @@
 import { Box, Text } from 'ink';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { type CliApiMode } from '@cli/runtime/apiAccessMode';
 import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import { useCancellableEffect } from '../state/useCancellableEffect';
 import { KeyHints } from '../ui/KeyHints';
 import { LoadingIndicator } from '../ui/LoadingIndicator';
 import { Select } from '../ui/Select';
@@ -21,20 +22,19 @@ export function ApiModeForm(props: ApiModeFormProps): React.JSX.Element {
     null,
   );
 
-  useEffect(() => {
-    let cancelled = false;
-    setStatusLines(null);
-    void loadCliApiStatusLines({ apiMode: props.currentMode })
-      .then((lines) => {
-        if (!cancelled) setStatusLines(lines);
-      })
-      .catch((error: unknown) => {
-        if (!cancelled) setStatusLines([String(error)]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [props.currentMode]);
+  useCancellableEffect(
+    (isCancelled) => {
+      setStatusLines(null);
+      void loadCliApiStatusLines({ apiMode: props.currentMode })
+        .then((lines) => {
+          if (!isCancelled()) setStatusLines(lines);
+        })
+        .catch((error: unknown) => {
+          if (!isCancelled()) setStatusLines([String(error)]);
+        });
+    },
+    [props.currentMode],
+  );
 
   const items = [
     {

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -4,13 +4,14 @@
 // copied verbatim across every list form; it lives here once.
 
 import { useInput } from 'ink';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import {
   isEscapeInput,
   isPlainReturnInput,
   type ReturnKeyInput,
 } from '@cli/chat/tui/input/inputKeys';
+import { useCancellableEffect } from '@cli/chat/tui/state/useCancellableEffect';
 
 export interface AsyncListFormState<T> {
   readonly data: T | undefined;
@@ -116,24 +117,23 @@ export function useAsyncListForm<T>(
   });
 
   const { load } = options;
-  useEffect(() => {
-    let cancelled = false;
-    void load()
-      .then((result) => {
-        if (cancelled) return;
-        setData(result);
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+  useCancellableEffect(
+    (isCancelled) => {
+      void load()
+        .then((result) => {
+          if (isCancelled()) return;
+          setData(result);
+          setLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (isCancelled()) return;
+          setError(String(err));
+          setLoading(false);
+        });
+    },
     // Load once on mount, matching the original per-form `useEffect(..., [])`.
-  }, []);
+    [],
+  );
 
   return { data, loading, error, pendingInput, clearPendingInput, setData };
 }

--- a/packages/cli/src/chat/tui/state/useCancellableEffect.ts
+++ b/packages/cli/src/chat/tui/state/useCancellableEffect.ts
@@ -1,0 +1,32 @@
+// Shared "did this unmount / re-run before my async work finished?" guard.
+// Every async `useEffect` in the TUI needs to drop state updates that resolve
+// after the effect's cleanup has already run; that boilerplate (a `cancelled`
+// flag set in the cleanup, read from the async continuation) was previously
+// hand-rolled at each call site. `useCancellableEffect` centralizes it.
+
+import { useEffect } from 'react';
+
+export type IsEffectCancelled = () => boolean;
+
+/**
+ * Runs `effect` like a normal `useEffect`, but passes it an `isCancelled()`
+ * check the effect can poll before applying async state updates after
+ * unmount or a dependency change. `effect` may itself be async (its returned
+ * promise is not awaited) and may optionally return its own cleanup
+ * function, mirroring the real `useEffect` contract.
+ */
+export function useCancellableEffect(
+  effect: (
+    isCancelled: IsEffectCancelled,
+  ) => void | Promise<void> | (() => void),
+  deps: React.DependencyList,
+): void {
+  useEffect(() => {
+    let cancelled = false;
+    const cleanup = effect(() => cancelled);
+    return () => {
+      cancelled = true;
+      if (typeof cleanup === 'function') cleanup();
+    };
+  }, deps);
+}

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -14,7 +14,7 @@
 
 import { render, Box, Text, useApp, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { platform } from '@platform/platform';
 import {
@@ -28,6 +28,7 @@ import { setPreferCodexSubscription, type CodexSession } from '@auth/codex';
 import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { type OAuthProvider } from '@auth/sharedConfig';
 import { type SupabaseSession } from '@auth/SupabaseSession';
+import { useCancellableEffect } from '@cli/chat/tui/state/useCancellableEffect';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
@@ -608,28 +609,23 @@ interface RelayProgressCallbacks {
  * Run a sign-in exactly once on mount. Empty deps is deliberate (not the
  * captured props): re-running would open a second browser + loopback server
  * (or request a second device code), and a deps-triggered cleanup would flip
- * `cancelled` and orphan the in-flight login (eternal spinner). The captured
- * callbacks only invoke stable state setters / app.exit, so the mount-time
- * closure stays correct. `cancelled` guards against the real unmount (the
- * user navigating away); progress callbacks receive it to drop late updates.
+ * `isCancelled()` and orphan the in-flight login (eternal spinner). The
+ * captured callbacks only invoke stable state setters / app.exit, so the
+ * mount-time closure stays correct. `isCancelled()` guards against the real
+ * unmount (the user navigating away); progress callbacks receive it to drop
+ * late updates.
  */
 function useSignInOnMount(
   signIn: (isCancelled: () => boolean) => Promise<SupabaseSession>,
   callbacks: RelayProgressCallbacks,
 ): void {
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const session = await signIn(() => cancelled);
-        if (!cancelled) callbacks.onSuccess(session.account.label);
-      } catch (loginError: unknown) {
-        if (!cancelled) callbacks.onError(toErrorMessage(loginError));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+  useCancellableEffect(async (isCancelled) => {
+    try {
+      const session = await signIn(isCancelled);
+      if (!isCancelled()) callbacks.onSuccess(session.account.label);
+    } catch (loginError: unknown) {
+      if (!isCancelled()) callbacks.onError(toErrorMessage(loginError));
+    }
   }, []);
 }
 
@@ -755,36 +751,30 @@ function ChatGptProgressStep(
       : 'Preparing ChatGPT sign-in...',
   );
 
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const session = await signInCliChatGpt(
-          { device, noBrowser: false },
-          {
-            writeProgress: (next) => {
-              if (!cancelled) setMessage(next);
-            },
+  useCancellableEffect(async (isCancelled) => {
+    try {
+      const session = await signInCliChatGpt(
+        { device, noBrowser: false },
+        {
+          writeProgress: (next) => {
+            if (!isCancelled()) setMessage(next);
           },
-        );
-        const update = await setPreferCodexSubscription(true);
-        if (!update.effective) {
-          if (!cancelled) {
-            props.onError(
-              'Signed in with ChatGPT, but a more specific setting keeps the subscription disabled. Choose Researcher Access or a provider API key instead.',
-            );
-          }
-          return;
+        },
+      );
+      const update = await setPreferCodexSubscription(true);
+      if (!update.effective) {
+        if (!isCancelled()) {
+          props.onError(
+            'Signed in with ChatGPT, but a more specific setting keeps the subscription disabled. Choose Researcher Access or a provider API key instead.',
+          );
         }
-        invalidateModelOptionsCache();
-        if (!cancelled) props.onSuccess(session);
-      } catch (loginError: unknown) {
-        if (!cancelled) props.onError(toErrorMessage(loginError));
+        return;
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
+      invalidateModelOptionsCache();
+      if (!isCancelled()) props.onSuccess(session);
+    } catch (loginError: unknown) {
+      if (!isCancelled()) props.onError(toErrorMessage(loginError));
+    }
   }, []);
 
   return (

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -42,6 +42,7 @@ import { isNonEmptyString } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { extractMimeSubtype } from '@utils/text/stringUtils';
 import { computeUtilizationPercent } from '../support/contextUtilization';
+import { toDataUrl } from '../support/dataUrl';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import { tagOpenAISdkError } from './openAISdkError';
 
@@ -786,7 +787,7 @@ export class ModelHandlerOpenAI<
       {
         type: 'image_url',
         image_url: {
-          url: `data:${media.media_type};base64,${media.data}`,
+          url: toDataUrl(media.media_type, media.data),
           detail: 'high',
         },
       },

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -58,6 +58,7 @@ import { getConfig } from '@utils/config/configUtils';
 import { getWebSocketEnabled } from '@utils/config/providerConfig';
 import { computeUtilizationPercent } from '../support/contextUtilization';
 import { logCompactionEvent } from '../support/compactionLogging';
+import { toDataUrl } from '../support/dataUrl';
 import { shouldUseOpenRouter } from '../support/ProxyConfigResolver';
 import { toOpenAIReasoningEffort } from '../support/reasoningEffort';
 import {
@@ -1221,7 +1222,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           createInputText(`Image: ${media.file_name}`),
           {
             type: 'input_image',
-            image_url: `data:${mediaType};base64,${media.data}`,
+            image_url: toDataUrl(mediaType, media.data),
             detail: 'high',
           },
         ];

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -21,6 +21,7 @@ import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 
 import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
+import { parseDataUrl, toDataUrl } from '../support/dataUrl';
 import { reportMediaAttachmentFailure } from '../support/mediaAttachmentPolicy';
 import { isInputFileContent, isMessageItem } from './openAIResponseContent';
 import type {
@@ -104,12 +105,8 @@ async function replaceFileDataWithUpload(
   let buffer: Buffer | undefined;
 
   try {
-    const base64Separator = ';base64,';
-    const separatorIndex = fileData.indexOf(base64Separator);
-    const payload =
-      separatorIndex >= 0
-        ? fileData.slice(separatorIndex + base64Separator.length)
-        : fileData;
+    const parsed = parseDataUrl(fileData);
+    const payload = parsed ? parsed.base64Data : fileData;
 
     buffer = Buffer.from(payload, 'base64');
     const uploadedFile = await client.files.create({
@@ -254,7 +251,7 @@ export async function buildInlineAttachmentParts(
         parts.push({
           type: 'input_image',
           detail: 'auto',
-          image_url: `data:${mimeType};base64,${base64}`,
+          image_url: toDataUrl(mimeType, base64),
         });
       } else {
         // PDF, office documents, and other file types accepted by input_file
@@ -263,7 +260,7 @@ export async function buildInlineAttachmentParts(
           : 'attachment';
         parts.push({
           type: 'input_file',
-          file_data: `data:${mimeType};base64,${base64}`,
+          file_data: toDataUrl(mimeType, base64),
           filename,
         });
       }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -36,6 +36,7 @@ import type {
 } from '@shared/schemas/toolResult';
 import { isNonEmptyString } from '@utils/core';
 import { extractMimeSubtype } from '@utils/text/stringUtils';
+import { toDataUrl } from '../support/dataUrl';
 import {
   computeOpenRouterPrice,
   normalizeOpenRouterUsage,
@@ -440,7 +441,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
           {
             type: 'image_url',
             imageUrl: {
-              url: `data:${media.media_type};base64,${media.data}`,
+              url: toDataUrl(media.media_type, media.data),
               detail: 'high',
             },
           } as ChatContentItems,

--- a/src/agent/modelHandlers/support/dataUrl.ts
+++ b/src/agent/modelHandlers/support/dataUrl.ts
@@ -7,13 +7,15 @@ export function toDataUrl(mediaType: string, base64Data: string): string {
 }
 
 /**
- * Parses a `data:<mediaType>;base64,<data>` URL into its parts. Returns
- * `undefined` if the string doesn't match the expected base64 data URL shape.
+ * Parses a `data:<mediaType>;base64,<data>` URL into its parts. `mediaType`
+ * captures everything up to the `;base64,` marker, including any extra
+ * parameters (e.g. `application/pdf;charset=utf-8`). Returns `undefined` if
+ * the string doesn't match the expected base64 data URL shape.
  */
 export function parseDataUrl(
   dataUrl: string,
 ): { mediaType: string; base64Data: string } | undefined {
-  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
+  const match = /^data:(.+?);base64,(.+)$/s.exec(dataUrl);
   if (!match) return undefined;
   return { mediaType: match[1], base64Data: match[2] };
 }

--- a/src/agent/modelHandlers/support/dataUrl.ts
+++ b/src/agent/modelHandlers/support/dataUrl.ts
@@ -1,0 +1,19 @@
+// Shared helpers for building and parsing `data:` URLs used across model
+// handlers to inline base64-encoded media/documents in provider requests.
+
+/** Builds a `data:` URL from a MIME type and base64-encoded payload. */
+export function toDataUrl(mediaType: string, base64Data: string): string {
+  return `data:${mediaType};base64,${base64Data}`;
+}
+
+/**
+ * Parses a `data:<mediaType>;base64,<data>` URL into its parts. Returns
+ * `undefined` if the string doesn't match the expected base64 data URL shape.
+ */
+export function parseDataUrl(
+  dataUrl: string,
+): { mediaType: string; base64Data: string } | undefined {
+  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) return undefined;
+  return { mediaType: match[1], base64Data: match[2] };
+}

--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AbsoluteFS } from '@utils/files';
 import { byStringProp, normalizeFilePath } from '@utils/core';
+import { isStrictlyWithin } from '@utils/core/pathCore';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 export interface ExecutionWorkspaceFile {
@@ -26,11 +27,7 @@ export function resolveExecutionWorkspaceFilePath(
     ? path.normalize(cleanedPath)
     : path.resolve(absoluteRoot, cleanedPath);
   const relativePath = path.relative(absoluteRoot, absolutePath);
-  if (
-    !relativePath ||
-    relativePath.startsWith('..') ||
-    path.isAbsolute(relativePath)
-  ) {
+  if (!isStrictlyWithin(absoluteRoot, absolutePath)) {
     return undefined;
   }
 

--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 // Local imports - shared
 import type { AgentCategory } from '@shared/schemas/agent';
+import { isStrictlyWithin } from '@utils/core/pathCore';
 
 export interface SettingsAgentFileEntry {
   path: string;
@@ -121,14 +122,9 @@ export class SettingsAgentFileController {
   }
 
   private isInside(parentDir: string, candidatePath: string): boolean {
-    const relativePath = path.relative(
+    return isStrictlyWithin(
       path.resolve(parentDir),
       path.resolve(candidatePath),
-    );
-    return (
-      relativePath !== '' &&
-      !relativePath.startsWith('..') &&
-      !path.isAbsolute(relativePath)
     );
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -16,7 +16,11 @@ import { getExtensionLowercase, hasExtension } from '@utils/core/pathCore';
 // Local file imports
 import { extractLatexFileDependencies } from './extractFileDependencies';
 import { extractFigurePathsFromLatex } from './extractFigure';
-import { resolveLatexDir, stripLatexComments } from './latexParsingUtils';
+import {
+  collectCommaSeparatedMatches,
+  resolveLatexDir,
+  stripLatexComments,
+} from './latexParsingUtils';
 import { TikzPictureManager } from './TikzPictureManager';
 import { compileLatex2Pdf } from './texTools';
 
@@ -292,19 +296,19 @@ export class LatexMediaManager {
       const uncommented = stripLatexComments(content);
       const baseDir = path.dirname(realPath);
 
-      for (const match of uncommented.matchAll(USEPACKAGE_PATTERN)) {
-        for (const entry of match[1].split(',')) {
-          const name = entry.trim();
-          if (!name) continue;
-          const candidate = path.join(baseDir, `${name}.sty`);
-          if (
-            await FlexibleFS.exists({
-              kind: 'external',
-              absolutePath: candidate,
-            })
-          ) {
-            found.add(candidate);
-          }
+      const packageNames = collectCommaSeparatedMatches(
+        uncommented,
+        USEPACKAGE_PATTERN,
+      );
+      for (const name of packageNames) {
+        const candidate = path.join(baseDir, `${name}.sty`);
+        if (
+          await FlexibleFS.exists({
+            kind: 'external',
+            absolutePath: candidate,
+          })
+        ) {
+          found.add(candidate);
         }
       }
     } catch (error) {

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -5,6 +5,7 @@
 import * as path from 'node:path';
 
 import { normalizeFilePath } from '@utils/core';
+import { isPathWithin } from '@utils/core/pathCore';
 
 import type { WorkspaceProvider } from '../interfaces';
 
@@ -20,7 +21,7 @@ export function createNodeWorkspace(
       const root = this.getWorkspacePath();
       if (!root) return filePath;
       const relative = path.relative(root, filePath);
-      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      if (!isPathWithin(root, filePath)) {
         return filePath;
       }
       return normalizeFilePath(relative);

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -1,7 +1,9 @@
 // Node imports
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
-import { basename, isAbsolute, join, normalize, relative } from 'node:path';
+import { basename, join, normalize, relative } from 'node:path';
+
+import { isPathWithin } from '@utils/core/pathCore';
 
 // Local imports - platform
 import type { StorageProvider } from '../interfaces';
@@ -68,7 +70,7 @@ export function resolveMemoryStoragePath(
 ): string {
   const normalized = normalize(storagePath);
   const memoryRelative = relative(MEMORY_STORAGE_DIR, normalized);
-  if (memoryRelative.startsWith('..') || isAbsolute(memoryRelative)) {
+  if (!isPathWithin(MEMORY_STORAGE_DIR, normalized)) {
     throw new Error(`Invalid memory path: ${storagePath}`);
   }
   return memoryRelative
@@ -107,8 +109,7 @@ export function resolveRunStorageRelativePath(
     '\\',
     '/',
   );
-  if (relativePath.startsWith('..') || isAbsolute(relativePath))
-    return undefined;
+  if (!isPathWithin(runDirectory, absolutePath)) return undefined;
   return relativePath || undefined;
 }
 

--- a/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
@@ -30,4 +30,14 @@ describe('parseDataUrl', () => {
   it('returns undefined for a raw base64 string with no data URL prefix', () => {
     expect(parseDataUrl('ABC123')).toBeUndefined();
   });
+
+  it('returns undefined for a ";base64," separator without the "data:" prefix', () => {
+    // Documents an intentional behavior change from the original inline
+    // openAIResponseFileUploads.ts extraction, which used a plain
+    // `indexOf(';base64,')` and would have matched this input. The sole
+    // caller always receives proper `data:` URLs from the OpenAI Response
+    // API, so the stricter contract is safe there; this test exists so the
+    // narrowing is documented rather than silently relied upon.
+    expect(parseDataUrl('something;base64,ABC123')).toBeUndefined();
+  });
 });

--- a/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDataUrl, toDataUrl } from '@agent/modelHandlers/support/dataUrl';
+
+describe('toDataUrl', () => {
+  it('builds a data URL from a media type and base64 payload', () => {
+    expect(toDataUrl('application/pdf', 'ABC123')).toBe(
+      'data:application/pdf;base64,ABC123',
+    );
+  });
+});
+
+describe('parseDataUrl', () => {
+  it('parses a simple media type and base64 payload', () => {
+    expect(parseDataUrl('data:application/pdf;base64,ABC123')).toEqual({
+      mediaType: 'application/pdf',
+      base64Data: 'ABC123',
+    });
+  });
+
+  it('parses a media type with extra parameters before the base64 marker', () => {
+    expect(
+      parseDataUrl('data:application/pdf;charset=utf-8;base64,ABC123'),
+    ).toEqual({
+      mediaType: 'application/pdf;charset=utf-8',
+      base64Data: 'ABC123',
+    });
+  });
+
+  it('returns undefined for a raw base64 string with no data URL prefix', () => {
+    expect(parseDataUrl('ABC123')).toBeUndefined();
+  });
+});

--- a/src/test-kernel/utils/PathCore.vitest.ts
+++ b/src/test-kernel/utils/PathCore.vitest.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getPathSegments,
+  isPathWithin,
+  isStrictlyWithin,
   normalizeLatexPath,
   toPosixPath,
 } from '@utils/core/pathCore';
@@ -75,6 +77,56 @@ describe('normalizeLatexPath', () => {
     ).join('/');
 
     expect(normalizeLatexPath(`./${longPath}`)).toBe(expected);
+  });
+});
+
+describe('isPathWithin', () => {
+  it('treats the target equal to base as contained', () => {
+    expect(isPathWithin('/base', '/base')).toBe(true);
+  });
+
+  it('treats a strict descendant as contained', () => {
+    expect(isPathWithin('/base', '/base/child/file.tex')).toBe(true);
+  });
+
+  it('rejects a sibling directory that merely shares a string prefix', () => {
+    expect(isPathWithin('/base', '/base-other/file.tex')).toBe(false);
+  });
+
+  it('rejects a parent-traversal escape, including via backslashes', () => {
+    expect(isPathWithin('/base/child', '/base/child/../../etc/passwd')).toBe(
+      false,
+    );
+    expect(
+      isPathWithin(
+        String.raw`C:\base\child`,
+        String.raw`C:\base\child\..\..\etc\passwd`,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects an absolute target unrelated to a relative base', () => {
+    expect(isPathWithin('base/child', '/etc/passwd')).toBe(false);
+  });
+});
+
+describe('isStrictlyWithin', () => {
+  it('rejects the target equal to base', () => {
+    expect(isStrictlyWithin('/base', '/base')).toBe(false);
+  });
+
+  it('accepts a strict descendant', () => {
+    expect(isStrictlyWithin('/base', '/base/child/file.tex')).toBe(true);
+  });
+
+  it('rejects a sibling directory that merely shares a string prefix', () => {
+    expect(isStrictlyWithin('/base', '/base-other/file.tex')).toBe(false);
+  });
+
+  it('rejects a parent-traversal escape', () => {
+    expect(
+      isStrictlyWithin('/base/child', '/base/child/../../etc/passwd'),
+    ).toBe(false);
   });
 });
 

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -22,6 +22,7 @@ import {
 } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getValidatedConfig } from '@utils/config/configUtils';
+import { isStrictlyWithin } from '@utils/core/pathCore';
 
 export type BuildDisplayFn = (
   location: FileLocation,
@@ -198,11 +199,7 @@ function tempPathToLocation(tempPath: string): FileLocation {
     normalizedTempPath,
   );
 
-  if (
-    relativePath &&
-    !relativePath.startsWith('..') &&
-    !path.isAbsolute(relativePath)
-  ) {
+  if (isStrictlyWithin(normalizedWorkspacePath, normalizedTempPath)) {
     return createWorkspaceLocation(tempPath, relativePath);
   }
 

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -15,6 +15,7 @@ import { WorkspaceFS } from '@utils/files';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 import {
+  emptyExtractionResult,
   resolveLatexFileOrThrow,
   texPathField,
 } from './figureExtractionShared';
@@ -80,26 +81,24 @@ export class ExtractBibliographyTool extends defineTool({
       bibliographyFiles.length === 0 &&
       missingBibliographyFiles.length === 0
     ) {
-      const summary = `No citations or bibliography directives found in ${display}.`;
-      return {
-        status: 'executed',
-        summary,
-        output: formatToolOutput(`BibTeX entries in ${display}`, null),
-      };
+      return emptyExtractionResult(
+        `BibTeX entries in ${display}`,
+        `No citations or bibliography directives found in ${display}.`,
+      );
     }
 
     if (citationKeys.length === 0) {
-      const summary = `No citation commands found in ${display}.`;
-      const baseOutput = formatToolOutput(`BibTeX entries in ${display}`, null);
       const missingNote =
         missingBibliographyFiles.length > 0
           ? `\n\nNote: Missing bibliography files: ${formatPathList(missingBibliographyFiles)}.`
           : '';
-      return {
-        status: 'executed',
-        summary,
-        output: `${baseOutput}${missingNote}`,
-      };
+      const result = emptyExtractionResult(
+        `BibTeX entries in ${display}`,
+        `No citation commands found in ${display}.`,
+      );
+      return missingNote
+        ? { ...result, output: `${result.output}${missingNote}` }
+        : result;
     }
 
     const { entries, missingKeys } = await loadBibliographyEntries(

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -12,6 +12,7 @@ import { unique } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
+  emptyExtractionResult,
   resolveLatexFileOrThrow,
   texPathField,
 } from './figureExtractionShared';
@@ -41,12 +42,10 @@ export class ExtractLatexFiguresTool extends defineTool({
     const uniqueFigures = unique(figurePaths);
 
     if (uniqueFigures.length === 0) {
-      const summary = `No figures found in ${display}.`;
-      return {
-        status: 'executed',
-        summary,
-        output: formatToolOutput('Figures', null),
-      };
+      return emptyExtractionResult(
+        'Figures',
+        `No figures found in ${display}.`,
+      );
     }
 
     const { attachments, limitedPaths, limitReached } =

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -13,6 +13,7 @@ import { pathToLocation } from '@utils/files';
 import { formatResultCount } from '@utils/text/stringUtils';
 import {
   buildLimitedAttachments,
+  emptyExtractionResult,
   resolveLatexFileOrThrow,
   texPathField,
 } from './figureExtractionShared';
@@ -45,12 +46,10 @@ export class ExtractTikzFiguresTool extends defineTool({
       pathToLocation(path.absolute),
     );
     if (tikzFigures.length === 0) {
-      const summary = `No TikZ figures found in ${display}.`;
-      return {
-        status: 'executed',
-        summary,
-        output: formatToolOutput('TikZ figures', null),
-      };
+      return emptyExtractionResult(
+        'TikZ figures',
+        `No TikZ figures found in ${display}.`,
+      );
     }
 
     const formattedEntries = tikzFigures.map(([label, pictures]) => {

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { ToolError, type ToolFileAttachment } from '@shared/schemas/toolResult';
 import { buildFileAttachment } from '@tools/attachments';
+import { formatToolOutput } from '@tools/formatting';
 import {
   resolveAndFormat,
   type WorkspacePathResolution,
@@ -28,6 +29,21 @@ interface AttachmentLimitOptions {
   limit: number;
   describe: (filePath: string) => string;
   mimeType?: string;
+}
+
+/**
+ * Shared "nothing found" result for extraction tools: an executed result
+ * with no output body, formatted via `formatToolOutput(label, null)`.
+ */
+export function emptyExtractionResult(
+  label: string,
+  summary: string,
+): { status: 'executed'; summary: string; output: string } {
+  return {
+    status: 'executed',
+    summary,
+    output: formatToolOutput(label, null),
+  };
 }
 
 export async function resolveLatexFileOrThrow(

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { normalizeFilePath } from '@utils/core';
+import { isPathWithin } from '@utils/core/pathCore';
 
 import { MEMORY_DISPLAY_ROOT } from './constants';
 
@@ -48,7 +49,7 @@ export function displayToStoragePath(displayPath: string): string {
   const resolved = path.resolve(MEMORY_STORAGE_DIR, suffix);
   const base = path.resolve(MEMORY_STORAGE_DIR);
   const relative = path.relative(base, resolved);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+  if (!isPathWithin(base, resolved)) {
     throw new Error(`Invalid memory path: ${displayPath}`);
   }
   return relative

--- a/src/tools/pathResolution.ts
+++ b/src/tools/pathResolution.ts
@@ -14,7 +14,11 @@ import { ToolError } from '@shared/schemas/toolResult';
 import { WorkspaceFS } from '@utils/files';
 import { findExternalRoot } from '@utils/files/externalRoots';
 import { locatePathInRoot } from '@utils/files/workspaceRoot';
-import { getPathSegments, toPosixPath } from '@utils/core/pathCore';
+import {
+  getPathSegments,
+  isPathWithin,
+  toPosixPath,
+} from '@utils/core/pathCore';
 
 export interface WorkspacePathResolution {
   relative: string;
@@ -94,7 +98,7 @@ export function resolveWorkspaceRelativePath(
       // Normalize to POSIX separators so .relative is consistent across platforms
       // (locatePathInRoot and WorkspaceFS.locatePath already do this).
       const relative = path.relative(root, input).replaceAll('\\', '/');
-      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      if (!isPathWithin(root, input)) {
         const external = externalAllowance(input);
         if (external) {
           return external;

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -34,6 +34,31 @@ export function normalizeLatexPath(value: string): string {
   return toPosixPath(trimmed);
 }
 
+/**
+ * True if `target` is `base` itself or a descendant of it.
+ * Computed via path.relative — works for both absolute and relative inputs
+ * as long as both are resolved the same way by the caller.
+ */
+export function isPathWithin(base: string, target: string): boolean {
+  const relativePath = path.relative(base, target);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
+/**
+ * True if `target` is a strict descendant of `base` (excludes `target === base`).
+ */
+export function isStrictlyWithin(base: string, target: string): boolean {
+  const relativePath = path.relative(base, target);
+  return (
+    relativePath !== '' &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
 /** Get the file extension in lowercase (e.g. `'.tex'` for `'Paper.TEX'`). */
 export function getExtensionLowercase(filePath: string): string {
   if (!filePath) return '';

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import { isPathWithin } from '@utils/core/pathCore';
 
 /**
  * Allowlist of external filesystem roots that tools may read or write.
@@ -150,9 +151,7 @@ export function findExternalRoot(
   let best: MatchedExternalRoot | null = null;
   for (const root of roots.values()) {
     const relativePath = path.relative(root.absolutePath, resolved);
-    const contained =
-      relativePath === '' ||
-      (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+    const contained = isPathWithin(root.absolutePath, resolved);
     if (!contained) continue;
 
     const candidate: MatchedExternalRoot = {


### PR DESCRIPTION
## Summary

Codebase-wide scan for duplicate logic and hand-rolled reimplementations of things that should be shared helpers. The scan (four parallel research passes over `src/agent/`+`src/model/`, `src/utils/`+`src/common/`+`src/platform/`, `src/latex/`+`src/tools/`, and `packages/cli/`+webviews) found the codebase already heavily consolidated — most candidate duplication had already been factored out in prior PRs. This PR lands the four highest-confidence, verified-behavior-preserving consolidations that remained:

1. **Path containment** — `isPathWithin` / `isStrictlyWithin` in `src/utils/core/pathCore.ts` replace 9 independent copies of the `path.relative(base, target)` + `startsWith('..')`/`isAbsolute` containment check scattered across workspace resolution, storage path resolution, memory paths, and tool path guards.
2. **Data URLs** — `toDataUrl` / `parseDataUrl` in `src/agent/modelHandlers/support/dataUrl.ts` replace duplicated `` `data:${mediaType};base64,${data}` `` string building (5 sites) and one manual `;base64,`-separator payload extraction in the OpenAI/OpenRouter model handlers.
3. **Effect cancellation** — `useCancellableEffect` in `packages/cli/src/chat/tui/state/` replaces the hand-rolled `let cancelled = false` / cleanup-flag `useEffect` pattern duplicated across 4 CLI TUI call sites (form loaders + onboarding sign-in flows).
4. **LaTeX extraction tools** — `emptyExtractionResult` in `src/tools/latex/figureExtractionShared.ts` replaces 4 duplicated "nothing found" result-construction blocks; `LatexMediaManager`'s package-name comma-split loop now reuses the already-shared `collectCommaSeparatedMatches` instead of a second inline implementation.

No behavior changes. One candidate site (`WorkspaceFS.locatePath`) was deliberately left untouched because it goes through a host-provided `asRelativePath` abstraction that may add symlink-aware behavior beyond plain `path.relative`, so folding it into `isPathWithin` wasn't provably equivalent. Two candidate `parseDataUrl` sites (`anthropicDocumentHandling.ts`, `MediaAttachmentProcessor.ts`) were skipped after confirming they only ever hold raw base64 strings, never full `data:` URLs.

**Review follow-ups (commits `1837ada`, `a1efb77`):** review caught that the initial `parseDataUrl` regex (`[^;]+` for the media type) was stricter than the original `indexOf(';base64,')` scan it replaced — it rejected data URLs with extra media-type parameters (e.g. `application/pdf;charset=utf-8`), silently falling back to base64-decoding the whole URL string and corrupting uploaded bytes. Fixed with a lazy capture (`.+?`) up to the first `;base64,` marker, plus dedicated regression tests for `isPathWithin`/`isStrictlyWithin` and `parseDataUrl`'s edge cases.

## Issue acceptance gates

No linked issue — this is a proactive housekeeping pass (consolidate duplicate logic / prefer native-shaped shared helpers over hand-rolled reimplementations), not a bug fix or feature.

## Single source of truth

- Path containment: `isPathWithin` / `isStrictlyWithin` in `src/utils/core/pathCore.ts` (already the host-agnostic home for path primitives; existing `hasExtension`/`toPosixPath` etc. live there).
- Data URL encode/decode: `src/agent/modelHandlers/support/dataUrl.ts`, alongside the other single-purpose model-handler support helpers (`contextUtilization.ts`, `reasoningEffort.ts`).
- Effect cancellation: `packages/cli/src/chat/tui/state/useCancellableEffect.ts`, alongside the TUI's other shared hooks (`useLiveNowMs.ts`, `useSignal.ts`).
- Empty LaTeX extraction result: `src/tools/latex/figureExtractionShared.ts`, the tools' existing shared module.

## Duplication and abstraction budget

Removed: 9 copies of the path-containment check, 5 copies of data-URL construction + 1 manual data-URL parse, 4 copies of the cancelled-flag `useEffect` pattern, 4 copies of the empty-extraction-result shape, 1 duplicated comma-split loop. Every new helper has ≥3 real call sites except `parseDataUrl`, which currently has one caller — kept because it's the inverse of `toDataUrl` (5 callers) and forms one cohesive encode/decode pair for the `data:` URL shape rather than a single-purpose extraction; flagging this transparently per the single-caller guideline rather than hiding it. No new ports, facades, or template-method layers — every helper is a pure function with no indirection beyond the call itself.

## Net elements (R6)

- Files: +3 new (`src/agent/modelHandlers/support/dataUrl.ts`, `packages/cli/src/chat/tui/state/useCancellableEffect.ts`, `src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts`), 22 modified, 0 deleted.
- Exported symbols: +7 (`isPathWithin`, `isStrictlyWithin`, `toDataUrl`, `parseDataUrl`, `IsEffectCancelled`, `useCancellableEffect`, `emptyExtractionResult`), 0 removed.
- Diffstat (current, after review-fix commits): 25 files changed, 331 insertions(+), 155 deletions(-) — net +176 LoC, mostly the new regression tests (`DataUrl.vitest.ts`, plus added cases in `PathCore.vitest.ts`) and JSDoc on the new helpers; duplicated logic at call sites shrank correspondingly.

## Consumer counts (R8)

Not applicable — no emit path, event bus key, or export surface was deleted or re-routed. All changes are internal call-site substitutions behind unchanged function signatures/return shapes.

## Host impact

Extension: `SettingsAgentFileController.ts`'s `isInside` now delegates to `isStrictlyWithin`; no behavior change.

Desktop: none touched directly (desktop shares the same host-agnostic `src/` modules that were edited).

CLI: 4 TUI/onboarding call sites now use `useCancellableEffect`; `StatusBar.tsx`'s cancelled-flag + polling block was deliberately left alone since it's entangled with a `setInterval`/`unref` loop that doesn't fit the hook's single-run contract.

## Scheduled refactoring

None. (Untouched candidates noted above — `WorkspaceFS.locatePath`, the two non-data-URL base64 sites, and `StatusBar.tsx`'s polling block — were intentionally left as-is, not deferred; they don't fit the new helpers without changing behavior or scope.)

## Validation

- `npm run typecheck` — clean across the full workspace (root, test-kernel, extension, CLI, trace-viewer, desktop), re-verified after each review-fix commit.
- `npx eslint` on all touched files — clean (found and fixed one invalid `eslint-disable` for a rule not registered in this project's config, and one `import/order` warning).
- `npx prettier --check` on all touched files — clean.
- `npx vitest run` on every test file covering touched modules (`PathCore`, `PathResolution`, `ExecutionsToolWorkspaceFiles`, `SettingsAgentFileController`, `WorkspaceStorage`, `MemoryFileSystemConcurrency`, `LatexProcessingHelpers`, `ExtractBibliographyTool`, `ExtractTikzFiguresTool`, `DataUrl`) — all passing.
- Full `src/test-kernel/agent/modelHandlers/` suite — 444/444 passed (4 unrelated skipped).
- Full `src/test-kernel/cli/` suite — 1680/1680 passed (4 unrelated skipped).
- Two rounds of automated + agent code review addressed: a P2 data-URL parsing regression (fixed in `1837ada`) and test-coverage gaps for the new path helpers and `parseDataUrl`'s edge cases (fixed in `a1efb77`).
