### PR TITLE
fix(cli): preserve session list selection

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2033,15 +2033,13 @@ const SCENARIOS = [
     // Steps: A, S(running), R_P+, E_P+.
     checkpoints: [
       {
-        expect: ['Tab sessions'],
-        unexpect: ['1 sub', 'orderChecker'],
+        unexpect: ['Tab sessions', '1 sub', 'orderChecker'],
       },
       {
-        expect: ['Tab sessions'],
-        unexpect: ['1 sub', 'orderChecker'],
+        unexpect: ['Tab sessions', '1 sub', 'orderChecker'],
       },
       {
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['Tab sessions', '1 sub', 'orderChecker running'],
       },
       {
         expect: ['1 sub', 'orderChecker running'],
@@ -2128,17 +2126,25 @@ const SCENARIOS = [
     // Steps: S(running), A, E_P+, R_P+.
     checkpoints: [
       {
-        expect: ['Tab sessions'],
-        unexpect: ['1 sub', 'orderChecker', 'harness-child-eve'],
+        unexpect: [
+          'Tab sessions',
+          '1 sub',
+          'orderChecker',
+          'harness-child-eve',
+        ],
       },
       {
         // Attachment does not supply a parent edge, so the running slice is
         // registered but still absent from the root's session list.
-        expect: ['Tab sessions'],
-        unexpect: ['1 sub', 'orderChecker', 'harness-child-eve'],
+        unexpect: [
+          'Tab sessions',
+          '1 sub',
+          'orderChecker',
+          'harness-child-eve',
+        ],
       },
       {
-        expect: ['harness-child-eve'],
+        expect: ['Tab sessions', 'harness-child-eve'],
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
@@ -2447,6 +2453,20 @@ const SCENARIOS = [
     resizes: [{ cols: 44, rows: 7 }],
     expect: ['leanSolver waiti', '+3 sessions', 'latex build running'],
     maxOccurrences: [{ text: 'leanSolver waiting for you', max: 1 }],
+  },
+  {
+    name: 'subagent-list-remembers-selection',
+    frame: 'viewport',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'Tab sessions',
+    keys: ['\t', DOWN, ESC, '\t'],
+    expect: ['›   ● strategy running', 'Tab input', 'Esc input'],
+    unexpect: ['signal read during notification phase', 'ERROR'],
   },
   {
     name: 'subagent-list-tiny-resize-releases-focus',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -427,13 +427,7 @@ export function App(props: AppProps): React.JSX.Element {
     // Tab transfers keyboard ownership from the input to the session list.
     if (key.tab) {
       if (sessionViews.length > 0) {
-        setSelectedSessionId(
-          resolveSessionSelectionId(
-            sessionViews,
-            activeStreamId,
-            activeStreamId,
-          ),
-        );
+        setSelectedSessionId(resolvedSelectedSessionId);
         setSessionListFocused(true);
       }
       return;

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,5 +1,7 @@
+// Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 
+// Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
   COLOR_BORDER,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -557,6 +557,7 @@ function sessionListBindingsText(
     [
       keyHintText({ key: 'Up/Down', action: 'select' }),
       keyHintText({ key: 'Enter', action: 'focus' }),
+      keyHintText({ key: 'Tab', action: 'input' }),
       keyHintText({ key: 'Esc', action: 'input' }),
       ctrlCBinding,
     ].join(KEY_HINT_SEPARATOR),

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -8,10 +8,14 @@
 // receive a single-key shortcut prefix so the row can be jumped to directly:
 // `1`-`9` for the first nine rows, then `a`-`z` for rows 10-35.
 
+// Third-party imports
 import { Box, Text, useInput } from 'ink';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
+// Local imports - shared utilities
 import { clamp, clampIndex } from '@utils/core';
+
+// Local imports - TUI input and presentation
 import { COLOR_HINT } from './colors';
 import { POINTER, TICK } from './glyphs';
 

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -242,6 +242,7 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.bindings).toContain('Up/Down select');
     expect(display.bindings).toContain('Enter focus');
+    expect(display.bindings).toContain('Tab input');
     expect(display.bindings).toContain('Esc input');
     expect(display.bindings).not.toContain('Tab sessions');
   });

--- a/src/test-kernel/cli/StreamViews.vitest.mts
+++ b/src/test-kernel/cli/StreamViews.vitest.mts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeStreamParentOrSelfId,
+  activeStreamScope,
+  nearestActiveStreamAncestor,
+} from '@cli/chat/tui/state/streamViews';
+import type { StreamTabId } from '@shared/schemas';
+
+function streamId(value: string): StreamTabId {
+  return value as StreamTabId;
+}
+
+describe('active stream scope', () => {
+  it('projects root and child ownership', () => {
+    const root = streamId('root');
+    const child = streamId('child');
+    const parentStream = new Map<StreamTabId, StreamTabId>([[child, root]]);
+
+    expect(
+      activeStreamScope({ activeStreamId: undefined, parentStream }),
+    ).toEqual({ kind: 'none' });
+    expect(activeStreamScope({ activeStreamId: root, parentStream })).toEqual({
+      kind: 'root',
+      streamId: root,
+    });
+    expect(activeStreamScope({ activeStreamId: child, parentStream })).toEqual({
+      kind: 'child',
+      parentStreamId: root,
+      streamId: child,
+    });
+    expect(
+      activeStreamParentOrSelfId({ activeStreamId: child, parentStream }),
+    ).toBe(root);
+  });
+
+  it('finds the nearest usable ancestor', () => {
+    const root = streamId('root');
+    const child = streamId('child');
+    const grandchild = streamId('grandchild');
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [child, root],
+      [grandchild, child],
+    ]);
+    const values = new Map([
+      [root, { usable: true }],
+      [child, { usable: false }],
+    ]);
+
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: grandchild,
+        parentStream,
+        values,
+        canUseValue: (value) => value.usable,
+      }),
+    ).toEqual({ streamId: root, value: { usable: true } });
+  });
+
+  it('stops ancestor traversal at parent cycles', () => {
+    const first = streamId('first');
+    const second = streamId('second');
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [first, second],
+      [second, first],
+    ]);
+
+    expect(
+      nearestActiveStreamAncestor({
+        activeStreamId: first,
+        parentStream,
+        values: new Map([[first, { usable: true }]]),
+        canUseValue: (value) => value.usable,
+      }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Follow up on #8404 by making the vertical session list preserve its remembered row across Escape and re-entry.

The status bar now advertises both Tab and Escape as ways to return to the input, and pre-focus terminal states show the session shortcut only after a child is actually selectable. The focused tests for active stream scope and cycle-safe ancestor traversal that were previously coupled to the deleted horizontal strip now live in a dedicated stream-view suite.

## Root cause

The Tab handler rebuilt selection from the active stream every time it entered the list, even though the rendered list already retained a valid selected stream id. Separately, several test fixtures still treated any known stream as session-list eligible instead of using the active tree projection.

## Cleanup

- Add import grouping to the remaining rewritten navigation modules.
- Keep scope-helper coverage independent of any particular session-list component.

## Validation

- CLI TypeScript type-check passed.
- Targeted ESLint passed.
- 62 focused Vitest tests passed.
- Five affected PTY scenarios passed, including Escape and Tab re-entry with a remembered child selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused TUI keyboard and status-bar copy changes with new unit/PTY coverage; no auth, persistence, or API surface changes.
> 
> **Overview**
> **Tab into the vertical session list** no longer resets the highlighted row to the active stream every time. The handler reuses the already-resolved selection (`resolvedSelectedSessionId`) so a row you picked with Up/Down survives **Esc back to input** and **Tab** again.
> 
> While the list has focus, the **status bar** now shows **Tab** and **Esc** as ways to return to the input (with a Vitest assertion on `Tab input`). **PTY harness** expectations for child-stream event ordering were tightened so **Tab sessions** only appears when the tree projection actually makes sessions selectable, and a new **`subagent-list-remembers-selection`** scenario locks in the remembered-child highlight.
> 
> **`activeStreamScope` / `nearestActiveStreamAncestor`** coverage moved into a dedicated **`StreamViews.vitest.mts`**; touched navigation modules got **import grouping** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65816c8ed05d842bac894286d459e2dc258f4054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->