### PR TITLE
refactor(cli): carry resolved run outcomes internally

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -41,10 +41,7 @@ import {
   resolveCliResumeSnapshot,
   type CliToolUseResumeResolution,
 } from '@cli/runtime/sessionResume';
-import {
-  cliTerminalStatus,
-  terminalStatusExitCode,
-} from '@cli/runtime/terminalStatus';
+import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import {
   EXECUTION_STATUS,
@@ -408,8 +405,8 @@ export function createChatSessionController(
       })
       .then((result) => {
         agentSettled = true;
-        session.runExitCode = terminalStatusExitCode(
-          cliTerminalStatus(result),
+        session.runExitCode = runOutcomeExitCode(
+          result.outcome,
           sessionContext,
         );
         if (result.streamId) {
@@ -531,8 +528,8 @@ export function createChatSessionController(
           if (session.streamId) {
             projectStreamTranscript(session.streamId, { finalize: true });
           }
-          session.runExitCode = terminalStatusExitCode(
-            cliTerminalStatus(result),
+          session.runExitCode = runOutcomeExitCode(
+            result.outcome,
             sessionContext,
           );
           notify({ kind: 'agentFinished' });

--- a/packages/cli/src/commands/agentsRun.ts
+++ b/packages/cli/src/commands/agentsRun.ts
@@ -25,7 +25,10 @@ import {
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { emitCliResult } from './_helpers/output';
 import { executeCliToolUseConfig } from '../runtime/runExecution';
-import { toolUseResultText } from '../runtime/terminalStatus';
+import {
+  serializeCliRunResult,
+  toolUseResultText,
+} from '../runtime/terminalStatus';
 import { formatToolUseAgentRunInstruction } from './_helpers/toolUseRunInstruction';
 import { withExpandedRunInputs } from '../runtime/workflowInputs';
 
@@ -87,10 +90,11 @@ export async function runToolUseAgent(
       });
       if (!execution.ok) return execution.exitCode;
 
+      const displayResult = serializeCliRunResult(execution.result);
       emitCliResult(runContext, {
-        json: execution.displayResult,
-        ndjson: { kind: 'agent-result', result: execution.displayResult },
-        text: toolUseResultText(execution.displayResult),
+        json: displayResult,
+        ndjson: { kind: 'agent-result', result: displayResult },
+        text: toolUseResultText(execution.result),
       });
 
       return execution.exitCode;

--- a/packages/cli/src/commands/multiAgent.ts
+++ b/packages/cli/src/commands/multiAgent.ts
@@ -49,6 +49,7 @@ import {
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { executeCliToolUseConfig } from '../runtime/runExecution';
 import {
+  serializeCliRunResult,
   toolUseResultText,
   type CliToolUseRunResult,
 } from '../runtime/terminalStatus';
@@ -76,6 +77,7 @@ function writeMultiAgentRunResult(
   plan: CliMultiAgentPresetRunPlan,
   result: CliToolUseRunResult,
 ): void {
+  const displayResult = serializeCliRunResult(result);
   const payload = {
     preset: {
       id: plan.preset.id,
@@ -83,7 +85,7 @@ function writeMultiAgentRunResult(
       source: plan.preset.source,
     },
     rootAgent: plan.rootAgent?.name,
-    result,
+    result: displayResult,
   };
 
   emitCliResult(context, {
@@ -231,7 +233,7 @@ export async function runMultiAgentPreset(
       });
       if (!execution.ok) return execution.exitCode;
 
-      writeMultiAgentRunResult(runContext, plan, execution.displayResult);
+      writeMultiAgentRunResult(runContext, plan, execution.result);
 
       return execution.exitCode;
     },

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -5,11 +5,7 @@ import {
 } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import {
-  EXECUTION_STATUS,
-  RUN_OUTCOME,
-  executionStatusToRunOutcome,
-} from '@shared/schemas';
+import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
@@ -39,7 +35,10 @@ import {
 } from './_helpers/globalArgs';
 import { resolveFileBackedInstruction } from './_helpers/instructionFile';
 import { executeCliConfig } from '../runtime/runExecution';
-import { terminalStatusExitCode } from '../runtime/terminalStatus';
+import {
+  serializeCliRunResult,
+  runOutcomeExitCode,
+} from '../runtime/terminalStatus';
 import {
   hasMixedStdinWorkflowInputSpecs,
   withExpandedRunInputs,
@@ -124,9 +123,7 @@ export async function runWorkflowAgent(
       });
       if (!execution.ok) return execution.exitCode;
 
-      const { executionId, result, terminalStatus } = execution;
-      const outcome =
-        executionStatusToRunOutcome(terminalStatus) ?? result.outcome;
+      const { executionId, result } = execution;
       let workflowResult: CliWorkflowRunResult;
       try {
         workflowResult = await resolveWorkflowOutput(
@@ -138,13 +135,12 @@ export async function runWorkflowAgent(
             expectedOutputFiles: init.outputDir
               ? expectedOutputFilesForOutputDir(agent, inputFiles)
               : undefined,
-            terminalStatus,
           },
         );
         await persistWorkflowResultMeta(
           executionId,
           buildCliWorkflowResultMeta(result, {
-            outcome,
+            outcome: result.outcome,
             copiedOutput: workflowResult.copiedOutput,
             copiedOutputs: workflowResult.copiedOutputs,
           }),
@@ -154,12 +150,12 @@ export async function runWorkflowAgent(
           executionId,
           buildCliWorkflowResultMeta(result, {
             outcome:
-              terminalStatus === EXECUTION_STATUS.INTERRUPTED
-                ? outcome
+              result.outcome === RUN_OUTCOME.CANCELLED
+                ? result.outcome
                 : RUN_OUTCOME.FAILED,
           }),
         );
-        if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+        if (result.outcome === RUN_OUTCOME.CANCELLED) {
           writeErrorStderr(error);
           return CliExitCode.Interrupted;
         }
@@ -169,13 +165,14 @@ export async function runWorkflowAgent(
         return CliExitCode.AgentError;
       }
 
+      const displayResult = serializeCliRunResult(workflowResult);
       emitCliResult(runContext, {
-        json: workflowResult,
-        ndjson: { kind: 'result', result: workflowResult },
+        json: displayResult,
+        ndjson: { kind: 'result', result: displayResult },
         text: formatWorkflowTextResult(workflowResult),
       });
 
-      return terminalStatusExitCode(terminalStatus, runContext);
+      return runOutcomeExitCode(result.outcome, runContext);
     },
   );
 }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -11,7 +11,7 @@ import {
 import { runAgent } from '@agent/runtime/runAgent';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { AgentError } from '@common/errors';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
@@ -22,9 +22,8 @@ import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
 import { CliExitCode } from './exitCodes';
 import { writeTextStderr } from './logSinks';
 import {
-  createCliRunResult,
-  readCliTerminalStatus,
-  terminalStatusExitCode,
+  readCliRunOutcome,
+  runOutcomeExitCode,
   type ExecuteAgentResult,
 } from './terminalStatus';
 import { CLI_UNAVAILABLE_TOOLS } from './unavailableTools';
@@ -69,7 +68,6 @@ export type CliConfigExecuteResult<C extends AgentCategory | undefined> =
       readonly ok: true;
       readonly executionId: string;
       readonly result: ExecuteAgentResultForCategory<C>;
-      readonly terminalStatus: ExecutionStatus;
     }
   | {
       readonly ok: false;
@@ -106,7 +104,7 @@ export async function executeCliConfig<
   if (!execution.ok) {
     return execution;
   }
-  const { result, terminalStatus } = execution;
+  const { result } = execution;
 
   if (expectedCategory !== undefined && result.category !== expectedCategory) {
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
@@ -121,7 +119,6 @@ export async function executeCliConfig<
     ok: true,
     executionId,
     result: result as ExecuteAgentResultForCategory<C>,
-    terminalStatus,
   };
 }
 
@@ -136,23 +133,23 @@ export async function executeCliToolUseConfig(
   });
   if (!execution.ok) return execution;
 
-  const { result, terminalStatus } = execution;
+  const { result } = execution;
   return {
     ok: true,
-    displayResult: createCliRunResult(result, {
-      terminalStatus,
+    result: {
+      ...result,
       workingDirectory: runContext.cwd,
-    }),
-    exitCode: terminalStatusExitCode(terminalStatus, runContext),
+    },
+    exitCode: runOutcomeExitCode(result.outcome, runContext),
   };
 }
 
 /**
  * Shared headless-execution skeleton for `run`, `agents run`, and
  * `multi-agent run`: stand up a runtime host, run the request (optionally
- * wrapped), always close the host, and resolve the terminal status.
+ * wrapped), always close the host, and resolve the terminal outcome.
  * Centralizing this stops the three runners from drifting apart on host
- * lifecycle and status handling, which is how their behavior diverged before.
+ * lifecycle and outcome handling, which is how their behavior diverged before.
  *
  * A classified run failure (AgentRunLifecycle already ran it through
  * `classifyAgentError` and wrote the terminal outcome before rethrowing an
@@ -171,7 +168,7 @@ export async function executeCliRequest(
   runContext: CliContext,
   options: CliExecuteOptions = {},
 ): Promise<
-  | { ok: true; result: ExecuteAgentResult; terminalStatus: ExecutionStatus }
+  | { ok: true; result: ExecuteAgentResult }
   | { ok: false; exitCode: CliExitCode }
 > {
   // Transcript persistence is a launch prerequisite for every headless run.
@@ -286,14 +283,14 @@ export async function executeCliRequest(
   if (!runResult.ok) {
     // The message was already presented once via the run's `result` event
     // (attachTerminalResultToast → requestShowError); nothing more to print
-    // here. Reuse the same status→exit-code mapping the non-throw ERROR path
+    // here. Reuse the same outcome-to-exit-code mapping the non-throw failure path
     // uses below, so approval-denied stays distinct from a generic failure.
     return {
       ok: false,
-      exitCode: terminalStatusExitCode(EXECUTION_STATUS.ERROR, runContext),
+      exitCode: runOutcomeExitCode(RUN_OUTCOME.FAILED, runContext),
     };
   }
 
-  const terminalStatus = await readCliTerminalStatus(runResult.result);
-  return { ok: true, result: runResult.result, terminalStatus };
+  const outcome = await readCliRunOutcome(runResult.result);
+  return { ok: true, result: { ...runResult.result, outcome } };
 }

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -5,9 +5,8 @@ import {
   runOutcomeToExecutionStatus,
 } from '@common/constants/streamStatus';
 import {
-  EXECUTION_STATUS,
-  executionStatusToRunOutcome,
   type ExecutionStatus,
+  RUN_OUTCOME,
   type RunOutcome,
 } from '@shared/schemas';
 
@@ -17,18 +16,23 @@ import type { CliContext } from './cliContext';
 
 export type ExecuteAgentResult = Awaited<ReturnType<typeof runAgent>>;
 
-type CliRunResultFor<T extends ExecuteAgentResult> = T & {
+interface CliRunResultMetadata {
+  readonly workingDirectory?: string;
+  readonly runDirectory?: string;
+  readonly copiedOutput?: string;
+  readonly copiedOutputs?: string[];
+}
+
+type CliRunResultFor<T extends ExecuteAgentResult> = T & CliRunResultMetadata;
+
+type PublishedCliRunResultFor<T extends ExecuteAgentResult> = T & {
   /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   status: ExecutionStatus;
   /** @deprecated Use `outcome`; this is a frozen 2-value projection for JSON-output compatibility. */
   endGroupStatus: 'error' | 'stopped';
   /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   terminalStatus: ExecutionStatus;
-  workingDirectory?: string;
-  runDirectory?: string;
-  copiedOutput?: string;
-  copiedOutputs?: string[];
-};
+} & CliRunResultMetadata;
 
 export type CliRunResult = ExecuteAgentResult extends infer T
   ? T extends ExecuteAgentResult
@@ -41,68 +45,65 @@ export type CliToolUseRunResult = Extract<
   { category: 'toolUse' }
 >;
 
+export type PublishedCliRunResult = ExecuteAgentResult extends infer T
+  ? T extends ExecuteAgentResult
+    ? PublishedCliRunResultFor<T>
+    : never
+  : never;
+
 /** Display text for a finished tool-use run: the last response if present,
  *  otherwise a terse status/execution-id summary. */
 export function toolUseResultText(result: CliToolUseRunResult): string {
   return (
     result.lastResponse?.trim() ||
-    `${result.status}\nExecution: ${result.executionId}`
+    `${runOutcomeToExecutionStatus(result.outcome)}\nExecution: ${result.executionId}`
   );
 }
 
-export function cliTerminalStatus(
-  result: ExecuteAgentResult,
-  storedOutcome?: RunOutcome,
-): ExecutionStatus {
-  return runOutcomeToExecutionStatus(storedOutcome ?? result.outcome);
-}
-
-export function createCliRunResult<T extends ExecuteAgentResult>(
-  result: T,
-  extras: {
-    readonly terminalStatus?: ExecutionStatus;
-    readonly workingDirectory?: string;
-    readonly runDirectory?: string;
-    readonly copiedOutput?: string;
-    readonly copiedOutputs?: string[];
-  } = {},
-): T extends ExecuteAgentResult ? CliRunResultFor<T> : never {
-  const { terminalStatus: resolvedTerminalStatus, ...metadata } = extras;
-  const terminalStatus =
-    resolvedTerminalStatus ?? runOutcomeToExecutionStatus(result.outcome);
-  const terminalOutcome =
-    executionStatusToRunOutcome(terminalStatus) ?? result.outcome;
+/** Add the frozen v0.40 status fields at the CLI serialization boundary. */
+export function serializeCliRunResult<T extends ExecuteAgentResult>(
+  result: CliRunResultFor<T>,
+): T extends ExecuteAgentResult ? PublishedCliRunResultFor<T> : never {
+  const {
+    workingDirectory,
+    runDirectory,
+    copiedOutput,
+    copiedOutputs,
+    ...executionResult
+  } = result;
+  const terminalStatus = runOutcomeToExecutionStatus(result.outcome);
   return {
-    ...result,
+    ...executionResult,
     status: terminalStatus,
-    endGroupStatus: legacyEndGroupStatusForOutcome(terminalOutcome),
+    endGroupStatus: legacyEndGroupStatusForOutcome(result.outcome),
     terminalStatus,
-    ...metadata,
-  } as T extends ExecuteAgentResult ? CliRunResultFor<T> : never;
+    ...(Object.hasOwn(result, 'workingDirectory') ? { workingDirectory } : {}),
+    ...(Object.hasOwn(result, 'runDirectory') ? { runDirectory } : {}),
+    ...(Object.hasOwn(result, 'copiedOutput') ? { copiedOutput } : {}),
+    ...(Object.hasOwn(result, 'copiedOutputs') ? { copiedOutputs } : {}),
+  } as T extends ExecuteAgentResult ? PublishedCliRunResultFor<T> : never;
 }
 
-/** Map a terminal execution status to the CLI process exit code, treating an
+/** Map a run outcome to the CLI process exit code, treating an
  *  approval-denied error distinctly from a generic agent error. */
-export function terminalStatusExitCode(
-  terminalStatus: ExecutionStatus,
+export function runOutcomeExitCode(
+  outcome: RunOutcome,
   context: CliContext,
 ): CliExitCode {
-  if (terminalStatus === EXECUTION_STATUS.ERROR) {
+  if (outcome === RUN_OUTCOME.FAILED) {
     return hasCliApprovalDenied(context)
       ? CliExitCode.ApprovalDenied
       : CliExitCode.AgentError;
   }
-  if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
+  if (outcome === RUN_OUTCOME.CANCELLED) {
     return CliExitCode.Interrupted;
   }
   return CliExitCode.Success;
 }
 
-export async function readCliTerminalStatus(
+export async function readCliRunOutcome(
   result: ExecuteAgentResult,
-): Promise<ExecutionStatus> {
-  const meta = await getExecutionStore(result.executionId)
-    .readMeta()
-    .catch(() => undefined);
-  return cliTerminalStatus(result, meta?.outcome);
+): Promise<RunOutcome> {
+  const meta = await getExecutionStore(result.executionId).readMeta();
+  return meta?.outcome ?? result.outcome;
 }

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -5,8 +5,9 @@ import type { AgentEntry } from '@agent/index';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
+import { runOutcomeToExecutionStatus } from '@common/constants/streamStatus';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import { RUN_OUTCOME } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { getRunDir } from '@utils/files';
@@ -16,11 +17,7 @@ import { getRunDir } from '@utils/files';
 import { toPosixPath } from '@utils/core/pathCore';
 
 import { CliUsageError, type CliContext } from './cliContext';
-import {
-  createCliRunResult,
-  type CliRunResult,
-  type ExecuteAgentResult,
-} from './terminalStatus';
+import { type CliRunResult, type ExecuteAgentResult } from './terminalStatus';
 import {
   isMaterializedStdinWorkflowInputPath,
   STDIN_WORKFLOW_INPUT_BASENAME,
@@ -96,7 +93,6 @@ type WorkflowAgentResult = Extract<
 interface WorkflowOutputResolutionOptions {
   readonly expectedOutputFiles?: readonly string[];
   readonly runDirectory?: string;
-  readonly terminalStatus: ExecutionStatus;
 }
 
 function outputCopyRelativePath(output: OutputFileSummary): string {
@@ -203,13 +199,13 @@ export async function resolveWorkflowOutput(
   context: CliContext,
   options: WorkflowOutputResolutionOptions,
 ): Promise<CliWorkflowRunResult> {
-  const { terminalStatus } = options;
+  const terminalStatus = runOutcomeToExecutionStatus(result.outcome);
   if (result.outputs.length === 0 && (outputFile || outputDir)) {
-    if (terminalStatus === EXECUTION_STATUS.INTERRUPTED) {
-      return createCliRunResult(result, {
-        terminalStatus,
+    if (result.outcome === RUN_OUTCOME.CANCELLED) {
+      return {
+        ...result,
         workingDirectory: context.cwd,
-      });
+      };
     }
     if (outputDir) {
       throw new Error(
@@ -258,29 +254,29 @@ export async function resolveWorkflowOutput(
       );
     }
 
-    return createCliRunResult(result, {
-      terminalStatus,
+    return {
+      ...result,
       workingDirectory: context.cwd,
       runDirectory,
       copiedOutputs,
-    });
+    };
   }
 
   if (!outputFile) {
-    return createCliRunResult(result, {
-      terminalStatus,
+    return {
+      ...result,
       workingDirectory: context.cwd,
       runDirectory,
-    });
+    };
   }
 
   const finalOutput = latestWorkflowOutput(result.outputs);
   if (!finalOutput) {
-    return createCliRunResult(result, {
-      terminalStatus,
+    return {
+      ...result,
       workingDirectory: context.cwd,
       runDirectory,
-    });
+    };
   }
 
   const targetPath = joinCwdRelative(outputFile, context.cwd);
@@ -289,12 +285,12 @@ export async function resolveWorkflowOutput(
     await fs.copyFile(finalOutput.absolutePath, targetPath);
   }
 
-  return createCliRunResult(result, {
-    terminalStatus,
+  return {
+    ...result,
     workingDirectory: context.cwd,
     runDirectory,
     copiedOutput: targetPath,
-  });
+  };
 }
 
 export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
@@ -306,7 +302,11 @@ export function formatWorkflowTextResult(result: CliWorkflowRunResult): string {
   }
 
   const finalOutput = result.outputs.at(-1);
-  return finalOutput?.absolutePath ?? result.runDirectory ?? result.status;
+  return (
+    finalOutput?.absolutePath ??
+    result.runDirectory ??
+    runOutcomeToExecutionStatus(result.outcome)
+  );
 }
 
 export function resumeWorkflowOutputFile(

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
+  emitCliResult: vi.fn(),
   executeCliToolUseConfig: vi.fn(),
   withExpandedRunInputs: vi.fn(),
   initLocalCliPlatform: vi.fn(),
@@ -50,7 +53,7 @@ vi.mock('@cli/runtime/logSinks', () => ({
 }));
 
 vi.mock('@cli/commands/_helpers/output', () => ({
-  emitCliResult: vi.fn(),
+  emitCliResult: mocks.emitCliResult,
 }));
 
 vi.mock('@cli/runtime/agents', async (importOriginal) => ({
@@ -112,7 +115,14 @@ describe('CLI agents run command', () => {
     );
     mocks.executeCliToolUseConfig.mockResolvedValue({
       ok: true,
-      displayResult: { lastResponse: 'Correct.' },
+      result: {
+        category: AgentCategory.ToolUse,
+        executionId: 'exec-1',
+        streamId: 'stream-1',
+        outcome: RUN_OUTCOME.COMPLETED,
+        lastResponse: 'Correct.',
+        workingDirectory: '/tmp/project',
+      },
       exitCode: 0,
     });
   });
@@ -160,6 +170,64 @@ describe('CLI agents run command', () => {
     expect(config?.instruction).toContain('- "notes.md"');
     expect(config?.instruction).toContain('Additional user instruction:');
     expect(config?.instruction).toContain('Assess the proof concisely.');
+    const emission = mocks.emitCliResult.mock.calls[0]?.[1];
+    expect(emission?.json).toEqual({
+      category: AgentCategory.ToolUse,
+      executionId: 'exec-1',
+      streamId: 'stream-1',
+      outcome: RUN_OUTCOME.COMPLETED,
+      lastResponse: 'Correct.',
+      status: EXECUTION_STATUS.COMPLETED,
+      endGroupStatus: 'stopped',
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+      workingDirectory: '/tmp/project',
+    });
+    expect(Object.keys(emission?.json ?? {})).toEqual([
+      'category',
+      'executionId',
+      'streamId',
+      'outcome',
+      'lastResponse',
+      'status',
+      'endGroupStatus',
+      'terminalStatus',
+      'workingDirectory',
+    ]);
+    expect(emission?.ndjson).toEqual({
+      kind: 'agent-result',
+      result: emission.json,
+    });
+    expect(emission?.text).toBe('Correct.');
+  });
+
+  it('publishes the frozen projection for a shutdown cancellation', async () => {
+    mocks.executeCliToolUseConfig.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        category: AgentCategory.ToolUse,
+        executionId: 'exec-interrupted',
+        streamId: 'stream-interrupted',
+        outcome: RUN_OUTCOME.CANCELLED,
+        workingDirectory: '/tmp/project',
+      },
+      exitCode: CliExitCode.Interrupted,
+    });
+    const { runToolUseAgent } = await import('@cli/commands/agentsRun');
+
+    const exitCode = await runToolUseAgent(cliContext(), {
+      agent: 'chat',
+      inputFiles: ['problem.md'],
+      contextFiles: [],
+      instruction: 'Assess the proof.',
+    });
+
+    expect(exitCode).toBe(CliExitCode.Interrupted);
+    expect(mocks.emitCliResult.mock.calls[0]?.[1].json).toMatchObject({
+      outcome: RUN_OUTCOME.CANCELLED,
+      status: EXECUTION_STATUS.INTERRUPTED,
+      endGroupStatus: 'stopped',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+    });
   });
 
   it('reports missing instruction before resolving the model', async () => {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -32,10 +32,7 @@ import {
   optionalStringFlagValue,
   rejectHeadlessOnlyFlags,
 } from '@cli/commands/_helpers/globalArgs';
-import {
-  cliTerminalStatus,
-  createCliRunResult,
-} from '@cli/runtime/terminalStatus';
+import { serializeCliRunResult } from '@cli/runtime/terminalStatus';
 import {
   createStdinWorkflowInputMaterializer,
   expandRunInputs,
@@ -855,53 +852,22 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         cliContext(),
-        { terminalStatus: EXECUTION_STATUS.ERROR },
+        {},
       ),
     ).rejects.toThrow(
       'Workflow error without a generated output; corrected.tex was not written.',
     );
   });
 
-  it('maps run outcomes to terminal statuses by default', () => {
-    expect(
-      cliTerminalStatus({
-        outcome: RUN_OUTCOME.COMPLETED,
-      } as Parameters<typeof cliTerminalStatus>[0]),
-    ).toBe(EXECUTION_STATUS.COMPLETED);
-    expect(
-      cliTerminalStatus({
-        outcome: RUN_OUTCOME.CANCELLED,
-      } as Parameters<typeof cliTerminalStatus>[0]),
-    ).toBe(EXECUTION_STATUS.INTERRUPTED);
-    expect(
-      cliTerminalStatus({
-        outcome: RUN_OUTCOME.FAILED,
-      } as Parameters<typeof cliTerminalStatus>[0]),
-    ).toBe(EXECUTION_STATUS.ERROR);
-  });
-
-  it('honors stored cancelled outcome', () => {
-    expect(
-      cliTerminalStatus(
-        {
-          outcome: RUN_OUTCOME.COMPLETED,
-        } as Parameters<typeof cliTerminalStatus>[0],
-        RUN_OUTCOME.CANCELLED,
-      ),
-    ).toBe(EXECUTION_STATUS.INTERRUPTED);
-  });
-
-  it('includes working directory metadata in CLI run results', () => {
-    const result = createCliRunResult(
-      {
-        outcome: RUN_OUTCOME.COMPLETED,
-        category: AgentCategory.ToolUse,
-        executionId: 'completed-without-output',
-        streamId: 'stream-without-output',
-        lastResponse: 'done',
-      } as Parameters<typeof createCliRunResult>[0],
-      { workingDirectory: '/tmp/project' },
-    );
+  it('projects frozen CLI status fields before result metadata', () => {
+    const result = serializeCliRunResult({
+      outcome: RUN_OUTCOME.COMPLETED,
+      category: AgentCategory.ToolUse,
+      executionId: 'completed-without-output',
+      streamId: 'stream-without-output',
+      lastResponse: 'done',
+      workingDirectory: '/tmp/project',
+    } as Parameters<typeof serializeCliRunResult>[0]);
 
     expect(result).toMatchObject({
       executionId: 'completed-without-output',
@@ -910,22 +876,28 @@ describe('CLI root argument routing', () => {
       status: EXECUTION_STATUS.COMPLETED,
       endGroupStatus: 'stopped',
     });
+    expect(Object.keys(result)).toEqual([
+      'outcome',
+      'category',
+      'executionId',
+      'streamId',
+      'lastResponse',
+      'status',
+      'endGroupStatus',
+      'terminalStatus',
+      'workingDirectory',
+    ]);
   });
 
-  it('uses a caller-resolved terminal status in CLI run results', () => {
-    const result = createCliRunResult(
-      {
-        outcome: RUN_OUTCOME.COMPLETED,
-        category: AgentCategory.ToolUse,
-        executionId: 'completed-after-shutdown',
-        streamId: 'stream-after-shutdown',
-        lastResponse: 'done',
-      } as Parameters<typeof createCliRunResult>[0],
-      {
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-        workingDirectory: '/tmp/project',
-      },
-    );
+  it('projects a resolved cancellation with the frozen v0.40 values', () => {
+    const result = serializeCliRunResult({
+      outcome: RUN_OUTCOME.CANCELLED,
+      category: AgentCategory.ToolUse,
+      executionId: 'completed-after-shutdown',
+      streamId: 'stream-after-shutdown',
+      lastResponse: 'done',
+      workingDirectory: '/tmp/project',
+    } as Parameters<typeof serializeCliRunResult>[0]);
 
     expect(result).toMatchObject({
       executionId: 'completed-after-shutdown',
@@ -933,6 +905,22 @@ describe('CLI root argument routing', () => {
       terminalStatus: EXECUTION_STATUS.INTERRUPTED,
       status: EXECUTION_STATUS.INTERRUPTED,
       endGroupStatus: 'stopped',
+    });
+  });
+
+  it('projects a failed outcome with the frozen v0.40 values', () => {
+    const result = serializeCliRunResult({
+      outcome: RUN_OUTCOME.FAILED,
+      category: AgentCategory.ToolUse,
+      executionId: 'failed-run',
+      streamId: 'failed-stream',
+    } as Parameters<typeof serializeCliRunResult>[0]);
+
+    expect(result).toMatchObject({
+      outcome: RUN_OUTCOME.FAILED,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      status: EXECUTION_STATUS.ERROR,
+      endGroupStatus: 'error',
     });
   });
 
@@ -1010,7 +998,7 @@ describe('CLI root argument routing', () => {
           compileFailures: [],
         },
         cliContext(),
-        { terminalStatus: EXECUTION_STATUS.COMPLETED },
+        {},
       ),
     ).rejects.toThrow(
       'Workflow completed without a generated output; corrected.tex was not written.',
@@ -1030,12 +1018,13 @@ describe('CLI root argument routing', () => {
         compileFailures: [],
       },
       cliContext(),
-      { terminalStatus: EXECUTION_STATUS.INTERRUPTED },
+      {},
     );
 
     expect(result).toMatchObject({
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
     });
+    expect(Object.hasOwn(result, 'terminalStatus')).toBe(false);
     expect(Object.hasOwn(result, 'copiedOutput')).toBe(false);
   });
 

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -5,8 +5,10 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CliContext } from '@cli/runtime/cliContext';
+import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
+  emitCliResult: vi.fn(),
   executeCliToolUseConfig: vi.fn(),
   withExpandedRunInputs: vi.fn(),
   cliMultiAgentPlanHasGaps: vi.fn(),
@@ -48,6 +50,10 @@ vi.mock('@cli/runtime/logSinks', () => ({
   writeNdjsonStdout: vi.fn(),
   writeTextStderr: mocks.writeTextStderr,
   writeTextStdout: mocks.writeTextStdout,
+}));
+
+vi.mock('@cli/commands/_helpers/output', () => ({
+  emitCliResult: mocks.emitCliResult,
 }));
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({
@@ -205,7 +211,14 @@ describe('CLI multi-agent run command', () => {
     mocks.canAccessRemoteAgentCatalog.mockResolvedValue(false);
     mocks.executeCliToolUseConfig.mockResolvedValue({
       ok: true,
-      displayResult: { lastResponse: 'The proof is correct.' },
+      result: {
+        category: 'toolUse',
+        executionId: 'exec-team',
+        streamId: 'stream-team',
+        outcome: RUN_OUTCOME.COMPLETED,
+        lastResponse: 'The proof is correct.',
+        workingDirectory: '/tmp/project',
+      },
       exitCode: 0,
     });
   });
@@ -249,6 +262,34 @@ describe('CLI multi-agent run command', () => {
     expect(config?.instruction).toContain(
       'Do not end by asking the user whether to perform more work',
     );
+    const emission = mocks.emitCliResult.mock.calls[0]?.[1];
+    expect(emission?.json.result).toEqual({
+      category: 'toolUse',
+      executionId: 'exec-team',
+      streamId: 'stream-team',
+      outcome: RUN_OUTCOME.COMPLETED,
+      lastResponse: 'The proof is correct.',
+      status: EXECUTION_STATUS.COMPLETED,
+      endGroupStatus: 'stopped',
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+      workingDirectory: '/tmp/project',
+    });
+    expect(Object.keys(emission?.json.result ?? {})).toEqual([
+      'category',
+      'executionId',
+      'streamId',
+      'outcome',
+      'lastResponse',
+      'status',
+      'endGroupStatus',
+      'terminalStatus',
+      'workingDirectory',
+    ]);
+    expect(emission?.ndjson).toEqual({
+      kind: 'multi-agent-result',
+      ...emission.json,
+    });
+    expect(emission?.text).toBe('The proof is correct.');
   });
 
   it('marks run-plan resolution when authenticated gaps triggered a remote load', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => ({
   createCliRuntimeHost: vi.fn(),
   disposeHostInteractions: vi.fn(),
   prepareInteractivePrompt: vi.fn(),
-  readCliTerminalStatus: vi.fn(),
+  readCliRunOutcome: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
   writeTerminalStatus: vi.fn(),
@@ -93,7 +93,7 @@ vi.mock('@cli/runtime/approvalAdapter', async (importOriginal) => ({
 
 vi.mock('@cli/runtime/terminalStatus', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@cli/runtime/terminalStatus')>()),
-  readCliTerminalStatus: mocks.readCliTerminalStatus,
+  readCliRunOutcome: mocks.readCliRunOutcome,
 }));
 
 vi.mock('@cli/runtime/sessionProgressSubscription', () => ({
@@ -157,11 +157,11 @@ function stubRunExecutionDeps(): void {
     prepareInteractivePrompt: mocks.prepareInteractivePrompt,
     close: mocks.close,
   });
-  mocks.readCliTerminalStatus.mockResolvedValue('completed');
+  mocks.readCliRunOutcome.mockResolvedValue('completed');
   mocks.runAgent.mockResolvedValue({
     category: 'toolUse',
     executionId: 'exec-1',
-    status: 'completed',
+    outcome: 'completed',
     streamId: 'stream-1',
   });
 }
@@ -647,10 +647,19 @@ describe('executeCliRequest', () => {
     resolveRun?.({
       category: 'toolUse',
       executionId: 'exec-1',
-      status: 'completed',
+      outcome: 'completed',
       streamId: 'stream-1',
     });
-    await run;
+    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
+    await expect(run).resolves.toEqual({
+      ok: true,
+      result: {
+        category: 'toolUse',
+        executionId: 'exec-1',
+        outcome: 'cancelled',
+        streamId: 'stream-1',
+      },
+    });
     expect(mocks.writeTerminalStatus).toHaveBeenCalledTimes(2);
     expect(mocks.writeTerminalStatus).toHaveBeenLastCalledWith(
       'exec-1',
@@ -695,7 +704,7 @@ describe('executeCliConfig', () => {
     expect(mocks.runAgent).not.toHaveBeenCalled();
   });
 
-  it('derives the CLI display result and exit code for tool-use configs', async () => {
+  it('derives the internal CLI result and exit code for tool-use configs', async () => {
     const { AgentCategory } =
       await import('@agent/core/definition/AgentDataclass');
     const { executeCliToolUseConfig } =
@@ -706,9 +715,7 @@ describe('executeCliConfig', () => {
       outcome: 'completed',
       lastResponse: 'Done.',
     });
-    mocks.readCliTerminalStatus.mockResolvedValueOnce(
-      EXECUTION_STATUS.COMPLETED,
-    );
+    mocks.readCliRunOutcome.mockResolvedValueOnce('completed');
 
     const result = await executeCliToolUseConfig(
       toolUseConfig(),
@@ -722,16 +729,24 @@ describe('executeCliConfig', () => {
     expect(result).toMatchObject({
       ok: true,
       exitCode: 0,
-      displayResult: {
-        status: EXECUTION_STATUS.COMPLETED,
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
+      result: {
+        outcome: 'completed',
         workingDirectory: '/tmp/project',
         lastResponse: 'Done.',
       },
     });
+    if (result.ok) {
+      expect(Object.keys(result.result)).toEqual([
+        'category',
+        'executionId',
+        'outcome',
+        'lastResponse',
+        'workingDirectory',
+      ]);
+    }
   });
 
-  it('uses the resolved terminal status for tool-use JSON output', async () => {
+  it('carries only the resolved outcome after a shutdown interruption', async () => {
     const { AgentCategory } =
       await import('@agent/core/definition/AgentDataclass');
     const { executeCliToolUseConfig } =
@@ -742,9 +757,7 @@ describe('executeCliConfig', () => {
       outcome: 'completed',
       lastResponse: 'Done.',
     });
-    mocks.readCliTerminalStatus.mockResolvedValueOnce(
-      EXECUTION_STATUS.INTERRUPTED,
-    );
+    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
 
     const result = await executeCliToolUseConfig(
       toolUseConfig(),
@@ -758,13 +771,16 @@ describe('executeCliConfig', () => {
     expect(result).toMatchObject({
       ok: true,
       exitCode: CliExitCode.Interrupted,
-      displayResult: {
-        status: EXECUTION_STATUS.INTERRUPTED,
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-        endGroupStatus: 'stopped',
+      result: {
+        outcome: 'cancelled',
         workingDirectory: '/tmp/project',
       },
     });
+    if (result.ok) {
+      expect(Object.hasOwn(result.result, 'status')).toBe(false);
+      expect(Object.hasOwn(result.result, 'terminalStatus')).toBe(false);
+      expect(Object.hasOwn(result.result, 'endGroupStatus')).toBe(false);
+    }
   });
 
   it('marks executions errored when the resolved category is unexpected', async () => {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -10,11 +10,7 @@ import {
   resolveWorkflowOutput,
 } from '@cli/runtime/workflowOutput';
 import type { CliContext } from '@cli/runtime/cliContext';
-import {
-  END_GROUP_STATUS,
-  EXECUTION_STATUS,
-  RUN_OUTCOME,
-} from '@shared/schemas';
+import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 
 type WorkflowResult = Parameters<typeof resolveWorkflowOutput>[2];
 
@@ -53,10 +49,11 @@ function workflowResult(
     originalPath?: string | null;
     round?: number;
   }>,
+  outcome: RunOutcome = RUN_OUTCOME.COMPLETED,
 ): WorkflowResult {
   return {
     category: AgentCategory.Workflow,
-    outcome: RUN_OUTCOME.COMPLETED,
+    outcome,
     executionId: 'workflow-output-test',
     streamId: 'workflow-output-test',
     compileFailures: [],
@@ -88,32 +85,30 @@ describe('CLI workflow output resolution', () => {
         {
           expectedOutputFiles: ['a.tex', 'b.tex'],
           runDirectory: join(cwd, 'run'),
-          terminalStatus: EXECUTION_STATUS.COMPLETED,
         },
       ),
     ).rejects.toThrow(/b\.tex/);
   });
 
-  it('uses resolved interrupted status for missing workflow output results', async () => {
+  it('carries only the cancelled outcome for missing workflow outputs', async () => {
     const cwd = await makeTempDir();
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       'out.tex',
       undefined,
-      workflowResult([]),
+      workflowResult([], RUN_OUTCOME.CANCELLED),
       testContext(cwd),
-      {
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-      },
+      {},
     );
 
-    expect(displayResult).toMatchObject({
-      status: EXECUTION_STATUS.INTERRUPTED,
-      endGroupStatus: END_GROUP_STATUS.STOPPED,
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+    expect(result).toMatchObject({
+      outcome: RUN_OUTCOME.CANCELLED,
       workingDirectory: cwd,
     });
-    expect(Object.hasOwn(displayResult, 'copiedOutput')).toBe(false);
+    expect(Object.hasOwn(result, 'status')).toBe(false);
+    expect(Object.hasOwn(result, 'terminalStatus')).toBe(false);
+    expect(Object.hasOwn(result, 'endGroupStatus')).toBe(false);
+    expect(Object.hasOwn(result, 'copiedOutput')).toBe(false);
   });
 
   it('copies every expected --output-dir workflow output', async () => {
@@ -127,7 +122,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runA2, 'A2');
     await writeFile(runB, 'B');
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -139,14 +134,11 @@ describe('CLI workflow output resolution', () => {
       {
         expectedOutputFiles: ['a.tex', 'b.tex'],
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
-    expect(displayResult).toMatchObject({
-      status: EXECUTION_STATUS.COMPLETED,
-      endGroupStatus: END_GROUP_STATUS.STOPPED,
-      terminalStatus: EXECUTION_STATUS.COMPLETED,
+    expect(result).toMatchObject({
+      outcome: RUN_OUTCOME.COMPLETED,
       workingDirectory: cwd,
       copiedOutputs: [join(cwd, 'out', 'a.tex'), join(cwd, 'out', 'b.tex')],
     });
@@ -170,7 +162,7 @@ describe('CLI workflow output resolution', () => {
 
     expect(expectedOutputFiles).toEqual(['stdin.tex']);
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -190,11 +182,10 @@ describe('CLI workflow output resolution', () => {
       {
         expectedOutputFiles,
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
-    expect(displayResult).toMatchObject({
+    expect(result).toMatchObject({
       copiedOutputs: [join(cwd, 'out', 'stdin.tex')],
     });
     await expect(readFile(join(cwd, 'out', 'stdin.tex'), 'utf8')).resolves.toBe(
@@ -210,7 +201,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runMain, 'main');
     await writeFile(runSeries, 'series');
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -236,11 +227,10 @@ describe('CLI workflow output resolution', () => {
       {
         expectedOutputFiles: ['paper/main.tex', 'paper/chapters/series.tex'],
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
-    expect(displayResult).toMatchObject({
+    expect(result).toMatchObject({
       copiedOutputs: [
         join(cwd, 'out', 'paper', 'main.tex'),
         join(cwd, 'out', 'paper', 'chapters', 'series.tex'),
@@ -263,7 +253,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runRoot, 'root');
     await writeFile(runNested, 'nested');
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       undefined,
       'out',
       workflowResult([
@@ -289,11 +279,10 @@ describe('CLI workflow output resolution', () => {
       {
         expectedOutputFiles: ['paper/main.tex', 'paper/chapters/main.tex'],
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
-    expect(displayResult).toMatchObject({
+    expect(result).toMatchObject({
       copiedOutputs: [
         join(cwd, 'out', 'paper', 'main.tex'),
         join(cwd, 'out', 'paper', 'chapters', 'main.tex'),
@@ -328,7 +317,6 @@ describe('CLI workflow output resolution', () => {
         {
           expectedOutputFiles: ['paper/input.tex'],
           runDirectory: join(cwd, 'run'),
-          terminalStatus: EXECUTION_STATUS.COMPLETED,
         },
       ),
     ).rejects.toThrow(/paper[/\\]input\.tex/);
@@ -378,7 +366,6 @@ describe('CLI workflow output resolution', () => {
         {
           expectedOutputFiles: ['chapters/series.tex'],
           runDirectory: join(cwd, 'run'),
-          terminalStatus: EXECUTION_STATUS.COMPLETED,
         },
       ),
     ).rejects.toThrow(/chapters[/\\]series\.tex/);
@@ -404,7 +391,6 @@ describe('CLI workflow output resolution', () => {
       {
         expectedOutputFiles: ['a.tex'],
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
@@ -422,7 +408,7 @@ describe('CLI workflow output resolution', () => {
     await writeFile(runA1, 'A1');
     await writeFile(runA2, 'A2');
 
-    const displayResult = await resolveWorkflowOutput(
+    const result = await resolveWorkflowOutput(
       'out/a.tex',
       undefined,
       workflowResult([
@@ -432,11 +418,10 @@ describe('CLI workflow output resolution', () => {
       testContext(cwd),
       {
         runDirectory: join(cwd, 'run'),
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       },
     );
 
-    expect(displayResult).toMatchObject({
+    expect(result).toMatchObject({
       workingDirectory: cwd,
       copiedOutput: join(cwd, 'out', 'a.tex'),
     });

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -141,7 +141,6 @@ describe('CLI workflow run command', () => {
         outputs: [],
         compileFailures: [],
       },
-      terminalStatus: EXECUTION_STATUS.COMPLETED,
     });
   });
 
@@ -356,7 +355,6 @@ describe('CLI workflow run command', () => {
           outputs: [outputSummary],
           compileFailures: [compileFailure],
         },
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       });
 
       const { runWorkflowAgent } = await import('@cli/commands/workflow');
@@ -391,6 +389,34 @@ describe('CLI workflow run command', () => {
           cost: 0,
         },
       });
+      const emission = mocks.emitCliResult.mock.calls[0]?.[1];
+      expect(emission?.json).toMatchObject({
+        outcome: RUN_OUTCOME.COMPLETED,
+        status: EXECUTION_STATUS.COMPLETED,
+        endGroupStatus: 'stopped',
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+        workingDirectory: root,
+        runDirectory: '/tmp/runs/exec-output',
+        copiedOutput: path.join(root, 'polished.tex'),
+      });
+      expect(Object.keys(emission?.json ?? {})).toEqual([
+        'category',
+        'executionId',
+        'streamId',
+        'outcome',
+        'outputs',
+        'compileFailures',
+        'status',
+        'endGroupStatus',
+        'terminalStatus',
+        'workingDirectory',
+        'runDirectory',
+        'copiedOutput',
+      ]);
+      expect(emission?.ndjson).toEqual({
+        kind: 'result',
+        result: emission.json,
+      });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -422,7 +448,6 @@ describe('CLI workflow run command', () => {
           outputs: [outputSummary],
           compileFailures: [],
         },
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       });
 
       const { runWorkflowAgent } = await import('@cli/commands/workflow');
@@ -483,7 +508,6 @@ describe('CLI workflow run command', () => {
           ],
           compileFailures: [],
         },
-        terminalStatus: EXECUTION_STATUS.COMPLETED,
       });
       mocks.writeResultMeta.mockRejectedValueOnce(
         new Error('metadata disk full'),
@@ -537,7 +561,6 @@ describe('CLI workflow run command', () => {
         outputs: [outputSummary],
         compileFailures: [],
       },
-      terminalStatus: EXECUTION_STATUS.COMPLETED,
     });
 
     const { runWorkflowAgent } = await import('@cli/commands/workflow');
@@ -575,11 +598,10 @@ describe('CLI workflow run command', () => {
         category: AgentCategory.Workflow,
         executionId: 'exec-interrupted',
         streamId: 'stream-interrupted',
-        outcome: RUN_OUTCOME.COMPLETED,
+        outcome: RUN_OUTCOME.CANCELLED,
         outputs: [],
         compileFailures: [],
       },
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
     });
 
     const { runWorkflowAgent } = await import('@cli/commands/workflow');

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -119,6 +119,7 @@ import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
 import type { ResumeQueuedToolUseOptions } from '@agent/runtime/resumeQueuedToolUse';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
+import { readCliRunOutcome } from '@cli/runtime/terminalStatus';
 import type { ChatSessionControllerInit } from '@cli/chat/chatSessionController';
 import { createChatSessionController } from '@cli/chat/chatSessionController';
 import {
@@ -176,6 +177,44 @@ function makeSessionContext(): CliContext {
     apiMode: 'included',
   } as CliContext;
 }
+
+describe('CLI terminal outcome resolution', () => {
+  beforeEach(() => {
+    mocks.getExecutionStore.mockReset();
+  });
+
+  it('prefers the persisted post-shutdown outcome', async () => {
+    mocks.getExecutionStore.mockReturnValue({
+      readMeta: vi.fn().mockResolvedValue({
+        outcome: RUN_OUTCOME.CANCELLED,
+      }),
+    });
+
+    await expect(
+      readCliRunOutcome({
+        category: 'toolUse',
+        executionId: 'shutdown-race',
+        outcome: RUN_OUTCOME.COMPLETED,
+        streamId: 'shutdown-race',
+      } as Parameters<typeof readCliRunOutcome>[0]),
+    ).resolves.toBe(RUN_OUTCOME.CANCELLED);
+  });
+
+  it('surfaces storage failures instead of masking them', async () => {
+    mocks.getExecutionStore.mockReturnValue({
+      readMeta: vi.fn().mockRejectedValue(new Error('metadata read failed')),
+    });
+
+    await expect(
+      readCliRunOutcome({
+        category: 'toolUse',
+        executionId: 'broken-storage',
+        outcome: RUN_OUTCOME.COMPLETED,
+        streamId: 'broken-storage',
+      } as Parameters<typeof readCliRunOutcome>[0]),
+    ).rejects.toThrow('metadata read failed');
+  });
+});
 
 function makeInit(
   overrides: Partial<ChatSessionControllerInit> = {},


### PR DESCRIPTION
## Summary

- keep `RunOutcome` as the sole terminal fact in CLI runtime, workflow, multi-agent, and chat paths
- preserve the post-shutdown metadata read so a persisted interruption still replaces the in-memory outcome
- project `status`, `endGroupStatus`, and `terminalStatus` only at JSON and NDJSON emission boundaries
- surface metadata storage failures instead of masking them with the in-memory outcome
- fix compatibility-field values and key order with command-level regression tests

## Design

Previously, the CLI converted `RunOutcome` to the legacy `ExecutionStatus` vocabulary inside runtime objects and sometimes converted it back for control flow. This allowed compatibility fields for older machine consumers to shape internal behavior. The new path resolves the canonical outcome once after host shutdown, carries that value through internal decisions, and serializes the frozen legacy fields only when publishing a result.

The execution store already represents missing or invalid metadata as `null` and logs invalid persisted data. Consequently, the inherited catch-all around `readMeta()` only hid genuine storage failures; it is removed so the shared CLI error path can report them.

This preserves the shutdown race correction from #6989 while reducing duplicated state and conversion paths. Published JSON, NDJSON, text output, and exit codes remain unchanged.

## Net elements (R6)

- remove four legacy status helpers: `cliTerminalStatus`, `createCliRunResult`, `terminalStatusExitCode`, and `readCliTerminalStatus`
- add three outcome-native boundary helpers: `serializeCliRunResult`, `runOutcomeExitCode`, and `readCliRunOutcome`
- remove `terminalStatus` and `displayResult` from internal execution and workflow result shapes
- add two focused assertions to an existing storage-mocked CLI suite, without increasing the host-mock baseline

The result is one fewer helper and one terminal vocabulary in internal CLI code.

## Consumer counts (R8)

- `serializeCliRunResult`: 3 command-family consumers (`agents run`, `multi-agent run`, workflow run)
- `runOutcomeExitCode`: 3 runtime consumers (headless execution, workflow, interactive chat)
- `readCliRunOutcome`: 1 lifecycle owner (`executeCliRequest`)

Closes #8327

## Verification

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `node packages/cli/scripts/validate-run.mjs`
- 177 focused CLI tests
- outcome-storage and host-mock regressions (34 focused tests)
- `npm test` (6,006 passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches exit codes, workflow interruption/cancellation handling, and JSON contract boundaries across all headless run paths; behavior is intended to stay compatible but spans critical CLI lifecycle code.
> 
> **Overview**
> The CLI now treats **`RunOutcome`** as the single terminal fact through headless execution, workflow output handling, multi-agent runs, and interactive chat exit codes. Legacy **`ExecutionStatus`** conversion and fields (`status`, `terminalStatus`, `endGroupStatus`) are no longer threaded on internal result objects or used for control flow.
> 
> **`executeCliRequest`** resolves the final outcome after shutdown via **`readCliRunOutcome`** (persisted execution metadata overrides the in-memory value, preserving the post-shutdown interruption race fix). Storage read failures propagate instead of being swallowed. **`runOutcomeExitCode`** replaces status-based exit mapping everywhere.
> 
> **`serializeCliRunResult`** adds the frozen v0.40 compatibility projection only at JSON/NDJSON emission in **`agents run`**, **`multi-agent run`**, and workflow **`run`**. Workflow paths drop **`terminalStatus`** from **`resolveWorkflowOutput`** options and use **`result.outcome`** directly for metadata and interruption handling.
> 
> Removed helpers: **`cliTerminalStatus`**, **`createCliRunResult`**, **`terminalStatusExitCode`**, **`readCliTerminalStatus`**. Tests assert published payload shape, key order, and cancellation projections at command boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8163ca1f1901b4d42fe16106a3fb2fd392fe82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->