### PR TITLE
fix(settings): keep generated config loadable

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -20,7 +20,7 @@ import type {
   ProviderKeyStatus,
 } from '@shared/schemas/settingsViewMessages';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
-import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/copy/subscriptionRouting';
+import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/schemas/coreSettings';
 
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/ApiAccessSection';

--- a/src/shared/copy/subscriptionRouting.ts
+++ b/src/shared/copy/subscriptionRouting.ts
@@ -1,2 +1,0 @@
-export const CHATGPT_TOOL_USE_ONLY_DESCRIPTION =
-  'Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.';

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -1,8 +1,8 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - shared copy
-import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/copy/subscriptionRouting';
+export const CHATGPT_TOOL_USE_ONLY_DESCRIPTION =
+  'Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.';
 
 /**
  * Core (host-neutral) TeXRA settings.


### PR DESCRIPTION
## Summary
- move the ChatGPT tool-use-only description into the core settings schema that owns it
- update the settings UI to consume that schema export
- remove the shallow one-constant copy module whose runtime path alias broke generated CommonJS loading

## Root Cause
`check:package-contributes` executes the TypeScript output directly from `out/`. The new runtime import of `@shared/copy/subscriptionRouting` remained an unresolved path alias in CommonJS, so the 0.39.4 release gate could not load `coreSettings.js`.

## Validation
- `corepack pnpm run check:package-contributes`
- focused settings/schema tests: 68 passed
- `npm run compile:fast`
- `npm run lint` (0 errors; 47 pre-existing warnings)

Closes #8349

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String relocation and import path updates only; no routing, auth, or settings semantics change.
> 
> **Overview**
> Moves **`CHATGPT_TOOL_USE_ONLY_DESCRIPTION`** into `coreSettings.ts` (next to the `chatgptCodex.subscriptionToolUseOnly` schema that already uses it) and points the settings **Models** tab at that export.
> 
> Deletes **`src/shared/copy/subscriptionRouting.ts`**, which only held that string. Loading generated CommonJS from `out/` during **`check:package-contributes`** failed because `coreSettings.js` still imported `@shared/copy/subscriptionRouting`, and that path alias does not resolve at runtime.
> 
> No user-facing behavior change—same hint text in the UI and the same setting description in the schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c531e8e616667ecb383c546b1d5736c5b025bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->