### PR TITLE
refactor: move agent policies out of utils

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -94,7 +94,6 @@
     { "from": "transcript", "to": "logger", "kind": "value" },
     { "from": "transcript", "to": "shared", "kind": "value" },
     { "from": "transcript", "to": "utils", "kind": "value" },
-    { "from": "utils", "to": "agent", "kind": "type-only" },
     { "from": "utils", "to": "common", "kind": "value" },
     { "from": "utils", "to": "logger", "kind": "value" },
     { "from": "utils", "to": "platform", "kind": "value" },

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -3,6 +3,7 @@ import { dirname } from 'node:path';
 import { z } from 'zod';
 
 import { BaseNode, Flow } from '@agent/node';
+import { getSystemPromptWithRules } from '@agent/prompt';
 import { recordRound } from '@agent/core/state/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
@@ -25,7 +26,6 @@ import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
 import { isApprovalGatedToolName } from '@tools/approvalGatedTools';
 import { AbsoluteFS, FlexibleFS } from '@utils/files';
-import { getSystemPromptWithRules } from '@utils/prompt';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { extractScratchpad } from '@utils/text/xmlUtils';
 

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -1,3 +1,4 @@
+import type { PromptBuilder } from '@agent/prompt';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type {
   BaseFlowContextInit,
@@ -8,7 +9,6 @@ import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import type { LatexMediaManager } from '@latex/LatexMediaManager';
 import type { AgentFileLocation, WorkspaceFileLocation } from '@shared/schemas';
-import type { PromptBuilder } from '@utils/prompt';
 import type { TaskRunFileService } from '@utils/files';
 
 export interface WorkflowOutputPolicy {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
+import { PromptBuilder } from '@agent/prompt';
 import {
   createOutputState,
   setActiveRun,
@@ -23,10 +24,6 @@ import {
   readPersistedFlowRecord,
 } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
-import {
-  WORKFLOW_DOCUMENT_OUTPUT_EXT,
-  WORKFLOW_RAW_OUTPUT_EXT,
-} from '@shared/constants/workflowOutput';
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import { LatexMediaManager } from '@latex/LatexMediaManager';
 import {
@@ -38,6 +35,10 @@ import {
   type StorageKey,
   type WorkspaceFileLocation,
 } from '@shared/schemas';
+import {
+  WORKFLOW_DOCUMENT_OUTPUT_EXT,
+  WORKFLOW_RAW_OUTPUT_EXT,
+} from '@shared/constants/workflowOutput';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   AbsoluteFS,
@@ -45,7 +46,6 @@ import {
   WorkspaceFS,
   createWorkspaceLocation,
 } from '@utils/files';
-import { PromptBuilder } from '@utils/prompt';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import { TeXCountNode } from './nodes/TeXCountNode';

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -1,11 +1,11 @@
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
+import { buildInitialToolUsePrompts } from '@agent/prompt';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
-import { buildInitialToolUsePrompts } from '@utils/prompt';
 
 import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, CyclePrepResult } from './types';

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,6 +1,7 @@
 import { logMissingOutputs, type AgentTrace } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
+import { replaceInputCommands } from '@agent/output/fileMapping';
 import {
   type FileLocation,
   type OutputFileInfo,
@@ -8,7 +9,7 @@ import {
 } from '@shared/schemas';
 import { OUTPUT_DOCUMENTS_TAG } from '@shared/constants/outputProtocol';
 import { normalizeFilePath } from '@utils/core';
-import { FlexibleFS, replaceInputCommands } from '@utils/files';
+import { FlexibleFS } from '@utils/files';
 import {
   extractMultipleTextFromTag,
   extractTextFromTag,

--- a/src/agent/output/fileMapping.ts
+++ b/src/agent/output/fileMapping.ts
@@ -1,19 +1,17 @@
 // Standard library imports
 import * as path from 'node:path';
 
-// Local imports - common
+// Local imports - agent
 import type { AgentTrace } from '@agent/trace/AgentTrace';
+
+// Local imports - shared
 import type { FileLocation } from '@shared/schemas';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
-// Local imports - logger
-
-// Local imports - core utilities
+// Local imports - utilities
 import { normalizeLatexPath, getPathSegments } from '@utils/core/pathCore';
-
-// Local file imports
-import { FlexibleFS } from './flexibleFS';
-import { getComparablePath } from './taskRunStorage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { FlexibleFS } from '@utils/files/flexibleFS';
+import { getComparablePath } from '@utils/files/taskRunStorage';
 
 /**
  * Create a mapping between two file lists based on name similarity.

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -7,9 +7,10 @@
 
 import * as path from 'node:path';
 
+import { createFileMapping } from '@agent/output/fileMapping';
 import type { FileLocation } from '@shared/schemas';
 import { normalizeFilePath } from '@utils/core';
-import { createFileMapping, getComparablePath } from '@utils/files';
+import { getComparablePath } from '@utils/files';
 
 import type { OutputState } from './outputState';
 import type { RoundFileEntry, RoundFileMapping } from './types';

--- a/src/agent/prompt/PromptBuilder.ts
+++ b/src/agent/prompt/PromptBuilder.ts
@@ -1,12 +1,12 @@
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace/AgentTrace';
 import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
-import { ensureArray } from '@utils/core';
-import { loadTexraRules } from '@utils/files/rulesUtils';
-import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 
 // Local imports - utilities
-import { renderPrompt } from './promptUtils';
+import { ensureArray } from '@utils/core';
+import { renderPrompt } from '@utils/prompt';
+import { loadTexraRules } from '@utils/files/rulesUtils';
+import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 
 /** Instructions appended to tool-use agent prompts */
 const TOOL_USE_INSTRUCTIONS = `<tool_use_instructions>

--- a/src/agent/prompt/index.ts
+++ b/src/agent/prompt/index.ts
@@ -1,0 +1,1 @@
+export * from './PromptBuilder';

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { buildInitialToolUsePrompts } from '@agent/prompt';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentPromptSchema } from '@agent/core/definition/AgentDataclass';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
@@ -10,7 +11,6 @@ import { ToolUsePrepareNode } from '@agent/implementations/flows/tooluse/nodes/T
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
-import { buildInitialToolUsePrompts } from '@utils/prompt';
 
 function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},

--- a/src/test-kernel/agent/output/FileMapping.vitest.ts
+++ b/src/test-kernel/agent/output/FileMapping.vitest.ts
@@ -1,0 +1,129 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent
+import { noopTrace, type AgentTrace } from '@agent/trace';
+import {
+  createFileMapping,
+  replaceInputCommands,
+} from '@agent/output/fileMapping';
+
+// Local imports - shared
+import type { FileLocation } from '@shared/schemas';
+
+// Local imports - utilities
+import { FlexibleFS } from '@utils/files/flexibleFS';
+
+function externalLocation(absolutePath: string): FileLocation {
+  return { kind: 'external', absolutePath };
+}
+
+function createLogger(): {
+  logger: AgentTrace;
+  warn: ReturnType<typeof vi.fn<AgentTrace['warn']>>;
+} {
+  const warn = vi.fn<AgentTrace['warn']>();
+  return {
+    logger: { ...noopTrace, debug: vi.fn(), warn },
+    warn,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createFileMapping', () => {
+  it('resolves a basename collision to the first source file', () => {
+    const firstSource = externalLocation('/workspace/chapters/results.tex');
+    const secondSource = externalLocation('/workspace/appendix/results.tex');
+    const target = externalLocation('/run/results_r2.tex');
+
+    const mapping = createFileMapping(
+      [firstSource, secondSource],
+      [target],
+      'basename',
+      true,
+    );
+
+    expect([...mapping.entries()]).toEqual([
+      [firstSource.absolutePath, target],
+    ]);
+  });
+
+  it('matches generated files across round suffixes only when round-aware', () => {
+    const previousRound = externalLocation('/run/results_r1.tex');
+    const currentRound = externalLocation('/run/results_r2.tex');
+
+    expect(
+      createFileMapping([previousRound], [currentRound], 'basename'),
+    ).toEqual(new Map());
+    expect(
+      createFileMapping([previousRound], [currentRound], 'basename', true),
+    ).toEqual(new Map([[previousRound.absolutePath, currentRound]]));
+  });
+});
+
+describe('replaceInputCommands', () => {
+  it('rewrites an extensionless LaTeX input to the generated file', async () => {
+    const baseMain = externalLocation('/workspace/main.tex');
+    const baseSection = externalLocation('/workspace/sections/method.tex');
+    const outputMain = externalLocation('/run/main_r1.tex');
+    const outputSection = externalLocation('/run/sections/method_r1.tex');
+    const read = vi
+      .spyOn(FlexibleFS, 'read')
+      .mockImplementation((location) =>
+        Promise.resolve(
+          location === outputMain
+            ? String.raw`\input{sections/method}`
+            : 'Section content',
+        ),
+      );
+    const write = vi.spyOn(FlexibleFS, 'write').mockResolvedValue();
+
+    await replaceInputCommands(
+      [baseMain, baseSection],
+      [outputMain, outputSection],
+    );
+
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenCalledOnce();
+    expect(write).toHaveBeenCalledWith(
+      outputMain,
+      String.raw`\input{sections/method_r1}`,
+    );
+  });
+
+  it('logs a read failure and leaves the output unchanged', async () => {
+    const base = externalLocation('/workspace/chapter.tex');
+    const output = externalLocation('/run/chapter_r1.tex');
+    vi.spyOn(FlexibleFS, 'read').mockRejectedValue(new Error('read failed'));
+    const write = vi.spyOn(FlexibleFS, 'write').mockResolvedValue();
+    const { logger, warn } = createLogger();
+
+    await expect(
+      replaceInputCommands([base], [output], logger),
+    ).resolves.toBeUndefined();
+
+    expect(write).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      'Error processing input commands in /run/chapter_r1.tex: read failed',
+    );
+  });
+
+  it('logs a write failure without rejecting the replacement pass', async () => {
+    const base = externalLocation('/workspace/chapter.tex');
+    const output = externalLocation('/run/chapter_r1.tex');
+    vi.spyOn(FlexibleFS, 'read').mockResolvedValue(String.raw`\input{chapter}`);
+    vi.spyOn(FlexibleFS, 'write').mockRejectedValue(new Error('write failed'));
+    const { logger, warn } = createLogger();
+
+    await expect(
+      replaceInputCommands([base], [output], logger),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      'Error processing input commands in /run/chapter_r1.tex: write failed',
+    );
+  });
+});

--- a/src/test-kernel/agent/prompt/PromptBuilder.vitest.ts
+++ b/src/test-kernel/agent/prompt/PromptBuilder.vitest.ts
@@ -3,8 +3,8 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Type imports
+import { buildInitialToolUsePrompts, PromptBuilder } from '@agent/prompt';
 import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
-import { buildInitialToolUsePrompts, PromptBuilder } from '@utils/prompt';
 
 describe('PromptBuilder', () => {
   it('uses array-based userRequest entries for reflections', async () => {

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -11,7 +11,7 @@ import {
   loadRuntimeSkillCatalog,
   setRuntimeSkillSources,
 } from '@skills/runtimeSkills';
-import { buildInitialToolUsePrompts } from '@utils/prompt';
+import { buildInitialToolUsePrompts } from '@agent/prompt';
 
 const tempRoots: string[] = [];
 

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -4,7 +4,6 @@ export { AbsoluteFS } from './absoluteFS';
 export { StorageFS, GlobalStorageFS } from './storageFS';
 
 // Heavily-used utilities (re-exported for convenience)
-export * from './fileMappingUtils';
 export * from './mimeUtils';
 export * from './taskRunStorage';
 export * from './flexibleFS';

--- a/src/utils/prompt/index.ts
+++ b/src/utils/prompt/index.ts
@@ -1,2 +1,1 @@
 export * from './promptUtils';
-export * from './PromptBuilder';


### PR DESCRIPTION
Closes #8371.

## Summary

- move agent prompt construction from `src/utils/prompt` to `src/agent/prompt`
- move generated-output lineage and LaTeX input rewriting from `src/utils/files` to `src/agent/output`
- remove the obsolete utility exports without compatibility shims
- add direct file-mapping characterization for collisions, round suffixes, extensionless inputs, and read/write failures
- remove the final `utils -> agent` architecture edge

## Design

Before:

```text
agent flows  -> @utils/prompt/PromptBuilder  -> @agent types
agent output -> @utils/files/fileMappingUtils -> @agent/trace
```

The generic utility layer owned policies that describe agent rounds, tool-use prompt composition, generated-output lineage, and agent trace diagnostics. This made utility barrels expose domain behaviour and pointed three type imports from `utils` back into `agent`.

After:

```text
agent flows  -> @agent/prompt
agent output -> @agent/output/fileMapping
generic prompt rendering and filesystem primitives remain in @utils
```

The moved modules continue to use generic rendering and filesystem primitives, but their public policy surface now belongs to the agent domain. No forwarding module remains at the old paths.

## Net elements (R6)

- production modules relocated: 2
- test modules relocated: 1
- focused test modules added: 1
- agent prompt barrels added: 1
- utility barrel exports removed: 2
- architecture baseline edges removed: 1
- compatibility shims or forwarding modules added: 0
- net source change: 155 insertions, 28 deletions

## Consumer counts (R8)

- prompt construction: 4 production consumers and 3 direct test consumers retargeted
- output file mapping: 2 production consumers retargeted
- production `src/utils` imports from `@agent/*`: 3 before, 0 after
- architecture baseline pairs `utils -> agent`: 1 before, 0 after
- obsolete utility exports: 2 before, 0 after

## Verification

- `npm run format`
- `npm run lint` (0 errors; warning baseline reduced from 53 to 52)
- `npm run typecheck`
- `npm run compile:fast`
- focused Vitest suites: 110 tests passed
- full Vitest suite: 6,043 passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with import path changes only; behavior is preserved and covered by relocated and new characterization tests, with no compatibility layer to maintain.
> 
> **Overview**
> Moves **agent-owned policies** from `@utils` into the agent domain: prompt construction (`PromptBuilder`, `getSystemPromptWithRules`, `buildInitialToolUsePrompts`) now lives under `@agent/prompt`, and output lineage helpers (`createFileMapping`, `replaceInputCommands`) under `@agent/output/fileMapping`.
> 
> **Consumers** (reflection/tool-use flows, `OutputFileProcessor`, `lineageMapping`) import the new modules directly. **`@utils/prompt`** and **`@utils/files`** barrels drop those exports with **no forwarding shims**. Generic rendering (`renderPrompt`) and filesystem primitives stay in utils.
> 
> The architecture ratchet removes the last **`utils → agent`** edge. Tests follow the new import paths and add **`FileMapping.vitest.ts`** for basename collisions, round-aware suffix matching, LaTeX `\input` rewriting, and read/write failure logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981780107eec815eee6bab55f7f7d872b8eec6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->