### PR TITLE
feat: discover Copilot subscription models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to this project will be documented in this file.
 
 ### Extension (VS Code)
 
+#### New Features
+
+- **Copilot subscription models appear alongside other model choices** — TeXRA
+  discovers compatible models from VS Code and uses the user's existing
+  Copilot access without requiring a provider API key.
+
 #### Bug Fixes
 
 - **Delegated-work approval uses a clear name** — proposal menus now describe

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -115,6 +115,8 @@ const INCLUDED_ACCESS_STATUS_BY_AVAILABILITY = {
   'openrouter-key': 'included: unavailable; OpenRouter key set',
   'missing-key': 'included: unavailable; missing API key',
   'subscription-access': 'chatgpt subscription',
+  'copilot-access': 'copilot: unavailable in CLI',
+  'copilot-permission-required': 'copilot: unavailable in CLI',
   retired: 'retired',
 } satisfies Record<ModelAvailabilityKind, string>;
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -92,7 +92,9 @@ import { VscodeStorage } from '@frontend/vscode/vscodeStorage';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
 import * as logger from '@logger/logUtils';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
+import { invalidateRuntimeModelRegistry } from '@model/runtimeModelRegistry';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { migrateLegacyGlobalBashApprovalOverride } from '@shared/settingsView/handlers/approvalHandlers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -207,6 +209,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }),
   });
   lifecycleHost = lifecycle;
+  const languageModel = createLanguageModelPort(context);
   initPlatform({
     config: new VscodeConfigProvider(),
     globalState: context.globalState,
@@ -226,7 +229,7 @@ export async function activate(context: vscode.ExtensionContext) {
       isVscodeExtensionInstalled: (id) =>
         vscode.extensions.getExtension(id) !== undefined,
     },
-    languageModel: createLanguageModelPort(context),
+    languageModel,
     linter: getLinterMessages,
     addCriticismSink: (payload) => {
       const accepted = pushManualCriticism({
@@ -262,6 +265,14 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     },
   });
+  const invalidateLanguageModels = () => {
+    invalidateRuntimeModelRegistry();
+    invalidateModelOptionsCache();
+  };
+  context.subscriptions.push(
+    languageModel.onDidChangeModels(invalidateLanguageModels),
+    languageModel.onDidChangeAccess(invalidateLanguageModels),
+  );
   initializeDefaultSession({ transcripts: await StreamLogStore.open() });
   registerAgentFeatures();
   // Mirrors the CLI/desktop Node-host wiring (`nodeHost.ts`'s

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -1,8 +1,6 @@
 import { isDeepStrictEqual } from 'node:util';
 
 // Third-party imports
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
 import {
@@ -31,6 +29,7 @@ import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -237,8 +236,8 @@ export async function runToolUseFlow<C = unknown>(
   const modelSwitchDisabledReason = (model: string): string | undefined => {
     if (services.config.model === model) return undefined;
 
-    const nextConfig = MODEL_CONFIGS[model];
-    if (!nextConfig) return `Model ${model} not found in MODEL_CONFIGS`;
+    const nextConfig = getRuntimeModelConfig(model);
+    if (!nextConfig) return `Model ${model} is not registered`;
 
     const activeKey = activeModelHandlerCompatibilityKey(services.modelHandler);
     if (!activeKey) {
@@ -254,9 +253,9 @@ export async function runToolUseFlow<C = unknown>(
   };
 
   const switchModel = async (model: string): Promise<void> => {
-    const nextConfig = MODEL_CONFIGS[model];
+    const nextConfig = getRuntimeModelConfig(model);
     if (!nextConfig) {
-      throw new Error(`Model ${model} not found in MODEL_CONFIGS`);
+      throw new Error(`Model ${model} is not registered`);
     }
     if (services.config.model === model) return;
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -29,7 +29,10 @@ import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
+import {
+  getRuntimeModelConfig,
+  resolveRuntimeModelConfig,
+} from '@model/runtimeModelRegistry';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -253,7 +256,7 @@ export async function runToolUseFlow<C = unknown>(
   };
 
   const switchModel = async (model: string): Promise<void> => {
-    const nextConfig = getRuntimeModelConfig(model);
+    const nextConfig = await resolveRuntimeModelConfig(model);
     if (!nextConfig) {
       throw new Error(`Model ${model} is not registered`);
     }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
 import { ZodError } from 'zod';
-import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
 import { createRunTrace, type RunTrace } from '@transcript';
 import {
@@ -41,6 +41,7 @@ import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
 import { normalizeRunId } from '@common/constants/runIds';
+import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { INSTRUCTION_ACTION } from '@shared/schemas';
 import {
   STREAM_PHASE,
@@ -166,8 +167,9 @@ export async function getAgentPath(
 async function validateModelExists(
   modelName: string,
   runtimeHost: AgentRuntimeHost,
-): Promise<void> {
-  if (modelName in MODEL_CONFIGS) return;
+): Promise<ModelConfig> {
+  const modelConfig = await resolveRuntimeModelConfig(modelName);
+  if (modelConfig) return modelConfig;
 
   runtimeHost.emit('requestShowInstruction', {
     key: 'modelNotRecognized',
@@ -175,7 +177,7 @@ async function validateModelExists(
     actions: [INSTRUCTION_ACTION.OPEN_MODELS_DOC],
     showSuppress: false,
   });
-  throw new AgentError(`Model ${modelName} not found in MODEL_CONFIGS`);
+  throw new AgentError(`Model ${modelName} is not registered`);
 }
 
 async function inferLaunchModelHandlerCompatibilityKey(
@@ -278,14 +280,13 @@ async function assembleAgentLaunchContext(
     );
   }
 
-  await validateModelExists(fullConfig.model, runtimeHost);
+  const modelConfig = await validateModelExists(fullConfig.model, runtimeHost);
 
   const config: AgentConfig = {
     ...fullConfig,
     agentCategory: setting.agentCategory,
   };
 
-  const modelConfig = MODEL_CONFIGS[fullConfig.model];
   const modelHandlerCompatibilityKey =
     input.modelHandlerCompatibilityKey ??
     (await inferLaunchModelHandlerCompatibilityKey(executionId, config.model));

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -6,11 +6,10 @@
  * LLM calls that share the same configured "helper model" setting.
  */
 
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
 import { getModelUnavailableReason } from '@model/computeModelOptions';
+import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 
 import { getHelperModelName } from './helperModelName';
 
@@ -35,7 +34,15 @@ export async function createHelperModelKit(): Promise<HelperModelResult> {
     return { kit: undefined, reason };
   }
 
-  const handler = await createModelHandler(MODEL_CONFIGS[modelName]);
+  const modelConfig = await resolveRuntimeModelConfig(modelName);
+  if (!modelConfig) {
+    return {
+      kit: undefined,
+      reason: `Model "${modelName}" is not recognized.`,
+    };
+  }
+
+  const handler = await createModelHandler(modelConfig);
   handler.setOutputStreaming(false);
   handler.setProgressViewEnabled(false);
 

--- a/src/agent/runtime/helperModelPreference.ts
+++ b/src/agent/runtime/helperModelPreference.ts
@@ -8,11 +8,10 @@
  * orchestrator delegation) leaves the flag off and keeps the chosen model.
  */
 
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { getModelUnavailableReason } from '@model/computeModelOptions';
+import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 
 import { getHelperModelName } from './helperModelName';
 
@@ -28,6 +27,8 @@ export async function applyHelperModelPreference(
   const helperModel = getHelperModelName();
   if (helperModel === config.model) return config;
 
+  const helperModelConfig = await resolveRuntimeModelConfig(helperModel);
+
   // A tool-use agent (e.g. latexFixer) needs its tools. The tool-use flow drops
   // every tool unless the model positively declares function calling
   // (`responseCycleToolsForModel` returns nothing when
@@ -35,7 +36,7 @@ export async function applyHelperModelPreference(
   // unless the helper model declares it — not only on an explicit `=== false`.
   if (
     config.agentCategory === AgentCategory.ToolUse &&
-    !MODEL_CONFIGS[helperModel]?.capabilities.supportsFunctionCalling
+    !helperModelConfig?.capabilities.supportsFunctionCalling
   ) {
     return config;
   }

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -1,9 +1,10 @@
-import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 
 import {
   normalizeProviderMessages,
   type ProviderMessage,
 } from '@agent/types/ProviderMessage';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import { isObject } from '@utils/core';
 import {
   ModelHandlerCompatibilityKeySchema,
@@ -51,7 +52,7 @@ export function inferPersistedModelHandlerCompatibilityKey(
   model: string,
   messages: readonly ProviderMessage[],
 ): ModelHandlerCompatibilityKey | undefined {
-  const modelConfig = MODEL_CONFIGS[model];
+  const modelConfig = getRuntimeModelConfig(model);
   // Copilot had no direct handler before ModelHandlerVscodeLm. Its only
   // runnable legacy route was OpenRouter, so a keyless persisted transcript
   // necessarily uses the OpenRouter message format. New Copilot sessions

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -4,7 +4,10 @@ import {
   normalizeProviderMessages,
   type ProviderMessage,
 } from '@agent/types/ProviderMessage';
-import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
+import {
+  getRuntimeModelConfig,
+  isRuntimeModel,
+} from '@model/runtimeModelRegistry';
 import { isObject } from '@utils/core';
 import {
   ModelHandlerCompatibilityKeySchema,
@@ -53,6 +56,8 @@ export function inferPersistedModelHandlerCompatibilityKey(
   messages: readonly ProviderMessage[],
 ): ModelHandlerCompatibilityKey | undefined {
   const modelConfig = getRuntimeModelConfig(model);
+  if (isRuntimeModel(model)) return 'ModelHandlerVscodeLm';
+
   // Copilot had no direct handler before ModelHandlerVscodeLm. Its only
   // runnable legacy route was OpenRouter, so a keyless persisted transcript
   // necessarily uses the OpenRouter message format. New Copilot sessions

--- a/src/controllers/progressView/backend/streamTabInfo.ts
+++ b/src/controllers/progressView/backend/streamTabInfo.ts
@@ -1,9 +1,8 @@
 import * as path from 'node:path';
 
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isRemoteAgent } from '@agent/index/agentRegistry';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
 import { AgentCategory, getCleanAgentName } from '@shared/schemas/agent';
 import { isProcessAgent } from '@shared/streams/agentKind';
@@ -120,7 +119,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
         kind: 'agent',
         model: config?.model,
         modelLabel: config?.model
-          ? (MODEL_CONFIGS[config.model]?.label ?? config.model)
+          ? (getRuntimeModelConfig(config.model)?.label ?? config.model)
           : undefined,
       };
 }

--- a/src/model/codexSubscriptionActive.ts
+++ b/src/model/codexSubscriptionActive.ts
@@ -7,12 +7,11 @@
  * never disagree, and the single place that pairs the routing predicate with
  * `getUseOpenRouter()` - keeping that config read out of the CLI render path.
  */
-import { MODEL_CONFIGS } from 'llm-zoo';
-
 import { isCodexSignedIn } from '@auth/codex';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 import { resolveCodexSubscriptionCapabilities } from './codexSubscriptionRouting';
+import { resolveRuntimeModelConfig } from './runtimeModelRegistry';
 
 /**
  * Whether a request for `modelId` would be served by the ChatGPT subscription
@@ -22,7 +21,7 @@ import { resolveCodexSubscriptionCapabilities } from './codexSubscriptionRouting
 export async function isCodexSubscriptionActive(
   modelId: string,
 ): Promise<boolean> {
-  const config = MODEL_CONFIGS[modelId];
+  const config = await resolveRuntimeModelConfig(modelId);
   if (!config) return false;
   if (!resolveCodexSubscriptionCapabilities(config, getUseOpenRouter())) {
     return false;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,4 +1,3 @@
-import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 import { LRUCache } from 'lru-cache';
 
 import { platform } from '@platform/platform';
@@ -22,7 +21,16 @@ import {
 } from './modelOptionsBasic';
 import { getVisibleModels } from './modelOptionsState';
 import { shouldRouteModelThroughOpenRouter } from './openRouterRouting';
+import {
+  availableRuntimeModelIds,
+  getRuntimeModelConfig,
+  isRuntimeModel,
+  refreshRuntimeModelRegistry,
+  runtimeModelAccess,
+  runtimeModelConfigEntries,
+} from './runtimeModelRegistry';
 import type { ProviderCapabilityProfile } from './providerCapabilities';
+import type { ModelConfig } from 'llm-zoo';
 import type { PlatformSecrets } from '@platform/secrets';
 
 type PersonalModelAccessKind = 'provider-key' | 'openrouter-key';
@@ -93,6 +101,16 @@ const AVAILABILITY_STATUS_FIELDS: Record<
   'subscription-access': {
     label: 'ChatGPT subscription',
     available: true,
+    requiresKey: false,
+  },
+  'copilot-access': {
+    label: 'Copilot subscription',
+    available: true,
+    requiresKey: false,
+  },
+  'copilot-permission-required': {
+    label: 'Copilot access required',
+    available: false,
     requiresKey: false,
   },
   'relay-quota-exhausted': {
@@ -172,6 +190,12 @@ async function resolveModelAvailability(
 ): Promise<ModelAvailabilityStatus> {
   if (config.retired) {
     return availabilityStatus('retired');
+  }
+
+  if (isRuntimeModel(model)) {
+    return runtimeModelAccess(model) === true
+      ? availabilityStatus('copilot-access')
+      : availabilityStatus('copilot-permission-required');
   }
 
   // ChatGPT subscription (Codex) is a preference, not a hard requirement. When
@@ -286,7 +310,8 @@ export async function getModelUnavailableReason(
   access?: ModelOptionsAccess,
   options: ModelOptionsComputationOptions = {},
 ): Promise<string | null> {
-  const config = MODEL_CONFIGS[model];
+  await refreshRuntimeModelRegistry();
+  const config = getRuntimeModelConfig(model);
   if (!config) return `Model "${model}" is not recognized.`;
 
   // buildDefaultModelOptionsAccess already folds in options.agentCategory, so
@@ -315,6 +340,10 @@ export async function getModelUnavailableReason(
     return `Model "${model}" is unavailable because your monthly TeXRA relay quota is exhausted. Switch to personal API keys or wait for the next quota period.`;
   }
 
+  if (availability.kind === 'copilot-permission-required') {
+    return `Model "${model}" requires permission to use your Copilot subscription in VS Code.`;
+  }
+
   // Personal key mode or unauthenticated — missing key or keyless provider.
   const providerName =
     PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
@@ -329,7 +358,7 @@ async function buildModelOptionData(
   model: string,
   ctx: ModelAvailabilityContext,
 ): Promise<ModelOptionData> {
-  const config = MODEL_CONFIGS[model];
+  const config = getRuntimeModelConfig(model);
   if (!config) {
     return { value: model, label: model };
   }
@@ -448,6 +477,7 @@ async function computeModelOptionsDataUncached(
   access: ModelOptionsAccess,
   useApiKeyCache: boolean,
 ): Promise<ModelOptionData[]> {
+  await refreshRuntimeModelRegistry();
   const availabilityCtx = await buildAvailabilityContext(
     access,
     useApiKeyCache,
@@ -465,10 +495,10 @@ function visibleModelsForAccess(
   configuredModels: readonly string[],
   context: ModelAvailabilityContext,
 ): readonly string[] {
-  if (!context.codexSignedIn) return configuredModels;
+  const models = new Set([...configuredModels, ...availableRuntimeModelIds()]);
+  if (!context.codexSignedIn) return [...models];
 
-  const models = new Set(configuredModels);
-  for (const [model, config] of Object.entries(MODEL_CONFIGS)) {
+  for (const [model, config] of runtimeModelConfigEntries()) {
     if (
       !config.retired &&
       !config.deprecated &&

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -1,4 +1,4 @@
-import { MODEL_CONFIGS, hint, type ModelConfig } from 'llm-zoo';
+import { hint, type ModelConfig } from 'llm-zoo';
 
 import type { ModelOptionData } from '@shared/schemas';
 import {
@@ -9,15 +9,16 @@ import {
   FAST_FIRST_RESPONSE_HINT,
   isFastFirstResponseModel,
 } from '@shared/constants/fastModels';
+import { getRuntimeModelConfig } from './runtimeModelRegistry';
 
 /** Return whether the registry marks a model as deprecated. */
 export function isDeprecatedModel(model: string): boolean {
-  return MODEL_CONFIGS[model]?.deprecated ?? false;
+  return getRuntimeModelConfig(model)?.deprecated ?? false;
 }
 
 /** Return whether the registry marks a model as no longer served. */
 export function isRetiredModel(model: string): boolean {
-  return MODEL_CONFIGS[model]?.retired ?? false;
+  return getRuntimeModelConfig(model)?.retired ?? false;
 }
 
 /**
@@ -215,7 +216,7 @@ export function buildBasicModelOptionsData(
   visibleModels: readonly string[],
 ): ModelOptionData[] {
   return visibleModels.map((model) => {
-    const config = MODEL_CONFIGS[model];
+    const config = getRuntimeModelConfig(model);
     if (!config) return { value: model, label: model };
     return buildBaseModelOption(model, config);
   });

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -1,0 +1,183 @@
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  MODEL_CONFIGS,
+  ModelProvider,
+  type ModelConfig,
+} from 'llm-zoo';
+
+import { platform } from '@platform/platform';
+import type { LanguageModelInfo } from '@platform/languageModel';
+
+const COPILOT_MODEL_PREFIX = 'copilot:';
+
+interface RuntimeModelEntry {
+  readonly config: ModelConfig;
+  readonly access: boolean | undefined;
+}
+
+const runtimeModels = new Map<string, RuntimeModelEntry>();
+let discoveryEpoch = 0;
+let discoveryComplete = false;
+let pendingDiscovery: Promise<void> | undefined;
+
+function modelRouteNames(config: ModelConfig): readonly string[] {
+  return [config.copilotFullName, config.vscodeLMFullName].filter(
+    (name): name is string => Boolean(name),
+  );
+}
+
+function matchingBaseModel(
+  info: LanguageModelInfo,
+): readonly [string, ModelConfig] | undefined {
+  const nativeNames = new Set(
+    [info.id, info.family].map((name) => name.trim().toLowerCase()),
+  );
+  return Object.entries(MODEL_CONFIGS)
+    .filter(([, config]) => !config.retired && !config.deprecated)
+    .filter(([, config]) =>
+      modelRouteNames(config).some((name) =>
+        nativeNames.has(name.trim().toLowerCase()),
+      ),
+    )
+    .toSorted(([, left], [, right]) => {
+      const byReasoning =
+        Number(left.capabilities.supportsReasoning) -
+        Number(right.capabilities.supportsReasoning);
+      return byReasoning || left.name.localeCompare(right.name);
+    })
+    .at(0);
+}
+
+function runtimeModelId(baseModel: string): string {
+  return `${COPILOT_MODEL_PREFIX}${baseModel}`;
+}
+
+function runtimeConfig(
+  id: string,
+  base: ModelConfig,
+  info: LanguageModelInfo,
+): ModelConfig {
+  return {
+    ...base,
+    name: id,
+    label: `Copilot · ${info.name || base.label}`,
+    fullName: info.id,
+    shortName: info.id,
+    provider: ModelProvider.COPILOT,
+    contextWindow: info.maxInputTokens,
+    inputPrice: 0,
+    outputPrice: 0,
+    openRouterOnly: false,
+    openrouterFullName: undefined,
+    vscodeLMFullName: info.id,
+    copilotFullName: info.id,
+    codexSubscription: false,
+    deprecated: false,
+    retired: false,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsFunctionCalling: base.capabilities.supportsFunctionCalling,
+      supportsReasoning: base.capabilities.supportsReasoning,
+      supportsTokenCounting: true,
+      supportsVision: false,
+      supportsSystemPrompt: false,
+    },
+  };
+}
+
+async function discoverCopilotModels(): Promise<
+  Map<string, RuntimeModelEntry>
+> {
+  const languageModel = platform().languageModel;
+  if (!languageModel.isAvailable()) return new Map();
+
+  const discovered = await languageModel.selectModels({ vendor: 'copilot' });
+  const entries = new Map<string, RuntimeModelEntry>();
+  for (const info of discovered.toSorted((left, right) =>
+    right.version.localeCompare(left.version),
+  )) {
+    const match = matchingBaseModel(info);
+    if (!match) continue;
+    const [baseModel, baseConfig] = match;
+    const id = runtimeModelId(baseModel);
+    if (entries.has(id)) continue;
+    entries.set(id, {
+      config: runtimeConfig(id, baseConfig, info),
+      access: await languageModel.canSendRequest({
+        vendor: info.vendor,
+        id: info.id,
+      }),
+    });
+  }
+  return entries;
+}
+
+/** Refresh editor-supplied models after the native model/access cache changes. */
+export async function refreshRuntimeModelRegistry(): Promise<void> {
+  if (discoveryComplete) return;
+  if (pendingDiscovery) return pendingDiscovery;
+
+  const epoch = discoveryEpoch;
+  const request = (async () => {
+    const discovered = await discoverCopilotModels();
+    if (epoch !== discoveryEpoch) return;
+    runtimeModels.clear();
+    for (const [id, entry] of discovered) runtimeModels.set(id, entry);
+    discoveryComplete = true;
+  })();
+  pendingDiscovery = request;
+  try {
+    await request;
+  } finally {
+    if (pendingDiscovery === request) pendingDiscovery = undefined;
+  }
+}
+
+/** Drop native discovery state; the next async registry read repopulates it. */
+export function invalidateRuntimeModelRegistry(): void {
+  discoveryEpoch += 1;
+  discoveryComplete = false;
+  pendingDiscovery = undefined;
+  runtimeModels.clear();
+}
+
+/** Resolve a static or editor-discovered model config by its persisted id. */
+export function getRuntimeModelConfig(model: string): ModelConfig | undefined {
+  return runtimeModels.get(model)?.config ?? MODEL_CONFIGS[model];
+}
+
+/** Resolve a model after ensuring native discovery has run in this host. */
+export async function resolveRuntimeModelConfig(
+  model: string,
+): Promise<ModelConfig | undefined> {
+  await refreshRuntimeModelRegistry();
+  return getRuntimeModelConfig(model);
+}
+
+/** Available editor-supplied model ids appended to ordinary visible models. */
+export function availableRuntimeModelIds(): readonly string[] {
+  return [...runtimeModels]
+    .filter(([, entry]) => entry.access === true)
+    .map(([id]) => id);
+}
+
+/** Access state reported by the editor for a discovered runtime model. */
+export function runtimeModelAccess(model: string): boolean | undefined {
+  return runtimeModels.get(model)?.access;
+}
+
+/** Whether an id belongs to the currently discovered editor model catalog. */
+export function isRuntimeModel(model: string): boolean {
+  return runtimeModels.has(model);
+}
+
+/** Static and discovered entries for consumers that enumerate the registry. */
+export function runtimeModelConfigEntries(): readonly (readonly [
+  string,
+  ModelConfig,
+])[] {
+  return [
+    ...Object.entries(MODEL_CONFIGS),
+    ...[...runtimeModels].map(([id, entry]) => [id, entry.config] as const),
+  ];
+}

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -133,12 +133,11 @@ export async function refreshRuntimeModelRegistry(): Promise<void> {
   }
 }
 
-/** Drop native discovery state; the next async registry read repopulates it. */
+/** Mark discovery stale while retaining last-known configs for sync readers. */
 export function invalidateRuntimeModelRegistry(): void {
   discoveryEpoch += 1;
   discoveryComplete = false;
   pendingDiscovery = undefined;
-  runtimeModels.clear();
 }
 
 /** Resolve a static or editor-discovered model config by its persisted id. */
@@ -150,8 +149,11 @@ export function getRuntimeModelConfig(model: string): ModelConfig | undefined {
 export async function resolveRuntimeModelConfig(
   model: string,
 ): Promise<ModelConfig | undefined> {
+  const staticConfig = MODEL_CONFIGS[model];
+  if (staticConfig) return staticConfig;
+
   await refreshRuntimeModelRegistry();
-  return getRuntimeModelConfig(model);
+  return runtimeModels.get(model)?.config;
 }
 
 /** Available editor-supplied model ids appended to ordinary visible models. */

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -52,6 +52,10 @@ const ModelAvailabilityKindSchema = z.enum([
   // distinct from relay `included-access` because it is the user's own
   // credential and runs regardless of relay-vs-personal API mode.
   'subscription-access',
+  // Editor-hosted Copilot access is keyless but distinct from ChatGPT and the
+  // TeXRA relay. Permission state is reported by the VS Code host.
+  'copilot-access',
+  'copilot-permission-required',
 ]);
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
 

--- a/src/test-kernel/agent/runtime/helperModelPreference.vitest.ts
+++ b/src/test-kernel/agent/runtime/helperModelPreference.vitest.ts
@@ -6,18 +6,19 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 
 const getHelperModelName = vi.hoisted(() => vi.fn());
 const getModelUnavailableReason = vi.hoisted(() => vi.fn());
+const resolveRuntimeModelConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('@agent/runtime/helperModelName', () => ({ getHelperModelName }));
 vi.mock('@model/computeModelOptions', () => ({ getModelUnavailableReason }));
-vi.mock('llm-zoo', () => ({
-  MODEL_CONFIGS: {
-    deepseek: { capabilities: { supportsFunctionCalling: true } },
-    chatonly: { capabilities: { supportsFunctionCalling: false } },
-    // Known model whose capabilities omit supportsFunctionCalling — the tool-use
-    // flow treats this as "no function calling".
-    undeclared: { capabilities: {} },
-  },
-}));
+vi.mock('@model/runtimeModelRegistry', () => ({ resolveRuntimeModelConfig }));
+
+const MODEL_CONFIGS = {
+  deepseek: { capabilities: { supportsFunctionCalling: true } },
+  chatonly: { capabilities: { supportsFunctionCalling: false } },
+  // Known model whose capabilities omit supportsFunctionCalling — the tool-use
+  // flow treats this as "no function calling".
+  undeclared: { capabilities: {} },
+};
 
 function configFor(model: string, agentCategory = 'toolUse'): AgentConfig {
   return {
@@ -32,6 +33,11 @@ describe('applyHelperModelPreference', () => {
     vi.resetModules();
     getHelperModelName.mockReset();
     getModelUnavailableReason.mockReset();
+    resolveRuntimeModelConfig.mockImplementation(async (model: string) =>
+      Object.hasOwn(MODEL_CONFIGS, model)
+        ? MODEL_CONFIGS[model as keyof typeof MODEL_CONFIGS]
+        : undefined,
+    );
   });
 
   async function resolve(config: AgentConfig): Promise<AgentConfig> {

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { installPlatform } from '@test/support/setupPlatform';
+import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import {
   computeModelOptionsData,
   invalidateModelOptionsCache,
@@ -11,6 +12,7 @@ import {
   getRuntimeModelConfig,
   invalidateRuntimeModelRegistry,
   refreshRuntimeModelRegistry,
+  resolveRuntimeModelConfig,
   runtimeModelAccess,
 } from '@model/runtimeModelRegistry';
 import type {
@@ -105,6 +107,9 @@ describe('runtime model registry', () => {
         supportsNativeCodeExecution: false,
       },
     });
+    expect(
+      inferPersistedModelHandlerCompatibilityKey('copilot:sonnet46', []),
+    ).toBe('ModelHandlerVscodeLm');
   });
 
   it('keeps denied models resolvable without advertising them as available', async () => {
@@ -190,10 +195,27 @@ describe('runtime model registry', () => {
     expect(availableRuntimeModelIds()).toEqual(['copilot:sonnet46']);
 
     invalidateRuntimeModelRegistry();
+    expect(getRuntimeModelConfig('copilot:sonnet46')).toBeDefined();
     await installPlatform({}, { languageModel: languageModelPort([]) });
     await refreshRuntimeModelRegistry();
 
     expect(availableRuntimeModelIds()).toEqual([]);
     expect(getRuntimeModelConfig('copilot:sonnet46')).toBeUndefined();
+  });
+
+  it('does not make static models depend on native discovery', async () => {
+    await installPlatform(
+      {},
+      {
+        languageModel: {
+          ...languageModelPort([]),
+          selectModels: async () => {
+            throw new Error('native discovery failed');
+          },
+        },
+      },
+    );
+
+    await expect(resolveRuntimeModelConfig('gpt55')).resolves.toBeDefined();
   });
 });

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installPlatform } from '@test/support/setupPlatform';
+import {
+  computeModelOptionsData,
+  invalidateModelOptionsCache,
+  type ModelOptionsAccess,
+} from '@model/computeModelOptions';
+import {
+  availableRuntimeModelIds,
+  getRuntimeModelConfig,
+  invalidateRuntimeModelRegistry,
+  refreshRuntimeModelRegistry,
+  runtimeModelAccess,
+} from '@model/runtimeModelRegistry';
+import type {
+  LanguageModelInfo,
+  LanguageModelPort,
+} from '@platform/languageModel';
+
+const SONNET: LanguageModelInfo = {
+  id: 'claude-sonnet-4.6',
+  name: 'Claude Sonnet 4.6',
+  family: 'claude-sonnet-4.6',
+  vendor: 'copilot',
+  version: '2026-07',
+  maxInputTokens: 160_000,
+};
+
+function languageModelPort(
+  models: readonly LanguageModelInfo[],
+  access: boolean | undefined = true,
+): LanguageModelPort {
+  return {
+    isAvailable: () => true,
+    selectModels: vi.fn(async () => models),
+    onDidChangeModels: () => ({ dispose() {} }),
+    sendRequest: () =>
+      (async function* () {
+        // Registry tests do not make model requests.
+      })(),
+    countTokens: async () => 0,
+    canSendRequest: vi.fn(async () => access),
+    onDidChangeAccess: () => ({ dispose() {} }),
+  };
+}
+
+function modelOptionsAccess(): ModelOptionsAccess {
+  return {
+    visibleModels: [],
+    secrets: {
+      get: async () => undefined,
+      getStored: async () => undefined,
+      set: async () => {},
+      delete: async () => {},
+      listStoredKeys: async () => [],
+      getEnv: () => undefined,
+    },
+    useOpenRouter: false,
+    serverSideKeyService: {
+      canUseServerSideKeys: async () => false,
+      getUseIncludedModelAccess: () => false,
+      wasQuotaAutoSwitched: () => false,
+      isRelayQuotaExceeded: () => false,
+      isProviderOnServer: () => false,
+      canUseModelSync: () => false,
+    },
+  };
+}
+
+describe('runtime model registry', () => {
+  beforeEach(() => {
+    invalidateRuntimeModelRegistry();
+    invalidateModelOptionsCache();
+  });
+  afterEach(() => {
+    invalidateRuntimeModelRegistry();
+    invalidateModelOptionsCache();
+  });
+
+  it('projects a known native Copilot model onto shared TeXRA metadata', async () => {
+    const port = languageModelPort([SONNET]);
+    await installPlatform({}, { languageModel: port });
+
+    await refreshRuntimeModelRegistry();
+
+    expect(port.selectModels).toHaveBeenCalledWith({ vendor: 'copilot' });
+    expect(availableRuntimeModelIds()).toEqual(['copilot:sonnet46']);
+    expect(runtimeModelAccess('copilot:sonnet46')).toBe(true);
+    expect(getRuntimeModelConfig('copilot:sonnet46')).toMatchObject({
+      name: 'copilot:sonnet46',
+      label: 'Copilot · Claude Sonnet 4.6',
+      fullName: SONNET.id,
+      provider: 'copilot',
+      contextWindow: SONNET.maxInputTokens,
+      inputPrice: 0,
+      outputPrice: 0,
+      capabilities: {
+        supportsFunctionCalling: true,
+        supportsReasoning: false,
+        supportsReasoningEffort: false,
+        supportsTokenCounting: true,
+        supportsVision: false,
+        supportsNativeWebSearch: false,
+        supportsNativeCodeExecution: false,
+      },
+    });
+  });
+
+  it('keeps denied models resolvable without advertising them as available', async () => {
+    await installPlatform(
+      {},
+      { languageModel: languageModelPort([SONNET], false) },
+    );
+
+    await refreshRuntimeModelRegistry();
+
+    expect(availableRuntimeModelIds()).toEqual([]);
+    expect(runtimeModelAccess('copilot:sonnet46')).toBe(false);
+    expect(getRuntimeModelConfig('copilot:sonnet46')).toBeDefined();
+  });
+
+  it('adds accessible native models to the ordinary model options', async () => {
+    await installPlatform(
+      {},
+      { languageModel: languageModelPort([SONNET], true) },
+    );
+
+    const options = await computeModelOptionsData(
+      undefined,
+      modelOptionsAccess(),
+    );
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        value: 'copilot:sonnet46',
+        provider: 'copilot',
+        availability: 'copilot-access',
+        availabilityLabel: 'Copilot subscription',
+        cost: '$0.000/$0.000',
+        disabled: false,
+        requiresKey: false,
+      }),
+    ]);
+  });
+
+  it('shows a denied persisted selection as requiring Copilot permission', async () => {
+    await installPlatform(
+      {},
+      { languageModel: languageModelPort([SONNET], false) },
+    );
+
+    const [option] = await computeModelOptionsData(
+      ['copilot:sonnet46'],
+      modelOptionsAccess(),
+    );
+
+    expect(option).toMatchObject({
+      availability: 'copilot-permission-required',
+      availabilityLabel: 'Copilot access required',
+      disabled: true,
+      requiresKey: false,
+    });
+  });
+
+  it('omits native models whose capabilities TeXRA cannot establish', async () => {
+    await installPlatform(
+      {},
+      {
+        languageModel: languageModelPort([
+          {
+            ...SONNET,
+            id: 'future-model',
+            family: 'future-model',
+            name: 'Future model',
+          },
+        ]),
+      },
+    );
+
+    await refreshRuntimeModelRegistry();
+
+    expect(availableRuntimeModelIds()).toEqual([]);
+    expect(getRuntimeModelConfig('copilot:future-model')).toBeUndefined();
+  });
+
+  it('replaces native model state after invalidation', async () => {
+    await installPlatform({}, { languageModel: languageModelPort([SONNET]) });
+    await refreshRuntimeModelRegistry();
+    expect(availableRuntimeModelIds()).toEqual(['copilot:sonnet46']);
+
+    invalidateRuntimeModelRegistry();
+    await installPlatform({}, { languageModel: languageModelPort([]) });
+    await refreshRuntimeModelRegistry();
+
+    expect(availableRuntimeModelIds()).toEqual([]);
+    expect(getRuntimeModelConfig('copilot:sonnet46')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Discover compatible GitHub Copilot models from the native VS Code Language Model API and present them through TeXRA's ordinary model-option and runtime paths. Copilot remains an extension-only, keyless access route: CLI and desktop hosts expose no native models, and no provider API key is required.

The consumer-side VS Code API does not expose `LanguageModelChatInformation.capabilities`. The registry therefore matches native identities only to established `llm-zoo` Copilot routes, retains the known tool/reasoning profile, and disables media and provider-SDK features that the host-neutral VS Code handler cannot supply. Unknown native models are omitted rather than assigned invented capabilities.

## Issue acceptance gates

Closes #6728.

- Registers discovered Copilot models only when the host language-model port exists.
- Uses native model identity, family, version, input context, access state, and token counting.
- Represents Copilot as keyless subscription access with zero per-token cost.
- Omits inaccessible models from automatic choices while preserving an inaccessible saved selection as disabled.
- Routes launch, model switch, helper-model, resume-compatibility, and progress metadata through the same runtime registry.
- Invalidates discovery and rendered-option caches on native model and access changes without invalidating active synchronous model references.
- Leaves CLI and desktop discovery empty through their unavailable language-model port.

The issue's original capability gate referred to provider-registration metadata that is not available from `selectChatModels()` consumers. The issue discussion records the corrected native API boundary.

## Single source of truth

`src/model/runtimeModelRegistry.ts` owns the union of static `llm-zoo` configurations and host-discovered model configurations, including native access state and discovery cache invalidation.

## Duplication and abstraction budget

The runtime registry replaces direct `MODEL_CONFIGS[model]` assumptions in the shared launch and switching paths. Its API hides discovery, stable runtime IDs, native-to-known route matching, access state, and race-safe invalidation; consumers continue to work with `ModelConfig` rather than learning VS Code details.

## Net elements (R6)

- Files: 2 added, 14 modified, 0 deleted.
- Lines: +533 / -52, net +481, including 225 lines of focused registry tests.
- Exports: 8 registry functions added; no exported classes, interfaces, or enums added.

## Consumer counts (R8)

n/a. No event key, subscriber, or existing export is deleted. Existing model-resolution consumers are rerouted from direct static-map reads to the registry.

## Host impact

Extension: discovers compatible Copilot models through `vscode.lm`, shows native access state, launches through `ModelHandlerVscodeLm`, and invalidates caches on native changes.

Desktop: no Copilot models are discovered because the Node host supplies the unavailable language-model port.

CLI: no Copilot models are discovered; exhaustive availability copy identifies the state as unavailable in CLI if it is ever received.

## Scheduled refactoring

#6729 owns the Models-tab presentation, first-request consent affordance, quota/retry presentation, and user documentation.

## Validation

- All direct workspace TypeScript checks passed: root, test kernel, extension, CLI, trace viewer, and desktop.
- `npm run compile:fast` passed.
- `npm test` passed: 675 files passed, 1 skipped; 6,096 tests passed, 4 skipped.
- Focused post-review Vitest passed: runtime registry, compatibility inference, model factory routing, and architecture edge ratchet (61 tests).
- Focused ESLint over every changed TypeScript file passed.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Model resolution is centralized across launch, switching, and availability paths; incorrect registry or invalidation could affect which models run, though Copilot is extension-scoped and CLI/desktop discovery is intentionally empty.
> 
> **Overview**
> **Copilot models in VS Code** — TeXRA discovers compatible GitHub Copilot models through the VS Code Language Model API, exposes them as `copilot:*` runtime IDs in the ordinary model picker, and treats them as keyless **Copilot subscription** access (zero listed cost). Native models are matched only to known `llm-zoo` Copilot routes so capabilities are not invented; denied access omits them from auto-choices but keeps a saved selection visible as disabled.
> 
> **`runtimeModelRegistry` as the resolution layer** — Shared code now resolves configs via `getRuntimeModelConfig` / `resolveRuntimeModelConfig` instead of reading `MODEL_CONFIGS` directly for launch validation, mid-session model switch, helper-model preference, stream tab labels, Codex-subscription checks, and compatibility inference (runtime Copilot sessions use `ModelHandlerVscodeLm`).
> 
> **Extension lifecycle** — Subscriptions on `onDidChangeModels` and `onDidChangeAccess` invalidate the registry and model-options cache when Copilot availability changes.
> 
> **CLI** — Copilot availability kinds map to explicit “unavailable in CLI” copy; discovery stays empty where the language-model port is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99753b3cee07254a1ebf779e7b046b65d568c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->