### PR TITLE
refactor(cli): make model recovery defaults explicit

### DIFF
--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -154,12 +154,19 @@ function startSentence(text: string): string {
 function cliModelRecoveryActions(
   options: CliNoAvailableModelsRecoveryOptions = {},
 ): Required<CliNoAvailableModelsRecoveryOptions> {
-  // Drop null/undefined overrides so each missing field keeps its default,
-  // matching the per-field `?? DEFAULT` fallback this replaced.
-  const overrides = Object.fromEntries(
-    Object.entries(options).filter(([, value]) => value != null),
-  ) as Partial<CliNoAvailableModelsRecoveryOptions>;
-  return { ...DEFAULT_CLI_MODEL_RECOVERY_ACTIONS, ...overrides };
+  return {
+    includedModeAction:
+      options.includedModeAction ??
+      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.includedModeAction,
+    loginAction:
+      options.loginAction ?? DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.loginAction,
+    personalModeAction:
+      options.personalModeAction ??
+      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.personalModeAction,
+    configureKeyAction:
+      options.configureKeyAction ??
+      DEFAULT_CLI_MODEL_RECOVERY_ACTIONS.configureKeyAction,
+  };
 }
 
 function isCliModelOptionBasicallyAvailable(model: ModelOptionData): boolean {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -613,6 +613,35 @@ describe('CLI model access resolution', () => {
     );
   });
 
+  it('keeps defaults for omitted and nullish recovery actions', () => {
+    expect(
+      formatCliNoAvailableModelsRecovery('included', {
+        personalModeAction: 'choose personal access',
+      }),
+    ).toBe(
+      'Run `texra login` for included TeXRA access, or choose personal access after configuring a provider API key.',
+    );
+
+    const runtimeNullishActions = {
+      includedModeAction: null,
+      loginAction: undefined,
+      personalModeAction: null,
+      configureKeyAction: undefined,
+    };
+    expect(
+      // @ts-expect-error JavaScript callers can supply null at this boundary.
+      formatCliNoAvailableModelsRecovery(undefined, runtimeNullishActions),
+    ).toBe(
+      'Run `texra login` for included TeXRA access, retry with `--api-mode included`, or add a provider API key with `texra setup`.',
+    );
+    expect(
+      // @ts-expect-error JavaScript callers can supply null at this boundary.
+      formatCliNoRunnableModelsMessage('included', runtimeNullishActions),
+    ).toBe(
+      'No included TeXRA models are runnable. Retry with `--api-mode personal` or try again later.',
+    );
+  });
+
   it('formats empty model picker messages with caller-owned recovery actions', () => {
     expect(
       emptyModelListMessageForCliMode(


### PR DESCRIPTION
## Summary

- replace the generic `Object.entries` / `Object.fromEntries` recovery-action normalization with four explicit nullish defaults
- remove the unchecked type assertion from model-access recovery copy
- cover partial overrides and runtime nullish values

## Design

`CliNoAvailableModelsRecoveryOptions` has four fixed fields. Constructing the required result field by field keeps the fallback rule visible and lets TypeScript check that every field is supplied. There is no intermediate dictionary and no erased key/value type to recover with an assertion.

This is an internal simplification. Shell defaults and interactive overrides are unchanged.

## Verification

- Prettier on changed files
- focused model-access tests (48 passed)
- CLI TypeScript check
- test-kernel TypeScript check
- focused ESLint
- `git diff --check`

Closes #8385

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of recovery-copy normalization with added tests; user-facing recovery strings and defaults are unchanged.
> 
> **Overview**
> **`cliModelRecoveryActions`** in `modelAccess.ts` no longer builds overrides via `Object.entries` / `Object.fromEntries` and a spread merge with a type assertion. It now returns a **required** recovery-options object by applying **`??`** on each of the four fields (`includedModeAction`, `loginAction`, `personalModeAction`, `configureKeyAction`) against `DEFAULT_CLI_MODEL_RECOVERY_ACTIONS`, so defaults stay the same but TypeScript can verify every field.
> 
> Tests add **`keeps defaults for omitted and nullish recovery actions`**, covering a partial override plus `null`/`undefined` values at the JS boundary for `formatCliNoAvailableModelsRecovery` and `formatCliNoRunnableModelsMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96fcbfe99a426679c1288b912cb6e5dc615d8ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->