### PR TITLE
fix(model): allow medium reasoning effort on current Grok models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   `engines.vscode` requirement moved from 1.106 to 1.125; users on older VS
   Code releases must update before installing this version.
 
+#### Bug Fixes
+
+- **Grok models keep a medium reasoning-effort selection** — the xAI effort
+  clamp no longer converts `medium` to `high`; current Grok reasoning models
+  (grok-4.3, grok-4.5) support low/medium/high.
+
 ## [0.39.3] - 2026-07-10
 
 ### Shared (all surfaces)

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -750,10 +750,15 @@ export abstract class ModelHandler<
    */
   protected validateReasoningEffort(effort: string): string {
     if (this.config.provider !== ModelProvider.XAI) return effort;
-    if (effort === 'low' || effort === 'high') return effort;
+    // Current Grok reasoning models (grok-4.3 / grok-4.5) document
+    // low/medium/high (docs.x.ai reasoning guide); xhigh only exists on the
+    // multi-agent variant where it means agent count, so clamp it to high.
+    if (effort === 'low' || effort === 'medium' || effort === 'high') {
+      return effort;
+    }
 
     this.logger.warn(
-      `xAI models only support 'low' or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
+      `xAI models only support 'low', 'medium', or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
     );
     return 'high';
   }

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -10,8 +10,10 @@ import type { ChatCompletion } from 'openai/resources/chat/completions';
 /**
  * Handler for xAI models using OpenAI-compatible API.
  *
- * Note: reasoning_effort is not supported by grok-4 models.
- * Specifying reasoning_effort parameter will result in an error response.
+ * Note: the legacy grok-4 generation (deprecated May 2026) rejected the
+ * reasoning_effort parameter outright. Current reasoning models (grok-4.3,
+ * grok-4.5) document low/medium/high effort control — see
+ * validateReasoningEffort in the base class for the clamp.
  *
  * processThinkingBlock is inherited from ModelHandlerOpenAI which already
  * extracts reasoning_content from the response message.

--- a/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAICompatibleProviderParams.vitest.ts
@@ -15,6 +15,7 @@ import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGLM } from '@agent/modelHandlers/openai/modelHandlerGLM';
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
+import { ModelHandlerXAI } from '@agent/modelHandlers/openai/modelHandlerXAI';
 
 function buildConfig(
   provider: ModelProvider,
@@ -313,5 +314,57 @@ describe('OpenAI-compatible provider request params', () => {
     });
 
     assert.equal(createCalls[0].reasoning_effort, 'max');
+  });
+
+  it('passes medium reasoning effort through for current Grok models', async () => {
+    const handler = new ModelHandlerXAI(
+      buildConfig(ModelProvider.XAI, {
+        name: 'grok45',
+        fullName: 'grok-4.5',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+          supportsReasoningEffort: true,
+          reasoningEffort: ReasoningEffort.MEDIUM,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'think' }],
+      temperature: 0,
+    });
+
+    assert.equal(createCalls[0].reasoning_effort, 'medium');
+  });
+
+  it('clamps above-high reasoning effort to high for Grok models', async () => {
+    const handler = new ModelHandlerXAI(
+      buildConfig(ModelProvider.XAI, {
+        name: 'grok45',
+        fullName: 'grok-4.5',
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+          supportsReasoningEffort: true,
+          reasoningEffort: ReasoningEffort.XHIGH,
+        },
+      }),
+    );
+    handler.setLogger(createLoggerStub() as AgentTrace);
+    (handler as any).getStreamingConfig = () => false;
+
+    const { client, createCalls } = createClientStub();
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'think harder' }],
+      temperature: 0,
+    });
+
+    assert.equal(createCalls[0].reasoning_effort, 'high');
   });
 });


### PR DESCRIPTION
## Summary

The xAI reasoning-effort clamp silently converted a user's `medium` selection to `high`. That rule described the retired model generation: grok-4 / grok-3-mini (deprecated 2026-05-15, retiring 2026-08-15) either rejected `reasoning_effort` outright or only accepted low/high. Current Grok reasoning models document three tiers:

- `grok-4.5`: `low` / `medium` / `high` (default `high`) — docs.x.ai reasoning guide
- `grok-4.3`: `none` / `low` (default) / `medium` / `high`
- `xhigh` exists only on `grok-4.20-multi-agent`, where it controls agent count rather than reasoning depth — so above-high values still clamp to `high`.

Changes:
- `ModelHandler.validateReasoningEffort` now passes `medium` through for xAI (previously warned and coerced to `high`).
- Replaced the stale "reasoning_effort is not supported by grok-4 models" comment on `ModelHandlerXAI` with the current model-generation facts.
- Changelog entry under Bug Fixes.

## Test plan

Two new tests in `OpenAICompatibleProviderParams.vitest.ts`: a grok-4.5-shaped config with `medium` effort sends `reasoning_effort: 'medium'` on the wire, and `xhigh` still clamps to `high`. `tsc --noEmit` (root + test-kernel) and lint pass.

## Verified

- docs.x.ai reasoning guide + models page and the May-15 retirement migration page (fetched live 2026-07-12): per-model effort values and the deprecation redirects quoted above.
- `src/agent/modelHandlers/ModelHandler.ts` clamp call path via `modelHandlerOpenAI.ts` `buildChatBaseParams` (`reasoning_effort` assignment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to xAI reasoning-effort validation and API param mapping; covered by new unit tests with no auth or data-path impact.
> 
> **Overview**
> Fixes **xAI (Grok) reasoning-effort handling** so a user’s **Medium** choice is sent on the wire instead of being silently upgraded to **high**.
> 
> `ModelHandler.validateReasoningEffort` now treats **`low` / `medium` / `high`** as valid for `ModelProvider.XAI`; values above **high** (e.g. **xhigh**) still clamp to **high** with an updated warning. **`ModelHandlerXAI`** comments are refreshed to describe current grok-4.3/grok-4.5 behavior versus the retired grok-4 generation. **CHANGELOG** documents the bug fix; tests assert **medium** passes through and **xhigh** still clamps for a grok-4.5-shaped config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987eb082e64e69352a710af33599c61ff1840b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->