### PR TITLE
refactor(desktop): isolate crash-reporting settings

### DIFF
--- a/packages/desktop/src/main/desktopCrashReportingSettingsController.ts
+++ b/packages/desktop/src/main/desktopCrashReportingSettingsController.ts
@@ -1,0 +1,98 @@
+// Local imports - shared settings
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+
+// Local imports - crash-reporting settings
+import {
+  getDesktopCrashReportingStatus,
+  setDesktopCrashReportingDsn,
+  setDesktopCrashReportingEnabled,
+} from './desktopCrashReporting.js';
+
+// Local imports - supporting types
+import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
+import type { StateStore } from '@platform/interfaces';
+import type { PlatformSecrets } from '@platform/secrets';
+
+interface DesktopCrashReportingRendererPort {
+  postToRenderer(message: unknown): void;
+}
+
+interface DesktopCrashReportingPromptPort {
+  input(input: { title: string; prompt: string }): Promise<string | undefined>;
+}
+
+interface DesktopCrashReportingInitializationPort {
+  initialize(): Promise<void>;
+}
+
+interface DesktopCrashReportingSettingsControllerOptions {
+  readonly state: StateStore;
+  readonly secrets: PlatformSecrets;
+  readonly renderer: DesktopCrashReportingRendererPort;
+  readonly prompt: DesktopCrashReportingPromptPort;
+  readonly initialization: DesktopCrashReportingInitializationPort;
+}
+
+export interface DesktopCrashReportingSettingsController {
+  readonly actions: SettingsViewCommandActions['desktopCrashReporting'];
+  postStartupData(): Promise<void>;
+}
+
+/** Owns desktop crash-reporting settings state and renderer updates. */
+export class DefaultDesktopCrashReportingSettingsController implements DesktopCrashReportingSettingsController {
+  readonly actions: SettingsViewCommandActions['desktopCrashReporting'];
+
+  constructor(
+    private readonly options: DesktopCrashReportingSettingsControllerOptions,
+  ) {
+    this.actions = {
+      get: () => this.postStatus(),
+      setEnabled: (enabled) => this.setEnabled(enabled),
+      setDsn: () => this.promptForDsn(),
+    };
+  }
+
+  async postStartupData(): Promise<void> {
+    await this.postStatus();
+  }
+
+  private async postStatus(): Promise<void> {
+    const status = await getDesktopCrashReportingStatus(
+      this.options.state,
+      this.options.secrets,
+    );
+    this.options.renderer.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+      ...status,
+    });
+  }
+
+  private async finishSettingsChange(): Promise<void> {
+    const status = await getDesktopCrashReportingStatus(
+      this.options.state,
+      this.options.secrets,
+    );
+    if (status.enabled && status.configured) {
+      await this.options.initialization.initialize();
+    }
+    this.options.renderer.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+      ...status,
+    });
+  }
+
+  private async setEnabled(enabled: boolean): Promise<void> {
+    await setDesktopCrashReportingEnabled(this.options.state, enabled);
+    await this.finishSettingsChange();
+  }
+
+  private async promptForDsn(): Promise<void> {
+    const dsn = await this.options.prompt.input({
+      title: 'Set Sentry DSN',
+      prompt: 'Enter the Sentry DSN for opt-in desktop crash reports',
+    });
+    if (dsn == null) return;
+    await setDesktopCrashReportingDsn(this.options.secrets, dsn);
+    await this.finishSettingsChange();
+  }
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,4 +1,4 @@
-import { platform, tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
@@ -30,13 +30,7 @@ import {
   buildGitAuthorSettingsMessage,
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
-import {
-  type DesktopCrashReportingStatus,
-  getDesktopCrashReportingStatus,
-  setDesktopCrashReportingDsn,
-  setDesktopCrashReportingEnabled,
-} from './desktopCrashReporting.js';
-import { defaultOnError, emptySecrets } from './desktopSettingsIpcHelpers.js';
+import { defaultOnError } from './desktopSettingsIpcHelpers.js';
 import {
   createDesktopErrorReporter,
   type DesktopCommandMessage,
@@ -47,14 +41,15 @@ import {
   type DesktopHistoryOptions,
 } from './desktopHistoryHandlers.js';
 import type { ConfigProvider, StateStore } from '@platform/interfaces';
-import type { PlatformSecrets } from '@platform/secrets';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
+import type { DesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
 export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   postToRenderer(message: unknown): void;
   agentSettingsController: DesktopAgentSettingsController;
+  crashReportingSettingsController: DesktopCrashReportingSettingsController;
   credentialSettingsController: DesktopCredentialSettingsController;
   toolingSettingsController: DesktopToolingSettingsController;
   sendStartupCatalogData?: boolean;
@@ -64,15 +59,9 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   openPath?: (filePath: string) => Promise<void>;
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
-  promptSecret?: (input: {
-    title: string;
-    prompt: string;
-  }) => Promise<string | undefined>;
   showInfoMessage?: (message: string) => Promise<void>;
   showErrorMessage?: (message: string) => Promise<void>;
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
-  initializeCrashReporting?: () => Promise<void>;
-  secrets?: PlatformSecrets;
   onError?: (error: unknown) => void;
 }
 
@@ -106,7 +95,6 @@ export function createDesktopSettingsIpc(
     showErrorMessage: options.showErrorMessage,
     onError,
   });
-  const secrets = options.secrets ?? tryPlatform()?.secrets ?? emptySecrets;
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),
   });
@@ -191,28 +179,6 @@ export function createDesktopSettingsIpc(
     await options.openPath?.(StorageFS.fullPath(resolveMemoryStoragePath()));
   }
 
-  function postDesktopCrashReportingStatusMessage(
-    status: DesktopCrashReportingStatus,
-  ): void {
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
-      ...status,
-    });
-  }
-
-  async function postDesktopCrashReportingStatus(): Promise<void> {
-    const status = await getDesktopCrashReportingStatus(globalState, secrets);
-    postDesktopCrashReportingStatusMessage(status);
-  }
-
-  async function finishDesktopCrashReportingSettingsChange(): Promise<void> {
-    const status = await getDesktopCrashReportingStatus(globalState, secrets);
-    if (status.enabled && status.configured) {
-      await options.initializeCrashReporting?.();
-    }
-    postDesktopCrashReportingStatusMessage(status);
-  }
-
   function postSuperYoloEnabled(): void {
     options.postToRenderer(
       buildSuperYoloMessage({
@@ -260,7 +226,7 @@ export function createDesktopSettingsIpc(
       modelSelectionDataPosted,
       options.credentialSettingsController.postStartupData(),
       options.toolingSettingsController.postStartupData(),
-      postDesktopCrashReportingStatus(),
+      options.crashReportingSettingsController.postStartupData(),
       options.agentSettingsController.postStartupData(),
     ]);
   }
@@ -297,23 +263,6 @@ export function createDesktopSettingsIpc(
 
   async function updatePreferShortModelNames(enabled: boolean): Promise<void> {
     await settingsHost.setPreferShortModelNames(enabled);
-  }
-
-  async function updateDesktopCrashReportingEnabled(
-    enabled: boolean,
-  ): Promise<void> {
-    await setDesktopCrashReportingEnabled(globalState, enabled);
-    await finishDesktopCrashReportingSettingsChange();
-  }
-
-  async function updateDesktopCrashReportingDsn(): Promise<void> {
-    const dsn = await options.promptSecret?.({
-      title: 'Set Sentry DSN',
-      prompt: 'Enter the Sentry DSN for opt-in desktop crash reports',
-    });
-    if (dsn == null) return;
-    await setDesktopCrashReportingDsn(secrets, dsn);
-    await finishDesktopCrashReportingSettingsChange();
   }
 
   async function refreshAuthDependentData(
@@ -468,11 +417,7 @@ export function createDesktopSettingsIpc(
       revealStream: (streamId) =>
         options.revealStream?.(streamId) ?? Promise.resolve(),
     },
-    desktopCrashReporting: {
-      get: () => postDesktopCrashReportingStatus(),
-      setEnabled: (enabled) => updateDesktopCrashReportingEnabled(enabled),
-      setDsn: () => updateDesktopCrashReportingDsn(),
-    },
+    desktopCrashReporting: options.crashReportingSettingsController.actions,
   };
 
   const settingsHandlers = createSettingsViewCommandHandlers(settingsActions);

--- a/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
+++ b/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
@@ -1,6 +1,5 @@
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
-import type { PlatformSecrets } from '@platform/secrets';
 
 /**
  * Module-level helpers for the desktop settings IPC. These have no closure
@@ -9,15 +8,6 @@ import type { PlatformSecrets } from '@platform/secrets';
  * helper defers its `@tools` import so the heavy module only loads when a tool
  * dashboard request actually arrives.
  */
-
-export const emptySecrets: PlatformSecrets = {
-  get: () => Promise.resolve(undefined),
-  getStored: () => Promise.resolve(undefined),
-  set: () => Promise.resolve(),
-  delete: () => Promise.resolve(),
-  listStoredKeys: () => Promise.resolve([]),
-  getEnv: () => undefined,
-};
 
 export function defaultOnError(error: unknown): void {
   console.error(error);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -68,6 +68,7 @@ import { refreshDesktopModelListStateIfNeeded } from './desktopModelListRefresh.
 import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsController.js';
+import { DefaultDesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import { DefaultDesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import {
@@ -830,9 +831,23 @@ function createWindow(options: {
       latexConfigPersistenceController: new LatexConfigPersistenceController(),
     },
   );
+  const crashReportingSettingsController =
+    new DefaultDesktopCrashReportingSettingsController({
+      state: platform().globalState,
+      secrets: platform().secrets,
+      renderer: {
+        postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+      },
+      prompt: {
+        input: (input) =>
+          promptInRenderer(window, { ...input, password: true }),
+      },
+      initialization: { initialize: options.initializeCrashReporting },
+    });
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     agentSettingsController,
+    crashReportingSettingsController,
     credentialSettingsController,
     toolingSettingsController,
     sendStartupCatalogData: true,
@@ -845,8 +860,6 @@ function createWindow(options: {
     },
     restoreTaskState: async (taskState) =>
       (await getAgentExecution()).progress.restoreTaskState(taskState),
-    promptSecret: (input) =>
-      promptInRenderer(window, { ...input, password: true }),
     showInfoMessage,
     showErrorMessage,
     confirmAction: async (message, confirmLabel = 'OK') => {
@@ -859,7 +872,6 @@ function createWindow(options: {
       });
       return result.response === 0;
     },
-    initializeCrashReporting: options.initializeCrashReporting,
     openPath: previewHost.openPath,
     revealStream: async (streamId) => {
       try {

--- a/src/test-kernel/desktop/DesktopCrashReportingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCrashReportingSettingsController.vitest.mts
@@ -1,0 +1,216 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - desktop crash reporting
+import { DefaultDesktopCrashReportingSettingsController } from '@desktop/main/desktopCrashReportingSettingsController';
+import { DESKTOP_CRASH_REPORTING_DSN_SECRET } from '@desktop/main/desktopCrashReporting';
+
+// Local imports - shared settings
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import { assertSupported } from '@shared/utils/dispatcher';
+
+// Local imports - supporting types
+import type { StateStore } from '@platform/interfaces';
+import type { PlatformSecrets } from '@platform/secrets';
+
+class MemoryStateStore implements StateStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+}
+
+class MemorySecrets implements PlatformSecrets {
+  readonly values = new Map<string, string>();
+
+  async get(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
+  async getStored(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+
+  async listStoredKeys(): Promise<readonly string[]> {
+    return [...this.values.keys()];
+  }
+
+  getEnv(): string | undefined {
+    return undefined;
+  }
+}
+
+type ControllerOptions = ConstructorParameters<
+  typeof DefaultDesktopCrashReportingSettingsController
+>[0];
+
+function createFixture(overrides: Partial<ControllerOptions> = {}) {
+  const posted: unknown[] = [];
+  const state = overrides.state ?? new MemoryStateStore();
+  const memorySecrets = new MemorySecrets();
+  const secrets = overrides.secrets ?? memorySecrets;
+  const promptInput = vi.fn<ControllerOptions['prompt']['input']>(
+    async () => undefined,
+  );
+  const initialize = vi.fn(async () => undefined);
+  const controller = new DefaultDesktopCrashReportingSettingsController({
+    state,
+    secrets,
+    renderer: { postToRenderer: (message) => posted.push(message) },
+    prompt: { input: promptInput },
+    initialization: { initialize },
+    ...overrides,
+  });
+
+  return { controller, initialize, memorySecrets, posted };
+}
+
+describe('DefaultDesktopCrashReportingSettingsController', () => {
+  it('posts the current status during startup', async () => {
+    const state = new MemoryStateStore();
+    const secrets = new MemorySecrets();
+    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
+    secrets.values.set(
+      DESKTOP_CRASH_REPORTING_DSN_SECRET,
+      'https://example.invalid/1',
+    );
+    const { controller, posted } = createFixture({ state, secrets });
+
+    await controller.postStartupData();
+
+    expect(posted).toEqual([
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: true,
+        configured: true,
+      },
+    ]);
+  });
+
+  it('leaves settings unchanged when DSN prompting is cancelled', async () => {
+    const promptInput = vi.fn(async () => undefined);
+    const { controller, initialize, memorySecrets, posted } = createFixture({
+      prompt: { input: promptInput },
+    });
+
+    await assertSupported(controller.actions.setDsn)();
+
+    expect(promptInput).toHaveBeenCalledWith({
+      title: 'Set Sentry DSN',
+      prompt: 'Enter the Sentry DSN for opt-in desktop crash reports',
+    });
+    expect(memorySecrets.values).toEqual(new Map());
+    expect(initialize).not.toHaveBeenCalled();
+    expect(posted).toEqual([]);
+  });
+
+  it('deletes a stored DSN when the prompt returns a blank value', async () => {
+    const state = new MemoryStateStore();
+    const secrets = new MemorySecrets();
+    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
+    secrets.values.set(
+      DESKTOP_CRASH_REPORTING_DSN_SECRET,
+      'https://example.invalid/old',
+    );
+    const { controller, initialize, posted } = createFixture({
+      state,
+      secrets,
+      prompt: { input: async () => '   ' },
+    });
+
+    await assertSupported(controller.actions.setDsn)();
+
+    expect(secrets.values.has(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(false);
+    expect(initialize).not.toHaveBeenCalled();
+    expect(posted).toEqual([
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: true,
+        configured: false,
+      },
+    ]);
+  });
+
+  it('stores a trimmed nonblank DSN and initializes when enabled', async () => {
+    const state = new MemoryStateStore();
+    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
+    const { controller, initialize, memorySecrets, posted } = createFixture({
+      state,
+      prompt: { input: async () => ' https://example.invalid/new ' },
+    });
+
+    await assertSupported(controller.actions.setDsn)();
+
+    expect(memorySecrets.values.get(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(
+      'https://example.invalid/new',
+    );
+    expect(initialize).toHaveBeenCalledOnce();
+    expect(posted).toEqual([
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: true,
+        configured: true,
+      },
+    ]);
+  });
+
+  it('initializes only when an enablement change leaves reporting ready', async () => {
+    const state = new MemoryStateStore();
+    const secrets = new MemorySecrets();
+    const { controller, initialize, posted } = createFixture({
+      state,
+      secrets,
+    });
+
+    await assertSupported(controller.actions.setEnabled)(true);
+
+    expect(
+      state.values.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED),
+    ).toBe(true);
+    expect(initialize).not.toHaveBeenCalled();
+
+    secrets.values.set(
+      DESKTOP_CRASH_REPORTING_DSN_SECRET,
+      'https://example.invalid/ready',
+    );
+    await assertSupported(controller.actions.setEnabled)(false);
+    await assertSupported(controller.actions.setEnabled)(true);
+
+    expect(initialize).toHaveBeenCalledOnce();
+    expect(posted).toEqual([
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: true,
+        configured: false,
+      },
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: false,
+        configured: true,
+      },
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
+        enabled: true,
+        configured: true,
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -13,6 +13,7 @@ import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 import {
   createStubDesktopAgentSettingsController,
+  createStubDesktopCrashReportingSettingsController,
   createStubDesktopCredentialSettingsController,
   createStubDesktopHistoryOptions,
   createStubDesktopToolingSettingsController,
@@ -46,12 +47,14 @@ type RendererMessage = Parameters<
 type SettingsFixtureOverrides = Omit<
   Partial<DesktopSettingsIpcOptions>,
   | 'agentSettingsController'
+  | 'crashReportingSettingsController'
   | 'credentialSettingsController'
   | 'toolingSettingsController'
   | 'postToRenderer'
   | keyof DesktopHistoryOptions
 > & {
   agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
+  crashReportingSettingsController?: DesktopSettingsIpcOptions['crashReportingSettingsController'];
   credentialSettingsController?: DesktopSettingsIpcOptions['credentialSettingsController'];
   toolingSettingsController?: DesktopSettingsIpcOptions['toolingSettingsController'];
   history?: Partial<DesktopHistoryOptions>;
@@ -121,34 +124,6 @@ class MemoryConfigStore {
   }
 }
 
-class MemorySecrets {
-  readonly values = new Map<string, string>();
-
-  async get(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async getStored(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    this.values.set(key, value);
-  }
-
-  async delete(key: string): Promise<void> {
-    this.values.delete(key);
-  }
-
-  async listStoredKeys(): Promise<readonly string[]> {
-    return [...this.values.keys()];
-  }
-
-  getEnv(): string | undefined {
-    return undefined;
-  }
-}
-
 async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopSettingsIpc.ts'))
@@ -168,6 +143,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
     agentSettingsController:
       overrides.agentSettingsController ??
       createStubDesktopAgentSettingsController(),
+    crashReportingSettingsController:
+      overrides.crashReportingSettingsController ??
+      createStubDesktopCrashReportingSettingsController(),
     credentialSettingsController:
       overrides.credentialSettingsController ??
       createStubDesktopCredentialSettingsController({
@@ -369,39 +347,29 @@ describe('desktop settings IPC', () => {
     expect(isWorktreeSupportEnabled()).toBe(true);
   });
 
-  it('round-trips desktop crash reporting settings through global state and secrets', async () => {
-    const globalState = new MemoryStateStore();
-    const secrets = new MemorySecrets();
-
-    let initializeCalls = 0;
-
-    const { settings, posted } = createCapturedSettingsFixture({
-      globalState,
-      secrets,
-      promptSecret: async () => ' https://example.invalid/123 ',
-      initializeCrashReporting: async () => {
-        initializeCalls += 1;
-      },
+  it('delegates crash-reporting commands to the required controller', async () => {
+    const get = vi.fn(async () => undefined);
+    const setEnabled = vi.fn(async () => undefined);
+    const setDsn = vi.fn(async () => undefined);
+    const crashReportingSettingsController =
+      createStubDesktopCrashReportingSettingsController({
+        actions: { get, setEnabled, setDsn },
+      });
+    const { settings } = createSettingsFixture({
+      crashReportingSettingsController,
     });
 
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_DESKTOP_CRASH_REPORTING,
+      }),
+    ).toBe(true);
     expect(
       settings.handleMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_DESKTOP_CRASH_REPORTING_ENABLED,
         enabled: true,
       }),
     ).toBe(true);
-    await flushAsyncWork();
-
-    expect(
-      globalState.values.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED),
-    ).toBe(true);
-    expect(posted.at(-1)).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
-      enabled: true,
-      configured: false,
-    });
-    expect(initializeCalls).toBe(0);
-
     expect(
       settings.handleMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_DESKTOP_CRASH_REPORTING_DSN,
@@ -409,40 +377,9 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(posted.at(-1)).toMatchObject({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_DESKTOP_CRASH_REPORTING,
-      enabled: true,
-      configured: true,
-    });
-    expect(initializeCalls).toBe(1);
-  });
-
-  it('initializes desktop crash reporting when users enable an existing DSN', async () => {
-    const globalState = new MemoryStateStore();
-    const secrets = new MemorySecrets();
-    await secrets.set(
-      'texra.desktop.crashReporting.dsn',
-      'https://example.invalid/123',
-    );
-    let initializeCalls = 0;
-
-    const { settings } = createSettingsFixture({
-      globalState,
-      secrets,
-      initializeCrashReporting: async () => {
-        initializeCalls += 1;
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_DESKTOP_CRASH_REPORTING_ENABLED,
-        enabled: true,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(initializeCalls).toBe(1);
+    expect(get).toHaveBeenCalledOnce();
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(setDsn).toHaveBeenCalledOnce();
   });
 
   it('serves the goal list instead of the desktop "not available" stub (issue #7751 FS6)', async () => {
@@ -667,7 +604,7 @@ describe('desktop settings IPC', () => {
     });
   });
 
-  it('delegates tooling startup and posts approval settings on readiness', async () => {
+  it('delegates domain startup and posts approval settings on readiness', async () => {
     const workspaceState = new MemoryStateStore();
     workspaceState.values.set(
       WorkspaceStateKey.CODEX_SANDBOX_MODE,
@@ -678,6 +615,11 @@ describe('desktop settings IPC', () => {
     const agentSettingsController = createStubDesktopAgentSettingsController();
     const postAgentStartupData = vi.fn(async () => undefined);
     agentSettingsController.postStartupData = postAgentStartupData;
+    const postCrashReportingStartupData = vi.fn(async () => undefined);
+    const crashReportingSettingsController =
+      createStubDesktopCrashReportingSettingsController({
+        postStartupData: postCrashReportingStartupData,
+      });
     const postToolingStartupData = vi.fn(async () => undefined);
     const postLatexConfigValues = vi.fn();
     const toolingSettingsController =
@@ -688,6 +630,7 @@ describe('desktop settings IPC', () => {
 
     const { settings, posted } = createCapturedSettingsFixture({
       agentSettingsController,
+      crashReportingSettingsController,
       toolingSettingsController,
       workspaceState,
       config,
@@ -705,6 +648,7 @@ describe('desktop settings IPC', () => {
 
     expect(postLatexConfigValues).toHaveBeenCalledOnce();
     expect(postToolingStartupData).toHaveBeenCalledOnce();
+    expect(postCrashReportingStartupData).toHaveBeenCalledOnce();
     expect(postAgentStartupData).toHaveBeenCalledOnce();
 
     expect(

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -1,6 +1,7 @@
 // Desktop imports
 import { createModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionControllerFactory';
 import type { DesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
+import type { DesktopCrashReportingSettingsController } from '@desktop/main/desktopCrashReportingSettingsController';
 import type { DesktopCredentialSettingsController } from '@desktop/main/desktopCredentialSettingsController';
 import type { DesktopHistoryOptions } from '@desktop/main/desktopHistoryHandlers';
 import type { DesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
@@ -55,6 +56,20 @@ export function createStubDesktopAgentSettingsController(): DesktopAgentSettings
     },
     postStartupData: noOp,
     refreshCatalogData: noOp,
+  };
+}
+
+export function createStubDesktopCrashReportingSettingsController(
+  overrides: Partial<DesktopCrashReportingSettingsController> = {},
+): DesktopCrashReportingSettingsController {
+  return {
+    actions: {
+      get: noOp,
+      setEnabled: noOp,
+      setDsn: noOp,
+    },
+    postStartupData: noOp,
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary

Extract desktop crash-reporting settings transitions from the general settings IPC into one required controller composed
by the Electron host.

Closes #8425.

## Design

`DefaultDesktopCrashReportingSettingsController` owns settings status, DSN prompting and persistence, enablement
changes, conditional initialization, renderer updates, and the complete crash-reporting dispatcher action group.

The boundary remains deliberately narrow:

- Native Sentry initialization, sensitive-path selection, filtering, and scrubbing remain in
  `desktopCrashReporting.ts`.
- The application-wide initialization guard remains in `main/index.ts` and is supplied as a required port.
- Startup coordination remains in `desktopSettingsIpc.ts`.
- Tooling, credentials, models, memory, history, and other settings remain outside this controller.
- Prompt cancellation, blank-DSN deletion, initialization conditions, and error propagation retain their established
  behavior.

## Acceptance gates

- Desktop composition constructs one required crash-reporting settings controller from explicit state, secret, prompt,
  renderer, and initialization ports.
- `promptSecret`, `initializeCrashReporting`, and `secrets` leave `DesktopSettingsIpcOptions`.
- The IPC factory no longer selects an empty secret-store fallback.
- Startup status, prompt cancellation, blank and nonblank DSNs, enablement changes, and conditional initialization have
  focused controller coverage.
- `desktopSettingsIpc.ts` shrinks from 515 to 460 lines.
- Native Sentry lifecycle and `SettingsViewHost` ownership remain unchanged.

## Net elements (R6)

- Files: 2 added, 5 modified.
- Diff: +381 / -161, net +220.
- Production: +119 / -74, net +45.
- Tests: +262 / -87, net +175.
- Public production surface: one controller class and one controller interface; supporting ports are module-private.
- Optional `DesktopSettingsIpcOptions` fields: 13 to 10; one required controller replaces the three removed callbacks.

## Consumer counts (R8)

No command, event, schema, renderer message key, or external package surface changes.

## Host impact

- Desktop: crash-reporting settings capabilities are required at composition time; runtime behavior and wire messages
  are preserved.
- Extension: no change.
- CLI: no change.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 50 unchanged warnings)
- focused desktop crash-reporting and settings tests: 25 passed
- independent architecture and behavior review: no findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with preserved settings IPC messages and Sentry lifecycle boundaries; risk is mainly composition wiring, covered by moved and new unit tests.
> 
> **Overview**
> Moves desktop opt-in crash reporting settings out of `desktopSettingsIpc.ts` into **`DefaultDesktopCrashReportingSettingsController`**, aligned with other domain settings controllers.
> 
> The controller owns status reads, enable/disable, Sentry DSN prompting and persistence (via existing `desktopCrashReporting` helpers), conditional crash-reporting init when enabled and configured, and `UPDATE_DESKTOP_CRASH_REPORTING` renderer updates. The Electron host in `index.ts` constructs it with explicit state, secrets, renderer, password prompt, and initialization ports.
> 
> **`createDesktopSettingsIpc`** now requires `crashReportingSettingsController` and wires `desktopCrashReporting` actions through it; inline handlers and optional `promptSecret`, `initializeCrashReporting`, and `secrets` (plus the empty secret-store fallback) are removed. Native Sentry setup and the app-wide init guard stay in `main/index.ts` and `desktopCrashReporting.ts`.
> 
> Tests shift to focused controller coverage and IPC tests that assert delegation and startup coordination only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5b6eb123ccb5744525fac803a908ca7bea5373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->