### PR TITLE
fix(cli): preserve context after interrupted response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Interrupted chats retain their earlier context** — pressing Escape during
+  an active CLI response now preserves the resumable conversation, and the next
+  message continues that conversation instead of silently starting a new one.
 - **Model access choices apply to the launched session** — switching access at
   startup overrides an earlier command-line mode, and selecting ChatGPT turns
   off OpenRouter routing so requests use the chosen subscription.

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -83,6 +83,37 @@ import {
 } from './tui/state/transcript';
 import { projectStreamTranscript } from './tui/state/transcriptProjection';
 
+interface InterruptedFollowUp {
+  readonly text: string;
+  readonly mediaFiles?: readonly string[] | undefined;
+  readonly displayText?: string | undefined;
+}
+
+type InterruptedFollowUpAdmission =
+  | { readonly kind: 'not_interrupted' }
+  | {
+      readonly kind: 'accepted';
+      readonly streamId: StreamTabId;
+      readonly completion: Promise<boolean>;
+    };
+
+interface InterruptedContinuationBatch {
+  readonly streamId: StreamTabId;
+  readonly followUps: InterruptedFollowUp[];
+  completion: Promise<boolean>;
+  superseded: boolean;
+}
+
+interface SupersededInterruptedRecovery {
+  readonly streamId: StreamTabId;
+  readonly followUps: readonly InterruptedFollowUp[];
+}
+
+interface AutoResumeOptions {
+  readonly extraFollowUps?: readonly InterruptedFollowUp[];
+  readonly onFollowUpQueueReady?: () => void;
+}
+
 // ---------------------------------------------------------------------------
 // Reusable config builders & execution-registration helpers
 // (moved from runChatTui.tsx — host-neutral, no Ink dependency)
@@ -168,6 +199,15 @@ export interface ChatSessionController {
   stop(): void;
 
   /**
+   * Atomically admit a message into an interrupted root conversation.
+   * Messages arriving during teardown share one resume and are replayed in
+   * admission order.
+   */
+  admitInterruptedFollowUp(
+    followUp: InterruptedFollowUp,
+  ): InterruptedFollowUpAdmission;
+
+  /**
    * Attempt to resume a queued follow-up target from the CLI platform port.
    * Returns true only when this controller accepts the target resume.
    */
@@ -204,6 +244,48 @@ export function createChatSessionController(
     followUpQueue,
     snapshotStore,
   } = init;
+  let interruptedContinuation: InterruptedContinuationBatch | undefined;
+
+  const supersedeInterruptedRecovery = ():
+    SupersededInterruptedRecovery | undefined => {
+    const streamId = session.interruptedStreamId;
+    const followUps = interruptedContinuation
+      ? [...interruptedContinuation.followUps]
+      : [];
+    if (interruptedContinuation) {
+      interruptedContinuation.superseded = true;
+      interruptedContinuation = undefined;
+    }
+    session.interruptedStreamId = undefined;
+    return streamId ? { streamId, followUps } : undefined;
+  };
+
+  const enqueueRecoveryFollowUps = (
+    recovery: SupersededInterruptedRecovery | undefined,
+    streamId: StreamTabId,
+  ): void => {
+    for (const followUp of recovery?.followUps ?? []) {
+      defaultSession().followUps.enqueue(streamId, followUp, { force: true });
+    }
+    if (recovery?.followUps.length) {
+      defaultSession().events.emit({
+        scope: 'session',
+        event: {
+          type: 'updateQueuedFollowUps',
+          payload: { streamId },
+        },
+      });
+    }
+  };
+
+  const restoreInterruptedRecovery = (
+    recovery: SupersededInterruptedRecovery | undefined,
+  ): void => {
+    const streamId = session.interruptedStreamId ?? recovery?.streamId;
+    if (!streamId) return;
+    session.interruptedStreamId = streamId;
+    enqueueRecoveryFollowUps(recovery, streamId);
+  };
 
   // -----------------------------------------------------------------------
   // Internal helpers
@@ -212,6 +294,7 @@ export function createChatSessionController(
   const interruptActiveRun = (): void => {
     clearApprovals();
     if (!session.streamId) return;
+    session.interruptedStreamId = session.streamId;
     defaultSession().executions.stopAgentStream(session.streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: session.runtimeHost,
@@ -277,6 +360,7 @@ export function createChatSessionController(
   // -----------------------------------------------------------------------
 
   const startRootRun = (config: AgentConfigPayload): void => {
+    session.interruptedStreamId = undefined;
     const currentModel = config.model;
     const sessionContext = getSessionContext(currentModel);
     patchSessionMeta({
@@ -362,9 +446,11 @@ export function createChatSessionController(
       return;
     }
 
+    const supersededRecovery = supersedeInterruptedRecovery();
     try {
       const resolution = preResolved ?? (await resolveCliResumeSnapshot(id));
       if (resolution.kind !== 'toolUse') {
+        restoreInterruptedRecovery(supersededRecovery);
         appendLocalErrorTranscript(explainNonResumable(resolution, id));
         markChatTuiRunCompleted(session);
         resolveRunPromise();
@@ -414,6 +500,7 @@ export function createChatSessionController(
       // matching `tryResumeStream()`'s stop-check after its own preparatory
       // awaits — instead of starting an agent the user already cancelled.
       if (session.stopRequested) {
+        restoreInterruptedRecovery(supersededRecovery);
         finalize();
         resolveRunPromise();
         return;
@@ -424,6 +511,10 @@ export function createChatSessionController(
           resumeToolUseFromSnapshot(resolution.snapshot, runtimeHost, {
             approvalPromptsUnavailable: approvalsUnavailable,
             runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+            drainedFollowUps: supersededRecovery?.followUps.map((followUp) => ({
+              ...followUp,
+              origin: 'user' as const,
+            })),
             isCancellationRequested: () => session.stopRequested,
           }),
         )
@@ -448,13 +539,17 @@ export function createChatSessionController(
       // interface contract.
       runChain.then(resolveRunPromise, rejectRunPromise);
     } catch (error: unknown) {
+      restoreInterruptedRecovery(supersededRecovery);
       reportRunFailure(error);
       markChatTuiRunCompleted(session);
       resolveRunPromise();
     }
   };
 
-  const tryResumeStream = (streamId: StreamTabId): Promise<boolean> => {
+  const tryResumeStream = (
+    streamId: StreamTabId,
+    options: AutoResumeOptions = {},
+  ): Promise<boolean> => {
     let resolveRun: (resumed: boolean) => void = () => {};
     let rejectRun: (error: unknown) => void = () => {};
     const runPromise = new Promise<boolean>((resolve, reject) => {
@@ -529,6 +624,15 @@ export function createChatSessionController(
                 approvalPromptsUnavailable: approvalsUnavailable,
                 runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
                 allowWaitingResult: true,
+                extraFollowUps: options.extraFollowUps,
+                onFollowUpQueueReady: () => {
+                  if (options.onFollowUpQueueReady) {
+                    options.onFollowUpQueueReady();
+                  } else {
+                    const recovery = supersedeInterruptedRecovery();
+                    enqueueRecoveryFollowUps(recovery, streamId);
+                  }
+                },
                 isCancellationRequested: () => session.stopRequested,
                 onResult: (result) => {
                   resumedToWaiting = result.outcome === STREAM_PHASE.WAITING;
@@ -575,6 +679,63 @@ export function createChatSessionController(
     return runPromise;
   };
 
+  const admitInterruptedFollowUp = (
+    followUp: InterruptedFollowUp,
+  ): InterruptedFollowUpAdmission => {
+    if (interruptedContinuation) {
+      interruptedContinuation.followUps.push(followUp);
+      return {
+        kind: 'accepted',
+        streamId: interruptedContinuation.streamId,
+        completion: interruptedContinuation.completion,
+      };
+    }
+
+    if (!session.interruptedStreamId) {
+      return { kind: 'not_interrupted' };
+    }
+
+    const batch: InterruptedContinuationBatch = {
+      streamId: session.interruptedStreamId,
+      followUps: [followUp],
+      completion: Promise.resolve(false),
+      superseded: false,
+    };
+    batch.completion = (async () => {
+      await session.runPromise?.catch(() => undefined);
+      if (batch.superseded) return true;
+      try {
+        const resumed = await tryResumeStream(batch.streamId, {
+          extraFollowUps: batch.followUps,
+          onFollowUpQueueReady: () => {
+            session.interruptedStreamId = undefined;
+            if (interruptedContinuation === batch) {
+              interruptedContinuation = undefined;
+            }
+          },
+        });
+        if (
+          !resumed &&
+          !batch.superseded &&
+          session.interruptedStreamId === undefined
+        ) {
+          session.interruptedStreamId = batch.streamId;
+        }
+        return resumed;
+      } finally {
+        if (interruptedContinuation === batch) {
+          interruptedContinuation = undefined;
+        }
+      }
+    })();
+    interruptedContinuation = batch;
+    return {
+      kind: 'accepted',
+      streamId: batch.streamId,
+      completion: batch.completion,
+    };
+  };
+
   // -----------------------------------------------------------------------
   // stop
   // -----------------------------------------------------------------------
@@ -588,6 +749,7 @@ export function createChatSessionController(
     startRootRun,
     resume,
     stop,
+    admitInterruptedFollowUp,
     tryResumeStream,
     canStartRootRun: () => chatTuiCanStartRootRun(session),
   };

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -439,6 +439,7 @@ export async function runChat(
 
   const session: TuiSession = {
     streamId: undefined,
+    interruptedStreamId: undefined,
     executionId: undefined,
     runtimeHost: undefined,
     runPromise: undefined,
@@ -687,6 +688,23 @@ export async function runChat(
         prepared.reservedSkillActivations,
       );
     };
+    if (!childFollowUpTarget) {
+      const interruptedAdmission = chatController.admitInterruptedFollowUp({
+        text: prepared.instruction,
+        mediaFiles,
+        displayText: prepared.displayInstruction,
+      });
+      if (interruptedAdmission.kind === 'accepted') {
+        const resumed = await interruptedAdmission.completion;
+        if (resumed) return;
+        restoreReservedSkillActivations();
+        appendLocalAssistantTranscript(
+          'The interrupted conversation could not be restored. Use /resume to retry it, or /clear to start a new conversation.',
+          interruptedAdmission.streamId,
+        );
+        return;
+      }
+    }
     if (!childFollowUpTarget && chatTuiCanStartRootRun(session)) {
       const started = await startSession(
         prepared.instruction,

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -15,6 +15,8 @@ import {
 
 export interface ClearableTuiSessionState {
   streamId: StreamTabId | undefined;
+  /** Root conversation that remains recoverable after an interrupted turn. */
+  interruptedStreamId: StreamTabId | undefined;
   executionId: string | undefined;
   runtimeHost?: AgentRuntimeHost;
   runPromise: Promise<void> | undefined;
@@ -44,6 +46,7 @@ export function clearTuiSessionRunState(
   session: ClearableTuiSessionState,
 ): void {
   session.streamId = undefined;
+  session.interruptedStreamId = undefined;
   session.executionId = undefined;
   session.runtimeHost = undefined;
   session.runPromise = undefined;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -165,10 +165,15 @@ export type ToolUseFlowSetupCallback = (
   context: ToolUseFlowContext,
 ) => void | (() => void);
 
-type ToolUsePersistedFlow<C> = PersistedFlow<
+class ToolUsePersistedFlow<C> extends PersistedFlow<
   ToolUseRunShared,
   ToolUseServices<C>
->;
+> {
+  async prepareForFollowUp(shared: ToolUseRunShared): Promise<void> {
+    shared.shouldSkipCycle = true;
+    await this.resetNodeHistory(shared);
+  }
+}
 
 const IMMEDIATE_COMPACTION_FOLLOW_UP =
   'The user requested immediate context compaction. Do not start a new task; continue only far enough for the runtime to process any available context compaction, and do not claim that compaction has completed.';
@@ -352,6 +357,7 @@ export async function runToolUseFlow<C = unknown>(
   let teardownSetup: (() => void) | undefined;
   let preserveResumeRecord = false;
   let persistenceRecoveryPending = false;
+  let flowRunStarted = false;
   const compatibilityKey = activeModelHandlerCompatibilityKey(
     services.modelHandler,
   );
@@ -477,7 +483,7 @@ export async function runToolUseFlow<C = unknown>(
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);
     waitNode.on(FlowTransition.WAITING, waitNode);
-    const pf: ToolUsePersistedFlow<C> = new PersistedFlow(
+    const pf = new ToolUsePersistedFlow<C>(
       prepareNode,
       kv,
       executionId,
@@ -495,7 +501,17 @@ export async function runToolUseFlow<C = unknown>(
         await store.writeWorkspaceFiles(currentTouchedFiles);
       }
     });
-    const finalAction = await pf.run(shared);
+    flowRunStarted = true;
+    let finalAction: Awaited<ReturnType<typeof pf.run>>;
+    try {
+      finalAction = await pf.run(shared);
+    } catch (error: unknown) {
+      if (input.checkInterruption()) {
+        shared = (await pf.getShared()) ?? shared;
+        await pf.prepareForFollowUp(shared);
+      }
+      throw error;
+    }
     // Re-read shared from the flow record — PersistedFlow deep-clones the
     // initial shared via structuredClone, so nodes mutate the clone, not the
     // original object.  Without this, reads of lastError, messages, etc. below
@@ -527,6 +543,9 @@ export async function runToolUseFlow<C = unknown>(
         cancelled: input.checkInterruption(),
       });
     }
+    if (outcome === RUN_OUTCOME.CANCELLED && input.checkInterruption()) {
+      await pf.prepareForFollowUp(shared);
+    }
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification, while preserving terminal run accounting.
@@ -555,6 +574,8 @@ export async function runToolUseFlow<C = unknown>(
         'Flow record preserved after persistence recovery failure';
     } else if (outcome === STREAM_PHASE.WAITING) {
       preservationReason = 'Flow record preserved for native subagent WAITING';
+    } else if (flowRunStarted && input.checkInterruption()) {
+      preservationReason = 'Flow record preserved after user interruption';
     } else if (shared.userCancelledRetry) {
       preservationReason =
         'Flow record preserved for resume after retry cancellation';

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -33,6 +33,11 @@ export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
    */
   readonly extraFollowUps?: readonly FollowUpQueueInput[];
   /**
+   * Fires after the shared stream queue is acquired and marked RESUMING, but
+   * before its queued items are drained into the rebuilt session.
+   */
+  readonly onFollowUpQueueReady?: () => void;
+  /**
    * Host-specific failure surface (log + toast). Invoked after the stream has
    * been returned to WAITING, so a blocking host dialog cannot strand the
    * stream in RESUMING while it awaits dismissal.
@@ -91,6 +96,7 @@ export async function resumeQueuedToolUseSnapshot(
     }
   };
   try {
+    options.onFollowUpQueueReady?.();
     followUps = [...seed, ...followUpsQueue.drainItems(streamId)];
     session.events.emit({
       scope: 'session',

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -17,6 +17,7 @@ import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   FLOW_RECORD_SCHEMA_VERSION,
+  PersistedFlow,
   PersistedFlowStateError,
   flowKey,
   type FlowRecord,
@@ -115,6 +116,10 @@ async function runPersistedFlow(
   snapshot: ToolUseSessionSnapshot | undefined,
   onSetup?: (context: ToolUseSetupContext) => void,
   session: SessionHandle = createTestSession(),
+  options: {
+    readonly isSubagent?: boolean;
+    readonly onIdle?: () => void;
+  } = {},
 ): Promise<RunToolUseFlowResult> {
   const config = snapshot?.agentConfig ?? CONFIG;
   const userVarChannels = snapshot?.user ?? {
@@ -151,7 +156,8 @@ async function runPersistedFlow(
           },
           setAbortController: () => {},
           ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
-          isSubagent: true,
+          isSubagent: options.isSubagent ?? true,
+          onIdle: options.onIdle,
           toolInjections: new ToolInjectionRegistry(),
         },
         new MapToolRegistry({}),
@@ -775,6 +781,80 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     } finally {
       readSpy.mockRestore();
       writeSpy.mockRestore();
+      deleteSpy.mockRestore();
+    }
+  });
+
+  it('preserves the resumable flow after an established run is interrupted', async () => {
+    const executionId = 'abc-interrupted-conversation' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-interrupted-conversation' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    let flowContext: ToolUseSetupContext | undefined;
+
+    const result = await runPersistedFlow(
+      executionId,
+      streamId,
+      snapshot,
+      (context) => {
+        flowContext = context;
+      },
+      createTestSession(),
+      {
+        isSubagent: false,
+        onIdle: () => flowContext?.interrupt(),
+      },
+    );
+
+    expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+    expect(await store.read<FlowRecord>(flowKey(executionId))).toMatchObject({
+      cursor: { nextNodeId: 'start' },
+      shared: { shouldSkipCycle: true },
+    });
+  });
+
+  it('preserves an established flow when provider cancellation rejects the run', async () => {
+    const executionId = 'abc-interrupted-provider' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-interrupted-provider' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const store = getExecutionStore(executionId);
+    let flowContext: ToolUseSetupContext | undefined;
+    const stored = {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        ...VALID_TOOL_USE_SHARED,
+        modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    };
+    await store.write(flowKey(executionId), stored);
+    const abortError = new DOMException(
+      'This operation was aborted',
+      'AbortError',
+    );
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockImplementationOnce(async () => {
+        flowContext?.interrupt();
+        throw abortError;
+      });
+    const deleteSpy = vi.spyOn(store, 'delete');
+
+    try {
+      await expect(
+        runPersistedFlow(executionId, streamId, snapshot, (context) => {
+          flowContext = context;
+        }),
+      ).rejects.toBe(abortError);
+      expect(deleteSpy).not.toHaveBeenCalledWith(flowKey(executionId));
+      expect(await store.read<FlowRecord>(flowKey(executionId))).toMatchObject({
+        cursor: { nextNodeId: 'start' },
+        shared: { shouldSkipCycle: true },
+      });
+    } finally {
+      runSpy.mockRestore();
       deleteSpy.mockRestore();
     }
   });

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -124,6 +124,27 @@ describe('resumeToolUseSnapshot', () => {
     });
   });
 
+  it('opens late follow-up routing before draining the resume queue', async () => {
+    const onFollowUpQueueReady = vi.fn(() => {
+      defaultSession().followUps.enqueue(STREAM, {
+        text: 'queued at the ready boundary',
+      });
+    });
+
+    await resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+      onFollowUpQueueReady,
+      onError: vi.fn(),
+    });
+
+    expect(onFollowUpQueueReady).toHaveBeenCalledOnce();
+    const appendFollowUp = vi.fn();
+    capturedSetupSession()({ appendFollowUp });
+    expect(appendFollowUp).toHaveBeenCalledWith({
+      text: 'queued at the ready boundary',
+      origin: 'user',
+    });
+  });
+
   it('passes snapshot parent stream identity to the leaf resume', async () => {
     const parentStreamId = 'stream:parent' as StreamTabId;
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -45,6 +45,7 @@ afterEach(() => {
 function createSession(): TuiSession {
   return {
     streamId: undefined,
+    interruptedStreamId: undefined,
     executionId: undefined,
     runPromise: undefined,
     runExitCode: CliExitCode.Success,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -727,6 +727,7 @@ describe('CLI TUI row allocation', () => {
     const startupPromise = new Promise<void>(() => {});
     const session = {
       streamId: root,
+      interruptedStreamId: undefined,
       executionId: 'exec-old',
       runPromise: undefined,
       runExitCode: CliExitCode.AgentError,
@@ -752,6 +753,7 @@ describe('CLI TUI row allocation', () => {
     const startupPromise = new Promise<void>(() => {});
     const session = {
       streamId: root,
+      interruptedStreamId: undefined,
       executionId: 'exec-old',
       runPromise: startupPromise,
       runExitCode: CliExitCode.AgentError,
@@ -1142,6 +1144,7 @@ describe('CLI TUI row allocation', () => {
   it('clears stale resume ids when clearing chat session run state', () => {
     const session = {
       streamId: root,
+      interruptedStreamId: root,
       executionId: 'old-execution',
       runPromise: Promise.resolve(),
       runExitCode: CliExitCode.Interrupted,
@@ -1153,6 +1156,7 @@ describe('CLI TUI row allocation', () => {
 
     expect(session).toMatchObject({
       streamId: undefined,
+      interruptedStreamId: undefined,
       executionId: undefined,
       runPromise: undefined,
       runExitCode: 0,

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   clearLocalTranscript: vi.fn(),
   moveLocalTranscriptToStream: vi.fn(),
   resolveCliResumeSnapshot: vi.fn(),
+  followUpEnqueue: vi.fn(),
+  sessionEventEmit: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -147,6 +149,7 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 function makeSession(overrides: Partial<TuiSession> = {}): TuiSession {
   return {
     streamId: undefined,
+    interruptedStreamId: undefined,
     executionId: undefined,
     runtimeHost: undefined,
     runPromise: undefined,
@@ -228,6 +231,34 @@ function makeResolvedResume() {
   };
 }
 
+function makeInterruptedController(
+  runPromise: Promise<void>,
+  runCompleted: boolean,
+) {
+  const session = makeSession({
+    streamId: 'stream-1' as StreamTabId,
+    interruptedStreamId: 'stream-1' as StreamTabId,
+    executionId: 'exec-1',
+    runPromise,
+    runCompleted,
+    stopRequested: true,
+  });
+  const snapshotStore = makeResumeSnapshotStore({
+    executionId: 'exec-1',
+    config: makeResumeConfig(),
+  });
+  mocks.resolveAndResumeStream.mockImplementationOnce(
+    async (
+      _streamId: StreamTabId,
+      ports: { resumeToolUseSnapshot(snapshot: unknown): Promise<boolean> },
+    ) => ports.resumeToolUseSnapshot({ version: 2 }),
+  );
+  return {
+    ctrl: createChatSessionController(makeInit({ session, snapshotStore })),
+    session,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Predicate: chatTuiCanStartRootRun
 // ---------------------------------------------------------------------------
@@ -292,7 +323,8 @@ describe('createChatSessionController', () => {
     mocks.defaultSession.mockReturnValue({
       useHostInteractions: vi.fn(() => mocks.detachHostInteractions),
       interactions: {},
-      events: {},
+      events: { emit: mocks.sessionEventEmit },
+      followUps: { enqueue: mocks.followUpEnqueue },
       status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
       executions: { stopAgentStream: mocks.stopAgentStream },
       transcripts: { ensureLoaded: vi.fn(async () => undefined) },
@@ -300,7 +332,13 @@ describe('createChatSessionController', () => {
     mocks.resolveAndResumeStream.mockReset();
     mocks.resolveAndResumeStream.mockResolvedValue(true);
     mocks.resumeQueuedToolUseSnapshot.mockReset();
-    mocks.resumeQueuedToolUseSnapshot.mockResolvedValue(true);
+    mocks.resumeQueuedToolUseSnapshot.mockImplementation(
+      async (...args: unknown[]) => {
+        const options = args[3] as ResumeQueuedToolUseOptions;
+        options.onFollowUpQueueReady?.();
+        return true;
+      },
+    );
     mocks.projectStreamTranscript.mockReset();
     mocks.notify.mockReset();
     mocks.appendLocalAssistantTranscript.mockReset();
@@ -309,6 +347,8 @@ describe('createChatSessionController', () => {
     mocks.clearLocalTranscript.mockReset();
     mocks.moveLocalTranscriptToStream.mockReset();
     mocks.resolveCliResumeSnapshot.mockReset();
+    mocks.followUpEnqueue.mockReset();
+    mocks.sessionEventEmit.mockReset();
     mocks.resumeToolUseFromSnapshot.mockReset();
     mocks.resumeToolUseFromSnapshot.mockResolvedValue({
       category: 'toolUse',
@@ -438,6 +478,56 @@ describe('createChatSessionController', () => {
     expect(session.runCompleted).toBe(true);
   });
 
+  it('manual resume supersedes stale interrupted recovery state', async () => {
+    const session = makeSession({
+      interruptedStreamId: 'stream-interrupted' as StreamTabId,
+      runCompleted: true,
+      stopRequested: true,
+    });
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    await ctrl.resume('aaaaaa' as ExecutionId, makeResolvedResume());
+
+    expect(session.streamId).toBe('stream-resume');
+    expect(session.interruptedStreamId).toBeUndefined();
+    expect(ctrl.admitInterruptedFollowUp({ text: 'Route normally.' })).toEqual({
+      kind: 'not_interrupted',
+    });
+  });
+
+  it('transfers an admitted interruption batch to manual resume', async () => {
+    const teardown = pDefer<void>();
+    const { ctrl } = makeInterruptedController(teardown.promise, true);
+    const admission = ctrl.admitInterruptedFollowUp({
+      text: 'Preserve this accepted message.',
+    });
+    expect(admission.kind).toBe('accepted');
+    if (admission.kind !== 'accepted') return;
+
+    const manualResume = ctrl.resume(
+      'aaaaaa' as ExecutionId,
+      makeResolvedResume(),
+    );
+    teardown.resolve();
+
+    await manualResume;
+    await expect(admission.completion).resolves.toBe(true);
+    await vi.waitFor(() =>
+      expect(mocks.resumeToolUseFromSnapshot).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Object),
+        expect.objectContaining({
+          drainedFollowUps: [
+            {
+              text: 'Preserve this accepted message.',
+              origin: 'user',
+            },
+          ],
+        }),
+      ),
+    );
+  });
+
   it('resume() suspended on the resolved snapshot keeps a concurrent follow-up wake from also claiming the root-run slot', async () => {
     // Reproduces the finding's interleaving: resume(A) suspends on
     // resolveCliResumeSnapshot (an await-suspension point) with the slot
@@ -490,7 +580,10 @@ describe('createChatSessionController', () => {
       transcripts: { ensureLoaded: () => ensureLoaded.promise },
     });
 
-    const session = makeSession({ runCompleted: true });
+    const session = makeSession({
+      interruptedStreamId: 'stream-interrupted' as StreamTabId,
+      runCompleted: true,
+    });
     const snapshotStore = makeResumeSnapshotStore({});
     const ctrl = createChatSessionController(
       makeInit({ session, snapshotStore }),
@@ -536,10 +629,14 @@ describe('createChatSessionController', () => {
 
     expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
     expect(session.runCompleted).toBe(true);
+    expect(session.interruptedStreamId).toBe('stream-resume');
   });
 
   it('reports resume rehydration failures without rejecting the TUI submit path', async () => {
-    const session = makeSession({ runCompleted: true });
+    const session = makeSession({
+      interruptedStreamId: 'stream-interrupted' as StreamTabId,
+      runCompleted: true,
+    });
     const snapshotStore = makeResumeSnapshotStore({
       load: async () => {
         throw new Error('snapshot load failed');
@@ -559,6 +656,7 @@ describe('createChatSessionController', () => {
     expect(mocks.resumeToolUseFromSnapshot).not.toHaveBeenCalled();
     expect(session.runExitCode).toBe(CliExitCode.AgentError);
     expect(session.runCompleted).toBe(true);
+    expect(session.interruptedStreamId).toBe('stream-interrupted');
     expect(ctrl.canStartRootRun()).toBe(true);
   });
 
@@ -690,6 +788,151 @@ describe('createChatSessionController', () => {
     });
     expect(rootStreamId.get()).toBe('stream-1');
     expect(mocks.notify).not.toHaveBeenCalledWith({ kind: 'agentFinished' });
+  });
+
+  it('launcher resume supersedes stale interrupted recovery state', async () => {
+    const { ctrl, session } = makeInterruptedController(
+      Promise.resolve(),
+      true,
+    );
+
+    await expect(ctrl.tryResumeStream('stream-1')).resolves.toBe(true);
+
+    expect(session.interruptedStreamId).toBeUndefined();
+    expect(ctrl.admitInterruptedFollowUp({ text: 'Route normally.' })).toEqual({
+      kind: 'not_interrupted',
+    });
+  });
+
+  it('transfers an admitted interruption batch to launcher resume', async () => {
+    const teardown = pDefer<void>();
+    const { ctrl } = makeInterruptedController(teardown.promise, true);
+    const admission = ctrl.admitInterruptedFollowUp({
+      text: 'Transfer this accepted message.',
+    });
+    expect(admission.kind).toBe('accepted');
+    if (admission.kind !== 'accepted') return;
+
+    const launcherResume = ctrl.tryResumeStream('stream-1');
+    teardown.resolve();
+
+    await expect(launcherResume).resolves.toBe(true);
+    await expect(admission.completion).resolves.toBe(true);
+    expect(mocks.followUpEnqueue).toHaveBeenCalledWith(
+      'stream-1',
+      { text: 'Transfer this accepted message.' },
+      { force: true },
+    );
+  });
+
+  it('holds a message submitted while interruption teardown finishes', async () => {
+    const teardown = pDefer<void>();
+    const { ctrl, session } = makeInterruptedController(
+      teardown.promise,
+      false,
+    );
+
+    const admission = ctrl.admitInterruptedFollowUp({
+      text: 'Do not drop this message.',
+    });
+    expect(admission.kind).toBe('accepted');
+    expect(mocks.resolveAndResumeStream).not.toHaveBeenCalled();
+
+    session.runCompleted = true;
+    teardown.resolve();
+    if (admission.kind !== 'accepted') return;
+    await expect(admission.completion).resolves.toBe(true);
+    expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledWith(
+      'stream-1',
+      { version: 2 },
+      expect.any(Object),
+      expect.objectContaining({
+        extraFollowUps: [{ text: 'Do not drop this message.' }],
+      }),
+    );
+    expect(session.stopRequested).toBe(false);
+  });
+
+  it('batches parallel messages into one interrupted resume', async () => {
+    const teardown = pDefer<void>();
+    const { ctrl, session } = makeInterruptedController(
+      teardown.promise,
+      false,
+    );
+
+    const first = ctrl.admitInterruptedFollowUp({ text: 'First message.' });
+    const second = ctrl.admitInterruptedFollowUp({ text: 'Second message.' });
+    expect(first.kind).toBe('accepted');
+    expect(second.kind).toBe('accepted');
+    if (first.kind !== 'accepted' || second.kind !== 'accepted') return;
+    expect(second.completion).toBe(first.completion);
+
+    session.runCompleted = true;
+    teardown.resolve();
+    await expect(first.completion).resolves.toBe(true);
+    expect(mocks.resolveAndResumeStream).toHaveBeenCalledOnce();
+    expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledWith(
+      'stream-1',
+      { version: 2 },
+      expect.any(Object),
+      expect.objectContaining({
+        extraFollowUps: [
+          { text: 'First message.' },
+          { text: 'Second message.' },
+        ],
+      }),
+    );
+  });
+
+  it('stops batching once ordinary follow-up routing is ready', async () => {
+    const resume = pDefer<boolean>();
+    const { ctrl } = makeInterruptedController(Promise.resolve(), true);
+    mocks.resumeQueuedToolUseSnapshot.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[3] as ResumeQueuedToolUseOptions;
+        options.onFollowUpQueueReady?.();
+        return resume.promise;
+      },
+    );
+
+    const first = ctrl.admitInterruptedFollowUp({ text: 'Resume now.' });
+    expect(first.kind).toBe('accepted');
+    if (first.kind !== 'accepted') return;
+    await vi.waitFor(() =>
+      expect(mocks.resumeQueuedToolUseSnapshot).toHaveBeenCalledOnce(),
+    );
+
+    expect(ctrl.admitInterruptedFollowUp({ text: 'Route normally.' })).toEqual({
+      kind: 'not_interrupted',
+    });
+    resume.resolve(true);
+    await expect(first.completion).resolves.toBe(true);
+  });
+
+  it('retains the interrupted conversation after a failed resume', async () => {
+    const { ctrl, session } = makeInterruptedController(
+      Promise.resolve(),
+      true,
+    );
+    mocks.resolveAndResumeStream.mockReset().mockResolvedValueOnce(false);
+
+    const failed = ctrl.admitInterruptedFollowUp({ text: 'First attempt.' });
+    expect(failed.kind).toBe('accepted');
+    if (failed.kind !== 'accepted') return;
+    await expect(failed.completion).resolves.toBe(false);
+    expect(session.interruptedStreamId).toBe('stream-1');
+
+    mocks.resolveAndResumeStream.mockImplementationOnce(
+      async (
+        _streamId: StreamTabId,
+        ports: { resumeToolUseSnapshot(snapshot: unknown): Promise<boolean> },
+      ) => ports.resumeToolUseSnapshot({ version: 2 }),
+    );
+    const retry = ctrl.admitInterruptedFollowUp({ text: 'Retry.' });
+    expect(retry.kind).toBe('accepted');
+    if (retry.kind !== 'accepted') return;
+    await expect(retry.completion).resolves.toBe(true);
+    expect(session.interruptedStreamId).toBeUndefined();
   });
 
   it('preserves root ownership when auto-resuming a child stream', async () => {


### PR DESCRIPTION
## Summary

- preserve the established tool-use flow record when Escape interrupts an active CLI response
- prepare both normally returned and provider-rejected cancellations at the same resumable follow-up boundary
- route subsequent user messages through one controller-owned interrupted-execution admission path
- retain messages submitted during teardown, queue handoff, and explicit-resume replacement
- batch concurrent post-interruption submissions into one ordered resume
- transfer accepted batches to manual or launcher resume instead of competing with them
- retain an explicit recoverable-stream identity and requeue accepted input when resume preparation fails
- add regression coverage for persistence, provider rejection, concurrent admission, ownership transfer, retry, cancellation, and rehydration failure

## Root cause

Escape correctly stopped the active stream, but ordinary mid-run cancellation deleted the persisted flow record. The terminal transcript remained visible, while the next message was admitted as a fresh root execution. This made the displayed conversation diverge from the context sent to the model.

The repair gives `ChatSessionController` one atomic admission operation and gives the session an explicit interrupted-stream identity. The controller owns interruption detection, captures the stream before teardown clears active state, preserves message order, and gives every accepted message exactly one owner. Before the resumed queue is ready, messages belong to the interruption batch; afterward, they belong to the shared follow-up queue. If an explicit manual or launcher resume supersedes the batch, its ordered messages are transferred to that resume. If preparation fails, they are requeued with restored recovery state. At the flow layer, both returned and thrown interruption paths persist `shouldSkipCycle` and reset the cursor to the flow entry point before later continuation. The TUI only handles the controller's admission result.

## User impact

Pressing Escape now cancels the active response without silently discarding the preceding conversation. Messages entered immediately afterward are retained through teardown and every resume handoff; concurrent submissions cannot compete for separate resumes; provider cancellation cannot leave a preserved flow at a mid-cycle cursor; and explicit resume cannot drop an already accepted message or attach later input to an obsolete interrupted stream.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run lint` (no errors; existing repository warnings remain)
- `corepack pnpm run compile:fast`
- `corepack pnpm test`: 5,901 passed, 4 skipped; the unrelated `RunChatSignalOwnership` test reached its 10-second timeout under full-suite concurrency and passed when rerun alone
- 177 focused tests on the contributor-revised branch head
- final ownership-transfer revision: full type check and 28 controller tests; 67 directly affected tests passed in the preceding combined run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI session lifecycle, resume orchestration, and persisted tool-use flow teardown — incorrect ordering could still drop follow-ups or start duplicate root runs, but behavior is heavily regression-tested.
> 
> **Overview**
> **Escape during an active CLI response no longer silently starts a new conversation** — the interrupted root stream is tracked, the tool-use flow record is kept, and the next user message is routed through resume instead of a fresh root run.
> 
> On **stop**, the session records `interruptedStreamId` before tearing down the active stream. **`ChatSessionController.admitInterruptedFollowUp`** batches messages sent during teardown into one ordered resume, waits for the prior run to finish, then calls **`tryResumeStream`** with **`extraFollowUps`**. Failed resumes restore recoverability; explicit **`resume`** / **`tryResumeStream`** supersedes stale interruption state and can transfer pending messages (manual resume passes them as **`drainedFollowUps`**).
> 
> In **`runToolUseFlow`**, user interruption now **preserves the persisted flow** (new preservation reason), and **`ToolUsePersistedFlow.prepareForFollowUp`** sets **`shouldSkipCycle`** and resets the cursor so continuation is valid — including when **`pf.run`** throws after interruption (e.g. provider abort).
> 
> **`resumeQueuedToolUse`** adds **`onFollowUpQueueReady`**, invoked after the queue is marked resuming but before drain, so late follow-ups can attach at the right boundary. The TUI submit path consults admission before **`startSession`**. Changelog and regression tests cover persistence, batching, handoff, and failure/retry paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3de53132ab72f19e12cbb5ec95753f8440f80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->