### PR TITLE
refactor: restore progress inquiries through one API

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -15,7 +15,7 @@ import {
 } from '@controllers/progressView/backend/events/ProgressInteractionHandler';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
-import { hydrateProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryHydration';
+import { restoreProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryRestore';
 import {
   buildApprovalRequestHandlerSet,
   createProgressBackendUiConfig,
@@ -1070,14 +1070,6 @@ export class DesktopProgressBridge {
     this.syncStreamContent(this.updateStreamMetadata());
   }
 
-  async hydrateProgressViewInquiries(): Promise<void> {
-    await hydrateProgressViewInquiries({
-      webviewUpdater: this.backend.webviewUpdater,
-      externalInquiry: this.approvalHandlers.externalInquiry,
-      logger: this.logger,
-    });
-  }
-
   replayPendingPrompts(): void {
     replayApprovalRequestHandlers(this.approvalHandlers);
   }
@@ -1091,11 +1083,15 @@ export class DesktopProgressBridge {
    * `webviewReady` caller.
    */
   async completeWebviewReady(
-    onInquiryHydrationError: (error: unknown) => void = () => {},
+    onInquiryRestoreError: (error: unknown) => void = () => {},
   ): Promise<void> {
     await this.restartRepair;
     this.syncFullView();
-    void this.hydrateProgressViewInquiries().catch(onInquiryHydrationError);
+    void restoreProgressViewInquiries({
+      webviewUpdater: this.backend.webviewUpdater,
+      externalInquiry: this.approvalHandlers.externalInquiry,
+      logger: this.logger,
+    }).catch(onInquiryRestoreError);
     this.replayPendingPrompts();
   }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -8,7 +8,7 @@ import {
   replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
-import { hydrateProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryHydration';
+import { restoreProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryRestore';
 import { repairRestartedStreams } from '@controllers/progressView/backend/restartRepair';
 import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
 import { computeAgentOptionsData } from '@agent/index';
@@ -380,18 +380,14 @@ export class ProgressViewProvider
     this._panelJustDisposed = false;
     this.syncFullView({ forceRebuild: true });
     // Manifest-backed inquiry state is durable, but handler pending state is
-    // in-memory. Fire-and-forget: replay covers warm targets, hydration covers
+    // in-memory. Fire-and-forget: replay covers warm targets, restoration covers
     // host restarts.
-    void this.hydrateProgressViewInquiries();
-    this.replayPendingPrompts();
-  }
-
-  public async hydrateProgressViewInquiries(): Promise<void> {
-    await hydrateProgressViewInquiries({
+    void restoreProgressViewInquiries({
       webviewUpdater: this.webviewUpdater,
       externalInquiry: this.approvalHandlers.externalInquiry,
       logger: this.logger,
     });
+    this.replayPendingPrompts();
   }
 
   private replayPendingPrompts(): void {

--- a/src/controllers/progressView/backend/externalInquiryRestore.ts
+++ b/src/controllers/progressView/backend/externalInquiryRestore.ts
@@ -12,9 +12,9 @@ import {
 import type { ApprovalRequestHandlerSet } from './progressBackendUiConfig';
 import type { WebviewUpdater } from './WebviewUpdater';
 
-const MAX_INQUIRY_THREAD_HYDRATION = 100;
+const MAX_RESTORED_INQUIRY_THREADS = 100;
 
-type InquiryHydrationWebview = Pick<
+type InquiryRestoreWebview = Pick<
   WebviewUpdater,
   'isAvailable' | 'syncInquiryThreads'
 >;
@@ -24,8 +24,8 @@ type ExternalInquiryHandler = Pick<
   'pendingSize' | 'show'
 >;
 
-export interface ProgressInquiryHydrationParams {
-  webviewUpdater: InquiryHydrationWebview;
+interface ProgressInquiryRestoreParams {
+  webviewUpdater: InquiryRestoreWebview;
   externalInquiry: ExternalInquiryHandler;
   logger?: Pick<AgentTrace, 'debug'>;
 }
@@ -35,8 +35,8 @@ export interface ProgressInquiryHydrationParams {
  * manifest should not prevent stream or prompt replay, so storage errors are
  * intentionally swallowed here.
  */
-export async function syncProgressInquiryThreads(
-  params: Pick<ProgressInquiryHydrationParams, 'webviewUpdater'>,
+async function syncProgressInquiryThreads(
+  params: Pick<ProgressInquiryRestoreParams, 'webviewUpdater'>,
 ): Promise<void> {
   if (!params.webviewUpdater.isAvailable()) return;
 
@@ -44,7 +44,7 @@ export async function syncProgressInquiryThreads(
     const threads: InquiryThreadUpdatedEvent[] = await listThreadsByStatus({
       status: 'any',
       scope: 'all',
-      limit: MAX_INQUIRY_THREAD_HYDRATION,
+      limit: MAX_RESTORED_INQUIRY_THREADS,
     });
     params.webviewUpdater.syncInquiryThreads(threads);
   } catch {
@@ -57,8 +57,8 @@ export async function syncProgressInquiryThreads(
  * in-memory handler owns delivery idempotency for the current webview target;
  * this function only reconstructs missing pending entries from durable storage.
  */
-export async function hydrateOpenInquiryPermissions(
-  params: ProgressInquiryHydrationParams,
+async function restoreOpenInquiryPermissions(
+  params: ProgressInquiryRestoreParams,
 ): Promise<void> {
   if (!params.webviewUpdater.isAvailable()) return;
   if (params.externalInquiry.pendingSize > 0) return;
@@ -77,7 +77,7 @@ export async function hydrateOpenInquiryPermissions(
       const lastTurn = manifest.turns.at(-1);
       if (!lastTurn || lastTurn.kind !== 'open') continue;
 
-      const hydrationFields = {
+      const restoredFields = {
         sessionLinks: collectKnownSessionLinks(manifest),
         draft: getOpenTurnDraft(manifest),
         transcript: manifestToTranscript(manifest),
@@ -96,12 +96,12 @@ export async function hydrateOpenInquiryPermissions(
         manifest.turns.length > 1
           ? {
               ...basePermission,
-              ...hydrationFields,
+              ...restoredFields,
               mode: 'followUp',
             }
           : {
               ...basePermission,
-              ...hydrationFields,
+              ...restoredFields,
               mode: 'new',
             },
       );
@@ -111,11 +111,11 @@ export async function hydrateOpenInquiryPermissions(
   }
 }
 
-export async function hydrateProgressViewInquiries(
-  params: ProgressInquiryHydrationParams,
+export async function restoreProgressViewInquiries(
+  params: ProgressInquiryRestoreParams,
 ): Promise<void> {
   await Promise.all([
     syncProgressInquiryThreads(params),
-    hydrateOpenInquiryPermissions(params),
+    restoreOpenInquiryPermissions(params),
   ]);
 }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -89,7 +89,7 @@ type TestableBridge = Bridge & {
   handleInteractionEvent(event: string, payload: unknown): void;
   syncFullView(): void;
   completeWebviewReady(
-    onInquiryHydrationError?: (error: unknown) => void,
+    onInquiryRestoreError?: (error: unknown) => void,
   ): Promise<void>;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
   setActiveStream(streamId: StreamTabId): void;

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -32,7 +32,7 @@ function fillRegistry(
 
 interface DesktopProgressIpcBridgeStub {
   completeWebviewReady(
-    onInquiryHydrationError?: (error: unknown) => void,
+    onInquiryRestoreError?: (error: unknown) => void,
   ): Promise<void>;
   progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
 }

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -20,7 +20,7 @@ vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
 }));
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { hydrateOpenInquiryPermissions } from '@controllers/progressView/backend/externalInquiryHydration';
+import { restoreProgressViewInquiries } from '@controllers/progressView/backend/externalInquiryRestore';
 import {
   type ExternalInquiryPermission,
   type ExternalInquiryThreadId,
@@ -111,13 +111,13 @@ function openFollowUpLegacyManifest(): Record<string, unknown> {
 }
 
 function createProgressProviderShell(): {
-  hydrate: () => Promise<void>;
+  restore: () => Promise<void>;
   show: ReturnType<typeof vi.fn>;
 } {
   const show = vi.fn<(permission: ExternalInquiryPermission) => void>();
   return {
-    hydrate: () =>
-      hydrateOpenInquiryPermissions({
+    restore: () =>
+      restoreProgressViewInquiries({
         webviewUpdater: {
           isAvailable: () => true,
           syncInquiryThreads: vi.fn(),
@@ -132,14 +132,14 @@ function createProgressProviderShell(): {
   };
 }
 
-function createHydrationShellWithPendingInquiry(): {
-  hydrate: () => Promise<void>;
+function createRestoreShellWithPendingInquiry(): {
+  restore: () => Promise<void>;
   show: ReturnType<typeof vi.fn>;
 } {
   const show = vi.fn<(permission: ExternalInquiryPermission) => void>();
   return {
-    hydrate: () =>
-      hydrateOpenInquiryPermissions({
+    restore: () =>
+      restoreProgressViewInquiries({
         webviewUpdater: {
           isAvailable: () => true,
           syncInquiryThreads: vi.fn(),
@@ -196,13 +196,13 @@ describe('external inquiry read boundary', () => {
     );
   });
 
-  it('hydrates legacy answers through progress-view inquiry hydration', async () => {
+  it('restores legacy answers with progress-view inquiries', async () => {
     await seedThread(OPEN_THREAD, openFollowUpLegacyManifest(), {
       't1/answer.txt': 'Legacy A',
     });
-    const { hydrate, show } = createProgressProviderShell();
+    const { restore, show } = createProgressProviderShell();
 
-    await hydrate();
+    await restore();
 
     expect(show).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -216,13 +216,13 @@ describe('external inquiry read boundary', () => {
     );
   });
 
-  it('does not rehydrate durable inquiries when pending state is already warm', async () => {
+  it('does not restore durable inquiries when pending state is already warm', async () => {
     await seedThread(OPEN_THREAD, openFollowUpLegacyManifest(), {
       't1/answer.txt': 'Legacy A',
     });
-    const { hydrate, show } = createHydrationShellWithPendingInquiry();
+    const { restore, show } = createRestoreShellWithPendingInquiry();
 
-    await hydrate();
+    await restore();
 
     expect(show).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- rename the external-inquiry hydration module/API around restoring durable progress state
- expose one `restoreProgressViewInquiries` operation while keeping list sync and open-panel reconstruction private
- remove the extension and desktop pass-through hydration methods
- test restoration through the public operation instead of importing an internal phase

Closes #8367.

## Design

The controller now hides its two implementation phases behind one lifecycle operation:

1. synchronize the durable inquiry-thread list
2. reconstruct an open permission panel when in-memory pending state is cold

Hosts provide their existing updater, handler, and logger dependencies directly at the webview-ready boundary. They no longer mirror the controller API with shallow methods. “Restore” describes the restart behavior more precisely than “hydrate,” while the existing best-effort storage error isolation and pending-state idempotency remain unchanged.

## Impact

No user-visible behavior change is intended. Extension and desktop still restore inquiry state at the same lifecycle points, but the controller has one public entry point and fewer pass-through methods.

## Net elements (R6)

- Files: 6 changed (5 modified and 1 renamed); 0 added, 0 deleted, net 0 files.
- Lines: 42 insertions and 50 deletions, net -8 lines.
- Exported symbols: 4 before and 1 after, net -3 exports.
- Class/interface/enum declarations: 1 interface removed and 1 private interface added, net 0 declarations; no classes or enums were added or removed.
- Host pass-through methods: 2 removed and 0 added, net -2 methods.

## Consumer counts (R8)

Counts exclude each symbol's defining module and its internal calls.

- `hydrateProgressViewInquiries`: 2 production importers (desktop and extension); both now import `restoreProgressViewInquiries` directly.
- `hydrateOpenInquiryPermissions`: 1 test importer with 2 calls; both calls now use the public restore operation.
- `syncProgressInquiryThreads`: 0 external consumers; it is now a private phase of the restore operation.
- `ProgressInquiryHydrationParams`: 0 external consumers; its replacement is private.
- `restoreProgressViewInquiries`: 2 production importers and 1 test importer after the change.

## Validation

- rebased onto `d7a162312ccc3bc85ba00a1c7f1ccd02876f504a`, which contains #8370
- stable patch ID and `git range-diff` confirm that the rebased logical change is unchanged
- `git diff --check`
- Prettier check on all 6 changed files
- `npm run typecheck`
- `npm run lint` (0 errors; 52 pre-existing warnings)
- focused Vitest: 3 files and 90 tests passed
- full Vitest: 671 files passed, 1 skipped; 6,043 tests passed, 4 skipped
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only rename and API consolidation with no logic changes described; lifecycle and error isolation unchanged.
> 
> **Overview**
> **Refactors** how the progress view reloads durable external-inquiry state after restarts: terminology moves from *hydration* to *restore*, and the controller exposes one public **`restoreProgressViewInquiries`** instead of several exported helpers.
> 
> The module **`externalInquiryHydration`** becomes **`externalInquiryRestore`**. List sync and open-panel reconstruction stay as **private** phases inside that operation; **`syncProgressInquiryThreads`**, **`hydrateOpenInquiryPermissions`**, and **`ProgressInquiryHydrationParams`** are no longer part of the public surface.
> 
> **Desktop** and **extension** call **`restoreProgressViewInquiries`** directly at webview-ready (desktop via **`completeWebviewReady`**, extension via **`markWebviewReady`**), dropping **`hydrateProgressViewInquiries`** pass-through methods. Error callback naming follows suit (**`onInquiryRestoreError`**). Tests exercise the public restore API rather than the former internal **`hydrateOpenInquiryPermissions`** import.
> 
> No intended user-visible behavior change: same lifecycle timing, best-effort storage error handling, and pending-state idempotency when in-memory handlers are already warm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3fdcfe653f83035c63186876873236b091aa1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

