### PR TITLE
refactor: make inquiry selection key-based

### DIFF
--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -40,7 +40,7 @@ import {
   groupPermissions,
   isActiveExternalInquiryCarousel,
   isTextInput,
-  resolveExternalInquiryIndex,
+  selectExternalInquiryKey,
   type PermissionGroups,
 } from './RequestPanelsState';
 
@@ -131,11 +131,8 @@ export class RequestPanels extends LitElement {
 
   @property({ attribute: false }) permissions: PermissionState[] = [];
 
-  /** Currently displayed external inquiry index (carousel). */
-  @state() private _eiIndex = 0;
-
-  /** Key of the currently viewed external inquiry, for stable tracking across list changes. */
-  private _eiTrackedKey: string | null = null;
+  /** Canonical selection for the external-inquiry carousel. */
+  @state() private selectedExternalInquiryKey: string | null = null;
 
   /** Memoized permission groups - recomputed in willUpdate() when permissions change. */
   private permissionGroups: PermissionGroups = createEmptyPermissionGroups();
@@ -143,13 +140,18 @@ export class RequestPanels extends LitElement {
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('permissions')) return;
 
+    const previousPermissions = changedProperties.get('permissions') ?? [];
+    const previousKeys =
+      groupPermissions(previousPermissions).externalInquiry.map(
+        getPermissionKey,
+      );
     this.permissionGroups = groupPermissions(this.permissions);
-    this._eiIndex = resolveExternalInquiryIndex(
-      this._eiIndex,
-      this.permissionGroups.externalInquiry,
-      this._eiTrackedKey,
+    const keys = this.permissionGroups.externalInquiry.map(getPermissionKey);
+    this.selectedExternalInquiryKey = selectExternalInquiryKey(
+      this.selectedExternalInquiryKey,
+      previousKeys,
+      keys,
     );
-    this._updateTrackedKey();
   }
 
   override connectedCallback(): void {
@@ -246,14 +248,15 @@ export class RequestPanels extends LitElement {
     }
 
     const config = SECTION_CONFIGS.externalInquiry;
-    const current = perms[this._eiIndex];
+    const index = this.externalInquiryIndex;
+    const current = perms[index];
     const nav = html`
       <div class="external-inquiry-requests__nav">
         <wa-button
           appearance="plain"
           size="small"
           title="Previous inquiry"
-          ?disabled=${this._eiIndex === 0}
+          ?disabled=${index === 0}
           @click=${this._eiPrev}
         >
           <wa-icon
@@ -263,13 +266,13 @@ export class RequestPanels extends LitElement {
           ></wa-icon>
         </wa-button>
         <span class="external-inquiry-requests__counter">
-          ${this._eiIndex + 1} / ${perms.length}
+          ${index + 1} / ${perms.length}
         </span>
         <wa-button
           appearance="plain"
           size="small"
           title="Next inquiry"
-          ?disabled=${this._eiIndex === perms.length - 1}
+          ?disabled=${index === perms.length - 1}
           @click=${this._eiNext}
         >
           <wa-icon
@@ -291,23 +294,30 @@ export class RequestPanels extends LitElement {
     `;
   }
 
-  private _updateTrackedKey(): void {
-    const ei = this.permissionGroups.externalInquiry;
-    this._eiTrackedKey =
-      ei.length > 0 ? getPermissionKey(ei[this._eiIndex]) : null;
+  private get externalInquiryIndex(): number {
+    const index = this.permissionGroups.externalInquiry.findIndex(
+      (permission) =>
+        getPermissionKey(permission) === this.selectedExternalInquiryKey,
+    );
+    return Math.max(index, 0);
   }
 
-  private _eiPrev(): void {
-    if (this._eiIndex > 0) {
-      this._eiIndex--;
-      this._updateTrackedKey();
+  private selectExternalInquiry(index: number): void {
+    const permission = this.permissionGroups.externalInquiry[index];
+    if (permission) {
+      this.selectedExternalInquiryKey = getPermissionKey(permission);
     }
   }
 
+  private _eiPrev(): void {
+    const index = this.externalInquiryIndex;
+    if (index > 0) this.selectExternalInquiry(index - 1);
+  }
+
   private _eiNext(): void {
-    if (this._eiIndex < this.permissionGroups.externalInquiry.length - 1) {
-      this._eiIndex++;
-      this._updateTrackedKey();
+    const index = this.externalInquiryIndex;
+    if (index < this.permissionGroups.externalInquiry.length - 1) {
+      this.selectExternalInquiry(index + 1);
     }
   }
 
@@ -371,7 +381,7 @@ export class RequestPanels extends LitElement {
     const target = getActivePermission({
       permissions: this.permissions,
       externalInquiryPermissions: this.permissionGroups.externalInquiry,
-      externalInquiryIndex: this._eiIndex,
+      externalInquiryIndex: this.externalInquiryIndex,
     });
     return findPanelForPermission(this.renderRoot, target);
   }

--- a/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
@@ -56,26 +56,18 @@ export function groupPermissions(
   return groups;
 }
 
-/**
- * Resolve the external inquiry carousel index after the permissions list
- * changes. When a tracked permission key is provided, try to find it in
- * the updated list so the carousel stays on the same inquiry even when
- * earlier entries are resolved. Falls back to clamping when the tracked
- * entry is no longer present.
- */
-export function resolveExternalInquiryIndex(
-  prevIndex: number,
-  permissions: PermissionState[],
-  trackedKey: string | null,
-): number {
-  if (permissions.length === 0) return 0;
-  if (trackedKey) {
-    const found = permissions.findIndex(
-      (p) => getPermissionKey(p) === trackedKey,
-    );
-    if (found >= 0) return found;
-  }
-  return Math.min(prevIndex, permissions.length - 1);
+/** Keep a selected inquiry by key, choosing its nearest successor if removed. */
+export function selectExternalInquiryKey(
+  selectedKey: string | null,
+  previousKeys: readonly string[],
+  keys: readonly string[],
+): string | null {
+  if (keys.length === 0) return null;
+  if (selectedKey && keys.includes(selectedKey)) return selectedKey;
+
+  const previousIndex = selectedKey ? previousKeys.indexOf(selectedKey) : 0;
+  const fallbackIndex = Math.min(Math.max(previousIndex, 0), keys.length - 1);
+  return keys[fallbackIndex] ?? null;
 }
 
 export function isTextInput(el: Element | null): boolean {

--- a/src/test-kernel/progressView/RequestPanelsState.vitest.ts
+++ b/src/test-kernel/progressView/RequestPanelsState.vitest.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectExternalInquiryKey } from '@progressView/frontend/components/RequestPanelsState';
+
+describe('external inquiry carousel selection', () => {
+  it('selects the first inquiry when no selection exists', () => {
+    expect(selectExternalInquiryKey(null, [], ['a', 'b'])).toBe('a');
+  });
+
+  it('retains the selected inquiry when earlier entries change', () => {
+    expect(selectExternalInquiryKey('b', ['a', 'b'], ['new', 'a', 'b'])).toBe(
+      'b',
+    );
+    expect(selectExternalInquiryKey('b', ['a', 'b'], ['b'])).toBe('b');
+  });
+
+  it('selects the next inquiry when the selected entry is removed', () => {
+    expect(selectExternalInquiryKey('b', ['a', 'b', 'c'], ['a', 'c'])).toBe(
+      'c',
+    );
+  });
+
+  it('falls back to the previous inquiry when the last entry is removed', () => {
+    expect(selectExternalInquiryKey('c', ['a', 'b', 'c'], ['a', 'b'])).toBe(
+      'b',
+    );
+  });
+
+  it('clears selection with the carousel', () => {
+    expect(selectExternalInquiryKey('a', ['a'], [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary\n\nReplace the external-inquiry carousel's synchronized index/key pair with one canonical selected key. The visible index is derived, and list changes retain the same inquiry or choose the nearest deterministic successor.\n\n## Issue acceptance gates\n\nCloses #8377.\n\n- remove duplicated mutable carousel selection state\n- preserve selection across insertion and removal\n- cover first, retained, removed-middle, removed-last, and empty transitions\n\n## Single source of truth\n\n now owns carousel selection. The index is derived from the current grouped permissions and is never stored independently.\n\n## Duplication and abstraction budget\n\nThe refactor deletes the index/key synchronization method and one mutable state field.  owns the list-transition rule and has two consumers: the component and its focused test suite. No pass-through layer is added.\n\n## Net elements (R6)\n\n- Files: 2 modified, 1 test file added.\n- Raw lines: 81 added, 47 deleted, net +34.\n- Production lines: 49 added, 47 deleted, net +2.\n- Test lines: 32 added for five previously absent selection-transition cases; doubled test accounting is +64.\n- Exported symbols: 1 added (), 1 deleted (), net 0.\n- Classes/interfaces/enums: none added or deleted.\n- Mutable selection fields: 1 added, 2 deleted, net -1.\n\n## Consumer counts (R8)\n\n- : 1 production caller and 0 test callers on the base; 0 after this PR.\n- , , and : private to ; no external consumers.\n- No event key, emitter path, or subscriber route changes.\n\n## Host impact\n\nExtension: progress-view carousel state only.\n\nDesktop: none.\n\nCLI: none.\n\n## Scheduled refactoring\n\nNone.\n\n## Validation\n\n- 
> texra-workspace@0.39.5 typecheck
> tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck && corepack pnpm --filter @texra-ai/cli typecheck && corepack pnpm --filter @texra/trace-viewer run typecheck && corepack pnpm --filter @texra/desktop typecheck\n- 
> texra-workspace@0.39.5 lint
> node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js src packages/extension/src packages/desktop/src packages/cli/src


/Users/siruilu/Local/AI-Projects/coauthor/packages/cli/src/commands/_helpers/dispatch.ts
   6:1  warning  `./globalArgs` import should occur after import of `@cli/runtime/cliContext`              import/order
  19:1  warning  `@utils/text/editDistance` import should occur after import of `@cli/runtime/cliContext`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/cli/src/runtime/cliConfig.ts
  11:1  warning  `@utils/core` import should occur before import of `@utils/errors/errorMessage`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/cli/src/runtime/gitOps.ts
  5:1  warning  `@shared/schemas/opResults` type import should occur before import of `@utils/system/execUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/desktop/src/main/platform/paths.ts
  7:1  warning  `@platform/defaults/nodeStorage` import should occur before import of `@agent/index/BundledAgentDirectories`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/extension/src/commands/housekeeping/cleanCommands.ts
  5:1  warning  `@shared/schemas/opResults` type import should occur after import of `@logger/logUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/extension/src/commands/housekeeping/packCommands.ts
  6:1  warning  `@shared/schemas/opResults` type import should occur after import of `@logger/logUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/extension/src/common/webview/BaseViewMessageHandler.ts
  14:1  warning  `@shared/ipc` import should occur before import of `@shared/utils/dispatcher`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
  36:1  warning  `@shared/wa/webAwesomeIcons` import should occur before import of `@utils/core`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/packages/extension/src/webview/frontend/persistence.ts
  48:1  warning  `@shared/hostBridge` import should occur before type import of `@shared/schemas/commonViewMessages`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/agent/modelHandlers/openai/openAIResponseErrors.ts
  9:1  warning  `openai/resources/responses/responses` type import should occur after import of `./openAISdkError`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/controllers/settingsView/LatexConfigPersistenceController.ts
  11:1  warning  `@shared/ipc` import should occur before import of `@shared/state/stateKeys`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/controllers/settingsView/SettingsGoalController.ts
  5:1  warning  `@shared/ipc` import should occur before type import of `@shared/schemas/settingsViewMessages`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts
  13:1  warning  `@shared/ipc` import should occur before import of `@shared/state/stateKeys`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/housekeeping/utils.ts
  8:1  warning  `@shared/constants/legacyWorkflowOutput` import should occur after import of `@logger/logUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/latex/latexdiff/diffOperations.ts
  11:1  warning  `@shared/constants/legacyWorkflowOutput` import should occur after type import of `@shared/schemas`  import/order
  15:1  warning  `@shared/constants/workflowOutput` import should occur after type import of `@shared/schemas`        import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/latex/latexdiff/outputDiscovery.ts
  14:1  warning  `@shared/constants/workflowOutput` import should occur after type import of `@shared/schemas`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/model/codexSubscriptionRouting.ts
  12:1  warning  `llm-zoo` type import should occur after import of `./providerCapabilities`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/shared/settingsView/handlers/approvalHandlers.ts
  11:1  warning  `@shared/ipc` import should occur before import of `@shared/state/stateKeys`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/shared/settingsView/handlers/superYoloHandlers.ts
  10:1  warning  `@shared/ipc` import should occur before import of `@shared/state/stateKeys`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/agent/AgentCreatorToolCatalogParity.vitest.mts
  44:50  warning  Prefer `String#replaceAll()` over `String#replace()`  unicorn/prefer-string-replace-all

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
  16:1  warning  `@agent/index/agentRegistry` import should occur before import of `@logger/logUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
  10:1  warning  `@transcript` type import should occur after import of `@shared/schemas`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/controllers/SettingsGoalController.vitest.ts
  5:1  warning  `@shared/ipc` import should occur before type import of `@shared/schemas/settingsViewMessages`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
  12:1  warning  `node:assert` import should occur before import of `vitest`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/frontend/NativeToolEditApproval.vitest.mts
  10:1  warning  `@test/support/sessionTestUtils` import should occur before type import of `@agent/runtime/AgentRuntimeHost`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/schemas/SharedSchemas.vitest.ts
  11:1  warning  `@shared/ipc` import should occur before import of `@shared/schemas/workPlan`      import/order
  13:1  warning  `@shared/schemas` import should occur before import of `@shared/schemas/workPlan`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
  21:1  warning  `@test/support/setupPlatform` import should occur before import of `@housekeeping/utils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/shared/SharedStreams.vitest.ts
  6:1  warning  `@shared/schemas` import should occur before import of `@shared/streams/childActivityReducer`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
  7:1  warning  `@tools/github/annotationFetchBudget` import should occur before import of `../support/githubClientMock`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/tools/Wolfram.vitest.ts
  22:1  warning  `node:assert` import should occur before import of `vitest`                                  import/order
  23:1  warning  `@utils/system/toolUtils` import should occur before import of `../agent/progressTestUtils`  import/order
  24:1  warning  `@utils/system/execUtils` import should occur before import of `../agent/progressTestUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/tools/lean/LeanTools.vitest.ts
   5:1  warning  `vitest` import should occur after import of `node:perf_hooks`                               import/order
   6:1  warning  `@tools/lean/leanTypes` import should occur after import of `node:perf_hooks`                import/order
  11:1  warning  `@tools/lean/direct/directLspAdapter` import should occur after import of `node:perf_hooks`  import/order
  12:1  warning  `@tools/externalToolDefs` import should occur after import of `node:perf_hooks`              import/order
  13:1  warning  `@tools/lean/leanServerRegistry` import should occur after import of `node:perf_hooks`       import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/utils/config/ConfigUtils.vitest.ts
  12:1  warning  `@shared/constants/latex` import should occur before import of `@utils/config/configUtils`  import/order
  13:1  warning  `@shared/state/stateKeys` import should occur before import of `@utils/config/configUtils`  import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/utils/files/FilesUtils.vitest.ts
   5:1  warning  `vitest` import should occur after import of `node:fs`                                           import/order
  14:1  warning  `@utils/files/workspaceFS` import should occur after import of `@test/support/setupPlatform`     import/order
  15:1  warning  `@utils/files` import should occur after import of `@test/support/setupPlatform`                 import/order
  17:1  warning  `@common/files/fileTypeUtils` import should occur after import of `@test/support/setupPlatform`  import/order
  18:1  warning  `@utils/files/flexibleFS` import should occur after import of `@test/support/setupPlatform`      import/order
  19:1  warning  `@utils/files/taskRunStorage` import should occur after import of `@test/support/setupPlatform`  import/order
  20:1  warning  `@utils/files/absoluteFS` import should occur after import of `@test/support/setupPlatform`      import/order

/Users/siruilu/Local/AI-Projects/coauthor/src/test-kernel/utils/system/SystemUtils.vitest.ts
  10:1  warning  `vitest` import should occur after import of `node:fs/promises`                             import/order
  11:1  warning  `@test/support/setupPlatform` import should occur after import of `node:fs/promises`        import/order
  12:1  warning  `@utils/system/execUtils` import should occur after import of `@test/support/FakePlatform`  import/order

✖ 52 problems (0 errors, 52 warnings)
  0 errors and 51 warnings potentially fixable with the `--fix` option. - 0 errors; 52 pre-existing warnings\n- focused RequestPanelsState Vitest suite - 5 tests passed\n- targeted Prettier and ESLint\n- \n