### PR TITLE
fix(auth): require signup hook secret

### DIFF
--- a/supabase/functions/before-user-created/index.ts
+++ b/supabase/functions/before-user-created/index.ts
@@ -14,18 +14,16 @@
 // (verified via the reference `standardwebhooks` library, which also enforces
 // the spec's timestamp tolerance against replay).
 
-import { Webhook } from 'standardwebhooks';
+// Local imports
 import {
   checkEmailDomain,
   checkGitHubAccountAge,
 } from '../_shared/emailPolicy.ts';
+import { createWebhookVerifier } from './webhookVerification.ts';
 
-const HOOK_SECRET_RAW = Deno.env.get('BEFORE_USER_CREATED_HOOK_SECRET') ?? '';
-// Supabase stores the secret as "v1,whsec_<base64>"; strip the prefix.
-const HOOK_SECRET_BASE64 = HOOK_SECRET_RAW.replace(/^v1,whsec_/, '');
-
-// null = secret not configured; requests are allowed unsigned (with a warning).
-const webhook = HOOK_SECRET_BASE64 ? new Webhook(HOOK_SECRET_BASE64) : null;
+const webhook = createWebhookVerifier(
+  Deno.env.get('BEFORE_USER_CREATED_HOOK_SECRET'),
+);
 
 const GITHUB_FETCH_TIMEOUT_MS = 3000;
 
@@ -110,25 +108,18 @@ Deno.serve(async (req) => {
     return new Response('Invalid JSON', { status: 400 });
   }
 
-  if (webhook) {
-    try {
-      // verify() enforces the spec's timestamp tolerance (anti-replay) and
-      // validates the signed raw body. JSON was already parsed above so
-      // malformed payloads remain 400 rather than looking like auth failures.
-      webhook.verify(rawBody, {
-        'webhook-id': req.headers.get('webhook-id') ?? '',
-        'webhook-timestamp': req.headers.get('webhook-timestamp') ?? '',
-        'webhook-signature': req.headers.get('webhook-signature') ?? '',
-      });
-    } catch {
-      warn('Signature verification failed');
-      return new Response('Unauthorized', { status: 401 });
-    }
-  } else {
-    warn(
-      'BEFORE_USER_CREATED_HOOK_SECRET is not set; allowing unsigned requests. ' +
-        'Configure the hook secret to enforce verification.',
-    );
+  try {
+    // verify() enforces the spec's timestamp tolerance (anti-replay) and
+    // validates the signed raw body. JSON was already parsed above so
+    // malformed payloads remain 400 rather than looking like auth failures.
+    webhook.verify(rawBody, {
+      'webhook-id': req.headers.get('webhook-id') ?? '',
+      'webhook-timestamp': req.headers.get('webhook-timestamp') ?? '',
+      'webhook-signature': req.headers.get('webhook-signature') ?? '',
+    });
+  } catch {
+    warn('Signature verification failed');
+    return new Response('Unauthorized', { status: 401 });
   }
 
   const user = payload.user;

--- a/supabase/functions/before-user-created/webhookVerification.ts
+++ b/supabase/functions/before-user-created/webhookVerification.ts
@@ -1,0 +1,21 @@
+// Third-party imports
+import { Webhook } from 'standardwebhooks';
+
+const HOOK_SECRET_NAME = 'BEFORE_USER_CREATED_HOOK_SECRET';
+
+/** Creates the hook verifier or prevents the worker from starting insecurely. */
+export function createWebhookVerifier(rawSecret: string | undefined): Webhook {
+  if (!rawSecret) {
+    throw new Error(`${HOOK_SECRET_NAME} is required`);
+  }
+
+  // Supabase stores the secret as "v1,whsec_<base64>"; the library expects
+  // either the Base64 value or its own "whsec_" prefix.
+  const secret = rawSecret.replace(/^v1,whsec_/, '');
+
+  try {
+    return new Webhook(secret);
+  } catch (cause) {
+    throw new Error(`${HOOK_SECRET_NAME} is unusable`, { cause });
+  }
+}

--- a/supabase/functions/before-user-created/webhookVerification_test.ts
+++ b/supabase/functions/before-user-created/webhookVerification_test.ts
@@ -1,0 +1,40 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Local imports
+import { createWebhookVerifier } from './webhookVerification.ts';
+
+Deno.test('requires a configured hook secret', () => {
+  for (const secret of [undefined, '']) {
+    assert.throws(
+      () => createWebhookVerifier(secret),
+      /BEFORE_USER_CREATED_HOOK_SECRET is required/,
+    );
+  }
+});
+
+Deno.test('rejects unusable hook secrets', () => {
+  for (const secret of ['not-base64', 'v1,whsec_']) {
+    assert.throws(
+      () => createWebhookVerifier(secret),
+      /BEFORE_USER_CREATED_HOOK_SECRET is unusable/,
+    );
+  }
+});
+
+Deno.test('creates a verifier for the Supabase secret format', () => {
+  const verifier = createWebhookVerifier('v1,whsec_dGVzdC1ob29rLXNlY3JldA==');
+  const body = '{}';
+  const id = 'test-message';
+  const timestamp = new Date();
+  const signature = verifier.sign(id, timestamp, body);
+
+  assert.deepEqual(
+    verifier.verify(body, {
+      'webhook-id': id,
+      'webhook-timestamp': String(Math.floor(timestamp.getTime() / 1000)),
+      'webhook-signature': signature,
+    }),
+    {},
+  );
+});


### PR DESCRIPTION
## Root cause

The Before User Created hook represented an absent secret as a null verifier and deliberately bypassed signature verification. A caller could therefore submit valid JSON without Standard Webhooks headers and reach the sign-up policy as an authenticated hook request.

## Behavior

- The verifier is now constructed during worker initialization.
- A missing, empty, or malformed `BEFORE_USER_CREATED_HOOK_SECRET` prevents the worker from starting.
- A configured worker verifies every valid hook payload, while missing or incorrect signatures continue to return `401 Unauthorized`.
- The GitHub account-age availability policy is unchanged.

## Deployment impact

`BEFORE_USER_CREATED_HOOK_SECRET` must contain a usable `v1,whsec_<base64>` value before the function is deployed or restarted. A configuration error now makes the hook unavailable instead of accepting unsigned requests. Correctly configured deployments retain their existing request behavior.

## Checks

- `deno fmt --check --single-quote webhookVerification.ts webhookVerification_test.ts`
- `deno check index.ts webhookVerification.ts webhookVerification_test.ts`
- `deno lint index.ts webhookVerification.ts webhookVerification_test.ts`
- `deno test webhookVerification_test.ts` (3 passed)
- Focused Prettier check for the three changed files
- Cold-start probes for absent and malformed secrets (both failed before serving, as required)
- Local unsigned POST with a usable secret (`401 Unauthorized`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is an auth-boundary change on the signup hook: misconfigured secrets break signups, while correct config tightens verification on a security-sensitive path.
> 
> **Overview**
> Closes a **fail-open** path on the Before User Created auth hook: when `BEFORE_USER_CREATED_HOOK_SECRET` was unset, the function logged a warning and accepted **unsigned** POSTs, so anyone could hit signup policy checks without Standard Webhooks headers.
> 
> Verification is now centralized in `createWebhookVerifier`, which strips the Supabase `v1,whsec_` prefix and builds a `standardwebhooks` verifier. **Missing, empty, or malformed secrets throw at cold start**, so the worker does not serve in an insecure mode. The request handler **always** calls `verify()`; bad signatures still return `401`. Signup policy logic (email domain, GitHub age) is unchanged.
> 
> **Deployment:** a valid `v1,whsec_<base64>` secret must be set before deploy/restart; misconfiguration makes the hook unavailable instead of accepting unsigned traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64766db2ef8acd0246964f6f5c436ebb45af79da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->