### PR TITLE
fix(review): add execution-owned stop action

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1234,6 +1234,13 @@
         "icon": "$(ellipsis)"
       },
       {
+        "command": "texra.agentReview.stop",
+        "title": "Stop Agent Review",
+        "shortTitle": "Stop",
+        "category": "TeXRA",
+        "icon": "$(debug-stop)"
+      },
+      {
         "command": "texra.agentReview.fixAllIssues",
         "title": "Fix All Agent Review Issues",
         "shortTitle": "Fix All Issues",
@@ -1502,12 +1509,17 @@
         },
         {
           "command": "texra.agentReview.run",
-          "when": "texra.activated && view == texra.scmAgentReviewView",
+          "when": "texra.activated && view == texra.scmAgentReviewView && !texra.agentReview.running",
+          "group": "navigation@1"
+        },
+        {
+          "command": "texra.agentReview.stop",
+          "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.running",
           "group": "navigation@1"
         },
         {
           "command": "texra.agentReview.runWithOptions",
-          "when": "texra.activated && view == texra.scmAgentReviewView",
+          "when": "texra.activated && view == texra.scmAgentReviewView && !texra.agentReview.running",
           "group": "navigation@2"
         },
         {
@@ -1560,11 +1572,15 @@
       "commandPalette": [
         {
           "command": "texra.agentReview.run",
-          "when": "texra.activated"
+          "when": "texra.activated && !texra.agentReview.running"
         },
         {
           "command": "texra.agentReview.runWithOptions",
-          "when": "texra.activated"
+          "when": "texra.activated && !texra.agentReview.running"
+        },
+        {
+          "command": "texra.agentReview.stop",
+          "when": "texra.activated && texra.agentReview.running"
         },
         {
           "command": "texra.agentReview.fixAllIssues",

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -39,6 +39,7 @@ const CHANNEL = 'AgentReview';
 const agentReviewCommands = {
   run: 'texra.agentReview.run',
   runWithOptions: 'texra.agentReview.runWithOptions',
+  stop: 'texra.agentReview.stop',
   fixAll: 'texra.agentReview.fixAllIssues',
   fixIssue: 'texra.agentReview.fixIssue',
   dismissIssue: 'texra.agentReview.dismissIssue',
@@ -139,6 +140,10 @@ export function registerAgentReviewCommands(
     {
       id: agentReviewCommands.runWithOptions,
       handler: () => void handleRunWithOptions(),
+    },
+    {
+      id: agentReviewCommands.stop,
+      handler: () => AgentReviewService.stop(),
     },
     {
       id: agentReviewCommands.fixAll,

--- a/packages/extension/src/frontend/review/AgentReviewRunController.ts
+++ b/packages/extension/src/frontend/review/AgentReviewRunController.ts
@@ -1,0 +1,67 @@
+// Local imports
+import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
+import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+
+export interface AgentReviewRunToken {
+  readonly session: SessionHandle;
+  handle?: AgentRunHandle;
+  stopRequested: boolean;
+}
+
+/** Owns the active Agent Review execution and its stop request. */
+export class AgentReviewRunController {
+  private activeRun: AgentReviewRunToken | undefined;
+
+  /** Whether a review still owns the service run slot. */
+  get isActive(): boolean {
+    return this.activeRun !== undefined;
+  }
+
+  /** Whether the active run has already accepted a stop request. */
+  get stopRequested(): boolean {
+    return this.activeRun?.stopRequested ?? false;
+  }
+
+  /** Claim the run slot for one explicit runtime session. */
+  start(session: SessionHandle): AgentReviewRunToken {
+    if (this.activeRun)
+      throw new Error('An Agent Review run is already active.');
+    const run: AgentReviewRunToken = { session, stopRequested: false };
+    this.activeRun = run;
+    return run;
+  }
+
+  /** Attach the exact execution handle and replay any earlier stop. */
+  bind(run: AgentReviewRunToken, handle: AgentRunHandle): void {
+    if (this.activeRun !== run) return;
+    run.handle = handle;
+    if (run.stopRequested) this.stop(run);
+  }
+
+  /** Request one idempotent stop of the active run. */
+  requestStop(): boolean {
+    const run = this.activeRun;
+    if (!run || run.stopRequested) return false;
+    run.stopRequested = true;
+    this.stop(run);
+    return true;
+  }
+
+  /** Release the run slot only when the caller still owns it. */
+  finish(run: AgentReviewRunToken): boolean {
+    if (this.activeRun !== run) return false;
+    this.activeRun = undefined;
+    return true;
+  }
+
+  private stop(run: AgentReviewRunToken): void {
+    const handle = run.handle;
+    if (!handle) return;
+    if (run.session.executions.getHandle(handle.executionId) !== handle) return;
+    run.session.executions.stopAgentStream(handle.childStreamId, {
+      runtimeHost: handle.runtimeHost,
+      detachActiveChildren: detachSubagentsOnStop(),
+    });
+  }
+}

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -31,6 +31,7 @@ import {
   type ReviewSeverity,
 } from '@agent/review/reviewIssues';
 import { runAgent } from '@agent/runtime/runAgent';
+import { currentSession } from '@agent/runtime/SessionHandle';
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import {
@@ -44,6 +45,10 @@ import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig, getValidatedConfig } from '@utils/config/configUtils';
+import {
+  AgentReviewRunController,
+  type AgentReviewRunToken,
+} from './AgentReviewRunController';
 
 const CHANNEL = 'AgentReview';
 const COLLECTION_NAME = 'texra-agent-review';
@@ -116,7 +121,7 @@ class AgentReviewServiceImpl {
   private issues: ReviewIssue[] = [];
   /** Fingerprints of dismissed issues, kept for the session so re-reviews don't resurrect them. */
   private readonly dismissed = new Set<string>();
-  private running = false;
+  private readonly reviewRuns = new AgentReviewRunController();
   private summary: string | undefined;
   /** Repository root the current issues' paths are relative to. */
   private reviewRoot: string | undefined;
@@ -135,7 +140,7 @@ class AgentReviewServiceImpl {
 
   getState(): AgentReviewStateSnapshot {
     return {
-      running: this.running,
+      running: this.reviewRuns.isActive,
       issues: this.issues,
       summary: this.summary,
     };
@@ -169,12 +174,12 @@ class AgentReviewServiceImpl {
     trigger: AgentReviewTrigger,
     options: AgentReviewRunOptions = {},
   ): Promise<void> {
-    if (this.running) {
+    if (this.reviewRuns.isActive) {
       if (trigger === 'manual') {
         void vscode.window.showInformationMessage(
           'An agent review is already running.',
         );
-      } else {
+      } else if (!this.reviewRuns.stopRequested) {
         this.pendingCommitReview ??= options;
       }
       return;
@@ -190,7 +195,8 @@ class AgentReviewServiceImpl {
       return;
     }
 
-    this.running = true;
+    const run = this.reviewRuns.start(currentSession());
+    const generation = ++this.reviewGeneration;
     this.summary = 'Reviewing changes…';
     await this.syncContextKeys();
     this.emitter.fire();
@@ -201,7 +207,7 @@ class AgentReviewServiceImpl {
           location: { viewId: AGENT_REVIEW_VIEW_ID },
           title: 'Agent review',
         },
-        () => this.executeReview(cwd, trigger, options),
+        () => this.executeReview(cwd, trigger, options, run, generation),
       );
     } catch (err) {
       // Backstop for anything executeReview's own handling missed — the
@@ -212,14 +218,15 @@ class AgentReviewServiceImpl {
         `Agent review failed unexpectedly: ${toErrorMessage(err)}`,
       );
     } finally {
-      this.activeReview = undefined;
-      this.running = false;
-      await this.syncContextKeys();
-      this.emitter.fire();
-      const pending = this.pendingCommitReview;
-      this.pendingCommitReview = undefined;
-      if (pending) {
-        void this.runReview('commit', pending);
+      if (this.reviewRuns.finish(run)) {
+        this.activeReview = undefined;
+        const pending = this.pendingCommitReview;
+        this.pendingCommitReview = undefined;
+        this.emitter.fire();
+        await this.syncContextKeys();
+        if (pending) {
+          void this.runReview('commit', pending);
+        }
       }
     }
   }
@@ -228,11 +235,12 @@ class AgentReviewServiceImpl {
     cwd: string,
     trigger: AgentReviewTrigger,
     options: AgentReviewRunOptions,
+    run: AgentReviewRunToken,
+    generation: number,
   ): Promise<void> {
-    // `clear()` bumps the generation. Capture this before the async diff
-    // collection so a clear/checkout during collection cannot resurrect a
-    // review after the panel was intentionally reset.
-    const generation = ++this.reviewGeneration;
+    // `clear()` bumps the generation. Check before collecting so a clear that
+    // landed during the initial context-key update cannot start stale work.
+    if (generation !== this.reviewGeneration) return;
     const collected = await collectReviewDiff({
       cwd,
       includeUntracked: getConfig<boolean>(
@@ -248,6 +256,10 @@ class AgentReviewServiceImpl {
       baseBranch: options.baseBranch,
     });
     if (generation !== this.reviewGeneration) return;
+    if (run.stopRequested) {
+      this.summary = 'Review cancelled';
+      return;
+    }
 
     if (!collected.ok) {
       // Issues from the previous run stay available rather than vanishing on
@@ -336,6 +348,8 @@ class AgentReviewServiceImpl {
           runtimeHost: extensionAgentRuntimeHost,
           openWorkflowOutput: openFinalOutputIfAvailable,
           stopAfterCycle: true,
+          session: run.session,
+          onRun: (handle) => this.reviewRuns.bind(run, handle),
         },
       );
       outcome = result.outcome;
@@ -477,11 +491,12 @@ class AgentReviewServiceImpl {
   }
 
   /**
-   * Clear results and forget dismissals. A reviewer session still running
-   * is detached from the panel: its future reports are rejected (no active
-   * collector) and its outcome is discarded (stale generation).
+   * Clear results and forget dismissals. A reviewer session still running is
+   * stopped; its future reports are rejected and its outcome is discarded.
+   * The run slot stays occupied until that execution actually settles.
    */
   clear(): void {
+    this.reviewRuns.requestStop();
     this.issues = [];
     this.dismissed.clear();
     this.summary = undefined;
@@ -489,6 +504,15 @@ class AgentReviewServiceImpl {
     this.pendingCommitReview = undefined;
     this.reviewGeneration++;
     this.updateDiagnostics();
+    void this.syncContextKeys();
+    this.emitter.fire();
+  }
+
+  /** Stop the active review while preserving any findings already reported. */
+  stop(): void {
+    if (!this.reviewRuns.requestStop()) return;
+    this.pendingCommitReview = undefined;
+    this.summary = 'Stopping review…';
     void this.syncContextKeys();
     this.emitter.fire();
   }
@@ -563,7 +587,7 @@ class AgentReviewServiceImpl {
     await vscode.commands.executeCommand(
       'setContext',
       'texra.agentReview.running',
-      this.running,
+      this.reviewRuns.isActive,
     );
     await vscode.commands.executeCommand(
       'setContext',

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -207,11 +207,15 @@
         "commandPalette": [
           {
             "command": "texra.agentReview.run",
-            "when": "texra.activated"
+            "when": "texra.activated && !texra.agentReview.running"
           },
           {
             "command": "texra.agentReview.runWithOptions",
-            "when": "texra.activated"
+            "when": "texra.activated && !texra.agentReview.running"
+          },
+          {
+            "command": "texra.agentReview.stop",
+            "when": "texra.activated && texra.agentReview.running"
           },
           {
             "command": "texra.agentReview.fixAllIssues",
@@ -591,12 +595,17 @@
           {
             "command": "texra.agentReview.run",
             "group": "navigation@1",
-            "when": "texra.activated && view == texra.scmAgentReviewView"
+            "when": "texra.activated && view == texra.scmAgentReviewView && !texra.agentReview.running"
+          },
+          {
+            "command": "texra.agentReview.stop",
+            "group": "navigation@1",
+            "when": "texra.activated && view == texra.scmAgentReviewView && texra.agentReview.running"
           },
           {
             "command": "texra.agentReview.runWithOptions",
             "group": "navigation@2",
-            "when": "texra.activated && view == texra.scmAgentReviewView"
+            "when": "texra.activated && view == texra.scmAgentReviewView && !texra.agentReview.running"
           },
           {
             "command": "texra.agentReview.fixAllIssues",

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -277,6 +277,7 @@ export async function runFlowWithLifecycle(
     runtimeHost,
     ctx.logger,
   );
+  handle.enablePendingInterrupt();
   session.executions.track(handle);
   // Expose the live handle to the launcher (F-2). Guarded: neither a synchronous
   // throw nor an async rejection from a consumer callback may abort the run.
@@ -320,8 +321,13 @@ export async function runFlowWithLifecycle(
     // The lifecycle owns every stream-status transition: RUNNING here,
     // terminal states in the success/error arms below. Runners must not
     // set stream status themselves.
-    transitionRunStart(ctx);
-    const result = await runner(handle);
+    if (!handle.hasPendingInterrupt) transitionRunStart(ctx);
+    let result: AgentRuntimeFlowResult;
+    try {
+      result = await runner(handle);
+    } finally {
+      handle.closePendingInterruptWindow();
+    }
     if (isWaitingFlowResult(result)) {
       logger.debug(`Task suspended with outcome: ${result.outcome}`);
       // The handle stays tracked (correct for resume) but the live tool-use

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -88,6 +88,8 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private _deliveryTargetStreamId: StreamTabId | undefined;
   private interruptHandler?: ExecutionInterruptHandler;
   private toolUseFlowContext?: LiveToolUseFlowContext;
+  private acceptsPendingInterrupt = false;
+  private pendingInterrupt = false;
   private waitingCleanups?: Set<() => void>;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
@@ -153,17 +155,38 @@ export class AgentExecutionHandle implements ExecutionHandle {
     return this._deliveryTargetStreamId;
   }
 
+  /** Whether lifecycle startup must preserve an already-cancelled status. */
+  get hasPendingInterrupt(): boolean {
+    return this.pendingInterrupt;
+  }
+
   /** Promote this subagent to a top-level execution (detach from parent). */
   detach(): void {
     this._deliveryTargetStreamId = undefined;
     this._parentStreamId = this.childStreamId;
   }
 
+  /** Allow a stop request to arrive between lifecycle tracking and setup. */
+  enablePendingInterrupt(): void {
+    this.acceptsPendingInterrupt = true;
+  }
+
+  /** Discard an undeliverable pre-attach stop when the runner exits. */
+  closePendingInterruptWindow(): void {
+    this.acceptsPendingInterrupt = false;
+    this.pendingInterrupt = false;
+  }
+
   attachToolUseFlow(context: LiveToolUseFlowContext): void {
     if (this.category !== 'toolUse') {
       throw new Error('Only tool-use execution handles can attach tool flows.');
     }
+    this.acceptsPendingInterrupt = false;
     this.toolUseFlowContext = context;
+    if (this.pendingInterrupt) {
+      this.pendingInterrupt = false;
+      context.interrupt();
+    }
   }
 
   detachToolUseFlow(context?: LiveToolUseFlowContext): void {
@@ -176,7 +199,12 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 
   attachInterruptHandler(handler: ExecutionInterruptHandler): () => void {
+    this.acceptsPendingInterrupt = false;
     this.interruptHandler = handler;
+    if (this.pendingInterrupt) {
+      this.pendingInterrupt = false;
+      handler.interrupt();
+    }
     return () => this.detachInterruptHandler(handler);
   }
 
@@ -192,8 +220,12 @@ export class AgentExecutionHandle implements ExecutionHandle {
       return true;
     }
     const context = this.toolUseFlowContext;
-    if (!context) return false;
-    context.interrupt();
+    if (context) {
+      context.interrupt();
+      return true;
+    }
+    if (!this.acceptsPendingInterrupt) return false;
+    this.pendingInterrupt = true;
     return true;
   }
 

--- a/src/shared/commands/catalog.ts
+++ b/src/shared/commands/catalog.ts
@@ -451,6 +451,13 @@ export const commandCatalog = [
     icon: '$(ellipsis)',
   },
   {
+    id: 'texra.agentReview.stop',
+    title: 'Stop Agent Review',
+    shortTitle: 'Stop',
+    category: 'TeXRA',
+    icon: '$(debug-stop)',
+  },
+  {
     id: 'texra.agentReview.fixAllIssues',
     title: 'Fix All Agent Review Issues',
     shortTitle: 'Fix All Issues',

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -17,7 +17,10 @@ import {
   AgentSettingSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
+import {
+  AgentExecutionHandle,
+  type LiveToolUseFlowContext,
+} from '@agent/runtime/executionRegistry';
 import { createRunScope } from '@agent/runtime/RunScope';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
@@ -486,6 +489,46 @@ describe('runFlowWithLifecycle', () => {
       defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }
+  });
+
+  it('replays a stop requested by onRun once interruption is attached', async () => {
+    const { executionId, streamId, ctx } = lifecycleFixture(
+      'lifecycle-early-stop',
+    );
+    const interrupt = vi.fn();
+
+    const result = await runFlowWithLifecycle(
+      ctx,
+      async (handle) => {
+        expect(defaultSession().status.get(streamId)).toBe(
+          STREAM_PHASE.CANCELLED,
+        );
+        const flowContext: LiveToolUseFlowContext = {
+          session: { appendFollowUp: vi.fn() },
+          modelHandler: { supportsManualCompaction: false },
+          requestImmediateCompaction: vi.fn(),
+          modelSwitchDisabledReason: vi.fn(),
+          switchModel: vi.fn().mockResolvedValue(undefined),
+          interrupt,
+        };
+        handle.attachToolUseFlow(flowContext);
+        expect(interrupt).toHaveBeenCalledOnce();
+        handle.detachToolUseFlow(flowContext);
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId,
+          streamId,
+        };
+      },
+      {
+        onRun: () => {
+          expect(defaultSession().executions.kill(executionId)).toBe(true);
+        },
+      },
+    );
+
+    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
   });
 
   it('lets a stop/kill tear down a subagent suspended at WAITING (issue #7287)', async () => {

--- a/src/test-kernel/frontend/AgentReviewRunController.vitest.ts
+++ b/src/test-kernel/frontend/AgentReviewRunController.vitest.ts
@@ -1,0 +1,72 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  AgentReviewRunController,
+  type AgentReviewRunToken,
+} from '@frontend/review/AgentReviewRunController';
+
+function createRunHarness() {
+  const stopAgentStream = vi.fn();
+  let currentHandle: AgentRunHandle | undefined;
+  const session = {
+    executions: {
+      getHandle: () => currentHandle,
+      stopAgentStream,
+    },
+  } as unknown as SessionHandle;
+  const bind = (
+    controller: AgentReviewRunController,
+    run: AgentReviewRunToken,
+    executionId: string,
+  ) => {
+    const handle = {
+      executionId,
+      childStreamId: `review#${executionId}`,
+      runtimeHost: {},
+    } as AgentRunHandle;
+    currentHandle = handle;
+    controller.bind(run, handle);
+    return handle;
+  };
+  return { bind, session, stopAgentStream };
+}
+
+describe('AgentReviewRunController', () => {
+  it('latches a stop requested before the execution handle arrives', () => {
+    const controller = new AgentReviewRunController();
+    const { bind, session, stopAgentStream } = createRunHarness();
+    const run = controller.start(session);
+
+    expect(controller.requestStop()).toBe(true);
+    expect(controller.isActive).toBe(true);
+    bind(controller, run, 'review-a');
+
+    expect(stopAgentStream).toHaveBeenCalledOnce();
+    expect(controller.requestStop()).toBe(false);
+    expect(stopAgentStream).toHaveBeenCalledOnce();
+    expect(controller.isActive).toBe(true);
+    expect(controller.finish(run)).toBe(true);
+    expect(controller.isActive).toBe(false);
+  });
+
+  it('ignores a stale finalizer and stops only the current run', () => {
+    const controller = new AgentReviewRunController();
+    const first = createRunHarness();
+    const runA = controller.start(first.session);
+    first.bind(controller, runA, 'review-a');
+    expect(controller.finish(runA)).toBe(true);
+
+    const second = createRunHarness();
+    const runB = controller.start(second.session);
+    second.bind(controller, runB, 'review-b');
+
+    expect(controller.finish(runA)).toBe(false);
+    expect(controller.requestStop()).toBe(true);
+    expect(first.stopAgentStream).not.toHaveBeenCalled();
+    expect(second.stopAgentStream).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- give Agent Review one active run token that owns its session and execution handle
- route Stop and clear-while-running through the shared execution registry stop API
- replace Find Issues with a Stop action while review is running
- preserve partial findings on Stop while Clear still discards stale results
- latch stops that arrive after lifecycle tracking but before an interrupt capability attaches

## Design
`AgentReviewRunController` is the single source of truth for review activity, stop intent, and exact cancellation identity. `AgentExecutionHandle` owns the narrow pre-setup stop window: lifecycle launches explicitly enable it, the first attached flow/handler replays a pending stop, and the window closes once setup returns so suspended and post-detach handles keep their existing semantics.

## Tests
- stop requested before review handle capture is replayed once the handle binds
- repeated Stop is idempotent
- stale finalization cannot clear or stop the newer review run
- lifecycle stop from `onRun` replays once tool-use interruption attaches
- existing execution-registry waiting/teardown coverage remains green
- command catalog and extension package invariants

## Validation
- focused Vitest: 4 files, 50 tests passed
- root and test-kernel TypeScript checks
- full repository ESLint (0 errors; existing warnings only)
- direct extension-host esbuild bundle
- Prettier and `git diff --check`

`compile:fast` through pnpm is blocked only by isolated-worktree dependency symlinks; the underlying extension esbuild succeeds and CI runs from a clean install.

Closes #8260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent run lifecycle and cancellation semantics (pending interrupt window), but scope is narrow and covered by new controller and lifecycle tests.
> 
> **Overview**
> Adds a **Stop Agent Review** command and swaps the SCM panel’s “Find Issues” action for **Stop** while a review is running (`texra.agentReview.running`).
> 
> **`AgentReviewRunController`** owns the single active review run: it claims a run slot, binds the live execution handle from `runAgent`’s `onRun`, and routes stop/clear through `session.executions.stopAgentStream`. **Stop** keeps partial findings and clears pending commit re-runs; **Clear** still discards results but now also stops an in-flight reviewer.
> 
> The agent runtime gains a **pending interrupt** window on `AgentExecutionHandle` so a stop requested between lifecycle tracking and tool-flow attach is latched and replayed once interruption is wired; lifecycle skips the RUNNING transition when a pre-setup stop already landed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67290c3455dbfad56fbb28802d322f5c8ba403f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->