### PR TITLE
refactor(progress): single-source run-fact dispatch as a typed table

### DIFF
--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -78,22 +78,41 @@ export type DeleteProgressStream = (
   stream: StreamTabId,
 ) => void | Promise<void>;
 
+/**
+ * Run-scoped event types this backend handles, and the single source of truth
+ * for the `runFactHandlers` table: the `RunFactHandlers` mapped type requires
+ * exactly one handler per entry, so a listed type without a handler (or vice
+ * versa) is a compile error. `ProgressBackend` reuses this as its run-scope
+ * subscription filter, keeping delivered and handled events in sync by
+ * construction.
+ */
+const RUN_FACT_EVENT_TYPES = [
+  'conversation.progress',
+  'updateTodos',
+  'updatePlan',
+  'addOutputFiles',
+  'updateMissingOutputs',
+  'updateCompileFailures',
+  'goalPaused',
+  'run.config',
+  'usage',
+  'status',
+  'stage.start',
+  'child.activity',
+  'process.output',
+] as const satisfies readonly AgentEvent['type'][];
+
 export const PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] =
-  [
-    'conversation.progress',
-    'updateTodos',
-    'updatePlan',
-    'addOutputFiles',
-    'updateMissingOutputs',
-    'updateCompileFailures',
-    'goalPaused',
-    'run.config',
-    'usage',
-    'status',
-    'stage.start',
-    'child.activity',
-    'process.output',
-  ];
+  RUN_FACT_EVENT_TYPES;
+
+type RunFactType = (typeof RUN_FACT_EVENT_TYPES)[number];
+
+type RunFactHandlers = {
+  [K in RunFactType]: (
+    streamId: StreamTabId,
+    event: Extract<AgentEvent, { type: K }>,
+  ) => void;
+};
 
 function getDefaultProgressStreamControls(): ProgressStreamControls {
   return {
@@ -108,6 +127,119 @@ export class ProgressFactApplier {
   private readonly logger: AgentTrace;
   private progressThrottleTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingProgressUpdates = new Map<StreamTabId, ConversationProgress>();
+
+  /** Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive. */
+  private readonly runFactHandlers: RunFactHandlers = {
+    usage: (streamId, event) => {
+      const payload = toUpdateStreamUsagePayload(event.data, streamId);
+      if (payload) {
+        this.applyFact('failed to handle usage fact', () =>
+          this.handleUpdateStreamUsage(payload),
+        );
+      }
+    },
+    'run.config': (_streamId, event) => {
+      this.applyFact('failed to handle run.config fact', () =>
+        this.handleSetTaskState({
+          streamId: event.streamId,
+          executionId: event.executionId,
+          taskState: agentConfigToTaskState(event.config),
+        }),
+      );
+    },
+    status: (_streamId, event) => {
+      this.applyFact('failed to handle status fact', () =>
+        this.setStreamStatus(
+          event.streamId,
+          event.phase,
+          event.previousPhase,
+          event.substate,
+        ),
+      );
+    },
+    updateTodos: (_streamId, event) => {
+      this.applyFact('failed to handle updateTodos fact', () =>
+        this.handleUpdateTodos(event),
+      );
+    },
+    updatePlan: (_streamId, event) => {
+      this.applyFact('failed to handle updatePlan fact', () =>
+        this.handleUpdatePlan(event),
+      );
+    },
+    addOutputFiles: (_streamId, event) => {
+      this.applyFact('failed to handle addOutputFiles fact', () =>
+        this.handleAddOutputFiles(event),
+      );
+    },
+    updateMissingOutputs: (_streamId, event) => {
+      this.applyFact('failed to handle updateMissingOutputs fact', () =>
+        this.handleUpdateMissingOutputs(event),
+      );
+    },
+    updateCompileFailures: (_streamId, event) => {
+      this.applyFact('failed to handle updateCompileFailures fact', () =>
+        this.handleUpdateCompileFailures(event),
+      );
+    },
+    goalPaused: () => {
+      // No progress-view state change; listed only to keep the run-fact type
+      // set exhaustive (it stays in the subscription filter for parity).
+    },
+    'conversation.progress': (streamId, event) => {
+      this.applyFact('failed to handle conversation.progress fact', () =>
+        this.handleUpdateConversationProgress({
+          streamId,
+          progress: event.progress,
+        }),
+      );
+    },
+    'stage.start': (streamId, event) => {
+      if (event.kind !== 'round') return;
+      this.applyFact('failed to handle stage.start fact', () =>
+        this.handleUpdateRoundStage({
+          streamId,
+          roundStage: {
+            index: event.index ?? 0,
+            ...(event.total !== undefined && event.total > 0
+              ? { total: event.total }
+              : {}),
+          },
+        }),
+      );
+    },
+    'child.activity': (_streamId, event) => {
+      if (event.kind === 'subagents') {
+        this.applyFact('failed to handle subagent activity fact', () =>
+          this.updateActiveChildren(event.parentStreamId, {
+            activeField: 'activeSubagents',
+            countField: 'finishedSubagentCount',
+            next: [...event.children],
+          }),
+        );
+        return;
+      }
+      if (event.kind === 'processes') {
+        this.applyFact('failed to handle process activity fact', () =>
+          this.updateActiveChildren(event.parentStreamId, {
+            activeField: 'activeProcesses',
+            countField: 'finishedProcessCount',
+            next: [...event.processes],
+          }),
+        );
+      }
+    },
+    'process.output': (_streamId, event) => {
+      this.applyFact('failed to handle process.output fact', () =>
+        this.handleUpdateProcessOutput({
+          parentStreamId: event.parentStreamId,
+          executionId: event.executionId,
+          stdout: event.stdout,
+          stderr: event.stderr,
+        }),
+      );
+    },
+  };
 
   constructor(
     private state: ProgressViewState,
@@ -217,139 +349,16 @@ export class ProgressFactApplier {
   }
 
   handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
-    if (event.type === 'usage') {
-      const payload = toUpdateStreamUsagePayload(event.data, streamId);
-      if (payload) {
-        this.applyFact('failed to handle usage fact', () =>
-          this.handleUpdateStreamUsage(payload),
-        );
-      }
-      return;
-    }
-
-    if (event.type === 'run.config') {
-      this.applyFact('failed to handle run.config fact', () =>
-        this.handleSetTaskState({
-          streamId: event.streamId,
-          executionId: event.executionId,
-          taskState: agentConfigToTaskState(event.config),
-        }),
-      );
-      return;
-    }
-
-    if (event.type === 'status') {
-      this.applyFact('failed to handle status fact', () =>
-        this.setStreamStatus(
-          event.streamId,
-          event.phase,
-          event.previousPhase,
-          event.substate,
-        ),
-      );
-      return;
-    }
-
-    if (event.type === 'updateTodos') {
-      this.applyFact('failed to handle updateTodos fact', () =>
-        this.handleUpdateTodos(event),
-      );
-      return;
-    }
-
-    if (event.type === 'updatePlan') {
-      this.applyFact('failed to handle updatePlan fact', () =>
-        this.handleUpdatePlan(event),
-      );
-      return;
-    }
-
-    if (event.type === 'addOutputFiles') {
-      this.applyFact('failed to handle addOutputFiles fact', () =>
-        this.handleAddOutputFiles(event),
-      );
-      return;
-    }
-
-    if (event.type === 'updateMissingOutputs') {
-      this.applyFact('failed to handle updateMissingOutputs fact', () =>
-        this.handleUpdateMissingOutputs(event),
-      );
-      return;
-    }
-
-    if (event.type === 'updateCompileFailures') {
-      this.applyFact('failed to handle updateCompileFailures fact', () =>
-        this.handleUpdateCompileFailures(event),
-      );
-      return;
-    }
-
-    if (event.type === 'goalPaused') {
-      return;
-    }
-
-    if (event.type === 'conversation.progress') {
-      this.applyFact('failed to handle conversation.progress fact', () =>
-        this.handleUpdateConversationProgress({
-          streamId,
-          progress: event.progress,
-        }),
-      );
-      return;
-    }
-
-    if (event.type === 'stage.start') {
-      if (event.kind !== 'round') return;
-      this.applyFact('failed to handle stage.start fact', () =>
-        this.handleUpdateRoundStage({
-          streamId,
-          roundStage: {
-            index: event.index ?? 0,
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
-        }),
-      );
-      return;
-    }
-
-    if (event.type === 'child.activity') {
-      if (event.kind === 'subagents') {
-        this.applyFact('failed to handle subagent activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeSubagents',
-            countField: 'finishedSubagentCount',
-            next: [...event.children],
-          }),
-        );
-        return;
-      }
-      if (event.kind === 'processes') {
-        this.applyFact('failed to handle process activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeProcesses',
-            countField: 'finishedProcessCount',
-            next: [...event.processes],
-          }),
-        );
-        return;
-      }
-      return;
-    }
-
-    if (event.type === 'process.output') {
-      this.applyFact('failed to handle process.output fact', () =>
-        this.handleUpdateProcessOutput({
-          parentStreamId: event.parentStreamId,
-          executionId: event.executionId,
-          stdout: event.stdout,
-          stderr: event.stderr,
-        }),
-      );
-      return;
-    }
+    // Widen the exhaustive table to the full event union so an unlisted type
+    // (not in the subscription filter, but defensively tolerated) is a no-op
+    // rather than a lookup on a missing key.
+    const handlers = this.runFactHandlers as Partial<
+      Record<
+        AgentEvent['type'],
+        (streamId: StreamTabId, event: AgentEvent) => void
+      >
+    >;
+    handlers[event.type]?.(streamId, event);
   }
 
   private applyFact(context: string, handle: () => void | Promise<void>): void {


### PR DESCRIPTION
## Summary

`ProgressFactApplier` routed run-scoped agent events through a 135-line
`if (event.type === …) { … return; }` ladder, while the *set* of handled event
types was written out a second time — independently — as the exported
`PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES` subscription filter. Keeping the two
in lockstep was a manual chore and a documented drift hazard: add a type to one
but not the other and events are silently dropped or mis-routed.

This replaces both with a single `RUN_FACT_EVENT_TYPES` `as const` array that drives:

- the exported subscription filter (same runtime value/shape as before), and
- a `RunFactHandlers` mapped type whose keys must be *exactly* those event types,
  so the new `runFactHandlers` dispatch table is exhaustive **by construction**.

`handleRunFact` collapses to a one-line table lookup. Handler bodies, the
per-event error-context strings passed to `applyFact`, and the
`usage` / `stage.start` / `child.activity` guards are all carried over verbatim,
so runtime behavior is identical — this is a structural change only.

This is the first of the ranked items from a codebase refactoring audit; it was
chosen first because it is self-contained to one file and fully covered by the
existing `progressView` suite. Larger items (model-handler streaming/orchestration
scaffolding, cross-host settings-wiring duplication) are noted as follow-ups.

## Issue acceptance gates

No tracking issue — this is refactoring surfaced by a code-quality audit. Gate:
no behavior change, drift between the run-fact type list and the handler set is
now a compile error. Satisfied.

## Single source of truth

`RUN_FACT_EVENT_TYPES` (module-scope, in `ProgressFactApplier.ts`) is now the
sole authority for which run events this backend handles. Both the subscription
filter and the exhaustiveness of the `runFactHandlers` table derive from it.

## Duplication and abstraction budget

Removes a two-place, hand-synced enumeration of run-event types (the if-ladder
branches vs the subscription-filter array). The one new construct — the
`RunFactHandlers` mapped type + `runFactHandlers` table — owns exactly one
invariant: *every subscribed run-event type has a handler and vice versa*,
enforced at compile time. No pass-through layer is introduced; `handleRunFact`
remains the single dispatch entry point.

## Net elements (R6)

- Files: 1 changed, 0 added, 0 deleted (diffstat: +157 / −148, net +9 LoC).
- Exported symbols: none added or removed (`^[+-]export` over the diff is empty);
  `PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES` keeps its name, type, and value.
- New non-exported constructs: 1 const (`RUN_FACT_EVENT_TYPES`), 2 type aliases
  (`RunFactType`, `RunFactHandlers`), 1 private instance field (`runFactHandlers`).
- Deleted: the 135-line `handleRunFact` if-ladder body and the hand-written
  16-line type array literal.

## Consumer counts (R8)

No emit path or export is deleted or re-routed.
`PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES` has 1 consumer
(`ProgressBackend.ts`, the run-scope subscription); it is unchanged.

## Host impact

Extension: none (shared controller code; behavior identical).

Desktop: none (same shared controller).

CLI: none (same shared controller).

## Scheduled refactoring

None required for this change. Remaining audit items (model-handler streaming
scaffolding, cross-host settings wiring, transcript store consolidation) are
candidate follow-ups but are out of scope here.

## Validation

- `npm run typecheck` — passes (all workspace projects).
- `npx vitest run src/test-kernel/progressView/` — 42 files, 248 tests passing.
- `npx eslint …/ProgressFactApplier.ts` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TA38XkgJpDrJnfBWQ8CvP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA38XkgJpDrJnfBWQ8CvP6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file structural refactor with identical handler logic; progress-view tests cover the path and the public subscription export is unchanged for ProgressBackend.
> 
> **Overview**
> **`ProgressFactApplier`** no longer keeps two hand-maintained lists of run-scoped agent events (subscription filter vs. a long `if (event.type === …)` chain). A single **`RUN_FACT_EVENT_TYPES`** const drives **`PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES`** and an exhaustive **`runFactHandlers`** map typed via **`RunFactHandlers`**, so a missing or extra handler is a compile error.
> 
> **`handleRunFact`** dispatches through that table (with a widened lookup so unknown types are a no-op). Per-event **`applyFact`** bodies and guards (**`usage`**, **`stage.start`** round-only, **`child.activity`** kinds) are unchanged—runtime behavior should match the prior ladder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3155fb571093b0149aa76f08d7e61838e56fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->