### PR TITLE
fix(openai): accept response metadata stream events

### DIFF
--- a/patches/openai@6.46.0.patch
+++ b/patches/openai@6.46.0.patch
@@ -1,0 +1,114 @@
+diff --git a/lib/responses/ResponseAccumulator.d.mts b/lib/responses/ResponseAccumulator.d.mts
+index 3012f7c5f9abe2e123188a5c94b9f36756ada1b8..5386313127f81a3c22e68ea074ed11099dc84df1 100644
+--- a/lib/responses/ResponseAccumulator.d.mts
++++ b/lib/responses/ResponseAccumulator.d.mts
+@@ -3,6 +3,10 @@ type ResponseKeepAliveEvent = {
+     type: 'keepalive';
+     sequence_number: number;
+ };
++type ResponseMetadataEvent = {
++    type: 'response.metadata';
++    [key: string]: unknown;
++};
+ /**
+  * Applies a streaming event to a response snapshot.
+  *
+@@ -10,6 +14,6 @@ type ResponseKeepAliveEvent = {
+  * in place, while response lifecycle events return a detached replacement. Event
+  * payloads are cloned, so retaining or replaying the raw events is safe.
+  */
+-export declare function accumulateResponse(event: ResponseStreamEvent | ResponseKeepAliveEvent, snapshot?: Response): Response;
++export declare function accumulateResponse(event: ResponseStreamEvent | ResponseKeepAliveEvent | ResponseMetadataEvent, snapshot?: Response): Response;
+ export {};
+ //# sourceMappingURL=ResponseAccumulator.d.mts.map
+\ No newline at end of file
+diff --git a/lib/responses/ResponseAccumulator.d.ts b/lib/responses/ResponseAccumulator.d.ts
+index 55f6fa542ac012f3d0d2db4a714f1848ba1341ed..2cfbe36c0526d15afbfd3f05a54bcf1eb8e95f80 100644
+--- a/lib/responses/ResponseAccumulator.d.ts
++++ b/lib/responses/ResponseAccumulator.d.ts
+@@ -3,6 +3,10 @@ type ResponseKeepAliveEvent = {
+     type: 'keepalive';
+     sequence_number: number;
+ };
++type ResponseMetadataEvent = {
++    type: 'response.metadata';
++    [key: string]: unknown;
++};
+ /**
+  * Applies a streaming event to a response snapshot.
+  *
+@@ -10,6 +14,6 @@ type ResponseKeepAliveEvent = {
+  * in place, while response lifecycle events return a detached replacement. Event
+  * payloads are cloned, so retaining or replaying the raw events is safe.
+  */
+-export declare function accumulateResponse(event: ResponseStreamEvent | ResponseKeepAliveEvent, snapshot?: Response): Response;
++export declare function accumulateResponse(event: ResponseStreamEvent | ResponseKeepAliveEvent | ResponseMetadataEvent, snapshot?: Response): Response;
+ export {};
+ //# sourceMappingURL=ResponseAccumulator.d.ts.map
+\ No newline at end of file
+diff --git a/lib/responses/ResponseAccumulator.js b/lib/responses/ResponseAccumulator.js
+index 44ff31698e5d2abe99ab4bfe4e9781be707598ca..b180b41d92918ec9dd2f842c1942e7670913691b 100644
+--- a/lib/responses/ResponseAccumulator.js
++++ b/lib/responses/ResponseAccumulator.js
+@@ -365,8 +365,10 @@ function accumulateResponse(event, snapshot) {
+         case 'response.mcp_list_tools.in_progress':
+         case 'response.mcp_list_tools.completed':
+         case 'response.mcp_list_tools.failed':
++        case 'response.metadata':
+         case 'keepalive':
+         case 'error': {
++            // TODO: Remove response.metadata compatibility once the upstream SDK supports it.
+             // These events do not contain state represented by the Response object.
+             break;
+         }
+diff --git a/lib/responses/ResponseAccumulator.mjs b/lib/responses/ResponseAccumulator.mjs
+index 7b50c8f82eef65d991020bd433cea6202ffaf98e..ae9dc909e9de7fe1b841ea29e07f3dc2b6390c47 100644
+--- a/lib/responses/ResponseAccumulator.mjs
++++ b/lib/responses/ResponseAccumulator.mjs
+@@ -362,8 +362,10 @@ export function accumulateResponse(event, snapshot) {
+         case 'response.mcp_list_tools.in_progress':
+         case 'response.mcp_list_tools.completed':
+         case 'response.mcp_list_tools.failed':
++        case 'response.metadata':
+         case 'keepalive':
+         case 'error': {
++            // TODO: Remove response.metadata compatibility once the upstream SDK supports it.
+             // These events do not contain state represented by the Response object.
+             break;
+         }
+diff --git a/src/lib/responses/ResponseAccumulator.ts b/src/lib/responses/ResponseAccumulator.ts
+index f3dee49f0da1d063824a00f1228d773862d34e49..76a3d515aac046165fef4ab36aae1327c9495e74 100644
+--- a/src/lib/responses/ResponseAccumulator.ts
++++ b/src/lib/responses/ResponseAccumulator.ts
+@@ -11,6 +11,11 @@ type ResponseKeepAliveEvent = {
+   sequence_number: number;
+ };
+
++type ResponseMetadataEvent = {
++  type: 'response.metadata';
++  [key: string]: unknown;
++};
++
+ /**
+  * Applies a streaming event to a response snapshot.
+  *
+@@ -19,7 +24,7 @@ type ResponseKeepAliveEvent = {
+  * payloads are cloned, so retaining or replaying the raw events is safe.
+  */
+ export function accumulateResponse(
+-  event: ResponseStreamEvent | ResponseKeepAliveEvent,
++  event: ResponseStreamEvent | ResponseKeepAliveEvent | ResponseMetadataEvent,
+   snapshot?: Response,
+ ): Response {
+   if (!snapshot) {
+@@ -379,8 +384,10 @@ export function accumulateResponse(
+     case 'response.mcp_list_tools.in_progress':
+     case 'response.mcp_list_tools.completed':
+     case 'response.mcp_list_tools.failed':
++    case 'response.metadata':
+     case 'keepalive':
+     case 'error': {
++      // TODO: Remove response.metadata compatibility once the upstream SDK supports it.
+       // These events do not contain state represented by the Response object.
+       break;
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 patchedDependencies:
   ink@7.1.0: db8f5740efe4e780f6517316175dfed1e68d62e76e533c06bf0b8f5e94b48aa6
+  openai@6.46.0: 0cb4ad59ef11c717ee7f75293ca497ccc244033387f62d1b4b93b6d4aadb949e
 
 importers:
 
@@ -187,7 +188,7 @@ importers:
         version: 8.2.0
       openai:
         specifier: ^6.46.0
-        version: 6.46.0(ws@8.21.0)(zod@4.4.3)
+        version: 6.46.0(patch_hash=0cb4ad59ef11c717ee7f75293ca497ccc244033387f62d1b4b93b6d4aadb949e)(ws@8.21.0)(zod@4.4.3)
       p-defer:
         specifier: ^4.0.1
         version: 4.0.1
@@ -658,7 +659,7 @@ importers:
         version: 6.0.0
       openai:
         specifier: ^6.46.0
-        version: 6.46.0(ws@8.21.0)(zod@4.4.3)
+        version: 6.46.0(patch_hash=0cb4ad59ef11c717ee7f75293ca497ccc244033387f62d1b4b93b6d4aadb949e)(ws@8.21.0)(zod@4.4.3)
       p-map:
         specifier: ^7.0.5
         version: 7.0.5
@@ -10754,7 +10755,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@6.46.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.46.0(patch_hash=0cb4ad59ef11c717ee7f75293ca497ccc244033387f62d1b4b93b6d4aadb949e)(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ allowBuilds:
   unrs-resolver: true
 patchedDependencies:
   ink@7.1.0: patches/ink@7.1.0.patch
+  openai@6.46.0: patches/openai@6.46.0.patch
 # pnpm 11 enables a 24h minimumReleaseAge supply-chain quarantine by default,
 # which blocked same-day dependency bumps (e.g. a fresh llm-zoo for a new model)
 # until they aged out, forcing a per-package allowlist. Disable it repo-wide so

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseMetadata.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseMetadata.vitest.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from 'node:assert';
+import { createRequire } from 'node:module';
+import { describe, it } from 'vitest';
+
+import type {
+  Response,
+  ResponseCompletedEvent,
+  ResponseCreatedEvent,
+} from 'openai/resources/responses/responses';
+
+type MetadataEvent = {
+  type: 'response.metadata';
+  [key: string]: unknown;
+};
+
+type AccumulateResponse = (
+  event: MetadataEvent | ResponseCreatedEvent | ResponseCompletedEvent,
+  snapshot?: Response,
+) => Response;
+
+const nodeRequire = createRequire(import.meta.url);
+
+function createResponse(status: 'in_progress' | 'completed'): Response {
+  return {
+    id: 'resp_metadata_test',
+    created_at: 1,
+    output_text: status,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-4.1',
+    object: 'response',
+    output: [],
+    parallel_tool_calls: true,
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    status,
+  };
+}
+
+function assertMetadataIsIgnored(
+  accumulateResponse: AccumulateResponse,
+  event: MetadataEvent,
+  snapshot: Response,
+): Response {
+  const before = structuredClone(snapshot);
+  const result = accumulateResponse(event, snapshot);
+
+  assert.equal(result, snapshot);
+  assert.deepEqual(result, before);
+  assert.equal('internal' in result, false);
+  return result;
+}
+
+function assertLifecycleSequence(accumulateResponse: AccumulateResponse): void {
+  const metadata = {
+    type: 'response.metadata',
+    sequence_number: 1,
+    internal: { opaque: true },
+  } as const satisfies MetadataEvent;
+
+  assert.throws(
+    () => accumulateResponse(metadata),
+    /expected 'response.created' event/,
+  );
+
+  let snapshot = accumulateResponse({
+    type: 'response.created',
+    sequence_number: 0,
+    response: createResponse('in_progress'),
+  });
+  snapshot = assertMetadataIsIgnored(accumulateResponse, metadata, snapshot);
+
+  snapshot = accumulateResponse(
+    {
+      type: 'response.completed',
+      sequence_number: 2,
+      response: createResponse('completed'),
+    },
+    snapshot,
+  );
+  assertMetadataIsIgnored(
+    accumulateResponse,
+    { ...metadata, sequence_number: 3 },
+    snapshot,
+  );
+}
+
+describe('OpenAI ResponseAccumulator response.metadata compatibility', () => {
+  it('preserves the response snapshot in the CJS runtime', () => {
+    const { accumulateResponse } = nodeRequire(
+      'openai/lib/responses/ResponseAccumulator.js',
+    ) as { accumulateResponse: AccumulateResponse };
+
+    assertLifecycleSequence(accumulateResponse);
+  });
+
+  it('preserves the response snapshot in the ESM runtime', async () => {
+    const { accumulateResponse } =
+      await import('openai/lib/responses/ResponseAccumulator.mjs');
+
+    assertLifecycleSequence(accumulateResponse);
+  });
+});


### PR DESCRIPTION
## Summary
- patch `openai@6.46.0` so the Responses accumulator treats the newly emitted `response.metadata` stream event as opaque, state-free metadata
- preserve streaming without forcing the existing polling fallback, including for stateless responses
- cover both CJS and ESM SDK runtimes with lifecycle-sequence regression tests

The patch is intentionally version-scoped and can be removed once the upstream OpenAI SDK supports `response.metadata`.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/modelHandlers/OpenAIResponseMetadata.vitest.ts`
- `npm run typecheck`
- `npm run lint` (passes with 52 pre-existing warnings, 0 errors)
- `npm test` (6,074 passed; one unrelated `RunChatSignalOwnership` timeout under the full parallel suite, then passed in isolation)
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/RunChatSignalOwnership.vitest.mts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small vendor patch to no-op an extra event type with tests; no app auth or data-path changes beyond keeping streaming stable.
> 
> **Overview**
> Patches **`openai@6.46.0`** so `accumulateResponse` recognizes **`response.metadata`** as a stateless stream event (same handling as `keepalive` / `error`), avoiding breakage when the Responses API emits that event during streaming.
> 
> The patch is registered via **`pnpm` `patchedDependencies`** and is meant to be dropped once upstream supports the event. **Vitest** coverage asserts metadata events do not mutate the response snapshot in both CJS and ESM SDK entrypoints across a create → metadata → complete lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98407ad10aead941ab73e04e10c9e0973ecde250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->