### PR TITLE
fix(telemetry): expose usage rejection outcome

### DIFF
--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -1,4 +1,7 @@
-import { UsageLogService } from '@telemetry/UsageLogService';
+import {
+  USAGE_LOG_FLUSH_OUTCOME,
+  UsageLogService,
+} from '@telemetry/UsageLogService';
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
@@ -304,10 +307,14 @@ export class UsageMonitor {
       // pre-call check sees this round's cost before the next call — bounding
       // free-tier overage to roughly one round instead of a whole session.
       if (usedRelay) {
-        const flushed = await UsageLogService.flush();
-        if (!flushed) {
+        const flushOutcome = await UsageLogService.flush();
+        if (flushOutcome === USAGE_LOG_FLUSH_OUTCOME.PENDING) {
           this.context.logger.debug(
             'Relay usage logging is queued; spend-cap data will retry later.',
+          );
+        } else if (flushOutcome === USAGE_LOG_FLUSH_OUTCOME.REJECTED) {
+          this.context.logger.error(
+            'Relay usage logging was permanently rejected; spend-cap accounting is incomplete.',
           );
         }
       }

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -22,7 +22,14 @@ const USAGE_LOG_ENDPOINT = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/log-u
 const MAX_QUEUE_SIZE = 1000;
 const REQUEST_TIMEOUT_MS = 10000;
 
-type BatchFlushOutcome = 'processed' | 'blocked';
+export const USAGE_LOG_FLUSH_OUTCOME = {
+  ACCEPTED: 'accepted',
+  PENDING: 'pending',
+  REJECTED: 'rejected',
+} as const;
+
+export type UsageLogFlushOutcome =
+  (typeof USAGE_LOG_FLUSH_OUTCOME)[keyof typeof USAGE_LOG_FLUSH_OUTCOME];
 
 interface UsageLogConfig {
   batchSize: number;
@@ -40,7 +47,7 @@ class UsageLogServiceImpl {
   private queue: UsageLogEntry[] = [];
   private retryBatch: UsageLogBatch | null = null;
   private flushTimer: NodeJS.Timeout | null = null;
-  private activeFlush: Promise<BatchFlushOutcome> | null = null;
+  private activeFlush: Promise<UsageLogFlushOutcome> | null = null;
   private config: UsageLogConfig = DEFAULT_CONFIG;
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
@@ -87,33 +94,42 @@ class UsageLogServiceImpl {
     }
   }
 
-  async flush(): Promise<boolean> {
+  async flush(): Promise<UsageLogFlushOutcome> {
+    let finalOutcome: UsageLogFlushOutcome = USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
+
     while (this.retryBatch || this.queue.length > 0 || this.activeFlush) {
+      let batchOutcome: UsageLogFlushOutcome;
       if (this.activeFlush) {
-        const outcome = await this.activeFlush;
-        if (outcome === 'blocked') return false;
-        continue;
+        batchOutcome = await this.activeFlush;
+      } else {
+        this.activeFlush = this.flushQueuedBatch();
+        try {
+          batchOutcome = await this.activeFlush;
+        } finally {
+          this.activeFlush = null;
+        }
       }
 
-      this.activeFlush = this.flushQueuedBatch();
-      try {
-        const outcome = await this.activeFlush;
-        if (outcome === 'blocked') return false;
-      } finally {
-        this.activeFlush = null;
+      if (batchOutcome === USAGE_LOG_FLUSH_OUTCOME.PENDING) {
+        return finalOutcome === USAGE_LOG_FLUSH_OUTCOME.REJECTED
+          ? finalOutcome
+          : batchOutcome;
+      }
+      if (batchOutcome === USAGE_LOG_FLUSH_OUTCOME.REJECTED) {
+        finalOutcome = batchOutcome;
       }
     }
 
-    return true;
+    return finalOutcome;
   }
 
-  private async flushQueuedBatch(): Promise<BatchFlushOutcome> {
+  private async flushQueuedBatch(): Promise<UsageLogFlushOutcome> {
     let batch: UsageLogBatch | null = null;
     try {
       const token = await SupabaseClient.getRelayAccessToken();
       if (!token) {
         logger.debug(CHANNEL, 'Skipping flush - user not authenticated');
-        return 'blocked';
+        return USAGE_LOG_FLUSH_OUTCOME.PENDING;
       }
 
       batch = this.retryBatch;
@@ -122,7 +138,7 @@ class UsageLogServiceImpl {
       } else {
         const entries = this.queue;
         this.queue = [];
-        if (entries.length === 0) return 'blocked';
+        if (entries.length === 0) return USAGE_LOG_FLUSH_OUTCOME.PENDING;
 
         batch = {
           entries,
@@ -140,7 +156,7 @@ class UsageLogServiceImpl {
         const message = response.error ?? 'Usage batch was rejected';
         if (response.retryable === false) {
           this.reportPermanentRejection(batch, message);
-          return 'processed';
+          return USAGE_LOG_FLUSH_OUTCOME.REJECTED;
         }
         throw new Error(message);
       }
@@ -148,7 +164,7 @@ class UsageLogServiceImpl {
         CHANNEL,
         `Batch ${batch.batchId} sent successfully (${response.accepted} entries)`,
       );
-      return 'processed';
+      return USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
     } catch (error) {
       const requeued = batch?.entries.length ?? 0;
       if (batch) this.retryBatch = batch;
@@ -158,7 +174,7 @@ class UsageLogServiceImpl {
         CHANNEL,
         `Failed to send usage batch${requeuedMessage}: ${toErrorMessage(error)}`,
       );
-      return 'blocked';
+      return USAGE_LOG_FLUSH_OUTCOME.PENDING;
     }
   }
 

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -1,8 +1,12 @@
 // Third-party imports
 import { ModelProvider } from 'llm-zoo';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import {
+  USAGE_LOG_FLUSH_OUTCOME,
+  UsageLogService,
+} from '@telemetry/UsageLogService';
 import { TraceEmitter } from '@agent/trace';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { recordNormalizedUsage } from '@agent/core/usage/RunUsageAccumulator';
@@ -54,6 +58,7 @@ function createMonitorWithEvents() {
   );
   return {
     monitor,
+    logger,
     events: recorded.events,
     dispose: () => {
       recorded.detach();
@@ -62,7 +67,7 @@ function createMonitorWithEvents() {
   };
 }
 
-describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
+describe('UsageMonitor', () => {
   it('is undefined before any round and caches the totals after recordUsage', async () => {
     const { dispose, monitor } = createMonitorWithEvents();
     try {
@@ -104,6 +109,38 @@ describe('UsageMonitor.lastTotals (SDK Step 7d PR 5)', () => {
       });
       expect(usageData?.usage).not.toHaveProperty('viaChatGptSubscription');
     } finally {
+      dispose();
+    }
+  });
+
+  it('reports permanent relay rejection to the spend-cap caller', async () => {
+    const { dispose, logger, monitor } = createMonitorWithEvents();
+    const error = vi.spyOn(logger, 'error');
+    const log = vi.spyOn(UsageLogService, 'log').mockImplementation(() => {});
+    const flush = vi
+      .spyOn(UsageLogService, 'flush')
+      .mockResolvedValue(USAGE_LOG_FLUSH_OUTCOME.REJECTED);
+
+    try {
+      const state = AgentRunStateSnapshotSchema.parse({});
+      recordNormalizedUsage(state.usageAccumulator, {
+        inputTokens: 10,
+        outputTokens: 2,
+        cost: 0.01,
+        responseTimeMs: 50,
+        provider: 'openai-response',
+        usageRoute: 'relay',
+      });
+
+      await monitor.recordUsage(state);
+
+      expect(error).toHaveBeenCalledWith(
+        'Relay usage logging was permanently rejected; spend-cap accounting is incomplete.',
+      );
+    } finally {
+      error.mockRestore();
+      log.mockRestore();
+      flush.mockRestore();
       dispose();
     }
   });

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -8,7 +8,10 @@ import {
   type Mock,
 } from 'vitest';
 
-import { UsageLogService } from '@telemetry/UsageLogService';
+import {
+  USAGE_LOG_FLUSH_OUTCOME,
+  UsageLogService,
+} from '@telemetry/UsageLogService';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { SupabaseClient } from '@auth/SupabaseClient';
 
@@ -33,6 +36,10 @@ function batchId(batch: unknown): string {
   return (batch as { batchId: string }).batchId;
 }
 
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
 // ky passes a Request object; read each batch body from it. `beforeRespond`
 // lets a test stall or fail a specific call before the success response.
 function stubFetch(
@@ -44,12 +51,7 @@ function stubFetch(
   const fetchMock = vi.fn(async (request: Request) => {
     batches.push(await request.json());
     const response = await beforeRespond(fetchMock.mock.calls.length);
-    return (
-      response ??
-      new Response(JSON.stringify({ success: true, accepted: 1 }), {
-        status: 200,
-      })
-    );
+    return response ?? jsonResponse({ success: true, accepted: 1 });
   });
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
@@ -94,8 +96,8 @@ describe('UsageLogService', () => {
 
     releaseFirstFetch?.();
     await expect(Promise.all([firstFlush, secondFlush])).resolves.toEqual([
-      true,
-      true,
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
     ]);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -111,65 +113,50 @@ describe('UsageLogService', () => {
     const fetchMock = stubFetch(batches);
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(false);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.PENDING,
+    );
 
     expect(fetchMock).not.toHaveBeenCalled();
 
-    await expect(UsageLogService.flush()).resolves.toBe(true);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(batches.map(batchModels)).toEqual([['first']]);
   });
 
-  it('requeues entries when send fails after dequeue', async () => {
+  it.each([
+    ['network failure', new Error('network unavailable')],
+    ['malformed acknowledgement', { success: true }],
+    [
+      'retryable rejection',
+      { success: false, accepted: 0, error: 'invalid batch' },
+    ],
+    ['partial acknowledgement', { success: true, accepted: 0 }],
+  ])('requeues entries after a %s', async (_case, firstFailure) => {
     vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue('token');
 
     const batches: unknown[] = [];
     const fetchMock = stubFetch(batches, (callCount) => {
-      if (callCount === 1) {
-        throw new Error('network unavailable');
-      }
+      if (callCount !== 1) return;
+      if (firstFailure instanceof Error) throw firstFailure;
+      return jsonResponse(firstFailure);
     });
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(false);
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    await expect(UsageLogService.flush()).resolves.toBe(true);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.PENDING,
+    );
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['first'], ['first']]);
     expect(batchId(batches[1])).toBe(batchId(batches[0]));
   });
-
-  it.each([
-    ['malformed', { success: true }],
-    ['rejected', { success: false, accepted: 0, error: 'invalid batch' }],
-    ['partial', { success: true, accepted: 0 }],
-  ])(
-    'requeues entries after a %s acknowledgement',
-    async (_case, acknowledgement) => {
-      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
-        'token',
-      );
-
-      const batches: unknown[] = [];
-      const fetchMock = stubFetch(batches, (callCount) => {
-        if (callCount === 1) {
-          return new Response(JSON.stringify(acknowledgement), { status: 200 });
-        }
-      });
-
-      UsageLogService.log(usageEntry('first'));
-      await expect(UsageLogService.flush()).resolves.toBe(false);
-      await expect(UsageLogService.flush()).resolves.toBe(true);
-
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(batches.map(batchModels)).toEqual([['first'], ['first']]);
-      expect(batchId(batches[1])).toBe(batchId(batches[0]));
-    },
-  );
 
   it('discards a permanent rejection and continues with later entries', async () => {
     vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue('token');
@@ -180,17 +167,15 @@ describe('UsageLogService', () => {
     });
     const batches: unknown[] = [];
     const fetchMock = stubFetch(batches, async (callCount) => {
+      if (callCount === 2) throw new Error('network unavailable');
       if (callCount !== 1) return;
       await rejectionReleased;
-      return new Response(
-        JSON.stringify({
-          success: false,
-          accepted: 0,
-          error: 'invalid batch',
-          retryable: false,
-        }),
-        { status: 200 },
-      );
+      return jsonResponse({
+        success: false,
+        accepted: 0,
+        error: 'invalid batch',
+        retryable: false,
+      });
     });
 
     UsageLogService.log(usageEntry('invalid'));
@@ -200,13 +185,20 @@ describe('UsageLogService', () => {
     UsageLogService.log(usageEntry('valid'));
     releaseRejection?.();
 
-    await expect(flush).resolves.toBe(true);
+    await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.REJECTED);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(batches.map(batchModels)).toEqual([['invalid'], ['valid']]);
     expect(batchId(batches[1])).not.toBe(batchId(batches[0]));
 
-    await expect(UsageLogService.flush()).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+    );
+    expect(batches.map(batchModels)).toEqual([
+      ['invalid'],
+      ['valid'],
+      ['valid'],
+    ]);
+    expect(batchId(batches[2])).toBe(batchId(batches[1]));
   });
 
   it('keeps a failed batch id separate from later queued entries', async () => {
@@ -220,10 +212,14 @@ describe('UsageLogService', () => {
     });
 
     UsageLogService.log(usageEntry('first'));
-    await expect(UsageLogService.flush()).resolves.toBe(false);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.PENDING,
+    );
 
     UsageLogService.log(usageEntry('second'));
-    await expect(UsageLogService.flush()).resolves.toBe(true);
+    await expect(UsageLogService.flush()).resolves.toBe(
+      USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(batches.map(batchModels)).toEqual([


### PR DESCRIPTION
## Summary

- replace `UsageLogService.flush()`'s ambiguous boolean with `accepted | pending | rejected`
- preserve permanent-rejection evidence while continuing later valid batches
- report rejected relay accounting to the spend-cap caller
- consolidate retry-cause coverage and remove redundant assertions

## Issue acceptance gates

Closes #8312. Full acknowledgements return `accepted`; ambiguous failures retain the batch and return `pending`; explicit `retryable: false` rejection returns `rejected` while later queued batches continue. The spend-cap caller now distinguishes permanent accounting loss from a retryable delay. Aggregate precedence is `rejected` over `pending` over `accepted`: a later retry cannot erase permanent loss, while the retained batch remains warning-logged and queued.

## Single source of truth

`UsageLogService` owns the client flush outcome and its aggregation across concurrent/multi-batch flushes. The wire acknowledgement schema remains owned by `UsageLogTypes.ts`.

## Duplication and abstraction budget

No quarantine, counters, or pass-through layer added. The standalone network retry test is folded into the existing retry-cause table, reducing `UsageLogService.vitest.ts` from 237 to 233 lines while preserving the same failure cases.

## Net elements (R6)

- files: 4 modified, 0 added, 0 deleted
- exported symbols: 2 added (`USAGE_LOG_FLUSH_OUTCOME`, `UsageLogFlushOutcome`), 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- net LoC: +56 (142 additions, 86 deletions), including focused caller coverage

## Consumer counts (R8)

`UsageLogService.flush()` has 1 external production consumer (`UsageMonitor`) plus internal timer/dispose calls that intentionally ignore the outcome. No event or subscriber path is deleted.

## Host impact

Extension: relay-backed rounds surface permanent accounting rejection through the run trace.

Desktop: shared runtime behavior only; no desktop-specific API change.

CLI: shared runtime behavior only; rejected relay accounting is no longer reported like successful delivery.

## Scheduled refactoring

None.

## Validation

- focused Vitest: 11 tests passed
- `npm run typecheck`
- targeted ESLint: 0 warnings/errors
- `npm run compile:fast`
- `npm test`: 6,001 passed, 4 skipped
- Prettier and `git diff --check`
