### PR TITLE
refactor: move usage provider schema to shared

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -75,7 +75,6 @@
     { "from": "skills", "to": "common", "kind": "value" },
     { "from": "skills", "to": "shared", "kind": "value" },
     { "from": "skills", "to": "utils", "kind": "value" },
-    { "from": "telemetry", "to": "agent", "kind": "value" },
     { "from": "telemetry", "to": "auth", "kind": "value" },
     { "from": "telemetry", "to": "logger", "kind": "value" },
     { "from": "telemetry", "to": "shared", "kind": "value" },

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -7,25 +7,9 @@ import { z } from 'zod';
 import {
   TokenCountSchema,
   TokenUsageStatsBaseSchema,
+  UsageProviderSchema,
   UsageRouteSchema,
 } from '@shared/schemas';
-
-/** Provider identifiers for usage tracking. */
-export const UsageProviderSchema = z.enum([
-  'anthropic',
-  'openai',
-  'openai-response',
-  'google',
-  'deepseek',
-  'openrouter',
-  'dashscope',
-  'xai',
-  'moonshot',
-  'minimax',
-  'glm',
-  'meta',
-  'unknown',
-]);
 
 /**
  * Normalized usage statistics from any model provider.

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -7,7 +7,6 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import { usesServerSideKeysRoute } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import type {
   ExtendedTokenUsageStats,
@@ -15,6 +14,7 @@ import type {
   StreamTabId,
   UsageRoute,
 } from '@shared/schemas';
+import { UsageProviderSchema } from '@shared/schemas/usage';
 import { roundTo } from '@utils/core';
 import type { UsageLogStats } from '@telemetry/UsageLogTypes';
 import type { ModelCapabilities, ModelConfig } from 'llm-zoo';

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -2,6 +2,23 @@ import { z } from 'zod';
 
 export const TokenCountSchema = z.int().nonnegative();
 
+/** Provider identifiers for usage tracking. */
+export const UsageProviderSchema = z.enum([
+  'anthropic',
+  'openai',
+  'openai-response',
+  'google',
+  'deepseek',
+  'openrouter',
+  'dashscope',
+  'xai',
+  'moonshot',
+  'minimax',
+  'glm',
+  'meta',
+  'unknown',
+]);
+
 export const UsageRouteSchema = z.enum([
   'chatgpt-subscription',
   'relay',

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod';
 
-import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
-import { UsageRouteSchema } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
+import { UsageProviderSchema, UsageRouteSchema } from '@shared/schemas/usage';
 
 const UsageLogMetadataSchema = z.object({
   model: z.string(),

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -4,9 +4,28 @@ import {
   emptyUsageStats,
   parseUsageData,
   sumUsageStats,
+  UsageProviderSchema,
 } from '@shared/schemas';
 
 describe('stream data usage parsing', () => {
+  it('preserves the exact usage-provider wire vocabulary', () => {
+    expect(UsageProviderSchema.options).toEqual([
+      'anthropic',
+      'openai',
+      'openai-response',
+      'google',
+      'deepseek',
+      'openrouter',
+      'dashscope',
+      'xai',
+      'moonshot',
+      'minimax',
+      'glm',
+      'meta',
+      'unknown',
+    ]);
+  });
+
   it('coerces persisted usage fields and defaults missing cache counters', () => {
     const { usage } = parseUsageData({
       run: {


### PR DESCRIPTION
## Summary

- move `UsageProviderSchema` from agent-owned types to the shared usage schema
- make telemetry consume `AgentCategory`, usage routes, and provider vocabulary from shared schemas
- remove the obsolete `telemetry → agent` value edge from the architecture baseline
- protect the exact persisted provider vocabulary with a focused schema test

## Design

Telemetry previously imported runtime values from the agent subsystem solely to describe persisted usage records. This inverted ownership: the wire contract was shaped by telemetry and consumed by both telemetry and agents, but lived beneath agent runtime types. The shared schema layer is the natural owner because it already owns usage routes and the persisted usage contract.

The move preserves every provider literal and introduces no compatibility re-export because no current repository consumer uses the old deep path. The legitimate `agent → telemetry` service dependency remains unchanged.

Closes #8325

## Verification

- focused schema, architecture, telemetry, and usage-monitor tests (12 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 46 pre-existing warnings)
- `npm run compile:fast`
- `npm test` (6,004 passed, 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and ownership refactor with no enum or schema behavior changes; billing and telemetry contracts stay the same.
> 
> **Overview**
> **`UsageProviderSchema`** is relocated from agent runtime types into **`@shared/schemas/usage`**, so the persisted usage wire vocabulary lives with routes and token stats instead of under the agent layer.
> 
> **Telemetry** (`UsageLogTypes`) now pulls **`AgentCategory`**, **`UsageProviderSchema`**, and **`UsageRouteSchema`** from shared schemas only, which drops the **`telemetry → agent`** value dependency reflected in the architecture ratchet baseline. Agent code (**`NormalizedUsage`**, **`UsageMonitor`**) imports the same schema from shared paths; provider enum literals are unchanged.
> 
> A focused test locks the exact **`UsageProviderSchema.options`** list so persisted provider strings cannot drift silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0dc997bbcdbb369d0b836e23af81f7807483ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->