### PR TITLE
Preserve desktop approvals across window rebinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ All notable changes to this project will be documented in this file.
   thinking, tool, and file entries use Web Awesome's native left-side
   disclosure placement consistently.
 
+### Desktop
+
+#### Bug Fixes
+
+- **Approvals survive window replacement** — closing and reopening the desktop
+  window no longer rejects or loses an approval requested by a session that is
+  still running.
+
 ### CLI
 
 #### New Features

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -260,6 +260,14 @@ export class DesktopProgressBridge {
       ...hostChannel,
       interactions: this.session.interactions,
     };
+    this.toolEditApprovals = createDesktopToolEditApprovalController({
+      runtimeHost: this.runtimeHost,
+      session: this.session,
+      openPath: options.openPath,
+      openBuildDisplay: options.openBuildDisplay,
+      openDiff: options.openDiff,
+      showErrorMessage: this.options.showErrorMessage,
+    });
     this.detachHostInteractions = this.session.useHostInteractions(
       createDesktopHostInteractions({
         runtimeHost: this.runtimeHost,
@@ -278,7 +286,7 @@ export class DesktopProgressBridge {
       },
       hasTarget: () => true,
       getStreamControls: (stream) =>
-        getProgressStreamControls(stream, this.session),
+        getProgressStreamControls(stream, this.sessionForStream(stream)),
       deleteStream: (stream) => this.deleteStream(stream),
       getUnsupportedCommands: () =>
         unsupportedCommands(this.progressViewInboundHandlers),
@@ -371,14 +379,6 @@ export class DesktopProgressBridge {
       this.session,
       this.runtimeHost,
     );
-    this.toolEditApprovals = createDesktopToolEditApprovalController({
-      runtimeHost: this.runtimeHost,
-      session: this.session,
-      openPath: options.openPath,
-      openBuildDisplay: options.openBuildDisplay,
-      openDiff: options.openDiff,
-      showErrorMessage: this.options.showErrorMessage,
-    });
     this.fileActions = new DesktopProgressFileActions(
       {
         openPath: options.openPath,
@@ -535,6 +535,7 @@ export class DesktopProgressBridge {
         bypass: {
           runtimeHost: this.runtimeHost,
           session: this.session,
+          sessionForStream: (stream) => this.sessionForStream(stream),
         },
         file: {
           openFile: async (file, line) => {
@@ -691,8 +692,8 @@ export class DesktopProgressBridge {
 
   dispose(): void {
     this.detachResultToast?.();
-    this.detachHostInteractions();
     this.executionRebinder.dispose();
+    this.detachHostInteractions();
     this.toolEditApprovals.dispose();
     this.unsubscribe();
     this.backend.dispose();
@@ -1149,12 +1150,14 @@ export class DesktopProgressBridge {
     ) {
       return;
     }
+    const ownerSession = this.sessionForStream(streamId);
     this.deletedStreams.add(streamId);
-    this.sessionProgress.onStreamDeleted(streamId);
 
     // Releases approval state (pending approvals, bypass flags, pending
-    // requests) and the follow-up queue for this stream.
-    releaseStreamResources(streamId, this.session);
+    // requests) and the follow-up queue for this stream. Do this before the
+    // deletion event releases the rebound binding that identifies the owner.
+    releaseStreamResources(streamId, ownerSession);
+    this.sessionProgress.onStreamDeleted(streamId);
 
     this.releaseApprovalsForStream(streamId);
     this.workflowFileActions.clearStreamBackups(streamId);
@@ -1177,7 +1180,7 @@ export class DesktopProgressBridge {
     // approvals or bypass flags.
     for (const streamId of streamIds) {
       this.deletedStreams.add(streamId);
-      releaseStreamResources(streamId, this.session);
+      releaseStreamResources(streamId, this.sessionForStream(streamId));
     }
     // Catch pending approvals with no concrete stream context (undefined or
     // empty streamId) — the per-stream loop skips them because they do not
@@ -1227,16 +1230,23 @@ export class DesktopProgressBridge {
   }
 
   private stopStream(streamId: StreamTabId): void {
+    const ownerSession = this.sessionForStream(streamId);
     // Kind-scoped: clear only the pending retry panel for this stream.
-    this.session.interactions.cancel({
+    ownerSession.interactions.cancel({
       streamId,
       kind: 'retry',
       cause: 'Retry request cleared.',
     });
-    this.session.executions.stopAgentStream(streamId, {
+    ownerSession.executions.stopAgentStream(streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
       runtimeHost: this.runtimeHost,
     });
+  }
+
+  private sessionForStream(streamId: StreamTabId): SessionHandle {
+    return (
+      this.executionRebinder.ownerSessionForStream(streamId) ?? this.session
+    );
   }
 
   async tryResumeStream(streamId: StreamTabId): Promise<boolean> {

--- a/packages/desktop/src/main/desktopExecutionRebinder.ts
+++ b/packages/desktop/src/main/desktopExecutionRebinder.ts
@@ -95,6 +95,16 @@ export class DesktopExecutionRebinder {
     this.interactionForwards.clear();
   }
 
+  /** Resolve the durable runtime owner for a stream mirrored into this window. */
+  ownerSessionForStream(streamId: StreamTabId): SessionHandle | undefined {
+    const rootOwner = this.rootOwners.get(streamId);
+    if (rootOwner) return rootOwner;
+    for (const binding of this.agentBindings.values()) {
+      if (binding.streamId === streamId) return binding.ownerSession;
+    }
+    return undefined;
+  }
+
   private forwardInteractions(ownerSession: SessionHandle): void {
     if (
       ownerSession === this.targetSession ||
@@ -102,28 +112,11 @@ export class DesktopExecutionRebinder {
     ) {
       return;
     }
-    const target = this.targetSession.interactions;
     this.interactionForwards.set(
       ownerSession,
-      ownerSession.useHostInteractions({
-        requestToolEditApproval: (request, options) =>
-          target.requestToolEditApproval(request, options),
-        requestBashApproval: (request, options) =>
-          target.requestBashApproval(request, options),
-        requestPlanApproval: (request, options) =>
-          target.requestPlanApproval(request, options),
-        requestAgentProposal: (request, options) =>
-          target.requestAgentProposal(request, options),
-        requestRetry: (request, options) =>
-          target.requestRetry(request, options),
-        askUserQuestion: (request, options) =>
-          target.askUserQuestion(request, options),
-        openExternalInquiry: (request) => target.openExternalInquiry(request),
-        setApprovalBypassState: (update) =>
-          target.setApprovalBypassState(update),
-        resolve: (requestId, result) => target.resolve(requestId, result),
-        cancel: (selector) => target.cancel(selector),
-      }),
+      ownerSession.useHostInteractions(
+        this.targetSession.interactions.createForwarder(),
+      ),
     );
   }
 
@@ -156,6 +149,7 @@ export class DesktopExecutionRebinder {
         this.rootOwners.delete(streamId);
         this.detachOwnerObserverIfUnused(ownerSession);
       }
+      this.detachInteractionForwardIfUnused(ownerSession);
     };
     const releaseCurrent = (): void => {
       const staleHandle = currentHandle;
@@ -404,6 +398,17 @@ export class DesktopExecutionRebinder {
     this.ownerRegistrationObservers.delete(ownerSession);
   }
 
+  private detachInteractionForwardIfUnused(ownerSession: SessionHandle): void {
+    for (const binding of this.agentBindings.values()) {
+      if (binding.ownerSession === ownerSession) return;
+    }
+    for (const binding of this.processBindings.values()) {
+      if (binding.ownerSession === ownerSession) return;
+    }
+    this.interactionForwards.get(ownerSession)?.();
+    this.interactionForwards.delete(ownerSession);
+  }
+
   private bindProcess(
     executionId: ExecutionId,
     ownerSession: SessionHandle,
@@ -422,6 +427,7 @@ export class DesktopExecutionRebinder {
       if (this.processBindings.get(executionId) === binding) {
         this.processBindings.delete(executionId);
       }
+      this.detachInteractionForwardIfUnused(ownerSession);
     };
     const binding: ReboundProcessBinding = {
       ownerSession,

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -5,6 +5,7 @@ import {
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
+  type HostInteractionOptions,
   type HostInteractionResolution,
   type HostInteractions,
   type HostPlanApprovalRequest,
@@ -34,21 +35,25 @@ type PendingDesktopInteraction =
   | {
       kind: 'bash';
       streamId?: StreamTabId;
+      cancellationScope?: object;
       settle: (result: HostBashApprovalResult) => void;
     }
   | {
       kind: 'plan';
       streamId: StreamTabId;
+      cancellationScope?: object;
       settle: (result: PlanApprovalResult) => void;
     }
   | {
       kind: 'proposal';
       streamId: StreamTabId;
+      cancellationScope?: object;
       settle: (result: ProposalResult) => void;
     }
   | {
       kind: 'userQuestion';
       streamId?: StreamTabId;
+      cancellationScope?: object;
       settle: (result: HostUserQuestionResult) => void;
     };
 
@@ -75,12 +80,17 @@ class DesktopHostInteractions implements HostInteractions {
 
   requestToolEditApproval(
     request: ToolEditApprovalRequest,
+    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult> {
-    return this.options.getToolEditApprovals().requestApproval(request);
+    const approvals = this.options.getToolEditApprovals();
+    return options
+      ? approvals.requestApproval(request, options)
+      : approvals.requestApproval(request);
   }
 
   requestBashApproval(
     request: HostBashApprovalRequest,
+    options?: HostInteractionOptions,
   ): Promise<HostBashApprovalResult> {
     const requestId = `desktop-bash-${nanoid()}`;
     const streamId = request.streamId ?? undefined;
@@ -91,37 +101,48 @@ class DesktopHostInteractions implements HostInteractions {
       allowBypass: true,
       streamId: streamId ?? '',
     };
-    return this.showPending(requestId, { kind: 'bash', streamId }, (settle) => {
-      this.revealStream(streamId);
-      this.options.getApprovalHandlers().bash.show(payload);
-      return settle;
-    });
+    return this.showPending(
+      requestId,
+      { kind: 'bash', streamId, cancellationScope: options?.cancellationScope },
+      () => {
+        this.revealStream(streamId);
+        this.options.getApprovalHandlers().bash.show(payload);
+      },
+    );
   }
 
   requestPlanApproval(
     request: HostPlanApprovalRequest,
+    options?: HostInteractionOptions,
   ): Promise<PlanApprovalResult> {
     return this.showPending(
       request.approvalId,
-      { kind: 'plan', streamId: request.streamId },
-      (settle) => {
+      {
+        kind: 'plan',
+        streamId: request.streamId,
+        cancellationScope: options?.cancellationScope,
+      },
+      () => {
         this.revealStream(request.streamId);
         this.options.getApprovalHandlers().planApproval.show(request);
-        return settle;
       },
     );
   }
 
   requestAgentProposal(
     request: AgentProposalPermission,
+    options?: HostInteractionOptions,
   ): Promise<ProposalResult> {
     return this.showPending(
       request.proposalId,
-      { kind: 'proposal', streamId: request.streamId },
-      (settle) => {
+      {
+        kind: 'proposal',
+        streamId: request.streamId,
+        cancellationScope: options?.cancellationScope,
+      },
+      () => {
         this.revealStream(request.streamId);
         this.options.getApprovalHandlers().agentProposal.show(request);
-        return settle;
       },
     );
   }
@@ -132,15 +153,19 @@ class DesktopHostInteractions implements HostInteractions {
 
   askUserQuestion(
     request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
+    options?: HostInteractionOptions,
   ): Promise<HostUserQuestionResult> {
     const streamId = request.streamId || undefined;
     return this.showPending(
       request.requestId,
-      { kind: 'userQuestion', streamId },
-      (settle) => {
+      {
+        kind: 'userQuestion',
+        streamId,
+        cancellationScope: options?.cancellationScope,
+      },
+      () => {
         this.revealStream(streamId);
         this.options.getApprovalHandlers().userQuestion.show(request);
-        return settle;
       },
     );
   }
@@ -198,6 +223,9 @@ class DesktopHostInteractions implements HostInteractions {
    * one settle identically for a given kind.
    */
   cancel(selector: HostInteractionCancelSelector = {}): void {
+    if (selector.kind == null || selector.kind === 'toolEdit') {
+      this.options.getToolEditApprovals().cancel(selector);
+    }
     for (const [requestId, request] of [...this.pendingRequests.entries()]) {
       if (!matchesCancelSelector(request, selector)) continue;
       this.resolve(requestId, {
@@ -215,7 +243,7 @@ class DesktopHostInteractions implements HostInteractions {
   private showPending<TResult, TEntry extends PendingDesktopInteraction>(
     requestId: string,
     entry: Omit<TEntry, 'settle'>,
-    show: (settle: TEntry['settle']) => TEntry['settle'],
+    show: () => void,
   ): Promise<TResult> {
     // Replacement cancellation: a request re-issued under a still-pending id
     // rejects the stale prompt before the replacement is shown.
@@ -227,11 +255,17 @@ class DesktopHostInteractions implements HostInteractions {
       });
     }
     return new Promise<TResult>((resolve) => {
-      const settle = show((result: unknown) => resolve(result as TResult));
+      const settle = (result: unknown) => resolve(result as TResult);
       this.pendingRequests.set(requestId, {
         ...entry,
         settle,
       } as TEntry);
+      try {
+        show();
+      } catch (error) {
+        this.pendingRequests.delete(requestId);
+        throw error;
+      }
     });
   }
 

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -4,6 +4,11 @@ import path from 'node:path';
 import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  matchesCancelSelector,
+  type HostInteractionCancelSelector,
+  type HostInteractionOptions,
+} from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { DiffViewHost } from '@hosts/uiHosts';
@@ -40,6 +45,7 @@ export interface DesktopToolEditApprovalOptions {
 }
 
 export interface DesktopToolEditApprovalController {
+  cancel(selector?: HostInteractionCancelSelector): void;
   handleAction(payload: {
     requestId: string;
     action: ToolEditApprovalAction;
@@ -47,6 +53,7 @@ export interface DesktopToolEditApprovalController {
   }): boolean;
   requestApproval(
     request: ToolEditApprovalRequest,
+    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult>;
   dispose(): void;
 }
@@ -60,9 +67,20 @@ interface DesktopPendingToolEditApproval extends LatexPreviewEntry {
   originalContent: string;
   proposedContent: string;
   settle: (result: ToolEditApprovalResult) => void;
+  cancellationScope?: object;
+}
+
+interface InitializingToolEditApproval {
+  readonly request: ToolEditApprovalRequest;
+  readonly cancellationScope?: object;
+  cancellation?: ToolEditApprovalResult;
 }
 
 class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalController {
+  private readonly initializing = new Map<
+    string,
+    InitializingToolEditApproval
+  >();
   private readonly pending = new Map<string, DesktopPendingToolEditApproval>();
   private disposed = false;
 
@@ -70,6 +88,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
 
   async requestApproval(
     request: ToolEditApprovalRequest,
+    options?: HostInteractionOptions,
   ): Promise<ToolEditApprovalResult> {
     if (this.disposed) {
       throw new Error('Desktop tool edit approval controller is disposed.');
@@ -80,7 +99,27 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
       request.originalContent,
       request.proposedContent,
     );
-    const entry = await this.createPendingEntry(requestId, request);
+    const initialization: InitializingToolEditApproval = {
+      request,
+      cancellationScope: options?.cancellationScope,
+    };
+    this.initializing.set(requestId, initialization);
+    let entry: DesktopPendingToolEditApproval;
+    try {
+      entry = await this.createPendingEntry(requestId, request);
+    } catch (error) {
+      this.initializing.delete(requestId);
+      throw error;
+    }
+    this.initializing.delete(requestId);
+    if (initialization.cancellation) {
+      this.cleanupEntry(entry);
+      return {
+        ...initialization.cancellation,
+        lineChanges: initialization.cancellation.lineChanges ?? lineChanges,
+      };
+    }
+    entry.cancellationScope = initialization.cancellationScope;
     let settled = false;
 
     const result = await new Promise<ToolEditApprovalResult>((resolve) => {
@@ -154,12 +193,50 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     }
   }
 
+  cancel(selector: HostInteractionCancelSelector = {}): void {
+    for (const initialization of this.initializing.values()) {
+      if (
+        initialization.cancellation ||
+        !matchesCancelSelector(
+          {
+            kind: 'toolEdit',
+            streamId: initialization.request.streamId ?? undefined,
+            cancellationScope: initialization.cancellationScope,
+          },
+          selector,
+        )
+      ) {
+        continue;
+      }
+      initialization.cancellation = {
+        accepted: false,
+        userMessage: selector.cause,
+      };
+    }
+    for (const [requestId, entry] of [...this.pending.entries()]) {
+      if (
+        !matchesCancelSelector(
+          {
+            kind: 'toolEdit',
+            streamId: entry.request.streamId ?? undefined,
+            cancellationScope: entry.cancellationScope,
+          },
+          selector,
+        )
+      ) {
+        continue;
+      }
+      this.settle(requestId, {
+        accepted: false,
+        userMessage: selector.cause,
+      });
+    }
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    for (const requestId of [...this.pending.keys()]) {
-      this.settle(requestId, { accepted: false });
-    }
+    this.cancel({ cause: 'Desktop session disposed.' });
   }
 
   private async createPendingEntry(

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -15,6 +15,10 @@ import { nanoid } from 'nanoid';
 import * as vscode from 'vscode';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  matchesCancelSelector,
+  type HostInteractionCancelSelector,
+} from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
 import { showLoggedMessage } from '@frontend/ui/errorHandlingUtils';
@@ -57,6 +61,14 @@ interface PendingApprovalEntry extends LatexPreviewEntry {
   streamId?: StreamTabId;
   lineChanges: LineChanges;
   settle: (result: ToolEditApprovalResult) => void;
+  cancellationScope?: object;
+}
+
+interface InitializingNativeApproval {
+  readonly request: ToolEditApprovalRequest;
+  readonly session: SessionHandle;
+  readonly cancellationScope?: object;
+  cancellation?: ToolEditApprovalResult;
 }
 
 interface ToolEditApprovalActionPayload {
@@ -66,9 +78,53 @@ interface ToolEditApprovalActionPayload {
 }
 
 const pendingApprovals = new Map<string, PendingApprovalEntry>();
+const initializingApprovals = new Map<string, InitializingNativeApproval>();
 const diffViewHost: DiffViewHost = new VscodeDiffViewHost();
 let storageDirectory: string | undefined;
 let runtimeHost: AgentRuntimeHost | undefined;
+
+/** Reject native approvals owned by one session and selected interaction scope. */
+export function cancelNativeToolEditApprovals(
+  session: SessionHandle,
+  selector: HostInteractionCancelSelector = {},
+): void {
+  for (const initialization of initializingApprovals.values()) {
+    if (
+      initialization.session !== session ||
+      initialization.cancellation ||
+      !matchesCancelSelector(
+        {
+          kind: 'toolEdit',
+          streamId: initialization.request.streamId ?? undefined,
+          cancellationScope: initialization.cancellationScope,
+        },
+        selector,
+      )
+    ) {
+      continue;
+    }
+    initialization.cancellation = {
+      accepted: false,
+      userMessage: selector.cause,
+    };
+  }
+  for (const entry of pendingApprovals.values()) {
+    if (
+      entry.session !== session ||
+      !matchesCancelSelector(
+        {
+          kind: 'toolEdit',
+          streamId: entry.streamId,
+          cancellationScope: entry.cancellationScope,
+        },
+        selector,
+      )
+    ) {
+      continue;
+    }
+    entry.settle({ accepted: false, userMessage: selector.cause });
+  }
+}
 
 function getStorageDir(): string {
   if (!storageDirectory) {
@@ -116,6 +172,9 @@ async function showProgressViewApprovalPrompt(
   await Promise.resolve(
     vscode.commands.executeCommand('texra.showProgressView'),
   ).catch(() => {});
+
+  const entry = pendingApprovals.get(requestId);
+  if (!entry || entry.session !== session || entry.isSettled()) return;
 
   publishProgressViewApprovalPrompt(
     session,
@@ -165,7 +224,7 @@ function restoreProgressViewApprovalPrompt(
 
 export async function nativeRequestApproval(
   request: ToolEditApprovalRequest,
-  options: { session: SessionHandle },
+  options: { session: SessionHandle; cancellationScope?: object },
 ): Promise<ToolEditApprovalResult> {
   getStorageDir(); // Validates initialization
 
@@ -178,26 +237,47 @@ export async function nativeRequestApproval(
   } = request;
 
   const requestId = `approval-${nanoid()}`;
-  const directory = await ensureStorageDir();
+  const lineChanges = computeLineChangeSummary(
+    originalContent,
+    proposedContent,
+  );
+  const initialization: InitializingNativeApproval = {
+    request,
+    session: options.session,
+    cancellationScope: options.cancellationScope,
+  };
+  initializingApprovals.set(requestId, initialization);
+  let approvalSources: Awaited<ReturnType<typeof writeApprovalTempFiles>>;
+  try {
+    const directory = await ensureStorageDir();
+    approvalSources = await writeApprovalTempFiles({
+      directory,
+      targetPath: filePath,
+      originalContent,
+      proposedContent,
+    });
+  } catch (error) {
+    initializingApprovals.delete(requestId);
+    throw error;
+  }
   const {
     originalPath,
     proposedPath,
     cleanup: cleanupApprovalSources,
-  } = await writeApprovalTempFiles({
-    directory,
-    targetPath: filePath,
-    originalContent,
-    proposedContent,
-  });
+  } = approvalSources;
+  if (initialization.cancellation) {
+    initializingApprovals.delete(requestId);
+    await cleanupApprovalSources();
+    return {
+      ...initialization.cancellation,
+      lineChanges: initialization.cancellation.lineChanges ?? lineChanges,
+    };
+  }
   const originalSource: DiffSource = { filePath: originalPath };
   const proposedSource: DiffSource = { filePath: proposedPath };
 
   const description = vscode.workspace.asRelativePath(
     WorkspaceFS.fullPath(filePath),
-  );
-  const lineChanges = computeLineChangeSummary(
-    originalContent,
-    proposedContent,
   );
   const { added, removed } = lineChanges;
   const totalChanged = added + removed;
@@ -222,6 +302,14 @@ export async function nativeRequestApproval(
     );
     diffSession = openedSession;
 
+    if (initialization.cancellation) {
+      result = initialization.cancellation;
+      return {
+        ...result,
+        lineChanges: result.lineChanges ?? lineChanges,
+      };
+    }
+
     let approvalSettled = false;
     const approvalPromise = new Promise<ToolEditApprovalResult>((resolve) => {
       const settle = (value: ToolEditApprovalResult) => {
@@ -245,6 +333,7 @@ export async function nativeRequestApproval(
         relativePath: description,
         streamId: streamId ?? undefined,
         lineChanges,
+        cancellationScope: initialization.cancellationScope,
         isSettled: () => approvalSettled,
         settle,
         workspaceTempCleanup: [],
@@ -253,6 +342,7 @@ export async function nativeRequestApproval(
       };
 
       pendingApprovals.set(requestId, entry);
+      initializingApprovals.delete(requestId);
       // Register with the owning session's registry for rejection tracking
       registerPendingApproval(
         requestId,
@@ -344,14 +434,16 @@ export async function nativeRequestApproval(
       lineChanges: result.lineChanges ?? lineChanges,
     };
   } finally {
+    initializingApprovals.delete(requestId);
     // Stop listening for tab closes before we programmatically close the diff.
     tabCloseDisposable?.dispose();
     // Get entry before deleting to access workspace temp cleanup functions
     const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);
     unregisterPendingApproval(requestId, options.session);
-    if (diffSession) {
-      await diffViewHost.closeDiff(diffSession);
+    const currentDiffSession = entry?.diffSession ?? diffSession;
+    if (currentDiffSession) {
+      await diffViewHost.closeDiff(currentDiffSession);
     }
     await cleanupApprovalSources();
 
@@ -375,19 +467,28 @@ export async function handleProgressViewToolEditApprovalAction(
   }
 
   switch (payload.action) {
-    case 'openDiff':
-      entry.diffSession = await diffViewHost.openDiff(
+    case 'openDiff': {
+      const reopenedSession = await diffViewHost.openDiff(
         entry.diffSession.original,
         entry.diffSession.proposed,
         entry.title,
         { preserveFocus: true },
       );
+      if (
+        entry.isSettled() ||
+        pendingApprovals.get(payload.requestId) !== entry
+      ) {
+        await diffViewHost.closeDiff(reopenedSession);
+        return;
+      }
+      entry.diffSession = reopenedSession;
       await revealFirstChangedLine(
         entry.diffSession,
         entry.originalContent,
         entry.proposedContent,
       );
       break;
+    }
 
     case 'showLatexdiff':
       // Use ONLYCHANGEDPAGE for tool edit approvals to focus on changes

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -6,6 +6,7 @@ import {
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
+  type HostInteractionOptions,
   type HostInteractionResolution,
   type HostInteractions,
   type HostPlanApprovalRequest,
@@ -24,7 +25,10 @@ import {
   toUserQuestionResult,
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import { nativeRequestApproval } from '@frontend/approval/nativeToolEditApproval';
+import {
+  cancelNativeToolEditApprovals,
+  nativeRequestApproval,
+} from '@frontend/approval/nativeToolEditApproval';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
@@ -47,6 +51,7 @@ interface PendingExtensionInteraction<T> {
   readonly id: string;
   readonly kind: PendingKind;
   readonly streamId?: StreamTabId;
+  readonly cancellationScope?: object;
   readonly settle: (value: T) => void;
 }
 
@@ -161,6 +166,9 @@ export function createExtensionHostInteractions(
   };
 
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
+    if (selector.kind == null || selector.kind === 'toolEdit') {
+      cancelNativeToolEditApprovals(options.session, selector);
+    }
     for (const pending of [...pendingRequests.values()]) {
       if (matchesCancelSelector(pending, selector)) {
         releasePending(pending, selector.cause);
@@ -171,18 +179,28 @@ export function createExtensionHostInteractions(
   return {
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
+      interactionOptions?: HostInteractionOptions,
     ): Promise<ToolEditApprovalResult> {
-      return nativeRequestApproval(request, { session: options.session });
+      return nativeRequestApproval(request, {
+        session: options.session,
+        cancellationScope: interactionOptions?.cancellationScope,
+      });
     },
 
     requestBashApproval(
       request: HostBashApprovalRequest,
+      interactionOptions?: HostInteractionOptions,
     ): Promise<HostBashApprovalResult> {
       const requestId = `bash-${nanoid()}`;
       const streamId = request.streamId ?? '';
       revealStream(request.streamId);
       return showPending<HostBashApprovalResult>(
-        { id: requestId, kind: 'bash', streamId },
+        {
+          id: requestId,
+          kind: 'bash',
+          streamId,
+          cancellationScope: interactionOptions?.cancellationScope,
+        },
         () =>
           handlers().bash.show({
             requestId,
@@ -196,6 +214,7 @@ export function createExtensionHostInteractions(
 
     requestPlanApproval(
       request: HostPlanApprovalRequest,
+      interactionOptions?: HostInteractionOptions,
     ): Promise<PlanApprovalResult> {
       revealStream(request.streamId);
       return showPending<PlanApprovalResult>(
@@ -203,6 +222,7 @@ export function createExtensionHostInteractions(
           id: request.approvalId,
           kind: 'plan',
           streamId: request.streamId,
+          cancellationScope: interactionOptions?.cancellationScope,
         },
         () => handlers().planApproval.show(request),
       );
@@ -210,6 +230,7 @@ export function createExtensionHostInteractions(
 
     requestAgentProposal(
       request: AgentProposalPermission,
+      interactionOptions?: HostInteractionOptions,
     ): Promise<ProposalResult> {
       revealStream(request.streamId);
       return showPending<ProposalResult>(
@@ -217,18 +238,23 @@ export function createExtensionHostInteractions(
           id: request.proposalId,
           kind: 'proposal',
           streamId: request.streamId,
+          cancellationScope: interactionOptions?.cancellationScope,
         },
         () => handlers().agentProposal.show(request),
       );
     },
 
-    requestRetry(request: HostRetryRequest): Promise<RetryResult> {
+    requestRetry(
+      request: HostRetryRequest,
+      interactionOptions?: HostInteractionOptions,
+    ): Promise<RetryResult> {
       revealStream(request.streamId);
       return showPending<RetryResult>(
         {
           id: request.streamId,
           kind: 'retry',
           streamId: request.streamId,
+          cancellationScope: interactionOptions?.cancellationScope,
         },
         () => handlers().retry.show(request),
       );
@@ -236,6 +262,7 @@ export function createExtensionHostInteractions(
 
     askUserQuestion(
       request: Parameters<NonNullable<HostInteractions['askUserQuestion']>>[0],
+      interactionOptions?: HostInteractionOptions,
     ): Promise<HostUserQuestionResult> {
       revealStream(request.streamId || undefined);
       return showPending<HostUserQuestionResult>(
@@ -243,6 +270,7 @@ export function createExtensionHostInteractions(
           id: request.requestId,
           kind: 'userQuestion',
           streamId: request.streamId,
+          cancellationScope: interactionOptions?.cancellationScope,
         },
         () => handlers().userQuestion.show(request),
       );

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -14,6 +14,8 @@ import type {
 
 export interface HostInteractionOptions {
   readonly timeoutMs?: number;
+  /** Internal identity used to cancel one forwarded presentation request. */
+  readonly cancellationScope?: object;
 }
 
 export type PlanApprovalResult =
@@ -130,6 +132,8 @@ export interface HostInteractionCancelSelector {
   readonly streamId?: StreamTabId | null;
   readonly kind?: PendingInteractionKind;
   readonly cause?: string;
+  /** Internal identity for one forwarded presentation request. */
+  readonly cancellationScope?: object;
 }
 
 /** Shared selector predicate for the ports' pending registries. */
@@ -137,10 +141,17 @@ export function matchesCancelSelector(
   pending: {
     readonly kind: PendingInteractionKind;
     readonly streamId?: StreamTabId;
+    readonly cancellationScope?: object;
   },
   selector: HostInteractionCancelSelector,
 ): boolean {
   if (selector.kind !== undefined && pending.kind !== selector.kind) {
+    return false;
+  }
+  if (
+    selector.cancellationScope !== undefined &&
+    pending.cancellationScope !== selector.cancellationScope
+  ) {
     return false;
   }
   if (selector.streamId === undefined) return true;
@@ -151,10 +162,9 @@ export function matchesCancelSelector(
 /**
  * Session-owned host interaction surface.
  *
- * Runtime code asks the session for an interaction; host code owns display,
- * replay (via `ApprovalRequestHandler`), request bookkeeping (the pending
- * id→stream registry each implementation keeps), first-wins resolution, and
- * replacement cancellation for duplicate request ids.
+ * Runtime code asks the session for an interaction. The session owns the
+ * request until it settles or is explicitly cancelled, while concrete host
+ * adapters own presentation, request-id resolution, and local disposal.
  */
 export interface HostInteractions {
   requestToolEditApproval?(
@@ -191,28 +201,52 @@ export interface HostInteractions {
   dispose?(): void;
 }
 
-const noopHostInteractions: HostInteractions = {
-  resolve: () => false,
-  cancel: () => {},
-};
+interface HostInteractionAttachment {
+  readonly interactions: HostInteractions;
+  disposed: boolean;
+}
+
+interface PendingSessionInteraction {
+  readonly kind: PendingInteractionKind;
+  readonly streamId?: StreamTabId;
+  readonly dispatch: (
+    interactions: HostInteractions,
+  ) => Promise<unknown> | undefined;
+  readonly cancellationResult: (cause?: string) => unknown;
+  readonly settle: (result: unknown) => void;
+  readonly reject: (reason?: unknown) => void;
+  cancellationRequested: boolean;
+}
 
 /**
- * Stable per-session slot. The `SessionHandle` exposes this object once, while
- * each host installs the concrete implementation for the session lifetime it
- * owns. Keeping the slot stable avoids passing a mutable host callback through
- * every run-construction path during the staged migration.
+ * Stable per-session interaction owner. The `SessionHandle` exposes this
+ * object once, while hosts may attach and detach presentation adapters without
+ * cancelling requests owned by a still-running session.
  */
 export class SessionHostInteractions implements HostInteractions {
-  private active: HostInteractions = noopHostInteractions;
+  private readonly attachments: HostInteractionAttachment[] = [];
+  private readonly pending = new Set<PendingSessionInteraction>();
+  private attachmentVersion = 0;
+  private disposed = false;
 
   use(interactions: HostInteractions): () => void {
-    const previous = this.active;
-    this.active = interactions;
-    let disposed = false;
+    if (this.disposed) {
+      interactions.dispose?.();
+      return () => {};
+    }
+    const attachment: HostInteractionAttachment = {
+      interactions,
+      disposed: false,
+    };
+    this.attachments.push(attachment);
+    this.activateCurrentAttachment();
     return () => {
-      if (disposed) return;
-      disposed = true;
-      if (this.active === interactions) this.active = previous;
+      if (attachment.disposed) return;
+      const wasActive = this.activeAttachment === attachment;
+      attachment.disposed = true;
+      const index = this.attachments.indexOf(attachment);
+      if (index !== -1) this.attachments.splice(index, 1);
+      if (wasActive) this.activateCurrentAttachment();
       interactions.dispose?.();
     };
   }
@@ -220,65 +254,343 @@ export class SessionHostInteractions implements HostInteractions {
   requestToolEditApproval(
     request: ToolEditApprovalRequest,
     options?: HostInteractionOptions,
-  ): Promise<ToolEditApprovalResult> | undefined {
-    return this.active.requestToolEditApproval?.(request, options);
+  ): Promise<ToolEditApprovalResult> {
+    return this.enqueue<ToolEditApprovalResult>(
+      'toolEdit',
+      request.streamId as StreamTabId | null | undefined,
+      (interactions) =>
+        interactions.requestToolEditApproval?.(request, options),
+      (cause) => ({ accepted: false, userMessage: cause }),
+    );
   }
 
   requestBashApproval(
     request: HostBashApprovalRequest,
     options?: HostInteractionOptions,
-  ): Promise<HostBashApprovalResult> | undefined {
-    return this.active.requestBashApproval?.(request, options);
+  ): Promise<HostBashApprovalResult> {
+    return this.enqueue<HostBashApprovalResult>(
+      'bash',
+      request.streamId ?? undefined,
+      (interactions) => interactions.requestBashApproval?.(request, options),
+      (cause) => ({ accepted: false, userMessage: cause }),
+    );
   }
 
   requestPlanApproval(
     request: HostPlanApprovalRequest,
     options?: HostInteractionOptions,
-  ): Promise<PlanApprovalResult> | undefined {
-    return this.active.requestPlanApproval?.(request, options);
+  ): Promise<PlanApprovalResult> {
+    return this.enqueue<PlanApprovalResult>(
+      'plan',
+      request.streamId,
+      (interactions) => interactions.requestPlanApproval?.(request, options),
+      (cause) => ({ action: 'reject', feedback: cause }),
+    );
   }
 
   requestAgentProposal(
     request: HostAgentProposalRequest,
     options?: HostInteractionOptions,
-  ): Promise<ProposalResult> | undefined {
-    return this.active.requestAgentProposal?.(request, options);
+  ): Promise<ProposalResult> {
+    return this.enqueue<ProposalResult>(
+      'proposal',
+      request.streamId,
+      (interactions) => interactions.requestAgentProposal?.(request, options),
+      (cause) => ({ action: 'reject', feedback: cause }),
+    );
   }
 
   requestRetry(
     request: HostRetryRequest,
     options?: HostInteractionOptions,
-  ): Promise<RetryResult> | undefined {
-    return this.active.requestRetry?.(request, options);
+  ): Promise<RetryResult> {
+    return this.enqueue<RetryResult>(
+      'retry',
+      request.streamId,
+      (interactions) => interactions.requestRetry?.(request, options),
+      () => ({ action: 'cancel' }),
+    );
   }
 
   askUserQuestion(
     request: HostUserQuestionRequest,
     options?: HostInteractionOptions,
-  ): Promise<HostUserQuestionResult> | undefined {
-    return this.active.askUserQuestion?.(request, options);
+  ): Promise<HostUserQuestionResult> {
+    return this.enqueue<HostUserQuestionResult>(
+      'userQuestion',
+      request.streamId || undefined,
+      (interactions) => interactions.askUserQuestion?.(request, options),
+      (cause) => ({ submitted: false, feedback: cause }),
+    );
   }
 
   openExternalInquiry(
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined {
-    return this.active.openExternalInquiry?.(request);
+    // Opening an inquiry is a notification whose tool contract returns
+    // immediately; it is not a response-bearing approval. Preserve the
+    // existing loud unavailable path instead of parking the agent while no UI
+    // is attached.
+    return this.activeAttachment?.interactions.openExternalInquiry?.(request);
   }
 
   setApprovalBypassState(update: HostApprovalBypassStateUpdate): void {
-    this.active.setApprovalBypassState?.(update);
+    this.activeAttachment?.interactions.setApprovalBypassState?.(update);
   }
 
   resolve(requestId: string, result: HostInteractionResolution): boolean {
-    return this.active.resolve(requestId, result);
+    return (
+      this.activeAttachment?.interactions.resolve(requestId, result) ?? false
+    );
   }
 
-  cancel(selector?: HostInteractionCancelSelector): void {
-    this.active.cancel(selector);
+  cancel(selector: HostInteractionCancelSelector = {}): void {
+    const matching = [...this.pending].filter((pending) =>
+      matchesCancelSelector(pending, selector),
+    );
+    for (const pending of matching) pending.cancellationRequested = true;
+
+    const settleFallbacks = (): void => {
+      for (const pending of matching) {
+        if (!this.pending.delete(pending)) continue;
+        pending.settle(pending.cancellationResult(selector.cause));
+      }
+    };
+    const active = this.activeAttachment;
+    try {
+      active?.interactions.cancel(selector);
+    } finally {
+      if (active) queueMicrotask(settleFallbacks);
+      else settleFallbacks();
+    }
   }
 
   dispose(): void {
-    this.active.dispose?.();
-    this.active = noopHostInteractions;
+    if (this.disposed) return;
+    this.disposed = true;
+    let firstError: unknown;
+    try {
+      this.cancel({ cause: 'Session disposed.' });
+    } catch (error) {
+      firstError = error;
+    }
+    this.attachmentVersion += 1;
+    for (const attachment of this.attachments.toReversed()) {
+      if (attachment.disposed) continue;
+      attachment.disposed = true;
+      try {
+        attachment.interactions.dispose?.();
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    this.attachments.length = 0;
+    if (firstError !== undefined) throw firstError;
   }
+
+  /**
+   * Return a presentation-only adapter for another session owner. Requests
+   * pass directly to this slot's current concrete host, so forwarding does not
+   * create a second session-owned pending record. Disposal is deliberately
+   * absent: detaching a forwarder must not dispose the target host adapter.
+   */
+  createForwarder(): HostInteractions {
+    return createHostInteractionsForwarder(
+      () => this.activeAttachment?.interactions,
+    );
+  }
+
+  private get activeAttachment(): HostInteractionAttachment | undefined {
+    return this.attachments.at(-1);
+  }
+
+  private enqueue<TResult>(
+    kind: PendingInteractionKind,
+    streamId: StreamTabId | null | undefined,
+    dispatch: (interactions: HostInteractions) => Promise<TResult> | undefined,
+    cancellationResult: (cause?: string) => TResult,
+  ): Promise<TResult> {
+    if (this.disposed) {
+      return Promise.resolve(cancellationResult());
+    }
+
+    return new Promise<TResult>((resolve, reject) => {
+      const pending: PendingSessionInteraction = {
+        kind,
+        streamId: streamId ?? undefined,
+        dispatch,
+        cancellationResult,
+        settle: (result) => resolve(result as TResult),
+        reject,
+        cancellationRequested: false,
+      };
+      this.pending.add(pending);
+      this.dispatch(pending);
+    });
+  }
+
+  private activateCurrentAttachment(): void {
+    this.attachmentVersion += 1;
+    if (!this.activeAttachment) return;
+    for (const pending of this.pending) {
+      if (!pending.cancellationRequested) this.dispatch(pending);
+    }
+  }
+
+  private dispatch(pending: PendingSessionInteraction): void {
+    const attachment = this.activeAttachment;
+    if (!attachment) return;
+    const version = this.attachmentVersion;
+    let result: Promise<unknown> | undefined;
+    try {
+      result = pending.dispatch(attachment.interactions);
+    } catch (error) {
+      this.rejectCurrentDispatch(pending, attachment, version, error);
+      return;
+    }
+    if (!result) {
+      this.pending.delete(pending);
+      pending.settle(pending.cancellationResult());
+      return;
+    }
+    void result.then(
+      (value) => {
+        if (!this.isCurrentDispatch(pending, attachment, version)) return;
+        this.pending.delete(pending);
+        pending.settle(value);
+      },
+      (error: unknown) => {
+        this.rejectCurrentDispatch(pending, attachment, version, error);
+      },
+    );
+  }
+
+  private rejectCurrentDispatch(
+    pending: PendingSessionInteraction,
+    attachment: HostInteractionAttachment,
+    version: number,
+    error: unknown,
+  ): void {
+    if (!this.isCurrentDispatch(pending, attachment, version)) return;
+    this.pending.delete(pending);
+    pending.reject(error);
+  }
+
+  private isCurrentDispatch(
+    pending: PendingSessionInteraction,
+    attachment: HostInteractionAttachment,
+    version: number,
+  ): boolean {
+    return (
+      this.pending.has(pending) &&
+      this.activeAttachment === attachment &&
+      this.attachmentVersion === version
+    );
+  }
+}
+
+/**
+ * Build a non-owning adapter for forwarding one session's requests to another.
+ * Disposal is intentionally not forwarded: detaching the adapter must not
+ * dispose the target session's interaction owner.
+ */
+function createHostInteractionsForwarder(
+  target: () => HostInteractions | undefined,
+): HostInteractions {
+  const pending = new Set<{
+    readonly kind: PendingInteractionKind;
+    readonly streamId?: StreamTabId;
+    readonly cancellationScope: object;
+  }>();
+
+  const forward = <T>(
+    kind: PendingInteractionKind,
+    streamId: StreamTabId | null | undefined,
+    options: HostInteractionOptions | undefined,
+    invoke: (
+      interactions: HostInteractions,
+      options: HostInteractionOptions,
+    ) => Promise<T> | undefined,
+  ): Promise<T> | undefined => {
+    const interactions = target();
+    if (!interactions) return undefined;
+    const cancellationScope = options?.cancellationScope ?? {};
+    const record = {
+      kind,
+      streamId: streamId ?? undefined,
+      cancellationScope,
+    };
+    pending.add(record);
+    let result: Promise<T> | undefined;
+    try {
+      result = invoke(interactions, { ...options, cancellationScope });
+    } catch (error) {
+      pending.delete(record);
+      throw error;
+    }
+    if (!result) {
+      pending.delete(record);
+      return undefined;
+    }
+    return result.finally(() => pending.delete(record));
+  };
+
+  return {
+    requestToolEditApproval: (request, options) =>
+      forward(
+        'toolEdit',
+        request.streamId as StreamTabId | null | undefined,
+        options,
+        (interactions, forwardedOptions) =>
+          interactions.requestToolEditApproval?.(request, forwardedOptions),
+      ),
+    requestBashApproval: (request, options) =>
+      forward('bash', request.streamId, options, (interactions, forwarded) =>
+        interactions.requestBashApproval?.(request, forwarded),
+      ),
+    requestPlanApproval: (request, options) =>
+      forward('plan', request.streamId, options, (interactions, forwarded) =>
+        interactions.requestPlanApproval?.(request, forwarded),
+      ),
+    requestAgentProposal: (request, options) =>
+      forward(
+        'proposal',
+        request.streamId,
+        options,
+        (interactions, forwarded) =>
+          interactions.requestAgentProposal?.(request, forwarded),
+      ),
+    requestRetry: (request, options) =>
+      forward('retry', request.streamId, options, (interactions, forwarded) =>
+        interactions.requestRetry?.(request, forwarded),
+      ),
+    askUserQuestion: (request, options) =>
+      forward(
+        'userQuestion',
+        request.streamId,
+        options,
+        (interactions, forwarded) =>
+          interactions.askUserQuestion?.(request, forwarded),
+      ),
+    openExternalInquiry: (request) => target()?.openExternalInquiry?.(request),
+    setApprovalBypassState: (update) =>
+      target()?.setApprovalBypassState?.(update),
+    resolve: (requestId, result) =>
+      target()?.resolve(requestId, result) ?? false,
+    cancel: (selector = {}) => {
+      const interactions = target();
+      if (!interactions) return;
+      const scopes = [...pending].filter((record) =>
+        matchesCancelSelector(record, selector),
+      );
+      for (const scope of scopes) {
+        interactions.cancel({
+          kind: scope.kind,
+          streamId: scope.streamId ?? null,
+          cause: selector.cause,
+          cancellationScope: scope.cancellationScope,
+        });
+      }
+    },
+  };
 }

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -79,6 +79,8 @@ export interface ProgressViewBypassCommandOptions {
    * window session; the extension omits it so the default session applies.
    */
   session?: SessionHandle;
+  /** Resolve a retained stream's durable approval owner. */
+  sessionForStream?(stream: StreamTabId): SessionHandle | undefined;
   showInfo?(message: string): void | PromiseLike<unknown>;
 }
 
@@ -154,7 +156,9 @@ export function createProgressViewCommandHandlers(
   actions: ProgressViewCommandActions,
 ) {
   const { lifecycle, run, file, followUp, approval, externalInquiry } = actions;
-  const { runtimeHost, session, showInfo } = actions.bypass;
+  const { runtimeHost, session, sessionForStream, showInfo } = actions.bypass;
+  const bypassSession = (stream: StreamTabId): SessionHandle | undefined =>
+    sessionForStream?.(stream) ?? session;
 
   // Single source of truth for the coupled edit + bash session bypass behind
   // the one Yolo concept. The shield toolbar button flips it; the inline "Yolo
@@ -164,10 +168,13 @@ export function createProgressViewCommandHandlers(
     stream: StreamTabId,
     enabled: boolean,
   ): Promise<void> => {
-    setToolEditApprovalSessionBypass(stream, enabled, runtimeHost, { session });
+    const ownerSession = bypassSession(stream);
+    setToolEditApprovalSessionBypass(stream, enabled, runtimeHost, {
+      session: ownerSession,
+    });
     setBashApprovalSessionBypass(stream, enabled, runtimeHost, {
       silent: true,
-      session,
+      session: ownerSession,
     });
     await showInfo?.(
       enabled
@@ -185,18 +192,21 @@ export function createProgressViewCommandHandlers(
     stream: StreamTabId,
     enabled: boolean,
   ): Promise<void> => {
+    const ownerSession = bypassSession(stream);
     if (enabled) {
-      if (!isApprovalBypassedForStream(stream, session)) {
+      if (!isApprovalBypassedForStream(stream, ownerSession)) {
         setToolEditApprovalSessionBypass(stream, true, runtimeHost, {
-          session,
+          session: ownerSession,
         });
       }
     } else {
-      setToolEditApprovalSessionBypass(stream, false, runtimeHost, { session });
+      setToolEditApprovalSessionBypass(stream, false, runtimeHost, {
+        session: ownerSession,
+      });
     }
     setBashApprovalSessionBypass(stream, enabled, runtimeHost, {
       silent: true,
-      session,
+      session: ownerSession,
     });
     await showInfo?.(
       enabled
@@ -255,7 +265,7 @@ export function createProgressViewCommandHandlers(
     [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]: (data) =>
       applyCoupledBypass(
         data.stream,
-        !isApprovalBypassedForStream(data.stream, session),
+        !isApprovalBypassedForStream(data.stream, bypassSession(data.stream)),
       ),
     // Inline "Yolo (this session)" prompt button: force bypass ON. Unlike the
     // shield toggle this is idempotent, so it can never invert an already-on
@@ -266,7 +276,10 @@ export function createProgressViewCommandHandlers(
     [PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS]: (data) =>
       applySuperYoloBypass(
         data.stream,
-        proposalApprovals(session).toggleBypass(data.stream, runtimeHost),
+        proposalApprovals(bypassSession(data.stream)).toggleBypass(
+          data.stream,
+          runtimeHost,
+        ),
       ),
     // Inline "Super Yolo (this session)" proposal button: force the
     // delegated-task auto-approval bypass ON. Idempotent like
@@ -277,7 +290,11 @@ export function createProgressViewCommandHandlers(
     // enabled branch: edit bypass rides along only if not already on, bash
     // silently.
     [PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS]: (data) => {
-      proposalApprovals(session).setBypass(data.stream, true, runtimeHost);
+      proposalApprovals(bypassSession(data.stream)).setBypass(
+        data.stream,
+        true,
+        runtimeHost,
+      );
       return applySuperYoloBypass(data.stream, true);
     },
 

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -24,6 +24,7 @@ import { createRecordingHost } from '../progressTestUtils';
 let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
+let detachHostInteractions = (): void => {};
 
 function installTestPlatform(): Promise<void> {
   return installPlatform({
@@ -31,7 +32,8 @@ function installTestPlatform(): Promise<void> {
     storagePath,
     globalStoragePath: '/global/.texra/storage',
   }).then(() => {
-    defaultSession().useHostInteractions({
+    detachHostInteractions();
+    detachHostInteractions = defaultSession().useHostInteractions({
       requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {
@@ -117,7 +119,8 @@ describe('accept_run_files progress events', () => {
     AbsoluteFS.read = originalAbsoluteRead;
     FlexibleFS.read = originalFlexibleRead;
     testApprovalHandler = undefined;
-    defaultSession().interactions.dispose();
+    detachHostInteractions();
+    detachHostInteractions = () => {};
     cleanupAllApprovals();
   });
 

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -32,10 +32,12 @@ import { createRecordingHost } from '../progressTestUtils';
 let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
+let detachHostInteractions = (): void => {};
 
 function installTestPlatform(): Promise<void> {
   return installPlatform({}).then(() => {
-    defaultSession().useHostInteractions({
+    detachHostInteractions();
+    detachHostInteractions = defaultSession().useHostInteractions({
       requestToolEditApproval: (request) => {
         const handler = testApprovalHandler;
         if (!handler) {
@@ -69,7 +71,8 @@ describe('human prompt progress events', () => {
 
   afterEach(() => {
     cleanupAllApprovals();
-    defaultSession().interactions.dispose();
+    detachHostInteractions();
+    detachHostInteractions = () => {};
     testApprovalHandler = undefined;
   });
 

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -2,12 +2,18 @@
 import { createTestSession } from '@test/support/sessionTestUtils';
 
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
 import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { HostInteractions } from '@agent/runtime/HostInteractions';
+import {
+  matchesCancelSelector,
+  type HostInteractionOptions,
+  HostInteractions,
+  type HostPlanApprovalRequest,
+  type PlanApprovalResult,
+} from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createDesktopHostInteractions } from '@desktop/main/desktopHostInteractions';
 import type { DesktopToolEditApprovalController } from '@desktop/main/desktopToolEditApproval';
@@ -102,15 +108,361 @@ function createPortSession(): {
     runtimeHost,
     session,
     getApprovalHandlers: () => handlers,
-    getToolEditApprovals: () => {
-      throw new Error('tool-edit approvals are not exercised here');
-    },
+    getToolEditApprovals: () => ({
+      cancel: () => {},
+      dispose: () => {},
+      handleAction: () => false,
+      requestApproval: async () => {
+        throw new Error('tool-edit approvals are not exercised here');
+      },
+    }),
   });
   session.useHostInteractions(interactions);
   return { session, uiEvents, emitted, interactions };
 }
 
+function createControllablePlanAdapter(
+  options: { settleOnDispose?: boolean } = {},
+) {
+  const requests: HostPlanApprovalRequest[] = [];
+  const pending = new Map<
+    string,
+    {
+      readonly request: HostPlanApprovalRequest;
+      readonly cancellationScope?: object;
+      readonly settle: (result: PlanApprovalResult) => void;
+    }
+  >();
+  const dispose = vi.fn(() => {
+    if (options.settleOnDispose === false) return;
+    for (const { settle } of pending.values()) settle({ action: 'reject' });
+    pending.clear();
+  });
+  const interactions: HostInteractions = {
+    requestPlanApproval(request, requestOptions?: HostInteractionOptions) {
+      requests.push(request);
+      return new Promise((settle) =>
+        pending.set(request.approvalId, {
+          request,
+          cancellationScope: requestOptions?.cancellationScope,
+          settle,
+        }),
+      );
+    },
+    resolve(requestId, result) {
+      const entry = pending.get(requestId);
+      if (!entry || result.kind !== 'plan') return false;
+      pending.delete(requestId);
+      entry.settle(
+        result.action === 'approve'
+          ? { action: 'approve' }
+          : { action: 'reject', feedback: result.feedback },
+      );
+      return true;
+    },
+    cancel(selector = {}) {
+      for (const [requestId, entry] of pending) {
+        if (
+          !matchesCancelSelector(
+            {
+              kind: 'plan',
+              streamId: entry.request.streamId,
+              cancellationScope: entry.cancellationScope,
+            },
+            selector,
+          )
+        )
+          continue;
+        pending.delete(requestId);
+        entry.settle({ action: 'reject' });
+      }
+    },
+    dispose,
+  };
+  return { interactions, requests, dispose };
+}
+
 describe('session.interactions request bookkeeping (coordinator fold)', () => {
+  it('disposes an adapter offered after terminal slot disposal', () => {
+    const session = createTestSession();
+    const adapter = createControllablePlanAdapter();
+    session.interactions.dispose();
+    session.useHostInteractions(adapter.interactions);
+
+    expect(adapter.dispose).toHaveBeenCalledOnce();
+    session.dispose();
+  });
+
+  it('does not turn an unattached external inquiry into a parked approval', () => {
+    const session = createTestSession();
+    try {
+      expect(
+        session.interactions.openExternalInquiry({
+          requestId: 'inquiry:unattached',
+          threadId: 'inquiry:unattached',
+          question: 'Can this notification be shown?',
+          streamId,
+          mode: 'new',
+          allowBypass: false,
+          sessionLinks: null,
+          draft: null,
+          transcript: null,
+        }),
+      ).toBeUndefined();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('limits forwarded cancellation to the source owner requests', async () => {
+    const source = createTestSession();
+    const target = createTestSession();
+    const adapter = createControllablePlanAdapter();
+    const cancel = vi.fn(adapter.interactions.cancel);
+    target.useHostInteractions({ ...adapter.interactions, cancel });
+    source.useHostInteractions(target.interactions.createForwarder());
+
+    const sourceStream = 'stream:forwarded-owner' as StreamTabId;
+    const targetStream = sourceStream;
+    const sourcePending = source.interactions.requestPlanApproval({
+      approvalId: 'approval:forwarded-owner',
+      streamId: sourceStream,
+      plan,
+      goalEnabled: false,
+    });
+    const targetPending = target.interactions.requestPlanApproval({
+      approvalId: 'approval:target-owner',
+      streamId: targetStream,
+      plan,
+      goalEnabled: false,
+    });
+
+    source.dispose();
+
+    await expect(sourcePending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session disposed.',
+    });
+    expect(cancel).toHaveBeenCalledWith({
+      kind: 'plan',
+      streamId: sourceStream,
+      cause: 'Session disposed.',
+      cancellationScope: expect.any(Object),
+    });
+    expect(
+      target.interactions.resolve('approval:target-owner', {
+        kind: 'plan',
+        action: 'approve',
+      }),
+    ).toBe(true);
+    await expect(targetPending).resolves.toEqual({ action: 'approve' });
+    target.dispose();
+  });
+
+  it('tracks forwarded ownership before presentation can cancel reentrantly', async () => {
+    const source = createTestSession();
+    const target = createTestSession();
+    let settle: ((result: PlanApprovalResult) => void) | undefined;
+    const cancel = vi.fn(() => {
+      settle?.({ action: 'reject', feedback: 'Cancelled while presenting.' });
+    });
+    target.useHostInteractions({
+      requestPlanApproval: () =>
+        new Promise<PlanApprovalResult>((resolve) => {
+          settle = resolve;
+          source.dispose();
+        }),
+      resolve: () => false,
+      cancel,
+    });
+    source.useHostInteractions(target.interactions.createForwarder());
+
+    const pending = source.interactions.requestPlanApproval({
+      approvalId: 'approval:reentrant-cancel',
+      streamId: 'stream:reentrant-cancel' as StreamTabId,
+      plan,
+      goalEnabled: false,
+    });
+
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session disposed.',
+    });
+    expect(cancel).toHaveBeenCalledWith({
+      kind: 'plan',
+      streamId: 'stream:reentrant-cancel',
+      cause: 'Session disposed.',
+      cancellationScope: expect.any(Object),
+    });
+    target.dispose();
+  });
+
+  it('disposes attachments even when cancellation throws', () => {
+    const session = createTestSession();
+    const dispose = vi.fn();
+    session.useHostInteractions({
+      resolve: () => false,
+      cancel: () => {
+        throw new Error('cancel failed');
+      },
+      dispose,
+    });
+
+    expect(() => session.interactions.dispose()).toThrow('cancel failed');
+    expect(dispose).toHaveBeenCalledOnce();
+    session.dispose();
+  });
+
+  it('buffers a request made while no adapter is attached', async () => {
+    const session = createTestSession();
+    const adapter = createControllablePlanAdapter();
+    try {
+      const pending = session.interactions.requestPlanApproval({
+        approvalId: 'approval:unattached',
+        streamId,
+        plan,
+        goalEnabled: false,
+      });
+      expect(adapter.requests).toEqual([]);
+
+      session.useHostInteractions(adapter.interactions);
+      expect(adapter.requests).toHaveLength(1);
+      expect(
+        session.interactions.resolve('approval:unattached', {
+          kind: 'plan',
+          action: 'approve',
+        }),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({ action: 'approve' });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('keeps a pending request across adapter detach and reattach', async () => {
+    const session = createTestSession();
+    const first = createControllablePlanAdapter();
+    const second = createControllablePlanAdapter();
+    try {
+      const detach = session.useHostInteractions(first.interactions);
+      const pending = session.interactions.requestPlanApproval({
+        approvalId: 'approval:reattach',
+        streamId,
+        plan,
+        goalEnabled: false,
+      });
+      detach();
+      await Promise.resolve();
+      expect(first.dispose).toHaveBeenCalledOnce();
+
+      session.useHostInteractions(second.interactions);
+      expect(second.requests).toHaveLength(1);
+      expect(
+        session.interactions.resolve('approval:reattach', {
+          kind: 'plan',
+          action: 'approve',
+        }),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({ action: 'approve' });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('ignores a result produced by a detached adapter', async () => {
+    const session = createTestSession();
+    const first = createControllablePlanAdapter({ settleOnDispose: false });
+    const second = createControllablePlanAdapter();
+    try {
+      const detach = session.useHostInteractions(first.interactions);
+      const pending = session.interactions.requestPlanApproval({
+        approvalId: 'approval:stale',
+        streamId,
+        plan,
+        goalEnabled: false,
+      });
+      detach();
+      session.useHostInteractions(second.interactions);
+
+      expect(
+        first.interactions.resolve('approval:stale', {
+          kind: 'plan',
+          action: 'reject',
+        }),
+      ).toBe(true);
+      await Promise.resolve();
+      expect(
+        session.interactions.resolve('approval:stale', {
+          kind: 'plan',
+          action: 'approve',
+        }),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({ action: 'approve' });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('settles an explicit cancellation while unattached', async () => {
+    const session = createTestSession();
+    const pending = session.interactions.requestPlanApproval({
+      approvalId: 'approval:cancel-unattached',
+      streamId,
+      plan,
+      goalEnabled: false,
+    });
+
+    session.interactions.cancel({ streamId, cause: 'Run ended.' });
+
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Run ended.',
+    });
+    session.dispose();
+  });
+
+  it('preserves user-question feedback while unattached', async () => {
+    const session = createTestSession();
+    const pending = session.interactions.askUserQuestion({
+      requestId: 'question:cancel-unattached',
+      questions: [
+        {
+          question: 'Which normalization should be used?',
+          options: [{ label: 'Unit volume' }, { label: 'Unit mass' }],
+        },
+      ],
+      allowBypass: false,
+      streamId: '',
+    });
+
+    session.interactions.cancel({
+      streamId: null,
+      cause: 'No stream owns this question.',
+    });
+
+    await expect(pending).resolves.toEqual({
+      submitted: false,
+      feedback: 'No stream owns this question.',
+    });
+    session.dispose();
+  });
+
+  it('settles buffered requests on terminal session disposal', async () => {
+    const session = createTestSession();
+    const pending = session.interactions.requestAgentProposal({
+      proposalId: 'proposal:dispose-unattached',
+      streamId,
+      ...proposal,
+    });
+
+    session.dispose();
+
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session disposed.',
+    });
+  });
+
   it('resolves a plan approval first-wins through the session slot', async () => {
     const { session, uiEvents, emitted } = createPortSession();
     try {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -4,6 +4,7 @@ import '@test/support/defaultSessionTestSetup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const handleExternalInquiryActionMock = vi.hoisted(() => vi.fn());
+let detachHostInteractions = (): void => {};
 
 vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
@@ -53,7 +54,8 @@ function useCliHostInteractions(
   cliContext: CliContext,
   hooks: CliApprovalPromptHooks = {},
 ): void {
-  defaultSession().useHostInteractions(
+  detachHostInteractions();
+  detachHostInteractions = defaultSession().useHostInteractions(
     createHeadlessCliHostInteractions(cliContext, hooks),
   );
 }
@@ -78,7 +80,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  defaultSession().interactions.dispose();
+  detachHostInteractions();
+  detachHostInteractions = () => {};
   handleExternalInquiryActionMock.mockClear();
 });
 

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -9,6 +9,7 @@ import {
   createProgressViewCommandHandlers as createSharedProgressViewCommandHandlers,
   type ProgressViewCommandActions,
 } from '@controllers/progressView/ProgressViewCommandHandlers';
+import { createTestSession } from '@test/support/sessionTestUtils';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -440,6 +441,42 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       event: 'updateToolEditApprovalBypassState',
       payload: { streamId: stream, bypassActive: false },
     });
+  });
+
+  it('updates the durable owner of a rebound stream', async () => {
+    const stream = 'stream:rebound-bypass';
+    const owner = createTestSession();
+    const presenter = createTestSession();
+    const { host } = createRecordingRuntimeHost();
+    const handlers = createProgressViewCommandHandlers(
+      createActions({
+        bypass: {
+          runtimeHost: host,
+          session: presenter,
+          sessionForStream: () => owner,
+        },
+      }),
+    );
+    try {
+      expect(
+        dispatchProgressViewInbound(
+          {
+            command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+            stream,
+          },
+          handlers,
+        ),
+      ).toBe(true);
+      await Promise.resolve();
+
+      expect(isApprovalBypassedForStream(stream, owner)).toBe(true);
+      expect(isBashApprovalBypassedForStream(stream, owner)).toBe(true);
+      expect(isApprovalBypassedForStream(stream, presenter)).toBe(false);
+      expect(isBashApprovalBypassedForStream(stream, presenter)).toBe(false);
+    } finally {
+      owner.dispose();
+      presenter.dispose();
+    }
   });
 
   it('forces edit and bash bypass on without inverting a decoupled stream', async () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -39,6 +39,10 @@ import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progres
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { assertSupported } from '@shared/utils/dispatcher';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import {
+  isApprovalBypassedForStream,
+  isBashApprovalBypassedForStream,
+} from '@tools/approval';
 
 // Local imports - desktop test support
 import {
@@ -72,6 +76,13 @@ type TestableBridge = Bridge & {
       }) => Promise<unknown>;
       requestBashApproval?: (request: {
         command: string;
+        streamId?: StreamTabId;
+      }) => Promise<unknown>;
+      requestToolEditApproval?: (request: {
+        path: string;
+        originalContent: string;
+        proposedContent: string;
+        sourceTool: string;
         streamId?: StreamTabId;
       }) => Promise<unknown>;
     };
@@ -417,6 +428,28 @@ function progressMessages(
       message !== null &&
       (message as ProgressMessage).command === command,
   );
+}
+
+function shownToolEditRequestId(messages: unknown[]): string | undefined {
+  for (const message of progressMessages(
+    messages,
+    PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+  )) {
+    const update = message as ProgressMessage & {
+      action?: string;
+      permission?: {
+        kind?: string;
+        data?: { requestId?: string };
+      };
+    };
+    if (
+      update.action === 'show' &&
+      update.permission?.kind === PERMISSION_KIND.TOOL_EDIT
+    ) {
+      return update.permission.data?.requestId;
+    }
+  }
+  return undefined;
 }
 
 function restoredSnapshot(
@@ -3353,7 +3386,10 @@ describe('DesktopProgressBridge', () => {
       bridgeA.session.executions.trackAgentExecution(handle, {
         status: STREAM_PHASE.RUNNING,
       });
+      let closed = false;
       const close = (): void => {
+        if (closed) return;
+        closed = true;
         activeExecutionIds = [executionId];
         bridgeA.dispose();
       };
@@ -3488,6 +3524,292 @@ describe('DesktopProgressBridge', () => {
           }),
         ).toBe(true);
         await expect(planPromise).resolves.toEqual({ action: 'approve' });
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('replays a tool-edit approval with a fresh window request id', async () => {
+      const streamId = 'rebound-stream-tool-edit' as StreamTabId;
+      const executionId = 'ec00ed' as ExecutionId;
+      const messagesA: unknown[] = [];
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+        messages: messagesA,
+      });
+      const approvalPromise =
+        owner.bridgeA.runtimeHost.interactions?.requestToolEditApproval?.({
+          path: '/workspace/rebound-tool-edit.txt',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+          streamId,
+        });
+      expect(approvalPromise).toBeDefined();
+      let oldRequestId = '';
+      await vi.waitFor(() => {
+        oldRequestId = shownToolEditRequestId(messagesA) ?? '';
+        expect(oldRequestId).not.toBe('');
+      });
+
+      const messagesB: unknown[] = [];
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING, messagesB);
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        let newRequestId = '';
+        await vi.waitFor(() => {
+          newRequestId = shownToolEditRequestId(messagesB) ?? '';
+          expect(newRequestId).not.toBe('');
+        });
+        expect(newRequestId).not.toBe(oldRequestId);
+
+        const handleToolEdit = assertSupported(
+          bridgeB.progressViewInboundHandlers[
+            PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
+          ],
+        );
+        await handleToolEdit({
+          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+          requestId: newRequestId,
+          action: 'reject',
+          feedback: 'Not this edit.',
+        });
+
+        await expect(approvalPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Not this edit.',
+        });
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('keeps owner approvals pending when a replacement window also closes', async () => {
+      const streamId = 'rebound-stream-second-close' as StreamTabId;
+      const executionId = 'ec00ec' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const messagesB: unknown[] = [];
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING, messagesB);
+      await (bridgeB as unknown as { restartRepair: Promise<void> })
+        .restartRepair;
+
+      const approval =
+        owner.bridgeA.runtimeHost.interactions?.requestPlanApproval?.({
+          approvalId: 'plan-second-window-close',
+          streamId,
+          plan: { objective: 'Survive a second window close.' },
+          goalEnabled: false,
+        });
+      expect(approval).toBeDefined();
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messagesB, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              data: expect.objectContaining({
+                approvalId: 'plan-second-window-close',
+              }),
+            }),
+          }),
+        );
+      });
+
+      bridgeB.dispose();
+      const messagesC: unknown[] = [];
+      const { bridgeB: bridgeC } = owner.reopen(
+        STREAM_PHASE.RUNNING,
+        messagesC,
+      );
+      try {
+        await (bridgeC as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        await vi.waitFor(() => {
+          expect(
+            progressMessages(
+              messagesC,
+              PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+            ),
+          ).toContainEqual(
+            expect.objectContaining({
+              action: 'show',
+              permission: expect.objectContaining({
+                data: expect.objectContaining({
+                  approvalId: 'plan-second-window-close',
+                }),
+              }),
+            }),
+          );
+        });
+        expect(
+          bridgeC.session.interactions.resolve('plan-second-window-close', {
+            kind: 'plan',
+            action: 'approve',
+          }),
+        ).toBe(true);
+        await expect(approval).resolves.toEqual({ action: 'approve' });
+      } finally {
+        bridgeC.dispose();
+      }
+    });
+
+    it('replays approvals requested before close and while awaiting reopen repair (#8261)', async () => {
+      const streamId = 'rebound-stream-approval-gap' as StreamTabId;
+      const executionId = 'ec00ef' as ExecutionId;
+      const messagesA: unknown[] = [];
+      const owner = await createReboundOwner({
+        streamId,
+        executionId,
+        messages: messagesA,
+      });
+      const pendingBeforeClose =
+        owner.bridgeA.runtimeHost.interactions?.requestPlanApproval?.({
+          approvalId: 'plan-before-close',
+          streamId,
+          plan: { objective: 'Preserve the pending approval.' },
+          goalEnabled: false,
+        });
+      expect(pendingBeforeClose).toBeDefined();
+      await vi.waitFor(() => {
+        expect(
+          progressMessages(messagesA, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'show',
+            permission: expect.objectContaining({
+              data: expect.objectContaining({
+                approvalId: 'plan-before-close',
+              }),
+            }),
+          }),
+        );
+      });
+
+      owner.close();
+      const pendingWhileClosed =
+        owner.bridgeA.runtimeHost.interactions?.requestPlanApproval?.({
+          approvalId: 'plan-while-closed',
+          streamId,
+          plan: { objective: 'Buffer the approval until repair.' },
+          goalEnabled: false,
+        });
+      expect(pendingWhileClosed).toBeDefined();
+
+      const messagesB: unknown[] = [];
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING, messagesB);
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+
+        const enableBypass = assertSupported(
+          bridgeB.progressViewInboundHandlers[
+            PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS
+          ],
+        );
+        await enableBypass({
+          command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+          stream: streamId,
+        });
+        expect(
+          isApprovalBypassedForStream(streamId, owner.bridgeA.session),
+        ).toBe(true);
+        expect(
+          isBashApprovalBypassedForStream(streamId, owner.bridgeA.session),
+        ).toBe(true);
+        expect(isApprovalBypassedForStream(streamId, bridgeB.session)).toBe(
+          false,
+        );
+
+        await vi.waitFor(() => {
+          const approvals = progressMessages(
+            messagesB,
+            PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          );
+          for (const approvalId of ['plan-before-close', 'plan-while-closed']) {
+            expect(approvals).toContainEqual(
+              expect.objectContaining({
+                action: 'show',
+                permission: expect.objectContaining({
+                  data: expect.objectContaining({ approvalId }),
+                }),
+              }),
+            );
+          }
+        });
+
+        for (const approvalId of ['plan-before-close', 'plan-while-closed']) {
+          expect(
+            bridgeB.session.interactions.resolve(approvalId, {
+              kind: 'plan',
+              action: 'approve',
+            }),
+          ).toBe(true);
+        }
+        await expect(pendingBeforeClose).resolves.toEqual({
+          action: 'approve',
+        });
+        await expect(pendingWhileClosed).resolves.toEqual({
+          action: 'approve',
+        });
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('releases rebound stream interactions from the durable owner session', async () => {
+      const streamId = 'rebound-stream-delete' as StreamTabId;
+      const executionId = 'ec00f9' as ExecutionId;
+      const owner = await createReboundOwner({ streamId, executionId });
+      const messagesB: unknown[] = [];
+      const { bridgeB } = owner.reopen(STREAM_PHASE.RUNNING, messagesB);
+
+      try {
+        await (bridgeB as unknown as { restartRepair: Promise<void> })
+          .restartRepair;
+        const planPromise =
+          owner.bridgeA.runtimeHost.interactions?.requestPlanApproval?.({
+            approvalId: 'plan-rebound-delete',
+            streamId,
+            plan: { objective: 'Cancel through the durable owner.' },
+            goalEnabled: false,
+          });
+        expect(planPromise).toBeDefined();
+        await vi.waitFor(() => {
+          expect(
+            progressMessages(
+              messagesB,
+              PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+            ),
+          ).toContainEqual(
+            expect.objectContaining({
+              action: 'show',
+              permission: expect.objectContaining({
+                data: expect.objectContaining({
+                  approvalId: 'plan-rebound-delete',
+                }),
+              }),
+            }),
+          );
+        });
+
+        await bridgeB.deleteStream(streamId);
+
+        await expect(planPromise).resolves.toEqual({
+          action: 'reject',
+          feedback: 'Stream resources released.',
+        });
+        expect(
+          progressMessages(messagesB, PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION),
+        ).toContainEqual(
+          expect.objectContaining({
+            action: 'resolve',
+            kind: PERMISSION_KIND.PLAN_APPROVAL,
+            id: 'plan-rebound-delete',
+          }),
+        );
       } finally {
         bridgeB.dispose();
       }

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -49,6 +49,7 @@ interface DesktopHostInteractionsModule {
     session: SessionHandle;
     getApprovalHandlers(): unknown;
     getToolEditApprovals(): {
+      cancel: ReturnType<typeof vi.fn>;
       requestApproval: ReturnType<typeof vi.fn>;
     };
   }): DesktopHostInteractions;
@@ -91,6 +92,7 @@ async function createInteractions(handlers = createHandlers()) {
   const runtimeHost = { emit: vi.fn() };
   const session = createTestSession();
   const toolEditApprovals = {
+    cancel: vi.fn(),
     requestApproval: vi.fn(async () => ({ accepted: true })),
   };
   const sessionEvents: SessionEvent[] = [];
@@ -179,7 +181,8 @@ describe('createDesktopHostInteractions', () => {
 
   it('forwards a cancellation cause as bash reject feedback', async () => {
     const handlers = createHandlers();
-    const { interactions } = await createInteractions(handlers);
+    const { interactions, toolEditApprovals } =
+      await createInteractions(handlers);
 
     const resultPromise = interactions.requestBashApproval({
       command: 'rm -rf build',
@@ -196,6 +199,48 @@ describe('createDesktopHostInteractions', () => {
       userMessage: 'Stream resources released.',
     });
     expect(handlers.bash.resolve).toHaveBeenCalled();
+    expect(toolEditApprovals.cancel).toHaveBeenCalledWith({
+      streamId: 'stream-a',
+      cause: 'Stream resources released.',
+    });
+  });
+
+  it('can cancel synchronously while presenting a request', async () => {
+    const handlers = createHandlers();
+    const { interactions } = await createInteractions(handlers);
+    handlers.bash.show.mockImplementation(() => {
+      interactions.cancel({
+        kind: 'bash',
+        streamId: 'stream-sync' as StreamTabId,
+        cause: 'Stopped during presentation.',
+      });
+    });
+
+    const result = interactions.requestBashApproval({
+      command: 'echo pending',
+      streamId: 'stream-sync' as StreamTabId,
+    });
+
+    await expect(result).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Stopped during presentation.',
+    });
+  });
+
+  it('routes tool-edit cancellation to the window controller', async () => {
+    const { interactions, toolEditApprovals } = await createInteractions();
+
+    interactions.cancel({
+      kind: 'toolEdit',
+      streamId: 'stream-a' as StreamTabId,
+      cause: 'Owning execution ended.',
+    });
+
+    expect(toolEditApprovals.cancel).toHaveBeenCalledWith({
+      kind: 'toolEdit',
+      streamId: 'stream-a',
+      cause: 'Owning execution ended.',
+    });
   });
 
   it('preserves a bash timeout resolution as distinct from rejection', async () => {

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -42,6 +42,11 @@ interface DesktopToolEditApprovalModule {
     showErrorMessage?: (message: string) => Promise<void> | void;
     tempRoot?: string;
   }): {
+    cancel(selector?: {
+      streamId?: string | null;
+      kind?: string;
+      cause?: string;
+    }): void;
     handleAction(payload: {
       requestId: string;
       action: string;
@@ -516,6 +521,157 @@ describe('desktop tool edit approval', () => {
         controller.dispose();
         await rm(tempRoot, { recursive: true, force: true });
         await rm(workspaceRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  approvalTest(
+    'does not present a stream approval cancelled during initialization',
+    async () => {
+      const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
+      const { requestToolEditApproval, desktopModule } =
+        await loadApprovalModules();
+      const runtimeHost = createRecordingRuntimeHost();
+      const controller = desktopModule.createDesktopToolEditApprovalController({
+        runtimeHost,
+        session: createTestSession(),
+        tempRoot,
+      });
+      useControllerApproval(controller);
+
+      try {
+        const resultPromise = requestToolEditApproval({
+          path: '/workspace/cancel-during-init.tex',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+          streamId: 'stream-cancel-during-init',
+        });
+        controller.cancel({
+          kind: 'toolEdit',
+          streamId: 'stream-cancel-during-init',
+          cause: 'Owning execution ended.',
+        });
+
+        await expect(resultPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Owning execution ended.',
+        });
+        expect(runtimeHost.shownToolEditPermissions).toEqual([]);
+        expect(runtimeHost.resolvedToolEditPermissions).toEqual([]);
+        await waitForEmptyDir(tempRoot);
+      } finally {
+        controller.dispose();
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  approvalTest(
+    'does not present an approval when disposed during initialization',
+    async () => {
+      const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
+      const { requestToolEditApproval, desktopModule } =
+        await loadApprovalModules();
+      const runtimeHost = createRecordingRuntimeHost();
+      const controller = desktopModule.createDesktopToolEditApprovalController({
+        runtimeHost,
+        session: createTestSession(),
+        tempRoot,
+      });
+      useControllerApproval(controller);
+
+      try {
+        const resultPromise = requestToolEditApproval({
+          path: '/workspace/dispose-during-init.tex',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+          streamId: 'stream-dispose-during-init',
+        });
+        controller.dispose();
+
+        await expect(resultPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Desktop session disposed.',
+        });
+        expect(runtimeHost.shownToolEditPermissions).toEqual([]);
+        expect(runtimeHost.resolvedToolEditPermissions).toEqual([]);
+        await waitForEmptyDir(tempRoot);
+      } finally {
+        controller.dispose();
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  approvalTest(
+    'cancels only tool-edit approvals selected for the owning stream',
+    async () => {
+      const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
+      const { requestToolEditApproval, desktopModule } =
+        await loadApprovalModules();
+      const runtimeHost = createRecordingRuntimeHost();
+      const controller = desktopModule.createDesktopToolEditApprovalController({
+        runtimeHost,
+        session: createTestSession(),
+        tempRoot,
+      });
+      useControllerApproval(controller);
+      const { shownToolEditPermissions: shown } = runtimeHost;
+      const { resolvedToolEditPermissions: resolved } = runtimeHost;
+
+      try {
+        const cancelledPromise = requestToolEditApproval({
+          path: '/workspace/cancelled.tex',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+          streamId: 'stream-cancelled',
+        });
+        const retainedPromise = requestToolEditApproval({
+          path: '/workspace/retained.tex',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+          streamId: 'stream-retained',
+        });
+        await vi.waitFor(() => expect(shown).toHaveLength(2));
+        const cancelledRequest = shown.find(
+          (request) => request.streamId === 'stream-cancelled',
+        );
+        const retainedRequest = shown.find(
+          (request) => request.streamId === 'stream-retained',
+        );
+        if (!cancelledRequest || !retainedRequest) {
+          throw new Error('Expected both stream-scoped approval prompts.');
+        }
+
+        controller.cancel({
+          kind: 'toolEdit',
+          streamId: 'stream-cancelled',
+          cause: 'Owning execution ended.',
+        });
+
+        await expect(cancelledPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Owning execution ended.',
+        });
+        expect(resolved).toEqual([{ requestId: cancelledRequest.requestId }]);
+
+        controller.handleAction({
+          requestId: retainedRequest.requestId,
+          action: 'reject',
+          feedback: 'Retained request resolved normally.',
+        });
+        await expect(retainedPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Retained request resolved normally.',
+        });
+        await waitForEmptyDir(tempRoot);
+      } finally {
+        controller.dispose();
+        await rm(tempRoot, { recursive: true, force: true });
       }
     },
   );

--- a/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
+++ b/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
@@ -9,6 +9,7 @@ import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInte
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import {
+  cancelNativeToolEditApprovals,
   handleProgressViewToolEditApprovalAction,
   initializeNativeToolEditApproval,
   nativeRequestApproval,
@@ -108,6 +109,7 @@ interface StartedApproval {
   readonly approval: Promise<ToolEditApprovalResult>;
   readonly requestId: string;
   readonly runtimeHost: RecordingRuntimeHost;
+  readonly session: SessionHandle;
 }
 
 const sessions: SessionHandle[] = [];
@@ -175,7 +177,7 @@ async function startApproval(): Promise<StartedApproval> {
   if (!requestId) {
     throw new Error('Expected a tool edit approval request ID.');
   }
-  return { approval, requestId, runtimeHost };
+  return { approval, requestId, runtimeHost, session };
 }
 
 beforeEach(async () => {
@@ -207,6 +209,112 @@ afterEach(async () => {
 });
 
 describe('native tool edit approval', () => {
+  it('does not present an approval cancelled during initialization', async () => {
+    const runtimeHost = createRecordingRuntimeHost();
+    const session = createTestSession();
+    sessions.push(session);
+    initializeNativeToolEditApproval(
+      {
+        storageUri: { fsPath: storageRoot },
+        globalStorageUri: { fsPath: storageRoot },
+      } as unknown as VSCode.ExtensionContext,
+      runtimeHost,
+    );
+    const approval = nativeRequestApproval(
+      {
+        path: '/workspace/cancel-initializing.txt',
+        originalContent: 'old\n',
+        proposedContent: 'new\n',
+        sourceTool: 'write_file',
+        streamId: 'stream-initializing',
+      },
+      { session },
+    );
+    activeApprovals.push(approval);
+
+    cancelNativeToolEditApprovals(session, {
+      kind: 'toolEdit',
+      streamId: 'stream-initializing',
+      cause: 'Run ended.',
+    });
+
+    await expect(approval).resolves.toMatchObject({
+      accepted: false,
+      userMessage: 'Run ended.',
+    });
+    expect(runtimeHost.shown).toEqual([]);
+  });
+
+  it('does not publish a prompt after cancellation while revealing the view', async () => {
+    let revealProgress: (() => void) | undefined;
+    vscodeMocks.executeCommand.mockImplementation(
+      async (command: unknown, ...args: unknown[]) => {
+        if (command === 'vscode.diff') {
+          const proposedUri = args[1] as TestUri;
+          vscodeMocks.visibleTextEditors.push({
+            document: { uri: proposedUri },
+            selections: [],
+            revealRange: vi.fn(),
+          });
+        }
+        if (command === 'texra.showProgressView') {
+          await new Promise<void>((resolve) => {
+            revealProgress = resolve;
+          });
+        }
+      },
+    );
+    const runtimeHost = createRecordingRuntimeHost();
+    const session = createTestSession();
+    sessions.push(session);
+    initializeNativeToolEditApproval(
+      {
+        storageUri: { fsPath: storageRoot },
+        globalStorageUri: { fsPath: storageRoot },
+      } as unknown as VSCode.ExtensionContext,
+      runtimeHost,
+    );
+    const approval = nativeRequestApproval(
+      {
+        path: '/workspace/cancel-reveal.txt',
+        originalContent: 'old\n',
+        proposedContent: 'new\n',
+        sourceTool: 'write_file',
+        streamId: 'stream-reveal',
+      },
+      { session },
+    );
+    activeApprovals.push(approval);
+    await vi.waitFor(() => expect(revealProgress).toBeTypeOf('function'));
+
+    cancelNativeToolEditApprovals(session, {
+      kind: 'toolEdit',
+      streamId: 'stream-reveal',
+      cause: 'Run ended.',
+    });
+    revealProgress?.();
+
+    await expect(approval).resolves.toMatchObject({ accepted: false });
+    await Promise.resolve();
+    expect(runtimeHost.shown).toEqual([]);
+  });
+
+  it('cancels and cleans a selected session approval', async () => {
+    const { approval, requestId, runtimeHost, session } = await startApproval();
+
+    cancelNativeToolEditApprovals(session, {
+      kind: 'toolEdit',
+      streamId: 'stream-approval',
+      cause: 'Stream resources released.',
+    });
+
+    await expect(approval).resolves.toMatchObject({
+      accepted: false,
+      userMessage: 'Stream resources released.',
+    });
+    expect(runtimeHost.resolved).toEqual([{ requestId }]);
+  });
+
   it('restores a failed approval prompt and accepts a later retry', async () => {
     const { approval, requestId, runtimeHost } = await startApproval();
     const proposedUri = currentProposedUri();

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -10,10 +10,12 @@ import type { StreamTabId } from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 
 const mocks = vi.hoisted(() => ({
+  cancelNativeToolEditApprovals: vi.fn(),
   nativeRequestApproval: vi.fn(),
 }));
 
 vi.mock('@frontend/approval/nativeToolEditApproval', () => ({
+  cancelNativeToolEditApprovals: mocks.cancelNativeToolEditApprovals,
   nativeRequestApproval: mocks.nativeRequestApproval,
 }));
 
@@ -215,6 +217,23 @@ describe('createExtensionHostInteractions', () => {
 
     await expect(resultPromise).resolves.toEqual({ action: 'cancel' });
     expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
+  });
+
+  it('routes tool-edit cancellation through the native approval owner', () => {
+    const session = createTestSession();
+    const interactions = createInteractions({ session });
+    const selector = {
+      kind: 'toolEdit' as const,
+      streamId: 'stream-a' as StreamTabId,
+      cause: 'Stream resources released.',
+    };
+
+    interactions.cancel(selector);
+
+    expect(mocks.cancelNativeToolEditApprovals).toHaveBeenCalledWith(
+      session,
+      selector,
+    );
   });
 
   it('forwards a cancellation cause as bash reject feedback', async () => {

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -35,6 +35,7 @@ const TEST_STREAM_ID = 'TestAgent@model: test.tex' as StreamTabId;
 let testApprovalHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
+let detachHostInteractions = (): void => {};
 
 async function installPlatform(
   config: Record<string, unknown> = {},
@@ -42,7 +43,8 @@ async function installPlatform(
 ) {
   testApprovalHandler = undefined;
   await installFakePlatform({ workspacePath: '/workspace', config, files });
-  defaultSession().useHostInteractions({
+  detachHostInteractions();
+  detachHostInteractions = defaultSession().useHostInteractions({
     requestToolEditApproval: (request) => {
       const handler = testApprovalHandler;
       if (!handler) {
@@ -93,7 +95,8 @@ describe('Tool edit approval gating', () => {
     WorkspaceFS.write = originalWrite;
     WorkspaceFS.appendFile = originalAppend;
     testApprovalHandler = undefined;
-    defaultSession().interactions.dispose();
+    detachHostInteractions();
+    detachHostInteractions = () => {};
     cleanupAllApprovals();
   });
 


### PR DESCRIPTION
## Summary

- make the execution session own pending host interactions while desktop presentation adapters attach and detach
- replay unanswered approvals in the replacement window and ignore late results from detached windows
- keep cancellation, bypass state, and stream controls scoped to the execution-owning session
- cancel presented tool-edit approvals by interaction kind and stream so ended executions leave no stale prompt or temporary files

## Design

`SessionHostInteractions` is the durable owner. Desktop windows provide replaceable presentation adapters through a non-owning forwarder; generation checks prevent a detached adapter from resolving an interaction after a replacement has taken over. External inquiry remains an immediate window operation and is deliberately not buffered.

The desktop rebinder resolves the owning session for stream controls and bypass changes. This keeps cross-window presentation separate from execution state.

Closes #8261.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- `npm run compile:fast`
- `npm test` (5,915 passed; 4 skipped; one unrelated CLI signal test timed out and passed on isolated rerun)
- final focused interaction/desktop suite (102 passed)
- `tsc --noEmit -p tsconfig.test-kernel.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core approval/session lifecycle across desktop and extension hosts; incorrect ownership or cancellation could reject valid edits or leave stale prompts, though coverage is heavy in new tests.
> 
> **Overview**
> **Desktop approvals and bypass state now follow the execution-owning session**, not the visible window, so closing and reopening the app no longer rejects or drops prompts for still-running work (#8261).
> 
> `SessionHostInteractions` is reworked to **own pending approval promises** while hosts attach and detach presentation adapters. Requests can buffer with no UI, **replay when a new adapter attaches**, and **ignore stale results** from detached adapters via generation checks. A **`cancellationScope`** on `HostInteractionOptions` / cancel selectors lets forwarded desktop requests cancel precisely without tearing down unrelated prompts.
> 
> **Desktop** wires `sessionForStream` through the execution rebinder for stream stop/delete, progress controls, and YOLO/bypass commands. Tool-edit approval setup runs before host interactions; **cancel** covers in-flight initialization as well as shown prompts (desktop + VS Code native paths).
> 
> The desktop rebinder uses **`createForwarder()`** instead of hand-rolled interaction forwarding and tears down forwards when bindings end. Changelog documents the desktop bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6affcc032bcd63491acbbef7b57545232abbd7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->