### PR TITLE
fix: fail closed on gitignore matcher errors

### DIFF
--- a/src/test-kernel/tools/GitignoreMatcher.vitest.mts
+++ b/src/test-kernel/tools/GitignoreMatcher.vitest.mts
@@ -2,9 +2,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const fsState = vi.hoisted(() => ({
-  workspacePath: '/workspace',
+  workspacePath: '/workspace' as string | undefined,
+  homeDirectory: undefined as string | undefined,
   workspaceFiles: new Map<string, string>(),
+  workspaceReadErrors: new Map<string, Error>(),
   absoluteFiles: new Map<string, string>(),
+  absoluteReadErrors: new Map<string, Error>(),
 }));
 
 vi.mock('@utils/files', () => ({
@@ -12,35 +15,118 @@ vi.mock('@utils/files', () => ({
     getPath: () => fsState.workspacePath,
     exists: async (relativePath: string) =>
       fsState.workspaceFiles.has(relativePath.replace(/^\/+/, '')),
-    read: async (relativePath: string) =>
-      fsState.workspaceFiles.get(relativePath.replace(/^\/+/, '')) ?? '',
+    read: async (relativePath: string) => {
+      const normalized = relativePath.replace(/^\/+/, '');
+      const readError = fsState.workspaceReadErrors.get(normalized);
+      if (readError) {
+        throw readError;
+      }
+      const content = fsState.workspaceFiles.get(normalized);
+      if (content === undefined) {
+        throw Object.assign(new Error(`File not found: ${normalized}`), {
+          code: 'ENOENT',
+        });
+      }
+      return content;
+    },
   },
   AbsoluteFS: {
     exists: async (absolutePath: string) =>
       fsState.absoluteFiles.has(absolutePath),
-    read: async (absolutePath: string) =>
-      fsState.absoluteFiles.get(absolutePath) ?? '',
+    read: async (absolutePath: string) => {
+      const readError = fsState.absoluteReadErrors.get(absolutePath);
+      if (readError) {
+        throw readError;
+      }
+      const content = fsState.absoluteFiles.get(absolutePath);
+      if (content === undefined) {
+        throw Object.assign(new Error(`File not found: ${absolutePath}`), {
+          code: 'ENOENT',
+        });
+      }
+      return content;
+    },
   },
 }));
 
 vi.mock('@utils/system/platformPaths', () => ({
-  safeHomedir: () => undefined,
+  safeHomedir: () => fsState.homeDirectory,
 }));
 
-async function loadWorkspaceMatcher(gitignore: string) {
+async function loadMatcher() {
   vi.resetModules();
-  fsState.workspacePath = '/workspace';
-  fsState.workspaceFiles.clear();
-  fsState.absoluteFiles.clear();
-  fsState.workspaceFiles.set('.gitignore', gitignore);
-
   const { getGitignoreMatcher } = await import('@tools/gitignore');
   return getGitignoreMatcher();
+}
+
+async function loadWorkspaceMatcher(gitignore: string) {
+  fsState.workspaceFiles.set('.gitignore', gitignore);
+  return loadMatcher();
 }
 
 describe('getGitignoreMatcher', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.doUnmock('ignore');
+    fsState.workspacePath = '/workspace';
+    fsState.homeDirectory = undefined;
+    fsState.workspaceFiles.clear();
+    fsState.workspaceReadErrors.clear();
+    fsState.absoluteFiles.clear();
+    fsState.absoluteReadErrors.clear();
+  });
+
+  it('uses an empty matcher when no workspace is available', async () => {
+    fsState.workspacePath = undefined;
+
+    const matcher = await loadMatcher();
+
+    expect(matcher.hasRules).toBe(false);
+    expect(matcher.ignoreFiles).toEqual([]);
+    expect(matcher.ignores('paper.tex')).toBe(false);
+  });
+
+  it('uses an empty matcher when all ignore policies are absent', async () => {
+    fsState.homeDirectory = '/home/user';
+
+    const matcher = await loadMatcher();
+
+    expect(matcher.hasRules).toBe(false);
+    expect(matcher.ignoreFiles).toEqual([]);
+    expect(matcher.ignores('paper.tex')).toBe(false);
+  });
+
+  it('rejects when a workspace ignore policy cannot be read', async () => {
+    const readError = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    fsState.workspaceReadErrors.set('.gitignore', readError);
+
+    await expect(loadMatcher()).rejects.toBe(readError);
+  });
+
+  it('rejects when a global ignore policy cannot be read', async () => {
+    const readError = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    fsState.homeDirectory = '/home/user';
+    fsState.absoluteReadErrors.set('/home/user/.gitignore_global', readError);
+
+    await expect(loadMatcher()).rejects.toBe(readError);
+  });
+
+  it('rejects when ignore policy construction fails', async () => {
+    const constructionError = new Error('Invalid ignore policy');
+    vi.doMock('ignore', () => ({
+      default: () => ({
+        add: () => {
+          throw constructionError;
+        },
+      }),
+    }));
+    fsState.workspaceFiles.set('.gitignore', 'dist/\n');
+
+    await expect(loadMatcher()).rejects.toBe(constructionError);
   });
 
   it('preserves directory-only rules for bare directory entries', async () => {
@@ -61,6 +147,14 @@ describe('getGitignoreMatcher', () => {
     const matcher = await loadWorkspaceMatcher('dist/\n!dist/.gitkeep\n');
 
     expect(matcher.ignores('dist/.gitkeep')).toBe(true);
+  });
+
+  it('propagates matcher failures', async () => {
+    const matcher = await loadWorkspaceMatcher('dist/\n');
+
+    expect(() => matcher.ignores('../outside')).toThrow(
+      'path should be a `path.relative()`d string',
+    );
   });
 });
 

--- a/src/test-kernel/tools/GitignoreMatcher.vitest.mts
+++ b/src/test-kernel/tools/GitignoreMatcher.vitest.mts
@@ -6,6 +6,7 @@ const fsState = vi.hoisted(() => ({
   homeDirectory: undefined as string | undefined,
   workspaceFiles: new Map<string, string>(),
   workspaceReadErrors: new Map<string, Error>(),
+  workspaceReadCounts: new Map<string, number>(),
   absoluteFiles: new Map<string, string>(),
   absoluteReadErrors: new Map<string, Error>(),
 }));
@@ -17,6 +18,10 @@ vi.mock('@utils/files', () => ({
       fsState.workspaceFiles.has(relativePath.replace(/^\/+/, '')),
     read: async (relativePath: string) => {
       const normalized = relativePath.replace(/^\/+/, '');
+      fsState.workspaceReadCounts.set(
+        normalized,
+        (fsState.workspaceReadCounts.get(normalized) ?? 0) + 1,
+      );
       const readError = fsState.workspaceReadErrors.get(normalized);
       if (readError) {
         throw readError;
@@ -72,6 +77,7 @@ describe('getGitignoreMatcher', () => {
     fsState.homeDirectory = undefined;
     fsState.workspaceFiles.clear();
     fsState.workspaceReadErrors.clear();
+    fsState.workspaceReadCounts.clear();
     fsState.absoluteFiles.clear();
     fsState.absoluteReadErrors.clear();
   });
@@ -127,6 +133,39 @@ describe('getGitignoreMatcher', () => {
     fsState.workspaceFiles.set('.gitignore', 'dist/\n');
 
     await expect(loadMatcher()).rejects.toBe(constructionError);
+  });
+
+  it('retries after a failed shared load attempt', async () => {
+    const readError = Object.assign(new Error('Temporarily unavailable'), {
+      code: 'EACCES',
+    });
+    fsState.workspaceFiles.set('.gitignore', 'dist/\n');
+    fsState.workspaceReadErrors.set('.gitignore', readError);
+    vi.resetModules();
+    const { getGitignoreMatcher } = await import('@tools/gitignore');
+
+    const failedCalls = await Promise.allSettled([
+      getGitignoreMatcher(),
+      getGitignoreMatcher(),
+    ]);
+
+    for (const result of failedCalls) {
+      expect(result.status).toBe('rejected');
+      if (result.status === 'rejected') {
+        expect(result.reason).toBe(readError);
+      }
+    }
+    expect(fsState.workspaceReadCounts.get('.gitignore')).toBe(1);
+
+    fsState.workspaceReadErrors.delete('.gitignore');
+    const [matcher, concurrentMatcher] = await Promise.all([
+      getGitignoreMatcher(),
+      getGitignoreMatcher(),
+    ]);
+
+    expect(matcher).toBe(concurrentMatcher);
+    expect(matcher.ignores('dist')).toBe(true);
+    expect(fsState.workspaceReadCounts.get('.gitignore')).toBe(2);
   });
 
   it('preserves directory-only rules for bare directory entries', async () => {

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -4,10 +4,12 @@ import * as path from 'node:path';
 // Third-party imports
 import ignore from 'ignore';
 
+// Local imports - common
+import { isFileNotFoundError } from '@common/errors';
+
 // Local imports - utils
-import { warn } from '@logger/logUtils';
-import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { filterNotNull } from '@utils/core';
+import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { toPosixPath } from '@utils/core/pathCore';
 import { safeHomedir } from '@utils/system/platformPaths';
 
@@ -37,8 +39,11 @@ async function readGitignoreFile(
   try {
     const content = await readContent();
     return { absolutePath, content };
-  } catch {
-    return null;
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -50,10 +55,6 @@ async function readWorkspaceGitignore(
     return null;
   }
   const normalized = relativePath.replace(/^\/+/, '');
-  const exists = await WorkspaceFS.exists(normalized);
-  if (!exists) {
-    return null;
-  }
   return readGitignoreFile(path.join(workspacePath, normalized), () =>
     WorkspaceFS.read(normalized),
   );
@@ -62,10 +63,6 @@ async function readWorkspaceGitignore(
 async function readAbsoluteGitignore(
   absolutePath: string,
 ): Promise<GitignoreSource | null> {
-  const exists = await AbsoluteFS.exists(absolutePath);
-  if (!exists) {
-    return null;
-  }
   return readGitignoreFile(absolutePath, () => AbsoluteFS.read(absolutePath));
 }
 
@@ -74,14 +71,10 @@ async function readGlobalGitignore(): Promise<GitignoreSource[]> {
   if (!homeDirectory) {
     return [];
   }
-  try {
-    const source = await readAbsoluteGitignore(
-      path.join(homeDirectory, '.gitignore_global'),
-    );
-    return source ? [source] : [];
-  } catch {
-    return [];
-  }
+  const source = await readAbsoluteGitignore(
+    path.join(homeDirectory, '.gitignore_global'),
+  );
+  return source ? [source] : [];
 }
 
 async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
@@ -90,59 +83,46 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
     return EMPTY_GITIGNORE_MATCHER;
   }
 
-  try {
-    const [globalSources, workspaceGlobalSource, workspaceSource] =
-      await Promise.all([
-        readGlobalGitignore(),
-        readWorkspaceGitignore('.gitignore_global'),
-        readWorkspaceGitignore('.gitignore'),
-      ]);
+  const [globalSources, workspaceGlobalSource, workspaceSource] =
+    await Promise.all([
+      readGlobalGitignore(),
+      readWorkspaceGitignore('.gitignore_global'),
+      readWorkspaceGitignore('.gitignore'),
+    ]);
 
-    const sources = [
-      ...globalSources,
-      workspaceGlobalSource,
-      workspaceSource,
-    ].filter(filterNotNull);
+  const sources = [
+    ...globalSources,
+    workspaceGlobalSource,
+    workspaceSource,
+  ].filter(filterNotNull);
 
-    if (sources.length === 0) {
-      return EMPTY_GITIGNORE_MATCHER;
-    }
-
-    const ig = ignore();
-    for (const source of sources) {
-      ig.add(source.content);
-    }
-
-    return {
-      hasRules: true,
-      ignores: (relativePath: string): boolean => {
-        if (!relativePath || relativePath === '.') {
-          return false;
-        }
-        const normalized = toPosixPath(relativePath);
-        try {
-          // Try plain path first; also try with trailing slash so that
-          // directory-only rules (e.g. "dist/") match bare directory names
-          // ("dist") the same way the old minimatch-based parser did.
-          // Known deviation from strict git spec: a *file* named "dist" would
-          // also be ignored by a "dist/" rule, because we cannot distinguish
-          // files from directories without a stat call. The old parser had the
-          // same behaviour (it expanded "dist/" → ["dist", "dist/**"]).
-          return ig.ignores(normalized) || ig.ignores(normalized + '/');
-        } catch {
-          return false;
-        }
-      },
-      ignoreFiles: sources.map((source) => source.absolutePath),
-    };
-  } catch (error) {
-    // Falling back to the empty matcher silently disables ALL gitignore
-    // filtering, so surface this rather than hiding a degraded mode.
-    warn('gitignore', 'Failed to load .gitignore rules; ignoring nothing', {
-      data: error,
-    });
+  if (sources.length === 0) {
     return EMPTY_GITIGNORE_MATCHER;
   }
+
+  const ig = ignore();
+  for (const source of sources) {
+    ig.add(source.content);
+  }
+
+  return {
+    hasRules: true,
+    ignores: (relativePath: string): boolean => {
+      if (!relativePath || relativePath === '.') {
+        return false;
+      }
+      const normalized = toPosixPath(relativePath);
+      // Try plain path first; also try with trailing slash so that
+      // directory-only rules (e.g. "dist/") match bare directory names
+      // ("dist") the same way the old minimatch-based parser did.
+      // Known deviation from strict git spec: a *file* named "dist" would
+      // also be ignored by a "dist/" rule, because we cannot distinguish
+      // files from directories without a stat call. The old parser had the
+      // same behaviour (it expanded "dist/" → ["dist", "dist/**"]).
+      return ig.ignores(normalized) || ig.ignores(normalized + '/');
+    },
+    ignoreFiles: sources.map((source) => source.absolutePath),
+  };
 }
 
 export async function getGitignoreMatcher(): Promise<GitignoreMatcher> {

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -129,5 +129,13 @@ export async function getGitignoreMatcher(): Promise<GitignoreMatcher> {
   if (!gitignoreMatcherPromise) {
     gitignoreMatcherPromise = loadGitignoreMatcher();
   }
-  return gitignoreMatcherPromise;
+  const matcherPromise = gitignoreMatcherPromise;
+  try {
+    return await matcherPromise;
+  } catch (error) {
+    if (gitignoreMatcherPromise === matcherPromise) {
+      gitignoreMatcherPromise = undefined;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

This PR makes gitignore policy loading fail closed when an ignore file cannot be read or when matcher construction or evaluation fails.

The root cause was a sequence of broad catches: filesystem existence checks hid operational errors, file readers treated every read failure as absence, the loader returned an empty matcher after construction failures, and the matcher returned `false` after evaluation failures. That degraded state could admit files that the user intended to exclude from model context.

Direct reads now distinguish confirmed `ENOENT`/`FileNotFound` absence from other failures. Operational failures propagate to the context or tool operation. The legitimate no-workspace and no-policy cases still use the empty matcher.

Rejected load attempts are removed from the cache only while they remain the current attempt. Concurrent callers therefore share one fail-closed result, while a later operation can retry after a transient failure.

## Issue acceptance gates

- Addresses fallback audit P0.10.
- Preserves the empty matcher when no workspace exists or all ignore policies are confirmed absent.
- Rejects workspace and global ignore policy read failures.
- Rejects matcher construction failures.
- Propagates matcher evaluation exceptions instead of converting them to `false`.
- Clears a rejected cached load conditionally so later operations retry without disrupting a newer attempt.
- Leaves the fallback audit report unchanged.

## Single source of truth

`src/tools/gitignore.ts` remains the single owner of ignore policy discovery, loading, matching, and load-attempt caching behavior.

## Duplication and abstraction budget

No new abstraction was added. The existing file-read helper centralizes the only permitted fallback: a confirmed file-not-found condition. Redundant existence probes and nested catch chains were removed.

## Net elements (R6)

- Files: 2 modified
- Exported symbols: 0 added or removed
- Classes/interfaces/enums: 0 added or removed
- Net LoC: +121

## Consumer counts (R8)

n/a: no emit path, export, or consumer routing changed.

## Host impact

Extension: Context-producing tools stop on unreadable or invalid ignore policies, while a later operation can recover from a transient failure.

Desktop: Shared core tool behavior uses the same fail-closed, retry-per-attempt policy.

CLI: Shared core tool behavior uses the same fail-closed, retry-per-attempt policy.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 46 existing warnings outside the changed files)
- `corepack pnpm exec eslint src/tools/gitignore.ts src/test-kernel/tools/GitignoreMatcher.vitest.mts`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/tools/GitignoreMatcher.vitest.mts` (12 tests passed)
