### PR TITLE
refactor: type chat export renderers

### DIFF
--- a/src/agent/export/chatExport/formatSpec.ts
+++ b/src/agent/export/chatExport/formatSpec.ts
@@ -62,11 +62,11 @@ function extractMeta(input: ChatExportInput): DocumentMeta {
 }
 
 /** Render a node through a format spec's renderer table. */
-function renderNode(node: ExportNode, renderers: NodeRenderers): string {
-  // TypeScript can't narrow discriminated unions through record access,
-  // so we cast here. NodeRenderers ensures every kind has a handler.
-
-  return (renderers as Record<string, (n: any) => string>)[node.kind](node);
+function renderNode<K extends ExportNode['kind']>(
+  node: Extract<ExportNode, { kind: K }>,
+  renderers: NodeRenderers,
+): string {
+  return renderers[node.kind](node);
 }
 
 export function renderDocument(


### PR DESCRIPTION
Closes #8362.

## Summary

Preserve the discriminant relationship between each chat-export node and its renderer so `renderNode` no longer casts an exhaustive table to an `any`-based record.

## Issue acceptance gates

- Removed the renderer-table assertion and explicit `any`.
- Preserved exhaustive `NodeRenderers` checking.
- Kept rendered output behavior unchanged.

## Single source of truth

`ExportNode["kind"]` remains the discriminant, and `NodeRenderers` remains the exhaustive kind-to-node renderer mapping. The generic `renderNode` now carries that same relationship through indexed access.

## Duplication and abstraction budget

No abstraction was added. The existing helper gained one type parameter and now uses the renderer type already present instead of duplicating a weaker `Record<string, ...>` view.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Functions: 0 added, 0 deleted; one existing local function made generic.
- Net LoC: 0 (5 additions, 5 deletions).

## Consumer counts (R8)

n/a: no emit path or exported API was deleted or rerouted. The private helper still has one call site.

## Host impact

Extension: Shared export formatting remains behaviorally unchanged.

Desktop: Shared export formatting remains behaviorally unchanged.

CLI: Shared export formatting remains behaviorally unchanged.

## Scheduled refactoring

None.

## Validation

- `./node_modules/.bin/prettier --check src/agent/export/chatExport/formatSpec.ts`
- `./node_modules/.bin/eslint src/agent/export/chatExport/formatSpec.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- Four focused chat-export suites: 25 tests passed
- `npm run lint`: 0 errors, 53 existing warnings outside this change
- `git diff --check -- src/agent/export/chatExport/formatSpec.ts`

The full `npm test` run was attempted, but the shared checkout contains more than twenty concurrent, unrelated in-progress source edits; tests covering those files timed out or failed while they were changing. The focused export suites are green, and this draft relies on clean-branch CI for the full-suite result. Full `npm run format` was not used because it would rewrite those unrelated user-owned edits; the changed file passes targeted Prettier. `compile:fast` was not repeated after its already-observed pnpm platform-package download failure (error 23); clean-branch CI covers compilation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper-only typing change with no API or runtime behavior changes; export rendering path is unchanged.
> 
> **Overview**
> **`renderNode`** in `formatSpec.ts` is now generic over `ExportNode['kind']` and calls `renderers[node.kind](node)` directly, instead of casting the renderer table to `Record<string, (n: any) => string>`.
> 
> That keeps the same exhaustive **`NodeRenderers`** mapping at compile time while tying each renderer to the correct **`Extract<ExportNode, { kind: K }>`** node shape. **`renderDocument`** and exported export output are unchanged at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923741619537e61c5aab41825b607743264fa92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->