### PR TITLE
refactor: comprehensive post-0.39.3 simplification sweep

### DIFF
--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -169,16 +169,6 @@ export function foregroundEscapeAction({
   }
 }
 
-function childControlForegroundMaxRows({
-  hasItems,
-}: {
-  readonly hasItems: boolean;
-}): number {
-  return hasItems
-    ? CHILD_CONTROL_FOREGROUND_MAX_ROWS
-    : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
-}
-
 function approvalForegroundMaxRows(
   approvalKind: ApprovalKind | undefined,
 ): number | undefined {
@@ -210,7 +200,9 @@ export function foregroundMaxRowsForKind({
 }): number | undefined {
   switch (kind) {
     case 'childControls':
-      return childControlForegroundMaxRows({ hasItems: childControlHasItems });
+      return childControlHasItems
+        ? CHILD_CONTROL_FOREGROUND_MAX_ROWS
+        : EMPTY_CHILD_CONTROL_FOREGROUND_MAX_ROWS;
     case 'form':
       return FORM_FOREGROUND_MAX_ROWS;
     case 'approval':

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -45,9 +45,7 @@ export interface SlashCommand {
    * Set for commands that take a free-text inline argument (e.g. `/foo bar`).
    * When true, Enter in the palette *completes* the command into the input
    * (with a trailing space) so the user can type the argument, rather than
-   * running it argument-less. No built-in command needs this today — every
-   * arg-taking command uses `formComponent` instead — but it's the hook for
-   * future inline-argument commands. See `slashPickIntent`.
+   * running it argument-less (used by `/subscription`). See `slashPickIntent`.
    */
   readonly takesArgs?: boolean;
 }

--- a/packages/cli/src/chat/tui/forms/ConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ConfigForm.tsx
@@ -403,15 +403,10 @@ export function ConfigForm(props: ConfigFormProps): React.JSX.Element {
   const categoryEntries = props.entries.filter(
     (entry) => entry.category === mode.category,
   );
+  // `mode.category` always comes from `buildConfigCategoryItems(props.entries)`,
+  // so a selected category always has at least one entry — no empty-list guard
+  // needed here (the categories view above handles empty `props.entries`).
   const items = buildConfigListItems(categoryEntries, effective);
-
-  if (items.length === 0) {
-    return (
-      <FormFrame title="/config">
-        <Text dimColor>No configurable settings are available here yet.</Text>
-      </FormFrame>
-    );
-  }
 
   const window = computeSelectWindowSize({
     availableRows: props.availableRows,

--- a/packages/cli/src/chat/tui/render/DiffView.tsx
+++ b/packages/cli/src/chat/tui/render/DiffView.tsx
@@ -167,14 +167,6 @@ export function diffVisualRowCount(
   return wrappedDiffDisplayLines(hunks, width, maxHunkLines).length;
 }
 
-export function boundedDiffDisplayLines(
-  hunks: readonly Hunk[],
-  maxHunkLines = 0,
-  maxDisplayLines = 0,
-): DiffDisplayLine[] {
-  return scrollBoundedDiffDisplayLines(hunks, maxHunkLines, maxDisplayLines, 0);
-}
-
 export function maxDiffScrollOffset(
   totalLines: number,
   maxDisplayLines: number,

--- a/packages/cli/src/chat/tui/render/noColorOutput.ts
+++ b/packages/cli/src/chat/tui/render/noColorOutput.ts
@@ -15,7 +15,7 @@ function isCsiFinalCode(code: number): boolean {
   return code >= 0x40 && code <= 0x7e;
 }
 
-function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
+export function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
   const input = `${state.pending}${text}`;
   state.pending = '';
 
@@ -53,12 +53,6 @@ function stripAnsiSgrChunk(text: string, state: SgrStripState): string {
   }
 
   return output;
-}
-
-export function stripAnsiSgrSequences(text: string): string {
-  const state: SgrStripState = { pending: '' };
-  const output = stripAnsiSgrChunk(text, state);
-  return `${output}${state.pending}`;
 }
 
 function chunkText(chunk: unknown): string | undefined {

--- a/packages/cli/src/chat/tui/render/overflowText.ts
+++ b/packages/cli/src/chat/tui/render/overflowText.ts
@@ -44,24 +44,10 @@ function inlineOverflowCountText(
   return `+${hiddenAfter} more`;
 }
 
-/** Select's inline overflow suffix on the focused row. Suppressed when the
- *  list already shows dedicated `... N earlier` / `... N more` marker rows
- *  (`showOverflow`), since that would double up the count. */
-export function selectInlineOverflowText({
-  hiddenAfter,
-  hiddenBefore,
-  showOverflow,
-}: {
-  readonly hiddenAfter: number;
-  readonly hiddenBefore: number;
-  readonly showOverflow: boolean | undefined;
-}): string | undefined {
-  if (showOverflow) return undefined;
-  return inlineOverflowCountText(hiddenBefore, hiddenAfter);
-}
-
-/** As {@link selectInlineOverflowText}, but suppressed entirely when there
- *  are no visible items to attach the suffix to. */
+/** Select's inline overflow suffix on the focused row. Suppressed when there
+ *  are no visible items to attach the suffix to, or when the list already
+ *  shows dedicated `... N earlier` / `... N more` marker rows (`showOverflow`),
+ *  since that would double up the count. */
 export function selectVisibleInlineOverflowText({
   hiddenAfter,
   hiddenBefore,
@@ -73,8 +59,8 @@ export function selectVisibleInlineOverflowText({
   readonly showOverflow: boolean | undefined;
   readonly visibleItemCount: number;
 }): string | undefined {
-  if (visibleItemCount <= 0) return undefined;
-  return selectInlineOverflowText({ hiddenAfter, hiddenBefore, showOverflow });
+  if (visibleItemCount <= 0 || showOverflow) return undefined;
+  return inlineOverflowCountText(hiddenBefore, hiddenAfter);
 }
 
 /** ChildControlPicker's ultra-compact title suffix: the same "+N earlier,

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -255,16 +255,3 @@ export function clearApprovalsWhere(
 ): number {
   return settleItems((item) => predicate(item.payload), decision);
 }
-
-/**
- * Settle every queued approval/question for a stream, of any kind — bash,
- * tool-edit, plan, proposal, retry, user-question, and external-inquiry
- * alike. Used by `HostInteractions.cancel` so a per-stream interrupt/cleanup
- * can settle whatever happens to be pending on that stream instead of leaving
- * it stuck forever.
- */
-export function clearApprovalsForStream(streamId: string): void {
-  clearApprovalsWhere(
-    (payload) => approvalPayloadStreamId(payload) === streamId,
-  );
-}

--- a/packages/cli/src/chat/tui/state/taskDetailScroll.ts
+++ b/packages/cli/src/chat/tui/state/taskDetailScroll.ts
@@ -47,38 +47,6 @@ export function taskDetailWrappedRowCount(
   return Math.max(1, wrapAnsiToWidth(line, outputColumns).split('\n').length);
 }
 
-export function taskDetailVisibleLineCountFromOffsetForColumns({
-  availableColumns,
-  compact,
-  tailLines,
-  visibleRowBudget,
-  offset,
-}: {
-  readonly availableColumns?: number;
-  readonly compact: boolean;
-  readonly tailLines: readonly string[];
-  readonly visibleRowBudget: number;
-  readonly offset: number;
-}): number {
-  if (visibleRowBudget <= 0) return 0;
-  if (!compact || tailLines.length === 0) return visibleRowBudget;
-
-  const outputColumns = taskDetailOutputColumnCount(availableColumns);
-  if (outputColumns === undefined) return visibleRowBudget;
-
-  const start = clamp(offset, 0, tailLines.length - 1);
-  let usedRows = 0;
-  let visibleLines = 0;
-  for (let index = start; index < tailLines.length; index += 1) {
-    const rowCount = taskDetailWrappedRowCount(tailLines[index], outputColumns);
-    if (visibleLines > 0 && usedRows + rowCount > visibleRowBudget) break;
-    visibleLines += 1;
-    usedRows += rowCount;
-    if (usedRows >= visibleRowBudget) break;
-  }
-  return Math.max(1, visibleLines);
-}
-
 export function taskDetailScrollableOutputRowCountForColumns({
   availableColumns,
   compact,

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -327,9 +327,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       case 'resume':
         return runResumeExecution(launchContext, action.id);
       case 'browse-resumes':
-        continue launcher;
       case 'configure-model-access':
-        continue launcher;
       case 'browse-agents':
       case 'browse-teams':
       case 'browse-accounts':

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -217,18 +217,6 @@ function projectCliRunFact(
   return undefined;
 }
 
-function emitProjectedProgressEvent(
-  writeRecord: CliNdjsonProgressRecordWriter,
-  projected: CliProjectedNdjsonProgressEvent,
-): void {
-  writeRecord({
-    kind: 'progress',
-    event: projected.event,
-    ts: new Date().toISOString(),
-    payload: projected.payload,
-  });
-}
-
 function statusProjectionKey(payload: UpdateStreamStatusPayload): string {
   return JSON.stringify([
     payload.streamId,
@@ -259,7 +247,12 @@ export function attachCliSessionProgressProjection(
     } else if (projected.event === 'removeStream') {
       lastStatusByStream.delete(projected.payload.streamId);
     }
-    emitProjectedProgressEvent(writeRecord, projected);
+    writeRecord({
+      kind: 'progress',
+      event: projected.event,
+      ts: new Date().toISOString(),
+      payload: projected.payload,
+    });
   }
 
   const detachSessionFacts = events.subscribe(

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -262,16 +262,8 @@ export async function resolveWorkflowOutput(
     };
   }
 
-  if (!outputFile) {
-    return {
-      ...result,
-      workingDirectory: context.cwd,
-      runDirectory,
-    };
-  }
-
   const finalOutput = latestWorkflowOutput(result.outputs);
-  if (!finalOutput) {
+  if (!outputFile || !finalOutput) {
     return {
       ...result,
       workingDirectory: context.cwd,

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -20,7 +20,7 @@ import type { MenuItemConstructorOptions } from 'electron';
 import type { DesktopRoute } from './desktopShellMessages.js';
 
 export { SETTINGS_TAB };
-export { formatDesktopAccelerator, toElectronAccelerator };
+export { formatDesktopAccelerator };
 
 export const DESKTOP_LOCAL_COMMANDS = {
   SHOW_LOGS: 'texra.desktop.showLogs',

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -139,30 +139,24 @@ async function runDesktopUpdateCheck({
 
   const release = await fetchRelease();
   if (!release) return;
-  if (!isNewerDesktopVersion(release.version, currentVersion)) {
+
+  // Notify at most once per release version; a matching-or-older release just
+  // refreshes the throttle stamp below.
+  if (
+    isNewerDesktopVersion(release.version, currentVersion) &&
+    globalState.get<string>(
+      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
+    ) !== release.version
+  ) {
+    await notify(release);
     await globalState.update(
-      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-      nowMs,
+      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
+      release.version,
     );
-    return;
   }
 
-  const lastNotifiedVersion = globalState.get<string>(
-    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-  );
-  if (lastNotifiedVersion === release.version) {
-    await globalState.update(
-      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-      nowMs,
-    );
-    return;
-  }
-
-  await notify(release);
-  await globalState.update(
-    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-    release.version,
-  );
+  // Stamp the daily throttle only after a successful fetch and any required
+  // notification, so a failed check retries on the next launch.
   await globalState.update(
     GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
     nowMs,

--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -16,7 +16,6 @@ import {
 } from '@commands/housekeeping';
 import {
   registerMergeCommands,
-  registerExecuteCommand,
   registerFollowUpCommand,
   registerResumeAgentCommand,
 } from '@commands/agent';
@@ -50,7 +49,6 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerPackCommands(context);
   registerCleanCommands(context);
   registerMergeCommands(context);
-  registerExecuteCommand(context);
   registerAuthCommands(context);
   registerStateRestoreCommand(context);
   registerSettingsViewCommands(context);

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -14,17 +14,6 @@ import type { ExecutionId } from '@shared/schemas';
 const CHANNEL = 'ExecuteCommand';
 
 /**
- * `texra.execute` migrated to the shared command registry in #3781 batch
- * 4 (handler is `runExecuteCommand`). Kept as a no-op for backward
- * compatibility with the existing call list in `commands.ts`.
- */
-export function registerExecuteCommand(
-  _context: vscode.ExtensionContext,
-): void {
-  // Intentionally empty: handler moved to the shared registry (#3781 batch 4).
-}
-
-/**
  * Execute an agent with the given configuration.
  *
  * Supports two modes:

--- a/packages/extension/src/commands/agent/index.ts
+++ b/packages/extension/src/commands/agent/index.ts
@@ -1,7 +1,7 @@
 // Barrel export for agent commands
 export { stopAgent, compactResponse } from './agentCommands';
 export { handleCreateAgentWithAI } from './agentCreatorCommands';
-export { runExecuteCommand, registerExecuteCommand } from './executeCommand';
+export { runExecuteCommand } from './executeCommand';
 export { registerFollowUpCommand } from './followUpCommand';
 export { registerMergeCommands } from './mergeCommands';
 export { registerResumeAgentCommand } from './resumeCommand';

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -23,7 +23,7 @@ import {
 } from '@utils/git/commitLogFormat';
 import { executeCommandSync } from '@utils/system/execUtils';
 import { extendEnvPath } from '@utils/system/platformPaths';
-import { isGitRepository as probeGitRepository } from '@utils/system/isGitRepository';
+import { isGitRepository } from '@utils/system/isGitRepository';
 
 const CHANNEL = 'gitCommands';
 logger.initialize(CHANNEL);
@@ -53,18 +53,6 @@ export function registerGitCommands(context: vscode.ExtensionContext): void {
     { id: gitCommands.getRecentCommits, handler: getRecentCommits },
     { id: gitCommands.findCommitInHistory, handler: findCommitInHistory },
   ]);
-}
-
-/**
- * Check if the workspace (or a given path) is inside a git repository.
- * Delegates to the host-neutral probe shared with the desktop host so both
- * hosts can't drift apart on worktree/submodule handling.
- *
- * @param rootPath - Optional root path override. Defaults to VS Code workspace.
- *   Pass a worktree path to check a specific checkout.
- */
-function isGitRepository(rootPath?: string): Promise<boolean> {
-  return probeGitRepository(rootPath);
 }
 
 async function getRecentCommits(rootPath?: string): Promise<string[] | null> {

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -48,7 +48,7 @@ const MAX_VISIBLE_ROWS = 20;
  * un-animated native-toggle timing) and the post-animation case (accurate
  * final layout for the fit-addon column/row calculation).
  */
-export const TERMINAL_REFIT_EVENTS = [
+const TERMINAL_REFIT_EVENTS = [
   'toggle',
   'wa-show',
   'wa-after-show',

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -48,11 +48,7 @@ const MAX_VISIBLE_ROWS = 20;
  * un-animated native-toggle timing) and the post-animation case (accurate
  * final layout for the fit-addon column/row calculation).
  */
-const TERMINAL_REFIT_EVENTS = [
-  'toggle',
-  'wa-show',
-  'wa-after-show',
-] as const;
+const TERMINAL_REFIT_EVENTS = ['toggle', 'wa-show', 'wa-after-show'] as const;
 
 /** Ancestor selector for the ancestor disclosure container, matching both
  * the Web Awesome `<wa-details>` custom element and any un-migrated native

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -53,9 +53,8 @@ export function createHostEventHandlerContext(): FrontendEventHandlerContext {
   return {
     getState: () => appState.get(),
     setState: (updater) => appState.set(updater(appState.get())),
-    setStreamState: (streamId, updater) =>
-      setStreamStateForId(streamId, updater),
-    setStreamLogs: (streamId, updater) => setStreamLogsForId(streamId, updater),
+    setStreamState: setStreamStateForId,
+    setStreamLogs: setStreamLogsForId,
   };
 }
 

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -67,7 +67,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
     this.fileManager = new FileManager();
     this.diffManager = new DiffManager();
-    this.instructionManager = new InstructionManager(context);
+    this.instructionManager = new InstructionManager();
     this.interactionController = new MainViewInteractionController({
       getProviderUrl: (provider) =>
         PROVIDER_URLS[provider as keyof typeof PROVIDER_URLS],

--- a/packages/extension/src/webview/frontend/fileDropHandler.ts
+++ b/packages/extension/src/webview/frontend/fileDropHandler.ts
@@ -124,8 +124,6 @@ export class FileDropController implements ReactiveController {
     return this.active;
   }
 
-  hostConnected(): void {}
-
   hostDisconnected(): void {
     this.reset();
   }

--- a/packages/extension/src/webview/managers/InstructionManager.ts
+++ b/packages/extension/src/webview/managers/InstructionManager.ts
@@ -31,7 +31,7 @@ type ClipboardImageMessage = Extract<
 export class InstructionManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
-  constructor(_context: vscode.ExtensionContext) {
+  constructor() {
     super();
     setTimeout(async () => {
       try {

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -167,11 +167,7 @@ export function replayTrace(
     : { ...streamTabBase, kind: 'agent', model: trace.config.model };
   const updateStreams: UpdateStreamsMessage = {
     command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-    streams: [
-      {
-        ...streamTabInfo,
-      },
-    ],
+    streams: [streamTabInfo],
     activeStream: trace.streamId,
     agentFilter: 'all',
     streamStates: {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -472,8 +472,7 @@ class ResponseContinuationNode<C> extends BaseNode<
     const shouldSkip =
       shared.shouldStop || !shared.stopReason || !shared.processedResponse;
 
-    const interrupted =
-      !shouldSkip && Boolean(await this.services.checkInterruption());
+    const interrupted = !shouldSkip && this.services.checkInterruption();
 
     return {
       shouldSkip,

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -11,10 +11,6 @@ import {
   type ExtractedToolAttachments,
 } from '@agent/core/tools/toolAttachmentExtraction';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
-import type {
-  FileInteractionState,
-  WorkPlanState,
-} from '@agent/core/state/AgentWorkspaceState';
 
 // Local imports - logging
 import type { FileLocation } from '@shared/schemas';
@@ -304,16 +300,9 @@ export class ToolUseDispatchNode<C> extends Node<
       return null;
     }
 
-    const { workspace } = this.services;
-    workspace.interactions.recordToolCall();
+    this.services.workspace.interactions.recordToolCall();
 
-    return this.executeToolCall(
-      call,
-      this.services,
-      workspace.interactions,
-      workspace.workPlan,
-      batchSignal,
-    );
+    return this.executeToolCall(call, this.services, batchSignal);
   }
 
   /**
@@ -362,8 +351,6 @@ export class ToolUseDispatchNode<C> extends Node<
     tool: { call(input: unknown): Promise<ToolResult> } | undefined,
     parsedInput: unknown,
     options: ToolUseRoundServices<C>,
-    tracker: FileInteractionState,
-    workPlanState: WorkPlanState,
     onExecutionReady?: () => void,
     onToolOutput?: (chunk: string) => void,
     signal?: AbortSignal,
@@ -378,8 +365,8 @@ export class ToolUseDispatchNode<C> extends Node<
     try {
       return await withToolFileInteractionContext(
         {
-          tracker,
-          workPlanState,
+          tracker: options.workspace.interactions,
+          workPlanState: options.workspace.workPlan,
           userInstruction:
             options.config.rootUserInstruction ?? this._currentUserInstruction,
           toolCallId: call.callId,
@@ -413,8 +400,6 @@ export class ToolUseDispatchNode<C> extends Node<
   private async executeToolCall(
     call: SdkToolCall,
     options: ToolUseRoundServices<C>,
-    tracker: FileInteractionState,
-    workPlanState: WorkPlanState,
     batchSignal: AbortSignal | null,
   ): Promise<ToolExecutionResult | null> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
@@ -491,8 +476,6 @@ export class ToolUseDispatchNode<C> extends Node<
         tool,
         parsedInput,
         options,
-        tracker,
-        workPlanState,
         onExecutionReady,
         onToolOutput,
         controller.signal,
@@ -524,7 +507,7 @@ export class ToolUseDispatchNode<C> extends Node<
       return null;
     }
 
-    const trackedEdits = tracker.recordEdits(
+    const trackedEdits = options.workspace.interactions.recordEdits(
       result.status === 'executed' ? result.edits : undefined,
     );
     if (
@@ -551,20 +534,6 @@ export class ToolUseDispatchNode<C> extends Node<
       editedFiles,
       logRef,
     };
-  }
-
-  /**
-   * Build a synthetic "cancelled" result for a tool_use that never executed
-   * (interrupted before dispatch, or aborted mid-flight and returned `null`
-   * from `exec()`). Mirrors the duplicate-call synthetic result shape so it
-   * flows through the same follow-up-message construction unchanged.
-   */
-  private buildCancelledResult(call: SdkToolCall): ToolExecutionResult {
-    const cancelledResult: ToolResult = {
-      status: 'error',
-      error: CANCELLED_CALL_ERROR,
-    };
-    return this.makeSyntheticResult(call, cancelledResult, call.input);
   }
 
   private async logAndProcessMediaFiles(
@@ -664,7 +633,11 @@ export class ToolUseDispatchNode<C> extends Node<
       const execResult = execResults[index];
       if (execResult) return execResult;
       interrupted = true;
-      return this.buildCancelledResult(call);
+      return this.makeSyntheticResult(
+        call,
+        { status: 'error', error: CANCELLED_CALL_ERROR },
+        call.input,
+      );
     });
 
     if (interrupted) {

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -153,7 +153,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
       kind: 'success',
       toolCalls: endTurn ? undefined : toolCalls,
       stopReason,
-      text: text ?? undefined,
+      text,
       endTurn,
       serverToolContentBlocks: serverToolData.contentBlocks,
       lastAssistantContent,

--- a/src/agent/export/chatExport/filenames.ts
+++ b/src/agent/export/chatExport/filenames.ts
@@ -21,17 +21,7 @@ export function generateExportFilename(
   input: ExportFilenameInput,
   extension: 'md' | 'tex' | 'html',
 ): string {
-  return `${generateExportFolderName(input)}.${extension}`;
-}
-
-/**
- * Shared filename stem (no extension) used by single-file exports (md/tex/html).
- */
-function generateExportFolderName(input: ExportFilenameInput): string {
-  const date = new Date(input.timestamp);
-  const datePart = isoDateOnly(date);
-
-  const parts = ['texra-chat', datePart];
+  const parts = ['texra-chat', isoDateOnly(new Date(input.timestamp))];
 
   if (input.config.agent) {
     parts.push(sanitizeFilename(input.config.agent));
@@ -43,7 +33,7 @@ function generateExportFolderName(input: ExportFilenameInput): string {
     parts.push(sanitizeFilename(shortModel));
   }
 
-  return parts.join('-');
+  return `${parts.join('-')}.${extension}`;
 }
 
 function sanitizeFilename(name: string): string {

--- a/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
@@ -5,7 +5,6 @@ import { computeUtilizationPercent } from '../support/contextUtilization';
 // Type imports - Anthropic SDK
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
-  BetaContentBlock,
   BetaContentBlockParam,
   BetaCompactionBlock,
   BetaCompactionIterationUsage,

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -23,12 +23,7 @@ import type { MediaEntry } from '@agent/utils/mediaTypes';
 // Local imports - common
 import { ANTHROPIC_STOP } from '@agent/types/StopReasonTypes';
 import {
-  extractAnthropicWebFetchResults,
-  extractAnthropicWebSearchResults,
   isAnthropicServerToolContent,
-  isAnthropicServerToolUse,
-  isAnthropicWebFetchResult,
-  isAnthropicWebSearchResult,
   type ServerToolExtractionResult,
 } from '@agent/types/ServerToolTypes';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
@@ -138,9 +133,6 @@ import type {
   DocumentBlockParam,
   ThinkingBlockParam,
   RedactedThinkingBlockParam,
-  ServerToolUseBlock,
-  WebSearchToolResultBlock,
-  WebFetchToolResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 type ErrorWithRequestId = Error & { request_id?: string };

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -17,7 +17,6 @@ import {
 
 // Local imports - agent
 import type { StreamHandle } from '@agent/trace';
-import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -14,7 +14,6 @@ import {
 
 // Local imports - agent
 import { logProgressStatus } from '@agent/trace';
-import { hasEndTag } from '@agent/core/definition/AgentDataclass';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { reportMediaAttachmentFailure } from '@agent/modelHandlers/support/mediaAttachmentPolicy';

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -44,8 +44,6 @@ export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   touchedFiles: z.array(z.string()).optional(),
 });
 
-export type ToolUseFlowResult = z.infer<typeof ToolUseFlowResultSchema>;
-
 const AgentFlowResultSchema = z.discriminatedUnion('category', [
   WorkflowFlowResultSchema,
   ToolUseFlowResultSchema,

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -159,19 +159,14 @@ export async function compileLatex2Pdf(
     // revised sibling wins over the original source fallback.
     const documentDir = path.dirname(latexFile);
 
-    // Get TikZ input directory from configuration
     const tikzInputDirectory = getConfig<string>(
       'texra.latex.tikzInputDirectory',
       '',
     );
-
-    // Check if workspace path should be included
     const includeWorkspace = getConfig<boolean>(
       'texra.latex.includeWorkspaceInTexinputs',
       true,
     );
-
-    // Build TEXINPUTS from configured paths
     const workspacePath = includeWorkspace ? WorkspaceFS.getPath() : null;
     const { texInputParts, bibSearchParts } = buildLatexSearchParts({
       documentDir,

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -15,11 +15,7 @@ import {
 } from '@shared/utils/dispatcher';
 
 import { SwitchViewMessageSchema } from '../commonViewMessages';
-import {
-  commandOnly,
-  withFilesArray,
-  withOptionalFilePath,
-} from '../messageFactories';
+import { commandOnly, withFilesArray } from '../messageFactories';
 import {
   ExtendedDocumentFileTypeSchema,
   MultipleDocumentFileTypeSchema,
@@ -126,7 +122,10 @@ const FileSelectionMessages = [
 ] as const;
 
 const FileSelectedMessages = [
-  withOptionalFilePath(MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED),
+  z.object({
+    command: z.literal(MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED),
+    filePath: z.string().optional(),
+  }),
 ] as const;
 
 const RequestFileMessages = [

--- a/src/shared/schemas/messageFactories.ts
+++ b/src/shared/schemas/messageFactories.ts
@@ -12,14 +12,6 @@ export function commandOnly<T extends string>(command: T) {
   return z.object({ command: z.literal(command) });
 }
 
-/** Schema with `command` + optional `filePath`. */
-export function withOptionalFilePath<T extends string>(command: T) {
-  return z.object({
-    command: z.literal(command),
-    filePath: z.string().optional(),
-  });
-}
-
 /** Schema with `command` + required `files` string array. */
 export function withFilesArray<T extends string>(command: T) {
   return z.object({ command: z.literal(command), files: z.array(z.string()) });

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -166,15 +166,12 @@ export const commonViewStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
-  .panel-collapsible::part(content) {
-    padding: 0 var(--wa-space-2xs) var(--wa-space-2xs);
-  }
-
   /* wa-details exposes the body via the 'content' part. The grid 1fr/0fr
      trick lets long content scale without a fixed max-height cap. The
      direct child wrapper carries 'overflow: hidden' and 'min-height: 0'
      so the grid row can clamp it without truncation jumps. */
   .panel-collapsible::part(content) {
+    padding: 0 var(--wa-space-2xs) var(--wa-space-2xs);
     display: grid;
     grid-template-rows: 1fr;
   }

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -25,10 +25,6 @@ export function listRuntimeSkillSources(): SkillSource[] {
   return runtimeSkillSources.map((source) => ({ ...source }));
 }
 
-export function clearRuntimeSkillSources(): void {
-  runtimeSkillSources.length = 0;
-}
-
 function formatRuntimeSkillCatalog(skills: readonly SourcedSkill[]): string {
   return skills
     .map(({ skill, source }) => {

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -16,7 +16,6 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 }));
 
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 
 // Local imports - event bus
 import { appSignals, type AppSignalPayloads } from '@eventBus/AppSignals';

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -22,7 +22,7 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
   type LiveToolUseFlowContext,

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -71,23 +71,6 @@ const RAW_USAGE = {
   output_tokens: 1_000_000,
 } as ResponseUsage;
 
-function createResponse(inputTokens: number) {
-  return {
-    id: 'response-id',
-    status: 'completed',
-    output: [],
-    output_text: 'ok',
-    usage: { input_tokens: inputTokens, output_tokens: 1 },
-  };
-}
-
-function createResponseStream(response: ReturnType<typeof createResponse>) {
-  return {
-    async *[Symbol.asyncIterator]() {},
-    finalResponse: async () => response,
-  };
-}
-
 /** Seed the handler's running input-token tally (owned by the chain-state
  *  collaborator; reached here via its narrow setter, not a raw field write). */
 function setCumulativeInputTokens(

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports - agent output
 

--- a/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentShutdown.vitest.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 // Local imports - runtime
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
-import { SessionHandle, defaultSession } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 // Local imports - CLI session stores
 import {
   ClaudeAgentSessions,

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -21,7 +21,6 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 
 // Local imports - runtime
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { ExecutionSubscriptionBinder } from '@agent/runtime/ExecutionSubscriptionBinder';
 import {
   AgentExecutionHandle,

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -9,7 +9,6 @@ import {
   generateSessionDescription,
   getSessionDescriptionInstruction,
 } from '@agent/runtime/sessionDescription';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 

--- a/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionEventHub.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { TraceEmitter } from '@agent/trace';
 import {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -16,7 +16,6 @@ import {
 } from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { createDesktopHostInteractions } from '@desktop/main/desktopHostInteractions';
-import type { DesktopToolEditApprovalController } from '@desktop/main/desktopToolEditApproval';
 import {
   AgentCategory,
   type AgentProposal,

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -21,7 +21,7 @@ import {
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { runFlowWithLifecycle } from '@agent/runtime/AgentRunLifecycle';
 import { createRunScope } from '@agent/runtime/RunScope';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
@@ -29,7 +29,6 @@ import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
-  STREAM_STATUS,
   type ExecutionId,
   type StorageKey,
   type StreamTabId,

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -18,7 +18,7 @@ import {
 } from '@test/helpers/streamStatusTestUtils';
 import { resumeToolUseSnapshot } from '@agent/runtime/resumeToolUseSnapshot';
 import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -7,10 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports - agent components
 import { FakeConfigProvider } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import {
-  clearRuntimeSkillSources,
-  setRuntimeSkillSources,
-} from '@skills/runtimeSkills';
+import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { noopTrace } from '@agent/trace';
 import {
   AgentConfigSchema,
@@ -106,7 +103,7 @@ describe('buildUserVars runtime skill diagnostics', () => {
   });
 
   afterEach(async () => {
-    clearRuntimeSkillSources();
+    setRuntimeSkillSources([]);
     await fakeConfig.update('texra.skills.enabled', undefined);
   });
 

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -14,7 +14,7 @@ import {
   approvalPayloadStreamId,
   approvalQueueStatus,
   clearApprovals,
-  clearApprovalsForStream,
+  clearApprovalsWhere,
   currentApproval,
   enqueueApproval,
   type ApprovalPayload,
@@ -247,8 +247,10 @@ describe('CLI approval queue', () => {
 
   // Regression coverage for #7306: the per-stream cancel previously only cancelled
   // retry routes, leaving bash/tool-edit/plan/proposal/user-question requests
-  // permanently pending on a stream-scoped interrupt.
-  it('clears every pending kind for a stream via clearApprovalsForStream, leaving other streams alone', async () => {
+  // permanently pending on a stream-scoped interrupt. HostInteractions.cancel
+  // now settles a stream via clearApprovalsWhere with a streamId predicate
+  // (see subscribeApprovals.ts), so this exercises that same multi-kind clear.
+  it('clears every pending kind for a stream via clearApprovalsWhere, leaving other streams alone', async () => {
     const planPayload = {
       kind: 'plan',
       payload: { approvalId: 'approval-1', streamId: 'stream-a' },
@@ -271,7 +273,9 @@ describe('CLI approval queue', () => {
       expect(currentApproval.get()?.payload).toBe(planPayload);
     });
 
-    clearApprovalsForStream('stream-a');
+    clearApprovalsWhere(
+      (payload) => approvalPayloadStreamId(payload) === 'stream-a',
+    );
 
     const interrupted = {
       accepted: false,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -29,7 +29,6 @@ import {
   taskDetailFollowTailScrollOffsetForColumns,
   taskDetailInitialScrollOffset,
   taskDetailScrollableOutputRowCountForColumns,
-  taskDetailVisibleLineCountFromOffsetForColumns,
   taskDetailVisibleOutputRowsFromOffsetForColumns,
   taskDetailVisibleScrollOffset,
   taskDetailWrappedRowCount,
@@ -1295,24 +1294,25 @@ describe('CLI child execution controls', () => {
   it('budgets compact task detail output by wrapped terminal rows', () => {
     expect(taskDetailWrappedRowCount('abcd', 4)).toBe(1);
     expect(taskDetailWrappedRowCount('abcde', 4)).toBe(2);
+    const mixedLines = ['x'.repeat(180), 'short 1', 'short 2', 'short 3'];
     expect(
-      taskDetailVisibleLineCountFromOffsetForColumns({
+      taskDetailVisibleOutputRowsFromOffsetForColumns({
         availableColumns: 80,
         compact: true,
-        tailLines: ['x'.repeat(180), 'short 1', 'short 2', 'short 3'],
+        tailLines: mixedLines,
         visibleRowBudget: 3,
         offset: 0,
       }),
-    ).toBe(1);
+    ).toEqual(['x'.repeat(76), 'x'.repeat(76), 'x'.repeat(28)]);
     expect(
-      taskDetailVisibleLineCountFromOffsetForColumns({
+      taskDetailVisibleOutputRowsFromOffsetForColumns({
         availableColumns: 80,
         compact: true,
-        tailLines: ['x'.repeat(180), 'short 1', 'short 2', 'short 3'],
+        tailLines: mixedLines,
         visibleRowBudget: 3,
-        offset: 1,
+        offset: 3,
       }),
-    ).toBe(3);
+    ).toEqual(['short 1', 'short 2', 'short 3']);
     const wrappedRows = taskDetailVisibleOutputRowsFromOffsetForColumns({
       availableColumns: 48,
       compact: true,

--- a/src/test-kernel/cli/CliSkills.vitest.mts
+++ b/src/test-kernel/cli/CliSkills.vitest.mts
@@ -5,10 +5,7 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { defaultSkillSources } from '@skills/skillSources';
-import {
-  clearRuntimeSkillSources,
-  setRuntimeSkillSources,
-} from '@skills/runtimeSkills';
+import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import {
   formatCliSkillList,
   readCliRuntimeSkills,
@@ -38,7 +35,7 @@ async function writeSkill(
 }
 
 afterEach(async () => {
-  clearRuntimeSkillSources();
+  setRuntimeSkillSources([]);
   await Promise.all(
     tempRoots.splice(0).map((root) => {
       return fs.rm(root, { recursive: true, force: true });

--- a/src/test-kernel/cli/DiffView.vitest.mts
+++ b/src/test-kernel/cli/DiffView.vitest.mts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  boundedDiffDisplayLines,
   buildHunks,
   diffVisualRowCount,
   maxDiffScrollOffset,
@@ -30,7 +29,7 @@ describe('CLI diff display', () => {
       'zeta',
     ]);
 
-    const lines = boundedDiffDisplayLines(hunks, 30, 4);
+    const lines = scrollBoundedDiffDisplayLines(hunks, 30, 4, 0);
 
     expect(lines).toHaveLength(4);
     expect(lines.at(-1)).toMatchObject({
@@ -106,7 +105,7 @@ describe('CLI diff display', () => {
     expect(rendered).toContain('after $2n-1$.');
     expect(rendered).not.toContain('…');
     expect(diffVisualRowCount(hunks, 36)).toBeGreaterThan(
-      boundedDiffDisplayLines(hunks).length,
+      scrollBoundedDiffDisplayLines(hunks, 0, 0, 0).length,
     );
   });
 

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -18,10 +18,7 @@ import {
   selectItemRenderKey,
   visibleSelectRange,
 } from '@cli/chat/tui/ui/Select';
-import {
-  selectInlineOverflowText,
-  selectVisibleInlineOverflowText,
-} from '@cli/chat/tui/render/overflowText';
+import { selectVisibleInlineOverflowText } from '@cli/chat/tui/render/overflowText';
 
 describe('CLI ModelListForm empty state', () => {
   it('uses a truthful description for empty and non-empty model lists', () => {
@@ -203,34 +200,49 @@ describe('CLI Select visible range', () => {
 describe('CLI Select inline overflow', () => {
   it('summarizes hidden choices when separate overflow rows are disabled', () => {
     expect(
-      selectInlineOverflowText({
+      selectVisibleInlineOverflowText({
         hiddenBefore: 0,
         hiddenAfter: 3,
         showOverflow: false,
+        visibleItemCount: 3,
       }),
     ).toBe('+3 more');
     expect(
-      selectInlineOverflowText({
+      selectVisibleInlineOverflowText({
         hiddenBefore: 2,
         hiddenAfter: 0,
         showOverflow: false,
+        visibleItemCount: 3,
       }),
     ).toBe('+2 earlier');
     expect(
-      selectInlineOverflowText({
+      selectVisibleInlineOverflowText({
         hiddenBefore: 2,
         hiddenAfter: 4,
         showOverflow: false,
+        visibleItemCount: 3,
       }),
     ).toBe('+2 earlier, +4 more');
   });
 
   it('defers to separate overflow rows when they are enabled', () => {
     expect(
-      selectInlineOverflowText({
+      selectVisibleInlineOverflowText({
         hiddenBefore: 0,
         hiddenAfter: 3,
         showOverflow: true,
+        visibleItemCount: 3,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('suppresses inline overflow when there are no visible items', () => {
+    expect(
+      selectVisibleInlineOverflowText({
+        hiddenBefore: 0,
+        hiddenAfter: 3,
+        showOverflow: false,
+        visibleItemCount: 0,
       }),
     ).toBeUndefined();
   });

--- a/src/test-kernel/cli/TuiNoColorOutput.vitest.mts
+++ b/src/test-kernel/cli/TuiNoColorOutput.vitest.mts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   sgrStrippingWriteStream,
-  stripAnsiSgrSequences,
+  stripAnsiSgrChunk,
 } from '@cli/chat/tui/render/noColorOutput';
 
 describe('TUI no-color output', () => {
@@ -24,7 +24,9 @@ describe('TUI no-color output', () => {
   it('strips SGR styling while preserving terminal control escapes', () => {
     const input = '\x1b[2mDim\x1b[22m\x1b[36m cyan\x1b[39m\x1b[2K\x1b[1;1H';
 
-    expect(stripAnsiSgrSequences(input)).toBe('Dim cyan\x1b[2K\x1b[1;1H');
+    expect(stripAnsiSgrChunk(input, { pending: '' })).toBe(
+      'Dim cyan\x1b[2K\x1b[1;1H',
+    );
   });
 
   it('strips SGR styling from byte chunks passed to write streams', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -5,7 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { EventEmitter } from 'node:events';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createRunTrace } from '@transcript';
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - command catalog and shared schemas
+import { toElectronAccelerator } from '@shared/commands/accelerators';
 import { commandCatalogById, type CommandId } from '@shared/commands/catalog';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
@@ -89,9 +90,7 @@ describe('desktop command surface', () => {
     ).toEqual(['Help', 'Help']);
   });
 
-  it('normalizes catalog keybindings to Electron accelerators', async () => {
-    const { toElectronAccelerator } = await loadDesktopCommandSurface();
-
+  it('normalizes catalog keybindings to Electron accelerators', () => {
     expect(
       toElectronAccelerator(
         { key: 'ctrl+alt+shift+c', mac: 'cmd+option+shift+c' },

--- a/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
@@ -4,9 +4,6 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
-// Local imports - runtime events
-import { SessionHandle } from '@agent/runtime/SessionHandle';
-
 // Local imports - status bar state
 import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
 import { subscribeStatusBarSessionEvents } from '@frontend/statusBar/statusBarSessionEvents';

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -19,7 +19,7 @@ vi.mock('@frontend/approval/nativeToolEditApproval', () => ({
   nativeRequestApproval: mocks.nativeRequestApproval,
 }));
 
-interface RecordingApprovalHandler<T extends { streamId: string }> {
+interface RecordingApprovalHandler {
   readonly show: ReturnType<typeof vi.fn>;
   readonly resolve: ReturnType<typeof vi.fn>;
   readonly replay: ReturnType<typeof vi.fn>;
@@ -30,9 +30,7 @@ interface RecordingApprovalHandler<T extends { streamId: string }> {
   readonly pendingSize: number;
 }
 
-function handler<
-  T extends { streamId: string },
->(): RecordingApprovalHandler<T> {
+function handler(): RecordingApprovalHandler {
   return {
     show: vi.fn(),
     resolve: vi.fn(),

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createFakePlatform } from '@test/support/FakePlatform';
 import {
-  clearRuntimeSkillSources,
   formatRuntimeSkillActivation,
   loadRuntimeSkillCatalog,
   setRuntimeSkillSources,
@@ -44,7 +43,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  clearRuntimeSkillSources();
+  setRuntimeSkillSources([]);
   await Promise.all(
     tempRoots.splice(0).map((root) => {
       return fs.rm(root, { recursive: true, force: true });

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -9,7 +9,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupApprovalsForStream,

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -218,7 +218,6 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     setupCommonMocks();
     const firstEnvStarted = pDefer<void>();
     const firstEnv = pDefer<NodeJS.ProcessEnv>();
-    const executions = { getAgentHandleByStream: () => undefined } as any;
     let strategy: ChildRunStrategy<unknown> | undefined;
     mocks.buildClaudeAgentEnv
       .mockImplementationOnce(() => {

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -190,7 +190,6 @@ describe('codex tool - atomic resume fallback', () => {
     const firstImportStarted = pDefer<void>();
     const firstImport = pDefer<any>();
     const thread = { id: 'stale-thread', runStreamed: vi.fn() };
-    const executions = { getAgentHandleByStream: () => undefined } as any;
     let strategy: ChildRunStrategy<unknown> | undefined;
     mocks.importCodexClass
       .mockImplementationOnce(() => {

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -19,7 +19,6 @@ import { flowKey } from '@agent/node/persistedFlow';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
-import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   RUN_DESCRIPTOR_SCHEMA_VERSION,
   STREAM_PHASE,

--- a/src/test-kernel/tools/GitignoreMatcher.vitest.mts
+++ b/src/test-kernel/tools/GitignoreMatcher.vitest.mts
@@ -196,22 +196,3 @@ describe('getGitignoreMatcher', () => {
     );
   });
 });
-
-describe('createGlobMatcher', () => {
-  it('does not apply basename matching to slash-containing patterns', async () => {
-    const { createGlobMatcher } = await import('@tools/utils');
-    const matcher = createGlobMatcher('src/*.js');
-
-    expect(matcher('src/foo.js')).toBe(true);
-    expect(matcher('lib/foo.js')).toBe(false);
-    expect(matcher('foo.js')).toBe(false);
-  });
-
-  it('keeps basename matching for slash-free patterns', async () => {
-    const { createGlobMatcher } = await import('@tools/utils');
-    const matcher = createGlobMatcher('*.js');
-
-    expect(matcher('foo.js')).toBe(true);
-    expect(matcher('src/foo.js')).toBe(true);
-  });
-});

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createRecordingHost } from '@test/agent/progressTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 

--- a/src/test-kernel/tools/GoalStateSubscription.vitest.ts
+++ b/src/test-kernel/tools/GoalStateSubscription.vitest.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 import { createRecordingHost } from '@test/agent/progressTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -707,13 +707,7 @@ describe('StreamSnapshotStore', () => {
     );
 
     const store = new StreamSnapshotStore();
-    const taskState = TaskStateSchema.parse({
-      agentConfig: {
-        agent: 'search',
-        model: 'deepseekproT',
-        agentCategory: AgentCategory.ToolUse,
-      },
-    }) as TaskState;
+    const taskState = toolUseTaskState();
     const executionId = 'abc123' as ExecutionId;
 
     store.setTaskState(STREAM, taskState, executionId);

--- a/src/test-kernel/utils/WorkflowPromptFileNames.vitest.mts
+++ b/src/test-kernel/utils/WorkflowPromptFileNames.vitest.mts
@@ -2,10 +2,10 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Local imports - test support
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 // Local imports - agent output
 import {
@@ -21,17 +21,12 @@ import {
 } from '@utils/prompt';
 
 describe('workflow prompt file names', () => {
-  beforeEach(async () => {
-    const { initPlatform } = await import('@platform/platform');
-    initPlatform(
-      createFakePlatform({
-        workspacePath: '/workspace',
-        files: {
-          '/workspace/chapter/main.tex': 'workspace text',
-          '/outside/absolute.tex': 'external text',
-        },
-      }),
-    );
+  setupPlatform({
+    workspacePath: '/workspace',
+    files: {
+      '/workspace/chapter/main.tex': 'workspace text',
+      '/outside/absolute.tex': 'external text',
+    },
   });
 
   it('uses workspace-relative names and external basenames in prompt variables', async () => {

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -66,16 +66,9 @@ describe('getValidatedConfig', () => {
 // PlatformSettings
 // ---------------------------------------------------------------------------
 
-function initWith(options: {
-  workspaceState?: Record<string, unknown>;
-  globalState?: Record<string, unknown>;
-}): Promise<void> {
-  return installPlatform(options);
-}
-
 describe('readPlatformSetting', () => {
   it('resolves the default from the catalog schema when the key is unset', async () => {
-    await initWith({});
+    await installPlatform({});
     expect(readPlatformSetting(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
       LATEX_CONFIG_DEFAULTS.latexFormatter,
     );
@@ -84,7 +77,7 @@ describe('readPlatformSetting', () => {
   });
 
   it('returns the stored value when present and valid', async () => {
-    await initWith({
+    await installPlatform({
       workspaceState: { [WorkspaceStateKey.LATEX_FORMATTER]: 'tex-fmt' },
     });
     expect(readPlatformSetting(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
@@ -93,7 +86,7 @@ describe('readPlatformSetting', () => {
   });
 
   it('snaps a stored value that fails the schema back to the catalog default', async () => {
-    await initWith({
+    await installPlatform({
       workspaceState: {
         [WorkspaceStateKey.LATEX_FORMATTER]: 'not-a-formatter',
       },
@@ -104,7 +97,7 @@ describe('readPlatformSetting', () => {
   });
 
   it('throws for a key with no catalog entry', async () => {
-    await initWith({});
+    await installPlatform({});
     expect(() => readPlatformSetting('texra.not.a.catalog.key')).toThrow(
       /no state-setting catalog entry/i,
     );

--- a/src/tools/deliveryEnvelope.ts
+++ b/src/tools/deliveryEnvelope.ts
@@ -19,21 +19,6 @@ interface DeliveryEnvelopeAttribute {
   readonly value: string | number | boolean | null | undefined;
 }
 
-interface DeliveryEnvelopeParams {
-  readonly tag: string;
-  readonly attributes: readonly DeliveryEnvelopeAttribute[];
-  readonly bodyLines: readonly string[];
-}
-
-function formatDeliveryEnvelope(params: DeliveryEnvelopeParams): string {
-  const attrs = params.attributes
-    .filter((attr) => attr.value != null)
-    .map((attr) => `${attr.name}="${escapeAttr(String(attr.value))}"`)
-    .join(' ');
-  const open = attrs ? `<${params.tag} ${attrs}>` : `<${params.tag}>`;
-  return [open, ...params.bodyLines, `</${params.tag}>`].join('\n');
-}
-
 /** Maximum prompt length echoed back in a delivery/error XML attribute. */
 const DELIVERY_PROMPT_MAX = 200;
 
@@ -54,22 +39,24 @@ function childRunEnvelopeXml(
   envelope: ChildRunEnvelope,
   bodyLines: readonly string[],
 ): string {
-  return formatDeliveryEnvelope({
-    tag: envelope.tag,
-    attributes: [
-      { name: 'id', value: envelope.executionId },
-      ...(envelope.prompt !== undefined
-        ? [
-            {
-              name: 'prompt',
-              value: envelope.prompt.slice(0, DELIVERY_PROMPT_MAX),
-            },
-          ]
-        : []),
-      ...(envelope.attributes ?? []),
-    ],
-    bodyLines,
-  });
+  const attributes: readonly DeliveryEnvelopeAttribute[] = [
+    { name: 'id', value: envelope.executionId },
+    ...(envelope.prompt !== undefined
+      ? [
+          {
+            name: 'prompt',
+            value: envelope.prompt.slice(0, DELIVERY_PROMPT_MAX),
+          },
+        ]
+      : []),
+    ...(envelope.attributes ?? []),
+  ];
+  const attrs = attributes
+    .filter((attr) => attr.value != null)
+    .map((attr) => `${attr.name}="${escapeAttr(String(attr.value))}"`)
+    .join(' ');
+  const open = attrs ? `<${envelope.tag} ${attrs}>` : `<${envelope.tag}>`;
+  return [open, ...bodyLines, `</${envelope.tag}>`].join('\n');
 }
 
 interface ChildRunDeliveryFacts {

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -59,15 +59,17 @@ export function getExecutionStatusInfo(
   const session = currentSession();
   const handle = session.executions.getHandle(executionId);
   if (handle) return session.executions.getStatus(handle);
+
   const persistedStatus = ExecutionStatusSchema.safeParse(terminalStatus);
-  return {
-    status: persistedStatus.success
-      ? persistedStatus.data
-      : terminalStatus === undefined
-        ? EXECUTION_STATUS.COMPLETED
-        : 'unknown',
-    elapsed: null,
-  };
+  let status: ExecutionStatusInfo['status'];
+  if (persistedStatus.success) {
+    status = persistedStatus.data;
+  } else if (terminalStatus === undefined) {
+    status = EXECUTION_STATUS.COMPLETED;
+  } else {
+    status = 'unknown';
+  }
+  return { status, elapsed: null };
 }
 
 /** Format a listing entry as a single summary line. */

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -50,7 +50,6 @@ import {
 } from './subscriptionBindings';
 import { SharedIssuePollingSource } from './IssuePollingSource';
 import { SharedPRPollingSource } from './PRPollingSource';
-import { SharedRepoPollingSource } from './RepoPollingSource';
 import type { GhIssue, GhPullRequest } from './prTypes';
 
 const GitHubSubscriptionInputSchema = z.strictObject({
@@ -312,17 +311,13 @@ function execUnsubscribe(input: GitHubSubscriptionInput): ToolResult {
 
 function execList(): ToolResult {
   const { streamId } = requireRunStream('github_subscription');
-  const prKeys = listPRSubscriptionBindings(SharedPRPollingSource.activeKeys())
+  const prKeys = listPRSubscriptionBindings()
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);
-  const repoKeys = listRepoSubscriptionBindings(
-    SharedRepoPollingSource.activeKeys(),
-  )
+  const repoKeys = listRepoSubscriptionBindings()
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);
-  const issueKeys = listIssueSubscriptionBindings(
-    SharedIssuePollingSource.activeKeys(),
-  )
+  const issueKeys = listIssueSubscriptionBindings()
     .filter((b) => b.streamIds.includes(streamId))
     .map((b) => b.key);
   const all = [...repoKeys, ...prKeys, ...issueKeys];

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,24 +1,6 @@
-// Third-party imports
-import micromatch from 'micromatch';
-
 // Local imports - common
 import { ToolError } from '@shared/schemas/toolResult';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-
-/**
- * Compile a glob pattern into a matcher that operates on POSIX-style paths.
- * Supports `*`, `?`, and `**` tokens.
- */
-export function createGlobMatcher(pattern: string): (value: string) => boolean {
-  // Preserve Minimatch semantics: basename matching is only enabled for
-  // slash-free patterns. micromatch changes slash-containing pattern behavior
-  // when matchBase is true, so gate it before compiling.
-  const isMatch = micromatch.matcher(pattern, {
-    dot: true,
-    matchBase: !pattern.includes('/'),
-  });
-  return (value: string) => isMatch(value.replaceAll('\\', '/'));
-}
 
 /**
  * Count non-overlapping occurrences of `needle` in `haystack`.

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -177,9 +177,11 @@ export class ZoteroSearchTool extends defineTool({
     }
 
     const collectionMap = include_collections
-      ? await this.fetchCollections(
-          result.map((r) => r.citekey),
+      ? await callBetterBibTeX(
+          'item.collections',
+          [result.map((r) => r.citekey), true],
           port,
+          z.record(z.string(), z.array(BbtCollectionChainSchema)),
         )
       : null;
 
@@ -200,18 +202,5 @@ export class ZoteroSearchTool extends defineTool({
       summary: `Found ${formatResultCount(result.length, 'item')} matching ${label}`,
       output: items.join('\n'),
     };
-  }
-
-  private async fetchCollections(
-    citekeys: string[],
-    port: number,
-  ): Promise<Record<string, BbtCollectionChain[]>> {
-    if (citekeys.length === 0) return {};
-    return callBetterBibTeX(
-      'item.collections',
-      [citekeys, true],
-      port,
-      z.record(z.string(), z.array(BbtCollectionChainSchema)),
-    );
   }
 }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -861,20 +861,13 @@ export class StreamLogStore {
   private parsePersistedSummary(value: unknown): StreamLogSummary | undefined {
     const result = StreamLogSummarySchema.safeParse(value);
     if (!result.success) return undefined;
-    const {
-      firstTimestamp,
-      lastTimestamp,
-      hasRunningGroup,
-      hasRunningStreamingText,
-    } = result.data;
-    if (firstTimestamp === undefined && lastTimestamp === undefined)
+    if (
+      result.data.firstTimestamp === undefined &&
+      result.data.lastTimestamp === undefined
+    ) {
       return undefined;
-    return {
-      firstTimestamp,
-      lastTimestamp,
-      hasRunningGroup,
-      hasRunningStreamingText,
-    };
+    }
+    return result.data;
   }
 
   private async writeStream(

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -362,21 +362,17 @@ export class StreamSnapshotStore {
         if (sessionEvent.scope !== 'run') return;
         const { event } = sessionEvent;
 
-        if (event.type === 'run.config') {
-          this.setTaskState(
-            event.streamId,
-            agentConfigToTaskState(event.config),
-            event.executionId,
-          );
-          return;
-        }
-
-        if (event.type === 'usage') {
-          this.handleSessionUsageEvent(event.data);
-          return;
-        }
-
         switch (event.type) {
+          case 'run.config':
+            this.setTaskState(
+              event.streamId,
+              agentConfigToTaskState(event.config),
+              event.executionId,
+            );
+            return;
+          case 'usage':
+            this.handleSessionUsageEvent(event.data);
+            return;
           case 'updateTodos':
             this.setTodos(event.streamId, event.todos);
             return;

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -18,7 +18,6 @@ import type {
   AgentEvent,
   AgentTrace,
   AgentTraceSubscriber,
-  LogEvent,
 } from '@agent/trace';
 import { computeUtilizationPercent } from '@agent/modelHandlers/support/contextUtilization';
 import { isDebugModeEnabled } from '@logger/logUtils';
@@ -200,24 +199,21 @@ export function attachTranscriptRecorder(
     });
   };
 
-  const handleLog = (event: LogEvent): void => {
-    const messageType = asMessageType(event.messageType);
-    if (!shouldEmit(event.level, messageType)) return;
-    appendLog({
-      level: event.level,
-      groupId: event.stageId,
-      messageType,
-      text: event.message,
-      data: event.data,
-      verbose: event.verbose,
-    });
-  };
-
   const subscriber: AgentTraceSubscriber = (event: AgentEvent) => {
     switch (event.type) {
-      case 'log':
-        handleLog(event);
+      case 'log': {
+        const messageType = asMessageType(event.messageType);
+        if (!shouldEmit(event.level, messageType)) return;
+        appendLog({
+          level: event.level,
+          groupId: event.stageId,
+          messageType,
+          text: event.message,
+          data: event.data,
+          verbose: event.verbose,
+        });
         return;
+      }
 
       case 'stage.start':
         if (event.kind) stageKinds.set(event.id, event.kind);

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -60,15 +60,16 @@ export async function assembleTrace(
   ]);
   if (!config) return { status: 'config_missing' };
 
+  const fallbackStreamId = getStreamTabId(config.agent, config.model, {
+    executionId,
+  });
   const streamId =
     (
       await resolvePersistedStreamIdForExecution(executionId, {
         streamLogStore,
-        fallbackStreamId: getStreamTabId(config.agent, config.model, {
-          executionId,
-        }),
+        fallbackStreamId,
       })
-    )?.streamId ?? getStreamTabId(config.agent, config.model, { executionId });
+    )?.streamId ?? fallbackStreamId;
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),


### PR DESCRIPTION
## Summary

This is a behavior-preserving simplification pass across the monorepo after the 0.39.3 release. The retained
changes remove dead exports and tests, inline single-caller helpers, reduce pass-through arguments, and collapse
equivalent control-flow branches. Each architectural area was first simplified and then independently audited;
the final full-repository verification caught and corrected cross-directory test consumers before submission.

The branch is rebased onto `0bfc7eee7bf6cb6208266ec7bb3a3345ab521a48`, including merged PRs #8373,
#8374, and #8369. The RuntimeSkills conflict preserves #8374's structured diagnostics and replaces all three
test resets with `setRuntimeSkillSources([])`. PR #8369's restored-inquiry API has no overlapping paths and is
unchanged. The incidental `pnpm-lock.yaml` rewrite has been removed; the branch lockfile is byte-identical to
`origin/main`.

The desktop update-check refactor does not introduce failed-check retry behavior. Before and after this PR, a
failed fetch returns before `DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT` is written, and a failed notification throws
before that write. Existing tests cover both retry paths. The diff only consolidates the successful-fetch
throttle writes.

## Issue acceptance gates

No linked issue. The requested gates are satisfied: preserve the intended simplifications, remove unrelated
lockfile churn, rebase onto current main, document R6/R8 counts, and pass the complete local verification set.

## Single source of truth

No new ownership layer is introduced. Existing owners remain authoritative; the changes remove wrappers around
those owners. Examples include `clearApprovalsWhere`, `setRuntimeSkillSources`,
`scrollBoundedDiffDisplayLines`, and the shared accelerator implementation.

## Duplication and abstraction budget

No new abstraction is added. Single-caller wrappers and pass-through helpers are removed where their underlying
operation is already the clear interface. The ConfigForm list invariant remains explicit beside the filter: a
selected category comes from `buildConfigCategoryItems(props.entries)`, which derives its keys from the same
entries array. The sole production caller supplies `CLI_STATE_SETTINGS`.

## Net elements (R6)

- Files: 79 modified, 0 added, 0 deleted.
- Lines: 204 added, 541 deleted, net -337.
- Export declaration lines by `^[+-]export`: 3 added, 13 deleted, net -10.
- Distinct exported symbols: 1 added (`stripAnsiSgrChunk`), 12 removed, net -11. The raw declaration-line count
  also includes rewritten multi-symbol and barrel-export lines.
- Class/interface/enum declarations: 1 added, 2 deleted, net -1. One generic test interface becomes
  non-generic (one declaration added and one deleted), and `DeliveryEnvelopeParams` is deleted.
- Tests: no files added or deleted; existing tests are redirected to the retained lower-level interfaces, except
  the tests that existed solely for the unused `createGlobMatcher` export.

## Consumer counts (R8)

Counts below distinguish production call sites from test call sites on the rebased base, then state the
post-change result.

- `boundedDiffDisplayLines`: 0 production, 2 calls in 1 test file -> 0; tests call
  `scrollBoundedDiffDisplayLines` directly.
- `stripAnsiSgrSequences`: 0 production, 1 call in 1 test file -> 0; the test uses the newly exported
  `stripAnsiSgrChunk`, whose post-change consumers are 1 production call and 1 test call.
- `selectInlineOverflowText`: 1 production call and 4 calls in 1 test file -> 0; its logic is folded into
  `selectVisibleInlineOverflowText`, and the tests target that retained export.
- `clearApprovalsForStream`: 0 production, 1 call in 1 test file -> 0; the test uses
  `clearApprovalsWhere` with the same stream predicate. Production cancellation already used
  `clearApprovalsWhere` on the rebased base.
- `taskDetailVisibleLineCountFromOffsetForColumns`: 0 production, 2 calls in 1 test file -> 0; tests exercise
  `taskDetailVisibleOutputRowsFromOffsetForColumns` directly.
- `toElectronAccelerator` re-export from `desktopCommandSurface`: 0 production import consumers, 2 calls in
  1 test file -> 0; the implementation and test import the retained shared owner directly.
- `registerExecuteCommand`: 1 production call through the agent-command barrel, 0 tests -> 0; the function was
  an empty compatibility registration.
- `TERMINAL_REFIT_EVENTS`: 0 external consumers and 2 local uses -> 0 external consumers; the constant remains
  local with both uses unchanged.
- `ToolUseFlowResult`: 0 production and 0 test consumers -> 0.
- `withOptionalFilePath`: 1 production call, 0 tests -> 0; the sole schema is written at its use site.
- `clearRuntimeSkillSources`: 0 production and 3 test calls in 3 test files -> 0; all use
  `setRuntimeSkillSources([])`.
- `createGlobMatcher`: 0 production and 2 calls in 1 test file -> 0; the unused export and its export-only tests
  are deleted.

No event key, emitter path, or subscriber route is deleted. The private `emitProjectedProgressEvent` helper had
one caller; its unchanged progress-record write is inlined at that call site.

## Host impact

Extension: removes no-op registration and small wrappers; behavior is unchanged.

Desktop: removes an unused re-export and consolidates update-check bookkeeping. Notification conditions,
successful-fetch throttling, and existing failed-fetch/failed-notification retry behavior are unchanged.

CLI: removes dead or single-caller helpers and simplifies equivalent control flow; behavior and test coverage are
preserved.

## Scheduled refactoring

None.

## Validation

- `npm run format` - passed; no source changes.
- `npm run lint` - passed with 0 errors (52 warnings; none in `runReflectionFlow.ts`).
- `npm run typecheck` - passed for root, test-kernel, extension, CLI, trace-viewer, and desktop.
- Affected tests - 3 files passed; 19 tests passed (`DesktopUpdateChecker`, `RuntimeSkills`, and `userVars`).
- Full Vitest coverage - 671 files passed, 1 skipped; 6,044 tests passed, 4 skipped across two partitions. The
  unchanged `RunChatSignalOwnership.vitest.mts` test passed alone in 5.08 seconds; every remaining file passed in
  the complementary run. Two exact parallel `npm test` runs timed out only that test at its 10-second limit under
  machine load; no source or timeout was changed.
- `npm run compile:fast` - passed; extension host, webviews, and trace-viewer assets built.
- `git diff --check origin/main` - passed.
- `git diff --exit-code origin/main -- pnpm-lock.yaml` - passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deletions and inlines with broad test coverage; no auth, payment, or wire-format changes. Residual risk is missed call sites for removed exports, which the PR description and tests explicitly address.
> 
> **Overview**
> This PR is a **behavior-preserving simplification sweep** (~337 net lines removed) that deletes unused exports, inlines one-off helpers, and drops pass-through parameters without changing product semantics.
> 
> **CLI TUI** drops thin wrappers (`childControlForegroundMaxRows`, `boundedDiffDisplayLines`, `clearApprovalsForStream`, `taskDetailVisibleLineCountFromOffsetForColumns`, `selectInlineOverflowText`) and folds their logic into the callers that remain (`clearApprovalsWhere`, `scrollBoundedDiffDisplayLines`, `selectVisibleInlineOverflowText`). **ConfigForm** no longer renders an empty category list—the selected category is always non-empty by construction. **ANSI no-color** exposes `stripAnsiSgrChunk` for tests instead of a full-string `stripAnsiSgrSequences` wrapper.
> 
> **Agent runtime** makes interruption checks synchronous in `ResponseCycleFlow`, routes tool execution through `options.workspace` instead of threaded tracker/workPlan args, and inlines cancelled synthetic tool results. **GitHub subscription list** reads bindings without passing polling-source active keys. **Desktop update check** consolidates throttle/notify bookkeeping into one path while keeping failed-fetch retry behavior.
> 
> **Extension/desktop** removes the no-op `registerExecuteCommand`, drops unused re-exports (`toElectronAccelerator` from desktop surface), and uses shared `isGitRepository` directly. **Schemas/skills** remove `withOptionalFilePath`, `clearRuntimeSkillSources` (tests use `setRuntimeSkillSources([])`), and `createGlobMatcher` plus its tests.
> 
> Tests are updated to call the retained lower-level APIs; no new features are introduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2dba7052fd210e16e00d9a50d2babad87646524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->