### PR TITLE
fix(cli): seed typed follow-ups in TUI harness

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -339,7 +339,7 @@ await initLocalCliPlatform({
 initializeDefaultSession({ transcripts: await StreamLogStore.open() });
 const harnessFollowUpQueue = defaultSession().followUps.acquire(STREAM_ID);
 for (const followUp of QUEUED_FOLLOW_UPS) {
-  harnessFollowUpQueue.enqueue(followUp);
+  harnessFollowUpQueue.enqueue({ text: followUp });
 }
 if (process.env.HARNESS_VISIBLE_TOOL_USE_AGENTS !== undefined) {
   await platform().workspaceState.update(

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -242,7 +242,11 @@ const SCENARIOS = [
       '1. ✓ reviewer completed All good <ok>',
       'Queued follow-ups (1)',
     ],
-    unexpect: ['<orchestrator-followup>', '<subagent-result'],
+    unexpect: [
+      '(empty follow-up)',
+      '<orchestrator-followup>',
+      '<subagent-result',
+    ],
   },
   {
     name: 'queued-subagent-followup-status-preview',


### PR DESCRIPTION
## Summary

- seed PTY harness follow-ups through the typed `{ text }` queue API
- prevent the existing subagent-summary scenario from accepting `(empty follow-up)`
- keep `/status` and the queued-follow-up panel backed by equivalent harness data

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; 47 existing warnings)
- `corepack pnpm --filter @texra-ai/cli validate:tui -- --snapshot-dir /private/tmp/texra-tui-followup-related queued-followups queued-subagent-followup-summary queued-subagent-followup-status-preview compact-queued-followups`
- `git diff --check`

Closes #8313

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CLI TUI test harness and PTY validation scenarios; no production chat or queue runtime behavior is modified.
> 
> **Overview**
> The PTY **TUI harness** now seeds queued follow-ups through the typed **`{ text }`** `enqueue` API instead of passing raw strings, matching production follow-up queue usage.
> 
> **validate-tui** for **`queued-subagent-followup-summary`** now fails if **`(empty follow-up)`** appears (guarding against empty queue entries when XML orchestrator follow-ups are seeded) and keeps asserting that raw **`<orchestrator-followup>`** / **`<subagent-result`** markup stays off the rendered **`/status`** and queued-follow-up panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e522eadac0f0439b2fba4a2c9eeec7a799182bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->