### PR TITLE
fix(ui): standardize three UI consistency gaps onto Web Awesome components

### DIFF
--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -239,6 +239,13 @@ export const streamTabStyles = css`
     flex-shrink: 0;
   }
 
+  .nested-stream-icon {
+    font-size: var(--font-size-xs);
+    opacity: var(--opacity-faint);
+    flex-shrink: 0;
+    margin-right: var(--wa-space-3xs);
+  }
+
   .tab-delete::part(base) {
     padding: 0;
     border-radius: var(--border-radius-small);

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -182,9 +182,16 @@ export class StreamTab extends LitElement {
         >
           <div class="tab-header">
             <span class="tab-title"
-              >${stream.parentStreamId ? '↳ ' : ''}${
-                stream.label || stream.name
-              }</span
+              >${
+                stream.parentStreamId
+                  ? html`<wa-icon
+                      library=${TEXRA_ICON_LIBRARY}
+                      name="chevron-right"
+                      class="nested-stream-icon"
+                      aria-hidden="true"
+                    ></wa-icon>`
+                  : nothing
+              }${stream.label || stream.name}</span
             >
             ${
               this.childCount > 0 && this.compact

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -4,8 +4,9 @@ import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 
-// Side-effect imports - register WA icon component
+// Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
 
 // Local imports - shared schemas
 import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
@@ -127,17 +128,12 @@ export class UsagePanel extends LitElement {
       .context-gauge__track {
         position: relative;
         width: 80px;
-        height: 6px;
-        background: var(--wa-color-surface-border);
-        border-radius: var(--border-radius);
-        overflow: hidden;
       }
 
-      .context-gauge__fill {
-        display: block;
-        height: 100%;
-        border-radius: var(--border-radius);
-        transition: width var(--transition-slow);
+      .context-gauge__bar {
+        width: 100%;
+        --track-height: 6px;
+        --track-color: var(--wa-color-surface-border);
       }
 
       /* Compaction threshold tick mark */
@@ -318,13 +314,12 @@ export class UsagePanel extends LitElement {
           aria-hidden="true"
         ></wa-icon>
         <span class="context-gauge__track">
-          <span
-            class="context-gauge__fill"
-            style=${styleMap({
-              width: `${clamped}%`,
-              backgroundColor: fillColor(clamped),
-            })}
-          ></span>
+          <wa-progress-bar
+            class="context-gauge__bar"
+            value=${clamped}
+            label="${clamped.toFixed(0)}% context used"
+            style=${styleMap({ '--indicator-color': fillColor(clamped) })}
+          ></wa-progress-bar>
           <span
             class="context-gauge__tick"
             style=${styleMap({ left: `${COMPACTION_THRESHOLD}%` })}

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -120,6 +120,7 @@ export class UsagePanel extends LitElement {
 
       /* Context gauge bar */
       .context-gauge {
+        --gauge-height: 6px;
         display: inline-flex;
         align-items: center;
         gap: var(--wa-space-2xs);
@@ -128,11 +129,14 @@ export class UsagePanel extends LitElement {
       .context-gauge__track {
         position: relative;
         width: 80px;
+        /* Pins the tick mark's height to the bar regardless of
+           wa-progress-bar's internal box model. */
+        height: var(--gauge-height);
       }
 
       .context-gauge__bar {
         width: 100%;
-        --track-height: 6px;
+        --track-height: var(--gauge-height);
         --track-color: var(--wa-color-surface-border);
       }
 

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -17,7 +17,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
-import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas and events
 import {
@@ -49,6 +49,15 @@ function isBuiltIn(source: string): boolean {
     source === AGENT_SOURCE.BUILT_IN_WORKFLOW ||
     source === AGENT_SOURCE.BUILT_IN_TOOL_USE
   );
+}
+
+/** Icon + label for the non-built-in source badge shown in both the list and detail panes. */
+function sourceBadgeMeta(
+  source: AgentSourceType,
+): { icon: TeXRAIconName; label: string } | undefined {
+  if (source === AGENT_SOURCE.CUSTOM) return { icon: 'star', label: 'Custom' };
+  if (source === AGENT_SOURCE.REMOTE) return { icon: 'cloud', label: 'Remote' };
+  return undefined;
 }
 
 @customElement('agent-selection-panel')
@@ -238,6 +247,7 @@ export class AgentSelectionPanel extends LitElement {
   private renderListItem(agent: AgentSelectionItem): TemplateResult {
     const key = agentKey(agent);
     const isSelected = this.selectedKey === key;
+    const badge = sourceBadgeMeta(agent.source);
 
     let sourceTone: 'builtin' | 'custom' | 'remote';
     if (agent.source === AGENT_SOURCE.CUSTOM) {
@@ -280,16 +290,9 @@ export class AgentSelectionPanel extends LitElement {
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${
-            agent.source === AGENT_SOURCE.REMOTE
-              ? html`<span title="Remote agent"
-                  >${waIcon('cloud', { label: 'Remote agent' })}</span
-                >`
-              : nothing
-          }
-          ${
-            agent.source === AGENT_SOURCE.CUSTOM
-              ? html`<span title="Custom agent"
-                  >${waIcon('star', { label: 'Custom agent' })}</span
+            badge
+              ? html`<span title="${badge.label} agent"
+                  >${waIcon(badge.icon, { label: `${badge.label} agent` })}</span
                 >`
               : nothing
           }
@@ -369,6 +372,7 @@ export class AgentSelectionPanel extends LitElement {
     const isCustom = agent.source === AGENT_SOURCE.CUSTOM;
     const showDeleteConfirm =
       isCustom && this.pendingDeleteKey === agentKey(agent);
+    const badge = sourceBadgeMeta(agent.source);
 
     return html`
       <div class="agent-detail-pane">
@@ -380,16 +384,12 @@ export class AgentSelectionPanel extends LitElement {
               : nothing
           }
           ${
-            isCustom
-              ? html`<wa-tag variant="neutral" size="small" title="Custom agent"
-                  >${waIcon('star')} Custom</wa-tag
-                >`
-              : nothing
-          }
-          ${
-            agent.source === AGENT_SOURCE.REMOTE
-              ? html`<wa-tag variant="neutral" size="small" title="Remote agent"
-                  >${waIcon('cloud')} Remote</wa-tag
+            badge
+              ? html`<wa-tag
+                  variant="neutral"
+                  size="small"
+                  title="${badge.label} agent"
+                  >${waIcon(badge.icon)} ${badge.label}</wa-tag
                 >`
               : nothing
           }


### PR DESCRIPTION
## Summary

A UI-consistency review (webview/progressView/settingsView frontends + CLI Ink TUI) found the codebase largely already standardized on Web Awesome components (`wa-*`) — the CLI TUI had zero findings, and most of the webview frontend was clean. This PR fixes the three genuine, low-risk deviations that survived verification:

- `UsagePanel.ts` — the context-usage gauge was a hand-rolled `<span>` fill bar (manual `width`/`background-color` via `styleMap`) duplicating what `wa-progress-bar` already does elsewhere in this codebase (`RelayQuotaMeter.ts`). Swapped to `<wa-progress-bar>` styled via its `--track-color`/`--indicator-color` custom properties, keeping only the compaction-threshold tick mark as bespoke overlay markup.
- `StreamTabs.ts` — child-stream tabs were prefixed with a literal `'↳ '` Unicode glyph, while the same component uses a proper `<wa-icon name="chevron-right">` a few lines below for the conceptually related "has children" indicator. Replaced the glyph with a themed `wa-icon` (adds a `.nested-stream-icon` style in `StreamTab.styles.ts`), which is accessible and themes with the rest of the icon set.
- `AgentSelectionPanel.ts` — the "Remote agent"/"Custom agent" badge was rendered two independent ways: a bare icon-in-a-span in the list view vs. a full `wa-tag` with icon+label in the detail view, each with its own copy of the icon-name/label mapping. Consolidated both into a single `sourceBadgeMeta()` helper; each render site now only differs in its wrapper markup (icon-only span vs. `wa-tag`), not in the underlying icon/label knowledge.

Not touched (reviewed and judged out of scope): a hand-built copy-to-clipboard split across three implementations is architecturally justified (static-HTML formatters can't use the Lit reactive controller), and a hand-built SVG donut chart in `ToolsTab.ts` has no Web Awesome equivalent — both are legitimate, not deviations.

## Issue acceptance gates

No linked issue — this was an ad-hoc UI-consistency review requested directly. Gate: replace each identified ad-hoc UI pattern with the established Web Awesome standard, or state why it's out of scope (done above for the two out-of-scope items).

## Single source of truth

`sourceBadgeMeta()` in `AgentSelectionPanel.ts` is now the single owner of the source→icon/label mapping for the "Custom"/"Remote" agent badge, consumed by both the list and detail render paths.

## Duplication and abstraction budget

Removed: two independent `agent.source === X ? ... : nothing` blocks (list view) collapsed to one; two independent icon/label literal pairs (`'star'`/`'Custom agent'`, `'cloud'`/`'Remote agent'`) removed from both list and detail render methods. Removed the hand-rolled `.context-gauge__fill` CSS/markup entirely in favor of the existing `wa-progress-bar` component. No new abstraction layers added — `sourceBadgeMeta()` is a plain function called from two existing methods (not a new class/factory).

## Net elements (R6)

`git diff --stat`: 4 files changed, 50 insertions(+), 41 deletions(-). No new exported symbols; one new module-private function (`sourceBadgeMeta`) replacing ~12 lines of duplicated inline conditionals.

## Consumer counts (R8)

n/a — no emit path, export, or public API changed; all edits are internal to the three Lit components' own render methods.

## Host impact

Extension: yes — all three touched files live under `packages/extension/src/{progressView,settingsView}/frontend/`.

Desktop: no.

CLI: no (the CLI Ink TUI scan for this same review came back with zero findings — already fully on Ink-native/shared-component patterns).

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (after `corepack pnpm install`, since node_modules wasn't present in this session)
- `npx eslint <changed files>` — clean
- `npx prettier --write <changed files>` — no changes needed (already formatted)
- `npm run compile:fast` — full extension + webview + settingsView + progressView + desktop build succeeds
- No dedicated unit tests exist for these three Lit components; not run in a browser/VS Code host in this session (no manual visual verification of the new `wa-progress-bar` gauge or badge markup was performed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVT1ZipXAoMYvZ6mHLcM9h)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Lit template/CSS changes in extension webviews; no APIs, auth, or data paths touched.
> 
> **Overview**
> Aligns three progress/settings UI spots with existing Web Awesome (`wa-*`) patterns instead of one-off markup.
> 
> In **`UsagePanel`**, the context-usage gauge drops the hand-rolled fill `<span>` and uses **`wa-progress-bar`** (same approach as `RelayQuotaMeter`), with `--indicator-color` for utilization coloring; the compaction threshold tick stays as an overlay on the track.
> 
> In **`StreamTabs`**, nested child stream titles replace the **`↳`** Unicode prefix with a themed **`wa-icon`** (`chevron-right`, `.nested-stream-icon`).
> 
> In **`AgentSelectionPanel`**, Custom/Remote badge icon and label logic moves into **`sourceBadgeMeta()`**, shared by the list (icon-only) and detail (`wa-tag`) views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa630340db9a4712c44b01130752af416b4e68b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->