### PR TITLE
fix(openai): make Codex compaction explicit

### DIFF
--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -79,6 +79,10 @@ export const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer. Crea
 
 Format the summary as a structured narrative that allows the conversation to continue seamlessly. Do NOT add any preamble or explanation — output only the summary.`;
 
+/** Final user instruction that makes the compaction task explicit after history. */
+export const COMPACTION_USER_PROMPT =
+  'Summarize the conversation history above now. Follow the compaction instructions exactly and output only the summary.';
+
 /** Compute reduced max tokens under context pressure (minimum 1). */
 export function computeReducedMaxTokens(
   availableTokens: number,

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -82,6 +82,7 @@ import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SYSTEM_PROMPT,
+  COMPACTION_USER_PROMPT,
   estimateTokensFromText,
   TOKEN_SAFETY_BUFFER,
   TOOL_USE_SAFETY_BUFFER,
@@ -983,7 +984,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           {
             model: this.config.fullName,
             instructions: COMPACTION_SYSTEM_PROMPT,
-            input: conversationMessages,
+            input: [
+              ...conversationMessages,
+              {
+                type: 'message',
+                role: 'user',
+                content: [createInputText(COMPACTION_USER_PROMPT)],
+              },
+            ],
             max_output_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
             store: this.storesResponsesServerSide,
             ...(this.capabilities.supportsReasoning && {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts
@@ -11,6 +11,7 @@ import type { AgentTrace } from '@agent/trace';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
+  COMPACTION_USER_PROMPT,
   estimateTokensFromText,
 } from '@agent/modelHandlers/contextManagementConstants';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
@@ -518,7 +519,14 @@ describe('ModelHandlerOpenAIResponse automatic compaction', () => {
     // The client-side path summarizes via a throwaway streaming call.
     expect(streamRequests).toHaveLength(1);
     expect(streamRequests[0].instructions).toBe(COMPACTION_SYSTEM_PROMPT);
-    expect(streamRequests[0].input).toEqual(secondTurnMessages);
+    expect(streamRequests[0].input).toEqual([
+      ...secondTurnMessages,
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: COMPACTION_USER_PROMPT }],
+      },
+    ]);
 
     const expectedCompactedMessages = [
       {


### PR DESCRIPTION
## Summary

- append a final user instruction to stateless Responses compaction requests
- keep the existing no-tools streaming summary path and empty-summary fallback
- adapt the robust dedicated-compaction pattern used by OpenCode without adding a second transport test

## Validation

- `npm test -- --run src/test-kernel/agent/modelHandlers/OpenAIResponseCompaction.vitest.ts` (7 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- targeted Prettier and ESLint
- `git diff --check`

Reference: OpenCode `packages/opencode/src/session/compaction.ts` at `cf7503687a2485621a690d18c4b0d1ff2060bc3e`.

Closes #8307

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the stateless client-side compaction request payload and tests; no auth, persistence, or main turn logic changes.
> 
> **Overview**
> **Codex / stateless Responses compaction** now sends conversation history plus a trailing synthetic **user** message with `COMPACTION_USER_PROMPT`, instead of relying on `instructions` alone. The shared constant lives in `contextManagementConstants.ts`; `compactConversationClientSide` still uses the same no-tools streaming summary path and fallbacks.
> 
> The stateful `/responses/compact` path is unchanged. `OpenAIResponseCompaction.vitest.ts` asserts the new `input` shape for the client-side summarize call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e135dd5a91b08037888c2fdc5ca656c2bc6d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->