### PR TITLE
fix(relay): fail closed on unavailable enforcement

### DIFF
--- a/supabase/functions/relay/enforcement.ts
+++ b/supabase/functions/relay/enforcement.ts
@@ -1,0 +1,135 @@
+// Local imports
+import { getSpendingLimit } from './models.ts';
+import type { RelayRpcClient, RelayRpcError } from './rpc.ts';
+
+/** Availability of the privileged client required by relay enforcement. */
+export type RelayEnforcementClientResult<T> =
+  | {
+      ok: true;
+      client: T;
+    }
+  | {
+      ok: false;
+      reason: 'service_role_unavailable';
+    };
+
+/** Verified spending, or an unavailable state that cannot be treated as allowed. */
+export type SpendingCheckResult =
+  | {
+      status: 'verified';
+      allowed: boolean;
+      currentSpend: number;
+      limit: number;
+      remaining: number;
+    }
+  | {
+      status: 'unavailable';
+      reason: 'spending_rpc_failed' | 'invalid_spending_response';
+      limit: number;
+    };
+
+const POSTGRES_NUMERIC_PATTERN = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/** Require the privileged client used by every key-bearing relay request. */
+export function requireRelayEnforcementClient<T>(
+  client: T | null,
+): RelayEnforcementClientResult<T> {
+  return client === null
+    ? { ok: false, reason: 'service_role_unavailable' }
+    : { ok: true, client };
+}
+
+function getCurrentMonthStartUTC(): string {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+  ).toISOString();
+}
+
+function parseCurrentSpend(data: unknown): number | undefined {
+  if (typeof data === 'number') {
+    return Number.isFinite(data) && data >= 0 ? data : undefined;
+  }
+  if (typeof data !== 'string' || !POSTGRES_NUMERIC_PATTERN.test(data)) {
+    return undefined;
+  }
+
+  const parsed = Number(data);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+  return 'unknown error';
+}
+
+/**
+ * Verify the user's monthly relay spending against the database aggregate.
+ * Unavailable or malformed results have no `allowed` value, so callers must
+ * handle them separately from a verified zero-dollar spend.
+ *
+ * This is a soft limit rather than a transaction boundary: usage is logged
+ * asynchronously, so concurrent requests can pass before their costs appear
+ * in the aggregate. The aggregation is defined by migrations
+ * `20260517100000_usage_logs_upsert_rpc.sql` and
+ * `20260517100100_usage_logs_aggregate_per_stream.sql`.
+ */
+export async function checkSpendingLimit(
+  adminClient: RelayRpcClient,
+  userId: string,
+  tier: string,
+): Promise<SpendingCheckResult> {
+  const limit = getSpendingLimit(tier);
+
+  let result: { data: unknown; error: RelayRpcError | null };
+  try {
+    result = await adminClient.rpc('get_user_monthly_relay_spend', {
+      p_user_id: userId,
+      p_month_start: getCurrentMonthStartUTC(),
+    });
+  } catch (error) {
+    console.error('[RELAY] Monthly spending RPC threw:', errorMessage(error));
+    return { status: 'unavailable', reason: 'spending_rpc_failed', limit };
+  }
+
+  if (result.error) {
+    console.error(
+      '[RELAY] Monthly spending RPC failed:',
+      result.error.message ?? 'unknown error',
+    );
+    return { status: 'unavailable', reason: 'spending_rpc_failed', limit };
+  }
+
+  const currentSpend = parseCurrentSpend(result.data);
+  if (currentSpend === undefined) {
+    const responseType = Array.isArray(result.data)
+      ? 'array'
+      : result.data === null
+        ? 'null'
+        : typeof result.data;
+    console.error(
+      `[RELAY] Monthly spending RPC returned invalid ${responseType} data`,
+    );
+    return {
+      status: 'unavailable',
+      reason: 'invalid_spending_response',
+      limit,
+    };
+  }
+
+  return {
+    status: 'verified',
+    allowed: currentSpend < limit,
+    currentSpend,
+    limit,
+    remaining: Math.max(0, limit - currentSpend),
+  };
+}

--- a/supabase/functions/relay/enforcement_test.ts
+++ b/supabase/functions/relay/enforcement_test.ts
@@ -1,0 +1,121 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Local imports
+import {
+  checkSpendingLimit,
+  requireRelayEnforcementClient,
+  type SpendingCheckResult,
+} from './enforcement.ts';
+import type { RelayRpcClient } from './rpc.ts';
+
+function rpcClient(
+  data: unknown,
+  error: { message?: string } | null = null,
+): RelayRpcClient {
+  return {
+    rpc: () => Promise.resolve({ data, error }),
+  };
+}
+
+function assertUnavailable(
+  result: SpendingCheckResult,
+  reason: 'spending_rpc_failed' | 'invalid_spending_response',
+): void {
+  assert.equal(result.status, 'unavailable');
+  if (result.status !== 'unavailable') return;
+
+  assert.equal(result.reason, reason);
+  assert.equal('allowed' in result, false);
+  assert.equal('currentSpend' in result, false);
+  assert.equal('remaining' in result, false);
+}
+
+Deno.test('requires an administrative client for relay enforcement', () => {
+  assert.deepEqual(requireRelayEnforcementClient(null), {
+    ok: false,
+    reason: 'service_role_unavailable',
+  });
+
+  const client = rpcClient(0);
+  assert.deepEqual(requireRelayEnforcementClient(client), {
+    ok: true,
+    client,
+  });
+});
+
+Deno.test('accepts verified numeric spending responses', async () => {
+  for (const data of [12.5, '12.50']) {
+    const result = await checkSpendingLimit(rpcClient(data), 'user-id', 'Max');
+
+    assert.deepEqual(result, {
+      status: 'verified',
+      allowed: true,
+      currentSpend: 12.5,
+      limit: 50,
+      remaining: 37.5,
+    });
+  }
+});
+
+Deno.test('denies spending at the verified tier limit', async () => {
+  const result = await checkSpendingLimit(rpcClient('50'), 'user-id', 'Max');
+
+  assert.deepEqual(result, {
+    status: 'verified',
+    allowed: false,
+    currentSpend: 50,
+    limit: 50,
+    remaining: 0,
+  });
+});
+
+Deno.test('reports RPC errors as unavailable for every tier', async () => {
+  for (const tier of ['free', 'Max', 'Ultra']) {
+    const result = await checkSpendingLimit(
+      rpcClient(null, { message: 'database unavailable' }),
+      'user-id',
+      tier,
+    );
+
+    assertUnavailable(result, 'spending_rpc_failed');
+  }
+});
+
+Deno.test('reports thrown RPC failures as unavailable', async () => {
+  const client: RelayRpcClient = {
+    rpc: () => Promise.reject(new Error('network unavailable')),
+  };
+
+  const result = await checkSpendingLimit(client, 'user-id', 'Ultra');
+
+  assertUnavailable(result, 'spending_rpc_failed');
+});
+
+Deno.test(
+  'rejects malformed spending data instead of treating it as zero',
+  async () => {
+    const malformedValues = [
+      null,
+      undefined,
+      '',
+      'not-a-number',
+      true,
+      {},
+      [],
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ];
+
+    for (const data of malformedValues) {
+      const result = await checkSpendingLimit(
+        rpcClient(data),
+        'user-id',
+        'Ultra',
+      );
+
+      assertUnavailable(result, 'invalid_spending_response');
+    }
+  },
+);

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -69,20 +69,24 @@
 
 import { Hono } from '@hono/hono';
 import { cors } from '@hono/hono/cors';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 import { resolveRelayCredential } from '../_shared/relayCiToken.ts';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
+  getSpendingLimit,
   getRequestLimits,
   isRetiredModelRequest,
   isModelAllowedForTier,
-  getSpendingLimit,
   FREE_TIER_SUGGESTED_MODEL,
   ULTRA_TIER,
   FREE_TIER,
   MAX_TIER,
 } from './models.ts';
+import {
+  checkSpendingLimit,
+  requireRelayEnforcementClient,
+} from './enforcement.ts';
 import { isJsonRecord } from './json.ts';
 import {
   capOpenAIReasoningEffortForTier,
@@ -115,8 +119,8 @@ const RELAY_VERSION = '1.10.0';
 const UPSTREAM_TIMEOUT_MS = 390000;
 
 // Env and the service-role client are fixed at cold start; no per-request state.
-// adminClient is null when SUPABASE_SERVICE_ROLE_KEY is absent — spending and
-// request gates are skipped but requests are still served.
+// Public metadata remains available without the service role, but proxy routes
+// require this client before any server-side key can be used.
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
 const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
@@ -349,80 +353,6 @@ function jsonError(
   );
 }
 
-/**
- * Get the start of the current month in UTC.
- * Uses UTC for consistency with billing views.
- */
-function getCurrentMonthStartUTC(): string {
-  const now = new Date();
-  return new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
-  ).toISOString();
-}
-
-/**
- * Check if user has exceeded their monthly spending limit.
- * Returns { allowed: true } or { allowed: false, currentSpend, limit, remaining }.
- *
- * Uses database function for server-side aggregation (efficient).
- *
- * RACE CONDITION NOTE: Usage is logged asynchronously after requests complete.
- * Concurrent requests may pass this check before their costs are logged.
- * This is acceptable for soft limits. See migration for mitigation options.
- */
-async function checkSpendingLimit(
-  adminClient: SupabaseClient,
-  userId: string,
-  tier: string,
-): Promise<{
-  allowed: boolean;
-  currentSpend: number;
-  limit: number;
-  remaining: number;
-  spendCheckFailed?: boolean;
-}> {
-  const limit = getSpendingLimit(tier);
-  const monthStart = getCurrentMonthStartUTC();
-
-  // Call database function for efficient server-side aggregation
-  // Aggregates relay usage server-side, summing workflow streams and
-  // relying on the canonical per-stream rows maintained by
-  // 20260517100000_usage_logs_upsert_rpc.sql and
-  // 20260517100100_usage_logs_aggregate_per_stream.sql.
-  const { data, error } = await adminClient.rpc(
-    'get_user_monthly_relay_spend',
-    {
-      p_user_id: userId,
-      p_month_start: monthStart,
-    },
-  );
-
-  if (error) {
-    console.error('[RELAY] Failed to check spending:', error.message);
-    // Fail closed for the free tier (the abuse-prone path): if we can't verify
-    // spend we must not hand out free relay budget. Paid tiers fail open so a
-    // transient DB error never blocks a paying user.
-    const failClosed = tier === FREE_TIER;
-    return {
-      allowed: !failClosed,
-      currentSpend: 0,
-      limit,
-      remaining: failClosed ? 0 : limit,
-      spendCheckFailed: true,
-    };
-  }
-
-  const currentSpend = Number(data) || 0;
-  const remaining = Math.max(0, limit - currentSpend);
-
-  return {
-    allowed: currentSpend < limit,
-    currentSpend,
-    limit,
-    remaining,
-  };
-}
-
 function isFutureTimestamp(
   timestamp: string | null | undefined,
   now = new Date(),
@@ -510,32 +440,58 @@ app.get('/tier-config', async (c) => {
 
         if (profile) {
           const now = new Date();
+          const tier = profile.tier || FREE_TIER;
           const userStatus = {
             ...calculateAccessStatus(profile.tier, profile.access_expires_at),
             isBanned: isFutureTimestamp(profile.banned_until, now),
           };
 
-          // Include current spending if service role key is available
-          let spendingStatus = null;
-          if (adminClient) {
-            const spending = await checkSpendingLimit(
-              adminClient,
-              userId,
-              profile.tier || FREE_TIER,
-            );
-            spendingStatus = {
-              currentSpend: spending.currentSpend,
-              limit: spending.limit,
-              remaining: spending.remaining,
-              spendCheckFailed: spending.spendCheckFailed ?? false,
-              percentUsed:
-                spending.limit > 0
-                  ? Math.round((spending.currentSpend / spending.limit) * 100)
-                  : 100,
-            };
+          const enforcement = requireRelayEnforcementClient(adminClient);
+          if (!enforcement.ok) {
+            return c.json({
+              ...config,
+              userStatus,
+              spendingStatus: null,
+              spendingStatusError: {
+                spendCheckFailed: true,
+                failureReason: enforcement.reason,
+                limit: getSpendingLimit(tier),
+              },
+            });
           }
 
-          return c.json({ ...config, userStatus, spendingStatus });
+          const spending = await checkSpendingLimit(
+            enforcement.client,
+            userId,
+            tier,
+          );
+          if (spending.status === 'unavailable') {
+            return c.json({
+              ...config,
+              userStatus,
+              spendingStatus: null,
+              spendingStatusError: {
+                spendCheckFailed: true,
+                failureReason: spending.reason,
+                limit: spending.limit,
+              },
+            });
+          }
+
+          const spendingStatus = {
+            currentSpend: spending.currentSpend,
+            limit: spending.limit,
+            remaining: spending.remaining,
+            percentUsed:
+              spending.limit > 0
+                ? Math.round((spending.currentSpend / spending.limit) * 100)
+                : 100,
+          };
+          return c.json({
+            ...config,
+            userStatus,
+            spendingStatus,
+          });
         }
       }
     } catch {
@@ -575,16 +531,34 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     return jsonError('Server configuration error', 500);
   }
 
-  // 4. Validate the credential: a normal user JWT, or a CI relay token
+  // 4. Require every privileged enforcement dependency before authentication
+  // or server-side provider key use. Public metadata routes remain available.
+  const enforcement = requireRelayEnforcementClient(adminClient);
+  if (!enforcement.ok) {
+    console.error(
+      '[RELAY] Relay enforcement unavailable: service-role client missing',
+    );
+    return jsonError(
+      'Relay enforcement is temporarily unavailable. Please try again shortly, or switch to your own API keys.',
+      503,
+      {
+        enforcementUnavailable: true,
+        failureReason: enforcement.reason,
+      },
+    );
+  }
+  const relayAdminClient = enforcement.client;
+
+  // 5. Validate the credential: a normal user JWT, or a CI relay token
   // (texra setup-token) checked hash-at-rest against relay_ci_tokens. Both
   // resolve to the owning user id; everything below is identical.
-  const credential = await resolveRelayCredential(jwtToken, adminClient);
+  const credential = await resolveRelayCredential(jwtToken, relayAdminClient);
   if (!credential.ok) {
     return jsonError(credential.message, credential.status);
   }
   const { userId, profileClient } = credential;
 
-  // 5. Get user profile and check ban / expiration
+  // 6. Get user profile and check ban / expiration
   const { data: profile, error: profileError } = await profileClient
     .from('profiles')
     .select('tier, access_expires_at, banned_until')
@@ -622,40 +596,36 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   const userTier = profile.tier || FREE_TIER;
 
-  // 5.5. Check monthly spending limit
-  if (adminClient) {
-    const spending = await checkSpendingLimit(adminClient, userId, userTier);
-
-    if (!spending.allowed) {
-      if (spending.spendCheckFailed) {
-        return jsonError(
-          'Unable to verify your monthly relay usage right now. Please try again shortly, or switch to your own API keys.',
-          503,
-          {
-            spendCheckFailed: true,
-            currentSpend: spending.currentSpend,
-            limit: spending.limit,
-            remaining: spending.remaining,
-          },
-        );
-      }
-
-      return jsonError(
-        `Monthly spending limit reached ($${spending.limit}). ` +
-          `Current usage: $${spending.currentSpend.toFixed(2)}. ` +
-          'You can continue using your own API keys, or wait for next month.',
-        429,
-        {
-          limitReached: true,
-          currentSpend: spending.currentSpend,
-          limit: spending.limit,
-          remaining: spending.remaining,
-        },
-      );
-    }
+  // 6.5. Check monthly spending limit
+  const spending = await checkSpendingLimit(relayAdminClient, userId, userTier);
+  if (spending.status === 'unavailable') {
+    return jsonError(
+      'Unable to verify your monthly relay usage right now. Please try again shortly, or switch to your own API keys.',
+      503,
+      {
+        spendCheckFailed: true,
+        failureReason: spending.reason,
+        limit: spending.limit,
+      },
+    );
   }
 
-  // 6. Apply retired-model and tier constraints for model endpoints.
+  if (!spending.allowed) {
+    return jsonError(
+      `Monthly spending limit reached ($${spending.limit}). ` +
+        `Current usage: $${spending.currentSpend.toFixed(2)}. ` +
+        'You can continue using your own API keys, or wait for next month.',
+      429,
+      {
+        limitReached: true,
+        currentSpend: spending.currentSpend,
+        limit: spending.limit,
+        remaining: spending.remaining,
+      },
+    );
+  }
+
+  // 7. Apply retired-model and tier constraints for model endpoints.
   // Skip model validation for endpoints that don't require a model.
   const isModelFreePath = isModelFreeRelayPath(apiPath);
 
@@ -770,68 +740,66 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     }
   }
 
-  // 7. Get server-side API key
+  // 8. Get server-side API key
   const apiKey = Deno.env.get(providerConfig.envKey);
   if (!apiKey) {
     console.error(`[RELAY] API key not configured: ${providerConfig.envKey}`);
     return jsonError(`API key not configured for ${provider}`, 503);
   }
 
-  // 7.5. Enforce server-side per-user request gates. This lives after local
+  // 8.5. Enforce server-side per-user request gates. This lives after local
   // request validation so rejected requests do not consume active slots.
   let releaseRelaySlot: (() => Promise<void>) | null = null;
   let refreshRelaySlot: (() => Promise<void>) | null = null;
-  if (adminClient) {
-    try {
-      const slot = await acquireRelayRequestSlot(
-        adminClient,
-        userId,
-        getRequestLimits(userTier),
-      );
-      if (!slot.allowed) {
-        const decision = slot.decision;
-        if (decision.reason === 'concurrency') {
-          return jsonError(
-            `Too many concurrent relay requests. Limit: ${decision.concurrencyLimit ?? 'unknown'}.`,
-            429,
-            {
-              requestLimitReached: true,
-              reason: 'concurrency',
-              activeRequests: decision.activeRequests,
-              concurrencyLimit: decision.concurrencyLimit,
-              retryAfterSeconds: decision.retryAfterSeconds,
-            },
-          );
-        }
+  try {
+    const slot = await acquireRelayRequestSlot(
+      relayAdminClient,
+      userId,
+      getRequestLimits(userTier),
+    );
+    if (!slot.allowed) {
+      const decision = slot.decision;
+      if (decision.reason === 'concurrency') {
         return jsonError(
-          `Relay request rate limit reached. Limit: ${decision.rateLimitPerMinute ?? 'unknown'} requests per minute.`,
+          `Too many concurrent relay requests. Limit: ${decision.concurrencyLimit ?? 'unknown'}.`,
           429,
           {
             requestLimitReached: true,
-            reason: 'rate',
-            requestsThisMinute: decision.requestsThisMinute,
-            rateLimitPerMinute: decision.rateLimitPerMinute,
+            reason: 'concurrency',
+            activeRequests: decision.activeRequests,
+            concurrencyLimit: decision.concurrencyLimit,
             retryAfterSeconds: decision.retryAfterSeconds,
           },
         );
       }
-      releaseRelaySlot = slot.release;
-      refreshRelaySlot = slot.refresh;
-    } catch (error) {
-      console.error('[RELAY] Failed to enforce request gate:', error);
       return jsonError(
-        'Unable to verify relay request limits right now. Please try again shortly, or switch to your own API keys.',
-        503,
-        { requestLimitCheckFailed: true },
+        `Relay request rate limit reached. Limit: ${decision.rateLimitPerMinute ?? 'unknown'} requests per minute.`,
+        429,
+        {
+          requestLimitReached: true,
+          reason: 'rate',
+          requestsThisMinute: decision.requestsThisMinute,
+          rateLimitPerMinute: decision.rateLimitPerMinute,
+          retryAfterSeconds: decision.retryAfterSeconds,
+        },
       );
     }
+    releaseRelaySlot = slot.release;
+    refreshRelaySlot = slot.refresh;
+  } catch (error) {
+    console.error('[RELAY] Failed to enforce request gate:', error);
+    return jsonError(
+      'Unable to verify relay request limits right now. Please try again shortly, or switch to your own API keys.',
+      503,
+      { requestLimitCheckFailed: true },
+    );
   }
 
-  // 8. Build target URL
+  // 9. Build target URL
   const url = new URL(c.req.url);
   const targetUrl = `${providerConfig.baseUrl}${apiPath}${url.search}`;
 
-  // 9. Prepare upstream headers
+  // 10. Prepare upstream headers
   const upstreamHeaders = new Headers();
   c.req.raw.headers.forEach((value, key) => {
     if (!SKIP_REQUEST_HEADERS.has(key.toLowerCase())) {
@@ -851,7 +819,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     upstreamHeaders.set('x-goog-api-key', apiKey);
   }
 
-  // 10. Forward request with timeout
+  // 11. Forward request with timeout
   let upstreamResponse: Response;
   try {
     const bodyToSend =
@@ -880,7 +848,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     );
   }
 
-  // 11. Forward response with headers
+  // 12. Forward response with headers
   const responseHeaders = new Headers();
   upstreamResponse.headers.forEach((value, key) => {
     if (!SKIP_RESPONSE_HEADERS.has(key.toLowerCase())) {

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -1,20 +1,9 @@
 import { asFiniteNumber, isJsonRecord } from './json.ts';
-
-interface RpcError {
-  message?: string;
-}
+import type { RelayRpcClient } from './rpc.ts';
 
 interface RequestLimit {
   ratePerMinute: number;
   concurrent: number;
-}
-
-interface RpcClient {
-  // PromiseLike, not Promise: supabase-js rpc() returns a thenable builder.
-  rpc(
-    name: string,
-    args: Record<string, unknown>,
-  ): PromiseLike<{ data: unknown; error: RpcError | null }>;
 }
 
 interface GateDecision {
@@ -100,7 +89,7 @@ function startStreamLeaseRefresh(
 }
 
 export async function acquireRelayRequestSlot(
-  client: RpcClient,
+  client: RelayRpcClient,
   userId: string,
   limits: RequestLimit,
 ): Promise<RelayRequestSlot> {

--- a/supabase/functions/relay/rpc.ts
+++ b/supabase/functions/relay/rpc.ts
@@ -1,0 +1,12 @@
+export interface RelayRpcError {
+  message?: string;
+}
+
+/** Minimal Supabase RPC surface shared by relay enforcement helpers. */
+export interface RelayRpcClient {
+  // PromiseLike, not Promise: supabase-js rpc() returns a thenable builder.
+  rpc(
+    name: string,
+    args: Record<string, unknown>,
+  ): PromiseLike<{ data: unknown; error: RelayRpcError | null }>;
+}


### PR DESCRIPTION
## Summary

- Requires a service-role administrative client before any provider proxy request can authenticate or use a server-side API key.
- Replaces ambiguous spending results with a discriminated verified/unavailable contract.
- Returns HTTP 503 for spending RPC errors, thrown failures, and malformed spending data for every tier.
- Keeps public relay metadata available and reports authenticated spending metadata as unavailable instead of verified zero.
- Adds focused Deno coverage for administrative-client readiness, numeric spending, tier limits, RPC failures, and malformed responses.

## Root cause

The proxy treated `adminClient` as optional and skipped spending and request-slot enforcement when `SUPABASE_SERVICE_ROLE_KEY` was absent. Separately, spending RPC errors were represented as allowed zero-dollar usage for paid tiers, while `Number(data) || 0` converted malformed responses into verified zero.

## Behavior

Provider proxy requests now stop with a structured 503 response when privileged enforcement is unavailable. Spending failures return an explicit unavailable state without `allowed`, `currentSpend`, or `remaining` fields, so they cannot be confused with verified usage. Server logs retain the RPC error message or malformed response type; client responses expose only stable failure reasons and no secret values.

Verified numeric spending continues to use the configured tier limit and returns 429 at or above that limit. The public `/providers` and `/tier-config` routes remain available.

## Checks

- `deno test --config supabase/functions/relay/deno.json supabase/functions/relay/enforcement_test.ts` (6 passed)
- `deno check --config supabase/functions/relay/deno.json supabase/functions/relay/enforcement.ts supabase/functions/relay/enforcement_test.ts`
- `deno lint supabase/functions/relay/index.ts supabase/functions/relay/enforcement.ts supabase/functions/relay/enforcement_test.ts`
- `corepack pnpm exec prettier --check supabase/functions/relay/index.ts supabase/functions/relay/enforcement.ts supabase/functions/relay/enforcement_test.ts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/supabase` (42 passed)
- `npm test` (5,763 passed, 4 skipped)
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (no errors; 46 existing warnings)
- `git diff --check`

A full `deno check` of `supabase/functions/relay/index.ts` remains blocked by the pre-existing `Uint8Array<ArrayBufferLike>` versus `BodyInit` error at the upstream request body. The same error was reproduced on the `f7d2429dc` base commit and is outside this focused change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fail-closed behavior on the relay proxy path that uses server-side API keys, monthly spend enforcement, and request gates—security- and abuse-sensitive infrastructure where misconfiguration or RPC outages now block all tiers.
> 
> **Overview**
> **Relay provider proxy** now **requires** a service-role admin client before JWT validation or server-side API keys; missing `SUPABASE_SERVICE_ROLE_KEY` returns **503** with structured `enforcementUnavailable` instead of skipping spending and request-slot gates.
> 
> Monthly spend checks move to **`enforcement.ts`** with a **`verified` / `unavailable`** result: RPC errors, thrown failures, and malformed numeric responses no longer expose `allowed` or zero-dollar usage. **All tiers** get **503** on spend verification failure (replacing paid-tier fail-open). Authenticated **`/tier-config`** returns `spendingStatus: null` plus `spendingStatusError` when enforcement or spend RPC is unavailable.
> 
> **`rpc.ts`** shares a minimal `RelayRpcClient` type with **`requestGate.ts`**. Deno tests cover admin-client gating, verified limits, and unavailable paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3623141c602a6042d179331738be0dc2880f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->