### PR TITLE
refactor: make dropped-file buckets explicit

### DIFF
--- a/src/controllers/mainView/MainViewDroppedFilesController.ts
+++ b/src/controllers/mainView/MainViewDroppedFilesController.ts
@@ -34,12 +34,11 @@ export interface MainViewDroppedFileAttachmentInput {
 export function planMainViewDroppedFileAttachments(
   input: MainViewDroppedFileAttachmentInput,
 ): MainViewDroppedFileAttachmentPlan {
-  const grouped = Object.fromEntries(
-    MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES.map((category) => [
-      category,
-      new Set<string>(),
-    ]),
-  ) as Record<MainViewAttachableDropCategory, Set<string>>;
+  const grouped = {
+    input: new Set<string>(),
+    context: new Set<string>(),
+    media: new Set<string>(),
+  } satisfies Record<MainViewAttachableDropCategory, Set<string>>;
   let rejectedCount = 0;
 
   for (const filePath of input.paths) {
@@ -57,12 +56,11 @@ export function planMainViewDroppedFileAttachments(
     grouped[category].add(filePath);
   }
 
-  const filesByCategory = Object.fromEntries(
-    MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES.map((category) => [
-      category,
-      [...grouped[category]],
-    ]),
-  ) as Record<MainViewAttachableDropCategory, string[]>;
+  const filesByCategory = {
+    input: [...grouped.input],
+    context: [...grouped.context],
+    media: [...grouped.media],
+  } satisfies Record<MainViewAttachableDropCategory, string[]>;
 
   return {
     filesByCategory,


### PR DESCRIPTION
## Summary

- replace two generic `Object.fromEntries` constructions with explicit `input`, `context`, and `media` records
- remove both unchecked record assertions from dropped-file planning
- preserve Set-based deduplication, insertion order, and the existing category iteration surface

## Issue acceptance gates

Closes #8384.

- no `Object.fromEntries` or record assertion remains in `planMainViewDroppedFileAttachments`
- both fixed records explicitly and exhaustively cover `input`, `context`, and `media`
- automatic targeting, explicit targeting, deduplication, rejection counts, and extension normalization remain covered and pass
- formatting, type checks, focused lint, and focused tests pass

## Single source of truth

`MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES` remains the closed attachable-category domain and the iterable used for totals and extension updates. The two object literals are checked against its derived `MainViewAttachableDropCategory` union with `satisfies`.

## Duplication and abstraction budget

The change removes two repeated map/fromEntries/assertion pipelines. It adds no module, helper, wrapper, or exported abstraction. The fixed three-member domain is represented directly at each of its two value constructions.

## Net elements (R6)

- files: 1 modified, 0 added, 0 deleted
- exported symbols: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- net LoC: -2 (`+10/-12`)

## Consumer counts (R8)

n/a: no export or emit path is deleted or rerouted. `MAIN_VIEW_ATTACHABLE_DROP_CATEGORIES` and the plan result contract are unchanged.

## Host impact

Extension: Dropped-file planning and category update order are unchanged; the existing manager continues to iterate the shared category constant.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- dropped-file controller and webview extraction tests (9 passed)
- root and test-kernel TypeScript checks
- focused ESLint
- Prettier check
- `git diff --check`
