### PR TITLE
refactor: simplify progress signal derivation

### DIFF
--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -15,7 +15,7 @@
  */
 
 import { create } from 'mutative';
-import { Signal, signal, select, combine } from '@shared/signals';
+import { Signal, signal, select } from '@shared/signals';
 import {
   createStreamState,
   type ProgressViewPlacement,
@@ -114,14 +114,12 @@ export const streams$ = new Signal.Computed(() => [
 ]);
 
 /** Top-level streams for the tab list (child streams excluded). */
-export const tabStreams$ = combine(
-  [streams$, streamFilter$] as const,
-  (streams, filter) => {
-    const topLevel = streams.filter((s) => !s.parentStreamId);
-    if (filter === 'all') return topLevel;
-    return topLevel.filter((s) => s.agentCategory === filter);
-  },
-);
+export const tabStreams$ = new Signal.Computed(() => {
+  const topLevel = streams$.get().filter((stream) => !stream.parentStreamId);
+  const filter = streamFilter$.get();
+  if (filter === 'all') return topLevel;
+  return topLevel.filter((stream) => stream.agentCategory === filter);
+});
 
 /**
  * Child streams grouped by parent stream ID.

--- a/src/shared/signals.ts
+++ b/src/shared/signals.ts
@@ -21,21 +21,3 @@ export function select<S, T>(
 ): Signal.Computed<T> {
   return new Signal.Computed(() => selector(source.get()));
 }
-
-/** Any signal with a `.get()` method (State or Computed). */
-type AnySignal<T> = Signal.State<T> | Signal.Computed<T>;
-
-/**
- * Derive a computed from multiple signal inputs.
- * Replaces the `void x.get()` pattern for explicit multi-signal dependency tracking.
- */
-export function combine<Inputs extends readonly AnySignal<any>[], R>(
-  inputs: [...Inputs],
-  fn: (
-    ...args: {
-      [K in keyof Inputs]: Inputs[K] extends AnySignal<infer T> ? T : never;
-    }
-  ) => R,
-): Signal.Computed<R> {
-  return new Signal.Computed(() => fn(...(inputs.map((s) => s.get()) as any)));
-}


### PR DESCRIPTION
Closes #8356

## Summary

- express the progress tab filter directly as a `Signal.Computed`
- delete the single-use `combine` helper and its `AnySignal` type
- remove the production `any` and variadic-tuple assertion the helper required

## Design

The old helper wrapped one call site in a generic input tuple, mapped output tuple,
and `as any` recovery step. Reading the two signals directly keeps dependency
tracking explicit, lets TypeScript infer both values without assertions, and
removes dead code instead of preserving a forwarding abstraction.

## Verification

- `npm run format`
- `npm run lint` (0 errors; 54 existing warnings, none in changed files)
- root, test-kernel, CLI, desktop-renderer, and trace-viewer typechecks
- `npm test` (6,024 passed, 4 skipped)
- extension host esbuild
- progress, settings, and main webview Vite builds
- `git diff --check`

`npm run compile:fast` itself was blocked before compilation because pnpm tried
to reconcile optional platform packages and received registry error 23; all
underlying extension and webview build commands passed when invoked directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no intended behavior change; reactivity stays on the same two inputs via explicit `.get()` calls in the computed.
> 
> **Overview**
> **Progress tab filtering** is now a plain `Signal.Computed` that reads `streams$` and `streamFilter$` directly instead of going through the shared `combine` helper.
> 
> The **`combine` helper and `AnySignal` type** are removed from `@shared/signals` — they had only that one call site and relied on `any` / tuple assertions for typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1957cb027f3133b78ea940316be6f7448f8cf16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->