### PR TITLE
fix(cli): restore input after nested select cancel

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1006,6 +1006,26 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'config-category-back-responsive',
+    env: { HARNESS_ENTRIES: '4' },
+    // Reuses the shared Select instance across category -> list -> category.
+    keys: ['/config', '\r', '\r', ESC, DOWN, '\r'],
+    frame: 'viewport',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/config · AI agents',
+      '↑/↓ navigate',
+      'Enter toggle / edit / open',
+      'Esc back',
+    ],
+    unexpect: [
+      '/config · Git and worktrees',
+      'No configurable settings are available here yet.',
+      'Platform not initialized',
+      '/config - error',
+    ],
+  },
+  {
     name: 'approval-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/approval', '\r'],

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -212,8 +212,9 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
     items: props.items,
   });
   const [highlight, setHighlight] = useState(initial);
-  // Select cancel handlers close their foreground form, so the component
-  // unmounts after this flips. Future persistent Select users should reset it.
+  // Drop input after cancel until React commits the resulting transition. A
+  // parent may reuse this Select instance for the destination screen, so the
+  // guard must not remain latched across renders.
   const cancelledRef = useRef(false);
 
   function cancelAndDrop(): void {
@@ -224,6 +225,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   useEffect(() => {
     setHighlight((h) => clampIndex(h, props.items.length));
   }, [props.items.length]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+  });
 
   const visibleRange = visibleSelectRange({
     itemCount: props.items.length,


### PR DESCRIPTION
## Summary

Fix the CLI chat TUI becoming unresponsive after returning from a nested `/config` category.

The shared `Select` cancellation guard was designed to suppress trailing terminal input until a foreground selector unmounted. React can instead reuse the same `Select` instance across nested screens, leaving the guard permanently latched. Reset the guard after the next committed render so same-turn input remains suppressed while the destination selector accepts subsequent input.

Add a PTY regression scenario that opens `Git and worktrees`, returns with Escape, moves to `AI agents`, and confirms Enter still opens it.

Closes #8388.

## Issue acceptance gates

- #8388: returning from a config category leaves the category selector responsive.
- The dedicated `config-category-back-responsive` PTY scenario passes.
- Existing adjacent TUI scenarios, TypeScript, lint, tests, and build remain green.

## Single source of truth

`packages/cli/src/chat/tui/ui/Select.tsx` continues to own selector cancellation and trailing-input suppression. The lifecycle reset is implemented once in that shared primitive, rather than in `/config`.

## Duplication and abstraction budget

No new abstraction or duplicated screen-specific workaround. The existing cancellation guard is scoped to its intended transition lifetime in the shared `Select` component.

## Net elements (R6)

n/a — targeted bug fix, not a refactor/simplification/consolidation PR. No files, exports, classes, interfaces, or enums added; 27 lines added and 2 removed across two existing files.

## Consumer counts (R8)

n/a — no emit path or export is deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Nested selectors that reuse the shared `Select` instance remain responsive after Escape/back navigation. Existing selectors that unmount on cancellation are unchanged.

## Scheduled refactoring

None.

## Validation

- Verified the new PTY scenario fails against the pre-fix `Select` behavior.
- `corepack pnpm exec prettier --check packages/cli/src/chat/tui/ui/Select.tsx packages/cli/scripts/validate-tui.mjs`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/cli/SelectHotkeys.vitest.mts src/test-kernel/cli/ConfigForm.vitest.mts` — 29 tests passed.
- `corepack pnpm --filter @texra-ai/cli validate:tui config-category-back-responsive config-form orchestrate-model-pick-esc-back-reselect` — 3 scenarios passed.
- `corepack pnpm --filter @texra-ai/cli typecheck`
- Scoped ESLint on `packages/cli/src/chat/tui/ui/Select.tsx`.
- `npm test`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle change in the shared TUI `Select` primitive plus a harness test; behavior for selectors that unmount on cancel should be unchanged.
> 
> **Overview**
> Fixes the CLI chat TUI going **dead** after **Esc** from a nested `/config` category when React **reuses** the same `Select` instance instead of unmounting it.
> 
> The shared `Select` **cancel-and-drop** guard (`cancelledRef`) now **clears after each committed render**, so it still blocks stray keys on the cancel turn but does not stay latched on the screen you return to. **Enter** and arrow keys work again on the category list.
> 
> Adds a PTY scenario **`config-category-back-responsive`**: open a category, **Esc** back, move to **AI agents**, and confirm **Enter** still opens it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 390ff086d6631ec3a134465a65d0659cebda5ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->