### PR TITLE
refactor: centralize conversation message formatting

### DIFF
--- a/packages/cli/src/runtime/history/conversationFormat.ts
+++ b/packages/cli/src/runtime/history/conversationFormat.ts
@@ -1,11 +1,4 @@
-import {
-  formatConversationContent,
-  hasProviderReasoningBlock,
-  stringifyConversationValue,
-  HIDDEN_PROVIDER_REASONING_MARKER,
-  type ConversationFormatOptions,
-} from '@agent/storage/conversationFormat';
-import { isObject } from '@utils/core';
+import { formatConversationMessage } from '@agent/storage/conversationFormat';
 
 import type {
   CliHistoryConversationPreview,
@@ -16,26 +9,8 @@ const CONVERSATION_PREVIEW_MESSAGE_LIMIT = 3;
 const CONVERSATION_PREVIEW_CONTENT_LIMIT = 4000;
 
 interface ConversationMessageFormatOptions {
-  readonly includeToolUseMarkers?: boolean;
+  readonly includeToolUseMarkers: boolean;
   readonly contentLimit?: number;
-}
-
-/**
- * The shared formatter never truncates tool_use/tool_result blocks or shows
- * their input/args for the CLI (unlike the ExecutionsTool endpoint, which
- * truncates both) — the CLI truncates once, at the whole-message level, in
- * {@link toConversationPreviewMessage}. Provider-reasoning (`thinking`)
- * blocks are always hidden here (surfaced instead via
- * {@link HIDDEN_PROVIDER_REASONING_MARKER} when they're the only content).
- */
-function toBlockFormatOptions(
-  options: ConversationMessageFormatOptions,
-): ConversationFormatOptions {
-  return {
-    includeToolUseMarkers: options.includeToolUseMarkers,
-    includeToolUseInput: false,
-    hideProviderReasoning: true,
-  };
 }
 
 export function createConversationPreview(
@@ -88,9 +63,13 @@ function toConversationPreviewMessage(
   index: number,
   options: ConversationMessageFormatOptions,
 ): CliHistoryConversationPreviewMessage {
-  const raw = isObject(message) ? message : {};
-  const role = typeof raw.role === 'string' ? raw.role : 'unknown';
-  const content = formatConversationMessage(raw, options);
+  const { role, content } = formatConversationMessage(message, {
+    // The CLI truncates once at the whole-message level below and hides
+    // provider reasoning and tool inputs from history output.
+    includeToolUseMarkers: options.includeToolUseMarkers,
+    includeToolUseInput: false,
+    hideProviderReasoning: true,
+  });
   const truncated =
     options.contentLimit !== undefined && content.length > options.contentLimit;
   return {
@@ -101,30 +80,6 @@ function toConversationPreviewMessage(
       : content,
     truncated,
   };
-}
-
-function formatConversationMessage(
-  raw: Record<string, unknown>,
-  options: ConversationMessageFormatOptions,
-): string {
-  const blockOptions = toBlockFormatOptions(options);
-  const role = typeof raw.role === 'string' ? raw.role : '';
-  const parts = [
-    formatConversationContent(raw.content, blockOptions),
-    formatConversationContent(raw.parts, blockOptions),
-    ...(options.includeToolUseMarkers === true
-      ? formatTopLevelToolCalls(raw.tool_calls)
-      : []),
-  ].filter((part) => part.trim().length > 0);
-  if (parts.length > 0) return parts.join('\n').trim();
-  if (
-    isAssistantMessageRole(role) &&
-    (hasProviderReasoningBlock(raw.content) ||
-      hasProviderReasoningBlock(raw.parts))
-  ) {
-    return HIDDEN_PROVIDER_REASONING_MARKER;
-  }
-  return '';
 }
 
 function isAssistantMessageRole(role: string): boolean {
@@ -162,22 +117,4 @@ function formatConversationMessages(
     lines.push('', `[${message.role} #${message.index}]`, message.content);
   }
   return lines.join('\n');
-}
-
-function formatTopLevelToolCalls(toolCalls: unknown): string[] {
-  if (!Array.isArray(toolCalls)) return [];
-  return toolCalls.map(formatTopLevelToolCall);
-}
-
-function formatTopLevelToolCall(toolCall: unknown): string {
-  if (!isObject(toolCall))
-    return `[tool_use: ${stringifyConversationValue(toolCall)}]`;
-  const nestedFunction = isObject(toolCall.function)
-    ? toolCall.function
-    : undefined;
-  const name =
-    [nestedFunction?.name, toolCall.name].find(
-      (value): value is string => typeof value === 'string',
-    ) ?? 'unknown';
-  return `[tool_use: ${name}]`;
 }

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -347,9 +347,14 @@ export function formatConversationMessage(
 ) {
   const raw = isObject(message) ? message : {};
   const role = asText(raw.role) || 'unknown';
+  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
   const content = [
     formatConversationContent(raw.content, options),
-    formatConversationContent(raw.parts, options),
+    truncate(
+      formatConversationContent(raw.parts, options),
+      options.textLimit,
+      marker,
+    ),
     formatTopLevelToolCalls(raw.tool_calls, options),
   ]
     .filter((part) => part.trim().length > 0)

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -17,17 +17,17 @@
  *  - the CLI's `texra history` / resume previews
  *    (`packages/cli/src/runtime/history/conversationFormat.ts`)
  *
- * Callers keep their own message-level composition (XML-ish `<message>`
- * blocks for the tools endpoint; a structured preview/transcript shape plus
- * whole-message truncation for the CLI) — only the per-content-block
- * recognition and truncation below is shared.
+ * Callers keep their own output composition (XML-ish `<message>` blocks for
+ * the tools endpoint; a structured preview/transcript shape plus whole-message
+ * truncation for the CLI). Provider-native message and content recognition is
+ * shared here.
  */
 import { extractWebFetchResultFields } from '@agent/types/ServerToolTypes';
 import { isObject } from '@utils/core';
 
 const DEFAULT_TRUNCATION_MARKER = '...';
 
-export const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
+const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
 
 export interface ConversationFormatOptions {
   /** Truncate string/JSON-ish top-level message content at this many chars. Omit for no limit. */
@@ -44,7 +44,7 @@ export interface ConversationFormatOptions {
   readonly hideProviderReasoning?: boolean;
 }
 
-export function asText(value: unknown): string {
+function asText(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
@@ -74,7 +74,7 @@ function truncate(
   return `${str.slice(0, Math.max(maxLen - marker.length, 0))}${marker}`;
 }
 
-export function hasProviderReasoningBlock(content: unknown): boolean {
+function hasProviderReasoningBlock(content: unknown): boolean {
   if (Array.isArray(content)) return content.some(isProviderReasoningBlock);
   return isProviderReasoningBlock(content);
 }
@@ -106,7 +106,7 @@ function formatToolUseMarker(
   if (options.includeToolUseInput === false) return `[tool_use: ${name}]`;
   const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
   const inputJson = truncate(
-    stringifyConversationValue(input ?? {}),
+    typeof input === 'string' ? input : stringifyConversationValue(input ?? {}),
     options.toolBlockLimit,
     marker,
   );
@@ -335,4 +335,69 @@ export function formatConversationContent(
     options.textLimit,
     marker,
   );
+}
+
+/**
+ * Normalize one provider-native stored message to the role and text consumed
+ * by conversation views.
+ */
+export function formatConversationMessage(
+  message: unknown,
+  options: ConversationFormatOptions = {},
+) {
+  const raw = isObject(message) ? message : {};
+  const role = asText(raw.role) || 'unknown';
+  const content = [
+    formatConversationContent(raw.content, options),
+    formatConversationContent(raw.parts, options),
+    formatTopLevelToolCalls(raw.tool_calls, options),
+  ]
+    .filter((part) => part.trim().length > 0)
+    .join('\n')
+    .trim();
+
+  if (content) return { role, content };
+  const onlyHiddenReasoning =
+    options.hideProviderReasoning === true &&
+    (role === 'assistant' || role === 'model') &&
+    (hasProviderReasoningBlock(raw.content) ||
+      hasProviderReasoningBlock(raw.parts));
+  return {
+    role,
+    content: onlyHiddenReasoning ? HIDDEN_PROVIDER_REASONING_MARKER : '',
+  };
+}
+
+function formatTopLevelToolCalls(
+  toolCalls: unknown,
+  options: ConversationFormatOptions,
+): string {
+  if (!Array.isArray(toolCalls) || options.includeToolUseMarkers === false) {
+    return '';
+  }
+  return toolCalls
+    .map((toolCall) => formatTopLevelToolCall(toolCall, options))
+    .join('\n');
+}
+
+function formatTopLevelToolCall(
+  toolCall: unknown,
+  options: ConversationFormatOptions,
+): string {
+  if (!isObject(toolCall)) {
+    const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
+    return `[tool_use: ${truncate(
+      stringifyConversationValue(toolCall),
+      options.toolBlockLimit,
+      marker,
+    )}]`;
+  }
+  const nestedFunction = isObject(toolCall.function)
+    ? toolCall.function
+    : undefined;
+  const name =
+    asText(nestedFunction?.name) || asText(toolCall.name) || 'unknown';
+  const input =
+    nestedFunction?.arguments ?? toolCall.arguments ?? toolCall.input ?? {};
+  return formatToolUseMarker(name, input, options);
 }

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -30,7 +30,7 @@ const DEFAULT_TRUNCATION_MARKER = '...';
 const HIDDEN_PROVIDER_REASONING_MARKER = '[provider reasoning hidden]';
 
 export interface ConversationFormatOptions {
-  /** Truncate string/JSON-ish top-level message content at this many chars. Omit for no limit. */
+  /** Truncate each string/text message value at this many chars. Omit for no limit. */
   readonly textLimit?: number;
   /** Truncate tool_use/tool_result (and Google functionCall/functionResponse) block text at this many chars. Omit for no limit. */
   readonly toolBlockLimit?: number;
@@ -195,7 +195,9 @@ function formatConversationBlock(
   options: ConversationFormatOptions = {},
 ): string {
   const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
-  if (typeof block === 'string') return block;
+  if (typeof block === 'string') {
+    return truncate(block, options.textLimit, marker);
+  }
   if (!isObject(block)) {
     return truncate(
       stringifyConversationValue(block),
@@ -205,7 +207,7 @@ function formatConversationBlock(
   }
   switch (block.kind) {
     case 'text':
-      return asText(block.text);
+      return truncate(asText(block.text), options.textLimit, marker);
     case 'toolCall':
       return formatToolUseMarker(
         asText(block.name) || 'unknown',
@@ -217,7 +219,9 @@ function formatConversationBlock(
   }
   // Google's `parts` entries have no `type` discriminator at all — a plain
   // `text` field is the only signal, so check it before the `type` switch.
-  if (typeof block.text === 'string') return block.text;
+  if (typeof block.text === 'string') {
+    return truncate(block.text, options.textLimit, marker);
+  }
 
   if (
     isObject(block.inlineData) ||
@@ -257,7 +261,7 @@ function formatConversationBlock(
     case 'text':
       // A recognized text block whose `text` failed the duck-type check
       // above (missing/non-string) — render empty, not its JSON form.
-      return asText(block.text);
+      return truncate(asText(block.text), options.textLimit, marker);
     case 'image':
     case 'image_url':
     case 'input_image':
@@ -347,14 +351,9 @@ export function formatConversationMessage(
 ) {
   const raw = isObject(message) ? message : {};
   const role = asText(raw.role) || 'unknown';
-  const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
   const content = [
     formatConversationContent(raw.content, options),
-    truncate(
-      formatConversationContent(raw.parts, options),
-      options.textLimit,
-      marker,
-    ),
+    formatConversationContent(raw.parts, options),
     formatTopLevelToolCalls(raw.tool_calls, options),
   ]
     .filter((part) => part.trim().length > 0)

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -30,6 +30,41 @@ describe('formatConversation', () => {
     expect(output).toContain('[tool_result: done]');
   });
 
+  it('formats Google parts at the shared message boundary', () => {
+    const output = formatConversation([
+      {
+        role: 'model',
+        parts: [
+          { text: 'I will inspect the workspace.' },
+          { functionCall: { name: 'ls', args: { path: '.' } } },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('I will inspect the workspace.');
+    expect(output).toContain('[tool_use: ls({"path":"."})]');
+  });
+
+  it('formats OpenAI top-level tool calls at the shared message boundary', () => {
+    const output = formatConversation([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            type: 'function',
+            function: {
+              name: 'read_file',
+              arguments: '{"path":"paper.tex"}',
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(output).toContain('[tool_use: read_file({"path":"paper.tex"})]');
+  });
+
   it('formats VS Code language-model tool parts through the shared policy', () => {
     const toolCall = {
       kind: 'toolCall',

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -47,11 +47,18 @@ describe('formatConversation', () => {
 
   it('bounds Google part text with the message text limit', () => {
     const output = formatConversation([
-      { role: 'model', parts: [{ text: 'x'.repeat(501) }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'x'.repeat(501) },
+          { functionCall: { name: 'ls', args: { path: '.' } } },
+        ],
+      },
     ]);
 
     expect(output).toContain(`${'x'.repeat(497)}...`);
     expect(output).not.toContain('x'.repeat(498));
+    expect(output).toContain('[tool_use: ls({"path":"."})]');
   });
 
   it('formats OpenAI top-level tool calls at the shared message boundary', () => {

--- a/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts
@@ -45,6 +45,15 @@ describe('formatConversation', () => {
     expect(output).toContain('[tool_use: ls({"path":"."})]');
   });
 
+  it('bounds Google part text with the message text limit', () => {
+    const output = formatConversation([
+      { role: 'model', parts: [{ text: 'x'.repeat(501) }] },
+    ]);
+
+    expect(output).toContain(`${'x'.repeat(497)}...`);
+    expect(output).not.toContain('x'.repeat(498));
+  });
+
   it('formats OpenAI top-level tool calls at the shared message boundary', () => {
     const output = formatConversation([
       {

--- a/src/tools/executions/conversationFormat.ts
+++ b/src/tools/executions/conversationFormat.ts
@@ -7,8 +7,7 @@
  * tool class stays focused on path routing and storage access.
  */
 import {
-  asText,
-  formatConversationContent,
+  formatConversationMessage,
   type ConversationFormatOptions,
 } from '@agent/storage/conversationFormat';
 
@@ -17,20 +16,11 @@ const CONVERSATION_FORMAT_OPTIONS: ConversationFormatOptions = {
   toolBlockLimit: 100,
 };
 
-interface ConversationMessage {
-  role?: unknown;
-  content?: unknown;
-}
-
 /** Render a stored conversation as numbered <message> blocks. */
 export function formatConversation(conversation: readonly unknown[]): string {
   const messages = conversation.map((msg, i) => {
-    const m = (msg ?? {}) as ConversationMessage;
-    // Coerce a missing, non-string, or empty role to "unknown": stored roles
-    // are untrusted, and an empty label would render a meaningless role="".
-    const role = asText(m.role) || 'unknown';
-    const content = formatConversationContent(
-      m.content,
+    const { role, content } = formatConversationMessage(
+      msg,
       CONVERSATION_FORMAT_OPTIONS,
     );
     return `<message index="${i + 1}" role="${role}">\n${content}\n</message>`;


### PR DESCRIPTION
## Summary

Centralize provider-native stored-message formatting in `src/agent/storage/conversationFormat.ts`. The CLI and Executions tool now share one boundary for role, `content`, Google `parts`, OpenAI top-level `tool_calls`, and hidden reasoning; each caller retains only its output layout and policy options.

This also fixes the Executions conversation view silently omitting Google parts and OpenAI top-level tool calls.

Closes #8381.

## Issue acceptance gates

- [x] Added one shared message-level formatter beside the existing block formatter.
- [x] Removed the CLI's duplicate provider-message parser.
- [x] Removed the Executions tool's assertion-based local message type.
- [x] Preserved CLI preview/transcript truncation, hidden-reasoning, and tool-input policies.
- [x] Added Executions coverage for Google parts and OpenAI top-level tool calls.
- [x] Bounded assembled Google parts with the Executions text limit after review feedback.
- [x] Formatting, typecheck, lint, build, focused tests, full tests, and dead-code ratchet pass.

## Single source of truth

`formatConversationMessage` now owns provider-native stored-message recognition. It delegates content blocks to the existing `formatConversationContent` policy and returns the normalized role/content pair consumed by both views.

## Duplication and abstraction budget

Removed the CLI's local `formatConversationMessage`, `formatTopLevelToolCalls`, and `formatTopLevelToolCall`, plus the Executions tool's local `ConversationMessage` assertion boundary. The shared module gains one exported function and two private OpenAI tool-call helpers. Three implementation-detail exports (`asText`, `hasProviderReasoningBlock`, and the hidden-reasoning marker) become private.

Production code is net -3 lines; the total diff is net +41 because it adds 44 lines of regression coverage.

## Net elements (R6)

- Files: 4 modified, 0 added, 0 deleted.
- Exported symbols: 1 added, 3 removed, net -2.
- Classes/interfaces/enums: 1 local interface removed, 0 added.
- LoC: 134 insertions, 93 deletions, net +41; excluding tests, 90 insertions and 93 deletions, net -3.

## Consumer counts (R8)

`formatConversationMessage` has exactly two production consumers: CLI history and Executions conversation output. The deleted CLI message/tool-call helpers had one consumer each inside their own file; the deleted Executions `ConversationMessage` interface supported one assertion site.

## Host impact

Extension/Desktop: Executions `/conversation` output now includes Google `parts` and OpenAI top-level `tool_calls`; content and assembled Google parts respect the existing text limit.

CLI: History previews/transcripts preserve existing visible output, including bare tool names and hidden provider reasoning, while no longer parsing provider fields independently.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 52 pre-existing warnings)
- `npm run compile:fast`
- `npm test` (673 files passed, 1 skipped; 6076 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- `npx vitest run src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts src/test-kernel/cli/History.vitest.mts --maxWorkers=2` (65 passed)
- Focused Prettier, ESLint, and CLI typecheck on changed surfaces

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared formatting used by CLI history and Executions conversation output; behavior changes for non-Anthropic message shapes but is covered by focused tests and preserves CLI display policies.
> 
> **Overview**
> **Centralizes** provider-native stored-message formatting in `@agent/storage/conversationFormat` via new **`formatConversationMessage`**, which normalizes role plus `content`, Google **`parts`**, and OpenAI top-level **`tool_calls`**, including hidden-reasoning handling.
> 
> The **CLI history** preview/transcript layer **drops** its local message and OpenAI tool-call parsers and **calls** the shared formatter with existing policies (whole-message truncation, bare tool names, hidden reasoning). The **Executions** `/conversation` formatter **switches** from formatting only `content` to the shared message boundary, so Google parts and OpenAI tool calls **appear** in output instead of being **omitted**.
> 
> Block formatting **now applies** `textLimit` to plain strings and text blocks; tool-use markers **preserve** string `arguments` without re-stringifying. Several helpers **are made module-private**; regression tests **cover** Google parts, text limits, and OpenAI tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96490a05dc05f642f7186c9d841e452b821d2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->