### PR TITLE
refactor: move subscription routing policy to model

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -16,7 +16,6 @@
     { "from": "agent", "to": "utils", "kind": "value" },
     { "from": "auth", "to": "common", "kind": "value" },
     { "from": "auth", "to": "logger", "kind": "value" },
-    { "from": "auth", "to": "model", "kind": "value" },
     { "from": "auth", "to": "platform", "kind": "value" },
     { "from": "auth", "to": "shared", "kind": "value" },
     { "from": "auth", "to": "utils", "kind": "value" },

--- a/docs/proposals/tech-debt-audit-2026-07.md
+++ b/docs/proposals/tech-debt-audit-2026-07.md
@@ -564,7 +564,7 @@ logs). `src/auth/` is 4,181 LoC. The debts:
   (context window clamped to a hardcoded 272k, token counting / compaction /
   uploads disabled, different pricing) — while the picker still advertises
   llm-zoo's API-key capabilities (`computeModelOptions.ts:180-189`). The
-  routing _predicate_ is properly centralized (`codexRouting.ts`); the
+  routing _predicate_ is properly centralized (`codexSubscriptionRouting.ts`); the
   _consequences_ are scattered. **Fix:** the declarative
   `ProviderCapabilities` record from A1, **keyed by (model, auth-mode)**
   with runtime resolvers — subscription becomes a capability profile the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -132,6 +132,15 @@ const AGENT_CORE_RESTRICTED_IMPORT_PATTERNS = [
   ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
 ];
 
+const AUTH_RESTRICTED_IMPORT_PATTERNS = [
+  {
+    regex: '^(?:@model(?:/|$)|(?:\\.\\./)+model(?:/|$))',
+    message:
+      'Authentication must not own or depend on model policy; move the policy to src/model.',
+  },
+  ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
+];
+
 function isUnderDir(filename, dir) {
   const relativePath = path.relative(dir, filename);
   return (
@@ -551,6 +560,21 @@ export default tseslint.config(
         {
           paths: HOST_LAYER_RESTRICTED_IMPORT_PATHS,
           patterns: AGENT_CORE_RESTRICTED_IMPORT_PATTERNS,
+        },
+      ],
+    },
+  },
+
+  // Authentication owns credentials, sessions, and preferences. Model policy
+  // may consume that state, but auth must not depend back on the model layer.
+  {
+    files: ['src/auth/**/*.{ts,tsx,mts,cts}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: HOST_LAYER_RESTRICTED_IMPORT_PATHS,
+          patterns: AUTH_RESTRICTED_IMPORT_PATTERNS,
         },
       ],
     },

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,10 +1,10 @@
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { isCodexSubscriptionActive } from '@auth/codex';
 import { formatCliApiMode } from '@cli/runtime/apiAccessMode';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import { parseCliHistoryId } from '@cli/runtime/history';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -2,9 +2,9 @@ import { Box, Text, useWindowSize } from 'ink';
 import { Badge } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
-import { isCodexSubscriptionActive } from '@auth/codex';
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import { isActivePhase } from '@common/constants/streamStatus';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 
 import { approvalQueueStatus } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';

--- a/packages/cli/src/runtime/credentialStatus.ts
+++ b/packages/cli/src/runtime/credentialStatus.ts
@@ -7,7 +7,7 @@
 
 import { platform } from '@platform/platform';
 import { hasAnyProviderApiKey } from '@controllers/onboarding/onboardingFunnel';
-import { isCodexSubscriptionActive } from '@auth/codex';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 
 import { getCliAuthProfile } from './supabaseAuth';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -12,10 +12,10 @@ import {
   CodexAuthError,
   formatCodexAuthUnavailableMessage,
   isCodexSessionRoutable,
-  resolveCodexSubscriptionCapabilitiesForAgentCategory,
 } from '@auth/codex';
 import { AgentError } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { resolveCodexSubscriptionCapabilitiesForAgentCategory } from '@model/codexSubscriptionRouting';
 import { isGpt5ModelName } from '@model/modelNames';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import type { AgentCategory } from '@shared/schemas/agent';

--- a/src/auth/codex/index.ts
+++ b/src/auth/codex/index.ts
@@ -65,11 +65,6 @@ export {
   type CodexSubscriptionPreferenceUpdate,
 } from './codexPreference';
 export {
-  resolveCodexSubscriptionCapabilities,
-  resolveCodexSubscriptionCapabilitiesForAgentCategory,
-} from './codexRouting';
-export { isCodexSubscriptionActive } from './codexActive';
-export {
   loginWithLoopback,
   type CodexLoopbackLoginOptions,
 } from './codexLoopbackLogin';

--- a/src/controllers/onboarding/onboardingFunnel.ts
+++ b/src/controllers/onboarding/onboardingFunnel.ts
@@ -15,9 +15,9 @@
  * `platform().globalState`.
  */
 
-import { isCodexSubscriptionActive } from '@auth/codex';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { API_PROVIDERS, lookupApiKey } from '@model/apiProviders';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import { CHATGPT_SETUP_MODEL } from '@model/setupModelDefaults';
 import type { OnboardingFunnelState } from '@shared/schemas/onboarding';
 import { isNonEmptyString } from '@utils/core';

--- a/src/controllers/onboarding/setupLaunch.ts
+++ b/src/controllers/onboarding/setupLaunch.ts
@@ -1,7 +1,7 @@
 import { platform } from '@platform/platform';
-import { isCodexSubscriptionActive } from '@auth/codex';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { lookupApiKey, API_PROVIDERS } from '@model/apiProviders';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import {
   decideRunModel,
   type RunModelCandidate,

--- a/src/model/codexSubscriptionActive.ts
+++ b/src/model/codexSubscriptionActive.ts
@@ -1,18 +1,18 @@
 /**
  * Live "is this model routing through the ChatGPT subscription right now?"
- * check: the (sync) capability resolver AND a current ChatGPT sign-in. Async
- * because it reads the stored session.
+ * check: the synchronous capability resolver and a current ChatGPT sign-in.
+ * Async because it reads the stored session.
  *
  * Shared by the CLI status bar badge and the `/status` text command so the two
  * never disagree, and the single place that pairs the routing predicate with
- * `getUseOpenRouter()` — keeping that config read out of the CLI render path.
+ * `getUseOpenRouter()` - keeping that config read out of the CLI render path.
  */
 import { MODEL_CONFIGS } from 'llm-zoo';
 
+import { isCodexSignedIn } from '@auth/codex';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
-import { isCodexSignedIn } from './codexAuthAccess';
-import { resolveCodexSubscriptionCapabilities } from './codexRouting';
+import { resolveCodexSubscriptionCapabilities } from './codexSubscriptionRouting';
 
 /**
  * Whether a request for `modelId` would be served by the ChatGPT subscription

--- a/src/model/codexSubscriptionRouting.ts
+++ b/src/model/codexSubscriptionRouting.ts
@@ -5,21 +5,22 @@
  *
  * Shared by the handler dispatch (ModelFactory) and the picker availability
  * gate (computeModelOptions) so the two never drift. Deliberately synchronous
- * (config + name match only) — the actual "are you signed in" check happens at
+ * (config + name match only) - the actual "are you signed in" check happens at
  * request time in the handler and in the async availability context, so the
  * conversation-compatibility key can stay sync.
  */
-import {
-  resolveProviderCapabilities,
-  type ProviderCapabilityProfile,
-} from '@model/providerCapabilities';
-import { AgentCategory } from '@shared/schemas/agent';
+import type { ModelConfig } from 'llm-zoo';
 
 import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
-} from './codexPreference';
-import type { ModelConfig } from 'llm-zoo';
+} from '@auth/codex';
+import { AgentCategory } from '@shared/schemas/agent';
+
+import {
+  resolveProviderCapabilities,
+  type ProviderCapabilityProfile,
+} from './providerCapabilities';
 
 export function resolveCodexSubscriptionCapabilities(
   config: ModelConfig,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -3,11 +3,7 @@ import { LRUCache } from 'lru-cache';
 
 import { platform } from '@platform/platform';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import {
-  isCodexSignedIn,
-  isPreferCodexSubscription,
-  resolveCodexSubscriptionCapabilitiesForAgentCategory,
-} from '@auth/codex';
+import { isCodexSignedIn, isPreferCodexSubscription } from '@auth/codex';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
@@ -19,6 +15,7 @@ import {
   isApiProvider,
   type ApiProvider,
 } from './apiProviders';
+import { resolveCodexSubscriptionCapabilitiesForAgentCategory } from './codexSubscriptionRouting';
 import {
   buildBaseModelOption,
   buildBasicModelOptionsData,

--- a/src/test-kernel/cli/CredentialStatus.vitest.mts
+++ b/src/test-kernel/cli/CredentialStatus.vitest.mts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   lookupApiKey: vi.fn(),
 }));
 
-vi.mock('@auth/codex', () => ({
+vi.mock('@model/codexSubscriptionActive', () => ({
   isCodexSubscriptionActive: mocks.isCodexSubscriptionActive,
 }));
 

--- a/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
+++ b/src/test-kernel/commands/setup/SetupAssistantRouting.vitest.ts
@@ -110,10 +110,6 @@ vi.mock('@controllers/onboarding/setupLaunch', () => ({
   ) => resolveSetupModelMock(includeAccessListFallback),
 }));
 
-vi.mock('@auth/codex', () => ({
-  isCodexSubscriptionActive: () => Promise.resolve(false),
-}));
-
 vi.mock('@auth/serverKeys', () => ({
   getServerSideKeyService: () => ({
     canUseServerSideKeys: () => Promise.resolve(false),
@@ -245,7 +241,6 @@ await import('@utils/config/providerConfig');
 await import('@frontend/secretManager');
 await import('@agent/runtime/SessionHandle');
 await import('@controllers/onboarding/setupLaunch');
-await import('@auth/codex');
 await import('@auth/serverKeys');
 await import('@controllers/onboarding/onboardingFunnel');
 await import('@common/state');

--- a/src/test-kernel/controllers/SetupLaunch.vitest.ts
+++ b/src/test-kernel/controllers/SetupLaunch.vitest.ts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   getUseOpenRouter: vi.fn<() => boolean>(),
 }));
 
-vi.mock('@auth/codex', () => ({
+vi.mock('@model/codexSubscriptionActive', () => ({
   isCodexSubscriptionActive: mocks.isCodexSubscriptionActive,
 }));
 

--- a/src/test-kernel/model/CodexSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/CodexSubscriptionRouting.vitest.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { installPlatform } from '@test/support/setupPlatform';
+import {
+  CODEX_SESSION_SECRET_KEY,
+  resetCodexCoordinator,
+  type CodexSession,
+} from '@auth/codex';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
+import {
+  resolveCodexSubscriptionCapabilities,
+  resolveCodexSubscriptionCapabilitiesForAgentCategory,
+} from '@model/codexSubscriptionRouting';
+import { AgentCategory } from '@shared/schemas/agent';
+
+const signedInSession: CodexSession = {
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresAtMs: Date.now() + 10 * 60_000,
+  accountId: 'account-id',
+};
+
+async function installSubscriptionPlatform(options?: {
+  useOpenRouter?: boolean;
+  signedIn?: boolean;
+  toolUseOnly?: boolean;
+}): Promise<void> {
+  await installPlatform({
+    config: {
+      'texra.chatgptCodex.preferSubscription': true,
+      'texra.chatgptCodex.subscriptionToolUseOnly':
+        options?.toolUseOnly ?? false,
+    },
+    globalState: {
+      'texra.useOpenRouter': options?.useOpenRouter ?? false,
+    },
+    secrets:
+      options?.signedIn === false
+        ? {}
+        : { [CODEX_SESSION_SECRET_KEY]: JSON.stringify(signedInSession) },
+  });
+}
+
+describe('ChatGPT subscription model routing', () => {
+  afterEach(() => {
+    resetCodexCoordinator();
+  });
+
+  it('keeps eligible OpenAI models on the direct API route when the preference is off', async () => {
+    await installPlatform();
+
+    expect(
+      resolveCodexSubscriptionCapabilities(MODEL_CONFIGS.gpt55, false),
+    ).toBeNull();
+  });
+
+  it('does not override OpenRouter routing', async () => {
+    await installSubscriptionPlatform({ useOpenRouter: true });
+
+    expect(
+      resolveCodexSubscriptionCapabilities(MODEL_CONFIGS.gpt55, true),
+    ).toBeNull();
+    await expect(isCodexSubscriptionActive('gpt55')).resolves.toBe(false);
+  });
+
+  it('routes an eligible direct OpenAI model through the preferred subscription', async () => {
+    await installSubscriptionPlatform();
+
+    expect(
+      resolveCodexSubscriptionCapabilities(MODEL_CONFIGS.gpt55, false),
+    ).not.toBeNull();
+  });
+
+  it('restricts subscription routing to tool-use agents when configured', async () => {
+    await installSubscriptionPlatform({ toolUseOnly: true });
+
+    expect(
+      resolveCodexSubscriptionCapabilitiesForAgentCategory(
+        MODEL_CONFIGS.gpt55,
+        false,
+        AgentCategory.Workflow,
+      ),
+    ).toBeNull();
+    expect(
+      resolveCodexSubscriptionCapabilitiesForAgentCategory(
+        MODEL_CONFIGS.gpt55,
+        false,
+        AgentCategory.ToolUse,
+      ),
+    ).not.toBeNull();
+    expect(
+      resolveCodexSubscriptionCapabilitiesForAgentCategory(
+        MODEL_CONFIGS.gpt55,
+        false,
+        undefined,
+      ),
+    ).toBeNull();
+  });
+
+  it('reports eligible models inactive while signed out', async () => {
+    await installSubscriptionPlatform({ signedIn: false });
+
+    await expect(isCodexSubscriptionActive('gpt55')).resolves.toBe(false);
+  });
+
+  it('reports eligible models active for a signed-in preferred subscription', async () => {
+    await installSubscriptionPlatform();
+
+    await expect(isCodexSubscriptionActive('gpt55')).resolves.toBe(true);
+  });
+
+  it('reports unknown model identifiers inactive', async () => {
+    await installSubscriptionPlatform();
+
+    await expect(
+      isCodexSubscriptionActive('unknown-subscription-model'),
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #8343.

## Summary

- move ChatGPT subscription capability routing and active-status policy from `src/auth/codex` to `src/model`;
- update model selection, model dispatch, onboarding, and CLI consumers to import the policy owner directly;
- remove the policy exports from the auth barrel, with no forwarding shim;
- remove the `auth → model` architecture edge and add an ESLint fence that prevents it from returning;
- add focused coverage for preference-off, direct OpenAI, OpenRouter, tool-use-only, signed-out, signed-in, and unknown-model cases.

## Design

Authentication now owns credentials, sessions, and access preferences. Model eligibility and route selection live with the model subsystem and consume auth state in one direction. This removes the direct `auth ↔ model` cycle without adding a port, adapter, or compatibility layer.

## Net elements (R6)

- 2 policy modules relocated; no duplicate implementation remains.
- 1 directed subsystem edge removed: `auth → model`.
- 3 policy symbols removed from the auth barrel.
- 1 explicit import fence added.
- 0 forwarding shims added.
- 7 focused routing/status tests added.
- Net diff: +131 lines, of which 120 lines are the new characterization suite.

## Consumer counts (R8)

Before: 7 production consumers outside auth reached subscription policy through the auth-owned modules/barrel, while auth itself imported model provider capabilities.

After: the same 7 consumers import the model-owned policy directly; `src/auth/**` has 0 production imports from `@model` or relative `src/model` paths, 0 stale references to `codexRouting`/`codexActive`, and 0 compatibility re-exports.

## Verification

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- focused model/routing/architecture suite: 92 tests passed
- full `npm test`: 6,014 passed, 4 skipped
- boundary lint probe: an auth-to-model import is rejected
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model dispatch, picker availability, onboarding, and CLI subscription UI—behavior should stay equivalent but mis-wired imports could change routing or status display; mitigated by focused routing tests and lint/architecture ratchets.
> 
> **Overview**
> Moves **ChatGPT subscription routing and “is subscription active?” policy** from `src/auth/codex` into **`src/model`** (`codexSubscriptionRouting`, `codexSubscriptionActive`). Auth keeps credentials, sessions, and preferences; model owns eligibility and route selection and reads auth state in one direction only.
> 
> **Consumers** (`ModelFactory`, `computeModelOptions`, onboarding/setup launch, CLI status bar, `/status`, credential checks) now import `@model/...` directly. The auth barrel **drops** the old routing/active exports with **no** forwarding shim.
> 
> **Architecture enforcement:** removes the `auth → model` edge from `architecture-edges-baseline.json` and adds an ESLint **`no-restricted-imports`** rule on `src/auth/**` blocking `@model` and relative `model/` imports.
> 
> Adds **`CodexSubscriptionRouting.vitest.ts`** covering preference off, OpenRouter, tool-use-only, signed-in/out, and unknown models; test mocks updated to target `@model/codexSubscriptionActive`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fa488817256a69be7f31d10ac9b3bbc463ac8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->