### PR TITLE
Improve startup access and retire legacy status readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@ All notable changes to this project will be documented in this file.
   subscription, included TeXRA access, or personal API keys before starting a
   session. ChatGPT-only users can select all compatible OpenAI models without
   configuring an OpenAI API key.
-- **Startup and settings lists are easier to scan** — resumable sessions now
-  live behind one Resume entry, and `/config` first groups settings by subject.
+- **Startup and settings lists are easier to scan** — resumable sessions,
+  agents, and teams now live behind one entry each; the launcher also provides
+  account sign-in and sign-out controls. `/config` groups settings by subject.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **ChatGPT sign-in unlocks compatible OpenAI models without an API key** —
+  the CLI and extension enable subscription routing, refresh model
+  availability, and expose supported OpenAI models after sign-in.
 - **Meta (Muse Spark) provider support** — Muse Spark 1.1 is now available as
   a direct provider with your own Meta Model API key (dev.meta.ai), including
   reasoning, tool calling, vision, and PDF input via Meta's Responses-compatible
@@ -47,8 +50,7 @@ All notable changes to this project will be documented in this file.
 
 - **Model access can be changed from the startup launcher** — choose a ChatGPT
   subscription, included TeXRA access, or personal API keys before starting a
-  session. ChatGPT-only users can select all compatible OpenAI models without
-  configuring an OpenAI API key.
+  session.
 - **Startup and settings lists are easier to scan** — resumable sessions,
   agents, and teams now live behind one entry each; the launcher also provides
   account sign-in and sign-out controls. `/config` groups settings by subject.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ All notable changes to this project will be documented in this file.
 
 ### Extension (VS Code)
 
+#### New Features
+
+- **Team application offers Researcher Access when remote members are missing**
+  — applying a team while signed out now offers sign-in, reloads remote agents
+  after authentication, and reapplies the complete roster.
+
 #### Bug Fixes
 
 - **Lean project commands wait for the Lean extension to become ready** — cache

--- a/docs/proposals/agent-sdk-readiness.md
+++ b/docs/proposals/agent-sdk-readiness.md
@@ -127,6 +127,10 @@ TeXRA is unusually well-positioned: YAML agent profiles are near-isomorphic to t
 
 **The cleanest internal seam** is the `agentCategory` dispatch at `executeAgent.ts:444/497`: both flows already take typed inputs (`RunReflectionFlowInput`/`RunToolUseFlowInput`) and return typed results. The improvement is to stop threading the 14-field `AgentLaunchContext` by spread (`{...ctx, ...interrupts, …}`) and pass explicit per-flow inputs, so adding an agent type = adding a flow keyed by category, not editing `executeAgent`.
 
+`AgentCategory` is permanently binary: `workflow` and `toolUse` are the two
+execution families. New agent profiles and execution modes belong within one
+of these families; they do not add a third category.
+
 **Risks that bound this work** (must be respected before promoting flows to config-selected delegates):
 
 1. **Shared coordinator state** — concurrent delegates keyed by `streamId` would cross-clear each other's retry/plan-approval requests. Move registries onto the per-run handle _first_.

--- a/packages/cli/src/chat/tui/modals/BashApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/BashApproval.tsx
@@ -171,7 +171,7 @@ export function BashApproval(props: BashApprovalProps): React.JSX.Element {
       borderStyle="double"
       color={COLOR_WARNING}
       title={COMMAND_APPROVAL_TITLE}
-      alwaysAllow={{ kind: 'bash', label: 'commands for session' }}
+      alwaysAllow={{ kind: 'bash', label: 'approve all' }}
       onDecide={props.onDecide}
     >
       {cwdLine ? <Text dimColor>{cwdLine}</Text> : null}

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -49,7 +49,7 @@ export function ConfirmCard({
   color,
   title,
   approveLabel = 'approve',
-  rejectLabel = 'reject',
+  rejectLabel = 'reject & note',
   alwaysAllow,
   extraActions = [],
   feedbackPlaceholder = 'Feedback to send with rejection',

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -58,7 +58,7 @@ export function confirmCardKeyAction(
 
 export function confirmCardKeyHints({
   approveLabel = 'approve',
-  rejectLabel = 'reject',
+  rejectLabel = 'reject & note',
   alwaysAllowLabel,
   extraActions = [],
 }: ConfirmCardHintOptions): ConfirmCardHintAction[] {
@@ -101,6 +101,8 @@ function hintsFit(
 
 function compactHintAction(action: string): string {
   switch (action) {
+    case 'reject & note':
+      return 'reject';
     case 'approve all':
       return 'all';
     case 'approve edits for session':

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -48,11 +48,9 @@ export function confirmCardKeyAction(
     case 'y':
       return 'approve';
     case 'n':
-      return 'reject';
+      return 'feedback';
     case 'a':
       return allowAlways ? 'approveAlways' : 'ignore';
-    case 'e':
-      return 'feedback';
     default:
       return 'ignore';
   }
@@ -71,7 +69,6 @@ export function confirmCardKeyHints({
       ? []
       : [{ key: 'a', action: alwaysAllowLabel }]),
     ...extraActions,
-    { key: 'e', action: 'feedback' },
     { key: 'Esc', action: 'cancel' },
   ];
 }
@@ -104,12 +101,10 @@ function hintsFit(
 
 function compactHintAction(action: string): string {
   switch (action) {
-    case 'commands for session':
-      return 'cmd session';
+    case 'approve all':
+      return 'all';
     case 'approve edits for session':
       return 'edit session';
-    case 'feedback':
-      return 'note';
     default:
       return action;
   }
@@ -132,19 +127,11 @@ export function confirmCardKeyHintsForWidth(
   if (hintsFit(compactHints, options.maxColumns)) return compactHints;
 
   const withoutExtraActions = compactHints.filter(
-    (hint) => isCoreApprovalHint(hint) || hint.key === 'a' || hint.key === 'e',
+    (hint) => isCoreApprovalHint(hint) || hint.key === 'a',
   );
   if (hintsFit(withoutExtraActions, options.maxColumns)) {
     return withoutExtraActions;
   }
-
-  const withoutFeedback = compactHints.filter((hint) => hint.key !== 'e');
-  if (hintsFit(withoutFeedback, options.maxColumns)) return withoutFeedback;
-
-  const withFeedback = compactHints.filter(
-    (hint) => isCoreApprovalHint(hint) || hint.key === 'e',
-  );
-  if (hintsFit(withFeedback, options.maxColumns)) return withFeedback;
 
   const coreHints = compactHints.filter(isCoreApprovalHint);
   if (hintsFit(coreHints, options.maxColumns)) return coreHints;

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -34,7 +34,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
       color={COLOR_WARNING}
       title="Retry the failed call?"
       approveLabel="retry"
-      rejectLabel="give up"
+      rejectLabel="give up & note"
       extraActions={
         canSwitchToPersonalKey
           ? [

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -270,6 +270,17 @@ async function runLoginCommand(
   });
 }
 
+/** Run the normal interactive TeXRA sign-in flow from another CLI surface. */
+export function runInteractiveCliLogin(
+  context: CliContext,
+  options: { readonly selectAccount?: boolean } = {},
+): Promise<number> {
+  return runLoginCommand(
+    context,
+    loginInitFromArgs({ selectAccount: options.selectAccount }),
+  );
+}
+
 export const logoutCommand = defineCliCommand({
   meta: { name: 'logout', description: 'Sign out of TeXRA' },
   args: {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -244,7 +244,7 @@ export const loginCommand = withUsageSections(
   ],
 );
 
-async function runLoginCommand(
+export async function runLoginCommand(
   context: CliContext,
   init: CliLoginInit,
 ): Promise<number> {
@@ -268,17 +268,6 @@ async function runLoginCommand(
     provider: choice,
     providerExplicit: true,
   });
-}
-
-/** Run the normal interactive TeXRA sign-in flow from another CLI surface. */
-export function runInteractiveCliLogin(
-  context: CliContext,
-  options: { readonly selectAccount?: boolean } = {},
-): Promise<number> {
-  return runLoginCommand(
-    context,
-    loginInitFromArgs({ selectAccount: options.selectAccount }),
-  );
 }
 
 export const logoutCommand = defineCliCommand({

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -30,8 +30,11 @@ import {
   writeMissingPresetAgents,
 } from '../runtime/multiAgentRunPlan';
 import {
+  buildCliAccountItems,
+  buildCliAgentItems,
   buildCliOrchestrationItems,
   buildCliResumeItems,
+  buildCliTeamItems,
 } from '../runtime/orchestration';
 import {
   getCliModelAccessList,
@@ -48,6 +51,11 @@ import {
   readCliModelAccessStatus,
   selectCliModelAccessRoute,
 } from '../runtime/modelAccessRoutes';
+import {
+  chatGptSignOutPreferenceMessage,
+  signOutCliChatGpt,
+} from '../runtime/chatgptLogin';
+import { getCliAuthProfile, signOutCliSupabase } from '../runtime/supabaseAuth';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -157,14 +165,30 @@ async function runOrchestration(context: CliContext): Promise<number> {
       context,
       launcherApiModeOverride,
     );
-    const modelAccess = await readCliModelAccessStatus(apiMode);
+    const [modelAccess, authProfile] = await Promise.all([
+      readCliModelAccessStatus(apiMode),
+      getCliAuthProfile(),
+    ]);
     await seedCliRosterFromDefaultTeam();
+    const toolUseAgents = getVisibleAgents(AgentCategory.ToolUse);
+    const accountStatus = {
+      texraSignedIn: authProfile.authenticated,
+      texraAccountLabel: authProfile.accountLabel,
+      texraCredentialSource: authProfile.credentialSource,
+      chatGptSignedIn: modelAccess.chatGptSignedIn,
+      chatGptAccountLabel: modelAccess.chatGptAccountLabel,
+    };
+    const launcherModelAccess = {
+      ...modelAccess,
+      texraSignedIn: authProfile.authenticated,
+    };
     const items = buildCliOrchestrationItems({
       presetPlans: presetPlanSet.plans,
       history,
-      toolUseAgents: getVisibleAgents(AgentCategory.ToolUse),
+      toolUseAgents,
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
-      modelAccess,
+      modelAccess: launcherModelAccess,
+      account: accountStatus,
     });
     // Load the model registry up front so the launcher can offer a model pick
     // after an agent/team choice. Best-effort: an unavailable registry just
@@ -174,7 +198,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
         apiMode,
         agentCategory: AgentCategory.ToolUse,
       }).catch((): readonly CliModelAccess[] => []),
-      loadCliApiStatusLines({ apiMode, includeActionHint: true }),
+      loadCliApiStatusLines({ apiMode }),
     ]);
     const allowDefaultModelLaunch = await canLaunchWithDefaultModel(
       launchContext,
@@ -186,8 +210,13 @@ async function runOrchestration(context: CliContext): Promise<number> {
     const action = await runOrchestrationTui(items, {
       models,
       resumeItems: buildCliResumeItems(history),
+      agentItems: buildCliAgentItems(toolUseAgents),
+      teamItems: buildCliTeamItems(presetPlanSet.plans, {
+        includeLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
+      }),
+      accountItems: buildCliAccountItems(accountStatus),
       apiMode,
-      modelAccess,
+      modelAccess: launcherModelAccess,
       version: context.version,
       statusLines,
       allowDefaultModelLaunch,
@@ -237,6 +266,41 @@ async function runOrchestration(context: CliContext): Promise<number> {
         continue launcher;
       case 'configure-model-access':
         continue launcher;
+      case 'browse-agents':
+      case 'browse-teams':
+      case 'browse-accounts':
+        continue launcher;
+      case 'account': {
+        try {
+          if (action.provider === 'chatgpt') {
+            if (action.operation === 'sign-out') {
+              const update = await signOutCliChatGpt();
+              writeTextStdout(
+                `Signed out of ChatGPT.\n${chatGptSignOutPreferenceMessage(update)}`,
+              );
+            } else {
+              const result = await selectCliModelAccessRoute(
+                launchContext,
+                'chatgpt',
+                { writeProgress: writeTextStdout },
+              );
+              launcherApiModeOverride = result.apiMode;
+              writeTextStdout(result.message);
+            }
+          } else if (action.operation === 'sign-out') {
+            await signOutCliSupabase();
+            writeTextStdout('Signed out of TeXRA.');
+          } else {
+            const { runInteractiveCliLogin } = await import('./auth');
+            await runInteractiveCliLogin(launchContext, {
+              selectAccount: action.operation === 'switch',
+            });
+          }
+        } catch (error: unknown) {
+          writeErrorStderr(error);
+        }
+        continue launcher;
+      }
       case 'set-model-access': {
         try {
           const result = await selectCliModelAccessRoute(

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -60,6 +60,7 @@ import { getCliAuthProfile, signOutCliSupabase } from '../runtime/supabaseAuth';
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
 import { setExitCode } from './_helpers/exitCode';
+import { loginInitFromArgs, runLoginCommand } from './auth';
 import {
   INTERACTIVE_AGENT_GLOBAL_ARGS,
   rejectHeadlessOnlyFlags,
@@ -291,10 +292,12 @@ async function runOrchestration(context: CliContext): Promise<number> {
             await signOutCliSupabase();
             writeTextStdout('Signed out of TeXRA.');
           } else {
-            const { runInteractiveCliLogin } = await import('./auth');
-            await runInteractiveCliLogin(launchContext, {
-              selectAccount: action.operation === 'switch',
-            });
+            await runLoginCommand(
+              launchContext,
+              loginInitFromArgs({
+                selectAccount: action.operation === 'switch',
+              }),
+            );
           }
         } catch (error: unknown) {
           writeErrorStderr(error);

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -4,6 +4,7 @@ import { platform } from '@platform/platform';
 import { getFirstRunDone } from '@controllers/onboarding/onboardingFunnel';
 import { getVisibleAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -299,6 +300,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
               }),
             );
           }
+          invalidateModelOptionsCache();
         } catch (error: unknown) {
           writeErrorStderr(error);
         }

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -23,6 +23,9 @@ import type { CliModelAccess } from '../runtime/modelAccess';
 export interface OrchestrationAppProps {
   readonly items: readonly CliOrchestrationItem[];
   readonly resumeItems?: readonly CliOrchestrationItem[];
+  readonly agentItems?: readonly CliOrchestrationItem[];
+  readonly teamItems?: readonly CliOrchestrationItem[];
+  readonly accountItems?: readonly CliOrchestrationItem[];
   /** Model access list for the second step. An empty list means unknown
    *  registry state, so the launcher still starts chats with runtime defaults;
    *  a known list with no runnable model disables chat/team starts. */
@@ -207,12 +210,25 @@ export function OrchestrationApp(
 ): React.JSX.Element {
   const app = useApp();
   const { columns, rows } = useWindowSize();
-  const { items, modelItems } = orchestrationModelAccessView(
+  const modelAccessView = orchestrationModelAccessView(
     props.items,
     props.models,
     props.apiMode,
     { allowDefaultModelLaunch: props.allowDefaultModelLaunch },
   );
+  const { items, modelItems } = modelAccessView;
+  const agentItems = orchestrationModelAccessView(
+    props.agentItems ?? [],
+    props.models,
+    props.apiMode,
+    { allowDefaultModelLaunch: props.allowDefaultModelLaunch },
+  ).items;
+  const teamItems = orchestrationModelAccessView(
+    props.teamItems ?? [],
+    props.models,
+    props.apiMode,
+    { allowDefaultModelLaunch: props.allowDefaultModelLaunch },
+  ).items;
   const listFooterHints = orchestrationFooterHints(items);
   const statusLines = props.statusLines ?? [];
   type LauncherStep =
@@ -220,13 +236,21 @@ export function OrchestrationApp(
     | {
         readonly kind: 'model';
         readonly action: CliOrchestrationModelPickAction;
+        readonly backTo: 'launcher' | 'agent' | 'team';
       }
     | { readonly kind: 'model-access' }
-    | { readonly kind: 'resume' };
+    | { readonly kind: 'resume' }
+    | { readonly kind: 'agent' }
+    | { readonly kind: 'team' }
+    | { readonly kind: 'account' };
   const [step, setStep] = useState<LauncherStep>({ kind: 'launcher' });
   const pending = step.kind === 'model' ? step.action : undefined;
+  const pendingBackTo = step.kind === 'model' ? step.backTo : 'launcher';
   const modelAccessOpen = step.kind === 'model-access';
   const resumeOpen = step.kind === 'resume';
+  const agentOpen = step.kind === 'agent';
+  const teamOpen = step.kind === 'team';
+  const accountOpen = step.kind === 'account';
   const modelAccessItems = props.modelAccess
     ? buildModelAccessItems(props.modelAccess)
     : [];
@@ -243,12 +267,18 @@ export function OrchestrationApp(
     ? ['Model access', 'Choose how TeXRA should authenticate model calls.']
     : resumeOpen
       ? ['Resume', 'Choose a previous session to continue.']
-      : pending
-        ? [
-            `${modelStepTitle} · ${formatCliApiMode(props.apiMode)}`,
-            modelStepSubtitle,
-          ]
-        : [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
+      : agentOpen
+        ? ['Agent', 'Choose one agent for this session.']
+        : teamOpen
+          ? ['Team', 'Choose a team for this session.']
+          : accountOpen
+            ? ['Account', 'Sign in, change account, or sign out.']
+            : pending
+              ? [
+                  `${modelStepTitle} · ${formatCliApiMode(props.apiMode)}`,
+                  modelStepSubtitle,
+                ]
+              : [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
   const layout = orchestrationLauncherLayout({
     rows,
     columns,
@@ -256,12 +286,22 @@ export function OrchestrationApp(
       ? modelAccessItems.length
       : resumeOpen
         ? (props.resumeItems?.length ?? 0)
-        : pending
-          ? modelItems.length
-          : items.length,
+        : agentOpen
+          ? agentItems.length
+          : teamOpen
+            ? teamItems.length
+            : accountOpen
+              ? (props.accountItems?.length ?? 0)
+              : pending
+                ? modelItems.length
+                : items.length,
     headerLines,
-    statusLines: pending ? [] : statusLines,
-    footerHints: pending ? [] : listFooterHints,
+    statusLines: step.kind === 'launcher' ? statusLines : [],
+    footerHints: teamOpen
+      ? orchestrationFooterHints(teamItems)
+      : step.kind === 'launcher'
+        ? listFooterHints
+        : [],
   });
 
   const finish = (action: CliOrchestrationAction): void => {
@@ -278,8 +318,27 @@ export function OrchestrationApp(
       setStep({ kind: 'resume' });
       return;
     }
+    if (action.kind === 'browse-agents') {
+      setStep({ kind: 'agent' });
+      return;
+    }
+    if (action.kind === 'browse-teams') {
+      setStep({ kind: 'team' });
+      return;
+    }
+    if (action.kind === 'browse-accounts') {
+      setStep({ kind: 'account' });
+      return;
+    }
     if (isCliOrchestrationModelPickAction(action) && modelItems.length > 0) {
-      setStep({ kind: 'model', action });
+      setStep({
+        kind: 'model',
+        action,
+        backTo:
+          step.kind === 'agent' || step.kind === 'team'
+            ? step.kind
+            : 'launcher',
+      });
     } else {
       finish(action);
     }
@@ -343,6 +402,56 @@ export function OrchestrationApp(
     );
   }
 
+  if (agentOpen || teamOpen || accountOpen) {
+    const picker = agentOpen
+      ? {
+          title: 'Agent',
+          subtitle: 'Choose one agent for this session.',
+          items: agentItems,
+        }
+      : teamOpen
+        ? {
+            title: 'Team',
+            subtitle: 'Choose a team for this session.',
+            items: teamItems,
+          }
+        : {
+            title: 'Account',
+            subtitle: 'Sign in, change account, or sign out.',
+            items: props.accountItems ?? [],
+          };
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold color="cyan">
+          {picker.title}
+        </Text>
+        <Text dimColor>{picker.subtitle}</Text>
+        <Box marginTop={1}>
+          <Select
+            key={`orchestration-${step.kind}-picker`}
+            items={picker.items}
+            maxVisibleItems={layout.maxVisibleItems}
+            showOverflow={layout.showOverflow}
+            onSelect={onItemSelect}
+            onCancel={() => setStep({ kind: 'launcher' })}
+          />
+        </Box>
+        {layout.footerHints.length > 0 ? (
+          <Box marginTop={1} flexDirection="column">
+            {layout.footerHints.map((hint) => (
+              <Text key={hint} dimColor wrap="wrap">
+                {hint}
+              </Text>
+            ))}
+          </Box>
+        ) : null}
+        <Box marginTop={1}>
+          <KeyHints hints={modelPickKeyHints()} confirmCancel={false} />
+        </Box>
+      </Box>
+    );
+  }
+
   if (pending) {
     return (
       <Box flexDirection="column" paddingX={1}>
@@ -359,7 +468,7 @@ export function OrchestrationApp(
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={(model) => finish({ ...pending, model })}
-            onCancel={() => setStep({ kind: 'launcher' })}
+            onCancel={() => setStep({ kind: pendingBackTo })}
           />
         </Box>
         <Box marginTop={1}>
@@ -373,7 +482,7 @@ export function OrchestrationApp(
     <Box flexDirection="column" paddingX={1}>
       <Box gap={1}>
         <Text bold color="cyan">
-          TeXRA
+          {'{ T } TeXRA'}
         </Text>
         <Text dimColor>v{props.version}</Text>
       </Box>
@@ -420,6 +529,9 @@ export interface RunOrchestrationTuiOptions {
    *  hidden configured model. */
   readonly models: readonly CliModelAccess[];
   readonly resumeItems?: readonly CliOrchestrationItem[];
+  readonly agentItems?: readonly CliOrchestrationItem[];
+  readonly teamItems?: readonly CliOrchestrationItem[];
+  readonly accountItems?: readonly CliOrchestrationItem[];
   readonly apiMode: CliApiMode;
   readonly modelAccess?: CliModelAccessStatus;
   readonly version: string;
@@ -443,6 +555,9 @@ export async function runOrchestrationTui(
       <OrchestrationApp
         items={items}
         resumeItems={options.resumeItems}
+        agentItems={options.agentItems}
+        teamItems={options.teamItems}
+        accountItems={options.accountItems}
         models={options.models}
         apiMode={options.apiMode}
         modelAccess={options.modelAccess}

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -40,6 +40,28 @@ export interface OrchestrationAppProps {
   readonly onResolve: (action: CliOrchestrationAction) => void;
 }
 
+export type OrchestrationLauncherStep =
+  | { readonly kind: 'launcher' }
+  | {
+      readonly kind: 'model';
+      readonly action: CliOrchestrationModelPickAction;
+      readonly backTo: 'launcher' | 'agent' | 'team';
+    }
+  | { readonly kind: 'model-access' }
+  | { readonly kind: 'resume' }
+  | { readonly kind: 'agent' }
+  | { readonly kind: 'team' }
+  | { readonly kind: 'account' };
+
+/** Return the parent picker for Escape, or null when Escape exits the launcher. */
+export function orchestrationPreviousStep(
+  step: OrchestrationLauncherStep,
+): OrchestrationLauncherStep | null {
+  if (step.kind === 'launcher') return null;
+  if (step.kind === 'model') return { kind: step.backTo };
+  return { kind: 'launcher' };
+}
+
 export function orchestrationKeyHints(): readonly KeyHint[] {
   return [
     { key: '↑/↓', action: 'navigate' },
@@ -231,21 +253,10 @@ export function OrchestrationApp(
   ).items;
   const listFooterHints = orchestrationFooterHints(items);
   const statusLines = props.statusLines ?? [];
-  type LauncherStep =
-    | { readonly kind: 'launcher' }
-    | {
-        readonly kind: 'model';
-        readonly action: CliOrchestrationModelPickAction;
-        readonly backTo: 'launcher' | 'agent' | 'team';
-      }
-    | { readonly kind: 'model-access' }
-    | { readonly kind: 'resume' }
-    | { readonly kind: 'agent' }
-    | { readonly kind: 'team' }
-    | { readonly kind: 'account' };
-  const [step, setStep] = useState<LauncherStep>({ kind: 'launcher' });
+  const [step, setStep] = useState<OrchestrationLauncherStep>({
+    kind: 'launcher',
+  });
   const pending = step.kind === 'model' ? step.action : undefined;
-  const pendingBackTo = step.kind === 'model' ? step.backTo : 'launcher';
   const modelAccessOpen = step.kind === 'model-access';
   const resumeOpen = step.kind === 'resume';
   const agentOpen = step.kind === 'agent';
@@ -309,6 +320,15 @@ export function OrchestrationApp(
     app.exit();
   };
 
+  const goBack = (): void => {
+    const previous = orchestrationPreviousStep(step);
+    if (previous) {
+      setStep(previous);
+    } else {
+      finish({ kind: 'exit' });
+    }
+  };
+
   const onItemSelect = (action: CliOrchestrationAction): void => {
     if (action.kind === 'configure-model-access') {
       setStep({ kind: 'model-access' });
@@ -346,11 +366,7 @@ export function OrchestrationApp(
 
   useInput((_input, key) => {
     if (!key.escape) return;
-    if (step.kind !== 'launcher') {
-      setStep({ kind: 'launcher' });
-    } else {
-      finish({ kind: 'exit' });
-    }
+    goBack();
   });
 
   if (modelAccessOpen) {
@@ -368,7 +384,7 @@ export function OrchestrationApp(
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={(access) => finish({ kind: 'set-model-access', access })}
-            onCancel={() => setStep({ kind: 'launcher' })}
+            onCancel={goBack}
           />
         </Box>
         <Box marginTop={1}>
@@ -392,7 +408,7 @@ export function OrchestrationApp(
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={finish}
-            onCancel={() => setStep({ kind: 'launcher' })}
+            onCancel={goBack}
           />
         </Box>
         <Box marginTop={1}>
@@ -433,7 +449,7 @@ export function OrchestrationApp(
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={onItemSelect}
-            onCancel={() => setStep({ kind: 'launcher' })}
+            onCancel={goBack}
           />
         </Box>
         {layout.footerHints.length > 0 ? (
@@ -468,7 +484,7 @@ export function OrchestrationApp(
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={(model) => finish({ ...pending, model })}
-            onCancel={() => setStep({ kind: pendingBackTo })}
+            onCancel={goBack}
           />
         </Box>
         <Box marginTop={1}>
@@ -503,7 +519,7 @@ export function OrchestrationApp(
           maxVisibleItems={layout.maxVisibleItems}
           showOverflow={layout.showOverflow}
           onSelect={onItemSelect}
-          onCancel={() => finish({ kind: 'exit' })}
+          onCancel={goBack}
         />
       </Box>
       {layout.footerHints.length > 0 ? (

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,5 +1,6 @@
 import { platform } from '@platform/platform';
 import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatPercent } from '@utils/text/stringUtils';
 
@@ -37,10 +38,13 @@ export function formatCliAuthStatusLine(
  */
 export function formatApiKeyShadowWarning(
   authenticated: boolean,
-  hasPersonalKey: boolean,
+  personalKeyProviders: readonly string[],
 ): string | undefined {
-  if (!authenticated || !hasPersonalKey) return undefined;
-  return 'note: a provider API key is set while signed in — `--api-mode` (or `/api`) controls which one is used.';
+  if (!authenticated || personalKeyProviders.length === 0) return undefined;
+  const providers = personalKeyProviders
+    .map((provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider)
+    .join(', ');
+  return `available: included TeXRA access; personal API keys: ${providers}`;
 }
 
 const CLI_API_STATUS_ACTION_HINTS: Record<
@@ -76,12 +80,12 @@ export function formatCliApiStatusActionHint(
   ];
 }
 
-async function anyPersonalKeyPresent(): Promise<boolean> {
+async function personalKeyProviders(): Promise<string[]> {
   const secrets = platform().secrets;
   const origins = await Promise.all(
     API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
   );
-  return origins.some((origin) => origin !== 'none');
+  return API_PROVIDERS.filter((_, index) => origins[index] !== 'none');
 }
 
 export async function loadCliApiStatusLines(
@@ -96,16 +100,20 @@ export async function loadCliApiStatusLines(
     `api: ${formatCliApiMode(mode)}`,
     formatCliAuthStatusLine(profile),
   ];
-  const hasPersonalKey =
+  const configuredPersonalKeyProviders =
     options.includeActionHint === true || profile.authenticated
-      ? await anyPersonalKeyPresent()
-      : false;
+      ? await personalKeyProviders()
+      : [];
+  const hasPersonalKey = configuredPersonalKeyProviders.length > 0;
   const actionHint = options.includeActionHint
     ? formatCliApiStatusActionHint(mode, profile, { hasPersonalKey })
     : undefined;
 
   if (profile.authenticated) {
-    const shadowWarning = formatApiKeyShadowWarning(true, hasPersonalKey);
+    const shadowWarning = formatApiKeyShadowWarning(
+      true,
+      configuredPersonalKeyProviders,
+    );
     if (shadowWarning) lines.push(shadowWarning);
   }
 

--- a/packages/cli/src/runtime/modelAccessRoutes.ts
+++ b/packages/cli/src/runtime/modelAccessRoutes.ts
@@ -65,7 +65,8 @@ export async function selectCliModelAccessRoute(
     };
   }
 
-  if (isPreferCodexSubscription()) {
+  const status = await getCodexStatus();
+  if (status.signedIn && isPreferCodexSubscription()) {
     const update = await setPreferCodexSubscription(false);
     invalidateModelOptionsCache();
     return {
@@ -76,7 +77,6 @@ export async function selectCliModelAccessRoute(
     };
   }
 
-  const status = await getCodexStatus();
   let accountLabel = status.email ?? status.accountId ?? 'your account';
   if (!status.signedIn) {
     const init = { device: false, noBrowser: false };

--- a/packages/cli/src/runtime/modelAccessRoutes.ts
+++ b/packages/cli/src/runtime/modelAccessRoutes.ts
@@ -65,6 +65,17 @@ export async function selectCliModelAccessRoute(
     };
   }
 
+  if (isPreferCodexSubscription()) {
+    const update = await setPreferCodexSubscription(false);
+    invalidateModelOptionsCache();
+    return {
+      apiMode: effectiveCliApiMode(context),
+      message: update.effective
+        ? `Prefer ChatGPT subscription remains enabled because a more specific setting overrides ${update.target} config.`
+        : 'Prefer ChatGPT subscription disabled for Codex models.',
+    };
+  }
+
   const status = await getCodexStatus();
   let accountLabel = status.email ?? status.accountId ?? 'your account';
   if (!status.signedIn) {
@@ -85,7 +96,7 @@ export async function selectCliModelAccessRoute(
   return {
     apiMode: effectiveCliApiMode(context),
     message: update.effective
-      ? `Model access set to ChatGPT subscription (${accountLabel}).`
+      ? `Prefer ChatGPT subscription enabled for Codex models (${accountLabel}).`
       : 'ChatGPT sign-in succeeded, but a more specific setting keeps subscription access disabled.',
   };
 }

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -1,6 +1,6 @@
 import type { AgentEntry } from '@agent/index';
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ExecutionId } from '@shared/schemas';
+import { agentKeyOf } from '@shared/schemas/agent';
 
 import {
   cliMultiAgentPresetCanLaunchTeam,
@@ -37,6 +37,14 @@ export type CliOrchestrationAction =
     }
   | { readonly kind: 'resume'; readonly id: ExecutionId }
   | { readonly kind: 'browse-resumes' }
+  | { readonly kind: 'browse-agents' }
+  | { readonly kind: 'browse-teams' }
+  | { readonly kind: 'browse-accounts' }
+  | {
+      readonly kind: 'account';
+      readonly provider: CliAccountProvider;
+      readonly operation: CliAccountOperation;
+    }
   | { readonly kind: 'configure-model-access' }
   | {
       readonly kind: 'set-model-access';
@@ -65,14 +73,26 @@ export interface BuildCliOrchestrationItemsInput {
   readonly toolUseAgents: readonly AgentEntry[];
   readonly includeMultiAgentLoginHint?: boolean;
   readonly modelAccess?: CliModelAccessStatus;
+  readonly account?: CliAccountStatus;
 }
 
 export type CliModelAccessRoute = 'chatgpt' | 'included' | 'personal';
+export type CliAccountProvider = 'chatgpt' | 'texra';
+export type CliAccountOperation = 'sign-in' | 'switch' | 'sign-out';
+
+export interface CliAccountStatus {
+  readonly texraSignedIn: boolean;
+  readonly texraAccountLabel?: string;
+  readonly texraCredentialSource?: 'session' | 'relayToken';
+  readonly chatGptSignedIn: boolean;
+  readonly chatGptAccountLabel?: string;
+}
 
 export interface CliModelAccessStatus {
   readonly active: CliModelAccessRoute;
   readonly chatGptSignedIn: boolean;
   readonly chatGptAccountLabel?: string;
+  readonly texraSignedIn?: boolean;
 }
 
 export interface CliModelAccessItem {
@@ -122,8 +142,6 @@ export function orchestrationModelAccessView(
   };
 }
 
-const MAX_RECENT_AGENT_ITEMS = 3;
-
 export function buildCliOrchestrationItems(
   input: BuildCliOrchestrationItemsInput,
 ): CliOrchestrationItem[] {
@@ -132,13 +150,9 @@ export function buildCliOrchestrationItems(
     {
       value: { kind: 'chat' },
       label: 'New chat',
-      description: 'Start the default tool-use chat',
+      description: `Start with ${pickDefaultToolUseAgent(input.toolUseAgents)}`,
     },
   ];
-
-  if (input.modelAccess) {
-    items.push(modelAccessItem(input.modelAccess));
-  }
 
   const resumeItems = buildCliResumeItems(userStartedHistory);
   if (resumeItems.length > 0) {
@@ -148,18 +162,132 @@ export function buildCliOrchestrationItems(
       description: `${resumeItems.length} resumable ${resumeItems.length === 1 ? 'session' : 'sessions'}`,
     });
   }
-  items.push(...recentAgentItems(userStartedHistory, input.toolUseAgents));
-  items.push(
-    ...presetItems(input.presetPlans, {
-      includeLoginHint: input.includeMultiAgentLoginHint,
-    }),
-  );
+  if (buildCliAgentItems(input.toolUseAgents).length > 0) {
+    items.push({
+      value: { kind: 'browse-agents' },
+      label: 'Agent',
+      description: 'Choose one agent',
+    });
+  }
+  if (input.presetPlans.length > 0) {
+    items.push({
+      value: { kind: 'browse-teams' },
+      label: 'Team',
+      description: 'Choose a team',
+    });
+  }
+  if (input.modelAccess) {
+    items.push(modelAccessItem(input.modelAccess));
+  }
+  if (input.account) {
+    items.push({
+      value: { kind: 'browse-accounts' },
+      label: 'Account',
+      description: accountSummary(input.account),
+    });
+  }
   items.push({
     value: { kind: 'help' },
     label: 'Help',
     description: 'Show CLI commands',
   });
   return items;
+}
+
+function accountSummary(status: CliAccountStatus): string {
+  if (status.texraCredentialSource === 'relayToken') {
+    return status.chatGptSignedIn
+      ? 'TeXRA relay token and ChatGPT signed in'
+      : 'TeXRA relay token configured';
+  }
+  if (status.texraSignedIn && status.chatGptSignedIn) {
+    return 'TeXRA and ChatGPT signed in';
+  }
+  if (status.chatGptSignedIn) {
+    return `ChatGPT · ${status.chatGptAccountLabel ?? 'signed in'}`;
+  }
+  if (status.texraSignedIn) {
+    return `TeXRA · ${status.texraAccountLabel ?? 'signed in'}`;
+  }
+  return 'Sign in or manage accounts';
+}
+
+export function buildCliAccountItems(
+  status: CliAccountStatus,
+): CliOrchestrationItem[] {
+  const items: CliOrchestrationItem[] = [];
+  if (status.chatGptSignedIn) {
+    items.push({
+      value: {
+        kind: 'account',
+        provider: 'chatgpt',
+        operation: 'sign-out',
+      },
+      label: 'Sign out of ChatGPT',
+      description: status.chatGptAccountLabel ?? 'ChatGPT subscription',
+    });
+  } else {
+    items.push({
+      value: {
+        kind: 'account',
+        provider: 'chatgpt',
+        operation: 'sign-in',
+      },
+      label: 'Sign in with ChatGPT',
+      description: 'Use a ChatGPT subscription',
+    });
+  }
+
+  if (status.texraSignedIn) {
+    if (status.texraCredentialSource === 'relayToken') {
+      items.push({
+        value: { kind: 'account', provider: 'texra', operation: 'sign-out' },
+        label: 'TeXRA relay token',
+        description: 'Managed by the TEXRA_RELAY_TOKEN environment variable',
+        disabled: true,
+      });
+    } else {
+      items.push(
+        {
+          value: { kind: 'account', provider: 'texra', operation: 'switch' },
+          label: 'Change TeXRA account',
+          description: status.texraAccountLabel ?? 'Researcher Access',
+        },
+        {
+          value: { kind: 'account', provider: 'texra', operation: 'sign-out' },
+          label: 'Sign out of TeXRA',
+          description: status.texraAccountLabel ?? 'Researcher Access',
+        },
+      );
+    }
+  } else {
+    items.push({
+      value: { kind: 'account', provider: 'texra', operation: 'sign-in' },
+      label: 'Sign in to TeXRA',
+      description: 'Use included Researcher Access',
+    });
+  }
+  return items;
+}
+
+export function buildCliAgentItems(
+  toolUseAgents: readonly AgentEntry[],
+): CliOrchestrationItem[] {
+  const priority = new Map([
+    ['assistant', 0],
+    ['orchestrator', 1],
+  ]);
+  return implicitDefaultToolUseAgents(toolUseAgents)
+    .toSorted((left, right) => {
+      const byPriority =
+        (priority.get(left.name) ?? 2) - (priority.get(right.name) ?? 2);
+      return byPriority || left.name.localeCompare(right.name);
+    })
+    .map((agent) => ({
+      value: { kind: 'chat', agent: agentKeyOf(agent) },
+      label: agent.name,
+      description: agent.description ?? 'Tool-use agent',
+    }));
 }
 
 function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
@@ -190,15 +318,21 @@ export function buildModelAccessItems(
   return [
     {
       value: 'chatgpt',
-      label: modelAccessRouteLabel('chatgpt'),
-      description: status.chatGptSignedIn
-        ? `Use ${status.chatGptAccountLabel ?? 'your account'} with ChatGPT`
-        : 'Sign in with ChatGPT Plus/Pro/Team',
+      label: 'Prefer ChatGPT subscription',
+      description:
+        status.active === 'chatgpt'
+          ? `On · ${status.chatGptAccountLabel ?? 'your account'}`
+          : status.chatGptSignedIn
+            ? `Off · ${status.chatGptAccountLabel ?? 'your account'}`
+            : 'Sign in with ChatGPT Plus/Pro/Team',
     },
     {
       value: 'included',
       label: modelAccessRouteLabel('included'),
-      description: 'Use your TeXRA account',
+      description:
+        status.texraSignedIn === false
+          ? 'Sign in through Account to use included models'
+          : 'Use your TeXRA account',
     },
     {
       value: 'personal',
@@ -220,41 +354,11 @@ export function buildCliResumeItems(
     }));
 }
 
-function recentAgentItems(
-  history: readonly CliHistoryEntry[],
-  toolUseAgents: readonly AgentEntry[],
-): CliOrchestrationItem[] {
-  const toolUseNames = new Set(
-    implicitDefaultToolUseAgents(toolUseAgents).map((agent) => agent.name),
-  );
-  // The agent "New chat" already starts (the roster-resolved default, which is
-  // `assistant` on a full catalog but the team lead under a scoped roster), so
-  // it isn't duplicated as a redundant "Chat with …" recent row.
-  const defaultAgent = pickDefaultToolUseAgent(toolUseAgents);
-  const seen = new Set<string>();
-  const items: CliOrchestrationItem[] = [];
-
-  for (const entry of history) {
-    if (entry.category && entry.category !== AgentCategory.ToolUse) continue;
-    if (entry.agent === defaultAgent) continue;
-    if (!toolUseNames.has(entry.agent) || seen.has(entry.agent)) continue;
-    seen.add(entry.agent);
-    items.push({
-      value: { kind: 'chat', agent: entry.agent },
-      label: `Chat with ${entry.agent}`,
-      description: 'Recent tool-use agent',
-    });
-    if (items.length >= MAX_RECENT_AGENT_ITEMS) break;
-  }
-
-  return items;
-}
-
 // Lists every available team (built-in and custom) so the user can pick and
 // switch among them in the launcher, rather than being pinned to one. The
 // Select component windows and scrolls the visible rows, so the full team list
 // is offered without an artificial data cap that would hide extra custom teams.
-function presetItems(
+export function buildCliTeamItems(
   plans: readonly CliMultiAgentPresetRunPlan[],
   options: {
     readonly includeLoginHint?: boolean;

--- a/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
+++ b/packages/extension/src/frontend/auth/codexSubscriptionSignIn.ts
@@ -10,6 +10,7 @@ import {
   type CodexSession,
 } from '@auth/codex';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 const COPY_SIGN_IN_LINK = 'Copy Sign-in Link';
 
@@ -81,6 +82,10 @@ export async function signInWithChatGptSubscription(
   let update: Awaited<ReturnType<typeof setPreferCodexSubscription>>;
   try {
     update = await setPreferCodexSubscription(true);
+    // The sign-in operation owns its model-availability postcondition. Every
+    // caller may now refresh a picker without inheriting a stale pre-login
+    // snapshot, including paths that do not pass through Settings.
+    invalidateModelOptionsCache();
   } catch (error) {
     await showLoggedErrorMessage(
       channel,

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -1,10 +1,10 @@
 // Local imports - stream state
+import { isActivePhase, isInFlightPhase } from '@common/constants/streamStatus';
 import {
-  isActiveStatus,
-  isInFlightStatus,
-  isTerminalStatus,
-} from '@common/constants/streamStatus';
-import type { StreamLifecycleStatus } from '@shared/schemas/stream';
+  DEFAULT_STREAM_METADATA_STATUS,
+  type StreamLifecycleStatus,
+  type StreamPhase,
+} from '@shared/schemas';
 import type { TokenUsageStats } from '@shared/schemas/usage';
 
 export interface StatusBarUsageTotals {
@@ -19,6 +19,12 @@ const ZERO_USAGE: StatusBarUsageTotals = {
   outputTokens: 0,
 };
 
+function lifecyclePhase(
+  status: StreamLifecycleStatus,
+): StreamPhase | undefined {
+  return status === DEFAULT_STREAM_METADATA_STATUS ? undefined : status;
+}
+
 /** Tracks active streams and usage totals for the extension status bar. */
 export class StatusBarUsageTracker {
   private readonly activeStreams = new Set<string>();
@@ -29,13 +35,14 @@ export class StatusBarUsageTracker {
     streamId: string,
     status: StreamLifecycleStatus,
   ): void {
-    if (isActiveStatus(status)) {
+    const phase = lifecyclePhase(status);
+    if (isActivePhase(phase)) {
       this.activeStreams.add(streamId);
     } else {
       this.activeStreams.delete(streamId);
     }
 
-    if (isTerminalStatus(status) && !isInFlightStatus(status)) {
+    if (!isInFlightPhase(phase)) {
       this.streamStatuses.delete(streamId);
       this.usageByStream.delete(streamId);
       return;
@@ -52,7 +59,7 @@ export class StatusBarUsageTracker {
    */
   public recordUsage(streamId: string, usage: TokenUsageStats): boolean {
     const status = this.streamStatuses.get(streamId);
-    if (status === undefined || !isInFlightStatus(status)) {
+    if (status === undefined || !isInFlightPhase(lifecyclePhase(status))) {
       return false;
     }
 

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -30,7 +30,8 @@ import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 // Local imports
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
-  STREAM_STATUS,
+  DEFAULT_STREAM_METADATA_STATUS,
+  STREAM_PHASE,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
@@ -543,8 +544,8 @@ function getTaskIcon(child: ActiveChildInfo): string {
 /** Check if a child is in a waiting/idle state rather than actively processing. */
 function isWaiting(child: ActiveChildInfo): boolean {
   return (
-    child.status === STREAM_STATUS.WAITING ||
-    child.status === STREAM_STATUS.READY
+    child.status === STREAM_PHASE.WAITING ||
+    child.status === DEFAULT_STREAM_METADATA_STATUS
   );
 }
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -14,8 +14,8 @@ import {
   commonViewStyles,
 } from '@shared/styles';
 import {
+  DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
-  STREAM_STATUS,
   STREAM_SUBSTATE,
   type ConversationProgress,
   type RoundStage,
@@ -301,7 +301,8 @@ export class StreamHeader extends LitElement {
   ];
 
   @property({ attribute: false }) stream: StreamTabInfo | null = null;
-  @property({ attribute: false }) status: string = STREAM_STATUS.READY;
+  @property({ attribute: false }) status: string =
+    DEFAULT_STREAM_METADATA_STATUS;
   @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) progress: ConversationProgress | undefined;
   @property({ attribute: false }) roundStage: RoundStage | undefined;
@@ -332,7 +333,7 @@ export class StreamHeader extends LitElement {
       return nothing;
     }
 
-    const status = this.status || STREAM_STATUS.READY;
+    const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const statusLabel = formatStreamStatusLabel(status, {
       style: 'progressHeader',
       ...(this.substate ? { substate: this.substate } : {}),

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -13,7 +13,7 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports
 import {
-  STREAM_STATUS,
+  DEFAULT_STREAM_METADATA_STATUS,
   type StreamSubstate,
   type StreamTabId,
   type StreamTabInfo,
@@ -102,7 +102,7 @@ export class StreamTab extends LitElement {
   static override styles = [designTokens, animationStyles, streamTabStyles];
 
   @property({ attribute: false }) info!: StreamTabInfo;
-  @property({ type: String }) status: string = STREAM_STATUS.READY;
+  @property({ type: String }) status: string = DEFAULT_STREAM_METADATA_STATUS;
   @property({ attribute: false }) substate: StreamSubstate | undefined;
   @property({ attribute: false }) lastTimestamp: number | undefined = undefined;
   @property({ type: Boolean }) active = false;
@@ -127,7 +127,7 @@ export class StreamTab extends LitElement {
     if (changed.has('info')) {
       this._agentDecorator = getAgentCategoryDecorator(this.info.agentCategory);
     }
-    const status = this.status || STREAM_STATUS.READY;
+    const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const statusLabel =
       formatStreamStatusLabel(status, {
         style: 'progressHeader',
@@ -138,7 +138,7 @@ export class StreamTab extends LitElement {
 
   override render(): TemplateResult {
     const stream = this.info;
-    const status = this.status || STREAM_STATUS.READY;
+    const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const statusKey = streamStatusDisplayKey(status, this.substate) ?? status;
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
@@ -350,7 +350,9 @@ export class StreamTabs extends LitElement {
   }
 
   private getStatus(name: StreamTabId): string {
-    return this.streamStates.get(name)?.status ?? STREAM_STATUS.READY;
+    return (
+      this.streamStates.get(name)?.status ?? DEFAULT_STREAM_METADATA_STATUS
+    );
   }
 
   private getSubstate(name: StreamTabId): StreamSubstate | undefined {

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -7,9 +7,13 @@ import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
 import { repeat } from 'lit/directives/repeat.js';
 
+// Local imports - stream state
+import { isInFlightPhase } from '@common/constants/streamStatus';
+
 // Local imports - shared schemas
 import {
   STREAM_PHASE,
+  StreamPhaseSchema,
   type GettingStartedAction,
   type LogMessageData,
   type TaskGroup,
@@ -30,11 +34,7 @@ import { renderEmptyState } from '@shared/wa/emptyState';
 import { formatDuration } from '@utils/core';
 
 // Local imports - progress view constants
-import {
-  ACTIVE_STREAM_STATUSES,
-  ELEMENT_IDS,
-  GROUP_DOM_IDS,
-} from '../constants';
+import { ELEMENT_IDS, GROUP_DOM_IDS } from '../constants';
 
 // Local imports - progress view styles
 import { logStyles } from '../styles/logStyles';
@@ -297,7 +297,7 @@ export class TaskGroupList extends LitElement {
   }
 
   /**
-   * Play sound when a run group completes. `STREAM_STATUS.STOPPED` folded
+   * Play sound when a run group completes. The former stopped status folded
    * `completed`/`cancelled` into one neutral bucket; the native
    * `TaskGroup.status` (#7993 step 3) keeps them apart, so this checks both
    * terminal-but-not-failed phases to preserve the prior "stopped" trigger
@@ -644,9 +644,8 @@ export class TaskGroupList extends LitElement {
     // with no messages the terminal buffer is empty and would render a blank
     // <pre>, so show the same "Run is starting" / idle text instead.
     if (this.messages.length === 0 && this.groups.length === 0) {
-      const active = this.streamStatus
-        ? ACTIVE_STREAM_STATUSES.has(this.streamStatus)
-        : false;
+      const parsedPhase = StreamPhaseSchema.safeParse(this.streamStatus);
+      const active = parsedPhase.success && isInFlightPhase(parsedPhase.data);
       return html`
         <div
           id=${ELEMENT_IDS.LOG_CONTENT}

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -18,7 +18,10 @@ import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
 
 import { isTerminalOutcomePhase } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { STREAM_STATUS, type StreamLifecycleStatus } from '@shared/schemas';
+import {
+  DEFAULT_STREAM_METADATA_STATUS,
+  type StreamLifecycleStatus,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { selectStyles } from '@shared/styles/selectStyles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
@@ -226,7 +229,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
         PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS,
       ) &&
       (this.status == null ||
-        this.status === STREAM_STATUS.READY ||
+        this.status === DEFAULT_STREAM_METADATA_STATUS ||
         isTerminalOutcomePhase(this.status))
     );
   }

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -1,5 +1,5 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { STREAM_PHASE, type AgentCategoryFilter } from '@shared/schemas';
+import type { AgentCategoryFilter } from '@shared/schemas';
 
 /**
  * DOM element IDs used across the progress view.
@@ -52,11 +52,6 @@ export const GROUP_DOM_IDS = Object.freeze({
   HEADER_PREFIX: 'group-header-',
   CONTENT_PREFIX: 'group-content-',
 });
-
-export const ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_PHASE.RUNNING,
-  STREAM_PHASE.WAITING,
-]);
 
 const STOP_STREAM_BUTTON = Object.freeze({
   id: ELEMENT_IDS.STOP_STREAM_BTN,

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -8,7 +8,7 @@ import { create } from 'mutative';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   createStreamState,
-  STREAM_STATUS,
+  STREAM_PHASE,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
@@ -130,7 +130,7 @@ export const streamMetaHandlers = {
     const { stream, status, lastTimestamp, substate } = data;
     const state = ctx.getState();
     const isActiveStream = stream === state.activeStreamId;
-    const shouldFocus = isActiveStream && status === STREAM_STATUS.WAITING;
+    const shouldFocus = isActiveStream && status === STREAM_PHASE.WAITING;
 
     // Single atomic update: stream state + tab metadata in one setState call,
     // avoiding two Map copies and two Lit re-render triggers.

--- a/packages/extension/src/progressView/frontend/streamTree.ts
+++ b/packages/extension/src/progressView/frontend/streamTree.ts
@@ -1,6 +1,10 @@
-import { type StreamTabId, type StreamTabInfo } from '@shared/schemas';
+import { isInFlightPhase } from '@common/constants/streamStatus';
+import {
+  DEFAULT_STREAM_METADATA_STATUS,
+  type StreamTabId,
+  type StreamTabInfo,
+} from '@shared/schemas';
 
-import { ACTIVE_STREAM_STATUSES } from './constants';
 import type { StreamState } from './store';
 
 export type StreamBranchActivity = 'active' | 'finished' | 'unknown';
@@ -136,5 +140,6 @@ function classifyStreamActivity(
 ): StreamBranchActivity {
   const status = streamStates.get(streamId)?.status;
   if (status === undefined) return 'unknown';
-  return ACTIVE_STREAM_STATUSES.has(status) ? 'active' : 'finished';
+  const phase = status === DEFAULT_STREAM_METADATA_STATUS ? undefined : status;
+  return isInFlightPhase(phase) ? 'active' : 'finished';
 }

--- a/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/packages/extension/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { isInFlightStatus } from '@common/constants/streamStatus';
+import { isInFlightPhase } from '@common/constants/streamStatus';
 import type { StreamTabId } from '@shared/schemas';
 import { cleanupAllApprovals, releaseStreamResources } from '@tools/approval';
 
@@ -30,7 +30,7 @@ export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostP
   }
 
   isStreamInFlight(stream: StreamTabId): boolean {
-    return isInFlightStatus(defaultSession().status.get(stream));
+    return isInFlightPhase(defaultSession().status.get(stream));
   }
 
   async stopStream(

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -250,8 +250,8 @@ export class ModelsTab extends LitElement {
           <span class="chatgpt-subscription__badge">experimental</span>
         </div>
         <p class="chatgpt-subscription__hint">
-          Use your own ChatGPT Plus/Pro/Team subscription for Codex models
-          instead of an API key.
+          Use OpenAI models through your ChatGPT Plus, Pro, or Team
+          subscription. No OpenAI API key is needed.
         </p>
         <p class="chatgpt-subscription__limit">
           ${waIcon('circle-info')}

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -14,6 +14,7 @@ import { createSettingsAgentControllers } from '@controllers/settingsView/Settin
 import { createKey, getAgent, loadAgents } from '@agent/index';
 import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
 import { SupabaseClient } from '@auth/SupabaseClient';
+import { AUTH_COMMANDS } from '@auth/constants';
 import { workspaceSM, globalSM } from '@common/state';
 import {
   showLoggedErrorMessage,
@@ -26,6 +27,7 @@ import {
   buildCustomAgentDirMessage,
   buildAgentModePresetsMessage,
 } from '@shared/settingsView/handlers/agentSelectionHandlers';
+import { REMOTE_ORCHESTRATOR_AGENT_NAMES } from '@shared/constants/agents';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
@@ -36,6 +38,10 @@ import type { SettingsAgentDirectoryController } from '@controllers/settingsView
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
+
+const REMOTE_TEAM_AGENT_NAMES = new Set<string>(
+  REMOTE_ORCHESTRATOR_AGENT_NAMES,
+);
 
 /**
  * Agent selection, directory, and team handler delegate.
@@ -415,7 +421,7 @@ export class AgentHandlers {
   ): Promise<void> {
     try {
       await loadAgents();
-      const result = await this.catalogController.applyPreset(data.presetId);
+      let result = await this.catalogController.applyPreset(data.presetId);
       if (!result.ok) {
         await showLoggedMessage(
           this.ctx.channel,
@@ -424,14 +430,48 @@ export class AgentHandlers {
         return;
       }
 
+      const unresolvedRemoteAgents = result.unresolvedNames.filter((name) =>
+        REMOTE_TEAM_AGENT_NAMES.has(name),
+      );
+      if (
+        unresolvedRemoteAgents.length > 0 &&
+        !(await SupabaseClient.isAuthenticated())
+      ) {
+        const count = unresolvedRemoteAgents.length;
+        const choice = await vscode.window.showInformationMessage(
+          `The "${result.preset.name}" team includes ${count} ${count === 1 ? 'member' : 'members'} provided through Researcher Access. Sign in to make the full team available.`,
+          'Sign in',
+          'Use available members',
+        );
+        if (choice === 'Sign in') {
+          const signedIn = await vscode.commands.executeCommand<boolean>(
+            AUTH_COMMANDS.SIGN_IN,
+          );
+          if (signedIn) {
+            await loadAgents();
+            result = await this.catalogController.applyPreset(data.presetId);
+            if (!result.ok) {
+              await showLoggedMessage(
+                this.ctx.channel,
+                `Team no longer exists: ${data.presetId}`,
+              );
+              return;
+            }
+          }
+        }
+      }
+
       await this.refreshAfterAgentMutation(
         this.catalogController.getPresetToolUseRoot(
           result.preset.toolUseAgents,
         ),
       );
 
+      const unresolvedCount = result.unresolvedNames.length;
       void vscode.window.showInformationMessage(
-        `Applied "${result.preset.name}" team`,
+        unresolvedCount === 0
+          ? `Applied "${result.preset.name}" team`
+          : `Applied "${result.preset.name}" with ${unresolvedCount} ${unresolvedCount === 1 ? 'member' : 'members'} still unavailable`,
       );
     } catch (error) {
       await showLoggedErrorMessage(

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -457,14 +457,22 @@ export class AgentHandlers {
             // load, so a normal cached load would not discover the newly
             // authorized agents.
             await refreshAgents({ includeRemote: true });
-            result = await this.catalogController.applyPreset(data.presetId);
-            if (!result.ok) {
+            const reapplied = await this.catalogController.applyPreset(
+              data.presetId,
+            );
+            if (!reapplied.ok) {
+              await this.refreshAfterAgentMutation(
+                this.catalogController.getPresetToolUseRoot(
+                  result.preset.toolUseAgents,
+                ),
+              );
               await showLoggedMessage(
                 this.ctx.channel,
                 `Team no longer exists: ${data.presetId}`,
               );
               return;
             }
+            result = reapplied;
           }
         }
       }

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -11,7 +11,12 @@ import * as vscode from 'vscode';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
-import { createKey, getAgent, loadAgents } from '@agent/index';
+import {
+  createKey,
+  getAgent,
+  loadAgents,
+  refresh as refreshAgents,
+} from '@agent/index';
 import { fetchRemoteAgentConfigYaml } from '@agent/remote/remoteAgentConfigClient';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { AUTH_COMMANDS } from '@auth/constants';
@@ -448,7 +453,10 @@ export class AgentHandlers {
             AUTH_COMMANDS.SIGN_IN,
           );
           if (signedIn) {
-            await loadAgents();
+            // A signed-out startup may already have completed an empty remote
+            // load, so a normal cached load would not discover the newly
+            // authorized agents.
+            await refreshAgents({ includeRemote: true });
             result = await this.catalogController.applyPreset(data.presetId);
             if (!result.ok) {
               await showLoggedMessage(

--- a/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/FollowupControlsMock.ts
@@ -10,7 +10,10 @@ import '@progressView/frontend/components/WorkflowToolUseFollowupSection';
 
 // Local imports - progress view types and shared styles
 import type { FollowupOptionsState } from '@progressView/frontend/store';
-import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import {
+  DEFAULT_STREAM_METADATA_STATUS,
+  type StreamLifecycleStatus,
+} from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 
 const SAMPLE_OPTIONS: FollowupOptionsState = {
@@ -53,7 +56,7 @@ const SAMPLE_OPTIONS: FollowupOptionsState = {
   ],
 };
 
-const SAMPLE_STATUS: StreamStatus = STREAM_STATUS.READY;
+const SAMPLE_STATUS: StreamLifecycleStatus = DEFAULT_STREAM_METADATA_STATUS;
 const SAMPLE_STREAM_MODEL = 'claude-opus-4-7';
 
 /**

--- a/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
+++ b/packages/extension/src/webview/frontend/mocks/ProgressBoardLayoutMock.ts
@@ -15,7 +15,6 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_PHASE,
-  STREAM_STATUS,
   type LogMessageData,
   type OutputFileInfo,
   type StreamState,
@@ -168,7 +167,7 @@ const SAMPLE_STREAM_STATES: Map<string, StreamState> = new Map([
   [
     ACTIVE_STREAM_ID,
     createWorkflowStreamState({
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       lastTimestamp: BASE_TIME + 41_000,
       conversationProgress: { toolCallCount: 4 },
       roundStage: { index: 1, total: 2 },
@@ -303,7 +302,7 @@ export class ProgressBoardLayoutMock extends LitElement {
         <div class="conversation">
           <stream-header
             .stream=${activeStream}
-            .status=${STREAM_STATUS.RUNNING}
+            .status=${STREAM_PHASE.RUNNING}
             .progress=${{ toolCallCount: 4 }}
             .roundStage=${{ index: 1, total: 2 }}
             .yoloActive=${true}
@@ -314,7 +313,7 @@ export class ProgressBoardLayoutMock extends LitElement {
               .groups=${SAMPLE_TASK_GROUPS}
               .messages=${SAMPLE_MESSAGES}
               .hasStreams=${true}
-              .streamStatus=${STREAM_STATUS.RUNNING}
+              .streamStatus=${STREAM_PHASE.RUNNING}
               .messageGeneration=${SAMPLE_MESSAGES.length}
             ></task-group-list>
           </div>

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -41,7 +41,11 @@ export interface SettingsAgentCatalogControllerDeps {
 }
 
 export type SettingsAgentPresetApplyResult =
-  | { ok: true; preset: AgentModePreset }
+  | {
+      ok: true;
+      preset: AgentModePreset;
+      unresolvedNames: string[];
+    }
   | { ok: false; reason: 'unknownPreset' };
 
 /**
@@ -171,9 +175,12 @@ export class SettingsAgentCatalogController {
     const preset = this.getPreset(presetId);
     if (!preset) return { ok: false, reason: 'unknownPreset' };
 
-    await applyPresetRoster(this.deps.state, preset);
+    const { unresolvedNames } = await applyPresetRoster(
+      this.deps.state,
+      preset,
+    );
 
-    return { ok: true, preset };
+    return { ok: true, preset, unresolvedNames };
   }
 
   async saveCurrentPreset(name: string): Promise<AgentModePreset> {

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -14,7 +14,8 @@ export const ONBOARDING_CARD_TITLE = 'Welcome to TeXRA';
 /** State 0 choice 1. */
 export const ONBOARDING_CHOICE_CHATGPT = {
   label: 'Use ChatGPT subscription',
-  description: 'Codex models through ChatGPT Plus, Pro, or Team',
+  description:
+    'OpenAI models through ChatGPT Plus, Pro, or Team; no API key needed',
 } as const;
 
 /** State 0 choice 2. */

--- a/src/shared/schemas/identifiers.ts
+++ b/src/shared/schemas/identifiers.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const StreamTabIdSchema = z.string().min(1);
 export type StreamTabId = z.infer<typeof StreamTabIdSchema>;
 
-/** Hex string (8-char current, 6/12-char and UUID legacy). */
+/** Hex string (12-char current, 6-char and UUID-like legacy forms). */
 export const ExecutionIdSchema = z
   .string()
   .min(6)

--- a/src/shared/schemas/inquiry.ts
+++ b/src/shared/schemas/inquiry.ts
@@ -18,6 +18,9 @@ export const ExternalInquirySessionLinksSchema = z.array(
   ExternalInquirySessionLinkSchema,
 );
 
+// Keep the 12-hex suffix aligned with hexId12(), the identifier-minting owner
+// used by externalInquiryStorage. The explicit bound rejects truncated or
+// extended identifiers at storage and tool-input boundaries.
 export const ExternalInquiryThreadIdSchema = z
   .string()
   .regex(/^ei_[0-9a-f]{12}$/i, 'Invalid external inquiry thread ID')

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -9,17 +9,17 @@ import {
 } from '@cli/chat/tui/modals/ConfirmCardState';
 
 describe('CLI confirm-card key handling', () => {
-  it('keeps y/n and escape approval behavior', () => {
+  it('approves with y, collects rejection feedback with n, and cancels with escape', () => {
     expect(confirmCardKeyAction('y', {}, false)).toBe('approve');
     expect(confirmCardKeyAction('Y', {}, false)).toBe('approve');
-    expect(confirmCardKeyAction('n', {}, false)).toBe('reject');
+    expect(confirmCardKeyAction('n', {}, false)).toBe('feedback');
     expect(confirmCardKeyAction('', { escape: true }, false)).toBe('reject');
     expect(confirmCardKeyAction('\u001B', {}, false)).toBe('reject');
     expect(confirmCardKeyAction('\u001Bn', {}, false)).toBe('ignore');
   });
 
-  it('enters feedback mode with e', () => {
-    expect(confirmCardKeyAction('e', {}, false)).toBe('feedback');
+  it('does not reserve a second key for rejection feedback', () => {
+    expect(confirmCardKeyAction('e', {}, false)).toBe('ignore');
   });
 
   it('only enables approve-always where the modal allows it', () => {
@@ -30,13 +30,12 @@ describe('CLI confirm-card key handling', () => {
   it('shows scoped session-wide approval hints for approval modals', () => {
     expect(
       confirmCardKeyHints({
-        alwaysAllowLabel: 'commands for session',
+        alwaysAllowLabel: 'approve all',
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'commands for session' },
-      { key: 'e', action: 'feedback' },
+      { key: 'a', action: 'approve all' },
       { key: 'Esc', action: 'cancel' },
     ]);
 
@@ -47,12 +46,12 @@ describe('CLI confirm-card key handling', () => {
     ).toContainEqual({ key: 'a', action: 'approve edits for session' });
 
     const compactRendered = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'commands for session',
+      alwaysAllowLabel: 'approve all',
       maxColumns: 72,
     })
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
-    expect(compactRendered).toContain('a commands for session');
+    expect(compactRendered).toContain('a approve all');
     expect(compactRendered.length).toBeLessThanOrEqual(72);
   });
 
@@ -66,23 +65,24 @@ describe('CLI confirm-card key handling', () => {
   it('compacts long optional approval hints before hiding cancel', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'commands for session',
+        alwaysAllowLabel: 'approve all',
         maxColumns: 80,
       }),
     ).toEqual(
-      confirmCardKeyHints({ alwaysAllowLabel: 'commands for session' }),
+      confirmCardKeyHints({
+        alwaysAllowLabel: 'approve all',
+      }),
     );
 
     const compact = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'commands for session',
+      alwaysAllowLabel: 'approve all',
       maxColumns: 60,
     });
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'cmd session' },
-      { key: 'e', action: 'note' },
+      { key: 'a', action: 'approve all' },
       { key: 'Esc', action: 'cancel' },
     ]);
     expect(
@@ -97,16 +97,16 @@ describe('CLI confirm-card key handling', () => {
     ).toContainEqual({ key: 'a', action: 'edit session' });
   });
 
-  it('keeps session-scope hints before feedback on mid-width terminals', () => {
+  it('keeps the approve-all hint on mid-width terminals', () => {
     const compact = confirmCardKeyHintsForWidth({
-      alwaysAllowLabel: 'commands for session',
+      alwaysAllowLabel: 'approve all',
       maxColumns: 50,
     });
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'cmd session' },
+      { key: 'a', action: 'approve all' },
       { key: 'Esc', action: 'cancel' },
     ]);
     expect(
@@ -117,19 +117,19 @@ describe('CLI confirm-card key handling', () => {
   it('drops optional approval hints before hiding cancel on narrow terminals', () => {
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'commands for session',
+        alwaysAllowLabel: 'approve all',
         maxColumns: 42,
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'e', action: 'note' },
+      { key: 'a', action: 'all' },
       { key: 'Esc', action: 'cancel' },
     ]);
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'commands for session',
+        alwaysAllowLabel: 'approve all',
         maxColumns: 36,
       }),
     ).toEqual([
@@ -140,7 +140,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(
       confirmCardKeyHintsForWidth({
-        alwaysAllowLabel: 'commands for session',
+        alwaysAllowLabel: 'approve all',
         maxColumns: 10,
       }),
     ).toEqual([{ key: 'Esc', action: 'cancel' }]);

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -34,7 +34,7 @@ describe('CLI confirm-card key handling', () => {
       }),
     ).toEqual([
       { key: 'y', action: 'approve' },
-      { key: 'n', action: 'reject' },
+      { key: 'n', action: 'reject & note' },
       { key: 'a', action: 'approve all' },
       { key: 'Esc', action: 'cancel' },
     ]);
@@ -52,6 +52,7 @@ describe('CLI confirm-card key handling', () => {
       .map((hint) => `${hint.key} ${hint.action}`)
       .join(' · ');
     expect(compactRendered).toContain('a approve all');
+    expect(compactRendered).toContain('n reject & note');
     expect(compactRendered.length).toBeLessThanOrEqual(72);
   });
 
@@ -81,7 +82,7 @@ describe('CLI confirm-card key handling', () => {
 
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
-      { key: 'n', action: 'reject' },
+      { key: 'n', action: 'reject & note' },
       { key: 'a', action: 'approve all' },
       { key: 'Esc', action: 'cancel' },
     ]);
@@ -106,7 +107,7 @@ describe('CLI confirm-card key handling', () => {
     expect(compact).toEqual([
       { key: 'y', action: 'approve' },
       { key: 'n', action: 'reject' },
-      { key: 'a', action: 'approve all' },
+      { key: 'a', action: 'all' },
       { key: 'Esc', action: 'cancel' },
     ]);
     expect(

--- a/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
@@ -128,8 +128,24 @@ describe('CLI model access routes', () => {
     );
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result.message).toBe(
-      'Model access set to ChatGPT subscription (user@example.com).',
+      'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
     );
     expect(result.apiMode).toBe('personal');
+  });
+
+  it('uses the ChatGPT row as a preference switch when already enabled', async () => {
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
+
+    const result = await selectCliModelAccessRoute(context, 'chatgpt', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.signInCliChatGpt).not.toHaveBeenCalled();
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      apiMode: 'personal',
+      message: 'Prefer ChatGPT subscription disabled for Codex models.',
+    });
   });
 });

--- a/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
@@ -134,6 +134,7 @@ describe('CLI model access routes', () => {
   });
 
   it('uses the ChatGPT row as a preference switch when already enabled', async () => {
+    mocks.getCodexStatus.mockResolvedValue({ signedIn: true });
     mocks.isPreferCodexSubscription.mockReturnValue(true);
 
     const result = await selectCliModelAccessRoute(context, 'chatgpt', {
@@ -147,5 +148,21 @@ describe('CLI model access routes', () => {
       apiMode: 'personal',
       message: 'Prefer ChatGPT subscription disabled for Codex models.',
     });
+  });
+
+  it('signs in instead of toggling off a stale signed-out preference', async () => {
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
+    mocks.signInCliChatGpt.mockResolvedValue({ email: 'user@example.com' });
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: true,
+      target: 'global',
+    });
+
+    await selectCliModelAccessRoute(context, 'chatgpt', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.signInCliChatGpt).toHaveBeenCalledOnce();
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
   });
 });

--- a/src/test-kernel/cli/OnboardingState.vitest.mts
+++ b/src/test-kernel/cli/OnboardingState.vitest.mts
@@ -69,10 +69,12 @@ describe('maskDisplayValue', () => {
 
 describe('formatApiKeyShadowWarning', () => {
   it('warns only when signed in AND a personal key is present', () => {
-    expect(formatApiKeyShadowWarning(true, true)).toMatch(/provider API key/);
-    expect(formatApiKeyShadowWarning(true, false)).toBeUndefined();
-    expect(formatApiKeyShadowWarning(false, true)).toBeUndefined();
-    expect(formatApiKeyShadowWarning(false, false)).toBeUndefined();
+    expect(formatApiKeyShadowWarning(true, ['deepseek'])).toBe(
+      'available: included TeXRA access; personal API keys: DeepSeek',
+    );
+    expect(formatApiKeyShadowWarning(true, [])).toBeUndefined();
+    expect(formatApiKeyShadowWarning(false, ['deepseek'])).toBeUndefined();
+    expect(formatApiKeyShadowWarning(false, [])).toBeUndefined();
   });
 });
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -7,6 +7,7 @@ import {
   orchestrationFooterHints,
   orchestrationKeyHints,
   orchestrationLauncherLayout,
+  orchestrationPreviousStep,
   orchestrationWrappedLineRows,
 } from '@cli/orchestration/runOrchestrationTui';
 import {
@@ -131,6 +132,20 @@ const ORCHESTRATION_TEST_HEADER_LINES = [
 ] as const;
 
 describe('CLI orchestration items', () => {
+  it('returns from model selection to the agent or team picker that opened it', () => {
+    const action = { kind: 'chat' as const, agent: 'assistant' };
+
+    expect(
+      orchestrationPreviousStep({ kind: 'model', action, backTo: 'agent' }),
+    ).toEqual({ kind: 'agent' });
+    expect(
+      orchestrationPreviousStep({ kind: 'model', action, backTo: 'team' }),
+    ).toEqual({ kind: 'team' });
+    expect(
+      orchestrationPreviousStep({ kind: 'model', action, backTo: 'launcher' }),
+    ).toEqual({ kind: 'launcher' });
+  });
+
   it('advertises the full direct-open hotkey range used by Select', () => {
     expect(orchestrationKeyHints()).toContainEqual({
       key: '1-9/a-z/Enter',

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -10,8 +10,11 @@ import {
   orchestrationWrappedLineRows,
 } from '@cli/orchestration/runOrchestrationTui';
 import {
+  buildCliAccountItems,
+  buildCliAgentItems,
   buildCliOrchestrationItems,
   buildCliResumeItems,
+  buildCliTeamItems,
   buildModelAccessItems,
   orchestrationModelAccessView,
 } from '@cli/runtime/orchestration';
@@ -298,8 +301,8 @@ describe('CLI orchestration items', () => {
     expect(buildModelAccessItems(status)).toEqual([
       {
         value: 'chatgpt',
-        label: 'ChatGPT subscription',
-        description: 'Use researcher@example.com with ChatGPT',
+        label: 'Prefer ChatGPT subscription',
+        description: 'Off · researcher@example.com',
       },
       {
         value: 'included',
@@ -314,7 +317,65 @@ describe('CLI orchestration items', () => {
     ]);
   });
 
-  it('groups resumable executions into one launcher row before recent agents', () => {
+  it('offers account management as one startup row with provider actions', () => {
+    const account = {
+      texraSignedIn: true,
+      texraAccountLabel: 'researcher@example.com',
+      chatGptSignedIn: false,
+    };
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [],
+      toolUseAgents: [],
+      account,
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      'New chat',
+      'Account',
+      'Help',
+    ]);
+    expect(buildCliAccountItems(account).map((item) => item.value)).toEqual([
+      { kind: 'account', provider: 'chatgpt', operation: 'sign-in' },
+      { kind: 'account', provider: 'texra', operation: 'switch' },
+      { kind: 'account', provider: 'texra', operation: 'sign-out' },
+    ]);
+  });
+
+  it('offers both sign-in paths when no account is present', () => {
+    const account = {
+      texraSignedIn: false,
+      chatGptSignedIn: false,
+    };
+
+    expect(buildCliAccountItems(account).map((item) => item.value)).toEqual([
+      { kind: 'account', provider: 'chatgpt', operation: 'sign-in' },
+      { kind: 'account', provider: 'texra', operation: 'sign-in' },
+    ]);
+    expect(
+      buildModelAccessItems({
+        active: 'personal',
+        chatGptSignedIn: false,
+        texraSignedIn: false,
+      })[1]?.description,
+    ).toBe('Sign in through Account to use included models');
+  });
+
+  it('does not offer to sign out an environment-managed relay token', () => {
+    const items = buildCliAccountItems({
+      texraSignedIn: true,
+      texraCredentialSource: 'relayToken',
+      chatGptSignedIn: false,
+    });
+
+    expect(items[1]).toMatchObject({
+      label: 'TeXRA relay token',
+      disabled: true,
+      description: 'Managed by the TEXRA_RELAY_TOKEN environment variable',
+    });
+  });
+
+  it('groups resumable executions into one launcher row before agent selection', () => {
     const history = [
       historyEntry('aaaaaaaaaaaa', {
         agent: 'review',
@@ -338,8 +399,7 @@ describe('CLI orchestration items', () => {
     expect(items.map((item) => item.label)).toEqual([
       'New chat',
       'Resume',
-      'Chat with review',
-      'Chat with orchestrator',
+      'Agent',
       'Help',
     ]);
     expect(items[1]?.description).toBe('2 resumable sessions');
@@ -349,7 +409,7 @@ describe('CLI orchestration items', () => {
     ]);
   });
 
-  it('hides delegated child executions from startup recent rows', () => {
+  it('hides delegated child executions from the resume menu', () => {
     const items = buildCliOrchestrationItems({
       presetPlans: [],
       history: [
@@ -380,7 +440,7 @@ describe('CLI orchestration items', () => {
     expect(items.map((item) => item.label)).toEqual([
       'New chat',
       'Resume',
-      'Chat with orchestrator',
+      'Agent',
       'Help',
     ]);
   });
@@ -401,8 +461,7 @@ describe('CLI orchestration items', () => {
 
     expect(items.map((item) => item.label)).toEqual([
       'New chat',
-      'Chat with review',
-      'Chat with orchestrator',
+      'Agent',
       'Help',
     ]);
   });
@@ -436,86 +495,29 @@ describe('CLI orchestration items', () => {
     );
   });
 
-  it('filters recent agent entries to known tool-use agents', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [],
-      history: [
-        historyEntry('aaaaaaaaaaaa', {
-          agent: 'polish',
-          category: AgentCategory.Workflow,
-        }),
-        historyEntry('bbbbbbbbbbbb', { agent: 'missing' }),
-        historyEntry('cccccccccccc', { agent: 'review' }),
-      ],
-      toolUseAgents: [toolUseAgent('assistant'), toolUseAgent('review')],
+  it('orders assistant and orchestrator first in the single-agent menu', () => {
+    const items = buildCliAgentItems([
+      toolUseAgent('review'),
+      toolUseAgent('orchestrator'),
+      toolUseAgent('assistant'),
+      toolUseAgent('research'),
+      toolUseAgent('simplifier'),
+    ]);
+
+    expect(items.map((item) => item.label)).toEqual([
+      'assistant',
+      'orchestrator',
+      'research',
+      'review',
+    ]);
+    expect(items[0]?.value).toEqual({
+      kind: 'chat',
+      agent: 'builtInToolUse:assistant',
     });
-
-    expect(items.map((item) => item.label)).toContain('Chat with review');
-    expect(items.map((item) => item.label)).not.toContain('Chat with polish');
-    expect(items.map((item) => item.label)).not.toContain('Chat with missing');
-  });
-
-  it('does not offer simplifier as an inferred startup chat agent', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [],
-      history: [
-        historyEntry('aaaaaaaaaaaa', { agent: 'simplifier' }),
-        historyEntry('bbbbbbbbbbbb', { agent: 'review' }),
-      ],
-      toolUseAgents: [
-        toolUseAgent('assistant'),
-        toolUseAgent('simplifier'),
-        toolUseAgent('review'),
-      ],
-    });
-
-    expect(items.map((item) => item.label)).toContain('Chat with review');
-    expect(items.map((item) => item.label)).not.toContain(
-      'Chat with simplifier',
-    );
-  });
-
-  it('does not duplicate the default chat agent in startup recent agents', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [],
-      history: [
-        historyEntry('aaaaaaaaaaaa', { agent: 'assistant' }),
-        historyEntry('bbbbbbbbbbbb', { agent: 'review' }),
-      ],
-      toolUseAgents: [toolUseAgent('assistant'), toolUseAgent('review')],
-    });
-
-    expect(items.map((item) => item.label)).toContain('New chat');
-    expect(items.map((item) => item.label)).toContain('Chat with review');
-    expect(items.map((item) => item.label)).not.toContain(
-      'Chat with assistant',
-    );
-  });
-
-  it('does not duplicate the roster default when assistant is hidden', () => {
-    // A scoped roster hides `assistant`, so New chat starts the roster-resolved
-    // default (`research`). It must not also appear as a "Chat with research"
-    // recent row, while a non-default recent agent still does.
-    const items = buildCliOrchestrationItems({
-      presetPlans: [],
-      history: [
-        historyEntry('aaaaaaaaaaaa', { agent: 'research' }),
-        historyEntry('bbbbbbbbbbbb', { agent: 'review' }),
-      ],
-      toolUseAgents: [toolUseAgent('research'), toolUseAgent('review')],
-    });
-
-    expect(items.map((item) => item.label)).toContain('New chat');
-    expect(items.map((item) => item.label)).toContain('Chat with review');
-    expect(items.map((item) => item.label)).not.toContain('Chat with research');
   });
 
   it('lists team presets as runnable orchestration actions', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [readyPresetPlan()],
-      history: [],
-      toolUseAgents: [],
-    });
+    const items = buildCliTeamItems([readyPresetPlan()], {});
 
     expect(items.find((item) => item.label === 'Team physicist')).toEqual(
       expect.objectContaining({
@@ -530,28 +532,32 @@ describe('CLI orchestration items', () => {
   });
 
   it('lists every team preset so the user can switch between teams', () => {
+    const plans = [
+      readyPresetPlan({ id: 'lean-project', name: 'Lean Project' }),
+      readyPresetPlan({ id: 'physicist', name: 'Physicist' }),
+      readyPresetPlan({ id: 'mathematician', name: 'Mathematician' }),
+    ];
     const items = buildCliOrchestrationItems({
-      presetPlans: [
-        readyPresetPlan({ id: 'lean-project', name: 'Lean Project' }),
-        readyPresetPlan({ id: 'physicist', name: 'Physicist' }),
-        readyPresetPlan({ id: 'mathematician', name: 'Mathematician' }),
-      ],
+      presetPlans: plans,
       history: [],
       toolUseAgents: [],
     });
 
     expect(items.map((item) => item.label)).toEqual([
       'New chat',
+      'Team',
+      'Help',
+    ]);
+    expect(buildCliTeamItems(plans, {}).map((item) => item.label)).toEqual([
       'Team lean-project',
       'Team physicist',
       'Team mathematician',
-      'Help',
     ]);
   });
 
   it('does not promote built-in team members to fallback roots', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [
+    const items = buildCliTeamItems(
+      [
         presetPlan(
           {
             id: 'lean-project',
@@ -564,9 +570,8 @@ describe('CLI orchestration items', () => {
           },
         ),
       ],
-      history: [],
-      toolUseAgents: [],
-    });
+      { includeLoginHint: true },
+    );
 
     expect(items.find((item) => item.label === 'Team lean-project')).toEqual(
       expect.objectContaining({
@@ -581,14 +586,13 @@ describe('CLI orchestration items', () => {
   });
 
   it('dedupes launcher footer hints from unavailable teams', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [
+    const items = buildCliTeamItems(
+      [
         presetPlan({ id: 'lean-project', name: 'Lean Project' }),
         presetPlan({ id: 'physicist', name: 'Physicist' }),
       ],
-      history: [],
-      toolUseAgents: [],
-    });
+      { includeLoginHint: true },
+    );
 
     expect(orchestrationFooterHints(items)).toEqual([
       'Team setup: run `texra multi-agent show <team-id>` using the team id shown in each row.',
@@ -597,12 +601,10 @@ describe('CLI orchestration items', () => {
   });
 
   it('omits the launcher login hint after a remote team load attempt', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [presetPlan({ id: 'lean-project', name: 'Lean Project' })],
-      history: [],
-      toolUseAgents: [],
-      includeMultiAgentLoginHint: false,
-    });
+    const items = buildCliTeamItems(
+      [presetPlan({ id: 'lean-project', name: 'Lean Project' })],
+      { includeLoginHint: false },
+    );
 
     expect(orchestrationFooterHints(items)).toEqual([
       'Team setup: run `texra multi-agent show <team-id>` using the team id shown in each row.',
@@ -610,11 +612,10 @@ describe('CLI orchestration items', () => {
   });
 
   it('keeps team launch actions keyed by preset id only', () => {
-    const items = buildCliOrchestrationItems({
-      presetPlans: [presetPlan({ id: 'physicist', name: 'Physicist' })],
-      history: [],
-      toolUseAgents: [],
-    });
+    const items = buildCliTeamItems(
+      [presetPlan({ id: 'physicist', name: 'Physicist' })],
+      {},
+    );
 
     expect(
       items.find((item) => item.label === 'Team physicist')?.value,
@@ -643,11 +644,7 @@ describe('CLI orchestration items', () => {
     const disabledLabels = view.items
       .filter((item) => item.disabled)
       .map((item) => item.label);
-    expect(disabledLabels).toEqual([
-      'New chat',
-      'Chat with review',
-      'Team physicist',
-    ]);
+    expect(disabledLabels).toEqual(['New chat']);
     expect(
       view.items.find((item) => item.label === 'Resume'),
     ).not.toHaveProperty('disabled');
@@ -660,8 +657,8 @@ describe('CLI orchestration items', () => {
 
   it('preserves unavailable team descriptions when model access is also blocked', () => {
     const view = orchestrationModelAccessView(
-      buildCliOrchestrationItems({
-        presetPlans: [
+      buildCliTeamItems(
+        [
           presetPlan(
             {
               id: 'lean-project',
@@ -674,18 +671,12 @@ describe('CLI orchestration items', () => {
             },
           ),
         ],
-        history: [],
-        toolUseAgents: [],
-      }),
+        {},
+      ),
       [modelAccess('deepseekT', 'provider-key', false)],
       'personal',
     );
 
-    expect(view.items[0]).toMatchObject({
-      label: 'New chat',
-      disabled: true,
-      description: 'No personal API-key models are runnable',
-    });
     expect(
       view.items.find((item) => item.label === 'Team lean-project'),
     ).toMatchObject({

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -165,6 +165,7 @@ describe('SettingsAgentCatalogController', () => {
         ...persistedPreset,
         icon: 'bookmark',
       },
+      unresolvedNames: ['missing'],
     });
     assert.deepEqual(enabled.workflow, ['remote:writer']);
     // Unresolved names are kept bare so the agent joins the roster the

--- a/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
+++ b/src/test-kernel/frontend/CodexSubscriptionSignIn.vitest.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   loginWithLoopback: vi.fn(),
+  invalidateModelOptionsCache: vi.fn(),
   setPreferCodexSubscription: vi.fn(),
   showLoggedErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
@@ -37,6 +38,10 @@ vi.mock('@auth/codex', () => ({
 
 vi.mock('@frontend/ui/errorHandlingUtils', () => ({
   showLoggedErrorMessage: mocks.showLoggedErrorMessage,
+}));
+
+vi.mock('@model/computeModelOptions', () => ({
+  invalidateModelOptionsCache: mocks.invalidateModelOptionsCache,
 }));
 
 const { signInWithChatGptSubscription } =
@@ -147,6 +152,7 @@ describe('signInWithChatGptSubscription', () => {
     const signedIn = await signInWithChatGptSubscription('TestChannel');
 
     expect(signedIn).toBe(true);
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(mocks.showInformationMessage).toHaveBeenCalledWith(
       'Signed in with ChatGPT as person@example.com. ChatGPT subscription is enabled for Codex models.',
     );

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -174,6 +174,33 @@ describe('executeCommand', () => {
     assert.doesNotThrow(() => process.kill(childPid, 0));
     process.kill(childPid, 'SIGKILL');
   }, 20_000);
+
+  it('unblocks timed-out array-form await when a descendant holds stdio', async () => {
+    if (process.platform === 'win32') return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'texra-exec-timeout-array-'));
+    tempDirs.push(dir);
+    const pidFile = join(dir, 'sleep.pid');
+    const promise = executeCommand(
+      ['bash', '-c', 'sleep 60 & echo $! > "$PID_FILE"; wait'],
+      {
+        cwd: dir,
+        env: { PID_FILE: pidFile },
+        timeout: 50,
+      },
+    );
+
+    await waitForFile(pidFile);
+    const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+    assert.ok(Number.isInteger(childPid) && childPid > 0);
+
+    const result = await promise;
+
+    assert.equal(result.success, false);
+    assert.equal(result.timedOut, true);
+    assert.doesNotThrow(() => process.kill(childPid, 0));
+    process.kill(childPid, 'SIGKILL');
+  }, 20_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -235,7 +235,7 @@ export async function executeCommand(
     // spawns a single non-detached process and leaves all signalling to
     // execa's own `cancelSignal` / `forceKillAfterDelay` natives below; its
     // only hand-rolled piece is the signal-free stream-destroy backstop
-    // installed in its abort listener.
+    // armed for abort and timeout teardown.
     const terminateSubprocess = (signal: NodeJS.Signals): void => {
       const pid = subprocess.pid;
       if (!pid) return;
@@ -253,13 +253,20 @@ export async function executeCommand(
       }
     };
 
-    const installAbortListener = (onAbort: () => void): void => {
-      if (!options.signal) return;
-      options.signal.addEventListener('abort', onAbort, { once: true });
-      removeAbortListener = () => {
-        options.signal?.removeEventListener('abort', onAbort);
-      };
-      if (options.signal.aborted) onAbort();
+    const installAbortListener = (
+      onAbort: () => void,
+      armOnTimeout = false,
+    ): void => {
+      if (options.signal) {
+        options.signal.addEventListener('abort', onAbort, { once: true });
+        removeAbortListener = () => {
+          options.signal?.removeEventListener('abort', onAbort);
+        };
+        if (options.signal.aborted) onAbort();
+      }
+      if (armOnTimeout && options.timeout !== undefined) {
+        shellTimeoutId = setTimeout(onAbort, options.timeout);
+      }
     };
 
     let shellTimeout: number | undefined;
@@ -323,11 +330,12 @@ export async function executeCommand(
       // No signal is sent here — the array form intentionally keeps no
       // process-group semantics, so the descendant itself is left alone.
       installAbortListener(() => {
+        if (forceKillTimeoutId !== undefined) return;
         forceKillTimeoutId = setTimeout(() => {
           subprocess.stdout?.destroy();
           subprocess.stderr?.destroy();
         }, FORCE_KILL_DELAY_MS);
-      });
+      }, true);
     } else {
       installAbortListener(() => {
         shellAborted = true;


### PR DESCRIPTION
## Summary

This change improves the CLI startup and approval experience while completing several currently actionable maintenance items.

- reorganizes the CLI launcher behind dedicated Resume, Agent, Team, Model access, and Account entries
- adds TeXRA and ChatGPT sign-in, account switching, and sign-out actions to the launcher
- presents ChatGPT subscription routing as the same “Prefer ChatGPT subscription” switch used by the extension
- makes extension ChatGPT sign-in refresh model availability and expose compatible OpenAI models without an API key
- prompts for Researcher Access when an applied team is missing relay-served members, then reloads and reapplies the roster
- changes command rejection to open the feedback field and shortens the session-wide command choice to “approve all”
- migrates the remaining extension and progress-view live-status readers from the legacy `STREAM_STATUS` vocabulary to `StreamPhase`
- arms the array-form command stream-teardown backstop for execa timeout kills as well as aborts
- records the binary agent-category decision and the 12-hex external-inquiry identifier ownership

## Motivation and design

The launcher had accumulated several top-level rows and separated account operations from the place where model access is selected. The revised structure keeps the primary menu short and makes account and access state directly manageable.

The extension status migration follows the binding StreamPhase-native design for #7993. Persisted-data and trace compatibility schemas remain intact; this change removes live extension decisions over the legacy vocabulary without advancing dated deletion gates.

For #8283, execa can kill the tracked array-form process on timeout while a descendant keeps inherited output streams open. The existing delayed stream teardown was armed only by an abort signal. The same owner now arms it for timeout teardown, preserving the deliberate absence of array-form process-group killing.

## User impact

- The CLI launcher is shorter and easier to scan.
- The extension exposes compatible OpenAI models immediately after ChatGPT sign-in, without requiring an OpenAI API key.
- Applying a team while signed out offers Researcher Access when relay-served members are unavailable.
- ChatGPT subscription preference is explicitly switchable rather than presented as an unrelated access route.
- Pressing `n` on an approval opens the rejection-feedback field; the separate `e feedback` action is removed.
- Commands whose descendants retain output streams no longer leave timeout callers awaiting those streams indefinitely.

Closes #8283.
Advances #7993 and #7727.

## Validation

- commit-time `npm run format` passed for every commit
- full TypeScript type checking passed
- `npm run lint` completed with zero errors
- `npm run compile:fast` passed
- focused CLI approval, launcher, model-access, extension status, architecture-ratchet, and timeout suites passed
- the full Vitest run passed 5,888 tests and had one timeout in `RunChatSignalOwnership.vitest.mts`; that test passed immediately when rerun in isolation
- `git diff --check origin/main...HEAD` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and subscription routing, a large launcher/orchestration refactor, and broad extension stream-status semantics; the exec timeout change alters subprocess teardown timing for array-form commands.
> 
> **Overview**
> **Reorganizes the CLI startup launcher** so Resume, Agent, Team, Model access, and Account are separate pickers with hierarchical back navigation, replacing long lists of recent agents and inline teams on the root menu. **Account** now drives TeXRA and ChatGPT sign-in, switch, and sign-out from the launcher loop, with model-option cache invalidation after auth changes.
> 
> **Aligns ChatGPT routing** with the extension: model access labels it **Prefer ChatGPT subscription** (toggle on/off when already signed in), extension ChatGPT sign-in **invalidates the model cache**, and onboarding/settings copy stresses OpenAI models without an API key.
> 
> **Extension team apply** surfaces unresolved remote members, offers Researcher Access sign-in, **refreshes remote agents**, and reapplies the preset; preset apply results now include **unresolved roster names**.
> 
> **CLI approval modals** map **`n` to rejection feedback** (removes separate **`e` feedback**), rename session-wide bash approval to **approve all**, and adjust compact hint fallbacks.
> 
> **Progress view and status bar** stop using legacy **`STREAM_STATUS`** for live UI; they use **`StreamPhase`**, **`DEFAULT_STREAM_METADATA_STATUS`**, and **`isInFlightPhase`** / related helpers instead.
> 
> **Array-form `executeCommand`** arms the delayed stdout/stderr destroy backstop on **timeout** as well as abort, so callers are not left awaiting streams held by descendants after execa kills the tracked process.
> 
> Smaller updates: changelog, agent SDK doc note on binary **`AgentCategory`**, external inquiry ID comment, and API status line when both relay and personal keys exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e17ac5e3ee7e71b550caacfad075c4435fe8568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->