### PR TITLE
refactor(model): use SDK Response type for background terminal state

### DIFF
--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -6,6 +6,7 @@ import {
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
+import type { Response } from 'openai/resources/responses/responses';
 import type { ProviderError } from '@shared/schemas';
 
 // Local imports - model handlers
@@ -21,12 +22,10 @@ interface RequestIdTaggedError extends Error {
   provider?: string;
 }
 
-interface OpenAIBackgroundTerminalState {
-  id: string;
-  status?: string | null;
-  error?: { message?: string | null } | null;
-  incomplete_details?: { reason?: string | null } | null;
-}
+type OpenAIBackgroundTerminalState = Pick<
+  Response,
+  'id' | 'status' | 'error' | 'incomplete_details'
+>;
 
 function setProviderHint(error: unknown, provider: string): void {
   if (error && typeof error === 'object' && !('provider' in error)) {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -94,8 +94,10 @@ describe('OpenAI Responses error normalization', () => {
         id: 'resp_failed',
         status: 'failed',
         error: {
+          code: 'server_error',
           message: 'The background response ended before completion.',
         },
+        incomplete_details: null,
       },
       'openai',
     );


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `OpenAIBackgroundTerminalState` interface in `openAIResponseErrors.ts` with `Pick<Response, 'id' | 'status' | 'error' | 'incomplete_details'>` from the OpenAI SDK.

The local interface re-declared four fields of the SDK's `Response` with looser types (`status?: string | null`, ad-hoc `{ message? }` error bag). Its only caller — `BackgroundRunLifecycle.waitForCompletion`, which is generic over `T extends Response` — always passes a real `Response`, so the SDK type is a strict improvement: `status` becomes the real `ResponseStatus` union and `error` the real `ResponseError` shape (required `code` + `message`), with no runtime change.

Found by an SDK-native-types audit of `src/agent/modelHandlers/` against the installed `openai@6.46.0` `.d.ts` files (the only replaceable hand-rolled type the audit surfaced — everything else either already imports SDK types or covers documented provider extensions the SDK doesn't model).

## Test plan

The tightened type caught one test fixture passing an incomplete `ResponseError` (missing required `code`) — updated to the real shape. `OpenAIResponseErrors.vitest.ts`, `tsc --noEmit` (root + test-kernel), and lint pass.

## Verified

- `node_modules/openai/resources/responses/responses.d.ts` (`Response`, `ResponseStatus`, `ResponseError`).
- `src/agent/modelHandlers/openai/BackgroundRunLifecycle.ts:263,359` — sole caller, `T extends Response` constraint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor at the provider error boundary with no runtime logic changes; risk is limited to compile-time alignment with the SDK.
> 
> **Overview**
> **`OpenAIBackgroundTerminalState`** in `openAIResponseErrors.ts` is no longer a local interface with loose optional/nullable fields. It is now **`Pick<Response, 'id' | 'status' | 'error' | 'incomplete_details'>`** from the OpenAI SDK, so terminal background errors align with **`ResponseStatus`** and **`ResponseError`** (including required **`code`**) instead of a hand-rolled error bag.
> 
> **`createOpenAIBackgroundTerminalError`** behavior is unchanged; **`BackgroundRunLifecycle`** still passes a full **`Response`**. The test for terminal failed backgrounds was updated so the fixture includes **`error.code`** and **`incomplete_details: null`** to satisfy the stricter type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d360a888203c89e7c70b230a6f3709f4cbb21b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->