### PR TITLE
fix: preserve invalid persisted flow state

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -17,7 +17,11 @@ import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import {
+  PersistedFlowStateError,
+  flowKey,
+  readPersistedFlowRecord,
+} from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
 import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
@@ -199,7 +203,7 @@ export async function runReflectionFlow<C = unknown>(
   const kv = getExecutionStore(executionId);
 
   try {
-    const flowRecord = await kv.read<FlowRecord>(flowKey(executionId));
+    const flowRecord = await readPersistedFlowRecord(kv, executionId);
     // Boundary hydration: the one place a freshly-read persisted record
     // (possibly written by an older build, hence the legacy todos/plan
     // fallback in AgentWorkspaceStateSnapshotSchema) is parsed. Downstream,
@@ -207,13 +211,17 @@ export async function runReflectionFlow<C = unknown>(
     // ReflectionFlowStateCanonicalSchema instead — see its constructor call
     // below — since by then `shared` is always this run's own canonical
     // toSnapshot() output, never a legacy shape.
-    const validated = flowRecord?.shared
-      ? ReflectionFlowStateSchema.safeParse(flowRecord.shared)
-      : null;
-    const isResume = validated?.success ?? false;
+    const isResume = flowRecord !== null;
 
-    if (validated?.success) {
-      shared = validated.data as ReflectionFlowShared;
+    if (flowRecord) {
+      const validated = ReflectionFlowStateSchema.safeParse(flowRecord.shared);
+      if (!validated.success) {
+        throw new PersistedFlowStateError(executionId, 'invalid-shared', {
+          cause: validated.error,
+        });
+      }
+
+      shared = validated.data;
       shared.modelHandlerCompatibilityKey ??=
         inferPersistedModelHandlerCompatibilityKey(
           config.model,
@@ -225,19 +233,7 @@ export async function runReflectionFlow<C = unknown>(
       logger.debug(
         `Resuming reflection flow from round ${shared.currentRound}/${shared.totalRounds}`,
       );
-    }
-
-    if (!shared) {
-      if (flowRecord) {
-        // A record already exists but its `shared` failed schema validation
-        // (or was missing) — it's stale/corrupt, not resumable. Delete it so
-        // PersistedFlow.ensureRecord() doesn't silently re-adopt the invalid
-        // record instead of the freshly-built `shared` below; otherwise the
-        // very next stepWithResult() would read that same invalid blob and
-        // fail sharedSchema validation again, crashing the run instead of
-        // starting over.
-        await kv.delete(flowKey(executionId));
-      }
+    } else {
       shared = {
         currentRound: 0,
         totalRounds,

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -103,6 +103,18 @@ export type PreparedShared = ToolUseRunShared & {
   stateSlices: StateSlicesSnapshot;
 };
 
+export type SharedStateMigrationResult =
+  | { success: true; data: ToolUseRunShared; migrated: boolean }
+  | { success: false; error: z.ZodError };
+
+function failedSharedMigration(value: unknown): SharedStateMigrationResult {
+  const result = ToolUseRunSharedSchema.safeParse(value);
+  if (result.success) {
+    throw new Error('Expected invalid tool-use shared state');
+  }
+  return result;
+}
+
 export function findLastAssistantText(
   messages: ProviderMessage[],
   extractAssistantText: (message: ProviderMessage) => string | undefined,
@@ -128,21 +140,25 @@ export function assertPreparedShared(
  */
 export function migrateSharedState(
   shared: unknown,
-): { data: ToolUseRunShared; migrated: boolean } | null {
-  if (!shared || typeof shared !== 'object') return null;
+): SharedStateMigrationResult {
+  if (!shared || typeof shared !== 'object') {
+    return failedSharedMigration(shared);
+  }
 
   // Unwrap nested `{ state: {...} }` wrapper if present. The unwrap itself
   // counts as a migration even if the inner shape is already canonical.
   const nested = 'state' in shared;
   const obj = nested ? (shared as Record<string, unknown>).state : shared;
-  if (!obj || typeof obj !== 'object') return null;
+  if (!obj || typeof obj !== 'object') return failedSharedMigration(obj);
 
   const record = obj as Record<string, unknown>;
   const messages = ProviderMessageArraySchema.safeParse(record.messages);
   const conversation = ProviderMessageArraySchema.safeParse(
     record.conversation,
   );
-  if (!messages.success && !conversation.success) return null;
+  if (!messages.success && !conversation.success) {
+    return failedSharedMigration(obj);
+  }
 
   const { conversation: _legacyConversation, ...candidate } = record;
   let migrated = nested;
@@ -154,9 +170,10 @@ export function migrateSharedState(
   }
 
   const parsed = ToolUseRunSharedSchema.safeParse(candidate);
-  if (!parsed.success) return null;
+  if (!parsed.success) return parsed;
 
   return {
+    success: true,
     data: parsed.data,
     migrated: migrated || !isDeepStrictEqual(candidate, parsed.data),
   };

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -389,8 +389,10 @@ export async function runToolUseFlow<C = unknown>(
     if (flowRecord) {
       logger.debug('Resuming tool-use flow from persistence');
       const migrationResult = migrateSharedState(flowRecord.shared);
-      if (migrationResult === null) {
-        throw new PersistedFlowStateError(executionId, 'invalid-shared');
+      if (!migrationResult.success) {
+        throw new PersistedFlowStateError(executionId, 'invalid-shared', {
+          cause: migrationResult.error,
+        });
       } else if (input.resumeSnapshot) {
         // The resume boundary (SessionResumeRetrieval.retrieveToolUseResumeData)
         // already migrated this record's legacy shapes and strictly validated
@@ -557,7 +559,9 @@ export async function runToolUseFlow<C = unknown>(
       preservationReason =
         'Flow record preserved for resume after retry cancellation';
     }
-    const preserveSessionState = preservationReason !== undefined;
+    const preserveFlowRecord = preservationReason !== undefined;
+    const preserveFollowUpQueue =
+      preserveFlowRecord && !persistenceRecoveryPending;
 
     if (preservationReason) {
       logger.debug(preservationReason);
@@ -569,15 +573,14 @@ export async function runToolUseFlow<C = unknown>(
       }
     }
 
-    // Every path that preserves the resumable flow record also preserves its
-    // follow-up queue. In particular, persistence recovery can fail after
-    // resume setup has already requeued input; releasing the queue here would
-    // discard that input while retaining only the flow record.
+    // Recovery failures preserve the unread record but release the rebuilt
+    // live queue. The resume wrapper owns the drained batch and restores it
+    // after rejection; retaining both copies here would replay it twice.
     //
     // WAITING retains its existing stronger property: the live lifecycle
     // remains attached to the queue so a racing follow-up, a genuine kill,
     // or the next resume observes the same queue instance.
-    if (!preserveSessionState) {
+    if (!preserveFollowUpQueue) {
       sessionLifecycle.dispose();
     }
     runSession.interactions.cancel({ streamId, cause: 'Run ended.' });

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -18,9 +18,10 @@ import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   PersistedFlow,
+  PersistedFlowStateError,
   flowKey,
+  readPersistedFlowRecord,
   stampFlowRecordSchemaVersion,
-  type FlowRecord,
 } from '@agent/node/persistedFlow';
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
@@ -42,7 +43,6 @@ import type { SubagentProgressUpdate } from '@shared/schemas';
 // Local imports - tools and flow
 import { getDefaultToolRegistry } from '@tools/registry';
 import { TaskRunFileService } from '@utils/files';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
@@ -351,6 +351,7 @@ export async function runToolUseFlow<C = unknown>(
   let totalCostUsd: number | undefined;
   let teardownSetup: (() => void) | undefined;
   let preserveResumeRecord = false;
+  let persistenceRecoveryComplete = false;
   const compatibilityKey = activeModelHandlerCompatibilityKey(
     services.modelHandler,
   );
@@ -371,17 +372,7 @@ export async function runToolUseFlow<C = unknown>(
       return { outcome };
     }
 
-    let flowRecord: FlowRecord | null = null;
-    try {
-      flowRecord = (await kv.read<FlowRecord>(flowKey(executionId))) ?? null;
-    } catch (error) {
-      // A failed read here silently converts a resume into an empty-history
-      // fresh run -- as loud as the adjacent migration-failure warning below,
-      // so it is visible instead of vanishing into debug output.
-      logger.warn('Resume parse failed, starting fresh', {
-        data: { executionId, error: toErrorMessage(error) },
-      });
-    }
+    const flowRecord = await readPersistedFlowRecord(kv, executionId);
     // Cancellation can also arrive while the recovery read is pending. Do not
     // start a migration or repair write after that handoff.
     if (input.checkInterruption()) {
@@ -393,13 +384,11 @@ export async function runToolUseFlow<C = unknown>(
     // queue clear instead of the resume-startup rescue above.
     inResumeStartupWindow = false;
 
-    if (flowRecord?.shared) {
+    if (flowRecord) {
       logger.debug('Resuming tool-use flow from persistence');
       const migrationResult = migrateSharedState(flowRecord.shared);
       if (migrationResult === null) {
-        logger.warn('Failed to parse flow record shared state, starting fresh');
-        await kv.delete(flowKey(executionId));
-        flowRecord = null;
+        throw new PersistedFlowStateError(executionId, 'invalid-shared');
       } else if (input.resumeSnapshot) {
         // The resume boundary (SessionResumeRetrieval.retrieveToolUseResumeData)
         // already migrated this record's legacy shapes and strictly validated
@@ -473,6 +462,9 @@ export async function runToolUseFlow<C = unknown>(
         }
       }
     }
+    // Cleanup may delete a terminal flow record only after absence was
+    // confirmed or a present record passed its migration boundary.
+    persistenceRecoveryComplete = true;
 
     const prepareNode = new ToolUsePrepareNode<C>();
     const cycleNode = new ToolUseCycleNode<C>();
@@ -552,6 +544,8 @@ export async function runToolUseFlow<C = unknown>(
     teardownSetup = undefined;
     if (preserveResumeRecord) {
       logger.debug('Flow record preserved after resume startup cancellation');
+    } else if (!persistenceRecoveryComplete) {
+      logger.debug('Flow record preserved after persistence recovery failure');
     } else if (outcome === STREAM_PHASE.WAITING) {
       logger.debug('Flow record preserved for native subagent WAITING');
     } else if (shared.userCancelledRetry) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -542,14 +542,23 @@ export async function runToolUseFlow<C = unknown>(
     activePersistedFlow = undefined;
     teardownSetup?.();
     teardownSetup = undefined;
+    let preservationReason: string | undefined;
     if (preserveResumeRecord) {
-      logger.debug('Flow record preserved after resume startup cancellation');
+      preservationReason =
+        'Flow record preserved after resume startup cancellation';
     } else if (!persistenceRecoveryComplete) {
-      logger.debug('Flow record preserved after persistence recovery failure');
+      preservationReason =
+        'Flow record preserved after persistence recovery failure';
     } else if (outcome === STREAM_PHASE.WAITING) {
-      logger.debug('Flow record preserved for native subagent WAITING');
+      preservationReason = 'Flow record preserved for native subagent WAITING';
     } else if (shared.userCancelledRetry) {
-      logger.debug('Flow record preserved for resume after retry cancellation');
+      preservationReason =
+        'Flow record preserved for resume after retry cancellation';
+    }
+    const preserveSessionState = preservationReason !== undefined;
+
+    if (preservationReason) {
+      logger.debug(preservationReason);
     } else {
       try {
         await kv.delete(flowKey(executionId));
@@ -558,26 +567,15 @@ export async function runToolUseFlow<C = unknown>(
       }
     }
 
-    // WAITING outcome: leave the follow-up queue live, matching the flow
-    // record preserved above. A delegate_agent follow-up can race into it via
-    // sendFollowUp's 'active' branch between the WAITING transition inside
-    // ToolUseWaitNode and this teardown — the tool-use flow context detaches
-    // above, but the stream doesn't leave WAITING until resume, so the same
-    // live queue instance is what a genuine kill (see ExecutionRegistry.
-    // terminate's waiting-cleanup path) or resume drains instead of a
-    // `dispose()` here silently discarding it.
+    // Every path that preserves the resumable flow record also preserves its
+    // follow-up queue. In particular, persistence recovery can fail after
+    // resume setup has already requeued input; releasing the queue here would
+    // discard that input while retaining only the flow record.
     //
-    // Resume-startup cancellation (preserveResumeRecord): a resume's
-    // setupSession re-appends its drained follow-up batch into this same
-    // live queue before the flow is interruptible. `flowContext.interrupt()`
-    // uses `sessionLifecycle.interruptPreservingQueue()` instead of
-    // `interrupt()` for exactly this window (see its call site above), so
-    // that batch survives a cancellation landing while the recovery read is
-    // pending. Skipping `dispose()`/release here too keeps it intact for the
-    // next `resumeQueuedToolUseSnapshot` call's `drainItems()` instead of
-    // discarding the user's queued input alongside the preserved flow
-    // record.
-    if (outcome !== STREAM_PHASE.WAITING && !preserveResumeRecord) {
+    // WAITING retains its existing stronger property: the live lifecycle
+    // remains attached to the queue so a racing follow-up, a genuine kill,
+    // or the next resume observes the same queue instance.
+    if (!preserveSessionState) {
       sessionLifecycle.dispose();
     }
     runSession.interactions.cancel({ streamId, cause: 'Run ended.' });

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -351,7 +351,7 @@ export async function runToolUseFlow<C = unknown>(
   let totalCostUsd: number | undefined;
   let teardownSetup: (() => void) | undefined;
   let preserveResumeRecord = false;
-  let persistenceRecoveryComplete = false;
+  let persistenceRecoveryPending = false;
   const compatibilityKey = activeModelHandlerCompatibilityKey(
     services.modelHandler,
   );
@@ -372,10 +372,12 @@ export async function runToolUseFlow<C = unknown>(
       return { outcome };
     }
 
+    persistenceRecoveryPending = true;
     const flowRecord = await readPersistedFlowRecord(kv, executionId);
     // Cancellation can also arrive while the recovery read is pending. Do not
     // start a migration or repair write after that handoff.
     if (input.checkInterruption()) {
+      persistenceRecoveryPending = false;
       preserveResumeRecord = input.resumeSnapshot !== undefined;
       return { outcome };
     }
@@ -464,7 +466,7 @@ export async function runToolUseFlow<C = unknown>(
     }
     // Cleanup may delete a terminal flow record only after absence was
     // confirmed or a present record passed its migration boundary.
-    persistenceRecoveryComplete = true;
+    persistenceRecoveryPending = false;
 
     const prepareNode = new ToolUsePrepareNode<C>();
     const cycleNode = new ToolUseCycleNode<C>();
@@ -546,7 +548,7 @@ export async function runToolUseFlow<C = unknown>(
     if (preserveResumeRecord) {
       preservationReason =
         'Flow record preserved after resume startup cancellation';
-    } else if (!persistenceRecoveryComplete) {
+    } else if (persistenceRecoveryPending) {
       preservationReason =
         'Flow record preserved after persistence recovery failure';
     } else if (outcome === STREAM_PHASE.WAITING) {

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -1,6 +1,8 @@
 // Based on https://github.com/Yuyz0112/koala-code-reader/blob/main/src/code-reader/persisted-flow.ts
 // Enhanced to use ExecutionKVStore as first-citizen interface
 
+import { z } from 'zod';
+
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
@@ -8,7 +10,6 @@ import * as logger from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { BaseNode, Flow, type Action } from '.';
-import type { z } from 'zod';
 
 /** Prefix for a flow record's KV key. Single source of truth for callers deriving it. */
 export const FLOW_KEY_PREFIX = 'flow_';
@@ -56,6 +57,47 @@ export interface FlowRecord {
   nodes: NodeRecord[];
 }
 
+const PersistedFlowNodeRecordSchema = z.looseObject({
+  action: z.string().optional(),
+  nodeId: z.string().optional(),
+});
+
+const PersistedFlowCursorSchema = z.looseObject({
+  nextNodeId: z.string().nullable(),
+  lastAction: z.string().optional(),
+});
+
+const PersistedFlowRecordObjectSchema = z.looseObject({
+  schemaVersion: z.int().min(1).max(FLOW_RECORD_SCHEMA_VERSION).optional(),
+  flowName: z.string(),
+  params: z.record(z.string(), z.unknown()).optional(),
+  shared: z.unknown(),
+  createdAt: z.string(),
+  cursor: PersistedFlowCursorSchema.optional(),
+  nodes: z.array(PersistedFlowNodeRecordSchema),
+});
+
+/**
+ * Runtime envelope shared by flow recovery and resume eligibility. The first
+ * stage checks the raw input so an inherited or parser-invented `shared` key
+ * cannot satisfy the persisted own-property contract.
+ */
+export const PersistedFlowRecordEnvelopeSchema = z
+  .unknown()
+  .refine(
+    (stored) =>
+      typeof stored === 'object' &&
+      stored !== null &&
+      !Array.isArray(stored) &&
+      Object.hasOwn(stored, 'shared'),
+    { message: 'Flow record must be an object with an own shared field' },
+  )
+  .pipe(PersistedFlowRecordObjectSchema)
+  .transform((record): FlowRecord => ({
+    ...record,
+    shared: record.shared,
+  }));
+
 export type PersistedFlowStateErrorReason =
   'read-failed' | 'unsupported-record' | 'missing-shared' | 'invalid-shared';
 
@@ -100,14 +142,21 @@ export async function readPersistedFlowRecord(
   }
 
   if (stored === undefined) return null;
-  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) {
-    throw new PersistedFlowStateError(runId, 'unsupported-record');
-  }
-  if (!Object.hasOwn(stored, 'shared')) {
-    throw new PersistedFlowStateError(runId, 'missing-shared');
+  const parsed = PersistedFlowRecordEnvelopeSchema.safeParse(stored);
+  if (!parsed.success) {
+    const missingShared =
+      typeof stored === 'object' &&
+      stored !== null &&
+      !Array.isArray(stored) &&
+      !Object.hasOwn(stored, 'shared');
+    throw new PersistedFlowStateError(
+      runId,
+      missingShared ? 'missing-shared' : 'unsupported-record',
+      { cause: parsed.error },
+    );
   }
 
-  return stored as FlowRecord;
+  return parsed.data;
 }
 
 export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -56,6 +56,60 @@ export interface FlowRecord {
   nodes: NodeRecord[];
 }
 
+export type PersistedFlowStateErrorReason =
+  'read-failed' | 'unsupported-record' | 'missing-shared' | 'invalid-shared';
+
+/** Persisted flow state cannot be read or resumed safely. */
+export class PersistedFlowStateError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly reason: PersistedFlowStateErrorReason,
+    options?: ErrorOptions,
+  ) {
+    const message = (() => {
+      switch (reason) {
+        case 'read-failed':
+          return `Failed to read persisted flow state for run "${runId}".`;
+        case 'unsupported-record':
+          return `Persisted flow state for run "${runId}" has an unsupported record format.`;
+        case 'missing-shared':
+          return `Persisted flow state for run "${runId}" is missing its shared state.`;
+        case 'invalid-shared':
+          return `Persisted shared state for flow run "${runId}" is invalid.`;
+      }
+    })();
+    super(message, options);
+    this.name = 'PersistedFlowStateError';
+  }
+}
+
+/**
+ * Read a flow record without conflating a stored unsupported value with an
+ * absent key. Flow-specific callers remain responsible for migrating and
+ * validating `shared`.
+ */
+export async function readPersistedFlowRecord(
+  kv: ExecutionKVStore,
+  runId: string,
+): Promise<FlowRecord | null> {
+  let stored: unknown;
+  try {
+    stored = await kv.read<unknown>(flowKey(runId));
+  } catch (cause) {
+    throw new PersistedFlowStateError(runId, 'read-failed', { cause });
+  }
+
+  if (stored === undefined) return null;
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) {
+    throw new PersistedFlowStateError(runId, 'unsupported-record');
+  }
+  if (!Object.hasOwn(stored, 'shared')) {
+    throw new PersistedFlowStateError(runId, 'missing-shared');
+  }
+
+  return stored as FlowRecord;
+}
+
 export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
   flow.schemaVersion = FLOW_RECORD_SCHEMA_VERSION;
   return flow;

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -1,14 +1,18 @@
 // Based on https://github.com/Yuyz0112/koala-code-reader/blob/main/src/code-reader/persisted-flow.ts
 // Enhanced to use ExecutionKVStore as first-citizen interface
 
+// Third-party imports
 import { z } from 'zod';
 
+// Local imports - agent
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
-
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+
+// Local imports - utilities
 import * as logger from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+// Local imports - flow engine
 import { BaseNode, Flow, type Action } from '.';
 
 /** Prefix for a flow record's KV key. Single source of truth for callers deriving it. */
@@ -92,11 +96,7 @@ export const PersistedFlowRecordEnvelopeSchema = z
       Object.hasOwn(stored, 'shared'),
     { message: 'Flow record must be an object with an own shared field' },
   )
-  .pipe(PersistedFlowRecordObjectSchema)
-  .transform((record): FlowRecord => ({
-    ...record,
-    shared: record.shared,
-  }));
+  .pipe(PersistedFlowRecordObjectSchema);
 
 export type PersistedFlowStateErrorReason =
   'read-failed' | 'unsupported-record' | 'missing-shared' | 'invalid-shared';

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -159,9 +159,12 @@ async function retrieveToolUseResumeData(
     const { flowRecord } = resumability;
 
     const migrationResult = migrateSharedState(flowRecord.shared);
-    if (migrationResult === null) {
+    if (!migrationResult.success) {
       logger.warn(
         `Invalid flow record structure for execution: ${executionId}`,
+        {
+          data: { error: migrationResult.error },
+        },
       );
       return null;
     }

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
-import { flowKey } from '@agent/node/persistedFlow';
-import type { FlowRecord } from '@agent/node/persistedFlow';
+import {
+  PersistedFlowRecordEnvelopeSchema,
+  flowKey,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
 import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
@@ -19,15 +22,14 @@ import {
 
 const CHANNEL = 'Resumability';
 
-const ResumableFlowRecordSchema = z.looseObject({
-  flowName: z.string(),
-  // Legacy records carry an (always-empty) params bag; new records omit it
-  // entirely after the params channel was deleted (#7691).
-  params: z.record(z.string(), z.unknown()).optional(),
-  shared: z.record(z.string(), z.unknown()),
-  createdAt: z.string(),
-  nodes: z.array(z.looseObject({ action: z.string().optional() })),
-});
+const ResumableSharedSchema = z.record(z.string(), z.unknown());
+const ResumableFlowRecordSchema = PersistedFlowRecordEnvelopeSchema.refine(
+  (record) => ResumableSharedSchema.safeParse(record.shared).success,
+  {
+    message: 'Resumable flow shared state must be an object',
+    path: ['shared'],
+  },
+);
 
 export const RESUMABILITY_CAUSE = {
   INTERRUPTED_WITH_FLOW: 'interrupted-with-flow',
@@ -155,7 +157,7 @@ export async function deriveResumability(
     };
   }
 
-  if (rawFlowRecord == null) {
+  if (rawFlowRecord === undefined) {
     return {
       resumable: false,
       cause: RESUMABILITY_CAUSE.MISSING_FLOW,
@@ -179,7 +181,7 @@ export async function deriveResumability(
       meta?.terminalStatus === EXECUTION_STATUS.INTERRUPTED
         ? RESUMABILITY_CAUSE.INTERRUPTED_WITH_FLOW
         : RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
-    flowRecord: flowResult.data as FlowRecord,
+    flowRecord: flowResult.data,
     ...metaFields,
   };
 }

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -1,8 +1,9 @@
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
 import { setupPlatform } from '@test/support/setupPlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
 
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
@@ -29,7 +30,6 @@ import { ReflectionFlowStateCanonicalSchema } from '@agent/implementations/flows
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   RUN_OUTCOME,
   type ExecutionId,
@@ -75,7 +75,7 @@ async function runPersistedReflectionFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
 ): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
-  const session = new SessionHandle();
+  const session = createTestSession();
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => CONFIG.model,
@@ -112,6 +112,16 @@ async function runPersistedReflectionFlow(
   }
 }
 
+function recoveryCase(name: string) {
+  const executionId = `reflection-flow-${name}` as ExecutionId;
+  const streamId = `workflow@gpt54#reflection-flow-${name}` as StreamTabId;
+  return {
+    key: flowKey(executionId),
+    run: () => runPersistedReflectionFlow(executionId, streamId),
+    store: getExecutionStore(executionId),
+  };
+}
+
 function flowRecord(shared: unknown): FlowRecord {
   return {
     flowName: 'texra',
@@ -140,17 +150,15 @@ function validReflectionShared(): unknown {
 
 describe('runReflectionFlow persisted-state recovery', () => {
   setupPlatform({ workspacePath: '/workspace' });
+  afterEach(() => vi.restoreAllMocks());
 
   it('creates fresh shared state when the flow record is absent', async () => {
-    const executionId = 'reflection-flow-absent' as ExecutionId;
-    const streamId = 'workflow@gpt54#reflection-flow-absent' as StreamTabId;
+    const { key, run, store } = recoveryCase('absent');
 
-    const result = await runPersistedReflectionFlow(executionId, streamId);
+    const result = await run();
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-    const stored = await getExecutionStore(executionId).read<FlowRecord>(
-      flowKey(executionId),
-    );
+    const stored = await store.read<FlowRecord>(key);
     expect(
       ReflectionFlowStateCanonicalSchema.parse(stored?.shared),
     ).toMatchObject({
@@ -162,27 +170,17 @@ describe('runReflectionFlow persisted-state recovery', () => {
   });
 
   it('propagates a persistence read failure without deleting the flow record', async () => {
-    const executionId = 'reflection-flow-read-failure' as ExecutionId;
-    const streamId =
-      'workflow@gpt54#reflection-flow-read-failure' as StreamTabId;
-    const store = getExecutionStore(executionId);
+    const { run, store } = recoveryCase('read-failure');
     const readFailure = new Error('flow storage unavailable');
-    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
+    vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
     const deleteSpy = vi.spyOn(store, 'delete');
 
-    try {
-      await expect(
-        runPersistedReflectionFlow(executionId, streamId),
-      ).rejects.toMatchObject({
-        name: PersistedFlowStateError.name,
-        reason: 'read-failed',
-        cause: readFailure,
-      });
-      expect(deleteSpy).not.toHaveBeenCalled();
-    } finally {
-      readSpy.mockRestore();
-      deleteSpy.mockRestore();
-    }
+    await expect(run()).rejects.toMatchObject({
+      name: PersistedFlowStateError.name,
+      reason: 'read-failed',
+      cause: readFailure,
+    });
+    expect(deleteSpy).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -223,33 +221,21 @@ describe('runReflectionFlow persisted-state recovery', () => {
       },
     },
   ])('rejects and preserves $name', async ({ name, reason, stored }) => {
-    const slug = name.replaceAll(' ', '-');
-    const executionId = `reflection-flow-${slug}` as ExecutionId;
-    const streamId = `workflow@gpt54#reflection-flow-${slug}` as StreamTabId;
-    const store = getExecutionStore(executionId);
-    await store.write(flowKey(executionId), stored);
+    const { key, run, store } = recoveryCase(name.replaceAll(' ', '-'));
+    await store.write(key, stored);
     const deleteSpy = vi.spyOn(store, 'delete');
 
-    try {
-      const expectedError = {
-        name: PersistedFlowStateError.name,
-        reason,
-        cause: expect.objectContaining({ name: 'ZodError' }),
-      };
-      await expect(
-        runPersistedReflectionFlow(executionId, streamId),
-      ).rejects.toMatchObject(expectedError);
-      expect(deleteSpy).not.toHaveBeenCalled();
-      expect(await store.read(flowKey(executionId))).toEqual(stored);
-    } finally {
-      deleteSpy.mockRestore();
-    }
+    await expect(run()).rejects.toMatchObject({
+      name: PersistedFlowStateError.name,
+      reason,
+      cause: expect.objectContaining({ name: 'ZodError' }),
+    });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(await store.read(key)).toEqual(stored);
   });
 
   it('migrates a valid legacy workspace snapshot before canonical writes', async () => {
-    const executionId = 'reflection-flow-legacy-workspace' as ExecutionId;
-    const streamId =
-      'workflow@gpt54#reflection-flow-legacy-workspace' as StreamTabId;
+    const { key, run, store } = recoveryCase('legacy-workspace');
     const todo = {
       content: 'Preserve legacy workflow state',
       status: 'in_progress' as const,
@@ -268,13 +254,12 @@ describe('runReflectionFlow persisted-state recovery', () => {
       continueRounds: true,
       endTurn: false,
     };
-    const store = getExecutionStore(executionId);
-    await store.write(flowKey(executionId), flowRecord(legacyShared));
+    await store.write(key, flowRecord(legacyShared));
 
-    const result = await runPersistedReflectionFlow(executionId, streamId);
+    const result = await run();
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-    const stored = await store.read<FlowRecord>(flowKey(executionId));
+    const stored = await store.read<FlowRecord>(key);
     const shared = ReflectionFlowStateCanonicalSchema.parse(stored?.shared);
     expect(shared.workspaceSnapshot.workPlan.todos).toEqual([todo]);
     expect(Object.hasOwn(shared.workspaceSnapshot, 'todos')).toBe(false);

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -14,7 +14,9 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
+  FLOW_RECORD_SCHEMA_VERSION,
   PersistedFlowStateError,
   flowKey,
   type FlowRecord,
@@ -120,6 +122,22 @@ function flowRecord(shared: unknown): FlowRecord {
   };
 }
 
+function validReflectionShared(): unknown {
+  return {
+    currentRound: 0,
+    totalRounds: 1,
+    workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
+    context: null,
+    outputLocation: null,
+    conversation: [],
+    runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+    roundStateSnapshots: [],
+    roundOutputs: [],
+    continueRounds: true,
+    endTurn: false,
+  };
+}
+
 describe('runReflectionFlow persisted-state recovery', () => {
   setupPlatform({ workspacePath: '/workspace' });
 
@@ -187,6 +205,23 @@ describe('runReflectionFlow persisted-state recovery', () => {
       reason: 'unsupported-record',
       stored: null,
     },
+    {
+      name: 'valid shared state without nodes',
+      reason: 'unsupported-record',
+      stored: {
+        flowName: 'texra',
+        shared: validReflectionShared(),
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    },
+    {
+      name: 'future envelope schema version',
+      reason: 'unsupported-record',
+      stored: {
+        ...flowRecord(validReflectionShared()),
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION + 1,
+      },
+    },
   ])('rejects and preserves $name', async ({ name, reason, stored }) => {
     const slug = name.replaceAll(' ', '-');
     const executionId = `reflection-flow-${slug}` as ExecutionId;
@@ -196,12 +231,14 @@ describe('runReflectionFlow persisted-state recovery', () => {
     const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
-      await expect(
-        runPersistedReflectionFlow(executionId, streamId),
-      ).rejects.toMatchObject({
+      const expectedError = {
         name: PersistedFlowStateError.name,
         reason,
-      });
+        cause: expect.objectContaining({ name: 'ZodError' }),
+      };
+      await expect(
+        runPersistedReflectionFlow(executionId, streamId),
+      ).rejects.toMatchObject(expectedError);
       expect(deleteSpy).not.toHaveBeenCalled();
       expect(await store.read(flowKey(executionId))).toEqual(stored);
     } finally {

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -1,0 +1,245 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - test support
+import { setupPlatform } from '@test/support/setupPlatform';
+
+// Local imports - agent
+import { getExecutionStore } from '@agent/storage';
+import { noopTrace } from '@agent/trace';
+import {
+  AgentCategory,
+  AgentPromptSchema,
+  AgentWorkflowSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
+import {
+  PersistedFlowStateError,
+  flowKey,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
+import {
+  runReflectionFlow,
+  type RunReflectionFlowInput,
+} from '@agent/implementations/flows/reflection/runReflectionFlow';
+import { ReflectionFlowStateCanonicalSchema } from '@agent/implementations/flows/reflection/ReflectionFlowState';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type StorageKey,
+  type StreamTabId,
+} from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+const CONFIG: AgentConfig = {
+  inputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  outputFiles: [],
+  editedFile: null,
+  agent: 'reflection-test',
+  model: 'gpt54',
+  instruction: 'Continue.',
+  agentCategory: AgentCategory.Workflow,
+  editedFiles: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+  memories: [],
+  workingDirectory: '/workspace',
+  cliOutputFile: null,
+  cliMultiAgentPresetId: null,
+};
+const SETTING = AgentWorkflowSettingSchema.parse({ rounds: 1 });
+const PROMPT = AgentPromptSchema.parse({ userRequest: 'Start the workflow.' });
+const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
+
+function createModelHandler(): RunReflectionFlowInput['modelHandler'] {
+  const handler = {
+    initializeMessages: async (_prefix: string, request: string) => [
+      { role: 'user' as const, content: request },
+    ],
+  };
+  Object.defineProperty(handler, '__texraModelHandlerCompatibilityKey', {
+    value: ACTIVE_COMPATIBILITY_KEY,
+  });
+  return handler as unknown as RunReflectionFlowInput['modelHandler'];
+}
+
+async function runPersistedReflectionFlow(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
+  const session = new SessionHandle();
+  const context = createRunContext({
+    modelSource: 'live',
+    getModel: () => CONFIG.model,
+    runScope: createRunScope({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId,
+      executionId,
+      agentName: CONFIG.agent,
+      session,
+    }),
+  });
+
+  try {
+    return await withRunContext(context, () =>
+      runReflectionFlow({
+        config: CONFIG,
+        setting: SETTING,
+        prompt: PROMPT,
+        logger: noopTrace,
+        storageKey: executionId as StorageKey,
+        parentStage: noopTrace.openStage('Reflection flow recovery test'),
+        userVarChannels: {
+          input: Object.freeze({ MODEL: CONFIG.model }),
+          transient: {},
+        },
+        modelHandler: createModelHandler(),
+        streamStatus: session.status,
+        checkInterruption: () => true,
+        setAbortController: () => {},
+      }),
+    );
+  } finally {
+    session.dispose();
+  }
+}
+
+function flowRecord(shared: unknown): FlowRecord {
+  return {
+    flowName: 'texra',
+    shared,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    cursor: { nextNodeId: null },
+    nodes: [],
+  };
+}
+
+describe('runReflectionFlow persisted-state recovery', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  it('creates fresh shared state when the flow record is absent', async () => {
+    const executionId = 'reflection-flow-absent' as ExecutionId;
+    const streamId = 'workflow@gpt54#reflection-flow-absent' as StreamTabId;
+
+    const result = await runPersistedReflectionFlow(executionId, streamId);
+
+    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+    const stored = await getExecutionStore(executionId).read<FlowRecord>(
+      flowKey(executionId),
+    );
+    expect(
+      ReflectionFlowStateCanonicalSchema.parse(stored?.shared),
+    ).toMatchObject({
+      currentRound: 0,
+      totalRounds: 1,
+      conversation: [],
+      modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
+    });
+  });
+
+  it('propagates a persistence read failure without deleting the flow record', async () => {
+    const executionId = 'reflection-flow-read-failure' as ExecutionId;
+    const streamId =
+      'workflow@gpt54#reflection-flow-read-failure' as StreamTabId;
+    const store = getExecutionStore(executionId);
+    const readFailure = new Error('flow storage unavailable');
+    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
+    const deleteSpy = vi.spyOn(store, 'delete');
+
+    try {
+      await expect(
+        runPersistedReflectionFlow(executionId, streamId),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason: 'read-failed',
+        cause: readFailure,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      deleteSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      name: 'invalid shared state',
+      reason: 'invalid-shared',
+      stored: flowRecord({ currentRound: 'zero' }),
+    },
+    {
+      name: 'missing shared state',
+      reason: 'missing-shared',
+      stored: {
+        flowName: 'texra',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        nodes: [],
+      },
+    },
+    {
+      name: 'unsupported null record',
+      reason: 'unsupported-record',
+      stored: null,
+    },
+  ])('rejects and preserves $name', async ({ name, reason, stored }) => {
+    const slug = name.replaceAll(' ', '-');
+    const executionId = `reflection-flow-${slug}` as ExecutionId;
+    const streamId = `workflow@gpt54#reflection-flow-${slug}` as StreamTabId;
+    const store = getExecutionStore(executionId);
+    await store.write(flowKey(executionId), stored);
+    const deleteSpy = vi.spyOn(store, 'delete');
+
+    try {
+      await expect(
+        runPersistedReflectionFlow(executionId, streamId),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(await store.read(flowKey(executionId))).toEqual(stored);
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
+  it('migrates a valid legacy workspace snapshot before canonical writes', async () => {
+    const executionId = 'reflection-flow-legacy-workspace' as ExecutionId;
+    const streamId =
+      'workflow@gpt54#reflection-flow-legacy-workspace' as StreamTabId;
+    const todo = {
+      content: 'Preserve legacy workflow state',
+      status: 'in_progress' as const,
+      activeForm: 'Preserving legacy workflow state',
+    };
+    const legacyShared = {
+      currentRound: 0,
+      totalRounds: 2,
+      workspaceSnapshot: { todos: { todos: [todo] } },
+      context: null,
+      outputLocation: null,
+      conversation: [],
+      runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+      roundStateSnapshots: [],
+      roundOutputs: [],
+      continueRounds: true,
+      endTurn: false,
+    };
+    const store = getExecutionStore(executionId);
+    await store.write(flowKey(executionId), flowRecord(legacyShared));
+
+    const result = await runPersistedReflectionFlow(executionId, streamId);
+
+    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+    const stored = await store.read<FlowRecord>(flowKey(executionId));
+    const shared = ReflectionFlowStateCanonicalSchema.parse(stored?.shared);
+    expect(shared.workspaceSnapshot.workPlan.todos).toEqual([todo]);
+    expect(Object.hasOwn(shared.workspaceSnapshot, 'todos')).toBe(false);
+  });
+});

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -15,7 +15,11 @@ import {
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import {
+  PersistedFlowStateError,
+  flowKey,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
@@ -519,6 +523,105 @@ describe('retrieveSessionResumeData', () => {
 describe('runToolUseFlow consumes the resume boundary instead of re-parsing', () => {
   setupPlatform({ workspacePath: '/workspace' });
 
+  it('creates fresh shared state when the flow record is absent', async () => {
+    const executionId = 'abc-flow-absent' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-absent' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+
+    const result = await runPersistedFlow(executionId, streamId, snapshot);
+
+    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+    const stored = await getExecutionStore(executionId).read<FlowRecord>(
+      flowKey(executionId),
+    );
+    expect(ToolUseRunSharedCanonicalSchema.parse(stored?.shared)).toMatchObject(
+      {
+        messages: snapshot.messages,
+        stateSlices: {
+          runStateSnapshot: snapshot.run,
+          workspaceSnapshot: snapshot.workspace,
+          userChannels: snapshot.user,
+        },
+      },
+    );
+  });
+
+  it('propagates a persistence read failure without deleting the flow record', async () => {
+    const executionId = 'abc-flow-read-failure' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-read-failure' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    const readFailure = new Error('flow storage unavailable');
+    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
+    const deleteSpy = vi.spyOn(store, 'delete');
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason: 'read-failed',
+        cause: readFailure,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+      deleteSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      name: 'invalid shared state',
+      reason: 'invalid-shared',
+      stored: {
+        flowName: 'texra',
+        shared: {
+          messages: [],
+          shouldSkipCycle: 'false',
+          stateSlices: null,
+        },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        nodes: [],
+      },
+    },
+    {
+      name: 'missing shared state',
+      reason: 'missing-shared',
+      stored: {
+        flowName: 'texra',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        nodes: [],
+      },
+    },
+    {
+      name: 'unsupported null record',
+      reason: 'unsupported-record',
+      stored: null,
+    },
+  ])('rejects and preserves $name', async ({ name, reason, stored }) => {
+    const slug = name.replaceAll(' ', '-');
+    const executionId = `abc-flow-${slug}` as ExecutionId;
+    const streamId = `chat@gpt54#abc-flow-${slug}` as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    await store.write(flowKey(executionId), stored);
+    const deleteSpy = vi.spyOn(store, 'delete');
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot),
+      ).rejects.toMatchObject({
+        name: PersistedFlowStateError.name,
+        reason,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(await store.read(flowKey(executionId))).toEqual(stored);
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
   it('skips persistence recovery when setup hands off a cancellation', async () => {
     const executionId = 'abc-cancel-setup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-setup' as StreamTabId;
@@ -621,7 +724,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       // Cancellation arrives while the recovery read is pending -- after
       // setupSession already appended the drained follow-up below.
       flowContext?.interrupt();
-      return null;
+      return undefined;
     });
 
     try {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -182,7 +182,10 @@ describe('retrieveSessionResumeData', () => {
         shouldSkipCycle: 'false',
         stateSlices: null,
       }),
-    ).toBeNull();
+    ).toEqual({
+      success: false,
+      error: expect.objectContaining({ name: 'ZodError' }),
+    });
   });
 
   it('uses the persisted current model while preserving the original stream id', async () => {
@@ -552,40 +555,48 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     );
   });
 
-  it('preserves the flow record and requeued follow-ups after a persistence read failure', async () => {
-    const executionId = 'abc-flow-read-failure' as ExecutionId;
-    const streamId = 'chat@gpt54#abc-flow-read-failure' as StreamTabId;
-    const snapshot = buildToolUseSnapshot(executionId, streamId);
-    const store = getExecutionStore(executionId);
-    const session = new SessionHandle();
-    const readFailure = new Error('flow storage unavailable');
-    const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
-    const deleteSpy = vi.spyOn(store, 'delete');
+  it('releases follow-ups while preserving the record after a persistence read failure', async () => {
+    for (const resume of [true, false]) {
+      const suffix = resume ? 'resume' : 'fresh';
+      const executionId = `abc-flow-read-failure-${suffix}` as ExecutionId;
+      const streamId =
+        `chat@gpt54#abc-flow-read-failure-${suffix}` as StreamTabId;
+      const snapshot = resume
+        ? buildToolUseSnapshot(executionId, streamId)
+        : undefined;
+      const store = getExecutionStore(executionId);
+      const session = createTestSession();
+      const readFailure = new Error('flow storage unavailable');
+      const readSpy = vi
+        .spyOn(store, 'read')
+        .mockRejectedValueOnce(readFailure);
+      const deleteSpy = vi.spyOn(store, 'delete');
 
-    try {
-      await expect(
-        runPersistedFlow(
-          executionId,
-          streamId,
-          snapshot,
-          (context) => {
-            context.session.appendFollowUp({ text: 'queued before recovery' });
-          },
-          session,
-        ),
-      ).rejects.toMatchObject({
-        name: PersistedFlowStateError.name,
-        reason: 'read-failed',
-        cause: readFailure,
-      });
-      expect(deleteSpy).not.toHaveBeenCalled();
-      expect(session.followUps.getAll(streamId)).toEqual([
-        'queued before recovery',
-      ]);
-    } finally {
-      readSpy.mockRestore();
-      deleteSpy.mockRestore();
-      session.followUps.release(streamId);
+      try {
+        await expect(
+          runPersistedFlow(
+            executionId,
+            streamId,
+            snapshot,
+            (context) => {
+              context.session.appendFollowUp({
+                text: 'queued before recovery',
+              });
+            },
+            session,
+          ),
+        ).rejects.toMatchObject({
+          name: PersistedFlowStateError.name,
+          reason: 'read-failed',
+          cause: readFailure,
+        });
+        expect(deleteSpy).not.toHaveBeenCalled();
+        expect(session.followUps.getAll(streamId)).toEqual([]);
+      } finally {
+        readSpy.mockRestore();
+        deleteSpy.mockRestore();
+        session.followUps.release(streamId);
+      }
     }
   });
 
@@ -651,9 +662,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       const expectedError = {
         name: PersistedFlowStateError.name,
         reason,
-        ...(reason === 'invalid-shared'
-          ? {}
-          : { cause: expect.objectContaining({ name: 'ZodError' }) }),
+        cause: expect.objectContaining({ name: 'ZodError' }),
       };
       await expect(
         runPersistedFlow(executionId, streamId, snapshot),
@@ -697,7 +706,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-fresh-cancel-setup' as ExecutionId;
     const streamId = 'chat@gpt54#abc-fresh-cancel-setup' as StreamTabId;
     const store = getExecutionStore(executionId);
-    const session = new SessionHandle();
+    const session = createTestSession();
     const readSpy = vi.spyOn(store, 'read');
     const deleteSpy = vi.spyOn(store, 'delete');
     const releaseSpy = vi.spyOn(session.followUps, 'release');

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -16,6 +16,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
+  FLOW_RECORD_SCHEMA_VERSION,
   PersistedFlowStateError,
   flowKey,
   type FlowRecord,
@@ -73,6 +74,11 @@ const TOOL_USE_SETTING = AgentToolUseSettingSchema.parse({});
 const TOOL_USE_PROMPT = AgentPromptSchema.parse({});
 const ACTIVE_COMPATIBILITY_KEY = 'ModelHandlerOpenAIResponse';
 const WAIT_NODE_CURSOR = 'start/default/default';
+const VALID_TOOL_USE_SHARED = {
+  messages: [],
+  shouldSkipCycle: false,
+  stateSlices: null,
+};
 type ToolUseSetupContext = Parameters<ToolUseFlowSetupCallback>[0];
 
 function createTaggedModelHandler(
@@ -546,27 +552,40 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     );
   });
 
-  it('propagates a persistence read failure without deleting the flow record', async () => {
+  it('preserves the flow record and requeued follow-ups after a persistence read failure', async () => {
     const executionId = 'abc-flow-read-failure' as ExecutionId;
     const streamId = 'chat@gpt54#abc-flow-read-failure' as StreamTabId;
     const snapshot = buildToolUseSnapshot(executionId, streamId);
     const store = getExecutionStore(executionId);
+    const session = new SessionHandle();
     const readFailure = new Error('flow storage unavailable');
     const readSpy = vi.spyOn(store, 'read').mockRejectedValueOnce(readFailure);
     const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
       await expect(
-        runPersistedFlow(executionId, streamId, snapshot),
+        runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          (context) => {
+            context.session.appendFollowUp({ text: 'queued before recovery' });
+          },
+          session,
+        ),
       ).rejects.toMatchObject({
         name: PersistedFlowStateError.name,
         reason: 'read-failed',
         cause: readFailure,
       });
       expect(deleteSpy).not.toHaveBeenCalled();
+      expect(session.followUps.getAll(streamId)).toEqual([
+        'queued before recovery',
+      ]);
     } finally {
       readSpy.mockRestore();
       deleteSpy.mockRestore();
+      session.followUps.release(streamId);
     }
   });
 
@@ -599,6 +618,26 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       reason: 'unsupported-record',
       stored: null,
     },
+    {
+      name: 'valid shared state without nodes',
+      reason: 'unsupported-record',
+      stored: {
+        flowName: 'texra',
+        shared: VALID_TOOL_USE_SHARED,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    },
+    {
+      name: 'future envelope schema version',
+      reason: 'unsupported-record',
+      stored: {
+        schemaVersion: FLOW_RECORD_SCHEMA_VERSION + 1,
+        flowName: 'texra',
+        shared: VALID_TOOL_USE_SHARED,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        nodes: [],
+      },
+    },
   ])('rejects and preserves $name', async ({ name, reason, stored }) => {
     const slug = name.replaceAll(' ', '-');
     const executionId = `abc-flow-${slug}` as ExecutionId;
@@ -609,12 +648,16 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const deleteSpy = vi.spyOn(store, 'delete');
 
     try {
-      await expect(
-        runPersistedFlow(executionId, streamId, snapshot),
-      ).rejects.toMatchObject({
+      const expectedError = {
         name: PersistedFlowStateError.name,
         reason,
-      });
+        ...(reason === 'invalid-shared'
+          ? {}
+          : { cause: expect.objectContaining({ name: 'ZodError' }) }),
+      };
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot),
+      ).rejects.toMatchObject(expectedError);
       expect(deleteSpy).not.toHaveBeenCalled();
       expect(await store.read(flowKey(executionId))).toEqual(stored);
     } finally {
@@ -671,6 +714,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
           },
         },
         createdAt: new Date().toISOString(),
+        nodes: [],
       };
     });
     const writeSpy = vi.spyOn(store, 'write');

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -693,6 +693,35 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
+  it('cleans up a fresh launch cancelled before persistence recovery', async () => {
+    const executionId = 'abc-fresh-cancel-setup' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-fresh-cancel-setup' as StreamTabId;
+    const store = getExecutionStore(executionId);
+    const session = new SessionHandle();
+    const readSpy = vi.spyOn(store, 'read');
+    const deleteSpy = vi.spyOn(store, 'delete');
+    const releaseSpy = vi.spyOn(session.followUps, 'release');
+
+    try {
+      const result = await runPersistedFlow(
+        executionId,
+        streamId,
+        undefined,
+        (flowContext) => flowContext.interrupt(),
+        session,
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).toHaveBeenCalledWith(flowKey(executionId));
+      expect(releaseSpy).toHaveBeenCalledWith(streamId);
+    } finally {
+      readSpy.mockRestore();
+      deleteSpy.mockRestore();
+      releaseSpy.mockRestore();
+    }
+  });
+
   it('skips repair writes when cancellation arrives during the recovery read', async () => {
     const executionId = 'abc-cancel-read' as ExecutionId;
     const streamId = 'chat@gpt54#abc-cancel-read' as StreamTabId;

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -9,7 +9,11 @@ import {
   RESUMABILITY_CAUSE,
 } from '@agent/storage';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
-import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
+import {
+  FLOW_RECORD_SCHEMA_VERSION,
+  flowKey,
+  type FlowRecord,
+} from '@agent/node/persistedFlow';
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
@@ -143,6 +147,28 @@ describe('deriveResumability', () => {
     });
   });
 
+  it('accepts an unstamped legacy envelope and preserves extra fields', async () => {
+    const executionId = 'legacy-extra-flow-envelope' as ExecutionId;
+    const legacyRecord = {
+      ...BASE_FLOW_RECORD,
+      legacyOwner: { host: 'extension' },
+    };
+    await getExecutionStore(executionId).write(
+      flowKey(executionId),
+      legacyRecord,
+    );
+
+    const decision = await deriveResumability(executionId);
+
+    expect(decision).toMatchObject({
+      resumable: true,
+      cause: RESUMABILITY_CAUSE.MISSING_TERMINAL_WITH_FLOW,
+    });
+    if (!decision.resumable) return;
+    expect(decision.flowRecord).toEqual(legacyRecord);
+    expect(Object.hasOwn(decision.flowRecord, 'schemaVersion')).toBe(false);
+  });
+
   it('reports missing flow records as not resumable', async () => {
     const executionId = 'missing-flow' as ExecutionId;
 
@@ -157,6 +183,29 @@ describe('deriveResumability', () => {
     await getExecutionStore(executionId).write(flowKey(executionId), {
       ...BASE_FLOW_RECORD,
       shared: null,
+    });
+
+    await expect(deriveResumability(executionId)).resolves.toEqual({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.INVALID_FLOW,
+    });
+  });
+
+  it('does not conflate a stored null flow envelope with an absent key', async () => {
+    const executionId = 'null-flow-envelope' as ExecutionId;
+    await getExecutionStore(executionId).write(flowKey(executionId), null);
+
+    await expect(deriveResumability(executionId)).resolves.toEqual({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.INVALID_FLOW,
+    });
+  });
+
+  it('rejects flow records from a future envelope schema version', async () => {
+    const executionId = 'future-flow-envelope' as ExecutionId;
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      ...BASE_FLOW_RECORD,
+      schemaVersion: FLOW_RECORD_SCHEMA_VERSION + 1,
     });
 
     await expect(deriveResumability(executionId)).resolves.toEqual({


### PR DESCRIPTION
## Summary

- Treat only a confirmed absent flow key as permission to initialize fresh shared state.
- Validate every persisted flow envelope through one legacy-compatible Zod schema shared by recovery and resumability.
- Raise typed persistence errors for read, envelope, version, and shared-state failures without deleting the original record.
- Preserve the flow record and queued follow-ups only when persisted-state recovery actually fails.
- Keep normal cleanup for a fresh launch cancelled before recovery begins.
- Remove reflection's invalid-record delete-and-restart fallback while retaining supported migrations.

## Design

Both flow runners previously conflated failure to recover persisted state with absence. A malformed envelope could pass a structural cast, fail later inside `PersistedFlow`, and then be deleted by cleanup. Tool-use recovery could also preserve the record while releasing a follow-up queue that resume setup had already repopulated.

`PersistedFlowRecordEnvelopeSchema` now owns the runtime envelope contract. It accepts legacy records without a version and supported versions through the current schema, requires the canonical envelope fields and an own `shared` key, rejects future versions, and preserves loose extra fields. `deriveResumability` reuses that contract and adds its stricter object-shaped `shared` requirement.

Tool-use tracks whether persisted recovery is still pending. An actual recovery failure preserves both the record and follow-up queue. A fresh launch cancelled before recovery follows the ordinary delete-and-release path, preventing stale state from being retained merely because execution stopped early. Reflection likewise reports invalid persisted state without deleting or silently restarting it.

## Verification

- Focused recovery and resumability suites: 48 tests passed.
- `npm run typecheck`.
- Targeted ESLint and Prettier checks.
- `npm run lint` (0 errors; pre-existing warnings only).
- `npm run compile:fast`.
- Constrained full Vitest run: 652 files passed, 1 skipped; 5,781 tests passed, 4 skipped.

The default parallel suite encountered unrelated timeouts while concurrent TypeScript and Lean builds drove host load above 44. Every timed-out file passed in isolation or in the constrained full run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resume and persistence boundaries for both workflow and tool-use flows; incorrect teardown could still affect queued follow-ups or cleanup, though behavior is heavily covered by new recovery tests.
> 
> **Overview**
> Centralizes persisted flow **envelope** validation in `readPersistedFlowRecord` and `PersistedFlowRecordEnvelopeSchema`, shared by recovery and `deriveResumability`. Read, format, version, and missing-`shared` failures now raise **`PersistedFlowStateError`** instead of being treated like a missing key or silently deleted.
> 
> **Reflection** and **tool-use** runners only initialize fresh shared state when the flow key is truly absent; invalid `shared` fails loudly and **keeps the stored record**. Reflection drops the delete-and-restart path for corrupt state.
> 
> Tool-use **`migrateSharedState`** returns an explicit success/error result (with `ZodError`). Recovery tracks **`persistenceRecoveryPending`**: real recovery failures preserve the flow record **and** follow-up queue, while failures during recovery **release** the live queue so resume does not double-replay. A **fresh launch cancelled before recovery** still follows normal delete/release cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977ba4ca99e6346e30420221f2d8b32824c6a839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->