### PR TITLE
fix: restore approval queue type safety

### DIFF
--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -146,7 +146,10 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
       pending.delete(id);
     },
     bypass: createStreamApprovalBypass(options.bypassEvent),
-    enqueue<T>(streamId, run): Promise<T> {
+    enqueue<T>(
+      streamId: StreamTabId | undefined,
+      run: () => Promise<T>,
+    ): Promise<T> {
       let queue = queues.get(streamId);
       if (!queue) {
         queue = new PQueue({ concurrency: 1 });

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -253,7 +253,7 @@ export async function requestToolEditApproval(
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
 
-  return session.approvals.toolEdit.enqueue(streamId, async () => {
+  return session.approvals.toolEdit.enqueue(streamId ?? undefined, async () => {
     if (streamId && session.approvals.toolEdit.bypass.isBypassed(streamId)) {
       return finalizeApprovalResult({ accepted: true }, preparedRequest);
     }


### PR DESCRIPTION
## Summary

- annotate the generic stream-approval queue implementation with its declared parameter types
- normalize nullable tool-edit stream identifiers at the external request boundary
- restore the Linux type-check gate broken after #8330

## Root cause

The generic method inside the returned controller object did not receive contextual parameter types under the CI TypeScript configuration, and the external tool-edit request schema permits `null` while the internal queue contract uses `undefined` for an unscoped request. These are type-boundary defects; approval behavior is unchanged.

Closes #8337

## Verification

- `npm run typecheck`
- focused approval tests (13 passed)
- `npm run lint` (0 errors; 46 pre-existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only boundary fixes; no change to queue serialization, bypass, or approval flow.
> 
> **Overview**
> Fixes **CI TypeScript failures** on the stream-scoped approval queue without changing approval behavior.
> 
> The `enqueue` implementation on the stream approval controller now declares **`streamId` and `run` parameter types** explicitly so the generic method type-checks under the Linux/CI TS config. **Tool-edit approval** passes **`streamId ?? undefined`** into `enqueue` so nullable `streamId` values from the external request shape match the internal queue key type (`undefined` for unscoped requests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1798cec7ecd31d129a6d0ac1bfb79d5935cfcb85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->