### PR TITLE
refactor(desktop): isolate tool and LaTeX settings

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,11 +1,6 @@
 import { platform, tryPlatform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
-import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
-import {
-  isAllowedLatexInstallCommand,
-  LatexToolingController,
-} from '@controllers/settingsView/LatexToolingController';
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
 import {
   createSettingsViewCommandHandlers,
@@ -14,18 +9,11 @@ import {
 import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  LATEX_WORKSHOP_EXT_ID,
-  normalizePlatform,
-} from '@shared/constants/latex';
-import type { LatexConfigField } from '@shared/constants/latex';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   dispatchSettingsViewInbound,
   SettingsViewInboundMessageSchema,
-  type LatexSettingsStatus,
   type ReasoningLevel,
-  type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import {
@@ -36,32 +24,19 @@ import {
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
 import { GoalStore } from '@tools/goal';
-import type { ExternalToolCheckResult } from '@tools/toolAvailability';
 import { StorageFS } from '@utils/files';
 import {
   applyGitAuthorSettings,
   buildGitAuthorSettingsMessage,
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
-import { BinaryResolver } from '@utils/system/binaryResolver';
-import {
-  checkToolInstalled,
-  detectPackageManager,
-} from '@utils/system/toolUtils';
 import {
   type DesktopCrashReportingStatus,
   getDesktopCrashReportingStatus,
   setDesktopCrashReportingDsn,
   setDesktopCrashReportingEnabled,
 } from './desktopCrashReporting.js';
-import {
-  buildDefaultToolDashboardItems,
-  defaultOnError,
-  emptySecrets,
-  findToolCommand,
-  getCachedToolCheckResults,
-  refreshDefaultDisabledToolCache,
-} from './desktopSettingsIpcHelpers.js';
+import { defaultOnError, emptySecrets } from './desktopSettingsIpcHelpers.js';
 import {
   createDesktopErrorReporter,
   type DesktopCommandMessage,
@@ -75,26 +50,20 @@ import type { ConfigProvider, StateStore } from '@platform/interfaces';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
-
-type ToolDashboardBuilder = (
-  cachedResults?: ExternalToolCheckResult[],
-) => Promise<ToolDashboardItem[]>;
+import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
 export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   postToRenderer(message: unknown): void;
   agentSettingsController: DesktopAgentSettingsController;
   credentialSettingsController: DesktopCredentialSettingsController;
+  toolingSettingsController: DesktopToolingSettingsController;
   sendStartupCatalogData?: boolean;
   globalState?: StateStore;
   workspaceState?: StateStore;
   config?: ConfigProvider;
-  buildToolDashboardItems?: ToolDashboardBuilder;
-  refreshToolAvailability?: () => Promise<void>;
   openPath?: (filePath: string) => Promise<void>;
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
-  openExternalUrl?: (url: string) => Promise<void>;
-  installToolExtension?: (extensionId: string) => Promise<void>;
   promptSecret?: (input: {
     title: string;
     prompt: string;
@@ -104,13 +73,6 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
   initializeCrashReporting?: () => Promise<void>;
   secrets?: PlatformSecrets;
-  detectLatexSettingsStatus?: () => Promise<LatexSettingsStatus>;
-  runInstallCommand?: (command: string) => Promise<void>;
-  runToolCommand?: (input: {
-    toolId: string;
-    command: string;
-    kind: 'install' | 'auth';
-  }) => Promise<void>;
   onError?: (error: unknown) => void;
 }
 
@@ -144,28 +106,9 @@ export function createDesktopSettingsIpc(
     showErrorMessage: options.showErrorMessage,
     onError,
   });
-  const usesDefaultToolDashboardBuilder =
-    options.buildToolDashboardItems == null;
-  const buildToolDashboardItems =
-    options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
-  const refreshToolAvailability = options.refreshToolAvailability;
   const secrets = options.secrets ?? tryPlatform()?.secrets ?? emptySecrets;
-  const latexConfigPersistenceController =
-    new LatexConfigPersistenceController();
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),
-  });
-  const latexToolingController = new LatexToolingController({
-    checkToolInstalled: (tool) => checkToolInstalled(tool, false),
-    findPath: (tool) => BinaryResolver.findPath(tool),
-    detectPackageManager,
-    getPlatform: () => normalizePlatform(process.platform),
-    isLatexWorkshopInstalled: () => false,
-    getRecommendedStatus: () => ({
-      outDir: true,
-      autoRevealExclude: true,
-    }),
-    onDetectionError: onError,
   });
   const settingsHost = createSettingsViewHost({
     state: { workspaceState, globalState },
@@ -202,14 +145,6 @@ export function createDesktopSettingsIpc(
     settings = readCurrentGitAuthorSettings(),
   ): void {
     options.postToRenderer(buildGitAuthorSettingsMessage(settings));
-  }
-
-  function postLatexConfigValues(): void {
-    options.postToRenderer(
-      latexConfigPersistenceController.buildConfigMessage((key) =>
-        workspaceState.get(key),
-      ),
-    );
   }
 
   async function postModelSelectionData(): Promise<void> {
@@ -254,30 +189,6 @@ export function createDesktopSettingsIpc(
   async function openMemoryFolder(): Promise<void> {
     await StorageFS.ensureDir(resolveMemoryStoragePath());
     await options.openPath?.(StorageFS.fullPath(resolveMemoryStoragePath()));
-  }
-
-  async function postToolDashboardData(postOptions?: {
-    skipChecks?: boolean;
-  }): Promise<void> {
-    const cachedResults =
-      postOptions?.skipChecks && usesDefaultToolDashboardBuilder
-        ? await getCachedToolCheckResults()
-        : undefined;
-    const items = await buildToolDashboardItems(cachedResults);
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
-      items,
-    });
-  }
-
-  async function postLatexSettingsStatus(): Promise<void> {
-    const settings =
-      (await options.detectLatexSettingsStatus?.()) ??
-      (await latexToolingController.detectStatus());
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
-      settings,
-    });
   }
 
   function postDesktopCrashReportingStatusMessage(
@@ -336,7 +247,7 @@ export function createDesktopSettingsIpc(
 
   async function postInitialSettingsData(): Promise<void> {
     postGitAuthorSettings();
-    postLatexConfigValues();
+    options.toolingSettingsController.postLatexConfigValues();
     postGoalList();
     const memoryEnabledPosted = postMemoryEnabled();
     const modelSelectionDataPosted = postModelSelectionData();
@@ -348,10 +259,9 @@ export function createDesktopSettingsIpc(
       historyHandlers.postHistoryData(),
       modelSelectionDataPosted,
       options.credentialSettingsController.postStartupData(),
-      postLatexSettingsStatus(),
+      options.toolingSettingsController.postStartupData(),
       postDesktopCrashReportingStatus(),
       options.agentSettingsController.postStartupData(),
-      postToolDashboardData(),
     ]);
   }
 
@@ -361,24 +271,6 @@ export function createDesktopSettingsIpc(
   ): Promise<void> {
     await workspaceState.update(key, value);
     postGitAuthorSettings(applyCurrentGitAuthorSettings());
-  }
-
-  async function updateLatexConfigValue(input: {
-    field: LatexConfigField;
-    value: unknown;
-  }): Promise<void> {
-    const plan = latexConfigPersistenceController.planUpdate(input);
-    if (!plan.ok) {
-      onError(
-        new Error(`Invalid LaTeX config value for ${input.field}`, {
-          cause: plan.error,
-        }),
-      );
-      return;
-    }
-
-    await workspaceState.update(plan.update.key, plan.update.value);
-    postLatexConfigValues();
   }
 
   async function updateModelEnabled(input: {
@@ -455,44 +347,6 @@ export function createDesktopSettingsIpc(
   ): Promise<void> {
     await workspaceState.update(key, enabled);
     postSuperYoloEnabled();
-  }
-
-  async function setToolEnabled(
-    toolId: string,
-    enabled: boolean,
-  ): Promise<void> {
-    const current = globalState.get<string[]>(
-      GlobalStateKey.DISABLED_TOOLS,
-      [],
-    );
-    const disabled = new Set(current);
-    if (enabled) {
-      disabled.delete(toolId);
-    } else {
-      disabled.add(toolId);
-    }
-    await globalState.update(GlobalStateKey.DISABLED_TOOLS, [...disabled]);
-    if (usesDefaultToolDashboardBuilder) {
-      await refreshDefaultDisabledToolCache();
-    }
-    await postToolDashboardData({ skipChecks: true });
-  }
-
-  async function recheckToolStatus(): Promise<void> {
-    const didRefresh = refreshToolAvailability != null;
-    if (didRefresh) {
-      await refreshToolAvailability();
-    }
-    await postToolDashboardData({ skipChecks: didRefresh });
-  }
-
-  async function runToolCommand(input: {
-    toolId: string;
-    kind: 'install' | 'auth';
-  }): Promise<void> {
-    const command = await findToolCommand(input.toolId, input.kind);
-    if (!command) return;
-    await options.runToolCommand?.({ ...input, command });
   }
 
   function runAsync(work: Promise<void>): void {
@@ -599,32 +453,8 @@ export function createDesktopSettingsIpc(
       setClaudeAgentEffort: (effort) =>
         setAgent(StateKeys.CLAUDE_AGENT_EFFORT, effort),
     },
-    tools: {
-      openInstallUrl: (url) =>
-        options.openExternalUrl?.(url) ?? Promise.resolve(),
-      installExtension: (extensionId) =>
-        options.installToolExtension?.(extensionId) ?? Promise.resolve(),
-      recheckStatus: () => recheckToolStatus(),
-      toggle: (toolId, enabled) => setToolEnabled(toolId, enabled),
-      runCommand: ({ toolId, kind }) => runToolCommand({ toolId, kind }),
-    },
-    latex: {
-      applySettings: () => postLatexSettingsStatus(),
-      installLatexWorkshop: () =>
-        options.installToolExtension?.(LATEX_WORKSHOP_EXT_ID) ??
-        Promise.resolve(),
-      runInstallCommand: (installCommand) => {
-        if (!isAllowedLatexInstallCommand(installCommand)) {
-          onError(
-            new Error(`Rejected unknown install command: ${installCommand}`),
-          );
-          return;
-        }
-        return options.runInstallCommand?.(installCommand) ?? Promise.resolve();
-      },
-      setConfigValue: ({ field, value }) =>
-        updateLatexConfigValue({ field, value }),
-    },
+    tools: options.toolingSettingsController.toolsActions,
+    latex: options.toolingSettingsController.latexActions,
     inlineCriticism: {
       getEnabled: unsupported(
         'Inline criticism is not available in the desktop app yet.',
@@ -667,7 +497,7 @@ export function createDesktopSettingsIpc(
             runAsync(postInitialSettingsData());
           } else {
             postGitAuthorSettings();
-            postLatexConfigValues();
+            options.toolingSettingsController.postLatexConfigValues();
             postGoalList();
           }
         }

--- a/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
+++ b/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
@@ -43,6 +43,11 @@ export async function refreshDefaultDisabledToolCache(): Promise<void> {
   refreshDisabledToolCache();
 }
 
+export async function refreshDefaultToolAvailability(): Promise<void> {
+  const { refreshToolAvailability } = await import('@tools/toolAvailability');
+  await refreshToolAvailability();
+}
+
 export async function findToolCommand(
   toolId: string,
   kind: 'install' | 'auth',

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -16,7 +16,7 @@ import type { SettingsStatePorts } from '@shared/settingsView/types';
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
 
-export interface DesktopToolDashboardPort {
+interface DesktopToolDashboardPort {
   buildItems(
     cachedResults?: ExternalToolCheckResult[],
   ): Promise<ToolDashboardItem[]>;
@@ -29,20 +29,20 @@ export interface DesktopToolDashboardPort {
   ): Promise<string | undefined>;
 }
 
-export interface DesktopToolingRendererPort {
+interface DesktopToolingRendererPort {
   postToRenderer(message: unknown): void;
 }
 
-export interface DesktopToolingNavigationPort {
+interface DesktopToolingNavigationPort {
   openExternal(url: string): Promise<void>;
   presentExtensionInstall(extensionId: string): Promise<void>;
 }
 
-export interface DesktopToolingCommandPort {
+interface DesktopToolingCommandPort {
   run(command: string): Promise<void>;
 }
 
-export interface DefaultDesktopToolingSettingsControllerOptions extends SettingsStatePorts {
+interface DefaultDesktopToolingSettingsControllerOptions extends SettingsStatePorts {
   readonly renderer: DesktopToolingRendererPort;
   readonly dashboard: DesktopToolDashboardPort;
   readonly navigation: DesktopToolingNavigationPort;
@@ -156,11 +156,7 @@ export class DefaultDesktopToolingSettingsController implements DesktopToolingSe
       input.toolId,
       input.kind,
     );
-    if (!command) {
-      throw new Error(
-        `No ${input.kind} command is configured for tool "${input.toolId}".`,
-      );
-    }
+    if (!command) return;
     await this.options.commands.run(command);
   }
 

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,0 +1,191 @@
+// Local imports - shared settings controllers
+import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
+import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
+import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
+
+// Local imports - shared settings types
+import {
+  LATEX_WORKSHOP_EXT_ID,
+  type LatexConfigField,
+} from '@shared/constants/latex';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
+
+// Local imports - tool dashboard types
+import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+import type { ExternalToolCheckResult } from '@tools/toolAvailability';
+
+export interface DesktopToolDashboardPort {
+  buildItems(
+    cachedResults?: ExternalToolCheckResult[],
+  ): Promise<ToolDashboardItem[]>;
+  getCachedCheckResults(): Promise<ExternalToolCheckResult[] | undefined>;
+  refreshAvailability(): Promise<void>;
+  refreshDisabledCache(): Promise<void>;
+  findCommand(
+    toolId: string,
+    kind: 'install' | 'auth',
+  ): Promise<string | undefined>;
+}
+
+export interface DesktopToolingRendererPort {
+  postToRenderer(message: unknown): void;
+}
+
+export interface DesktopToolingNavigationPort {
+  openExternal(url: string): Promise<void>;
+  presentExtensionInstall(extensionId: string): Promise<void>;
+}
+
+export interface DesktopToolingCommandPort {
+  run(command: string): Promise<void>;
+}
+
+export interface DefaultDesktopToolingSettingsControllerOptions extends SettingsStatePorts {
+  readonly renderer: DesktopToolingRendererPort;
+  readonly dashboard: DesktopToolDashboardPort;
+  readonly navigation: DesktopToolingNavigationPort;
+  readonly commands: DesktopToolingCommandPort;
+  readonly latexToolingController: LatexToolingController;
+  readonly latexConfigPersistenceController: LatexConfigPersistenceController;
+}
+
+export interface DesktopToolingSettingsController {
+  readonly toolsActions: SettingsViewCommandActions['tools'];
+  readonly latexActions: SettingsViewCommandActions['latex'];
+  postLatexConfigValues(): void;
+  postStartupData(): Promise<void>;
+}
+
+/** Owns the desktop settings Tools and LaTeX domains. */
+export class DefaultDesktopToolingSettingsController implements DesktopToolingSettingsController {
+  readonly toolsActions: SettingsViewCommandActions['tools'];
+  readonly latexActions: SettingsViewCommandActions['latex'];
+
+  private readonly latexConfigPersistenceController: LatexConfigPersistenceController;
+
+  constructor(
+    private readonly options: DefaultDesktopToolingSettingsControllerOptions,
+  ) {
+    this.latexConfigPersistenceController =
+      options.latexConfigPersistenceController;
+    this.toolsActions = {
+      openInstallUrl: (url) => options.navigation.openExternal(url),
+      installExtension: (extensionId) =>
+        options.navigation.presentExtensionInstall(extensionId),
+      recheckStatus: () => this.recheckToolStatus(),
+      toggle: (toolId, enabled) => this.setToolEnabled(toolId, enabled),
+      runCommand: (input) => this.runToolCommand(input),
+    };
+    this.latexActions = {
+      applySettings: () => this.postLatexSettingsStatus(),
+      installLatexWorkshop: () =>
+        options.navigation.presentExtensionInstall(LATEX_WORKSHOP_EXT_ID),
+      runInstallCommand: (command) => this.runLatexInstallCommand(command),
+      setConfigValue: (input) => this.updateLatexConfigValue(input),
+    };
+  }
+
+  postLatexConfigValues(): void {
+    this.options.renderer.postToRenderer(
+      this.latexConfigPersistenceController.buildConfigMessage((key) =>
+        this.options.workspaceState.get(key),
+      ),
+    );
+  }
+
+  async postStartupData(): Promise<void> {
+    await Promise.all([
+      this.postToolDashboardData(),
+      this.postLatexSettingsStatus(),
+    ]);
+  }
+
+  private async postToolDashboardData(useCachedResults = false): Promise<void> {
+    const cachedResults = useCachedResults
+      ? await this.options.dashboard.getCachedCheckResults()
+      : undefined;
+    const items = await this.options.dashboard.buildItems(cachedResults);
+    this.options.renderer.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items,
+    });
+  }
+
+  private async postLatexSettingsStatus(): Promise<void> {
+    const settings = await this.options.latexToolingController.detectStatus();
+    this.options.renderer.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
+      settings,
+    });
+  }
+
+  private async setToolEnabled(
+    toolId: string,
+    enabled: boolean,
+  ): Promise<void> {
+    const current = this.options.globalState.get<string[]>(
+      GlobalStateKey.DISABLED_TOOLS,
+      [],
+    );
+    const disabled = new Set(current);
+    if (enabled) {
+      disabled.delete(toolId);
+    } else {
+      disabled.add(toolId);
+    }
+
+    await this.options.globalState.update(GlobalStateKey.DISABLED_TOOLS, [
+      ...disabled,
+    ]);
+    await this.options.dashboard.refreshDisabledCache();
+    await this.postToolDashboardData(true);
+  }
+
+  private async recheckToolStatus(): Promise<void> {
+    await this.options.dashboard.refreshAvailability();
+    await this.postToolDashboardData(true);
+  }
+
+  private async runToolCommand(input: {
+    toolId: string;
+    kind: 'install' | 'auth';
+  }): Promise<void> {
+    const command = await this.options.dashboard.findCommand(
+      input.toolId,
+      input.kind,
+    );
+    if (!command) {
+      throw new Error(
+        `No ${input.kind} command is configured for tool "${input.toolId}".`,
+      );
+    }
+    await this.options.commands.run(command);
+  }
+
+  private async runLatexInstallCommand(command: string): Promise<void> {
+    if (!this.options.latexToolingController.isAllowedInstallCommand(command)) {
+      throw new Error(`Rejected unknown install command: ${command}`);
+    }
+    await this.options.commands.run(command);
+  }
+
+  private async updateLatexConfigValue(input: {
+    field: LatexConfigField;
+    value: unknown;
+  }): Promise<void> {
+    const plan = this.latexConfigPersistenceController.planUpdate(input);
+    if (!plan.ok) {
+      throw new Error(`Invalid LaTeX config value for ${input.field}`, {
+        cause: plan.error,
+      });
+    }
+
+    await this.options.workspaceState.update(
+      plan.update.key,
+      plan.update.value,
+    );
+    this.postLatexConfigValues();
+  }
+}

--- a/packages/desktop/src/main/desktopToolingSettingsController.ts
+++ b/packages/desktop/src/main/desktopToolingSettingsController.ts
@@ -1,20 +1,20 @@
 // Local imports - shared settings controllers
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
-import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
 
 // Local imports - shared settings types
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   LATEX_WORKSHOP_EXT_ID,
   type LatexConfigField,
 } from '@shared/constants/latex';
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 
-// Local imports - tool dashboard types
+// Local imports - controller and tool dashboard types
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
+import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
 
 interface DesktopToolDashboardPort {
   buildItems(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -14,6 +14,8 @@ import {
 
 import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
+import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
+import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import {
   computeAgentOptionsData,
   getAgent,
@@ -28,6 +30,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import type { TerminalRunResult } from '@hosts/uiHosts';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
+import { normalizePlatform } from '@shared/constants/latex';
 import {
   AgentCategory,
   agentKeyOf,
@@ -36,6 +39,11 @@ import {
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
+import { BinaryResolver } from '@utils/system/binaryResolver';
+import {
+  checkToolInstalled,
+  detectPackageManager,
+} from '@utils/system/toolUtils';
 import { setDesktopAgentResumeHandler } from './desktopAgentResume.js';
 import {
   openDesktopStreamSnapshotStore,
@@ -62,6 +70,14 @@ import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import { DefaultDesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
+import {
+  buildDefaultToolDashboardItems,
+  findToolCommand,
+  getCachedToolCheckResults,
+  refreshDefaultDisabledToolCache,
+  refreshDefaultToolAvailability,
+} from './desktopSettingsIpcHelpers.js';
+import { DefaultDesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 import { createDesktopGitHost } from './desktopGitHost.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
 import {
@@ -757,10 +773,68 @@ function createWindow(options: {
       },
       onError: reportAsyncError,
     });
+  const presentExtensionInstall = async (extensionId: string) => {
+    // TeXRA Desktop cannot host VS Code extensions. This action explicitly
+    // offers navigation to the VS Code marketplace or the extension id.
+    const result = await dialog.showMessageBox(window, {
+      type: 'info',
+      message: 'VS Code extension referenced',
+      detail:
+        `${extensionId}\n\n` +
+        'TeXRA Desktop runs standalone and cannot host VS Code extensions. ' +
+        'If you also use VS Code, you can install this extension there.',
+      buttons: ['Open in Marketplace', 'Copy ID', 'Close'],
+      defaultId: 0,
+      cancelId: 2,
+    });
+    if (result.response === 0) {
+      await previewHost.openExternal(
+        `https://marketplace.visualstudio.com/items?itemName=${encodeURIComponent(extensionId)}`,
+      );
+    } else if (result.response === 1) {
+      clipboard.writeText(extensionId);
+    }
+  };
+  const toolingSettingsController = new DefaultDesktopToolingSettingsController(
+    {
+      workspaceState: platform().workspaceState,
+      globalState: platform().globalState,
+      renderer: {
+        postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+      },
+      dashboard: {
+        buildItems: buildDefaultToolDashboardItems,
+        getCachedCheckResults: getCachedToolCheckResults,
+        refreshAvailability: refreshDefaultToolAvailability,
+        refreshDisabledCache: refreshDefaultDisabledToolCache,
+        findCommand: findToolCommand,
+      },
+      navigation: {
+        openExternal: previewHost.openExternal,
+        presentExtensionInstall,
+      },
+      commands: { run: runSetupCommand },
+      latexToolingController: new LatexToolingController({
+        checkToolInstalled: (tool) => checkToolInstalled(tool, false),
+        findPath: (tool) => BinaryResolver.findPath(tool),
+        detectPackageManager,
+        getPlatform: () => normalizePlatform(process.platform),
+        // Extension hosting is deliberately unavailable in TeXRA Desktop.
+        isLatexWorkshopInstalled: () => false,
+        getRecommendedStatus: () => ({
+          outDir: true,
+          autoRevealExclude: true,
+        }),
+        onDetectionError: reportAsyncError,
+      }),
+      latexConfigPersistenceController: new LatexConfigPersistenceController(),
+    },
+  );
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     agentSettingsController,
     credentialSettingsController,
+    toolingSettingsController,
     sendStartupCatalogData: true,
     resourcesPath: options.resourcesPath,
     // Rerun/Restore from history: same host-neutral owners the extension's
@@ -794,43 +868,6 @@ function createWindow(options: {
       } catch (error) {
         if (!windowClosed) reportAsyncError(error);
       }
-    },
-    openExternalUrl: (url) => previewHost.openExternal(url),
-    installToolExtension: async (extensionId) => {
-      // The desktop shell can't host VS Code extensions, so opening the
-      // marketplace URL was misleading. Surface an info dialog that names
-      // the extension and lets the user open the marketplace listing only
-      // if they explicitly want to install it inside VS Code. The 'Copy ID'
-      // button gives them the bare extension id for `code --install-extension`.
-      const result = await dialog.showMessageBox(window, {
-        type: 'info',
-        message: 'VS Code extension referenced',
-        detail:
-          `${extensionId}\n\n` +
-          'TeXRA Desktop runs standalone and cannot host VS Code extensions. ' +
-          'If you also use VS Code, you can install this extension there.',
-        buttons: ['Open in Marketplace', 'Copy ID', 'Close'],
-        defaultId: 0,
-        cancelId: 2,
-      });
-      if (result.response === 0) {
-        await previewHost.openExternal(
-          `https://marketplace.visualstudio.com/items?itemName=${encodeURIComponent(extensionId)}`,
-        );
-      } else if (result.response === 1) {
-        clipboard.writeText(extensionId);
-      }
-    },
-    runToolCommand: async ({ command }) => {
-      await runSetupCommand(command);
-    },
-    refreshToolAvailability: async () => {
-      const { refreshToolAvailability } =
-        await import('@tools/toolAvailability');
-      await refreshToolAvailability();
-    },
-    runInstallCommand: async (command) => {
-      await runSetupCommand(command);
     },
     onError: reportAsyncError,
   });

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -2,10 +2,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import type { LatexSettingsStatus } from '@shared/schemas/settingsViewMessages';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/constants/git';
-import { HOMEBREW_INSTALL_COMMAND } from '@shared/constants/latex';
 import {
   isWorktreeSupportEnabled,
   setWorktreeSupportEnabled,
@@ -17,6 +15,7 @@ import {
   createStubDesktopAgentSettingsController,
   createStubDesktopCredentialSettingsController,
   createStubDesktopHistoryOptions,
+  createStubDesktopToolingSettingsController,
 } from './desktopSettingsTestSupport';
 import type { StateStore } from '@platform/interfaces';
 
@@ -48,11 +47,13 @@ type SettingsFixtureOverrides = Omit<
   Partial<DesktopSettingsIpcOptions>,
   | 'agentSettingsController'
   | 'credentialSettingsController'
+  | 'toolingSettingsController'
   | 'postToRenderer'
   | keyof DesktopHistoryOptions
 > & {
   agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
   credentialSettingsController?: DesktopSettingsIpcOptions['credentialSettingsController'];
+  toolingSettingsController?: DesktopSettingsIpcOptions['toolingSettingsController'];
   history?: Partial<DesktopHistoryOptions>;
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
 };
@@ -160,6 +161,7 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const { history, ...settingsOverrides } = overrides;
   const globalState = overrides.globalState ?? new MemoryStateStore();
   const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
+  const postToRenderer = overrides.postToRenderer ?? (() => undefined);
   const settings = createDesktopSettingsIpc({
     ...settingsOverrides,
     ...createStubDesktopHistoryOptions(history),
@@ -172,8 +174,17 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
         globalState,
         workspaceState,
       }),
+    toolingSettingsController:
+      overrides.toolingSettingsController ??
+      createStubDesktopToolingSettingsController({
+        postLatexConfigValues: () =>
+          postToRenderer({
+            command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+            values: {},
+          }),
+      }),
     globalState,
-    postToRenderer: overrides.postToRenderer ?? (() => undefined),
+    postToRenderer,
     workspaceState,
   });
   return { globalState, settings, workspaceState };
@@ -209,28 +220,6 @@ function createDeferred(): {
 
 function commandOf(message: unknown): string | undefined {
   return (message as { command?: string }).command;
-}
-
-function inactiveLatexSettingsStatus(): LatexSettingsStatus {
-  return {
-    outDir: true,
-    autoRevealExclude: true,
-    texDistributionInstalled: false,
-    latexWorkshopInstalled: false,
-    latexdiffInstalled: false,
-    latexindentInstalled: false,
-    texcountInstalled: false,
-    imageProcessingInstalled: false,
-    platform: 'linux',
-    pdflatexPath: null,
-    latexmkPath: null,
-    latexdiffPath: null,
-    latexindentPath: null,
-    texcountPath: null,
-    ghostscriptPath: null,
-    graphicsmagickPath: null,
-    packageManager: null,
-  };
 }
 
 describe('desktop settings IPC', () => {
@@ -503,49 +492,51 @@ describe('desktop settings IPC', () => {
     expect(revealed).toEqual(['goal-owning-stream']);
   });
 
-  it('runs allowlisted LaTeX install commands through the desktop host', async () => {
-    const commands: string[] = [];
-
-    const { settings } = createSettingsFixture({
-      runInstallCommand: async (command) => {
-        commands.push(command);
-      },
-    });
+  it('delegates Tools and LaTeX commands to the required controller', async () => {
+    const baseController = createStubDesktopToolingSettingsController();
+    const toggle = vi.fn(async () => undefined);
+    const runInstallCommand = vi.fn(async () => undefined);
+    const setConfigValue = vi.fn(async () => undefined);
+    const toolingSettingsController =
+      createStubDesktopToolingSettingsController({
+        toolsActions: { ...baseController.toolsActions, toggle },
+        latexActions: {
+          ...baseController.latexActions,
+          runInstallCommand,
+          setConfigValue,
+        },
+      });
+    const { settings } = createSettingsFixture({ toolingSettingsController });
 
     expect(
       settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL,
+        toolId: 'zotero',
+        enabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      settings.handleMessage({
         command: SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND,
-        installCommand: HOMEBREW_INSTALL_COMMAND,
+        installCommand: 'brew install --cask mactex-no-gui',
+      }),
+    ).toBe(true);
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+        field: 'latexFormatter',
+        value: 'none',
       }),
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(commands).toEqual([HOMEBREW_INSTALL_COMMAND]);
-  });
-
-  it('rejects unknown desktop LaTeX install commands', async () => {
-    const commands: string[] = [];
-    const errors: unknown[] = [];
-
-    const { settings } = createSettingsFixture({
-      runInstallCommand: async (command) => {
-        commands.push(command);
-      },
-      onError: (error) => errors.push(error),
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND,
-        installCommand: 'echo not-allowlisted',
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(commands).toEqual([]);
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatchObject({
-      message: 'Rejected unknown install command: echo not-allowlisted',
+    expect(toggle).toHaveBeenCalledWith('zotero', false);
+    expect(runInstallCommand).toHaveBeenCalledWith(
+      'brew install --cask mactex-no-gui',
+    );
+    expect(setConfigValue).toHaveBeenCalledWith({
+      field: 'latexFormatter',
+      value: 'none',
     });
   });
 
@@ -602,82 +593,6 @@ describe('desktop settings IPC', () => {
     expect(signOut).toHaveBeenCalledOnce();
     expect(setProviderKey).toHaveBeenCalledWith('google', 'sk-test');
     expect(setPreferSubscription).toHaveBeenCalledWith(true);
-  });
-
-  it('round-trips LaTeX config writes through workspace state and refreshes the renderer', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
-        field: 'latexFormatter',
-        value: 'none',
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-
-    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
-      'none',
-    );
-    expect(posted.at(-1)).toEqual({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
-      values: {
-        latexFormatter: 'none',
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
-        field: 'latexFormatter',
-        value: null,
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-
-    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
-      undefined,
-    );
-    expect(workspaceState.values.has(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
-      false,
-    );
-    expect(posted.at(-1)).toEqual({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
-      values: {},
-    });
-  });
-
-  it('reports invalid LaTeX config writes without mutating workspace state', async () => {
-    const workspaceState = new MemoryStateStore();
-
-    const errors: unknown[] = [];
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      workspaceState,
-      onError: (error) => errors.push(error),
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
-        field: 'latexdiffTimeoutMs',
-        value: 100,
-      }),
-    ).toBe(true);
-    await Promise.resolve();
-
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatchObject({
-      message: 'Invalid LaTeX config value for latexdiffTimeoutMs',
-    });
-    expect(
-      workspaceState.values.has(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
-    ).toBe(false);
-    expect(posted).toEqual([]);
   });
 
   it('persists model settings through global state', async () => {
@@ -752,7 +667,7 @@ describe('desktop settings IPC', () => {
     });
   });
 
-  it('loads desktop tool dashboard and approval settings on settings readiness', async () => {
+  it('delegates tooling startup and posts approval settings on readiness', async () => {
     const workspaceState = new MemoryStateStore();
     workspaceState.values.set(
       WorkspaceStateKey.CODEX_SANDBOX_MODE,
@@ -761,26 +676,22 @@ describe('desktop settings IPC', () => {
     const config = new MemoryConfigStore();
     config.values.set('texra.toolUse.requireBashApproval', false);
     const agentSettingsController = createStubDesktopAgentSettingsController();
-    const postStartupData = vi.fn(async () => undefined);
-    agentSettingsController.postStartupData = postStartupData;
+    const postAgentStartupData = vi.fn(async () => undefined);
+    agentSettingsController.postStartupData = postAgentStartupData;
+    const postToolingStartupData = vi.fn(async () => undefined);
+    const postLatexConfigValues = vi.fn();
+    const toolingSettingsController =
+      createStubDesktopToolingSettingsController({
+        postLatexConfigValues,
+        postStartupData: postToolingStartupData,
+      });
 
     const { settings, posted } = createCapturedSettingsFixture({
       agentSettingsController,
+      toolingSettingsController,
       workspaceState,
       config,
       sendStartupCatalogData: true,
-      buildToolDashboardItems: async () => [
-        {
-          id: 'file-ops',
-          name: 'File & Shell Operations',
-          category: 'file',
-          description: 'Built-in file tools',
-          tools: [],
-          status: 'available',
-          requiresSetup: false,
-        },
-      ],
-      detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
       onError: () => undefined,
     });
 
@@ -792,7 +703,9 @@ describe('desktop settings IPC', () => {
     ).toBe(false);
     await flushAsyncWork();
 
-    expect(postStartupData).toHaveBeenCalledOnce();
+    expect(postLatexConfigValues).toHaveBeenCalledOnce();
+    expect(postToolingStartupData).toHaveBeenCalledOnce();
+    expect(postAgentStartupData).toHaveBeenCalledOnce();
 
     expect(
       posted.find(
@@ -805,15 +718,6 @@ describe('desktop settings IPC', () => {
       bashApprovalEnabled: false,
       codexSandboxMode: 'danger-full-access',
     });
-    expect(
-      posted.find(
-        (message) =>
-          commandOf(message) === SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
-      ),
-    ).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
-      items: [expect.objectContaining({ id: 'file-ops' })],
-    });
   });
 
   it('writes the bash-approval toggle to the workspace config scope, not global', async () => {
@@ -821,7 +725,6 @@ describe('desktop settings IPC', () => {
 
     const { settings, posted } = createCapturedSettingsFixture({
       config,
-      detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
       onError: () => undefined,
     });
 
@@ -867,8 +770,6 @@ describe('desktop settings IPC', () => {
       config: new MemoryConfigStore(),
       sendStartupCatalogData: true,
       credentialSettingsController,
-      buildToolDashboardItems: async () => [],
-      detectLatexSettingsStatus: async () => inactiveLatexSettingsStatus(),
       onError: () => undefined,
     });
 
@@ -907,65 +808,6 @@ describe('desktop settings IPC', () => {
     ).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
     });
-  });
-
-  it('handles desktop tool dashboard refreshes and toggles', async () => {
-    const globalState = new MemoryStateStore();
-
-    let refreshCount = 0;
-    const buildCalls: unknown[][] = [];
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      globalState,
-      config: new MemoryConfigStore(),
-      buildToolDashboardItems: async (cachedResults = []) => {
-        buildCalls.push(cachedResults);
-        return [
-          {
-            id: 'zotero',
-            name: 'Zotero Integration',
-            category: 'academic',
-            description: 'Citation tools',
-            tools: [],
-            status: 'available',
-            requiresSetup: true,
-            toggleable: true,
-            enabled: !(
-              globalState.values.get(GlobalStateKey.DISABLED_TOOLS) as
-                string[] | undefined
-            )?.includes('zotero'),
-          },
-        ];
-      },
-      refreshToolAvailability: async () => {
-        refreshCount++;
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL,
-        toolId: 'zotero',
-        enabled: false,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-    expect(globalState.values.get(GlobalStateKey.DISABLED_TOOLS)).toEqual([
-      'zotero',
-    ]);
-    expect(posted.at(-1)).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
-      items: [expect.objectContaining({ id: 'zotero', enabled: false })],
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-    expect(refreshCount).toBe(1);
-    expect(buildCalls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('refreshes credentials before conditionally refreshing the agent catalog', async () => {

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
@@ -1,0 +1,315 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - settings controllers
+import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
+import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
+import { DefaultDesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
+
+// Local imports - shared settings
+import {
+  HOMEBREW_INSTALL_COMMAND,
+  LATEX_WORKSHOP_EXT_ID,
+} from '@shared/constants/latex';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import { assertSupported } from '@shared/utils/dispatcher';
+
+// Local imports - platform and tool types
+import type { StateStore } from '@platform/interfaces';
+import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+import type { ExternalToolCheckResult } from '@tools/toolAvailability';
+
+class MemoryStateStore implements StateStore {
+  readonly values = new Map<string, unknown>();
+
+  constructor(private readonly onUpdate?: (key: string) => void) {}
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.onUpdate?.(key);
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
+
+const DASHBOARD_ITEM: ToolDashboardItem = {
+  id: 'zotero',
+  name: 'Zotero Integration',
+  category: 'academic',
+  description: 'Citation tools',
+  tools: [],
+  status: 'available',
+  requiresSetup: true,
+  toggleable: true,
+  enabled: true,
+};
+
+type ControllerOptions = ConstructorParameters<
+  typeof DefaultDesktopToolingSettingsController
+>[0];
+
+function createFixture(overrides: Partial<ControllerOptions> = {}) {
+  const posted: unknown[] = [];
+  const commands: string[] = [];
+  const openedUrls: string[] = [];
+  const presentedExtensions: string[] = [];
+  const globalState = overrides.globalState ?? new MemoryStateStore();
+  const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
+  const dashboard: ControllerOptions['dashboard'] = {
+    buildItems: async () => [DASHBOARD_ITEM],
+    getCachedCheckResults: async () => [],
+    refreshAvailability: async () => undefined,
+    refreshDisabledCache: async () => undefined,
+    findCommand: async (toolId, kind) => `${kind}:${toolId}`,
+    ...overrides.dashboard,
+  };
+  const controller = new DefaultDesktopToolingSettingsController({
+    globalState,
+    workspaceState,
+    renderer: {
+      postToRenderer: (message) => posted.push(message),
+    },
+    navigation: {
+      openExternal: async (url) => {
+        openedUrls.push(url);
+      },
+      presentExtensionInstall: async (extensionId) => {
+        presentedExtensions.push(extensionId);
+      },
+    },
+    commands: {
+      run: async (command) => {
+        commands.push(command);
+      },
+    },
+    latexToolingController: new LatexToolingController({
+      checkToolInstalled: async () => false,
+      findPath: () => null,
+      detectPackageManager: () => null,
+      getPlatform: () => 'linux',
+      isLatexWorkshopInstalled: () => false,
+      getRecommendedStatus: () => ({
+        outDir: true,
+        autoRevealExclude: true,
+      }),
+    }),
+    latexConfigPersistenceController: new LatexConfigPersistenceController(),
+    ...overrides,
+    dashboard,
+  });
+
+  return {
+    controller,
+    commands,
+    globalState,
+    openedUrls,
+    posted,
+    presentedExtensions,
+    workspaceState,
+  };
+}
+
+function commandOf(message: unknown): string | undefined {
+  return (message as { command?: string }).command;
+}
+
+describe('DefaultDesktopToolingSettingsController', () => {
+  it('posts the initial dashboard and LaTeX status', async () => {
+    const { controller, posted } = createFixture();
+
+    controller.postLatexConfigValues();
+    await controller.postStartupData();
+
+    expect(posted.map(commandOf)).toEqual([
+      SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
+    ]);
+  });
+
+  it('persists a toggle before refreshing caches and posting cached data', async () => {
+    const events: string[] = [];
+    const cachedResults: ExternalToolCheckResult[] = [];
+    const globalState = new MemoryStateStore(() => events.push('state:update'));
+    const { controller } = createFixture({
+      globalState,
+      renderer: {
+        postToRenderer: () => events.push('renderer:post'),
+      },
+      dashboard: {
+        buildItems: async (results) => {
+          expect(results).toBe(cachedResults);
+          events.push('dashboard:build');
+          return [DASHBOARD_ITEM];
+        },
+        getCachedCheckResults: async () => {
+          events.push('dashboard:cached');
+          return cachedResults;
+        },
+        refreshAvailability: async () => undefined,
+        refreshDisabledCache: async () => {
+          events.push('dashboard:disabled');
+        },
+        findCommand: async () => undefined,
+      },
+    });
+
+    await assertSupported(controller.toolsActions.toggle)('zotero', false);
+
+    expect(globalState.values.get(GlobalStateKey.DISABLED_TOOLS)).toEqual([
+      'zotero',
+    ]);
+    expect(events).toEqual([
+      'state:update',
+      'dashboard:disabled',
+      'dashboard:cached',
+      'dashboard:build',
+      'renderer:post',
+    ]);
+  });
+
+  it('completes a fresh availability check before rebuilding the dashboard', async () => {
+    const events: string[] = [];
+    const { controller } = createFixture({
+      renderer: {
+        postToRenderer: () => events.push('renderer:post'),
+      },
+      dashboard: {
+        buildItems: async () => {
+          events.push('dashboard:build');
+          return [DASHBOARD_ITEM];
+        },
+        getCachedCheckResults: async () => {
+          events.push('dashboard:cached');
+          return [];
+        },
+        refreshAvailability: async () => {
+          events.push('dashboard:refresh');
+        },
+        refreshDisabledCache: async () => undefined,
+        findCommand: async () => undefined,
+      },
+    });
+
+    await assertSupported(controller.toolsActions.recheckStatus)();
+
+    expect(events).toEqual([
+      'dashboard:refresh',
+      'dashboard:cached',
+      'dashboard:build',
+      'renderer:post',
+    ]);
+  });
+
+  it('resolves tool commands before execution and rejects missing commands', async () => {
+    const findCommand = vi
+      .fn<ControllerOptions['dashboard']['findCommand']>()
+      .mockResolvedValueOnce('npm install codex')
+      .mockResolvedValueOnce(undefined);
+    const { controller, commands } = createFixture({
+      dashboard: {
+        buildItems: async () => [],
+        getCachedCheckResults: async () => [],
+        refreshAvailability: async () => undefined,
+        refreshDisabledCache: async () => undefined,
+        findCommand,
+      },
+    });
+
+    await assertSupported(controller.toolsActions.runCommand)({
+      toolId: 'codex',
+      kind: 'install',
+    });
+    await expect(
+      assertSupported(controller.toolsActions.runCommand)({
+        toolId: 'codex',
+        kind: 'auth',
+      }),
+    ).rejects.toThrow('No auth command is configured for tool "codex".');
+
+    expect(findCommand).toHaveBeenNthCalledWith(1, 'codex', 'install');
+    expect(findCommand).toHaveBeenNthCalledWith(2, 'codex', 'auth');
+    expect(commands).toEqual(['npm install codex']);
+  });
+
+  it('validates LaTeX writes before persistence and reposts after the write', async () => {
+    const events: string[] = [];
+    const workspaceState = new MemoryStateStore(() =>
+      events.push('state:update'),
+    );
+    const { controller, posted } = createFixture({
+      workspaceState,
+      renderer: {
+        postToRenderer: (message) => {
+          posted.push(message);
+          events.push('renderer:post');
+        },
+      },
+    });
+
+    await assertSupported(controller.latexActions.setConfigValue)({
+      field: 'latexFormatter',
+      value: 'none',
+    });
+
+    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      'none',
+    );
+    expect(events).toEqual(['state:update', 'renderer:post']);
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      values: { latexFormatter: 'none' },
+    });
+
+    await expect(
+      assertSupported(controller.latexActions.setConfigValue)({
+        field: 'latexdiffTimeoutMs',
+        value: 100,
+      }),
+    ).rejects.toThrow('Invalid LaTeX config value for latexdiffTimeoutMs');
+    expect(
+      workspaceState.values.has(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
+    ).toBe(false);
+    expect(events).toEqual(['state:update', 'renderer:post']);
+  });
+
+  it('runs only allowlisted LaTeX installation commands', async () => {
+    const { controller, commands } = createFixture();
+
+    await assertSupported(controller.latexActions.runInstallCommand)(
+      HOMEBREW_INSTALL_COMMAND,
+    );
+    await expect(
+      assertSupported(controller.latexActions.runInstallCommand)(
+        'echo not-allowlisted',
+      ),
+    ).rejects.toThrow('Rejected unknown install command: echo not-allowlisted');
+
+    expect(commands).toEqual([HOMEBREW_INSTALL_COMMAND]);
+  });
+
+  it('routes URLs and extension references through explicit navigation', async () => {
+    const { controller, openedUrls, presentedExtensions } = createFixture();
+
+    await assertSupported(controller.toolsActions.openInstallUrl)(
+      'https://example.com/install',
+    );
+    await assertSupported(controller.toolsActions.installExtension)(
+      'publisher.extension',
+    );
+    await assertSupported(controller.latexActions.installLatexWorkshop)();
+
+    expect(openedUrls).toEqual(['https://example.com/install']);
+    expect(presentedExtensions).toEqual([
+      'publisher.extension',
+      LATEX_WORKSHOP_EXT_ID,
+    ]);
+  });
+});

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
@@ -208,7 +208,7 @@ describe('DefaultDesktopToolingSettingsController', () => {
     ]);
   });
 
-  it('resolves tool commands before execution and rejects missing commands', async () => {
+  it('resolves configured tool commands and ignores absent commands', async () => {
     const findCommand = vi
       .fn<ControllerOptions['dashboard']['findCommand']>()
       .mockResolvedValueOnce('npm install codex')
@@ -227,12 +227,10 @@ describe('DefaultDesktopToolingSettingsController', () => {
       toolId: 'codex',
       kind: 'install',
     });
-    await expect(
-      assertSupported(controller.toolsActions.runCommand)({
-        toolId: 'codex',
-        kind: 'auth',
-      }),
-    ).rejects.toThrow('No auth command is configured for tool "codex".');
+    await assertSupported(controller.toolsActions.runCommand)({
+      toolId: 'codex',
+      kind: 'auth',
+    });
 
     expect(findCommand).toHaveBeenNthCalledWith(1, 'codex', 'install');
     expect(findCommand).toHaveBeenNthCalledWith(2, 'codex', 'auth');

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
@@ -7,18 +7,18 @@ import { LatexToolingController } from '@controllers/settingsView/LatexToolingCo
 import { DefaultDesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
 
 // Local imports - shared settings
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   HOMEBREW_INSTALL_COMMAND,
   LATEX_WORKSHOP_EXT_ID,
 } from '@shared/constants/latex';
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { assertSupported } from '@shared/utils/dispatcher';
 
-// Local imports - platform and tool types
-import type { StateStore } from '@platform/interfaces';
+// Local imports - supporting types
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
+import type { StateStore } from '@platform/interfaces';
 
 class MemoryStateStore implements StateStore {
   readonly values = new Map<string, unknown>();

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -3,6 +3,7 @@ import { createModelSelectionController } from '@controllers/settingsView/Settin
 import type { DesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
 import type { DesktopCredentialSettingsController } from '@desktop/main/desktopCredentialSettingsController';
 import type { DesktopHistoryOptions } from '@desktop/main/desktopHistoryHandlers';
+import type { DesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
 
 // Shared imports - settings controllers
 import type { SettingsStatePorts } from '@shared/settingsView/types';
@@ -89,6 +90,29 @@ export function createStubDesktopCredentialSettingsController(
     postStartupData: noOp,
     refreshAuthDependentData: noOp,
     signInChatGpt: noOp,
+    ...overrides,
+  };
+}
+
+export function createStubDesktopToolingSettingsController(
+  overrides: Partial<DesktopToolingSettingsController> = {},
+): DesktopToolingSettingsController {
+  return {
+    toolsActions: {
+      openInstallUrl: noOp,
+      installExtension: noOp,
+      recheckStatus: noOp,
+      toggle: noOp,
+      runCommand: noOp,
+    },
+    latexActions: {
+      applySettings: noOp,
+      installLatexWorkshop: noOp,
+      runInstallCommand: noOp,
+      setConfigValue: noOp,
+    },
+    postLatexConfigValues: () => undefined,
+    postStartupData: noOp,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Extract desktop tool-dashboard and LaTeX settings behavior from the general settings IPC into one required controller
composed by the Electron host.

Closes #8424.

## Design

`DefaultDesktopToolingSettingsController` owns the desktop tool dashboard, availability refresh, tool enablement,
install/auth command resolution, extension-install navigation, LaTeX status detection, and LaTeX configuration writes.

The boundary remains deliberately narrow:

- `SettingsViewHost` continues to own ordinary model-selection commands and all memory behavior.
- Credential, history, goals, approval, Git author, and crash-reporting settings remain outside this controller.
- Production defaults are selected in `main/index.ts`; the IPC factory receives one required controller.
- Tool and LaTeX actions use required structural ports rather than optional callbacks and no-op composition fallbacks.
- A missing tool install/auth command retains the established no-op behavior; this PR changes structure, not policy.

## Acceptance gates

- Desktop composition constructs one required tool/LaTeX settings controller from explicit ports.
- Seven tool and LaTeX callbacks leave `DesktopSettingsIpcOptions`.
- Dashboard refresh, enable/disable, status recheck, install/auth commands, extension navigation, LaTeX allowlisting, and
  LaTeX configuration writes have focused coverage.
- State writes and cache refreshes complete before renderer updates.
- `desktopSettingsIpc.ts` shrinks from 685 to 515 lines while retaining the shared settings host.
- #8406 remains open for the remaining crash-reporting and general host domains; #8425 records the next boundary.

## Net elements (R6)

- Files: 2 added, 5 modified.
- Diff: +673 / -435, net +238.
- Production: +275 / -216, net +59.
- Tests: +398 / -219, net +179.
- Public production surface: one controller class and one controller interface; supporting ports are module-private.
- `DesktopSettingsIpcOptions`: seven optional callbacks removed and one required controller added, net -6 fields.

## Consumer counts (R8)

No command, event, schema, renderer message key, or external package surface changes.

## Host impact

- Desktop: tool and LaTeX settings capabilities are required at composition time; runtime behavior and wire messages are
  preserved.
- Extension: no change.
- CLI: no change.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 50 unchanged warnings)
- focused desktop tooling and settings tests: 24 passed
- independent architecture and behavior review
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors settings IPC composition and moves global/workspace state updates plus shell command execution for tools/LaTeX; wire protocol is unchanged but error paths now rely on thrown errors from the controller.
> 
> **Overview**
> Moves **desktop Tools and LaTeX settings** out of `createDesktopSettingsIpc` into a required **`DefaultDesktopToolingSettingsController`**, wired from `main/index.ts` with explicit ports (dashboard, navigation, setup commands, LaTeX controllers).
> 
> **`desktopSettingsIpc.ts`** drops seven optional callbacks (`buildToolDashboardItems`, `refreshToolAvailability`, `runToolCommand`, `runInstallCommand`, `openExternalUrl`, `installToolExtension`, `detectLatexSettingsStatus`) and instead forwards `tools` / `latex` handler actions plus startup posts (`postLatexConfigValues`, `postStartupData`) to the controller.
> 
> The new controller owns tool-dashboard renderer updates, disabled-tool persistence, availability recheck, install/auth command resolution, LaTeX status/config messaging, and allowlisted LaTeX install commands (invalid config/install commands **throw** rather than being handled inline in IPC).
> 
> **`desktopSettingsIpcHelpers.ts`** adds `refreshDefaultToolAvailability` for the default dashboard port.
> 
> Tests shift from IPC integration coverage to **delegation stubs** in `DesktopSettingsIpc.vitest.mts` plus a dedicated **`DesktopToolingSettingsController.vitest.mts`** for ordering (state/cache before renderer) and policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2711b04c91e4c24ece8738e5343bd503ca2a1aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->