### PR TITLE
test: drain snapshot writes before cleanup

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -525,6 +525,8 @@ describe('StreamSnapshotStore', () => {
     await store.preload([STREAM]);
 
     store.addOutputFiles(OTHER_STREAM, { 1: [next] });
+    const returned = store.getOutputFiles(OTHER_STREAM);
+    returned[1]?.push(outputFile('injected.tex', 1));
     expect(store.getOutputFiles(OTHER_STREAM)[1]).toEqual([next]);
     await store.flush();
 
@@ -533,20 +535,6 @@ describe('StreamSnapshotStore', () => {
       '0': [prior],
       '1': [next],
     });
-  });
-
-  it('returns a deep-enough copy from getOutputFiles so mutating the returned array cannot corrupt internal state', async () => {
-    const first = outputFile('first.tex', 0);
-    const store = new StreamSnapshotStore();
-    store.addOutputFiles(STREAM, { 0: [first] });
-
-    const returned = store.getOutputFiles(STREAM);
-    // Mutate the returned round's array directly (not just reassign the
-    // top-level record) — a shallow `{ ...map }` copy would still share this
-    // array by reference with the store's internal accumulator.
-    returned[0]?.push(outputFile('injected.tex', 0));
-
-    expect(store.getOutputFiles(STREAM)[0]).toEqual([first]);
   });
 
   it('keeps output overlays when flattening legacy output files after preload', async () => {


### PR DESCRIPTION
## Summary
- fold the standalone `getOutputFiles` copy assertion into the adjacent persisted-output scenario
- rely on that scenario's existing `flush()` before test temp-directory cleanup
- remove 12 net test lines and one redundant setup path

## Evidence
Latest main CI run 29198104778 failed with `ENOTEMPTY` while this standalone test left `addOutputFiles()`'s fire-and-forget sidecar write alive during `afterEach` cleanup.

## Validation
- focused StreamSnapshotStore suite: 10/10 repeated runs passed
- targeted ESLint
- Prettier
- `git diff --check`

Closes #8226

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; reduces flaky CI cleanup failures.
> 
> **Overview**
> Consolidates **`StreamSnapshotStore`** test coverage by moving the **`getOutputFiles`** deep-copy assertion into the existing scenario for streams outside a partial preload that persist output to disk.
> 
> That scenario now mutates the returned round array (push an injected file) and still expects internal state to stay **`[next]`**, then **`flush()`** before assertions on **`outputFiles.json`**—the same path that already drained snapshot writes before **`afterEach`** temp-dir removal.
> 
> Removes the standalone deep-copy test that called **`addOutputFiles()`** without **`flush()`**, which left async sidecar writes in flight and caused intermittent **`ENOTEMPTY`** failures during cleanup (closes #8226).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db8f51f6c3bca2143fefdce9ddeb8e2ec49ee0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->