### PR TITLE
Block team launches when delegation is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Team sessions require usable delegation** — the CLI now marks teams as
+  unavailable and stops before launch when the active approval policy would
+  remove subagent delegation.
 - **Model access choices apply to the launched session** — switching access at
   startup overrides an earlier command-line mode, and selecting ChatGPT turns
   off OpenRouter routing so requests use the chosen subscription.

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -53,6 +53,10 @@ import {
   type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
 import { withExpandedRunInputs } from '../runtime/workflowInputs';
+import {
+  evaluateTeamDelegationPolicy,
+  formatTeamDelegationPolicyBlock,
+} from '../runtime/approvalPolicyAvailability';
 
 interface MultiAgentRunInit {
   readonly preset: string;
@@ -66,10 +70,6 @@ interface MultiAgentRunInit {
 
 const MULTI_AGENT_TASK_REQUIRED_MESSAGE =
   'Provide --input, --instruction, or --instruction-file for the team task. Example: texra multi-agent run physicist --instruction "Check this derivation"';
-
-function headlessAskMultiAgentMessage(presetId: string): string {
-  return `Cannot run multi-agent preset "${presetId}" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`;
-}
 
 function writeMultiAgentRunResult(
   context: CliContext,
@@ -141,16 +141,17 @@ export async function runMultiAgentPreset(
   }
   await initCliPlatform({ ...context, quietLogs: true });
 
-  const rejectsHeadlessAsk =
-    context.mode === 'headless' && context.approvalPolicy === 'ask';
+  const delegationPolicy = evaluateTeamDelegationPolicy(context);
   const { plan, remoteAgentLoadAttempted } = await loadCliMultiAgentRunPlan(
     init,
     {
-      reloadRemoteAgents: !rejectsHeadlessAsk,
+      reloadRemoteAgents: delegationPolicy.allowed,
     },
   );
-  if (rejectsHeadlessAsk) {
-    writeTextStderr(headlessAskMultiAgentMessage(plan.preset.id));
+  if (!delegationPolicy.allowed) {
+    writeTextStderr(
+      formatTeamDelegationPolicyBlock(plan.preset.id, delegationPolicy),
+    );
     return CliExitCode.Usage;
   }
   if (remoteAgentLoadAttempted) {
@@ -198,12 +199,6 @@ export async function runMultiAgentPreset(
       readStdinText: readCliStdinText,
     },
     async ({ inputFiles, contextFiles }) => {
-      if (runContext.approvalPolicy === 'never') {
-        writeTextStderr(
-          `WARN preset ${plan.preset.id} may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.`,
-        );
-      }
-
       const config: AgentConfigPayload = {
         agent: rootAgent.name,
         model,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -57,6 +57,10 @@ import {
   signOutCliChatGpt,
 } from '../runtime/chatgptLogin';
 import { getCliAuthProfile, signOutCliSupabase } from '../runtime/supabaseAuth';
+import {
+  evaluateTeamDelegationPolicy,
+  formatTeamDelegationPolicyBlock,
+} from '../runtime/approvalPolicyAvailability';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -207,6 +211,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
       models,
       apiMode,
     );
+    const teamApprovalContext = {
+      mode: 'interactive' as const,
+      approvalPolicy: launchContext.approvalPolicy,
+    };
     const { runOrchestrationTui } =
       await import('../orchestration/runOrchestrationTui');
     const action = await runOrchestrationTui(items, {
@@ -215,6 +223,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       agentItems: buildCliAgentItems(toolUseAgents),
       teamItems: buildCliTeamItems(presetPlanSet.plans, {
         includeLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
+        approvalContext: teamApprovalContext,
       }),
       accountItems: buildCliAccountItems(accountStatus),
       apiMode,
@@ -235,6 +244,14 @@ async function runOrchestration(context: CliContext): Promise<number> {
         return result.exitCode;
       }
       case 'preset': {
+        const delegationPolicy =
+          evaluateTeamDelegationPolicy(teamApprovalContext);
+        if (!delegationPolicy.allowed) {
+          writeTextStderr(
+            formatTeamDelegationPolicyBlock(action.preset, delegationPolicy),
+          );
+          return CliExitCode.Usage;
+        }
         // Match the headless path: load remote premium agents (orchestrator,
         // delegation specialists) and replan so the team starts with its real
         // root instead of silently degrading to the first local tool-use agent.

--- a/packages/cli/src/runtime/approvalPolicyAvailability.ts
+++ b/packages/cli/src/runtime/approvalPolicyAvailability.ts
@@ -5,6 +5,14 @@ export type ApprovalInstructionContext = {
   readonly mode: 'headless' | 'interactive';
 };
 
+export type TeamDelegationPolicyDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly reason: string;
+      readonly recovery: string;
+    };
+
 export function approvalPromptsUnavailable(
   context: ApprovalInstructionContext,
 ): boolean {
@@ -12,4 +20,40 @@ export function approvalPromptsUnavailable(
     context.approvalPolicy === 'never' ||
     (context.mode === 'headless' && context.approvalPolicy === 'ask')
   );
+}
+
+/**
+ * Decide whether a team root can reach its members under the active CLI
+ * approval policy. Team launches must use this before entering the model
+ * picker or execution path; otherwise the runtime hides delegation and leaves
+ * an orchestrator that cannot use its team.
+ */
+export function evaluateTeamDelegationPolicy(
+  context: ApprovalInstructionContext,
+): TeamDelegationPolicyDecision {
+  if (!approvalPromptsUnavailable(context)) return { allowed: true };
+
+  if (context.approvalPolicy === 'never') {
+    return {
+      allowed: false,
+      reason: 'approval policy "never" denies subagent delegation',
+      recovery:
+        'Restart with `texra orchestrate --approval-policy ask` to approve delegation when requested, or use `--approval-policy yolo` only when you intend to auto-approve privileged actions.',
+    };
+  }
+
+  return {
+    allowed: false,
+    reason:
+      'a headless run cannot answer delegation prompts under approval policy "ask"',
+    recovery:
+      'Run `texra orchestrate --approval-policy ask` to answer delegation prompts, or use `--approval-policy yolo` only when you intend to auto-approve privileged actions.',
+  };
+}
+
+export function formatTeamDelegationPolicyBlock(
+  team: string,
+  decision: Exclude<TeamDelegationPolicyDecision, { readonly allowed: true }>,
+): string {
+  return `Team "${team}" cannot start: ${decision.reason}. ${decision.recovery}`;
 }

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -24,6 +24,10 @@ import {
   type CliModelAccess,
   type CliModelPickerItem,
 } from './modelAccess';
+import {
+  evaluateTeamDelegationPolicy,
+  type ApprovalInstructionContext,
+} from './approvalPolicyAvailability';
 import type { CliApiMode } from './apiAccessMode';
 
 export type CliOrchestrationAction =
@@ -362,18 +366,31 @@ export function buildCliTeamItems(
   plans: readonly CliMultiAgentPresetRunPlan[],
   options: {
     readonly includeLoginHint?: boolean;
+    readonly approvalContext?: ApprovalInstructionContext;
   },
 ): CliOrchestrationItem[] {
-  return plans.map((plan) => ({
-    value: { kind: 'preset', preset: plan.preset.id },
-    label: `Team ${plan.preset.id}`,
-    description: [
-      formatCliMultiAgentPresetLauncherSummary(plan),
-      plan.preset.name,
-    ].join('; '),
-    disabled: !cliMultiAgentPresetCanLaunchTeam(plan),
-    footerHints: formatCliMultiAgentPresetLauncherHints(plan, {
-      includeLoginHint: options.includeLoginHint,
-    }),
-  }));
+  const delegationPolicy = options.approvalContext
+    ? evaluateTeamDelegationPolicy(options.approvalContext)
+    : { allowed: true as const };
+
+  return plans.map((plan) => {
+    const staticLaunchable = cliMultiAgentPresetCanLaunchTeam(plan);
+    return {
+      value: { kind: 'preset' as const, preset: plan.preset.id },
+      label: `Team ${plan.preset.id}`,
+      description: [
+        delegationPolicy.allowed
+          ? formatCliMultiAgentPresetLauncherSummary(plan)
+          : `unavailable; ${delegationPolicy.reason}`,
+        plan.preset.name,
+      ].join('; '),
+      disabled: !staticLaunchable || !delegationPolicy.allowed,
+      footerHints: [
+        ...formatCliMultiAgentPresetLauncherHints(plan, {
+          includeLoginHint: options.includeLoginHint,
+        }),
+        delegationPolicy.allowed ? undefined : delegationPolicy.recovery,
+      ].filter((hint): hint is string => hint !== undefined),
+    };
+  });
 }

--- a/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
+++ b/src/test-kernel/cli/MultiAgentInstruction.vitest.ts
@@ -4,7 +4,11 @@ import { formatUnavailableApprovalInstruction } from '@cli/commands/_helpers/app
 import { formatMultiAgentRunInstruction } from '@cli/commands/_helpers/multiAgentInstruction';
 import { formatCliRunFileInstruction } from '@cli/commands/_helpers/runFileInstruction';
 import { formatToolUseAgentRunInstruction } from '@cli/commands/_helpers/toolUseRunInstruction';
-import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
+import {
+  approvalPromptsUnavailable,
+  evaluateTeamDelegationPolicy,
+  formatTeamDelegationPolicyBlock,
+} from '@cli/runtime/approvalPolicyAvailability';
 
 const workingDirectory = '/tmp/texra-workspace';
 
@@ -118,6 +122,40 @@ describe('formatUnavailableApprovalInstruction', () => {
 
       expect(instruction).toBeUndefined();
     }
+  });
+
+  it('returns actionable team-launch decisions for unavailable approvals', () => {
+    const neverDecision = evaluateTeamDelegationPolicy({
+      mode: 'interactive',
+      approvalPolicy: 'never',
+    });
+    expect(neverDecision).toMatchObject({
+      allowed: false,
+      reason: 'approval policy "never" denies subagent delegation',
+    });
+    if (neverDecision.allowed) throw new Error('Expected delegation to fail');
+    expect(
+      formatTeamDelegationPolicyBlock('software-engineer', neverDecision),
+    ).toContain('texra orchestrate --approval-policy ask');
+
+    expect(
+      evaluateTeamDelegationPolicy({
+        mode: 'headless',
+        approvalPolicy: 'ask',
+      }),
+    ).toMatchObject({ allowed: false });
+    expect(
+      evaluateTeamDelegationPolicy({
+        mode: 'interactive',
+        approvalPolicy: 'ask',
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      evaluateTeamDelegationPolicy({
+        mode: 'headless',
+        approvalPolicy: 'yolo',
+      }),
+    ).toEqual({ allowed: true });
   });
 });
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -109,7 +109,7 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
     cwd: '/tmp/project',
     mode: 'headless',
     outputFormat: 'text',
-    approvalPolicy: 'never',
+    approvalPolicy: 'yolo',
     quietLogs: false,
     renderRunProgress: true,
     stderrIsTty: false,
@@ -141,10 +141,10 @@ function mockExpandedRunInputs(inputs: {
 }
 
 describe('CLI multi-agent run command', () => {
-  const approvalUnavailableWarning =
-    'WARN preset mathematician may run without subagent delegation because approval policy "never" denies approval-gated delegation tools. Use an interactive run to answer prompts, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
+  const approvalNeverError =
+    'Team "mathematician" cannot start: approval policy "never" denies subagent delegation. Restart with `texra orchestrate --approval-policy ask` to approve delegation when requested, or use `--approval-policy yolo` only when you intend to auto-approve privileged actions.';
   const headlessAskError =
-    'Cannot run multi-agent preset "mathematician" with headless approval policy "ask": delegation prompts cannot be answered. Use an interactive run to answer prompts, pass --approval-policy never to deny approval-gated tools, or pass --approval-policy yolo only when you intentionally want to auto-approve privileged tools.';
+    'Team "mathematician" cannot start: a headless run cannot answer delegation prompts under approval policy "ask". Run `texra orchestrate --approval-policy ask` to answer delegation prompts, or use `--approval-policy yolo` only when you intend to auto-approve privileged actions.';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -332,21 +332,26 @@ describe('CLI multi-agent run command', () => {
     );
   });
 
-  it('warns when approval policy never blocks team delegation', async () => {
+  it('refuses approval policy never before launching a team run', async () => {
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
-    const exitCode = await runMultiAgentPreset(cliContext(), {
-      preset: 'mathematician',
-      inputFiles: ['problem.tex'],
-      contextFiles: [],
-      model: 'deepseekT',
-      instruction: 'Solve the problem with the team.',
-    });
-
-    expect(exitCode).toBe(0);
-    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
-      approvalUnavailableWarning,
+    const exitCode = await runMultiAgentPreset(
+      cliContext({ approvalPolicy: 'never' }),
+      {
+        preset: 'mathematician',
+        inputFiles: ['problem.tex'],
+        contextFiles: [],
+        model: 'deepseekT',
+        instruction: 'Solve the problem with the team.',
+      },
     );
+
+    expect(exitCode).toBe(2);
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(approvalNeverError);
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.withExpandedRunInputs).not.toHaveBeenCalled();
+    expect(mocks.executeCliToolUseConfig).not.toHaveBeenCalled();
   });
 
   it('refuses headless ask before launching a team run', async () => {
@@ -372,7 +377,7 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.executeCliToolUseConfig).not.toHaveBeenCalled();
   });
 
-  it('does not warn when yolo can auto-approve delegation', async () => {
+  it('allows yolo to auto-approve delegation', async () => {
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(
@@ -387,9 +392,7 @@ describe('CLI multi-agent run command', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(mocks.writeTextStderr).not.toHaveBeenCalledWith(
-      expect.stringContaining('may run without subagent delegation'),
-    );
+    expect(mocks.executeCliToolUseConfig).toHaveBeenCalledOnce();
   });
 
   it('allows instruction-only team runs without input files', async () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -546,6 +546,41 @@ describe('CLI orchestration items', () => {
     );
   });
 
+  it('shows teams as unavailable when the active policy denies delegation', () => {
+    const items = buildCliTeamItems([readyPresetPlan()], {
+      approvalContext: {
+        mode: 'interactive',
+        approvalPolicy: 'never',
+      },
+    });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        label: 'Team physicist',
+        description:
+          'unavailable; approval policy "never" denies subagent delegation; Physicist',
+        disabled: true,
+        footerHints: [
+          'Restart with `texra orchestrate --approval-policy ask` to approve delegation when requested, or use `--approval-policy yolo` only when you intend to auto-approve privileged actions.',
+        ],
+      }),
+    ]);
+  });
+
+  it('keeps teams available when interactive approvals can be answered', () => {
+    const item = buildCliTeamItems([readyPresetPlan()], {
+      approvalContext: {
+        mode: 'interactive',
+        approvalPolicy: 'ask',
+      },
+    })[0];
+
+    expect(item).toMatchObject({
+      description: 'ready; 1 workflow; 2 tools; Physicist',
+      disabled: false,
+    });
+  });
+
   it('lists every team preset so the user can switch between teams', () => {
     const plans = [
       readyPresetPlan({ id: 'lean-project', name: 'Lean Project' }),


### PR DESCRIPTION
## Summary

- makes the CLI approval-policy boundary decide whether a team can delegate
- marks every team unavailable in the startup picker when the active policy removes delegation
- stops interactive and headless team launches before model selection or execution
- replaces the former headless `never` warning-and-degrade behavior with an actionable usage error

## Design

Team launch eligibility has two independent parts: the selected preset must contain a runnable delegating root and at
least one member, and the active CLI policy must permit the root to invoke delegation. Static preset planning remains in
`multiAgentPresets.ts`; the dynamic policy decision belongs to `approvalPolicyAvailability.ts`.

Both launcher presentation and launch commands consume the same discriminated decision. This prevents the picker and
execution path from disagreeing while keeping approval policy out of the agent and preset domains.

## User impact

A team is no longer advertised or launched when `--approval-policy never` removes its delegation tools. The CLI explains
how to restart with interactive approvals or deliberate automatic approval. Headless `ask` remains blocked for the same
reason: no process can answer its prompts.

Closes #8296.

## Validation

- `npm run format`
- root TypeScript check
- test-kernel TypeScript check
- `npm run lint` (zero errors)
- 1,711 CLI tests
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when team sessions start and how the launcher labels them; behavior is intentional but users on `--approval-policy never` or headless `ask` lose team launch paths they could previously attempt (with warnings).
> 
> **Overview**
> Team launches now share one **approval-policy gate** for delegation instead of mixing warnings, silent degradation, and ad hoc errors.
> 
> **`evaluateTeamDelegationPolicy`** (with **`formatTeamDelegationPolicyBlock`**) decides whether subagent delegation can work: interactive **`ask`** and **`yolo`** allow teams; **`never`** and headless **`ask`** do not. **`texra multi-agent run`** exits with usage before planning/execution when blocked (including skipping remote-agent reload), replacing the old headless-`ask` message and the **`never`** path that only warned and still ran. **`texra orchestrate`** passes the active policy into **`buildCliTeamItems`**, so teams show as unavailable with recovery hints in the picker, and interactive team picks fail the same way before chat starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61fac01ad05b84dcc3a8e3ed5145e3f3ac5eafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->