### PR TITLE
refactor: unify agent-roster and delegation-scope resolution

### DIFF
--- a/packages/cli/src/runtime/agentRoster.ts
+++ b/packages/cli/src/runtime/agentRoster.ts
@@ -1,16 +1,13 @@
 import { platform } from '@platform/platform';
 import {
   AgentRosterController,
-  getAgentsByCategory,
-  getRosterAgent,
+  createWorkspaceAgentRosterController,
   loadAgents,
 } from '@agent/index';
-import { parseAgentModePresets } from '@shared/schemas/agentPresets';
 import type {
   AgentRosterCategorySelection,
   AgentRosterSelection,
 } from '@shared/schemas/agentRoster';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { loadWorkspaceCliConfig, resolveConfiguredAgent } from './cliConfig';
 
 export interface CliAgentRosterRecord {
@@ -29,18 +26,7 @@ export interface CliAgentRosterRecord {
 
 /** Construct the CLI's single roster controller over the active host stores. */
 export function cliAgentRosterController(): AgentRosterController {
-  const { workspaceState, globalState } = platform();
-  return new AgentRosterController({
-    workspaceState,
-    globalState,
-    getAgents: getAgentsByCategory,
-    getPresets: () =>
-      parseAgentModePresets(
-        workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
-      ),
-    resolveAgent: getRosterAgent,
-    fallbackTeamId: null,
-  });
+  return createWorkspaceAgentRosterController();
 }
 
 export async function readCliAgentRoster(): Promise<CliAgentRosterRecord> {

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -4,15 +4,8 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { platform } from '@platform/platform';
-import {
-  AgentRosterController,
-  getAgentsByCategory,
-  getRosterAgent,
-} from '@agent/index';
-import { workspaceSM, WorkspaceStateKey } from '@common/state';
+import { createWorkspaceAgentRosterController } from '@agent/index';
 import * as logger from '@logger/logUtils';
-import { parseAgentModePresets } from '@shared/schemas/agentPresets';
 import type { AgentSource } from '@shared/schemas/agent';
 
 const CHANNEL = 'AgentRegister';
@@ -36,17 +29,7 @@ export async function promptToAddAgentToConfig(
   autoAdd = false,
   category: 'workflow' | 'toolUse' = 'workflow',
 ): Promise<void> {
-  const roster = new AgentRosterController({
-    workspaceState: workspaceSM,
-    globalState: platform().globalState,
-    getAgents: getAgentsByCategory,
-    getPresets: () =>
-      parseAgentModePresets(
-        workspaceSM.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
-      ),
-    resolveAgent: getRosterAgent,
-    fallbackTeamId: null,
-  });
+  const roster = createWorkspaceAgentRosterController();
   const current = roster.getVisibleAgents(category).map((entry) => entry.name);
 
   const skipReason = getAgentRegistrationSkipReason(agentName, current);

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -545,27 +545,23 @@ export function getRosterAgent(
   category: AgentCategoryType,
   identifier: string,
 ): AgentEntry | undefined {
-  const entry = getAgent(identifier, category);
-  return entry?.category === category && !entry.internal ? entry : undefined;
+  const entry = getCategoryAgent(category, identifier);
+  return entry && !entry.internal ? entry : undefined;
 }
 
 /**
- * Resolve a delegation scope's agent keys to roster entries via `resolveOne`,
- * deduped by canonical key. Internal to `resolveDelegationScopeAgents` below —
- * that function is the single exported entry point for scope resolution.
+ * Resolve a delegation scope's agent keys to roster entries, deduped by
+ * canonical key. Internal to `resolveDelegationScopeAgents` below, which is
+ * the single exported entry point for scope resolution.
  */
 function resolveScopedAgentKeys(
   keys: readonly string[],
   category: AgentCategoryType,
-  resolveOne: (
-    category: AgentCategoryType,
-    key: string,
-  ) => AgentEntry | undefined,
 ): AgentEntry[] {
   const resolved: AgentEntry[] = [];
   const seen = new Set<string>();
   for (const key of keys) {
-    const entry = resolveOne(category, key);
+    const entry = getRosterAgent(category, key);
     if (!entry) continue;
     const canonicalKey = agentKeyOf(entry);
     if (seen.has(canonicalKey)) continue;
@@ -637,7 +633,7 @@ export function resolveDelegationScopeAgents(
     category === AgentCategory.Workflow
       ? scope.workflowAgentKeys
       : scope.toolUseAgentKeys;
-  return resolveScopedAgentKeys(keys, category, getRosterAgent);
+  return resolveScopedAgentKeys(keys, category);
 }
 
 /**

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -545,8 +545,12 @@ export function getRosterAgent(
   category: AgentCategoryType,
   identifier: string,
 ): AgentEntry | undefined {
-  const entry = getCategoryAgent(category, identifier);
-  return entry && !entry.internal ? entry : undefined;
+  const name = agentName(identifier);
+  const entry =
+    identifier === name
+      ? getCategoryAgent(category, identifier)
+      : getAgent(identifier, category);
+  return entry?.category === category && !entry.internal ? entry : undefined;
 }
 
 /**

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -12,6 +12,7 @@ import type {
   AgentCategory as AgentCategoryType,
   AgentSource,
 } from '@shared/schemas/agent';
+import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import {
   agentMatchesIdentifier,
   agentKey as createKey,
@@ -548,6 +549,32 @@ export function getRosterAgent(
   return entry?.category === category && !entry.internal ? entry : undefined;
 }
 
+/**
+ * Resolve a delegation scope's agent keys to roster entries via `resolveOne`,
+ * deduped by canonical key. Internal to `resolveDelegationScopeAgents` below —
+ * that function is the single exported entry point for scope resolution.
+ */
+function resolveScopedAgentKeys(
+  keys: readonly string[],
+  category: AgentCategoryType,
+  resolveOne: (
+    category: AgentCategoryType,
+    key: string,
+  ) => AgentEntry | undefined,
+): AgentEntry[] {
+  const resolved: AgentEntry[] = [];
+  const seen = new Set<string>();
+  for (const key of keys) {
+    const entry = resolveOne(category, key);
+    if (!entry) continue;
+    const canonicalKey = agentKeyOf(entry);
+    if (seen.has(canonicalKey)) continue;
+    seen.add(canonicalKey);
+    resolved.push(entry);
+  }
+  return resolved;
+}
+
 // =============================================================================
 // SOURCE HELPERS
 // =============================================================================
@@ -564,11 +591,11 @@ export function isRemoteAgent(identifier: string | undefined): boolean {
 // =============================================================================
 
 /**
- * Get visible agents for a category (filtered by user visibility config).
- * Agents are already deduplicated by name from the getter functions.
- * No default → undefined means "never configured" (show all).
+ * Construct the roster controller over the active host stores. This is the one
+ * place the durable roster's dependencies are wired, so every host reads and
+ * writes the same selection through identical resolution rules.
  */
-export function getVisibleAgents(category: AgentCategory): AgentEntry[] {
+export function createWorkspaceAgentRosterController(): AgentRosterController<AgentEntry> {
   const { workspaceState, globalState } = platform();
   return new AgentRosterController({
     workspaceState,
@@ -580,7 +607,37 @@ export function getVisibleAgents(category: AgentCategory): AgentEntry[] {
       ),
     resolveAgent: getRosterAgent,
     fallbackTeamId: null,
-  }).getVisibleAgents(category);
+  });
+}
+
+/**
+ * Get visible agents for a category (filtered by user visibility config).
+ * Agents are already deduplicated by name from the getter functions.
+ * No default → undefined means "never configured" (show all).
+ */
+export function getVisibleAgents(category: AgentCategory): AgentEntry[] {
+  return createWorkspaceAgentRosterController().getVisibleAgents(category);
+}
+
+/**
+ * Resolve delegation targets for a run: the scope's pinned keys when a
+ * delegation scope is active (dropping `internal` agents, same as the
+ * unscoped roster below), or the workspace-visible roster otherwise. The
+ * single resolver behind both the "Available agents:" tool-description block
+ * (`delegationAgentAvailability.ts`) and the prompt-template agent lists
+ * (`userVars.ts`), so a delegating agent's tool description and its own
+ * prompt vars can never list a different roster for the same run.
+ */
+export function resolveDelegationScopeAgents(
+  scope: AgentDelegationScope | undefined,
+  category: AgentCategoryType,
+): AgentEntry[] {
+  if (!scope) return getVisibleAgents(category);
+  const keys =
+    category === AgentCategory.Workflow
+      ? scope.workflowAgentKeys
+      : scope.toolUseAgentKeys;
+  return resolveScopedAgentKeys(keys, category, getRosterAgent);
 }
 
 /**

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -47,6 +47,8 @@ export {
   isRemoteAgent,
   // Visible agents (for dropdowns and tools)
   getVisibleAgents,
+  createWorkspaceAgentRosterController,
+  resolveDelegationScopeAgents,
   // Canonical name-or-key identity matcher (shared by out-of-registry callers)
   findAgentByIdentifier,
   // All built-in delegating team roots (relay-served + bundled)

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -7,8 +7,7 @@ import {
 import { logFileCategory, logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
-  getRosterAgent,
-  getVisibleAgents,
+  resolveDelegationScopeAgents,
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import {
@@ -18,7 +17,6 @@ import {
 } from '@agent/core/definition/AgentDataclass';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { FileListEntry } from '@shared/schemas';
-import { agentKeyOf } from '@shared/schemas/agent';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { parseFrontmatter } from '@tools/memory/memoryMeta';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
@@ -247,23 +245,10 @@ function getBasicVars(
   }
 
   function getPromptAgents(category: AgentCategory): AgentEntry[] {
-    const scope = options.delegationAgentScope;
-    if (!scope) return getVisibleAgents(category);
-
-    const keys =
-      category === AgentCategory.Workflow
-        ? scope.workflowAgentKeys
-        : scope.toolUseAgentKeys;
-    const seen = new Set<string>();
-    return keys.flatMap((key) => {
-      const entry = getRosterAgent(category, key);
-      if (!entry) return [];
-
-      const canonicalKey = agentKeyOf(entry);
-      if (seen.has(canonicalKey)) return [];
-      seen.add(canonicalKey);
-      return [entry];
-    });
+    return resolveDelegationScopeAgents(
+      options.delegationAgentScope ?? undefined,
+      category,
+    );
   }
 
   // Filter out the current agent so it doesn't see itself as a delegation target

--- a/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
+++ b/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
@@ -17,6 +17,7 @@ import {
   refresh,
   resolveAgent,
   resolveAgentForLaunch,
+  resolveDelegationScopeAgents,
 } from '@agent/index/agentRegistry';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentEntry } from '@agent/index/agentEntry';
@@ -185,6 +186,25 @@ describe('cross-category agent resolution', () => {
     // …but a command launch (no pinned source) still reaches them by name.
     expect(resolveAgent('secretAgent')?.entry.name).toBe('secretAgent');
     expect(getCategoryAgent('toolUse', 'secretAgent')?.internal).toBe(true);
+  });
+
+  it('resolves scoped names within category and excludes internal agents', () => {
+    const scoped = resolveDelegationScopeAgents(
+      {
+        workflowAgentKeys: [],
+        toolUseAgentKeys: [
+          'assistant',
+          'builtInToolUse:assistant',
+          'secretAgent',
+          'missing-agent',
+        ],
+      },
+      AgentCategory.ToolUse,
+    );
+
+    expect(scoped.map((entry) => `${entry.source}:${entry.name}`)).toEqual([
+      'builtInToolUse:assistant',
+    ]);
   });
 });
 

--- a/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
+++ b/src/test-kernel/agent/AgentCategoryResolution.vitest.mts
@@ -13,6 +13,7 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 import {
   findAgentByIdentifier,
   getCategoryAgent,
+  getRosterAgent,
   getVisibleAgent,
   refresh,
   resolveAgent,
@@ -69,6 +70,18 @@ describe('cross-category agent resolution', () => {
         '  internal: true',
         'prompts:',
         '  systemPrompt: Internal agent.',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(customDir, 'review.yaml'),
+      [
+        'name: review',
+        'description: Custom tool-use agent that shadows a built-in name.',
+        'settings:',
+        '  agentCategory: toolUse',
+        'prompts:',
+        '  systemPrompt: Custom review agent.',
         '',
       ].join('\n'),
     );
@@ -204,6 +217,26 @@ describe('cross-category agent resolution', () => {
 
     expect(scoped.map((entry) => `${entry.source}:${entry.name}`)).toEqual([
       'builtInToolUse:assistant',
+    ]);
+  });
+
+  it('preserves exact source-qualified roster entries before name deduplication', () => {
+    expect(getRosterAgent('toolUse', 'custom:review')?.source).toBe('custom');
+    expect(getRosterAgent('toolUse', 'builtInToolUse:review')?.source).toBe(
+      'builtInToolUse',
+    );
+
+    const scoped = resolveDelegationScopeAgents(
+      {
+        workflowAgentKeys: [],
+        toolUseAgentKeys: ['builtInToolUse:review', 'custom:review'],
+      },
+      AgentCategory.ToolUse,
+    );
+
+    expect(scoped.map((entry) => `${entry.source}:${entry.name}`)).toEqual([
+      'builtInToolUse:review',
+      'custom:review',
     ]);
   });
 });

--- a/src/test-kernel/agent/utils/UserVarsDelegationScope.vitest.ts
+++ b/src/test-kernel/agent/utils/UserVarsDelegationScope.vitest.ts
@@ -43,13 +43,14 @@ const roster = vi.hoisted(() => ({
 vi.mock('@agent/index/agentRegistry', () => ({
   resolveDelegationScopeAgents: (
     scope:
-      | { workflowAgentKeys: string[]; toolUseAgentKeys: string[] }
-      | undefined,
+      { workflowAgentKeys: string[]; toolUseAgentKeys: string[] } | undefined,
     category: string,
   ) => {
     if (!scope) return roster.entries.filter((e) => e.category === category);
     const keys =
-      category === 'workflow' ? scope.workflowAgentKeys : scope.toolUseAgentKeys;
+      category === 'workflow'
+        ? scope.workflowAgentKeys
+        : scope.toolUseAgentKeys;
     return keys.flatMap((key) => {
       const entry = roster.entries.find(
         (e) => e.category === category && `${e.source}:${e.name}` === key,

--- a/src/test-kernel/agent/utils/UserVarsDelegationScope.vitest.ts
+++ b/src/test-kernel/agent/utils/UserVarsDelegationScope.vitest.ts
@@ -35,15 +35,28 @@ const roster = vi.hoisted(() => ({
   ],
 }));
 
+// `resolveDelegationScopeAgents` is the single source of truth for scope
+// resolution (agentRegistry.ts, tested there); this test only exercises how
+// buildUserVars formats its result into WORKFLOW_AGENTS/TOOL_USE_AGENTS, so
+// the mock reproduces the fixture's key-to-entry mapping rather than
+// re-implementing the real resolver's priority/dedup logic.
 vi.mock('@agent/index/agentRegistry', () => ({
-  getRosterAgent: (category: string, identifier: string) =>
-    roster.entries.find(
-      (entry) =>
-        entry.category === category &&
-        `${entry.source}:${entry.name}` === identifier,
-    ),
-  getVisibleAgents: (category: string) =>
-    roster.entries.filter((entry) => entry.category === category),
+  resolveDelegationScopeAgents: (
+    scope:
+      | { workflowAgentKeys: string[]; toolUseAgentKeys: string[] }
+      | undefined,
+    category: string,
+  ) => {
+    if (!scope) return roster.entries.filter((e) => e.category === category);
+    const keys =
+      category === 'workflow' ? scope.workflowAgentKeys : scope.toolUseAgentKeys;
+    return keys.flatMap((key) => {
+      const entry = roster.entries.find(
+        (e) => e.category === category && `${e.source}:${e.name}` === key,
+      );
+      return entry ? [entry] : [];
+    });
+  },
 }));
 
 // Local imports - test support

--- a/src/test-kernel/tools/DelegationAgentAvailability.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentAvailability.vitest.mts
@@ -11,6 +11,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/index/agentRegistry', () => ({
   getVisibleAgents: mocks.getVisibleAgents,
   getVisibleAgent: mocks.getVisibleAgent,
+  // No test here activates a delegation scope (no RunContext mock), so this
+  // always falls through to the workspace-visible roster.
+  resolveDelegationScopeAgents: (scope: unknown, category: string) =>
+    scope ? [] : mocks.getVisibleAgents(category),
 }));
 
 vi.mock('@model/computeModelOptions', () => ({

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.mts
@@ -30,6 +30,11 @@ vi.mock('@agent/runtime/RunContext', () => ({
   tryUseRunContext: () => mocks.context,
 }));
 
+// `resolveDelegationScopeAgents` is the single source of truth for scope
+// resolution (agentRegistry.ts) — this test only exercises how
+// delegationAgentAvailability.ts consumes its result, so the mock reproduces
+// just this scope's expected resolution rather than re-implementing
+// priority/dedup logic that belongs to agentRegistry's own tests.
 vi.mock('@agent/index/agentRegistry', () => ({
   findAgentByIdentifier: (
     entries: Array<{ source: string; name: string }>,
@@ -43,10 +48,14 @@ vi.mock('@agent/index/agentRegistry', () => ({
     }
     return undefined;
   },
-  getCategoryAgent: (_category: string, identifier: string) =>
-    identifier === 'review' ? customReview : undefined,
   getVisibleAgent: () => customReview,
-  getVisibleAgents: () => [customReview],
+  resolveDelegationScopeAgents: (
+    scope: { toolUseAgentKeys: readonly string[] } | undefined,
+    category: string,
+  ) =>
+    scope && category === 'toolUse' && scope.toolUseAgentKeys.includes('remote:review')
+      ? [remoteReview]
+      : [],
 }));
 
 const { getDelegationAgent, getDelegationAgents } =

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.mts
@@ -81,18 +81,4 @@ describe('execution-scoped delegation agents', () => {
     expect(getDelegationAgent('toolUse', 'review')).toBe(remoteReview);
     expect(getDelegationAgent('toolUse', 'custom:review')).toBeUndefined();
   });
-
-  it('excludes internal agents from an execution-scoped roster', () => {
-    mocks.context = {
-      kind: 'launch',
-      runScope: {
-        delegationAgentScope: {
-          workflowAgentKeys: [],
-          toolUseAgentKeys: ['remote:review', 'builtInToolUse:internalReview'],
-        },
-      },
-    };
-
-    expect(getDelegationAgents('toolUse')).toEqual([remoteReview]);
-  });
 });

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.mts
@@ -53,7 +53,9 @@ vi.mock('@agent/index/agentRegistry', () => ({
     scope: { toolUseAgentKeys: readonly string[] } | undefined,
     category: string,
   ) =>
-    scope && category === 'toolUse' && scope.toolUseAgentKeys.includes('remote:review')
+    scope &&
+    category === 'toolUse' &&
+    scope.toolUseAgentKeys.includes('remote:review')
       ? [remoteReview]
       : [],
 }));

--- a/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.mts
+++ b/src/test-kernel/tools/DelegationWorktreeAvailability.vitest.mts
@@ -16,6 +16,10 @@ vi.mock('@utils/config/worktreeConfig', () => ({
 vi.mock('@agent/index/agentRegistry', () => ({
   getVisibleAgents: mocks.getVisibleAgents,
   getVisibleAgent: mocks.getVisibleAgent,
+  // No test here activates a delegation scope (no RunContext mock), so this
+  // always falls through to the workspace-visible roster.
+  resolveDelegationScopeAgents: (scope: unknown, category: string) =>
+    scope ? [] : mocks.getVisibleAgents(category),
 }));
 
 vi.mock('@model/computeModelOptions', () => ({

--- a/src/tools/delegationAgentAvailability.ts
+++ b/src/tools/delegationAgentAvailability.ts
@@ -19,9 +19,8 @@
 import {
   findAgentByIdentifier,
   getAgent,
-  getCategoryAgent,
   getVisibleAgent as getWorkspaceVisibleAgent,
-  getVisibleAgents,
+  resolveDelegationScopeAgents,
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import { tryUseRunContext } from '@agent/runtime/RunContext';
@@ -86,23 +85,7 @@ function activeDelegationScope(): AgentDelegationScope | undefined {
 
 /** Resolve delegation targets from the active run scope, then durable roster. */
 export function getDelegationAgents(category: AgentCategory): AgentEntry[] {
-  const scope = activeDelegationScope();
-  if (!scope) return getVisibleAgents(category);
-  const keys =
-    category === 'workflow' ? scope.workflowAgentKeys : scope.toolUseAgentKeys;
-  const resolved: AgentEntry[] = [];
-  const seen = new Set<string>();
-  for (const key of keys) {
-    const entry = key.includes(':')
-      ? getAgent(key, category)
-      : getCategoryAgent(category, key);
-    if (!entry || entry.category !== category || entry.internal) continue;
-    const canonicalKey = agentKeyOf(entry);
-    if (seen.has(canonicalKey)) continue;
-    seen.add(canonicalKey);
-    resolved.push(entry);
-  }
-  return resolved;
+  return resolveDelegationScopeAgents(activeDelegationScope(), category);
 }
 
 export function getDelegationAgent(

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -14,13 +14,11 @@
 
 import { z } from 'zod';
 
-import { platform } from '@platform/platform';
-import { AgentRosterController } from '@agent/roster/AgentRosterController';
 import {
+  createWorkspaceAgentRosterController,
   getAgentsByCategory,
-  getRosterAgent,
+  refresh,
 } from '@agent/index/agentRegistry';
-import { refresh } from '@agent/index/agentRegistry';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { preflightTeamAvailability } from '@common/teams/TeamAvailabilityPreflight';
 import {
@@ -31,10 +29,8 @@ import { resolveBuiltInTeamPreset } from '@common/teams/builtInTeamPresets';
 import { agentName } from '@shared/schemas/agent';
 import {
   AGENT_MODE_PRESETS,
-  parseAgentModePresets,
   STARTER_AGENT_MODE_PRESET,
 } from '@shared/schemas/agentPresets';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
@@ -94,7 +90,6 @@ ${describeTeams()}`,
       );
     }
 
-    const { workspaceState, globalState } = platform();
     const state = { getAgents: getAgentsByCategory };
     const initial = {
       preset,
@@ -161,17 +156,7 @@ ${describeTeams()}`,
 
     const { workflowKeys, toolUseKeys, unresolvedNames } =
       preflight.value.resolution;
-    const roster = new AgentRosterController({
-      workspaceState,
-      globalState,
-      getAgents: getAgentsByCategory,
-      getPresets: () =>
-        parseAgentModePresets(
-          workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
-        ),
-      resolveAgent: getRosterAgent,
-      fallbackTeamId: null,
-    });
+    const roster = createWorkspaceAgentRosterController();
     await roster.setTeam(preset.id);
     await roster.setDefaultTeam(preset.id);
 


### PR DESCRIPTION
## Summary

Consolidate workspace roster construction and run-scoped delegation resolution after #8403.

- add `createWorkspaceAgentRosterController()` as the single platform-backed roster composition point for CLI, extension registration, setup tools, and registry visibility;
- add `resolveDelegationScopeAgents()` as the shared policy for tool descriptions and prompt-template agent lists;
- preserve exact source-qualified identities, category-scoped bare-name lookup, internal-agent exclusion, missing-key omission, and canonical deduplication;
- replace a vacuous mocked filtering test with direct registry coverage.

Follow-up to #8403.

## Design

The durable workspace roster has one platform-backed constructor in `agentRegistry.ts`. The settings controller factory remains separate because it deliberately accepts injected state and catalog functions.

The run-scoped resolver accepts only a persisted `AgentDelegationScope` and category. It resolves exact keys and bare names through the existing category-aware roster lookup, excludes internal entries, and deduplicates by canonical source-qualified key. Both `delegationAgentAvailability.ts` and `userVars.ts` consume this function, so tool descriptions and prompt variables cannot disagree.

## Review fixes

Review exposed four problems, corrected across `9c6cdb123` and `f04391b34`:

- bare names no longer disappear when a higher-priority same-name agent exists in another category;
- the unused injectable resolver callback was removed;
- direct real-registry coverage now proves category collision handling, exact/bare deduplication, internal exclusion, and missing-key omission.

The same follow-up also removed the two remaining equivalent platform-backed `AgentRosterController` constructions.

## Net elements (R6)

- Files: 12 modified, 0 added, 0 deleted.
- LoC: +176/-123, net +53.
- Production code: +79/-98, net -19.
- One shared workspace roster factory and one shared delegation resolver replace three platform-backed controller constructions and two independent scope-resolution implementations.
- No compatibility shim or forwarding module is added.

## Consumer counts (R8)

- `createWorkspaceAgentRosterController`: four production consumers after this PR: registry visibility, CLI roster access, setup-team application, and extension agent registration.
- `resolveDelegationScopeAgents`: two production consumers: delegation tool availability and prompt variables.
- All replaced construction and resolution sites are updated in this PR; repository-wide search leaves only the intentionally injected settings-controller construction outside the shared factory.

## Host impact

- CLI: roster access uses the shared workspace controller.
- Extension: agent registration uses the shared workspace controller.
- Desktop: no direct behavior change; it consumes the same registry visibility functions.
- Runtime prompts/tools: scoped delegation lists now share one category-aware policy.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- targeted ESLint on all corrected files
- focused Vitest on the original review head: 6 files, 45 tests passed
- exact-key follow-up: 4 files, 46 tests passed
- `npm test`: 682 files passed, 1 skipped; 6,122 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared roster and delegation resolution used by prompts, delegation tools, CLI, extension, and setup; behavior is intentionally preserved but regressions would surface as wrong agent lists or team application.
> 
> **Overview**
> Introduces **`createWorkspaceAgentRosterController()`** in `agentRegistry.ts` as the single place platform-backed `AgentRosterController` wiring lives. CLI roster access, extension agent registration, setup **`apply_team`**, and **`getVisibleAgents`** now call it instead of duplicating controller construction.
> 
> Adds **`resolveDelegationScopeAgents()`** as the shared policy for run-scoped delegation lists: scoped keys resolve through **`getRosterAgent`** (category-aware bare names via **`getCategoryAgent`**, exact source-qualified keys preserved), **internal** agents drop out, missing keys are skipped, and results dedupe by canonical key. **`delegationAgentAvailability.ts`** and **`userVars.ts`** both delegate here so tool “Available agents” blocks and **`WORKFLOW_AGENTS` / `TOOL_USE_AGENTS`** prompts stay aligned.
> 
> **`getRosterAgent`** is tightened so bare identifiers use category-scoped lookup rather than blind **`getAgent`**, fixing cases where a same-name agent in another category could steal scoped resolution.
> 
> Tests move registry behavior into **`AgentCategoryResolution`** (scoped resolution, source identity, internal exclusion) and point consumer tests at mocked **`resolveDelegationScopeAgents`** instead of re-implementing resolver logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04391b341a9bec35c3e1ebea39c027a93ba1a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
