### PR TITLE
test(cli): focus onboarding runtime contract

### DIFF
--- a/packages/cli/scripts/validate-run.mjs
+++ b/packages/cli/scripts/validate-run.mjs
@@ -724,13 +724,10 @@ async function validateOrchestrateOnboardingPickers() {
     args: ['orchestrate'],
     env: {},
     expected: [
-      'Not signed in, and no provider API key is configured. Choose how to power model calls:',
       'Use ChatGPT subscription',
       'Sign in with Researcher Access',
       'Use your own provider API key',
-      'Codex models through ChatGPT Plus, Pro, or Team',
-      'Free for academics; no API key needed',
-      'Anthropic, OpenAI, Google, and more',
+      'Skip for now',
     ],
     forbidden: truncatedOnboardingLabels,
   });
@@ -739,11 +736,9 @@ async function validateOrchestrateOnboardingPickers() {
     args: ['orchestrate', '--api-mode', 'included'],
     env: { ANTHROPIC_API_KEY: VALIDATION_FAKE_API_KEY },
     expected: [
-      'Subscription or included access needs sign-in for this run:',
       'Use ChatGPT subscription',
       'Sign in with Researcher Access',
-      'Codex models through ChatGPT Plus, Pro, or Team',
-      'Free for academics; no API key needed',
+      'Skip for now',
     ],
     forbidden: [
       'Use your own provider API key',
@@ -756,11 +751,9 @@ async function validateOrchestrateOnboardingPickers() {
     args: ['orchestrate', '--api-mode', 'personal'],
     env: {},
     expected: [
-      'Personal mode needs ChatGPT sign-in or a provider key for this run:',
       'Use ChatGPT subscription',
       'Use your own provider API key',
-      'Codex models through ChatGPT Plus, Pro, or Team',
-      'Anthropic, OpenAI, Google, and more',
+      'Skip for now',
     ],
     forbidden: ['Sign in with Researcher Access', ...truncatedOnboardingLabels],
   });


### PR DESCRIPTION
## Summary

- keep real PTY onboarding coverage focused on visible route choices
- stop duplicating mutable subtitles and description copy
- assert the stable Skip action in every onboarding mode

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:run`
- `corepack pnpm exec prettier --check packages/cli/scripts/validate-run.mjs`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- `git diff --check`

Closes #8299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to CLI validation script expectations; no production onboarding or orchestrate behavior is modified.
> 
> **Overview**
> Tightens the **orchestrate onboarding** PTY checks in `validate-run.mjs` so they assert the stable **route labels** and **Skip for now** action instead of marketing or mode-specific header and subtitle copy.
> 
> For first-run, `--api-mode included`, and `--api-mode personal`, expectations now cover only the visible choices (e.g. ChatGPT subscription, Researcher Access, own API key where applicable) plus **Skip for now**. Assertions on intro lines like “Not signed in…” and per-option descriptions (“Codex models through…”, “Free for academics…”, etc.) are removed so the runtime contract does not break when copy changes.
> 
> Mode-specific **forbidden** lists are unchanged (e.g. personal mode still forbids Researcher Access; included mode still forbids own API key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8244656bb2ac5a85884722f48baa35f4640fe0a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->