### PR TITLE
fix: require explicit device approval decision

### DIFF
--- a/supabase/functions/auth-device/approvalRequest.ts
+++ b/supabase/functions/auth-device/approvalRequest.ts
@@ -1,0 +1,9 @@
+/** Parse an explicit approval decision from an untrusted request body. */
+export function parseApprovalDecision(body: unknown): boolean | null {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return null;
+  }
+
+  const approve = (body as Record<string, unknown>).approve;
+  return typeof approve === 'boolean' ? approve : null;
+}

--- a/supabase/functions/auth-device/approvalRequest_test.ts
+++ b/supabase/functions/auth-device/approvalRequest_test.ts
@@ -1,0 +1,29 @@
+import { deepStrictEqual, strictEqual } from 'node:assert/strict';
+
+import { parseApprovalDecision } from './approvalRequest.ts';
+
+Deno.test('parseApprovalDecision accepts explicit boolean values', () => {
+  strictEqual(
+    parseApprovalDecision({ user_code: 'BCDF2345', approve: true }),
+    true,
+  );
+  strictEqual(
+    parseApprovalDecision({ user_code: 'BCDF2345', approve: false }),
+    false,
+  );
+});
+
+Deno.test('parseApprovalDecision rejects non-boolean values', () => {
+  const malformedBodies = [
+    { user_code: 'BCDF2345' },
+    { user_code: 'BCDF2345', approve: null },
+    { user_code: 'BCDF2345', approve: 'true' },
+    { user_code: 'BCDF2345', approve: 1 },
+    { user_code: 'BCDF2345', approve: { value: true } },
+  ];
+
+  deepStrictEqual(
+    malformedBodies.map(parseApprovalDecision),
+    malformedBodies.map(() => null),
+  );
+});

--- a/supabase/functions/auth-device/index.ts
+++ b/supabase/functions/auth-device/index.ts
@@ -30,6 +30,7 @@
 
 import { Hono, type Context as HonoContext } from '@hono/hono';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { parseApprovalDecision } from './approvalRequest.ts';
 import { authenticateJwt, bearerToken } from '../_shared/auth.ts';
 import { getCorsHeaders, handleCors } from '../_shared/cors.ts';
 import { randomBase64Url } from '../_shared/crypto.ts';
@@ -247,7 +248,10 @@ app.post('/approve', async (c) => {
     if (userCode.length !== USER_CODE_LENGTH) {
       return errorResponse(c, 'Enter the code shown in your terminal', 400);
     }
-    const approve = body?.approve !== false;
+    const approve = parseApprovalDecision(body);
+    if (approve === null) {
+      return errorResponse(c, 'Approval decision must be true or false', 400);
+    }
 
     const { data, error } = await c
       .get('supabase')


### PR DESCRIPTION
## Summary

- Requires `POST /approve` to receive `approve` as an explicit JSON boolean.
- Preserves the existing approval path for `true` and denial path for `false`.
- Adds focused Deno tests for valid and malformed approval decisions.

## Root Cause

The handler used `body?.approve !== false`. That expression is true for every value except the literal boolean `false`, so omitted, null, string, numeric, and object values entered the approval path.

## Behavior

Requests with a valid user code and `approve: true` still approve, while `approve: false` still denies. Missing or non-boolean `approve` values now return HTTP 400 before the database update is constructed.

## Security Impact

This change removes the fail-open fallback at the device authorization boundary. Malformed or ambiguous approval requests can no longer authorize a pending device sign-in.

## Checks

- `deno fmt --check --single-quote approvalRequest.ts approvalRequest_test.ts`
- `deno check index.ts approvalRequest_test.ts`
- `deno test approvalRequest_test.ts` (2 passed)
- `deno lint approvalRequest.ts approvalRequest_test.ts`
- `git diff --cached --check`

The repository-wide `npm run format` hook also ran. It reported the three PR files unchanged but rewrote unrelated baseline files; those unrelated changes were discarded and the hook was skipped for the scoped commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Closes a fail-open device authorization bug where malformed approval requests could approve pending sign-ins; change is small and scoped to input validation.
> 
> **Overview**
> **POST `/approve`** no longer treats a missing or malformed `approve` field as approval. It now uses **`parseApprovalDecision`** so only literal JSON booleans `true` and `false` are accepted; anything else returns **HTTP 400** before updating `device_auth_requests`.
> 
> This replaces the previous **`body?.approve !== false`** check, which approved for omitted, null, string, numeric, or object values. **`approve: true`** and **`approve: false`** behavior is unchanged. Deno tests cover valid booleans and rejected bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8699ca16afc97808249080ef37cc82062a9b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->