### PR TITLE
fix: propagate YOLO across parallel approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.
 - **Approvals remain tied to the current session and proposal** — stale or
   unreadable diff fallbacks cannot be approved, and concurrent sessions no
   longer share pending approval state.
+- **YOLO approval carries across parallel tool calls** — approving the first
+  command or file edit for a stream now lets the remaining queued calls observe
+  that decision instead of prompting one by one.
 - **Background work reconnects more reliably** — waiting parents wake when a
   background shell task finishes, and Claude-agent sessions can recover their
   resume state from disk after a reload or crash.

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -2,7 +2,7 @@
  * Generic stream-scoped approval controller, owned per session.
  *
  * Encapsulates the shared concerns of bash and tool-edit approvals:
- *   - serialized request queue (one prompt at a time within a session)
+ *   - serialized request queues (one prompt at a time per stream)
  *   - registry of in-flight pending approvals keyed by request id
  *   - per-stream bypass state announced over a bound progress event
  *   - rejection on stream cleanup
@@ -101,7 +101,10 @@ export interface StreamApprovalController<R extends { accepted: boolean }> {
   registerPending(id: string, entry: PendingApproval<R>): void;
   unregisterPending(id: string): void;
   bypass: StreamApprovalBypass;
-  enqueue<T>(run: () => Promise<T>): Promise<T>;
+  enqueue<T>(
+    streamId: StreamTabId | undefined,
+    run: () => Promise<T>,
+  ): Promise<T>;
   rejectPendingForStream(streamId: StreamTabId): void;
   /**
    * Reject pending entries with no concrete stream context (streamId is
@@ -123,8 +126,7 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
   options: StreamApprovalControllerOptions<R>,
 ): StreamApprovalController<R> {
   const pending = new Map<string, PendingApproval<R>>();
-  // Serialize approvals so only one prompt is in flight at a time.
-  const queue = new PQueue({ concurrency: 1 });
+  const queues = new Map<StreamTabId | undefined, PQueue>();
 
   function rejectWhere(
     predicate: (entry: PendingApproval<R>) => boolean,
@@ -144,10 +146,25 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
       pending.delete(id);
     },
     bypass: createStreamApprovalBypass(options.bypassEvent),
-    enqueue<T>(run: () => Promise<T>): Promise<T> {
+    enqueue<T>(streamId, run): Promise<T> {
+      let queue = queues.get(streamId);
+      if (!queue) {
+        queue = new PQueue({ concurrency: 1 });
+        queues.set(streamId, queue);
+      }
+
       // `add` widens to `T | void` to cover abort via signal/timeout; we pass
       // neither, so the task always runs and resolves with `T`.
-      return queue.add(run) as Promise<T>;
+      const task = queue.add(run) as Promise<T>;
+      return task.finally(() => {
+        if (
+          queue.pending === 0 &&
+          queue.size === 0 &&
+          queues.get(streamId) === queue
+        ) {
+          queues.delete(streamId);
+        }
+      });
     },
     rejectPendingForStream(streamId) {
       rejectWhere((entry) => entry.streamId === streamId);

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -141,9 +141,12 @@ describe('session-owned approval state (#8144)', () => {
 
     try {
       // Session A's prompt slot is occupied by a never-answered approval.
-      void sessionA.approvals.bash.enqueue(() => new Promise(() => {}));
+      void sessionA.approvals.bash.enqueue(
+        undefined,
+        () => new Promise(() => {}),
+      );
 
-      const ranInB = sessionB.approvals.bash.enqueue(() =>
+      const ranInB = sessionB.approvals.bash.enqueue(undefined, () =>
         Promise.resolve('answered'),
       );
 

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -3,6 +3,7 @@ import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import * as assert from 'node:assert';
+import pDefer from 'p-defer';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports - tests
@@ -24,6 +25,7 @@ import {
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
 } from '@tools/approval';
+import { requestToolEditApproval } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 
 // Test stream ID for per-stream YOLO mode tests
@@ -216,6 +218,53 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(handlerCalled, false);
     assert.strictEqual(writtenContent, 'auto');
     assert.strictEqual(result.output, 'written');
+  });
+
+  it('rechecks session bypass between concurrent approval requests', async () => {
+    const firstApproval = pDefer<ToolEditApprovalResult>();
+    const firstPrompted = pDefer<void>();
+    let handlerCalls = 0;
+
+    testApprovalHandler = async () => {
+      handlerCalls += 1;
+      firstPrompted.resolve();
+      return firstApproval.promise;
+    };
+
+    const requestInStream = (path: string) =>
+      withRunContext(
+        createRunContext({
+          runtimeHost: noopAgentRuntimeHost,
+          streamId: TEST_STREAM_ID,
+        }),
+        () =>
+          requestToolEditApproval({
+            path,
+            originalContent: '',
+            proposedContent: path,
+            sourceTool: 'write_file',
+          }),
+      );
+
+    const firstRequest = requestInStream('first.txt');
+    const secondRequest = requestInStream('second.txt');
+    await firstPrompted.promise;
+
+    assert.strictEqual(handlerCalls, 1);
+    setToolEditApprovalSessionBypass(
+      TEST_STREAM_ID,
+      true,
+      noopAgentRuntimeHost,
+      { silent: true },
+    );
+    firstApproval.resolve({ accepted: true });
+
+    const results = await Promise.all([firstRequest, secondRequest]);
+    assert.deepStrictEqual(
+      results.map((result) => result.accepted),
+      [true, true],
+    );
+    assert.strictEqual(handlerCalls, 1);
   });
 
   it('keeps text editor undo history isolated between execution ids', async () => {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -89,7 +89,7 @@ export async function requestBashApproval(
 
   const runtimeHost = requireRuntimeHost('bash approval', context);
 
-  return session.approvals.bash.enqueue(() =>
+  return session.approvals.bash.enqueue(streamId, () =>
     showApprovalPrompt(request, streamId, runtimeHost, session),
   );
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -253,15 +253,21 @@ export async function requestToolEditApproval(
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
 
-  const hostInteraction =
-    session.interactions.requestToolEditApproval(preparedRequest);
-  if (hostInteraction) {
-    return finalizeApprovalResult(await hostInteraction, preparedRequest);
-  }
+  return session.approvals.toolEdit.enqueue(streamId, async () => {
+    if (streamId && session.approvals.toolEdit.bypass.isBypassed(streamId)) {
+      return finalizeApprovalResult({ accepted: true }, preparedRequest);
+    }
 
-  throw new Error(
-    'Tool edit approval requires session.interactions.requestToolEditApproval.',
-  );
+    const hostInteraction =
+      session.interactions.requestToolEditApproval(preparedRequest);
+    if (hostInteraction) {
+      return finalizeApprovalResult(await hostInteraction, preparedRequest);
+    }
+
+    throw new Error(
+      'Tool edit approval requires session.interactions.requestToolEditApproval.',
+    );
+  });
 }
 
 function finalizeApprovalResult(


### PR DESCRIPTION
## Summary

- serialize approval prompts per stream rather than globally or not at all
- recheck YOLO bypass when queued Bash/file-edit calls reach the prompt boundary
- preserve independent approval prompts across different streams
- add one focused same-stream concurrency regression
- document the user-visible fix for 0.39.4

## Design

Tool-edit approval bypass and queue ownership had diverged: the session controller owned a queue, but edit requests called the host directly. Routing both approval kinds through stream-scoped queues keeps policy and sequencing behind one session-owned interface without adding host-specific batch state.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; 46 pre-existing warnings)
- `npm test` (667 files; 6,004 passed, 4 skipped)
- focused approval suites (32 tests)

Closes #8328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-owned approval sequencing for bash and file edits; incorrect queue scoping could block prompts, double-prompt, or auto-approve the wrong stream, but changes are focused and covered by approval tests.
> 
> **Overview**
> **Parallel tool calls on one stream** no longer each block on a separate approval prompt after you approve the first or enable session YOLO. Bash and file-edit requests now share a **per-stream serialized queue** (replacing one queue for the whole session controller), while **different streams and sessions** still approve independently.
> 
> **Tool-edit approval** is routed through that same queue (it previously called the host directly), and both bash and edit paths **re-check per-stream bypass** when a queued item reaches the front—so enabling YOLO while the first prompt is open lets the rest auto-approve without extra UI.
> 
> A regression test covers same-stream concurrent edit approvals; the 0.39.4 changelog documents the user-visible behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243b3349d2c94539ab7bce3a9a60a4d32c8501eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->