### PR TITLE
fix(agent): stop auto-retrying context-window overflows unrecovered by provider compaction

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -8,7 +8,10 @@ import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
-import { isUserAbort } from '@common/errors/sdkErrorUtils';
+import {
+  isContextWindowError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 import {
   isCredentialExhausted,
   STREAM_PHASE,
@@ -199,12 +202,18 @@ export abstract class RetryableInvocationNode<
     }
   }
 
-  /** Auth/permission errors (401, 403) and credential-exhausted errors
-   *  (relay monthly limit, upstream credit/quota depletion) skip auto-retries —
-   *  they need human attention (switching keys, topping up). `userRetryable`
+  /** Auth/permission errors (401, 403), credential-exhausted errors (relay
+   *  monthly limit, upstream credit/quota depletion), and context-window
+   *  overflows skip auto-retries — they need human attention (switching
+   *  keys, topping up, shrinking the request) rather than an identical retry
+   *  that can only fail the same way again. A provider handler that knows
+   *  how to recover from an overflow (e.g. OpenAI Responses' compaction
+   *  retry) does so and never lets the error reach this gate; only overflow
+   *  errors nobody already recovered from are stopped here. `userRetryable`
    *  only gates the manual retry UI; auto-retry is a stricter subset. */
   shouldAutoRetry(error: Error): boolean {
     if (isUserAbort(error)) return false;
+    if (isContextWindowError(error)) return false;
 
     const formatted = normalizeProviderError(error);
     if (isCredentialExhausted(formatted)) return false;

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -296,17 +296,27 @@ export class OpenAIResponseWebSocketTransport {
       const onCompleted = (event: ResponseCompletedEvent): void =>
         finalizeSuccess(event.response);
 
-      // Failed responses must be rejected so the caller's catch block can
-      // run error recovery (e.g., context-window compaction).
+      // Failed responses must be rejected so the caller's catch block can run
+      // error recovery (e.g., context-window compaction). The response's own
+      // `error` (a structured { code, message } object, not just prose) is
+      // preserved on the thrown error — mirrored from the same pattern in
+      // createOpenAIBackgroundTerminalError — so isContextWindowError() can
+      // key off `error.code` instead of relying solely on `error.message`
+      // wording that can drift across model generations.
       const onFailed = (event: ResponseFailedEvent): void => {
         if (settled || !isCurrentResponse(event.response)) return;
         settled = true;
         cleanup();
+        const responseError = event.response.error;
         const errorMsg =
-          event.response.error?.message ?? 'Response failed without details';
-        rejectWithPartial(
-          new Error(`OpenAI WebSocket response failed: ${errorMsg}`),
-        );
+          responseError?.message ?? 'Response failed without details';
+        const wrapped = new Error(
+          `OpenAI WebSocket response failed: ${errorMsg}`,
+        ) as Error & { error?: unknown };
+        if (responseError) {
+          wrapped.error = responseError;
+        }
+        rejectWithPartial(wrapped);
       };
 
       // Incomplete responses are resolved (not rejected) to match the HTTP

--- a/src/common/errors/sdkError/errorPatterns.ts
+++ b/src/common/errors/sdkError/errorPatterns.ts
@@ -91,16 +91,36 @@ export function isMissingFinishReasonError(err: unknown): boolean {
 }
 
 /**
+ * True when `err` (or a nested `error` body, e.g. `WebSocketError#error`)
+ * carries OpenAI's native `param` field naming `previous_response_id` — the
+ * SDK flattens this from the JSON body onto `APIError#param` for any 4xx
+ * response, and `ResponseErrorEvent#param` carries it for the WebSocket
+ * transport's connection-level `error` event. This identifies the invalid
+ * parameter directly instead of pattern-matching for its name inside prose.
+ */
+function hasPreviousResponseIdErrorParam(err: unknown): boolean {
+  const isMatch = (param: unknown): boolean =>
+    isString(param) && param === 'previous_response_id';
+
+  if (!isObject(err)) return false;
+  if (isMatch((err as { param?: unknown }).param)) return true;
+
+  const body = detectRawErrorBody(err);
+  return isObject(body) && isMatch((body as { param?: unknown }).param);
+}
+
+/**
  * Checks if an error indicates the previous_response_id is invalid or expired
- * (OpenAI Responses API).
+ * (OpenAI Responses API): the stored id is unusable and the chain must be
+ * rebuilt from local history.
  *
- * OpenAI surfaces this in two shapes depending on how the SDK serializes the
- * error body:
- *   1. `... param: 'previous_response_id' ...` (parameter name in message)
- *   2. `Previous response with id 'resp_...' not found.` (user-facing message)
- * Both forms indicate the stored id is unusable and the chain must be rebuilt.
+ * Prefers the native `param` field (see {@link hasPreviousResponseIdErrorParam}).
+ * Where that isn't available — e.g. a 404 "not found" response, which OpenAI
+ * reports without a `param` since no parameter name applies to a missing
+ * resource — falls back to matching the user-facing message text.
  */
 export function isPreviousResponseIdError(err: unknown): boolean {
+  if (hasPreviousResponseIdErrorParam(err)) return true;
   if (!(err instanceof Error)) return false;
   const m = err.message.toLowerCase();
   return (

--- a/src/common/errors/sdkError/errorPatterns.ts
+++ b/src/common/errors/sdkError/errorPatterns.ts
@@ -1,10 +1,10 @@
-import { isObject } from '@utils/core';
+import { isObject, isString } from '@utils/core';
 
 import {
   detectSdkErrorMetadata,
   hasContextWindowErrorMarker,
 } from './errorMetadata';
-import { getErrorClassNames } from './errorInspection';
+import { detectRawErrorBody, getErrorClassNames } from './errorInspection';
 
 /** Max tail size (chars) for partial text attached to streaming errors.
  *  4KB is enough for a "continue from [tail]" prompt and UI display,
@@ -24,10 +24,34 @@ export function isUserAbort(err: unknown): boolean {
   return isObject(err) && (err as { name?: unknown }).name === 'AbortError';
 }
 
-// Third-party provider wordings only — do not add TeXRA-internal messages
-// here. Internal throws (e.g. ModelHandler.validateTokenLimits) are tagged
-// with attachContextWindowError() at the throw site instead, so this
-// function doesn't need to string-match a message it doesn't own.
+/**
+ * OpenAI's own error code for a prompt that overflows the model's context
+ * window — a stable, versioned field of its API error contract (`error.code`
+ * in the JSON body, flattened onto `APIError#code` by the SDK), not prose.
+ * Checked directly off the error and off a nested raw body (covers
+ * `WebSocketError#error.code` and any wrapper that preserves the response's
+ * `error` object) so this survives even if the wording OpenAI puts in
+ * `error.message` changes between model generations.
+ */
+const OPENAI_CONTEXT_WINDOW_ERROR_CODE = 'context_length_exceeded';
+
+function hasOpenAIContextWindowErrorCode(err: unknown): boolean {
+  const isMatch = (code: unknown): boolean =>
+    isString(code) && code === OPENAI_CONTEXT_WINDOW_ERROR_CODE;
+
+  if (!isObject(err)) return false;
+  if (isMatch((err as { code?: unknown }).code)) return true;
+
+  const body = detectRawErrorBody(err);
+  return isObject(body) && isMatch((body as { code?: unknown }).code);
+}
+
+// Message wordings for providers (Anthropic, Google) whose SDKs expose no
+// finer-grained error code for this failure than a generic 400 — the message
+// is the only signal they give. Do not add TeXRA-internal messages here.
+// Internal throws (e.g. ModelHandler.validateTokenLimits) are tagged with
+// attachContextWindowError() at the throw site instead, so this function
+// doesn't need to string-match a message it doesn't own.
 const CONTEXT_WINDOW_PATTERNS = [
   'exceeds context window', // Anthropic
   'exceeds the context window', // OpenAI Responses API
@@ -39,11 +63,16 @@ const CONTEXT_WINDOW_PATTERNS = [
 ] as const;
 
 /** Checks if an error is a context window violation (should not be retried).
- *  Recognizes TeXRA-internal throws via their typed marker (attached with
- *  `attachContextWindowError`) and third-party provider errors via message
- *  pattern matching. */
+ *  Recognizes, in order: TeXRA-internal throws via their typed marker
+ *  (attached with `attachContextWindowError`); OpenAI's native `code` field
+ *  (present on any SDK-thrown `APIError` and on our own error wrappers that
+ *  preserve the provider's raw body); and, only where no provider error code
+ *  exists, third-party message pattern matching as a last resort. */
 export function isContextWindowError(err: unknown): boolean {
   if (hasContextWindowErrorMarker(err)) {
+    return true;
+  }
+  if (hasOpenAIContextWindowErrorCode(err)) {
     return true;
   }
   if (!(err instanceof Error)) {

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -22,7 +22,10 @@ import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
-import { attachFlowAutoRetryRequired } from '@common/errors/sdkErrorUtils';
+import {
+  attachContextWindowError,
+  attachFlowAutoRetryRequired,
+} from '@common/errors/sdkErrorUtils';
 import {
   STREAM_PHASE,
   STREAM_STATUS,
@@ -184,6 +187,27 @@ describe('RetryState', () => {
     });
 
     expect(node.shouldAutoRetry(new Error('rate limit'))).toBe(true);
+  });
+
+  it('never auto-retries a context-window overflow, even one tagged flow-auto-retry-required', () => {
+    // Regression for the retry storm where a context-window overflow that
+    // slipped past provider-specific compaction recovery (e.g. no
+    // previous_response_id to chain from) was flattened into a plain,
+    // code-free Error and unconditionally tagged attachFlowAutoRetryRequired
+    // by the WebSocket transport before classification ran — so it looked
+    // identical to a genuinely transient failure and got auto-retried with
+    // the exact same oversized payload forever. The base shouldAutoRetry gate
+    // must refuse a context-window error unconditionally, regardless of any
+    // flow-auto-retry tag, so unrecovered overflows fail once instead of
+    // storming.
+    const node = createModelInvocationNode({
+      isAutoRetryManagedByProvider: () => false,
+    });
+    const overflow = new Error('OpenAI WebSocket response failed: overflow');
+    attachContextWindowError(overflow);
+    attachFlowAutoRetryRequired(overflow);
+
+    expect(node.shouldAutoRetry(overflow)).toBe(false);
   });
 
   it('updates the injected stream status owner during manual retry', async () => {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -562,6 +562,46 @@ describe('isContextWindowError', () => {
   it('does not misclassify an unrelated error as a context-window violation', () => {
     expect(isContextWindowError(new Error('rate limit exceeded'))).toBe(false);
   });
+
+  it("recognizes OpenAI's native error code even when the message wording is unfamiliar", () => {
+    // The SDK flattens error.code from the JSON body onto the thrown
+    // APIError/BadRequestError instance. A future model generation could
+    // reword the message freely without breaking detection, because this
+    // never inspects `.message`.
+    const err = new OpenAIBadRequestError(
+      400,
+      { code: 'context_length_exceeded', message: 'Some brand-new wording' },
+      'Some brand-new wording',
+      new Headers(),
+    );
+
+    expect(isContextWindowError(err)).toBe(true);
+  });
+
+  it('recognizes a nested error.code (e.g. a WebSocket error wrapper) without a top-level code', () => {
+    // Mirrors OpenAIResponseWebSocketTransport's onFailed wrapper, which
+    // preserves the response's structured `error` object on the thrown
+    // Error instead of just its `.message`.
+    const err = new Error(
+      'OpenAI WebSocket response failed: overflow',
+    ) as Error & {
+      error?: unknown;
+    };
+    err.error = { code: 'context_length_exceeded', message: 'overflow' };
+
+    expect(isContextWindowError(err)).toBe(true);
+  });
+
+  it('does not match an unrelated native error code', () => {
+    const err = new OpenAIRateLimitError(
+      429,
+      { code: 'rate_limit_exceeded', message: 'Too many requests' },
+      'Too many requests',
+      new Headers(),
+    );
+
+    expect(isContextWindowError(err)).toBe(false);
+  });
 });
 
 describe('provider error schemas', () => {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -12,6 +12,7 @@ import {
   APIUserAbortError as OpenAIAPIUserAbortError,
   AuthenticationError as OpenAIAuthenticationError,
   BadRequestError as OpenAIBadRequestError,
+  NotFoundError as OpenAINotFoundError,
   RateLimitError as OpenAIRateLimitError,
 } from 'openai';
 import { describe, expect, it } from 'vitest';
@@ -31,6 +32,7 @@ import {
   formatProviderHttpError,
   getSdkErrorMessage,
   isContextWindowError,
+  isPreviousResponseIdError,
   isUserAbort,
   normalizeProviderError,
   sdkErrorKindFromStatusCode,
@@ -601,6 +603,53 @@ describe('isContextWindowError', () => {
     );
 
     expect(isContextWindowError(err)).toBe(false);
+  });
+});
+
+describe('isPreviousResponseIdError', () => {
+  it("recognizes OpenAI's native param field naming previous_response_id", () => {
+    // The SDK flattens error.param from the JSON body onto the thrown
+    // APIError/BadRequestError instance — this identifies the invalid
+    // parameter directly, independent of how OpenAI phrases the message.
+    const err = new OpenAIBadRequestError(
+      400,
+      { param: 'previous_response_id', message: 'Some brand-new wording' },
+      'Some brand-new wording',
+      new Headers(),
+    );
+
+    expect(isPreviousResponseIdError(err)).toBe(true);
+  });
+
+  it('recognizes a nested error.param (e.g. a WebSocket error wrapper)', () => {
+    const err = new Error('response.create rejected') as Error & {
+      error?: unknown;
+    };
+    err.error = { param: 'previous_response_id', message: 'invalid' };
+
+    expect(isPreviousResponseIdError(err)).toBe(true);
+  });
+
+  it('falls back to message matching for a 404 with no param (missing resource, not an invalid parameter)', () => {
+    const err = new OpenAINotFoundError(
+      404,
+      { message: "Previous response with id 'resp_123' not found." },
+      "Previous response with id 'resp_123' not found.",
+      new Headers(),
+    );
+
+    expect(isPreviousResponseIdError(err)).toBe(true);
+  });
+
+  it('does not match an unrelated invalid-parameter error', () => {
+    const err = new OpenAIBadRequestError(
+      400,
+      { param: 'temperature', message: 'temperature must be between 0 and 2' },
+      'temperature must be between 0 and 2',
+      new Headers(),
+    );
+
+    expect(isPreviousResponseIdError(err)).toBe(false);
   });
 });
 


### PR DESCRIPTION
isContextWindowError() relied entirely on English message-pattern matching
against third-party provider wording, and the base shouldAutoRetry() gate
never consulted it at all — so a context-window overflow that slipped past
OpenAI Responses' compaction-recovery path (e.g. no previous_response_id to
chain from, as on a subagent's first turn) fell through as a generic
"retryable" error and got auto-retried forever with the same oversized
payload. The WebSocket transport's onFailed handler made this worse by
flattening the response's structured error object down to its .message
before wrapping it in a plain Error, discarding the one field (error.code)
that identifies the failure without depending on wording.

- isContextWindowError() now checks OpenAI's native error.code
  ("context_length_exceeded", flattened onto APIError by the SDK) before
  falling back to message-pattern matching, which stays as the only signal
  Anthropic/Google expose for this failure.
- OpenAIResponseWebSocketTransport's onFailed preserves the response's
  structured `error` object on the thrown Error instead of discarding
  everything but its message, mirroring the existing pattern in
  createOpenAIBackgroundTerminalError.
- RetryableInvocationNode.shouldAutoRetry now refuses to auto-retry any
  context-window error, regardless of flow-auto-retry tagging or chain
  state, across every provider. A handler that can recover (e.g. OpenAI's
  compaction retry) still does so transparently and never reaches this
  gate; only overflows nobody already recovered from are stopped here.

Claude-Session: https://claude.ai/code/session_016Ei7FguCLsCoYQ18PevJLh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core retry gating and error classification for all model invocations; behavior is narrower (fewer auto-retries) and covered by new tests, but misclassification could still affect recovery paths for OpenAI Responses/WebSocket.
> 
> **Overview**
> Fixes **infinite auto-retry loops** when a context-window overflow isn’t recovered by provider-specific compaction (e.g. first subagent turn with no `previous_response_id`). Those failures were treated like transient errors and retried with the same oversized payload.
> 
> **`RetryableInvocationNode.shouldAutoRetry`** now blocks auto-retry for any **`isContextWindowError`** result, including errors tagged **`attachFlowAutoRetryRequired`** (e.g. from the WebSocket path). Provider handlers that recover via compaction still handle overflow before this gate.
> 
> **`isContextWindowError`** now prefers OpenAI’s stable **`context_length_exceeded`** `code` (top-level or nested via **`detectRawErrorBody`**), with message patterns kept as a fallback for Anthropic/Google.
> 
> **OpenAI WebSocket `onFailed`** attaches the response’s structured **`error`** on the thrown `Error` (not only `.message`), so classification can use **`error.code`**.
> 
> **`isPreviousResponseIdError`** similarly prefers OpenAI’s **`param: 'previous_response_id`**, with message fallback for 404 “not found” cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47039887c7ee484d191406d021ca7d90518da5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->