### PR TITLE
refactor: narrow conversation provider guards

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -12,10 +12,7 @@
  * `@agent/modelHandlers/openai/*`, or `@google/genai`.
  */
 
-import {
-  isAssistantMessage,
-  isToolMessage,
-} from 'openai/lib/chatCompletionUtils';
+import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
 import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
 import { z } from 'zod';
 import {
@@ -31,10 +28,6 @@ import type {
   ChatCompletionMessageFunctionToolCall,
   ChatCompletionMessageToolCall,
 } from 'openai/resources/chat/completions';
-import type {
-  ResponseFunctionToolCallItem,
-  ResponseInputItem,
-} from 'openai/resources/responses/responses';
 
 import type { ExportNode, UserPart } from './schemas';
 
@@ -284,13 +277,12 @@ export function normalizeConversationForExport(
     }
 
     // OpenAI Response API: top-level function_call items (not wrapped in a message)
-    const responseToolCall = asCandidate<ResponseFunctionToolCallItem>(item);
-    if (isResponseFunctionToolCallItem(responseToolCall)) {
+    if (isResponseFunctionToolCallItem(item)) {
       const args =
-        typeof responseToolCall.arguments === 'string'
-          ? responseToolCall.arguments
-          : prettyJson(responseToolCall.arguments ?? {});
-      const name = responseToolCall.name ?? 'unknown';
+        typeof item.arguments === 'string'
+          ? item.arguments
+          : prettyJson(item.arguments ?? {});
+      const name = item.name ?? 'unknown';
       nodes.push({ kind: 'tool-call', name, input: args });
       lastAssistantHadToolUse = true;
       continue;
@@ -298,9 +290,8 @@ export function normalizeConversationForExport(
 
     // OpenAI Response API: top-level function_call_output items.
     // output can be a string OR an array of input_text/input_file/input_image parts.
-    const responseInputItem = asCandidate<ResponseInputItem>(item);
-    if (isFunctionCallOutputItem(responseInputItem)) {
-      const output = responseInputItem.output;
+    if (isFunctionCallOutputItem(item)) {
+      const output = item.output;
       if (Array.isArray(output)) {
         const textParts = output.flatMap((part) => {
           const text = extractTextContentPart(part);
@@ -366,29 +357,15 @@ export function normalizeConversationForExport(
     }
 
     // OpenAI Chat Completions tool role
-    const openaiMsg = asCandidate<ChatCompletionMessageParam>(item);
-    if (role === 'tool' || isToolMessage(openaiMsg)) {
+    if (role === 'tool') {
       const text =
-        typeof openaiMsg.content === 'string'
-          ? openaiMsg.content
-          : prettyJson(openaiMsg.content);
+        typeof msg.content === 'string' ? msg.content : prettyJson(msg.content);
       nodes.push({ kind: 'tool-result', text });
       lastAssistantHadToolUse = false;
     }
   }
 
   return nodes;
-}
-
-/**
- * Bridge a raw, provider-shape-unknown item into one of the candidate SDK
- * item types so a real type-guard function (e.g. `isResponseFunctionToolCallItem`)
- * can check its `type` discriminant. `item` may legitimately be any of
- * Anthropic's, OpenAI's, or Google's shapes — the guard, not this cast, is
- * what verifies it before the caller trusts the narrowed fields.
- */
-function asCandidate<T>(item: Record<string, unknown>): T {
-  return item as unknown as T;
 }
 
 function getAssistantToolCalls(

--- a/src/agent/modelHandlers/openai/openAIResponseContent.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseContent.ts
@@ -47,9 +47,14 @@ export function isAssistantTextMessage(
 
 /** Type guard for function_call_output input items. */
 export function isFunctionCallOutputItem(
-  item?: ResponseInputItem,
+  item: unknown,
 ): item is ResponseInputItem.FunctionCallOutput {
-  return item?.type === 'function_call_output';
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    item.type === 'function_call_output'
+  );
 }
 
 /** Extract the text from an input_text/output_text content part, if it is one. */

--- a/src/agent/modelHandlers/openai/responseStreamEvents.ts
+++ b/src/agent/modelHandlers/openai/responseStreamEvents.ts
@@ -21,9 +21,14 @@ import type {
 
 /** Type guard for function-call output items. */
 export function isResponseFunctionToolCallItem(
-  item: ResponseOutputItem | undefined,
+  item: unknown,
 ): item is ResponseFunctionToolCallItem {
-  return item?.type === 'function_call';
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    item.type === 'function_call'
+  );
 }
 
 /** Type guard for reasoning delta events (both raw and summary). */


### PR DESCRIPTION
## Summary

- accept raw provider values directly in the two OpenAI response-item guards
- remove the unconstrained `asCandidate<T>` assertion helper and its SDK-only type imports
- use the already-normalized role/content for Chat Completions tool messages, removing a redundant SDK role check

Closes #8364.

## Design

Conversation export is a provider boundary, so the guards now own the runtime object/discriminant check. The normalization loop consumes the narrowed value directly instead of asserting an arbitrary record to an SDK type first. This reduces information leakage from provider SDK types into the normalization control flow while preserving the existing output behavior.

The Chat Completions `isToolMessage` check only tested `role === "tool"`, which the loop had already normalized and checked. Removing it also deletes a needless duplicate transformation path.

## Impact

No user-visible output changes are intended. This is a type-safety and dead-code cleanup: 37 lines removed, including one generic helper and three unused imports, with 24 lines added for explicit runtime narrowing.

## Validation

- `corepack pnpm exec prettier --write` on the three changed files
- `corepack pnpm exec eslint` on the three changed files
- `corepack pnpm exec tsc --noEmit --pretty false`
- focused Vitest: 4 files, 25 tests passed
- `npm run lint` (0 errors; 53 pre-existing warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal type-safety and dead-code cleanup in conversation export normalization with no intended user-visible behavior change.
> 
> **Overview**
> Conversation export normalization no longer uses the generic `asCandidate<T>` cast or extra Response API SDK type imports. Raw loop items go straight into **`isResponseFunctionToolCallItem`** and **`isFunctionCallOutputItem`**, which now take **`unknown`** and perform explicit object/`type` discriminant checks before narrowing.
> 
> Chat Completions tool messages are detected only via the already-normalized **`role === 'tool'`** path, using **`msg.content`** directly instead of re-wrapping the item as **`ChatCompletionMessageParam`** and calling **`isToolMessage`**.
> 
> **`isToolMessage`** and three unused SDK imports are removed from the export normalizer; export output behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc12781db67e89dad341d9cdf43096247478e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->