### PR TITLE
fix(cli): preserve follow-up resume order

### DIFF
--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -119,11 +119,9 @@ export async function resumeQueuedToolUseSnapshot(
       onRun: options.onRun,
       isCancellationRequested: options.isCancellationRequested,
       setupSession: (session) => {
+        followUps = [...followUps, ...followUpsQueue.drainItems(streamId)];
         if (options.isCancellationRequested?.()) {
           cancelledBeforeSessionSetup = true;
-          // Capture messages accepted after the initial drain before the
-          // cancellation handoff disposes the shared stream queue.
-          followUps = [...followUps, ...followUpsQueue.drainItems(streamId)];
           return;
         }
         for (const item of followUps) {

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -124,7 +124,7 @@ describe('resumeToolUseSnapshot', () => {
     });
   });
 
-  it('opens late follow-up routing before draining the resume queue', async () => {
+  it('keeps ready-boundary and setup-race follow-ups in order', async () => {
     const onFollowUpQueueReady = vi.fn(() => {
       defaultSession().followUps.enqueue(STREAM, {
         text: 'queued at the ready boundary',
@@ -137,10 +137,17 @@ describe('resumeToolUseSnapshot', () => {
     });
 
     expect(onFollowUpQueueReady).toHaveBeenCalledOnce();
+    defaultSession().followUps.enqueue(STREAM, {
+      text: 'queued after the initial drain',
+    });
     const appendFollowUp = vi.fn();
     capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).toHaveBeenCalledWith({
+    expect(appendFollowUp).toHaveBeenNthCalledWith(1, {
       text: 'queued at the ready boundary',
+      origin: 'user',
+    });
+    expect(appendFollowUp).toHaveBeenNthCalledWith(2, {
+      text: 'queued after the initial drain',
       origin: 'user',
     });
   });


### PR DESCRIPTION
## Summary

- preserve FIFO order for follow-ups accepted during resume setup
- drain late arrivals at the same setup boundary used for replay and cancellation
- strengthen the existing resume-boundary test instead of adding another test case

## Root cause

Interrupted follow-ups were drained before the rebuilt session existed. Once ordinary routing reopened, a newer follow-up could enter the shared queue before `setupSession` replayed the earlier batch, producing `C, A, B` instead of `A, B, C`.

## Validation

- `corepack pnpm vitest run src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts src/test-kernel/cli/chatSessionController.vitest.mts` (40 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 47 existing warnings)
- `npm run compile:fast`

Closes #8315

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent resume and follow-up queue ordering at session setup; wrong ordering could affect multi-turn CLI behavior after interrupt/resume.
> 
> **Overview**
> Fixes **out-of-order follow-ups** when resuming an interrupted tool-use session by draining the shared follow-up queue again at the start of `setupSession`, before cancellation checks or replay.
> 
> Previously, items accepted after the initial drain but before the rebuilt session existed could be routed into the queue and replayed **after** an earlier batch, yielding wrong order (e.g. `C, A, B` instead of `A, B, C`). The second drain merges those late arrivals into the same replay batch used for normal resume and for cancellation restore.
> 
> The resume-boundary test now asserts FIFO for both **ready-boundary** and **post-initial-drain** enqueue paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b203961b5761df4a3f9666df22d39428ec9080eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->