### PR TITLE
test(cli): cover grouped launcher submenus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
           pnpm --filter @texra-ai/cli validate:tui -- \
             --snapshot-dir "$GITHUB_WORKSPACE/artifacts/tui-frames" \
             edit-approval subagent-picker hidden-root-approval-tab-return \
-            orchestrate-launcher orchestrate-delegated-history \
+            orchestrate-launcher orchestrate-agent-submenu \
+            orchestrate-delegated-history orchestrate-resume-submenu \
             compact-orchestrate-launcher
 
       - name: Upload CLI TUI smoke frames

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -9,7 +9,11 @@ import path from 'node:path';
 import { render } from 'ink';
 import React from 'react';
 
-import { getAgentsByCategory, loadAgents } from '@agent/index';
+import {
+  getAgentsByCategory,
+  getVisibleAgents,
+  loadAgents,
+} from '@agent/index';
 import {
   defaultSession,
   initializeDefaultSession,
@@ -403,24 +407,27 @@ function harnessOrchestrationHistory(): readonly CliHistoryEntry[] {
 }
 
 const HARNESS_ORCHESTRATION_HISTORY = harnessOrchestrationHistory();
-const HARNESS_TOOL_USE_AGENTS = getAgentsByCategory(AgentCategory.ToolUse);
+const HARNESS_VISIBLE_TOOL_USE_AGENT_ENTRIES = getVisibleAgents(
+  AgentCategory.ToolUse,
+);
+const HARNESS_ALL_TOOL_USE_AGENTS = getAgentsByCategory(AgentCategory.ToolUse);
 const HARNESS_PRESET_PLANS = planCliMultiAgentPresets(
   cliMultiAgentPresets(undefined),
   {
     workflowAgents: getAgentsByCategory(AgentCategory.Workflow),
-    toolUseAgents: HARNESS_TOOL_USE_AGENTS,
+    toolUseAgents: HARNESS_ALL_TOOL_USE_AGENTS,
   },
 );
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
   presetPlans: HARNESS_PRESET_PLANS,
   history: HARNESS_ORCHESTRATION_HISTORY,
-  toolUseAgents: HARNESS_TOOL_USE_AGENTS,
+  toolUseAgents: HARNESS_VISIBLE_TOOL_USE_AGENT_ENTRIES,
 });
 const HARNESS_ORCHESTRATION_RESUME_ITEMS = buildCliResumeItems(
   HARNESS_ORCHESTRATION_HISTORY,
 );
 const HARNESS_ORCHESTRATION_AGENT_ITEMS = buildCliAgentItems(
-  HARNESS_TOOL_USE_AGENTS,
+  HARNESS_VISIBLE_TOOL_USE_AGENT_ENTRIES,
 );
 const HARNESS_ORCHESTRATION_TEAM_ITEMS = buildCliTeamItems(
   HARNESS_PRESET_PLANS,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -378,6 +378,27 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'orchestrate-agent-submenu',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: 'assistant||review',
+    },
+    bootExpect: 'Agent — Choose one agent',
+    keys: ['2'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Agent',
+      'Choose one agent for this session.',
+      'assistant',
+      'review',
+      '1-9/a-z/Enter select',
+      'Esc back',
+    ],
+    unexpect: ['coder —', 'Resume aaaaaaaaaaaa'],
+  },
+  {
     name: 'orchestrate-delegated-history',
     frame: 'scrollback',
     env: {
@@ -401,6 +422,27 @@ const SCENARIOS = [
       'Chat with search',
       'Chat with review',
     ],
+  },
+  {
+    name: 'orchestrate-resume-submenu',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_DELEGATED_ORCHESTRATION_HISTORY: '1',
+    },
+    bootExpect: 'Resume — 1 resumable session',
+    keys: ['2'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Resume',
+      'Choose a previous session to continue.',
+      'cccccccccccc',
+      'orchestrator',
+      '1-9/a-z/Enter resume',
+      'Esc back',
+    ],
+    unexpect: ['aaaaaaaaaaaa', 'bbbbbbbbbbbb'],
   },
   {
     name: 'compact-orchestrate-launcher',


### PR DESCRIPTION
## Summary

- construct launcher Agent items from the visibility-filtered roster, as production does
- keep team availability planning on the complete local catalog
- add deterministic smoke scenarios for the Agent and Resume submenus
- include both scenarios in the Linux TUI smoke subset

## Design

The launcher has two distinct catalog views. New chat and Agent are user-facing choices and therefore consume `getVisibleAgents`; team planning resolves preset membership against the complete local registry. The harness now preserves that distinction instead of using one list for both purposes.

The Agent scenario configures a two-agent roster and verifies that a third local agent is absent. The Resume scenario verifies that delegated child executions are excluded and only the user-started resumable session is shown.

## Verification

- exact Linux TUI smoke subset (8 scenarios passed)
- CLI TypeScript check
- Prettier check
- `node --check packages/cli/scripts/validate-tui.mjs`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

Closes #8395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness and CI scenario changes; no production runtime behavior modified.
> 
> **Overview**
> Aligns the orchestration TUI harness with production: **Agent** launcher rows and orchestration items now use **`getVisibleAgents`**, while **team preset planning** still uses the full **`getAgentsByCategory`** catalog.
> 
> Adds two deterministic smoke scenarios—**`orchestrate-agent-submenu`** (two-agent visible roster, hidden agent absent) and **`orchestrate-resume-submenu`** (only user-started resumable session, delegated children excluded)—and wires both into the Linux CI **`validate:tui`** subset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ddf3059828cc519364fed056cb18270e93a48c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->