### PR TITLE
Prompt for TeXRA sign-in before applying incomplete teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Incomplete teams are decided before roster changes** — TeXRA now offers
+  sign-in, explicit partial-team continuation, or cancellation before applying
+  or launching a team whose TeXRA-hosted members are unavailable.
 - **Grok models keep a medium reasoning-effort selection** — the xAI effort
   clamp no longer converts `medium` to `high`; current Grok reasoning models
   (grok-4.3, grok-4.5) support low/medium/high.

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -11,6 +11,7 @@ import { CliExitCode } from '../runtime/exitCodes';
 import { listCliHistoryEntries } from '../runtime/history';
 import { initInteractiveCliPlatform } from '../runtime/initPlatform';
 import {
+  askCliQuestion,
   writeErrorStderr,
   writeTextStderr,
   writeTextStdout,
@@ -30,6 +31,7 @@ import {
   loadCliMultiAgentPresetPlanSet,
   writeMissingPresetAgents,
 } from '../runtime/multiAgentRunPlan';
+import { preflightCliTeamAvailability } from '../runtime/teamAvailabilityPreflight';
 import {
   buildCliAccountItems,
   buildCliAgentItems,
@@ -56,7 +58,11 @@ import {
   chatGptSignOutPreferenceMessage,
   signOutCliChatGpt,
 } from '../runtime/chatgptLogin';
-import { getCliAuthProfile, signOutCliSupabase } from '../runtime/supabaseAuth';
+import {
+  getCliAuthProfile,
+  getCliAuthProvider,
+  signOutCliSupabase,
+} from '../runtime/supabaseAuth';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -219,6 +225,8 @@ async function runOrchestration(context: CliContext): Promise<number> {
       agentItems: buildCliAgentItems(toolUseAgents),
       teamItems: buildCliTeamItems(presetPlanSet.plans, {
         includeLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
+        remoteAgentCatalogAvailable:
+          await getCliAuthProvider().canAccessRemoteAgentCatalog(),
         launchBlockReason:
           launchContext.approvalPolicy === 'never'
             ? 'delegation-denied'
@@ -243,19 +251,65 @@ async function runOrchestration(context: CliContext): Promise<number> {
         return result.exitCode;
       }
       case 'preset': {
-        // Match the headless path: load remote premium agents (orchestrator,
-        // delegation specialists) and replan so the team starts with its real
-        // root instead of silently degrading to the first local tool-use agent.
-        const { plan } = await loadCliMultiAgentRunPlan({
-          preset: action.preset,
+        const initialPlan =
+          presetPlanSet.plans.find(
+            (plan) => plan.preset.id === action.preset,
+          ) ??
+          (
+            await loadCliMultiAgentRunPlan(
+              { preset: action.preset },
+              { reloadRemoteAgents: false },
+            )
+          ).plan;
+        const preflight = await preflightCliTeamAvailability({
+          plan: initialPlan,
+          remoteCatalogRefreshAttempted: presetPlanSet.remoteAgentLoadAttempted,
+          canAccessRemoteCatalog: () =>
+            getCliAuthProvider().canAccessRemoteAgentCatalog(),
+          choose: async (names) => {
+            writeTextStderr(
+              `Team ${action.preset} has unavailable TeXRA-hosted members: ${names.join(', ')}.`,
+            );
+            const answer = (
+              await askCliQuestion(
+                'Choose: [s] Sign in to TeXRA, [c] Continue with available members, [q] Cancel: ',
+              )
+            )
+              .trim()
+              .toLowerCase();
+            if (answer === 's' || answer === 'sign-in') return 'sign-in';
+            if (answer === 'c' || answer === 'continue') return 'continue';
+            return 'cancel';
+          },
+          signIn: async () => {
+            const code = await runLoginCommand(
+              launchContext,
+              loginInitFromArgs({}),
+            );
+            return (
+              code === CliExitCode.Success &&
+              (await getCliAuthProvider().canAccessRemoteAgentCatalog())
+            );
+          },
+          refresh: async () =>
+            (await loadCliMultiAgentRunPlan({ preset: action.preset })).plan,
         });
+        if (preflight.status === 'choice-required') continue launcher;
+        if (preflight.status === 'cancelled') continue launcher;
+        if (preflight.status === 'unavailable') {
+          writeTextStderr(
+            `Team ${action.preset} is still unavailable after refreshing the TeXRA agent catalog: ${preflight.unavailableNames.join(', ')}.`,
+          );
+          continue launcher;
+        }
+        const plan = preflight.value;
         if (!cliMultiAgentPresetCanLaunchTeam(plan)) {
           writeTextStderr(
             formatCliMultiAgentTeamLaunchBlockMessage(plan, {
               requestedPreset: action.preset,
             }),
           );
-          return CliExitCode.Usage;
+          continue launcher;
         }
         const rootAgent = plan.rootAgent;
         writeMissingPresetAgents(plan);

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -132,7 +132,10 @@ export async function resolveCliAgent(
     return getAgent(name, lookupCategory);
   }
 
-  if (name.includes(':') || !(await getCliAuthProvider().isAuthenticated())) {
+  if (
+    name.includes(':') ||
+    !(await getCliAuthProvider().canAccessRemoteAgentCatalog())
+  ) {
     return agent;
   }
 

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -38,6 +38,14 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 
 // Local imports - shared state
 import { GlobalStateKey } from '@shared/state/stateKeys';
+
+// Local imports - setup tools
+import {
+  createDefaultSetupPlatform,
+  setSetupPlatform,
+} from '@tools/setup/platform';
+
+// Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports - config
@@ -49,7 +57,11 @@ import { isCliResumeInFlight, tryResumeCliStream } from './agentResume';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { flushNdjsonStdout, writeTextStderr } from './logSinks';
-import { getCliAuthProvider, initializeCliSupabaseAuth } from './supabaseAuth';
+import {
+  getCliAuthProvider,
+  initializeCliSupabaseAuth,
+  signInCliSupabase,
+} from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
 
@@ -336,6 +348,18 @@ export async function initCliPlatform(
     );
     serverSideKeysInitialized = true;
   }
+
+  const defaultSetupPlatform = createDefaultSetupPlatform();
+  setSetupPlatform({
+    ...defaultSetupPlatform,
+    auth: {
+      ...defaultSetupPlatform.auth,
+      signIn: async () => {
+        await signInCliSupabase({ openBrowser: true });
+        return getCliAuthProvider().canAccessRemoteAgentCatalog();
+      },
+    },
+  });
 
   const useOpenRouter = getUseOpenRouter();
   if (context.apiMode === 'included' && useOpenRouter) {

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -1,5 +1,6 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { platform } from '@platform/platform';
+import { teamHostedNamesForPreflight } from '@controllers/teams/TeamRoster';
 import {
   BUILTIN_TEAM_ROOT_AGENT_NAMES,
   findAgentByIdentifier,
@@ -242,6 +243,15 @@ export function cliMultiAgentPlanHasGaps(
     plan.missingWorkflowAgents.length > 0 ||
     plan.missingToolUseAgents.length > 0
   );
+}
+
+/** TeXRA-hosted definitions missing from this plan, independent of models. */
+export function cliMultiAgentTexraHostedMissingNames(
+  plan: CliMultiAgentPresetRunPlan,
+): string[] {
+  const missing = [...plan.missingWorkflowAgents, ...plan.missingToolUseAgents];
+  const hosted = teamHostedNamesForPreflight(plan.preset, missing);
+  return missing.filter((name) => hosted.has(name));
 }
 
 function cliMultiAgentPlanStatus(

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -1,4 +1,4 @@
-import { getAgentsByCategory, loadAgents } from '@agent/index';
+import { getAgentsByCategory, loadAgents, refresh } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 
 import { missingMultiAgentPresetMessage } from './agents';
@@ -116,8 +116,11 @@ async function reloadRemoteAgentsForGaps<T>(
   hasGaps: (value: T) => boolean,
   replan: () => T,
 ): Promise<RemoteAgentPlanReloadResult<T>> {
-  if (hasGaps(value) && (await getCliAuthProvider().isAuthenticated())) {
-    await loadAgents();
+  if (
+    hasGaps(value) &&
+    (await getCliAuthProvider().canAccessRemoteAgentCatalog())
+  ) {
+    await refresh({ includeRemote: true });
     return { value: replan(), remoteAgentLoadAttempted: true };
   }
   return { value, remoteAgentLoadAttempted: false };

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -4,6 +4,7 @@ import { agentKeyOf } from '@shared/schemas/agent';
 
 import {
   cliMultiAgentPresetCanLaunchTeam,
+  cliMultiAgentTexraHostedMissingNames,
   formatCliMultiAgentPresetLauncherHints,
   formatCliMultiAgentPresetLauncherSummary,
   type CliMultiAgentPresetRunPlan,
@@ -372,6 +373,7 @@ export function buildCliTeamItems(
   options: {
     readonly includeLoginHint?: boolean;
     readonly launchBlockReason?: CliPresetLaunchBlockReason;
+    readonly remoteAgentCatalogAvailable?: boolean;
   },
 ): CliOrchestrationItem[] {
   const launchBlockedDescription =
@@ -388,7 +390,11 @@ export function buildCliTeamItems(
       ),
     disabled:
       launchBlockedDescription !== undefined ||
-      !cliMultiAgentPresetCanLaunchTeam(plan),
+      (!cliMultiAgentPresetCanLaunchTeam(plan) &&
+        !(
+          options.remoteAgentCatalogAvailable === false &&
+          cliMultiAgentTexraHostedMissingNames(plan).length > 0
+        )),
     footerHints: formatCliMultiAgentPresetLauncherHints(plan, {
       includeLoginHint: options.includeLoginHint,
     }),

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -1,6 +1,9 @@
 // Local imports - platform
 import { tryPlatform } from '@platform/platform';
 
+// Local imports - agent
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
+
 // Local imports - auth
 import {
   DEFAULT_OAUTH_PROVIDER,
@@ -95,6 +98,8 @@ const deferredAuthLog: LogBackend = {
 };
 const cliAuthProvider = {
   isAuthenticated: () => SupabaseClient.isAuthenticated(),
+  canAccessRemoteAgentCatalog: () =>
+    SupabaseClient.canAccessRemoteAgentCatalog(),
   getUserTier: () => SupabaseClient.getUserTier(),
   getAccessToken: () => SupabaseClient.getRelayAccessToken(),
 };
@@ -223,6 +228,12 @@ export async function signOutCliSupabase(): Promise<void> {
     await serverSideKeyService.setUseIncludedModelAccess(false);
   }
   serverSideKeyService.clearAllCaches({ resetQuotaFlip: true });
+  await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
+    activeAuthLog?.warn(
+      'cli-auth',
+      `Local agent catalog refresh failed after sign-out: ${String(error)}`,
+    );
+  });
 }
 
 /**

--- a/packages/cli/src/runtime/teamAvailabilityPreflight.ts
+++ b/packages/cli/src/runtime/teamAvailabilityPreflight.ts
@@ -1,0 +1,41 @@
+import {
+  preflightTeamAvailability,
+  type TeamAvailabilityChoice,
+  type TeamAvailabilityPreflightResult,
+} from '@controllers/teams/TeamAvailabilityPreflight';
+import { teamHostedNamesForPreflight } from '@controllers/teams/TeamRoster';
+
+import {
+  cliMultiAgentTexraHostedMissingNames,
+  type CliMultiAgentPresetRunPlan,
+} from './multiAgentPresets';
+
+export interface CliTeamAvailabilityPreflightDeps {
+  readonly plan: CliMultiAgentPresetRunPlan;
+  readonly remoteCatalogRefreshAttempted: boolean;
+  readonly canAccessRemoteCatalog: () => Promise<boolean>;
+  readonly choose: (
+    unavailableNames: readonly string[],
+  ) => Promise<TeamAvailabilityChoice>;
+  readonly signIn: () => Promise<boolean>;
+  readonly refresh: () => Promise<CliMultiAgentPresetRunPlan>;
+}
+
+/** CLI host adapter for the shared team availability policy. */
+export function preflightCliTeamAvailability(
+  deps: CliTeamAvailabilityPreflightDeps,
+): Promise<TeamAvailabilityPreflightResult<CliMultiAgentPresetRunPlan>> {
+  return preflightTeamAvailability({
+    initial: deps.plan,
+    unresolvedNames: cliMultiAgentTexraHostedMissingNames,
+    texraHostedNames: teamHostedNamesForPreflight(deps.plan.preset, [
+      ...deps.plan.missingWorkflowAgents,
+      ...deps.plan.missingToolUseAgents,
+    ]),
+    canAccessRemoteCatalog: deps.canAccessRemoteCatalog,
+    choose: deps.choose,
+    signIn: deps.signIn,
+    refresh: deps.refresh,
+    remoteCatalogRefreshAttempted: deps.remoteCatalogRefreshAttempted,
+  });
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -13,13 +13,16 @@ import {
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
+import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
 import {
   computeAgentOptionsData,
   getAgentsByCategory,
   getVisibleAgents as getVisibleRegistryAgents,
   loadAgents,
+  refresh,
   type AgentEntry,
 } from '@agent/index/agentRegistry';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   codexCoordinator,
   getChatGptAuthStatus,
@@ -119,6 +122,7 @@ import {
   DesktopHistoryHandlers,
   type DesktopHistoryOptions,
 } from './desktopHistoryHandlers.js';
+import type { TeamAvailabilityChoice } from '@controllers/teams/TeamAvailabilityPreflight';
 import type { ConfigProvider, StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
 
@@ -130,6 +134,7 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   postToRenderer(message: unknown): void;
   sendStartupCatalogData?: boolean;
   loadAgents?: typeof loadAgents;
+  refreshAgents?: typeof refresh;
   loadAgentOptionsData?: typeof computeAgentOptionsData;
   getAgents?: (category: AgentCategory) => AgentEntry[];
   getVisibleAgents?: (category: AgentCategory) => AgentEntry[];
@@ -164,6 +169,12 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   showInfoMessage?: (message: string) => Promise<void>;
   showErrorMessage?: (message: string) => Promise<void>;
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
+  chooseTeamAvailability?: (input: {
+    presetName: string;
+    unavailableNames: readonly string[];
+  }) => Promise<TeamAvailabilityChoice>;
+  canAccessRemoteAgentCatalog?: () => Promise<boolean>;
+  signInForRemoteAgentCatalog?: () => Promise<boolean>;
   signIn?: () => Promise<void>;
   signOut?: () => Promise<void>;
   setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
@@ -183,7 +194,9 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
 }
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
-  refreshAuthDependentData(): Promise<void>;
+  refreshAuthDependentData(options?: {
+    deferAgentCatalogRefresh?: boolean;
+  }): Promise<void>;
   signInChatGpt(options?: { enableSubscription?: boolean }): Promise<void>;
 }
 
@@ -211,6 +224,7 @@ export function createDesktopSettingsIpc(
     onError,
   });
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
+  const refreshAgentRegistry = options.refreshAgents ?? refresh;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
   const getAgentEntries = options.getAgents ?? getAgentsByCategory;
@@ -848,15 +862,15 @@ export function createDesktopSettingsIpc(
     await finishDesktopCrashReportingSettingsChange();
   }
 
-  async function refreshAuthDependentData(): Promise<void> {
+  async function refreshAuthDependentData(
+    refreshOptions: { deferAgentCatalogRefresh?: boolean } = {},
+  ): Promise<void> {
     invalidateModelOptionsCache();
     await postModelSelectionData();
     await postMainModelOptionsData();
-    await Promise.all([
-      postProfileData(),
-      postAgentSelectionData(),
-      postMainAgentOptionsData(),
-    ]);
+    await postProfileData();
+    if (refreshOptions.deferAgentCatalogRefresh) return;
+    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
   }
 
   async function updateAgentSetting(
@@ -1004,10 +1018,32 @@ export function createDesktopSettingsIpc(
   }
 
   async function applyAgentModePreset(presetId: string): Promise<void> {
-    await loadAgentRegistry();
-    const result = await agentCatalogController.applyPreset(presetId);
-    if (!result.ok) {
+    const result = await applyTeamRosterWithPreflight(presetId, {
+      catalog: agentCatalogController,
+      loadLocalCatalog: () => loadAgentRegistry({ includeRemote: false }),
+      canAccessRemoteCatalog:
+        options.canAccessRemoteAgentCatalog ??
+        (() => SupabaseClient.canAccessRemoteAgentCatalog()),
+      choose: (preset, unavailableNames) =>
+        options.chooseTeamAvailability?.({
+          presetName: preset.name,
+          unavailableNames,
+        }) ?? Promise.resolve('cancel'),
+      signIn:
+        options.signInForRemoteAgentCatalog ?? (() => Promise.resolve(false)),
+      forceRefreshRemoteCatalog: () =>
+        refreshAgentRegistry({ includeRemote: true }),
+    });
+    if (result.status === 'unknown') {
       await options.showErrorMessage?.(`Unknown team: ${presetId}`);
+      return;
+    }
+    if (result.status === 'cancelled') return;
+    if (result.status === 'choice-required') return;
+    if (result.status === 'unavailable') {
+      await options.showErrorMessage?.(
+        `Team "${result.preset.name}" is still unavailable: ${result.unavailableNames.join(', ')}`,
+      );
       return;
     }
     await Promise.all([

--- a/packages/desktop/src/main/desktopSetupAuth.ts
+++ b/packages/desktop/src/main/desktopSetupAuth.ts
@@ -1,0 +1,30 @@
+import {
+  createDefaultSetupPlatform,
+  setSetupPlatform,
+} from '@tools/setup/platform';
+
+let activeSignIn: (() => Promise<boolean>) | undefined;
+
+/** Install a process-owned setup adapter that resolves the active window lazily. */
+export function initializeDesktopSetupAuth(): void {
+  const defaults = createDefaultSetupPlatform();
+  setSetupPlatform({
+    ...defaults,
+    auth: {
+      ...defaults.auth,
+      signIn: () => activeSignIn?.() ?? Promise.resolve(false),
+    },
+  });
+}
+
+/** Register one window without retaining it after the returned handle closes. */
+export function registerDesktopSetupSignIn(signIn: () => Promise<boolean>): {
+  dispose(): void;
+} {
+  activeSignIn = signIn;
+  return {
+    dispose() {
+      if (activeSignIn === signIn) activeSignIn = undefined;
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { z } from 'zod';
 
 import { platform } from '@platform/platform';
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { DEFAULT_OAUTH_PROVIDER, getAuthCallbackUri } from '@auth/config';
 import { createHostAuthCoordinator } from '@auth/SupabaseAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -38,6 +39,10 @@ type DesktopPendingOAuthState = z.infer<typeof DesktopPendingOAuthStateSchema>;
 
 export interface DesktopSupabaseAuth {
   signIn(provider?: OAuthProvider): Promise<void>;
+  signInAndWaitForSession(
+    provider?: OAuthProvider,
+    options?: { timeoutMs?: number },
+  ): Promise<boolean>;
   signOut(): Promise<void>;
   dispose(): void;
 }
@@ -51,7 +56,7 @@ export interface DesktopAuthCallbackState {
    * but foreign-account token deeplink can't complete a sign-in (login-CSRF).
    */
   matchesPendingNonce(nonce: string | undefined): boolean;
-  clearAwaitingCallback(): Promise<void>;
+  clearAwaitingCallback(nonce?: string): Promise<void>;
 }
 
 export interface DesktopSupabaseAuthOptions {
@@ -98,13 +103,23 @@ export function createDesktopAuthCallbackState(
   store?: Pick<StateStore, 'get' | 'update'>,
 ): DesktopAuthCallbackState {
   let pendingState = readPendingOAuthState(store);
+  let persistQueue = Promise.resolve();
 
   const persistPendingState = async (
     state: DesktopPendingOAuthState | null,
   ): Promise<void> => {
     if (!store) return;
-    await store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state);
+    const update = persistQueue.then(() =>
+      store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state),
+    );
+    persistQueue = update.catch(() => undefined);
+    await update;
   };
+
+  if (pendingState && isPendingOAuthStateExpired(pendingState)) {
+    pendingState = null;
+    void persistPendingState(null).catch(() => {});
+  }
 
   // True only while a non-expired sign-in attempt is pending; clears and
   // best-effort persists the reset once the stored attempt has expired.
@@ -128,7 +143,8 @@ export function createDesktopAuthCallbackState(
       if (!nonce) return false;
       return hasValidPendingState() && pendingState?.nonce === nonce;
     },
-    async clearAwaitingCallback() {
+    async clearAwaitingCallback(nonce?: string) {
+      if (nonce && pendingState?.nonce !== nonce) return;
       pendingState = null;
       await persistPendingState(null);
     },
@@ -143,14 +159,7 @@ function readPendingOAuthState(
   if (!parsed.success) {
     return null;
   }
-  const pendingState = parsed.data;
-  if (isPendingOAuthStateExpired(pendingState)) {
-    void Promise.resolve(
-      store?.update(DESKTOP_PENDING_OAUTH_STATE_KEY, null),
-    ).catch(() => {});
-    return null;
-  }
-  return pendingState;
+  return parsed.data;
 }
 
 function isPendingOAuthStateExpired(state: DesktopPendingOAuthState): boolean {
@@ -165,18 +174,91 @@ export function createDesktopSupabaseAuth(
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
   const callbackState =
     options.callbackState ?? createDesktopAuthCallbackState();
-  const callbackQueue: DesktopProtocolCallback[] = [];
+  const callbackQueue: Array<{
+    callback: DesktopProtocolCallback;
+    nonce: string;
+    generation: number;
+  }> = [];
+  const pendingCompletions = new Map<
+    string,
+    { settle(success: boolean): void }
+  >();
+  const settleCompletion = (nonce: string, success: boolean): void => {
+    pendingCompletions.get(nonce)?.settle(success);
+  };
+  const settleAllCompletions = (): void => {
+    for (const completion of pendingCompletions.values()) {
+      completion.settle(false);
+    }
+  };
+  let attemptGeneration = 0;
+  let activeAttempt:
+    { readonly generation: number; readonly nonce: string } | undefined;
+  const ownsAttempt = (generation: number, nonce: string): boolean =>
+    activeAttempt?.generation === generation && activeAttempt.nonce === nonce;
+  let authCommitQueue = Promise.resolve();
+  const runAuthCommit = <T>(commit: () => Promise<T>): Promise<T> => {
+    const result = authCommitQueue.then(commit);
+    authCommitQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+  const invalidateActiveAttempt = (): void => {
+    attemptGeneration += 1;
+    activeAttempt = undefined;
+    settleAllCompletions();
+  };
+  const waitForCompletion = (
+    nonce: string,
+    generation: number,
+    timeoutMs: number,
+  ) =>
+    new Promise<boolean>((resolve) => {
+      const timeout = setTimeout(() => {
+        settleCompletion(nonce, false);
+        if (ownsAttempt(generation, nonce)) {
+          activeAttempt = undefined;
+          void callbackState.clearAwaitingCallback(nonce).catch(() => {});
+        }
+      }, timeoutMs);
+      let settled = false;
+      pendingCompletions.set(nonce, {
+        settle(success) {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          pendingCompletions.delete(nonce);
+          resolve(success);
+        },
+      });
+    });
   let isProcessingCallbacks = false;
   const processCallbackQueue = async (): Promise<void> => {
     if (isProcessingCallbacks) return;
     isProcessingCallbacks = true;
     try {
       while (callbackQueue.length > 0) {
-        const callback = callbackQueue.shift();
-        if (!callback) continue;
+        const queued = callbackQueue.shift();
+        if (!queued) continue;
         try {
-          await processProtocolCallback(coordinator, callback, options);
+          const success = await processProtocolCallback(
+            coordinator,
+            queued.callback,
+            options,
+            () => ownsAttempt(queued.generation, queued.nonce),
+            runAuthCommit,
+          );
+          settleCompletion(queued.nonce, success);
+          if (ownsAttempt(queued.generation, queued.nonce)) {
+            activeAttempt = undefined;
+          }
         } catch (error) {
+          settleCompletion(queued.nonce, false);
+          if (ownsAttempt(queued.generation, queued.nonce)) {
+            activeAttempt = undefined;
+          }
           const message = toErrorMessage(error);
           options.log?.error?.(`Desktop auth callback failed: ${message}`);
           await options.showErrorMessage?.(`Sign-in failed: ${message}`);
@@ -196,18 +278,30 @@ export function createDesktopSupabaseAuth(
     }
     const callbackNonce =
       new URLSearchParams(callback.query).get('app_nonce') ?? undefined;
-    if (!callbackState.matchesPendingNonce(callbackNonce)) {
+    if (!callbackNonce || !callbackState.matchesPendingNonce(callbackNonce)) {
       options.log?.warn?.(
         'Desktop auth callback rejected: nonce mismatch (possible login-CSRF or stale callback)',
       );
       return;
     }
-    void callbackState.clearAwaitingCallback().catch((error: unknown) => {
-      options.log?.debug?.(
-        `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
-      );
+    if (!activeAttempt) {
+      attemptGeneration += 1;
+      activeAttempt = { generation: attemptGeneration, nonce: callbackNonce };
+    }
+    const claimedAttempt = activeAttempt;
+    if (claimedAttempt.nonce !== callbackNonce) return;
+    void callbackState
+      .clearAwaitingCallback(callbackNonce)
+      .catch((error: unknown) => {
+        options.log?.debug?.(
+          `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
+        );
+      });
+    callbackQueue.push({
+      callback,
+      nonce: callbackNonce,
+      generation: claimedAttempt.generation,
     });
-    callbackQueue.push(callback);
     if (isProcessingCallbacks) {
       options.log?.debug?.(
         'Desktop auth callback queued while another callback is being processed',
@@ -216,51 +310,99 @@ export function createDesktopSupabaseAuth(
     void processCallbackQueue();
   });
 
-  return {
-    async signIn(provider = DEFAULT_OAUTH_PROVIDER) {
-      try {
-        // Bind this attempt to a one-time nonce carried on the callback URL.
-        // Supabase preserves redirect_to query params through to the callback
-        // (the same mechanism the Codespaces ?state= routing token relies on),
-        // so the nonce returns in the texra:// callback query — letting us reject
-        // a foreign token deeplink delivered while a sign-in is merely pending.
-        const nonce = randomBytes(16).toString('hex');
-        const callbackUri = getAuthCallbackUri(TEXRA_PROTOCOL);
-        const sep = callbackUri.includes('?') ? '&' : '?';
-        const redirectTo = `${callbackUri}${sep}app_nonce=${nonce}`;
-        await callbackState.beginAuthAttempt(nonce);
-        const { data, error } = await oauthClient.auth.signInWithOAuth({
-          provider,
-          options: { redirectTo },
-        });
-        if (error || !data.url) {
-          throw new Error(
-            `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
-          );
-        }
+  const startSignIn = async (
+    provider: OAuthProvider,
+    onAttempt?: (attempt: { generation: number; nonce: string }) => void,
+  ): Promise<void> => {
+    invalidateActiveAttempt();
+    const generation = attemptGeneration;
+    const nonce = randomBytes(16).toString('hex');
+    activeAttempt = { generation, nonce };
+    onAttempt?.({ generation, nonce });
+    try {
+      await runAuthCommit(async () => {});
+      if (!ownsAttempt(generation, nonce)) return;
 
-        await options.openExternalUrl(data.url);
-        await options.showInfoMessage?.(
-          'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
+      // Bind this attempt to a one-time nonce carried on the callback URL.
+      // Supabase preserves redirect_to query params through to the callback
+      // (the same mechanism the Codespaces ?state= routing token relies on),
+      // so the nonce returns in the texra:// callback query — letting us reject
+      // a foreign token deeplink delivered while a sign-in is merely pending.
+      const callbackUri = getAuthCallbackUri(TEXRA_PROTOCOL);
+      const sep = callbackUri.includes('?') ? '&' : '?';
+      const redirectTo = `${callbackUri}${sep}app_nonce=${nonce}`;
+      await callbackState.beginAuthAttempt(nonce);
+      if (!ownsAttempt(generation, nonce)) return;
+      const { data, error } = await oauthClient.auth.signInWithOAuth({
+        provider,
+        options: { redirectTo },
+      });
+      if (error || !data.url) {
+        throw new Error(
+          `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
         );
+      }
+      if (!ownsAttempt(generation, nonce)) return;
+
+      await options.openExternalUrl(data.url);
+      await options.showInfoMessage?.(
+        'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
+      );
+    } catch (error) {
+      if (ownsAttempt(generation, nonce)) activeAttempt = undefined;
+      await callbackState.clearAwaitingCallback(nonce);
+      await options.showErrorMessage?.(
+        `Sign-in failed: ${toErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  };
+
+  return {
+    signIn(provider = DEFAULT_OAUTH_PROVIDER) {
+      return startSignIn(provider);
+    },
+
+    async signInAndWaitForSession(
+      provider = DEFAULT_OAUTH_PROVIDER,
+      waitOptions = {},
+    ) {
+      let nonce: string | undefined;
+      let completion: Promise<boolean> | undefined;
+      try {
+        await startSignIn(provider, (attempt) => {
+          nonce = attempt.nonce;
+          completion = waitForCompletion(
+            attempt.nonce,
+            attempt.generation,
+            waitOptions.timeoutMs ?? DESKTOP_PENDING_OAUTH_STATE_TTL_MS,
+          );
+        });
       } catch (error) {
-        await callbackState.clearAwaitingCallback();
-        await options.showErrorMessage?.(
-          `Sign-in failed: ${toErrorMessage(error)}`,
-        );
+        if (nonce) settleCompletion(nonce, false);
         throw error;
       }
+      return completion ?? false;
     },
 
     async signOut() {
-      await callbackState.clearAwaitingCallback();
-      await coordinator.clearSession();
+      invalidateActiveAttempt();
+      await runAuthCommit(async () => {
+        await callbackState.clearAwaitingCallback();
+        await coordinator.clearSession();
+      });
       SupabaseClient.setTokenExpiry(null);
       clearDesktopServerSideKeyCaches(options.log);
+      await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
+        options.log?.warn?.(
+          `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
+        );
+      });
       await options.onSessionChanged?.();
     },
 
     dispose() {
+      invalidateActiveAttempt();
       subscription.dispose();
     },
   };
@@ -307,7 +449,9 @@ async function processProtocolCallback(
   coordinator: DesktopAuthCoordinator,
   callback: DesktopProtocolCallback,
   options: DesktopSupabaseAuthOptions,
-): Promise<void> {
+  ownsAttempt: () => boolean,
+  runAuthCommit: <T>(commit: () => Promise<T>) => Promise<T>,
+): Promise<boolean> {
   const result = await coordinator.createSessionFromCallback({
     path: callback.path,
     query: callback.query,
@@ -320,15 +464,45 @@ async function processProtocolCallback(
     } else {
       options.log?.debug?.(`Desktop auth callback ignored: ${result.error}`);
     }
-    return;
+    return false;
   }
 
-  await coordinator.storeSession(result.session);
-  clearDesktopServerSideKeyCaches(options.log);
-  await options.showInfoMessage?.(
-    `Signed in as ${result.session.account.label}`,
-  );
-  await options.onSessionChanged?.();
+  return runAuthCommit(async () => {
+    if (!ownsAttempt()) return false;
+
+    await coordinator.storeSession(result.session);
+    if (!ownsAttempt()) {
+      await coordinator.clearSession();
+      return false;
+    }
+
+    clearDesktopServerSideKeyCaches(options.log);
+    try {
+      await options.showInfoMessage?.(
+        `Signed in as ${result.session.account.label}`,
+      );
+    } catch (error) {
+      options.log?.warn?.(
+        `Desktop sign-in notification failed: ${toErrorMessage(error)}`,
+      );
+    }
+    if (!ownsAttempt()) {
+      await coordinator.clearSession();
+      return false;
+    }
+    try {
+      await options.onSessionChanged?.();
+    } catch (error) {
+      options.log?.warn?.(
+        `Desktop auth surface refresh failed: ${toErrorMessage(error)}`,
+      );
+    }
+    if (!ownsAttempt()) {
+      await coordinator.clearSession();
+      return false;
+    }
+    return true;
+  });
 }
 
 function createSessionLog(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -59,6 +59,10 @@ import {
 } from './desktopSetupTerminal.js';
 import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
 import {
+  initializeDesktopSetupAuth,
+  registerDesktopSetupSignIn,
+} from './desktopSetupAuth.js';
+import {
   checkForDesktopUpdate,
   DESKTOP_RELEASES_PAGE_URL,
 } from './desktopUpdateChecker.js';
@@ -419,6 +423,7 @@ function createWindow(options: {
     // disappear.
     postToRenderer: postToRendererIfAlive,
   });
+  let teamSignInPending = false;
   const refreshDesktopAuthSurfaces = async () => {
     const authenticated = await SupabaseClient.isAuthenticated();
     ipcRef.current?.postToRenderer({
@@ -426,7 +431,9 @@ function createWindow(options: {
         ? MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER
         : MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
     });
-    await settingsIpcRef.current?.refreshAuthDependentData();
+    await settingsIpcRef.current?.refreshAuthDependentData({
+      deferAgentCatalogRefresh: teamSignInPending,
+    });
     await onboardingIpcRef.current?.refreshOnboardingFunnel();
   };
   const desktopAuth = createDesktopSupabaseAuth({
@@ -440,6 +447,21 @@ function createWindow(options: {
     log: console,
     callbackState: options.authCallbackState,
   });
+  const signInForRemoteAgentCatalog = async (): Promise<boolean> => {
+    teamSignInPending = true;
+    try {
+      return (
+        (await desktopAuth.signInAndWaitForSession()) &&
+        (await SupabaseClient.canAccessRemoteAgentCatalog())
+      );
+    } finally {
+      teamSignInPending = false;
+    }
+  };
+  initializeDesktopSetupAuth();
+  const setupSignInRegistration = registerDesktopSetupSignIn(
+    signInForRemoteAgentCatalog,
+  );
   setOpenBuildDisplay(previewHost.openBuildDisplay);
   const folderPickerDefaultPath = options.workspacePath ?? app.getPath('home');
   const openLogsFolder = async () =>
@@ -627,6 +649,23 @@ function createWindow(options: {
       });
       return result.response === 0;
     },
+    chooseTeamAvailability: async ({ presetName, unavailableNames }) => {
+      const result = await dialog.showMessageBox(window, {
+        type: 'warning',
+        message: `Team "${presetName}" has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`,
+        buttons: [
+          'Sign in to TeXRA',
+          'Continue with available members',
+          'Cancel',
+        ],
+        defaultId: 0,
+        cancelId: 2,
+      });
+      if (result.response === 0) return 'sign-in';
+      if (result.response === 1) return 'continue';
+      return 'cancel';
+    },
+    signInForRemoteAgentCatalog,
     signIn: () => desktopAuth.signIn(),
     signOut: () => desktopAuth.signOut(),
     setApiAccessMode: async (mode) => {
@@ -918,6 +957,7 @@ function createWindow(options: {
         .catch(reportAsyncError);
     }
     desktopAuth.dispose();
+    setupSignInRegistration.dispose();
   });
   window.webContents.once('did-finish-load', () => {
     void options.initializeCrashReporting();

--- a/packages/extension/resources/tool_use_agents/setup.yaml
+++ b/packages/extension/resources/tool_use_agents/setup.yaml
@@ -150,14 +150,16 @@ prompts:
          not skip ahead.
       E. Roster — ask, if their intro didn't already tell you, what
          they're working on: math, physics, CS/ML, Lean 4, or a
-         software project. Apply the matching team with one
-         `apply_team` call: `mathematician`, `physicist`, `cs-ml`,
+         software project. Apply the matching team with
+         `apply_team`: `mathematician`, `physicist`, `cs-ml`,
          `lean-project`, or `software-engineer`. If they're unsure or
          want a bit of everything, use `starter` — never stall on this
          question. One question, one call. The tool also saves the
          choice as their default team for future projects; if it
-         reports a relay-served lead that unlocks after sign-in, relay
-         that in one sentence.
+         reports unavailable TeXRA-hosted members, ask the user to choose
+         Sign in to TeXRA, Continue with available members, or Cancel, then
+         call it again with the corresponding `unavailableAction`. Never
+         choose partial continuation or sign-in on the user's behalf.
       F. Optional extras (Zotero, Lean 4, SoX for audio) — ask once
          whether to install; default is skip (but do offer Lean 4 when
          phase E picked `lean-project`). Use `update_config` to set

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -27,6 +27,10 @@ import { EXTENSION_CATEGORIES, getFilterExtensions } from '@common/files';
 import { agentDirectories } from '@frontend/agents';
 import { loadMainViewModelOptions } from '@frontend/agents/optionsLoader';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
+import {
+  isAgentCatalogAuthRefreshDeferred,
+  runAfterAgentCatalogAuthRefresh,
+} from '@frontend/auth/agentCatalogRefreshScope';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { MainViewPersistedStateSchema } from '@shared/schemas';
 import { agentKeyOf } from '@shared/schemas/agent';
@@ -115,6 +119,15 @@ export class MainViewProvider
 
   private setupAuthListener() {
     onTexraAuthSessionsChanged(this.context, () => {
+      if (isAgentCatalogAuthRefreshDeferred()) {
+        runAfterAgentCatalogAuthRefresh(async () => {
+          await Promise.all([
+            this.refreshModelOptions(),
+            this.refreshOnboardingFunnel(),
+          ]);
+        });
+        return;
+      }
       void this.refreshOptionsAndView();
     });
     this.context.subscriptions.push(

--- a/packages/extension/src/commands/system/mainViewCommands.ts
+++ b/packages/extension/src/commands/system/mainViewCommands.ts
@@ -29,6 +29,7 @@ type ModelOptionsByCategory = Awaited<
 type AgentOptionsData = Awaited<ReturnType<typeof computeAgentOptionsData>>;
 interface RefreshAllOptionsArgs {
   readonly selectedToolUseAgent?: string;
+  readonly agentCatalogAlreadyFresh?: boolean;
 }
 
 function postModelOptions(
@@ -97,7 +98,7 @@ export function registerMainViewCommands(
       id: mainViewCommands.refreshAllOptions,
       handler: (args?: RefreshAllOptionsArgs) =>
         runRefresh('options', async (webview) => {
-          await refresh();
+          if (!args?.agentCatalogAlreadyFresh) await refresh();
           const [modelOptionsByCategory, agentOptionsData] = await Promise.all([
             loadMainViewModelOptions(),
             computeAgentOptionsData(),

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -38,7 +38,7 @@ import {
   setExternalAuthCallbackResolver,
   setRuntimeExtensionId,
 } from '@auth/config';
-import { AUTH_PROVIDER_ID } from '@auth/constants';
+import { AUTH_COMMANDS, AUTH_PROVIDER_ID } from '@auth/constants';
 import { hasAnyUsableSetupCredential } from '@commands/setup';
 import {
   isResumeInFlight,
@@ -548,8 +548,16 @@ export async function activate(context: vscode.ExtensionContext) {
       } satisfies vscode.TextDocumentShowOptions,
     );
   });
+  const defaultSetupPlatform = createDefaultSetupPlatform();
   setSetupPlatform({
-    ...createDefaultSetupPlatform(),
+    ...defaultSetupPlatform,
+    auth: {
+      ...defaultSetupPlatform.auth,
+      signIn: async () =>
+        (await vscode.commands.executeCommand<boolean>(
+          AUTH_COMMANDS.SIGN_IN,
+        )) === true,
+    },
     commands: {
       invoke: (cmd, ...args) =>
         Promise.resolve(vscode.commands.executeCommand(cmd, ...args)),

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { platform } from '@platform/platform';
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   AUTH_BRIDGE_URL,
@@ -482,6 +483,12 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       await this.sessionCoordinator.clearSession();
       // Clear server-side key cache when session is removed (handles automatic invalidation)
       getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
+      await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
+        logger.warn(
+          'SupabaseAuthProvider',
+          `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
+        );
+      });
       this._onDidChangeSessions.fire({
         added: [],
         removed: [

--- a/packages/extension/src/frontend/auth/agentCatalogRefreshScope.ts
+++ b/packages/extension/src/frontend/auth/agentCatalogRefreshScope.ts
@@ -1,0 +1,38 @@
+let deferDepth = 0;
+let deferredWork: Array<() => Promise<void>> = [];
+
+export function isAgentCatalogAuthRefreshDeferred(): boolean {
+  return deferDepth > 0;
+}
+
+export function runAfterAgentCatalogAuthRefresh(
+  work: () => Promise<void>,
+): void {
+  if (deferDepth === 0) {
+    void work();
+    return;
+  }
+  deferredWork.push(work);
+}
+
+/** Keep auth listeners from racing the team preflight's single catalog fetch. */
+export async function withAgentCatalogAuthRefreshDeferred<T>(
+  work: () => Promise<T>,
+): Promise<T> {
+  deferDepth += 1;
+  try {
+    return await work();
+  } finally {
+    deferDepth -= 1;
+    if (deferDepth === 0) {
+      const pending = deferredWork;
+      deferredWork = [];
+      await Promise.allSettled(pending.map((refresh) => refresh()));
+    }
+  }
+}
+
+export function resetAgentCatalogAuthRefreshScopeForTests(): void {
+  deferDepth = 0;
+  deferredWork = [];
+}

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -226,8 +226,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         setGlobalStreaming,
       },
     });
-    this.agentHandlers = new AgentHandlers(ctx, (selectedToolUseAgent) =>
-      this.refreshAfterAgentMutation(selectedToolUseAgent),
+    this.agentHandlers = new AgentHandlers(
+      ctx,
+      (selectedToolUseAgent, agentCatalogAlreadyFresh) =>
+        this.refreshAfterAgentMutation(
+          selectedToolUseAgent,
+          agentCatalogAlreadyFresh,
+        ),
     );
     this.latexHandlers = new LatexSettingsHandlers(ctx);
     this.historyHandlers = new HistoryHandlers(ctx);
@@ -954,6 +959,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   /** Refresh settings-view agent list and main-view dropdown after agent mutations. */
   private async refreshAfterAgentMutation(
     selectedToolUseAgent?: string,
+    agentCatalogAlreadyFresh = false,
   ): Promise<void> {
     await Promise.all([
       this.withActiveWebview((w) =>
@@ -961,7 +967,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       ),
       safeExecuteCommand(
         'texra.refreshAllOptions',
-        selectedToolUseAgent ? [{ selectedToolUseAgent }] : [],
+        selectedToolUseAgent || agentCatalogAlreadyFresh
+          ? [{ selectedToolUseAgent, agentCatalogAlreadyFresh }]
+          : [],
         this.viewName,
       ),
     ]);

--- a/packages/extension/src/settingsView/SettingsViewProvider.ts
+++ b/packages/extension/src/settingsView/SettingsViewProvider.ts
@@ -7,6 +7,10 @@ import {
   BundledViewContentProvider,
 } from '@common/webview';
 import { onTexraAuthSessionsChanged } from '@frontend/events/onTexraAuthSessionsChanged';
+import {
+  isAgentCatalogAuthRefreshDeferred,
+  runAfterAgentCatalogAuthRefresh,
+} from '@frontend/auth/agentCatalogRefreshScope';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { SettingsTab } from '@shared/schemas/settingsViewMessages';
 
@@ -38,6 +42,12 @@ export class SettingsViewProvider
     // Listen for auth state changes to refresh all data
     onTexraAuthSessionsChanged(context, () => {
       if (this._view) {
+        if (isAgentCatalogAuthRefreshDeferred()) {
+          runAfterAgentCatalogAuthRefresh(() =>
+            this.messageHandler.sendAllData(this._view!.webview),
+          );
+          return;
+        }
         void this.messageHandler.sendAllData(this._view.webview);
       }
     });

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
 import {
   createKey,
   getAgent,
@@ -26,13 +27,13 @@ import {
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import { withAgentCatalogAuthRefreshDeferred } from '@frontend/auth/agentCatalogRefreshScope';
 import { renderAgentTemplateFromBundle } from '@frontend/agents/agentTemplateBundle';
 import {
   buildAgentSelectionMessage,
   buildCustomAgentDirMessage,
   buildAgentModePresetsMessage,
 } from '@shared/settingsView/handlers/agentSelectionHandlers';
-import { REMOTE_ORCHESTRATOR_AGENT_NAMES } from '@shared/constants/agents';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
@@ -43,10 +44,6 @@ import type { SettingsAgentDirectoryController } from '@controllers/settingsView
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
-
-const REMOTE_TEAM_AGENT_NAMES = new Set<string>(
-  REMOTE_ORCHESTRATOR_AGENT_NAMES,
-);
 
 /**
  * Agent selection, directory, and team handler delegate.
@@ -67,6 +64,7 @@ export class AgentHandlers {
     private readonly ctx: SettingsHandlerContext,
     private readonly refreshAfterAgentMutation: (
       selectedToolUseAgent?: string,
+      agentCatalogAlreadyFresh?: boolean,
     ) => Promise<void>,
   ) {
     const controllers = createSettingsAgentControllers({
@@ -425,65 +423,57 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      await loadAgents();
-      let result = await this.catalogController.applyPreset(data.presetId);
-      if (!result.ok) {
+      const result = await withAgentCatalogAuthRefreshDeferred(() =>
+        applyTeamRosterWithPreflight(data.presetId, {
+          catalog: this.catalogController,
+          loadLocalCatalog: () => loadAgents({ includeRemote: false }),
+          canAccessRemoteCatalog: () =>
+            SupabaseClient.canAccessRemoteAgentCatalog(),
+          choose: async (preset, unavailableNames) => {
+            const choice = await vscode.window.showInformationMessage(
+              `The "${preset.name}" team includes TeXRA-hosted members that are unavailable: ${unavailableNames.join(', ')}.`,
+              { modal: true },
+              'Sign in to TeXRA',
+              'Continue with available members',
+            );
+            if (choice === 'Sign in to TeXRA') return 'sign-in';
+            if (choice === 'Continue with available members') return 'continue';
+            return 'cancel';
+          },
+          signIn: async () =>
+            (await vscode.commands.executeCommand<boolean>(
+              AUTH_COMMANDS.SIGN_IN,
+            )) === true,
+          forceRefreshRemoteCatalog: () =>
+            refreshAgents({ includeRemote: true }),
+        }),
+      );
+
+      if (result.status === 'unknown') {
         await showLoggedMessage(
           this.ctx.channel,
           `Unknown team: ${data.presetId}`,
         );
         return;
       }
-
-      const unresolvedRemoteAgents = result.unresolvedNames.filter((name) =>
-        REMOTE_TEAM_AGENT_NAMES.has(name),
-      );
-      if (
-        unresolvedRemoteAgents.length > 0 &&
-        !(await SupabaseClient.isAuthenticated())
-      ) {
-        const count = unresolvedRemoteAgents.length;
-        const choice = await vscode.window.showInformationMessage(
-          `The "${result.preset.name}" team includes ${count} ${count === 1 ? 'member' : 'members'} provided through Researcher Access. Sign in to make the full team available.`,
-          'Sign in',
-          'Use available members',
+      if (result.status === 'choice-required') return;
+      if (result.status === 'cancelled') return;
+      if (result.status === 'unavailable') {
+        await showLoggedMessage(
+          this.ctx.channel,
+          `The "${result.preset.name}" team is unavailable because these TeXRA-hosted members could not be loaded: ${result.unavailableNames.join(', ')}.`,
         );
-        if (choice === 'Sign in') {
-          const signedIn = await vscode.commands.executeCommand<boolean>(
-            AUTH_COMMANDS.SIGN_IN,
-          );
-          if (signedIn) {
-            // A signed-out startup may already have completed an empty remote
-            // load, so a normal cached load would not discover the newly
-            // authorized agents.
-            await refreshAgents({ includeRemote: true });
-            const reapplied = await this.catalogController.applyPreset(
-              data.presetId,
-            );
-            if (!reapplied.ok) {
-              await this.refreshAfterAgentMutation(
-                this.catalogController.getPresetToolUseRoot(
-                  result.preset.toolUseAgents,
-                ),
-              );
-              await showLoggedMessage(
-                this.ctx.channel,
-                `Team no longer exists: ${data.presetId}`,
-              );
-              return;
-            }
-            result = reapplied;
-          }
-        }
+        return;
       }
 
       await this.refreshAfterAgentMutation(
         this.catalogController.getPresetToolUseRoot(
           result.preset.toolUseAgents,
         ),
+        true,
       );
 
-      const unresolvedCount = result.unresolvedNames.length;
+      const unresolvedCount = result.resolution.unresolvedNames.length;
       void vscode.window.showInformationMessage(
         unresolvedCount === 0
           ? `Applied "${result.preset.name}" team`

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -92,6 +92,8 @@ const cache = new Map<string, AgentEntry>();
 let initialized = false;
 let initPromise: Promise<void> | null = null;
 let cacheIncludesRemote = false;
+let refreshQueue: Promise<void> = Promise.resolve();
+let registryEpoch = 0;
 
 export interface LoadAgentsOptions {
   /** Include remote agent metadata that requires auth/network access. */
@@ -121,8 +123,10 @@ export async function loadAgents(
 
   const previousInitialized = initialized;
   const previousCacheIncludesRemote = cacheIncludesRemote;
-  initPromise = doLoad(includeRemote)
-    .then(() => {
+  const loadEpoch = registryEpoch;
+  initPromise = doLoad(includeRemote, loadEpoch)
+    .then((published) => {
+      if (!published) return;
       initialized = true;
       cacheIncludesRemote = includeRemote;
     })
@@ -138,7 +142,10 @@ export async function loadAgents(
   return initPromise;
 }
 
-async function doLoad(includeRemote: boolean): Promise<void> {
+async function doLoad(
+  includeRemote: boolean,
+  loadEpoch: number,
+): Promise<boolean> {
   const startTime = Date.now();
 
   // Migrate legacy builtIn:* → builtInWorkflow:* in persisted state
@@ -178,6 +185,8 @@ async function doLoad(includeRemote: boolean): Promise<void> {
     ),
   );
 
+  if (loadEpoch !== registryEpoch) return false;
+
   cache.clear();
   for (const entry of allEntries) {
     if (toolUseOverrides.has(entry.name)) {
@@ -196,6 +205,7 @@ async function doLoad(includeRemote: boolean): Promise<void> {
     CHANNEL,
     `Loaded ${cache.size} agents in ${Date.now() - startTime}ms`,
   );
+  return true;
 }
 
 /**
@@ -468,11 +478,44 @@ export function isAgentRegistryReady(): boolean {
   return initialized;
 }
 
-/** Refresh the cache. */
-export async function refresh(options: LoadAgentsOptions = {}): Promise<void> {
-  initialized = false;
+/**
+ * Refresh the cache after every older load has settled, then force a new load.
+ * This prevents a post-sign-in refresh from joining an in-flight signed-out
+ * remote request and incorrectly treating that stale request as authoritative.
+ */
+export function refresh(options: LoadAgentsOptions = {}): Promise<void> {
+  const refreshEpoch = ++registryEpoch;
+  const run = refreshQueue.then(async () => {
+    if (refreshEpoch !== registryEpoch) return;
+    if (initPromise) await initPromise.catch(() => undefined);
+    if (refreshEpoch !== registryEpoch) return;
+    initialized = false;
+    cacheIncludesRemote = false;
+    await loadAgents(options);
+  });
+  refreshQueue = run.catch(() => undefined);
+  return run;
+}
+
+function removeRemoteEntries(): void {
+  for (const [key, entry] of cache) {
+    if (entry.source === 'remote') cache.delete(key);
+  }
   cacheIncludesRemote = false;
-  await loadAgents(options);
+}
+
+/** Remove remote definitions immediately, then rebuild the local catalog. */
+export function invalidateRemoteAgentsAfterSignOut(): Promise<void> {
+  removeRemoteEntries();
+  return refresh({ includeRemote: false }).catch((error: unknown) => {
+    // An older in-flight remote load may have settled before the rebuild.
+    // Preserve the signed-out invariant even when local directory I/O fails.
+    removeRemoteEntries();
+    logger.warn(
+      CHANNEL,
+      `Local agent catalog rebuild failed after sign-out: ${String(error)}`,
+    );
+  });
 }
 
 // =============================================================================

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -29,6 +29,7 @@ export {
   getAgentsByCategory,
   getAgentsBySource,
   refresh,
+  invalidateRemoteAgentsAfterSignOut,
   // Typed data options
   computeAgentOptionsData,
   // Key helpers

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -390,6 +390,15 @@ export class SupabaseClient {
     return token !== null;
   }
 
+  /**
+   * Whether PostgREST-backed remote agent definitions can be queried.
+   * CI relay tokens authenticate model relay endpoints only; this capability
+   * deliberately requires a normal GoTrue session access token.
+   */
+  static async canAccessRemoteAgentCatalog(): Promise<boolean> {
+    return (await this.getAccessToken()) !== null;
+  }
+
   /** Get configuration for re-initialization. */
   static getConfig(): { url: string; publicKey: string } | null {
     return this.config;

--- a/src/controllers/onboarding/defaultTeamSeeding.ts
+++ b/src/controllers/onboarding/defaultTeamSeeding.ts
@@ -11,9 +11,9 @@
  */
 
 import {
-  applyPresetRoster,
-  type PresetRosterState,
-} from '@controllers/settingsView/SettingsAgentCatalogController';
+  applyTeamRoster,
+  type TeamRosterState,
+} from '@controllers/teams/TeamRoster';
 import { getAgentsByCategory } from '@agent/index/agentRegistry';
 import {
   AGENT_MODE_PRESETS_BY_ID,
@@ -42,7 +42,7 @@ export function resolveTeamPreset(teamId: string): AgentModePreset | undefined {
  */
 export function registryPresetRosterState(
   workspaceState: StateStore,
-): PresetRosterState {
+): TeamRosterState {
   return {
     getAgents: (category) => getAgentsByCategory(category),
     setEnabledAgentKeys: async (category, enabledKeys) => {
@@ -90,6 +90,6 @@ export async function seedRosterFromDefaultTeam(
     (defaultTeamId ? resolveTeamPreset(defaultTeamId) : undefined) ??
     (fallbackTeamId ? resolveTeamPreset(fallbackTeamId) : undefined);
   if (!preset) return false;
-  await applyPresetRoster(registryPresetRosterState(workspaceState), preset);
+  await applyTeamRoster(registryPresetRosterState(workspaceState), preset);
   return true;
 }

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -1,3 +1,11 @@
+// Local imports - controllers
+import {
+  applyTeamRoster,
+  commitTeamRoster,
+  resolveTeamRoster,
+  type TeamRosterResolution,
+} from '@controllers/teams/TeamRoster';
+
 // Local imports - shared
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import {
@@ -67,72 +75,6 @@ export function enabledKeysIncludeAgent(
  * subset of {@link SettingsAgentCatalogState}, so the controller's state port
  * satisfies it directly.
  */
-export interface PresetRosterState {
-  getAgents(category: AgentCategory): { name: string; source: AgentSource }[];
-  setEnabledAgentKeys(
-    category: AgentCategory,
-    enabledKeys: string[],
-  ): Promise<void>;
-}
-
-/**
- * Resolve a preset's agent names against the live catalog and write both
- * workspace roster keys. Single application path shared by the Settings
- * "apply team" action, the setup agent's `apply_team` tool, and default-team
- * seeding of fresh workspaces — so the paths can't drift.
- *
- * Resolved names are written as `source:name` keys. Names that don't resolve
- * right now (relay-served orchestrators while signed out, agents not yet
- * installed) are kept as bare names: visibility filtering matches by name, so
- * the agent joins the roster the moment it appears (e.g. after sign-in)
- * instead of being silently dropped. Returns the written keys per category
- * plus the names that didn't resolve.
- */
-export async function applyPresetRoster(
-  state: PresetRosterState,
-  preset: AgentModePreset,
-): Promise<{
-  workflowKeys: string[];
-  toolUseKeys: string[];
-  unresolvedNames: string[];
-}> {
-  const workflow = resolvePresetAgentKeys(
-    state,
-    'workflow',
-    preset.workflowAgents,
-  );
-  const toolUse = resolvePresetAgentKeys(
-    state,
-    'toolUse',
-    preset.toolUseAgents,
-  );
-  await state.setEnabledAgentKeys('workflow', workflow.keys);
-  await state.setEnabledAgentKeys('toolUse', toolUse.keys);
-  return {
-    workflowKeys: workflow.keys,
-    toolUseKeys: toolUse.keys,
-    unresolvedNames: [...workflow.unresolved, ...toolUse.unresolved],
-  };
-}
-
-function resolvePresetAgentKeys(
-  state: PresetRosterState,
-  category: AgentCategory,
-  names: string[],
-): { keys: string[]; unresolved: string[] } {
-  const entries = state.getAgents(category);
-  const unresolved: string[] = [];
-  const keys = names.map((name) => {
-    const entry = entries.find((candidate) => candidate.name === name);
-    if (entry) return agentKeyOf(entry);
-    unresolved.push(name);
-    // Keep unresolved names so relay-only team members survive until sign-in
-    // loads the source that can resolve them.
-    return name;
-  });
-  return { keys, unresolved };
-}
-
 export class SettingsAgentCatalogController {
   constructor(private readonly deps: SettingsAgentCatalogControllerDeps) {}
 
@@ -175,22 +117,39 @@ export class SettingsAgentCatalogController {
     const preset = this.getPreset(presetId);
     if (!preset) return { ok: false, reason: 'unknownPreset' };
 
-    const { unresolvedNames } = await applyPresetRoster(
-      this.deps.state,
-      preset,
-    );
+    const { unresolvedNames } = await applyTeamRoster(this.deps.state, preset);
 
     return { ok: true, preset, unresolvedNames };
   }
 
+  resolvePreset(presetId: string):
+    | {
+        readonly ok: true;
+        readonly preset: AgentModePreset;
+        readonly resolution: TeamRosterResolution;
+      }
+    | { readonly ok: false; readonly reason: 'unknownPreset' } {
+    const preset = this.getPreset(presetId);
+    if (!preset) return { ok: false, reason: 'unknownPreset' };
+    return {
+      ok: true,
+      preset,
+      resolution: resolveTeamRoster(this.deps.state, preset),
+    };
+  }
+
+  async commitPresetResolution(
+    resolution: TeamRosterResolution,
+  ): Promise<void> {
+    await commitTeamRoster(this.deps.state, resolution);
+  }
+
   async saveCurrentPreset(name: string): Promise<AgentModePreset> {
     const trimmedName = name.trim();
-    const workflowAgents = this.deps.state
-      .getVisibleAgents('workflow')
-      .map((entry) => entry.name);
-    const toolUseAgents = this.deps.state
-      .getVisibleAgents('toolUse')
-      .map((entry) => entry.name);
+    const visibleWorkflow = this.deps.state.getVisibleAgents('workflow');
+    const visibleToolUse = this.deps.state.getVisibleAgents('toolUse');
+    const workflowAgents = visibleWorkflow.map((entry) => entry.name);
+    const toolUseAgents = visibleToolUse.map((entry) => entry.name);
     const preset: AgentModePreset = {
       id: `custom-${this.deps.now?.() ?? Date.now()}`,
       name: trimmedName,
@@ -198,6 +157,9 @@ export class SettingsAgentCatalogController {
       icon: 'bookmark',
       workflowAgents,
       toolUseAgents,
+      texraHostedAgents: [...visibleWorkflow, ...visibleToolUse]
+        .filter((entry) => entry.source === 'remote')
+        .map((entry) => entry.name),
     };
 
     await this.deps.state.setCustomPresets([

--- a/src/controllers/teams/TeamAvailabilityPreflight.ts
+++ b/src/controllers/teams/TeamAvailabilityPreflight.ts
@@ -1,0 +1,106 @@
+export type TeamAvailabilityChoice = 'sign-in' | 'continue' | 'cancel';
+
+export type TeamAvailabilityPreflightResult<T> =
+  | { readonly status: 'proceed'; readonly value: T; readonly partial: boolean }
+  | {
+      readonly status: 'choice-required';
+      readonly value: T;
+      readonly unavailableNames: readonly string[];
+    }
+  | { readonly status: 'cancelled'; readonly value: T }
+  | {
+      readonly status: 'unavailable';
+      readonly value: T;
+      readonly unavailableNames: readonly string[];
+    };
+
+export interface TeamAvailabilityPreflightOptions<T> {
+  readonly initial: T;
+  readonly unresolvedNames: (value: T) => readonly string[];
+  readonly texraHostedNames: ReadonlySet<string>;
+  readonly canAccessRemoteCatalog: () => Promise<boolean>;
+  /** A decision already supplied by a non-interactive caller. */
+  readonly providedChoice?: TeamAvailabilityChoice;
+  readonly choose: (
+    unavailableNames: readonly string[],
+  ) => Promise<TeamAvailabilityChoice | undefined>;
+  readonly signIn: () => Promise<boolean>;
+  readonly refresh: () => Promise<T>;
+  /** The caller already forced a remote catalog fetch for `initial`. */
+  readonly remoteCatalogRefreshAttempted?: boolean;
+}
+
+function unavailableTexraHostedNames<T>(
+  value: T,
+  options: TeamAvailabilityPreflightOptions<T>,
+): string[] {
+  return options
+    .unresolvedNames(value)
+    .filter((name) => options.texraHostedNames.has(name));
+}
+
+/**
+ * Decide whether an incomplete team may proceed before its caller writes or
+ * launches anything. Model credentials are deliberately absent from this API:
+ * only TeXRA authentication can make TeXRA-hosted definitions available.
+ */
+export async function preflightTeamAvailability<T>(
+  options: TeamAvailabilityPreflightOptions<T>,
+): Promise<TeamAvailabilityPreflightResult<T>> {
+  const initialUnavailable = unavailableTexraHostedNames(
+    options.initial,
+    options,
+  );
+  if (initialUnavailable.length === 0) {
+    return { status: 'proceed', value: options.initial, partial: false };
+  }
+
+  if (options.providedChoice === 'cancel') {
+    return { status: 'cancelled', value: options.initial };
+  }
+  if (options.providedChoice === 'continue') {
+    return { status: 'proceed', value: options.initial, partial: true };
+  }
+
+  const canAccessRemoteCatalog = await options.canAccessRemoteCatalog();
+  if (canAccessRemoteCatalog) {
+    if (options.remoteCatalogRefreshAttempted) {
+      return {
+        status: 'unavailable',
+        value: options.initial,
+        unavailableNames: initialUnavailable,
+      };
+    }
+    const refreshed = await options.refresh();
+    const unavailableNames = unavailableTexraHostedNames(refreshed, options);
+    return unavailableNames.length === 0
+      ? { status: 'proceed', value: refreshed, partial: false }
+      : { status: 'unavailable', value: refreshed, unavailableNames };
+  }
+
+  const choice =
+    options.providedChoice ?? (await options.choose(initialUnavailable));
+  if (choice === undefined) {
+    return {
+      status: 'choice-required',
+      value: options.initial,
+      unavailableNames: initialUnavailable,
+    };
+  }
+  if (choice === 'cancel') {
+    return { status: 'cancelled', value: options.initial };
+  }
+  if (choice === 'continue') {
+    return { status: 'proceed', value: options.initial, partial: true };
+  }
+
+  if (!(await options.signIn())) {
+    return { status: 'cancelled', value: options.initial };
+  }
+
+  const refreshed = await options.refresh();
+  const unavailableNames = unavailableTexraHostedNames(refreshed, options);
+  return unavailableNames.length === 0
+    ? { status: 'proceed', value: refreshed, partial: false }
+    : { status: 'unavailable', value: refreshed, unavailableNames };
+}

--- a/src/controllers/teams/TeamRoster.ts
+++ b/src/controllers/teams/TeamRoster.ts
@@ -1,0 +1,91 @@
+import {
+  agentKeyOf,
+  type AgentCategory,
+  type AgentSource,
+} from '@shared/schemas/agent';
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+
+export interface TeamRosterState {
+  getAgents(category: AgentCategory): { name: string; source: AgentSource }[];
+  setEnabledAgentKeys(
+    category: AgentCategory,
+    enabledKeys: string[],
+  ): Promise<void>;
+}
+
+export interface TeamRosterResolution {
+  readonly workflowKeys: string[];
+  readonly toolUseKeys: string[];
+  readonly unresolvedNames: string[];
+}
+
+export interface TeamRosterCatalog {
+  resolvePreset(presetId: string):
+    | {
+        readonly ok: true;
+        readonly preset: AgentModePreset;
+        readonly resolution: TeamRosterResolution;
+      }
+    | { readonly ok: false; readonly reason: 'unknownPreset' };
+  commitPresetResolution(resolution: TeamRosterResolution): Promise<void>;
+}
+
+/** Resolve a team against the current catalog without writing roster state. */
+export function resolveTeamRoster(
+  state: Pick<TeamRosterState, 'getAgents'>,
+  preset: AgentModePreset,
+): TeamRosterResolution {
+  const workflow = resolveAgentKeys(state, 'workflow', preset.workflowAgents);
+  const toolUse = resolveAgentKeys(state, 'toolUse', preset.toolUseAgents);
+  return {
+    workflowKeys: workflow.keys,
+    toolUseKeys: toolUse.keys,
+    unresolvedNames: [...workflow.unresolved, ...toolUse.unresolved],
+  };
+}
+
+/** Commit a previously resolved roster. */
+export async function commitTeamRoster(
+  state: Pick<TeamRosterState, 'setEnabledAgentKeys'>,
+  resolution: TeamRosterResolution,
+): Promise<void> {
+  await state.setEnabledAgentKeys('workflow', resolution.workflowKeys);
+  await state.setEnabledAgentKeys('toolUse', resolution.toolUseKeys);
+}
+
+export async function applyTeamRoster(
+  state: TeamRosterState,
+  preset: AgentModePreset,
+): Promise<TeamRosterResolution> {
+  const resolution = resolveTeamRoster(state, preset);
+  await commitTeamRoster(state, resolution);
+  return resolution;
+}
+
+/**
+ * Legacy presets without provenance conservatively preflight every unresolved
+ * member. Known local members already resolve and therefore never enter this
+ * set; explicit metadata remains authoritative for current presets.
+ */
+export function teamHostedNamesForPreflight(
+  preset: AgentModePreset,
+  unresolvedNames: readonly string[],
+): ReadonlySet<string> {
+  return new Set(preset.texraHostedAgents ?? unresolvedNames);
+}
+
+function resolveAgentKeys(
+  state: Pick<TeamRosterState, 'getAgents'>,
+  category: AgentCategory,
+  names: string[],
+): { keys: string[]; unresolved: string[] } {
+  const entries = state.getAgents(category);
+  const unresolved: string[] = [];
+  const keys = names.map((name) => {
+    const entry = entries.find((candidate) => candidate.name === name);
+    if (entry) return agentKeyOf(entry);
+    unresolved.push(name);
+    return name;
+  });
+  return { keys, unresolved };
+}

--- a/src/controllers/teams/TeamRosterApplication.ts
+++ b/src/controllers/teams/TeamRosterApplication.ts
@@ -1,0 +1,101 @@
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+
+import {
+  preflightTeamAvailability,
+  type TeamAvailabilityChoice,
+} from './TeamAvailabilityPreflight';
+import {
+  teamHostedNamesForPreflight,
+  type TeamRosterCatalog,
+  type TeamRosterResolution,
+} from './TeamRoster';
+
+interface ResolvedTeam {
+  readonly ok: true;
+  readonly preset: AgentModePreset;
+  readonly resolution: TeamRosterResolution;
+}
+
+export type TeamRosterApplicationResult =
+  | { readonly status: 'unknown' }
+  | { readonly status: 'cancelled'; readonly preset: AgentModePreset }
+  | {
+      readonly status: 'choice-required';
+      readonly preset: AgentModePreset;
+      readonly unavailableNames: readonly string[];
+    }
+  | {
+      readonly status: 'unavailable';
+      readonly preset: AgentModePreset;
+      readonly unavailableNames: readonly string[];
+    }
+  | {
+      readonly status: 'applied';
+      readonly preset: AgentModePreset;
+      readonly resolution: TeamRosterResolution;
+    };
+
+export interface TeamRosterApplicationDeps {
+  readonly catalog: TeamRosterCatalog;
+  readonly loadLocalCatalog: () => Promise<void>;
+  readonly canAccessRemoteCatalog: () => Promise<boolean>;
+  readonly choose: (
+    preset: AgentModePreset,
+    unavailableNames: readonly string[],
+  ) => Promise<TeamAvailabilityChoice>;
+  readonly signIn: () => Promise<boolean>;
+  readonly forceRefreshRemoteCatalog: () => Promise<void>;
+}
+
+/** Host sequence for preflighting and committing one team roster. */
+export async function applyTeamRosterWithPreflight(
+  presetId: string,
+  deps: TeamRosterApplicationDeps,
+): Promise<TeamRosterApplicationResult> {
+  await deps.loadLocalCatalog();
+  const initial = deps.catalog.resolvePreset(presetId);
+  if (!initial.ok) return { status: 'unknown' };
+
+  const preflight = await preflightTeamAvailability<ResolvedTeam>({
+    initial,
+    unresolvedNames: (value) => value.resolution.unresolvedNames,
+    texraHostedNames: teamHostedNamesForPreflight(
+      initial.preset,
+      initial.resolution.unresolvedNames,
+    ),
+    canAccessRemoteCatalog: deps.canAccessRemoteCatalog,
+    choose: (names) => deps.choose(initial.preset, names),
+    signIn: deps.signIn,
+    refresh: async () => {
+      await deps.forceRefreshRemoteCatalog();
+      const refreshed = deps.catalog.resolvePreset(presetId);
+      if (!refreshed.ok) throw new Error(`Team no longer exists: ${presetId}`);
+      return refreshed;
+    },
+  });
+
+  if (preflight.status === 'cancelled') {
+    return { status: 'cancelled', preset: initial.preset };
+  }
+  if (preflight.status === 'choice-required') {
+    return {
+      status: 'choice-required',
+      preset: initial.preset,
+      unavailableNames: preflight.unavailableNames,
+    };
+  }
+  if (preflight.status === 'unavailable') {
+    return {
+      status: 'unavailable',
+      preset: initial.preset,
+      unavailableNames: preflight.unavailableNames,
+    };
+  }
+
+  await deps.catalog.commitPresetResolution(preflight.value.resolution);
+  return {
+    status: 'applied',
+    preset: preflight.value.preset,
+    resolution: preflight.value.resolution,
+  };
+}

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -49,6 +49,8 @@ export const AgentModePresetSchema = z.object({
   icon: AgentModePresetIconSchema,
   workflowAgents: z.array(z.string()),
   toolUseAgents: z.array(z.string()),
+  /** Members whose definitions may be supplied by TeXRA's remote catalog. */
+  texraHostedAgents: z.array(z.string()).optional(),
 });
 
 export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
@@ -58,9 +60,10 @@ export function parseAgentModePresets(raw: unknown): AgentModePreset[] {
     .array(z.unknown())
     .catch([])
     .parse(raw)
-    .flatMap((preset) => {
-      const result = AgentModePresetSchema.safeParse(preset);
-      return result.success ? [result.data] : [];
+    .flatMap((rawPreset) => {
+      const result = AgentModePresetSchema.safeParse(rawPreset);
+      if (!result.success) return [];
+      return [result.data];
     });
 }
 
@@ -89,6 +92,7 @@ export const STARTER_AGENT_MODE_PRESET: AgentModePreset = {
     'setup',
     'orchestrator',
   ],
+  texraHostedAgents: ['orchestrator'],
 };
 
 /**
@@ -111,6 +115,14 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'leanSimplifier',
       'leanBlueprint',
       'latexFixer',
+      'progressCheck',
+      'leanOrchestrator',
+    ],
+    texraHostedAgents: [
+      'lean',
+      'leanSearch',
+      'leanSimplifier',
+      'leanBlueprint',
       'progressCheck',
       'leanOrchestrator',
     ],
@@ -140,6 +152,17 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'progressCheck',
       'search',
     ],
+    texraHostedAgents: [
+      'generic',
+      'devise',
+      'apply',
+      'criticize',
+      'orchestrator',
+      'presenter',
+      'simplifier',
+      'progressCheck',
+      'search',
+    ],
   },
   {
     id: 'mathematician',
@@ -156,6 +179,15 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'review',
       'simplifier',
       'latexFixer',
+      'progressCheck',
+      'orchestrator',
+    ],
+    texraHostedAgents: [
+      'generic',
+      'devise',
+      'apply',
+      'lean',
+      'simplifier',
       'progressCheck',
       'orchestrator',
     ],
@@ -180,6 +212,17 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'latexFixer',
       'progressCheck',
     ],
+    texraHostedAgents: [
+      'criticize',
+      'generic',
+      'devise',
+      'apply',
+      'orchestrator',
+      'search',
+      'presenter',
+      'simplifier',
+      'progressCheck',
+    ],
   },
   {
     id: 'software-engineer',
@@ -195,6 +238,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'testEngineer',
       'codeSimplifier',
     ],
+    texraHostedAgents: [],
   },
 ];
 

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -12,30 +12,37 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform } from '@platform/platform';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import * as logger from '@logger/logUtils';
 import {
   computeAgentOptionsData,
   getAgent,
+  getAgentsBySource,
   getVisibleAgent,
   getVisibleAgents,
   isAgentRegistryReady,
+  invalidateRemoteAgentsAfterSignOut,
   loadAgents,
   refresh,
 } from '@agent/index/agentRegistry';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { AgentDirectoriesPort } from '@platform/interfaces';
 
+const listRemoteAgents = vi.hoisted(() =>
+  vi.fn(async () => [
+    {
+      id: 'remote-orchestrator',
+      name: 'orchestrator',
+      description: 'Remote team root',
+      visibility: ['researcher'],
+      tools: ['delegate_agent'],
+      agentCategory: 'toolUse',
+    },
+  ]),
+);
+
 vi.mock('@agent/remote/RemoteAgentLoader', () => ({
   RemoteAgentLoader: {
-    listRemoteAgents: vi.fn(async () => [
-      {
-        id: 'remote-orchestrator',
-        name: 'orchestrator',
-        description: 'Remote team root',
-        visibility: ['researcher'],
-        tools: ['delegate_agent'],
-        agentCategory: 'toolUse',
-      },
-    ]),
+    listRemoteAgents,
   },
 }));
 
@@ -70,6 +77,17 @@ const mutableAgentDirectories: AgentDirectoriesPort = {
   builtIn: () => activeAgentDirectories.builtIn(),
   builtInToolUse: () => activeAgentDirectories.builtInToolUse(),
 };
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 /** Point the platform at the real bundled agent YAMLs, overriding any dir. */
 function useAgentDirectories(
@@ -157,6 +175,147 @@ describe('agent registry legacy aliases', () => {
 
     releaseBuiltInToolUseDir?.();
     await pendingRefresh;
+  });
+
+  it('forces a new remote fetch after an older initialization settles', async () => {
+    useAgentDirectories();
+    await refresh({ includeRemote: false });
+
+    let releaseStaleLoad: (() => void) | undefined;
+    const staleLoadGate = new Promise<void>((resolveLoad) => {
+      releaseStaleLoad = resolveLoad;
+    });
+    let remoteCall = 0;
+    listRemoteAgents.mockImplementation(async () => {
+      remoteCall += 1;
+      if (remoteCall === 1) {
+        await staleLoadGate;
+        return [
+          {
+            id: 'stale-agent',
+            name: 'staleAgent',
+            description: 'Stale',
+            visibility: [],
+            tools: [],
+            agentCategory: 'toolUse',
+          },
+        ];
+      }
+      return [
+        {
+          id: 'fresh-agent',
+          name: 'freshAgent',
+          description: 'Fresh',
+          visibility: [],
+          tools: [],
+          agentCategory: 'toolUse',
+        },
+      ];
+    });
+
+    const staleInitialization = loadAgents({ includeRemote: true });
+    await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalledOnce());
+    const forcedRefresh = refresh({ includeRemote: true });
+
+    releaseStaleLoad?.();
+    await staleInitialization;
+    await forcedRefresh;
+
+    expect(listRemoteAgents).toHaveBeenCalledTimes(2);
+    expect(getAgent('freshAgent')?.source).toBe('remote');
+    expect(getAgent('staleAgent')).toBeUndefined();
+
+    listRemoteAgents.mockReset();
+    listRemoteAgents.mockResolvedValue([
+      {
+        id: 'remote-orchestrator',
+        name: 'orchestrator',
+        description: 'Remote team root',
+        visibility: ['researcher'],
+        tools: ['delegate_agent'],
+        agentCategory: 'toolUse',
+      },
+    ]);
+    await refresh({ includeRemote: false });
+  });
+
+  it('reloads local-only definitions after sign-out invalidation', async () => {
+    useAgentDirectories();
+    await refresh({ includeRemote: true });
+    expect(getAgentsBySource('remote')).not.toHaveLength(0);
+    const remoteFetchCount = listRemoteAgents.mock.calls.length;
+
+    await invalidateRemoteAgentsAfterSignOut();
+
+    expect(getAgentsBySource('remote')).toEqual([]);
+    expect(listRemoteAgents).toHaveBeenCalledTimes(remoteFetchCount);
+  });
+
+  it('removes remote definitions even when the local rebuild fails', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    useAgentDirectories();
+    await refresh({ includeRemote: true });
+    expect(getAgentsBySource('remote')).not.toHaveLength(0);
+    useAgentDirectories({
+      builtIn: async () => {
+        throw new Error('local catalog unavailable');
+      },
+    });
+
+    const invalidation = invalidateRemoteAgentsAfterSignOut();
+    expect(getAgentsBySource('remote')).toEqual([]);
+    await expect(invalidation).resolves.toBeUndefined();
+    expect(getAgentsBySource('remote')).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      'agentRegistry',
+      expect.stringContaining(
+        'Local agent catalog rebuild failed after sign-out',
+      ),
+    );
+
+    useAgentDirectories();
+    await refresh({ includeRemote: false });
+    warn.mockRestore();
+  });
+
+  it('fences an in-flight remote load before rebuilding locally', async () => {
+    useAgentDirectories();
+    await refresh({ includeRemote: false });
+    const remoteLoad = createDeferred<void>();
+    const localRebuild = createDeferred<void>();
+    let builtInCalls = 0;
+    useAgentDirectories({
+      builtIn: async () => {
+        builtInCalls += 1;
+        if (builtInCalls === 2) await localRebuild.promise;
+        return BUILTIN_AGENTS_DIR;
+      },
+    });
+    listRemoteAgents.mockImplementationOnce(async () => {
+      await remoteLoad.promise;
+      return [
+        {
+          id: 'late-remote',
+          name: 'lateRemote',
+          description: 'Late remote result',
+          visibility: [],
+          tools: [],
+          agentCategory: 'toolUse',
+        },
+      ];
+    });
+
+    const staleLoad = loadAgents({ includeRemote: true });
+    await vi.waitFor(() => expect(listRemoteAgents).toHaveBeenCalled());
+    const invalidation = invalidateRemoteAgentsAfterSignOut();
+    remoteLoad.resolve();
+    await staleLoad;
+
+    expect(getAgent('lateRemote')).toBeUndefined();
+    expect(getAgentsBySource('remote')).toEqual([]);
+
+    localRebuild.resolve();
+    await invalidation;
   });
 
   it('keeps the registry marked ready when a later refresh fails', async () => {

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -88,6 +88,22 @@ describe('SupabaseClient', () => {
       assert.equal(await SupabaseClient.getAccessToken(), 'session-token');
       assert.equal(await SupabaseClient.getRelayAccessToken(), relayToken);
       assert.equal(await SupabaseClient.isAuthenticated(), true);
+      assert.equal(await SupabaseClient.canAccessRemoteAgentCatalog(), true);
+    });
+  });
+
+  it('keeps relay-only model auth separate from remote catalog access', async () => {
+    const relayToken = `${RELAY_CI_TOKEN_PREFIX}relayonly`;
+    const provider = createTokenProvider({
+      ensureFreshToken: async () => null,
+    });
+
+    await withRelayTokenEnv(relayToken, async () => {
+      SupabaseClient.setAuthProvider(provider);
+
+      assert.equal(await SupabaseClient.isAuthenticated(), true);
+      assert.equal(await SupabaseClient.getRelayAccessToken(), relayToken);
+      assert.equal(await SupabaseClient.canAccessRemoteAgentCatalog(), false);
     });
   });
 

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -6,6 +6,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 const mocks = vi.hoisted(() => ({
   authProvider: {
     isAuthenticated: vi.fn(),
+    canAccessRemoteAgentCatalog: vi.fn(),
   },
   getAgent: vi.fn(),
   getAgentsByCategory: vi.fn(),
@@ -41,6 +42,8 @@ describe('CLI agent resolution', () => {
   beforeEach(() => {
     mocks.authProvider.isAuthenticated.mockReset();
     mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockReset();
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
     mocks.getAgent.mockReset();
     mocks.getAgentsByCategory.mockReset();
     mocks.getVisibleAgents.mockReset();
@@ -56,7 +59,9 @@ describe('CLI agent resolution', () => {
 
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+    expect(
+      mocks.authProvider.canAccessRemoteAgentCatalog,
+    ).toHaveBeenCalledOnce();
   });
 
   it('does a full registry load when the local registry misses', async () => {
@@ -70,29 +75,31 @@ describe('CLI agent resolution', () => {
       includeRemote: false,
     });
     expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
-    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+    expect(
+      mocks.authProvider.canAccessRemoteAgentCatalog,
+    ).not.toHaveBeenCalled();
   });
 
-  it('lets authenticated relay users prefer remote definitions over local built-ins', async () => {
+  it('does not treat relay-only model access as remote-catalog access', async () => {
     const local = agent('lean');
-    const remote = agent('lean', 'remote');
     mocks.authProvider.isAuthenticated.mockResolvedValue(true);
-    mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    mocks.getAgent.mockReturnValue(local);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
-    await expect(resolveCliAgent('lean')).resolves.toBe(remote);
+    await expect(resolveCliAgent('lean')).resolves.toBe(local);
 
-    expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
+    expect(mocks.loadAgents).toHaveBeenCalledOnce();
+    expect(mocks.loadAgents).toHaveBeenCalledWith({
       includeRemote: false,
     });
-    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
-    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
-    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
     const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
 
@@ -116,7 +123,7 @@ describe('CLI agent resolution', () => {
 
   it('does not apply remote priority to source-qualified agent names', async () => {
     const local = agent('local:lean');
-    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
     mocks.getAgent.mockReturnValue(local);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
@@ -124,7 +131,9 @@ describe('CLI agent resolution', () => {
 
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+    expect(
+      mocks.authProvider.canAccessRemoteAgentCatalog,
+    ).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for local and remote-fallback lookups', async () => {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -6,6 +6,7 @@ import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import type { StreamTabId } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import { getSetupPlatform } from '@tools/setup/platform';
 
 type SignalSpyEvent = 'SIGINT' | 'SIGTERM';
 
@@ -67,7 +68,9 @@ function spyOnSignalRegistration(): {
 const mocks = vi.hoisted(() => ({
   authProvider: {
     isAuthenticated: vi.fn(),
+    canAccessRemoteAgentCatalog: vi.fn(),
   },
+  signInCliSupabase: vi.fn(),
   bootstrapNodeAgentDirectories: vi.fn(),
   createPlatformAgentDirectories: vi.fn(() => ({
     custom: vi.fn(),
@@ -103,6 +106,7 @@ vi.mock('@auth/serverKeys', () => ({
 vi.mock('@cli/runtime/supabaseAuth', () => ({
   getCliAuthProvider: () => mocks.authProvider,
   initializeCliSupabaseAuth: mocks.initializeCliSupabaseAuth,
+  signInCliSupabase: mocks.signInCliSupabase,
 }));
 
 vi.mock('@logger/logUtils', () => ({
@@ -209,6 +213,7 @@ describe('CLI platform init', () => {
       },
     });
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
     mocks.serverSideKeyService.setUseIncludedModelAccess.mockResolvedValue(
       undefined,
     );
@@ -430,6 +435,18 @@ describe('CLI platform init', () => {
         additionalPaths: ['vendor/skills'],
       },
     });
+  });
+
+  it('wires setup sign-in to the existing CLI login implementation', async () => {
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
+    mocks.signInCliSupabase.mockResolvedValue({ account: { label: 'User' } });
+
+    await initCliPlatform(cliContext());
+
+    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(true);
+    expect(mocks.signInCliSupabase).toHaveBeenCalledOnce();
+    expect(mocks.signInCliSupabase).toHaveBeenCalledWith({ openBrowser: true });
   });
 });
 

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -23,8 +23,13 @@ const mocks = vi.hoisted(() => {
     toStorableSupabaseSession: vi.fn((session) => session),
     tryPlatform: vi.fn(),
     updateGlobalState: vi.fn(),
+    invalidateRemoteAgentsAfterSignOut: vi.fn(),
   };
 });
+
+vi.mock('@agent/index', () => ({
+  invalidateRemoteAgentsAfterSignOut: mocks.invalidateRemoteAgentsAfterSignOut,
+}));
 
 vi.mock('@auth/config', () => ({
   DEFAULT_OAUTH_PROVIDER: 'github',
@@ -107,6 +112,7 @@ describe('CLI Supabase auth', () => {
     mocks.getCliSecrets.mockReturnValue({ kind: 'cli-secrets' });
     mocks.setUseIncludedModelAccess.mockResolvedValue(undefined);
     mocks.updateGlobalState.mockResolvedValue(undefined);
+    mocks.invalidateRemoteAgentsAfterSignOut.mockResolvedValue(undefined);
   });
 
   it('uses platform-owned secrets after CLI platform init', async () => {
@@ -180,6 +186,39 @@ describe('CLI Supabase auth', () => {
     expect(mocks.updateGlobalState).toHaveBeenCalledWith(
       GlobalStateKey.USE_OPENROUTER,
       false,
+    );
+  });
+
+  it('removes cached remote agents after sign-out', async () => {
+    const { signOutCliSupabase } = await loadSupabaseAuth();
+
+    await signOutCliSupabase();
+
+    expect(mocks.authCoordinator.clearSession).toHaveBeenCalledOnce();
+    expect(mocks.invalidateRemoteAgentsAfterSignOut).toHaveBeenCalledOnce();
+  });
+
+  it('completes sign-out when the local catalog rebuild fails', async () => {
+    mocks.invalidateRemoteAgentsAfterSignOut.mockRejectedValueOnce(
+      new Error('local rebuild failed'),
+    );
+    const warn = vi.fn();
+    const { initializeCliSupabaseAuth, signOutCliSupabase } =
+      await loadSupabaseAuth();
+    initializeCliSupabaseAuth({
+      initialize: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    });
+
+    await expect(signOutCliSupabase()).resolves.toBeUndefined();
+
+    expect(mocks.authCoordinator.clearSession).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      'cli-auth',
+      'Local agent catalog refresh failed after sign-out: Error: local rebuild failed',
     );
   });
 });

--- a/src/test-kernel/cli/CliTeamAvailabilityPreflight.vitest.mts
+++ b/src/test-kernel/cli/CliTeamAvailabilityPreflight.vitest.mts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { preflightCliTeamAvailability } from '@cli/runtime/teamAvailabilityPreflight';
+import type { CliMultiAgentPresetRunPlan } from '@cli/runtime/multiAgentPresets';
+
+function plan(missing: readonly string[]): CliMultiAgentPresetRunPlan {
+  return {
+    preset: {
+      id: 'custom-team',
+      name: 'Custom team',
+      description: 'Test team',
+      icon: 'tools',
+      workflowAgents: [],
+      toolUseAgents: ['orchestrator'],
+      texraHostedAgents: ['orchestrator'],
+      source: 'custom',
+    },
+    workflowAgentKeys: [],
+    toolUseAgentKeys: [],
+    missingWorkflowAgents: [],
+    missingToolUseAgents: [...missing],
+  };
+}
+
+function deps(input: {
+  choice?: 'sign-in' | 'continue' | 'cancel';
+  canAccess?: boolean;
+  signedIn?: boolean;
+  refreshAttempted?: boolean;
+  refreshed?: CliMultiAgentPresetRunPlan;
+}) {
+  const refresh = vi.fn(async () => input.refreshed ?? plan([]));
+  const signIn = vi.fn(async () => input.signedIn ?? true);
+  return {
+    refresh,
+    signIn,
+    value: {
+      plan: plan(['orchestrator']),
+      remoteCatalogRefreshAttempted: input.refreshAttempted ?? false,
+      canAccessRemoteCatalog: async () => input.canAccess ?? false,
+      choose: vi.fn(async () => input.choice ?? 'cancel'),
+      signIn,
+      refresh,
+    },
+  };
+}
+
+describe('CLI team availability host adapter', () => {
+  it.each([
+    ['cancel', 'cancelled'],
+    ['continue', 'proceed'],
+  ] as const)('maps the explicit %s choice to %s', async (choice, status) => {
+    const subject = deps({ choice });
+    await expect(
+      preflightCliTeamAvailability(subject.value),
+    ).resolves.toMatchObject({ status });
+    expect(subject.signIn).not.toHaveBeenCalled();
+    expect(subject.refresh).not.toHaveBeenCalled();
+  });
+
+  it('cancels when login does not produce catalog access', async () => {
+    const subject = deps({ choice: 'sign-in', signedIn: false });
+    await expect(
+      preflightCliTeamAvailability(subject.value),
+    ).resolves.toMatchObject({ status: 'cancelled' });
+    expect(subject.signIn).toHaveBeenCalledOnce();
+    expect(subject.refresh).not.toHaveBeenCalled();
+  });
+
+  it('forces exactly one fetch after successful login', async () => {
+    const subject = deps({ choice: 'sign-in', signedIn: true });
+    await expect(
+      preflightCliTeamAvailability(subject.value),
+    ).resolves.toMatchObject({ status: 'proceed' });
+    expect(subject.signIn).toHaveBeenCalledOnce();
+    expect(subject.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('does not fetch again after the launcher already refreshed', async () => {
+    const subject = deps({ canAccess: true, refreshAttempted: true });
+    await expect(
+      preflightCliTeamAvailability(subject.value),
+    ).resolves.toMatchObject({ status: 'unavailable' });
+    expect(subject.refresh).not.toHaveBeenCalled();
+  });
+
+  it('requires a choice for an arbitrary unresolved legacy member', async () => {
+    const legacyPlan = plan(['remoteSpecialist']);
+    const legacyPreset = { ...legacyPlan.preset };
+    delete legacyPreset.texraHostedAgents;
+    const choose = vi.fn(async () => 'cancel' as const);
+
+    await expect(
+      preflightCliTeamAvailability({
+        plan: {
+          ...legacyPlan,
+          preset: legacyPreset,
+          toolUseAgentKeys: ['remoteSpecialist'],
+          missingToolUseAgents: ['remoteSpecialist'],
+        },
+        remoteCatalogRefreshAttempted: false,
+        canAccessRemoteCatalog: async () => false,
+        choose,
+        signIn: async () => false,
+        refresh: async () => legacyPlan,
+      }),
+    ).resolves.toMatchObject({ status: 'cancelled' });
+    expect(choose).toHaveBeenCalledWith(['remoteSpecialist']);
+  });
+
+  it('preserves full hosted provenance when refresh reveals a new missing member', async () => {
+    const initial = plan(['orchestrator']);
+    const preset = {
+      ...initial.preset,
+      toolUseAgents: ['orchestrator', 'presenter'],
+      texraHostedAgents: ['orchestrator', 'presenter'],
+    };
+    const refreshed = {
+      ...initial,
+      preset,
+      toolUseAgentKeys: ['remote:orchestrator', 'presenter'],
+      missingToolUseAgents: ['presenter'],
+    };
+
+    await expect(
+      preflightCliTeamAvailability({
+        plan: { ...initial, preset },
+        remoteCatalogRefreshAttempted: false,
+        canAccessRemoteCatalog: async () => false,
+        choose: async () => 'sign-in',
+        signIn: async () => true,
+        refresh: async () => refreshed,
+      }),
+    ).resolves.toMatchObject({
+      status: 'unavailable',
+      unavailableNames: ['presenter'],
+    });
+  });
+});

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -50,6 +50,23 @@ function findPreset(id: string) {
 }
 
 describe('CLI multi-agent presets', () => {
+  it('preserves missing hosted provenance on a legacy custom preset', () => {
+    const presets = cliMultiAgentPresets([
+      {
+        id: 'legacy',
+        name: 'Legacy',
+        description: 'Saved before hosted metadata existed',
+        icon: 'tools',
+        workflowAgents: ['generic', 'polish'],
+        toolUseAgents: ['orchestrator', 'review'],
+      },
+    ]);
+
+    expect(
+      findCliMultiAgentPreset(presets, 'legacy')?.texraHostedAgents,
+    ).toBeUndefined();
+  });
+
   it('lists planned built-in team presets with stable counts', () => {
     const presets = cliMultiAgentPresets(undefined);
     const plans = planCliMultiAgentPresets(presets, {

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -18,7 +18,9 @@ const mocks = vi.hoisted(() => ({
   getVisibleAgents: vi.fn(),
   initCliPlatform: vi.fn(),
   isAuthenticated: vi.fn(),
+  canAccessRemoteAgentCatalog: vi.fn(),
   loadAgents: vi.fn(),
+  refreshAgents: vi.fn(),
   planCliMultiAgentPresets: vi.fn(),
   planCliMultiAgentPresetRun: vi.fn(),
   writeTextStderr: vi.fn(),
@@ -30,6 +32,7 @@ vi.mock('@agent/index', () => ({
   getAgentsByCategory: mocks.getAgentsByCategory,
   getVisibleAgents: mocks.getVisibleAgents,
   loadAgents: mocks.loadAgents,
+  refresh: mocks.refreshAgents,
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -50,6 +53,7 @@ vi.mock('@cli/runtime/logSinks', () => ({
 vi.mock('@cli/runtime/supabaseAuth', () => ({
   getCliAuthProvider: () => ({
     isAuthenticated: mocks.isAuthenticated,
+    canAccessRemoteAgentCatalog: mocks.canAccessRemoteAgentCatalog,
   }),
 }));
 
@@ -198,6 +202,7 @@ describe('CLI multi-agent run command', () => {
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
     });
     mocks.isAuthenticated.mockResolvedValue(false);
+    mocks.canAccessRemoteAgentCatalog.mockResolvedValue(false);
     mocks.executeCliToolUseConfig.mockResolvedValue({
       ok: true,
       displayResult: { lastResponse: 'The proof is correct.' },
@@ -250,7 +255,7 @@ describe('CLI multi-agent run command', () => {
     const { loadCliMultiAgentRunPlan } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.isAuthenticated.mockResolvedValueOnce(true);
+    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentRunPlan({
       preset: 'mathematician',
@@ -262,15 +267,16 @@ describe('CLI multi-agent run command', () => {
       includeRemote: false,
     });
     // The second call is the remote-inclusive reload: `loadAgents()`.
-    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+    expect(mocks.refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });
 
-  it('does not mark run-plan resolution when unauthenticated gaps stay local-only', async () => {
+  it('does not load remote agents for relay-token-only model authentication', async () => {
     const { loadCliMultiAgentRunPlan } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.isAuthenticated.mockResolvedValueOnce(false);
+    mocks.isAuthenticated.mockResolvedValueOnce(true);
+    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(false);
 
     const result = await loadCliMultiAgentRunPlan({
       preset: 'mathematician',
@@ -279,6 +285,8 @@ describe('CLI multi-agent run command', () => {
     expect(result.remoteAgentLoadAttempted).toBe(false);
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
+    expect(mocks.refreshAgents).not.toHaveBeenCalled();
+    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(1);
   });
 
@@ -286,7 +294,7 @@ describe('CLI multi-agent run command', () => {
     const { loadCliMultiAgentPresetPlanSet } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.isAuthenticated.mockResolvedValueOnce(true);
+    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentPresetPlanSet([
       {
@@ -304,7 +312,7 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.loadAgents).toHaveBeenNthCalledWith(1, {
       includeRemote: false,
     });
-    expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
+    expect(mocks.refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(2);
   });
 
@@ -314,7 +322,7 @@ describe('CLI multi-agent run command', () => {
     mocks.cliMultiAgentPlanHasGaps
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
-    mocks.isAuthenticated.mockResolvedValueOnce(true);
+    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(cliContext(), {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -93,6 +93,7 @@ function preset(overrides: Partial<CliMultiAgentPreset>): CliMultiAgentPreset {
     icon: 'symbol-operator',
     workflowAgents: ['criticize'],
     toolUseAgents: ['orchestrator', 'review'],
+    texraHostedAgents: ['orchestrator'],
     source: 'built-in',
     ...overrides,
   };
@@ -623,6 +624,18 @@ describe('CLI orchestration items', () => {
         ],
       }),
     );
+  });
+
+  it('keeps sign-in-remediable teams actionable while signed out', () => {
+    const items = buildCliTeamItems(
+      [presetPlan({ id: 'physicist', name: 'Physicist' })],
+      { includeLoginHint: true, remoteAgentCatalogAvailable: false },
+    );
+
+    expect(items[0]).toMatchObject({
+      value: { kind: 'preset', preset: 'physicist' },
+      disabled: false,
+    });
   });
 
   it('dedupes launcher footer hints from unavailable teams', () => {

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -191,6 +191,14 @@ describe('SettingsAgentCatalogController', () => {
     assert.deepEqual(controller.getCustomPresets(), []);
   });
 
+  it('records hosted-definition ownership when saving a custom team', async () => {
+    const { controller } = createController();
+
+    const preset = await controller.saveCurrentPreset('Current Team');
+
+    assert.deepEqual(preset.texraHostedAgents, ['writer']);
+  });
+
   it('collects built-in and capability-based orchestrator agent names', () => {
     const { controller } = createController({
       agents: {
@@ -278,6 +286,7 @@ describe('SettingsAgentCatalogController', () => {
       icon: 'bookmark',
       workflowAgents: ['correct'],
       toolUseAgents: ['review'],
+      texraHostedAgents: [],
     });
     assert.equal(state.customPresets.length, 1);
   });

--- a/src/test-kernel/controllers/TeamAvailabilityPreflight.vitest.ts
+++ b/src/test-kernel/controllers/TeamAvailabilityPreflight.vitest.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { preflightTeamAvailability } from '@controllers/teams/TeamAvailabilityPreflight';
+
+interface Resolution {
+  readonly unresolvedNames: readonly string[];
+}
+
+const hosted = new Set(['orchestrator']);
+
+function options(overrides: {
+  initial?: Resolution;
+  authenticated?: boolean;
+  choice?: 'sign-in' | 'continue' | 'cancel';
+  providedChoice?: 'sign-in' | 'continue' | 'cancel';
+  choiceRequired?: boolean;
+  signedIn?: boolean;
+  refreshed?: Resolution;
+  remoteCatalogRefreshAttempted?: boolean;
+}) {
+  const refresh = vi.fn(
+    async () => overrides.refreshed ?? { unresolvedNames: [] },
+  );
+  const signIn = vi.fn(async () => overrides.signedIn ?? true);
+  const choose = vi.fn(async () =>
+    overrides.choiceRequired ? undefined : (overrides.choice ?? 'cancel'),
+  );
+  return {
+    refresh,
+    signIn,
+    choose,
+    input: {
+      initial: overrides.initial ?? { unresolvedNames: ['orchestrator'] },
+      unresolvedNames: (value: Resolution) => value.unresolvedNames,
+      texraHostedNames: hosted,
+      canAccessRemoteCatalog: async () => overrides.authenticated ?? false,
+      providedChoice: overrides.providedChoice,
+      choose,
+      signIn,
+      refresh,
+      remoteCatalogRefreshAttempted: overrides.remoteCatalogRefreshAttempted,
+    },
+  };
+}
+
+describe('team availability preflight', () => {
+  it('does not prompt or refresh a local-only team', async () => {
+    const deps = options({ initial: { unresolvedNames: ['local-plugin'] } });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toEqual({
+      status: 'proceed',
+      value: { unresolvedNames: ['local-plugin'] },
+      partial: false,
+    });
+    expect(deps.choose).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('continues only after an explicit partial-team choice', async () => {
+    const deps = options({ choice: 'continue' });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'proceed',
+      partial: true,
+    });
+    expect(deps.signIn).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('cancels without signing in or refreshing', async () => {
+    const deps = options({ choice: 'cancel' });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'cancelled',
+    });
+    expect(deps.signIn).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('honors a supplied partial-team choice before authenticated refresh', async () => {
+    const deps = options({ authenticated: true, providedChoice: 'continue' });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'proceed',
+      partial: true,
+    });
+    expect(deps.choose).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('honors a supplied cancellation before authenticated refresh', async () => {
+    const deps = options({ authenticated: true, providedChoice: 'cancel' });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'cancelled',
+    });
+    expect(deps.choose).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('returns an actionable choice-required result without side effects', async () => {
+    const deps = options({ choiceRequired: true });
+
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'choice-required',
+      unavailableNames: ['orchestrator'],
+    });
+    expect(deps.signIn).not.toHaveBeenCalled();
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and retries exactly once after successful sign-in', async () => {
+    const deps = options({ choice: 'sign-in', signedIn: true });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'proceed',
+      partial: false,
+    });
+    expect(deps.signIn).toHaveBeenCalledOnce();
+    expect(deps.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('reports the real availability failure after authenticated refresh', async () => {
+    const deps = options({
+      authenticated: true,
+      refreshed: { unresolvedNames: ['orchestrator'] },
+    });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toEqual({
+      status: 'unavailable',
+      value: { unresolvedNames: ['orchestrator'] },
+      unavailableNames: ['orchestrator'],
+    });
+    expect(deps.choose).not.toHaveBeenCalled();
+    expect(deps.signIn).not.toHaveBeenCalled();
+    expect(deps.refresh).toHaveBeenCalledOnce();
+  });
+
+  it('does not repeat an authenticated refresh already performed by the caller', async () => {
+    const deps = options({
+      authenticated: true,
+      remoteCatalogRefreshAttempted: true,
+    });
+    await expect(preflightTeamAvailability(deps.input)).resolves.toMatchObject({
+      status: 'unavailable',
+      unavailableNames: ['orchestrator'],
+    });
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1156,6 +1156,7 @@ describe('desktop settings IPC', () => {
       }),
       getAgents: (category) => catalog[category],
       getVisibleAgents: (category) => catalog[category],
+      chooseTeamAvailability: async () => 'continue',
       showInfoMessage: async (message) => {
         infoMessages.push(message);
       },
@@ -1234,6 +1235,117 @@ describe('desktop settings IPC', () => {
         ],
       },
     });
+  });
+
+  it('signs in, forces one catalog refresh, then commits a desktop team once', async () => {
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'remote-team',
+        name: 'Remote team',
+        description: 'Uses a hosted root',
+        icon: 'tools',
+        workflowAgents: [],
+        toolUseAgents: ['orchestrator'],
+        texraHostedAgents: ['orchestrator'],
+      },
+    ]);
+    let toolUseAgents: Array<{
+      source: 'remote';
+      name: string;
+      path: string;
+      category: 'toolUse';
+      tools: string[];
+    }> = [];
+    const refreshAgents = vi.fn(async () => {
+      toolUseAgents = [
+        {
+          source: 'remote',
+          name: 'orchestrator',
+          path: '/remote/orchestrator.yaml',
+          category: 'toolUse',
+          tools: ['delegate_agent'],
+        },
+      ];
+    });
+    const signInForRemoteAgentCatalog = vi.fn(async () => true);
+    const update = vi.spyOn(workspaceState, 'update');
+    const { settings } = createSettingsFixture({
+      workspaceState,
+      loadAgents: vi.fn(async () => undefined),
+      refreshAgents,
+      getAgents: (category) => (category === 'workflow' ? [] : toolUseAgents),
+      getVisibleAgents: (category) =>
+        category === 'workflow' ? [] : toolUseAgents,
+      canAccessRemoteAgentCatalog: async () => false,
+      chooseTeamAvailability: async () => 'sign-in',
+      signInForRemoteAgentCatalog,
+    });
+    update.mockClear();
+
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+      presetId: 'remote-team',
+    });
+    await flushAsyncWork();
+
+    expect(signInForRemoteAgentCatalog).toHaveBeenCalledOnce();
+    expect(refreshAgents).toHaveBeenCalledOnce();
+    expect(refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
+    expect(
+      update.mock.calls.filter(
+        ([key]) => key === WorkspaceStateKey.ENABLED_AGENTS,
+      ),
+    ).toHaveLength(1);
+    expect(
+      update.mock.calls.filter(
+        ([key]) => key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toHaveLength(1);
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toEqual(['remote:orchestrator']);
+  });
+
+  it('does not write desktop roster state when team preflight is cancelled', async () => {
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'legacy-remote-team',
+        name: 'Legacy remote team',
+        description: 'Legacy hosted metadata is inferred',
+        icon: 'tools',
+        workflowAgents: [],
+        toolUseAgents: ['orchestrator'],
+      },
+    ]);
+    const update = vi.spyOn(workspaceState, 'update');
+    const refreshAgents = vi.fn(async () => undefined);
+    const { settings } = createSettingsFixture({
+      workspaceState,
+      loadAgents: vi.fn(async () => undefined),
+      refreshAgents,
+      getAgents: () => [],
+      getVisibleAgents: () => [],
+      canAccessRemoteAgentCatalog: async () => false,
+      chooseTeamAvailability: async () => 'cancel',
+    });
+    update.mockClear();
+
+    settings.handleMessage({
+      command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+      presetId: 'legacy-remote-team',
+    });
+    await flushAsyncWork();
+
+    expect(refreshAgents).not.toHaveBeenCalled();
+    expect(
+      update.mock.calls.some(
+        ([key]) =>
+          key === WorkspaceStateKey.ENABLED_AGENTS ||
+          key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toBe(false);
   });
 
   it('saves desktop team presets from currently visible agents', async () => {
@@ -1486,6 +1598,37 @@ describe('desktop settings IPC', () => {
         MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       ]),
     );
+  });
+
+  it('defers agent catalog loading while roster sign-in owns the refresh', async () => {
+    const loadAgents = vi.fn(async () => undefined);
+    const { settings, posted } = createCapturedSettingsFixture({
+      loadAgents,
+    });
+
+    await settings.refreshAuthDependentData({
+      deferAgentCatalogRefresh: true,
+    });
+
+    expect(loadAgents).not.toHaveBeenCalled();
+    expect(
+      posted.some(
+        (message) =>
+          commandOf(message) === SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toBe(true);
+    expect(
+      posted.some(
+        (message) =>
+          commandOf(message) === SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+      ),
+    ).toBe(false);
+    expect(
+      posted.some(
+        (message) =>
+          commandOf(message) === MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      ),
+    ).toBe(false);
   });
 
   it('refreshes persisted model list on desktop startup', async () => {

--- a/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  initializeDesktopSetupAuth,
+  registerDesktopSetupSignIn,
+} from '@desktop/main/desktopSetupAuth';
+import { getSetupPlatform } from '@tools/setup/platform';
+
+describe('desktop setup auth adapter', () => {
+  it('exposes the existing desktop sign-in capability to setup tools', async () => {
+    const signIn = vi.fn(async () => true);
+    initializeDesktopSetupAuth();
+    registerDesktopSetupSignIn(signIn);
+
+    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(true);
+    expect(signIn).toHaveBeenCalledOnce();
+  });
+
+  it('does not retain a closed window sign-in capability', async () => {
+    const signIn = vi.fn(async () => true);
+    initializeDesktopSetupAuth();
+    const windowRegistration = registerDesktopSetupSignIn(signIn);
+
+    windowRegistration.dispose();
+
+    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(false);
+    expect(signIn).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildProfileMessage } from '@controllers/settingsView/ProfileMessageBuilder';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -159,6 +159,12 @@ function installAuthenticatedSupabaseProvider() {
 }
 
 describe('desktop Supabase auth', () => {
+  beforeEach(() => {
+    vi.spyOn(
+      agentRegistry,
+      'invalidateRemoteAgentsAfterSignOut',
+    ).mockResolvedValue(undefined);
+  });
   afterEach(() => {
     vi.restoreAllMocks();
     SupabaseClient.resetForTests();
@@ -276,6 +282,65 @@ describe('desktop Supabase auth', () => {
 
     expect(await SupabaseClient.isAuthenticated()).toBe(false);
     auth.dispose();
+  });
+
+  it('waits for the matching callback before completing sign-in', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const oauthClient = createOAuthClient();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+    });
+
+    let completed = false;
+    const completion = auth
+      .signInAndWaitForSession(undefined, { timeoutMs: 1_000 })
+      .then((result) => {
+        completed = true;
+        return result;
+      });
+    await vi.waitFor(() =>
+      expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalled(),
+    );
+    expect(completed).toBe(false);
+
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        nonce: nonceFor(oauthClient),
+      }),
+    );
+
+    await expect(completion).resolves.toBe(true);
+    expect(coordinator.storeSession).toHaveBeenCalledOnce();
+    auth.dispose();
+  });
+
+  it('cancels a waiting sign-in when its window auth is disposed', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const oauthClient = createOAuthClient();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator: createCoordinator(),
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+    });
+    const completion = auth.signInAndWaitForSession(undefined, {
+      timeoutMs: 1_000,
+    });
+    await vi.waitFor(() =>
+      expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalled(),
+    );
+
+    auth.dispose();
+
+    await expect(completion).resolves.toBe(false);
   });
 
   it('rejects a foreign callback whose nonce does not match the pending sign-in (login-CSRF)', async () => {
@@ -477,6 +542,40 @@ describe('desktop Supabase auth', () => {
     }
   });
 
+  it('finishes expired-state cleanup before persisting a newer attempt', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
+      const stateStore = createStateStore();
+      const initialState = createDesktopAuthCallbackState(stateStore);
+      await initialState.beginAuthAttempt('expired-nonce');
+      vi.setSystemTime(Date.now() + 11 * 60 * 1000);
+
+      const cleanup = createDeferred<void>();
+      const update = stateStore.update.bind(stateStore);
+      vi.spyOn(stateStore, 'update').mockImplementationOnce(
+        async (key, value) => {
+          await cleanup.promise;
+          await update(key, value);
+        },
+      );
+
+      const recreatedState = createDesktopAuthCallbackState(stateStore);
+      const beginNewAttempt = recreatedState.beginAuthAttempt('new-nonce');
+      await vi.waitFor(() => {
+        expect(stateStore.update).toHaveBeenCalledOnce();
+      });
+
+      cleanup.resolve();
+      await beginNewAttempt;
+
+      const persistedState = createDesktopAuthCallbackState(stateStore);
+      expect(persistedState.matchesPendingNonce('new-nonce')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels pending callback state on sign-out', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
@@ -541,15 +640,15 @@ describe('desktop Supabase auth', () => {
 
     await vi.waitFor(() => {
       expect(coordinator.createSessionFromCallback).toHaveBeenCalledTimes(1);
+      expect(coordinator.storeSession).toHaveBeenCalledTimes(1);
     });
-    expect(coordinator.storeSession).toHaveBeenCalledTimes(1);
     expect(log.debug).toHaveBeenCalledWith(
       'Desktop auth callback ignored because no sign-in is in progress',
     );
     auth.dispose();
   });
 
-  it('does not clear a newer sign-in while a claimed callback finishes', async () => {
+  it('does not store a superseded callback or clear the newer sign-in', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const callbackState = createDesktopAuthCallbackState();
@@ -583,10 +682,243 @@ describe('desktop Supabase auth', () => {
     await auth.signIn();
     callbackProcessing.resolve();
 
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(coordinator.storeSession).not.toHaveBeenCalled();
+    expect(callbackState.hasPendingSignIn()).toBe(true);
+    auth.dispose();
+  });
+
+  it('removes a callback session when sign-out begins during storage', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const oauthClient = createOAuthClient();
+    const sessionStorage = createDeferred<void>();
+    const storeSession = coordinator.storeSession.getMockImplementation();
+    coordinator.storeSession.mockImplementationOnce(async (session) => {
+      await sessionStorage.promise;
+      await storeSession?.(session);
+    });
+    const onSessionChanged = vi.fn(async () => {});
+    const showInfoMessage = vi.fn(async () => {});
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      onSessionChanged,
+      showInfoMessage,
+    });
+
+    await auth.signIn();
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+        nonce: nonceFor(oauthClient),
+      }),
+    );
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledOnce();
     });
+
+    const signOut = auth.signOut();
+    sessionStorage.resolve();
+    await signOut;
+
+    expect(await coordinator.loadSession()).toBeNull();
+    expect(showInfoMessage).not.toHaveBeenCalledWith(
+      'Signed in as user@example.com',
+    );
+    expect(onSessionChanged).toHaveBeenCalledOnce();
+    auth.dispose();
+  });
+
+  it('removes a stored callback before starting a newer sign-in', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const callbackState = createDesktopAuthCallbackState();
+    const oauthClient = createOAuthClient();
+    const sessionStorage = createDeferred<void>();
+    const storeSession = coordinator.storeSession.getMockImplementation();
+    coordinator.storeSession.mockImplementationOnce(async (session) => {
+      await sessionStorage.promise;
+      await storeSession?.(session);
+    });
+    const onSessionChanged = vi.fn(async () => {});
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      callbackState,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      onSessionChanged,
+    });
+
+    await auth.signIn();
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+        nonce: nonceFor(oauthClient),
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(coordinator.storeSession).toHaveBeenCalledOnce();
+    });
+
+    const newerSignIn = auth.signIn();
+    expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledOnce();
+    sessionStorage.resolve();
+    await newerSignIn;
+
+    expect(coordinator.clearSession).toHaveBeenCalledOnce();
+    expect(await coordinator.loadSession()).toBeNull();
+    expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledTimes(2);
     expect(callbackState.hasPendingSignIn()).toBe(true);
+    expect(onSessionChanged).not.toHaveBeenCalled();
+
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        nonce: nonceFor(oauthClient),
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(coordinator.storeSession).toHaveBeenCalledTimes(2);
+      expect(onSessionChanged).toHaveBeenCalledOnce();
+    });
+
+    expect(coordinator.clearSession).toHaveBeenCalledOnce();
+    expect(await coordinator.loadSession()).toMatchObject({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+    auth.dispose();
+  });
+
+  it.each(['signIn', 'dispose'] as const)(
+    'removes a callback session when %s invalidates it during session refresh',
+    async (action) => {
+      const router = createDesktopProtocolCallbackRouter();
+      const coordinator = createCoordinator();
+      const oauthClient = createOAuthClient();
+      const sessionRefresh = createDeferred<void>();
+      const onSessionChanged = vi.fn(async () => {
+        await sessionRefresh.promise;
+      });
+      const auth = createDesktopSupabaseAuth({
+        router,
+        coordinator,
+        oauthClient,
+        secrets: createSecrets(),
+        openExternalUrl: vi.fn(async () => {}),
+        onSessionChanged,
+      });
+
+      await auth.signIn();
+      router.routeUrl(
+        authCallbackUrl({
+          accessToken: 'stale-access-token',
+          refreshToken: 'stale-refresh-token',
+          nonce: nonceFor(oauthClient),
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(onSessionChanged).toHaveBeenCalledOnce();
+      });
+
+      const newerSignIn = action === 'signIn' ? auth.signIn() : undefined;
+      if (action === 'dispose') auth.dispose();
+      sessionRefresh.resolve();
+      await newerSignIn;
+      await vi.waitFor(() => {
+        expect(coordinator.clearSession).toHaveBeenCalledOnce();
+      });
+
+      expect(await coordinator.loadSession()).toBeNull();
+      if (action === 'signIn') {
+        expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledTimes(2);
+        auth.dispose();
+      }
+    },
+  );
+
+  it.each(['signOut', 'dispose'] as const)(
+    'does not store a claimed callback after %s',
+    async (action) => {
+      const router = createDesktopProtocolCallbackRouter();
+      const coordinator = createCoordinator();
+      const oauthClient = createOAuthClient();
+      const callbackProcessing = createDeferred<void>();
+      coordinator.createSessionFromCallback.mockImplementationOnce(async () => {
+        await callbackProcessing.promise;
+        return callbackSessionResult();
+      });
+      const auth = createDesktopSupabaseAuth({
+        router,
+        coordinator,
+        oauthClient,
+        secrets: createSecrets(),
+        openExternalUrl: vi.fn(async () => {}),
+      });
+
+      await auth.signIn();
+      router.routeUrl(
+        authCallbackUrl({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          nonce: nonceFor(oauthClient),
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+      });
+
+      if (action === 'signOut') await auth.signOut();
+      else auth.dispose();
+      callbackProcessing.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(coordinator.storeSession).not.toHaveBeenCalled();
+      if (action === 'signOut') auth.dispose();
+    },
+  );
+
+  it('keeps a newer attempt valid beyond a superseded waiter timeout', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const oauthClient = createOAuthClient();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+    });
+
+    const first = auth.signInAndWaitForSession(undefined, { timeoutMs: 10 });
+    await vi.waitFor(() => {
+      expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledOnce();
+    });
+    const second = auth.signInAndWaitForSession(undefined, {
+      timeoutMs: 1_000,
+    });
+    await expect(first).resolves.toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        nonce: nonceFor(oauthClient),
+      }),
+    );
+
+    await expect(second).resolves.toBe(true);
+    expect(coordinator.storeSession).toHaveBeenCalledOnce();
     auth.dispose();
   });
 
@@ -647,6 +979,36 @@ describe('desktop Supabase auth', () => {
 
     expect(coordinator.clearSession).toHaveBeenCalled();
     expect(clearAllCaches).toHaveBeenCalledOnce();
+    expect(
+      agentRegistry.invalidateRemoteAgentsAfterSignOut,
+    ).toHaveBeenCalledOnce();
+    auth.dispose();
+  });
+
+  it('still publishes sign-out when the local catalog rebuild fails', async () => {
+    vi.mocked(
+      agentRegistry.invalidateRemoteAgentsAfterSignOut,
+    ).mockRejectedValueOnce(new Error('local rebuild failed'));
+    const coordinator = createCoordinator();
+    const onSessionChanged = vi.fn(async () => {});
+    const log = createLog();
+    const auth = createDesktopSupabaseAuth({
+      router: createDesktopProtocolCallbackRouter(),
+      coordinator,
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      onSessionChanged,
+      log,
+    });
+
+    await expect(auth.signOut()).resolves.toBeUndefined();
+
+    expect(coordinator.clearSession).toHaveBeenCalledOnce();
+    expect(onSessionChanged).toHaveBeenCalledOnce();
+    expect(log.warn).toHaveBeenCalledWith(
+      'Local agent catalog refresh failed after sign-out: local rebuild failed',
+    );
     auth.dispose();
   });
 

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -105,7 +105,10 @@ function setupApiKeyToolPlatform(store: Map<string, string>): void {
     },
     auth: {
       async getStatus() {
-        return { authenticated: false };
+        return {
+          authenticated: false,
+          remoteAgentCatalogAvailable: false,
+        };
       },
     },
     config: {

--- a/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
+++ b/src/test-kernel/settings/ExtensionTeamAuthRefreshScope.vitest.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
+import {
+  resetAgentCatalogAuthRefreshScopeForTests,
+  runAfterAgentCatalogAuthRefresh,
+  withAgentCatalogAuthRefreshDeferred,
+} from '@frontend/auth/agentCatalogRefreshScope';
+
+describe('extension team auth catalog refresh scope', () => {
+  beforeEach(resetAgentCatalogAuthRefreshScopeForTests);
+
+  it('defers auth listeners and fetches the remote catalog exactly once', async () => {
+    let refreshed = false;
+    let remoteFetches = 0;
+    const commitPresetResolution = vi.fn(async () => {});
+    const preset = {
+      id: 'remote-team',
+      name: 'Remote team',
+      description: 'Hosted team',
+      icon: 'tools' as const,
+      workflowAgents: [],
+      toolUseAgents: ['orchestrator'],
+      texraHostedAgents: ['orchestrator'],
+    };
+
+    const result = await withAgentCatalogAuthRefreshDeferred(() =>
+      applyTeamRosterWithPreflight('remote-team', {
+        catalog: {
+          resolvePreset: () => ({
+            ok: true,
+            preset,
+            resolution: refreshed
+              ? {
+                  workflowKeys: [],
+                  toolUseKeys: ['remote:orchestrator'],
+                  unresolvedNames: [],
+                }
+              : {
+                  workflowKeys: [],
+                  toolUseKeys: ['orchestrator'],
+                  unresolvedNames: ['orchestrator'],
+                },
+          }),
+          commitPresetResolution,
+        },
+        loadLocalCatalog: async () => {},
+        canAccessRemoteCatalog: async () => false,
+        choose: async () => 'sign-in',
+        signIn: async () => {
+          // Models/settings listeners run after the preflight-owned fetch and
+          // then reuse the populated cache instead of forcing another fetch.
+          runAfterAgentCatalogAuthRefresh(async () => {
+            if (!refreshed) remoteFetches += 1;
+          });
+          return true;
+        },
+        forceRefreshRemoteCatalog: async () => {
+          remoteFetches += 1;
+          refreshed = true;
+        },
+      }),
+    );
+
+    expect(result.status).toBe('applied');
+    expect(remoteFetches).toBe(1);
+    expect(commitPresetResolution).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test-kernel/settings/TeamRosterApplication.vitest.ts
+++ b/src/test-kernel/settings/TeamRosterApplication.vitest.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+
+const preset: AgentModePreset = {
+  id: 'research',
+  name: 'Research',
+  description: 'Research team',
+  icon: 'bookmark',
+  workflowAgents: [],
+  toolUseAgents: ['orchestrator'],
+  texraHostedAgents: ['orchestrator'],
+};
+
+const unresolved = {
+  workflowKeys: [],
+  toolUseKeys: ['orchestrator'],
+  unresolvedNames: ['orchestrator'],
+};
+
+const resolved = {
+  workflowKeys: [],
+  toolUseKeys: ['remote:orchestrator'],
+  unresolvedNames: [],
+};
+
+describe('extension team roster application', () => {
+  it('signs in, forces one refresh, and commits exactly once', async () => {
+    const calls: string[] = [];
+    let refreshed = false;
+    const commitPresetResolution = vi.fn(async () => {
+      calls.push('commit');
+    });
+
+    const result = await applyTeamRosterWithPreflight('research', {
+      catalog: {
+        resolvePreset: () => ({
+          ok: true,
+          preset,
+          resolution: refreshed ? resolved : unresolved,
+        }),
+        commitPresetResolution,
+      },
+      loadLocalCatalog: async () => {
+        calls.push('local-load');
+      },
+      canAccessRemoteCatalog: async () => false,
+      choose: async () => {
+        calls.push('choose');
+        return 'sign-in';
+      },
+      signIn: async () => {
+        calls.push('sign-in');
+        return true;
+      },
+      forceRefreshRemoteCatalog: async () => {
+        calls.push('forced-refresh');
+        refreshed = true;
+      },
+    });
+
+    expect(result).toEqual({
+      status: 'applied',
+      preset,
+      resolution: resolved,
+    });
+    expect(calls).toEqual([
+      'local-load',
+      'choose',
+      'sign-in',
+      'forced-refresh',
+      'commit',
+    ]);
+    expect(commitPresetResolution).toHaveBeenCalledOnce();
+    expect(commitPresetResolution).toHaveBeenCalledWith(resolved);
+  });
+
+  it('cancels before refresh or roster writes', async () => {
+    const commitPresetResolution = vi.fn();
+    const forceRefreshRemoteCatalog = vi.fn();
+    const signIn = vi.fn();
+
+    const result = await applyTeamRosterWithPreflight('research', {
+      catalog: {
+        resolvePreset: () => ({ ok: true, preset, resolution: unresolved }),
+        commitPresetResolution,
+      },
+      loadLocalCatalog: async () => {},
+      canAccessRemoteCatalog: async () => false,
+      choose: async () => 'cancel',
+      signIn,
+      forceRefreshRemoteCatalog,
+    });
+
+    expect(result).toEqual({ status: 'cancelled', preset });
+    expect(signIn).not.toHaveBeenCalled();
+    expect(forceRefreshRemoteCatalog).not.toHaveBeenCalled();
+    expect(commitPresetResolution).not.toHaveBeenCalled();
+  });
+
+  it('preflights an arbitrary unresolved member in a legacy custom team', async () => {
+    const legacyPreset: AgentModePreset = {
+      id: 'legacy',
+      name: 'Legacy',
+      description: 'Saved before hosted provenance',
+      icon: 'bookmark',
+      workflowAgents: [],
+      toolUseAgents: ['review', 'remoteSpecialist'],
+    };
+    const choose = vi.fn(
+      async (_names: readonly string[]) => 'cancel' as const,
+    );
+    const commitPresetResolution = vi.fn();
+
+    const result = await applyTeamRosterWithPreflight('legacy', {
+      catalog: {
+        resolvePreset: () => ({
+          ok: true,
+          preset: legacyPreset,
+          resolution: {
+            workflowKeys: [],
+            toolUseKeys: ['builtInToolUse:review', 'remoteSpecialist'],
+            unresolvedNames: ['remoteSpecialist'],
+          },
+        }),
+        commitPresetResolution,
+      },
+      loadLocalCatalog: async () => {},
+      canAccessRemoteCatalog: async () => false,
+      choose: async (_preset, names) => choose(names),
+      signIn: async () => false,
+      forceRefreshRemoteCatalog: async () => {},
+    });
+
+    expect(result.status).toBe('cancelled');
+    expect(choose).toHaveBeenCalledWith(['remoteSpecialist']);
+    expect(commitPresetResolution).not.toHaveBeenCalled();
+  });
+
+  it('preflights recognized and arbitrary unresolved members in a mixed legacy team', async () => {
+    const legacyPreset: AgentModePreset = {
+      id: 'mixed-legacy',
+      name: 'Mixed legacy',
+      description: 'Contains local and remote members without provenance',
+      icon: 'bookmark',
+      workflowAgents: ['generic'],
+      toolUseAgents: ['review', 'remoteSpecialist'],
+    };
+    const choose = vi.fn(
+      async (_names: readonly string[]) => 'cancel' as const,
+    );
+
+    await applyTeamRosterWithPreflight('mixed-legacy', {
+      catalog: {
+        resolvePreset: () => ({
+          ok: true,
+          preset: legacyPreset,
+          resolution: {
+            workflowKeys: ['generic'],
+            toolUseKeys: ['builtInToolUse:review', 'remoteSpecialist'],
+            unresolvedNames: ['generic', 'remoteSpecialist'],
+          },
+        }),
+        commitPresetResolution: vi.fn(),
+      },
+      loadLocalCatalog: async () => {},
+      canAccessRemoteCatalog: async () => false,
+      choose: async (_preset, names) => choose(names),
+      signIn: async () => false,
+      forceRefreshRemoteCatalog: async () => {},
+    });
+
+    expect(choose).toHaveBeenCalledWith(['generic', 'remoteSpecialist']);
+    expect(legacyPreset).not.toHaveProperty('texraHostedAgents');
+  });
+});

--- a/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
+++ b/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_MODE_PRESETS,
+  STARTER_AGENT_MODE_PRESET,
+} from '@shared/schemas/agentPresets';
+
+describe('agent preset hosted-definition metadata', () => {
+  it('keeps every hosted name inside its owning preset roster', () => {
+    for (const preset of [STARTER_AGENT_MODE_PRESET, ...AGENT_MODE_PRESETS]) {
+      const roster = new Set([
+        ...preset.workflowAgents,
+        ...preset.toolUseAgents,
+      ]);
+      expect(
+        (preset.texraHostedAgents ?? []).filter((name) => !roster.has(name)),
+        `${preset.id} has hosted metadata outside its roster`,
+      ).toEqual([]);
+    }
+  });
+
+  it('marks the bundled software-engineer team as local-only', () => {
+    const softwareTeam = AGENT_MODE_PRESETS.find(
+      (preset) => preset.id === 'software-engineer',
+    );
+
+    expect(softwareTeam?.texraHostedAgents).toEqual([]);
+  });
+});

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Third-party imports
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -17,6 +17,12 @@ import { seedRosterFromDefaultTeam } from '@controllers/onboarding/defaultTeamSe
 import { refresh } from '@agent/index/agentRegistry';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ApplyTeamTool } from '@tools/setup/ApplyTeamTool';
+import {
+  __resetSetupPlatformForTests,
+  setSetupPlatform,
+} from '@tools/setup/platform';
+
+import { createFakeSetupPlatform } from './fixtures';
 
 const REPO_ROOT = resolve(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -49,6 +55,7 @@ function workspaceRoster(): {
 }
 
 async function clearOnboardingState(): Promise<void> {
+  __resetSetupPlatformForTests();
   await platform().workspaceState.update(
     WorkspaceStateKey.ENABLED_AGENTS,
     undefined,
@@ -90,7 +97,10 @@ describe('apply_team', () => {
   beforeEach(clearOnboardingState);
 
   it('applies the starter roster as source-qualified workspace keys', async () => {
-    const result = await new ApplyTeamTool().call({ teamId: 'starter' });
+    const result = await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'continue',
+    });
 
     expect(result.status).toBe('executed');
     const roster = workspaceRoster();
@@ -109,15 +119,24 @@ describe('apply_team', () => {
   });
 
   it('records the user-level default team id', async () => {
-    await new ApplyTeamTool().call({ teamId: 'starter' });
+    await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'continue',
+    });
     expect(getDefaultTeamId(platform().globalState)).toBe('starter');
 
-    await new ApplyTeamTool().call({ teamId: 'physicist' });
+    await new ApplyTeamTool().call({
+      teamId: 'physicist',
+      unavailableAction: 'continue',
+    });
     expect(getDefaultTeamId(platform().globalState)).toBe('physicist');
   });
 
   it('reports the relay-served orchestrator as available after sign-in', async () => {
-    const result = await new ApplyTeamTool().call({ teamId: 'starter' });
+    const result = await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'continue',
+    });
 
     expect(result.status).toBe('executed');
     expect(result.summary).toMatch(/sign-in/);
@@ -133,6 +152,104 @@ describe('apply_team', () => {
     expect(roster.workflow).toBeUndefined();
     expect(roster.toolUse).toBeUndefined();
     expect(getDefaultTeamId(platform().globalState)).toBeUndefined();
+  });
+
+  it('performs no writes before an unresolved-team choice', async () => {
+    const result = await new ApplyTeamTool().call({ teamId: 'starter' });
+
+    expect(result.status).toBe('executed');
+    expect(result.output).toMatch(/Sign in to TeXRA/);
+    expect(workspaceRoster()).toEqual({
+      workflow: undefined,
+      toolUse: undefined,
+    });
+    expect(getDefaultTeamId(platform().globalState)).toBeUndefined();
+  });
+
+  it('applies a preset declared local-only without prompting for sign-in', async () => {
+    const result = await new ApplyTeamTool().call({
+      teamId: 'software-engineer',
+    });
+
+    expect(result.status).toBe('executed');
+    expect(workspaceRoster().toolUse).toEqual([
+      'builtInToolUse:engineer',
+      'builtInToolUse:coder',
+      'builtInToolUse:codeReviewer',
+      'builtInToolUse:testEngineer',
+      'builtInToolUse:codeSimplifier',
+    ]);
+  });
+
+  it('cancels without writing roster or default-team state', async () => {
+    const result = await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'cancel',
+    });
+
+    expect(result.status).toBe('executed');
+    expect(result.output).toMatch(
+      /No roster or default-team state was written/,
+    );
+    expect(workspaceRoster()).toEqual({
+      workflow: undefined,
+      toolUse: undefined,
+    });
+    expect(getDefaultTeamId(platform().globalState)).toBeUndefined();
+  });
+
+  it('honors an explicit continuation when catalog access is available', async () => {
+    setSetupPlatform(
+      createFakeSetupPlatform({
+        auth: {
+          getStatus: async () => ({
+            authenticated: true,
+            remoteAgentCatalogAvailable: true,
+          }),
+        },
+      }),
+    );
+
+    const result = await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'continue',
+    });
+
+    expect(result.status).toBe('executed');
+    expect(result.summary).toMatch(/Applied the Starter roster/);
+    expect(workspaceRoster().toolUse).toContain('orchestrator');
+    expect(getDefaultTeamId(platform().globalState)).toBe('starter');
+  });
+
+  it('uses the host setup sign-in capability before its forced retry', async () => {
+    const signIn = vi.fn(async () => true);
+    setSetupPlatform(
+      createFakeSetupPlatform({
+        auth: {
+          getStatus: async () => ({
+            authenticated: true,
+            remoteAgentCatalogAvailable: false,
+          }),
+          signIn,
+        },
+      }),
+    );
+
+    const result = await new ApplyTeamTool().call({
+      teamId: 'starter',
+      unavailableAction: 'sign-in',
+    });
+
+    expect(signIn).toHaveBeenCalledOnce();
+    expect(result.status).toBe('error');
+    expect(result).toHaveProperty(
+      'error',
+      expect.stringContaining('still unavailable after refreshing'),
+    );
+    expect(workspaceRoster()).toEqual({
+      workflow: undefined,
+      toolUse: undefined,
+    });
   });
 });
 

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -33,7 +33,10 @@ async function assertAuthPrecedesCredentialProbe(
     auth: {
       async getStatus() {
         calls.push('auth');
-        return { authenticated: false };
+        return {
+          authenticated: false,
+          remoteAgentCatalogAvailable: false,
+        };
       },
     },
     secrets: {

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -83,6 +83,7 @@ describe('default setup platform', () => {
 
     await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
       authenticated: false,
+      remoteAgentCatalogAvailable: false,
     });
   });
 
@@ -107,7 +108,24 @@ describe('default setup platform', () => {
 
     await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
       authenticated: true,
+      remoteAgentCatalogAvailable: true,
       email: 'researcher@example.com',
+      tier: 'Max',
+    });
+  });
+
+  it('reports relay-only model auth without remote-catalog access', async () => {
+    vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+    vi.spyOn(SupabaseClient, 'canAccessRemoteAgentCatalog').mockResolvedValue(
+      false,
+    );
+    vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
+    vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('Max');
+
+    await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
+      authenticated: true,
+      remoteAgentCatalogAvailable: false,
+      email: undefined,
       tier: 'Max',
     });
   });
@@ -118,6 +136,7 @@ describe('default setup platform', () => {
     await expect(setup.secrets.anyUsableCredentialExists()).resolves.toBe(true);
     await expect(setup.auth.getStatus()).resolves.toEqual({
       authenticated: false,
+      remoteAgentCatalogAvailable: false,
     });
   });
 });

--- a/src/test-kernel/tools/setup/fixtures.ts
+++ b/src/test-kernel/tools/setup/fixtures.ts
@@ -49,7 +49,10 @@ export function createFakeSetupPlatform(
     },
     auth: {
       async getStatus() {
-        return { authenticated: false };
+        return {
+          authenticated: false,
+          remoteAgentCatalogAvailable: false,
+        };
       },
       ...overrides.auth,
     },

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -7,7 +7,7 @@
  * UI is never built — the setup agent asks in conversation and calls this.
  *
  * The roster write goes through the same shared application path as the
- * Settings "apply team" action (`applyPresetRoster`), so the two can't
+ * Settings "apply team" action, so the two can't
  * drift. Relay-served leads (orchestrators) that aren't in the registry yet
  * (signed out) are reported as "after sign-in" rather than silently dropped.
  */
@@ -19,9 +19,15 @@ import {
   resolveTeamPreset,
 } from '@controllers/onboarding/defaultTeamSeeding';
 import { setDefaultTeamId } from '@controllers/onboarding/onboardingFunnel';
-import { applyPresetRoster } from '@controllers/settingsView/SettingsAgentCatalogController';
+import {
+  commitTeamRoster,
+  resolveTeamRoster,
+  teamHostedNamesForPreflight,
+} from '@controllers/teams/TeamRoster';
+import { preflightTeamAvailability } from '@controllers/teams/TeamAvailabilityPreflight';
 import { platform } from '@platform/platform';
-import { REMOTE_ORCHESTRATOR_AGENT_NAMES } from '@shared/constants/agents';
+import { refresh } from '@agent/index/agentRegistry';
+import { AUTH_COMMANDS } from '@auth/constants';
 import { agentName } from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
@@ -30,6 +36,7 @@ import {
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
+import { getSetupPlatform } from './platform';
 
 /**
  * Built from the actual preset list (plus the hidden starter team) so the
@@ -55,6 +62,12 @@ const ApplyTeamInputSchema = z.strictObject({
       message: `Expected one of: ${TEAM_IDS.join(', ')}`,
     })
     .describe(`Team to apply. One of:\n${describeTeams()}`),
+  unavailableAction: z
+    .enum(['sign-in', 'continue', 'cancel'])
+    .nullish()
+    .describe(
+      'Explicit response when TeXRA-hosted members are unavailable. Omit on the first call; after asking the user, pass sign-in, continue, or cancel.',
+    ),
 });
 
 type ApplyTeamInput = z.infer<typeof ApplyTeamInputSchema>;
@@ -79,11 +92,73 @@ ${describeTeams()}`,
       );
     }
 
-    const { workflowKeys, toolUseKeys, unresolvedNames } =
-      await applyPresetRoster(
-        registryPresetRosterState(platform().workspaceState),
-        preset,
+    const state = registryPresetRosterState(platform().workspaceState);
+    const initial = {
+      preset,
+      resolution: resolveTeamRoster(state, preset),
+    };
+    const texraHostedNames = teamHostedNamesForPreflight(
+      preset,
+      initial.resolution.unresolvedNames,
+    );
+    const setupPlatform = getSetupPlatform();
+    const authenticated = await setupPlatform.auth.getStatus();
+
+    const preflight = await preflightTeamAvailability({
+      initial,
+      unresolvedNames: (value) => value.resolution.unresolvedNames,
+      texraHostedNames,
+      canAccessRemoteCatalog: async () =>
+        authenticated.remoteAgentCatalogAvailable,
+      providedChoice: input.unavailableAction ?? undefined,
+      choose: async () => undefined,
+      signIn: async () => {
+        if (setupPlatform.auth.signIn) return setupPlatform.auth.signIn();
+        if (setupPlatform.commands) {
+          return (
+            (await setupPlatform.commands.invoke(AUTH_COMMANDS.SIGN_IN)) ===
+            true
+          );
+        }
+        return false;
+      },
+      refresh: async () => {
+        await refresh({ includeRemote: true });
+        return { preset, resolution: resolveTeamRoster(state, preset) };
+      },
+    });
+
+    if (preflight.status === 'choice-required') {
+      const names = preflight.unavailableNames.join(', ');
+      return {
+        status: 'executed',
+        summary: `Team not applied; TeXRA-hosted members are unavailable: ${names}.`,
+        output: `The ${preset.name} team has unavailable TeXRA-hosted members: ${names}. Ask the user to choose one action: Sign in to TeXRA, Continue with available members, or Cancel. Then call apply_team again with unavailableAction set to "sign-in", "continue", or "cancel". No roster or default-team state was written.`,
+      };
+    }
+
+    if (preflight.status === 'cancelled') {
+      const signInAdvice =
+        input.unavailableAction === 'sign-in' &&
+        !setupPlatform.auth.signIn &&
+        !setupPlatform.commands
+          ? ' Sign-in is unavailable in this host; sign in through the host account UI, then call apply_team again.'
+          : '';
+      return {
+        status: 'executed',
+        summary: `Cancelled ${preset.name} team application.`,
+        output: `Cancelled. No roster or default-team state was written.${signInAdvice}`,
+      };
+    }
+    if (preflight.status === 'unavailable') {
+      throw new ToolError(
+        `The ${preset.name} team is still unavailable after refreshing the TeXRA agent catalog: ${preflight.unavailableNames.join(', ')}.`,
       );
+    }
+
+    const { workflowKeys, toolUseKeys, unresolvedNames } =
+      preflight.value.resolution;
+    await commitTeamRoster(state, preflight.value.resolution);
     await setDefaultTeamId(platform().globalState, preset.id);
 
     // Names that didn't resolve in the registry right now stay in the roster
@@ -93,12 +168,11 @@ ${describeTeams()}`,
     const unresolved = new Set(unresolvedNames);
     const activeWorkflow = workflowKeys.filter((key) => !unresolved.has(key));
     const activeToolUse = toolUseKeys.filter((key) => !unresolved.has(key));
-    const remoteLeadNames = new Set<string>(REMOTE_ORCHESTRATOR_AGENT_NAMES);
     const pendingRemoteLeads = unresolvedNames.filter((name) =>
-      remoteLeadNames.has(name),
+      texraHostedNames.has(name),
     );
     const pendingOther = unresolvedNames.filter(
-      (name) => !remoteLeadNames.has(name),
+      (name) => !texraHostedNames.has(name),
     );
 
     const signInNote =

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -71,9 +71,12 @@ export interface SetupExtensionAdapter {
 export interface SetupAuthAdapter {
   getStatus(): Promise<{
     authenticated: boolean;
+    remoteAgentCatalogAvailable: boolean;
     email?: string;
     tier?: string;
   }>;
+  /** Start the host's existing TeXRA account sign-in flow, when available. */
+  signIn?: () => Promise<boolean>;
 }
 
 /** Configuration-value surface. Reads/writes scoped to `texra.*` keys. */
@@ -134,6 +137,7 @@ function assertTexraScopedKey(key: string): void {
 
 async function defaultAuthStatus(): Promise<{
   authenticated: boolean;
+  remoteAgentCatalogAvailable: boolean;
   email?: string;
   tier?: string;
 }> {
@@ -144,13 +148,22 @@ async function defaultAuthStatus(): Promise<{
   }
 
   const authenticated = await SupabaseClient.isAuthenticated();
-  if (!authenticated) return { authenticated: false };
+  const remoteAgentCatalogAvailable =
+    await SupabaseClient.canAccessRemoteAgentCatalog();
+  if (!authenticated) {
+    return { authenticated: false, remoteAgentCatalogAvailable: false };
+  }
 
   const [user, tier] = await Promise.all([
     SupabaseClient.getUser(),
     SupabaseClient.getUserTier(),
   ]);
-  return { authenticated: true, email: user?.email, tier };
+  return {
+    authenticated: true,
+    remoteAgentCatalogAvailable,
+    email: user?.email,
+    tier,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- preflight team-member availability before changing roster or default-team state
- offer **Sign in to TeXRA**, **Continue with available members**, and **Cancel** consistently in CLI, extension, desktop, and setup flows
- distinguish remote-agent catalog access from included model access, so relay-only and ChatGPT-only credentials do not falsely imply that hosted team definitions are available
- force exactly one post-login catalog refresh, preserve explicit partial-team choices, and report unresolved authenticated teams as availability errors
- remove cached remote definitions immediately on logout and preserve legacy custom-team provenance conservatively

## Design

The host-neutral team domain owns roster resolution, availability preflight, and commit sequencing. Hosts provide only their existing sign-in, choice, catalog-capability, and refresh operations. No roster write occurs before preflight returns an applied result.

TeXRA model access and TeXRA remote-agent catalog access are separate capabilities. ChatGPT sign-in continues to enable OpenAI models, while a team that needs hosted definitions offers TeXRA account sign-in. Desktop OAuth waits for its matching callback and stored session before the preflight refresh proceeds.

Closes #8303.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 48 pre-existing warnings)
- `npm run compile:fast`
- focused cross-host suites (226 passed)
- final desktop, registry, and setup rerun (94 passed)
- `npm test` (5,967 passed; 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, agent catalog loading, and workspace roster state across multiple hosts; behavior changes are broad but centralized in shared preflight and covered by extensive tests.
> 
> **Overview**
> Adds a **shared team availability preflight** that runs before any roster write or team launch when TeXRA-hosted members are missing. Users get the same three choices everywhere: **Sign in to TeXRA**, **Continue with available members**, or **Cancel**. CLI orchestration, extension/desktop settings, and the setup `apply_team` tool all route through this policy instead of applying teams immediately.
> 
> **Remote catalog access is split from model auth.** New `canAccessRemoteAgentCatalog()` requires a GoTrue session; relay-only or included-model credentials no longer trigger remote agent loads or imply hosted agents are available. Agent registry **refresh is serialized** and **remote entries are cleared on sign-out**, with one forced refresh after successful sign-in.
> 
> Built-in presets gain optional `texraHostedAgents` metadata; roster logic moves to `TeamRoster` / `TeamRosterApplication`. Desktop OAuth gains `signInAndWaitForSession` and stricter callback/attempt handling so team sign-in can complete before catalog refresh; extension auth listeners can defer catalog refresh during preflight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c6ebdd098470a2db025cdaa90555b198c8fd6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->