### PR TITLE
refactor(desktop): require history capabilities

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -34,11 +34,11 @@ type HistoryExportFormat = 'md' | 'tex' | 'html';
 /** History-specific capabilities supplied by the desktop host. */
 export interface DesktopHistoryOptions {
   /** Resolved extension resources used by chat export templates. */
-  resourcesPath?: string;
+  resourcesPath: string;
   /** Run a validated request created from a persisted history entry. */
-  runExecution?: (request: ValidatedExecutionRequest) => Promise<void>;
+  runExecution: (request: ValidatedExecutionRequest) => Promise<void>;
   /** Restore a persisted agent configuration into the main view. */
-  restoreTaskState?: (taskState: TaskState) => Promise<boolean>;
+  restoreTaskState: (taskState: TaskState) => Promise<boolean>;
 }
 
 interface DesktopHistoryHandlerDependencies extends DesktopHistoryOptions {
@@ -129,12 +129,6 @@ export class DesktopHistoryHandlers {
       await this.dependencies.showErrorMessage?.(validated.message);
       return;
     }
-    if (!this.dependencies.runExecution) {
-      await this.dependencies.showErrorMessage?.(
-        'Rerunning agents from history is not available in this build',
-      );
-      return;
-    }
     await this.dependencies.showInfoMessage?.('Rerunning agent from history');
     await this.dependencies.runExecution(validated.request);
   }
@@ -147,10 +141,9 @@ export class DesktopHistoryHandlers {
       );
       return;
     }
-    const restored =
-      (await this.dependencies.restoreTaskState?.(
-        agentConfigToTaskState(result.config),
-      )) ?? false;
+    const restored = await this.dependencies.restoreTaskState(
+      agentConfigToTaskState(result.config),
+    );
     if (!restored) {
       await this.dependencies.showErrorMessage?.(
         'Failed to restore configuration',
@@ -158,21 +151,16 @@ export class DesktopHistoryHandlers {
     }
   }
 
-  private getResourcesPath(): string {
-    if (!this.dependencies.resourcesPath) {
-      throw new Error(
-        'Desktop settings IPC missing resourcesPath; cannot export chat.',
-      );
-    }
-    return this.dependencies.resourcesPath;
-  }
-
   private getChatExportController(): Promise<ChatExportController> {
     this.chatExportControllerLoad ??=
       import('@controllers/settingsView/ChatExportController')
         .then(({ ChatExportController }) => {
           const latexPreamble = readFileSync(
-            path.join(this.getResourcesPath(), 'templates', 'chatExport.tex'),
+            path.join(
+              this.dependencies.resourcesPath,
+              'templates',
+              'chatExport.tex',
+            ),
             'utf8',
           );
           return new ChatExportController({ latexPreamble });
@@ -218,7 +206,11 @@ export class DesktopHistoryHandlers {
     const controller = await this.getChatExportController();
     const outcome = await controller.exportAsHtml(
       historyId,
-      path.join(this.getResourcesPath(), 'traceViewerStandalone', 'index.html'),
+      path.join(
+        this.dependencies.resourcesPath,
+        'traceViewerStandalone',
+        'index.html',
+      ),
     );
     if (outcome.status !== 'ok') {
       await this.reportHtmlExportError(outcome.status);

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import type { DesktopHistoryOptions } from '@desktop/main/desktopHistoryHandlers';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { AgentCategory } from '@shared/schemas/agent';
 import { assertSupported } from '@shared/utils/dispatcher';
@@ -15,6 +16,7 @@ import {
   moduleFileUrl,
   repoPath,
 } from './desktopTestPaths.mjs';
+import { createStubDesktopHistoryOptions } from './desktopSettingsTestSupport';
 
 // Local imports - controller types
 import type { ChatExportInput } from '@controllers/settingsView/ChatExportController';
@@ -49,6 +51,11 @@ type DesktopHistoryHandlersModule =
 type DesktopHistoryDependencies = ConstructorParameters<
   DesktopHistoryHandlersModule['DesktopHistoryHandlers']
 >[0];
+type DesktopHistoryActionOverrides = Partial<
+  Omit<DesktopHistoryDependencies, keyof DesktopHistoryOptions>
+> & {
+  history?: Partial<DesktopHistoryOptions>;
+};
 
 const RESOURCES_PATH = repoPath('packages', 'extension', 'resources');
 const HISTORY_ID = 'bbbb2222';
@@ -68,14 +75,21 @@ let DesktopHistoryHandlers!: DesktopHistoryHandlersModule['DesktopHistoryHandler
 
 setupPlatform();
 
-function createHistoryActions(
-  overrides: Partial<DesktopHistoryDependencies> = {},
-) {
+function createHistoryActions(overrides: DesktopHistoryActionOverrides = {}) {
+  const {
+    history,
+    postToRenderer = vi.fn(),
+    onError = vi.fn(),
+    ...optionalDependencies
+  } = overrides;
   return new DesktopHistoryHandlers({
-    postToRenderer: vi.fn(),
-    resourcesPath: RESOURCES_PATH,
-    onError: vi.fn(),
-    ...overrides,
+    ...createStubDesktopHistoryOptions({
+      resourcesPath: RESOURCES_PATH,
+      ...history,
+    }),
+    postToRenderer,
+    onError,
+    ...optionalDependencies,
   }).actions;
 }
 
@@ -103,7 +117,7 @@ describe('DesktopHistoryHandlers', () => {
     const restoreTaskState = vi.fn(async () => true);
     const actions = createHistoryActions({
       showErrorMessage,
-      restoreTaskState,
+      history: { restoreTaskState },
     });
 
     await assertSupported(actions.restoreAgent)({
@@ -142,23 +156,25 @@ describe('DesktopHistoryHandlers', () => {
     );
   });
 
-  it('errors instead of a false success when rerun has no runExecution dependency wired (Copilot #7827)', async () => {
+  it('reports when restoring the task state fails', async () => {
     await writeHistoryConfig();
-    const showInfoMessage = vi.fn();
     const showErrorMessage = vi.fn();
+    const restoreTaskState = vi.fn(async () => false);
     const actions = createHistoryActions({
-      showInfoMessage,
       showErrorMessage,
+      history: { restoreTaskState },
     });
 
-    await assertSupported(actions.rerunAgent)({
-      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+    await assertSupported(actions.restoreAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RESTORE_AGENT,
       historyId: HISTORY_ID,
     });
 
-    expect(showInfoMessage).not.toHaveBeenCalled();
+    expect(restoreTaskState).toHaveBeenCalledWith({
+      agentConfig: HISTORY_CONFIG,
+    });
     expect(showErrorMessage).toHaveBeenCalledWith(
-      'Rerunning agents from history is not available in this build',
+      'Failed to restore configuration',
     );
   });
 

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -15,7 +15,10 @@ import {
 import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import { createStubDesktopAgentSettingsController } from './desktopSettingsTestSupport';
+import {
+  createStubDesktopAgentSettingsController,
+  createStubDesktopHistoryOptions,
+} from './desktopSettingsTestSupport';
 import type { StateStore } from '@platform/interfaces';
 
 const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
@@ -36,16 +39,18 @@ type DesktopSettingsIpcModule =
 type DesktopSettingsIpcOptions = Parameters<
   DesktopSettingsIpcModule['createDesktopSettingsIpc']
 >[0];
+type DesktopHistoryOptions = ReturnType<typeof createStubDesktopHistoryOptions>;
 
 type RendererMessage = Parameters<
   DesktopSettingsIpcOptions['postToRenderer']
 >[0];
 
 type SettingsFixtureOverrides = Omit<
-  DesktopSettingsIpcOptions,
-  'agentSettingsController' | 'postToRenderer'
+  Partial<DesktopSettingsIpcOptions>,
+  'agentSettingsController' | 'postToRenderer' | keyof DesktopHistoryOptions
 > & {
   agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
+  history?: Partial<DesktopHistoryOptions>;
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
 };
 
@@ -149,10 +154,12 @@ async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
 let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIpc'];
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
+  const { history, ...settingsOverrides } = overrides;
   const globalState = overrides.globalState ?? new MemoryStateStore();
   const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
   const settings = createDesktopSettingsIpc({
-    ...overrides,
+    ...settingsOverrides,
+    ...createStubDesktopHistoryOptions(history),
     agentSettingsController:
       overrides.agentSettingsController ??
       createStubDesktopAgentSettingsController(),
@@ -1304,8 +1311,10 @@ describe('desktop settings IPC', () => {
       showInfoMessage: async (message) => {
         infos.push(message);
       },
-      runExecution: async (request) => {
-        runRequests.push(request);
+      history: {
+        runExecution: async (request) => {
+          runRequests.push(request);
+        },
       },
     });
 

--- a/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
@@ -19,7 +19,10 @@ import { apiKeySecretName } from '@model/apiProviders';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 
 // Local imports - desktop test support
-import { createStubDesktopAgentSettingsController } from './desktopSettingsTestSupport';
+import {
+  createStubDesktopAgentSettingsController,
+  createStubDesktopHistoryOptions,
+} from './desktopSettingsTestSupport';
 
 // Local imports - platform
 import type { StateStore } from '@platform/interfaces';
@@ -92,6 +95,7 @@ async function createSettingsIpc(options: {
   } as unknown as ReturnType<typeof serverKeysModule.getServerSideKeyService>);
 
   return createDesktopSettingsIpc({
+    ...createStubDesktopHistoryOptions(),
     postToRenderer: () => {},
     agentSettingsController: createStubDesktopAgentSettingsController(),
     globalState: new MemoryStateStore(),

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -1,10 +1,25 @@
 // Desktop imports
 import type { DesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
+import type { DesktopHistoryOptions } from '@desktop/main/desktopHistoryHandlers';
 
 // Shared imports
 import { unsupported } from '@shared/utils/dispatcher';
 
+// Local imports - desktop test paths
+import { repoPath } from './desktopTestPaths.mjs';
+
 const noOp = async (): Promise<void> => undefined;
+
+export function createStubDesktopHistoryOptions(
+  overrides: Partial<DesktopHistoryOptions> = {},
+): DesktopHistoryOptions {
+  return {
+    resourcesPath: repoPath('packages', 'extension', 'resources'),
+    runExecution: noOp,
+    restoreTaskState: async () => true,
+    ...overrides,
+  };
+}
 
 export function createStubDesktopAgentSettingsController(): DesktopAgentSettingsController {
   return {


### PR DESCRIPTION
## Summary

Make the desktop history capabilities that production always supplies statically required, and remove runtime branches for host states that cannot occur.

- require `resourcesPath`, `runExecution`, and `restoreTaskState` in `DesktopHistoryOptions`;
- call those capabilities directly while preserving genuine rerun, restore, and export failures;
- replace flattened test omissions with one typed history-domain fake and nested overrides.

Closes #8415. Advances #8406.

## Issue acceptance gates

- [x] `DesktopHistoryOptions` requires all three production capabilities.
- [x] Rerun, restore, and export no longer check for missing host wiring.
- [x] Desktop composition continues to supply the same capabilities unchanged.
- [x] Settings tests use a complete typed history fake rather than impossible missing-capability states.
- [x] Focused tests, typecheck, lint, compile, format, and the full suite pass.

## Single source of truth

`DesktopHistoryOptions` in `desktopHistoryHandlers.ts` owns the desktop host contract for history execution, restoration, and export resources. `DesktopSettingsIpcOptions` extends that required contract, so capability presence is enforced at composition instead of rediscovered inside handlers.

## Duplication and abstraction budget

No production abstraction is added. Three optional fields become required in the existing history contract, 24 production lines are removed, and the missing-capability fallback branches disappear. Tests gain one shared `createStubDesktopHistoryOptions()` factory so each fixture supplies a complete history domain and overrides only behavior relevant to the test.

## Net elements (R6)

- Files: 5 modified, 0 added, 0 deleted.
- LoC: +82/-46, net +36.
- Production code: +16/-24, net -8.
- Exported production symbols: unchanged; `DesktopHistoryOptions` is tightened in place.
- Test-only exports: one typed history-options factory added.
- No compatibility shim, forwarding module, class, or enum is added.

## Consumer counts (R8)

No event, emit path, or public runtime export is deleted or rerouted. The required history contract has two production type consumers (`DesktopHistoryHandlerDependencies` and `DesktopSettingsIpcOptions`) and one production composition site in desktop `createWindow`; all are updated through the shared type without parallel fallback logic.

## Host impact

Extension: none.

Desktop: impossible missing-history states are rejected at compile time; supported behavior and user-visible failure messages remain unchanged.

CLI: none.

## Scheduled refactoring

#8406 remains open for later extraction of the remaining optional settings domains. This PR completes only the history-capability stage defined by #8415.

## Validation

- `npm run format`
- `npm run lint` (0 errors; 50 pre-existing warnings)
- `npm run typecheck`
- `npm run compile:fast`
- focused desktop Vitest: 3 files, 41 tests passed
- `npm test`: 683 files passed, 1 skipped; 6,125 tests passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time contract tightening and removal of dead runtime guards; production composition already supplies the capabilities, so runtime behavior for supported desktop builds should be unchanged.
> 
> **Overview**
> **Desktop history host contract** now requires `resourcesPath`, `runExecution`, and `restoreTaskState` on `DesktopHistoryOptions` (and via `DesktopSettingsIpcOptions`), so missing wiring is caught at composition/typecheck instead of at runtime.
> 
> **Handler behavior** drops branches for absent host capabilities: rerun always calls `runExecution` after validation; restore calls `restoreTaskState` directly; chat export reads `resourcesPath` inline and no longer uses `getResourcesPath()` or throws for a missing path. User-visible errors for bad history, failed restore, and export issues are unchanged.
> 
> **Tests** add `createStubDesktopHistoryOptions()` and route history overrides through a nested `history` field; the old “rerun unavailable in this build” case is replaced by asserting **“Failed to restore configuration”** when `restoreTaskState` returns false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097aa4f22aa80ca6383edcffdeb2c110c02fdd64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->