### PR TITLE
fix: omit diagnostics without host linter

### DIFF
--- a/packages/cli/src/runtime/unavailableTools.ts
+++ b/packages/cli/src/runtime/unavailableTools.ts
@@ -1,9 +1,6 @@
 import type { RegisteredToolName } from '@tools/registry';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
-
-type CliUnavailableTool =
-  RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
 
 /**
  * Tools hidden from every `texra` CLI run — both the headless command paths
@@ -22,16 +19,17 @@ type CliUnavailableTool =
  * The `inline_comment` tool is backed by VS Code's CommentController, which the
  * CLI has no equivalent for, so it is hidden too.
  *
- * The `diagnostics.add` capability writes VS Code diagnostics through the
- * extension host. Keep diagnostics `list`/`count` available, but hide that
- * write sub-command from the CLI tool schema.
+ * The diagnostics tool requires a host linter for `list`/`count`. The CLI has
+ * no linter integration, so the whole tool is hidden rather than returning a
+ * successful empty result. Hosts with read support may instead hide only the
+ * `diagnostics.add` command.
  *
  * Subagents inherit these exclusions through `runtimeUnavailableTools` on the
  * run context.
  */
-export const CLI_UNAVAILABLE_TOOLS: readonly CliUnavailableTool[] = [
+export const CLI_UNAVAILABLE_TOOLS: readonly RegisteredToolName[] = [
   'inquiry',
   ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
   'inline_comment',
-  DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+  DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
 ];

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -87,7 +87,7 @@ import {
   releaseStreamResources,
 } from '@tools/approval';
 import type { RegisteredToolName } from '@tools/registry';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -115,13 +115,10 @@ import {
 import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
-type DesktopUnavailableTool =
-  RegisteredToolName | typeof DIAGNOSTICS_ADD_RUNTIME_CAPABILITY;
-
-const DESKTOP_UNAVAILABLE_TOOLS: readonly DesktopUnavailableTool[] = [
+const DESKTOP_UNAVAILABLE_TOOLS: readonly RegisteredToolName[] = [
   ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
   'inline_comment',
-  DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+  DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
 ];
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -38,7 +38,10 @@ import {
   getUnavailableToolNamesCached,
 } from '@tools/toolAvailability';
 import { withoutDiagnosticsAddCommand } from '@tools/DiagnosticsTool';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import {
+  DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+  DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
+} from '@tools/diagnosticsRuntimeCapabilities';
 import { notifyUnavailableTools } from '@tools/toolUnavailableNotification';
 import {
   availableModelNamesFromOptions,
@@ -135,9 +138,12 @@ export async function resolveAgentTools({
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
   const runtimeUnavailable = new Set(runtimeUnavailableTools ?? []);
-  const diagnosticsAddUnavailable = runtimeUnavailable.has(
-    DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+  const diagnosticsReadUnavailable = runtimeUnavailable.has(
+    DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
   );
+  const diagnosticsAddUnavailable =
+    !diagnosticsReadUnavailable &&
+    runtimeUnavailable.has(DIAGNOSTICS_ADD_RUNTIME_CAPABILITY);
   const missingDependency: string[] = [];
 
   const toolConfigs = Array.isArray(tools) ? tools : [];

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -6,7 +6,10 @@ import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import type { ToolDefinition } from '@model';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import {
+  DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+  DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
+} from '@tools/diagnosticsRuntimeCapabilities';
 
 const logger = { warn: () => {} };
 
@@ -154,6 +157,22 @@ describe('tool-use tool resolution', () => {
         confidence: 4,
       }).success,
     ).toBe(false);
+  });
+
+  it('omits diagnostics when read support is host-unavailable', async () => {
+    const diagnostics = new DiagnosticsTool();
+    const registry = new MapToolRegistry({ diagnostics });
+
+    const { tools } = await resolveAgentTools({
+      tools: [diagnostics.definition],
+      registry,
+      logger,
+      toolInjections,
+      runtimeUnavailableTools: [DIAGNOSTICS_READ_RUNTIME_CAPABILITY],
+      approvalPromptsUnavailable: false,
+    });
+
+    expect(tools).toEqual([]);
   });
 
   it('filters injected approval-gated tools when approval prompts are unavailable', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -20,7 +20,7 @@ import {
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 
 const mocks = vi.hoisted(() => ({
@@ -257,7 +257,7 @@ describe('executeCliRequest', () => {
           'inquiry',
           ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
           'inline_comment',
-          DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+          DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
         ],
       }),
     );
@@ -278,7 +278,7 @@ describe('executeCliRequest', () => {
           'inquiry',
           ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
           'inline_comment',
-          DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+          DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
           'custom_tool',
         ],
       }),

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - shared schemas and tools
 import { RUN_OUTCOME } from '@shared/schemas';
-import { DIAGNOSTICS_ADD_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
+import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 
 // Local imports - desktop test support
@@ -169,7 +169,7 @@ describe('createDesktopAgentExecution', () => {
         runtimeUnavailableTools: [
           ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
           'inline_comment',
-          DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
+          DIAGNOSTICS_READ_RUNTIME_CAPABILITY,
         ],
       }),
     );

--- a/src/test-kernel/tools/DiagnosticsTool.vitest.ts
+++ b/src/test-kernel/tools/DiagnosticsTool.vitest.ts
@@ -30,6 +30,21 @@ function worktreeContext() {
 }
 
 describe('DiagnosticsTool', () => {
+  it('reports a capability error when the host has no linter', async () => {
+    await installPlatform({}, { linter: undefined });
+
+    const result = await withRunContext(worktreeContext(), () =>
+      new DiagnosticsTool().call({ command: 'list', path: 'paper.tex' }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error:
+        'Diagnostics capability unavailable: this host did not configure Platform.linter.',
+      diagnostics: { name: 'ToolError' },
+    });
+  });
+
   it('reads diagnostics from the active working directory root', async () => {
     const paths: string[] = [];
     await installLinter(async (path) => {
@@ -61,6 +76,28 @@ describe('DiagnosticsTool', () => {
     expect(result.error).toContain('at message');
     expect(result.error).toContain('at severity');
     expect(result.error).toContain('at confidence');
+  });
+
+  it('reports a capability error when the host has no criticism sink', async () => {
+    await installPlatform({}, { addCriticismSink: undefined });
+
+    const result = await withRunContext(worktreeContext(), () =>
+      new DiagnosticsTool().call({
+        command: 'add',
+        path: 'paper.tex',
+        line: 3,
+        message: 'tighten this claim',
+        severity: 4,
+        confidence: 5,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error:
+        'Diagnostics add capability unavailable: this host did not configure Platform.addCriticismSink.',
+      diagnostics: { name: 'ToolError' },
+    });
   });
 
   it('reports when the criticism sink does not accept (feature disabled)', async () => {

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -129,9 +129,15 @@ export class DiagnosticsTool extends defineTool({
   ): Promise<ToolResult> {
     const { command, path } = input;
     const diagnosticsPath = this.resolveAbsolutePath(path);
+    const linter = platform().linter;
+    if (!linter) {
+      throw new ToolError(
+        'Diagnostics capability unavailable: this host did not configure Platform.linter.',
+      );
+    }
 
     try {
-      const messages = (await platform().linter?.(diagnosticsPath)) ?? [];
+      const messages = await linter(diagnosticsPath);
       const counts = countBySeverity(messages);
       const header = `${diagnosticsPath}: ${formatCounts(counts)}`;
       const summary = `Diagnostics ${command} for ${diagnosticsPath}`;
@@ -173,16 +179,22 @@ export class DiagnosticsTool extends defineTool({
     input: Extract<DiagnosticsInput, { command: 'add' }>,
   ): Promise<ToolResult> {
     const { path, line, message, severity, confidence } = input;
+    const addCriticismSink = platform().addCriticismSink;
+    if (!addCriticismSink) {
+      throw new ToolError(
+        'Diagnostics add capability unavailable: this host did not configure Platform.addCriticismSink.',
+      );
+    }
 
     try {
       const absolutePath = this.resolveAbsolutePath(path);
-      const result = platform().addCriticismSink?.({
+      const result = addCriticismSink({
         absolutePath,
         line,
         message,
         severity,
         confidence,
-      }) ?? { accepted: false, resolvedPath: '' };
+      });
       if (!result.accepted) {
         return {
           status: 'executed',

--- a/src/tools/diagnosticsRuntimeCapabilities.ts
+++ b/src/tools/diagnosticsRuntimeCapabilities.ts
@@ -1,2 +1,12 @@
-/** Runtime capability hidden on hosts that cannot surface criticism diagnostics. */
+/**
+ * Runtime marker that removes the diagnostics tool when a host cannot read
+ * linter diagnostics. Its value is the tool name so the normal runtime tool
+ * gate excludes every diagnostics command.
+ */
+export const DIAGNOSTICS_READ_RUNTIME_CAPABILITY = 'diagnostics' as const;
+
+/**
+ * Command-level marker for hosts that can read diagnostics but cannot surface
+ * criticism diagnostics. Do not use this as a substitute for the read marker.
+ */
 export const DIAGNOSTICS_ADD_RUNTIME_CAPABILITY = 'diagnostics.add' as const;


### PR DESCRIPTION
## Summary

- Omits the diagnostics tool entirely from CLI and desktop agent runs because those hosts do not provide `Platform.linter`.
- Preserves command-level `diagnostics.add` narrowing for hosts that can read diagnostics but cannot add criticism diagnostics.
- Makes direct diagnostics calls fail with an explicit capability error when `Platform.linter` or `Platform.addCriticismSink` is absent.
- Adds focused coverage for absent ports, resolver narrowing, and the CLI and desktop unavailable-tool lists.

## Root cause

CLI and desktop advertised the diagnostics `list` and `count` commands while omitting `Platform.linter`. `DiagnosticsTool` treated the missing port as an empty diagnostics list, so an unsupported capability appeared to execute successfully.

## Impact

Agents running in CLI or desktop no longer see a diagnostics tool that those hosts cannot execute truthfully. Hosts with read support retain the narrower option to hide only the `add` command. Missing composition ports now produce explicit tool errors rather than successful empty or disabled results.

## Checks

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with 0 errors; 46 pre-existing warnings remain)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/DiagnosticsTool.vitest.ts src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts` (46 tests)
- `npm run compile:fast`
- `corepack pnpm --filter @texra-ai/cli bundle`
- `corepack pnpm --filter @texra/desktop build:main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to diagnostics availability and agent tool lists on CLI/desktop; VS Code hosts with linter configured should behave as before aside from stricter errors on misconfigured direct calls.
> 
> **Overview**
> **CLI and desktop** no longer expose the diagnostics tool at all (via `DIAGNOSTICS_READ_RUNTIME_CAPABILITY` / tool name `diagnostics`) because those hosts lack `Platform.linter`. Previously only `diagnostics.add` was hidden, so `list`/`count` could still appear and succeed with empty results.
> 
> **Agent tool resolution** treats read-unavailable as dropping the whole tool; **add-only** unavailability still narrows the schema to read-only commands through `withoutDiagnosticsAddCommand`, and add narrowing is skipped when read is already unavailable.
> 
> **`DiagnosticsTool`** now throws explicit capability errors when `Platform.linter` or `Platform.addCriticismSink` is missing instead of defaulting to an empty diagnostic list or a silent “not accepted” path.
> 
> Tests cover resolver behavior, CLI/desktop unavailable-tool lists, and direct tool calls without host ports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab10637d2321d61f217166cea3a13d5d8e84908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->