### PR TITLE
fix(cli): block teams when delegation is denied

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -191,6 +191,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
+      presetLaunchBlockReason:
+        launchContext.approvalPolicy === 'never'
+          ? 'delegation-denied'
+          : undefined,
     });
     // Load the model registry up front so the launcher can offer a model pick
     // after an agent/team choice. Best-effort: an unavailable registry just
@@ -215,6 +219,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
       agentItems: buildCliAgentItems(toolUseAgents),
       teamItems: buildCliTeamItems(presetPlanSet.plans, {
         includeLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
+        launchBlockReason:
+          launchContext.approvalPolicy === 'never'
+            ? 'delegation-denied'
+            : undefined,
       }),
       accountItems: buildCliAccountItems(accountStatus),
       apiMode,

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -67,6 +67,8 @@ export interface CliOrchestrationItem {
   readonly footerHints?: readonly string[];
 }
 
+type CliPresetLaunchBlockReason = 'delegation-denied';
+
 export interface BuildCliOrchestrationItemsInput {
   readonly presetPlans: readonly CliMultiAgentPresetRunPlan[];
   readonly history: readonly CliHistoryEntry[];
@@ -74,6 +76,7 @@ export interface BuildCliOrchestrationItemsInput {
   readonly includeMultiAgentLoginHint?: boolean;
   readonly modelAccess?: CliModelAccessStatus;
   readonly account?: CliAccountStatus;
+  readonly presetLaunchBlockReason?: CliPresetLaunchBlockReason;
 }
 
 export type CliModelAccessRoute = 'chatgpt' | 'included' | 'personal';
@@ -142,6 +145,8 @@ export function orchestrationModelAccessView(
   };
 }
 
+const TEAM_DELEGATION_DENIED_DESCRIPTION =
+  'Delegation blocked by "never"; use ask or yolo';
 export function buildCliOrchestrationItems(
   input: BuildCliOrchestrationItemsInput,
 ): CliOrchestrationItem[] {
@@ -170,10 +175,14 @@ export function buildCliOrchestrationItems(
     });
   }
   if (input.presetPlans.length > 0) {
+    const launchBlocked = input.presetLaunchBlockReason === 'delegation-denied';
     items.push({
       value: { kind: 'browse-teams' },
       label: 'Team',
-      description: 'Choose a team',
+      description: launchBlocked
+        ? TEAM_DELEGATION_DENIED_DESCRIPTION
+        : 'Choose a team',
+      disabled: launchBlocked,
     });
   }
   if (input.modelAccess) {
@@ -362,16 +371,24 @@ export function buildCliTeamItems(
   plans: readonly CliMultiAgentPresetRunPlan[],
   options: {
     readonly includeLoginHint?: boolean;
+    readonly launchBlockReason?: CliPresetLaunchBlockReason;
   },
 ): CliOrchestrationItem[] {
+  const launchBlockedDescription =
+    options.launchBlockReason === 'delegation-denied'
+      ? TEAM_DELEGATION_DENIED_DESCRIPTION
+      : undefined;
   return plans.map((plan) => ({
     value: { kind: 'preset', preset: plan.preset.id },
     label: `Team ${plan.preset.id}`,
-    description: [
-      formatCliMultiAgentPresetLauncherSummary(plan),
-      plan.preset.name,
-    ].join('; '),
-    disabled: !cliMultiAgentPresetCanLaunchTeam(plan),
+    description:
+      launchBlockedDescription ??
+      [formatCliMultiAgentPresetLauncherSummary(plan), plan.preset.name].join(
+        '; ',
+      ),
+    disabled:
+      launchBlockedDescription !== undefined ||
+      !cliMultiAgentPresetCanLaunchTeam(plan),
     footerHints: formatCliMultiAgentPresetLauncherHints(plan, {
       includeLoginHint: options.includeLoginHint,
     }),

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -546,6 +546,31 @@ describe('CLI orchestration items', () => {
     );
   });
 
+  it('disables team presets when the approval policy blocks delegation', () => {
+    const launcherItems = buildCliOrchestrationItems({
+      presetPlans: [readyPresetPlan()],
+      history: [],
+      toolUseAgents: [],
+      presetLaunchBlockReason: 'delegation-denied',
+    });
+    const teamItems = buildCliTeamItems([readyPresetPlan()], {
+      launchBlockReason: 'delegation-denied',
+    });
+
+    expect(launcherItems.find((item) => item.label === 'Team')).toEqual(
+      expect.objectContaining({
+        description: 'Delegation blocked by "never"; use ask or yolo',
+        disabled: true,
+      }),
+    );
+    expect(teamItems.find((item) => item.label === 'Team physicist')).toEqual(
+      expect.objectContaining({
+        description: 'Delegation blocked by "never"; use ask or yolo',
+        disabled: true,
+      }),
+    );
+  });
+
   it('lists every team preset so the user can switch between teams', () => {
     const plans = [
       readyPresetPlan({ id: 'lean-project', name: 'Lean Project' }),


### PR DESCRIPTION
## Summary
- disable rich launcher team rows when interactive approval policy `never` removes delegation tools
- keep the launch block as a typed reason so the item builder owns display copy
- preserve normal `ask` team launch and delegation behavior

Closes #8296

## Evidence
- `never`: all team rows show `Delegation blocked by "never"; use ask or yolo` at 80 columns and cannot be opened
- `ask`: software-engineer remains ready; root execution `5c88e9d60315` delegated to child `2dc99045e5a0`, which completed in 8s

## Validation
- `corepack pnpm exec vitest run src/test-kernel/cli/Orchestration.vitest.mts` (32/32)
- `corepack pnpm --filter @texra-ai/cli typecheck`
- targeted Prettier and ESLint
- `npm run lint` (0 errors; pre-existing warnings remain)
- rebuilt/relinked `texra-local` and exercised both policies in a real PTY
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only UX gating with a typed reason; no auth, execution, or delegation runtime changes beyond hiding unusable team launches under `never`.
> 
> **Overview**
> When interactive **approval policy** is **`never`**, the orchestrate launcher now **disables Team** entry points instead of offering presets that cannot delegate.
> 
> `orchestrate` maps `launchContext.approvalPolicy === 'never'` to a typed **`delegation-denied`** launch block passed into `buildCliOrchestrationItems` and `buildCliTeamItems`. The orchestration item builders own the copy (`Delegation blocked by "never"; use ask or yolo`) and set **`disabled`** on the top-level **Team** row and every team preset row. **`ask`** / **`yolo`** paths are unchanged; existing “team not ready” disabling still applies when delegation is allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020bd3f72f7efb76671255cdec6820245a6434f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->