### PR TITLE
fix(settings): refresh agent model guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ All notable changes to this project will be documented in this file.
 - **Pasted images stay with the conversation that accepted them** — switching
   streams while an image is being prepared no longer delivers it to the wrong
   follow-up input.
+- **AI-agent settings reflect current routing and models** — Claude Code now
+  defaults to Sonnet 5, and the ChatGPT tool-use-only option no longer cites an
+  outdated Codex background-mode limitation.
 
 ### Desktop
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -315,7 +315,7 @@
           "texra.chatgptCodex.subscriptionToolUseOnly": {
             "type": "boolean",
             "default": false,
-            "description": "Use the ChatGPT subscription for tool-use agents only. Workflow agents fall back to your OpenAI API key or relay, because the Codex backend has no background mode and is less stable for long workflow runs.",
+            "description": "Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.",
             "scope": "resource"
           }
         }

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -48,6 +48,7 @@ import {
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
+import { CLAUDE_AGENT_DEFAULT_MODEL } from '@shared/schemas/agentCliSettings';
 
 /** Target for the desktop-host "set provider key" modal. */
 export interface ProviderKeyModalTarget {
@@ -127,7 +128,9 @@ export const bashApprovalEnabled = signal(true);
 export const codexSandboxMode = signal<string>('workspace-write');
 export const codexReasoningEffort = signal<string>('high');
 export const codexApprovalPolicy = signal<string>('never');
-export const claudeAgentModel = signal<ClaudeAgentModel>('claude-sonnet-4-6');
+export const claudeAgentModel = signal<ClaudeAgentModel>(
+  CLAUDE_AGENT_DEFAULT_MODEL,
+);
 export const claudeAgentPermissionMode =
   signal<ClaudeAgentPermissionMode>('acceptEdits');
 export const claudeAgentEffort = signal<ClaudeAgentEffort>('high');
@@ -225,7 +228,7 @@ export function resetSettingsState(): void {
   codexSandboxMode.set('workspace-write');
   codexReasoningEffort.set('high');
   codexApprovalPolicy.set('never');
-  claudeAgentModel.set('claude-sonnet-4-6');
+  claudeAgentModel.set(CLAUDE_AGENT_DEFAULT_MODEL);
   claudeAgentPermissionMode.set('acceptEdits');
   claudeAgentEffort.set('high');
 

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -32,6 +32,7 @@ import {
   stateSettingByKey,
 } from '@shared/schemas/stateSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { CLAUDE_AGENT_DEFAULT_MODEL } from '@shared/schemas/agentCliSettings';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -168,7 +169,7 @@ export class AIAgentsTab extends LitElement {
   @property({ type: String }) codexReasoningEffort = 'high';
   @property({ type: String }) codexApprovalPolicy = 'never';
   @property({ type: String }) claudeAgentModel: ClaudeAgentModel =
-    'claude-sonnet-4-6';
+    CLAUDE_AGENT_DEFAULT_MODEL;
   @property({ type: String })
   claudeAgentPermissionMode: ClaudeAgentPermissionMode = 'acceptEdits';
   @property({ type: String }) claudeAgentEffort: ClaudeAgentEffort = 'high';

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -20,6 +20,7 @@ import type {
   ProviderKeyStatus,
 } from '@shared/schemas/settingsViewMessages';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
+import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/copy/subscriptionRouting';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/ApiAccessSection';
@@ -272,7 +273,7 @@ export class ModelsTab extends LitElement {
           <wa-switch
             ?checked=${subscriptionToolUseOnly}
             ?disabled=${!preferSubscription}
-            hint="Workflow agents use your API key or relay instead — the Codex backend has no background mode and is less stable for long runs."
+            hint=${CHATGPT_TOOL_USE_ONLY_DESCRIPTION}
             @change=${this.handleSubscriptionToolUseOnlyChange}
           >
             Use subscription for tool-use agents only

--- a/src/shared/copy/subscriptionRouting.ts
+++ b/src/shared/copy/subscriptionRouting.ts
@@ -1,0 +1,2 @@
+export const CHATGPT_TOOL_USE_ONLY_DESCRIPTION =
+  'Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.';

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -65,18 +65,19 @@ export const parseCodexApprovalPolicy = parseEnumSetting(
 
 /** Claude Code CLI model options surfaced in the picker. */
 export const ClaudeAgentModelSchema = z.enum([
-  'claude-sonnet-4-6',
+  'claude-sonnet-5',
   'claude-fable-5',
   'claude-opus-4-8',
   'claude-haiku-4-5-20251001',
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
 
-export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-4-6';
+export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-5';
 
 const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
   {
     'claude-opus-4-7': 'claude-opus-4-8',
+    'claude-sonnet-4-6': 'claude-sonnet-5',
   };
 
 export const parseClaudeAgentModel = parseEnumSetting(

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - shared copy
+import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/copy/subscriptionRouting';
+
 /**
  * Core (host-neutral) TeXRA settings.
  *
@@ -409,7 +412,7 @@ export const CoreSettingsShape = {
       ),
       subscriptionToolUseOnly: boolField(
         DEFAULT_CORE_SETTINGS.chatgptCodex.subscriptionToolUseOnly,
-        'Use the ChatGPT subscription for tool-use agents only. Workflow agents fall back to your OpenAI API key or relay, because the Codex backend has no background mode and is less stable for long workflow runs.',
+        CHATGPT_TOOL_USE_ONLY_DESCRIPTION,
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.chatgptCodex),

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -324,7 +324,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['vscode', 'desktop', 'cli'],
     cliConsumer: CLAUDE_AGENT_CONFIG_CONSUMER,
     cliRuntimeReachability: CLAUDE_AGENT_RUNTIME_REACHABILITY,
-    enumLabels: ['Sonnet 4.6', 'Fable 5', 'Opus 4.8', 'Haiku 4.5'],
+    enumLabels: ['Sonnet 5', 'Fable 5', 'Opus 4.8', 'Haiku 4.5'],
   },
   {
     key: WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -44,12 +44,13 @@ describe('parseCodexApprovalPolicy', () => {
 });
 
 describe('parseClaudeAgentModel', () => {
-  it('maps retired Opus selections to the current Opus model', () => {
+  it('maps retired selections to their current model', () => {
     expect(parseClaudeAgentModel('claude-opus-4-7')).toBe('claude-opus-4-8');
+    expect(parseClaudeAgentModel('claude-sonnet-4-6')).toBe('claude-sonnet-5');
   });
 
   it('defaults invalid persisted selections to Sonnet', () => {
-    expect(parseClaudeAgentModel('claude-opus-3')).toBe('claude-sonnet-4-6');
+    expect(parseClaudeAgentModel('claude-opus-3')).toBe('claude-sonnet-5');
   });
 });
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -297,7 +297,7 @@ describe('state settings catalog', () => {
       'on-failure — Ask on failure',
     ]);
     assert.deepEqual(labelsFor(WorkspaceStateKey.CLAUDE_AGENT_MODEL), [
-      'claude-sonnet-4-6 — Sonnet 4.6',
+      'claude-sonnet-5 — Sonnet 5',
       'claude-fable-5 — Fable 5',
       'claude-opus-4-8 — Opus 4.8',
       'claude-haiku-4-5-20251001 — Haiku 4.5',

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -113,7 +113,7 @@ const ClaudeAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      "Claude model to use (e.g. 'claude-sonnet-4-6', 'claude-fable-5', 'claude-opus-4-8'). Defaults to user-configured model.",
+      "Claude model to use (e.g. 'claude-sonnet-5', 'claude-fable-5', 'claude-opus-4-8'). Defaults to user-configured model.",
     ),
   effort: z
     .enum(CLAUDE_AGENT_EFFORT_LEVELS)


### PR DESCRIPTION
## Summary
- replace the retired Claude Code Sonnet 4.6 selection with Sonnet 5 and migrate persisted selections
- reuse the Claude default model constant across settings state and UI defaults
- replace outdated ChatGPT tool-use-only guidance with shared copy used by the schema and settings UI
- update the 0.39.4 changelog entry

## Design
The Claude default and subscription-routing description now each have one authoritative source, avoiding duplicated defaults and copy drift across schema and UI layers.

## Validation
- `npm run typecheck`
- focused schema/settings tests: 79 passed
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; 46 pre-existing warnings)
- `npm test` (6,004 passed; 4 skipped; generated metadata parity corrected and rechecked)

Closes #8339

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk settings, copy, and model-default changes with migration for retired Claude model IDs; no auth or data-handling logic changes.
> 
> **Overview**
> **Claude Code** now treats **Sonnet 5** as the default and picker option (replacing Sonnet 4.6). Persisted `claude-sonnet-4-6` values map to Sonnet 5 via the existing retired-model parser. Settings state, the AI Agents tab, enum labels, and tool docs all pull from **`CLAUDE_AGENT_DEFAULT_MODEL`** so defaults stay in one place.
> 
> **ChatGPT subscription routing** copy for “tool-use agents only” no longer mentions Codex lacking background mode. A shared **`CHATGPT_TOOL_USE_ONLY_DESCRIPTION`** drives the VS Code setting, core settings schema, and Models tab hint so UI and packaged descriptions stay aligned.
> 
> The **0.39.4 changelog** notes these AI-agent setting updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9347dfb6ac1b86e906b6612c70994001b22c1571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->