### PR TITLE
refactor(desktop): require settings state

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,4 +1,3 @@
-import { platform } from '@platform/platform';
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
@@ -23,6 +22,7 @@ import {
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
+import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { GoalStore } from '@tools/goal';
 import { StorageFS } from '@utils/files';
 import {
@@ -40,7 +40,7 @@ import {
   DesktopHistoryHandlers,
   type DesktopHistoryOptions,
 } from './desktopHistoryHandlers.js';
-import type { ConfigProvider, StateStore } from '@platform/interfaces';
+import type { ConfigProvider } from '@platform/interfaces';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import type { DesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
@@ -52,10 +52,9 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   crashReportingSettingsController: DesktopCrashReportingSettingsController;
   credentialSettingsController: DesktopCredentialSettingsController;
   toolingSettingsController: DesktopToolingSettingsController;
+  state: SettingsStatePorts;
+  config: ConfigProvider;
   sendStartupCatalogData?: boolean;
-  globalState?: StateStore;
-  workspaceState?: StateStore;
-  config?: ConfigProvider;
   openPath?: (filePath: string) => Promise<void>;
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
@@ -75,8 +74,7 @@ export interface DesktopSettingsIpc extends DesktopMessageHandler {
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
 ): DesktopSettingsIpc {
-  const workspaceState = options.workspaceState ?? platform().workspaceState;
-  const globalState = options.globalState ?? platform().globalState;
+  const { globalState, workspaceState } = options.state;
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
   const onError = createDesktopErrorReporter(
@@ -119,10 +117,6 @@ export function createDesktopSettingsIpc(
 
   function readCurrentGitAuthorSettings() {
     return readGitAuthorSettingsFromState(workspaceState);
-  }
-
-  function getConfigProvider(): ConfigProvider {
-    return options.config ?? platform().config;
   }
 
   function applyCurrentGitAuthorSettings() {
@@ -194,7 +188,7 @@ export function createDesktopSettingsIpc(
       buildApprovalSettingsMessage({
         workspaceState,
         globalState,
-        config: getConfigProvider(),
+        config: options.config,
       }),
     );
   }
@@ -283,7 +277,7 @@ export function createDesktopSettingsIpc(
 
   async function updateBashApprovalEnabled(enabled: boolean): Promise<void> {
     await setBashApprovalEnabled(
-      { workspaceState, globalState, config: getConfigProvider() },
+      { workspaceState, globalState, config: options.config },
       enabled,
       BASH_APPROVAL_CONFIG_TARGET,
     );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -850,6 +850,11 @@ function createWindow(options: {
     crashReportingSettingsController,
     credentialSettingsController,
     toolingSettingsController,
+    state: {
+      globalState: platform().globalState,
+      workspaceState: platform().workspaceState,
+    },
+    config: platform().config,
     sendStartupCatalogData: true,
     resourcesPath: options.resourcesPath,
     // Rerun/Restore from history: same host-neutral owners the extension's

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -49,6 +49,8 @@ type SettingsFixtureOverrides = Omit<
   | 'agentSettingsController'
   | 'crashReportingSettingsController'
   | 'credentialSettingsController'
+  | 'state'
+  | 'config'
   | 'toolingSettingsController'
   | 'postToRenderer'
   | keyof DesktopHistoryOptions
@@ -56,6 +58,9 @@ type SettingsFixtureOverrides = Omit<
   agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
   crashReportingSettingsController?: DesktopSettingsIpcOptions['crashReportingSettingsController'];
   credentialSettingsController?: DesktopSettingsIpcOptions['credentialSettingsController'];
+  globalState?: StateStore;
+  workspaceState?: StateStore;
+  config?: DesktopSettingsIpcOptions['config'];
   toolingSettingsController?: DesktopSettingsIpcOptions['toolingSettingsController'];
   history?: Partial<DesktopHistoryOptions>;
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
@@ -133,9 +138,13 @@ async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
 let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIpc'];
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
-  const { history, ...settingsOverrides } = overrides;
-  const globalState = overrides.globalState ?? new MemoryStateStore();
-  const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
+  const {
+    history,
+    globalState = new MemoryStateStore(),
+    workspaceState = new MemoryStateStore(),
+    config = new MemoryConfigStore(),
+    ...settingsOverrides
+  } = overrides;
   const postToRenderer = overrides.postToRenderer ?? (() => undefined);
   const settings = createDesktopSettingsIpc({
     ...settingsOverrides,
@@ -161,9 +170,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
             values: {},
           }),
       }),
-    globalState,
+    state: { globalState, workspaceState },
+    config,
     postToRenderer,
-    workspaceState,
   });
   return { globalState, settings, workspaceState };
 }


### PR DESCRIPTION
## Summary

Require desktop settings state and configuration at Electron composition time instead of letting
`createDesktopSettingsIpc` select `platform()` fallbacks.

Closes #8428.

## Issue acceptance gates

- `DesktopSettingsIpcOptions` now requires `state: SettingsStatePorts` and `config: ConfigProvider`.
- `main/index.ts` passes the initialized platform state stores and config explicitly.
- The settings IPC no longer imports or calls `platform()`.
- `getConfigProvider()` and all three missing-dependency fallback branches are deleted.
- Existing settings behavior remains covered by the focused IPC suite and full kernel suite.
- Parent issue #8406 remains open for the remaining UI and navigation capabilities.

## Single source of truth

The Electron composition root now owns platform dependency selection. The settings IPC receives one required
`SettingsStatePorts` value and one required `ConfigProvider` and only consumes them.

## Duplication and abstraction budget

This removes the repeated state/config fallback decisions without adding an abstraction. It reuses the existing
`SettingsStatePorts` interface, and the shared test fixture continues to offer per-store overrides while always
constructing the required production-shaped input.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Diff: +26 / -18, net +8.
- Production: +12 / -13, net -1.
- Tests: +14 / -5, net +9.
- Exported symbols, classes, interfaces, and enums: no additions or deletions.
- `DesktopSettingsIpcOptions`: 3 optional fields removed; 2 required fields added, net -1 field.

## Consumer counts (R8)

n/a: no command, event, schema, renderer message, or exported runtime path changes. Both constructor consumers were
updated: the Electron composition root and the shared desktop settings test fixture.

## Host impact

Extension: no change.

Desktop: state and config are now explicit required composition dependencies; runtime behavior is unchanged.

CLI: no change.

## Scheduled refactoring

Parent #8406 tracks the remaining optional desktop settings UI and navigation capabilities.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; 50 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only baseline report)
- `npm run compile:fast`
- focused `DesktopSettingsIpc.vitest.mts`: 16 passed
- `npm test -- --reporter=dot`: 6,139 passed, 4 skipped across 686 passed files and 1 skipped file
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composition-time dependency wiring only; no IPC commands, schemas, or settings behavior changes beyond removing implicit platform fallbacks.
> 
> **Overview**
> **Desktop settings IPC** no longer imports or calls `platform()`. `DesktopSettingsIpcOptions` now requires `state: SettingsStatePorts` and `config: ConfigProvider` instead of optional `globalState`, `workspaceState`, and `config`.
> 
> The Electron window setup in `main/index.ts` passes `platform().globalState`, `platform().workspaceState`, and `platform().config` when creating settings IPC. Inside `createDesktopSettingsIpc`, state comes from `options.state`, approval/bash paths use `options.config` directly, and the `getConfigProvider()` helper and its fallback branches are removed.
> 
> The **desktop settings IPC test fixture** builds the same required shape: per-test `globalState` / `workspaceState` / `config` overrides are folded into `state` and `config` on the factory call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a299008561821c1dcb5e62253c08d5c883c34034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->