### PR TITLE
fix: preserve corrupt JSON stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Corrupt local state is preserved for recovery** — malformed CLI and desktop
+  state, settings, credentials, and stream snapshots now fail visibly instead
+  of being treated as empty data and overwritten by the next update.
 - **Incomplete teams are decided before roster changes** — TeXRA now offers
   sign-in, explicit partial-team continuation, or cancellation before applying
   or launching a team whose TeXRA-hosted members are unavailable.

--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -20,9 +20,9 @@ const SECRETS_FILE_MODE = 0o600;
  * Environment variables remain the highest-priority source so automation can
  * keep using ephemeral keys. Values written by CLI login are persisted under
  * the user's TeXRA state directory through the shared `JsonStore` (the same
- * owner `ElectronSecrets` wraps for the desktop host), with `strict: true`
- * so a corrupt secrets file aborts a write instead of silently wiping every
- * other stored credential (see `JsonStoreOptions.strict`).
+ * owner `ElectronSecrets` wraps for the desktop host), with a fail-on-corrupt
+ * policy so a corrupt secrets file aborts a write instead of silently wiping
+ * every other stored credential.
  *
  * Each operation opens its own `JsonStore` rather than caching one for the
  * lifetime of this instance, so reads (`get`/`getStored`/`listStoredKeys`)
@@ -75,7 +75,7 @@ export class CliSecrets implements PlatformSecrets {
   private openStore(): Promise<JsonStore> {
     return JsonStore.open(this.filePath, {
       mode: SECRETS_FILE_MODE,
-      strict: true,
+      corruptionPolicy: 'fail',
     });
   }
 }

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -24,8 +24,12 @@ export async function createCliStateStores(
     workspacePath: init.workspacePath,
   });
   const [globalStore, workspaceStore] = await Promise.all([
-    JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json')),
-    JsonStore.open(path.join(storage.getStoragePath(), 'state.json')),
+    JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json'), {
+      corruptionPolicy: 'fail',
+    }),
+    JsonStore.open(path.join(storage.getStoragePath(), 'state.json'), {
+      corruptionPolicy: 'fail',
+    }),
   ]);
 
   return {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -267,6 +267,7 @@ export async function initCliPlatform(
   if (!tryPlatform()) {
     const configStore = await JsonStore.open(
       workspaceTexraConfigPath(cliWorkspaceCwd),
+      { corruptionPolicy: 'fail' },
     );
     const stateStores = await createCliStateStores({
       storageRoot: context.storageRoot,
@@ -281,6 +282,7 @@ export async function initCliPlatform(
         stateStores.storage.getGlobalStoragePath(),
         TEXRA_CONFIG_FILE_NAME,
       ),
+      { corruptionPolicy: 'fail' },
     );
     // Same severity and wording as the extension/desktop hosts: a shutdown
     // handler failure is an error everywhere, not a warning in one host.

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -420,6 +420,7 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
         createNodeStorageProvider().getGlobalStoragePath(),
         'state.json',
       ),
+      { corruptionPolicy: 'fail' },
     );
     latest = await checkCliUpdateAvailable({
       currentVersion: context.version,

--- a/packages/desktop/src/main/desktopStreamSnapshot.ts
+++ b/packages/desktop/src/main/desktopStreamSnapshot.ts
@@ -20,8 +20,6 @@
  * the previous file intact rather than corrupting the snapshot.
  */
 
-import { z } from 'zod';
-
 import { JsonStore } from '@platform/defaults/jsonStore';
 import {
   RestoredStreamsFileSchema,
@@ -62,11 +60,6 @@ export interface DesktopStreamSnapshotStore {
   getAll(): RestoredStreamSnapshot[];
 }
 
-interface OpenOptions {
-  /** Optional logger override (defaults to `console`). */
-  log?: Pick<Console, 'warn'>;
-}
-
 /**
  * Open the persisted snapshot file and return a write-through store.
  * The file is created on first write — opening a non-existent file
@@ -74,10 +67,10 @@ interface OpenOptions {
  */
 export async function openDesktopStreamSnapshotStore(
   filePath: string,
-  options: OpenOptions = {},
 ): Promise<DesktopStreamSnapshotStore> {
-  const log = options.log ?? console;
-  const store = await JsonStore.open(filePath);
+  const store = await JsonStore.open(filePath, {
+    corruptionPolicy: 'fail',
+  });
   const raw = store.get<unknown>(STREAMS_KEY);
 
   // Live in-memory list keyed by streamId, seeded from the persisted file.
@@ -85,7 +78,7 @@ export async function openDesktopStreamSnapshotStore(
   // upserts share one debounced write. Destructive edits stay immediate so
   // callers can rely on durability when remove()/replaceAll() resolve.
   const live = new Map<StreamTabId, RestoredStreamSnapshot>(
-    parseHydrated(raw, log).map((s) => [s.streamId, s]),
+    parseHydrated(raw).map((s) => [s.streamId, s]),
   );
   let pendingUpsertWaiters: Array<{
     resolve(): void;
@@ -207,23 +200,14 @@ export async function openDesktopStreamSnapshotStore(
 }
 
 /**
- * Parse the persisted blob, returning a normalized list. A malformed
- * or missing file yields an empty list — never throw at startup; a
- * corrupt snapshot must not block the user from launching the app.
+ * Parse the persisted blob, returning a normalized list. A missing snapshot
+ * value yields an empty list. Invalid present data fails the open so the
+ * caller can disable snapshot persistence without overwriting the source.
  */
-function parseHydrated(
-  raw: unknown,
-  log: Pick<Console, 'warn'>,
-): RestoredStreamSnapshot[] {
+function parseHydrated(raw: unknown): RestoredStreamSnapshot[] {
   if (raw == null) return [];
   const parsed = RestoredStreamsFileSchema.safeParse(raw);
-  if (!parsed.success) {
-    log.warn(
-      '[texra-desktop] Discarding malformed stream snapshot file',
-      z.prettifyError(parsed.error),
-    );
-    return [];
-  }
+  if (!parsed.success) throw parsed.error;
   // Preserve in-flight phases so startup repair can classify them. A finished
   // or already-inert prior phase remains an inactive ghost on the next launch.
   return parsed.data.streams.map((s) => ({

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -107,6 +107,7 @@ export async function initializeElectronPlatform(
   const userDataPath = app.getPath('userData');
   const globalStateStore = await JsonStore.open(
     join(userDataPath, 'state', 'global.json'),
+    { corruptionPolicy: 'fail' },
   );
   const workspacePath = resolveWorkspacePath({
     storedWorkspacePath: globalStateStore.get<string>(
@@ -123,9 +124,11 @@ export async function initializeElectronPlatform(
   const storage = new WorkspaceStorageProvider(dataRoot, workspacePath);
   const workspaceStateStore = await JsonStore.open(
     join(storage.getStoragePath(), 'state.json'),
+    { corruptionPolicy: 'fail' },
   );
   const globalConfigStore = await JsonStore.open(
     join(userDataPath, 'config', 'global.json'),
+    { corruptionPolicy: 'fail' },
   );
   // Workspace config lives in the project's `.texra/config.json` — the same
   // file the CLI reads and writes — so a checked-in config behaves
@@ -145,7 +148,9 @@ export async function initializeElectronPlatform(
   if (workspacePath) {
     const projectConfigPath = workspaceTexraConfigPath(workspacePath);
     try {
-      projectConfigStore = await JsonStore.open(projectConfigPath);
+      projectConfigStore = await JsonStore.open(projectConfigPath, {
+        corruptionPolicy: 'fail',
+      });
       projectConfigWritable = await canCreateOrWrite(projectConfigPath);
     } catch (error) {
       console.warn(
@@ -160,7 +165,9 @@ export async function initializeElectronPlatform(
   // degradation.
   let internalConfigStore: JsonStore | undefined;
   try {
-    internalConfigStore = await JsonStore.open(legacyWorkspaceConfigPath);
+    internalConfigStore = await JsonStore.open(legacyWorkspaceConfigPath, {
+      corruptionPolicy: 'fail',
+    });
   } catch (error) {
     if (projectConfigStore === undefined) throw error;
     console.warn(
@@ -246,7 +253,10 @@ export async function initializeElectronPlatform(
       );
     }
   }
-  const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
+  const secretsStore = await JsonStore.open(
+    join(userDataPath, 'secrets.json'),
+    { corruptionPolicy: 'fail' },
+  );
 
   repairLaunchPath();
   const agentDirectories = createPlatformAgentDirectories({

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -4,11 +4,9 @@ import { dirname, resolve } from 'node:path';
 import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
-import * as logger from '@logger/logUtils';
 
 import type { StateStore } from '../interfaces';
 
-const CHANNEL = 'JsonStore';
 const LOCK_STALE_MS = 10_000;
 const LOCK_RETRY_OPTIONS = {
   retries: 120,
@@ -21,6 +19,13 @@ type JsonRecord = Record<string, unknown>;
 
 export interface JsonStoreOptions {
   /**
+   * Determines how a present file containing malformed or non-object JSON is
+   * handled. The current contract permits only `fail`; a recovery policy must
+   * define how the original bytes are preserved and how recovery is reported
+   * before this type is widened.
+   */
+  corruptionPolicy: 'fail';
+  /**
    * POSIX mode for the store file (e.g. `0o600` to restrict a secrets file
    * to its owner). The containing directory is created/chmod'd with the
    * same owner permissions plus execute — `0o600` -> `0o700` — so it stays
@@ -32,16 +37,6 @@ export interface JsonStoreOptions {
    * `JsonStore` behavior.
    */
   mode?: number;
-  /**
-   * When true, malformed JSON is a hard failure (rethrown) instead of being
-   * silently treated as an empty store. Callers that overwrite the whole
-   * file on every write (read-mutate-write, e.g. `CliSecrets`) need this:
-   * defaulting a transient parse failure to `{}` would permanently wipe
-   * every other stored value on the very next write. Defaults to false,
-   * preserving the self-healing behavior existing state/config stores rely
-   * on.
-   */
-  strict?: boolean;
 }
 
 /** `0o600` -> `0o700`: adds owner-execute wherever owner-read is set. */
@@ -51,25 +46,17 @@ function dirModeFor(fileMode: number): number {
 
 async function readJsonRecord(
   filePath: string,
-  strict: boolean,
-  fallback: JsonRecord = {},
+  missingFallback: JsonRecord = {},
 ): Promise<JsonRecord> {
   try {
     const content = await readFile(filePath, 'utf8');
     const parsed: unknown = JSON.parse(content);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as JsonRecord)
-      : { ...fallback };
-  } catch (error) {
-    if (isFileNotFoundError(error)) return { ...fallback };
-    if (error instanceof SyntaxError && !strict) {
-      logger.warn(
-        CHANNEL,
-        `Discarding unreadable ${filePath}; using the fallback snapshot.`,
-        { data: error },
-      );
-      return { ...fallback };
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as JsonRecord;
     }
+    throw new TypeError(`Expected ${filePath} to contain a JSON object.`);
+  } catch (error) {
+    if (isFileNotFoundError(error)) return { ...missingFallback };
     throw error;
   }
 }
@@ -115,14 +102,10 @@ export class JsonStore implements StateStore {
    */
   static async open(
     filePath: string,
-    options: JsonStoreOptions = {},
+    options: JsonStoreOptions,
   ): Promise<JsonStore> {
     const storePath = resolve(filePath);
-    return new JsonStore(
-      storePath,
-      await readJsonRecord(storePath, options.strict ?? false),
-      options,
-    );
+    return new JsonStore(storePath, await readJsonRecord(storePath), options);
   }
 
   get<T>(key: string, defaultValue?: T): T {
@@ -162,9 +145,9 @@ export class JsonStore implements StateStore {
   private enqueueFlush(
     key: string,
     value: unknown,
-    fallback: JsonRecord,
+    missingFallback: JsonRecord,
   ): Promise<void> {
-    const flush = () => this.flush(key, value, fallback);
+    const flush = () => this.flush(key, value, missingFallback);
     const chain = writeChains.get(this.filePath) ?? Promise.resolve();
     const next = chain.then(flush, flush);
     writeChains.set(this.filePath, next);
@@ -180,7 +163,7 @@ export class JsonStore implements StateStore {
   private async flush(
     key: string,
     value: unknown,
-    fallback: JsonRecord,
+    missingFallback: JsonRecord,
   ): Promise<void> {
     await ensureDir(dirname(this.filePath), this.options.mode);
     const { lock } = await import('proper-lockfile');
@@ -190,11 +173,7 @@ export class JsonStore implements StateStore {
       retries: LOCK_RETRY_OPTIONS,
     });
     try {
-      const record = await readJsonRecord(
-        this.filePath,
-        this.options.strict ?? false,
-        fallback,
-      );
+      const record = await readJsonRecord(this.filePath, missingFallback);
       if (value === undefined) {
         delete record[key];
       } else {

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -368,14 +368,26 @@ describe('DesktopStreamSnapshot', () => {
     expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
   });
 
-  it('discards a malformed snapshot file without throwing', async () => {
+  it('rejects a malformed snapshot file without changing its bytes', async () => {
     const filePath = await tempFilePath();
-    await writeFile(filePath, '{ not json');
+    const malformed = '{ not json';
+    await writeFile(filePath, malformed);
 
-    const store = await openDesktopStreamSnapshotStore(filePath, {
-      log: { warn: () => {} },
+    await expect(
+      openDesktopStreamSnapshotStore(filePath),
+    ).rejects.toBeInstanceOf(SyntaxError);
+    expect(await readFile(filePath, 'utf8')).toBe(malformed);
+  });
+
+  it('rejects an invalid present snapshot value without changing its bytes', async () => {
+    const filePath = await tempFilePath();
+    const invalid = JSON.stringify({
+      restoredStreams: { version: 1, streams: 'not-an-array' },
     });
-    expect(store.hydrated).toEqual([]);
+    await writeFile(filePath, invalid);
+
+    await expect(openDesktopStreamSnapshotStore(filePath)).rejects.toThrow();
+    expect(await readFile(filePath, 'utf8')).toBe(invalid);
   });
 
   it('writes a versioned envelope under the restoredStreams key', async () => {

--- a/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
+++ b/src/test-kernel/desktop/DesktopStreamSnapshot.vitest.mts
@@ -368,18 +368,7 @@ describe('DesktopStreamSnapshot', () => {
     expect(writeFileAtomicMock).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects a malformed snapshot file without changing its bytes', async () => {
-    const filePath = await tempFilePath();
-    const malformed = '{ not json';
-    await writeFile(filePath, malformed);
-
-    await expect(
-      openDesktopStreamSnapshotStore(filePath),
-    ).rejects.toBeInstanceOf(SyntaxError);
-    expect(await readFile(filePath, 'utf8')).toBe(malformed);
-  });
-
-  it('rejects an invalid present snapshot value without changing its bytes', async () => {
+  it('rejects an invalid present snapshot value', async () => {
     const filePath = await tempFilePath();
     const invalid = JSON.stringify({
       restoredStreams: { version: 1, streams: 'not-an-array' },
@@ -387,7 +376,6 @@ describe('DesktopStreamSnapshot', () => {
     await writeFile(filePath, invalid);
 
     await expect(openDesktopStreamSnapshotStore(filePath)).rejects.toThrow();
-    expect(await readFile(filePath, 'utf8')).toBe(invalid);
   });
 
   it('writes a versioned envelope under the restoredStreams key', async () => {

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -28,7 +28,10 @@ interface JsonStore {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string): Promise<JsonStore>;
+    open(
+      filePath: string,
+      options: { corruptionPolicy: 'fail' },
+    ): Promise<JsonStore>;
   };
 }
 
@@ -113,9 +116,11 @@ describe('desktop agent directory bootstrap', () => {
     const storage = new WorkspaceStorageProvider(userDataPath, workspacePath);
     const globalStateStore = await JsonStore.open(
       join(userDataPath, 'state', 'global.json'),
+      { corruptionPolicy: 'fail' },
     );
     const workspaceStateStore = await JsonStore.open(
       join(storage.getStoragePath(), 'state.json'),
+      { corruptionPolicy: 'fail' },
     );
 
     initPlatform({

--- a/src/test-kernel/desktop/ElectronConfig.vitest.mts
+++ b/src/test-kernel/desktop/ElectronConfig.vitest.mts
@@ -36,7 +36,10 @@ interface JsonConfigProvider {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string): Promise<JsonStore>;
+    open(
+      filePath: string,
+      options: { corruptionPolicy: 'fail' },
+    ): Promise<JsonStore>;
   };
 }
 
@@ -77,9 +80,12 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
     const { JsonStore, JsonConfigProvider } =
       await loadDesktopConfigConstructors();
     tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-config-'));
-    const globalStore = await JsonStore.open(join(tempDir, 'global.json'));
+    const globalStore = await JsonStore.open(join(tempDir, 'global.json'), {
+      corruptionPolicy: 'fail',
+    });
     const workspaceStore = await JsonStore.open(
       join(tempDir, 'workspace.json'),
+      { corruptionPolicy: 'fail' },
     );
     return {
       provider: new JsonConfigProvider({

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -37,7 +37,10 @@ interface JsonStore {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string): Promise<JsonStore>;
+    open(
+      filePath: string,
+      options: { corruptionPolicy: 'fail' },
+    ): Promise<JsonStore>;
   };
 }
 
@@ -124,7 +127,9 @@ describe('desktop platform adapters', () => {
       loadJsonStore(),
     ]);
     const root = await makeTempDir('texra-electron-secrets-');
-    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const store = await JsonStore.open(join(root, 'secrets.json'), {
+      corruptionPolicy: 'fail',
+    });
     const secrets = new secretsModule.ElectronSecrets(store, options);
     return { module: secretsModule, store, secrets };
   }
@@ -157,7 +162,9 @@ describe('desktop platform adapters', () => {
   it('persists state values and deletes undefined updates through JsonStore', async () => {
     const JsonStore = await loadJsonStore();
     const root = await makeTempDir('texra-electron-state-');
-    const store = await JsonStore.open(join(root, 'state.json'));
+    const store = await JsonStore.open(join(root, 'state.json'), {
+      corruptionPolicy: 'fail',
+    });
 
     await store.update('session', { active: true });
     await store.update('cleared', 'value');

--- a/src/test-kernel/desktop/JsonStore.vitest.mts
+++ b/src/test-kernel/desktop/JsonStore.vitest.mts
@@ -31,13 +31,13 @@ interface JsonStore {
 }
 
 interface JsonStoreOptions {
+  corruptionPolicy: 'fail';
   mode?: number;
-  strict?: boolean;
 }
 
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string, options?: JsonStoreOptions): Promise<JsonStore>;
+    open(filePath: string, options: JsonStoreOptions): Promise<JsonStore>;
   };
 }
 
@@ -66,28 +66,31 @@ describe('shared JsonStore', () => {
     return filePath;
   }
 
-  it('recovers from malformed JSON stores and overwrites on the next write', async () => {
+  it('fails on malformed JSON without changing the original bytes', async () => {
     const JsonStore = await loadJsonStore();
-    const filePath = await createTempFile('state.json', '{"truncated"');
-
-    const store = await JsonStore.open(filePath);
-
-    expect(store.snapshot()).toEqual({});
-
-    await store.set('ready', true);
-
-    expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
-      ready: true,
-    });
-  });
-
-  it('rethrows malformed JSON instead of discarding it when opened with strict: true', async () => {
-    const JsonStore = await loadJsonStore();
-    const filePath = await createTempFile('state.json', '{"truncated"');
+    const original = '{"truncated"';
+    const filePath = await createTempFile('state.json', original);
 
     await expect(
-      JsonStore.open(filePath, { strict: true }),
+      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
     ).rejects.toBeInstanceOf(SyntaxError);
+    expect(await readFile(filePath, 'utf8')).toBe(original);
+  });
+
+  it.each([
+    ['array', '[]'],
+    ['null', 'null'],
+    ['string', '"text"'],
+    ['number', '42'],
+    ['boolean', 'true'],
+  ])('treats valid non-object JSON (%s) as corruption', async (_, content) => {
+    const JsonStore = await loadJsonStore();
+    const filePath = await createTempFile('state.json', content);
+
+    await expect(
+      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
+    ).rejects.toThrow('to contain a JSON object');
+    expect(await readFile(filePath, 'utf8')).toBe(content);
   });
 
   it('merges with a concurrent writer instead of flushing a stale open-time snapshot', async () => {
@@ -97,7 +100,9 @@ describe('shared JsonStore', () => {
       '{"keep": 1, "drop": 1}\n',
     );
 
-    const store = await JsonStore.open(filePath);
+    const store = await JsonStore.open(filePath, {
+      corruptionPolicy: 'fail',
+    });
     // Simulate another process persisting a key while this store sits open
     // (e.g. across an awaited network fetch).
     await writeFile(filePath, '{"keep": 1, "drop": 1, "foreign": 2}\n');
@@ -110,12 +115,28 @@ describe('shared JsonStore', () => {
     });
   });
 
-  it('preserves its snapshot when a non-strict flush cannot reread the file', async () => {
+  it('rejects a mutation when the file becomes corrupt and preserves its bytes', async () => {
     const JsonStore = await loadJsonStore();
     const filePath = await createTempFile('state.json', '{"keep": 1}\n');
-    const store = await JsonStore.open(filePath);
+    const store = await JsonStore.open(filePath, {
+      corruptionPolicy: 'fail',
+    });
 
-    await writeFile(filePath, '{"truncated"');
+    const corrupt = '{"truncated"';
+    await writeFile(filePath, corrupt);
+
+    await expect(store.set('added', 2)).rejects.toBeInstanceOf(SyntaxError);
+    expect(await readFile(filePath, 'utf8')).toBe(corrupt);
+  });
+
+  it('preserves loaded keys when the backing file disappears before a mutation', async () => {
+    const JsonStore = await loadJsonStore();
+    const filePath = await createTempFile('state.json', '{"keep": 1}\n');
+    const store = await JsonStore.open(filePath, {
+      corruptionPolicy: 'fail',
+    });
+
+    await rm(filePath);
     await store.set('added', 2);
 
     expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
@@ -129,8 +150,8 @@ describe('shared JsonStore', () => {
     const filePath = await createTempFile('state.json', '{}\n');
 
     const [a, b] = await Promise.all([
-      JsonStore.open(filePath),
-      JsonStore.open(filePath),
+      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
+      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
     ]);
     // Both instances opened off the same on-disk snapshot; without per-path
     // read-modify-write serialization the later flush drops the other's key.
@@ -186,7 +207,7 @@ describe('shared JsonStore', () => {
     const script = `
       (async () => {
         const { JsonStore } = require(${JSON.stringify(bundlePath)});
-        const store = await JsonStore.open(${JSON.stringify(filePath)});
+        const store = await JsonStore.open(${JSON.stringify(filePath)}, { corruptionPolicy: 'fail' });
         console.log('ready');
         await store.set('child', 2);
       })().catch((error) => {
@@ -239,7 +260,10 @@ describe('shared JsonStore', () => {
     await chmod(tempDir, 0o500);
 
     try {
-      const store = await JsonStore.open(filePath, { mode: 0o600 });
+      const store = await JsonStore.open(filePath, {
+        corruptionPolicy: 'fail',
+        mode: 0o600,
+      });
 
       expect(store.get('key', 'fallback')).toBe('fallback');
       await expect(stat(dir)).rejects.toMatchObject({ code: 'ENOENT' });
@@ -260,7 +284,10 @@ describe('shared JsonStore', () => {
     tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
     const filePath = join(tempDir, 'nested', 'secrets.json');
 
-    const store = await JsonStore.open(filePath, { mode: 0o600 });
+    const store = await JsonStore.open(filePath, {
+      corruptionPolicy: 'fail',
+      mode: 0o600,
+    });
     await store.set('key', 'value');
 
     const fileStat = await stat(filePath);

--- a/src/test-kernel/desktop/JsonStore.vitest.mts
+++ b/src/test-kernel/desktop/JsonStore.vitest.mts
@@ -81,8 +81,6 @@ describe('shared JsonStore', () => {
     ['array', '[]'],
     ['null', 'null'],
     ['string', '"text"'],
-    ['number', '42'],
-    ['boolean', 'true'],
   ])('treats valid non-object JSON (%s) as corruption', async (_, content) => {
     const JsonStore = await loadJsonStore();
     const filePath = await createTempFile('state.json', content);
@@ -90,7 +88,6 @@ describe('shared JsonStore', () => {
     await expect(
       JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
     ).rejects.toThrow('to contain a JSON object');
-    expect(await readFile(filePath, 'utf8')).toBe(content);
   });
 
   it('merges with a concurrent writer instead of flushing a stale open-time snapshot', async () => {


### PR DESCRIPTION
## Summary

- require every production `JsonStore.open()` caller to select an explicit fail-on-corruption policy
- preserve malformed and valid non-object JSON instead of converting it to an empty writable record
- reject schema-invalid present desktop stream snapshots before exposing a writable snapshot store
- preserve loaded keys when an otherwise valid backing file is deleted before the next mutation
- remove the permissive default and the `strict` compatibility option

## Design

The storage primitive previously owned a recovery decision it could not make: it did not know whether a file was disposable cache or authoritative user state. That shallow fallback converted distinct states—missing and corrupt—into the same empty object, and a later mutation could erase the evidence.

The new contract makes the composition roots state their policy. All current production stores contain authoritative state, so the only supported policy is `fail`. A reset or quarantine branch is intentionally absent until a real reconstructible-cache caller exists and recovery can preserve the source bytes and report its path. Missing files still open as empty stores; if a valid file disappears after opening, a mutation reconstructs it from the instance snapshot rather than dropping loaded keys.

Desktop stream snapshots retain their existing host-level degradation: startup catches an open failure, warns, and continues without snapshot persistence. The corrupt file remains untouched.

## Verification

- full Vitest suite: 5,990 passed, 4 skipped (664 files passed, 1 skipped)
- focused storage/desktop suite after review fixes: 85 passed
- complete workspace type check: passed
- root and test-kernel type checks after final review fix: passed
- focused ESLint: passed
- Prettier and commit hooks: passed

Closes #8310
Tracks #7726.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure modes for authoritative local state (credentials, settings, snapshots): corrupt files now block opens/writes instead of being silently reset, which is intentional but can prevent startup or persistence until manual recovery.
> 
> **Overview**
> **Local JSON persistence no longer self-heals by wiping corrupt files.** `JsonStore` drops the optional `strict` flag and requires an explicit **`corruptionPolicy: 'fail'`** at every `open()`. Malformed JSON, valid JSON that is not an object, and flush-time re-read corruption now **throw** instead of being logged and treated as an empty store that the next write could overwrite.
> 
> **CLI and desktop composition roots** pass `corruptionPolicy: 'fail'` for secrets, global/workspace state, workspace and global config, and (CLI) the pre-init update-check state file. **Desktop stream snapshots** stop discarding invalid `streams` data with a warning: schema-invalid present data fails open so startup can catch the error, warn, and continue **without** snapshot persistence while leaving `streams.json` untouched.
> 
> Tests are updated to assert on-disk bytes are preserved and opens/mutations reject corruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 932808a2c6abedf0f9175847ad624d17f15e904c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->