### PR TITLE
feat(model): add Meta (Muse Spark) provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to this project will be documented in this file.
   `engines.vscode` requirement moved from 1.106 to 1.125; users on older VS
   Code releases must update before installing this version.
 
+#### New Features
+
+- **Meta (Muse Spark) provider support** — Muse Spark 1.1 is now available as
+  a direct provider with your own Meta Model API key (dev.meta.ai), including
+  reasoning, tool calling, vision, and PDF input via Meta's Responses-compatible
+  API surface.
+
 #### Bug Fixes
 
 - **Grok models keep a medium reasoning-effort selection** — the xAI effort

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -111,6 +111,19 @@ GLM models support thinking mode (reasoning is shown inline). The API uses a non
 - **China (BigModel)**: Get your API key at [open.bigmodel.cn](https://open.bigmodel.cn/) — endpoint: open.bigmodel.cn (default)
 - **Coding Plan**: GLM offers monthly subscription plans as an alternative to pay-as-you-go, with access to all GLM models. Coding Plan uses a separate endpoint (`/api/coding/paas/v4`). Enable the "Coding Plan" toggle in the Models tab. [Subscribe here](https://z.ai/subscribe).
 
+## Meta (Muse Spark) Models
+
+| Model ID     | Use Case                                 | Cost | Speed  |
+| :----------- | :--------------------------------------- | :--- | :----- |
+| `musespark11` | Reasoning + vision + PDF, 1M context    | $$   | Medium |
+
+Muse Spark always reasons (effort is adjustable but cannot be disabled). TeXRA
+talks to the Meta Model API's Responses surface, which carries reasoning across
+turns and supports tool calling. The API is in public preview for US-based
+developers.
+
+- Get your API key at [dev.meta.ai](https://dev.meta.ai/) (Model API dashboard → API keys tab)
+
 ## Grok / xAI Models
 
 | Model ID | Use Case                        | Cost | Speed  |

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -113,9 +113,9 @@ GLM models support thinking mode (reasoning is shown inline). The API uses a non
 
 ## Meta (Muse Spark) Models
 
-| Model ID     | Use Case                                 | Cost | Speed  |
-| :----------- | :--------------------------------------- | :--- | :----- |
-| `musespark11` | Reasoning + vision + PDF, 1M context    | $$   | Medium |
+| Model ID      | Use Case                             | Cost | Speed  |
+| :------------ | :----------------------------------- | :--- | :----- |
+| `musespark11` | Reasoning + vision + PDF, 1M context | $$   | Medium |
 
 Muse Spark always reasons (effort is adjustable but cannot be disabled). TeXRA
 talks to the Meta Model API's Responses surface, which carries reasoning across

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -16,6 +16,7 @@ The following table lists the AI model providers supported by TeXRA, along with 
 | DashScope (Alibaba) | Hangzhou, China        | [Terms](https://www.alibabacloud.com/help/en/legal/) · [Privacy](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy)     |
 | MiniMax             | Beijing, China         | [Terms](https://www.minimax.io/platform/protocol/terms-of-service) · [Privacy](https://www.minimax.io/platform/protocol/privacy-policy)                                    |
 | Zhipu AI (GLM)      | Beijing, China         | [Terms](https://docs.z.ai/legal-agreement/terms-of-use) · [Privacy](https://docs.z.ai/legal-agreement/privacy-policy)                                                      |
+| Meta (Muse Spark)   | Menlo Park, CA, USA    | Model API terms presented at [dev.meta.ai](https://dev.meta.ai/) signup · [Privacy](https://www.facebook.com/privacy/policy/)                                              |
 
 ## Access Modes
 

--- a/src/agent/modelHandlers/openai/modelHandlerMeta.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMeta.ts
@@ -1,0 +1,54 @@
+// Local file imports
+import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
+
+// Type imports
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+
+/**
+ * Handler for Meta Muse Spark models via the Meta Model API
+ * (https://api.meta.ai/v1).
+ *
+ * Meta serves three request formats off one base URL; TeXRA uses the
+ * Responses surface because the Chat Completions surface supports neither
+ * tool calling nor cross-turn reasoning ("Chat Completions does not carry
+ * reasoning across turns") — both are Responses-only. Where TeXRA touches it,
+ * the wire contract matches OpenAI's Responses API, so the base handler
+ * applies without request rewriting:
+ *  - `reasoning: { effort, summary }` (nested lowercase keys; effort accepts
+ *    minimal|low|medium|high|xhigh, and `none` is rejected because Muse Spark
+ *    always reasons — the shared `toOpenAIReasoningEffort` clamp already
+ *    floors `none` to `low` and caps `max` to `xhigh`);
+ *  - flat `tools` entries, `function_call` / `function_call_output` items,
+ *    `parallel_tool_calls`;
+ *  - `store: true` default with `previous_response_id` chaining, or
+ *    `store: false` + `include: ["reasoning.encrypted_content"]` replay;
+ *  - top-level `instructions` do not persist across turns, and the base
+ *    handler already resends them on every request.
+ *
+ * Background mode stays off: the base eligibility gate is GPT-family-named,
+ * and although Meta documents `background: true` + GET polling with the same
+ * status vocabulary, enabling it here is unexercised — revisit if long
+ * workflow runs start timing out. WebSocket transport self-disables on any
+ * non-null base URL. API key and base URL resolve generically from
+ * `config.provider` ('meta').
+ *
+ * @see https://ai.developer.meta.com/docs/features/responses
+ * @see https://ai.developer.meta.com/docs/features/reasoning
+ * @see https://ai.developer.meta.com/docs/features/tool-calling
+ */
+export class ModelHandlerMeta extends ModelHandlerOpenAIResponse {
+  /** Tag usage with the Meta provider, not the OpenAI Responses surface. */
+  protected override get usageProvider(): NormalizedUsage['provider'] {
+    return 'meta';
+  }
+
+  /**
+   * The base getter assumes every directly-routed backend implements OpenAI's
+   * `/responses/input_tokens` endpoint; Meta's token-counting support is not
+   * verified for that endpoint, so defer to the per-model llm-zoo capability
+   * (false for Muse Spark) and let the heuristic fallback size the budget.
+   */
+  override get supportsTokenCounting(): boolean {
+    return this.capabilities.supportsTokenCounting;
+  }
+}

--- a/src/agent/modelHandlers/openai/modelHandlerMeta.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMeta.ts
@@ -1,8 +1,8 @@
-// Local file imports
-import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
-
 // Type imports
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+
+// Local file imports
+import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
 
 /**
  * Handler for Meta Muse Spark models via the Meta Model API
@@ -40,15 +40,5 @@ export class ModelHandlerMeta extends ModelHandlerOpenAIResponse {
   /** Tag usage with the Meta provider, not the OpenAI Responses surface. */
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'meta';
-  }
-
-  /**
-   * The base getter assumes every directly-routed backend implements OpenAI's
-   * `/responses/input_tokens` endpoint; Meta's token-counting support is not
-   * verified for that endpoint, so defer to the per-model llm-zoo capability
-   * (false for Muse Spark) and let the heuristic fallback size the budget.
-   */
-  override get supportsTokenCounting(): boolean {
-    return this.capabilities.supportsTokenCounting;
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2367,6 +2367,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     );
   }
 
+  /**
+   * Provider identifier for usage tracking. `openai-response` distinguishes
+   * OpenAI's Responses surface from its Chat Completions surface; non-OpenAI
+   * backends on this surface (Meta) override to their own provider.
+   */
+  protected get usageProvider(): NormalizedUsage['provider'] {
+    return 'openai-response';
+  }
+
   /** Normalizes OpenAI Responses API usage data into a unified format. */
   normalizeUsage(
     rawUsage: ResponseUsage,
@@ -2375,6 +2384,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const usage = normalizeOpenAIResponseUsage(
       rawUsage,
       responseTimeMs,
+      this.usageProvider,
       (usage) => this.computePrice(usage),
     );
     const usageRoute = this.getActiveProviderCapabilities()?.usageRoute;

--- a/src/agent/modelHandlers/openai/openAIUsage.ts
+++ b/src/agent/modelHandlers/openai/openAIUsage.ts
@@ -81,17 +81,19 @@ export function computeOpenAIResponsePrice(
 /**
  * Normalizes OpenAI Responses API usage into the unified format. Mirrors
  * {@link normalizeOpenAIUsage} but reads the Responses token fields
- * (`input_tokens`/`output_tokens` and their `*_details`) and is fixed to the
- * `openai-response` usage provider.
+ * (`input_tokens`/`output_tokens` and their `*_details`). The usage provider
+ * comes from the handler (`openai-response` for OpenAI/Codex; other backends
+ * on this surface tag their own provider, e.g. `meta`).
  */
 export function normalizeOpenAIResponseUsage(
   rawUsage: ResponseUsage,
   responseTimeMs: number,
+  provider: NormalizedUsage['provider'],
   computePrice: (usage: ResponseUsage) => number,
 ): NormalizedUsage {
   return normalizeUsage(
     {
-      provider: 'openai-response',
+      provider,
       computePrice,
       extract: (usage) => ({
         inputTokens: usage.input_tokens ?? 0,

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -48,7 +48,7 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.DASHSCOPE]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.MINIMAX]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.GLM]: null, // Resolved dynamically (China/international toggle)
-  [ModelProvider.META]: null,
+  [ModelProvider.META]: 'https://api.meta.ai/v1',
   [ModelProvider.COPILOT]: null,
   [ModelProvider.OTHERS]: null,
 };

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -108,8 +108,10 @@ const PROVIDER_HANDLER_ROUTES: Record<ModelProvider, ProviderHandlerRoute> = {
     compatibilityKey: 'ModelHandlerGLM',
   },
   [ModelProvider.META]: {
-    load: null,
-    compatibilityKey: null,
+    load: async () =>
+      (await import('@agent/modelHandlers/openai/modelHandlerMeta'))
+        .ModelHandlerMeta,
+    compatibilityKey: 'ModelHandlerMeta',
   },
   [ModelProvider.OTHERS]: {
     load: async () =>

--- a/src/agent/runtime/modelHandlerCompatibilityKey.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityKey.ts
@@ -14,6 +14,7 @@ export const MODEL_HANDLER_COMPATIBILITY_KEYS = [
   'ModelHandlerDashScope',
   'ModelHandlerMiniMax',
   'ModelHandlerGLM',
+  'ModelHandlerMeta',
 ] as const;
 
 export type ModelHandlerCompatibilityKey =

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -23,6 +23,7 @@ export const UsageProviderSchema = z.enum([
   'moonshot',
   'minimax',
   'glm',
+  'meta',
   'unknown',
 ]);
 

--- a/src/logger/redaction.ts
+++ b/src/logger/redaction.ts
@@ -63,6 +63,7 @@ export const PROVIDER_KEY_REDACTION_RULES = {
     patterns: [OPENAI_COMPATIBLE_API_KEY_PATTERN],
   },
   glm: OPENAI_COMPATIBLE_REDACTION,
+  meta: OPENAI_COMPATIBLE_REDACTION,
 } as const satisfies Record<ApiKeyProviderId, ProviderKeyRedactionRule>;
 
 const PROVIDER_KEY_PATTERNS = [

--- a/src/model/setupModelDefaults.ts
+++ b/src/model/setupModelDefaults.ts
@@ -25,6 +25,7 @@ const PREFERRED_SETUP_MODEL_BY_PROVIDER: Readonly<Record<string, string>> = {
   dashscope: 'qwen3max',
   minimax: 'minimax01',
   glm: 'glm5',
+  meta: 'musespark11',
 };
 
 /**
@@ -44,6 +45,7 @@ const FALLBACK_MODEL_PROVIDER: Readonly<Record<string, ModelProvider>> = {
   dashscope: ModelProvider.DASHSCOPE,
   minimax: ModelProvider.MINIMAX,
   glm: ModelProvider.GLM,
+  meta: ModelProvider.META,
 };
 
 /** Whether `config` is safe to hand to the setup assistant for `setupProvider`. */

--- a/src/shared/constants/apiKeyProviders.ts
+++ b/src/shared/constants/apiKeyProviders.ts
@@ -16,4 +16,5 @@ export const API_KEY_PROVIDER_IDS = [
   'dashscope',
   'minimax',
   'glm',
+  'meta',
 ] as const;

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -142,12 +142,22 @@ const PROVIDER_REGISTRY = [
       keyUrlWhenUnset: 'https://z.ai/',
     },
   },
+  {
+    id: ModelProvider.META,
+    displayName: 'Meta',
+    // The supabase relay does not forward to Meta yet (see
+    // supabase/functions/relay/models.ts ALL_PROVIDERS) — flip this together
+    // with the relay-side provider registration when Included Access lands.
+    hasServerKey: false,
+    keyUrl: 'https://dev.meta.ai/',
+    streamingKey: GlobalStateKey.STREAMING_META,
+    endpointKey: GlobalStateKey.ENDPOINT_META,
+  },
 ] as const satisfies readonly ProviderDef[];
 
 /** Providers not in the main registry (no server-side keys, no model selection). */
 const EXTRA_DISPLAY_NAMES: Record<string, string> = {
   openRouter: 'OpenRouter',
-  [ModelProvider.META]: 'Meta',
   [ModelProvider.COPILOT]: 'Copilot',
   [ModelProvider.OTHERS]: 'Others',
 };

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -97,6 +97,7 @@ export enum GlobalStateKey {
   STREAMING_DASHSCOPE = 'texra.streaming.dashscope',
   STREAMING_MINIMAX = 'texra.streaming.minimax',
   STREAMING_GLM = 'texra.streaming.glm',
+  STREAMING_META = 'texra.streaming.meta',
 
   // LaTeX settings
   LATEX_CONFIG_VERSION = 'texra.latexConfigVersion',
@@ -118,6 +119,7 @@ export enum GlobalStateKey {
   ENDPOINT_DASHSCOPE = 'texra.endpoint.dashscope',
   ENDPOINT_MINIMAX = 'texra.endpoint.minimax',
   ENDPOINT_GLM = 'texra.endpoint.glm',
+  ENDPOINT_META = 'texra.endpoint.meta',
 
   // Region settings
   DASHSCOPE_USE_CHINA = 'texra.dashscope.useChina',

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -19,6 +19,7 @@ import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDe
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 import { ModelHandlerMiniMax } from '@agent/modelHandlers/openai/modelHandlerMiniMax';
 import { ModelHandlerGLM } from '@agent/modelHandlers/openai/modelHandlerGLM';
+import { ModelHandlerMeta } from '@agent/modelHandlers/openai/modelHandlerMeta';
 import {
   activeModelHandlerCompatibilityKey,
   createModelHandler,
@@ -150,6 +151,15 @@ describe('OpenAI model handler routing', () => {
     );
     expect(
       modelHandlerCompatibilityKey(MODEL_CONFIGS.deepseekT, true, false),
+    ).toBe('ModelHandlerOpenRouterNative');
+  });
+
+  it('routes Meta Muse Spark to the Meta handler directly and OpenRouter when proxied', () => {
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.musespark11, false, false),
+    ).toBe('ModelHandlerMeta');
+    expect(
+      modelHandlerCompatibilityKey(MODEL_CONFIGS.musespark11, true, false),
     ).toBe('ModelHandlerOpenRouterNative');
   });
 
@@ -751,6 +761,19 @@ describe('direct handler capability overrides', () => {
       new ModelHandlerOpenAI(modelConfig(ModelProvider.OPENAI))
         .requiresBatchedParallelToolResults,
     ).toBe(false);
+  });
+
+  it('defers Meta token counting to the model capability instead of the Responses default', () => {
+    // The base Responses handler assumes every directly-routed backend
+    // implements /responses/input_tokens; Meta must follow llm-zoo instead.
+    const handler = new ModelHandlerMeta(
+      modelConfig(ModelProvider.META, { supportsTokenCounting: false }),
+    );
+    try {
+      expect(handler.supportsTokenCounting).toBe(false);
+    } finally {
+      handler.dispose();
+    }
   });
 
   it('grants a reasoning-level override to DeepSeek with reasoning but no granular effort', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -19,7 +19,6 @@ import { ModelHandlerDeepSeek } from '@agent/modelHandlers/openai/modelHandlerDe
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
 import { ModelHandlerMiniMax } from '@agent/modelHandlers/openai/modelHandlerMiniMax';
 import { ModelHandlerGLM } from '@agent/modelHandlers/openai/modelHandlerGLM';
-import { ModelHandlerMeta } from '@agent/modelHandlers/openai/modelHandlerMeta';
 import {
   activeModelHandlerCompatibilityKey,
   createModelHandler,
@@ -761,19 +760,6 @@ describe('direct handler capability overrides', () => {
       new ModelHandlerOpenAI(modelConfig(ModelProvider.OPENAI))
         .requiresBatchedParallelToolResults,
     ).toBe(false);
-  });
-
-  it('defers Meta token counting to the model capability instead of the Responses default', () => {
-    // The base Responses handler assumes every directly-routed backend
-    // implements /responses/input_tokens; Meta must follow llm-zoo instead.
-    const handler = new ModelHandlerMeta(
-      modelConfig(ModelProvider.META, { supportsTokenCounting: false }),
-    );
-    try {
-      expect(handler.supportsTokenCounting).toBe(false);
-    } finally {
-      handler.dispose();
-    }
   });
 
   it('grants a reasoning-level override to DeepSeek with reasoning but no granular effort', () => {


### PR DESCRIPTION
## Summary

Adds Meta (Muse Spark) as a first-class direct provider. `muse-spark-1.1` was already registered in llm-zoo (`META_MODELS`) and `ModelProvider.META` existed as a stub route — this PR fills in the handler and every registration site.

- **`ModelHandlerMeta`** extends `ModelHandlerOpenAIResponse`. The Meta Model API serves three surfaces off `https://api.meta.ai/v1`; TeXRA uses the **Responses** surface because the Chat Completions surface supports neither tool calling nor cross-turn reasoning (per ai.developer.meta.com feature docs). Where TeXRA touches it, the wire contract matches OpenAI's Responses API (nested `reasoning.effort`/`summary`, flat `tools`, `function_call`/`function_call_output` items, `store` + `previous_response_id`, `include: ["reasoning.encrypted_content"]`), so the subclass needs only two overrides:
  - `supportsTokenCounting` — defers to the llm-zoo capability (false for Muse Spark) instead of the base's assumption that every directly-routed backend implements `/responses/input_tokens`.
  - `usageProvider: 'meta'` — new overridable hook on the Responses handler (threaded through `normalizeOpenAIResponseUsage`, mirroring the chat handler's existing `usageProvider` idiom) so usage telemetry attributes to Meta rather than `openai-response`.
- **Provider wiring** (per the registry pattern): `PROVIDER_REGISTRY` entry (BYO key from dev.meta.ai; `hasServerKey: false` — the relay's `ALL_PROVIDERS` doesn't forward to Meta, flip both together when Included Access lands), `STREAMING_META`/`ENDPOINT_META` state keys, `BASE_URLS` entry, `ModelFactory` route + `ModelHandlerMeta` compatibility key, `API_KEY_PROVIDER_IDS`, key redaction rule, `UsageProviderSchema`, setup-probe model `musespark11`.
- **Docs**: provider jurisdiction row in `docs/providers.md`, model section in `docs/guide/models.md`, changelog entry.

Deliberately out of scope: background mode (Meta documents `background: true` + polling, but the base eligibility gate is GPT-family-named and enabling it here is unexercised — noted in the handler doc) and relay/Included-Access.

## Test plan

- New routing test: `musespark11` routes to `ModelHandlerMeta` directly and `ModelHandlerOpenRouterNative` when proxied.
- New capability test: Meta token counting defers to the model capability instead of the Responses default.
- `tsc --noEmit` (root + test-kernel), lint, and full `npm test` pass.

⚠️ **Not live-tested against the real endpoint**: the Meta Model API is a US-only public preview (waitlisted) and is not available from Germany, so no end-to-end request could be made. The wire contract is verified against Meta's own docs (https://dev.meta.ai/docs/getting-started/overview/ and the ai.developer.meta.com feature pages), and the handler adds no request rewriting on top of the already-exercised OpenAI Responses path — but a first smoke test needs a US-based key (`texra` chat on `musespark11`, then a tool-use agent turn to exercise `function_call` round-trips).

## Verified

- `ai.developer.meta.com/docs/features/{responses,reasoning,tool-calling,chat-completion}` and `dev.meta.ai/docs/getting-started/{overview,authentication}` (fetched live): Responses-only tools/reasoning-continuity, nested lowercase `reasoning.effort` wire shape, `reasoning.encrypted_content` include spelling, `function_call` output items, key dashboard at dev.meta.ai.
- `node_modules/llm-zoo` `META_MODELS.musespark11` entry (capabilities, `supportsTokenCounting: false`).
- `src/agent/runtime/ModelFactory.ts`, `modelHandlerCompatibilityKey.ts`, `src/shared/constants/providers.ts` + every derived consumer (secretManager, apiKeyCommands, settings catalog), `supabase/functions/relay/models.ts` (confirmed Meta absent → `hasServerKey: false`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new model provider path and outbound API integration, but reuses the exercised Responses handler with minimal overrides and BYO keys only (no relay); end-to-end behavior against Meta’s preview API is not verified in this PR.
> 
> **Overview**
> **Meta (Muse Spark)** is wired as a first-class **bring-your-own-key** provider for `musespark11`, using the Meta Model API at `https://api.meta.ai/v1` on the **Responses** surface (tools and cross-turn reasoning), via a thin `ModelHandlerMeta` on top of the existing OpenAI Responses handler.
> 
> Registration follows the same pattern as other direct providers: `PROVIDER_REGISTRY` (no relay/`hasServerKey: false` yet), `ModelFactory` + compatibility key, default base URL, API key provider id, log redaction, streaming/endpoint state keys, setup probe default, and a new `meta` usage provider tag. The Responses usage normalizer now takes the provider from an overridable `usageProvider` hook so Meta telemetry is not labeled `openai-response`.
> 
> Docs/changelog cover Muse Spark capabilities and dev.meta.ai keys; a routing test asserts direct `ModelHandlerMeta` vs OpenRouter when proxied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0139a82934679ecca3a3e3a199173d4c1800e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->