### PR TITLE
refactor: discriminate agent configs by category

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ExecutionMeta } from '@agent/storage';
-import { AgentCategorySchema, AgentSourceSchema } from '@shared/schemas/agent';
+import { AgentCategory, AgentSourceSchema } from '@shared/schemas/agent';
 import {
   ExecutionIdSchema,
   StreamTabIdSchema,
@@ -42,14 +42,13 @@ const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
     .prefault(STREAM_SNAPSHOT_SCHEMA_VERSION),
 });
 
-const TraceAgentConfigSchema = NullableFileFieldsSchema.extend({
+const TraceAgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
   agent: z.string(),
   agentSource: AgentSourceSchema.nullish(),
   model: z.string(),
   instruction: z.string(),
   rootUserInstruction: z.string().nullish(),
   displayInstruction: z.string().nullish(),
-  agentCategory: AgentCategorySchema,
   editedFiles: z.array(z.string()),
   toolConfig: ToolConfigSchema,
   memories: z.array(z.string()),
@@ -57,16 +56,27 @@ const TraceAgentConfigSchema = NullableFileFieldsSchema.extend({
   cliOutputFile: z.string().nullish(),
   cliMultiAgentPresetId: z.string().nullish(),
   delegationAgentScope: AgentDelegationScopeSchema.nullish(),
-}).superRefine((config, ctx) => {
-  if (config.outputFiles.length > config.inputFiles.length) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['outputFiles'],
-      message:
-        'Number of output files must not be greater than the number of input files.',
-    });
-  }
 });
+
+const TraceAgentConfigSchema = z
+  .discriminatedUnion('agentCategory', [
+    TraceAgentConfigSharedFieldsSchema.extend({
+      agentCategory: z.literal(AgentCategory.Workflow),
+    }),
+    TraceAgentConfigSharedFieldsSchema.extend({
+      agentCategory: z.literal(AgentCategory.ToolUse),
+    }),
+  ])
+  .superRefine((config, ctx) => {
+    if (config.outputFiles.length > config.inputFiles.length) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['outputFiles'],
+        message:
+          'Number of output files must not be greater than the number of input files.',
+      });
+    }
+  });
 
 const TraceExecutionMetaSchema = z.object({
   schemaVersion: z.literal(TRACE_EXECUTION_META_SCHEMA_VERSION).prefault(1),

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -13,8 +13,8 @@ import { AgentCategory } from './AgentDataclass';
 const DEFAULT_AGENT_NAME = 'correct';
 const DEFAULT_AGENT_INSTRUCTION = '';
 
-/** Pure object schema without refinements for use with .partial(). */
-const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
+/** Fields shared by both category-specific config variants. */
+const AgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
   agent: z.string().prefault(DEFAULT_AGENT_NAME),
   /**
    * Resolved source of `agent`, captured once when the delegation is validated
@@ -30,7 +30,6 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   rootUserInstruction: z.string().nullish(),
   /** Optional user-facing text for logs when instruction contains hidden context. */
   displayInstruction: z.string().nullish(),
-  agentCategory: z.enum(AgentCategory).prefault(AgentCategory.Workflow),
   editedFiles: z.array(z.string()).prefault([]),
   toolConfig: ToolConfigSchema,
   /** Memory display paths attached to this delegation (e.g. /memories/conventions.md). */
@@ -50,33 +49,89 @@ const AgentConfigFieldsSchema = NullableFileFieldsSchema.extend({
   delegationAgentScope: AgentDelegationScopeSchema.nullish(),
 });
 
+const WorkflowAgentConfigFieldsSchema = AgentConfigSharedFieldsSchema.extend({
+  agentCategory: z.literal(AgentCategory.Workflow),
+});
+
+const ToolUseAgentConfigFieldsSchema = AgentConfigSharedFieldsSchema.extend({
+  agentCategory: z.literal(AgentCategory.ToolUse),
+});
+
+const AgentConfigFieldsSchema = z.discriminatedUnion('agentCategory', [
+  WorkflowAgentConfigFieldsSchema,
+  ToolUseAgentConfigFieldsSchema,
+]);
+
+/**
+ * Normalize legacy file fields and materialize the historical absent-category
+ * default before the discriminated union selects a variant.
+ */
+function normalizeAgentConfigInput(input: unknown): unknown {
+  const migrated = migrateLegacyContextFileFields(input);
+  if (
+    typeof migrated !== 'object' ||
+    migrated === null ||
+    Array.isArray(migrated) ||
+    ('agentCategory' in migrated && migrated.agentCategory !== undefined)
+  ) {
+    return migrated;
+  }
+  return { ...migrated, agentCategory: AgentCategory.Workflow };
+}
+
+function validateOutputFileCount(
+  config: z.output<typeof AgentConfigSharedFieldsSchema>,
+  ctx: z.RefinementCtx,
+): void {
+  if (config.outputFiles.length > config.inputFiles.length) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['outputFiles'],
+      message:
+        'Number of output files must not be greater than the number of input files.',
+    });
+  }
+}
+
 /**
  * Agent configuration schema with output file count validation.
  * Wrapped in `z.preprocess` so old execution records persisted before
  * the reference/auxiliary → context rename keep parsing on read.
  */
 export const AgentConfigSchema = z.preprocess(
-  migrateLegacyContextFileFields,
-  AgentConfigFieldsSchema.superRefine((config, ctx) => {
-    // Output files must not outnumber input files.
-    if (config.outputFiles.length > config.inputFiles.length) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['outputFiles'],
-        message:
-          'Number of output files must not be greater than the number of input files.',
-      });
-    }
-  }),
+  normalizeAgentConfigInput,
+  AgentConfigFieldsSchema.superRefine(validateOutputFileCount),
 );
 
 export type AgentConfig = z.output<typeof AgentConfigSchema>;
-export type AgentConfigInput = z.input<typeof AgentConfigFieldsSchema>;
+export type WorkflowAgentConfig = Extract<
+  AgentConfig,
+  { agentCategory: typeof AgentCategory.Workflow }
+>;
+export type ToolUseAgentConfig = Extract<
+  AgentConfig,
+  { agentCategory: typeof AgentCategory.ToolUse }
+>;
+export const WorkflowAgentConfigSchema = z.preprocess(
+  normalizeAgentConfigInput,
+  WorkflowAgentConfigFieldsSchema.superRefine(validateOutputFileCount),
+);
+export const ToolUseAgentConfigSchema = z.preprocess(
+  normalizeAgentConfigInput,
+  ToolUseAgentConfigFieldsSchema.superRefine(validateOutputFileCount),
+);
+export type AgentConfigInput = z.input<typeof AgentConfigSharedFieldsSchema> & {
+  agentCategory?: AgentCategory;
+};
 
 /** Agent configuration payload with required agent and model fields. */
-const AgentConfigPayloadSchema = AgentConfigFieldsSchema.partial().required({
-  agent: true,
-  model: true,
-});
+const AgentConfigPayloadSchema = AgentConfigSharedFieldsSchema.extend({
+  agentCategory: z.enum(AgentCategory).optional(),
+})
+  .partial()
+  .required({
+    agent: true,
+    model: true,
+  });
 
 export type AgentConfigPayload = z.infer<typeof AgentConfigPayloadSchema>;

--- a/src/agent/core/state/TaskState.ts
+++ b/src/agent/core/state/TaskState.ts
@@ -6,7 +6,12 @@ import {
 } from '@shared/schemas/fileTypes';
 
 import { AgentCategory } from '../definition/AgentDataclass';
-import { AgentConfigSchema, type AgentConfig } from '../definition/AgentConfig';
+import {
+  ToolUseAgentConfigSchema,
+  WorkflowAgentConfigSchema,
+  type ToolUseAgentConfig,
+  type WorkflowAgentConfig,
+} from '../definition/AgentConfig';
 
 const ActiveFilesSchema = z
   .partialRecord(z.enum(MULTIPLE_DOCUMENT_FILE_TYPES), z.boolean())
@@ -18,14 +23,6 @@ const ActiveFilesSchema = z
     return complete;
   });
 
-type WorkflowAgentConfig = AgentConfig & {
-  agentCategory: typeof AgentCategory.Workflow;
-};
-
-type ToolUseAgentConfig = AgentConfig & {
-  agentCategory: typeof AgentCategory.ToolUse;
-};
-
 export interface WorkflowTaskState {
   agentConfig: WorkflowAgentConfig;
   activeFiles: Record<MultipleDocumentFileType, boolean>;
@@ -36,16 +33,6 @@ export interface ToolUseTaskState {
 }
 
 export type TaskState = WorkflowTaskState | ToolUseTaskState;
-
-const WorkflowAgentConfigSchema = AgentConfigSchema.refine(
-  (c) => c.agentCategory === AgentCategory.Workflow,
-  { error: 'Expected Workflow category' },
-) as z.ZodType<WorkflowAgentConfig>;
-
-const ToolUseAgentConfigSchema = AgentConfigSchema.refine(
-  (c) => c.agentCategory === AgentCategory.ToolUse,
-  { error: 'Expected ToolUse category' },
-) as z.ZodType<ToolUseAgentConfig>;
 
 const WorkflowTaskStateSchema = z.object({
   agentConfig: WorkflowAgentConfigSchema,

--- a/src/agent/utils/agentConfigToTaskState.ts
+++ b/src/agent/utils/agentConfigToTaskState.ts
@@ -6,7 +6,8 @@ import { type TaskState } from '@agent/core/state/TaskState';
  * Converts an AgentConfig object to a TaskState object.
  */
 export function agentConfigToTaskState(config: AgentConfig): TaskState {
-  switch (config.agentCategory) {
+  const { agentCategory } = config;
+  switch (agentCategory) {
     case AgentCategory.ToolUse:
       return {
         agentConfig: config,
@@ -21,5 +22,9 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
           output: config.outputFiles.length > 0,
         },
       };
+    default: {
+      const _exhaustive: never = agentCategory;
+      throw new Error(`Unknown agent category: ${String(_exhaustive)}`);
+    }
   }
 }

--- a/src/agent/utils/agentConfigToTaskState.ts
+++ b/src/agent/utils/agentConfigToTaskState.ts
@@ -1,10 +1,6 @@
 import { type AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import {
-  type TaskState,
-  type ToolUseTaskState,
-  type WorkflowTaskState,
-} from '@agent/core/state/TaskState';
+import { type TaskState } from '@agent/core/state/TaskState';
 
 /**
  * Converts an AgentConfig object to a TaskState object.
@@ -13,25 +9,17 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
   switch (config.agentCategory) {
     case AgentCategory.ToolUse:
       return {
-        // TaskState stores the already-normalized AgentConfig object by
-        // identity; the switch discriminant is the runtime/type invariant.
-        agentConfig: config as ToolUseTaskState['agentConfig'],
+        agentConfig: config,
       };
     case AgentCategory.Workflow:
       return {
-        // TaskState stores the already-normalized AgentConfig object by
-        // identity; the switch discriminant is the runtime/type invariant.
-        agentConfig: config as WorkflowTaskState['agentConfig'],
+        agentConfig: config,
         activeFiles: {
-          input: (config.inputFiles?.length ?? 0) > 0,
-          context: (config.contextFiles?.length ?? 0) > 0,
-          media: (config.mediaFiles?.length ?? 0) > 0,
-          output: (config.outputFiles?.length ?? 0) > 0,
+          input: config.inputFiles.length > 0,
+          context: config.contextFiles.length > 0,
+          media: config.mediaFiles.length > 0,
+          output: config.outputFiles.length > 0,
         },
       };
-    default: {
-      const _exhaustive: never = config.agentCategory;
-      throw new Error(`Unknown agent category: ${_exhaustive}`);
-    }
   }
 }

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -1,8 +1,5 @@
 // Local imports - agent
-import {
-  AgentConfigSchema,
-  type AgentConfig,
-} from '@agent/core/definition/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ProposalResult } from '@agent/runtime/HostInteractions';
 
@@ -79,35 +76,24 @@ export class ProgressAgentProposalController {
   }
 
   private buildTaskState(proposal: AgentProposal): TaskState | null {
-    const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
-    const activeFiles = isWorkflow
-      ? {
-          input: proposal.inputFiles.length > 0,
-          context: proposal.contextFiles.length > 0,
-          media: proposal.mediaFiles.length > 0,
-          output: proposal.outputFiles.length > 0,
-        }
-      : undefined;
-
-    const result = AgentConfigSchema.safeParse({
-      ...proposal,
-      ...(activeFiles && {
-        inputFilesActive: activeFiles.input,
-        contextFilesActive: activeFiles.context,
-        mediaFilesActive: activeFiles.media,
-        outputFilesActive: activeFiles.output,
-      }),
-    });
+    const result = AgentConfigSchema.safeParse(proposal);
 
     if (!result.success) {
       this.deps.onInvalidProposal?.(result.error.issues);
       return null;
     }
 
-    return (
-      activeFiles
-        ? { agentConfig: result.data, activeFiles }
-        : { agentConfig: result.data }
-    ) as TaskState & { agentConfig: AgentConfig };
+    if (result.data.agentCategory === AgentCategory.Workflow) {
+      return {
+        agentConfig: result.data,
+        activeFiles: {
+          input: result.data.inputFiles.length > 0,
+          context: result.data.contextFiles.length > 0,
+          media: result.data.mediaFiles.length > 0,
+          output: result.data.outputFiles.length > 0,
+        },
+      };
+    }
+    return { agentConfig: result.data };
   }
 }

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -2,6 +2,7 @@
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AgentConfigSchema,
+  ToolUseAgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
 import type { ExecutionRequest } from '@agent/core/state/executionRequests';
@@ -172,7 +173,7 @@ export class ProgressFollowUpController {
       };
     }
 
-    const agentConfig = AgentConfigSchema.parse({
+    const agentConfig = ToolUseAgentConfigSchema.parse({
       ...input.taskState.agentConfig,
       agent: input.agent,
       model: input.model,
@@ -185,7 +186,7 @@ export class ProgressFollowUpController {
       outputFiles: [],
       editedFile: null,
       editedFiles: [],
-    }) as AgentConfig & { agentCategory: typeof AgentCategory.ToolUse };
+    });
 
     return {
       kind: 'restoreState',

--- a/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
+++ b/src/test-kernel/agent/AgentConfigToTaskState.vitest.ts
@@ -5,10 +5,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Local imports - agent
-import {
-  AgentConfigSchema,
-  type AgentConfig,
-} from '@agent/core/definition/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   isToolUseTaskState,
@@ -86,23 +83,22 @@ describe('agentConfigToTaskState', () => {
     assert.deepEqual(taskState, { agentConfig: config });
   });
 
-  it('tolerates minimal workflow configs from tests and legacy callers', () => {
-    const config = {
-      agentCategory: AgentCategory.Workflow,
-      agent: 'correct',
-      model: 'sonnet46T',
-      inputFiles: [],
-      outputFiles: [],
-    } as unknown as AgentConfig;
-
-    const taskState = agentConfigToTaskState(config);
-
+  it('normalizes a legacy workflow config nested inside task state', () => {
+    const taskState = TaskStateSchema.parse({
+      agentConfig: {
+        inputFile: 'main.tex',
+      },
+      activeFiles: {
+        input: true,
+      },
+    });
     if (!isWorkflowTaskState(taskState)) {
       assert.fail('Expected a workflow task state');
     }
-    assert.equal(taskState.agentConfig, config);
+    assert.equal(taskState.agentConfig.agentCategory, AgentCategory.Workflow);
+    assert.deepEqual(taskState.agentConfig.inputFiles, ['main.tex']);
     assert.deepEqual(taskState.activeFiles, {
-      input: false,
+      input: true,
       context: false,
       media: false,
       output: false,

--- a/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
+++ b/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
@@ -6,7 +6,11 @@ import { describe, it } from 'vitest';
 
 // Local imports - agent core
 
-import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  AgentConfigSchema,
+  ToolUseAgentConfigSchema,
+  WorkflowAgentConfigSchema,
+} from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { MainViewPersistedStateSchema } from '@shared/schemas/mainView';
 import { ToolConfigSchema } from '@shared/schemas/toolConfig';
@@ -58,6 +62,27 @@ describe('AgentConfigSchema', () => {
     const parsed = AgentConfigSchema.parse({});
 
     assert.strictEqual(parsed.agentCategory, AgentCategory.Workflow);
+  });
+
+  it('keeps category-specific parsers aligned with the discriminated union', () => {
+    const workflow = WorkflowAgentConfigSchema.parse({});
+    const toolUse = ToolUseAgentConfigSchema.parse({
+      agentCategory: AgentCategory.ToolUse,
+    });
+
+    assert.strictEqual(workflow.agentCategory, AgentCategory.Workflow);
+    assert.strictEqual(toolUse.agentCategory, AgentCategory.ToolUse);
+    assert.throws(() => ToolUseAgentConfigSchema.parse(workflow));
+    assert.throws(() => WorkflowAgentConfigSchema.parse(toolUse));
+  });
+
+  it('applies shared output-file validation to category-specific parsers', () => {
+    assert.throws(() =>
+      ToolUseAgentConfigSchema.parse({
+        agentCategory: AgentCategory.ToolUse,
+        outputFiles: ['result.tex'],
+      }),
+    );
   });
 
   it('migrates legacy single file slots into canonical file lists', () => {

--- a/src/test-kernel/cli/SessionResumeResolution.vitest.mts
+++ b/src/test-kernel/cli/SessionResumeResolution.vitest.mts
@@ -7,7 +7,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
 import type { ExecutionId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
@@ -32,22 +35,19 @@ const EXECUTION_ID = 'exec-1' as ExecutionId;
 const STREAM_ID = 'stream-1';
 
 function toolUseConfig(): AgentConfig {
-  // Minimal config: the resolver only reads `agentCategory`, `agent`, `model`.
-  return {
+  return AgentConfigSchema.parse({
     agent: 'planner',
     model: 'gpt-5',
     agentCategory: AgentCategory.ToolUse,
-  } as unknown as AgentConfig;
+  });
 }
 
 function workflowConfig(): AgentConfig {
-  return {
+  return AgentConfigSchema.parse({
     agent: 'correct',
     model: 'gemini31p',
     agentCategory: AgentCategory.Workflow,
-    inputFiles: [],
-    outputFiles: [],
-  } as unknown as AgentConfig;
+  });
 }
 
 async function resolve(id: ExecutionId = EXECUTION_ID) {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -11,8 +11,14 @@ import {
 // Local imports - agent state
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { noopTrace, type AgentEvent, type AgentTrace } from '@agent/trace';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { TaskStateSchema } from '@agent/core/state/TaskState';
+import {
+  WorkflowAgentConfigSchema,
+  type AgentConfig,
+} from '@agent/core/definition/AgentConfig';
+import {
+  TaskStateSchema,
+  type WorkflowTaskState,
+} from '@agent/core/state/TaskState';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -488,23 +494,20 @@ function createStreamSnapshotStore(
   };
 }
 
-function workflowTaskState(): {
-  agentConfig: {
-    agent: string;
-    model: string;
-    agentCategory: typeof AgentCategory.Workflow;
-    toolConfig: typeof DEFAULT_TOOL_CONFIG;
-  };
-  activeFiles: Record<string, boolean>;
-} {
+function workflowTaskState(): WorkflowTaskState {
   return {
-    agentConfig: {
+    agentConfig: WorkflowAgentConfigSchema.parse({
       agent: 'proofreader',
       model: 'deepseekproT',
       agentCategory: AgentCategory.Workflow,
       toolConfig: DEFAULT_TOOL_CONFIG,
+    }),
+    activeFiles: {
+      input: false,
+      context: false,
+      media: false,
+      output: false,
     },
-    activeFiles: {},
   };
 }
 


### PR DESCRIPTION
## Summary

- model workflow and tool-use agent configs as a category-discriminated union
- normalize the legacy missing category once at the parsing boundary
- consume narrowed variants without intersection schemas, category refinements, casts, or repeated optional checks
- keep the trace-viewer schema aligned with the runtime contract
- build proposal task state from parsed variants without assertions

## Issue acceptance gates

Closes #8405.

- `AgentConfig` is discriminated by `agentCategory`; a missing legacy category still becomes workflow before union selection.
- Output-file validation and legacy `files` migration remain centralized in `AgentConfig.ts`.
- `TaskState.ts` consumes category-specific schemas directly, with no reconstructed intersections or asserted refinements.
- Task-state conversion and progress follow-up code narrow or parse the required variant without category casts.
- Focused config/task-state/resume/desktop tests and all repository gates listed below pass.

## Single source of truth

`src/agent/core/definition/AgentConfig.ts` owns the shared fields, category variants, legacy-input normalization, output-file invariant, and exported category-specific schemas/types.

## Duplication and abstraction budget

Removed the second category model from `TaskState.ts` and the corresponding category casts in consumers. The new variant schemas are not pass-through layers: they expose the runtime invariant at the existing config boundary and are reused by task-state and progress consumers.

## Net elements (R6)

- Files: 10 modified, 0 added, 0 deleted.
- LoC: +194/-138, net +56.
- Exported symbols: +4 net (`WorkflowAgentConfig`, `ToolUseAgentConfig`, and their two schemas); `AgentConfigInput` is retained with a new definition.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Replaced two inline task-state config types and two reconstructed intersection/refinement schemas with the category variants owned by `AgentConfig.ts`.

## Consumer counts (R8)

No emit path or existing export is deleted. The two types moved from inline task-state declarations to `AgentConfig.ts`; each has one production consumer module (`TaskState.ts`). `WorkflowAgentConfigSchema` has one production and one test consumer; `ToolUseAgentConfigSchema` has two production and one test consumer. All five distinct consumer files are updated in this PR, and repository-wide search found no severed consumers.

## Host impact

Extension: progress follow-up creation parses the tool-use variant directly; proposal task state is derived from the parsed discriminated variant.

Desktop: no runtime behavior change; desktop fixtures now parse valid workflow configs.

CLI: no runtime behavior change; resume fixtures now use schema-valid configs.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused Vitest coverage: 129 tests passed
- `npm test`: 682 files passed, 1 skipped; 6122 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core agent config and task-state validation contract used across resume, progress UI, and trace loading; behavior is intended to stay compatible via centralized legacy normalization, but miscategorization or parse failures would affect execution setup and persisted session reads.
> 
> **Overview**
> **`AgentConfig`** is now a Zod **discriminated union** on `agentCategory` (workflow vs tool-use), with shared fields extracted once and **legacy inputs** still normalized at parse time (missing category → workflow, file-field migration unchanged). Category-specific **`WorkflowAgentConfigSchema` / `ToolUseAgentConfigSchema`** and matching types are exported from `AgentConfig.ts` so callers can parse or narrow without casts.
> 
> **`TaskState`** drops its duplicate category refinements and inline config types; it wires **`WorkflowAgentConfigSchema` / `ToolUseAgentConfigSchema`** directly into task-state schemas. **`agentConfigToTaskState`**, proposal setup, and workflow follow-up planning branch on the discriminant instead of asserting types.
> 
> The **trace-viewer** mirror schema follows the same discriminated-union shape for `TraceAgentConfig`. Tests and fixtures use real schema parsing instead of minimal `as unknown as AgentConfig` objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf789865300f07a565f15571d61d78b63c7e0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->