### PR TITLE
fix(progress): stop retry/approval requests from stealing active-stream focus

### DIFF
--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -92,7 +92,7 @@ class DesktopHostInteractions implements HostInteractions {
       streamId: streamId ?? '',
     };
     return this.showPending(requestId, { kind: 'bash', streamId }, (settle) => {
-      this.activateStream(streamId);
+      this.revealStream(streamId);
       this.options.getApprovalHandlers().bash.show(payload);
       return settle;
     });
@@ -105,7 +105,7 @@ class DesktopHostInteractions implements HostInteractions {
       request.approvalId,
       { kind: 'plan', streamId: request.streamId },
       (settle) => {
-        this.activateStream(request.streamId);
+        this.revealStream(request.streamId);
         this.options.getApprovalHandlers().planApproval.show(request);
         return settle;
       },
@@ -119,7 +119,7 @@ class DesktopHostInteractions implements HostInteractions {
       request.proposalId,
       { kind: 'proposal', streamId: request.streamId },
       (settle) => {
-        this.activateStream(request.streamId);
+        this.revealStream(request.streamId);
         this.options.getApprovalHandlers().agentProposal.show(request);
         return settle;
       },
@@ -138,7 +138,7 @@ class DesktopHostInteractions implements HostInteractions {
       request.requestId,
       { kind: 'userQuestion', streamId },
       (settle) => {
-        this.activateStream(streamId);
+        this.revealStream(streamId);
         this.options.getApprovalHandlers().userQuestion.show(request);
         return settle;
       },
@@ -235,12 +235,23 @@ class DesktopHostInteractions implements HostInteractions {
     });
   }
 
-  private activateStream(streamId: StreamTabId | undefined): void {
+  // Interaction requests surface per-stream (pending badge on the stream
+  // row); `suppressViewSwitch` registers the stream without yanking the
+  // active tab away from whatever the user is inspecting — matches the
+  // extension host contract (#8246).
+  private revealStream(streamId: StreamTabId | undefined): void {
     this.options.runtimeHost.emit('requestEnsureProgressView', {});
     if (streamId) {
       this.options.session.events.emit({
         scope: 'session',
-        event: { type: 'setActiveStream', payload: { streamId } },
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId,
+            suppressViewSwitch: true,
+            ensureVisible: true,
+          },
+        },
       });
     }
   }

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -67,12 +67,23 @@ export function createExtensionHostInteractions(
 
   const handlers = () => options.getApprovalHandlers();
 
-  const activateStream = (streamId?: StreamTabId | null) => {
+  // Interaction requests surface per-stream: the request panel is scoped to
+  // the viewed stream and the requesting stream's row shows a pending badge.
+  // `suppressViewSwitch` registers the stream so that row exists without
+  // yanking the active tab away from whatever the user is inspecting (#8246).
+  const revealStream = (streamId?: StreamTabId | null) => {
     options.runtimeHost.emit('requestEnsureProgressView', {});
     if (streamId) {
       options.session.events.emit({
         scope: 'session',
-        event: { type: 'setActiveStream', payload: { streamId } },
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId,
+            suppressViewSwitch: true,
+            ensureVisible: true,
+          },
+        },
       });
     }
   };
@@ -169,7 +180,7 @@ export function createExtensionHostInteractions(
     ): Promise<HostBashApprovalResult> {
       const requestId = `bash-${nanoid()}`;
       const streamId = request.streamId ?? '';
-      activateStream(request.streamId);
+      revealStream(request.streamId);
       return showPending<HostBashApprovalResult>(
         { id: requestId, kind: 'bash', streamId },
         () =>
@@ -186,7 +197,7 @@ export function createExtensionHostInteractions(
     requestPlanApproval(
       request: HostPlanApprovalRequest,
     ): Promise<PlanApprovalResult> {
-      activateStream(request.streamId);
+      revealStream(request.streamId);
       return showPending<PlanApprovalResult>(
         {
           id: request.approvalId,
@@ -200,7 +211,7 @@ export function createExtensionHostInteractions(
     requestAgentProposal(
       request: AgentProposalPermission,
     ): Promise<ProposalResult> {
-      activateStream(request.streamId);
+      revealStream(request.streamId);
       return showPending<ProposalResult>(
         {
           id: request.proposalId,
@@ -212,7 +223,7 @@ export function createExtensionHostInteractions(
     },
 
     requestRetry(request: HostRetryRequest): Promise<RetryResult> {
-      activateStream(request.streamId);
+      revealStream(request.streamId);
       return showPending<RetryResult>(
         {
           id: request.streamId,
@@ -226,7 +237,7 @@ export function createExtensionHostInteractions(
     askUserQuestion(
       request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
     ): Promise<HostUserQuestionResult> {
-      activateStream(request.streamId || undefined);
+      revealStream(request.streamId || undefined);
       return showPending<HostUserQuestionResult>(
         {
           id: request.requestId,
@@ -238,7 +249,7 @@ export function createExtensionHostInteractions(
     },
 
     async openExternalInquiry(request) {
-      activateStream(request.streamId || undefined);
+      revealStream(request.streamId || undefined);
       handlers().externalInquiry.show(request);
       return { threadId: request.threadId };
     },

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -536,6 +536,14 @@ export class ProgressFactApplier {
     if (agentCategory) {
       this.state.getOrCreateStreamState(streamId, agentCategory);
     }
+    if (
+      payload.suppressViewSwitch === true &&
+      payload.ensureVisible === true &&
+      this.state.agentCategoryFilter !== 'all' &&
+      (!agentCategory || this.state.agentCategoryFilter !== agentCategory)
+    ) {
+      this.state.agentCategoryFilter = 'all';
+    }
     // Don't switch away from the current stream if it has pending permissions
     // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
     // interact with the approval panel before losing sight of it.
@@ -575,7 +583,12 @@ export class ProgressFactApplier {
     if (shouldSwitch && this.state.activeStream !== streamId) return;
 
     const filterChanged = this.state.agentCategoryFilter !== previousFilter;
-    if (!wasKnownStream || filterChanged) {
+    if (filterChanged && payload.ensureVisible === true) {
+      this.webviewUpdater.sendStreamMetadata(
+        this.state,
+        this.state.streamStatus.getAllStreamStates(),
+      );
+    } else if (!wasKnownStream || filterChanged) {
       this.webviewUpdater.updateStreamMetadata(
         this.state,
         streamId,

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -36,6 +36,11 @@ export interface SetActiveStreamPayload {
    * stream tab appears without yanking the user away from their current view.
    */
   suppressViewSwitch?: boolean;
+  /**
+   * When suppressing a switch, widen a restrictive category filter so this
+   * stream remains reachable. Used for interaction requests with pending UI.
+   */
+  ensureVisible?: boolean;
 }
 
 export interface UpdateStreamDescriptionPayload {

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -96,7 +96,14 @@ describe('human prompt progress events', () => {
 
     expect(explicit.events).toEqual([
       { event: 'requestEnsureProgressView', payload: {} },
-      { event: 'setActiveStream', payload: { streamId } },
+      {
+        event: 'setActiveStream',
+        payload: {
+          streamId,
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      },
       {
         event: 'showBashPermission',
         payload: {
@@ -152,7 +159,14 @@ describe('human prompt progress events', () => {
 
     expect(explicit.events).toEqual([
       { event: 'requestEnsureProgressView', payload: {} },
-      { event: 'setActiveStream', payload: { streamId } },
+      {
+        event: 'setActiveStream',
+        payload: {
+          streamId,
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      },
       {
         event: 'showUserQuestion',
         payload: {

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -99,17 +99,26 @@ export function createRecordingHost(): {
     string,
     { streamId?: string; settle: (result: HostUserQuestionResult) => void }
   >();
-  const activateStream = (streamId?: string | null) => {
+  // Mirrors the host contract: interaction requests register the stream
+  // without switching the active tab (#8246).
+  const revealStream = (streamId?: string | null) => {
     events.push({ event: 'requestEnsureProgressView', payload: {} });
     if (streamId) {
-      events.push({ event: 'setActiveStream', payload: { streamId } });
+      events.push({
+        event: 'setActiveStream',
+        payload: {
+          streamId,
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      });
     }
   };
   const interactions: HostInteractions = {
     requestBashApproval: (request) => {
       const requestId = `bash-${pendingBashes.size + 1}`;
       const streamId = request.streamId ?? '';
-      activateStream(request.streamId);
+      revealStream(request.streamId);
       events.push({
         event: 'showBashPermission',
         payload: {
@@ -164,7 +173,7 @@ export function createRecordingHost(): {
       });
     },
     askUserQuestion: (request) => {
-      activateStream(request.streamId || undefined);
+      revealStream(request.streamId || undefined);
       events.push({
         event: 'showUserQuestion',
         payload: request,

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -159,9 +159,18 @@ describe('createDesktopHostInteractions', () => {
       'setActiveStream',
       expect.anything(),
     );
+    // Interaction requests register the stream without yanking the active
+    // tab away from what the user is viewing (#8246).
     expect(sessionEvents).toContainEqual({
       scope: 'session',
-      event: { type: 'setActiveStream', payload: { streamId: 'stream-a' } },
+      event: {
+        type: 'setActiveStream',
+        payload: {
+          streamId: 'stream-a',
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      },
     });
   });
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -250,6 +250,7 @@ describe('desktop tool edit approval', () => {
       const { requestToolEditApproval, desktopModule } =
         await loadApprovalModules();
       const runtimeHost = createRecordingRuntimeHost();
+      const emitSpy = vi.spyOn(runtimeHost, 'emit');
       const session = createTestSession();
       const sessionEvents = recordSessionEvents(session);
       const opened: string[] = [];
@@ -277,9 +278,14 @@ describe('desktop tool edit approval', () => {
           scope: 'session',
           event: {
             type: 'setActiveStream',
-            payload: { streamId: 'stream-2' },
+            payload: {
+              streamId: 'stream-2',
+              suppressViewSwitch: true,
+              ensureVisible: true,
+            },
           },
         });
+        expect(emitSpy).toHaveBeenCalledWith('requestEnsureProgressView', {});
         expect(shown[0]).toMatchObject({
           path: '/workspace/notes.txt',
           relativePath: 'notes.txt',

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -127,7 +127,14 @@ describe('createExtensionHostInteractions', () => {
     );
     expect(sessionEvents).toContainEqual({
       scope: 'session',
-      event: { type: 'setActiveStream', payload: { streamId: 'stream-a' } },
+      event: {
+        type: 'setActiveStream',
+        payload: {
+          streamId: 'stream-a',
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      },
     });
     expect(handlers.planApproval.show).toHaveBeenCalledWith({
       approvalId: 'plan-a',
@@ -150,6 +157,41 @@ describe('createExtensionHostInteractions', () => {
     expect(
       interactions.resolve('plan-a', { kind: 'plan', action: 'approve' }),
     ).toBe(false);
+  });
+
+  it('surfaces retry requests without stealing active-stream focus (#8246)', async () => {
+    const handlers = createHandlers();
+    const session = createTestSession();
+    const sessionEvents = recordSessionEvents(session);
+    const interactions = createInteractions({ handlers, session });
+
+    void interactions.requestRetry?.({
+      streamId: 'failing-subagent' as StreamTabId,
+      operation: 'Model invocation',
+    });
+
+    // The stream is registered so its row can carry the pending badge, but
+    // the active tab must not switch — the user may be inspecting another
+    // stream while a failing subagent re-raises retry requests.
+    const activations = sessionEvents.filter(
+      (e) => e.scope === 'session' && e.event.type === 'setActiveStream',
+    );
+    expect(activations).toEqual([
+      {
+        scope: 'session',
+        event: {
+          type: 'setActiveStream',
+          payload: {
+            streamId: 'failing-subagent',
+            suppressViewSwitch: true,
+            ensureVisible: true,
+          },
+        },
+      },
+    ]);
+    expect(handlers.retry.show).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: 'failing-subagent' }),
+    );
   });
 
   it('cancels pending retry requests for a removed stream', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -401,6 +401,47 @@ describe('ProgressBackend', () => {
     backend.dispose();
   });
 
+  it('keeps a filtered interaction stream reachable without switching', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages } = target;
+    const subscription = backend.setupEventListeners();
+
+    try {
+      emitActiveStream(target, {
+        streamId: 'root',
+        agentCategory: AgentCategory.Workflow,
+      });
+      await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+      backend.state.agentCategoryFilter = AgentCategory.Workflow;
+      messages.length = 0;
+
+      emitActiveStream(target, {
+        streamId: 'hidden-approval',
+        agentCategory: AgentCategory.ToolUse,
+        suppressViewSwitch: true,
+        ensureVisible: true,
+      });
+
+      await vi.waitFor(() =>
+        expect(backend.state.agentCategoryFilter).toBe('all'),
+      );
+      expect(backend.state.activeStream).toBe('root');
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+          activeStream: 'root',
+          agentFilter: 'all',
+          streams: expect.arrayContaining([
+            expect.objectContaining({ name: 'hidden-approval' }),
+          ]),
+        }),
+      );
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+    }
+  });
+
   it('patches one stream for subagent registration and run-start metadata', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages, session } = target;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -97,9 +97,11 @@ export function isApprovalBypassedForStream(
 }
 
 /**
- * Emit the tool-edit approval prompt to the progress view: activate the stream
- * awaiting input and post the `showToolEditPermission` event with the bypass
- * affordance gated on the stream's current bypass state.
+ * Emit the tool-edit approval prompt to the progress view: register the
+ * stream awaiting input (without switching the active tab — the request
+ * surfaces as a pending badge on the stream's row, #8246) and post the
+ * `showToolEditPermission` event with the bypass affordance gated on the
+ * stream's current bypass state.
  *
  * Shared host-agnostic logic for the VS Code (`nativeToolEditApproval`) and
  * desktop (`desktopToolEditApproval`) approval surfaces. Each host computes
@@ -119,9 +121,17 @@ export function emitToolEditApprovalPrompt(
   const { requestId, request, relativePath, lineChanges } = params;
   const { streamId } = request;
   if (streamId) {
+    runtimeHost.emit('requestEnsureProgressView', {});
     session.events.emit({
       scope: 'session',
-      event: { type: 'setActiveStream', payload: { streamId } },
+      event: {
+        type: 'setActiveStream',
+        payload: {
+          streamId,
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
+      },
     });
   }
   const isBypassed = streamId

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -395,12 +395,19 @@ export class ExternalInquiryTool extends defineTool({
       }
     }
 
+    // Register the asking stream without switching the active view: hosts
+    // own presentation focus (the extension/desktop progress views badge the
+    // stream row, the CLI TUI activates on modal present) — #8246.
     runtimeHost.emit('requestEnsureProgressView', {});
     ownerSession.events.emit({
       scope: 'session',
       event: {
         type: 'setActiveStream',
-        payload: { streamId },
+        payload: {
+          streamId,
+          suppressViewSwitch: true,
+          ensureVisible: true,
+        },
       },
     });
     const isFollowUp = !!input.thread_id;


### PR DESCRIPTION
Closes #8246

## Problem

1. **Focus steal**: every retry/approval/user-question/external-inquiry request emitted `setActiveStream` without `suppressViewSwitch`, so a failing subagent yanked the Progress view back to its stream on every request cycle while the user was inspecting another stream. The only backend guard (`ProgressFactApplier.handleSetActiveStream`) protects the *current* stream only when it has pending permissions of its own.
2. **"Dismiss does nothing"**: dismiss works — it cancels that stream's retry cycle (`CANCEL_RETRY_REQUEST` → `resolve(kind:'retry', action:'cancel')` → `RetryState` → stream CANCELLED, flow stops). But under subagent fan-out, each failing stream raises its own banner and the focus steal immediately surfaced the *next* failing stream's banner, so the UX read as one un-dismissable banner.

## Fix: interaction requests surface per-stream, never switch focus

Interaction-request emitters now pass `suppressViewSwitch: true` — the existing applier vocabulary for "register the stream (state, logs, hints, content sync) but do NOT switch the active tab" (same contract background child streams already use in `childStream.ts`). The switch policy stays owned by `ProgressFactApplier.handleSetActiveStream`; no new wire surface, no new controls.

What the user sees instead of a yank: the requesting stream's row carries the existing pending-approval indicator (`pendingApprovalIds$` → `has-pending-approval` orange rail), the request panel is already stream-scoped (`filterPermissionsForStream`), and the Progress view is still revealed via `requestEnsureProgressView`. Selecting the badged row shows the panel; dismissing it cancels exactly that stream's cycle and nothing steals focus afterwards.

Applied to all four emitters of the same pattern:

- `packages/extension/src/progressView/extensionHostInteractions.ts` — `activateStream` → `revealStream` (bash, plan, proposal, retry, userQuestion, externalInquiry)
- `packages/desktop/src/main/desktopHostInteractions.ts` — same helper, same contract
- `src/tools/approval/toolEditApproval.ts` — `emitToolEditApprovalPrompt` (shared by the VS Code and desktop tool-edit surfaces; CLI does not use it)
- `src/tools/inquiry/ExternalInquiryTool.ts` — the ask-time registration emission. CLI unaffected: the TUI's inquiry presentation goes through `enqueueTuiApproval`, whose `onPresent` deliberately emits its own (un-suppressed) activation when the modal is actually presented; headless drops inquiries entirely.

Not done (deliberately): no "Retry all / Dismiss all" aggregation — the issue marked it non-prescriptive, and per-panel actions remain the single home for each action (duplicate-UI-controls rule).

## Verified

Opened: `extensionHostInteractions.ts`, `desktopHostInteractions.ts`, `toolEditApproval.ts`, `ExternalInquiryTool.ts`, `ProgressFactApplier.ts` (`handleSetActiveStream` suppress path :510-599), `progressBackendUiConfig.ts`, `RetryState.ts` (dismiss → `userCancelled` → CANCELLED), `ProgressViewMessageHandler.ts` (`handleCancelRetryRequest`), `RetryRequestPanel.ts`, `RequestPanels.ts`, `BaseStreamContent.ts` (stream-scoped panels), `StreamTabs.ts` + `StreamTab.styles.ts` + `progressState.ts` (existing per-row pending badge), `desktopSessionProgressBridge.ts` (`requestEnsureProgressView` still routes to progress), CLI `subscribeApprovals.ts`/`subscribeRuntimeHost.ts`/`approvalAdapter.ts` (on-present activation, headless parity).

- `npm run typecheck` clean (all 6 projects)
- Full `npm test`: 5768 passed, 4 skipped (652 files), exit 0
- Regression test: `ExtensionHostInteractions.vitest.mts` "surfaces retry requests without stealing active-stream focus (#8246)"; updated the payload-exact assertions in `DesktopHostInteractions.vitest.mts`, `DesktopToolEditApproval.vitest.mts`, `HumanPromptProgressEvents.vitest.ts` (+ the `progressTestUtils` recording fake) to the new contract
- Lint: 0 errors; remaining warnings pre-existing in unrelated files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all interaction requests drive Progress tab focus and category filtering; behavior is user-visible across extension, desktop, and shared approval paths, though logic reuses existing `suppressViewSwitch` handling.
> 
> **Overview**
> Fixes **#8246**: retry, approval, user-question, and similar prompts no longer force the Progress view onto the requesting stream while you are inspecting another tab.
> 
> **Host emitters** (extension `revealStream`, desktop equivalent, `emitToolEditApprovalPrompt`, external inquiry) now emit `setActiveStream` with **`suppressViewSwitch: true`** and **`ensureVisible: true`** instead of switching the active tab. Progress is still opened via `requestEnsureProgressView`; the stream row can show the pending badge and stream-scoped panels.
> 
> **Backend** (`ProgressFactApplier`): adds schema flag **`ensureVisible`**. When both flags are set, a restrictive **agent category filter** widens to `all` so the stream tab is not hidden, and filter changes trigger a full stream metadata sync while **keeping** the current `activeStream`.
> 
> Tests and recording fakes were updated to the new payload contract, including a retry focus-steal regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c458c513e1aec9b14fd723a2c0d97f129011fadb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->