### PR TITLE
fix(cli): preserve session list selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Session navigation remembers its place** — after returning from the
+  vertical session list to the input, pressing `Tab` again restores the same
+  highlighted session instead of jumping back to the main conversation.
 - **Retry prompts no longer ask for discarded feedback** — choosing “give up”
   now cancels immediately instead of opening a rejection note that the retry
   flow cannot use.

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -7,8 +7,8 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useReducer,
   useRef,
-  useState,
 } from 'react';
 
 // Local imports - shared runtime
@@ -35,7 +35,6 @@ import { TranscriptViewer } from './modals/TranscriptViewer';
 import { InputBar } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
-import { resolveSessionSelectionId } from './panes/SubagentListDisplay';
 import { currentApproval } from './state/approvalQueue';
 import {
   isEscapeInput,
@@ -63,6 +62,10 @@ import {
   parentStream as parentStreamSignal,
 } from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
+import {
+  INITIAL_SESSION_LIST_SELECTION,
+  reduceSessionListSelection,
+} from './state/sessionListSelection';
 import { activeStreamTreeViews, streamDisplayLabel } from './state/streamViews';
 import { useSignal } from './state/useSignal';
 import type { TranscriptViewportChange } from './state/transcriptViewportMode';
@@ -110,8 +113,12 @@ export function App(props: AppProps): React.JSX.Element {
   const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
   const childControlMode = useSignal(childControlModeSignal);
   const childControlEscapeAction = useSignal(childControlEscapeActionSignal);
-  const [sessionListFocused, setSessionListFocused] = useState(false);
-  const [selectedSessionId, setSelectedSessionId] = useState<StreamTabId>();
+  const [sessionListSelection, dispatchSessionListSelection] = useReducer(
+    reduceSessionListSelection,
+    INITIAL_SESSION_LIST_SELECTION,
+  );
+  const sessionListFocused = sessionListSelection.focused;
+  const selectedSessionId = sessionListSelection.selectedStreamId;
   const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
@@ -203,23 +210,24 @@ export function App(props: AppProps): React.JSX.Element {
       }),
     [activeStreamId, childStreamEntries, parentStream, streams],
   );
-  const resolvedSelectedSessionId = resolveSessionSelectionId(
-    sessionViews,
-    selectedSessionId,
-    activeStreamId,
-  );
+  useEffect(() => {
+    dispatchSessionListSelection({
+      kind: 'reconcile',
+      activeStreamId,
+      sessions: sessionViews,
+    });
+  }, [activeStreamId, sessionViews]);
   useEffect(() => {
     if (sessionViews.length === 0 && sessionListFocused) {
-      setSessionListFocused(false);
+      dispatchSessionListSelection({ kind: 'blur' });
     }
   }, [sessionListFocused, sessionViews.length]);
   const cancelSessionList = useCallback(() => {
-    setSessionListFocused(false);
+    dispatchSessionListSelection({ kind: 'blur' });
   }, []);
   const focusSession = useCallback((streamId: StreamTabId) => {
-    setSelectedSessionId(streamId);
+    dispatchSessionListSelection({ kind: 'focusStream', streamId });
     activeStreamIdSignal.set(streamId);
-    setSessionListFocused(false);
   }, []);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
@@ -411,7 +419,7 @@ export function App(props: AppProps): React.JSX.Element {
     }
 
     if (sessionListFocused) {
-      if (key.tab) setSessionListFocused(false);
+      if (key.tab) dispatchSessionListSelection({ kind: 'blur' });
       return;
     }
 
@@ -427,8 +435,7 @@ export function App(props: AppProps): React.JSX.Element {
     // Tab transfers keyboard ownership from the input to the session list.
     if (key.tab) {
       if (sessionViews.length > 0) {
-        setSelectedSessionId(resolvedSelectedSessionId);
-        setSessionListFocused(true);
+        dispatchSessionListSelection({ kind: 'focus' });
       }
       return;
     }
@@ -511,14 +518,16 @@ export function App(props: AppProps): React.JSX.Element {
         slashPaletteOpen,
         sessionListFocused,
         sessionViews,
-        selectedSessionId: resolvedSelectedSessionId,
+        selectedSessionId,
         streams,
         childExecutionPanelTarget: childControlTargets.tasks,
         transcriptViewerStreamId,
       }}
       onCancelSessionList={cancelSessionList}
       onFocusSession={focusSession}
-      onSessionSelectionChange={setSelectedSessionId}
+      onSessionSelectionChange={(streamId) =>
+        dispatchSessionListSelection({ kind: 'highlight', streamId })
+      }
     />
   );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,6 +1,3 @@
-// Local imports - shared stream identity
-import type { StreamTabId } from '@shared/schemas';
-
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
@@ -10,21 +7,6 @@ import {
   COLOR_WARNING,
 } from '../ui/colors';
 import { STATUS_DOT } from '../ui/glyphs';
-import type { StreamView } from '../state/streamViews';
-
-export function resolveSessionSelectionId(
-  sessions: readonly StreamView[],
-  selectedStreamId: StreamTabId | undefined,
-  activeStreamId: StreamTabId | undefined,
-): StreamTabId | undefined {
-  if (sessions.some((session) => session.id === selectedStreamId)) {
-    return selectedStreamId;
-  }
-  if (sessions.some((session) => session.id === activeStreamId)) {
-    return activeStreamId;
-  }
-  return sessions[0]?.id;
-}
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return COLOR_SUCCESS;

--- a/packages/cli/src/chat/tui/state/sessionListSelection.ts
+++ b/packages/cli/src/chat/tui/state/sessionListSelection.ts
@@ -1,0 +1,71 @@
+// Local imports - shared stream identity
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - TUI state
+import type { StreamView } from './streamViews';
+
+export interface SessionListSelectionState {
+  readonly focused: boolean;
+  readonly selectedStreamId: StreamTabId | undefined;
+}
+
+type SessionListSelectionAction =
+  | { readonly kind: 'blur' }
+  | { readonly kind: 'focus' }
+  | { readonly kind: 'focusStream'; readonly streamId: StreamTabId }
+  | { readonly kind: 'highlight'; readonly streamId: StreamTabId }
+  | {
+      readonly kind: 'reconcile';
+      readonly activeStreamId: StreamTabId | undefined;
+      readonly sessions: readonly StreamView[];
+    };
+
+export const INITIAL_SESSION_LIST_SELECTION: SessionListSelectionState = {
+  focused: false,
+  selectedStreamId: undefined,
+};
+
+function resolveSessionSelectionId(
+  sessions: readonly StreamView[],
+  selectedStreamId: StreamTabId | undefined,
+  activeStreamId: StreamTabId | undefined,
+): StreamTabId | undefined {
+  if (sessions.some((session) => session.id === selectedStreamId)) {
+    return selectedStreamId;
+  }
+  if (sessions.some((session) => session.id === activeStreamId)) {
+    return activeStreamId;
+  }
+  return sessions[0]?.id;
+}
+
+/** Apply one keyboard or stream-lifecycle transition to session-list state. */
+export function reduceSessionListSelection(
+  state: SessionListSelectionState,
+  action: SessionListSelectionAction,
+): SessionListSelectionState {
+  switch (action.kind) {
+    case 'blur':
+      return { ...state, focused: false };
+    case 'focus':
+      return { ...state, focused: true };
+    case 'focusStream':
+      return {
+        focused: false,
+        selectedStreamId: action.streamId,
+      };
+    case 'highlight':
+      return { ...state, selectedStreamId: action.streamId };
+    case 'reconcile': {
+      if (action.sessions.length === 0) return state;
+      const selectedStreamId = resolveSessionSelectionId(
+        action.sessions,
+        state.selectedStreamId,
+        action.activeStreamId,
+      );
+      return selectedStreamId === state.selectedStreamId
+        ? state
+        : { ...state, selectedStreamId };
+    }
+  }
+}

--- a/src/test-kernel/cli/SessionListSelection.vitest.mts
+++ b/src/test-kernel/cli/SessionListSelection.vitest.mts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  INITIAL_SESSION_LIST_SELECTION,
+  reduceSessionListSelection,
+  type SessionListSelectionState,
+} from '@cli/chat/tui/state/sessionListSelection';
+import type { StreamView } from '@cli/chat/tui/state/streamViews';
+import type { StreamTabId } from '@shared/schemas';
+
+function session(id: string, active = false): StreamView {
+  return {
+    id: id as StreamTabId,
+    label: id,
+    slice: undefined,
+    active,
+  };
+}
+
+function reconcileSelection(
+  state: SessionListSelectionState,
+  sessions: readonly StreamView[],
+  activeStreamId: StreamTabId | undefined,
+): SessionListSelectionState {
+  return reduceSessionListSelection(state, {
+    kind: 'reconcile',
+    activeStreamId,
+    sessions,
+  });
+}
+
+describe('CLI session list selection', () => {
+  it('preserves selection by stream id across focus changes', () => {
+    const main = 'main' as StreamTabId;
+    const strategy = 'strategy' as StreamTabId;
+    let state = reconcileSelection(
+      INITIAL_SESSION_LIST_SELECTION,
+      [session('main', true), session('strategy')],
+      main,
+    );
+
+    state = reduceSessionListSelection(state, { kind: 'focus' });
+    state = reduceSessionListSelection(state, {
+      kind: 'highlight',
+      streamId: strategy,
+    });
+    state = reduceSessionListSelection(state, { kind: 'blur' });
+    state = reduceSessionListSelection(state, { kind: 'focus' });
+
+    expect(state).toEqual({
+      focused: true,
+      selectedStreamId: strategy,
+    });
+  });
+
+  it('keeps selection through reordering while its stream remains present', () => {
+    const main = 'main' as StreamTabId;
+    const strategy = 'strategy' as StreamTabId;
+    const state = reconcileSelection(
+      { focused: true, selectedStreamId: strategy },
+      [session('review'), session('main', true), session('strategy')],
+      main,
+    );
+
+    expect(state.selectedStreamId).toBe(strategy);
+  });
+
+  it('preserves selection while the session list is hidden', () => {
+    const main = 'main' as StreamTabId;
+    const strategy = 'strategy' as StreamTabId;
+    const selected: SessionListSelectionState = {
+      focused: false,
+      selectedStreamId: strategy,
+    };
+
+    const hidden = reconcileSelection(selected, [], main);
+    const restored = reconcileSelection(
+      hidden,
+      [session('main', true), session('strategy')],
+      main,
+    );
+
+    expect(hidden).toBe(selected);
+    expect(restored.selectedStreamId).toBe(strategy);
+  });
+
+  it('falls back after a hidden selected session disappears', () => {
+    const main = 'main' as StreamTabId;
+    const strategy = 'strategy' as StreamTabId;
+    const selected: SessionListSelectionState = {
+      focused: false,
+      selectedStreamId: strategy,
+    };
+
+    const hidden = reconcileSelection(selected, [], main);
+    const restored = reconcileSelection(
+      hidden,
+      [session('main', true), session('review')],
+      main,
+    );
+
+    expect(hidden).toBe(selected);
+    expect(restored.selectedStreamId).toBe(main);
+  });
+
+  it('falls back to the active session, then the first available session', () => {
+    const main = 'main' as StreamTabId;
+    const strategy = 'strategy' as StreamTabId;
+    let state = reconcileSelection(
+      { focused: true, selectedStreamId: strategy },
+      [session('review'), session('main', true)],
+      main,
+    );
+    expect(state.selectedStreamId).toBe(main);
+
+    state = reconcileSelection(
+      state,
+      [session('review'), session('strategy')],
+      undefined,
+    );
+    expect(state.selectedStreamId).toBe('review');
+  });
+});

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   CHILD_STATUS_MARKER,
   childStatusColor,
-  resolveSessionSelectionId,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
   compactChildRowText,
@@ -66,26 +65,6 @@ describe('CLI session list display model', () => {
         items,
       }),
     ).toBe(2);
-  });
-
-  it('preserves selection by stream id as rows change', () => {
-    const selected = 'lean' as StreamTabId;
-    const reordered = [
-      session('review'),
-      session('main', true),
-      session('lean'),
-    ];
-
-    expect(
-      resolveSessionSelectionId(reordered, selected, 'main' as StreamTabId),
-    ).toBe(selected);
-    expect(
-      resolveSessionSelectionId(
-        reordered.slice(0, 2),
-        selected,
-        'main' as StreamTabId,
-      ),
-    ).toBe('main');
   });
 
   it('relocates a controlled highlight after a same-length reorder', () => {


### PR DESCRIPTION
## Summary

Preserve the highlighted session when keyboard focus leaves the CLI's vertical session list and later returns.

Entering the list previously dispatched two independent state updates: one copied the selection derived by an earlier render, and one changed keyboard focus. A child highlight could therefore be overwritten by the active root session. Focus and selection now transition through one reducer-owned state, and entering the list no longer rewrites a valid selection.

Closes #8420. Follow-up to #8401 and #8404.

## Issue acceptance gates

- Up and Down continue to change the highlighted session.
- Escape or Tab returns to the input without resetting the highlighted stream.
- Re-entering the list restores the last highlighted stream while it exists.
- A temporarily hidden single-session list preserves the remembered stream.
- Removed selections fall back to the active stream, then the first available stream, when rows return.
- Enter continues to focus the highlighted stream.
- Focused unit and PTY coverage exercises focus return, direct focus, resize retention, and tiny-terminal focus release.

## Single source of truth

`packages/cli/src/chat/tui/state/sessionListSelection.ts` owns session-list focus, selected stream identity, fallback resolution, and their transitions. Display modules only render the resolved state.

## Duplication and abstraction budget

The new state module replaces two independently updated React states and relocates the existing fallback resolver out of `SubagentListDisplay.ts`. Its reducer owns the invariant that focus changes do not change stream selection; it is not a pass-through layer.

## Net elements (R6)

- 6 files changed: +224 / -57, net +167 lines.
- Production: +98 / -36, net +62 lines.
- Tests: +123 / -21, net +102 lines.
- Changelog: +3 lines.
- One new state module and one focused test file.
- Net +2 exported symbols: selection state, initial state, and reducer are added; the former display-level resolver becomes a private state-module detail.
- No new classes, schemas, interfaces outside the private TUI state boundary, or runtime dependencies.

## Consumer counts (R8)

n/a: no event, command, IPC, or public package export is removed or rerouted. Selection resolution remains internal to the only production consumer, the CLI `App` state transition.

## Host impact

Extension: None.

Desktop: None.

CLI: The vertical session list remembers its highlighted row across input/list focus changes and temporary single-session intervals. Rendering, row order, and navigation keys are unchanged.

## Scheduled refactoring

None. This completes the selection-retention follow-up for the unified session list.

## Validation

- `npm run typecheck`
- `corepack pnpm exec vitest run src/test-kernel/cli/SessionListSelection.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts` (11 tests passed after review fix)
- Rebuilt `@texra-ai/cli` bundle
- PTY: `subagent-list-remembers-selection`
- PTY: `subagent-list-focus-full-frame`
- PTY: `subagent-list-resize-selection`
- PTY: `subagent-list-tiny-resize-releases-focus`
- Ten repeated worker runs of the selection-retention PTY scenario
- Prettier, focused ESLint, and `git diff --check`
