### PR TITLE
refactor: make progress host own controller actions

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -517,10 +517,8 @@ export class DesktopProgressBridge {
           deleteAllStreams: () => this.deleteAllStreams(),
           stopStream: (stream) => this.stopStream(stream),
         },
-        run: {
-          resumeStream: async (stream) => {
-            await this.tryResumeStream(stream);
-          },
+        resumeStream: async (stream) => {
+          await this.tryResumeStream(stream);
         },
         followUp: {
           sendFollowUp: ({ stream, text, mediaFiles }) =>

--- a/src/controllers/progressView/ProgressViewHost.ts
+++ b/src/controllers/progressView/ProgressViewHost.ts
@@ -25,20 +25,16 @@ import {
 type ProgressViewFileHostActions = Pick<
   ProgressViewFileCommandActions,
   'openFile' | 'openFileCompile'
-> &
-  Partial<Omit<ProgressViewFileCommandActions, 'openFile' | 'openFileCompile'>>;
+>;
 
 type ProgressViewApprovalHostActions = Omit<
   ProgressViewApprovalCommandActions,
   'handleAgentProposalAction'
-> &
-  Partial<
-    Pick<ProgressViewApprovalCommandActions, 'handleAgentProposalAction'>
-  >;
+>;
 
 export interface ProgressViewHostCommandOptions {
   readonly lifecycle: ProgressViewLifecycleCommandActions;
-  readonly run?: Partial<ProgressViewRunCommandActions>;
+  readonly resumeStream?: ProgressViewRunCommandActions['resumeStream'];
   readonly followUp: ProgressViewFollowUpCommandActions;
   readonly bypass: ProgressViewBypassCommandOptions;
   readonly file: ProgressViewFileHostActions;
@@ -74,54 +70,38 @@ export class ProgressViewHost {
       lifecycle: options.commands.lifecycle,
       run: {
         resumeStream:
-          options.commands.run?.resumeStream ??
+          options.commands.resumeStream ??
           ((stream) => this.workflowActionsController.resume(stream)),
-        runNewStream:
-          options.commands.run?.runNewStream ??
-          ((stream) => this.workflowActionsController.runNew(stream)),
+        runNewStream: (stream) => this.workflowActionsController.runNew(stream),
       },
       followUp: options.commands.followUp,
       bypass: options.commands.bypass,
       file: {
         openFile: options.commands.file.openFile,
         openFileCompile: options.commands.file.openFileCompile,
-        openTaskStorage:
-          options.commands.file.openTaskStorage ??
-          ((stream) =>
-            this.workflowFileActionsController.openTaskStorage(stream)),
-        compareOriginal:
-          options.commands.file.compareOriginal ??
-          ((file, base) =>
-            this.workflowFileActionsController.compareOriginal(file, base)),
-        comparePrevious:
-          options.commands.file.comparePrevious ??
-          ((file, base, previous) =>
-            this.workflowFileActionsController.comparePrevious(
-              file,
-              base,
-              previous,
-            )),
-        acceptFile:
-          options.commands.file.acceptFile ??
-          ((file, base) =>
-            this.workflowFileActionsController.acceptFile(file, base)),
-        mergeFile:
-          options.commands.file.mergeFile ??
-          ((file, base) =>
-            this.workflowFileActionsController.mergeFile(file, base)),
-        latexdiffFile:
-          options.commands.file.latexdiffFile ??
-          ((file, base) =>
-            this.workflowFileActionsController.latexdiffFile(file, base)),
-        openLabel:
-          options.commands.file.openLabel ??
-          ((label) => this.workflowFileActionsController.openLabel(label)),
+        openTaskStorage: (stream) =>
+          this.workflowFileActionsController.openTaskStorage(stream),
+        compareOriginal: (file, base) =>
+          this.workflowFileActionsController.compareOriginal(file, base),
+        comparePrevious: (file, base, previous) =>
+          this.workflowFileActionsController.comparePrevious(
+            file,
+            base,
+            previous,
+          ),
+        acceptFile: (file, base) =>
+          this.workflowFileActionsController.acceptFile(file, base),
+        mergeFile: (file, base) =>
+          this.workflowFileActionsController.mergeFile(file, base),
+        latexdiffFile: (file, base) =>
+          this.workflowFileActionsController.latexdiffFile(file, base),
+        openLabel: (label) =>
+          this.workflowFileActionsController.openLabel(label),
       },
       approval: {
         ...options.commands.approval,
-        handleAgentProposalAction:
-          options.commands.approval.handleAgentProposalAction ??
-          ((message) => this.agentProposalController.handleAction(message)),
+        handleAgentProposalAction: (message) =>
+          this.agentProposalController.handleAction(message),
       },
       externalInquiry: options.commands.externalInquiry,
     });


### PR DESCRIPTION
## Summary

Narrow `ProgressViewHostCommandOptions` to the adapters hosts actually own. Run-new, workflow-file commands, and agent-proposal actions now route unconditionally through the controllers constructed by `ProgressViewHost`; desktop's distinct resume path remains the sole optional run adapter.

Closes #8379.

## Issue acceptance gates

- [x] Removed `Partial` from controller-backed command groups.
- [x] Wired run-new, workflow-file, and proposal commands directly to their owning controllers.
- [x] Preserved desktop's explicit resume adapter; extension retains the workflow-controller default.
- [x] Existing ProgressViewHost, desktop, and extension types/tests pass.
- [x] Formatting, typecheck, lint, and build validation pass.

## Single source of truth

`ProgressViewHost` now owns the decision that `ProgressWorkflowActionsController`, `ProgressWorkflowFileActionsController`, and `ProgressAgentProposalController` implement their respective shared commands. Host options carry only host capabilities rather than alternate implementations of controller-owned behavior.

## Duplication and abstraction budget

Removed nine unused override points and their repeated nullish fallback branches. No abstraction was added; the existing controllers become the unconditional owners their construction already implied.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted; one exported interface is narrowed.
- Classes/interfaces/enums: net 0.
- LoC: 27 insertions, 49 deletions, net -22.

## Consumer counts (R8)

`rg` finds three `new ProgressViewHost` consumers: extension, desktop, and the controller test. Only desktop supplied an optional override (`run.resumeStream`); zero consumers supplied `runNewStream`, the seven workflow-file overrides, or `handleAgentProposalAction`. The desktop adapter is retained as `resumeStream`; all zero-consumer override paths are removed.

## Host impact

Extension: No call-site change; shared workflow/file/proposal controllers continue to handle the same commands.

Desktop: Moves the existing resume callback from `commands.run.resumeStream` to `commands.resumeStream`; behavior is unchanged.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 52 pre-existing warnings)
- `npm run compile:fast`
- `npm test` (673 files passed, 1 skipped; 6073 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- Focused: `npx vitest run src/test-kernel/controllers/ProgressViewHost.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts --maxWorkers=2` (78 passed)
- Focused ESLint on both changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API narrowing and removal of unused override points with no change to desktop resume semantics or extension defaults; risk is mainly compile-time breakage for hypothetical custom overrides.
> 
> **Overview**
> **`ProgressViewHost`** no longer accepts optional overrides for run-new, workflow-file commands, or agent-proposal handling. Those IPC paths always go through the **`ProgressWorkflowActionsController`**, **`ProgressWorkflowFileActionsController`**, and **`ProgressAgentProposalController`** instances the host constructs.
> 
> Host command options are narrowed: **`Partial`** is removed from file/approval groups (hosts only supply **`openFile`** / **`openFileCompile`** and approval actions except proposals). The nested **`commands.run`** object is replaced by a single optional **`resumeStream`** callback—the only run adapter any consumer customized (desktop).
> 
> **Desktop** moves its resume hook from **`commands.run.resumeStream`** to **`commands.resumeStream`**; resume behavior is unchanged. Extension callers keep using the default **`workflowActionsController.resume`** when they omit **`resumeStream`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61a6db9fb607d43273a267896ccbd3a8d56ec5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->