### PR TITLE
refactor(runtime): preserve canonical child phases

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -13,8 +13,7 @@ export function childStatusColor(status: string | undefined): string {
   if (isChildExecutionErrorStatus(status)) return COLOR_ERROR;
   // A user stop is neither success nor error — show it neutral, matching the
   // progress view / webview (gray), not green (which reads as completed).
-  // Stream slices carry the canonical `cancelled` phase (RUN_OUTCOME); roster
-  // summaries still spell it as the legacy `stopped`.
+  // `stopped` remains accepted for historical snapshots.
   if (status === 'cancelled' || status === 'stopped') return COLOR_BORDER;
   return COLOR_SUCCESS;
 }

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -13,24 +13,16 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import {
-  STREAM_STATUS,
-  streamStatusesWithTrait,
+  type ExecutionStatus,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import type { AgentCategory } from '@shared/schemas/agent';
 
 export interface ExecutionStatusInfo {
-  status: string;
+  status: StreamPhase | ExecutionStatus | 'unknown';
   elapsed: string | null;
 }
-
-/**
- * Statuses that represent a live execution (running, transitioning, or
- * paused). This is exactly the `inFlight` trait — derived from the shared
- * trait table rather than re-declared.
- */
-export const ACTIVE_STATUSES: ReadonlySet<string> =
-  streamStatusesWithTrait('inFlight');
 
 export interface ExecutionHandle {
   readonly executionId: string;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -17,14 +17,13 @@ import {
   type StreamStatusEmitOptions,
 } from '@agent/runtime/StreamStatusService';
 import {
-  isInFlightStatus,
-  isLiveElapsedStatus,
+  isActivePhase,
+  isInFlightPhase,
   projectRunOutcome,
 } from '@common/constants/streamStatus';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
-  STREAM_STATUS,
   STREAM_SUBSTATE,
   type ActiveChildInfo,
   type StreamPhase,
@@ -47,7 +46,6 @@ export {
   type ExecutionStatusInfo,
   type LiveToolUseFlowContext,
   type AgentRunHandle,
-  ACTIVE_STATUSES,
   AgentExecutionHandle,
   ProcessExecutionHandle,
 } from './ExecutionHandle';
@@ -355,13 +353,15 @@ export class ExecutionRegistry {
     return this.handles.get(executionId);
   }
 
-  getStatus(handle: ExecutionHandle): ExecutionStatusInfo {
+  getStatus(
+    handle: ExecutionHandle,
+  ): ExecutionStatusInfo & { status: StreamPhase } {
     const status =
       handle instanceof AgentExecutionHandle
         ? (this.streamStatus.get(handle.childStreamId) ?? STREAM_PHASE.RUNNING)
         : STREAM_PHASE.RUNNING;
 
-    if (!isLiveElapsedStatus(status)) {
+    if (!isActivePhase(status)) {
       return { status, elapsed: null };
     }
 
@@ -435,7 +435,7 @@ export class ExecutionRegistry {
     const status = this.streamStatus.get(streamId);
     const hasActiveChildren = this.hasActiveChildren(streamId);
 
-    if (status !== undefined && !isInFlightStatus(status)) {
+    if (status !== undefined && !isInFlightPhase(status)) {
       if (hasActiveChildren) {
         return { kind: 'queue', reason: 'children_running' };
       }
@@ -783,12 +783,10 @@ export class ExecutionRegistry {
         continue;
       }
       const { status, elapsed } = this.getStatus(handle);
-      const summaryStatus =
-        status === STREAM_PHASE.CANCELLED ? STREAM_STATUS.STOPPED : status;
       const base = {
         executionId: handle.executionId,
         agentName: handle.agentName,
-        status: summaryStatus,
+        status,
         startedAt: handle.startedAt,
         elapsed: elapsed ?? null,
         ...(handle.toolName ? { toolName: handle.toolName } : {}),

--- a/src/agent/runtime/followUpResumeDetection.ts
+++ b/src/agent/runtime/followUpResumeDetection.ts
@@ -1,4 +1,4 @@
-import { isInFlightStatus } from '@common/constants/streamStatus';
+import { isInFlightPhase } from '@common/constants/streamStatus';
 import type { StreamPhase } from '@shared/schemas';
 
 /**
@@ -8,5 +8,5 @@ import type { StreamPhase } from '@shared/schemas';
 export function shouldProbePersistedFlowForFollowUp(
   status: StreamPhase | undefined,
 ): boolean {
-  return !isInFlightStatus(status);
+  return !isInFlightPhase(status);
 }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -18,7 +18,7 @@ import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
-import { isInFlightStatus } from '@common/constants/streamStatus';
+import { isInFlightPhase } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   STREAM_PHASE,
@@ -849,7 +849,7 @@ export class ProgressFactApplier {
       this.state.streamLogs.mode.kind === 'persistent' &&
       this.state.streamLogs.has(streamId) &&
       !this.state.streamLogs.get(streamId);
-    if (isInFlightStatus(status)) {
+    if (isInFlightPhase(status)) {
       if (requiresPersistentRehydrate) {
         await this.state.streamLogs.ensureLoaded(streamId);
       }

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -10,7 +10,7 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import { isInFlightStatus } from '@common/constants/streamStatus';
+import { isInFlightPhase } from '@common/constants/streamStatus';
 import { createChannelTrace } from '@logger';
 import {
   AgentCategoryFilterSchema,
@@ -199,7 +199,7 @@ export class ProgressViewState {
    * call this on the stream being moved away from to close the loop.
    */
   releasePreviousActive(streamId: StreamTabId): void {
-    if (!isInFlightStatus(this.streamStatus.get(streamId))) {
+    if (!isInFlightPhase(this.streamStatus.get(streamId))) {
       this.streamLogs.releaseEntries(streamId);
     }
   }

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -899,7 +899,7 @@ describe('executionRegistry', () => {
       expect(registry.getActiveChildren(parentStreamId).subagents).toEqual([
         expect.objectContaining({
           executionId,
-          status: STREAM_STATUS.STOPPED,
+          status: STREAM_PHASE.CANCELLED,
         }),
       ]);
       expect(

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -3,6 +3,7 @@ import { type ExecutionStatusInfo } from '@agent/runtime/executionRegistry';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import {
   EXECUTION_STATUS,
+  ExecutionStatusSchema,
   STATUS_DISPLAY,
   TODO_STATUS,
   type TodoStatus,
@@ -58,8 +59,13 @@ export function getExecutionStatusInfo(
   const session = currentSession();
   const handle = session.executions.getHandle(executionId);
   if (handle) return session.executions.getStatus(handle);
+  const persistedStatus = ExecutionStatusSchema.safeParse(terminalStatus);
   return {
-    status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,
+    status: persistedStatus.success
+      ? persistedStatus.data
+      : terminalStatus === undefined
+        ? EXECUTION_STATUS.COMPLETED
+        : 'unknown',
     elapsed: null,
   };
 }

--- a/src/tools/executions/waitCoordination.ts
+++ b/src/tools/executions/waitCoordination.ts
@@ -8,20 +8,18 @@ import {
   getRunContextStreamId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
-import {
-  ACTIVE_STATUSES,
-  AgentExecutionHandle,
-} from '@agent/runtime/executionRegistry';
+import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { onFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
-import { STREAM_STATUS } from '@shared/schemas';
+import { isInFlightPhase } from '@common/constants/streamStatus';
+import { STREAM_PHASE } from '@shared/schemas';
 
 /**
  * Single-pass check: should the wait endpoint skip blocking on this execution?
  *
  * Returns true when:
  * - The handle is gone (execution already untracked / completed), OR
- * - The stream left all ACTIVE_STATUSES, OR
+ * - The stream left the canonical in-flight phases, OR
  * - The execution is a *tool-use subagent* in WAITING (job done, result
  *   already delivered by the child-run loop's per-turn delivery — see
  *   childRunLoop.ts). Workflow subagents in WAITING may still be awaiting
@@ -35,7 +33,7 @@ export function shouldSkipWait(executionId: string): boolean {
   if (!handle) return true;
 
   const { status } = session.executions.getStatus(handle);
-  if (!ACTIVE_STATUSES.has(status)) return true;
+  if (!isInFlightPhase(status)) return true;
 
   // Tool-use subagent in WAITING = job delivered by the child-run loop, don't block.
   // Workflow subagent in WAITING = may be waiting for retry/user action. Blocking
@@ -43,7 +41,7 @@ export function shouldSkipWait(executionId: string): boolean {
   // technically active so we don't skip — avoids misreporting it as done.
   // Non-subagent WAITING = human input needed, keep blocking.
   if (
-    status === STREAM_STATUS.WAITING &&
+    status === STREAM_PHASE.WAITING &&
     handle instanceof AgentExecutionHandle &&
     handle.category === 'toolUse' &&
     handle.parentStreamId !== handle.childStreamId


### PR DESCRIPTION
## Summary

- preserve canonical `StreamPhase` values in live child activity summaries
- replace legacy stream-status trait adapters with typed phase predicates at live runtime callers
- normalize persisted execution status once at the history formatting boundary, reporting malformed values as `unknown`
- retain dated compatibility readers and historical `stopped` display support

## Issue acceptance gates

Advances #7993 by removing the remaining immediate reverse projection from canonical `cancelled` to legacy `stopped` and retiring legacy trait adapters from typed live callers. The final dated compatibility-schema/read removal remains incomplete and gated by #6981 after July 24, 2026.

## Single source of truth

`StreamPhaseSchema` owns the live status vocabulary; `isActivePhase()` and `isInFlightPhase()` in `src/common/constants/streamStatus.ts` own its active/in-flight predicates.

## Duplication and abstraction budget

Removes the duplicate `ACTIVE_STATUSES` set and the hand-written cancelled-to-stopped child-summary projection. Adds no module or pass-through abstraction; the existing persisted-history formatter is the only normalization boundary.

## Net elements (R6)

- files: 9 modified, 0 added, 0 deleted
- exported symbols: 0 added, 1 deleted (`ACTIVE_STATUSES`)
- classes/interfaces/enums: 0 added, 0 deleted
- net LoC: -7 (32 additions, 39 deletions)

## Consumer counts (R8)

`ACTIVE_STATUSES` had 1 direct runtime consumer (`waitCoordination.ts`) plus its barrel re-export; both are removed. No event key or subscriber path is deleted.

## Host impact

Extension: progress state reads canonical phase predicates; no UI contract change beyond preserving `cancelled`.

Desktop: shared runtime behavior only; no desktop-specific changes.

CLI: subagent roster receives canonical `cancelled`; historical `stopped` snapshots remain display-compatible.

## Scheduled refactoring

#6981 tracks deletion of the dated compatibility schemas/readers after July 24, 2026.

## Validation

- affected suites: 99 tests passed
- final formatter/runtime follow-up: 32 tests passed
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:fast`
- `npm test` (6,000 passed, 4 skipped before the final display-fallback review adjustment)
