### PR TITLE
refactor: remove type-only agent config schema

### DIFF
--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -124,14 +124,6 @@ export type AgentConfigInput = z.input<typeof AgentConfigSharedFieldsSchema> & {
   agentCategory?: AgentCategory;
 };
 
-/** Agent configuration payload with required agent and model fields. */
-const AgentConfigPayloadSchema = AgentConfigSharedFieldsSchema.extend({
-  agentCategory: z.enum(AgentCategory).optional(),
-})
-  .partial()
-  .required({
-    agent: true,
-    model: true,
-  });
-
-export type AgentConfigPayload = z.infer<typeof AgentConfigPayloadSchema>;
+/** Partial agent configuration accepted before launch-time normalization. */
+export type AgentConfigPayload = Partial<AgentConfig> &
+  Pick<AgentConfig, 'agent' | 'model'>;


### PR DESCRIPTION
## Summary

Delete the private `AgentConfigPayloadSchema`, which was never used to parse data, and express its compile-time contract directly from `AgentConfig`.

## Issue acceptance gates

Closes #8412.

- `AgentConfigPayloadSchema` is deleted.
- `AgentConfigPayload` is derived from `AgentConfig`, with `agent` and `model` required and other normalized fields optional.
- All payload producers and the launch-time `AgentConfigSchema.parse(configPayload)` boundary typecheck unchanged.
- Focused and repository-wide validation pass.

## Single source of truth

`AgentConfig` remains the normalized configuration type, and `AgentConfigSchema` remains the sole launch-time runtime validation boundary.

## Duplication and abstraction budget

Removes a second Zod construction that duplicated the normalized config shape solely for `z.infer`. No abstraction or pass-through layer is added.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted.
- LoC: +3/-11, net -8.
- Exported symbols: 0 added, 0 deleted; `AgentConfigPayload` is retained with a direct type definition.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Private runtime constructs: 1 unused schema constant deleted.

## Consumer counts (R8)

n/a: no export or emit path is deleted or rerouted. `AgentConfigPayload` keeps the same exported name, and all repository consumers pass typecheck.

## Host impact

Extension: none.

Desktop: none.

CLI: compile-time payload typing is simpler; runtime behavior and launch validation are unchanged.

## Scheduled refactoring

None.

## Validation

- `npx prettier --write src/agent/core/definition/AgentConfig.ts`
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused Vitest coverage: 20 tests passed
- `npm test`: 682 files passed, 1 skipped; 6122 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in AgentConfig.ts; runtime launch validation via AgentConfigSchema is unchanged.
> 
> **Overview**
> Removes the unused **`AgentConfigPayloadSchema`** Zod object that duplicated the normalized agent config shape only for `z.infer`.
> 
> **`AgentConfigPayload`** is now defined directly as `Partial<AgentConfig>` with **`agent`** and **`model`** required, matching the old compile-time contract. Launch still normalizes payloads through **`AgentConfigSchema.parse`**; producers and consumers typecheck the same way with no runtime validation change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f21632d8e1ffaf7baa8b401a23954a390283a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->