### PR TITLE
fix: make transcript store lifecycle explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
   clamp no longer converts `medium` to `high`; current Grok reasoning models
   (grok-4.3, grok-4.5) support low/medium/high.
 
+- **Agent runs no longer start with unavailable transcript persistence** —
+  headless CLI, desktop, and extension execution now fail initialization when
+  persistent transcripts cannot be opened. Interactive CLI fallback sessions
+  are clearly marked as ephemeral and are not advertised as resumable.
+
 ## [0.39.3] - 2026-07-10
 
 ### Shared (all surfaces)

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -10,7 +10,10 @@ import { render } from 'ink';
 import React from 'react';
 
 import { getAgentsByCategory, loadAgents } from '@agent/index';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  initializeDefaultSession,
+} from '@agent/runtime/SessionHandle';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { STREAM_TRANSITION_CAUSE } from '@common/constants/streamStatus';
@@ -39,6 +42,7 @@ import {
 } from '@shared/schemas';
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
 import { GoalStore } from '@tools/goal';
+import { StreamLogStore } from '@transcript';
 
 import { App } from '../src/chat/tui/App';
 import { registerBuiltinSlashCommands } from '../src/chat/tui/commands/registerBuiltins';
@@ -273,7 +277,6 @@ const EDIT_APPROVAL_DELAY_MS = Number(
   process.env.HARNESS_EDIT_APPROVAL_DELAY_MS ?? '0',
 );
 const QUEUED_FOLLOW_UPS = parseList(process.env.HARNESS_QUEUED_FOLLOWUPS);
-const HARNESS_FOLLOW_UP_QUEUE = defaultSession().followUps.acquire(STREAM_ID);
 const HARNESS_CWD_INPUT = process.env.HARNESS_CWD?.trim();
 // Keep platform state writes out of the repository unless a scenario opts in.
 const HARNESS_CWD =
@@ -288,10 +291,6 @@ if (!HARNESS_CWD_INPUT && process.env.HARNESS_KEEP_CWD !== '1') {
     rmSync(HARNESS_CWD, { recursive: true, force: true });
   });
 }
-for (const followUp of QUEUED_FOLLOW_UPS) {
-  HARNESS_FOLLOW_UP_QUEUE.enqueue(followUp);
-}
-
 function seedHarnessProjectSkill(): void {
   const skillDir = path.join(HARNESS_CWD, '.texra', 'skills', 'proof-audit');
   mkdirSync(skillDir, { recursive: true });
@@ -337,6 +336,11 @@ await initLocalCliPlatform({
   storageRoot: path.join(HARNESS_CWD, '.texra-storage'),
   helperModel: 'harness-model',
 });
+initializeDefaultSession({ transcripts: await StreamLogStore.open() });
+const harnessFollowUpQueue = defaultSession().followUps.acquire(STREAM_ID);
+for (const followUp of QUEUED_FOLLOW_UPS) {
+  harnessFollowUpQueue.enqueue(followUp);
+}
 if (process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS !== undefined) {
   await platform().workspaceState.update(
     WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -172,7 +172,10 @@ export async function handleTuiSlashCommand(
             : undefined,
           // Only surface the resume id once a stream exists — never next to
           // a "not started" status.
-          sessionId: slice ? context.session.executionId : undefined,
+          sessionId:
+            slice && meta.transcriptMode === 'persistent'
+              ? context.session.executionId
+              : undefined,
           commandName: context.commandName,
           cwd: context.cwd,
           processCwd: context.processCwd,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -148,6 +148,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     hasMultipleStreams: streams.size > 1,
     model: sessionMeta.model,
     apiMode: shortCliApiMode(sessionMeta.apiMode),
+    transcriptMode: sessionMeta.transcriptMode,
     subscriptionActive,
     approvalPolicy: sessionMeta.approvalPolicy,
     shiftEnterNewline: caps.kittyKeyboard,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -95,6 +95,8 @@ export interface StatusBarDisplayInput {
   readonly hasMultipleStreams: boolean;
   readonly model: string;
   readonly apiMode: string;
+  /** Ephemeral transcripts cannot be resumed and require a persistent warning. */
+  readonly transcriptMode?: 'persistent' | 'ephemeral';
   /** True when the active model routes through the ChatGPT subscription; the
    *  mode segment then reads "subscription" instead of the api-mode. */
   readonly subscriptionActive?: boolean;
@@ -681,6 +683,14 @@ export function buildStatusBarDisplay(
   const left: StatusBarSegment[] = [
     { text: STATUS_DIAMOND, color: COLOR_HINT, decorative: true },
   ];
+  if (input.transcriptMode === 'ephemeral') {
+    left.push({
+      text: 'EPHEMERAL TRANSCRIPT',
+      compactText: 'EPHEMERAL',
+      badge: true,
+      badgeColor: COLOR_WARNING,
+    });
+  }
 
   if (input.pendingExitHint) {
     left.push({ text: PENDING_EXIT_HINT_TEXT, color: COLOR_WARNING });

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -50,6 +50,7 @@ import {
   type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
 import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
+import { initializeInteractiveTranscriptSession } from '@cli/runtime/transcriptSession';
 import { cliSettingsStores } from '@cli/runtime/settingsStores';
 import {
   formatInteractiveTerminalFailure,
@@ -274,6 +275,15 @@ export async function runChat(
   // exactly one owner is ever registered for a given signal; see
   // initInteractiveCliPlatform's doc comment for the full handoff design.
   await initInteractiveCliPlatform({ ...context, quietLogs: true });
+  const initialResume = init.initialResume;
+  const transcriptLifecycle = await initializeInteractiveTranscriptSession(
+    initialResume
+      ? { onPersistentOpenFailure: 'fail' }
+      : {
+          onPersistentOpenFailure: 'use-ephemeral',
+          showPersistentWarning: writeTextStderr,
+        },
+  );
   // First-run gate (interactive only; headless already rejected above). A
   // credential-less user signs in or saves a key here; the apiMode + model
   // resolution below then see the freshly-set credentials in the same process.
@@ -287,7 +297,6 @@ export async function runChat(
     return { exitCode: CliExitCode.Success };
   }
   const apiMode = effectiveCliApiMode(context);
-  const initialResume = init.initialResume;
   // State 1 continuation (docs/prds/2026-06-11-agent-native-onboarding.md): on a true
   // first run the post-picker session starts with the setup agent. Threaded
   // through the same override slot resolveChatDefaults already honors, and
@@ -382,9 +391,13 @@ export async function runChat(
     apiMode,
     approvalPolicy: activeApprovalPolicy,
     canDelegate: chatAgentSupportsDelegation(agent),
+    transcriptMode: transcriptLifecycle.canResume ? 'persistent' : 'ephemeral',
     teamName: init.teamName,
     version,
   });
+  if (transcriptLifecycle.warning) {
+    appendLocalErrorTranscript(transcriptLifecycle.warning);
+  }
   if (modelSelection.notice) {
     appendLocalAssistantTranscript(modelSelection.notice);
   }
@@ -400,19 +413,6 @@ export async function runChat(
     stdin: process.stdin,
     stdout: process.stdout,
   });
-
-  // Enable StreamLog persistence for the interactive session so transcripts
-  // survive exit and can be reopened on resume. Uses the shared (extension-
-  // compatible) StreamLogStore, so a workspace opened in either surface reads
-  // the same `streamLogs/<id>.json`. load() is summaries-only (lazy) and must
-  // run before any append — it clears in-memory logs on entry — hence before
-  // subscribeStreamLog wires the append→sync bridge below. Best-effort: a load
-  // failure leaves persistence off (save() no-ops) rather than breaking chat.
-  try {
-    await defaultSession().transcripts.load();
-  } catch {
-    // Persistence stays disabled; the session still runs in-memory as before.
-  }
 
   // Persist per-stream sidecar data (todos, plan, usage, output files) via the
   // shared, host-agnostic snapshot store so a `texra resume` restores the full
@@ -496,6 +496,7 @@ export async function runChat(
       status: rootStreamStatus(),
     });
   const isResumableIdle = (): boolean =>
+    transcriptLifecycle.canResume &&
     chatTuiIsResumableIdleOnExit({
       canInterruptActiveRun: canInterruptActiveRun(),
       canStopActiveRun: canStopActiveRun(),
@@ -852,7 +853,7 @@ export async function runChat(
   // resumable tool-use subagent, so any route can be continued by its own id.
   // Read the streams slice before resetCliState() clears it.
   const printResumeHintOnExit = (): void => {
-    if (!session.executionId) return;
+    if (!transcriptLifecycle.canResume || !session.executionId) return;
     const streams = streamsSignal.get();
     const hint = formatResumeHint(
       collectResumeTargets({
@@ -872,8 +873,8 @@ export async function runChat(
   };
   // Materialize buffered trace chunks, then drain the debounced StreamLog disk
   // writes so the tail of the session isn't lost (SAVE_DEBOUNCE_MS window).
-  // flush() is bounded (MAX_WRITE_RETRIES) and a no-op when persistence never
-  // loaded, so this can neither hang nor affect headless paths.
+  // Persistent flushes have bounded retries; an explicitly ephemeral session
+  // has no disk work to drain.
   const drainPersistence = async (): Promise<void> => {
     flushPendingRunTraces();
     detachSnapshotPersistence();
@@ -915,7 +916,9 @@ export async function runChat(
   const armExit = (): void => {
     exitArmed = true;
     pendingExitHint.set(true);
-    pendingExitResumeId.set(session.executionId);
+    pendingExitResumeId.set(
+      transcriptLifecycle.canResume ? session.executionId : undefined,
+    );
     if (pendingExitTimer) clearTimeout(pendingExitTimer);
     pendingExitTimer = setTimeout(clearPendingExit, 800);
   };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -92,6 +92,7 @@ export interface SessionMeta {
   readonly apiMode: CliApiMode;
   readonly approvalPolicy: CliApprovalPolicy;
   readonly canDelegate: boolean;
+  readonly transcriptMode: 'persistent' | 'ephemeral';
   readonly teamName?: string;
   readonly version: string;
 }
@@ -291,6 +292,7 @@ const EMPTY_SESSION_META: SessionMeta = {
   apiMode: 'personal',
   approvalPolicy: 'ask',
   canDelegate: false,
+  transcriptMode: 'persistent',
   version: '',
 };
 
@@ -307,9 +309,14 @@ export function setCliSessionModelOverride(model: string): void {
   patchSessionMeta({ model, modelSource: 'explicit-override' });
 }
 
-/** Preserve the resolved CLI version across resets; everything else clears. */
+/** Preserve process-session properties across conversation resets. */
 function defaultSessionMeta(): SessionMeta {
-  return { ...EMPTY_SESSION_META, version: SESSION_META.get().version };
+  const current = SESSION_META.get();
+  return {
+    ...EMPTY_SESSION_META,
+    transcriptMode: current.transcriptMode,
+    version: current.version,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -9,7 +9,6 @@ import {
   type ValidatedExecutionRequest,
 } from '@agent/core/state/executionRequests';
 import { runAgent } from '@agent/runtime/runAgent';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { AgentError } from '@common/errors';
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
@@ -18,6 +17,7 @@ import { generateExecutionId } from '@utils/core';
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
+import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
 import { CliExitCode } from './exitCodes';
 import { writeTextStderr } from './logSinks';
@@ -174,33 +174,33 @@ export async function executeCliRequest(
   | { ok: true; result: ExecuteAgentResult; terminalStatus: ExecutionStatus }
   | { ok: false; exitCode: CliExitCode }
 > {
+  // Transcript persistence is a launch prerequisite for every headless run.
+  // This executes before runtime-host construction and before runAgent.
+  const { session } = await initializeHeadlessTranscriptSession();
   const runtimeHost = createCliRuntimeHost(runContext);
   const snapshotStore = new StreamSnapshotStore();
   const detachSnapshotEvents = snapshotStore.attachSessionEvents(
-    defaultSession().events,
+    session.events,
   );
   const detachRunProgressRenderer = runtimeHost.attachRunProgressRenderer(
-    defaultSession().events,
+    session.events,
   );
-  const detachHostInteractions = defaultSession().useHostInteractions(
+  const detachHostInteractions = session.useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
     }),
   );
   const interactionHost: CliRuntimeHost = {
     ...runtimeHost,
-    interactions: defaultSession().interactions,
+    interactions: session.interactions,
   };
   // Present terminal-error toasts from the run's `result` event through the same
   // runtimeHost path the lifecycle used before (so ndjson / logger output is
   // unchanged); the lifecycle no longer emits them directly.
-  const detachResultToast = attachTerminalResultToast(
-    defaultSession(),
-    interactionHost,
-  );
+  const detachResultToast = attachTerminalResultToast(session, interactionHost);
   const detachSessionProgressProjection =
     runContext.outputFormat === 'ndjson'
-      ? attachCliSessionProgressProjection(defaultSession().events)
+      ? attachCliSessionProgressProjection(session.events)
       : () => undefined;
   const ownedExecutionId = options.registerExecution
     ? request.executionId
@@ -218,6 +218,7 @@ export async function executeCliRequest(
   const invoke = (): Promise<ExecuteAgentResult> =>
     runAgent(request, {
       runtimeHost: interactionHost,
+      session,
       enforceCategory: options.enforceCategory,
       registerExecution: options.registerExecution,
       stopAfterCycle: options.stopAfterCycle,
@@ -228,19 +229,7 @@ export async function executeCliRequest(
       ],
     });
 
-  // Headless runs append to StreamLogStore the same as the interactive TUI
-  // (via createRunTrace's transcript recorder), but StreamLogStore.save()/
-  // flush() silently no-op until .load() has run once — without this, every
-  // headless run's streamLogs are appended in memory and then lost entirely
-  // when the process exits. Mirrors runChatTui.tsx's best-effort load. Done
-  // last (right before the run starts) so it can't delay the synchronous
-  // shutdown-hook registration above.
-  const streamLogStore = defaultSession().transcripts;
-  try {
-    await streamLogStore.load();
-  } catch {
-    // Persistence stays disabled; the run still executes in-memory as before.
-  }
+  const streamLogStore = session.transcripts;
 
   let runResult:
     | { readonly ok: true; readonly result: ExecuteAgentResult }

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -23,8 +23,12 @@ type OpenPersistentStore = () => Promise<StreamLogStore>;
 
 function persistentSession(session: SessionHandle): CliTranscriptSession {
   if (session.transcripts.mode.kind !== 'persistent') {
+    const detail =
+      session.transcripts.mode.kind === 'ephemeral'
+        ? `ephemeral (${session.transcripts.mode.reason})`
+        : 'read-only';
     throw new Error(
-      `Persistent transcripts are required, but the default session is ephemeral (${session.transcripts.mode.reason}).`,
+      `Persistent transcripts are required, but the default session is ${detail}.`,
     );
   }
   return { session, canResume: true };
@@ -53,6 +57,9 @@ export async function initializeInteractiveTranscriptSession(
   if (existing) {
     if (existing.transcripts.mode.kind === 'persistent') {
       return { session: existing, canResume: true };
+    }
+    if (existing.transcripts.mode.kind === 'read-only') {
+      return persistentSession(existing);
     }
     if (policy.onPersistentOpenFailure === 'fail') {
       return persistentSession(existing);

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -1,0 +1,85 @@
+import { StreamLogStore } from '@transcript';
+import {
+  initializeDefaultSession,
+  tryDefaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+export type InteractiveTranscriptPolicy =
+  | { readonly onPersistentOpenFailure: 'fail' }
+  | {
+      readonly onPersistentOpenFailure: 'use-ephemeral';
+      readonly showPersistentWarning: (message: string) => void;
+    };
+
+export interface CliTranscriptSession {
+  readonly session: SessionHandle;
+  readonly canResume: boolean;
+  readonly warning?: string;
+}
+
+type OpenPersistentStore = () => Promise<StreamLogStore>;
+
+function persistentSession(session: SessionHandle): CliTranscriptSession {
+  if (session.transcripts.mode.kind !== 'persistent') {
+    throw new Error(
+      `Persistent transcripts are required, but the default session is ephemeral (${session.transcripts.mode.reason}).`,
+    );
+  }
+  return { session, canResume: true };
+}
+
+/** Prepare the process session for a noninteractive run before it can start. */
+export async function initializeHeadlessTranscriptSession(
+  openPersistentStore: OpenPersistentStore = () => StreamLogStore.open(),
+): Promise<CliTranscriptSession> {
+  const existing = tryDefaultSession();
+  if (existing) return persistentSession(existing);
+
+  const transcripts = await openPersistentStore();
+  return persistentSession(initializeDefaultSession({ transcripts }));
+}
+
+/**
+ * Prepare the interactive TUI session under an explicit persistence policy.
+ * Only the `use-ephemeral` arm permits an in-memory session after open failure.
+ */
+export async function initializeInteractiveTranscriptSession(
+  policy: InteractiveTranscriptPolicy,
+  openPersistentStore: OpenPersistentStore = () => StreamLogStore.open(),
+): Promise<CliTranscriptSession> {
+  const existing = tryDefaultSession();
+  if (existing) {
+    if (existing.transcripts.mode.kind === 'persistent') {
+      return { session: existing, canResume: true };
+    }
+    if (policy.onPersistentOpenFailure === 'fail') {
+      return persistentSession(existing);
+    }
+    const warning = formatEphemeralWarning(existing.transcripts.mode.reason);
+    policy.showPersistentWarning(warning);
+    return { session: existing, canResume: false, warning };
+  }
+
+  let transcripts: StreamLogStore;
+  try {
+    transcripts = await openPersistentStore();
+  } catch (error) {
+    if (policy.onPersistentOpenFailure === 'fail') throw error;
+
+    const reason = `Persistent transcript opening failed: ${toErrorMessage(error)}`;
+    const warning = formatEphemeralWarning(reason);
+    const session = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral(reason),
+    });
+    policy.showPersistentWarning(warning);
+    return { session, canResume: false, warning };
+  }
+
+  return persistentSession(initializeDefaultSession({ transcripts }));
+}
+
+function formatEphemeralWarning(reason: string): string {
+  return `Transcript persistence is unavailable for this session. Its conversation cannot be resumed. ${reason}`;
+}

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -8,7 +8,7 @@ import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
-import { StreamSnapshotStore } from '@transcript';
+import { StreamLogStore, StreamSnapshotStore } from '@transcript';
 import {
   isProgressBackendInteractionEvent,
   type ProgressBackendInteractionPayloads,
@@ -165,6 +165,7 @@ interface DesktopRunExecutionOptions {
 }
 
 export interface DesktopProgressBridgeOptions {
+  transcripts: StreamLogStore;
   openPath?: (filePath: string, line?: number) => Promise<void>;
   openBuildDisplay?: BuildDisplayFn;
   openDiff?: DiffViewHost['openDiff'];
@@ -242,12 +243,15 @@ export class DesktopProgressBridge {
 
   constructor(
     private readonly postToRenderer: (message: unknown) => boolean | void,
-    private readonly options: DesktopProgressBridgeOptions = {},
+    private readonly options: DesktopProgressBridgeOptions,
   ) {
     const hostChannel: AgentRuntimeHost = {
       emit: (event, payload) => this.handleInteractionEvent(event, payload),
     };
-    this.session = new SessionHandle({ hostChannel });
+    this.session = new SessionHandle({
+      hostChannel,
+      transcripts: options.transcripts,
+    });
     this.executionRebinder = new DesktopExecutionRebinder(
       this.session,
       this.logger,
@@ -840,7 +844,6 @@ export class DesktopProgressBridge {
 
   private async repairOrphanedStreamsAfterRestart(): Promise<void> {
     try {
-      await this.state.streamLogs.load();
       this.sessionProgress.hydrateRestoredStreams();
       const { activeExecutionIds, allExecutionIds } =
         this.refreshActiveExecutionIds();
@@ -1080,14 +1083,11 @@ export class DesktopProgressBridge {
 
   /**
    * Owns the Progress webview's readiness sequence. Restored streams are
-   * only folded into `streamLogs`/`session.status` once `restartRepair`
-   * settles (`repairOrphanedStreamsAfterRestart` awaits `streamLogs.load()`
-   * first), so painting the rail before that leaves restored streams
-   * missing from the first paint with nothing guaranteed to correct it —
-   * the same race class `revealStream` was fixed for (#7850). Gating the
-   * whole sequence here, instead of each `webviewReady` call site awaiting
-   * `restartRepair` inline, makes the ordering impossible to get wrong from
-   * a caller.
+   * folded into `session.status` by `restartRepair`; transcript persistence is
+   * already open before this bridge can be constructed. Painting the rail
+   * before repair settles would omit restored status from the first paint.
+   * Gating the whole sequence here makes the ordering uniform for every
+   * `webviewReady` caller.
    */
   async completeWebviewReady(
     onInquiryHydrationError: (error: unknown) => void = () => {},
@@ -1207,13 +1207,23 @@ export class DesktopProgressBridge {
       return;
     }
 
-    void this.streamLogs.ensureLoaded(streamId).then(() => {
-      if (this.state.activeStream !== streamId) return;
-      this.backend.factApplier.syncStreamContent(streamId, {
-        includeActiveState: true,
+    void this.streamLogs
+      .ensureLoaded(streamId)
+      .then(() => {
+        if (this.state.activeStream !== streamId) return;
+        this.backend.factApplier.syncStreamContent(streamId, {
+          includeActiveState: true,
+        });
+        this.sessionProgress.sendRestoredDisplay(streamId);
+      })
+      .catch((error: unknown) => {
+        this.logger.error(`Failed to load desktop transcript ${streamId}`, {
+          data: toLogData(error),
+        });
+        void this.options.showErrorMessage?.(
+          `Transcript load failed: ${toErrorMessage(error)}`,
+        );
       });
-      this.sessionProgress.sendRestoredDisplay(streamId);
-    });
   }
 
   private stopStream(streamId: StreamTabId): void {
@@ -1563,10 +1573,12 @@ export class DesktopProgressBridge {
   }
 }
 
-export function createDesktopAgentExecution(
+export async function createDesktopAgentExecution(
   options: DesktopAgentExecutionOptions,
-): DesktopAgentExecution {
+): Promise<DesktopAgentExecution> {
+  const transcripts = await StreamLogStore.open();
   const progress = new DesktopProgressBridge(options.postToRenderer, {
+    transcripts,
     openPath: options.opener?.openPath,
     openBuildDisplay: options.opener?.openBuildDisplay,
     openDiff: options.diff?.openDiff,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -543,8 +543,10 @@ function createWindow(options: {
     }
 
     agentExecutionLoad ??= import('./desktopAgentExecution.js')
-      .then(({ createDesktopAgentExecution }) => {
-        const created = createDesktopAgentExecution(agentExecutionOptions);
+      .then(async ({ createDesktopAgentExecution }) => {
+        const created = await createDesktopAgentExecution(
+          agentExecutionOptions,
+        );
         if (windowClosed) {
           created.dispose();
           throw new Error(

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -15,11 +15,15 @@ import { UsageLogService } from '@telemetry/UsageLogService';
 import { backfillFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { seedRosterFromDefaultTeam } from '@controllers/onboarding/defaultTeamSeeding';
 import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
+import { StreamLogStore } from '@transcript';
 import { loadAgents } from '@agent/index';
 import { clearStoreCache, listExecutions } from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal/promptLoader';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  initializeDefaultSession,
+} from '@agent/runtime/SessionHandle';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import {
@@ -255,6 +259,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     },
   });
+  initializeDefaultSession({ transcripts: await StreamLogStore.open() });
   registerAgentFeatures();
   // Mirrors the CLI/desktop Node-host wiring (`nodeHost.ts`'s
   // `initializeNodeRuntimeSkills`, inlined here rather than imported so the

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -23,6 +23,7 @@ import { initializeGoalPrompts } from '@agent/goal/promptLoader';
 import {
   defaultSession,
   initializeDefaultSession,
+  teardownDefaultSession,
 } from '@agent/runtime/SessionHandle';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { initializePolishModel } from '@agent/runtime/polishModel';
@@ -770,6 +771,10 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
   const host = lifecycleHost;
   lifecycleHost = undefined;
-  leanVscodeIntegration.clearVscodeLeanServerEntries();
-  await host?.runShutdown();
+  try {
+    leanVscodeIntegration.clearVscodeLeanServerEntries();
+    await host?.runShutdown();
+  } finally {
+    teardownDefaultSession();
+  }
 }

--- a/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -13,7 +13,9 @@ import {
 import { emitExtensionInteractionEvent } from '@frontend/events/extensionInteractionEvents';
 
 export const extensionAgentRuntimeHost: AgentRuntimeHost = {
-  interactions: defaultSession().interactions,
+  get interactions() {
+    return defaultSession().interactions;
+  },
   emit: (event, payload) => {
     if (isExtensionPresentationEvent(event)) {
       extensionPresentationEvents.emit(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -189,8 +189,20 @@ export class ProgressViewProvider
 
     this._disposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-        await this.backend.load();
-        this.syncFullView({ forceRebuild: true });
+        try {
+          await this.backend.load();
+          this.syncFullView({ forceRebuild: true });
+        } catch (error) {
+          this.logger.error(
+            'Failed to reload transcripts after workspace change',
+            {
+              data: error,
+            },
+          );
+          void vscode.window.showErrorMessage(
+            'TeXRA could not reload transcript persistence for the new workspace. The previous transcript view was preserved.',
+          );
+        }
       }),
       vscode.window.onDidChangeActiveColorTheme(() => {
         if (this.isViewVisible()) {
@@ -328,10 +340,21 @@ export class ProgressViewProvider
       // syncing so the webview doesn't render an empty log. Fall back to
       // an immediate sync when the log is already resident.
       if (activeStream && !this.state.streamLogs.get(activeStream)) {
-        void this.state.streamLogs.ensureLoaded(activeStream).then(() => {
-          if (this.state.activeStream !== activeStream) return;
-          this.backend.factApplier.syncStreamContent(activeStream);
-        });
+        void this.state.streamLogs
+          .ensureLoaded(activeStream)
+          .then(() => {
+            if (this.state.activeStream !== activeStream) return;
+            this.backend.factApplier.syncStreamContent(activeStream);
+          })
+          .catch((error: unknown) => {
+            this.logger.error(
+              `Failed to load transcript ${activeStream} for display`,
+              { data: error },
+            );
+            void vscode.window.showErrorMessage(
+              'TeXRA could not read this persisted transcript.',
+            );
+          });
       } else {
         this.backend.factApplier.syncStreamContent(activeStream);
       }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -107,6 +107,11 @@ export class SessionHandle {
   readonly hostChannel?: AgentRuntimeHost;
 
   constructor(init: SessionHandleInit) {
+    if (init.transcripts.mode.kind === 'read-only') {
+      throw new Error(
+        'SessionHandle requires a writable transcript store; read-only stores are reserved for call-scoped readers.',
+      );
+    }
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
     const status = init.status ?? new StreamStatusMachine();
@@ -379,6 +384,13 @@ export function initializeDefaultSession(
 /** Inspect whether the host has installed its process-default session. */
 export function tryDefaultSession(): SessionHandle | undefined {
   return cachedDefaultSession;
+}
+
+/** Clear and dispose the process-default session during host teardown. */
+export function teardownDefaultSession(): void {
+  const session = cachedDefaultSession;
+  cachedDefaultSession = undefined;
+  session?.dispose();
 }
 
 /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -10,10 +10,9 @@
  * optional session-scoped host channel.
  *
  * A session is one per host context: extension activation (per VS Code window),
- * CLI process, or desktop `BrowserWindow`. The default instance,
- * {@link defaultSession}, is the sanctioned single-session entry point —
- * it lazily constructs its owners on first use (module-private, process-wide)
- * exactly like any other fresh session. There is no other way to reach
+ * CLI process, or desktop `BrowserWindow`. The default instance is installed
+ * explicitly through {@link initializeDefaultSession}; {@link defaultSession}
+ * only retrieves that process-wide owner. There is no other way to reach
  * these owners: the invariant is "no session-scoped mutable module export"
  * (#7694) — a run-scoped caller resolves through {@link currentSession} /
  * {@link defaultSession}, never a standalone singleton import.
@@ -30,11 +29,7 @@
  * session is justified only as the ownership container.
  */
 
-import {
-  getActiveFlushers,
-  StreamLogStore,
-  unregisterFlushers,
-} from '@transcript';
+import { getActiveFlushers, unregisterFlushers } from '@transcript/runTrace';
 import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { createChannelTrace } from '@logger';
@@ -57,25 +52,26 @@ import {
   createSessionApprovals,
   type SessionApprovals,
 } from './streamApprovalQueue';
+import type { StreamLogStore } from '@transcript/StreamLogStore';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 const logger = createChannelTrace('sessionHandle');
 
-/** Members callers may inject; everything else is fresh-constructed in order. */
-export type SessionHandleInit = Partial<
-  Pick<
-    SessionHandle,
-    | 'executions'
-    | 'subscriptions'
-    | 'events'
-    | 'status'
-    | 'transcripts'
-    | 'followUps'
-    | 'flushers'
-    | 'interactions'
-    | 'hostChannel'
-  >
->;
+/** A valid transcript store is required; other owners may be injected. */
+export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
+  Partial<
+    Pick<
+      SessionHandle,
+      | 'executions'
+      | 'subscriptions'
+      | 'events'
+      | 'status'
+      | 'followUps'
+      | 'flushers'
+      | 'interactions'
+      | 'hostChannel'
+    >
+  >;
 
 export interface SessionDisposeOptions {
   /**
@@ -110,12 +106,12 @@ export class SessionHandle {
    */
   readonly hostChannel?: AgentRuntimeHost;
 
-  constructor(init: SessionHandleInit = {}) {
+  constructor(init: SessionHandleInit) {
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
     const status = init.status ?? new StreamStatusMachine();
     const events = init.events ?? new SessionEventHub();
-    const transcripts = init.transcripts ?? new StreamLogStore();
+    const transcripts = init.transcripts;
     const followUps = init.followUps ?? new ToolUseFollowUpQueue();
     const executions =
       init.executions ??
@@ -364,6 +360,27 @@ export function killAllSessionBackgroundProcesses(): void {
 
 let cachedDefaultSession: SessionHandle | undefined;
 
+export type DefaultSessionInit = Omit<SessionHandleInit, 'flushers'>;
+
+/** Install the process-default session after its transcript store is valid. */
+export function initializeDefaultSession(
+  init: DefaultSessionInit,
+): SessionHandle {
+  if (cachedDefaultSession) {
+    throw new Error('The default session has already been initialized.');
+  }
+  cachedDefaultSession = new SessionHandle({
+    ...init,
+    flushers: getActiveFlushers(),
+  });
+  return cachedDefaultSession;
+}
+
+/** Inspect whether the host has installed its process-default session. */
+export function tryDefaultSession(): SessionHandle | undefined {
+  return cachedDefaultSession;
+}
+
 /**
  * The process-default session — the sole owner of the process-wide runtime
  * singletons (#7694). Every member the constructor doesn't receive is
@@ -371,16 +388,17 @@ let cachedDefaultSession: SessionHandle | undefined;
  * uses; there is no separate `Shared*`/`*Service` module export to alias
  * anymore, so this construction *is* where those singletons now live.
  *
- * Constructed lazily on first use rather than at module evaluation: many
- * run-scoped modules import `currentSession`, which pulls this module into
- * their import cycle, and an eager construction here would risk reading a
- * cross-module singleton before its own module finished initializing (TDZ).
- * Deferring to first call sidesteps that entirely.
+ * Hosts must initialize it explicitly after opening transcript persistence.
+ * Access before that composition step is a lifecycle error rather than an
+ * implicit memory-only session.
  */
 export function defaultSession(): SessionHandle {
-  return (cachedDefaultSession ??= new SessionHandle({
-    flushers: getActiveFlushers(),
-  }));
+  if (!cachedDefaultSession) {
+    throw new Error(
+      'The default session has not been initialized. Call initializeDefaultSession() after opening its transcript store.',
+    );
+  }
+  return cachedDefaultSession;
 }
 
 /**

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -97,6 +97,8 @@ export interface KVStoreOptions {
    * stores where repeated pretty-printing adds avoidable CPU and disk I/O.
    */
   compactJson?: boolean;
+  /** Propagate adapter failures instead of converting them to false/missing. */
+  throwOnErrors?: boolean;
 }
 
 export class KVStore {
@@ -112,6 +114,7 @@ export class KVStore {
       // The directory is the namespace; keys are stored literally.
       namespace: undefined,
       useKeyPrefix: false,
+      throwOnErrors: options.throwOnErrors,
       serialize: (data) => JSON.stringify(data.value, null, indent),
       deserialize: (raw) => ({ value: JSON.parse(raw) }),
     });

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -849,8 +849,10 @@ export class ProgressFactApplier {
       this.state.streamLogs.mode.kind === 'persistent' &&
       this.state.streamLogs.has(streamId) &&
       !this.state.streamLogs.get(streamId);
-    if (isInFlightStatus(status) && requiresPersistentRehydrate) {
-      await this.state.streamLogs.ensureLoaded(streamId);
+    if (isInFlightStatus(status)) {
+      if (requiresPersistentRehydrate) {
+        await this.state.streamLogs.ensureLoaded(streamId);
+      }
     } else if (streamId !== this.state.activeStream) {
       this.state.streamLogs.releaseEntries(streamId);
     }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -845,8 +845,12 @@ export class ProgressFactApplier {
     //    an empty getOrCreate.
     //  - leaving the in-flight set drops heavy entries; disk stays
     //    authoritative and `setActiveStream` re-reads on demand.
-    if (isInFlightStatus(status)) {
-      void this.state.streamLogs.ensureLoaded(streamId);
+    const requiresPersistentRehydrate =
+      this.state.streamLogs.mode.kind === 'persistent' &&
+      this.state.streamLogs.has(streamId) &&
+      !this.state.streamLogs.get(streamId);
+    if (isInFlightStatus(status) && requiresPersistentRehydrate) {
+      await this.state.streamLogs.ensureLoaded(streamId);
     } else if (streamId !== this.state.activeStream) {
       this.state.streamLogs.releaseEntries(streamId);
     }

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -362,7 +362,7 @@ export class ProgressViewState {
     this.logger.info('[Persistence] Starting state load from storage');
 
     // Load stream logs first — they define the set of known streams
-    await this.streamLogs.load();
+    await this.streamLogs.reload();
 
     const streamIds = this.streamLogs.keys();
     this.logger.info(`[Persistence] Discovered ${streamIds.length} stream(s)`);

--- a/src/test-kernel/agent/GoalContinuation.vitest.ts
+++ b/src/test-kernel/agent/GoalContinuation.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -219,7 +219,7 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
       const kv = createFakeKv();
       const logger = new TraceEmitter();
       const streamId = `stream:reflection-round-${name}` as StreamTabId;
-      const store = new StreamLogStore();
+      const store = StreamLogStore.ephemeral('test');
       const control: OutcomeControl = {
         terminalOutcome,
         interrupted: false,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -101,7 +104,7 @@ async function runPersistedFlow(
   streamId: StreamTabId,
   snapshot: ToolUseSessionSnapshot | undefined,
   onSetup?: (context: ToolUseSetupContext) => void,
-  session: SessionHandle = new SessionHandle(),
+  session: SessionHandle = createTestSession(),
 ): Promise<RunToolUseFlowResult> {
   const config = snapshot?.agentConfig ?? CONFIG;
   const userVarChannels = snapshot?.user ?? {
@@ -612,7 +615,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const streamId = 'chat@gpt54#abc-cancel-followup' as StreamTabId;
     const snapshot = buildToolUseSnapshot(executionId, streamId);
     const store = getExecutionStore(executionId);
-    const session = new SessionHandle();
+    const session = createTestSession();
     let flowContext: ToolUseSetupContext | undefined;
     const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
       // Cancellation arrives while the recovery read is pending -- after

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -75,7 +75,7 @@ interface HarnessOptions {
 function dispatchHarness(opts: HarnessOptions) {
   const runTrace = createRunTrace(
     'DispatchParallelTest' as StreamTabId,
-    new StreamLogStore(),
+    StreamLogStore.ephemeral('test'),
   );
   const services = {
     config: AgentConfigSchema.parse({

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ClaudeAgentProgressEvents.vitest.ts
@@ -31,7 +31,7 @@ async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
 async function runWithLoggerStore<T>(
   fn: (store: StreamLogStore, logger: AgentTrace) => Promise<T>,
 ): Promise<T> {
-  const store = new StreamLogStore();
+  const store = StreamLogStore.ephemeral('test');
   await store.clear();
 
   return await fn(store, createRunTrace(streamId, store).trace);

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -88,7 +88,7 @@ describe('codex progress events', () => {
   });
 
   it('updates in-flight Codex command items in place', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     await store.clear();
 
     const logger = createRunTrace(streamId, store).trace;

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -248,7 +254,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
     const streamId = 'stream-a' as StreamTabId;
     const host = createRecordingHost();
     const source = new RegistryTestSource();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const registry = new StreamSubscriptionRegistry<string, string>({
       name: 'test subscriptions',
       source,

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -86,7 +86,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       logger: createRunTrace(
         'ToolUseDispatchInterruption',
-        new StreamLogStore(),
+        StreamLogStore.ephemeral('test'),
       ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
@@ -259,7 +259,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       logger: createRunTrace(
         'ToolUseDispatchInterruption',
-        new StreamLogStore(),
+        StreamLogStore.ephemeral('test'),
       ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -1,5 +1,11 @@
-// Third-party imports
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
 import { strict as assert } from 'node:assert';
+import { createTestSession } from '@test/support/sessionTestUtils';
+
+// Third-party imports
 import { describe, it, afterEach } from 'vitest';
 
 // Standard library imports
@@ -457,7 +463,7 @@ describe('ToolUseFollowUp', () => {
 
     const result = { status: 'queued' as const, reason: 'waiting' as const };
 
-    const routedSession = new SessionHandle({
+    const routedSession = createTestSession({
       status: new StreamStatusMachine(),
     });
     seedStreamStatusForTest(

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -95,7 +101,7 @@ describe('tool-use follow-up progress events', () => {
 
   it('publishes sent follow-up events through the owning session fact hub', async () => {
     const { events, host } = createRecordingHost();
-    const session = new SessionHandle();
+    const session = createTestSession();
     sessions.add(session);
     const facts: unknown[] = [];
     const detachFacts = session.events.subscribe((event) => {
@@ -134,8 +140,8 @@ describe('tool-use follow-up progress events', () => {
 
   it('prefers an explicit session over the active run context when notifying follow-up sent', () => {
     const run = createRecordingHost();
-    const explicitSession = new SessionHandle();
-    const activeSession = new SessionHandle();
+    const explicitSession = createTestSession();
+    const activeSession = createTestSession();
     sessions.add(explicitSession);
     sessions.add(activeSession);
     const explicitFacts: unknown[] = [];
@@ -175,7 +181,7 @@ describe('tool-use follow-up progress events', () => {
 
   it("routes follow-up sent notifications through the active run's current session", () => {
     const run = createRecordingHost();
-    const session = new SessionHandle();
+    const session = createTestSession();
     sessions.add(session);
     const facts: unknown[] = [];
     const detachFacts = session.events.subscribe((event) => {
@@ -256,7 +262,7 @@ describe('tool-use follow-up progress events', () => {
   });
 
   it('runs observers before session emission and catches observer errors', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     sessions.add(session);
     const order: string[] = [];
     const detachFacts = session.events.subscribe(() => {
@@ -318,7 +324,7 @@ describe('tool-use follow-up progress events', () => {
   });
 
   it('does not emit a follow-up sent fact when no follow-up reaches a live session', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     sessions.add(session);
     const facts: unknown[] = [];
     const detachFacts = session.events.subscribe((event) => {

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -192,7 +192,7 @@ describe('tool-use round outcome persistence (#8023)', () => {
       const { host } = createRecordingHost();
       const logger = new TraceEmitter();
       const streamId = `stream:tool-use-round-${name}` as StreamTabId;
-      const store = new StreamLogStore();
+      const store = StreamLogStore.ephemeral('test');
       store.ensureStream(streamId);
       const recorder = attachTranscriptRecorder(logger, streamId, store);
       const node = new ToolUseCycleNode().setServices({

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -34,8 +34,10 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseRoundFollowUpMedia', new StreamLogStore())
-        .trace,
+      logger: createRunTrace(
+        'ToolUseRoundFollowUpMedia',
+        StreamLogStore.ephemeral('test'),
+      ).trace,
       modelHandler: {
         addMediaToUserMessage,
         capabilities: { supportsVision: true },
@@ -164,7 +166,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       },
       logger: createRunTrace(
         'ToolUseRoundBlankToolResult',
-        new StreamLogStore(),
+        StreamLogStore.ephemeral('test'),
       ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
@@ -351,8 +353,10 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
       fileService: {
         createLocation: (filePath: string) => ({ absolutePath: filePath }),
       },
-      logger: createRunTrace('ToolUseRoundSystemPrompt', new StreamLogStore())
-        .trace,
+      logger: createRunTrace(
+        'ToolUseRoundSystemPrompt',
+        StreamLogStore.ephemeral('test'),
+      ).trace,
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { DEFAULT_MODEL_CAPABILITIES } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
@@ -114,7 +117,7 @@ describe('AgentLaunchContext', () => {
   it('compensates a late launch-assembly failure before trace disposal', async () => {
     const order: string[] = [];
     const failure = new Error('user vars unavailable');
-    const session = new SessionHandle();
+    const session = createTestSession();
     const detachEvents = session.events.subscribe(() => undefined);
     const detachStatus = session.status.onDidChange(({ status }) => {
       if (status === STREAM_PHASE.FAILED) order.push('terminal');

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';

--- a/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,8 +24,8 @@ describe('agent shutdown', () => {
   });
 
   it('drains every live session once and interrupts global CLI sessions', async () => {
-    const firstSession = new SessionHandle();
-    const secondSession = new SessionHandle();
+    const firstSession = createTestSession();
+    const secondSession = createTestSession();
     const compatibilitySession = defaultSession();
     const firstDrain = vi.spyOn(
       firstSession.executions,

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // E2E fixtures for the promoted "one loop, N strategies" child-run driver.
 // These exercise the loop's own mechanics (queue acquire/drain, one
 // run-handle interrupt target for the child's whole lifetime, per-turn delivery, terminal
@@ -29,7 +32,10 @@ import {
   type ChildRunPorts,
   type ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   STREAM_PHASE,
@@ -37,7 +43,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
-const session = defaultSession();
+let session: SessionHandle;
 const trackedExecutionIds = new Set<string>();
 
 function uniqueStreamId(label: string): StreamTabId {
@@ -133,6 +139,7 @@ function createFakeStrategy(): FakeStrategyHandle {
 }
 
 beforeEach(() => {
+  session = defaultSession();
   vi.clearAllMocks();
   mocks.persistChildRunReport.mockImplementation(async (_id, msg: string) => {
     return { kind: 'persisted' as const, msg };

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('default session lifecycle', () => {
+  it('rejects access before explicit initialization', async () => {
+    vi.resetModules();
+    const { defaultSession, initializeDefaultSession } =
+      await import('@agent/runtime/SessionHandle');
+    const { StreamLogStore } = await import('@transcript');
+
+    expect(() => defaultSession()).toThrow(
+      'The default session has not been initialized',
+    );
+
+    const transcripts = StreamLogStore.ephemeral(
+      'default session lifecycle test',
+    );
+    const session = initializeDefaultSession({ transcripts });
+    try {
+      expect(defaultSession()).toBe(session);
+      expect(defaultSession().transcripts).toBe(transcripts);
+      expect(() => initializeDefaultSession({ transcripts })).toThrow(
+        'already been initialized',
+      );
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('defers extension host session access until composition is initialized', async () => {
+    vi.resetModules();
+    const { initializeDefaultSession } =
+      await import('@agent/runtime/SessionHandle');
+    const { StreamLogStore } = await import('@transcript/StreamLogStore');
+    const { extensionAgentRuntimeHost } =
+      await import('@frontend/agentRuntime/extensionAgentRuntimeHost');
+
+    expect(() => extensionAgentRuntimeHost.interactions).toThrow(
+      'The default session has not been initialized',
+    );
+
+    const session = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral(
+        'extension composition lifecycle test',
+      ),
+    });
+    try {
+      expect(extensionAgentRuntimeHost.interactions).toBe(session.interactions);
+    } finally {
+      session.dispose();
+    }
+  });
+});

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 describe('default session lifecycle', () => {
   it('rejects access before explicit initialization', async () => {
     vi.resetModules();
-    const { defaultSession, initializeDefaultSession } =
+    const { defaultSession, initializeDefaultSession, teardownDefaultSession } =
       await import('@agent/runtime/SessionHandle');
     const { StreamLogStore } = await import('@transcript');
 
@@ -22,13 +22,13 @@ describe('default session lifecycle', () => {
         'already been initialized',
       );
     } finally {
-      session.dispose();
+      teardownDefaultSession();
     }
   });
 
   it('defers extension host session access until composition is initialized', async () => {
     vi.resetModules();
-    const { initializeDefaultSession } =
+    const { initializeDefaultSession, teardownDefaultSession } =
       await import('@agent/runtime/SessionHandle');
     const { StreamLogStore } = await import('@transcript/StreamLogStore');
     const { extensionAgentRuntimeHost } =
@@ -46,7 +46,50 @@ describe('default session lifecycle', () => {
     try {
       expect(extensionAgentRuntimeHost.interactions).toBe(session.interactions);
     } finally {
-      session.dispose();
+      teardownDefaultSession();
+    }
+  });
+
+  it('can initialize again only after explicit teardown', async () => {
+    vi.resetModules();
+    const {
+      defaultSession,
+      initializeDefaultSession,
+      teardownDefaultSession,
+      tryDefaultSession,
+    } = await import('@agent/runtime/SessionHandle');
+    const { StreamLogStore } = await import('@transcript/StreamLogStore');
+
+    const first = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral('first activation'),
+    });
+    expect(() =>
+      initializeDefaultSession({
+        transcripts: StreamLogStore.ephemeral('replacement attempt'),
+      }),
+    ).toThrow('already been initialized');
+
+    const originalDispose = first.dispose.bind(first);
+    const disposeSpy = vi
+      .spyOn(first, 'dispose')
+      .mockImplementation((options) => {
+        expect(tryDefaultSession()).toBeUndefined();
+        originalDispose(options);
+      });
+
+    teardownDefaultSession();
+
+    expect(disposeSpy).toHaveBeenCalledOnce();
+    expect(tryDefaultSession()).toBeUndefined();
+
+    const second = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral('second activation'),
+    });
+    try {
+      expect(defaultSession()).toBe(second);
+      expect(second).not.toBe(first);
+    } finally {
+      teardownDefaultSession();
     }
   });
 });

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -58,7 +61,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
 
   it('passes the owning session to subscription follow-ups', async () => {
     const registry = new ExecutionRegistry();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const recorded = recordSessionEvents(session.events, { scope: 'session' });
     const explicit = createRecordingHost();
     const binder = new ExecutionSubscriptionBinder({
@@ -116,7 +119,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
     'emits the queued-follow-up fact only for delivered follow-ups: %o',
     async (sendResult, shouldEmit) => {
       const registry = new ExecutionRegistry();
-      const session = new SessionHandle();
+      const session = createTestSession();
       const recorded = recordSessionEvents(session.events, {
         scope: 'session',
       });
@@ -169,7 +172,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
 
   it('falls back to the current session when the binder has no explicit session', async () => {
     const registry = new ExecutionRegistry();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const recorded = recordSessionEvents(session.events, { scope: 'session' });
     const explicit = createRecordingHost();
     const binder = new ExecutionSubscriptionBinder({
@@ -222,7 +225,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
     const registry = new ExecutionRegistry();
     const explicit = createRecordingHost();
     const logger = createLogger();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const recorded = recordSessionEvents(session.events, { scope: 'session' });
     const binder = new ExecutionSubscriptionBinder({
       registry,

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi, type Mock } from 'vitest';
 
@@ -246,7 +252,7 @@ describe('RetryState', () => {
 
   it('resolves manual retries through the session host interactions', async () => {
     const streamId = 'retry-state-session-bridge' as StreamTabId;
-    const session = new SessionHandle();
+    const session = createTestSession();
     const recording = createRecordingHost();
     session.useHostInteractions(recording.interactions);
     const { node, streamStatus } = createRetryNode(streamId);

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
@@ -63,7 +66,7 @@ describe('session description helpers', () => {
   });
 
   it('does not generate helper-model descriptions for workflow runs', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const events: SessionEvent[] = [];
     const detach = session.events.subscribe((event) => events.push(event), {
       scope: 'session',
@@ -83,7 +86,7 @@ describe('session description helpers', () => {
   });
 
   it('keeps generating compact descriptions for tool-use runs', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const events: SessionEvent[] = [];
     const detach = session.events.subscribe((event) => events.push(event), {
       scope: 'session',

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -8,7 +8,7 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import { getActiveFlushers } from '@transcript';
+import { getActiveFlushers, StreamLogStore } from '@transcript';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   SessionHandle,
@@ -41,6 +41,14 @@ function trackAgent(
 }
 
 describe('SessionHandle', () => {
+  it('rejects a read-only transcript store', async () => {
+    const transcripts = await StreamLogStore.openReadOnly();
+
+    expect(() => new SessionHandle({ transcripts })).toThrow(
+      'requires a writable transcript store',
+    );
+  });
+
   it('defaultSession is a stable process-wide singleton (#7694: no separate module export to alias)', () => {
     // No `Shared*`/`*Service` module export exists anymore — the process
     // default's owners are installed together by the test composition root.

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
@@ -37,7 +43,7 @@ function trackAgent(
 describe('SessionHandle', () => {
   it('defaultSession is a stable process-wide singleton (#7694: no separate module export to alias)', () => {
     // No `Shared*`/`*Service` module export exists anymore — the process
-    // default's owners are constructed inside `defaultSession()` itself.
+    // default's owners are installed together by the test composition root.
     // What's left to verify is that repeated calls return the identical
     // session (and therefore identical members), and that the flushers
     // member still aliases the process-wide flush registry by identity
@@ -57,7 +63,7 @@ describe('SessionHandle', () => {
   });
 
   it('a fresh session shares no member with the default session', () => {
-    const fresh = new SessionHandle();
+    const fresh = createTestSession();
     try {
       expect(fresh.executions).not.toBe(defaultSession().executions);
       expect(fresh.subscriptions).not.toBe(defaultSession().subscriptions);
@@ -76,7 +82,7 @@ describe('SessionHandle', () => {
 
   it('builds fresh registries even when only a host channel is injected', () => {
     const { host } = createRecordingHost();
-    const session = new SessionHandle({ hostChannel: host });
+    const session = createTestSession({ hostChannel: host });
     try {
       expect(session.hostChannel).toBe(host);
       expect(session.executions).not.toBe(defaultSession().executions);
@@ -86,8 +92,8 @@ describe('SessionHandle', () => {
   });
 
   it('keeps execution tracking isolated between sessions', () => {
-    const a = new SessionHandle();
-    const b = new SessionHandle();
+    const a = createTestSession();
+    const b = createTestSession();
     const { host } = createRecordingHost();
     try {
       const handle = trackAgent(
@@ -110,8 +116,8 @@ describe('SessionHandle', () => {
   });
 
   it("an unfiltered cancel on one session leaves the other's pending requests", async () => {
-    const a = new SessionHandle();
-    const b = new SessionHandle();
+    const a = createTestSession();
+    const b = createTestSession();
     const hostA = createRecordingHost();
     const hostB = createRecordingHost();
     const streamId = 'stream:cleanup-scope' as StreamTabId;
@@ -172,7 +178,7 @@ describe('SessionHandle', () => {
   });
 
   it('dispose tears down each owned member', () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const interactions = vi.spyOn(session.interactions, 'dispose');
     const subscriptions = vi.spyOn(session.subscriptions, 'dispose');
     const executions = vi.spyOn(session.executions, 'dispose');
@@ -185,7 +191,7 @@ describe('SessionHandle', () => {
   });
 
   it('can keep active executions visible until they settle', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const { host } = createRecordingHost();
     const executionId = 'exec:dispose-keep-active';
     const streamId = 'stream:dispose-keep-active' as StreamTabId;
@@ -215,7 +221,7 @@ describe('SessionHandle', () => {
   });
 
   it('makes deferred dispose idempotent while executions are active', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const { host } = createRecordingHost();
     const executionId = 'exec:dispose-idempotent';
     const streamId = 'stream:dispose-idempotent' as StreamTabId;

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
@@ -94,7 +97,7 @@ function createPortSession(): {
     emit: (event) => emitted.push(event),
   };
   const handlers = createHandlerSet(uiEvents);
-  const session = new SessionHandle();
+  const session = createTestSession();
   const interactions = createDesktopHostInteractions({
     runtimeHost,
     session,

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
@@ -117,7 +123,7 @@ function createLifecycleContext(
 
 describe('session isolation (SDK Step 7d PR 2)', () => {
   it('currentSession() resolves the active run context session, default otherwise', () => {
-    const sessionB = new SessionHandle();
+    const sessionB = createTestSession();
     try {
       expect(currentSession()).toBe(defaultSession());
       const ctx = createRunContext({
@@ -135,7 +141,7 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
   });
 
   it('a handle interrupt target lands in the run session only', () => {
-    const sessionB = new SessionHandle();
+    const sessionB = createTestSession();
     const executionId = 'exec:iso-interrupt' as ExecutionId;
     const streamId = 'stream:iso-interrupt' as StreamTabId;
     const interrupt = vi.fn();
@@ -165,7 +171,7 @@ describe('session isolation (SDK Step 7d PR 2)', () => {
     await initTestPlatform();
     const executionId = 'e15001' as ExecutionId;
     const streamId = 'stream:iso-track' as StreamTabId;
-    const sessionB = new SessionHandle();
+    const sessionB = createTestSession();
     const ctx = createLifecycleContext(executionId, streamId, sessionB);
 
     try {

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
@@ -460,7 +466,7 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   });
 
   it('marks subagent runs and bridges results to session.onResult', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const logger = new TraceEmitter();
     const onResult = vi.fn();
     const { ctx, streamStatus } = createCtx({ logger });

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 
@@ -24,8 +30,8 @@ const plan: Plan = { objective: 'Scope session-owned state.' };
 
 describe('cross-session active executions (SDK Step 7d PR 4)', () => {
   it('aggregates active execution ids across live sessions and drops them on dispose', () => {
-    const a = new SessionHandle();
-    const b = new SessionHandle();
+    const a = createTestSession();
+    const b = createTestSession();
     const { host } = createRecordingHost();
     const track = (session: SessionHandle, id: string): void => {
       session.executions.track(
@@ -62,8 +68,8 @@ describe('cross-session active executions (SDK Step 7d PR 4)', () => {
 
 describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
   it('registers the flush in the run session set, not the default set', () => {
-    const store = new StreamLogStore();
-    const sessionB = new SessionHandle();
+    const store = StreamLogStore.ephemeral('test');
+    const sessionB = createTestSession();
     try {
       const defaultBefore = getActiveFlushers().size;
       const handle = createRunTrace(
@@ -86,8 +92,8 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
   });
 
   it("drops the disposed session's flusher set from the process-wide drain", () => {
-    const store = new StreamLogStore();
-    const sessionB = new SessionHandle();
+    const store = StreamLogStore.ephemeral('test');
+    const sessionB = createTestSession();
     let drained = 0;
 
     // Registers sessionB.flushers in the process-wide drain registry.
@@ -115,8 +121,8 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
 
 describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
   it("writes run trace entries to the launching session's transcript store only", () => {
-    const launching = new SessionHandle();
-    const sibling = new SessionHandle();
+    const launching = createTestSession();
+    const sibling = createTestSession();
     const streamId = 'stream:session-transcript-owner' as StreamTabId;
 
     try {
@@ -147,8 +153,8 @@ describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
   });
 
   it('keeps same-stream follow-up queues isolated by session', () => {
-    const a = new SessionHandle();
-    const b = new SessionHandle();
+    const a = createTestSession();
+    const b = createTestSession();
     const streamId = 'stream:session-followups' as StreamTabId;
 
     try {
@@ -170,8 +176,8 @@ describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
 
 describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
   it("clears only the given session's pending interactions", async () => {
-    const a = new SessionHandle();
-    const b = new SessionHandle();
+    const a = createTestSession();
+    const b = createTestSession();
     const hostA = createRecordingHost();
     const hostB = createRecordingHost();
     const streamId = 'stream:approval-scope' as StreamTabId;
@@ -212,7 +218,7 @@ describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
 
 describe('sendFollowUp host-path session routing (SDK Step 7d PR 4)', () => {
   it('resolves the follow-up target against the passed session, not the process default', async () => {
-    const windowSession = new SessionHandle();
+    const windowSession = createTestSession();
     const { host } = createRecordingHost();
     const parentStream = 'stream:fu-parent' as StreamTabId;
 

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const retrieveSessionResumeDataMock = vi.hoisted(() => vi.fn());

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const resumeToolUseFromSnapshotMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -294,7 +300,7 @@ describe('resumeToolUseSnapshot', () => {
   it('uses the supplied session status plane for resume markers', async () => {
     const failure = new Error('session-scoped resume failed');
     resumeToolUseFromSnapshotMock.mockRejectedValue(failure);
-    const session = new SessionHandle();
+    const session = createTestSession();
 
     try {
       await expect(
@@ -316,7 +322,7 @@ describe('resumeToolUseSnapshot', () => {
   it('preserves failed resume follow-ups in the supplied session queue only', async () => {
     const failure = new Error('session queue resume failed');
     resumeToolUseFromSnapshotMock.mockRejectedValue(failure);
-    const session = new SessionHandle();
+    const session = createTestSession();
 
     try {
       session.followUps.enqueue(

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -165,7 +165,7 @@ describe('logFileCategory', () => {
   let store: StreamLogStore;
 
   beforeEach(async () => {
-    store = new StreamLogStore();
+    store = StreamLogStore.ephemeral('test');
     await store.clear();
     const runTrace = createRunTrace('TestFileListLogger', store);
     logger = runTrace.trace;

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -17,7 +17,7 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 function withStore(
   run: (store: StreamLogStore, logger: AgentTrace) => void,
 ): void {
-  const store = new StreamLogStore();
+  const store = StreamLogStore.ephemeral('test');
   run(store, createRunTrace('stream', store).trace);
 }
 
@@ -222,7 +222,7 @@ describe('tool-use card groupId resolution', () => {
   });
 
   it('reuses the captured groupId when endToolUseCard is called with no explicit stage', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const logger = createRunTrace('stream', store).trace;
     const outer = logger.openStage('outer');
     const ref = await outer.within(async () =>
@@ -247,7 +247,7 @@ describe('tool-use card groupId resolution', () => {
 
 describe('per-trace stage scope (cross-trace isolation)', () => {
   it('a run stage opened on its own trace does not inherit an active stage from another trace', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
 
     // Orchestrator trace with an active "Task:" stage — mirrors a subagent
     // launched from inside a delegation tool's stage scope.

--- a/src/test-kernel/agent/trace/logUserMessage.vitest.ts
+++ b/src/test-kernel/agent/trace/logUserMessage.vitest.ts
@@ -17,7 +17,7 @@ describe('logUserMessage', () => {
   let store: StreamLogStore;
 
   beforeEach(async () => {
-    store = new StreamLogStore();
+    store = StreamLogStore.ephemeral('test');
     await store.clear();
     const runTrace = createRunTrace('TestUserMessageLogger', store);
     logger = runTrace.trace;

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const notifyMock = vi.hoisted(() => vi.fn());

--- a/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
+++ b/src/test-kernel/cli/CliPersistenceFlush.vitest.mts
@@ -70,8 +70,7 @@ describe('CLI StreamLog persistence (flush on exit is load-bearing)', () => {
 
   it('persists appended entries only once flush() drains the debounce window', async () => {
     const storage = emptyStorage();
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     const streamId = 'reviewer@opus#e1';
     store.append(streamId, entry('a', 'first'));
@@ -92,13 +91,11 @@ describe('CLI StreamLog persistence (flush on exit is load-bearing)', () => {
     ]);
   });
 
-  it('writes nothing when load() was never called (one-shot/headless paths)', async () => {
+  it('writes nothing for an explicitly ephemeral store', async () => {
     const storage = emptyStorage();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
 
-    // No load() — mirrors `texra run`/`resume`/`agentsRun`, which never enable
-    // persistence. append()/flush() must be inert so headless output and the
-    // on-disk store stay untouched.
+    // Ephemeral mode is deliberate and inspectable; it never reaches storage.
     store.append('main@opus#e2', entry('x', 'headless'));
     await store.flush();
 

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -341,6 +341,7 @@ describe('/config slash command wiring', () => {
       apiMode: 'included',
       approvalPolicy: 'ask',
       canDelegate: false,
+      transcriptMode: 'persistent',
       version: 'test',
     });
     const { stores } = makeFakeSettingsStores();

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it } from 'vitest';
 
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
@@ -64,6 +67,7 @@ const SESSION_META = {
   apiMode: 'personal',
   approvalPolicy: 'ask',
   canDelegate: false,
+  transcriptMode: 'persistent',
   version: '0.38.0',
 } as const;
 

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1,4 +1,8 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 /* eslint-disable import/order -- Vitest mocks must be declared before importing the runtime under test. */
+
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -110,6 +114,8 @@ const config = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 } as AgentConfig;
 
+let historyStoragePath: string | undefined;
+
 /** Creates a temp dir for the test body, then removes it (recursively) after. */
 async function withTempDir(
   prefix: string,
@@ -131,7 +137,18 @@ describe('CLI history runtime', () => {
         import('@platform/defaults/nodeFilesystem'),
         import('@test/support/FakePlatform'),
       ]);
-    initPlatform(createFakePlatform({}, { fs: nodeFilesystem }));
+    historyStoragePath = await mkdtemp(
+      path.join(tmpdir(), 'texra-history-storage-'),
+    );
+    initPlatform(
+      createFakePlatform(
+        {
+          storagePath: historyStoragePath,
+          globalStoragePath: historyStoragePath,
+        },
+        { fs: nodeFilesystem },
+      ),
+    );
     vi.clearAllMocks();
     mocks.readConfig.mockResolvedValue(config);
     mocks.readConversation.mockResolvedValue(null);
@@ -146,6 +163,12 @@ describe('CLI history runtime', () => {
     });
     mocks.readCliToolUseResumeData.mockResolvedValue(null);
     mocks.readCliToolUseResumeDataForListing.mockResolvedValue(null);
+  });
+
+  afterEach(async () => {
+    if (!historyStoragePath) return;
+    await rm(historyStoragePath, { recursive: true, force: true });
+    historyStoragePath = undefined;
   });
 
   it('formats history list rows with the stable tab-separated text shape', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -42,10 +42,14 @@ const tempDirs: string[] = [];
 async function installFreshDefaultSession(): Promise<void> {
   const { installPlatform } = await import('@test/support/setupPlatform');
   await installPlatform();
-  const [{ initializeDefaultSession }, { StreamLogStore }] = await Promise.all([
+  const [
+    { initializeDefaultSession, teardownDefaultSession },
+    { StreamLogStore },
+  ] = await Promise.all([
     import('@agent/runtime/SessionHandle'),
     import('@transcript'),
   ]);
+  teardownDefaultSession();
   initializeDefaultSession({ transcripts: await StreamLogStore.open() });
 }
 
@@ -163,7 +167,10 @@ function stubRunExecutionDeps(): void {
 }
 
 describe('executeCliRequest', () => {
-  beforeEach(stubRunExecutionDeps);
+  beforeEach(async () => {
+    stubRunExecutionDeps();
+    await installFreshDefaultSession();
+  });
 
   afterEach(async () => {
     vi.restoreAllMocks();
@@ -669,7 +676,10 @@ describe('executeCliRequest', () => {
 });
 
 describe('executeCliConfig', () => {
-  beforeEach(stubRunExecutionDeps);
+  beforeEach(async () => {
+    stubRunExecutionDeps();
+    await installFreshDefaultSession();
+  });
 
   it('reports invalid configs without starting the runtime host', async () => {
     const { executeCliConfig } = await import('@cli/runtime/runExecution');

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
-import { AgentError } from '@common/errors';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
@@ -13,6 +12,7 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
+import { AgentError } from '@common/errors';
 import {
   EXECUTION_STATUS,
   type ExecutionId,
@@ -38,6 +38,16 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const tempDirs: string[] = [];
+
+async function installFreshDefaultSession(): Promise<void> {
+  const { installPlatform } = await import('@test/support/setupPlatform');
+  await installPlatform();
+  const [{ initializeDefaultSession }, { StreamLogStore }] = await Promise.all([
+    import('@agent/runtime/SessionHandle'),
+    import('@transcript'),
+  ]);
+  initializeDefaultSession({ transcripts: await StreamLogStore.open() });
+}
 
 async function installStoragePlatform(): Promise<void> {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-run-'));
@@ -423,15 +433,12 @@ describe('executeCliRequest', () => {
     });
   });
 
-  it('loads the stream log store before the run and flushes it after, in order', async () => {
+  it('uses an opened persistent store and flushes it after the run', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
     const store = defaultSession().transcripts;
     const callOrder: string[] = [];
-    vi.spyOn(store, 'load').mockImplementation(async () => {
-      callOrder.push('load');
-    });
     vi.spyOn(store, 'flush').mockImplementation(async () => {
       callOrder.push('flush');
     });
@@ -447,10 +454,8 @@ describe('executeCliRequest', () => {
 
     await executeCliRequest(request, cliContext());
 
-    // The bug this test guards: StreamLogStore.save()/flush() silently no-op
-    // until .load() has run once, so headless runs lost their whole
-    // streamLogs timeline. `load` must precede the run, `flush` must follow it.
-    expect(callOrder).toEqual(['load', 'runAgent', 'flush']);
+    expect(store.mode).toEqual({ kind: 'persistent' });
+    expect(callOrder).toEqual(['runAgent', 'flush']);
   });
 
   it('flushes the stream log store even when the run throws', async () => {
@@ -458,7 +463,6 @@ describe('executeCliRequest', () => {
     const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
     const store = defaultSession().transcripts;
-    const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     mocks.runAgent.mockRejectedValueOnce(new AgentError('boom'));
 
@@ -469,7 +473,6 @@ describe('executeCliRequest', () => {
     const result = await executeCliRequest(request, cliContext());
 
     expect(result).toEqual({ ok: false, exitCode: CliExitCode.AgentError });
-    expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(flushSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -478,7 +481,6 @@ describe('executeCliRequest', () => {
     const { defaultSession } = await import('@agent/runtime/SessionHandle');
     const request = baseRequest();
     const store = defaultSession().transcripts;
-    const loadSpy = vi.spyOn(store, 'load').mockResolvedValue(undefined);
     const flushSpy = vi.spyOn(store, 'flush').mockResolvedValue(undefined);
     // An unclassified failure (e.g. registerExecution disk I/O,
     // workspaceState.update) is genuinely unexpected — it must keep
@@ -491,7 +493,6 @@ describe('executeCliRequest', () => {
     );
 
     // Cleanup still runs via `finally` even though the error propagates.
-    expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(flushSpy).toHaveBeenCalledTimes(1);
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
@@ -594,6 +595,7 @@ describe('executeCliRequest', () => {
     });
 
     try {
+      await installFreshDefaultSession();
       const { executeCliRequest } = await import('@cli/runtime/runExecution');
       const request = baseRequest();
 
@@ -605,6 +607,7 @@ describe('executeCliRequest', () => {
     } finally {
       vi.doUnmock('@transcript');
       vi.resetModules();
+      await installFreshDefaultSession();
     }
   });
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Slash command execution dispatch.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +17,7 @@ import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import {
   activeForm,
   activeStreamId,
+  patchSessionMeta,
   resetCliState,
   patchStream,
   streams,
@@ -260,5 +264,25 @@ describe('handleTuiSlashCommand', () => {
     const statusText = lastEntryText(streamId);
     expect(statusText).toContain('resume later with: texra resume exec-1');
     expect(statusText).not.toContain('--cwd');
+  });
+
+  it('does not advertise the current ephemeral session as resumable', async () => {
+    registerBuiltinSlashCommands();
+    const session = createSession();
+    const streamId = 'stream-ephemeral' as StreamTabId;
+    session.streamId = streamId;
+    session.executionId = 'exec-ephemeral' as ExecutionId;
+    activeStreamId.set(streamId);
+    patchSessionMeta({ transcriptMode: 'ephemeral' });
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      status: STREAM_PHASE.WAITING,
+    }));
+
+    await handleTuiSlashCommand('/status', createContext(session));
+
+    const statusText = lastEntryText(streamId);
+    expect(statusText).not.toContain('session: exec-ephemeral');
+    expect(statusText).not.toContain('resume later with:');
   });
 });

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -37,6 +37,7 @@ const INCLUDED_CHAT_SESSION: SessionMeta = {
   apiMode: 'included',
   approvalPolicy: 'ask',
   canDelegate: false,
+  transcriptMode: 'persistent',
   version: 'test',
 };
 
@@ -299,6 +300,7 @@ describe('slashRegistry', () => {
       apiMode: 'personal',
       approvalPolicy: 'ask',
       canDelegate: false,
+      transcriptMode: 'persistent',
       version: 'test',
     });
     registerBuiltinSlashCommands({

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -146,6 +146,7 @@ describe('Static band resize', () => {
       apiMode: 'personal',
       approvalPolicy: 'ask',
       canDelegate: false,
+      transcriptMode: 'persistent',
       version: '0.0.0-test',
     });
     patchStream(streamId, (slice) => ({

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -107,6 +107,22 @@ describe('CLI StatusBar display model', () => {
     expect(shortCliApiMode('personal')).toBe('personal');
   });
 
+  it('keeps an ephemeral transcript warning in the durable status row', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({ transcriptMode: 'ephemeral' }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toContain(
+      'EPHEMERAL TRANSCRIPT',
+    );
+    expect(
+      display.left.find(
+        (segment) => statusBarSegmentText(segment) === 'EPHEMERAL TRANSCRIPT',
+      ),
+    ).toMatchObject({ badge: true, badgeColor: 'yellow' });
+    expect(display.bindings).not.toContain('Resume this session');
+  });
+
   it('surfaces non-default approval policies in the durable status row', () => {
     const input = statusInput({ approvalPolicy: 'ask' });
     const ask = buildStatusBarDisplay(input);

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Regression coverage for subscribeStreamLog's shared createFlushableDebounce
 // migration: the "only start the batch window on its first tick" coalescing
 // behavior, and dispose() cancelling (not flushing) a still-pending batch.

--- a/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
+++ b/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.doUnmock('@agent/runtime/runAgent');
+  vi.doUnmock('@cli/runtime/runtimeHost');
+  vi.doUnmock('@cli/runtime/transcriptSession');
+  vi.resetModules();
+});
+
+describe('CLI transcript session policy', () => {
+  it('fails a headless execution before runtime construction when opening fails', async () => {
+    vi.resetModules();
+    const failure = new Error('transcript directory is unreadable');
+    const runAgent = vi.fn();
+    const createCliRuntimeHost = vi.fn();
+    vi.doMock('@cli/runtime/transcriptSession', () => ({
+      initializeHeadlessTranscriptSession: vi.fn(async () => {
+        throw failure;
+      }),
+    }));
+    vi.doMock('@agent/runtime/runAgent', () => ({ runAgent }));
+    vi.doMock('@cli/runtime/runtimeHost', () => ({ createCliRuntimeHost }));
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+
+    await expect(
+      executeCliRequest(
+        { config: {}, executionId: 'exec-open-failure' } as never,
+        {
+          cwd: '/workspace',
+          mode: 'headless',
+          outputFormat: 'text',
+          approvalPolicy: 'never',
+        } as never,
+      ),
+    ).rejects.toBe(failure);
+
+    expect(createCliRuntimeHost).not.toHaveBeenCalled();
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  it('selects ephemeral mode only through the explicit interactive policy', async () => {
+    vi.resetModules();
+    const { initializeInteractiveTranscriptSession } =
+      await import('@cli/runtime/transcriptSession');
+    const warning = vi.fn();
+
+    const result = await initializeInteractiveTranscriptSession(
+      {
+        onPersistentOpenFailure: 'use-ephemeral',
+        showPersistentWarning: warning,
+      },
+      async () => {
+        throw new Error('permission denied');
+      },
+    );
+
+    try {
+      expect(result.canResume).toBe(false);
+      expect(result.session.transcripts.mode).toEqual({
+        kind: 'ephemeral',
+        reason: 'Persistent transcript opening failed: permission denied',
+      });
+      expect(warning).toHaveBeenCalledOnce();
+      expect(result.warning).toContain('cannot be resumed');
+    } finally {
+      result.session.dispose();
+    }
+  });
+
+  it('does not fall back when the interactive policy requires persistence', async () => {
+    vi.resetModules();
+    const { initializeInteractiveTranscriptSession } =
+      await import('@cli/runtime/transcriptSession');
+    const failure = new Error('permission denied');
+
+    await expect(
+      initializeInteractiveTranscriptSession(
+        { onPersistentOpenFailure: 'fail' },
+        async () => {
+          throw failure;
+        },
+      ),
+    ).rejects.toBe(failure);
+  });
+});

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Phase 4 state + focus-cycle smoke.
 
 import { EventEmitter } from 'node:events';

--- a/src/test-kernel/commands/agent/ResumeExtensionToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/commands/agent/ResumeExtensionToolUseSnapshot.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**

--- a/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
+++ b/src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts
@@ -127,8 +127,7 @@ describe('ChatExportController.exportAsHtml', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(streamId, {
       id: 'entry-1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -162,8 +161,7 @@ describe('ChatExportController.exportAsHtml', () => {
     await installStoragePlatform();
     const executionId = 'exec-missing-template' as ExecutionId;
     await getExecutionStore(executionId).writeConfig(config());
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     const streamId = getStreamTabId('orchestrator', 'deepseekT', {
       executionId,
     });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - transcript
 import {
   STREAM_LOGS_DIR,
+  type StreamLogStore,
   type StreamSnapshotStore as ProgressSnapshotStore,
 } from '@transcript';
 
@@ -98,7 +99,7 @@ type TestableBridge = Bridge & {
       },
     ): unknown;
     releaseEntries(streamId: StreamTabId): void;
-    load(): Promise<void>;
+    reload(): Promise<void>;
     ensureLoaded(streamId: StreamTabId): Promise<void>;
     get(streamId: StreamTabId):
       | {
@@ -145,10 +146,10 @@ function bridgeFollowUps(
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
-  /** Forces `state.streamLogs.load()` to reject, to exercise the restart-repair fallback (catch) path. */
-  streamLogsLoadError?: Error;
-  /** Delays `state.streamLogs.load()`'s directory scan until this resolves, to exercise the narrow startup window before restart repair has populated `streamLogs` (issue #7850). */
-  streamLogsLoadGate?: Promise<void>;
+  /** Forces persistent transcript opening to reject. */
+  transcriptOpenError?: Error;
+  /** Delays persistent transcript opening until this promise resolves. */
+  transcriptOpenGate?: Promise<void>;
   retrieveSessionResumeData?: ReturnType<typeof vi.fn>;
   resumeToolUseFromSnapshot?: ReturnType<typeof vi.fn>;
   runAgent?: RunExecutionRequest;
@@ -196,6 +197,8 @@ const SEARCH_TOOL_USE_AGENT_CONFIG = {
  */
 async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   bridgeModule: DesktopAgentExecutionModule;
+  openTranscripts(): Promise<StreamLogStore>;
+  ephemeralTranscripts(): StreamLogStore;
   progressSnapshotStore?: ProgressSnapshotStore;
 }> {
   vi.resetModules();
@@ -265,12 +268,16 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         return false;
       }
 
+      async modifiedAt(): Promise<number | undefined> {
+        return 1;
+      }
+
       async listKeys(): Promise<string[]> {
-        if (options.streamLogsLoadError && this.dir === STREAM_LOGS_DIR) {
-          throw options.streamLogsLoadError;
+        if (options.transcriptOpenError && this.dir === STREAM_LOGS_DIR) {
+          throw options.transcriptOpenError;
         }
-        if (options.streamLogsLoadGate && this.dir === STREAM_LOGS_DIR) {
-          await options.streamLogsLoadGate;
+        if (options.transcriptOpenGate && this.dir === STREAM_LOGS_DIR) {
+          await options.transcriptOpenGate;
         }
         if (!options.kvStoreBacking) return [];
         const prefix = `${this.dir}/`;
@@ -363,21 +370,34 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   const bridgeModule = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  return { bridgeModule, progressSnapshotStore };
+  const { StreamLogStore } = await import('@transcript');
+  const { initializeDefaultSession } =
+    await import('@agent/runtime/SessionHandle');
+  initializeDefaultSession({
+    transcripts: StreamLogStore.ephemeral('desktop module test default'),
+  });
+  return {
+    bridgeModule,
+    openTranscripts: () => StreamLogStore.open(),
+    ephemeralTranscripts: () => StreamLogStore.ephemeral('desktop bridge test'),
+    progressSnapshotStore,
+  };
 }
 
 async function createBridge(
   messages: unknown[],
   options: CreateBridgeOptions = {},
 ): Promise<TestableBridge> {
-  const { bridgeModule, progressSnapshotStore } =
+  const { bridgeModule, openTranscripts, progressSnapshotStore } =
     await loadBridgeModule(options);
+  const transcripts = await openTranscripts();
   return disposeAfterTest(
     new bridgeModule.DesktopProgressBridge(
       (message) => {
         messages.push(message);
       },
       {
+        transcripts,
         streamSnapshotStore: options.streamSnapshotStore,
         progressSnapshotStore,
         showErrorMessage: options.showErrorMessage,
@@ -1104,44 +1124,33 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
-  it('gates the Progress webview readiness paint on desktop startup repair', async () => {
-    // Regression test: the desktop webviewReady handler used to call
-    // syncFullView() / hydrateProgressViewInquiries() / replayPendingPrompts()
-    // directly, without awaiting `restartRepair` first. Restored streams are
-    // only folded into `streamLogs`/`session.status` once
-    // `repairOrphanedStreamsAfterRestart` (i.e. `restartRepair`) resolves --
-    // it awaits `state.streamLogs.load()` before anything else -- so a
-    // webviewReady race landing in that window paints the rail without the
-    // restored streams, with no guaranteed later repaint. Same race class as
-    // revealStream's #7850 fix. Gate the on-disk stream-log scan and assert
-    // `completeWebviewReady()` defers its entire paint sequence until
-    // `restartRepair` has actually settled.
-    let finishStreamLogsLoad!: () => void;
-    const streamLogsLoadGate = new Promise<void>((resolve) => {
-      finishStreamLogsLoad = resolve;
+  it('does not expose the desktop bridge before transcript opening settles', async () => {
+    let finishTranscriptOpen!: () => void;
+    const transcriptOpenGate = new Promise<void>((resolve) => {
+      finishTranscriptOpen = resolve;
     });
     const messages: unknown[] = [];
-    const bridge = await createBridge(messages, { streamLogsLoadGate });
+    const opening = createBridge(messages, { transcriptOpenGate });
+    const opened = vi.fn();
+    void opening.then(opened);
+    let bridge: TestableBridge | undefined;
 
     try {
-      const readyPromise = bridge.completeWebviewReady();
-
-      // streamLogs.load() is still gated, so restartRepair has not settled;
-      // completeWebviewReady() must not have painted anything yet.
       await settleProgressEvents();
+      expect(opened).not.toHaveBeenCalled();
       expect(messages).toEqual([]);
 
-      finishStreamLogsLoad();
-      await readyPromise;
+      finishTranscriptOpen();
+      bridge = await opening;
+      await bridge.completeWebviewReady();
 
-      // Once restartRepair settles, the deferred paint goes out.
       expect(
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)
           .length,
       ).toBeGreaterThan(0);
     } finally {
-      finishStreamLogsLoad();
-      bridge.dispose();
+      finishTranscriptOpen();
+      bridge?.dispose();
     }
   });
 
@@ -1177,46 +1186,20 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
-  it('restores a RUNNING stream with a persisted flow record to WAITING when streamLogs.load() throws', async () => {
-    // Regression test: the catch-fallback path used to only
-    // consider streams whose CURRENT in-memory status was already WAITING,
-    // missing a stream that was RUNNING at crash time but still has a valid
-    // persisted flow record -- wrongly demoting it to FAILED instead of
-    // WAITING. The fallback must now consult detectWaitingStreams() (ground
-    // truth from the persisted KV record) just like the primary try path.
-    const detectWaitingStreams = vi.fn(
-      async (executionIds: ReadonlyMap<StreamTabId, string>) =>
-        new Set<StreamTabId>(
-          [...executionIds.keys()].filter(
-            (streamId) => streamId === 'resumable-stream',
-          ),
-        ),
-    );
-    const bridge = await createBridge([], {
-      detectWaitingStreams,
-      streamLogsLoadError: new Error('stream log store unavailable'),
-      streamSnapshotStore: createStreamSnapshotStore([
-        restoredSnapshot({
-          streamId: 'resumable-stream',
-          executionId: 'abc123',
-          lastKnownStatus: STREAM_STATUS.RUNNING,
-        }),
-      ]),
-    });
+  it('fails desktop bridge initialization when transcript opening fails', async () => {
+    const detectWaitingStreams = vi.fn();
+    const failure = new Error('stream log store unavailable');
 
-    try {
-      await vi.waitFor(() => {
-        expect(detectWaitingStreams).toHaveBeenCalledOnce();
-        expect(bridgeStatus(bridge).get('resumable-stream')).toBe(
-          STREAM_STATUS.WAITING,
-        );
-      });
-    } finally {
-      bridgeStatus(bridge).clearStream('resumable-stream');
-    }
+    await expect(
+      createBridge([], {
+        detectWaitingStreams,
+        transcriptOpenError: failure,
+      }),
+    ).rejects.toBe(failure);
+    expect(detectWaitingStreams).not.toHaveBeenCalled();
   });
 
-  it('closes fallback waiting groups from durable snapshots outside restored streams', async () => {
+  it('closes waiting groups from durable snapshots outside restored streams', async () => {
     let finishDetection!: (value: Set<StreamTabId>) => void;
     const detectionGate = new Promise<Set<StreamTabId>>((resolve) => {
       finishDetection = resolve;
@@ -1231,7 +1214,6 @@ describe('DesktopProgressBridge', () => {
         );
       },
       detectWaitingStreams,
-      streamLogsLoadError: new Error('stream log store unavailable'),
     });
     const restartRepair = (
       bridge as unknown as { restartRepair: Promise<void> }
@@ -1692,21 +1674,14 @@ describe('DesktopProgressBridge', () => {
     });
   });
 
-  it('waits for desktop startup repair before revealing a goal-owned stream (issue #7850)', async () => {
-    // Regression test: revealStream() used to check streamLogs.has()
-    // synchronously, before streamLogs.load() (which only resolves inside
-    // restartRepair) had populated it. A goal-owned stream restored from a
-    // prior session would look "unknown" during that narrow startup window
-    // and reveal would silently no-op. Gate the on-disk stream-log scan and
-    // assert reveal does not route until restartRepair (and thus the load)
-    // has actually completed.
-    let finishStreamLogsLoad!: () => void;
-    const streamLogsLoadGate = new Promise<void>((resolve) => {
-      finishStreamLogsLoad = resolve;
+  it('reveals a goal-owned stream after persistent opening completes', async () => {
+    let finishTranscriptOpen!: () => void;
+    const transcriptOpenGate = new Promise<void>((resolve) => {
+      finishTranscriptOpen = resolve;
     });
     const messages: unknown[] = [];
-    const bridge = await createBridge(messages, {
-      streamLogsLoadGate,
+    const opening = createBridge(messages, {
+      transcriptOpenGate,
       kvStoreBacking: new Map<string, unknown>([
         [
           `${STREAM_LOGS_DIR}/goal-owning-stream`,
@@ -1721,17 +1696,18 @@ describe('DesktopProgressBridge', () => {
         ],
       ]),
     });
+    const opened = vi.fn();
+    void opening.then(opened);
+    let bridge: TestableBridge | undefined;
 
     try {
-      const revealPromise = bridge.revealStream('goal-owning-stream');
-
-      // streamLogs.load() is still gated, so the stream has not been
-      // repaired into this window's streamLogs yet.
       await settleProgressEvents();
+      expect(opened).not.toHaveBeenCalled();
       expect(messages).toEqual([]);
 
-      finishStreamLogsLoad();
-      await revealPromise;
+      finishTranscriptOpen();
+      bridge = await opening;
+      await bridge.revealStream('goal-owning-stream');
 
       expect(messages).toContainEqual({
         command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
@@ -1744,7 +1720,8 @@ describe('DesktopProgressBridge', () => {
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
       });
     } finally {
-      finishStreamLogsLoad();
+      finishTranscriptOpen();
+      bridge?.dispose();
     }
   });
 
@@ -2109,6 +2086,7 @@ describe('DesktopProgressBridge', () => {
       streamId: 'second',
       agentCategory: AgentCategory.Workflow,
     });
+    await bridge.streamLogs.ensureLoaded('first');
     bridge.streamLogs.append('first', {
       id: 'first-log',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -2872,7 +2850,7 @@ describe('DesktopProgressBridge', () => {
 
     await bridge.flush();
     bridge.streamLogs.releaseEntries(streamId);
-    await bridge.streamLogs.load();
+    await bridge.streamLogs.reload();
     await bridge.streamLogs.ensureLoaded(streamId);
 
     expect(
@@ -2921,7 +2899,7 @@ describe('DesktopProgressBridge', () => {
     };
 
     async function createWindowPair(): Promise<WindowPair> {
-      const { bridgeModule } = await loadBridgeModule();
+      const { bridgeModule, ephemeralTranscripts } = await loadBridgeModule();
       // Same registry as the bridge module graph — identity comparisons
       // against process-wide defaults must use this instance, not a
       // statically imported copy from the pre-reset registry.
@@ -2933,7 +2911,10 @@ describe('DesktopProgressBridge', () => {
           (message) => {
             messages.push(message);
           },
-          { streamSnapshotStore: snapshots },
+          {
+            transcripts: ephemeralTranscripts(),
+            streamSnapshotStore: snapshots,
+          },
         ) as unknown as TestableBridge;
         const session = (bridge as unknown as { session: SessionHandle })
           .session;
@@ -3331,16 +3312,19 @@ describe('DesktopProgressBridge', () => {
       messages?: unknown[];
     }) {
       let activeExecutionIds: readonly string[] = [];
-      const { bridgeModule } = await loadBridgeModule({
+      const { bridgeModule, ephemeralTranscripts } = await loadBridgeModule({
         activeExecutionIds: () => activeExecutionIds,
       });
       const { AgentExecutionHandle, ProcessExecutionHandle } =
         await import('@agent/runtime/executionRegistry');
       const { noopAgentRuntimeHost } =
         await import('@agent/runtime/AgentRuntimeHost');
-      const bridgeA = new bridgeModule.DesktopProgressBridge((message) => {
-        messages.push(message);
-      }) as unknown as TestableBridge & { session: SessionHandle };
+      const bridgeA = new bridgeModule.DesktopProgressBridge(
+        (message) => {
+          messages.push(message);
+        },
+        { transcripts: ephemeralTranscripts() },
+      ) as unknown as TestableBridge & { session: SessionHandle };
       await settleProgressEvents();
       const createHandle = (
         options: {
@@ -3386,7 +3370,7 @@ describe('DesktopProgressBridge', () => {
           (message) => {
             reopenedMessages.push(message);
           },
-          { streamSnapshotStore },
+          { transcripts: ephemeralTranscripts(), streamSnapshotStore },
         ) as unknown as TestableBridge & {
           session: SessionHandle;
         };

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -34,6 +34,7 @@ async function createExecution(options: {
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
   runAgent?: RunExecutionRequest;
   onRunCompleted?: () => void;
+  transcriptOpenError?: Error;
 }): Promise<DesktopExecution> {
   vi.resetModules();
   const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
@@ -70,6 +71,7 @@ async function createExecution(options: {
       }
 
       async listKeys(): Promise<string[]> {
+        if (options.transcriptOpenError) throw options.transcriptOpenError;
         return [];
       }
     },
@@ -82,7 +84,7 @@ async function createExecution(options: {
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
   return disposeAfterTest(
-    createDesktopAgentExecution({
+    await createDesktopAgentExecution({
       postToRenderer: options.postToRenderer ?? vi.fn(),
       opener: options.opener,
       showErrorMessage: options.showErrorMessage,
@@ -101,6 +103,17 @@ describe('createDesktopAgentExecution', () => {
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger');
     vi.restoreAllMocks();
+  });
+
+  it('fails initialization when persistent transcripts cannot be opened', async () => {
+    const failure = new Error('desktop transcript storage unavailable');
+
+    await expect(
+      createExecution({
+        transcriptOpenError: failure,
+        prepareMainViewExecutionRequest: vi.fn(),
+      }),
+    ).rejects.toBe(failure);
   });
 
   it('surfaces invalid execution requests through the host error path', async () => {

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
@@ -86,7 +89,7 @@ async function createInteractions(handlers = createHandlers()) {
     moduleFileUrl(desktopSourcePath('main', 'desktopHostInteractions.ts'))
   )) as DesktopHostInteractionsModule;
   const runtimeHost = { emit: vi.fn() };
-  const session = new SessionHandle();
+  const session = createTestSession();
   const toolEditApprovals = {
     requestApproval: vi.fn(async () => ({ accepted: true })),
   };

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -1,6 +1,9 @@
+// Test support imports
+
 import { access, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createTestSession as createIsolatedTestSession } from '@test/support/sessionTestUtils';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -62,7 +65,7 @@ let activeToolEditApproval:
 const testSessions: SessionHandle[] = [];
 
 function createTestSession(): SessionHandle {
-  const session = new SessionHandle();
+  const session = createIsolatedTestSession();
   testSessions.push(session);
   return session;
 }

--- a/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
+++ b/src/test-kernel/frontend/ExtensionAgentRuntimeHost.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it } from 'vitest';
 
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';

--- a/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
+++ b/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { createTestSession } from '@test/support/sessionTestUtils';
 import {
   handleProgressViewToolEditApprovalAction,
   initializeNativeToolEditApproval,
@@ -147,7 +148,7 @@ function currentProposedUri(): TestUri {
 
 async function startApproval(): Promise<StartedApproval> {
   const runtimeHost = createRecordingRuntimeHost();
-  const session = new SessionHandle();
+  const session = createTestSession();
   sessions.push(session);
   initializeNativeToolEditApproval(
     {

--- a/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
@@ -11,7 +14,7 @@ import { STREAM_PHASE } from '@shared/schemas';
 
 describe('subscribeStatusBarSessionEvents', () => {
   it('tracks stream status changes from the session status plane', () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const tracker = new StatusBarUsageTracker();
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();
@@ -35,7 +38,7 @@ describe('subscribeStatusBarSessionEvents', () => {
   });
 
   it('records valid run usage events after an in-flight status', () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const tracker = new StatusBarUsageTracker();
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();
@@ -72,7 +75,7 @@ describe('subscribeStatusBarSessionEvents', () => {
   });
 
   it('ignores malformed usage payloads and usage for unknown streams', () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const tracker = new StatusBarUsageTracker();
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -11,7 +11,7 @@ describe('createRunTrace dispose', () => {
   let store: StreamLogStore;
 
   beforeEach(() => {
-    store = new StreamLogStore();
+    store = StreamLogStore.ephemeral('test');
   });
 
   afterEach(() => {

--- a/src/test-kernel/logger/errorData.vitest.ts
+++ b/src/test-kernel/logger/errorData.vitest.ts
@@ -7,7 +7,7 @@ describe('AgentTrace error data', () => {
   let store: StreamLogStore;
 
   beforeEach(async () => {
-    store = new StreamLogStore();
+    store = StreamLogStore.ephemeral('test');
     await store.clear();
   });
 

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -1,3 +1,6 @@
+// Test support imports
+import { createTestSession as createIsolatedTestSession } from '@test/support/sessionTestUtils';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -63,7 +66,7 @@ afterEach(() => {
 });
 
 function createTestSession(): SessionHandle {
-  const session = new SessionHandle();
+  const session = createIsolatedTestSession();
   testSessions.push(session);
   return session;
 }

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1516,6 +1516,31 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('keeps resident background entries during an in-flight status update', async () => {
+    const { backend } = createRecordingBackend();
+    const stream = 'background-stream' as StreamTabId;
+    const releaseSpy = vi.spyOn(backend.state.streamLogs, 'releaseEntries');
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.updateStreamHints(stream, {
+        agentCategory: AgentCategory.ToolUse,
+      });
+      backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+
+      await backend.factApplier.setStreamStatus(
+        stream,
+        STREAM_PHASE.RUNNING,
+        STREAM_PHASE.RUNNING,
+      );
+
+      expect(releaseSpy).not.toHaveBeenCalled();
+      expect(backend.state.streamLogs.get(stream)).toBeDefined();
+    } finally {
+      backend.dispose();
+    }
+  });
+
   it('drops buffered conversation progress when an existing stream re-enters running', async () => {
     vi.useFakeTimers();
     const { backend, messages } = createRecordingBackend();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1,11 +1,21 @@
-// Standard library imports
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
 import * as path from 'node:path';
+import { createTestSession } from '@test/support/sessionTestUtils';
+
+// Standard library imports
 
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - transcript
-import { streamDataDir, StreamSnapshotStore } from '@transcript';
+import {
+  streamDataDir,
+  StreamLogStore,
+  StreamSnapshotStore,
+} from '@transcript';
 import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
 
 // Local imports - agent
@@ -111,13 +121,14 @@ function createRecordingBackend(): {
   return { backend, messages };
 }
 
-function createIsolatedRecordingBackend(): {
+function createIsolatedRecordingBackend(
+  session: SessionHandle = createTestSession(),
+): {
   backend: ProgressBackend;
   messages: ProgressViewOutboundMessage[];
   session: SessionHandle;
 } {
   const messages: ProgressViewOutboundMessage[] = [];
-  const session = new SessionHandle();
   const backend = new ProgressBackend({
     storage: new MemoryMementoStorage(),
     snapshots: new StreamSnapshotStore(),
@@ -130,6 +141,14 @@ function createIsolatedRecordingBackend(): {
     configureUi: () => createUiConfig(),
   });
   return { backend, messages, session };
+}
+
+async function createPersistentRecordingBackend(): Promise<
+  ReturnType<typeof createIsolatedRecordingBackend>
+> {
+  return createIsolatedRecordingBackend(
+    createTestSession({ transcripts: await StreamLogStore.open() }),
+  );
 }
 
 async function writeExecutionConfig(executionId: ExecutionId): Promise<void> {
@@ -241,7 +260,7 @@ describe('ProgressBackend', () => {
   });
 
   it('routes removeStream session facts through the shared lifecycle delete path', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const deletedStreams: StreamTabId[] = [];
     const backendRef: { current?: ProgressBackend } = {};
     const backend = new ProgressBackend({
@@ -284,7 +303,7 @@ describe('ProgressBackend', () => {
   });
 
   it('handles removeStream session facts before backend load', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const deletedStreams: StreamTabId[] = [];
     const backend = new ProgressBackend({
       storage: new MemoryMementoStorage(),
@@ -1742,7 +1761,6 @@ describe('ProgressBackend', () => {
     const { backend, session } = createIsolatedRecordingBackend();
 
     try {
-      await backend.state.streamLogs.load();
       backend.state.streamLogs.ensureStream(stream);
       await GoalStore.start(stream, 'clear this goal');
 
@@ -1762,7 +1780,7 @@ describe('ProgressBackend', () => {
     const orphanExecution = 'b6966b' as ExecutionId;
     const historyExecution = 'c6966c' as ExecutionId;
 
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend, session } = await createPersistentRecordingBackend();
     try {
       const seed = new StreamSnapshotStore();
       await seed.load([orphanStream]);
@@ -1824,7 +1842,7 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(sweptExecution);
     await seed.flush();
 
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend, session } = await createPersistentRecordingBackend();
     const originalDeleteStream = backend.state.snapshots.deleteStream.bind(
       backend.state.snapshots,
     );
@@ -1886,7 +1904,7 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(sweptExecution);
     await seed.flush();
 
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend, session } = await createPersistentRecordingBackend();
     const stores = backend.state.stores as unknown as {
       deleteExecution(executionId: ExecutionId): Promise<boolean>;
     };
@@ -1941,11 +1959,6 @@ describe('ProgressBackend', () => {
       backend: ReturnType<typeof createIsolatedRecordingBackend>['backend'],
       stream: StreamTabId,
     ): Promise<void> {
-      // `flush()` is a no-op until the store has `load()`ed once, so run an
-      // initial (empty) load first — mirrors the prior session that actually
-      // persisted this stream's log to disk before the extension restarted.
-      await backend.state.load();
-
       // A prior session's log has entries, but (as with pre-#3061 tabs) never
       // recorded a user-message entry for the run's initial instruction.
       backend.state.streamLogs.append(stream, {
@@ -1962,7 +1975,7 @@ describe('ProgressBackend', () => {
     it('hydrates the initial user message from legacyInstructions.json', async () => {
       const stream = 'polish@gpt#legacy01' as StreamTabId;
       const legacyText = 'Polish the introduction section for clarity.';
-      const { backend, session } = createIsolatedRecordingBackend();
+      const { backend, session } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);
@@ -1998,7 +2011,7 @@ describe('ProgressBackend', () => {
     it('falls back to the older runInstructions.json key (never migrated on disk)', async () => {
       const stream = 'polish@gpt#legacy02' as StreamTabId;
       const legacyText = 'Rewrite the abstract to lead with the contribution.';
-      const { backend, session } = createIsolatedRecordingBackend();
+      const { backend, session } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);
@@ -2039,7 +2052,7 @@ describe('ProgressBackend', () => {
     it('does not duplicate the backfilled message on a second load()', async () => {
       const stream = 'polish@gpt#legacy03' as StreamTabId;
       const legacyText = 'Tighten the related-work section.';
-      const { backend, session } = createIsolatedRecordingBackend();
+      const { backend, session } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);

--- a/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -52,7 +52,7 @@ describe('WebviewBridge', () => {
   });
 
   it('flushes active stream log deltas', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
     const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
@@ -78,7 +78,7 @@ describe('WebviewBridge', () => {
   });
 
   it('does not queue inactive stream flushes that race with tab switches', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     let activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
     const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
@@ -96,7 +96,7 @@ describe('WebviewBridge', () => {
   });
 
   it('syncs inactive stream history explicitly on tab switch', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     let activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
     const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
@@ -127,7 +127,7 @@ describe('WebviewBridge', () => {
   });
 
   it('replays full streamed text when a webview syncs mid-stream', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
     const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
@@ -156,7 +156,7 @@ describe('WebviewBridge', () => {
   });
 
   it('keeps the cursor and dirty updates when no target accepts a log delta', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const sendMessage = vi
       .fn()
@@ -201,7 +201,7 @@ describe('WebviewBridge', () => {
   });
 
   it('serializes async flushes and preserves updates made during delivery', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const firstDelivery = deferredBoolean();
     const sendMessage = vi
@@ -242,7 +242,7 @@ describe('WebviewBridge', () => {
   });
 
   it('does not resend streamed text already covered by an in-flight full entry', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const firstDelivery = deferredBoolean();
     const sendMessage = vi
@@ -290,7 +290,7 @@ describe('WebviewBridge', () => {
   });
 
   it('ships streamed text as O(L) append deltas instead of full updates', async () => {
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     let deliveredBytes = 0;
     const sendMessage = vi.fn((message) => {

--- a/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
+++ b/src/test-kernel/settings/PlanToolTerminalAction.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 

--- a/src/test-kernel/support/agentCliResumeTestUtils.ts
+++ b/src/test-kernel/support/agentCliResumeTestUtils.ts
@@ -8,7 +8,10 @@ import type { ChildStream } from '@tools/childStream';
 export function createFakeAgentCliChildStream(
   childStreamId: StreamTabId,
 ): ChildStream {
-  const logger = createRunTrace(childStreamId, new StreamLogStore()).trace;
+  const logger = createRunTrace(
+    childStreamId,
+    StreamLogStore.ephemeral('test'),
+  ).trace;
   return {
     childStreamId,
     logger,

--- a/src/test-kernel/support/defaultSessionTestSetup.ts
+++ b/src/test-kernel/support/defaultSessionTestSetup.ts
@@ -1,0 +1,6 @@
+import { StreamLogStore } from '@transcript/StreamLogStore';
+import { initializeDefaultSession } from '@agent/runtime/SessionHandle';
+
+initializeDefaultSession({
+  transcripts: StreamLogStore.ephemeral('test process default session'),
+});

--- a/src/test-kernel/support/sessionTestUtils.ts
+++ b/src/test-kernel/support/sessionTestUtils.ts
@@ -1,0 +1,18 @@
+import { StreamLogStore } from '@transcript';
+import {
+  SessionHandle,
+  type SessionHandleInit,
+} from '@agent/runtime/SessionHandle';
+
+type TestSessionInit = Omit<SessionHandleInit, 'transcripts'> & {
+  readonly transcripts?: StreamLogStore;
+};
+
+/** Construct an isolated session with an explicitly ephemeral transcript. */
+export function createTestSession(init: TestSessionInit = {}): SessionHandle {
+  return new SessionHandle({
+    ...init,
+    transcripts:
+      init.transcripts ?? StreamLogStore.ephemeral('isolated test session'),
+  });
+}

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
@@ -54,8 +60,8 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
   });
 
   it('scopes streamless cleanup to the owning session', () => {
-    const sessionA = new SessionHandle();
-    const sessionB = new SessionHandle();
+    const sessionA = createTestSession();
+    const sessionB = createTestSession();
     const cancelA = vi.fn();
     sessionA.useHostInteractions({ resolve: () => false, cancel: cancelA });
     const settled = new Set<string>();
@@ -108,8 +114,8 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
 
 describe('session-owned approval state (#8144)', () => {
   it('keeps bypass state for equal stream ids isolated between sessions', () => {
-    const sessionA = new SessionHandle();
-    const sessionB = new SessionHandle();
+    const sessionA = createTestSession();
+    const sessionB = createTestSession();
     const streamId = sid('s:appr-same-id');
 
     try {
@@ -130,8 +136,8 @@ describe('session-owned approval state (#8144)', () => {
   });
 
   it("an unanswered approval in one session does not delay another session's queue", async () => {
-    const sessionA = new SessionHandle();
-    const sessionB = new SessionHandle();
+    const sessionA = createTestSession();
+    const sessionB = createTestSession();
 
     try {
       // Session A's prompt slot is occupied by a never-answered approval.
@@ -149,7 +155,7 @@ describe('session-owned approval state (#8144)', () => {
   });
 
   it('session disposal rejects its remaining pending approvals and clears bypass state', () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const streamId = sid('s:appr-dispose');
     const settled = new Set<string>();
 

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { strict as assert } from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
@@ -246,7 +249,8 @@ describe('BashTool', () => {
 
     const options = roundServices({
       toolName: 'bash',
-      logger: createRunTrace('BashToolTest', new StreamLogStore()).trace,
+      logger: createRunTrace('BashToolTest', StreamLogStore.ephemeral('test'))
+        .trace,
       streamId: 'bash-tool' as StreamTabId,
       toolRegistry: new MapToolRegistry({ bash: bashTool }),
     });
@@ -280,7 +284,7 @@ describe('BashTool', () => {
   it('keeps result status out of visible tool log output', async () => {
     const runTrace = createRunTrace(
       'ToolStatusLogTest' as StreamTabId,
-      new StreamLogStore(),
+      StreamLogStore.ephemeral('test'),
     );
     const events: AgentEvent[] = [];
     const unsubscribe = runTrace.trace.subscribe((event) => {
@@ -671,7 +675,7 @@ describe('BashTool', () => {
 
     const runTrace = createRunTrace(
       'BashToolAbortTest' as StreamTabId,
-      new StreamLogStore(),
+      StreamLogStore.ephemeral('test'),
     );
     const events: AgentEvent[] = [];
     const unsubscribe = runTrace.trace.subscribe((event) => {

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -1,5 +1,11 @@
-// Third-party imports
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
 import * as assert from 'node:assert';
+import { createTestSession as createIsolatedTestSession } from '@test/support/sessionTestUtils';
+
+// Third-party imports
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports - tests
@@ -31,7 +37,7 @@ describe('Concurrent session tool edit approval handlers', () => {
   const testSessions: SessionHandle[] = [];
 
   function createTestSession(): SessionHandle {
-    const session = new SessionHandle();
+    const session = createIsolatedTestSession();
     testSessions.push(session);
     return session;
   }

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -64,7 +70,7 @@ function runtimeHost(): AgentRuntimeHost {
 
 /** Real session whose interactions slot is the host's fake port. */
 function sessionFor(host: AgentRuntimeHost): SessionHandle {
-  const session = new SessionHandle();
+  const session = createTestSession();
   if (host.interactions) session.useHostInteractions(host.interactions);
   return session;
 }

--- a/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolResumability.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -1,6 +1,12 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
+import { createTestSession } from '@test/support/sessionTestUtils';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -174,7 +180,7 @@ describe('ExecutionsTool', () => {
 
   it('does not duplicate auto-delivered live subagent reports for the parent stream', async () => {
     const explicit = createRecordingHost();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const executionId = 'abc123';
     const parentStreamId = 'stream:parent-report-suppression' as StreamTabId;
     const childStreamId = 'stream:child-report-suppression' as StreamTabId;

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createRecordingHost } from '@test/agent/progressTestUtils';
@@ -46,8 +52,8 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
   });
 
   it('routes explicit-session forget notifications only to the passed session', async () => {
-    const runSession = new SessionHandle();
-    const explicitSession = new SessionHandle();
+    const runSession = createTestSession();
+    const explicitSession = createTestSession();
     const seenRun: unknown[] = [];
     const seenExplicit: unknown[] = [];
     const seenDefault: unknown[] = [];

--- a/src/test-kernel/tools/GoalStateSubscription.vitest.ts
+++ b/src/test-kernel/tools/GoalStateSubscription.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { describe, expect, it } from 'vitest';
 
 import { createRecordingHost } from '@test/agent/progressTestUtils';
@@ -13,8 +19,8 @@ describe('subscribeGoalStateChanges', () => {
   setupPlatform();
 
   it('delivers only goal changes from the supplied session', () => {
-    const sessionA = new SessionHandle();
-    const sessionB = new SessionHandle();
+    const sessionA = createTestSession();
+    const sessionB = createTestSession();
     const seen: unknown[] = [];
     const detach = subscribeGoalStateChanges(sessionA, (change) => {
       seen.push(change);
@@ -52,8 +58,8 @@ describe('subscribeGoalStateChanges', () => {
   });
 
   it('routes start, status, and edit notifications through the current run session only', async () => {
-    const runSession = new SessionHandle();
-    const otherSession = new SessionHandle();
+    const runSession = createTestSession();
+    const otherSession = createTestSession();
     const seenRun: unknown[] = [];
     const seenOther: unknown[] = [];
     const seenDefault: unknown[] = [];

--- a/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
+++ b/src/test-kernel/tools/GoalStoreConcurrency.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { describe, expect, it } from 'vitest';
 
 import { installPlatform } from '@test/support/setupPlatform';

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -1,3 +1,9 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
+import { createTestSession } from '@test/support/sessionTestUtils';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sendFollowUpMock = vi.hoisted(() =>
@@ -115,7 +121,7 @@ describe('external inquiry continuation session routing', () => {
   });
 
   it('emits inquiry thread updates through the explicit session hub', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const explicitFacts: unknown[] = [];
     const defaultFacts: unknown[] = [];
     const detachExplicitFacts = session.events.subscribe((event) => {
@@ -159,7 +165,7 @@ describe('external inquiry continuation session routing', () => {
 
   it("emits inquiry thread updates through the active run's session when no explicit session is provided", async () => {
     const { host } = createRecordingHost();
-    const session = new SessionHandle();
+    const session = createTestSession();
     const runFacts: unknown[] = [];
     const defaultFacts: unknown[] = [];
     const detachRunFacts = session.events.subscribe((event) => {
@@ -200,7 +206,7 @@ describe('external inquiry continuation session routing', () => {
 
   it('falls back to the default session when the selected session has no event hub', async () => {
     const { host } = createRecordingHost();
-    const runSession = new SessionHandle();
+    const runSession = createTestSession();
     const runFacts: unknown[] = [];
     const defaultFacts: unknown[] = [];
     const detachRunFacts = runSession.events.subscribe((event) => {
@@ -245,7 +251,7 @@ describe('external inquiry continuation session routing', () => {
   });
 
   it('does not emit an inquiry thread update when no summary is returned', async () => {
-    const session = new SessionHandle();
+    const session = createTestSession();
     const facts: unknown[] = [];
     const detachFacts = session.events.subscribe((event) => {
       facts.push(event);

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sendFollowUpMock = vi.hoisted(() =>

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -1,5 +1,11 @@
-// Third-party imports
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Test support imports
 import { setTimeout as sleep } from 'node:timers/promises';
+import { createTestSession } from '@test/support/sessionTestUtils';
+
+// Third-party imports
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -60,7 +66,7 @@ function fakePorts() {
   return { notify: vi.fn(), recordCost: vi.fn() };
 }
 
-function baseParams(parentSession = new SessionHandle()) {
+function baseParams(parentSession = createTestSession()) {
   if (parentSession !== defaultSession()) ownedSessions.add(parentSession);
   return {
     configPayload: {

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import * as assert from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'vitest';

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 import { describe, expect, it } from 'vitest';
 

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Suites for src/tools/wolfram (WolframTool approval gating +
 // wolframScriptUtils argument handling).
 

--- a/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
+++ b/src/test-kernel/tools/setup/SendToTerminalTool.vitest.ts
@@ -1,3 +1,6 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 // Third-party imports
 
 // Node.js built-in imports

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -135,8 +135,7 @@ describe('replayTrace legacy-status fallback (issue #7188)', () => {
     const streamId = getStreamTabId(config.agent, config.model, {
       executionId,
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(streamId, {
       id: 'terminal-stage',
       type: STREAM_LOG_ENTRY_TYPES.GROUP_START,

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -239,6 +239,76 @@ describe('StreamLogStore load', () => {
     vi.restoreAllMocks();
   });
 
+  it('opens a valid persistent store before exposing it', async () => {
+    mockStorage({ logs: {}, summaries: {} });
+
+    const store = await StreamLogStore.open();
+
+    expect(store.mode).toEqual({ kind: 'persistent' });
+    expect(Object.isFrozen(store.mode)).toBe(true);
+    expect(store.keys()).toEqual([]);
+  });
+
+  it('constructs an inspectable ephemeral store only with an explicit reason', async () => {
+    const store = StreamLogStore.ephemeral('interactive fallback test');
+
+    store.append('ephemeral-stream', logEntry('ephemeral-stream', 1, 100));
+    store.releaseEntries('ephemeral-stream');
+    await store.flush();
+
+    expect(store.mode).toEqual({
+      kind: 'ephemeral',
+      reason: 'interactive fallback test',
+    });
+    expect(store.get('ephemeral-stream')?.size).toBe(1);
+    expect(() => StreamLogStore.ephemeral('  ')).toThrow('requires a reason');
+  });
+
+  it('rejects when persistent storage cannot be opened', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(
+      new Error('storage permission denied'),
+    );
+
+    await expect(StreamLogStore.open()).rejects.toThrow(
+      'storage permission denied',
+    );
+  });
+
+  it('preserves live state when a transactional reload fails', async () => {
+    const logs: Record<string, unknown> = {
+      alpha: [logEntry('alpha', 1, 100)],
+    };
+    mockStorage({
+      logs,
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: false,
+        },
+      },
+    });
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+    const liveAlpha = store.get('alpha');
+    logs.beta = { corrupted: true };
+
+    await expect(store.reload()).rejects.toThrow(
+      'persisted log is not an array',
+    );
+
+    expect(store.keys()).toEqual(['alpha']);
+    expect(store.get('alpha')).toBe(liveAlpha);
+    expect(
+      store
+        .get('alpha')
+        ?.getRange(0)
+        .map((entry) => entry.id),
+    ).toEqual(['alpha-1']);
+    expect(store.getFirstTimestamp('alpha')).toBe(100);
+    expect(store.has('beta')).toBe(false);
+  });
+
   it('uses stream summaries without reading full log files at startup', async () => {
     const storage = mockStorage({
       logs: {
@@ -259,8 +329,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(0);
     expect(store.keys()).toEqual(['beta', 'alpha']);
@@ -288,8 +357,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(0);
     expect(store.keys()).toEqual(['alpha']);
@@ -305,8 +373,7 @@ describe('StreamLogStore load', () => {
       summaries: {},
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(1);
     expect(store.keys()).toEqual(['alpha']);
@@ -338,8 +405,7 @@ describe('StreamLogStore load', () => {
       summaryMtimes: { alpha: 10 },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(1);
     expect(store.getFirstTimestamp('alpha')).toBe(200);
@@ -367,8 +433,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(0);
 
@@ -413,8 +478,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     const affected = await store.endRunningGroupsForStreams(['alpha'], 300);
     await store.flush();
@@ -456,8 +520,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(storage.fullLogReads()).toBe(0);
 
@@ -492,8 +555,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     // A caller-supplied RunOutcome (e.g. restart repair's graceful-interrupt
     // classification, #7993 step 2) reaches the row directly — no fold to
@@ -550,8 +612,7 @@ describe('StreamLogStore load', () => {
       summaries: {},
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     await store.ensureLoaded('delta');
 
     const entries = store.get('delta')?.getRange(0) ?? [];
@@ -595,8 +656,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     const affected = await store.endRunningGroupsForStreams(
       ['alpha', 'beta'],
@@ -649,8 +709,7 @@ describe('StreamLogStore load', () => {
       },
     });
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     const endRunningGroups = store.endRunningGroups(300);
     await waitForCondition(
@@ -694,8 +753,7 @@ describe('StreamLogStore load', () => {
         await readGate;
       },
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     const load = store.ensureLoaded('alpha');
     await readStarted;
 
@@ -731,8 +789,7 @@ describe('StreamLogStore load', () => {
       summaries: {},
       pauseLogWriteKey: 'delete-me',
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     store.append('delete-me', {
       id: 'delete-me-entry',
@@ -768,8 +825,7 @@ describe('StreamLogStore load', () => {
       logs: {},
       summaries: {},
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     vi.useFakeTimers();
     try {
@@ -806,8 +862,7 @@ describe('StreamLogStore load', () => {
       summaries: {},
       pauseLogWriteKey: 'reuse-me',
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     store.append('reuse-me', {
       id: 'old-entry',
@@ -854,8 +909,7 @@ describe('StreamLogStore load', () => {
 
   it('writes stream summaries with dirty log flushes', async () => {
     const storage = mockStorage({ logs: {}, summaries: {} });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     store.append('new-stream', {
       id: 'new-stream-entry',
@@ -914,8 +968,7 @@ describe('StreamLogStore load', () => {
       },
     });
     const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     await store.ensureLoaded('alpha');
 
     expect(
@@ -967,8 +1020,7 @@ describe('StreamLogStore load', () => {
       },
       summaries: {},
     });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
 
     expect(store.keys()).toEqual(['beta']);
     expect(store.get('beta')).toBeUndefined();
@@ -990,7 +1042,7 @@ describe('StreamLogStore load', () => {
     ]);
   });
 
-  it('fails the load for a non-array persisted log and refuses to overwrite it', async () => {
+  it('surfaces a non-array stream read and refuses memory-only appends', async () => {
     const storage = mockStorage({
       logs: { gamma: { corrupted: 'not an array' } },
       summaries: {
@@ -1002,9 +1054,10 @@ describe('StreamLogStore load', () => {
       },
     });
     const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
-    const store = new StreamLogStore();
-    await store.load();
-    await store.ensureLoaded('gamma');
+    const store = await StreamLogStore.open();
+    await expect(store.ensureLoaded('gamma')).rejects.toThrow(
+      'persisted log is not an array',
+    );
 
     // Parses-but-not-an-array is corrupt, not an empty log: the load fails
     // loudly, exactly like unparseable JSON.
@@ -1014,17 +1067,16 @@ describe('StreamLogStore load', () => {
       expect.stringContaining('Failed to reload stream gamma from disk'),
     );
 
-    // New appends stay in memory, but save() refuses to destructively
-    // rewrite the corrupt on-disk file with a fresh array (#7464).
-    store.append('gamma', {
-      id: 'gamma-new',
-      type: STREAM_LOG_ENTRY_TYPES.LOG,
-      level: LOG_LEVELS.INFO,
-      timestamp: 400,
-      messageType: MESSAGE_TYPES.DEFAULT,
-      text: 'new entry',
-    });
-    await store.flush();
+    expect(() =>
+      store.append('gamma', {
+        id: 'gamma-new',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 400,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'new entry',
+      }),
+    ).toThrow('failed to load');
 
     expect(
       storage.writes.get(storageFile(STREAM_LOGS_DIR, 'gamma')),
@@ -1032,19 +1084,43 @@ describe('StreamLogStore load', () => {
     expect(storage.writes.size).toBe(0);
   });
 
-  it('skips a non-array persisted log at startup with a warning', async () => {
+  it('rejects flush when a concurrent append cannot join persisted history', async () => {
+    const storage = mockStorage({
+      logs: { gamma: { corrupted: 'not an array' } },
+      summaries: {
+        gamma: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: false,
+        },
+      },
+    });
+    const store = await StreamLogStore.open();
+    const load = store.ensureLoaded('gamma');
+
+    store.append('gamma', {
+      id: 'gamma-concurrent',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 200,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'arrived while the persisted transcript was being read',
+    });
+
+    await expect(load).rejects.toThrow('persisted log is not an array');
+    await expect(store.flush()).rejects.toThrow(
+      'persisted transcripts failed to load',
+    );
+    expect(storage.writes.size).toBe(0);
+  });
+
+  it('fails persistent opening for a corrupt startup log', async () => {
     const storage = mockStorage({
       logs: { delta: 'not an array at all' },
       summaries: {},
     });
-    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
-    const store = new StreamLogStore();
-    await store.load();
-
-    expect(store.keys()).toEqual([]);
-    expect(warnSpy).toHaveBeenCalledWith(
-      'StreamLogStore',
-      expect.stringContaining('Skipping corrupt stream log: delta'),
+    await expect(StreamLogStore.open()).rejects.toThrow(
+      'persisted log is not an array',
     );
     expect(storage.writes.size).toBe(0);
   });

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -29,6 +29,8 @@ interface MockStorageOptions {
   /** Values are usually arrays; non-array values simulate corrupt logs. */
   logs: Record<string, unknown>;
   summaries: Record<string, unknown>;
+  rawLogJson?: Record<string, string>;
+  rawSummaryJson?: Record<string, string>;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
   onLogRead?: (key: string) => Promise<void> | void;
@@ -110,6 +112,8 @@ function fileStat(mtime: number): FileStat {
 function mockStorage({
   logs,
   summaries,
+  rawLogJson = {},
+  rawSummaryJson = {},
   logMtimes = {},
   summaryMtimes = {},
   onLogRead,
@@ -149,14 +153,14 @@ function mockStorage({
 
     if (target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`)) {
       if (!Object.hasOwn(summaries, key)) throw notFound();
-      return JSON.stringify(summaries[key]);
+      return rawSummaryJson[key] ?? JSON.stringify(summaries[key]);
     }
 
     if (target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
       if (!Object.hasOwn(logs, key)) throw notFound();
       fullLogReads += 1;
       await onLogRead?.(key);
-      return JSON.stringify(logs[key]);
+      return rawLogJson[key] ?? JSON.stringify(logs[key]);
     }
 
     throw new Error(`Unexpected read target: ${target}`);
@@ -363,6 +367,36 @@ describe('StreamLogStore load', () => {
     expect(store.keys()).toEqual(['alpha']);
     expect(store.getFirstTimestamp('alpha')).toBe(200);
     expect(store.getLastTimestamp('alpha')).toBeUndefined();
+  });
+
+  it('rebuilds malformed summary JSON from the authoritative stream log', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 200), logEntry('alpha', 2, 250)],
+      },
+      summaries: { alpha: {} },
+      rawSummaryJson: { alpha: '{"firstTimestamp":' },
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+
+    const store = await StreamLogStore.open();
+
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.keys()).toEqual(['alpha']);
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(store.getLastTimestamp('alpha')).toBe(250);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Ignoring corrupt summary cache for alpha'),
+    );
+    expect(
+      storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
+    ).toEqual({
+      firstTimestamp: 200,
+      lastTimestamp: 250,
+      hasRunningGroup: false,
+      hasRunningStreamingText: false,
+    });
   });
 
   it('falls back once for missing summaries and writes the sidecar cache', async () => {
@@ -1116,12 +1150,11 @@ describe('StreamLogStore load', () => {
 
   it('fails persistent opening for a corrupt startup log', async () => {
     const storage = mockStorage({
-      logs: { delta: 'not an array at all' },
+      logs: { delta: [] },
       summaries: {},
+      rawLogJson: { delta: '[{"id":' },
     });
-    await expect(StreamLogStore.open()).rejects.toThrow(
-      'persisted log is not an array',
-    );
+    await expect(StreamLogStore.open()).rejects.toThrow(SyntaxError);
     expect(storage.writes.size).toBe(0);
   });
 });

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -31,6 +31,11 @@ interface MockStorageOptions {
   summaries: Record<string, unknown>;
   rawLogJson?: Record<string, string>;
   rawSummaryJson?: Record<string, string>;
+  logReadError?: Error;
+  summaryEnsureDirError?: Error;
+  summaryWriteError?: Error;
+  summaryDeleteError?: Error;
+  logWriteError?: Error;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
   onLogRead?: (key: string) => Promise<void> | void;
@@ -114,12 +119,18 @@ function mockStorage({
   summaries,
   rawLogJson = {},
   rawSummaryJson = {},
+  logReadError,
+  summaryEnsureDirError,
+  summaryWriteError,
+  summaryDeleteError,
+  logWriteError,
   logMtimes = {},
   summaryMtimes = {},
   onLogRead,
   pauseLogWriteKey,
 }: MockStorageOptions): {
   deletes: string[];
+  ensuredDirs: string[];
   fullLogReads: () => number;
   releasePausedWrite: () => void;
   waitForPausedWrite: () => Promise<void>;
@@ -136,6 +147,7 @@ function mockStorage({
           markPausedWriteStarted = resolve;
         });
   const deletes: string[] = [];
+  const ensuredDirs: string[] = [];
   const writes = new Map<string, unknown>();
 
   vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
@@ -159,6 +171,7 @@ function mockStorage({
     if (target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
       if (!Object.hasOwn(logs, key)) throw notFound();
       fullLogReads += 1;
+      if (logReadError) throw logReadError;
       await onLogRead?.(key);
       return rawLogJson[key] ?? JSON.stringify(logs[key]);
     }
@@ -166,7 +179,12 @@ function mockStorage({
     throw new Error(`Unexpected read target: ${target}`);
   });
 
-  vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+  vi.spyOn(StorageFS, 'ensureDir').mockImplementation(async (target) => {
+    ensuredDirs.push(target);
+    if (target === STREAM_LOG_SUMMARIES_DIR && summaryEnsureDirError) {
+      throw summaryEnsureDirError;
+    }
+  });
   vi.spyOn(StorageFS, 'exists').mockImplementation(async (target) => {
     const key = streamKeyFromFile(target);
     if (target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`)) {
@@ -193,6 +211,15 @@ function mockStorage({
     target: string,
     content: string | Uint8Array,
   ): Promise<void> => {
+    if (logWriteError && target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
+      throw logWriteError;
+    }
+    if (
+      summaryWriteError &&
+      target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`)
+    ) {
+      throw summaryWriteError;
+    }
     if (
       pauseLogWriteKey != null &&
       !pausedLogWriteUsed &&
@@ -214,12 +241,20 @@ function mockStorage({
   vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
+    if (
+      summaryDeleteError &&
+      (target === STREAM_LOG_SUMMARIES_DIR ||
+        target.startsWith(`${STREAM_LOG_SUMMARIES_DIR}${path.sep}`))
+    ) {
+      throw summaryDeleteError;
+    }
     deletes.push(target);
     writes.delete(target);
   });
 
   return {
     deletes,
+    ensuredDirs,
     fullLogReads: () => fullLogReads,
     releasePausedWrite: () => releasePausedWriteImpl(),
     waitForPausedWrite: () => waitForPausedWrite,
@@ -253,6 +288,26 @@ describe('StreamLogStore load', () => {
     expect(store.keys()).toEqual([]);
   });
 
+  it('opens a read-only store without creating directories or writing caches', async () => {
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {},
+    });
+
+    const store = await StreamLogStore.openReadOnly();
+
+    expect(store.mode).toEqual({ kind: 'read-only' });
+    expect(storage.ensuredDirs).toEqual([]);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(storage.writes.size).toBe(0);
+    expect(store.keys()).toEqual(['alpha']);
+    await store.ensureLoaded('alpha');
+    expect(store.get('alpha')?.size).toBe(1);
+    expect(() => store.append('alpha', logEntry('alpha', 2, 250))).toThrow(
+      'read-only transcript store',
+    );
+  });
+
   it('constructs an inspectable ephemeral store only with an explicit reason', async () => {
     const store = StreamLogStore.ephemeral('interactive fallback test');
 
@@ -275,6 +330,101 @@ describe('StreamLogStore load', () => {
 
     await expect(StreamLogStore.open()).rejects.toThrow(
       'storage permission denied',
+    );
+  });
+
+  it('rejects when an authoritative transcript log cannot be read', async () => {
+    const failure = new Error('authoritative transcript read denied');
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {},
+      logReadError: failure,
+    });
+
+    await expect(StreamLogStore.open()).rejects.toBe(failure);
+  });
+
+  it('opens from authoritative logs when the summary directory cannot be prepared', async () => {
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {},
+      summaryEnsureDirError: new Error('summary directory is read-only'),
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+
+    const store = await StreamLogStore.open();
+
+    expect(store.keys()).toEqual(['alpha']);
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Failed to prepare transcript summary cache'),
+    );
+  });
+
+  it('opens from authoritative logs when summary cache writeback fails', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [logEntry('alpha', 1, 200)],
+        beta: [logEntry('beta', 1, 300)],
+      },
+      summaries: {},
+      summaryWriteError: new Error('summary write denied'),
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+
+    const store = await StreamLogStore.open();
+
+    expect(store.keys()).toEqual(['alpha', 'beta']);
+    expect(store.getFirstTimestamp('alpha')).toBe(200);
+    expect(storage.fullLogReads()).toBe(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Failed to write transcript summary cache for'),
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes authoritative logs when summary cache deletion fails', async () => {
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {
+        alpha: { firstTimestamp: 200, lastTimestamp: 200 },
+      },
+      summaryDeleteError: new Error('summary delete denied'),
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const store = await StreamLogStore.open();
+
+    await expect(store.delete('alpha')).resolves.toBeUndefined();
+
+    expect(storage.deletes).toContain(storageFile(STREAM_LOGS_DIR, 'alpha'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining(
+        'Failed to delete transcript summary cache for alpha',
+      ),
+    );
+  });
+
+  it('clears authoritative logs when summary cache clearing fails', async () => {
+    const storage = mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {
+        alpha: { firstTimestamp: 200, lastTimestamp: 200 },
+      },
+      summaryDeleteError: new Error('summary clear denied'),
+    });
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const store = await StreamLogStore.open();
+
+    await expect(store.clear()).resolves.toBeUndefined();
+
+    expect(storage.deletes).toContain(STREAM_LOGS_DIR);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamLogStore',
+      expect.stringContaining('Failed to clear transcript summary cache'),
     );
   });
 
@@ -1146,6 +1296,20 @@ describe('StreamLogStore load', () => {
       'persisted transcripts failed to load',
     );
     expect(storage.writes.size).toBe(0);
+  });
+
+  it('rejects flush when authoritative transcript writes fail', async () => {
+    mockStorage({
+      logs: {},
+      summaries: {},
+      logWriteError: new Error('authoritative transcript write denied'),
+    });
+    const store = await StreamLogStore.open();
+    store.append('alpha', logEntry('alpha', 1, 200));
+
+    await expect(store.flush()).rejects.toThrow(
+      'Transcript flush failed after 3 retries',
+    );
   });
 
   it('fails persistent opening for a corrupt startup log', async () => {

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -15,7 +15,7 @@ import { isObject } from '@utils/core';
 describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)', () => {
   it("writes GROUP_START's data.status as StreamPhase.RUNNING", () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-start-native' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -33,7 +33,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
 
   it('defaults GROUP_END to the literal RunOutcome.COMPLETED, not a folded EndGroupStatus', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-default-outcome' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -52,7 +52,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
 
   it('writes an explicit RunOutcome passed to stage.end() verbatim', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-explicit-outcome' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -70,7 +70,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
 
   it('defaults a stage.run() failure to RunOutcome.FAILED', async () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-run-failure' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -94,7 +94,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
 describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
   it("preserves a round stage's kind onto its persisted GROUP_END row", () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:kind-preserved' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -111,7 +111,7 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
 
   it("preserves the root run stage's kind onto its persisted GROUP_END row", () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:run-kind-preserved' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -130,7 +130,7 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
 describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
   it('upserts the round MODEL_RESPONSE stream entry to the authoritative text', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:upsert' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -154,7 +154,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
 
   it('appends a fresh MODEL_RESPONSE entry when the round never streamed', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:append' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -171,7 +171,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
 
   it('does not let an earlier round leak its stream id into a later round', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:round-reset' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -203,7 +203,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
 
   it('does not let an earlier invocation in the same round stage overwrite a later finalized response', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:inner-round-reset' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);
@@ -238,7 +238,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
 
   it('ignores an empty finalized response', () => {
     const trace = new TraceEmitter();
-    const store = new StreamLogStore();
+    const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:empty' as StreamTabId;
     store.ensureStream(streamId);
     attachTranscriptRecorder(trace, streamId, store);

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -96,8 +96,7 @@ async function writeSidecarFixture(
   ]);
   await snapshots.flush();
 
-  const logs = new StreamLogStore();
-  await logs.load();
+  const logs = await StreamLogStore.open();
   logs.ensureStream(streamId);
   logs.append(
     streamId,
@@ -396,8 +395,7 @@ describe('completedRunArchive facade', () => {
     snapshots.setTaskState(fullStream, taskState('orchestrator'), executionId);
     await snapshots.flush();
 
-    const logs = new StreamLogStore();
-    await logs.load();
+    const logs = await StreamLogStore.open();
     logs.ensureStream(emptyStream);
     logs.append(
       emptyStream,
@@ -431,8 +429,7 @@ describe('completedRunArchive facade', () => {
     snapshots.setTaskState(streamId, taskState('orchestrator'), executionId);
     await snapshots.flush();
 
-    const logs = new StreamLogStore();
-    await logs.load();
+    const logs = await StreamLogStore.open();
     logs.ensureStream(streamId);
     logs.append(
       streamId,

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -169,8 +169,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
       await snapshotWriter.flush();
 
-      const logStore = new StreamLogStore();
-      await logStore.load();
+      const logStore = await StreamLogStore.open();
       logStore.append(childStream, {
         id: 'entry-1',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -221,8 +220,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotWriter.setTodos(workPlanOnlyStream, [TODO]);
       await snapshotWriter.flush();
 
-      const logStore = new StreamLogStore();
-      await logStore.load();
+      const logStore = await StreamLogStore.open();
       logStore.append(logBackedStream, {
         id: 'entry-1',
         type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -348,8 +346,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
       await snapshotWriter.flush();
 
-      const logStore = new StreamLogStore();
-      await logStore.load();
+      const logStore = await StreamLogStore.open();
       logStore.append(childStream, {
         id: 'entry-1',
         type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -87,8 +87,7 @@ describe('assembleTrace', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(streamId, {
       id: 'entry-1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -152,8 +151,7 @@ describe('assembleTrace', () => {
     const actualChildStreamId = `bash@tool#${executionId}`;
     expect(actualChildStreamId).not.toBe(derivedId);
 
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(actualChildStreamId as ReturnType<typeof getStreamTabId>, {
       id: 'entry-1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,
@@ -185,8 +183,7 @@ describe('assembleTrace', () => {
       executionConfig.model,
       { executionId },
     );
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(streamId, {
       id: 'entry-1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -91,8 +91,7 @@ describe('trace-viewer TraceDataSchema', () => {
     });
 
     const streamId = getStreamTabId('review', 'sonnet46T', { executionId });
-    const store = new StreamLogStore();
-    await store.load();
+    const store = await StreamLogStore.open();
     store.append(streamId, {
       id: 'entry-1',
       type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -6,7 +6,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import {
-  defaultSession,
+  tryDefaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas/identifiers';
@@ -47,10 +47,11 @@ function emitGoalStateChanged(
   streamId: StreamTabId,
   session?: SessionHandle,
 ): void {
-  // Preserve the old fallback rule while deleting the bus dependency:
-  // older direct-node tests may carry a partial run session.
+  // Local storage commands can update goals without composing an agent
+  // session. In that case there is no live observer to notify.
   const owner = session ?? getRunContextSession(tryUseRunContext());
-  const target = owner?.events ? owner : defaultSession();
+  const target = owner?.events ? owner : tryDefaultSession();
+  if (!target) return;
   target.events.emit({
     scope: 'session',
     event: {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -798,9 +798,19 @@ export class StreamLogStore {
   private async readSummary(
     streamId: StreamTabId,
   ): Promise<StreamLogSummary | undefined> {
-    const summary = this.parsePersistedSummary(
-      await this.summaryKv.read<unknown>(streamId),
-    );
+    let persisted: unknown;
+    try {
+      persisted = await this.summaryKv.read<unknown>(streamId);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      log.warn(
+        LOG_TAG,
+        `Ignoring corrupt summary cache for ${streamId}; rebuilding from the stream log.`,
+      );
+      return undefined;
+    }
+
+    const summary = this.parsePersistedSummary(persisted);
     if (!summary) return undefined;
 
     const [summaryMtime, logMtime] = await Promise.all([

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -14,6 +14,7 @@ import {
 } from '@shared/schemas';
 import { debounce, filterNotNull, isObject } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { StorageFS } from '@utils/files/storageFS';
 
 import {
   isRunningGroupEntry,
@@ -49,6 +50,10 @@ interface ParsedPersistedEntries {
   entries: StreamLogEntry[];
   preservedRawEntries: StreamLogPreservedRawEntry[];
 }
+
+export type StreamLogStoreMode =
+  | { readonly kind: 'persistent' }
+  | { readonly kind: 'ephemeral'; readonly reason: string };
 
 function summaryOf(logInstance: StreamLog): StreamLogSummary {
   return {
@@ -117,6 +122,8 @@ function hasSomethingRunning(summary: StreamLogSummary | undefined): boolean {
 }
 
 export class StreamLogStore {
+  readonly mode: StreamLogStoreMode;
+
   private readonly logs = new Map<StreamTabId, StreamLog>();
   private readonly listeners = new Set<StreamLogListener>();
   private readonly dirtyStreamIds = new Set<StreamTabId>();
@@ -126,8 +133,8 @@ export class StreamLogStore {
   });
 
   /**
-   * Lightweight summary per stream (first/last timestamp). Populated at load
-   * and refreshed on append/update. Survives `releaseEntries` so sidebar
+   * Lightweight summary per stream (first/last timestamp). Populated at open
+   * or reload and refreshed on append/update. Survives `releaseEntries` so sidebar
    * metadata stays available for streams whose heavy entries have been evicted.
    */
   private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
@@ -154,13 +161,10 @@ export class StreamLogStore {
    * Streams whose rehydrate read from disk failed. While marked, saves skip
    * them so we never overwrite the authoritative disk copy with a fresh
    * empty-log-plus-new-appends that would drop persisted history.
-   * Cleared when `ensureLoaded` eventually succeeds (subsequent `append`s
-   * opportunistically retry the load).
+   * Cleared when an explicit `ensureLoaded` retry succeeds; appends reject
+   * while the stream remains in this state.
    */
   private readonly loadFailed = new Set<StreamTabId>();
-
-  /** Guards persistence — tests create store without calling load(). */
-  private loaded = false;
 
   private readonly debouncedSave = debounce(
     () => this.executeWrite(),
@@ -183,6 +187,35 @@ export class StreamLogStore {
   private writeGeneration = 0;
   private readonly writeTombstones = new Set<StreamTabId>();
   private clearing = false;
+  private stateRevision = 0;
+  private pendingReload: Promise<void> | undefined;
+
+  private constructor(mode: StreamLogStoreMode) {
+    this.mode = Object.freeze(mode);
+  }
+
+  /** Open and validate the persistent transcript store before exposing it. */
+  static async open(): Promise<StreamLogStore> {
+    const store = new StreamLogStore({ kind: 'persistent' });
+    await Promise.all([
+      StorageFS.ensureDir(STREAM_LOGS_DIR),
+      StorageFS.ensureDir(STREAM_LOG_SUMMARIES_DIR),
+    ]);
+    store.replaceSummaries(await store.readPersistentSummaries());
+    return store;
+  }
+
+  /** Create an explicitly non-persistent transcript store. */
+  static ephemeral(reason: string): StreamLogStore {
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      throw new Error('An ephemeral transcript store requires a reason.');
+    }
+    return new StreamLogStore({
+      kind: 'ephemeral',
+      reason: normalizedReason,
+    });
+  }
 
   onChange(listener: StreamLogListener): () => void {
     this.listeners.add(listener);
@@ -213,6 +246,7 @@ export class StreamLogStore {
     const logInstance = new StreamLog();
     this.logs.set(streamId, logInstance);
     this.summaries.set(streamId, {});
+    this.stateRevision += 1;
   }
 
   /**
@@ -222,6 +256,9 @@ export class StreamLogStore {
    * Subsequent access must go through `ensureLoaded` to rehydrate.
    */
   releaseEntries(streamId: StreamTabId): void {
+    // Ephemeral entries have no durable copy from which they could be restored.
+    if (this.mode.kind === 'ephemeral') return;
+
     const logInstance = this.logs.get(streamId);
     if (!logInstance) {
       // Can't drop what isn't resident — but if a rehydrate is in flight,
@@ -240,6 +277,7 @@ export class StreamLogStore {
     this.pendingRelease.delete(streamId);
     this.refreshSummary(streamId, logInstance);
     this.logs.delete(streamId);
+    this.stateRevision += 1;
   }
 
   /**
@@ -247,13 +285,14 @@ export class StreamLogStore {
    * resident or when the stream is unknown.
    */
   async ensureLoaded(streamId: StreamTabId): Promise<void> {
+    if (this.mode.kind === 'ephemeral') return;
+
     // Reactivation cancels any deferred release so the fresh agent work
     // doesn't get evicted mid-run.
     this.pendingRelease.delete(streamId);
-    // Normally skip when already resident. But after a failed rehydrate a
-    // subsequent `append` may have populated a fresh empty log — we still
-    // need to retry the disk read so the merge path can reunite it with
-    // the persisted history before saves are re-enabled.
+    // Normally skip when already resident. A concurrent append may have
+    // populated a fresh log before a rehydrate failed, so a retry must still
+    // reunite it with persisted history before saves are re-enabled.
     if (this.logs.has(streamId) && !this.loadFailed.has(streamId)) return;
     if (!this.summaries.has(streamId)) return;
     const existing = this.pendingLoads.get(streamId);
@@ -282,6 +321,7 @@ export class StreamLogStore {
             diskEntries.preservedRawEntries,
           );
           this.logs.set(streamId, merged);
+          this.stateRevision += 1;
           this.refreshSummary(streamId, merged);
           this.markDirty(streamId);
           void this.save();
@@ -292,6 +332,7 @@ export class StreamLogStore {
             diskEntries.preservedRawEntries,
           );
           this.logs.set(streamId, logInstance);
+          this.stateRevision += 1;
           this.refreshSummary(streamId, logInstance);
           // A `releaseEntries` that arrived while the load was in flight gets
           // queued; honor it now (unless a reactivation cleared the intent).
@@ -309,33 +350,40 @@ export class StreamLogStore {
         this.loadFailed.delete(streamId);
         if (this.dirtyStreamIds.has(streamId)) void this.save();
       } catch (err) {
-        // Rehydrate failed. Mark so `executeWrite` skips this stream and
-        // doesn't overwrite the on-disk history with whatever empty/partial
-        // log the agent may now be appending to. `append` retries the load
-        // in the background; once it succeeds the merge path runs.
+        // Keep the disk copy authoritative and surface the failed read. A
+        // caller may retry `ensureLoaded`, but no append is accepted until a
+        // retry succeeds and reunites the in-memory view with persisted data.
         this.loadFailed.add(streamId);
         log.warn(
           LOG_TAG,
           `Failed to reload stream ${streamId} from disk: ` +
             toErrorMessage(err),
         );
+        throw err;
       }
     })();
     this.pendingLoads.set(streamId, work);
-    // `work` traps every failure internally (the catch above marks
-    // loadFailed), so it never rejects and the cleanup always runs.
-    await work;
-    this.pendingLoads.delete(streamId);
+    try {
+      await work;
+    } finally {
+      this.pendingLoads.delete(streamId);
+    }
   }
 
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
     // New writes mean the stream is live again — cancel any deferred release.
     this.pendingRelease.delete(streamId);
-    // If a previous rehydrate errored, retry in the background so the
-    // eventual merge can combine disk history with these new entries
-    // before we're allowed to save. `ensureLoaded` dedupes via
-    // `pendingLoads` so repeated appends don't spam overlapping reads.
-    if (this.loadFailed.has(streamId)) void this.ensureLoaded(streamId);
+    this.assertWritableStream(streamId);
+    if (
+      this.mode.kind === 'persistent' &&
+      this.summaries.has(streamId) &&
+      !this.logs.has(streamId) &&
+      !this.pendingLoads.has(streamId)
+    ) {
+      throw new Error(
+        `Cannot append to released stream ${streamId}. Await ensureLoaded() first.`,
+      );
+    }
     const logInstance = this.getOrCreate(streamId);
     const appended = logInstance.append(entry);
     this.commitChange(streamId, logInstance);
@@ -348,6 +396,7 @@ export class StreamLogStore {
     id: string,
     patch: StreamLogUpdatePatch,
   ): StreamLogEntry | undefined {
+    this.assertWritableStream(streamId);
     const logInstance = this.logs.get(streamId);
     if (!logInstance) return undefined;
 
@@ -364,6 +413,7 @@ export class StreamLogStore {
     id: string,
     appendText: string,
   ): StreamLogEntry | undefined {
+    this.assertWritableStream(streamId);
     const logInstance = this.logs.get(streamId);
     if (!logInstance) return undefined;
 
@@ -397,12 +447,13 @@ export class StreamLogStore {
     this.writeTombstones.add(streamId);
     this.debouncedSave.cancel();
     this.forgetStreamState(streamId);
+    this.stateRevision += 1;
 
     try {
       await this.inFlightWrite;
       this.forgetStreamState(streamId);
       await this.executeWrite();
-      if (!this.loaded) return;
+      if (this.mode.kind === 'ephemeral') return;
 
       log.info(LOG_TAG, `Deleting stream: ${streamId}`);
       await Promise.all([
@@ -420,11 +471,12 @@ export class StreamLogStore {
     this.writeGeneration += 1;
     this.cancelPendingSave();
     this.forgetAllStreamState();
+    this.stateRevision += 1;
 
     try {
       await this.inFlightWrite;
       this.forgetAllStreamState();
-      if (!this.loaded) return;
+      if (this.mode.kind === 'ephemeral') return;
 
       log.info(LOG_TAG, `Clearing all ${count} streams`);
       await Promise.all([this.kv.deleteDir(), this.summaryKv.deleteDir()]);
@@ -441,7 +493,10 @@ export class StreamLogStore {
   ): Promise<StreamTabId[]> {
     const streamsToLoad = new Set(streamIds);
     for (const [streamId, summary] of this.summaries) {
-      if (hasSomethingRunning(summary) && !this.logs.has(streamId)) {
+      if (
+        hasSomethingRunning(summary) &&
+        (!this.logs.has(streamId) || this.loadFailed.has(streamId))
+      ) {
         streamsToLoad.add(streamId);
       }
     }
@@ -467,7 +522,9 @@ export class StreamLogStore {
   ): Promise<StreamTabId[]> {
     if (streamIds.length === 0) return [];
     const streamsToLoad = streamIds.filter(
-      (id) => !this.logs.has(id) && hasSomethingRunning(this.summaries.get(id)),
+      (id) =>
+        (!this.logs.has(id) || this.loadFailed.has(id)) &&
+        hasSomethingRunning(this.summaries.get(id)),
     );
     if (streamsToLoad.length > 0) {
       await pMap(streamsToLoad, (id) => this.ensureLoaded(id), {
@@ -528,54 +585,31 @@ export class StreamLogStore {
     return affected;
   }
 
-  /** Load stream-log summaries from disk. */
-  async load(): Promise<void> {
-    this.logs.clear();
-    this.summaries.clear();
-    this.dirtyStreamIds.clear();
-    this.pendingRelease.clear();
-    this.flushing.clear();
-    this.loadFailed.clear();
-    this.pendingLoads.clear();
-    this.writeTombstones.clear();
-    this.clearing = false;
-
-    // 1. Scan directory — filenames decode back to stream IDs
-    const streamIds = await this.kv.listKeys();
-
-    if (streamIds.length > 0) {
-      const results = await pMap(
-        streamIds,
-        (streamId) => this.loadStreamSummary(streamId as StreamTabId),
-        { concurrency: STREAM_LOG_LOAD_CONCURRENCY },
+  /**
+   * Transactionally reload persistent summaries. A failed read leaves the
+   * previously valid in-memory state untouched and rejects to the host.
+   */
+  async reload(): Promise<void> {
+    if (this.mode.kind === 'ephemeral') {
+      throw new Error(
+        `Cannot reload an ephemeral transcript store (${this.mode.reason}).`,
       );
-
-      const sortedResults = results
-        .filter(filterNotNull)
-        .sort(
-          (a, b) =>
-            (a.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) -
-              (b.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) ||
-            a.streamId.localeCompare(b.streamId),
-        );
-
-      for (const { streamId, summary } of sortedResults) {
-        this.summaries.set(streamId, summary);
-      }
-
-      log.info(
-        LOG_TAG,
-        `Loaded ${this.summaries.size} stream summaries (file-backed)`,
-      );
-      this.loaded = true;
-      return;
     }
+    if (this.pendingReload) return this.pendingReload;
 
-    this.loaded = true;
+    const work = this.executeReload();
+    this.pendingReload = work;
+    try {
+      await work;
+    } finally {
+      if (this.pendingReload === work) this.pendingReload = undefined;
+    }
   }
 
   save(): Promise<void> {
-    if (!this.loaded) return Promise.resolve();
+    if (this.mode.kind === 'ephemeral' || this.dirtyStreamIds.size === 0) {
+      return Promise.resolve();
+    }
     // Start/extend the debounce timer. perfect-debounce handles timer
     // management and returns a shared promise, but we ignore it and track
     // our own awaiters so we can settle them when the debounce is cancelled
@@ -587,7 +621,7 @@ export class StreamLogStore {
   }
 
   async flush(): Promise<void> {
-    if (!this.loaded) return;
+    if (this.mode.kind === 'ephemeral') return;
 
     // Drain iteratively: executeWrite may re-queue streams that are still
     // rehydrating (`pendingLoads`) or whose prior load failed. Wait for
@@ -615,14 +649,19 @@ export class StreamLogStore {
         const canRetry = [...this.dirtyStreamIds].some(
           (id) => !this.loadFailed.has(id),
         );
-        if (!canRetry) return;
-        if (writeAttempts >= MAX_WRITE_RETRIES) {
-          log.warn(
-            LOG_TAG,
-            `flush() gave up after ${MAX_WRITE_RETRIES} retries; ` +
-              `${this.dirtyStreamIds.size} stream(s) still dirty`,
-          );
+        if (!canRetry) {
+          if (this.dirtyStreamIds.size > 0) {
+            throw new Error(
+              `Cannot flush ${this.dirtyStreamIds.size} stream(s) whose persisted transcripts failed to load.`,
+            );
+          }
           return;
+        }
+        if (writeAttempts >= MAX_WRITE_RETRIES) {
+          throw new Error(
+            `Transcript flush failed after ${MAX_WRITE_RETRIES} retries; ` +
+              `${this.dirtyStreamIds.size} stream(s) remain dirty.`,
+          );
         }
         await this.executeWrite();
         writeAttempts++;
@@ -640,10 +679,18 @@ export class StreamLogStore {
     return logInstance;
   }
 
+  private assertWritableStream(streamId: StreamTabId): void {
+    if (!this.loadFailed.has(streamId)) return;
+    throw new Error(
+      `Cannot modify stream ${streamId} after its persisted transcript failed to load. Retry ensureLoaded() first.`,
+    );
+  }
+
   /** Shared post-mutation bookkeeping for append/update/appendText/endRunningGroups. */
   private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
     this.refreshSummary(streamId, logInstance);
-    this.markDirty(streamId);
+    this.stateRevision += 1;
+    if (this.mode.kind === 'persistent') this.markDirty(streamId);
     this.notify(streamId);
   }
 
@@ -662,6 +709,70 @@ export class StreamLogStore {
     }
   }
 
+  private async executeReload(): Promise<void> {
+    await this.flush();
+    if (this.dirtyStreamIds.size > 0) {
+      throw new Error(
+        'Cannot reload transcripts while persistent writes remain unresolved.',
+      );
+    }
+
+    const revision = this.stateRevision;
+    const summaries = await this.readPersistentSummaries();
+    if (revision !== this.stateRevision || this.pendingLoads.size > 0) {
+      throw new Error(
+        'Transcript state changed during reload; preserving the live state.',
+      );
+    }
+    this.replaceSummaries(summaries);
+  }
+
+  private async readPersistentSummaries(): Promise<
+    Map<StreamTabId, StreamLogSummary>
+  > {
+    const streamIds = await this.kv.listKeys();
+    const results = await pMap(
+      streamIds,
+      (streamId) => this.loadStreamSummary(streamId as StreamTabId),
+      { concurrency: STREAM_LOG_LOAD_CONCURRENCY },
+    );
+    const sortedResults = results
+      .filter(filterNotNull)
+      .sort(
+        (a, b) =>
+          (a.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) -
+            (b.summary.firstTimestamp ?? Number.POSITIVE_INFINITY) ||
+          a.streamId.localeCompare(b.streamId),
+      );
+
+    return new Map(
+      sortedResults.map(({ streamId, summary }) => [streamId, summary]),
+    );
+  }
+
+  private replaceSummaries(
+    summaries: ReadonlyMap<StreamTabId, StreamLogSummary>,
+  ): void {
+    this.logs.clear();
+    this.summaries.clear();
+    for (const [streamId, summary] of summaries) {
+      this.summaries.set(streamId, summary);
+    }
+    this.dirtyStreamIds.clear();
+    this.pendingRelease.clear();
+    this.flushing.clear();
+    this.loadFailed.clear();
+    this.pendingLoads.clear();
+    this.writeTombstones.clear();
+    this.clearing = false;
+    this.stateRevision += 1;
+
+    log.info(
+      LOG_TAG,
+      `Loaded ${this.summaries.size} stream summaries (file-backed)`,
+    );
+  }
+
   private async loadStreamSummary(
     streamId: StreamTabId,
   ): Promise<StreamLoadResult | null> {
@@ -670,56 +781,41 @@ export class StreamLogStore {
       return { streamId, summary: persistedSummary };
     }
 
-    try {
-      const raw = await this.kv.read<unknown[]>(streamId);
-      const entries = this.parsePersistedEntries(streamId, raw);
-      if (
-        entries.entries.length === 0 &&
-        entries.preservedRawEntries.length === 0
-      ) {
-        return null;
-      }
-
-      const summary = this.summarizeEntries(entries.entries);
-      await this.writeSummary(streamId, summary).catch(() => {
-        log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
-      });
-      return { streamId, summary };
-    } catch (err) {
-      log.warn(
-        LOG_TAG,
-        `Skipping corrupt stream log: ${streamId} (${toErrorMessage(err)})`,
-      );
+    const raw = await this.kv.read<unknown[]>(streamId);
+    const entries = this.parsePersistedEntries(streamId, raw);
+    if (
+      entries.entries.length === 0 &&
+      entries.preservedRawEntries.length === 0
+    ) {
       return null;
     }
+
+    const summary = this.summarizeEntries(entries.entries);
+    await this.writeSummary(streamId, summary);
+    return { streamId, summary };
   }
 
   private async readSummary(
     streamId: StreamTabId,
   ): Promise<StreamLogSummary | undefined> {
-    try {
-      const summary = this.parsePersistedSummary(
-        await this.summaryKv.read<unknown>(streamId),
-      );
-      if (!summary) return undefined;
+    const summary = this.parsePersistedSummary(
+      await this.summaryKv.read<unknown>(streamId),
+    );
+    if (!summary) return undefined;
 
-      const [summaryMtime, logMtime] = await Promise.all([
-        this.summaryKv.modifiedAt(streamId),
-        this.kv.modifiedAt(streamId),
-      ]);
-      if (
-        summaryMtime !== undefined &&
-        logMtime !== undefined &&
-        summaryMtime < logMtime
-      ) {
-        return undefined;
-      }
-
-      return summary;
-    } catch {
-      log.warn(LOG_TAG, `Ignoring corrupt stream summary: ${streamId}`);
+    const [summaryMtime, logMtime] = await Promise.all([
+      this.summaryKv.modifiedAt(streamId),
+      this.kv.modifiedAt(streamId),
+    ]);
+    if (
+      summaryMtime !== undefined &&
+      logMtime !== undefined &&
+      summaryMtime < logMtime
+    ) {
       return undefined;
     }
+
+    return summary;
   }
 
   private summarizeEntries(
@@ -852,7 +948,7 @@ export class StreamLogStore {
     // is corrupt persisted data — throw so both callers route through the
     // same failure path as unparseable JSON (`ensureLoaded` marks the load
     // failed, which blocks saves from overwriting the on-disk file; startup
-    // summary loading skips the stream). Returning an empty log here would
+    // opening rejects). Returning an empty log here would
     // let a later save() destructively rewrite the corrupt source (#7464).
     if (rawEntries === undefined) return parsed;
     if (!Array.isArray(rawEntries)) {
@@ -892,10 +988,6 @@ export class StreamLogStore {
   }
 
   private executeWrite(): Promise<void> {
-    if (!this.loaded) {
-      return Promise.resolve();
-    }
-
     // Skip streams whose rehydrate is pending or errored — writing now
     // would clobber the authoritative on-disk history with a fresh
     // empty-plus-new-appends log before `ensureLoaded` merges disk entries

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -53,6 +53,7 @@ interface ParsedPersistedEntries {
 
 export type StreamLogStoreMode =
   | { readonly kind: 'persistent' }
+  | { readonly kind: 'read-only' }
   | { readonly kind: 'ephemeral'; readonly reason: string };
 
 function summaryOf(logInstance: StreamLog): StreamLogSummary {
@@ -127,9 +128,13 @@ export class StreamLogStore {
   private readonly logs = new Map<StreamTabId, StreamLog>();
   private readonly listeners = new Set<StreamLogListener>();
   private readonly dirtyStreamIds = new Set<StreamTabId>();
-  private readonly kv = new KVStore(STREAM_LOGS_DIR, { compactJson: true });
+  private readonly kv = new KVStore(STREAM_LOGS_DIR, {
+    compactJson: true,
+    throwOnErrors: true,
+  });
   private readonly summaryKv = new KVStore(STREAM_LOG_SUMMARIES_DIR, {
     compactJson: true,
+    throwOnErrors: true,
   });
 
   /**
@@ -189,6 +194,7 @@ export class StreamLogStore {
   private clearing = false;
   private stateRevision = 0;
   private pendingReload: Promise<void> | undefined;
+  private summaryCacheMaintenanceEnabled = true;
 
   private constructor(mode: StreamLogStoreMode) {
     this.mode = Object.freeze(mode);
@@ -197,10 +203,15 @@ export class StreamLogStore {
   /** Open and validate the persistent transcript store before exposing it. */
   static async open(): Promise<StreamLogStore> {
     const store = new StreamLogStore({ kind: 'persistent' });
-    await Promise.all([
-      StorageFS.ensureDir(STREAM_LOGS_DIR),
-      StorageFS.ensureDir(STREAM_LOG_SUMMARIES_DIR),
-    ]);
+    await StorageFS.ensureDir(STREAM_LOGS_DIR);
+    await store.prepareSummaryCache();
+    store.replaceSummaries(await store.readPersistentSummaries());
+    return store;
+  }
+
+  /** Open persisted transcripts for reading without creating or writing files. */
+  static async openReadOnly(): Promise<StreamLogStore> {
+    const store = new StreamLogStore({ kind: 'read-only' });
     store.replaceSummaries(await store.readPersistentSummaries());
     return store;
   }
@@ -238,6 +249,7 @@ export class StreamLogStore {
   }
 
   ensureStream(streamId: StreamTabId): void {
+    this.assertWritableStore('ensure a transcript stream');
     // No-op if the stream is already known — either resident in `logs` or
     // released with metadata in `summaries`. Creating a fresh empty log here
     // for a released stream would shadow the on-disk copy from
@@ -371,9 +383,9 @@ export class StreamLogStore {
   }
 
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
+    this.assertWritableStream(streamId);
     // New writes mean the stream is live again — cancel any deferred release.
     this.pendingRelease.delete(streamId);
-    this.assertWritableStream(streamId);
     if (
       this.mode.kind === 'persistent' &&
       this.summaries.has(streamId) &&
@@ -426,6 +438,7 @@ export class StreamLogStore {
   }
 
   clearDirtyUpdates(streamId: StreamTabId): void {
+    this.assertWritableStore('clear transcript update state');
     this.logs.get(streamId)?.clearDirtyUpdates();
   }
 
@@ -444,6 +457,7 @@ export class StreamLogStore {
   }
 
   async delete(streamId: StreamTabId): Promise<void> {
+    this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
     this.debouncedSave.cancel();
     this.forgetStreamState(streamId);
@@ -456,16 +470,15 @@ export class StreamLogStore {
       if (this.mode.kind === 'ephemeral') return;
 
       log.info(LOG_TAG, `Deleting stream: ${streamId}`);
-      await Promise.all([
-        this.kv.delete(streamId),
-        this.summaryKv.delete(streamId),
-      ]);
+      await this.kv.delete(streamId);
+      await this.deleteSummaryCache(streamId);
     } finally {
       this.writeTombstones.delete(streamId);
     }
   }
 
   async clear(): Promise<void> {
+    this.assertWritableStore('clear transcript streams');
     const count = this.summaries.size;
     this.clearing = true;
     this.writeGeneration += 1;
@@ -479,7 +492,8 @@ export class StreamLogStore {
       if (this.mode.kind === 'ephemeral') return;
 
       log.info(LOG_TAG, `Clearing all ${count} streams`);
-      await Promise.all([this.kv.deleteDir(), this.summaryKv.deleteDir()]);
+      await this.kv.deleteDir();
+      await this.clearSummaryCache();
     } finally {
       this.writeTombstones.clear();
       this.clearing = false;
@@ -491,6 +505,7 @@ export class StreamLogStore {
     streamIds: readonly StreamTabId[] = [],
     status: RunOutcome = RUN_OUTCOME.FAILED,
   ): Promise<StreamTabId[]> {
+    this.assertWritableStore('finalize running transcript groups');
     const streamsToLoad = new Set(streamIds);
     for (const [streamId, summary] of this.summaries) {
       if (
@@ -520,6 +535,7 @@ export class StreamLogStore {
     now: number = Date.now(),
     status: RunOutcome = RUN_OUTCOME.FAILED,
   ): Promise<StreamTabId[]> {
+    this.assertWritableStore('finalize running transcript groups');
     if (streamIds.length === 0) return [];
     const streamsToLoad = streamIds.filter(
       (id) =>
@@ -607,6 +623,7 @@ export class StreamLogStore {
   }
 
   save(): Promise<void> {
+    this.assertWritableStore('save transcripts');
     if (this.mode.kind === 'ephemeral' || this.dirtyStreamIds.size === 0) {
       return Promise.resolve();
     }
@@ -621,6 +638,7 @@ export class StreamLogStore {
   }
 
   async flush(): Promise<void> {
+    this.assertWritableStore('flush transcripts');
     if (this.mode.kind === 'ephemeral') return;
 
     // Drain iteratively: executeWrite may re-queue streams that are still
@@ -680,6 +698,7 @@ export class StreamLogStore {
   }
 
   private assertWritableStream(streamId: StreamTabId): void {
+    this.assertWritableStore('modify transcript entries');
     if (!this.loadFailed.has(streamId)) return;
     throw new Error(
       `Cannot modify stream ${streamId} after its persisted transcript failed to load. Retry ensureLoaded() first.`,
@@ -688,6 +707,7 @@ export class StreamLogStore {
 
   /** Shared post-mutation bookkeeping for append/update/appendText/endRunningGroups. */
   private commitChange(streamId: StreamTabId, logInstance: StreamLog): void {
+    this.assertWritableStore('commit transcript changes');
     this.refreshSummary(streamId, logInstance);
     this.stateRevision += 1;
     if (this.mode.kind === 'persistent') this.markDirty(streamId);
@@ -710,7 +730,7 @@ export class StreamLogStore {
   }
 
   private async executeReload(): Promise<void> {
-    await this.flush();
+    if (this.mode.kind === 'persistent') await this.flush();
     if (this.dirtyStreamIds.size > 0) {
       throw new Error(
         'Cannot reload transcripts while persistent writes remain unresolved.',
@@ -791,41 +811,40 @@ export class StreamLogStore {
     }
 
     const summary = this.summarizeEntries(entries.entries);
-    await this.writeSummary(streamId, summary);
+    await this.maintainSummaryCache(streamId, summary);
     return { streamId, summary };
   }
 
   private async readSummary(
     streamId: StreamTabId,
   ): Promise<StreamLogSummary | undefined> {
-    let persisted: unknown;
     try {
-      persisted = await this.summaryKv.read<unknown>(streamId);
+      const persisted = await this.summaryKv.read<unknown>(streamId);
+      const summary = this.parsePersistedSummary(persisted);
+      if (!summary) return undefined;
+
+      const [summaryMtime, logMtime] = await Promise.all([
+        this.summaryKv.modifiedAt(streamId),
+        this.kv.modifiedAt(streamId),
+      ]);
+      if (
+        summaryMtime !== undefined &&
+        logMtime !== undefined &&
+        summaryMtime < logMtime
+      ) {
+        return undefined;
+      }
+
+      return summary;
     } catch (error) {
-      if (!(error instanceof SyntaxError)) throw error;
+      const condition =
+        error instanceof SyntaxError ? 'corrupt' : 'unavailable';
       log.warn(
         LOG_TAG,
-        `Ignoring corrupt summary cache for ${streamId}; rebuilding from the stream log.`,
+        `Ignoring ${condition} summary cache for ${streamId}; rebuilding from the stream log: ${toErrorMessage(error)}`,
       );
       return undefined;
     }
-
-    const summary = this.parsePersistedSummary(persisted);
-    if (!summary) return undefined;
-
-    const [summaryMtime, logMtime] = await Promise.all([
-      this.summaryKv.modifiedAt(streamId),
-      this.kv.modifiedAt(streamId),
-    ]);
-    if (
-      summaryMtime !== undefined &&
-      logMtime !== undefined &&
-      summaryMtime < logMtime
-    ) {
-      return undefined;
-    }
-
-    return summary;
   }
 
   private summarizeEntries(
@@ -866,21 +885,15 @@ export class StreamLogStore {
     if (this.shouldSkipWrite(streamId, expectedGeneration)) return;
     await this.kv.write(streamId, logInstance.toPersistedEntries());
     if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await Promise.all([
-        this.kv.delete(streamId),
-        this.summaryKv.delete(streamId),
-      ]);
+      await this.kv.delete(streamId);
+      await this.deleteSummaryCache(streamId);
       return;
     }
 
-    await this.writeSummary(streamId, summaryOf(logInstance)).catch(() => {
-      log.warn(LOG_TAG, `Failed to write stream summary: ${streamId}`);
-    });
+    await this.maintainSummaryCache(streamId, summaryOf(logInstance));
     if (this.shouldSkipWrite(streamId, expectedGeneration)) {
-      await Promise.all([
-        this.kv.delete(streamId),
-        this.summaryKv.delete(streamId),
-      ]);
+      await this.kv.delete(streamId);
+      await this.deleteSummaryCache(streamId);
     }
   }
 
@@ -916,11 +929,66 @@ export class StreamLogStore {
     this.pendingLoads.clear();
   }
 
-  private async writeSummary(
+  private assertWritableStore(operation: string): void {
+    if (this.mode.kind !== 'read-only') return;
+    throw new Error(`Cannot ${operation} with a read-only transcript store.`);
+  }
+
+  private async prepareSummaryCache(): Promise<void> {
+    try {
+      await StorageFS.ensureDir(STREAM_LOG_SUMMARIES_DIR);
+    } catch (error) {
+      this.disableSummaryCacheMaintenance(
+        `Failed to prepare transcript summary cache; continuing with authoritative logs: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private async maintainSummaryCache(
     streamId: StreamTabId,
     summary: StreamLogSummary,
   ): Promise<void> {
-    await this.summaryKv.write(streamId, summary);
+    if (
+      this.mode.kind !== 'persistent' ||
+      !this.summaryCacheMaintenanceEnabled
+    ) {
+      return;
+    }
+    try {
+      await this.summaryKv.write(streamId, summary);
+    } catch (error) {
+      this.disableSummaryCacheMaintenance(
+        `Failed to write transcript summary cache for ${streamId}: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private async deleteSummaryCache(streamId: StreamTabId): Promise<void> {
+    if (!this.summaryCacheMaintenanceEnabled) return;
+    try {
+      await this.summaryKv.delete(streamId);
+    } catch (error) {
+      this.disableSummaryCacheMaintenance(
+        `Failed to delete transcript summary cache for ${streamId}: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private async clearSummaryCache(): Promise<void> {
+    if (!this.summaryCacheMaintenanceEnabled) return;
+    try {
+      await this.summaryKv.deleteDir();
+    } catch (error) {
+      this.disableSummaryCacheMaintenance(
+        `Failed to clear transcript summary cache: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private disableSummaryCacheMaintenance(message: string): void {
+    if (!this.summaryCacheMaintenanceEnabled) return;
+    this.summaryCacheMaintenanceEnabled = false;
+    log.warn(LOG_TAG, message);
   }
 
   private markDirty(streamId: StreamTabId): void {

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -140,8 +140,8 @@ export interface CompletedRunConversationReadResult {
 
 export interface CompletedRunConversationReaderOptions extends CompletedRunReaderOptions {
   /**
-   * An already-open store. When omitted a call-scoped persistent instance is
-   * opened so this read path never reloads a shared live store.
+   * An already-open store. When omitted a call-scoped read-only instance is
+   * opened so this reader neither reloads a live store nor mutates persistence.
    */
   readonly streamLogStore?: StreamLogStore;
 }
@@ -477,7 +477,7 @@ export async function readCompletedRunConversation(
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
   let streamLogStore = options.streamLogStore;
   if (!streamLogStore) {
-    streamLogStore = await StreamLogStore.open();
+    streamLogStore = await StreamLogStore.openReadOnly();
   }
   const loadedStreamLogStore = streamLogStore;
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -140,9 +140,8 @@ export interface CompletedRunConversationReadResult {
 
 export interface CompletedRunConversationReaderOptions extends CompletedRunReaderOptions {
   /**
-   * An already-`load()`ed store. When omitted a call-scoped instance is
-   * created and loaded — never pass the shared live store un-loaded, since
-   * `load()` clears a store's in-memory state (see `assembleTrace`).
+   * An already-open store. When omitted a call-scoped persistent instance is
+   * opened so this read path never reloads a shared live store.
    */
   readonly streamLogStore?: StreamLogStore;
 }
@@ -478,11 +477,7 @@ export async function readCompletedRunConversation(
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
   let streamLogStore = options.streamLogStore;
   if (!streamLogStore) {
-    // Call-scoped instance, same rationale as assembleTrace: load() clears a
-    // store's in-memory state, so the shared live store must never be
-    // re-loaded from a read path.
-    streamLogStore = new StreamLogStore();
-    await streamLogStore.load();
+    streamLogStore = await StreamLogStore.open();
   }
   const loadedStreamLogStore = streamLogStore;
 

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -13,6 +13,7 @@ export {
   StreamLogStore,
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
+  type StreamLogStoreMode,
 } from './StreamLogStore';
 export { StreamLog, type StreamLogAppendInput } from './StreamLog';
 export {

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -51,16 +51,12 @@ export async function assembleTrace(
   executionId: ExecutionId,
 ): Promise<AssembleTraceResult> {
   const executionStore = getExecutionStore(executionId);
-  // A fresh instance, not the session's shared `transcripts` store: .load()
-  // clears all of a store's in-memory state, which would wipe out a live
-  // host's in-flight session if this ran against the shared instance. Reads
-  // the same on-disk files regardless — StreamSnapshotStore below already
-  // follows this same call-scoped-instance pattern.
-  const streamLogStore = new StreamLogStore();
-  const [config, meta] = await Promise.all([
+  // A call-scoped persistent store avoids reloading a live host's session while
+  // reading the same on-disk transcript files.
+  const [streamLogStore, config, meta] = await Promise.all([
+    StreamLogStore.open(),
     executionStore.readConfig(),
     executionStore.readMeta(),
-    streamLogStore.load(),
   ]);
   if (!config) return { status: 'config_missing' };
 

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -51,10 +51,10 @@ export async function assembleTrace(
   executionId: ExecutionId,
 ): Promise<AssembleTraceResult> {
   const executionStore = getExecutionStore(executionId);
-  // A call-scoped persistent store avoids reloading a live host's session while
-  // reading the same on-disk transcript files.
+  // A call-scoped read-only store avoids reloading a live host's session or
+  // mutating persistence while reading the same transcript files.
   const [streamLogStore, config, meta] = await Promise.all([
-    StreamLogStore.open(),
+    StreamLogStore.openReadOnly(),
     executionStore.readConfig(),
     executionStore.readMeta(),
   ]);


### PR DESCRIPTION
## Summary

Addresses fallback-audit finding P0.4 in #7726 by making transcript-store lifecycle explicit and valid by construction.

- `StreamLogStore.open()` returns a prepared writable persistent store.
- `StreamLogStore.openReadOnly()` supports archive and trace readers without creating directories or mutating cache files.
- `StreamLogStore.ephemeral(reason)` is the only in-memory construction path, and its reason is inspectable.
- `SessionHandle` requires a writable or explicit ephemeral store; read-only stores are rejected.
- The process default is installed and torn down explicitly, including extension reactivation.
- Persistent reloads are transactional, and authoritative transcript failures propagate.
- Corrupt or unavailable summary caches are rebuilt from authoritative logs; cache preparation, write, delete, and clear failures are bounded best effort.
- In-flight background streams retain resident entries instead of being released on repeated status updates.

## Host policy

- Headless CLI, desktop, and extension execution require persistent transcripts before runtime construction.
- Interactive CLI may select explicit ephemeral mode after an open failure, but it shows a persistent warning badge and suppresses resume identifiers and exit hints.
- A resume request always requires persistent storage.
- Extension deactivation clears and disposes the process-default session so activation can run again in the same host process.

## Design

The previous public constructor produced an unopened object whose read, write, and flush methods compensated with `loaded` guards and successful no-ops. Hosts then added independent best-effort opening fallbacks. The revised factories establish one valid mode before exposing the store, so callers no longer carry lifecycle checks.

Call-scoped readers have a distinct read-only mode. Summary files remain reconstructible caches: their failures never mask a valid authoritative transcript, while malformed or unreadable authoritative logs still fail opening. `KVStore` error propagation is enabled for transcript stores so persistence failures cannot be converted into missing data.

## Verification

- `npm run typecheck`.
- `npm run lint`.
- Targeted Prettier and `git diff --check`.
- Focused lifecycle, transcript, CLI, desktop, extension, and progress suites: 15 files and 268 tests passed.
- Initial full suite: 653 files passed, 1 skipped; 5,780 tests passed, 4 skipped.
- Post-merge default-timeout run encountered three 10-second test timeouts and three setup-timeout files under shared host load; all six files passed in isolated one-worker runs with a 30-second timeout (26 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core session composition, transcript persistence contracts, and startup gates across CLI, desktop, and extension—mistakes could block runs or misrepresent resumability.
> 
> **Overview**
> Agent runs no longer rely on lazy `StreamLogStore` construction or silent `load()` no-ops. Hosts must **`StreamLogStore.open()`** (or **`ephemeral`**) and **`initializeDefaultSession({ transcripts })`** before execution; **`defaultSession()`** throws if that step was skipped, and the extension calls **`teardownDefaultSession()`** on deactivate.
> 
> **Headless CLI, desktop, and extension** fail startup when persistent transcripts cannot be opened. **Interactive CLI** may opt into ephemeral mode after open failure (with stderr warning, status-bar badge, and no resume IDs or exit hints); **resume** always requires persistence.
> 
> **CLI** centralizes this in `transcriptSession.ts`; **desktop** opens transcripts before constructing the progress bridge; **progress view** uses `reload()` instead of implicit load, surfaces transcript load errors, and avoids releasing in-flight background log entries on status churn.
> 
> Tests adopt **`defaultSessionTestSetup`**, **`createTestSession`**, and **`StreamLogStore.open()` / `ephemeral()`** instead of bare constructors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27153a9d75ba1ee93220dbfd2ce8b92a06378afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->