### PR TITLE
fix(desktop): await bulk edit approvals

### DIFF
--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -241,7 +241,7 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
         });
       }
     }
-    this.options.getToolEditApprovals().approvePendingForStream(streamId);
+    await this.options.getToolEditApprovals().approvePendingForStream(streamId);
   }
 
   /**

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -46,7 +46,7 @@ export interface DesktopToolEditApprovalOptions {
 }
 
 export interface DesktopToolEditApprovalController {
-  approvePendingForStream(streamId: StreamTabId): void;
+  approvePendingForStream(streamId: StreamTabId): Promise<void>;
   cancel(selector?: HostInteractionCancelSelector): void;
   handleAction(payload: {
     requestId: string;
@@ -166,7 +166,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
 
     switch (payload.action) {
       case 'approve':
-        this.runAction(payload.requestId, () =>
+        void this.runAction(payload.requestId, () =>
           this.approveProposedEdit(payload.requestId, entry),
         );
         return true;
@@ -177,13 +177,15 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
         });
         return true;
       case 'openDiff':
-        this.runAction(payload.requestId, () => this.openDiffPatch(entry));
+        void this.runAction(payload.requestId, () => this.openDiffPatch(entry));
         return true;
       case 'previewProposed':
-        this.runAction(payload.requestId, () => this.previewProposed(entry));
+        void this.runAction(payload.requestId, () =>
+          this.previewProposed(entry),
+        );
         return true;
       case 'showLatexdiff':
-        this.runAction(payload.requestId, () =>
+        void this.runAction(payload.requestId, () =>
           runLatexdiff(entry, {
             subtype: 'ONLYCHANGEDPAGE',
             openBuildDisplay: this.options.openBuildDisplay,
@@ -195,7 +197,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     }
   }
 
-  approvePendingForStream(streamId: StreamTabId): void {
+  async approvePendingForStream(streamId: StreamTabId): Promise<void> {
     for (const initialization of this.initializing.values()) {
       if (
         initialization.earlyResolution ||
@@ -208,11 +210,16 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
         appliedContent: initialization.request.proposedContent,
       };
     }
-    for (const [requestId, entry] of this.pending) {
-      if (entry.request.streamId === streamId && !entry.isSettled()) {
-        this.handleAction({ requestId, action: 'approve' });
-      }
-    }
+    const pending = [...this.pending].filter(
+      ([, entry]) => entry.request.streamId === streamId && !entry.isSettled(),
+    );
+    await Promise.all(
+      pending.map(([requestId, entry]) =>
+        this.runAction(requestId, () =>
+          this.approveProposedEdit(requestId, entry),
+        ),
+      ),
+    );
   }
 
   cancel(selector: HostInteractionCancelSelector = {}): void {
@@ -328,12 +335,17 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     this.cleanupEntry(entry);
   }
 
-  private runAction(requestId: string, action: () => Promise<void>): void {
-    void action().catch((error) => {
+  private async runAction(
+    requestId: string,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await action();
+    } catch (error) {
       if (this.pending.has(requestId)) {
-        this.report(toErrorMessage(error));
+        await this.report(toErrorMessage(error));
       }
-    });
+    }
   }
 
   private async previewProposed(

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -108,7 +108,7 @@ function createPortSession(): {
     session,
     getApprovalHandlers: () => handlers,
     getToolEditApprovals: () => ({
-      approvePendingForStream: () => {},
+      approvePendingForStream: async () => {},
       cancel: () => {},
       dispose: () => {},
       handleAction: () => false,

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -97,7 +97,7 @@ async function createInteractions(handlers = createHandlers()) {
   const runtimeHost = { emit: vi.fn() };
   const session = createTestSession();
   const toolEditApprovals = {
-    approvePendingForStream: vi.fn(),
+    approvePendingForStream: vi.fn(async (): Promise<void> => {}),
     cancel: vi.fn(),
     requestApproval: vi.fn(async () => ({ accepted: true })),
   };
@@ -141,20 +141,36 @@ describe('createDesktopHostInteractions', () => {
       command: 'npm test',
       streamId: 'stream-b',
     });
+    let releaseToolEdits: (() => void) | undefined;
+    toolEditApprovals.approvePendingForStream.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseToolEdits = resolve;
+      }),
+    );
 
-    await interactions.approvePendingDelegatedWork(
+    let approvalCompleted = false;
+    const approval = interactions.approvePendingDelegatedWork(
       'stream-a',
       'proposal-current',
     );
+    void approval.then(() => {
+      approvalCompleted = true;
+    });
+
+    await vi.waitFor(() =>
+      expect(toolEditApprovals.approvePendingForStream).toHaveBeenCalledWith(
+        'stream-a',
+      ),
+    );
+    expect(approvalCompleted).toBe(false);
+    releaseToolEdits?.();
+    await approval;
 
     await expect(parallel).resolves.toEqual({ action: 'approve' });
     await expect(bash).resolves.toEqual({
       accepted: true,
       userMessage: undefined,
     });
-    expect(toolEditApprovals.approvePendingForStream).toHaveBeenCalledWith(
-      'stream-a',
-    );
     expect(handlers.agentProposal.resolve).toHaveBeenCalledWith(
       'proposal-parallel',
     );

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -42,7 +42,7 @@ interface DesktopToolEditApprovalModule {
     showErrorMessage?: (message: string) => Promise<void> | void;
     tempRoot?: string;
   }): {
-    approvePendingForStream(streamId: string): void;
+    approvePendingForStream(streamId: string): Promise<void>;
     cancel(selector?: {
       streamId?: string | null;
       kind?: string;
@@ -284,7 +284,12 @@ describe('desktop tool edit approval', () => {
           expect(runtimeHost.shownToolEditPermissions).toHaveLength(2),
         );
 
-        controller.approvePendingForStream('stream-target');
+        let targetSettled = false;
+        void target.then(() => {
+          targetSettled = true;
+        });
+        await controller.approvePendingForStream('stream-target');
+        expect(targetSettled).toBe(true);
         await expect(target).resolves.toMatchObject({
           accepted: true,
           appliedContent: 'new target\n',


### PR DESCRIPTION
## Summary

- wait for same-stream desktop edit approvals before delegated approve-all completes
- preserve the existing error path, which reports a failed edit and leaves its prompt pending
- verify completion ordering at both the edit controller and desktop host boundaries

This is a follow-up to #8382 and addresses the late review finding on that merged pull request.

## Design

The desktop approval controller now exposes one asynchronous bulk operation. It snapshots the matching pending edits, runs their existing approval action, and awaits all of those actions. The desktop host adapter awaits this operation before returning. This keeps file-edit behavior inside the controller rather than duplicating it in the host layer.

## Verification

- `npm run lint` (0 errors; 51 pre-existing warnings)
- root and test-kernel TypeScript checks
- all desktop TypeScript configurations
- 35 focused tests across desktop edit approval, desktop host interactions, and session interactions
- `git diff --check`
- independent review: no actionable findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of delegated approval completion and bulk file-edit settlement on the desktop host; incorrect awaiting could leave agents proceeding before edits apply or stall approve-all.
> 
> **Overview**
> **Delegated “approve all” on a stream no longer finishes while same-stream file-edit approvals are still in flight.**
> 
> `approvePendingDelegatedWork` now **awaits** `approvePendingForStream` after auto-approving bash/proposal prompts. The tool-edit controller’s bulk path is **async**: it snapshots unsettled edits for that stream, runs the existing approve path for each via `runAction`, and **`Promise.all`s** them instead of firing `handleAction` without waiting. `runAction` is now **awaitable** (try/catch, `await report` on failure) so bulk approval and error reporting complete before the host returns; single UI actions still kick off `runAction` without blocking the handler.
> 
> Tests and stubs were updated for the `Promise<void>` contract and to assert **ordering**—delegated work does not resolve until stream tool-edit bulk approval finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81f5adde6746e60f2d97a83f771fa859a42f09a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->