### PR TITLE
refactor: return runtime skill diagnostics

### DIFF
--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -67,7 +67,6 @@
     { "from": "shared", "to": "logger", "kind": "value" },
     { "from": "shared", "to": "platform", "kind": "type-only" },
     { "from": "shared", "to": "utils", "kind": "value" },
-    { "from": "skills", "to": "agent", "kind": "type-only" },
     { "from": "skills", "to": "common", "kind": "value" },
     { "from": "skills", "to": "shared", "kind": "value" },
     { "from": "skills", "to": "utils", "kind": "value" },

--- a/docs/proposals/host-parity-audit-2026-07.md
+++ b/docs/proposals/host-parity-audit-2026-07.md
@@ -172,8 +172,8 @@ landed → convergence.
 ### FS5. `texra.skills.enabled` is an advertised VS Code setting that does nothing
 
 - Extension contributes it (`package.json:832-840`) but never calls
-  `setRuntimeSkillSources`; `loadRuntimeSkillCatalog` returns `''` on empty
-  sources (`runtimeSkills.ts:62-63`) — the setting toggles an already-no-op.
+  `setRuntimeSkillSources`; `loadRuntimeSkillCatalog` returns an empty catalog
+  on empty sources (`runtimeSkills.ts:62-63`) — the setting toggles an already-no-op.
   CLI is the only production setter (`initPlatform.ts:341`) with full
   `/skills` + `texra skills`. Desktop: **not decided-for-free** — #7692
   (CLOSED) explicitly deferred the skill-sources fold as a product decision.

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -1,6 +1,9 @@
 import * as path from 'node:path';
 
-import { loadRuntimeSkillCatalog } from '@skills/runtimeSkills';
+import {
+  loadRuntimeSkillCatalog,
+  type SkillLoadIssue,
+} from '@skills/runtimeSkills';
 import { logFileCategory, logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { getVisibleAgents, type AgentEntry } from '@agent/index/agentRegistry';
@@ -140,6 +143,11 @@ type AttachedMemoriesResult = {
   misses: AttachedMemoryMiss[];
 };
 
+function formatRuntimeSkillIssue(issue: SkillLoadIssue): string {
+  const location = issue.path ? ` (${issue.path})` : '';
+  return `${issue.severity}: ${issue.message}${location}`;
+}
+
 /**
  * Build all user variables needed for prompt rendering.
  *
@@ -160,7 +168,7 @@ export async function buildUserVars(
     { vars: patternVars, files: patternFiles },
     latexStyleRules,
     attachedMemories,
-    availableSkills,
+    runtimeSkills,
   ] = await Promise.all([
     getRequiredFileVars(agentSetting, agentPath),
     getPatternBasedFileVars(agentConfig, agentSetting),
@@ -175,10 +183,14 @@ export async function buildUserVars(
     // switch that skips discovery and leaves AVAILABLE_SKILLS empty.
     agentSetting.agentCategory === AgentCategory.ToolUse &&
     getConfig<boolean>('texra.skills.enabled', true)
-      ? loadRuntimeSkillCatalog(logger)
-      : Promise.resolve(''),
+      ? loadRuntimeSkillCatalog()
+      : Promise.resolve({ catalog: '', issues: [] }),
   ]);
   const allLoadedFiles: LoadedFileEntry[] = [...requiredFiles, ...patternFiles];
+
+  for (const issue of runtimeSkills.issues) {
+    logger.warn(`Skill import ${formatRuntimeSkillIssue(issue)}`);
+  }
 
   // Merge all variable sources using spread operator.
   // LATEX_STYLE_RULES is placed last to prevent silent overrides from spreads.
@@ -192,7 +204,7 @@ export async function buildUserVars(
     LATEX_STYLE_RULES: latexStyleRules,
     ATTACHED_MEMORIES: attachedMemories.xml,
     ATTACHED_MEMORY_MISSES: attachedMemories.misses,
-    AVAILABLE_SKILLS: availableSkills,
+    AVAILABLE_SKILLS: runtimeSkills.catalog,
   };
 
   // Emit aggregated file list if any files were loaded

--- a/src/skills/runtimeSkills.ts
+++ b/src/skills/runtimeSkills.ts
@@ -1,4 +1,3 @@
-import type { AgentTrace } from '@agent/trace';
 import { escapeAttr, escapeText } from '@shared/utils/xmlEscape';
 
 import {
@@ -9,6 +8,13 @@ import {
 } from './loadSkills';
 
 const runtimeSkillSources: SkillSource[] = [];
+
+export interface RuntimeSkillCatalogResult {
+  catalog: string;
+  issues: SkillLoadIssue[];
+}
+
+export type { SkillLoadIssue } from './loadSkills';
 
 export function setRuntimeSkillSources(sources: readonly SkillSource[]): void {
   runtimeSkillSources.length = 0;
@@ -21,11 +27,6 @@ export function listRuntimeSkillSources(): SkillSource[] {
 
 export function clearRuntimeSkillSources(): void {
   runtimeSkillSources.length = 0;
-}
-
-function formatSkillIssue(issue: SkillLoadIssue): string {
-  const location = issue.path ? ` (${issue.path})` : '';
-  return `${issue.severity}: ${issue.message}${location}`;
 }
 
 function formatRuntimeSkillCatalog(skills: readonly SourcedSkill[]): string {
@@ -57,17 +58,13 @@ export function formatRuntimeSkillActivation({
   ].join('\n');
 }
 
-export async function loadRuntimeSkillCatalog(
-  logger?: AgentTrace,
-): Promise<string> {
+export async function loadRuntimeSkillCatalog(): Promise<RuntimeSkillCatalogResult> {
   const sources = listRuntimeSkillSources();
-  if (sources.length === 0) return '';
+  if (sources.length === 0) return { catalog: '', issues: [] };
 
   const result = await discoverSkillSources(sources);
-  for (const issue of result.errors) {
-    logger?.warn(`Skill import ${formatSkillIssue(issue)}`);
-  }
-  if (result.skills.length === 0) return '';
-
-  return formatRuntimeSkillCatalog(result.skills);
+  return {
+    catalog: formatRuntimeSkillCatalog(result.skills),
+    issues: result.errors,
+  };
 }

--- a/src/test-kernel/agent/utils/userVars.vitest.ts
+++ b/src/test-kernel/agent/utils/userVars.vitest.ts
@@ -1,12 +1,17 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Standard library imports
 
 // Local imports - agent components
 import { FakeConfigProvider } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  clearRuntimeSkillSources,
+  setRuntimeSkillSources,
+} from '@skills/runtimeSkills';
+import { noopTrace } from '@agent/trace';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -82,5 +87,44 @@ describe('getToolFlags', () => {
 
     const flags = getToolFlags(baseConfig, setting, prompt);
     assert.equal(flags.ROUNDS, 3);
+  });
+});
+
+describe('buildUserVars runtime skill diagnostics', () => {
+  const missingSource = '/missing/runtime-skill-source';
+
+  beforeEach(() => {
+    fakeConfig.set('texra.skills.enabled', true);
+    setRuntimeSkillSources([
+      {
+        scope: 'bundled',
+        path: missingSource,
+        label: 'bundled',
+        required: true,
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    clearRuntimeSkillSources();
+    await fakeConfig.update('texra.skills.enabled', undefined);
+  });
+
+  it('emits catalog load issues through the agent trace', async () => {
+    const warn = vi.fn();
+    const vars = await buildUserVars(
+      baseConfig,
+      { ...baseSetting, agentCategory: AgentCategory.ToolUse },
+      basePrompt,
+      '/agents/generic',
+      { isOpenai: false, isAnthropic: false, isGoogle: false },
+      { ...noopTrace, warn },
+      '/workspace',
+    );
+
+    expect(vars.AVAILABLE_SKILLS).toBe('');
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      `Skill import error: Skill source does not exist (${missingSource})`,
+    );
   });
 });

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -91,13 +91,36 @@ describe('runtime skills', () => {
       { scope: 'project', path: root, label: 'project' },
     ]);
 
-    const catalog = await loadRuntimeSkillCatalog();
+    const result = await loadRuntimeSkillCatalog();
 
-    expect(catalog).toContain(
+    expect(result.catalog).toContain(
       '- manuscript-review: Review mathematical manuscripts.',
     );
-    expect(catalog).toContain('Source: project');
-    expect(catalog).toContain(`Path: ${skillPath}`);
+    expect(result.catalog).toContain('Source: project');
+    expect(result.catalog).toContain(`Path: ${skillPath}`);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('returns structured issues when a required source is unavailable', async () => {
+    const root = path.join(os.tmpdir(), 'texra-missing-runtime-skill-source');
+    await fs.rm(root, { recursive: true, force: true });
+    setRuntimeSkillSources([
+      { scope: 'bundled', path: root, label: 'bundled', required: true },
+    ]);
+
+    const result = await loadRuntimeSkillCatalog();
+
+    expect(result).toEqual({
+      catalog: '',
+      issues: [
+        {
+          severity: 'error',
+          code: 'missing_source',
+          message: 'Skill source does not exist',
+          path: root,
+        },
+      ],
+    });
   });
 
   it('injects the available skill catalog into tool-use instructions', async () => {


### PR DESCRIPTION
Closes #8372.

## Summary

- return runtime skill discovery issues beside the formatted catalog
- keep skill discovery independent of `AgentTrace`
- emit unchanged user-facing warnings from the agent caller
- remove the final `skills -> agent` architecture edge
- add direct tests for structured discovery failures and caller-side warning emission

## Design

Before:

```text
agent user variables -> skills.loadRuntimeSkillCatalog(trace)
skills -> @agent/trace
```

The skills layer accepted an agent-runtime trace solely to present discovery warnings. That made a lower-level discovery module depend on one execution protocol and hid diagnostics as side effects.

After:

```text
agent user variables -> skills.loadRuntimeSkillCatalog()
                    -> { catalog, issues }
                    -> AgentTrace warning presentation
```

Skill discovery now returns its existing `SkillLoadIssue` values without copying or weakening them. The agent layer owns warning wording, and no compatibility path remains.

## Net elements (R6)

- files changed: 6
- production modules changed: 2
- focused test modules changed: 2
- architecture baseline edges removed: 1
- audit documents synchronized: 1
- compatibility shims or fallback paths added: 0
- net source change: 104 insertions, 29 deletions

## Consumer counts (R8)

- `loadRuntimeSkillCatalog`: 1 production consumer and 1 direct test consumer updated
- production `src/skills` imports from `@agent/*`: 1 before, 0 after
- architecture baseline pairs `skills -> agent`: 1 before, 0 after
- discovery warning emitters in the skills layer: 1 before, 0 after
- caller-side warning emitters in the agent layer: 0 before, 1 after

## Verification

- `npm run format`
- focused ESLint: 0 errors
- `npm run typecheck`
- focused Vitest suites: 7 tests passed
- full Vitest suite: 6,045 passed, 4 skipped
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering refactor with preserved warning text and focused tests; no auth, data, or API contract changes beyond the single catalog consumer.
> 
> **Overview**
> **`loadRuntimeSkillCatalog`** no longer takes **`AgentTrace`** or logs discovery problems as a side effect. It now returns **`{ catalog, issues }`** (`RuntimeSkillCatalogResult`), surfacing existing **`SkillLoadIssue`** values from discovery.
> 
> **`buildUserVars`** is the sole place that turns those issues into user-facing **`Skill import …`** warnings on the agent trace and still sets **`AVAILABLE_SKILLS`** from **`catalog`**. When skills are disabled or sources are empty, it uses **`{ catalog: '', issues: [] }`** instead of a bare empty string.
> 
> The **`skills → agent`** architecture baseline edge is removed because **`runtimeSkills`** no longer imports **`@agent/trace`**. Tests cover structured missing-source issues and caller-side warning emission; the host-parity audit doc wording for empty catalogs is aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 650f56964f42808cc05e27799362be223da398cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->