### PR TITLE
feat(openai): enable parallel tool calls by default

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -288,8 +288,8 @@
           },
           "texra.model.openaiParallelToolCalls": {
             "type": "boolean",
-            "default": false,
-            "description": "Let OpenAI models use multiple tools at the same time for faster results. Disabled by default for more predictable behavior.",
+            "default": true,
+            "description": "Let OpenAI models use multiple tools at the same time for faster results. Enabled by default; disable for models that require sequential tool execution.",
             "scope": "resource"
           },
           "texra.model.compactionThresholdPercent": {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -34,6 +34,7 @@ import type { ToolDefinition } from '@model';
 // Local imports - tools and utils
 import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
+import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import type {
   ToolFileAttachment,
   ToolResult,
@@ -336,11 +337,9 @@ export class ModelHandlerOpenAI<
     if (tools?.length) {
       const parallelToolCalls = getConfig<boolean>(
         'texra.model.openaiParallelToolCalls',
-        false,
+        DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls,
       );
-      if (!parallelToolCalls) {
-        baseParams.parallel_tool_calls = false;
-      }
+      baseParams.parallel_tool_calls = parallelToolCalls;
       // These tools are parsed by TeXRA after the response. The SDK's
       // auto-parse validator requires strict schemas, but several TeXRA tools
       // intentionally expose nullable or optional fields.

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -51,6 +51,7 @@ import type {
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas/toolResult';
+import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 
 // Local imports - utils
 import { clamp, filterNotNullish } from '@utils/core';
@@ -1754,7 +1755,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Phase 4: EXECUTE - Build final params and make the API call
     const parallelToolCalls = getConfig<boolean>(
       'texra.model.openaiParallelToolCalls',
-      false,
+      DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls,
     );
     const params: ResponseCreateParamsBase = {
       ...baseParams,
@@ -1762,7 +1763,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       store: this.storesResponsesServerSide,
       ...(convertedTools?.length && {
         tool_choice: 'auto' as const,
-        ...(!parallelToolCalls && { parallel_tool_calls: false }),
+        parallel_tool_calls: parallelToolCalls,
       }),
     };
 

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -309,7 +309,8 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       key: 'texra.model.openaiParallelToolCalls',
       label: 'Parallel Tool Calls',
       description:
-        'Allow the model to call multiple tools in parallel. Off by default to preserve sequential tool execution.',
+        'Allow the model to call multiple tools in parallel. On by default; disable for models that require sequential execution.',
+      defaultValue: true,
     },
     {
       key: GlobalStateKey.WEBSOCKET_OPENAI,

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -82,7 +82,7 @@ export const DEFAULT_CORE_SETTINGS = {
     useGoogleInteractionsAPI: true,
     useGoogleInteractionsServerState: true,
     useBackgroundResponses: true,
-    openaiParallelToolCalls: false,
+    openaiParallelToolCalls: true,
     compactionThresholdPercent: 75,
     gpt5ReasoningSummary: false,
     retry: {
@@ -374,7 +374,7 @@ export const CoreSettingsShape = {
       ),
       openaiParallelToolCalls: boolField(
         DEFAULT_CORE_SETTINGS.model.openaiParallelToolCalls,
-        'Let OpenAI models use multiple tools at the same time for faster results. Disabled by default for more predictable behavior.',
+        'Let OpenAI models use multiple tools at the same time for faster results. Enabled by default; disable for models that require sequential tool execution.',
       ),
       compactionThresholdPercent: numberField(
         DEFAULT_CORE_SETTINGS.model.compactionThresholdPercent,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -34,6 +34,7 @@ import {
   hasContextWindowErrorMarker,
   isContextWindowError,
 } from '@common/errors/sdkErrorUtils';
+import type { ToolDefinition } from '@model';
 
 // Type imports
 import { pathToLocation } from '@utils/files';
@@ -164,6 +165,32 @@ function createMessages(count: number): ResponseInputItem[] {
 }
 
 describe('ModelHandlerOpenAIResponse.createResponse', () => {
+  it('enables parallel tool calls by default', async () => {
+    const handler = createHandler();
+    let request: Record<string, unknown> | undefined;
+    const client = {
+      responses: {
+        create: async (params: Record<string, unknown>) => {
+          request = params;
+          return createResponse('resp-parallel-tools', { input_tokens: 12 });
+        },
+      },
+    };
+    const tools: ToolDefinition[] = [
+      { name: 'lookup', description: 'Look up a value' },
+    ];
+
+    await handler.createResponse({
+      client: client as any,
+      messages: createMessages(1),
+      temperature: 0,
+      tools,
+    });
+
+    assert.equal(request?.tool_choice, 'auto');
+    assert.equal(request?.parallel_tool_calls, true);
+  });
+
   it('rejects concurrent calls on the same handler instance', async () => {
     const handler = createHandler();
     let resolveCreate: (response: any) => void = () => undefined;


### PR DESCRIPTION
## Summary

- enable parallel tool calls in the canonical OpenAI setting by default
- send the explicit boolean through both Responses and Chat Completions requests
- keep extension and provider-setting metadata aligned
- add one request-boundary regression test

## Validation

- `npm test -- --run src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts src/test-kernel/shared/settingsConfiguration.vitest.ts` (41 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- targeted Prettier and ESLint
- `git diff --check`

Closes #8302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on parallel tool execution changes agent tool-use behavior for users who never set the flag; models or workflows that need strictly sequential tools may need the setting turned off.
> 
> **Overview**
> **Parallel OpenAI tool calls are now on by default** for Chat Completions and the Responses API. The `texra.model.openaiParallelToolCalls` default flips from `false` to `true`, with matching copy in extension settings, `DEFAULT_CORE_SETTINGS`, and provider metadata.
> 
> Both OpenAI handlers now **always send** `parallel_tool_calls` as the configured boolean (using `DEFAULT_CORE_SETTINGS` as the `getConfig` fallback), instead of only adding `parallel_tool_calls: false` when the setting was off. That makes the API request explicit whether parallel calls are enabled or disabled.
> 
> A Responses API test asserts that tool requests default to `parallel_tool_calls: true` with `tool_choice: 'auto'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221df8d01d6a48ac1ff9ca46db53f5f174e0d602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->