### PR TITLE
refactor(desktop): require history capabilities

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -34,11 +34,11 @@ type HistoryExportFormat = 'md' | 'tex' | 'html';
 /** History-specific capabilities supplied by the desktop host. */
 export interface DesktopHistoryOptions {
   /** Resolved extension resources used by chat export templates. */
-  resourcesPath?: string;
+  resourcesPath: string;
   /** Run a validated request created from a persisted history entry. */
-  runExecution?: (request: ValidatedExecutionRequest) => Promise<void>;
+  runExecution(request: ValidatedExecutionRequest): Promise<void>;
   /** Restore a persisted agent configuration into the main view. */
-  restoreTaskState?: (taskState: TaskState) => Promise<boolean>;
+  restoreTaskState(taskState: TaskState): Promise<boolean>;
 }
 
 interface DesktopHistoryHandlerDependencies extends DesktopHistoryOptions {
@@ -129,12 +129,6 @@ export class DesktopHistoryHandlers {
       await this.dependencies.showErrorMessage?.(validated.message);
       return;
     }
-    if (!this.dependencies.runExecution) {
-      await this.dependencies.showErrorMessage?.(
-        'Rerunning agents from history is not available in this build',
-      );
-      return;
-    }
     await this.dependencies.showInfoMessage?.('Rerunning agent from history');
     await this.dependencies.runExecution(validated.request);
   }
@@ -147,10 +141,9 @@ export class DesktopHistoryHandlers {
       );
       return;
     }
-    const restored =
-      (await this.dependencies.restoreTaskState?.(
-        agentConfigToTaskState(result.config),
-      )) ?? false;
+    const restored = await this.dependencies.restoreTaskState(
+      agentConfigToTaskState(result.config),
+    );
     if (!restored) {
       await this.dependencies.showErrorMessage?.(
         'Failed to restore configuration',
@@ -158,21 +151,16 @@ export class DesktopHistoryHandlers {
     }
   }
 
-  private getResourcesPath(): string {
-    if (!this.dependencies.resourcesPath) {
-      throw new Error(
-        'Desktop settings IPC missing resourcesPath; cannot export chat.',
-      );
-    }
-    return this.dependencies.resourcesPath;
-  }
-
   private getChatExportController(): Promise<ChatExportController> {
     this.chatExportControllerLoad ??=
       import('@controllers/settingsView/ChatExportController')
         .then(({ ChatExportController }) => {
           const latexPreamble = readFileSync(
-            path.join(this.getResourcesPath(), 'templates', 'chatExport.tex'),
+            path.join(
+              this.dependencies.resourcesPath,
+              'templates',
+              'chatExport.tex',
+            ),
             'utf8',
           );
           return new ChatExportController({ latexPreamble });
@@ -218,7 +206,11 @@ export class DesktopHistoryHandlers {
     const controller = await this.getChatExportController();
     const outcome = await controller.exportAsHtml(
       historyId,
-      path.join(this.getResourcesPath(), 'traceViewerStandalone', 'index.html'),
+      path.join(
+        this.dependencies.resourcesPath,
+        'traceViewerStandalone',
+        'index.html',
+      ),
     );
     if (outcome.status !== 'ok') {
       await this.reportHtmlExportError(outcome.status);

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -74,6 +74,8 @@ function createHistoryActions(
   return new DesktopHistoryHandlers({
     postToRenderer: vi.fn(),
     resourcesPath: RESOURCES_PATH,
+    runExecution: vi.fn(async () => undefined),
+    restoreTaskState: vi.fn(async () => true),
     onError: vi.fn(),
     ...overrides,
   }).actions;
@@ -142,13 +144,13 @@ describe('DesktopHistoryHandlers', () => {
     );
   });
 
-  it('errors instead of a false success when rerun has no runExecution dependency wired (Copilot #7827)', async () => {
+  it('reruns a valid history item through the required execution capability', async () => {
     await writeHistoryConfig();
     const showInfoMessage = vi.fn();
-    const showErrorMessage = vi.fn();
+    const runExecution = vi.fn(async () => undefined);
     const actions = createHistoryActions({
       showInfoMessage,
-      showErrorMessage,
+      runExecution,
     });
 
     await assertSupported(actions.rerunAgent)({
@@ -156,10 +158,10 @@ describe('DesktopHistoryHandlers', () => {
       historyId: HISTORY_ID,
     });
 
-    expect(showInfoMessage).not.toHaveBeenCalled();
-    expect(showErrorMessage).toHaveBeenCalledWith(
-      'Rerunning agents from history is not available in this build',
+    expect(showInfoMessage).toHaveBeenCalledWith(
+      'Rerunning agent from history',
     );
+    expect(runExecution).toHaveBeenCalledOnce();
   });
 
   it('exports a history chat to Markdown via the shared ChatExportController', async () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -41,13 +41,7 @@ type RendererMessage = Parameters<
   DesktopSettingsIpcOptions['postToRenderer']
 >[0];
 
-type SettingsFixtureOverrides = Omit<
-  DesktopSettingsIpcOptions,
-  'agentSettingsController' | 'postToRenderer'
-> & {
-  agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
-  postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
-};
+type SettingsFixtureOverrides = Partial<DesktopSettingsIpcOptions>;
 
 type CapturedSettingsFixtureOverrides = Omit<
   SettingsFixtureOverrides,
@@ -158,6 +152,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
       createStubDesktopAgentSettingsController(),
     globalState,
     postToRenderer: overrides.postToRenderer ?? (() => undefined),
+    resourcesPath: overrides.resourcesPath ?? '/resources',
+    runExecution: overrides.runExecution ?? (async () => undefined),
+    restoreTaskState: overrides.restoreTaskState ?? (async () => true),
     workspaceState,
   });
   return { globalState, settings, workspaceState };

--- a/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
+++ b/src/test-kernel/desktop/desktopSettingsIpc.vitest.ts
@@ -94,6 +94,9 @@ async function createSettingsIpc(options: {
   return createDesktopSettingsIpc({
     postToRenderer: () => {},
     agentSettingsController: createStubDesktopAgentSettingsController(),
+    resourcesPath: '/resources',
+    runExecution: async () => undefined,
+    restoreTaskState: async () => true,
     globalState: new MemoryStateStore(),
     workspaceState: new MemoryStateStore(),
     secrets: options.secrets,


### PR DESCRIPTION
## Summary

Make the three history capabilities that production always supplies statically required at the desktop composition boundary. Delete the impossible missing-runner, missing-restorer, and missing-resources branches, and make test fixtures provide explicit fakes.

## Issue acceptance gates

Closes #8415 and advances #8406.

- `resourcesPath`, `runExecution`, and `restoreTaskState` are required by `DesktopHistoryOptions`.
- Production already supplies all three in `main/index.ts`; that remains the single composition site.
- Tests now declare the capabilities they exercise instead of manufacturing production-impossible absence states.
- History rerun, restore, and export behavior remains covered.

## Single source of truth

The desktop composition root owns whether history execution, restoration, and export resources exist. `DesktopHistoryHandlers` consumes that required contract directly and only handles real operation outcomes.

## Duplication and abstraction budget

No new abstraction is introduced. This tightens the existing `DesktopHistoryOptions` boundary and removes its repeated capability-absence interpretation plus the private `getResourcesPath()` assertion helper.

## Net elements (R6)

- Files: 4 changed.
- LoC: +31/-37, net -6.
- Exported symbols/classes/interfaces/enums: no additions or removals.
- Existing interface: three optional fields become required.
- Deleted logic: one missing-runner error branch, one optional restore fallback, and one private resources-path assertion method.

## Consumer counts (R8)

- Production `createDesktopSettingsIpc` composition sites: 1, already supplying all three capabilities.
- Direct history handler construction is limited to the IPC factory and its focused test fixture.
- Three desktop test fixtures were updated with explicit required fakes; no emit path or export was deleted.

## Host impact

Extension: unchanged.

Desktop: internal history dependency contract only; supported rerun, restore, and export behavior is unchanged.

CLI: unchanged.

## Scheduled refactoring

#8406 remains open for the remaining desktop settings domains. #8417 records the next credential/sign-in optional-callback cluster.

## Validation

- Prettier on all four changed files
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused desktop Vitest: 3 files, 41 tests passed
- `npm test`: 683 files passed, 1 skipped; 6,125 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-level contract tightening and dead-branch removal; production composition already provides the three capabilities, so runtime history behavior is unchanged.
> 
> **Overview**
> **`DesktopHistoryOptions`** now requires **`resourcesPath`**, **`runExecution`**, and **`restoreTaskState`** instead of treating them as optional host capabilities.
> 
> **`DesktopHistoryHandlers`** drops branches for “capability not wired in this build”: no more user error when rerun lacks a runner, no optional restore fallback, and no **`getResourcesPath()`** throw helper—export paths read **`dependencies.resourcesPath`** directly.
> 
> Desktop settings and history **tests** supply explicit fakes for those three fields and assert rerun goes through **`runExecution`** rather than testing an impossible missing-runner state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32272c2d937a77110db8dec83e6db70cd41e2505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->