### PR TITLE
refactor(desktop): extract agent settings controller

### DIFF
--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -80,7 +80,7 @@ export interface DefaultDesktopAgentSettingsControllerOptions extends SettingsSt
 export interface DesktopAgentSettingsController {
   readonly actions: SettingsViewCommandActions['agentSelection'];
   postStartupData(): Promise<void>;
-  refreshAfterAuth(): Promise<void>;
+  refreshCatalogData(): Promise<void>;
 }
 
 /** Owns the desktop settings agent catalog, directory, and roster behavior. */
@@ -159,7 +159,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     ]);
   }
 
-  async refreshAfterAuth(): Promise<void> {
+  async refreshCatalogData(): Promise<void> {
     await Promise.all([
       this.postAgentSelectionData(),
       this.postMainAgentOptionsData(),
@@ -210,7 +210,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     enabled: boolean;
   }): Promise<void> {
     await this.visibilityController.setAgentEnabled(input);
-    await this.refreshAfterAuth();
+    await this.refreshCatalogData();
   }
 
   private async updateAllAgentsEnabled(input: {
@@ -219,7 +219,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     enabled: boolean;
   }): Promise<void> {
     await this.visibilityController.setAllAgentsEnabled(input);
-    await this.refreshAfterAuth();
+    await this.refreshCatalogData();
   }
 
   private async setCustomAgentDir(): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -1,0 +1,328 @@
+// Controller imports
+import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
+
+// Shared imports
+import type {
+  computeAgentOptionsData,
+  loadAgents,
+  refresh,
+  AgentEntry,
+} from '@agent/index/agentRegistry';
+import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
+import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  buildAgentModePresetsMessage,
+  buildAgentSelectionMessage,
+  buildCustomAgentDirMessage,
+} from '@shared/settingsView/handlers/agentSelectionHandlers';
+import { unsupported } from '@shared/utils/dispatcher';
+
+// Type imports
+import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
+import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
+import type { StateStore } from '@platform/interfaces';
+
+export interface DesktopAgentRegistryPort {
+  readonly loadAgents: typeof loadAgents;
+  readonly refreshAgents: typeof refresh;
+  readonly loadAgentOptionsData: typeof computeAgentOptionsData;
+  readonly getAgents: (category: AgentCategory) => AgentEntry[];
+  readonly getVisibleAgents: (category: AgentCategory) => AgentEntry[];
+}
+
+export interface DesktopAgentDirectoryPort {
+  readonly getCustomAgentDirectory: () => Promise<string>;
+  readonly getSourceDirectory: (
+    source: AgentSource,
+  ) => Promise<string | undefined>;
+  readonly selectCustomAgentDirectory: () => Promise<string | undefined>;
+  readonly openPath: (filePath: string) => Promise<void>;
+  readonly revealPath: (filePath: string) => Promise<void>;
+}
+
+export interface DesktopAgentRendererPort {
+  readonly postToRenderer: (message: unknown) => void;
+}
+
+export interface DesktopAgentPromptPort {
+  readonly promptText: (input: {
+    title: string;
+    prompt: string;
+  }) => Promise<string | undefined>;
+  readonly chooseTeamAvailability: (input: {
+    presetName: string;
+    unavailableNames: readonly string[];
+  }) => Promise<TeamAvailabilityChoice>;
+}
+
+export interface DesktopRemoteAgentCatalogPort {
+  readonly canAccess: () => Promise<boolean>;
+  readonly signIn: () => Promise<boolean>;
+}
+
+export interface DesktopAgentNotificationPort {
+  readonly showInfoMessage: (message: string) => Promise<void>;
+  readonly showErrorMessage: (message: string) => Promise<void>;
+}
+
+export interface DesktopAgentSettingsState {
+  readonly workspaceState: StateStore;
+  readonly globalState: StateStore;
+}
+
+export interface DesktopAgentSettingsController {
+  readonly actions: SettingsViewCommandActions['agentSelection'];
+  postStartupData(): Promise<void>;
+  refreshAfterAuth(): Promise<void>;
+}
+
+/** Owns the desktop settings agent catalog, directory, and roster behavior. */
+export class DefaultDesktopAgentSettingsController implements DesktopAgentSettingsController {
+  readonly actions: SettingsViewCommandActions['agentSelection'];
+
+  private readonly catalogController;
+  private readonly directoryController;
+  private readonly visibilityController;
+
+  constructor(
+    state: DesktopAgentSettingsState,
+    private readonly registry: DesktopAgentRegistryPort,
+    private readonly directory: DesktopAgentDirectoryPort,
+    private readonly renderer: DesktopAgentRendererPort,
+    private readonly prompts: DesktopAgentPromptPort,
+    private readonly remoteCatalog: DesktopRemoteAgentCatalogPort,
+    private readonly notifications: DesktopAgentNotificationPort,
+  ) {
+    const controllers = createSettingsAgentControllers({
+      ...state,
+      getCustomAgentDirectory: directory.getCustomAgentDirectory,
+      getSourceDirectory: directory.getSourceDirectory,
+      getAgents: registry.getAgents,
+      getVisibleAgents: registry.getVisibleAgents,
+    });
+    this.catalogController = controllers.catalog;
+    this.directoryController = controllers.directory;
+    this.visibilityController = controllers.visibility;
+    this.actions = {
+      setEnabled: (input) => this.updateAgentEnabled(input),
+      setAllEnabled: (input) => this.updateAllAgentsEnabled(input),
+      openYaml: (input) => this.openAgentYaml(input),
+      openFolder: () => this.openAgentFolder(),
+      create: unsupported(
+        'Creating custom agents is not available in the desktop app yet.',
+      ),
+      customize: unsupported(
+        'Customizing agents is not available in the desktop app yet.',
+      ),
+      deleteCustom: unsupported(
+        'Deleting custom agents is not available in the desktop app yet.',
+      ),
+      revealFile: (input) => this.revealAgentFile(input),
+      viewRemotePrompt: unsupported(
+        'Viewing a remote agent prompt is not available in the desktop app yet.',
+      ),
+      setCustomDir: () => this.setCustomAgentDir(),
+      resetCustomDir: () => this.resetCustomAgentDir(),
+      applyModePreset: (presetId) => this.applyAgentModePreset(presetId),
+      saveModePreset: () => this.saveAgentModePreset(),
+      deleteModePreset: (presetId) => this.deleteAgentModePreset(presetId),
+    };
+  }
+
+  async postStartupData(): Promise<void> {
+    this.postAgentModePresets();
+    await Promise.all([
+      this.postAgentSelectionData(),
+      this.postCustomAgentDir(),
+    ]);
+  }
+
+  async refreshAfterAuth(): Promise<void> {
+    await Promise.all([
+      this.postAgentSelectionData(),
+      this.postMainAgentOptionsData(),
+    ]);
+  }
+
+  private async postAgentSelectionData(): Promise<void> {
+    this.renderer.postToRenderer(
+      await buildAgentSelectionMessage({
+        loadAgents: this.registry.loadAgents,
+        buildSelectionItems: () => this.catalogController.buildSelectionItems(),
+      }),
+    );
+  }
+
+  private async postMainAgentOptionsData(
+    selectedToolUseAgent?: string,
+  ): Promise<void> {
+    this.renderer.postToRenderer({
+      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      optionsData: await this.registry.loadAgentOptionsData(),
+      ...(selectedToolUseAgent ? { selectedToolUseAgent } : {}),
+    });
+  }
+
+  private async postCustomAgentDir(): Promise<void> {
+    this.renderer.postToRenderer(
+      await buildCustomAgentDirMessage({
+        getCustomDirStatus: () => this.directoryController.getCustomDirStatus(),
+      }),
+    );
+  }
+
+  private postAgentModePresets(): void {
+    this.renderer.postToRenderer(
+      buildAgentModePresetsMessage({
+        getCustomPresets: () => this.catalogController.getCustomPresets(),
+        getOrchestratorAgentNames: () =>
+          this.catalogController.getOrchestratorAgentNames(),
+      }),
+    );
+  }
+
+  private async updateAgentEnabled(input: {
+    category: AgentCategory;
+    source: AgentSource;
+    name: string;
+    enabled: boolean;
+  }): Promise<void> {
+    await this.visibilityController.setAgentEnabled(input);
+    await this.refreshAfterAuth();
+  }
+
+  private async updateAllAgentsEnabled(input: {
+    category: AgentCategory;
+    source: AgentSource;
+    enabled: boolean;
+  }): Promise<void> {
+    await this.visibilityController.setAllAgentsEnabled(input);
+    await this.refreshAfterAuth();
+  }
+
+  private async setCustomAgentDir(): Promise<void> {
+    const selectedPath = await this.directory.selectCustomAgentDirectory();
+    if (!selectedPath) return;
+
+    await this.directoryController.setCustomDir(selectedPath);
+    await Promise.all([
+      this.postCustomAgentDir(),
+      this.postAgentSelectionData(),
+      this.postMainAgentOptionsData(),
+    ]);
+  }
+
+  private async resetCustomAgentDir(): Promise<void> {
+    await this.directoryController.resetCustomDir();
+    await Promise.all([
+      this.postCustomAgentDir(),
+      this.postAgentSelectionData(),
+      this.postMainAgentOptionsData(),
+    ]);
+  }
+
+  private async openAgentYaml(input: {
+    source: AgentSource;
+    name: string;
+  }): Promise<void> {
+    const result = this.directoryController.planOpenAgentYaml(input);
+    if (!result.ok) {
+      await this.notifications.showErrorMessage(
+        result.reason === 'missingAgent'
+          ? `Agent not found: ${input.name}`
+          : `No configuration file found for agent: ${input.name}`,
+      );
+      return;
+    }
+    await this.directory.openPath(result.path);
+  }
+
+  private async openAgentFolder(): Promise<void> {
+    const result = await this.directoryController.planOpenAgentFolder('custom');
+    if (!result.ok) {
+      await this.notifications.showErrorMessage(
+        'No custom agent directory is available',
+      );
+      return;
+    }
+    await this.directory.openPath(result.path);
+  }
+
+  private async revealAgentFile(input: {
+    source: AgentSource;
+    name: string;
+  }): Promise<void> {
+    const result = this.directoryController.planRevealAgentFile(input);
+    if (!result.ok) {
+      await this.notifications.showErrorMessage(
+        `Agent not found or has no file: ${input.name}`,
+      );
+      return;
+    }
+    await this.directory.revealPath(result.path);
+  }
+
+  private async applyAgentModePreset(presetId: string): Promise<void> {
+    const result = await applyTeamRosterWithPreflight(presetId, {
+      catalog: this.catalogController,
+      loadLocalCatalog: () =>
+        this.registry.loadAgents({ includeRemote: false }),
+      canAccessRemoteCatalog: this.remoteCatalog.canAccess,
+      choose: (preset, unavailableNames) =>
+        this.prompts.chooseTeamAvailability({
+          presetName: preset.name,
+          unavailableNames,
+        }),
+      signIn: this.remoteCatalog.signIn,
+      forceRefreshRemoteCatalog: () =>
+        this.registry.refreshAgents({ includeRemote: true }),
+    });
+    if (result.status === 'unknown') {
+      await this.notifications.showErrorMessage(`Unknown team: ${presetId}`);
+      return;
+    }
+    if (result.status === 'cancelled') return;
+    if (result.status === 'choice-required') return;
+    if (result.status === 'unavailable') {
+      await this.notifications.showErrorMessage(
+        `Team "${result.preset.name}" is still unavailable: ${result.unavailableNames.join(', ')}`,
+      );
+      return;
+    }
+    await Promise.all([
+      this.postAgentSelectionData(),
+      this.postMainAgentOptionsData(
+        this.catalogController.getPresetToolUseRoot(
+          result.preset.toolUseAgents,
+        ),
+      ),
+    ]);
+    await this.notifications.showInfoMessage(
+      `Applied "${result.preset.name}" team`,
+    );
+  }
+
+  private async saveAgentModePreset(): Promise<void> {
+    const name = await this.prompts.promptText({
+      title: 'Save agent team',
+      prompt: 'Name for the new team',
+    });
+    if (!name?.trim()) return;
+    await this.registry.loadAgents();
+    const preset = await this.catalogController.saveCurrentPreset(name);
+    this.postAgentModePresets();
+    await this.notifications.showInfoMessage(`Saved team "${preset.name}"`);
+  }
+
+  private async deleteAgentModePreset(presetId: string): Promise<void> {
+    const deleted = await this.catalogController.deleteCustomPreset(presetId);
+    if (!deleted) {
+      await this.notifications.showErrorMessage(
+        `Unknown custom team: ${presetId}`,
+      );
+      return;
+    }
+    this.postAgentModePresets();
+  }
+}

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -1,8 +1,8 @@
-// Controller imports
+// Local imports - settings controllers
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
 
-// Shared imports
+// Local imports - agent registry
 import type {
   computeAgentOptionsData,
   loadAgents,
@@ -10,18 +10,20 @@ import type {
   AgentEntry,
 } from '@agent/index/agentRegistry';
 import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
+
+// Local imports - shared settings
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
   buildAgentModePresetsMessage,
   buildAgentSelectionMessage,
   buildCustomAgentDirMessage,
 } from '@shared/settingsView/handlers/agentSelectionHandlers';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { unsupported } from '@shared/utils/dispatcher';
 
-// Type imports
-import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
+// Local imports - controller types
 import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
-import type { StateStore } from '@platform/interfaces';
 
 export interface DesktopAgentRegistryPort {
   readonly loadAgents: typeof loadAgents;
@@ -66,9 +68,13 @@ export interface DesktopAgentNotificationPort {
   readonly showErrorMessage: (message: string) => Promise<void>;
 }
 
-export interface DesktopAgentSettingsState {
-  readonly workspaceState: StateStore;
-  readonly globalState: StateStore;
+export interface DefaultDesktopAgentSettingsControllerOptions extends SettingsStatePorts {
+  readonly registry: DesktopAgentRegistryPort;
+  readonly directory: DesktopAgentDirectoryPort;
+  readonly renderer: DesktopAgentRendererPort;
+  readonly prompts: DesktopAgentPromptPort;
+  readonly remoteCatalog: DesktopRemoteAgentCatalogPort;
+  readonly notifications: DesktopAgentNotificationPort;
 }
 
 export interface DesktopAgentSettingsController {
@@ -84,18 +90,33 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   private readonly catalogController;
   private readonly directoryController;
   private readonly visibilityController;
+  private readonly registry: DesktopAgentRegistryPort;
+  private readonly directory: DesktopAgentDirectoryPort;
+  private readonly renderer: DesktopAgentRendererPort;
+  private readonly prompts: DesktopAgentPromptPort;
+  private readonly remoteCatalog: DesktopRemoteAgentCatalogPort;
+  private readonly notifications: DesktopAgentNotificationPort;
 
-  constructor(
-    state: DesktopAgentSettingsState,
-    private readonly registry: DesktopAgentRegistryPort,
-    private readonly directory: DesktopAgentDirectoryPort,
-    private readonly renderer: DesktopAgentRendererPort,
-    private readonly prompts: DesktopAgentPromptPort,
-    private readonly remoteCatalog: DesktopRemoteAgentCatalogPort,
-    private readonly notifications: DesktopAgentNotificationPort,
-  ) {
+  constructor(options: DefaultDesktopAgentSettingsControllerOptions) {
+    const {
+      workspaceState,
+      globalState,
+      registry,
+      directory,
+      renderer,
+      prompts,
+      remoteCatalog,
+      notifications,
+    } = options;
+    this.registry = registry;
+    this.directory = directory;
+    this.renderer = renderer;
+    this.prompts = prompts;
+    this.remoteCatalog = remoteCatalog;
+    this.notifications = notifications;
     const controllers = createSettingsAgentControllers({
-      ...state,
+      workspaceState,
+      globalState,
       getCustomAgentDirectory: directory.getCustomAgentDirectory,
       getSourceDirectory: directory.getSourceDirectory,
       getAgents: registry.getAgents,

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -6,23 +6,12 @@ import {
   isAllowedLatexInstallCommand,
   LatexToolingController,
 } from '@controllers/settingsView/LatexToolingController';
-import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
-import { applyTeamRosterWithPreflight } from '@controllers/teams/TeamRosterApplication';
-import {
-  computeAgentOptionsData,
-  getAgentsByCategory,
-  getVisibleAgents as getVisibleRegistryAgents,
-  loadAgents,
-  refresh,
-  type AgentEntry,
-} from '@agent/index/agentRegistry';
-import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   codexCoordinator,
   getChatGptAuthStatus,
@@ -30,7 +19,6 @@ import {
   setCodexSubscriptionToolUseOnly,
   setPreferCodexSubscription,
 } from '@auth/codex';
-import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
 import {
   API_PROVIDERS,
   apiKeySecretName,
@@ -53,7 +41,7 @@ import {
   normalizePlatform,
 } from '@shared/constants/latex';
 import type { LatexConfigField } from '@shared/constants/latex';
-import { AgentCategory, type AgentSource } from '@shared/schemas/agent';
+import { AgentCategory } from '@shared/schemas/agent';
 import {
   dispatchSettingsViewInbound,
   SettingsViewInboundMessageSchema,
@@ -69,11 +57,6 @@ import {
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
-import {
-  buildAgentSelectionMessage,
-  buildCustomAgentDirMessage,
-  buildAgentModePresetsMessage,
-} from '@shared/settingsView/handlers/agentSelectionHandlers';
 import { buildChatGptAuthStatusMessage } from '@shared/settingsView/handlers/chatGptHandlers';
 import { GoalStore } from '@tools/goal';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
@@ -125,6 +108,7 @@ import {
 } from './desktopHistoryHandlers.js';
 import type { ConfigProvider, StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
+import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 
 type ToolDashboardBuilder = (
   cachedResults?: ExternalToolCheckResult[],
@@ -132,21 +116,14 @@ type ToolDashboardBuilder = (
 
 export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   postToRenderer(message: unknown): void;
+  agentSettingsController: DesktopAgentSettingsController;
   sendStartupCatalogData?: boolean;
-  loadAgents?: typeof loadAgents;
-  refreshAgents?: typeof refresh;
-  loadAgentOptionsData?: typeof computeAgentOptionsData;
-  getAgents?: (category: AgentCategory) => AgentEntry[];
-  getVisibleAgents?: (category: AgentCategory) => AgentEntry[];
   globalState?: StateStore;
   workspaceState?: StateStore;
   config?: ConfigProvider;
   buildToolDashboardItems?: ToolDashboardBuilder;
   refreshToolAvailability?: () => Promise<void>;
-  getCustomAgentDirectory?: () => Promise<string>;
-  selectCustomAgentDirectory?: () => Promise<string | undefined>;
   openPath?: (filePath: string) => Promise<void>;
-  revealPath?: (filePath: string) => Promise<void>;
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
   openExternalUrl?: (url: string) => Promise<void>;
@@ -162,19 +139,9 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
     title: string;
     prompt: string;
   }) => Promise<string | undefined>;
-  promptText?: (input: {
-    title: string;
-    prompt: string;
-  }) => Promise<string | undefined>;
   showInfoMessage?: (message: string) => Promise<void>;
   showErrorMessage?: (message: string) => Promise<void>;
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
-  chooseTeamAvailability?: (input: {
-    presetName: string;
-    unavailableNames: readonly string[];
-  }) => Promise<TeamAvailabilityChoice>;
-  canAccessRemoteAgentCatalog?: () => Promise<boolean>;
-  signInForRemoteAgentCatalog?: () => Promise<boolean>;
   signIn?: () => Promise<void>;
   signOut?: () => Promise<void>;
   setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
@@ -223,22 +190,12 @@ export function createDesktopSettingsIpc(
     showErrorMessage: options.showErrorMessage,
     onError,
   });
-  const loadAgentRegistry = options.loadAgents ?? loadAgents;
-  const refreshAgentRegistry = options.refreshAgents ?? refresh;
-  const loadAgentOptionsData =
-    options.loadAgentOptionsData ?? computeAgentOptionsData;
-  const getAgentEntries = options.getAgents ?? getAgentsByCategory;
-  const getVisibleAgentEntries =
-    options.getVisibleAgents ?? getVisibleRegistryAgents;
   const usesDefaultToolDashboardBuilder =
     options.buildToolDashboardItems == null;
   const buildToolDashboardItems =
     options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
   const refreshToolAvailability = options.refreshToolAvailability;
   const secrets = options.secrets ?? tryPlatform()?.secrets ?? emptySecrets;
-  const getCustomAgentDirectory =
-    options.getCustomAgentDirectory ??
-    (() => platform().agentDirectories.custom());
   const latexConfigPersistenceController =
     new LatexConfigPersistenceController();
   const goalController = new SettingsGoalController({
@@ -255,18 +212,6 @@ export function createDesktopSettingsIpc(
       autoRevealExclude: true,
     }),
     onDetectionError: onError,
-  });
-  const {
-    catalog: agentCatalogController,
-    directory: agentDirectoryController,
-    visibility: agentVisibilityController,
-  } = createSettingsAgentControllers({
-    workspaceState,
-    globalState,
-    getCustomAgentDirectory,
-    getSourceDirectory: getAgentDirectory,
-    getAgents: getAgentEntries,
-    getVisibleAgents: getVisibleAgentEntries,
   });
   const modelListRefresh =
     options.modelListRefresh ??
@@ -382,28 +327,6 @@ export function createDesktopSettingsIpc(
     );
   }
 
-  function getAgentDirectory(source: AgentSource): Promise<string | undefined> {
-    switch (source) {
-      case 'custom':
-        return getCustomAgentDirectory();
-      case 'builtInWorkflow':
-        return platform().agentDirectories.builtIn();
-      case 'builtInToolUse':
-        return platform().agentDirectories.builtInToolUse();
-      case 'remote':
-        return Promise.resolve(undefined);
-    }
-  }
-
-  async function postAgentSelectionData(): Promise<void> {
-    options.postToRenderer(
-      await buildAgentSelectionMessage({
-        loadAgents: loadAgentRegistry,
-        buildSelectionItems: () => agentCatalogController.buildSelectionItems(),
-      }),
-    );
-  }
-
   async function postModelSelectionData(): Promise<void> {
     await settingsHost.sendModelSelectionData();
   }
@@ -426,24 +349,6 @@ export function createDesktopSettingsIpc(
         toolUse: toolUseModelOptions,
       },
     });
-  }
-
-  async function postMainAgentOptionsData(
-    selectedToolUseAgent?: string,
-  ): Promise<void> {
-    options.postToRenderer({
-      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-      optionsData: await loadAgentOptionsData(),
-      ...(selectedToolUseAgent ? { selectedToolUseAgent } : {}),
-    });
-  }
-
-  async function postCustomAgentDir(): Promise<void> {
-    options.postToRenderer(
-      await buildCustomAgentDirMessage({
-        getCustomDirStatus: () => agentDirectoryController.getCustomDirStatus(),
-      }),
-    );
   }
 
   async function postProfileData(): Promise<void> {
@@ -552,16 +457,6 @@ export function createDesktopSettingsIpc(
     );
   }
 
-  function postAgentModePresets(): void {
-    options.postToRenderer(
-      buildAgentModePresetsMessage({
-        getCustomPresets: () => agentCatalogController.getCustomPresets(),
-        getOrchestratorAgentNames: () =>
-          agentCatalogController.getOrchestratorAgentNames(),
-      }),
-    );
-  }
-
   function postApprovalSettings(): void {
     options.postToRenderer(
       buildApprovalSettingsMessage({
@@ -591,7 +486,6 @@ export function createDesktopSettingsIpc(
     const memoryEnabledPosted = postMemoryEnabled();
     const modelSelectionDataPosted = postModelSelectionData();
     postSuperYoloEnabled();
-    postAgentModePresets();
     postApprovalSettings();
     await Promise.all([
       memoryEnabledPosted,
@@ -602,8 +496,7 @@ export function createDesktopSettingsIpc(
       postChatGptAuthStatus(),
       postLatexSettingsStatus(),
       postDesktopCrashReportingStatus(),
-      postAgentSelectionData(),
-      postCustomAgentDir(),
+      options.agentSettingsController.postStartupData(),
       postToolDashboardData(),
     ]);
   }
@@ -870,7 +763,7 @@ export function createDesktopSettingsIpc(
     await postMainModelOptionsData();
     await postProfileData();
     if (refreshOptions.deferAgentCatalogRefresh) return;
-    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
+    await options.agentSettingsController.refreshAfterAuth();
   }
 
   async function updateAgentSetting(
@@ -934,148 +827,6 @@ export function createDesktopSettingsIpc(
     const command = await findToolCommand(input.toolId, input.kind);
     if (!command) return;
     await options.runToolCommand?.({ ...input, command });
-  }
-
-  async function updateAgentEnabled(input: {
-    category: AgentCategory;
-    source: AgentSource;
-    name: string;
-    enabled: boolean;
-  }): Promise<void> {
-    await agentVisibilityController.setAgentEnabled(input);
-    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
-  }
-
-  async function updateAllAgentsEnabled(input: {
-    category: AgentCategory;
-    source: AgentSource;
-    enabled: boolean;
-  }): Promise<void> {
-    await agentVisibilityController.setAllAgentsEnabled(input);
-    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
-  }
-
-  async function setCustomAgentDir(): Promise<void> {
-    const selectedPath = await options.selectCustomAgentDirectory?.();
-    if (!selectedPath) return;
-
-    await agentDirectoryController.setCustomDir(selectedPath);
-    await Promise.all([
-      postCustomAgentDir(),
-      postAgentSelectionData(),
-      postMainAgentOptionsData(),
-    ]);
-  }
-
-  async function resetCustomAgentDir(): Promise<void> {
-    await agentDirectoryController.resetCustomDir();
-    await Promise.all([
-      postCustomAgentDir(),
-      postAgentSelectionData(),
-      postMainAgentOptionsData(),
-    ]);
-  }
-
-  async function openAgentYaml(input: {
-    source: AgentSource;
-    name: string;
-  }): Promise<void> {
-    const result = agentDirectoryController.planOpenAgentYaml(input);
-    if (!result.ok) {
-      await options.showErrorMessage?.(
-        result.reason === 'missingAgent'
-          ? `Agent not found: ${input.name}`
-          : `No configuration file found for agent: ${input.name}`,
-      );
-      return;
-    }
-    await options.openPath?.(result.path);
-  }
-
-  async function openAgentFolder(): Promise<void> {
-    const result = await agentDirectoryController.planOpenAgentFolder('custom');
-    if (!result.ok) {
-      await options.showErrorMessage?.(
-        'No custom agent directory is available',
-      );
-      return;
-    }
-    await options.openPath?.(result.path);
-  }
-
-  async function revealAgentFile(input: {
-    source: AgentSource;
-    name: string;
-  }): Promise<void> {
-    const result = agentDirectoryController.planRevealAgentFile(input);
-    if (!result.ok) {
-      await options.showErrorMessage?.(
-        `Agent not found or has no file: ${input.name}`,
-      );
-      return;
-    }
-    await (options.revealPath ?? options.openPath)?.(result.path);
-  }
-
-  async function applyAgentModePreset(presetId: string): Promise<void> {
-    const result = await applyTeamRosterWithPreflight(presetId, {
-      catalog: agentCatalogController,
-      loadLocalCatalog: () => loadAgentRegistry({ includeRemote: false }),
-      canAccessRemoteCatalog:
-        options.canAccessRemoteAgentCatalog ??
-        (() => SupabaseClient.canAccessRemoteAgentCatalog()),
-      choose: (preset, unavailableNames) =>
-        options.chooseTeamAvailability?.({
-          presetName: preset.name,
-          unavailableNames,
-        }) ?? Promise.resolve('cancel'),
-      signIn:
-        options.signInForRemoteAgentCatalog ?? (() => Promise.resolve(false)),
-      forceRefreshRemoteCatalog: () =>
-        refreshAgentRegistry({ includeRemote: true }),
-    });
-    if (result.status === 'unknown') {
-      await options.showErrorMessage?.(`Unknown team: ${presetId}`);
-      return;
-    }
-    if (result.status === 'cancelled') return;
-    if (result.status === 'choice-required') return;
-    if (result.status === 'unavailable') {
-      await options.showErrorMessage?.(
-        `Team "${result.preset.name}" is still unavailable: ${result.unavailableNames.join(', ')}`,
-      );
-      return;
-    }
-    await Promise.all([
-      postAgentSelectionData(),
-      postMainAgentOptionsData(
-        agentCatalogController.getPresetToolUseRoot(
-          result.preset.toolUseAgents,
-        ),
-      ),
-    ]);
-    await options.showInfoMessage?.(`Applied "${result.preset.name}" team`);
-  }
-
-  async function saveAgentModePreset(): Promise<void> {
-    const name = await options.promptText?.({
-      title: 'Save agent team',
-      prompt: 'Name for the new team',
-    });
-    if (!name?.trim()) return;
-    await loadAgentRegistry();
-    const preset = await agentCatalogController.saveCurrentPreset(name);
-    postAgentModePresets();
-    await options.showInfoMessage?.(`Saved team "${preset.name}"`);
-  }
-
-  async function deleteAgentModePreset(presetId: string): Promise<void> {
-    const deleted = await agentCatalogController.deleteCustomPreset(presetId);
-    if (!deleted) {
-      await options.showErrorMessage?.(`Unknown custom team: ${presetId}`);
-      return;
-    }
-    postAgentModePresets();
   }
 
   function runAsync(work: Promise<void>): void {
@@ -1151,32 +902,7 @@ export function createDesktopSettingsIpc(
           enabled,
         ),
     },
-    agentSelection: {
-      setEnabled: ({ category, source, name, enabled }) =>
-        updateAgentEnabled({ category, source, name, enabled }),
-      setAllEnabled: ({ category, source, enabled }) =>
-        updateAllAgentsEnabled({ category, source, enabled }),
-      openYaml: ({ source, name }) => openAgentYaml({ source, name }),
-      openFolder: () => openAgentFolder(),
-      create: unsupported(
-        'Creating custom agents is not available in the desktop app yet.',
-      ),
-      customize: unsupported(
-        'Customizing agents is not available in the desktop app yet.',
-      ),
-      deleteCustom: unsupported(
-        'Deleting custom agents is not available in the desktop app yet.',
-      ),
-      revealFile: ({ source, name }) => revealAgentFile({ source, name }),
-      viewRemotePrompt: unsupported(
-        'Viewing a remote agent prompt is not available in the desktop app yet.',
-      ),
-      setCustomDir: () => setCustomAgentDir(),
-      resetCustomDir: () => resetCustomAgentDir(),
-      applyModePreset: (presetId) => applyAgentModePreset(presetId),
-      saveModePreset: () => saveAgentModePreset(),
-      deleteModePreset: (presetId) => deleteAgentModePreset(presetId),
-    },
+    agentSelection: options.agentSettingsController.actions,
     gitAuthor: {
       setMarkCommits: (enabled) =>
         setGitAuthor(StateKeys.GIT_MARK_COMMITS, enabled),

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -763,7 +763,7 @@ export function createDesktopSettingsIpc(
     await postMainModelOptionsData();
     await postProfileData();
     if (refreshOptions.deferAgentCatalogRefresh) return;
-    await options.agentSettingsController.refreshAfterAuth();
+    await options.agentSettingsController.refreshCatalogData();
   }
 
   async function updateAgentSetting(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -631,19 +631,17 @@ function createWindow(options: {
   // Workspace-explorer sidebar removed in PR 3 (PRD § 7.D + § 8). File staging
   // happens entirely inside <main-app>'s built-in panel; the duplicate tree
   // sidebar and its IPC are gone.
-  const agentSettingsController = new DefaultDesktopAgentSettingsController(
-    {
-      workspaceState: platform().workspaceState,
-      globalState: platform().globalState,
-    },
-    {
+  const agentSettingsController = new DefaultDesktopAgentSettingsController({
+    workspaceState: platform().workspaceState,
+    globalState: platform().globalState,
+    registry: {
       loadAgents,
       refreshAgents: refresh,
       loadAgentOptionsData: computeAgentOptionsData,
       getAgents: getAgentsByCategory,
       getVisibleAgents,
     },
-    {
+    directory: {
       getCustomAgentDirectory: () => platform().agentDirectories.custom(),
       getSourceDirectory: (source: AgentSource) => {
         switch (source) {
@@ -670,8 +668,10 @@ function createWindow(options: {
         shell.showItemInFolder(filePath);
       },
     },
-    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
-    {
+    renderer: {
+      postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    },
+    prompts: {
       promptText: (input) => promptInRenderer(window, input),
       chooseTeamAvailability: async ({ presetName, unavailableNames }) => {
         const result = await dialog.showMessageBox(window, {
@@ -690,12 +690,12 @@ function createWindow(options: {
         return 'cancel';
       },
     },
-    {
+    remoteCatalog: {
       canAccess: () => SupabaseClient.canAccessRemoteAgentCatalog(),
       signIn: signInForRemoteAgentCatalog,
     },
-    { showInfoMessage, showErrorMessage },
-  );
+    notifications: { showInfoMessage, showErrorMessage },
+  });
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     agentSettingsController,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -14,14 +14,25 @@ import {
 
 import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
-import { getAgent } from '@agent/index/agentRegistry';
+import {
+  computeAgentOptionsData,
+  getAgent,
+  getAgentsByCategory,
+  getVisibleAgents,
+  loadAgents,
+  refresh,
+} from '@agent/index/agentRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { TerminalRunResult } from '@hosts/uiHosts';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { AgentCategory, agentKeyOf } from '@shared/schemas/agent';
+import {
+  AgentCategory,
+  agentKeyOf,
+  type AgentSource,
+} from '@shared/schemas/agent';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
@@ -48,6 +59,7 @@ import {
 import { refreshDesktopModelListStateIfNeeded } from './desktopModelListRefresh.js';
 import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
+import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopGitHost } from './desktopGitHost.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
@@ -619,8 +631,74 @@ function createWindow(options: {
   // Workspace-explorer sidebar removed in PR 3 (PRD § 7.D + § 8). File staging
   // happens entirely inside <main-app>'s built-in panel; the duplicate tree
   // sidebar and its IPC are gone.
+  const agentSettingsController = new DefaultDesktopAgentSettingsController(
+    {
+      workspaceState: platform().workspaceState,
+      globalState: platform().globalState,
+    },
+    {
+      loadAgents,
+      refreshAgents: refresh,
+      loadAgentOptionsData: computeAgentOptionsData,
+      getAgents: getAgentsByCategory,
+      getVisibleAgents,
+    },
+    {
+      getCustomAgentDirectory: () => platform().agentDirectories.custom(),
+      getSourceDirectory: (source: AgentSource) => {
+        switch (source) {
+          case 'custom':
+            return platform().agentDirectories.custom();
+          case 'builtInWorkflow':
+            return platform().agentDirectories.builtIn();
+          case 'builtInToolUse':
+            return platform().agentDirectories.builtInToolUse();
+          case 'remote':
+            return Promise.resolve(undefined);
+        }
+      },
+      selectCustomAgentDirectory: async () => {
+        const result = await dialog.showOpenDialog(window, {
+          title: 'Select Custom Agents Folder',
+          defaultPath: folderPickerDefaultPath,
+          properties: ['openDirectory', 'createDirectory'],
+        });
+        return result.canceled ? undefined : result.filePaths[0];
+      },
+      openPath: previewHost.openPath,
+      revealPath: async (filePath) => {
+        shell.showItemInFolder(filePath);
+      },
+    },
+    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
+    {
+      promptText: (input) => promptInRenderer(window, input),
+      chooseTeamAvailability: async ({ presetName, unavailableNames }) => {
+        const result = await dialog.showMessageBox(window, {
+          type: 'warning',
+          message: `Team "${presetName}" has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`,
+          buttons: [
+            'Sign in to TeXRA',
+            'Continue with available members',
+            'Cancel',
+          ],
+          defaultId: 0,
+          cancelId: 2,
+        });
+        if (result.response === 0) return 'sign-in';
+        if (result.response === 1) return 'continue';
+        return 'cancel';
+      },
+    },
+    {
+      canAccess: () => SupabaseClient.canAccessRemoteAgentCatalog(),
+      signIn: signInForRemoteAgentCatalog,
+    },
+    { showInfoMessage, showErrorMessage },
+  );
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    agentSettingsController,
     sendStartupCatalogData: true,
     modelListRefresh,
     resourcesPath: options.resourcesPath,
@@ -634,7 +712,6 @@ function createWindow(options: {
       (await getAgentExecution()).progress.restoreTaskState(taskState),
     promptSecret: (input) =>
       promptInRenderer(window, { ...input, password: true }),
-    promptText: (input) => promptInRenderer(window, input),
     showInfoMessage,
     showErrorMessage,
     confirmAction: async (message, confirmLabel = 'OK') => {
@@ -647,23 +724,6 @@ function createWindow(options: {
       });
       return result.response === 0;
     },
-    chooseTeamAvailability: async ({ presetName, unavailableNames }) => {
-      const result = await dialog.showMessageBox(window, {
-        type: 'warning',
-        message: `Team "${presetName}" has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`,
-        buttons: [
-          'Sign in to TeXRA',
-          'Continue with available members',
-          'Cancel',
-        ],
-        defaultId: 0,
-        cancelId: 2,
-      });
-      if (result.response === 0) return 'sign-in';
-      if (result.response === 1) return 'continue';
-      return 'cancel';
-    },
-    signInForRemoteAgentCatalog,
     signIn: () => desktopAuth.signIn(),
     signOut: () => desktopAuth.signOut(),
     setApiAccessMode: async (mode) => {
@@ -672,18 +732,7 @@ function createWindow(options: {
       );
     },
     initializeCrashReporting: options.initializeCrashReporting,
-    selectCustomAgentDirectory: async () => {
-      const result = await dialog.showOpenDialog(window, {
-        title: 'Select Custom Agents Folder',
-        defaultPath: folderPickerDefaultPath,
-        properties: ['openDirectory', 'createDirectory'],
-      });
-      return result.canceled ? undefined : result.filePaths[0];
-    },
     openPath: previewHost.openPath,
-    revealPath: async (filePath) => {
-      shell.showItemInFolder(filePath);
-    },
     revealStream: async (streamId) => {
       try {
         const execution = await getAgentExecution();

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -397,6 +397,40 @@ describe('DefaultDesktopAgentSettingsController', () => {
     });
   });
 
+  it('deletes custom teams and reports unknown team ids', async () => {
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'custom-team',
+        name: 'Custom Team',
+        description: 'test',
+        icon: 'codicon-bookmark',
+        workflowAgents: ['correct'],
+        toolUseAgents: ['review'],
+      },
+    ]);
+    const { controller, errorMessages, posted } = createControllerFixture({
+      workspaceState,
+    });
+    const deletePreset = requireAction(controller.actions.deleteModePreset) as (
+      presetId: string,
+    ) => Promise<void>;
+
+    await deletePreset('custom-team');
+
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+    ).toEqual([]);
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: [],
+    });
+
+    await deletePreset('missing-team');
+
+    expect(errorMessages).toEqual(['Unknown custom team: missing-team']);
+  });
+
   it('opens the custom agent directory through the required directory port', async () => {
     const { controller, opened } = createControllerFixture({
       getCustomAgentDirectory: async () => '/agents/custom',

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -58,9 +58,10 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
   const emptyCatalog: AgentCatalog = { workflow: [], toolUse: [] };
   const catalog = options.catalog ?? emptyCatalog;
   const visibleCatalog = options.visibleCatalog ?? catalog;
-  const controller = new DefaultDesktopAgentSettingsController(
-    { workspaceState, globalState },
-    {
+  const controller = new DefaultDesktopAgentSettingsController({
+    workspaceState,
+    globalState,
+    registry: {
       loadAgents: options.loadAgents ?? (async () => undefined),
       refreshAgents: options.refreshAgents ?? (async () => undefined),
       loadAgentOptionsData: async () => ({
@@ -76,7 +77,7 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
       getAgents: (category) => catalog[category],
       getVisibleAgents: (category) => visibleCatalog[category],
     },
-    {
+    directory: {
       getCustomAgentDirectory:
         options.getCustomAgentDirectory ?? (async () => '/agents/custom'),
       getSourceDirectory: async (source) => `/agents/${source}`,
@@ -88,17 +89,17 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
         revealed.push(filePath);
       },
     },
-    { postToRenderer: (message) => posted.push(message) },
-    {
+    renderer: { postToRenderer: (message) => posted.push(message) },
+    prompts: {
       promptText: options.promptText ?? (async () => undefined),
       chooseTeamAvailability:
         options.chooseTeamAvailability ?? (async () => 'cancel'),
     },
-    {
+    remoteCatalog: {
       canAccess: options.canAccessRemoteCatalog ?? (async () => false),
       signIn: options.signInForRemoteCatalog ?? (async () => false),
     },
-    {
+    notifications: {
       showInfoMessage: async (message) => {
         infoMessages.push(message);
       },
@@ -106,7 +107,7 @@ function createControllerFixture(options: ControllerFixtureOptions = {}) {
         errorMessages.push(message);
       },
     },
-  );
+  });
   return {
     controller,
     errorMessages,

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -1,0 +1,429 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentEntry } from '@agent/index/agentRegistry';
+import { DefaultDesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
+import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { isUnsupported } from '@shared/utils/dispatcher';
+
+import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
+import type { StateStore } from '@platform/interfaces';
+
+class MemoryStateStore implements StateStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
+
+type AgentCatalog = Record<AgentCategory, AgentEntry[]>;
+
+interface ControllerFixtureOptions {
+  readonly workspaceState?: MemoryStateStore;
+  readonly globalState?: MemoryStateStore;
+  readonly catalog?: AgentCatalog;
+  readonly visibleCatalog?: AgentCatalog;
+  readonly loadAgents?: (options?: {
+    includeRemote?: boolean;
+  }) => Promise<void>;
+  readonly refreshAgents?: (options?: {
+    includeRemote?: boolean;
+  }) => Promise<void>;
+  readonly promptText?: () => Promise<string | undefined>;
+  readonly chooseTeamAvailability?: () => Promise<
+    'cancel' | 'continue' | 'sign-in'
+  >;
+  readonly canAccessRemoteCatalog?: () => Promise<boolean>;
+  readonly signInForRemoteCatalog?: () => Promise<boolean>;
+  readonly getCustomAgentDirectory?: () => Promise<string>;
+}
+
+function createControllerFixture(options: ControllerFixtureOptions = {}) {
+  const workspaceState = options.workspaceState ?? new MemoryStateStore();
+  const globalState = options.globalState ?? new MemoryStateStore();
+  const posted: unknown[] = [];
+  const opened: string[] = [];
+  const revealed: string[] = [];
+  const infoMessages: string[] = [];
+  const errorMessages: string[] = [];
+  const emptyCatalog: AgentCatalog = { workflow: [], toolUse: [] };
+  const catalog = options.catalog ?? emptyCatalog;
+  const visibleCatalog = options.visibleCatalog ?? catalog;
+  const controller = new DefaultDesktopAgentSettingsController(
+    { workspaceState, globalState },
+    {
+      loadAgents: options.loadAgents ?? (async () => undefined),
+      refreshAgents: options.refreshAgents ?? (async () => undefined),
+      loadAgentOptionsData: async () => ({
+        workflow: catalog.workflow.map((entry) => ({
+          value: `${entry.source}:${entry.name}`,
+          label: entry.name,
+        })),
+        toolUse: catalog.toolUse.map((entry) => ({
+          value: `${entry.source}:${entry.name}`,
+          label: entry.name,
+        })),
+      }),
+      getAgents: (category) => catalog[category],
+      getVisibleAgents: (category) => visibleCatalog[category],
+    },
+    {
+      getCustomAgentDirectory:
+        options.getCustomAgentDirectory ?? (async () => '/agents/custom'),
+      getSourceDirectory: async (source) => `/agents/${source}`,
+      selectCustomAgentDirectory: async () => undefined,
+      openPath: async (filePath) => {
+        opened.push(filePath);
+      },
+      revealPath: async (filePath) => {
+        revealed.push(filePath);
+      },
+    },
+    { postToRenderer: (message) => posted.push(message) },
+    {
+      promptText: options.promptText ?? (async () => undefined),
+      chooseTeamAvailability:
+        options.chooseTeamAvailability ?? (async () => 'cancel'),
+    },
+    {
+      canAccess: options.canAccessRemoteCatalog ?? (async () => false),
+      signIn: options.signInForRemoteCatalog ?? (async () => false),
+    },
+    {
+      showInfoMessage: async (message) => {
+        infoMessages.push(message);
+      },
+      showErrorMessage: async (message) => {
+        errorMessages.push(message);
+      },
+    },
+  );
+  return {
+    controller,
+    errorMessages,
+    globalState,
+    infoMessages,
+    opened,
+    posted,
+    revealed,
+    workspaceState,
+  };
+}
+
+function messageCommand(message: unknown): string | undefined {
+  return (message as { command?: string }).command;
+}
+
+function requireAction(action: unknown): (...args: never[]) => unknown {
+  if (typeof action !== 'function') {
+    throw new Error('Expected a supported desktop agent settings action.');
+  }
+  return action as (...args: never[]) => unknown;
+}
+
+function physicistCatalog(): AgentCatalog {
+  const workflow = ['correct', 'polish'].map((name): AgentEntry => ({
+    source: 'builtInWorkflow',
+    name,
+    path: `/agents/${name}.yaml`,
+    category: 'workflow',
+  }));
+  const toolUse = [
+    ['orchestrator', 'builtInToolUse'],
+    ['research', 'custom'],
+    ['numerics', 'builtInToolUse'],
+    ['review', 'builtInToolUse'],
+    ['presenter', 'builtInToolUse'],
+    ['latexFixer', 'builtInToolUse'],
+  ].map(([name, source]): AgentEntry => ({
+    source: source as AgentSource,
+    name,
+    path: `/agents/${name}.yaml`,
+    category: 'toolUse',
+    ...(name === 'orchestrator' ? { tools: ['delegate_agent'] } : {}),
+  }));
+  return { workflow, toolUse };
+}
+
+describe('DefaultDesktopAgentSettingsController', () => {
+  it('declares unavailable desktop agent commands explicitly', () => {
+    const { actions } = createControllerFixture().controller;
+
+    expect(
+      [
+        actions.create,
+        actions.customize,
+        actions.deleteCustom,
+        actions.viewRemotePrompt,
+      ].every(isUnsupported),
+    ).toBe(true);
+  });
+
+  it('posts startup catalog data to settings and main renderer surfaces', async () => {
+    const loadAgents = vi.fn(async () => undefined);
+    const { controller, posted } = createControllerFixture({
+      catalog: physicistCatalog(),
+      loadAgents,
+    });
+
+    await controller.postStartupData();
+
+    expect(loadAgents).toHaveBeenCalledOnce();
+    expect(posted.map(messageCommand)).toEqual(
+      expect.arrayContaining([
+        SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+        SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+        SETTINGS_VIEW_COMMANDS.UPDATE_CUSTOM_AGENT_DIR,
+      ]),
+    );
+  });
+
+  it('updates source-qualified visibility state and both renderer surfaces', async () => {
+    const { controller, posted, workspaceState } = createControllerFixture({
+      catalog: physicistCatalog(),
+    });
+    const setEnabled = requireAction(controller.actions.setEnabled) as (input: {
+      category: AgentCategory;
+      source: AgentSource;
+      name: string;
+      enabled: boolean;
+    }) => Promise<void>;
+
+    await setEnabled({
+      category: 'workflow',
+      source: 'builtInWorkflow',
+      name: 'polish',
+      enabled: false,
+    });
+
+    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
+      expect.not.arrayContaining(['builtInWorkflow:polish', 'polish']),
+    );
+    expect(posted.map(messageCommand)).toEqual(
+      expect.arrayContaining([
+        SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+        MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      ]),
+    );
+  });
+
+  it('applies source-qualified teams and selects the tool-use root', async () => {
+    const { controller, infoMessages, posted, workspaceState } =
+      createControllerFixture({
+        catalog: physicistCatalog(),
+        chooseTeamAvailability: async () => 'continue',
+      });
+    const applyPreset = requireAction(controller.actions.applyModePreset) as (
+      presetId: string,
+    ) => Promise<void>;
+
+    await applyPreset('physicist');
+
+    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
+      expect.arrayContaining([
+        'builtInWorkflow:correct',
+        'builtInWorkflow:polish',
+      ]),
+    );
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toEqual(
+      expect.arrayContaining([
+        'builtInToolUse:orchestrator',
+        'custom:research',
+      ]),
+    );
+    expect(
+      posted.find(
+        (message) =>
+          messageCommand(message) === MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      ),
+    ).toMatchObject({
+      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      selectedToolUseAgent: 'orchestrator',
+    });
+    expect(
+      posted.some(
+        (message) =>
+          messageCommand(message) ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+      ),
+    ).toBe(true);
+    expect(infoMessages).toEqual(['Applied "Physicist" team']);
+  });
+
+  it('signs in before one forced remote refresh and commits the team once', async () => {
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'remote-team',
+        name: 'Remote team',
+        description: 'Uses a hosted root',
+        icon: 'tools',
+        workflowAgents: [],
+        toolUseAgents: ['orchestrator'],
+        texraHostedAgents: ['orchestrator'],
+      },
+    ]);
+    const catalog: AgentCatalog = { workflow: [], toolUse: [] };
+    const order: string[] = [];
+    const refreshAgents = vi.fn(async () => {
+      order.push('refresh');
+      catalog.toolUse = [
+        {
+          source: 'remote',
+          name: 'orchestrator',
+          path: '/remote/orchestrator.yaml',
+          category: 'toolUse',
+          tools: ['delegate_agent'],
+        },
+      ];
+    });
+    const update = vi.spyOn(workspaceState, 'update');
+    const { controller } = createControllerFixture({
+      workspaceState,
+      catalog,
+      canAccessRemoteCatalog: async () => false,
+      chooseTeamAvailability: async () => 'sign-in',
+      signInForRemoteCatalog: async () => {
+        order.push('sign-in');
+        return true;
+      },
+      refreshAgents,
+    });
+    update.mockClear();
+    const applyPreset = requireAction(controller.actions.applyModePreset) as (
+      presetId: string,
+    ) => Promise<void>;
+
+    await applyPreset('remote-team');
+
+    expect(order).toEqual(['sign-in', 'refresh']);
+    expect(refreshAgents).toHaveBeenCalledOnce();
+    expect(refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
+    expect(
+      update.mock.calls.filter(
+        ([key]) => key === WorkspaceStateKey.ENABLED_AGENTS,
+      ),
+    ).toHaveLength(1);
+    expect(
+      update.mock.calls.filter(
+        ([key]) => key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toHaveLength(1);
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toEqual(['remote:orchestrator']);
+  });
+
+  it('does not write roster state when team preflight is cancelled', async () => {
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'remote-team',
+        name: 'Remote team',
+        description: 'Uses a hosted root',
+        icon: 'tools',
+        workflowAgents: [],
+        toolUseAgents: ['orchestrator'],
+        texraHostedAgents: ['orchestrator'],
+      },
+    ]);
+    const update = vi.spyOn(workspaceState, 'update');
+    const refreshAgents = vi.fn(async () => undefined);
+    const { controller } = createControllerFixture({
+      workspaceState,
+      chooseTeamAvailability: async () => 'cancel',
+      refreshAgents,
+    });
+    update.mockClear();
+    const applyPreset = requireAction(controller.actions.applyModePreset) as (
+      presetId: string,
+    ) => Promise<void>;
+
+    await applyPreset('remote-team');
+
+    expect(refreshAgents).not.toHaveBeenCalled();
+    expect(
+      update.mock.calls.some(
+        ([key]) =>
+          key === WorkspaceStateKey.ENABLED_AGENTS ||
+          key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      ),
+    ).toBe(false);
+  });
+
+  it('saves visible agents as a custom team', async () => {
+    const catalog = physicistCatalog();
+    const visibleCatalog: AgentCatalog = {
+      workflow: [catalog.workflow[0]],
+      toolUse: [catalog.toolUse[3]],
+    };
+    const { controller, infoMessages, posted, workspaceState } =
+      createControllerFixture({
+        catalog,
+        visibleCatalog,
+        promptText: async () => '  Paper Team  ',
+      });
+    const savePreset = requireAction(
+      controller.actions.saveModePreset,
+    ) as () => Promise<void>;
+
+    await savePreset();
+
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+    ).toEqual([
+      expect.objectContaining({
+        name: 'Paper Team',
+        workflowAgents: ['correct'],
+        toolUseAgents: ['review'],
+      }),
+    ]);
+    expect(infoMessages).toEqual(['Saved team "Paper Team"']);
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: [expect.objectContaining({ name: 'Paper Team' })],
+    });
+  });
+
+  it('opens the custom agent directory through the required directory port', async () => {
+    const { controller, opened } = createControllerFixture({
+      getCustomAgentDirectory: async () => '/agents/custom',
+    });
+    const openFolder = requireAction(
+      controller.actions.openFolder,
+    ) as () => Promise<void>;
+
+    await openFolder();
+
+    expect(opened).toEqual(['/agents/custom']);
+  });
+
+  it('reports unknown presets without writing roster state', async () => {
+    const { controller, errorMessages, workspaceState } =
+      createControllerFixture();
+    const applyPreset = requireAction(controller.actions.applyModePreset) as (
+      presetId: string,
+    ) => Promise<void>;
+
+    await applyPreset('missing-team');
+
+    expect(errorMessages).toEqual(['Unknown team: missing-team']);
+    expect(workspaceState.values.has(WorkspaceStateKey.ENABLED_AGENTS)).toBe(
+      false,
+    );
+    expect(
+      workspaceState.values.has(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toBe(false);
+  });
+});

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -169,7 +169,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
     ).toBe(true);
   });
 
-  it('posts startup catalog data to settings and main renderer surfaces', async () => {
+  it('posts startup agent data to the settings renderer', async () => {
     const loadAgents = vi.fn(async () => undefined);
     const { controller, posted } = createControllerFixture({
       catalog: physicistCatalog(),

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1114,15 +1114,15 @@ describe('desktop settings IPC', () => {
 
   it('delegates agent refresh after desktop auth model data is current', async () => {
     const agentSettingsController = createStubDesktopAgentSettingsController();
-    const refreshAfterAuth = vi.fn(async () => undefined);
-    agentSettingsController.refreshAfterAuth = refreshAfterAuth;
+    const refreshCatalogData = vi.fn(async () => undefined);
+    agentSettingsController.refreshCatalogData = refreshCatalogData;
     const { settings, posted } = createCapturedSettingsFixture({
       agentSettingsController,
     });
 
     await settings.refreshAuthDependentData();
 
-    expect(refreshAfterAuth).toHaveBeenCalledOnce();
+    expect(refreshCatalogData).toHaveBeenCalledOnce();
     expect(invalidateModelOptionsCache).toHaveBeenCalled();
     expect(computeModelOptionsData).toHaveBeenCalled();
     expect(
@@ -1130,7 +1130,7 @@ describe('desktop settings IPC', () => {
     ).toBeLessThan(computeModelOptionsData.mock.invocationCallOrder[0]);
     expect(
       computeModelOptionsData.mock.invocationCallOrder.at(-1),
-    ).toBeLessThan(refreshAfterAuth.mock.invocationCallOrder[0]);
+    ).toBeLessThan(refreshCatalogData.mock.invocationCallOrder[0]);
     expect(posted.map((message) => commandOf(message))).toEqual(
       expect.arrayContaining([
         SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
@@ -1142,8 +1142,8 @@ describe('desktop settings IPC', () => {
 
   it('defers the controller refresh while roster sign-in owns the catalog', async () => {
     const agentSettingsController = createStubDesktopAgentSettingsController();
-    const refreshAfterAuth = vi.fn(async () => undefined);
-    agentSettingsController.refreshAfterAuth = refreshAfterAuth;
+    const refreshCatalogData = vi.fn(async () => undefined);
+    agentSettingsController.refreshCatalogData = refreshCatalogData;
     const { settings, posted } = createCapturedSettingsFixture({
       agentSettingsController,
     });
@@ -1152,7 +1152,7 @@ describe('desktop settings IPC', () => {
       deferAgentCatalogRefresh: true,
     });
 
-    expect(refreshAfterAuth).not.toHaveBeenCalled();
+    expect(refreshCatalogData).not.toHaveBeenCalled();
     expect(
       posted.some(
         (message) =>

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -15,6 +15,7 @@ import {
 import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import { createStubDesktopAgentSettingsController } from './desktopSettingsTestSupport';
 import type { StateStore } from '@platform/interfaces';
 
 const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
@@ -42,8 +43,9 @@ type RendererMessage = Parameters<
 
 type SettingsFixtureOverrides = Omit<
   DesktopSettingsIpcOptions,
-  'postToRenderer'
+  'agentSettingsController' | 'postToRenderer'
 > & {
+  agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
 };
 
@@ -151,6 +153,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
   const settings = createDesktopSettingsIpc({
     ...overrides,
+    agentSettingsController:
+      overrides.agentSettingsController ??
+      createStubDesktopAgentSettingsController(),
     globalState,
     postToRenderer: overrides.postToRenderer ?? (() => undefined),
     workspaceState,
@@ -282,6 +287,34 @@ describe('desktop settings IPC', () => {
       },
     ]);
   }, 15_000);
+
+  it('delegates agent-selection commands to the required controller', async () => {
+    const baseController = createStubDesktopAgentSettingsController();
+    const setEnabled = vi.fn(async () => undefined);
+    const agentSettingsController = {
+      ...baseController,
+      actions: { ...baseController.actions, setEnabled },
+    };
+    const { settings } = createSettingsFixture({ agentSettingsController });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED,
+        category: 'workflow',
+        agentSource: 'custom',
+        agentName: 'proofreader',
+        enabled: false,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(setEnabled).toHaveBeenCalledWith({
+      category: 'workflow',
+      source: 'custom',
+      name: 'proofreader',
+      enabled: false,
+    });
+  });
 
   it('round-trips Git author writes through workspace state and refreshes the renderer', async () => {
     const workspaceState = new MemoryStateStore();
@@ -822,13 +855,15 @@ describe('desktop settings IPC', () => {
     );
     const config = new MemoryConfigStore();
     config.values.set('texra.toolUse.requireBashApproval', false);
+    const agentSettingsController = createStubDesktopAgentSettingsController();
+    const postStartupData = vi.fn(async () => undefined);
+    agentSettingsController.postStartupData = postStartupData;
 
     const { settings, posted } = createCapturedSettingsFixture({
+      agentSettingsController,
       workspaceState,
       config,
       sendStartupCatalogData: true,
-      loadAgents: async () => undefined,
-      getCustomAgentDirectory: async () => '',
       buildToolDashboardItems: async () => [
         {
           id: 'file-ops',
@@ -851,6 +886,8 @@ describe('desktop settings IPC', () => {
       }),
     ).toBe(false);
     await flushAsyncWork();
+
+    expect(postStartupData).toHaveBeenCalledOnce();
 
     expect(
       posted.find(
@@ -879,8 +916,6 @@ describe('desktop settings IPC', () => {
 
     const { settings, posted } = createCapturedSettingsFixture({
       config,
-      loadAgents: async () => undefined,
-      getCustomAgentDirectory: async () => '',
       detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
       onError: () => undefined,
     });
@@ -918,8 +953,6 @@ describe('desktop settings IPC', () => {
       config: new MemoryConfigStore(),
       sendStartupCatalogData: true,
       modelListRefresh: modelListRefresh.promise,
-      loadAgents: async () => undefined,
-      getCustomAgentDirectory: async () => '',
       buildToolDashboardItems: async () => [],
       detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
       onError: () => undefined,
@@ -1021,493 +1054,6 @@ describe('desktop settings IPC', () => {
     expect(buildCalls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('refreshes launcher agent options after agent visibility changes', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-      loadAgents: async () => undefined,
-      loadAgentOptionsData: async () => ({
-        workflow: [{ value: 'builtInWorkflow:correct', label: 'correct' }],
-        toolUse: [],
-      }),
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED,
-        category: 'workflow',
-        agentSource: 'builtInWorkflow',
-        agentName: 'polish',
-        enabled: false,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
-      expect.not.arrayContaining(['builtInWorkflow:polish', 'polish']),
-    );
-    expect(
-      posted.some(
-        (message) =>
-          commandOf(message) === SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
-      ),
-    ).toBe(true);
-    expect(
-      posted.some(
-        (message) =>
-          commandOf(message) === MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-      ),
-    ).toBe(true);
-  });
-
-  it('opens the desktop custom agent directory through the shell opener', async () => {
-    const openPath = vi.fn(async (_filePath: string) => undefined);
-
-    const { settings } = createSettingsFixture({
-      getCustomAgentDirectory: async () => '/agents/custom',
-      openPath,
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.OPEN_AGENT_FOLDER,
-        folderType: 'custom',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(openPath).toHaveBeenCalledWith('/agents/custom');
-  });
-
-  it('applies desktop team presets and refreshes settings plus launcher options', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const infoMessages: string[] = [];
-    const errorMessages: string[] = [];
-    let loadCount = 0;
-
-    const catalog = {
-      workflow: [
-        {
-          source: 'builtInWorkflow' as const,
-          name: 'correct',
-          path: '/agents/correct.yaml',
-          category: 'workflow' as const,
-        },
-        {
-          source: 'builtInWorkflow' as const,
-          name: 'polish',
-          path: '/agents/polish.yaml',
-          category: 'workflow' as const,
-        },
-      ],
-      toolUse: [
-        {
-          source: 'builtInToolUse' as const,
-          name: 'orchestrator',
-          path: '/agents/orchestrator.yaml',
-          category: 'toolUse' as const,
-          tools: ['delegate'],
-        },
-        {
-          source: 'custom' as const,
-          name: 'research',
-          path: '/agents/research.yaml',
-          category: 'toolUse' as const,
-        },
-        {
-          source: 'builtInToolUse' as const,
-          name: 'numerics',
-          path: '/agents/numerics.yaml',
-          category: 'toolUse' as const,
-        },
-        {
-          source: 'builtInToolUse' as const,
-          name: 'review',
-          path: '/agents/review.yaml',
-          category: 'toolUse' as const,
-        },
-        {
-          source: 'builtInToolUse' as const,
-          name: 'presenter',
-          path: '/agents/presenter.yaml',
-          category: 'toolUse' as const,
-        },
-        {
-          source: 'builtInToolUse' as const,
-          name: 'latexFixer',
-          path: '/agents/latexFixer.yaml',
-          category: 'toolUse' as const,
-        },
-      ],
-    };
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-      loadAgents: async () => {
-        loadCount += 1;
-      },
-      loadAgentOptionsData: async () => ({
-        workflow: [{ value: 'builtInWorkflow:correct', label: 'correct' }],
-        toolUse: [
-          { value: 'builtInToolUse:orchestrator', label: 'orchestrator' },
-        ],
-      }),
-      getAgents: (category) => catalog[category],
-      getVisibleAgents: (category) => catalog[category],
-      chooseTeamAvailability: async () => 'continue',
-      showInfoMessage: async (message) => {
-        infoMessages.push(message);
-      },
-      showErrorMessage: async (message) => {
-        errorMessages.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
-        presetId: 'physicist',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(loadCount).toBeGreaterThanOrEqual(1);
-    // Catalog-resolved names become source-qualified keys, preserving the
-    // winning source when a custom agent overrides a built-in name.
-    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
-      [
-        'builtInWorkflow:correct',
-        'builtInWorkflow:polish',
-        'generic',
-        'devise',
-        'apply',
-        'criticize',
-      ],
-    );
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
-    ).toEqual([
-      'builtInToolUse:orchestrator',
-      'custom:research',
-      'builtInToolUse:numerics',
-      'builtInToolUse:review',
-      'builtInToolUse:presenter',
-      'simplifier',
-      'builtInToolUse:latexFixer',
-      'progressCheck',
-      'search',
-    ]);
-    expect(errorMessages).toEqual([]);
-    expect(infoMessages).toEqual(['Applied "Physicist" team']);
-
-    expect(
-      posted.find(
-        (message) =>
-          commandOf(message) === SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
-      ),
-    ).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
-      workflow: expect.arrayContaining([
-        expect.objectContaining({ name: 'correct', enabled: true }),
-        expect.objectContaining({ name: 'polish', enabled: true }),
-      ]),
-      toolUse: expect.arrayContaining([
-        expect.objectContaining({ name: 'orchestrator', enabled: true }),
-        expect.objectContaining({ name: 'research', enabled: true }),
-      ]),
-    });
-    expect(
-      posted.find(
-        (message) =>
-          commandOf(message) === MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-      ),
-    ).toMatchObject({
-      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-      selectedToolUseAgent: 'orchestrator',
-      optionsData: {
-        workflow: [
-          expect.objectContaining({ value: 'builtInWorkflow:correct' }),
-        ],
-        toolUse: [
-          expect.objectContaining({ value: 'builtInToolUse:orchestrator' }),
-        ],
-      },
-    });
-  });
-
-  it('signs in, forces one catalog refresh, then commits a desktop team once', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'remote-team',
-        name: 'Remote team',
-        description: 'Uses a hosted root',
-        icon: 'tools',
-        workflowAgents: [],
-        toolUseAgents: ['orchestrator'],
-        texraHostedAgents: ['orchestrator'],
-      },
-    ]);
-    let toolUseAgents: Array<{
-      source: 'remote';
-      name: string;
-      path: string;
-      category: 'toolUse';
-      tools: string[];
-    }> = [];
-    const refreshAgents = vi.fn(async () => {
-      toolUseAgents = [
-        {
-          source: 'remote',
-          name: 'orchestrator',
-          path: '/remote/orchestrator.yaml',
-          category: 'toolUse',
-          tools: ['delegate_agent'],
-        },
-      ];
-    });
-    const signInForRemoteAgentCatalog = vi.fn(async () => true);
-    const update = vi.spyOn(workspaceState, 'update');
-    const { settings } = createSettingsFixture({
-      workspaceState,
-      loadAgents: vi.fn(async () => undefined),
-      refreshAgents,
-      getAgents: (category) => (category === 'workflow' ? [] : toolUseAgents),
-      getVisibleAgents: (category) =>
-        category === 'workflow' ? [] : toolUseAgents,
-      canAccessRemoteAgentCatalog: async () => false,
-      chooseTeamAvailability: async () => 'sign-in',
-      signInForRemoteAgentCatalog,
-    });
-    update.mockClear();
-
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
-      presetId: 'remote-team',
-    });
-    await flushAsyncWork();
-
-    expect(signInForRemoteAgentCatalog).toHaveBeenCalledOnce();
-    expect(refreshAgents).toHaveBeenCalledOnce();
-    expect(refreshAgents).toHaveBeenCalledWith({ includeRemote: true });
-    expect(
-      update.mock.calls.filter(
-        ([key]) => key === WorkspaceStateKey.ENABLED_AGENTS,
-      ),
-    ).toHaveLength(1);
-    expect(
-      update.mock.calls.filter(
-        ([key]) => key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-      ),
-    ).toHaveLength(1);
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
-    ).toEqual(['remote:orchestrator']);
-  });
-
-  it('does not write desktop roster state when team preflight is cancelled', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'legacy-remote-team',
-        name: 'Legacy remote team',
-        description: 'Legacy hosted metadata is inferred',
-        icon: 'tools',
-        workflowAgents: [],
-        toolUseAgents: ['orchestrator'],
-      },
-    ]);
-    const update = vi.spyOn(workspaceState, 'update');
-    const refreshAgents = vi.fn(async () => undefined);
-    const { settings } = createSettingsFixture({
-      workspaceState,
-      loadAgents: vi.fn(async () => undefined),
-      refreshAgents,
-      getAgents: () => [],
-      getVisibleAgents: () => [],
-      canAccessRemoteAgentCatalog: async () => false,
-      chooseTeamAvailability: async () => 'cancel',
-    });
-    update.mockClear();
-
-    settings.handleMessage({
-      command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
-      presetId: 'legacy-remote-team',
-    });
-    await flushAsyncWork();
-
-    expect(refreshAgents).not.toHaveBeenCalled();
-    expect(
-      update.mock.calls.some(
-        ([key]) =>
-          key === WorkspaceStateKey.ENABLED_AGENTS ||
-          key === WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-      ),
-    ).toBe(false);
-  });
-
-  it('saves desktop team presets from currently visible agents', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const infoMessages: string[] = [];
-    const catalog = {
-      workflow: [
-        {
-          source: 'builtInWorkflow' as const,
-          name: 'correct',
-          path: '/agents/correct.yaml',
-          category: 'workflow' as const,
-        },
-        {
-          source: 'builtInWorkflow' as const,
-          name: 'polish',
-          path: '/agents/polish.yaml',
-          category: 'workflow' as const,
-        },
-      ],
-      toolUse: [
-        {
-          source: 'builtInToolUse' as const,
-          name: 'review',
-          path: '/agents/review.yaml',
-          category: 'toolUse' as const,
-        },
-        {
-          source: 'builtInToolUse' as const,
-          name: 'latexFixer',
-          path: '/agents/latexFixer.yaml',
-          category: 'toolUse' as const,
-        },
-      ],
-    };
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-      loadAgents: async () => undefined,
-      getAgents: (category) => catalog[category],
-      getVisibleAgents: (category) =>
-        category === 'workflow' ? [catalog.workflow[0]] : [catalog.toolUse[0]],
-      promptText: async () => '  Paper Team  ',
-      showInfoMessage: async (message) => {
-        infoMessages.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
-    ).toEqual([
-      expect.objectContaining({
-        id: expect.stringMatching(/^custom-/),
-        name: 'Paper Team',
-        workflowAgents: ['correct'],
-        toolUseAgents: ['review'],
-      }),
-    ]);
-    expect(infoMessages).toEqual(['Saved team "Paper Team"']);
-    expect(posted.at(-1)).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
-      orchestratorAgents: expect.arrayContaining([
-        'engineer',
-        'leanOrchestrator',
-        'orchestrator',
-      ]),
-      customPresets: [
-        expect.objectContaining({
-          name: 'Paper Team',
-          workflowAgents: ['correct'],
-          toolUseAgents: ['review'],
-        }),
-      ],
-    });
-  });
-
-  it('deletes desktop custom team presets and reports unknown team ids', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const errorMessages: string[] = [];
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'custom-team',
-        name: 'Custom Team',
-        description: 'test',
-        icon: 'codicon-bookmark',
-        workflowAgents: ['correct'],
-        toolUseAgents: ['review'],
-      },
-    ]);
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-      showErrorMessage: async (message) => {
-        errorMessages.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
-        presetId: 'custom-team',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
-    ).toEqual([]);
-    expect(posted.at(-1)).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
-      customPresets: [],
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
-        presetId: 'missing-team',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(errorMessages).toEqual(['Unknown custom team: missing-team']);
-  });
-
-  it('surfaces a visible desktop error for unknown team presets', async () => {
-    const workspaceState = new MemoryStateStore();
-    const errorMessages: string[] = [];
-
-    const { settings } = createSettingsFixture({
-      workspaceState,
-      loadAgents: async () => undefined,
-      showErrorMessage: async (message) => {
-        errorMessages.push(message);
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
-        presetId: 'missing-team',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(errorMessages).toEqual(['Unknown team: missing-team']);
-    expect(workspaceState.values.has(WorkspaceStateKey.ENABLED_AGENTS)).toBe(
-      false,
-    );
-    expect(
-      workspaceState.values.has(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
-    ).toBe(false);
-  });
-
   it('persists desktop API access mode changes before refreshing settings data', async () => {
     const persistedModes: string[] = [];
 
@@ -1566,51 +1112,47 @@ describe('desktop settings IPC', () => {
     expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes agent and model options after desktop auth changes', async () => {
-    let loadCount = 0;
-
+  it('delegates agent refresh after desktop auth model data is current', async () => {
+    const agentSettingsController = createStubDesktopAgentSettingsController();
+    const refreshAfterAuth = vi.fn(async () => undefined);
+    agentSettingsController.refreshAfterAuth = refreshAfterAuth;
     const { settings, posted } = createCapturedSettingsFixture({
-      loadAgents: async () => {
-        loadCount += 1;
-      },
-      loadAgentOptionsData: async () => ({
-        workflow: [
-          { value: 'remote:remote-workflow', label: 'remote-workflow' },
-        ],
-        toolUse: [{ value: 'remote:remote-tool', label: 'remote-tool' }],
-      }),
+      agentSettingsController,
     });
 
     await settings.refreshAuthDependentData();
 
-    expect(loadCount).toBe(1);
+    expect(refreshAfterAuth).toHaveBeenCalledOnce();
     expect(invalidateModelOptionsCache).toHaveBeenCalled();
     expect(computeModelOptionsData).toHaveBeenCalled();
     expect(
       invalidateModelOptionsCache.mock.invocationCallOrder[0],
     ).toBeLessThan(computeModelOptionsData.mock.invocationCallOrder[0]);
+    expect(
+      computeModelOptionsData.mock.invocationCallOrder.at(-1),
+    ).toBeLessThan(refreshAfterAuth.mock.invocationCallOrder[0]);
     expect(posted.map((message) => commandOf(message))).toEqual(
       expect.arrayContaining([
         SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
-        SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
         SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
-        MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
         MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       ]),
     );
   });
 
-  it('defers agent catalog loading while roster sign-in owns the refresh', async () => {
-    const loadAgents = vi.fn(async () => undefined);
+  it('defers the controller refresh while roster sign-in owns the catalog', async () => {
+    const agentSettingsController = createStubDesktopAgentSettingsController();
+    const refreshAfterAuth = vi.fn(async () => undefined);
+    agentSettingsController.refreshAfterAuth = refreshAfterAuth;
     const { settings, posted } = createCapturedSettingsFixture({
-      loadAgents,
+      agentSettingsController,
     });
 
     await settings.refreshAuthDependentData({
       deferAgentCatalogRefresh: true,
     });
 
-    expect(loadAgents).not.toHaveBeenCalled();
+    expect(refreshAfterAuth).not.toHaveBeenCalled();
     expect(
       posted.some(
         (message) =>

--- a/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
@@ -18,6 +18,9 @@ import { apiKeySecretName } from '@model/apiProviders';
 // Local imports - shared
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 
+// Local imports - desktop test support
+import { createStubDesktopAgentSettingsController } from './desktopSettingsTestSupport';
+
 // Local imports - platform
 import type { StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
@@ -90,6 +93,7 @@ async function createSettingsIpc(options: {
 
   return createDesktopSettingsIpc({
     postToRenderer: () => {},
+    agentSettingsController: createStubDesktopAgentSettingsController(),
     globalState: new MemoryStateStore(),
     workspaceState: new MemoryStateStore(),
     secrets: options.secrets,

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -33,6 +33,6 @@ export function createStubDesktopAgentSettingsController(): DesktopAgentSettings
       deleteModePreset: noOp,
     },
     postStartupData: noOp,
-    refreshAfterAuth: noOp,
+    refreshCatalogData: noOp,
   };
 }

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -1,0 +1,38 @@
+// Desktop imports
+import type { DesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
+
+// Shared imports
+import { unsupported } from '@shared/utils/dispatcher';
+
+const noOp = async (): Promise<void> => undefined;
+
+export function createStubDesktopAgentSettingsController(): DesktopAgentSettingsController {
+  return {
+    actions: {
+      setEnabled: noOp,
+      setAllEnabled: noOp,
+      openYaml: noOp,
+      openFolder: noOp,
+      create: unsupported(
+        'Creating custom agents is not available in the desktop app yet.',
+      ),
+      customize: unsupported(
+        'Customizing agents is not available in the desktop app yet.',
+      ),
+      deleteCustom: unsupported(
+        'Deleting custom agents is not available in the desktop app yet.',
+      ),
+      revealFile: noOp,
+      viewRemotePrompt: unsupported(
+        'Viewing a remote agent prompt is not available in the desktop app yet.',
+      ),
+      setCustomDir: noOp,
+      resetCustomDir: noOp,
+      applyModePreset: noOp,
+      saveModePreset: noOp,
+      deleteModePreset: noOp,
+    },
+    postStartupData: noOp,
+    refreshAfterAuth: noOp,
+  };
+}


### PR DESCRIPTION
## Summary

Extract the desktop agent-settings domain from the monolithic settings IPC factory into one required controller.

- move agent catalog, visibility, directories, team presets, and remote-catalog preflight into `DefaultDesktopAgentSettingsController`;
- resolve all production capabilities and defaults once in the desktop composition root;
- replace twelve optional IPC callbacks with one required `DesktopAgentSettingsController`;
- move agent behavior tests beside the new controller and retain narrow IPC delegation tests.

Advances #8406. This is the first staged domain extraction described by that issue; the remaining history, credentials, tools, and shared host capabilities stay open for later stages.

## Design

Before this change, `createDesktopSettingsIpc` selected production defaults and interpreted capability absence throughout the same 1,315-line factory that dispatches settings commands. Tests could construct combinations of missing agent callbacks that production never has.

After this change, the desktop composition root constructs a required agent-settings controller from explicit registry, directory, renderer, prompt, remote-catalog, notification, and state ports. The IPC factory sees only three agent operations:

- `actions` for command dispatch;
- `postStartupData()` for initial settings data;
- `refreshCatalogData()` for auth-dependent catalog refresh.

This keeps the existing `createSettingsAgentControllers` domain layer intact and hides desktop orchestration behind a smaller inbound API.

## Behavior preserved

- source-qualified roster keys and selected tool-use roots;
- sign-in before exactly one forced remote refresh and one roster commit;
- `deferAgentCatalogRefresh` while team sign-in owns refresh;
- settings-view and launcher renderer updates;
- explicit unsupported desktop commands;
- custom-directory open/reveal behavior and team preset messages.

## Net elements (R6)

- Files: 7 changed, including 3 new focused modules/test-support files.
- LoC: +996/-824, net +172.
- `desktopSettingsIpc.ts`: 1,315 to 1,041 lines.
- `DesktopSettingsIpcOptions`: twelve optional agent callbacks removed, one required controller added, net -11 fields.
- Production surface: one controller class, six required domain-port interfaces, and one named constructor-options interface added; no compatibility shim or fallback path added.
- The positive line delta is primarily explicit required port definitions and a dedicated controller test suite; the IPC factory itself loses 280 lines.

## Consumer counts (R8)

- `DesktopAgentSettingsController` has one production consumer: `createDesktopSettingsIpc`.
- `DefaultDesktopAgentSettingsController` has one production constructor site: desktop `createWindow`.
- The test stub is shared by both desktop IPC suites.
- All prior production agent callback consumers were removed from `DesktopSettingsIpcOptions`; repository-wide search shows no severed call sites.

## Host impact

Desktop only. CLI and extension behavior are unchanged.

## Scheduled refactoring

#8406 remains open for the later cohesive extractions. This PR intentionally does not replace the remaining optional settings capabilities with another generic dependency bag.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused desktop Vitest: 3 files, 42 tests passed
- `npm test`: 683 files passed, 1 skipped; 6,125 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors agent roster, team presets, and remote-catalog sign-in paths in desktop settings; behavior is meant to be unchanged but the surface area is user-visible and auth-adjacent.
> 
> **Overview**
> **Desktop agent settings** are pulled out of the large `createDesktopSettingsIpc` factory into `DefaultDesktopAgentSettingsController`, which owns catalog/visibility, custom agent directories, team presets, and remote-catalog preflight while still using the shared `createSettingsAgentControllers` layer.
> 
> **`createDesktopSettingsIpc`** now takes one required `agentSettingsController` (`actions`, `postStartupData()`, `refreshCatalogData()`) instead of a dozen optional agent-related callbacks; startup and auth-dependent refresh call into that controller. **Composition** in `createWindow` builds the controller once from explicit ports (registry, directory, dialogs/prompts, Supabase remote catalog, notifications).
> 
> Agent behavior tests live beside the new controller; IPC tests only assert command delegation. Runtime behavior (source-qualified roster keys, deferred catalog refresh during team sign-in, unsupported desktop agent commands) is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4307a91451ca4d6fe650d2deb9d504afaf78ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
