### PR TITLE
fix(openai): align GPT-5.6 Codex context limits

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -286,6 +286,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     );
   }
 
+  private getEffectiveInputTokenLimit(): number {
+    return (
+      this.getActiveProviderCapabilities()?.inputTokenLimit ??
+      this.getEffectiveContextWindow()
+    );
+  }
+
   /**
    * OpenAI Response API supports file uploads. Reads the ChatGPT-subscription
    * profile when active (that backend disables tool-result file upload);
@@ -634,8 +641,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (percent <= 0) {
       return 0;
     }
-    // Calculate threshold as percentage of context window
-    return Math.floor((percent / 100) * this.getEffectiveContextWindow());
+    return Math.floor((percent / 100) * this.getEffectiveInputTokenLimit());
   }
 
   /**
@@ -1374,6 +1380,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (inputEstimate <= 0) return maxOutputTokens;
 
     const buffer = this.getTokenSafetyBuffer();
+    const inputTokenLimit = this.getEffectiveInputTokenLimit();
+    if (inputEstimate + buffer >= inputTokenLimit) {
+      const error = new Error(
+        `Token estimate (${inputEstimate}) + safety buffer (${buffer}) exceeds route input limit (${inputTokenLimit}).`,
+      );
+      attachContextWindowError(error);
+      throw error;
+    }
     const contextWindow = this.getEffectiveContextWindow();
     const bufferedMaxTokens = contextWindow - inputEstimate - buffer;
     const validation = this.validateTokenLimits(

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -20,6 +20,7 @@ export interface OpenAIResponseProviderCapabilities {
 export interface ProviderCapabilityProfile {
   readonly authMode: ProviderAuthMode;
   readonly contextWindow: number;
+  readonly inputTokenLimit?: number;
   readonly inputPrice: number;
   readonly outputPrice: number;
   readonly usageRoute?: UsageRoute;
@@ -31,8 +32,13 @@ export interface ProviderCapabilityKey {
   readonly useOpenRouter: boolean;
 }
 
-/** Context window the ChatGPT-subscription (Codex) backend enforces. */
-export const CODEX_SUBSCRIPTION_CONTEXT_WINDOW = 272_000;
+/** Default Codex budget (GPT-5.5 and earlier). */
+export const CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW = 400_000;
+export const CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT = 272_000;
+
+/** GPT-5.6 Codex budget: 372k input plus 128k output. */
+export const CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW = 500_000;
+export const CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT = 372_000;
 
 /** Trailing llm-zoo date pin (`-2026-04-23`) on a model `fullName`. */
 const CODEX_MODEL_DATE_PIN = /-\d{4}-\d{2}-\d{2}$/;
@@ -46,6 +52,22 @@ export function codexBackendModelId(config: {
   readonly fullName: string;
 }): string {
   return config.shortName || config.fullName.replace(CODEX_MODEL_DATE_PIN, '');
+}
+
+function codexSubscriptionTokenLimits(model: ModelConfig): {
+  contextWindow: number;
+  inputTokenLimit: number;
+} {
+  if (codexBackendModelId(model).startsWith('gpt-5.6')) {
+    return {
+      contextWindow: CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
+      inputTokenLimit: CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
+    };
+  }
+  return {
+    contextWindow: CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+    inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+  };
 }
 
 /**
@@ -87,13 +109,12 @@ export function resolveProviderCapabilities({
   if (model.provider !== ModelProvider.OPENAI) return null;
   if (model.openRouterOnly) return null;
   if (!isCodexSubscriptionEligible(model)) return null;
+  const tokenLimits = codexSubscriptionTokenLimits(model);
 
   return {
     authMode: 'chatgpt-subscription',
-    contextWindow: Math.min(
-      CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
-      model.contextWindow,
-    ),
+    contextWindow: Math.min(tokenLimits.contextWindow, model.contextWindow),
+    inputTokenLimit: Math.min(tokenLimits.inputTokenLimit, model.contextWindow),
     inputPrice: 0,
     outputPrice: 0,
     usageRoute: 'chatgpt-subscription',

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -14,7 +14,10 @@ import {
   setPreferCodexSubscription,
 } from '@auth/codex';
 import { setServerSideKeyService } from '@auth/serverKeys';
-import { CODEX_SUBSCRIPTION_CONTEXT_WINDOW } from '@model/providerCapabilities';
+import {
+  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+} from '@model/providerCapabilities';
 import { AgentCategory } from '@shared/schemas/agent';
 
 import type { ResponseUsage } from 'openai/resources/responses/responses';
@@ -143,7 +146,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
     // The model's own 1.05M API window must not leak through on the
     // subscription path, where the backend rejects requests past the ceiling.
     expect(handler.getEffectiveContextWindow()).toBe(
-      CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+      CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
     );
   });
 
@@ -153,7 +156,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
     const handler = new ModelHandlerCodex(largeWindowConfig);
     handler.setAgentCategory(AgentCategory.ToolUse);
     expect(handler.getEffectiveContextWindow()).toBe(
-      CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+      CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
     );
 
     // "Use your own API key" routes to the real OpenAI API, which honors the
@@ -217,7 +220,10 @@ describe('ModelHandlerCodex subscription fallback', () => {
     const handler = new ModelHandlerCodex(largeWindowConfig);
     handler.setAgentCategory(AgentCategory.ToolUse);
     const requestSpy = vi.fn();
-    setCumulativeInputTokens(handler, CODEX_SUBSCRIPTION_CONTEXT_WINDOW - 10);
+    setCumulativeInputTokens(
+      handler,
+      CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT - 10,
+    );
 
     await expect(
       handler.createResponse({
@@ -225,7 +231,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
         messages: [],
         temperature: 0,
       }),
-    ).rejects.toThrow(/cannot enforce a reduced output budget locally/);
+    ).rejects.toThrow(/route input limit/);
     expect(requestSpy).not.toHaveBeenCalled();
   });
 
@@ -237,7 +243,7 @@ describe('ModelHandlerCodex subscription fallback', () => {
     const requestSpy = vi.fn();
     setCumulativeInputTokens(
       handler,
-      CODEX_SUBSCRIPTION_CONTEXT_WINDOW - config.maxOutputTokens - 100,
+      CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT - 100,
     );
 
     await expect(
@@ -248,32 +254,6 @@ describe('ModelHandlerCodex subscription fallback', () => {
       }),
     ).rejects.toThrow(/safety buffer/);
     expect(requestSpy).not.toHaveBeenCalled();
-  });
-
-  it('sends subscription requests when only the stripped output budget exceeds the Codex cap', async () => {
-    await initFakePlatformWithSubscription();
-
-    const handler = new ModelHandlerCodex(largeWindowConfig);
-    handler.setAgentCategory(AgentCategory.ToolUse);
-    const streamSpy = vi
-      .fn()
-      .mockResolvedValue(
-        createResponseStream(
-          createResponse(CODEX_SUBSCRIPTION_CONTEXT_WINDOW - 1),
-        ),
-      );
-    setCumulativeInputTokens(handler, CODEX_SUBSCRIPTION_CONTEXT_WINDOW - 3000);
-
-    await handler.createResponse({
-      client: { responses: { stream: streamSpy } } as never,
-      messages: [],
-      temperature: 0,
-    });
-
-    expect(streamSpy).toHaveBeenCalledOnce();
-    expect(streamSpy.mock.calls[0]?.[0]?.max_output_tokens).toBeLessThan(
-      config.maxOutputTokens,
-    );
   });
 
   it('keeps workflow agents on the subscription when the tool-use-only switch is off', async () => {

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -13,7 +13,7 @@ import {
 } from '@auth/codex';
 import { apiKeySecretName, invalidateApiKeyCache } from '@model/apiProviders';
 import {
-  CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
   isCodexSubscriptionEligible,
 } from '@model/providerCapabilities';
 import {
@@ -247,7 +247,7 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model.availability).toBe('subscription-access');
     expect(model.context).toBe(
-      `${Math.round(CODEX_SUBSCRIPTION_CONTEXT_WINDOW / 1000)}K`,
+      `${Math.round(CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW / 1000)}K`,
     );
     expect(model.cost).toBe('$0.000/$0.000');
     expect(model.hint).not.toContain(FAST_FIRST_RESPONSE_HINT);

--- a/src/test-kernel/model/ProviderCapabilities.vitest.ts
+++ b/src/test-kernel/model/ProviderCapabilities.vitest.ts
@@ -7,7 +7,10 @@ import {
 } from 'llm-zoo';
 
 import {
-  CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+  CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
+  CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+  CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
+  CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
   resolveProviderCapabilities,
 } from '@model/providerCapabilities';
 
@@ -31,6 +34,14 @@ const gpt55Config: ModelConfig = {
   codexSubscription: true,
 };
 
+const gpt56Config: ModelConfig = {
+  ...gpt55Config,
+  name: 'gpt56--',
+  label: 'GPT-5.6 Luna',
+  fullName: 'gpt-5.6-luna',
+  shortName: 'gpt-5.6-luna',
+};
+
 describe('provider capabilities', () => {
   it('resolves ChatGPT subscription profile from model routing context', () => {
     const capabilities = resolveProviderCapabilities({
@@ -40,7 +51,8 @@ describe('provider capabilities', () => {
 
     expect(capabilities).toMatchObject({
       authMode: 'chatgpt-subscription',
-      contextWindow: CODEX_SUBSCRIPTION_CONTEXT_WINDOW,
+      contextWindow: CODEX_DEFAULT_SUBSCRIPTION_CONTEXT_WINDOW,
+      inputTokenLimit: CODEX_DEFAULT_SUBSCRIPTION_INPUT_LIMIT,
       inputPrice: 0,
       outputPrice: 0,
       usageRoute: 'chatgpt-subscription',
@@ -60,6 +72,18 @@ describe('provider capabilities', () => {
         supportsToolResultFileUpload: false,
         failWhenFallbackOutputBudgetIsReduced: true,
       },
+    });
+  });
+
+  it('uses the larger Codex input budget for GPT-5.6', () => {
+    const capabilities = resolveProviderCapabilities({
+      model: gpt56Config,
+      useOpenRouter: false,
+    });
+
+    expect(capabilities).toMatchObject({
+      contextWindow: CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW,
+      inputTokenLimit: CODEX_GPT56_SUBSCRIPTION_INPUT_LIMIT,
     });
   });
 });


### PR DESCRIPTION
## Summary

- keep the existing 272k ChatGPT-subscription context cap for GPT-5.5 and earlier
- use the Codex-reported 372k input plus 128k output budget for GPT-5.6
- drive runtime and model-picker context from the same capability profile
- add one focused GPT-5.6 profile assertion

## Validation

- `npm test -- --run src/test-kernel/model/ProviderCapabilities.vitest.ts src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts src/test-kernel/model/ComputeModelOptions.vitest.ts` (29 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- targeted Prettier and ESLint
- `git diff --check`

Reference: https://github.com/anomalyco/opencode/pull/36248

Closes #8305

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-flight rejection and compaction math on the ChatGPT-subscription path where token counting is unavailable; wrong limits would block valid turns or allow backend failures, but scope is limited to Codex capability profiles and the OpenAI Responses handler.
> 
> **Overview**
> ChatGPT-subscription (Codex) limits are split so **GPT-5.5 and earlier** keep a **400k** total window with a **272k input** cap, while **GPT-5.6** uses **500k** total and **372k input** (per Codex-reported budgets). `ProviderCapabilityProfile` gains optional **`inputTokenLimit`**, resolved from `codexBackendModelId` when the model id starts with `gpt-5.6`.
> 
> **`ModelHandlerOpenAIResponse`** uses **`getEffectiveInputTokenLimit()`** for automatic compaction thresholds and, on routes without token counting, rejects requests locally when **input estimate + safety buffer** hits the input cap—before relying on shrinking **`max_output_tokens`**. The model picker still shows the profile **`contextWindow`** (now the larger default/GPT-5.6 totals).
> 
> Tests rename constants, assert GPT-5.6 limits, and drop the case that allowed a subscription request when only the output budget was trimmed past the old single ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98536adb71c815c652959a88d955a9c849f7d6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->