### PR TITLE
fix: block stale diff approval fallback

### DIFF
--- a/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
+++ b/packages/extension/src/frontend/approval/VscodeDiffViewHost.ts
@@ -121,19 +121,14 @@ export class VscodeDiffViewHost implements DiffViewHost {
     });
   }
 
-  async readProposedContent(
-    session: DiffSession,
-    fallbackContent: string,
-  ): Promise<string> {
+  async readProposedContent(session: DiffSession): Promise<string> {
     const proposedUri = this.toUri(session.proposed);
     const openDocument = vscode.workspace.textDocuments.find(
       (doc) => doc.uri.toString() === proposedUri.toString(),
     );
     return openDocument
       ? openDocument.getText()
-      : await fs
-          .readFile(proposedUri.fsPath, 'utf8')
-          .catch(() => fallbackContent);
+      : await fs.readFile(proposedUri.fsPath, 'utf8');
   }
 
   private toUri(source: DiffSource): vscode.Uri {

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -43,6 +43,7 @@ import {
   type ToolEditApprovalResult,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 
 const CHANNEL = 'nativeToolEditApproval';
@@ -288,10 +289,12 @@ export async function nativeRequestApproval(
     result = await approvalPromise;
 
     if (result.accepted) {
-      // Normalize here: these reads bypass BaseFS so may contain CRLF.
-      const appliedContent = normalizeLineEndings(
-        await diffViewHost.readProposedContent(openedSession, proposedContent),
-      );
+      const appliedContent = result.appliedContent;
+      if (appliedContent == null) {
+        throw new Error(
+          'Tool edit approval settled without the current proposed content.',
+        );
+      }
       const userPatch = computeUserPatch(proposedContent, appliedContent);
       result = {
         ...result,
@@ -360,14 +363,19 @@ export async function handleProgressViewToolEditApprovalAction(
       break;
 
     case 'approve': {
-      // Normalize: this read bypasses BaseFS so may contain CRLF.
-      const appliedContent = normalizeLineEndings(
-        await diffViewHost.readProposedContent(
-          entry.diffSession,
-          entry.proposedContent,
-        ),
-      );
-      entry.settle({ accepted: true, appliedContent });
+      try {
+        // Normalize: this read bypasses BaseFS so may contain CRLF.
+        const appliedContent = normalizeLineEndings(
+          await diffViewHost.readProposedContent(entry.diffSession),
+        );
+        entry.settle({ accepted: true, appliedContent });
+      } catch (error) {
+        if (!entry.isSettled()) {
+          entry.onError(
+            `Approval failed because the edited document could not be read: ${toErrorMessage(error)}`,
+          );
+        }
+      }
       break;
     }
 

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -50,8 +50,10 @@ const CHANNEL = 'nativeToolEditApproval';
 
 interface PendingApprovalEntry extends LatexPreviewEntry {
   request: ToolEditApprovalRequest;
+  session: SessionHandle;
   diffSession: DiffSession;
   title: string;
+  relativePath: string;
   streamId?: StreamTabId;
   lineChanges: LineChanges;
   settle: (result: ToolEditApprovalResult) => void;
@@ -115,6 +117,22 @@ async function showProgressViewApprovalPrompt(
     vscode.commands.executeCommand('texra.showProgressView'),
   ).catch(() => {});
 
+  publishProgressViewApprovalPrompt(
+    session,
+    requestId,
+    request,
+    relativePath,
+    lineChanges,
+  );
+}
+
+function publishProgressViewApprovalPrompt(
+  session: SessionHandle,
+  requestId: string,
+  request: ToolEditApprovalRequest,
+  relativePath: string,
+  lineChanges: LineChanges,
+): void {
   // Activate the stream that needs approval and post the prompt (shared with
   // the desktop host); VS Code computes the relative path via the workspace.
   emitToolEditApprovalPrompt(getRuntimeHost(), session, {
@@ -127,6 +145,22 @@ async function showProgressViewApprovalPrompt(
 
 function resolveProgressViewApprovalPrompt(requestId: string): void {
   getRuntimeHost().emit('resolveToolEditPermission', { requestId });
+}
+
+function restoreProgressViewApprovalPrompt(
+  requestId: string,
+  entry: PendingApprovalEntry,
+): void {
+  // The frontend removes the panel optimistically on approve. Reset backend
+  // delivery tracking, then publish the still-pending request under the same ID.
+  resolveProgressViewApprovalPrompt(requestId);
+  publishProgressViewApprovalPrompt(
+    entry.session,
+    requestId,
+    entry.request,
+    entry.relativePath,
+    entry.lineChanges,
+  );
 }
 
 export async function nativeRequestApproval(
@@ -201,12 +235,14 @@ export async function nativeRequestApproval(
 
       const entry: PendingApprovalEntry = {
         request,
+        session: options.session,
         diffSession: openedSession,
         originalUri: { fsPath: originalSource.filePath },
         proposedUri: { fsPath: proposedSource.filePath },
         originalContent,
         proposedContent,
         title,
+        relativePath: description,
         streamId: streamId ?? undefined,
         lineChanges,
         isSettled: () => approvalSettled,
@@ -374,6 +410,7 @@ export async function handleProgressViewToolEditApprovalAction(
           entry.onError(
             `Approval failed because the edited document could not be read: ${toErrorMessage(error)}`,
           );
+          restoreProgressViewApprovalPrompt(payload.requestId, entry);
         }
       }
       break;

--- a/src/hosts/uiHosts.ts
+++ b/src/hosts/uiHosts.ts
@@ -24,10 +24,7 @@ export interface DiffViewHost {
   ): Promise<DiffSession>;
   closeDiff(session: DiffSession): Promise<void>;
   revealFirstChange(session: DiffSession, line: number): Promise<void>;
-  readProposedContent(
-    session: DiffSession,
-    fallbackContent: string,
-  ): Promise<string>;
+  readProposedContent(session: DiffSession): Promise<string>;
 }
 
 export interface ExternalOpener {

--- a/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
+++ b/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
@@ -206,9 +206,10 @@ afterEach(async () => {
 });
 
 describe('native tool edit approval', () => {
-  it('does not accept when the current proposed document cannot be read', async () => {
+  it('restores a failed approval prompt and accepts a later retry', async () => {
     const { approval, requestId, runtimeHost } = await startApproval();
-    await rm(currentProposedUri().fsPath);
+    const proposedUri = currentProposedUri();
+    await rm(proposedUri.fsPath);
 
     await handleProgressViewToolEditApprovalAction({
       requestId,
@@ -219,13 +220,23 @@ describe('native tool edit approval', () => {
     expect(vscodeMocks.showErrorMessage).toHaveBeenCalledWith(
       expect.stringContaining('edited document could not be read'),
     );
-    expect(runtimeHost.resolved).toHaveLength(0);
+    expect(runtimeHost.resolved).toEqual([{ requestId }]);
+    expect(runtimeHost.shown).toHaveLength(2);
+    expect(runtimeHost.shown[1]).toEqual(runtimeHost.shown[0]);
 
+    const getText = vi.fn(() => 'beta after retry\r\n');
+    vscodeMocks.textDocuments.push({ uri: proposedUri, getText });
     await handleProgressViewToolEditApprovalAction({
       requestId,
-      action: 'reject',
+      action: 'approve',
     });
-    await expect(approval).resolves.toMatchObject({ accepted: false });
+
+    await expect(approval).resolves.toMatchObject({
+      accepted: true,
+      appliedContent: 'beta after retry\n',
+    });
+    expect(getText).toHaveBeenCalledOnce();
+    expect(runtimeHost.resolved).toEqual([{ requestId }, { requestId }]);
   });
 
   it('accepts the current edited document content', async () => {

--- a/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
+++ b/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
@@ -1,0 +1,252 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  handleProgressViewToolEditApprovalAction,
+  initializeNativeToolEditApproval,
+  nativeRequestApproval,
+} from '@frontend/approval/nativeToolEditApproval';
+import type { ToolEditApprovalResult } from '@tools/approval/toolEditApproval';
+import type * as VSCode from 'vscode';
+
+interface TestUri {
+  readonly fsPath: string;
+  readonly path: string;
+  toString(): string;
+}
+
+interface TestTextDocument {
+  readonly uri: TestUri;
+  getText(): string;
+}
+
+interface TestTextEditor {
+  readonly document: { readonly uri: TestUri };
+  selections: unknown[];
+  revealRange: ReturnType<typeof vi.fn>;
+}
+
+const vscodeMocks = vi.hoisted(() => ({
+  closeTabs: vi.fn(async () => undefined),
+  executeCommand: vi.fn(async (..._args: unknown[]) => undefined),
+  showErrorMessage: vi.fn(async (..._args: unknown[]) => undefined),
+  textDocuments: [] as TestTextDocument[],
+  visibleTextEditors: [] as TestTextEditor[],
+}));
+
+vi.mock('vscode', () => {
+  class Position {
+    constructor(
+      readonly line: number,
+      readonly character: number,
+    ) {}
+  }
+
+  class Selection {
+    constructor(
+      readonly anchor: Position,
+      readonly active: Position,
+    ) {}
+  }
+
+  class Range {
+    constructor(
+      readonly start: Position,
+      readonly end: Position,
+    ) {}
+  }
+
+  return {
+    Position,
+    Range,
+    Selection,
+    TabInputText: class {},
+    TabInputTextDiff: class {},
+    TextEditorRevealType: { InCenter: 0 },
+    Uri: {
+      file: (filePath: string): TestUri => ({
+        fsPath: filePath,
+        path: filePath,
+        toString: () => filePath,
+      }),
+    },
+    commands: { executeCommand: vscodeMocks.executeCommand },
+    window: {
+      onDidChangeVisibleTextEditors: () => ({ dispose: vi.fn() }),
+      showErrorMessage: vscodeMocks.showErrorMessage,
+      tabGroups: {
+        all: [],
+        close: vscodeMocks.closeTabs,
+        onDidChangeTabs: () => ({ dispose: vi.fn() }),
+      },
+      visibleTextEditors: vscodeMocks.visibleTextEditors,
+    },
+    workspace: {
+      asRelativePath: (filePath: string) => path.basename(filePath),
+      getConfiguration: () => ({
+        get: <T,>(_key: string, defaultValue?: T) => defaultValue,
+      }),
+      onDidChangeConfiguration: () => ({ dispose: vi.fn() }),
+      textDocuments: vscodeMocks.textDocuments,
+    },
+  };
+});
+
+interface RecordingRuntimeHost extends AgentRuntimeHost {
+  readonly shown: RuntimeInteractionEventPayloads['showToolEditPermission'][];
+  readonly resolved: RuntimeInteractionEventPayloads['resolveToolEditPermission'][];
+}
+
+interface StartedApproval {
+  readonly approval: Promise<ToolEditApprovalResult>;
+  readonly requestId: string;
+  readonly runtimeHost: RecordingRuntimeHost;
+}
+
+const sessions: SessionHandle[] = [];
+const activeApprovals: Promise<ToolEditApprovalResult>[] = [];
+let storageRoot: string;
+
+function createRecordingRuntimeHost(): RecordingRuntimeHost {
+  const shown: RuntimeInteractionEventPayloads['showToolEditPermission'][] = [];
+  const resolved: RuntimeInteractionEventPayloads['resolveToolEditPermission'][] =
+    [];
+  return {
+    shown,
+    resolved,
+    emit: (event, payload) => {
+      if (event === 'showToolEditPermission') {
+        shown.push(
+          payload as RuntimeInteractionEventPayloads['showToolEditPermission'],
+        );
+      } else if (event === 'resolveToolEditPermission') {
+        resolved.push(
+          payload as RuntimeInteractionEventPayloads['resolveToolEditPermission'],
+        );
+      }
+    },
+  };
+}
+
+function currentProposedUri(): TestUri {
+  const call = vscodeMocks.executeCommand.mock.calls.find(
+    ([command]) => command === 'vscode.diff',
+  );
+  const proposedUri = call?.[2] as TestUri | undefined;
+  if (!proposedUri) {
+    throw new Error('Expected the proposed diff URI.');
+  }
+  return proposedUri;
+}
+
+async function startApproval(): Promise<StartedApproval> {
+  const runtimeHost = createRecordingRuntimeHost();
+  const session = new SessionHandle();
+  sessions.push(session);
+  initializeNativeToolEditApproval(
+    {
+      storageUri: { fsPath: storageRoot },
+      globalStorageUri: { fsPath: storageRoot },
+    } as unknown as VSCode.ExtensionContext,
+    runtimeHost,
+  );
+
+  const approval = nativeRequestApproval(
+    {
+      path: '/workspace/notes.txt',
+      originalContent: 'alpha\n',
+      proposedContent: 'beta\n',
+      sourceTool: 'write_file',
+      streamId: 'stream-approval',
+    },
+    { session },
+  );
+  activeApprovals.push(approval);
+
+  await vi.waitFor(() => expect(runtimeHost.shown).toHaveLength(1));
+  const requestId = runtimeHost.shown[0]?.requestId;
+  if (!requestId) {
+    throw new Error('Expected a tool edit approval request ID.');
+  }
+  return { approval, requestId, runtimeHost };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vscodeMocks.textDocuments.splice(0);
+  vscodeMocks.visibleTextEditors.splice(0);
+  vscodeMocks.executeCommand.mockImplementation(
+    async (command: unknown, ...args: unknown[]) => {
+      if (command === 'vscode.diff') {
+        const proposedUri = args[1] as TestUri;
+        vscodeMocks.visibleTextEditors.push({
+          document: { uri: proposedUri },
+          selections: [],
+          revealRange: vi.fn(),
+        });
+      }
+      return undefined;
+    },
+  );
+  storageRoot = await mkdtemp(path.join(tmpdir(), 'texra-native-approval-'));
+});
+
+afterEach(async () => {
+  for (const session of sessions.splice(0)) {
+    session.dispose();
+  }
+  await Promise.allSettled(activeApprovals.splice(0));
+  await rm(storageRoot, { recursive: true, force: true });
+});
+
+describe('native tool edit approval', () => {
+  it('does not accept when the current proposed document cannot be read', async () => {
+    const { approval, requestId, runtimeHost } = await startApproval();
+    await rm(currentProposedUri().fsPath);
+
+    await handleProgressViewToolEditApprovalAction({
+      requestId,
+      action: 'approve',
+    });
+
+    expect(vscodeMocks.showErrorMessage).toHaveBeenCalledOnce();
+    expect(vscodeMocks.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('edited document could not be read'),
+    );
+    expect(runtimeHost.resolved).toHaveLength(0);
+
+    await handleProgressViewToolEditApprovalAction({
+      requestId,
+      action: 'reject',
+    });
+    await expect(approval).resolves.toMatchObject({ accepted: false });
+  });
+
+  it('accepts the current edited document content', async () => {
+    const { approval, requestId, runtimeHost } = await startApproval();
+    const getText = vi.fn(() => 'beta edited\r\n');
+    vscodeMocks.textDocuments.push({
+      uri: currentProposedUri(),
+      getText,
+    });
+
+    await handleProgressViewToolEditApprovalAction({
+      requestId,
+      action: 'approve',
+    });
+
+    await expect(approval).resolves.toMatchObject({
+      accepted: true,
+      appliedContent: 'beta edited\n',
+    });
+    expect(getText).toHaveBeenCalledOnce();
+    expect(vscodeMocks.showErrorMessage).not.toHaveBeenCalled();
+    expect(runtimeHost.resolved).toHaveLength(1);
+  });
+});

--- a/src/test-kernel/hosts/FakeHosts.vitest.ts
+++ b/src/test-kernel/hosts/FakeHosts.vitest.ts
@@ -83,10 +83,7 @@ describe('FakeHosts', () => {
     await hosts.diff.revealFirstChange(session, 12);
     await hosts.diff.closeDiff(session);
 
-    assert.equal(
-      await hosts.diff.readProposedContent(session, 'fallback'),
-      'edited',
-    );
+    assert.equal(await hosts.diff.readProposedContent(session), 'edited');
     assert.deepEqual(hosts.diff.opened, [
       {
         original: { filePath: '/tmp/original.tex' },
@@ -97,5 +94,19 @@ describe('FakeHosts', () => {
     ]);
     assert.deepEqual(hosts.diff.revealed, [{ session, line: 12 }]);
     assert.deepEqual(hosts.diff.closed, [session]);
+  });
+
+  it('fails when proposed diff content is unavailable', async () => {
+    const hosts = createFakeUIHosts();
+    const session = await hosts.diff.openDiff(
+      { filePath: '/tmp/original.tex' },
+      { filePath: '/tmp/missing.tex' },
+      'Changes',
+    );
+
+    await assert.rejects(
+      hosts.diff.readProposedContent(session),
+      /No proposed diff content/,
+    );
   });
 });

--- a/src/test-kernel/support/FakeHosts.ts
+++ b/src/test-kernel/support/FakeHosts.ts
@@ -168,13 +168,14 @@ class FakeDiffViewHost implements DiffViewHost {
     this.revealed.push({ session, line });
   }
 
-  async readProposedContent(
-    session: DiffSession,
-    fallbackContent: string,
-  ): Promise<string> {
-    return (
-      this.proposedContent.get(session.proposed.filePath) ?? fallbackContent
-    );
+  async readProposedContent(session: DiffSession): Promise<string> {
+    const content = this.proposedContent.get(session.proposed.filePath);
+    if (content === undefined) {
+      throw new Error(
+        `No proposed diff content for ${session.proposed.filePath}.`,
+      );
+    }
+    return content;
   }
 
   setProposedContent(filePath: string, content: string): void {


### PR DESCRIPTION
## Summary

- Removes fallback content from the `DiffViewHost.readProposedContent` contract.
- Makes the VS Code diff host fail when the current proposed document cannot be read.
- Reads edited content before acceptance, reports read failures through the existing approval error path, and leaves the same approval pending for retry or rejection.
- Updates the fake diff host and adds regression coverage for failed reads and edited buffer content.

## Root cause

The VS Code diff host swallowed current-document read failures and returned the original `proposedContent`. The approval handler then treated that stale fallback as the user's accepted document, so edits made in the diff editor could be discarded.

## User impact

A failed current-content read can no longer settle an accepted approval. The user receives the existing error notification and the approval remains pending. When the document is readable, the content currently shown in the edited buffer is accepted and returned.

## Checks

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with 46 pre-existing warnings and no warnings in touched files)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/frontend/NativeToolEditApproval.vitest.mts src/test-kernel/hosts/FakeHosts.vitest.ts` (7 tests passed)
- `npm test` (5,766 tests passed, 4 skipped; 652 test files passed, 1 skipped)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-edit acceptance semantics in a user-facing approval path; incorrect behavior could drop edits or leave approvals stuck, though the change is narrowly scoped with regression tests.
> 
> **Overview**
> Removes the **`fallbackContent`** argument from **`DiffViewHost.readProposedContent`** so hosts must return the live proposed document or fail—no silent substitute of the original tool proposal.
> 
> On **approve**, read failures surface via the existing error path and **`restoreProgressViewApprovalPrompt`** re-publishes the same pending request so the user can retry or reject. Accepted approvals require **`appliedContent`** from the diff buffer (with CRLF normalization); **`nativeRequestApproval`** errors if acceptance settles without it.
> 
> **`VscodeDiffViewHost`** drops the filesystem read **`.catch(() => fallback)`**; **`FakeDiffViewHost`** throws when proposed content is missing. New **`NativeToolEditApproval`** tests cover failed reads with prompt restore and successful acceptance from the edited buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b0dc5567c93c75fa3a82c79c9c560acdb8d460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->