### PR TITLE
fix(cli): restore architecture checks

### DIFF
--- a/packages/cli/scripts/check-host-imports.mjs
+++ b/packages/cli/scripts/check-host-imports.mjs
@@ -22,6 +22,7 @@ const processInputAllowedFiles = new Set([
   'packages/cli/src/chat/tui/runChatTui.tsx',
   'packages/cli/src/orchestration/runOrchestrationTui.tsx',
   'packages/cli/src/init/runInitWizard.tsx',
+  'packages/cli/src/config/runConfigTui.tsx',
 ]);
 
 const processTerminalInputAllowedFiles = new Set([
@@ -43,6 +44,7 @@ const processOutputAllowedFiles = new Set([
   'packages/cli/src/init/runInitWizard.tsx',
   'packages/cli/src/onboarding/runOnboarding.tsx',
   'packages/cli/src/commands/loginProviderPicker.tsx',
+  'packages/cli/src/config/runConfigTui.tsx',
 ]);
 
 const processOutputPatterns = [

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 
-import { InvalidAgentTeamError } from '@agent/roster/AgentRosterController';
+import { InvalidAgentTeamError } from '@agent/index';
 import { readSetting } from '@shared/config/settingsAccess';
 import { agentKeyOf } from '@shared/schemas/agent';
 import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -19,6 +19,7 @@ export { toRemoteAgentProfileData } from './remoteAgentProfileData';
 
 export {
   AgentRosterController,
+  InvalidAgentTeamError,
   type AgentRosterControllerDeps,
   type AgentRosterSnapshot,
 } from '../roster/AgentRosterController';

--- a/src/test-kernel/cli/ConfigCommand.vitest.mts
+++ b/src/test-kernel/cli/ConfigCommand.vitest.mts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { InvalidAgentTeamError } from '@agent/roster/AgentRosterController';
+import { InvalidAgentTeamError } from '@agent/index';
 
 const mocks = vi.hoisted(() => ({
   clearDefaultTeam: vi.fn(),


### PR DESCRIPTION
## Summary

Restore the two architecture gates that regressed when the standalone config TUI and unified roster landed:

- recognize `runConfigTui.tsx` as an Ink process-I/O boundary;
- expose `InvalidAgentTeamError` through `@agent/index` so the CLI does not add a new deep roster import.

Closes #8408.
Closes #8409.

## Root cause

The config TUI launcher was added without registering it beside the other Ink launchers in `check-host-imports.mjs`. The config command also bypassed the existing agent-index surface for one roster error type, increasing the CLI deep-import-width ratchet from 34 to 35.

## Impact

No product behavior changes. This makes current `main` green again and prevents every subsequent PR from inheriting the two baseline failures.

## Validation

- `corepack pnpm --filter @texra-ai/cli check:architecture`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- focused architecture/config tests: 11 passed
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test`: 682 files passed, 1 skipped; 6120 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Allowlist and public export/import path changes only; no auth, data, or product logic changes.
> 
> **Overview**
> Restores two CLI architecture gates that broke when the config TUI and unified roster landed, with **no runtime behavior changes**.
> 
> **`check-host-imports.mjs`** now treats `packages/cli/src/config/runConfigTui.tsx` like the other Ink launchers: it is allowed to use direct `process` stdin/stdout (and related patterns) as the interactive config TUI I/O boundary.
> 
> **`InvalidAgentTeamError`** is re-exported from `@agent/index`, and the config command (and its test) import it from there instead of `@agent/roster/AgentRosterController`, so the CLI does not widen deep-import violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffb211aa24c312042ccaf68360114ad161decf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->