### PR TITLE
fix(transcript): keep evicted streams deleted

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -121,7 +121,7 @@ function toolUseTaskState(agent = 'search', model = 'deepseekproT'): TaskState {
 
 function injectDuringExecutionConfigHydration(
   executionId: ExecutionId,
-  inject: () => void,
+  inject: () => void | Promise<void>,
 ) {
   const originalRead = StorageFS.read.bind(StorageFS);
   const configPath = path.join(
@@ -131,7 +131,9 @@ function injectDuringExecutionConfigHydration(
   const injected = vi.fn(inject);
   vi.spyOn(StorageFS, 'read').mockImplementation(async (target: string) => {
     const raw = await originalRead(target);
-    if (target === configPath && injected.mock.calls.length === 0) injected();
+    if (target === configPath && injected.mock.calls.length === 0) {
+      await injected();
+    }
     return raw;
   });
   return injected;
@@ -913,6 +915,42 @@ describe('StreamSnapshotStore', () => {
     ]);
     expect(missingOutputs).toEqual({ '1': ['late.tex'] });
     expect(usageStats).toMatchObject({ [RUN]: usage(10, 2, 0.1) });
+  });
+
+  it('does not recreate sidecars when a stream is deleted during hydration', async () => {
+    await installPlatform();
+    const dir = streamDataDir(STREAM);
+    const executionId = 'deadbeef' as ExecutionId;
+    await StorageFS.ensureDir(dir);
+    await Promise.all([
+      StorageFS.write(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({
+          schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+          executionId,
+          activeRunId: RUN,
+        }),
+      ),
+      StorageFS.write(
+        path.join(dir, 'missingOutputs.json'),
+        JSON.stringify({ [RUN]: { '0': ['legacy.tex'] } }),
+      ),
+      getExecutionStore(executionId).writeConfig(
+        toolUseTaskState().agentConfig,
+      ),
+    ]);
+
+    const store = new StreamSnapshotStore();
+    const wasDeletedDuringHydration = injectDuringExecutionConfigHydration(
+      executionId,
+      () => store.deleteStream(STREAM),
+    );
+
+    await store.load([STREAM]);
+    await store.flush();
+
+    expect(wasDeletedDuringHydration).toHaveBeenCalledOnce();
+    expect(await StorageFS.exists(dir)).toBe(false);
   });
 
   it('load refreshes already-seeded streams from disk instead of keeping stale memory', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1377,6 +1377,7 @@ export class StreamSnapshotStore {
     stream: StreamTabId,
     data: StreamData,
   ): Promise<void> {
+    const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
     const metaOverlay = record.metaOverlay ? record.meta : undefined;
     const runConfigOverlay =
@@ -1409,6 +1410,7 @@ export class StreamSnapshotStore {
     if (meta) {
       record.meta = meta;
       hydrated = await this.hydrateRunStateFromMeta(stream, meta);
+      if (this.streamVersion(stream) !== version) return;
     } else {
       record.meta = undefined;
     }


### PR DESCRIPTION
## Summary
- stop stream hydration when eviction changes the stream generation
- avoid recreating records and legacy sidecars after deletion
- cover the delete-during-config-hydration race with one focused regression test

## Design
`streamVersions` remains the single source of truth for invalidating in-flight work. The fix reuses that existing ownership boundary rather than adding another deletion flag or record state.

## Validation
- `vitest run src/test-kernel/transcript/StreamSnapshotStore.vitest.ts` (37 passed)
- pre-fix race test fails by observing the deleted stream directory recreated
- ESLint on both changed files
- root `tsc --noEmit`
- test-kernel `tsc --noEmit -p tsconfig.test-kernel.json`
- Prettier and `git diff --check`

Closes #8226

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent load/delete paths in transcript persistence; wrong guards could drop hydration or leave stale memory, but the change is narrow and covered by a targeted race test.
> 
> **Overview**
> Fixes a race where **`load()`** could **recreate** a stream’s `streamData/` sidecars after **`deleteStream()`** ran while execution config hydration was still in flight.
> 
> **`applyStreamData`** now snapshots the stream’s **`streamVersions`** token at entry and **bails out** right after the async **`hydrateRunStateFromMeta`** step if eviction/deletion bumped that generation—so it never finishes seeding, replays overlays, or calls **`writeMergedSidecars`**.
> 
> Tests add a regression that **`deleteStream`** during config read leaves the sidecar directory gone, and the hydration inject helper **`await`s** async callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd601e46c846498a9aef9c1e91a87fbbfd0e662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->