### PR TITLE
feat(relay): raise free concurrency to four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
 - **OpenAI parallel function calls are enabled by default** — supported OpenAI
   models can plan independent tool calls together, while TeXRA continues to
   preserve ordering for edits and other side-effectful actions.
+- **Free relay accounts can run four requests concurrently** — the free-tier
+  concurrency allowance has doubled from two while existing rate and spending
+  limits remain unchanged.
 
 #### Bug Fixes
 

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -17,6 +17,7 @@ import {
   acquireRelayRequestSlot,
   releaseWhenStreamCloses,
 } from '../../../supabase/functions/relay/requestGate';
+import { getRequestLimits } from '../../../supabase/functions/relay/models';
 import { isModelFreeRelayPath } from '../../../supabase/functions/relay/paths';
 
 function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
@@ -31,6 +32,10 @@ function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 }
 
 describe('relay free-tier request limits', () => {
+  it('allows four concurrent free-tier requests', () => {
+    assert.equal(getRequestLimits('free').concurrent, 4);
+  });
+
   it('rejects free-tier request bodies over the byte cap', () => {
     assert.deepEqual(checkRequestBodySizeLimit('abc', 3), {
       allowed: true,

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -181,7 +181,7 @@ export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
  * interactive use while blocking bulk free-tier fanout before costs are logged.
  */
 export const TIER_REQUEST_LIMITS: TierRequestLimits = {
-  free: { ratePerMinute: 20, concurrent: 2 },
+  free: { ratePerMinute: 20, concurrent: 4 },
   Max: { ratePerMinute: 60, concurrent: 8 },
   Ultra: { ratePerMinute: 120, concurrent: 16 },
 };


### PR DESCRIPTION
## Summary
- raise the free-tier relay concurrency allowance from two to four
- keep paid-tier, rate, and spending limits unchanged
- add one focused policy assertion without changing generic request-gate fixtures
- document the user-visible change for 0.39.4

## Design
The policy remains centralized in `TIER_REQUEST_LIMITS`; relay enforcement and user-facing rejection messages continue to consume that single value without duplicated client or database constants.

## Validation
- focused relay request-limit suite: 30 passed
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; 47 pre-existing warnings)
- `npm test` (6,008 passed; 4 skipped)

Closes #8344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy-only server-side limit change with no auth, billing, or client duplication; enforcement path is unchanged aside from the new concurrent value.
> 
> **Overview**
> **Free relay accounts can run four in-flight requests** instead of two. The change is a single update to `TIER_REQUEST_LIMITS` in `supabase/functions/relay/models.ts`; relay request-gate enforcement already reads limits through `getRequestLimits`, so paid tiers, per-minute rates, and spending caps are unchanged.
> 
> A focused test asserts `getRequestLimits('free').concurrent === 4`, and **0.39.4** changelog notes the user-visible allowance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3547cc10d4282580286ed13ac71e220190a28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->