### PR TITLE
fix(cli-tui): keep Ctrl-C hint in sync with active runs

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -59,7 +59,9 @@ import {
 } from '../src/chat/tui/commands/slashForms';
 import {
   activeStreamId as activeStreamIdSignal,
+  rootRunPending,
   rootRunStartAvailable,
+  rootRunStreamId,
   rootStreamId,
   resetCliState,
   sessionMeta,
@@ -1576,6 +1578,7 @@ if (SHOW_AGENT_PROPOSAL) {
 
 function markHarnessInterrupted(): void {
   canInterrupt = false;
+  rootRunPending.set(false);
   const childStreamIds = new Set(
     visibleSubagentRows(STREAM_ID, childStreamEntries.get(), streams.get())
       .map((child) => child.childStreamId)
@@ -1916,6 +1919,11 @@ registerBuiltinSlashCommands({
   },
 });
 rootRunStartAvailable.set(CAN_SELECT_AGENT);
+// Mirror the real publisher's run facts: an interruptible harness run is a
+// pending root-run claim on the harness stream, so the status bar derives
+// the Ctrl-C stop hint from these signals exactly as `texra chat` does.
+rootRunPending.set(canInterrupt);
+rootRunStreamId.set(canInterrupt ? STREAM_ID : undefined);
 
 const inkRef: { current?: ReturnType<typeof render> } = {};
 const viewportController = createTuiViewportController(inkRef);

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -68,7 +68,7 @@ import {
   chatTuiCanStartRootRun,
   markChatTuiRunCompleted,
   markChatTuiRunPending,
-  publishChatTuiRootRunStartAvailability,
+  publishChatTuiRunState,
   tryClaimRootRunSlot,
   type TuiSession,
 } from './tui/state/sessionRunState';
@@ -301,6 +301,7 @@ export function createChatSessionController(
           runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
+            publishChatTuiRunState(session);
             rootStreamId.set(resolvedStreamId);
             moveLocalTranscriptToStream(resolvedStreamId);
             activeStreamId.set(resolvedStreamId);
@@ -374,6 +375,7 @@ export function createChatSessionController(
       followUpQueue.clear();
       session.streamId = resolution.streamId;
       session.executionId = resolution.snapshot.executionId;
+      publishChatTuiRunState(session);
       rootStreamId.set(resolution.streamId);
 
       const currentModel = resolution.config.model;
@@ -508,7 +510,7 @@ export function createChatSessionController(
         activeStreamId.set(streamId);
         session.runCompleted = false;
         session.runExitCode = CliExitCode.Success;
-        publishChatTuiRootRunStartAvailability(session);
+        publishChatTuiRunState(session);
 
         let resumedToWaiting = false;
         const resumed = await setCliHelperModel(currentModel).then(() =>

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -72,7 +72,6 @@ export interface AppProps {
   readonly onKillExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;
-  readonly canStopPendingRunWithoutStream?: () => boolean;
   readonly colorEnabled?: boolean;
   readonly commandName?: string;
   readonly onInterruptActive: () => void;
@@ -108,8 +107,6 @@ export function App(props: AppProps): React.JSX.Element {
   const { exit } = useApp();
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
-  const canStopPendingRunWithoutStream =
-    props.canStopPendingRunWithoutStream ?? (() => false);
   const agentSelectionAvailable = rootRunStartAvailable;
   const activeApprovalVisible = approvalVisibleForActiveStream({
     activeStreamId,
@@ -446,8 +443,6 @@ export function App(props: AppProps): React.JSX.Element {
           <StreamTabsStrip items={streamTabItems} width={columns} />
           <StatusBar
             agentSelectionAvailable={agentSelectionAvailable}
-            canStopActiveRun={canStopActiveRun}
-            canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
             commandName={props.commandName}
             foregroundEscapeAction={foregroundEscapeAction({
               activeFormEscapeAction: activeForm?.escapeAction,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -13,10 +13,13 @@ import {
   pendingExitHint as pendingExitHintSignal,
   pendingExitResumeId as pendingExitResumeIdSignal,
   activeStreamId as activeStreamIdSignal,
+  rootRunPending as rootRunPendingSignal,
+  rootRunStreamId as rootRunStreamIdSignal,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
   NO_BYPASS,
 } from '../state/cliState';
+import { chatTuiCanStopVisibleRun } from '../state/sessionRunState';
 import {
   activeSubagentsFor,
   childStreamEntries as childStreamEntriesSignal,
@@ -34,8 +37,6 @@ const CODEX_SUBSCRIPTION_REFRESH_MS = 10_000;
 
 interface StatusBarProps {
   readonly agentSelectionAvailable?: boolean;
-  readonly canStopActiveRun?: () => boolean;
-  readonly canStopPendingRunWithoutStream?: () => boolean;
   readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
   readonly queuedFollowUpPreview?: boolean;
@@ -56,11 +57,23 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const approvals = useSignal(approvalQueueStatus);
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
+  // The Ctrl-C stop/exit hint derives from published run-state signals, never
+  // from impure session closures: memoized renders cache a closure's result
+  // on the closure's identity, which froze the hint at its boot-time value
+  // for the whole run (#8273).
+  const rootRunPending = useSignal(rootRunPendingSignal);
+  const rootRunStreamId = useSignal(rootRunStreamIdSignal);
   const target = statusBarStreamTarget({
     activeStreamId,
-    canStopActiveRun: props.canStopActiveRun?.() === true,
+    canStopActiveRun: chatTuiCanStopVisibleRun({
+      runPending: rootRunPending,
+      streamId: rootRunStreamId,
+      status: rootRunStreamId
+        ? streams.get(rootRunStreamId)?.status
+        : undefined,
+    }),
     canStopPendingRunWithoutStream:
-      props.canStopPendingRunWithoutStream?.() === true,
+      rootRunPending && rootRunStreamId === undefined,
     parentStream,
     streams,
   });

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -490,15 +490,17 @@ export async function runChat(
   const canInterruptActiveRun = (): boolean =>
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
-    chatTuiCanStopVisibleRun(session, rootStreamStatus());
+    chatTuiCanStopVisibleRun({
+      runPending: Boolean(session.runPromise && !session.runCompleted),
+      streamId: session.streamId,
+      status: rootStreamStatus(),
+    });
   const isResumableIdle = (): boolean =>
     chatTuiIsResumableIdleOnExit({
       canInterruptActiveRun: canInterruptActiveRun(),
       canStopActiveRun: canStopActiveRun(),
       hasActiveToolUseFlow: hasActiveToolUseFlow(),
     });
-  const canStopPendingRunWithoutStream = (): boolean =>
-    Boolean(session.runPromise && !session.runCompleted && !session.streamId);
   // Chat-session controller: owns run start/resume/stop orchestration.
   // The Ink layer never directly mutates session run-state fields — every
   // state transition flows through one of the controller's narrow commands.
@@ -779,7 +781,6 @@ export async function runChat(
       onSubmit={handleSubmit}
       canInterruptActiveRun={canInterruptActiveRun}
       canStopActiveRun={canStopActiveRun}
-      canStopPendingRunWithoutStream={canStopPendingRunWithoutStream}
       colorEnabled={stdoutColorEnabled}
       commandName={context.commandName}
       onInterruptActive={interruptActive}

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -324,6 +324,8 @@ function defaultSessionMeta(): SessionMeta {
 const ACTIVE_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 const ROOT_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 const ROOT_RUN_START_AVAILABLE = signal<boolean>(true);
+const ROOT_RUN_PENDING = signal<boolean>(false);
+const ROOT_RUN_STREAM_ID = signal<StreamTabId | undefined>(undefined);
 
 /** The stream currently focused in the transcript / status bar. */
 export const activeStreamId = ACTIVE_STREAM_ID;
@@ -331,6 +333,15 @@ export const activeStreamId = ACTIVE_STREAM_ID;
 export const rootStreamId = ROOT_STREAM_ID;
 /** Whether starting a new root run is currently available. */
 export const rootRunStartAvailable = ROOT_RUN_START_AVAILABLE;
+/** Whether the root session holds an unfinished run claim (run promise
+ *  pending). Published only by `publishChatTuiRunState`, so renders read the
+ *  session run-state reactively instead of calling impure session closures
+ *  that memoized renders would cache stale (#8273). */
+export const rootRunPending = ROOT_RUN_PENDING;
+/** Run-control mirror of `TuiSession.streamId` — cleared while a new run is
+ *  pending, unlike `rootStreamId`, which stays put as the transcript anchor
+ *  across pending windows. Published only by `publishChatTuiRunState`. */
+export const rootRunStreamId = ROOT_RUN_STREAM_ID;
 
 // ---------------------------------------------------------------------------
 // foregroundOverlaySlice
@@ -468,6 +479,8 @@ export function resetCliState(
   rootStreamId.set(undefined);
   streams.set(new Map());
   rootRunStartAvailable.set(true);
+  rootRunPending.set(false);
+  rootRunStreamId.set(undefined);
   resetChildStreamEntries();
   activeForm.set(undefined);
   slashPaletteOpen.set(false);

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -7,7 +7,11 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
-import { rootRunStartAvailable } from './cliState';
+import {
+  rootRunPending,
+  rootRunStartAvailable,
+  rootRunStreamId,
+} from './cliState';
 
 export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
@@ -31,6 +35,11 @@ type PendingTuiRunSessionState = Pick<
   'runPromise' | 'runCompleted'
 >;
 
+type PublishedTuiRunSessionState = Pick<
+  ClearableTuiSessionState,
+  'runPromise' | 'runCompleted' | 'streamId'
+>;
+
 export function clearTuiSessionRunState(
   session: ClearableTuiSessionState,
 ): void {
@@ -41,7 +50,7 @@ export function clearTuiSessionRunState(
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
   session.stopRequested = false;
-  publishChatTuiRootRunStartAvailability(session);
+  publishChatTuiRunState(session);
 }
 
 export function markChatTuiRunPending(
@@ -55,14 +64,14 @@ export function markChatTuiRunPending(
   session.runExitCode = CliExitCode.Success;
   session.runCompleted = false;
   session.stopRequested = false;
-  publishChatTuiRootRunStartAvailability(session);
+  publishChatTuiRunState(session);
 }
 
 export function markChatTuiRunCompleted(
-  session: PendingTuiRunSessionState,
+  session: PublishedTuiRunSessionState,
 ): void {
   session.runCompleted = true;
-  publishChatTuiRootRunStartAvailability(session);
+  publishChatTuiRunState(session);
 }
 
 /**
@@ -95,22 +104,28 @@ export function chatTuiCanInterruptActiveRun(
   );
 }
 
-export function chatTuiCanStopActiveRun(
-  session: InterruptibleTuiSessionState,
-  status: StreamPhase | undefined,
-): boolean {
-  if (!session.runPromise || session.runCompleted) return false;
-  if (!session.streamId) return true;
-  return status === undefined || isActivePhase(status);
+/**
+ * Run facts the stop predicates consume. Two producers share this shape:
+ * `runChatTui` derives it from the mutable session (signal-handler paths),
+ * and the StatusBar derives it from the `rootRunPending`/`rootRunStreamId`
+ * signals so the Ctrl-C hint recomputes reactively during renders.
+ */
+export interface ChatTuiRunStopFacts {
+  readonly runPending: boolean;
+  readonly streamId: StreamTabId | undefined;
+  readonly status: StreamPhase | undefined;
 }
 
-export function chatTuiCanStopVisibleRun(
-  session: InterruptibleTuiSessionState,
-  status: StreamPhase | undefined,
-): boolean {
+export function chatTuiCanStopActiveRun(facts: ChatTuiRunStopFacts): boolean {
+  if (!facts.runPending) return false;
+  if (!facts.streamId) return true;
+  return facts.status === undefined || isActivePhase(facts.status);
+}
+
+export function chatTuiCanStopVisibleRun(facts: ChatTuiRunStopFacts): boolean {
   return (
-    chatTuiCanStopActiveRun(session, status) ||
-    Boolean(session.streamId && isActivePhase(status))
+    chatTuiCanStopActiveRun(facts) ||
+    Boolean(facts.streamId && isActivePhase(facts.status))
   );
 }
 
@@ -120,10 +135,19 @@ export function chatTuiCanStartRootRun(
   return !session.runPromise || session.runCompleted;
 }
 
-export function publishChatTuiRootRunStartAvailability(
-  session: PendingTuiRunSessionState,
+/**
+ * Single publisher of the session run-state facts into cliState signals.
+ * Every mutation of `runPromise`/`runCompleted`/`streamId` must flow through
+ * a caller of this function — renders read only the published signals, so an
+ * unpublished mutation would leave the Ctrl-C hint stale (#8273).
+ */
+export function publishChatTuiRunState(
+  session: PublishedTuiRunSessionState,
 ): void {
-  rootRunStartAvailable.set(chatTuiCanStartRootRun(session));
+  const canStart = chatTuiCanStartRootRun(session);
+  rootRunStartAvailable.set(canStart);
+  rootRunPending.set(!canStart);
+  rootRunStreamId.set(session.streamId);
 }
 
 export function chatTuiCanSelectModel(input: {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -10,7 +10,9 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   activeStreamId,
+  rootRunPending,
   rootRunStartAvailable,
+  rootRunStreamId,
   rootStreamId,
   removeStream,
   resetCliState,
@@ -739,6 +741,8 @@ describe('CLI TUI row allocation', () => {
     expect(session.stopRequested).toBe(false);
     expect(chatTuiCanStartRootRun(session)).toBe(false);
     expect(rootRunStartAvailable.get()).toBe(false);
+    expect(rootRunPending.get()).toBe(true);
+    expect(rootRunStreamId.get()).toBeUndefined();
   });
 
   it('restores root run availability when clearing session run state', () => {
@@ -757,6 +761,8 @@ describe('CLI TUI row allocation', () => {
 
     expect(chatTuiCanStartRootRun(session)).toBe(true);
     expect(rootRunStartAvailable.get()).toBe(true);
+    expect(rootRunPending.get()).toBe(false);
+    expect(rootRunStreamId.get()).toBeUndefined();
   });
 
   it('allows model selection before start or while a tool-use chat is waiting', () => {
@@ -795,130 +801,78 @@ describe('CLI TUI row allocation', () => {
   });
 
   it('only reports Ctrl-C stoppable while the root stream is actively responding', () => {
-    const runPromise = Promise.resolve();
-
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: undefined,
-        },
-        undefined,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: undefined,
+        status: undefined,
+      }),
     ).toBe(true);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: root,
+        status: STREAM_PHASE.RUNNING,
+      }),
     ).toBe(true);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
-    ).toBe(true);
-    expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.WAITING,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: root,
+        status: STREAM_PHASE.WAITING,
+      }),
     ).toBe(false);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.FAILED,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: root,
+        status: STREAM_PHASE.FAILED,
+      }),
     ).toBe(false);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.CANCELLED,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: root,
+        status: STREAM_PHASE.CANCELLED,
+      }),
     ).toBe(false);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: false,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.COMPLETED,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: true,
+        streamId: root,
+        status: STREAM_PHASE.COMPLETED,
+      }),
     ).toBe(false);
     expect(
-      chatTuiCanStopActiveRun(
-        {
-          runCompleted: true,
-          runPromise,
-          streamId: root,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
+      chatTuiCanStopActiveRun({
+        runPending: false,
+        streamId: root,
+        status: STREAM_PHASE.RUNNING,
+      }),
     ).toBe(false);
   });
 
   it('keeps Ctrl-C stoppable when the visible stream is already live', () => {
     expect(
-      chatTuiCanStopVisibleRun(
-        {
-          runCompleted: false,
-          runPromise: undefined,
-          streamId: root,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
+      chatTuiCanStopVisibleRun({
+        runPending: false,
+        streamId: root,
+        status: STREAM_PHASE.RUNNING,
+      }),
     ).toBe(true);
     expect(
-      chatTuiCanStopVisibleRun(
-        {
-          runCompleted: true,
-          runPromise: undefined,
-          streamId: root,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
-    ).toBe(true);
-    expect(
-      chatTuiCanStopVisibleRun(
-        {
-          runCompleted: false,
-          runPromise: undefined,
-          streamId: undefined,
-        },
-        STREAM_PHASE.RUNNING,
-      ),
+      chatTuiCanStopVisibleRun({
+        runPending: false,
+        streamId: undefined,
+        status: STREAM_PHASE.RUNNING,
+      }),
     ).toBe(false);
     expect(
-      chatTuiCanStopVisibleRun(
-        {
-          runCompleted: false,
-          runPromise: undefined,
-          streamId: root,
-        },
-        STREAM_PHASE.WAITING,
-      ),
+      chatTuiCanStopVisibleRun({
+        runPending: false,
+        streamId: root,
+        status: STREAM_PHASE.WAITING,
+      }),
     ).toBe(false);
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -119,7 +119,11 @@ import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
 import { createChatSessionController } from '@cli/chat/chatSessionController';
-import { rootStreamId } from '@cli/chat/tui/state/cliState';
+import {
+  rootRunPending,
+  rootRunStreamId,
+  rootStreamId,
+} from '@cli/chat/tui/state/cliState';
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanStopActiveRun,
@@ -313,6 +317,8 @@ describe('createChatSessionController', () => {
       streamId: 'stream-resume',
     });
     rootStreamId.set(undefined);
+    rootRunPending.set(false);
+    rootRunStreamId.set(undefined);
   });
 
   it('returns an object satisfying the ChatSessionController interface', () => {
@@ -496,12 +502,18 @@ describe('createChatSessionController', () => {
     // already set to the resumed stream.
     expect(session.runPromise).toBeDefined();
     expect(session.streamId).toBe('stream-resume');
+    // #8273 regression: the controller must publish the run facts so status
+    // rendering can derive the Ctrl-C hint from signals instead of calling
+    // impure session closures that memoized renders cache stale.
+    expect(rootRunPending.get()).toBe(true);
+    expect(rootRunStreamId.get()).toBe('stream-resume');
 
     const canInterruptActiveRun = chatTuiCanInterruptActiveRun(session);
-    const canStopActiveRun = chatTuiCanStopActiveRun(
-      session,
-      STREAM_PHASE.WAITING,
-    );
+    const canStopActiveRun = chatTuiCanStopActiveRun({
+      runPending: Boolean(session.runPromise && !session.runCompleted),
+      streamId: session.streamId,
+      status: STREAM_PHASE.WAITING,
+    });
     const resumableIdle = chatTuiIsResumableIdleOnExit({
       canInterruptActiveRun,
       canStopActiveRun,


### PR DESCRIPTION
## Summary
- publish root-run pending and stream identity as reactive CLI signals
- derive the status-bar Ctrl-C action from those signals instead of impure closure props
- keep the signal-handler path and render path on one typed run-facts predicate
- update the controller-backed TUI harness and remove 80 lines of duplicate display-only test coverage

## Root cause
React Compiler memoized the stable `canStopActiveRun` closure result during rendering, freezing the footer at its boot-time `false`. The SIGINT handler reevaluated mutable session state outside render, so Ctrl-C correctly stopped the run even while the footer advertised exit.

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/TuiStateAndFocus.vitest.mts src/test-kernel/cli/chatSessionController.vitest.mts` (131 passed)
- `corepack pnpm --filter @texra-ai/cli validate:tui --snapshot-dir /private/tmp/texra-8273-fix ctrl-c-interrupt-active queued-followups`
- targeted Prettier and ESLint
- `npm run typecheck`
- `git diff --check`

Closes #8273

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches run-state publishing, status-bar UX, and SIGINT/stop semantics; behavior is well covered by targeted vitest and TUI harness scenarios, but incorrect signal updates could still mislabel stop vs exit during pending runs.
> 
> **Overview**
> Fixes **#8273**, where the status bar could show an exit-style Ctrl-C hint while a run was actually stoppable because React Compiler memoized stable `canStopActiveRun` / `canStopPendingRunWithoutStream` props and froze their boot-time values for the whole session.
> 
> The PR adds reactive **`rootRunPending`** and **`rootRunStreamId`** signals in `cliState`, published only through **`publishChatTuiRunState`** (replacing **`publishChatTuiRootRunStartAvailability`**). **`StatusBar`** now derives stop/exit hints from those signals via **`chatTuiCanStopVisibleRun`** on a shared **`ChatTuiRunStopFacts`** shape, instead of closure props from **`App`**. **`chatSessionController`** calls **`publishChatTuiRunState`** when the stream id is set on start, resume, and follow-up wake so the footer updates during rehydration.
> 
> **`runChatTui`** still passes session-derived facts into SIGINT handling; stop predicates take the typed facts object rather than the full session. The TUI harness seeds the same signals for interrupt scenarios, and tests assert signal publication on resume plus updated stop-fact unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e840e60274247cd94c2140d5224159ce9d1bce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->