### PR TITLE
fix(telemetry): reject invalid usage batches atomically

### DIFF
--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -12,6 +12,13 @@
  * Endpoints:
  * - POST /log-usage - Log a batch of usage entries
  *
+ * Response contract:
+ * - Complete writes return success with the exact accepted entry count.
+ * - Malformed JSON and invalid batches are rejected atomically with
+ *   `success: false`, `accepted: 0`, and `retryable: false`.
+ * - Authentication and operational failures omit the permanent-rejection
+ *   marker so clients retain and retry the original batch identifier.
+ *
  * Database Requirements:
  * - Tables: usage_logs, subscription_usage_logs
  * - RPCs: usage_logs_upsert, subscription_usage_logs_upsert (service role only)

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -17,6 +17,7 @@
  * - Invalid batches are rejected atomically over HTTP 200 with
  *   `success: false`, `accepted: 0`, and `retryable: false`; HTTP 200 lets
  *   clients predating the retry marker read the body during rolling deploys.
+ *   Restore HTTP 422 after clients predating #8267 age out under #6981.
  * - Malformed JSON uses the same permanent-rejection body with HTTP 400.
  * - Authentication and operational failures omit the permanent-rejection
  *   marker so clients retain and retry the original batch identifier.
@@ -238,7 +239,9 @@ Deno.serve(async (req: Request) => {
       // Keep the application-level rejection on HTTP 200 during the rolling
       // client transition. Older clients let ky throw before reading 4xx
       // bodies, which would pin this permanently invalid batch at the head of
-      // their retry queue. They already understand success:false on 2xx.
+      // their retry queue. They already understand success:false on 2xx. This
+      // compatibility status can return to 422 under the #6981 retirement gate
+      // once the minimum supported client includes #8267.
       return errorResponse(req, 'Invalid batch format or entry data', 200, {
         retryable: false,
       });

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -15,8 +15,10 @@
  * Response contract:
  * - Complete writes return success with the exact accepted entry count.
  * - Invalid batches are rejected atomically over HTTP 200 with
- *   `success: false`, `accepted: 0`, and `retryable: false`; HTTP 200 lets
- *   clients predating the retry marker read the body during rolling deploys.
+ *   `success: false`, `accepted: 0`, `retryable: false`, and a stable
+ *   `errorCode`; HTTP 200 lets clients predating the retry marker read the
+ *   body during rolling deploys. Sanitized validation issues identify the
+ *   rejected fields without echoing request values.
  *   Restore HTTP 422 after clients predating #8267 age out under #6981.
  * - Malformed JSON uses the same permanent-rejection body with HTTP 400.
  * - Authentication and operational failures omit the permanent-rejection
@@ -39,6 +41,7 @@ import { UsageBatchSchema, type UsageLogEntry } from './usageValidation.ts';
 // =============================================================================
 
 const LOG_USAGE_VERSION = '1.6.0';
+const MAX_REPORTED_VALIDATION_ISSUES = 20;
 
 const UsageDestinations = {
   paid: {
@@ -94,7 +97,16 @@ function errorResponse(
   req: Request,
   error: string,
   status: number,
-  options?: { retryable?: boolean },
+  options?: {
+    retryable?: boolean;
+    errorCode?: string;
+    issues?: readonly {
+      code: string;
+      path: readonly string[];
+      message: string;
+    }[];
+    issueCount?: number;
+  },
 ): Response {
   return versionedJsonResponse(
     req,
@@ -106,6 +118,13 @@ function errorResponse(
       ...(options?.retryable === undefined
         ? {}
         : { retryable: options.retryable }),
+      ...(options?.errorCode === undefined
+        ? {}
+        : { errorCode: options.errorCode }),
+      ...(options?.issues === undefined ? {} : { issues: options.issues }),
+      ...(options?.issueCount === undefined
+        ? {}
+        : { issueCount: options.issueCount }),
     },
     status,
   );
@@ -230,6 +249,7 @@ Deno.serve(async (req: Request) => {
     } catch {
       return errorResponse(req, 'Invalid JSON body', 400, {
         retryable: false,
+        errorCode: 'INVALID_JSON',
       });
     }
 
@@ -244,6 +264,15 @@ Deno.serve(async (req: Request) => {
       // once the minimum supported client includes #8267.
       return errorResponse(req, 'Invalid batch format or entry data', 200, {
         retryable: false,
+        errorCode: 'BATCH_REJECTED',
+        issueCount: batchResult.error.issues.length,
+        issues: batchResult.error.issues
+          .slice(0, MAX_REPORTED_VALIDATION_ISSUES)
+          .map((issue) => ({
+            code: issue.code,
+            path: issue.path.map((part) => String(part)),
+            message: issue.message,
+          })),
       });
     }
     const batch = batchResult.data;

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -14,8 +14,10 @@
  *
  * Response contract:
  * - Complete writes return success with the exact accepted entry count.
- * - Malformed JSON and invalid batches are rejected atomically with
- *   `success: false`, `accepted: 0`, and `retryable: false`.
+ * - Invalid batches are rejected atomically over HTTP 200 with
+ *   `success: false`, `accepted: 0`, and `retryable: false`; HTTP 200 lets
+ *   clients predating the retry marker read the body during rolling deploys.
+ * - Malformed JSON uses the same permanent-rejection body with HTTP 400.
  * - Authentication and operational failures omit the permanent-rejection
  *   marker so clients retain and retry the original batch identifier.
  *
@@ -233,7 +235,11 @@ Deno.serve(async (req: Request) => {
     // 4. Validate the complete batch before any destination write.
     const batchResult = UsageBatchSchema.safeParse(body);
     if (!batchResult.success) {
-      return errorResponse(req, 'Invalid batch format or entry data', 422, {
+      // Keep the application-level rejection on HTTP 200 during the rolling
+      // client transition. Older clients let ky throw before reading 4xx
+      // bodies, which would pin this permanently invalid batch at the head of
+      // their retry queue. They already understand success:false on 2xx.
+      return errorResponse(req, 'Invalid batch format or entry data', 200, {
         retryable: false,
       });
     }

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -18,79 +18,17 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { z } from 'zod';
 import { bearerToken } from '../_shared/auth.ts';
 import { handleCors } from '../_shared/cors.ts';
 import { resolveRelayCredential } from '../_shared/relayCiToken.ts';
 import { versionedJsonResponse } from '../_shared/responses.ts';
+import { UsageBatchSchema, type UsageLogEntry } from './usageValidation.ts';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.5.0';
-
-// =============================================================================
-// Schemas
-// =============================================================================
-
-// Invalid optional fields are dropped (`.catch(undefined)`) rather than
-// rejecting the whole entry; invalid required fields reject the entry.
-function optional<T extends z.ZodType>(schema: T) {
-  return schema
-    .nullish()
-    .catch(undefined)
-    .transform((value): z.infer<T> | undefined => value ?? undefined);
-}
-const optionalString = optional(z.string());
-const optionalNonnegativeInt = optional(z.int().nonnegative());
-const optionalBoolean = optional(z.boolean());
-const UsageRouteSchema = z.enum(['chatgpt-subscription', 'relay', 'api-key']);
-
-const UsageLogEntryInputSchema = z.object({
-  timestamp: z.iso.datetime(),
-  model: z.string(),
-  provider: z.string(),
-  inputTokens: z.int().nonnegative(),
-  outputTokens: z.int().nonnegative(),
-  cost: z.number().nonnegative(),
-  agentName: optionalString,
-  agentCategory: optional(z.enum(['workflow', 'toolUse'])),
-  isMultipleOutput: optionalBoolean,
-  responseTimeMs: optionalNonnegativeInt,
-  cachedInputTokens: optionalNonnegativeInt,
-  reasoningTokens: optionalNonnegativeInt,
-  usedRelay: optionalBoolean,
-  usageRoute: optional(UsageRouteSchema),
-  viaChatGptSubscription: z
-    .boolean()
-    .nullish()
-    .catch(false)
-    .transform((value) => value ?? false),
-  // Explicit subscription source (e.g. 'copilot') for future non-ChatGPT
-  // subscription clients. Omitted entries fall back to 'chatgpt' since
-  // that's the only subscription source today.
-  subscriptionSource: optionalString,
-  streamId: optionalString,
-  extensionVersion: optionalString,
-  editorType: optionalString,
-});
-
-const UsageLogEntrySchema = UsageLogEntryInputSchema.transform(
-  ({ viaChatGptSubscription, ...entry }) => ({
-    ...entry,
-    usageRoute:
-      entry.usageRoute ??
-      (viaChatGptSubscription ? 'chatgpt-subscription' : undefined),
-  }),
-);
-
-const UsageBatchSchema = z.object({
-  entries: z.array(z.unknown()),
-  batchId: z.uuid(),
-});
-
-type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;
+const LOG_USAGE_VERSION = '1.6.0';
 
 const UsageDestinations = {
   paid: {
@@ -142,11 +80,23 @@ function successResponse(
   );
 }
 
-function errorResponse(req: Request, error: string, status: number): Response {
+function errorResponse(
+  req: Request,
+  error: string,
+  status: number,
+  options?: { retryable?: boolean },
+): Response {
   return versionedJsonResponse(
     req,
     LOG_USAGE_VERSION,
-    { success: false, accepted: 0, error },
+    {
+      success: false,
+      accepted: 0,
+      error,
+      ...(options?.retryable === undefined
+        ? {}
+        : { retryable: options.retryable }),
+    },
     status,
   );
 }
@@ -268,32 +218,23 @@ Deno.serve(async (req: Request) => {
     try {
       body = await req.json();
     } catch {
-      return errorResponse(req, 'Invalid JSON body', 400);
+      return errorResponse(req, 'Invalid JSON body', 400, {
+        retryable: false,
+      });
     }
 
-    // 4. Validate batch structure
+    // 4. Validate the complete batch before any destination write.
     const batchResult = UsageBatchSchema.safeParse(body);
     if (!batchResult.success) {
-      return errorResponse(
-        req,
-        'Invalid batch format: expected { entries: [], batchId: UUID }',
-        400,
-      );
+      return errorResponse(req, 'Invalid batch format or entry data', 422, {
+        retryable: false,
+      });
     }
     const batch = batchResult.data;
 
-    // 5. Validate and transform entries
-    const validEntries: UsageLogEntry[] = [];
-    for (const entry of batch.entries) {
-      const result = UsageLogEntrySchema.safeParse(entry);
-      if (result.success) validEntries.push(result.data);
-    }
+    const entries = batch.entries;
 
-    if (validEntries.length === 0) {
-      return successResponse(req, 0, 'No valid entries in batch');
-    }
-
-    // 6. Check for duplicate batch (idempotency for client retries).
+    // 5. Check for duplicate batch (idempotency for client retries).
     // After per-stream compaction the canonical row keeps only one batch_id
     // out of the inputs that produced it, so this is best-effort: it catches
     // the common case of an immediate retry of an in-flight request. Each
@@ -301,12 +242,12 @@ Deno.serve(async (req: Request) => {
     // still fill the missing table.
     const destinationRows = await Promise.all(
       usageDestinations.map(async (destination) => {
-        const entries = validEntries.filter(destination.accepts);
+        const destinationEntries = entries.filter(destination.accepts);
         const rows =
-          entries.length === 0 ||
+          destinationEntries.length === 0 ||
           (await batchExists(destination, userId, batch.batchId))
             ? []
-            : destination.toRows(userId, batch.batchId, entries);
+            : destination.toRows(userId, batch.batchId, destinationEntries);
         return { destination, rows };
       }),
     );
@@ -314,7 +255,7 @@ Deno.serve(async (req: Request) => {
     if (destinationRows.every(({ rows }) => rows.length === 0)) {
       return successResponse(
         req,
-        validEntries.length,
+        entries.length,
         'Batch already processed (deduplicated)',
       );
     }
@@ -334,8 +275,8 @@ Deno.serve(async (req: Request) => {
       return errorResponse(req, 'Failed to store usage logs', 500);
     }
 
-    // 7. Return success response
-    return successResponse(req, validEntries.length);
+    // 6. Return success response
+    return successResponse(req, entries.length);
   } catch (error) {
     console.error('[LOG_USAGE] Unexpected error:', error);
     return errorResponse(req, 'Internal server error', 500);

--- a/supabase/functions/log-usage/usageValidation.ts
+++ b/supabase/functions/log-usage/usageValidation.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+/** Normalize absent/null legacy fields while rejecting malformed present values. */
+function optional<T extends z.ZodType>(schema: T) {
+  return schema
+    .nullish()
+    .transform((value): z.infer<T> | undefined => value ?? undefined);
+}
+
+const optionalString = optional(z.string());
+const optionalNonnegativeInt = optional(z.int().nonnegative());
+const optionalBoolean = optional(z.boolean());
+const UsageRouteSchema = z.enum(['chatgpt-subscription', 'relay', 'api-key']);
+
+const UsageLogEntryInputSchema = z.object({
+  timestamp: z.iso.datetime(),
+  model: z.string(),
+  provider: z.string(),
+  inputTokens: z.int().nonnegative(),
+  outputTokens: z.int().nonnegative(),
+  cost: z.number().nonnegative(),
+  agentName: optionalString,
+  agentCategory: optional(z.enum(['workflow', 'toolUse'])),
+  isMultipleOutput: optionalBoolean,
+  responseTimeMs: optionalNonnegativeInt,
+  cachedInputTokens: optionalNonnegativeInt,
+  reasoningTokens: optionalNonnegativeInt,
+  usedRelay: optionalBoolean,
+  usageRoute: optional(UsageRouteSchema),
+  viaChatGptSubscription: z
+    .boolean()
+    .nullish()
+    .transform((value) => value ?? false),
+  // The destination mapper supplies `chatgpt` for legacy subscription entries
+  // that predate an explicit source.
+  subscriptionSource: optionalString,
+  streamId: optionalString,
+  extensionVersion: optionalString,
+  editorType: optionalString,
+});
+
+export const UsageLogEntrySchema = UsageLogEntryInputSchema.transform(
+  ({ viaChatGptSubscription, ...entry }) => ({
+    ...entry,
+    usageRoute:
+      entry.usageRoute ??
+      (viaChatGptSubscription ? 'chatgpt-subscription' : undefined),
+  }),
+);
+
+export const UsageBatchSchema = z.object({
+  entries: z.array(UsageLogEntrySchema).min(1),
+  batchId: z.uuid(),
+});
+
+export type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;

--- a/supabase/functions/log-usage/usageValidation_test.ts
+++ b/supabase/functions/log-usage/usageValidation_test.ts
@@ -1,0 +1,77 @@
+import { deepStrictEqual, equal } from 'node:assert/strict';
+
+import { UsageBatchSchema, UsageLogEntrySchema } from './usageValidation.ts';
+
+const VALID_BATCH_ID = 'a584b784-a4f1-4d44-a99f-36767d31e79d';
+
+function usageEntry() {
+  return {
+    timestamp: '2026-07-12T12:00:00.000Z',
+    model: 'gpt-5',
+    provider: 'openai',
+    inputTokens: 10,
+    outputTokens: 5,
+    cost: 0.01,
+  };
+}
+
+Deno.test('normalizes only missing optional usage fields', () => {
+  const parsed = UsageLogEntrySchema.parse(usageEntry());
+
+  equal(parsed.usageRoute, undefined);
+  equal(parsed.usedRelay, undefined);
+  equal(Object.hasOwn(parsed, 'viaChatGptSubscription'), false);
+});
+
+Deno.test(
+  'derives the legacy subscription route from an explicit boolean',
+  () => {
+    const parsed = UsageLogEntrySchema.parse({
+      ...usageEntry(),
+      viaChatGptSubscription: true,
+    });
+
+    equal(parsed.usageRoute, 'chatgpt-subscription');
+  },
+);
+
+Deno.test('accepts a nonempty batch of valid entries', () => {
+  const parsed = UsageBatchSchema.parse({
+    batchId: VALID_BATCH_ID,
+    entries: [usageEntry()],
+  });
+
+  equal(parsed.batchId, VALID_BATCH_ID);
+  equal(parsed.entries.length, 1);
+});
+
+Deno.test('rejects invalid present optional fields', () => {
+  const invalidEntries = [
+    { ...usageEntry(), usedRelay: 'yes' },
+    { ...usageEntry(), responseTimeMs: -1 },
+    { ...usageEntry(), viaChatGptSubscription: 'true' },
+  ];
+
+  deepStrictEqual(
+    invalidEntries.map((entry) => UsageLogEntrySchema.safeParse(entry).success),
+    invalidEntries.map(() => false),
+  );
+});
+
+Deno.test('rejects a whole batch when any entry is invalid', () => {
+  const parsed = UsageBatchSchema.safeParse({
+    batchId: VALID_BATCH_ID,
+    entries: [usageEntry(), { ...usageEntry(), inputTokens: -1 }],
+  });
+
+  equal(parsed.success, false);
+});
+
+Deno.test('rejects empty usage batches', () => {
+  const parsed = UsageBatchSchema.safeParse({
+    batchId: VALID_BATCH_ID,
+    entries: [],
+  });
+
+  equal(parsed.success, false);
+});


### PR DESCRIPTION
## Summary

- Validate the complete usage batch before any destination write.
- Reject mixed-validity and empty batches instead of silently dropping records.
- Normalize only absent or null legacy optional fields; reject malformed present values.
- Return a stable permanent-rejection code and bounded, sanitized validation details.
- Keep successful acknowledgement counts equal to the complete accepted batch.

## Design

The endpoint previously validated entries independently, discarded invalid records, and acknowledged the remainder. A successful response therefore did not prove that the submitted accounting batch was durable. The extracted boundary schema now owns legacy normalization and gives the handler one atomic validity decision.

Schema rejection returns `{ success: false, accepted: 0, retryable: false, errorCode: "BATCH_REJECTED" }` over HTTP 200. The response includes the total issue count and at most 20 Zod issue summaries containing only codes, paths, and messages. Malformed JSON returns HTTP 400 with `INVALID_JSON`. Authentication and operational failures omit the permanent marker and remain retryable.

HTTP 200 for schema rejection is a temporary rolling-deployment measure: clients predating #8267 let `ky` throw before reading a 4xx body, which would pin a permanently invalid batch at the head of their retry queue. Restore HTTP 422 only after those clients age out under #6981.

## Deployment order

Deploy this server change before the client change in #8267. The current client already reads and drops `success: false` on a 2xx response; #8267 then makes that loss explicit by quarantining the rejected batch while allowing later valid batches to continue.

Related to #7726.

## Verification

- Targeted Prettier check.
- `deno check` for the function and validation tests.
- `deno lint` for the three changed TypeScript files.
- `deno test supabase/functions/log-usage/usageValidation_test.ts` (6 passed).
- `npm run typecheck`.
- `npm run lint` (0 errors; pre-existing warnings only).
- `npm run compile:fast`.
- Full Vitest run at the original commit: 5,762 tests passed; one unrelated timing-sensitive CLI test passed on immediate isolated rerun.
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry ingestion semantics and client retry behavior during rolling deploy; deploy server before client #8267 to avoid stuck retry queues on older clients.
> 
> **Overview**
> The **log-usage** edge function now treats each submitted batch as all-or-nothing: validation runs on the full batch before any database write, and success **`accepted`** counts only match a completely valid batch.
> 
> Validation moves into **`usageValidation.ts`**. Optional fields normalize only when absent or null; malformed present values fail the entry. Batches must be non-empty, and one bad entry rejects the whole batch (replacing per-entry filtering and silent drops). **`errorResponse`** can return **`retryable`**, **`errorCode`**, bounded sanitized Zod **`issues`**, and **`issueCount`**. Schema failures respond with **`BATCH_REJECTED`** and **`retryable: false`** on **HTTP 200** for older clients during rollout; malformed JSON uses **400** with **`INVALID_JSON`**. API version bumps to **1.6.0**. Deno tests cover the new validation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7350ba50d24603271d52da573231fcdb7b4c63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->