### PR TITLE
fix: preserve symlink loop write failures

### DIFF
--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -2,7 +2,15 @@
 // relativeFS JSON, pasted images).
 
 import * as assert from 'node:assert';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { getMimeType } from '@utils/files';
 import * as path from 'node:path';
@@ -107,52 +115,40 @@ describe('pathUtils Test Suite', () => {
 // ---------------------------------------------------------------------------
 
 describe('FlexibleFS.write', () => {
-  it('retries the write after clearing symlink loops', async () => {
-    const originalWrite = AbsoluteFS.write;
-    const originalDelete = AbsoluteFS.delete;
+  it('propagates ELOOP without deleting the path or retrying', async () => {
+    const location = pathToLocation('file.tex');
+    const expectedPath = WorkspaceFS.toAbsolute('file.tex');
+    const cause = new Error('native cause');
+    const loopError = new Error('loop detected', {
+      cause,
+    }) as NodeJS.ErrnoException;
+    loopError.code = 'ELOOP';
+    loopError.path = expectedPath;
 
-    const writes: string[] = [];
-    let deleteTarget: string | undefined;
-    let attempt = 0;
+    const write = vi.spyOn(AbsoluteFS, 'write').mockRejectedValue(loopError);
+    const deletePath = vi.spyOn(AbsoluteFS, 'delete').mockResolvedValue();
 
     try {
-      (AbsoluteFS as unknown as { write: typeof AbsoluteFS.write }).write =
-        (async (target: string, content: string | Uint8Array) => {
-          writes.push(target);
-          attempt += 1;
-          if (attempt === 1) {
-            const error = new Error('loop detected') as NodeJS.ErrnoException;
-            error.code = 'ELOOP';
-            throw error;
-          }
+      await assert.rejects(
+        () => FlexibleFS.write(location, 'content'),
+        (error: unknown) => {
+          assert.strictEqual(error, loopError);
+          assert.strictEqual((error as NodeJS.ErrnoException).code, 'ELOOP');
+          assert.strictEqual(
+            (error as NodeJS.ErrnoException).path,
+            expectedPath,
+          );
+          assert.strictEqual((error as Error).cause, cause);
+          return true;
+        },
+      );
 
-          const resolvedContent =
-            typeof content === 'string'
-              ? content
-              : Buffer.from(content).toString('utf-8');
-          assert.strictEqual(resolvedContent, 'content');
-        }) as typeof AbsoluteFS.write;
-
-      (AbsoluteFS as unknown as { delete: typeof AbsoluteFS.delete }).delete =
-        (async (
-          target: string,
-          options?: { recursive?: boolean; useTrash?: boolean },
-        ) => {
-          deleteTarget = target;
-          assert.deepEqual(options, { recursive: true, useTrash: false });
-        }) as typeof AbsoluteFS.delete;
-
-      const location = pathToLocation('file.tex');
-      const expectedPath = WorkspaceFS.toAbsolute('file.tex');
-      await FlexibleFS.write(location, 'content');
-
-      assert.deepEqual(writes, [expectedPath, expectedPath]);
-      assert.strictEqual(deleteTarget, expectedPath);
+      expect(write).toHaveBeenCalledOnce();
+      expect(write).toHaveBeenCalledWith(expectedPath, 'content');
+      expect(deletePath).not.toHaveBeenCalled();
     } finally {
-      (AbsoluteFS as unknown as { write: typeof AbsoluteFS.write }).write =
-        originalWrite;
-      (AbsoluteFS as unknown as { delete: typeof AbsoluteFS.delete }).delete =
-        originalDelete;
+      write.mockRestore();
+      deletePath.mockRestore();
     }
   });
 });

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -1,12 +1,6 @@
-// Local imports - log
-import * as logger from '@logger/logUtils';
-
 // Local imports - filesystem
 import type { FileLocation } from '@shared/schemas';
 import { AbsoluteFS } from './absoluteFS';
-
-const CHANNEL = 'flexibleFS';
-logger.initialize(CHANNEL);
 
 /**
  * Filesystem operations for FileLocation objects.
@@ -52,33 +46,8 @@ class FlexibleFSImpl {
     return AbsoluteFS.appendFile(target.absolutePath, content);
   }
 
-  async write(
-    target: FileLocation,
-    content: string | Uint8Array,
-  ): Promise<void> {
-    const absolutePath = target.absolutePath;
-
-    try {
-      await AbsoluteFS.write(absolutePath, content);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ELOOP') {
-        throw error;
-      }
-
-      const replacementSize =
-        typeof content === 'string'
-          ? Buffer.byteLength(content, 'utf-8')
-          : content.byteLength;
-      logger.warn(
-        CHANNEL,
-        `Detected circular symlink while writing ${absolutePath}, replaced with file (${replacementSize} bytes)`,
-      );
-      await AbsoluteFS.delete(absolutePath, {
-        recursive: true,
-        useTrash: false,
-      });
-      await AbsoluteFS.write(absolutePath, content);
-    }
+  write(target: FileLocation, content: string | Uint8Array): Promise<void> {
+    return AbsoluteFS.write(target.absolutePath, content);
   }
 
   ensureDir(target: FileLocation): Promise<void> {


### PR DESCRIPTION
## Summary

- Removes the `ELOOP` recovery branch from `FlexibleFS.write`.
- Preserves the original native filesystem rejection, including its `code`, `path`, and `cause`.
- Adds regression coverage requiring one write attempt and no call to `AbsoluteFS.delete`.

## Design

`FlexibleFS.write` is a general write operation, so it should not acquire authority to repair filesystem topology. The former fallback interpreted `ELOOP` as permission to recursively delete the target outside trash and replace it with a regular file. That behavior could destroy a path while hiding the failure that prompted it.

The implementation now delegates directly to `AbsoluteFS.write`. This keeps the write interface narrow and leaves any future repair operation to an explicit API with separately defined authority. No automatic repair operation is introduced here. Direct delegation also returns the native error object unchanged rather than wrapping it and risking loss of diagnostic evidence.

## Verification

- `npm test -- src/test-kernel/utils/files/FilesUtils.vitest.ts` (15 passed)
- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 46 warnings)
- `npm run compile:fast`
- `npm test` (5,763 passed; 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Write failures on symlink loops now surface instead of auto-deleting paths, which may change behavior for callers that relied on the old repair; the change reduces risk of unintended destructive filesystem edits.
> 
> **Overview**
> **`FlexibleFS.write` no longer treats symlink loop (`ELOOP`) as recoverable.** It now forwards straight to `AbsoluteFS.write`, so callers see the native rejection unchanged (`code`, `path`, `cause`) instead of a silent repair.
> 
> The removed behavior logged a warning, **recursively deleted** the target (outside trash), and retried the write—risking destructive changes while masking the underlying filesystem problem. Related logging setup in `flexibleFS.ts` is dropped with that branch.
> 
> Tests now assert **one** write attempt, **no** `AbsoluteFS.delete`, and full error identity preservation (using `vi` spies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d91da05007fbef6a7f279da2d3051e6aeba7de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->