### PR TITLE
fix(desktop): publish, defer, and replay rebound stream facts

### DIFF
--- a/packages/desktop/src/main/desktopExecutionRebinder.ts
+++ b/packages/desktop/src/main/desktopExecutionRebinder.ts
@@ -185,6 +185,15 @@ export class DesktopExecutionRebinder {
         });
       }
     };
+    // Tear down only once the target itself holds a terminal phase, so a
+    // rejected terminal mirror doesn't strand the tab non-terminal with the
+    // mirror already detached; a still-alive binding is reaped on window
+    // close, and a re-tracked handle rebinds through it.
+    const disposeBindingIfTargetTerminal = (): void => {
+      if (isTerminalOutcomePhase(this.targetSession.status.get(streamId))) {
+        disposeBinding();
+      }
+    };
     const seedStatus = (handle: AgentExecutionHandle): void => {
       const status = ownerSession.status.get(streamId);
       if (!status) return;
@@ -236,7 +245,7 @@ export class DesktopExecutionRebinder {
         const ownerStatus = ownerSession.status.get(streamId);
         if (isTerminalOutcomePhase(ownerStatus)) {
           mirrorTerminalStatus(ownerStatus);
-          disposeBinding();
+          disposeBindingIfTargetTerminal();
         }
         return;
       }
@@ -300,6 +309,16 @@ export class DesktopExecutionRebinder {
     );
     detachOwnerStatus = ownerSession.status.onDidChange((change) => {
       if (disposed || change.streamId !== streamId) return;
+      if (isTerminalOutcomePhase(change.status)) {
+        // Terminal outcomes need `transitionToTerminal`'s choreography (a
+        // WAITING or unseeded target resumes to RUNNING first); the plain
+        // cause-preserving transition below would reject those mirrors.
+        mirrorTerminalStatus(change.status);
+        // Owner already untracked the handle (see bindOwnerHandle): this
+        // terminal mirror is the binding's last mirrored fact.
+        if (!currentHandle) disposeBindingIfTargetTerminal();
+        return;
+      }
       if (
         !this.targetSession.status.transition(
           streamId,
@@ -322,11 +341,6 @@ export class DesktopExecutionRebinder {
             current: this.targetSession.status.get(streamId),
           },
         });
-      }
-      // Owner already untracked the handle (see bindOwnerHandle): this
-      // terminal transition is the binding's last mirrored fact.
-      if (!currentHandle && isTerminalOutcomePhase(change.status)) {
-        disposeBinding();
       }
     });
     const ownerDetach = ownerSession.executions.observeHandle(

--- a/packages/desktop/src/main/desktopExecutionRebinder.ts
+++ b/packages/desktop/src/main/desktopExecutionRebinder.ts
@@ -13,11 +13,15 @@ import {
   untrackActiveAgentExecution,
 } from '@agent/runtime/SessionHandle';
 
+// Local imports - constants
+import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
+
 // Local imports - shared schemas
 import {
   STREAM_PHASE,
   type ExecutionId,
   type RestoredStreamSnapshot,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -159,6 +163,28 @@ export class DesktopExecutionRebinder {
       disposeBinding();
       if (staleHandle) untrackActiveAgentExecution(staleHandle);
     };
+    // Drop only the per-handle mirrors (trace, terminal, mirrored registry
+    // entry), keeping the binding and its owner-status mirror alive.
+    const releaseHandleMirror = (): void => {
+      const staleHandle = currentHandle;
+      currentHandle = undefined;
+      detachTrace?.();
+      detachTrace = undefined;
+      detachTerminalMirror?.();
+      detachTerminalMirror = undefined;
+      if (staleHandle) untrackActiveAgentExecution(staleHandle);
+    };
+    const mirrorTerminalStatus = (status: StreamPhase): void => {
+      if (
+        !this.targetSession.status.transitionToTerminal(streamId, status, {
+          events: this.targetSession.events,
+        })
+      ) {
+        this.logger.warn('Failed to mirror rebound terminal status', {
+          data: { streamId, status },
+        });
+      }
+    };
     const seedStatus = (handle: AgentExecutionHandle): void => {
       const status = ownerSession.status.get(streamId);
       if (!status) return;
@@ -199,7 +225,19 @@ export class DesktopExecutionRebinder {
         !(handle instanceof AgentExecutionHandle) ||
         handle.childStreamId !== streamId
       ) {
-        releaseCurrent();
+        // The owner untracks BEFORE its terminal stream-status transition
+        // lands (`finalizeRunTerminal` untracks first), and a child stream's
+        // finalization never emits a `result` trace event, so tearing the
+        // whole binding down here would strand the mirrored stream at
+        // RUNNING/WAITING (#8257). Release the handle mirror only; the
+        // owner-status mirror below stays attached until the terminal phase
+        // arrives (or a replacement handle rebinds).
+        releaseHandleMirror();
+        const ownerStatus = ownerSession.status.get(streamId);
+        if (isTerminalOutcomePhase(ownerStatus)) {
+          mirrorTerminalStatus(ownerStatus);
+          disposeBinding();
+        }
         return;
       }
       if (handle === currentHandle) return;
@@ -213,17 +251,29 @@ export class DesktopExecutionRebinder {
         : undefined;
       detachTerminalMirror = handle.trace?.subscribe((event) => {
         if (event.type !== 'result' || event.streamId !== streamId) return;
-        if (
-          !this.targetSession.status.transitionToTerminal(
-            streamId,
-            event.outcome,
-          )
-        ) {
-          this.logger.warn('Failed to mirror rebound terminal status', {
-            data: { streamId, status: event.outcome },
+        mirrorTerminalStatus(event.outcome);
+      });
+      // Launch facts (run.config, child description) fired before this
+      // binding subscribed to the trace; replay them so the rebound stream
+      // carries its real task state and label, not defaults (#8258).
+      const facts = handle.initialRunFacts;
+      if (facts) {
+        this.targetSession.publishRunEvent(streamId, {
+          type: 'run.config',
+          streamId,
+          executionId,
+          config: facts.config,
+        });
+        if (facts.description !== undefined) {
+          this.targetSession.events.emit({
+            scope: 'session',
+            event: {
+              type: 'updateStreamDescription',
+              payload: { streamId, description: facts.description },
+            },
           });
         }
-      });
+      }
       seedStatus(handle);
       if (staleHandle) untrackActiveAgentExecution(staleHandle);
     };
@@ -255,7 +305,13 @@ export class DesktopExecutionRebinder {
           streamId,
           change.status,
           change.cause,
-          change.substate ? { substate: change.substate } : {},
+          {
+            // Publish the mirror as an `updateStreamStatus` session fact:
+            // without `events`, the transition only updates the in-memory
+            // status map and never reaches the UI or snapshot store (#8256).
+            events: this.targetSession.events,
+            ...(change.substate ? { substate: change.substate } : {}),
+          },
         ) &&
         this.targetSession.status.get(streamId) !== change.status
       ) {
@@ -266,6 +322,11 @@ export class DesktopExecutionRebinder {
             current: this.targetSession.status.get(streamId),
           },
         });
+      }
+      // Owner already untracked the handle (see bindOwnerHandle): this
+      // terminal transition is the binding's last mirrored fact.
+      if (!currentHandle && isTerminalOutcomePhase(change.status)) {
+        disposeBinding();
       }
     });
     const ownerDetach = ownerSession.executions.observeHandle(

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -278,6 +278,9 @@ export async function runFlowWithLifecycle(
     ctx.logger,
   );
   handle.enablePendingInterrupt();
+  // A session that binds this handle after launch (cross-window rebind) has
+  // missed the emitRunStart() `run.config` below and replays it from here (#8258).
+  handle.initialRunFacts = { config: ctx.config };
   session.executions.track(handle);
   // Expose the live handle to the launcher (F-2). Guarded: neither a synchronous
   // throw nor an async rejection from a consumer callback may abort the run.

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -8,6 +8,7 @@
 import pDefer from 'p-defer';
 
 import type { AgentTrace, ResultEvent } from '@agent/trace';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
@@ -94,6 +95,18 @@ export class AgentExecutionHandle implements ExecutionHandle {
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
   toolName?: string;
+
+  /**
+   * The launch facts a session must replay when it starts mirroring this
+   * execution after launch: `run.config` is emitted on the run's trace (and a
+   * child stream's description only on the spawning session's hub) before any
+   * cross-session rebinder can subscribe, so a late binder re-emits them from
+   * here into its own session (#8258).
+   */
+  initialRunFacts?: {
+    readonly config: AgentConfig;
+    readonly description?: string;
+  };
 
   /**
    * The run's terminal outcome, settled exactly once (by the run lifecycle, or

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3405,110 +3405,6 @@ describe('DesktopProgressBridge', () => {
       };
     }
 
-    it('reattaches a still-active execution to the newly created window instead of stranding it', async () => {
-      const streamId = 'rebound-stream' as StreamTabId;
-      const executionId = 'ec00cc' as ExecutionId;
-      // Window A launches a real, still-running execution.
-      const messagesA: unknown[] = [];
-      const owner = await createReboundOwner({
-        streamId,
-        executionId,
-        messages: messagesA,
-      });
-
-      // Closing the window retains its active execution for global guards.
-      owner.close();
-
-      // Headless progress has no live subscriber but must remain safe.
-      expect(() =>
-        owner.trace.emit({
-          type: 'status',
-          streamId,
-          phase: STREAM_PHASE.WAITING,
-          cause: 'wait',
-        }),
-      ).not.toThrow();
-
-      // Window B reopens from the persisted ghost entry.
-      const messagesB: unknown[] = [];
-      const { bridgeB, streamSnapshotStore: streamSnapshotStoreB } =
-        owner.reopen(STREAM_PHASE.RUNNING, messagesB);
-
-      try {
-        await (bridgeB as unknown as { restartRepair: Promise<void> })
-          .restartRepair;
-
-        // Window B can inspect and stop the still-active execution.
-        expect(bridgeB.session.executions.getHandle(executionId)).toBe(
-          owner.handle,
-        );
-        expect(
-          bridgeB.session.executions.getAgentHandleByStream(streamId),
-        ).toBe(owner.handle);
-        // The live binding replaces, rather than duplicates, the ghost.
-        expect(
-          (
-            bridgeB as unknown as {
-              sessionProgress: { hasRestoredStream(id: string): boolean };
-            }
-          ).sessionProgress.hasRestoredStream(streamId),
-        ).toBe(false);
-
-        // Later progress reaches B and refreshes its snapshot.
-        owner.trace.emit({
-          type: 'status',
-          streamId,
-          phase: STREAM_PHASE.WAITING,
-          cause: 'wait',
-          previousPhase: STREAM_PHASE.RUNNING,
-        });
-        await settleProgressEvents();
-        expect(streamSnapshotStoreB.upsert).toHaveBeenCalledWith(
-          expect.objectContaining({
-            streamId,
-            lastKnownStatus: STREAM_PHASE.WAITING,
-          }),
-        );
-        expect(
-          messagesA.some(
-            (message) =>
-              message &&
-              typeof message === 'object' &&
-              JSON.stringify(message).includes(STREAM_PHASE.WAITING),
-          ),
-        ).toBe(false);
-
-        // Mirror the real finalize order: result, settlement, then untrack.
-        const resultEvent = {
-          type: 'result' as const,
-          outcome: RUN_OUTCOME.COMPLETED,
-          executionId,
-          streamId,
-          agentName: 'proofreader',
-          category: 'workflow' as const,
-          isSubagent: false,
-        };
-        owner.trace.emit(resultEvent);
-        owner.handle.settleResult(
-          resultEvent as unknown as Parameters<
-            typeof owner.handle.settleResult
-          >[0],
-        );
-        owner.bridgeA.session.executions.untrack(executionId);
-        await owner.handle.result;
-        await settleProgressEvents();
-        expect(
-          bridgeB.session.executions.getHandle(executionId),
-        ).toBeUndefined();
-        // Both registries must go idle; otherwise retained window A leaks.
-        expect(
-          owner.bridgeA.session.executions.getHandle(executionId),
-        ).toBeUndefined();
-      } finally {
-        bridgeB.dispose();
-      }
-    });
-
     it('seeds the rebound stream with the live owning session status, not a stale on-disk snapshot (codex P2)', async () => {
       const streamId = 'rebound-stream-2' as StreamTabId;
       const executionId = 'ec00dd' as ExecutionId;
@@ -3540,6 +3436,14 @@ describe('DesktopProgressBridge', () => {
         );
         // The authoritative owner status wins over the ghost snapshot.
         expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+        // The live binding replaces, rather than duplicates, the ghost.
+        expect(
+          (
+            bridgeB as unknown as {
+              sessionProgress: { hasRestoredStream(id: string): boolean };
+            }
+          ).sessionProgress.hasRestoredStream(streamId),
+        ).toBe(false);
       } finally {
         bridgeB.dispose();
       }
@@ -3887,6 +3791,206 @@ describe('DesktopProgressBridge', () => {
           freshHandle,
         );
       } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('publishes mirrored owner status changes as updateStreamStatus session facts (#8256)', async () => {
+      const streamId = 'rebound-stream-7' as StreamTabId;
+      const executionId = 'ec00f7' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const { bridgeB, streamSnapshotStore } = owner.reopen(
+        STREAM_PHASE.RUNNING,
+      );
+      const facts: SessionFact[] = [];
+      const detachFacts = bridgeB.session.events.subscribe(
+        (event) => {
+          if (event.scope === 'session') facts.push(event.event);
+        },
+        { scope: 'session' },
+      );
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        // A bare owner-machine transition (no live trace) must still reach
+        // the reopened window's UI and snapshot store as a session fact.
+        expect(
+          owner.bridgeA.session.status.transitionToWaiting(streamId, 'wait'),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+        expect(facts).toContainEqual(
+          expect.objectContaining({
+            type: 'updateStreamStatus',
+            payload: expect.objectContaining({
+              streamId,
+              status: STREAM_PHASE.WAITING,
+            }),
+          }),
+        );
+        await settleProgressEvents();
+        expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId,
+            lastKnownStatus: STREAM_PHASE.WAITING,
+          }),
+        );
+      } finally {
+        detachFacts();
+        bridgeB.dispose();
+      }
+    });
+
+    it('mirrors a child terminal status that lands after the owner untracks (#8257)', async () => {
+      const streamId = 'rebound-stream-8' as StreamTabId;
+      const childStreamId = 'rebound-child-8' as StreamTabId;
+      const executionId = 'ec00f8' as ExecutionId;
+      const childExecutionId = 'ec00f9' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const { handle: childHandle } = owner.createHandle({
+        executionId: childExecutionId,
+        childStreamId,
+        agentName: 'searcher',
+        category: AgentCategory.ToolUse,
+      });
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING);
+      const facts: SessionFact[] = [];
+      const detachFacts = bridgeB.session.events.subscribe(
+        (event) => {
+          if (event.scope === 'session') facts.push(event.event);
+        },
+        { scope: 'session' },
+      );
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        owner.bridgeA.session.executions.trackAgentExecution(childHandle, {
+          status: STREAM_PHASE.RUNNING,
+        });
+        expect(bridgeB.session.status.get(childStreamId)).toBe(
+          STREAM_PHASE.RUNNING,
+        );
+
+        // Child finalization order (finalizeChildStream): untrack first,
+        // terminal stream status second, and no `result` trace event at all.
+        owner.bridgeA.session.executions.untrack(childExecutionId);
+        expect(
+          bridgeB.session.executions.getHandle(childExecutionId),
+        ).toBeUndefined();
+        expect(
+          owner.bridgeA.session.status.transitionToTerminal(
+            childStreamId,
+            STREAM_PHASE.COMPLETED,
+          ),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(childStreamId)).toBe(
+          STREAM_PHASE.COMPLETED,
+        );
+        expect(facts).toContainEqual(
+          expect.objectContaining({
+            type: 'updateStreamStatus',
+            payload: expect.objectContaining({
+              streamId: childStreamId,
+              status: STREAM_PHASE.COMPLETED,
+            }),
+          }),
+        );
+
+        // The terminal mirror was the binding's last act; later owner-machine
+        // transitions for the finished child no longer mirror.
+        expect(
+          owner.bridgeA.session.status.transition(
+            childStreamId,
+            STREAM_PHASE.RUNNING,
+            'resume',
+          ),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(childStreamId)).toBe(
+          STREAM_PHASE.COMPLETED,
+        );
+      } finally {
+        detachFacts();
+        bridgeB.dispose();
+      }
+    });
+
+    it('replays initial run config and description for descendants bound after tracking (#8258)', async () => {
+      const streamId = 'rebound-stream-9' as StreamTabId;
+      const childStreamId = 'rebound-child-9' as StreamTabId;
+      const executionId = 'ec00fa' as ExecutionId;
+      const childExecutionId = 'ec00fb' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const { bridgeB, streamSnapshotStore } = owner.reopen(
+        STREAM_PHASE.RUNNING,
+      );
+      const childConfig = {
+        agent: 'searcher',
+        model: 'deepseekproT',
+        agentCategory: AgentCategory.ToolUse,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+      } as unknown as AgentConfig;
+      const events: SessionEvent[] = [];
+      const detachEvents = bridgeB.session.events.subscribe((event) => {
+        events.push(event);
+      });
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        // Spawn a child AFTER the root was rebound: its run.config and
+        // description fired on the owner side before tracking, so only the
+        // handle-carried replay can deliver them to the reopened window.
+        const { handle: childHandle } = owner.createHandle({
+          executionId: childExecutionId,
+          childStreamId,
+          agentName: 'searcher',
+          category: AgentCategory.ToolUse,
+        });
+        childHandle.initialRunFacts = {
+          config: childConfig,
+          description: 'Search the docs',
+        };
+        owner.bridgeA.session.executions.trackAgentExecution(childHandle, {
+          status: STREAM_PHASE.RUNNING,
+        });
+
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            scope: 'run',
+            streamId: childStreamId,
+            event: expect.objectContaining({
+              type: 'run.config',
+              executionId: childExecutionId,
+              config: childConfig,
+            }),
+          }),
+        );
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            scope: 'session',
+            event: expect.objectContaining({
+              type: 'updateStreamDescription',
+              payload: {
+                streamId: childStreamId,
+                description: 'Search the docs',
+              },
+            }),
+          }),
+        );
+        await settleProgressEvents();
+        expect(streamSnapshotStore.upsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            streamId: childStreamId,
+            agent: 'searcher',
+            description: 'Search the docs',
+            executionId: childExecutionId,
+          }),
+        );
+      } finally {
+        detachEvents();
         bridgeB.dispose();
       }
     });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3916,6 +3916,38 @@ describe('DesktopProgressBridge', () => {
       }
     });
 
+    it('mirrors a terminal owner status onto a WAITING target through resume choreography', async () => {
+      const streamId = 'rebound-stream-12' as StreamTabId;
+      const executionId = 'ec00fe' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING);
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        // A target-local wait skews the machines: the target sits at WAITING
+        // while the owner finishes from RUNNING. The terminal mirror must go
+        // through transitionToTerminal's resume choreography, not the plain
+        // cause-preserving transition (which rejects WAITING -> terminal).
+        expect(
+          bridgeB.session.status.transitionToWaiting(streamId, 'wait'),
+        ).toBe(true);
+        owner.bridgeA.session.executions.untrack(executionId);
+        expect(
+          owner.bridgeA.session.status.transitionToTerminal(
+            streamId,
+            STREAM_PHASE.COMPLETED,
+          ),
+        ).toBe(true);
+        expect(bridgeB.session.status.get(streamId)).toBe(
+          STREAM_PHASE.COMPLETED,
+        );
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
     it('replays initial run config and description for descendants bound after tracking (#8258)', async () => {
       const streamId = 'rebound-stream-9' as StreamTabId;
       const childStreamId = 'rebound-child-9' as StreamTabId;

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -133,13 +133,14 @@ export function createChildStream(
     executionId,
     config: options.config,
   });
+  const description = truncateWithEllipsis(options.description, 80);
   session.events.emit({
     scope: 'session',
     event: {
       type: 'updateStreamDescription',
       payload: {
         streamId: childStreamId,
-        description: truncateWithEllipsis(options.description, 80),
+        description,
       },
     },
   });
@@ -154,6 +155,9 @@ export function createChildStream(
     runTrace.trace,
   );
   if (options.toolName) handle.toolName = options.toolName;
+  // Both facts above fire before the handle is tracked, so a session that
+  // rebinds this child later can only replay them from the handle (#8258).
+  handle.initialRunFacts = { config: options.config, description };
   session.executions.trackAgentExecution(handle, {
     status: STREAM_PHASE.RUNNING,
   });


### PR DESCRIPTION
Follow-up cluster from #8249's `DesktopExecutionRebinder` (tracking #8255). All three fixes extend the single rebind owner — no second rebind path.

Closes #8256
Closes #8257
Closes #8258
Closes #8274

## Design

**#8256 — mirrored status never published.** `StreamStatusMachine.publishStatus` only emits the `updateStreamStatus` session fact when `!options.trace && options.events` (`src/agent/runtime/StreamStatusService.ts:309`). Both mirror call sites in the rebinder passed neither, so mirrored transitions updated the in-memory status map but never reached `DesktopSessionProgressBridge.handleSessionFact` (UI badges, snapshot persistence). The ongoing owner-status mirror and the terminal mirror now pass `{ events: this.targetSession.events }`.

**#8257 — binding disposed before the terminal status lands.** `finalizeRunTerminal` untracks the handle *before* its terminal stream-status transition (`src/agent/runtime/AgentRunLifecycle.ts:173` vs `:175`), and `finalizeChildStream` deliberately emits no `result` trace event (`src/tools/childStream.ts`). The old `bindOwnerHandle` untrack branch called `releaseCurrent()`, tearing down the owner-status listener in that window — a finished child stayed RUNNING/WAITING in the reopened window forever. Now the untrack branch releases only the per-handle mirrors (trace, terminal, mirrored registry entry) and keeps the owner-status mirror attached; it mirrors an already-terminal owner phase immediately, otherwise the owner-status listener mirrors the terminal transition when it arrives and disposes the binding as its last act. The `releaseCurrent()` full-teardown path is unchanged for target-side handle replacement (#8229 resume-supersede).

**#8258 — late-bound descendants miss launch metadata.** `createChildStream` emits `run.config` (on the child trace) and `updateStreamDescription` (on the spawning session's hub) *before* `trackAgentExecution`, so a rebinder that subscribes at bind time can never see them. The handle is the one object that crosses sessions, so it now carries `initialRunFacts` (`config`, optional `description`), set by both spawn paths (`createChildStream`, `runFlowWithLifecycle`). `bindOwnerHandle` replays them into the target session — `run.config` via `publishRunEvent` (run scope) and the description as a session fact — before seeding status, so the rebound child tab gets its real task state, category, and label.

**#8274 — test cleanup.** Deletes the broad ~100-line rebinder scenario whose status/result/untrack, disposal, replacement, isolation, and snapshot assertions duplicate the narrower tests, and moves its one unique ghost-removal assertion into the focused seed/restoration test.

## Verified

- Read the merged rebinder at origin/main HEAD (`packages/desktop/src/main/desktopExecutionRebinder.ts`), `StreamStatusService.publishStatus`, `finalizeRunTerminal`, `finalizeChildStream`/`createChildStream`, and `ExecutionRegistry.untrackHandle` notification order to confirm each premise before coding.
- `npm run typecheck` — clean (all six sub-projects).
- `npm test -- DesktopAgentExecution.vitest` — 72 passed, including three new regression tests (`#8256` session-fact publication + snapshot upsert, `#8257` untrack-then-terminal child mirror + binding disposal, `#8258` run.config/description replay + snapshot content).
- `npm test -- ExecutionRegistry ChildRunLoop SessionHandle NativeToolUseStrategy AgentRunLifecycle childStream` — 88 passed.
- ESLint clean on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop rebind mirroring and stream status/terminal choreography across windows; behavior is well-covered by new regression tests but mistakes could strand tabs in wrong phases or omit UI updates.
> 
> **Overview**
> Fixes **cross-window execution rebind** so mirrored streams in a reopened desktop window stay accurate for UI, snapshots, and terminal lifecycle.
> 
> **`DesktopExecutionRebinder`** now passes `events` when mirroring owner status (including terminals via `transitionToTerminal`), so `updateStreamStatus` session facts reach the progress bridge instead of only updating in-memory state. When the owner untracks before terminal status lands (and child streams never emit a `result` trace), it **drops only handle mirrors** and keeps the owner-status listener until a terminal phase is mirrored, then disposes the binding safely. On bind, it **replays** `handle.initialRunFacts` as `run.config` and `updateStreamDescription`.
> 
> **`AgentExecutionHandle`** gains optional **`initialRunFacts`** (`config`, optional `description`), set at launch in **`runFlowWithLifecycle`** and **`createChildStream`** so late rebinders can emit facts subscribers missed.
> 
> Tests: removes a redundant broad rebinder scenario, adds focused regressions for **#8256**, **#8257**, and **#8258**, and folds ghost-removal into the seed test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55ac4c9172be10d69000175f9236a40331693f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->