### PR TITLE
fix: type stream-scoped approval queues

### DIFF
--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -146,7 +146,10 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
       pending.delete(id);
     },
     bypass: createStreamApprovalBypass(options.bypassEvent),
-    enqueue<T>(streamId, run): Promise<T> {
+    enqueue<T>(
+      streamId: StreamTabId | undefined,
+      run: () => Promise<T>,
+    ): Promise<T> {
       let queue = queues.get(streamId);
       if (!queue) {
         queue = new PQueue({ concurrency: 1 });

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -246,7 +246,7 @@ export async function requestToolEditApproval(
       ? request
       : { ...request, streamId: contextStreamId };
 
-  const streamId = preparedRequest.streamId;
+  const streamId = preparedRequest.streamId ?? undefined;
   const isStreamBypassed =
     streamId && session.approvals.toolEdit.bypass.isBypassed(streamId);
   if (!approvalsEnabled || isStreamBypassed) {


### PR DESCRIPTION
## Summary

- add explicit generic callback parameter types to the stream approval controller
- normalize nullable tool-edit stream ids before queueing
- restore strict TypeScript validation on main after #8330 merged before its CI failure completed

## Validation

- `npm run typecheck`
- focused approval suites (32 tests)

Follow-up to #8330 and #8328.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only alignment with existing queue/bypass behavior; no intended runtime logic changes.
> 
> **Overview**
> Tightens TypeScript around **stream-scoped approval serialization** so `main` typechecks again after a prior merge landed without a green CI run.
> 
> The `StreamApprovalController.enqueue` implementation now declares explicit parameters (`streamId: StreamTabId | undefined`, typed `run` callback) so they match the controller interface and the internal `Map<StreamTabId | undefined, PQueue>` keys.
> 
> Tool-edit approval normalizes `preparedRequest.streamId` with `?? undefined` before bypass checks and `session.approvals.toolEdit.enqueue`, aligning nullable `string | null` request fields with the queue’s `undefined`-keyed “unscoped” bucket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8af4edb6f9bce1cca4b2422f96654d17468fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->