### PR TITLE
refactor(desktop): inject the existing history controller

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -15,7 +15,6 @@ import {
   type ValidatedExecutionRequest,
 } from '@agent/core/state/executionRequests';
 import type { TaskState } from '@agent/core/state/TaskState';
-import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - IPC contracts
@@ -39,6 +38,8 @@ export interface DesktopHistoryOptions {
   readonly runExecution: (request: ValidatedExecutionRequest) => Promise<void>;
   /** Restore a persisted agent configuration into the main view. */
   readonly restoreTaskState: (taskState: TaskState) => Promise<boolean>;
+  /** Return execution ids that must be protected from history deletion. */
+  readonly getActiveExecutionIds: () => readonly string[];
   readonly postToRenderer: (message: unknown) => void;
   readonly openPath: (filePath: string) => Promise<void>;
   readonly showInfoMessage: (message: string) => Promise<void>;
@@ -80,7 +81,7 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
   }
 
   private async deleteItem(historyId: string): Promise<void> {
-    if (getAllActiveExecutionIds().includes(historyId)) {
+    if (this.dependencies.getActiveExecutionIds().includes(historyId)) {
       await this.dependencies.showInfoMessage(
         'Cannot delete a running execution',
       );
@@ -98,7 +99,9 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
   }
 
   private async clear(): Promise<void> {
-    await deleteAllExecutions(new Set(getAllActiveExecutionIds()));
+    await deleteAllExecutions(
+      new Set(this.dependencies.getActiveExecutionIds()),
+    );
     this.dependencies.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
     });

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -30,7 +30,7 @@ import type { SettingsViewCommandActions } from '@controllers/settingsView/Setti
 
 type HistoryExportFormat = 'md' | 'tex' | 'html';
 
-/** History-specific capabilities supplied by the desktop host. */
+/** Dependencies required by the desktop history controller. */
 export interface DesktopHistoryOptions {
   /** Resolved extension resources used by chat export templates. */
   readonly resourcesPath: string;

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -34,19 +34,16 @@ type HistoryExportFormat = 'md' | 'tex' | 'html';
 /** History-specific capabilities supplied by the desktop host. */
 export interface DesktopHistoryOptions {
   /** Resolved extension resources used by chat export templates. */
-  resourcesPath: string;
+  readonly resourcesPath: string;
   /** Run a validated request created from a persisted history entry. */
-  runExecution: (request: ValidatedExecutionRequest) => Promise<void>;
+  readonly runExecution: (request: ValidatedExecutionRequest) => Promise<void>;
   /** Restore a persisted agent configuration into the main view. */
-  restoreTaskState: (taskState: TaskState) => Promise<boolean>;
-}
-
-interface DesktopHistoryHandlerDependencies extends DesktopHistoryOptions {
-  postToRenderer(message: unknown): void;
-  openPath?: (filePath: string) => Promise<void>;
-  showInfoMessage?: (message: string) => Promise<void>;
-  showErrorMessage?: (message: string) => Promise<void>;
-  onError(error: unknown): void;
+  readonly restoreTaskState: (taskState: TaskState) => Promise<boolean>;
+  readonly postToRenderer: (message: unknown) => void;
+  readonly openPath: (filePath: string) => Promise<void>;
+  readonly showInfoMessage: (message: string) => Promise<void>;
+  readonly showErrorMessage: (message: string) => Promise<void>;
+  readonly onError: (error: unknown) => void;
 }
 
 const HISTORY_CONFIG_UNREADABLE_MESSAGE =
@@ -55,15 +52,18 @@ const HISTORY_CONFIG_UNREADABLE_MESSAGE =
 type HistoryConfigResult =
   { status: 'ok'; config: AgentConfig } | { status: 'unreadable' };
 
+export interface DesktopHistorySettingsController {
+  readonly actions: SettingsViewCommandActions['history'];
+  postHistoryData(): Promise<void>;
+}
+
 /** Own desktop history settings actions behind the dispatcher contract. */
-export class DesktopHistoryHandlers {
+export class DesktopHistoryHandlers implements DesktopHistorySettingsController {
   readonly actions: SettingsViewCommandActions['history'];
 
   private chatExportControllerLoad: Promise<ChatExportController> | undefined;
 
-  constructor(
-    private readonly dependencies: DesktopHistoryHandlerDependencies,
-  ) {
+  constructor(private readonly dependencies: DesktopHistoryOptions) {
     this.actions = {
       deleteAgent: (historyId) => this.deleteItem(historyId),
       clear: () => this.clear(),
@@ -81,7 +81,7 @@ export class DesktopHistoryHandlers {
 
   private async deleteItem(historyId: string): Promise<void> {
     if (getAllActiveExecutionIds().includes(historyId)) {
-      await this.dependencies.showInfoMessage?.(
+      await this.dependencies.showInfoMessage(
         'Cannot delete a running execution',
       );
       return;
@@ -89,7 +89,7 @@ export class DesktopHistoryHandlers {
 
     const deleted = await deleteExecution(historyId as ExecutionId);
     if (!deleted) {
-      await this.dependencies.showInfoMessage?.(
+      await this.dependencies.showInfoMessage(
         `History item not found: ${historyId}`,
       );
       return;
@@ -119,24 +119,24 @@ export class DesktopHistoryHandlers {
   private async rerun(historyId: string): Promise<void> {
     const result = await this.readHistoryConfig(historyId);
     if (result.status === 'unreadable') {
-      await this.dependencies.showErrorMessage?.(
+      await this.dependencies.showErrorMessage(
         HISTORY_CONFIG_UNREADABLE_MESSAGE,
       );
       return;
     }
     const validated = validateExecutionRequest({ config: result.config });
     if (!validated.valid) {
-      await this.dependencies.showErrorMessage?.(validated.message);
+      await this.dependencies.showErrorMessage(validated.message);
       return;
     }
-    await this.dependencies.showInfoMessage?.('Rerunning agent from history');
+    await this.dependencies.showInfoMessage('Rerunning agent from history');
     await this.dependencies.runExecution(validated.request);
   }
 
   private async restore(historyId: string): Promise<void> {
     const result = await this.readHistoryConfig(historyId);
     if (result.status === 'unreadable') {
-      await this.dependencies.showErrorMessage?.(
+      await this.dependencies.showErrorMessage(
         HISTORY_CONFIG_UNREADABLE_MESSAGE,
       );
       return;
@@ -145,7 +145,7 @@ export class DesktopHistoryHandlers {
       agentConfigToTaskState(result.config),
     );
     if (!restored) {
-      await this.dependencies.showErrorMessage?.(
+      await this.dependencies.showErrorMessage(
         'Failed to restore configuration',
       );
     }
@@ -177,10 +177,10 @@ export class DesktopHistoryHandlers {
   ): Promise<void> {
     switch (status) {
       case 'config_missing':
-        await this.dependencies.showInfoMessage?.('History item not found');
+        await this.dependencies.showInfoMessage('History item not found');
         return;
       case 'conversation_missing':
-        await this.dependencies.showInfoMessage?.(
+        await this.dependencies.showInfoMessage(
           'No conversation data available for this execution',
         );
         return;
@@ -192,10 +192,10 @@ export class DesktopHistoryHandlers {
   ): Promise<void> {
     switch (status) {
       case 'config_missing':
-        await this.dependencies.showInfoMessage?.('History item not found');
+        await this.dependencies.showInfoMessage('History item not found');
         return;
       case 'streamLogs_missing':
-        await this.dependencies.showInfoMessage?.(
+        await this.dependencies.showInfoMessage(
           'No stored transcript available for this execution — it may predate transcript persistence.',
         );
         return;
@@ -217,8 +217,8 @@ export class DesktopHistoryHandlers {
       return;
     }
     const { absolutePath, storagePath } = outcome.result;
-    await this.dependencies.openPath?.(absolutePath);
-    await this.dependencies.showInfoMessage?.(
+    await this.dependencies.openPath(absolutePath);
+    await this.dependencies.showInfoMessage(
       `Chat exported: ${path.basename(storagePath)}`,
     );
   }
@@ -245,8 +245,8 @@ export class DesktopHistoryHandlers {
         historyId,
         exportInput,
       );
-      await this.dependencies.openPath?.(absolutePath);
-      await this.dependencies.showInfoMessage?.(
+      await this.dependencies.openPath(absolutePath);
+      await this.dependencies.showInfoMessage(
         `Chat exported: ${path.basename(storagePath)}`,
       );
       return;
@@ -255,8 +255,8 @@ export class DesktopHistoryHandlers {
     const { absolutePath, storagePath, pdfPath, logTail } =
       await controller.exportAsLatex(historyId, exportInput);
     if (pdfPath) {
-      await this.dependencies.openPath?.(pdfPath);
-      await this.dependencies.showInfoMessage?.(
+      await this.dependencies.openPath(pdfPath);
+      await this.dependencies.showInfoMessage(
         `Chat exported and compiled: ${path.basename(storagePath).replace('.tex', '.pdf')}`,
       );
       return;
@@ -268,8 +268,8 @@ export class DesktopHistoryHandlers {
         ),
       );
     }
-    await this.dependencies.openPath?.(absolutePath);
-    await this.dependencies.showInfoMessage?.(
+    await this.dependencies.openPath(absolutePath);
+    await this.dependencies.showInfoMessage(
       'LaTeX compilation failed. The .tex source file has been opened instead.',
     );
   }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -36,21 +36,19 @@ import {
   type DesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
-import {
-  DesktopHistoryHandlers,
-  type DesktopHistoryOptions,
-} from './desktopHistoryHandlers.js';
+import type { DesktopHistorySettingsController } from './desktopHistoryHandlers.js';
 import type { ConfigProvider } from '@platform/interfaces';
 import type { DesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import type { DesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
-export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
+export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
   agentSettingsController: DesktopAgentSettingsController;
   crashReportingSettingsController: DesktopCrashReportingSettingsController;
   credentialSettingsController: DesktopCredentialSettingsController;
+  historySettingsController: DesktopHistorySettingsController;
   toolingSettingsController: DesktopToolingSettingsController;
   state: SettingsStatePorts;
   config: ConfigProvider;
@@ -59,7 +57,6 @@ export interface DesktopSettingsIpcOptions extends DesktopHistoryOptions {
   /** Route this window to the progress view and select the given stream. */
   revealStream?: (streamId: string) => Promise<void>;
   showInfoMessage?: (message: string) => Promise<void>;
-  showErrorMessage?: (message: string) => Promise<void>;
   confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
   onError?: (error: unknown) => void;
 }
@@ -83,16 +80,6 @@ export function createDesktopSettingsIpc(
       void options.showInfoMessage?.(error.reason);
     },
   );
-  const historyHandlers = new DesktopHistoryHandlers({
-    postToRenderer: options.postToRenderer,
-    resourcesPath: options.resourcesPath,
-    runExecution: options.runExecution,
-    restoreTaskState: options.restoreTaskState,
-    openPath: options.openPath,
-    showInfoMessage: options.showInfoMessage,
-    showErrorMessage: options.showErrorMessage,
-    onError,
-  });
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),
   });
@@ -216,7 +203,7 @@ export function createDesktopSettingsIpc(
     await Promise.all([
       memoryEnabledPosted,
       postMemoryData(),
-      historyHandlers.postHistoryData(),
+      options.historySettingsController.postHistoryData(),
       modelSelectionDataPosted,
       options.credentialSettingsController.postStartupData(),
       options.toolingSettingsController.postStartupData(),
@@ -325,7 +312,7 @@ export function createDesktopSettingsIpc(
       pin: (storagePath) => setMemoryPinned(storagePath, true),
       unpin: (storagePath) => setMemoryPinned(storagePath, false),
     },
-    history: historyHandlers.actions,
+    history: options.historySettingsController.actions,
     profile: options.credentialSettingsController.profileActions,
     modelSelection: {
       setEnabled: (modelName, enabled) =>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -25,6 +25,7 @@ import {
   refresh,
 } from '@agent/index/agentRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
+import { getAllActiveExecutionIds } from '@agent/runtime/SessionHandle';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { TerminalRunResult } from '@hosts/uiHosts';
@@ -855,6 +856,7 @@ function createWindow(options: {
     },
     restoreTaskState: async (taskState) =>
       (await getAgentExecution()).progress.restoreTaskState(taskState),
+    getActiveExecutionIds: getAllActiveExecutionIds,
     openPath: previewHost.openPath,
     showInfoMessage,
     showErrorMessage,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -848,6 +848,8 @@ function createWindow(options: {
   const historySettingsController = new DesktopHistoryHandlers({
     resourcesPath: options.resourcesPath,
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    // Rerun and restore use the same host-neutral owners as the extension,
+    // reached through the desktop execution bridge instead of VS Code commands.
     runExecution: async (request) => {
       await (await getAgentExecution()).progress.runExecution(request);
     },

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -70,6 +70,7 @@ import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsController.js';
 import { DefaultDesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import { DefaultDesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
+import { DesktopHistoryHandlers } from './desktopHistoryHandlers.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import {
   buildDefaultToolDashboardItems,
@@ -844,11 +845,25 @@ function createWindow(options: {
       },
       initialization: { initialize: options.initializeCrashReporting },
     });
+  const historySettingsController = new DesktopHistoryHandlers({
+    resourcesPath: options.resourcesPath,
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    runExecution: async (request) => {
+      await (await getAgentExecution()).progress.runExecution(request);
+    },
+    restoreTaskState: async (taskState) =>
+      (await getAgentExecution()).progress.restoreTaskState(taskState),
+    openPath: previewHost.openPath,
+    showInfoMessage,
+    showErrorMessage,
+    onError: reportAsyncError,
+  });
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     agentSettingsController,
     crashReportingSettingsController,
     credentialSettingsController,
+    historySettingsController,
     toolingSettingsController,
     state: {
       globalState: platform().globalState,
@@ -856,17 +871,7 @@ function createWindow(options: {
     },
     config: platform().config,
     sendStartupCatalogData: true,
-    resourcesPath: options.resourcesPath,
-    // Rerun/Restore from history: same host-neutral owners the extension's
-    // history handlers call (runAgent / buildMainViewState), reached through
-    // the desktop agent-execution bridge instead of a vscode command.
-    runExecution: async (request) => {
-      await (await getAgentExecution()).progress.runExecution(request);
-    },
-    restoreTaskState: async (taskState) =>
-      (await getAgentExecution()).progress.restoreTaskState(taskState),
     showInfoMessage,
-    showErrorMessage,
     confirmAction: async (message, confirmLabel = 'OK') => {
       const result = await dialog.showMessageBox(window, {
         type: 'warning',

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -29,6 +29,10 @@ const chatExportMocks = vi.hoisted(() => ({
   constructorDeps: [] as unknown[],
   constructorError: undefined as Error | undefined,
 }));
+const historyMocks = vi.hoisted(() => ({
+  activeExecutionIds: [] as string[],
+  buildHistoryMessage: vi.fn(),
+}));
 
 vi.mock('@controllers/settingsView/ChatExportController', () => ({
   ChatExportController: class {
@@ -46,15 +50,28 @@ vi.mock('@controllers/settingsView/ChatExportController', () => ({
   },
 }));
 
+vi.mock('@controllers/settingsView/HistoryMessageBuilder', () => ({
+  buildHistoryMessage: historyMocks.buildHistoryMessage,
+}));
+
+vi.mock('@agent/runtime/SessionHandle', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/runtime/SessionHandle')>()),
+  getAllActiveExecutionIds: () => historyMocks.activeExecutionIds,
+}));
+
 type DesktopHistoryHandlersModule =
   typeof import('@desktop/main/desktopHistoryHandlers');
 type DesktopHistoryDependencies = ConstructorParameters<
   DesktopHistoryHandlersModule['DesktopHistoryHandlers']
 >[0];
+type DesktopHistoryCapabilities = Pick<
+  DesktopHistoryOptions,
+  'resourcesPath' | 'runExecution' | 'restoreTaskState'
+>;
 type DesktopHistoryActionOverrides = Partial<
-  Omit<DesktopHistoryDependencies, keyof DesktopHistoryOptions>
+  Omit<DesktopHistoryDependencies, keyof DesktopHistoryCapabilities>
 > & {
-  history?: Partial<DesktopHistoryOptions>;
+  history?: Partial<DesktopHistoryCapabilities>;
 };
 
 const RESOURCES_PATH = repoPath('packages', 'extension', 'resources');
@@ -75,7 +92,9 @@ let DesktopHistoryHandlers!: DesktopHistoryHandlersModule['DesktopHistoryHandler
 
 setupPlatform();
 
-function createHistoryActions(overrides: DesktopHistoryActionOverrides = {}) {
+function createHistoryController(
+  overrides: DesktopHistoryActionOverrides = {},
+) {
   const {
     history,
     postToRenderer = vi.fn(),
@@ -90,7 +109,11 @@ function createHistoryActions(overrides: DesktopHistoryActionOverrides = {}) {
     postToRenderer,
     onError,
     ...optionalDependencies,
-  }).actions;
+  });
+}
+
+function createHistoryActions(overrides: DesktopHistoryActionOverrides = {}) {
+  return createHistoryController(overrides).actions;
 }
 
 async function writeHistoryConfig(): Promise<void> {
@@ -109,6 +132,104 @@ describe('DesktopHistoryHandlers', () => {
     chatExportMocks.constructorDeps.length = 0;
     chatExportMocks.constructorError = undefined;
     vi.resetAllMocks();
+    historyMocks.activeExecutionIds = [];
+    historyMocks.buildHistoryMessage.mockResolvedValue({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,
+      historyItems: [],
+    });
+  });
+
+  it('posts the current history message to the renderer', async () => {
+    const postToRenderer = vi.fn();
+    const controller = createHistoryController({ postToRenderer });
+
+    await controller.postHistoryData();
+
+    expect(historyMocks.buildHistoryMessage).toHaveBeenCalledOnce();
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,
+      historyItems: [],
+    });
+  });
+
+  it('reruns a persisted history configuration through the execution port', async () => {
+    await writeHistoryConfig();
+    const runExecution = vi.fn(async () => undefined);
+    const showInfoMessage = vi.fn(async () => undefined);
+    const actions = createHistoryActions({
+      history: { runExecution },
+      showInfoMessage,
+    });
+
+    await assertSupported(actions.rerunAgent)({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId: HISTORY_ID,
+    });
+
+    expect(showInfoMessage).toHaveBeenCalledWith(
+      'Rerunning agent from history',
+    );
+    expect(runExecution).toHaveBeenCalledWith({
+      config: HISTORY_CONFIG,
+      executionId: undefined,
+    });
+  });
+
+  it('protects an active execution from deletion', async () => {
+    await writeHistoryConfig();
+    historyMocks.activeExecutionIds = [HISTORY_ID];
+    const postToRenderer = vi.fn();
+    const showInfoMessage = vi.fn(async () => undefined);
+    const actions = createHistoryActions({
+      postToRenderer,
+      showInfoMessage,
+    });
+
+    await assertSupported(actions.deleteAgent)(HISTORY_ID);
+
+    expect(await getExecutionStore(HISTORY_ID).readConfig()).toEqual(
+      HISTORY_CONFIG,
+    );
+    expect(showInfoMessage).toHaveBeenCalledWith(
+      'Cannot delete a running execution',
+    );
+    expect(postToRenderer).not.toHaveBeenCalled();
+  });
+
+  it('deletes an inactive execution and refreshes history', async () => {
+    await writeHistoryConfig();
+    const postToRenderer = vi.fn();
+    const actions = createHistoryActions({ postToRenderer });
+
+    await assertSupported(actions.deleteAgent)(HISTORY_ID);
+
+    expect(await getExecutionStore(HISTORY_ID).readConfig()).toBeNull();
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,
+      historyItems: [],
+    });
+  });
+
+  it('clears inactive history while preserving active executions', async () => {
+    const activeHistoryId = 'cccc3333';
+    const inactiveHistoryId = 'dddd4444';
+    await Promise.all([
+      getExecutionStore(activeHistoryId).writeConfig(HISTORY_CONFIG),
+      getExecutionStore(inactiveHistoryId).writeConfig(HISTORY_CONFIG),
+    ]);
+    historyMocks.activeExecutionIds = [activeHistoryId];
+    const postToRenderer = vi.fn();
+    const actions = createHistoryActions({ postToRenderer });
+
+    await assertSupported(actions.clear)();
+
+    expect(await getExecutionStore(activeHistoryId).readConfig()).toEqual(
+      HISTORY_CONFIG,
+    );
+    expect(await getExecutionStore(inactiveHistoryId).readConfig()).toBeNull();
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
+    });
   });
 
   it("restores a history item's setup into the main view", async () => {

--- a/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHistoryHandlers.vitest.mts
@@ -30,7 +30,6 @@ const chatExportMocks = vi.hoisted(() => ({
   constructorError: undefined as Error | undefined,
 }));
 const historyMocks = vi.hoisted(() => ({
-  activeExecutionIds: [] as string[],
   buildHistoryMessage: vi.fn(),
 }));
 
@@ -54,11 +53,6 @@ vi.mock('@controllers/settingsView/HistoryMessageBuilder', () => ({
   buildHistoryMessage: historyMocks.buildHistoryMessage,
 }));
 
-vi.mock('@agent/runtime/SessionHandle', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@agent/runtime/SessionHandle')>()),
-  getAllActiveExecutionIds: () => historyMocks.activeExecutionIds,
-}));
-
 type DesktopHistoryHandlersModule =
   typeof import('@desktop/main/desktopHistoryHandlers');
 type DesktopHistoryDependencies = ConstructorParameters<
@@ -66,7 +60,10 @@ type DesktopHistoryDependencies = ConstructorParameters<
 >[0];
 type DesktopHistoryCapabilities = Pick<
   DesktopHistoryOptions,
-  'resourcesPath' | 'runExecution' | 'restoreTaskState'
+  | 'resourcesPath'
+  | 'runExecution'
+  | 'restoreTaskState'
+  | 'getActiveExecutionIds'
 >;
 type DesktopHistoryActionOverrides = Partial<
   Omit<DesktopHistoryDependencies, keyof DesktopHistoryCapabilities>
@@ -132,7 +129,6 @@ describe('DesktopHistoryHandlers', () => {
     chatExportMocks.constructorDeps.length = 0;
     chatExportMocks.constructorError = undefined;
     vi.resetAllMocks();
-    historyMocks.activeExecutionIds = [];
     historyMocks.buildHistoryMessage.mockResolvedValue({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,
       historyItems: [],
@@ -177,10 +173,10 @@ describe('DesktopHistoryHandlers', () => {
 
   it('protects an active execution from deletion', async () => {
     await writeHistoryConfig();
-    historyMocks.activeExecutionIds = [HISTORY_ID];
     const postToRenderer = vi.fn();
     const showInfoMessage = vi.fn(async () => undefined);
     const actions = createHistoryActions({
+      history: { getActiveExecutionIds: () => [HISTORY_ID] },
       postToRenderer,
       showInfoMessage,
     });
@@ -217,9 +213,11 @@ describe('DesktopHistoryHandlers', () => {
       getExecutionStore(activeHistoryId).writeConfig(HISTORY_CONFIG),
       getExecutionStore(inactiveHistoryId).writeConfig(HISTORY_CONFIG),
     ]);
-    historyMocks.activeExecutionIds = [activeHistoryId];
     const postToRenderer = vi.fn();
-    const actions = createHistoryActions({ postToRenderer });
+    const actions = createHistoryActions({
+      history: { getActiveExecutionIds: () => [activeHistoryId] },
+      postToRenderer,
+    });
 
     await assertSupported(actions.clear)();
 

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -15,7 +15,7 @@ import {
   createStubDesktopAgentSettingsController,
   createStubDesktopCrashReportingSettingsController,
   createStubDesktopCredentialSettingsController,
-  createStubDesktopHistoryOptions,
+  createStubDesktopHistorySettingsController,
   createStubDesktopToolingSettingsController,
 } from './desktopSettingsTestSupport';
 import type { StateStore } from '@platform/interfaces';
@@ -38,8 +38,6 @@ type DesktopSettingsIpcModule =
 type DesktopSettingsIpcOptions = Parameters<
   DesktopSettingsIpcModule['createDesktopSettingsIpc']
 >[0];
-type DesktopHistoryOptions = ReturnType<typeof createStubDesktopHistoryOptions>;
-
 type RendererMessage = Parameters<
   DesktopSettingsIpcOptions['postToRenderer']
 >[0];
@@ -51,9 +49,9 @@ type SettingsFixtureOverrides = Omit<
   | 'credentialSettingsController'
   | 'state'
   | 'config'
+  | 'historySettingsController'
   | 'toolingSettingsController'
   | 'postToRenderer'
-  | keyof DesktopHistoryOptions
 > & {
   agentSettingsController?: DesktopSettingsIpcOptions['agentSettingsController'];
   crashReportingSettingsController?: DesktopSettingsIpcOptions['crashReportingSettingsController'];
@@ -61,8 +59,8 @@ type SettingsFixtureOverrides = Omit<
   globalState?: StateStore;
   workspaceState?: StateStore;
   config?: DesktopSettingsIpcOptions['config'];
+  historySettingsController?: DesktopSettingsIpcOptions['historySettingsController'];
   toolingSettingsController?: DesktopSettingsIpcOptions['toolingSettingsController'];
-  history?: Partial<DesktopHistoryOptions>;
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
 };
 
@@ -139,7 +137,6 @@ let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIp
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const {
-    history,
     globalState = new MemoryStateStore(),
     workspaceState = new MemoryStateStore(),
     config = new MemoryConfigStore(),
@@ -148,7 +145,6 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const postToRenderer = overrides.postToRenderer ?? (() => undefined);
   const settings = createDesktopSettingsIpc({
     ...settingsOverrides,
-    ...createStubDesktopHistoryOptions(history),
     agentSettingsController:
       overrides.agentSettingsController ??
       createStubDesktopAgentSettingsController(),
@@ -161,6 +157,9 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
         globalState,
         workspaceState,
       }),
+    historySettingsController:
+      overrides.historySettingsController ??
+      createStubDesktopHistorySettingsController(),
     toolingSettingsController:
       overrides.toolingSettingsController ??
       createStubDesktopToolingSettingsController({
@@ -305,6 +304,31 @@ describe('desktop settings IPC', () => {
       source: 'custom',
       name: 'proofreader',
       enabled: false,
+    });
+  });
+
+  it('delegates history commands to the required controller', async () => {
+    const baseController = createStubDesktopHistorySettingsController();
+    const rerunAgent = vi.fn(async () => undefined);
+    const historySettingsController = {
+      ...baseController,
+      actions: { ...baseController.actions, rerunAgent },
+    };
+    const { settings } = createSettingsFixture({
+      historySettingsController,
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+        historyId: 'history-entry',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(rerunAgent).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
+      historyId: 'history-entry',
     });
   });
 
@@ -636,10 +660,14 @@ describe('desktop settings IPC', () => {
         postLatexConfigValues,
         postStartupData: postToolingStartupData,
       });
+    const postHistoryData = vi.fn(async () => undefined);
+    const historySettingsController =
+      createStubDesktopHistorySettingsController({ postHistoryData });
 
     const { settings, posted } = createCapturedSettingsFixture({
       agentSettingsController,
       crashReportingSettingsController,
+      historySettingsController,
       toolingSettingsController,
       workspaceState,
       config,
@@ -658,6 +686,7 @@ describe('desktop settings IPC', () => {
     expect(postLatexConfigValues).toHaveBeenCalledOnce();
     expect(postToolingStartupData).toHaveBeenCalledOnce();
     expect(postCrashReportingStartupData).toHaveBeenCalledOnce();
+    expect(postHistoryData).toHaveBeenCalledOnce();
     expect(postAgentStartupData).toHaveBeenCalledOnce();
 
     expect(
@@ -821,51 +850,6 @@ describe('desktop settings IPC', () => {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
       enabled: false,
     });
-  });
-
-  it('reruns an agent from history through the shared runAgent path', async () => {
-    const { clearStoreCache, getExecutionStore } =
-      await import('@agent/storage');
-    const { AgentConfigSchema } =
-      await import('@agent/core/definition/AgentConfig');
-    const { AgentCategory } = await import('@shared/schemas/agent');
-    const { installPlatform } = await import('@test/support/setupPlatform');
-
-    clearStoreCache();
-    await installPlatform();
-
-    const historyId = 'aaaa1111';
-    const config = AgentConfigSchema.parse({
-      agent: 'chat',
-      model: 'deepseekT',
-      instruction: 'Check a proof.',
-      agentCategory: AgentCategory.ToolUse,
-    });
-    await getExecutionStore(historyId).writeConfig(config);
-
-    const infos: string[] = [];
-    const runRequests: unknown[] = [];
-    const { settings } = createSettingsFixture({
-      showInfoMessage: async (message) => {
-        infos.push(message);
-      },
-      history: {
-        runExecution: async (request) => {
-          runRequests.push(request);
-        },
-      },
-    });
-
-    expect(
-      settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.RERUN_AGENT,
-        historyId,
-      }),
-    ).toBe(true);
-    await flushAsyncWork();
-
-    expect(infos).toEqual(['Rerunning agent from history']);
-    expect(runRequests).toEqual([{ config, executionId: undefined }]);
   });
 
   it('ignores unsupported or malformed settings messages', async () => {

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -3,7 +3,10 @@ import { createModelSelectionController } from '@controllers/settingsView/Settin
 import type { DesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
 import type { DesktopCrashReportingSettingsController } from '@desktop/main/desktopCrashReportingSettingsController';
 import type { DesktopCredentialSettingsController } from '@desktop/main/desktopCredentialSettingsController';
-import type { DesktopHistoryOptions } from '@desktop/main/desktopHistoryHandlers';
+import type {
+  DesktopHistoryOptions,
+  DesktopHistorySettingsController,
+} from '@desktop/main/desktopHistoryHandlers';
 import type { DesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
 
 // Shared imports - settings controllers
@@ -24,6 +27,29 @@ export function createStubDesktopHistoryOptions(
     resourcesPath: repoPath('packages', 'extension', 'resources'),
     runExecution: noOp,
     restoreTaskState: async () => true,
+    postToRenderer: () => undefined,
+    openPath: noOp,
+    showInfoMessage: noOp,
+    showErrorMessage: noOp,
+    onError: () => undefined,
+    ...overrides,
+  };
+}
+
+export function createStubDesktopHistorySettingsController(
+  overrides: Partial<DesktopHistorySettingsController> = {},
+): DesktopHistorySettingsController {
+  return {
+    actions: {
+      deleteAgent: noOp,
+      clear: noOp,
+      rerunAgent: noOp,
+      restoreAgent: noOp,
+      exportChatMd: noOp,
+      exportChatTex: noOp,
+      exportChatHtml: noOp,
+    },
+    postHistoryData: noOp,
     ...overrides,
   };
 }

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -27,6 +27,7 @@ export function createStubDesktopHistoryOptions(
     resourcesPath: repoPath('packages', 'extension', 'resources'),
     runExecution: noOp,
     restoreTaskState: async () => true,
+    getActiveExecutionIds: () => [],
     postToRenderer: () => undefined,
     openPath: noOp,
     showInfoMessage: noOp,


### PR DESCRIPTION
## Summary

Promote the existing deep desktop history module into the required history-settings controller and compose it in the
Electron host instead of inside the general settings IPC.

Closes #8429.

## Design

`DesktopHistoryHandlers` now implements `DesktopHistorySettingsController` directly. No wrapper class is added.

The controller continues to own history list construction, active-execution deletion guards, persisted configuration
validation, rerun and restoration flows, lazy chat-export construction, export outcomes, and history notifications.

The boundary remains explicit:

- Agent execution, main-view restoration, active-execution lookup, renderer transport, navigation, notifications, and
  error reporting are required host ports composed in `main/index.ts`.
- The general settings IPC owns dispatch and startup ordering only; it receives the controller action group and invokes
  `postHistoryData()`.
- Memory navigation and unrelated settings remain outside history.
- Active execution lookup is an explicit port, avoiding a desktop-test mock of agent runtime internals and preserving
  both host-agent architecture ratchets.

## Acceptance gates

- The existing `DesktopHistoryHandlers` class implements the required controller interface directly.
- `DesktopSettingsIpcOptions` no longer extends `DesktopHistoryOptions`.
- `resourcesPath`, `runExecution`, `restoreTaskState`, and the history-only error notification leave the general IPC
  options.
- Production constructs history from required capabilities in `main/index.ts`.
- Posting, rerun, restoration, active-run deletion, clearing, and exports remain in the focused history suite.
- The IPC suite covers action delegation and startup invocation.
- `desktopSettingsIpc.ts` shrinks from 460 to 447 lines.

## Net elements (R6)

- Files: 6 modified.
- Diff: +252 / -123, net +129.
- Production: +64 / -65, net -1.
- Tests: +188 / -58, net +130.
- Production classes: no additions; the existing deep history class gains one controller interface.
- `DesktopSettingsIpcOptions`: 18 to 15 fields; optional fields fall from 10 to 9.

## Consumer counts (R8)

No command, event, schema, renderer message key, or external package surface changes.

## Host impact

- Desktop: history capabilities are required at composition time; runtime behavior and wire messages are preserved.
- Extension: no change.
- CLI: no change.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 unchanged warnings)
- focused desktop history and settings tests: 30 passed
- host-agent mock and deep-import ratchets: 6 passed
- independent review and full-suite run; the reported mock-ratchet failure was corrected before publication
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved wire behavior and no auth or schema changes; main risk is wiring mistakes at composition time, covered by moved and new tests.
> 
> **Overview**
> **Desktop history** is no longer constructed inside `createDesktopSettingsIpc`. `DesktopHistoryHandlers` now implements `DesktopHistorySettingsController`, and the Electron host in `main/index.ts` builds it and passes it into settings IPC like the other domain controllers.
> 
> `DesktopHistoryOptions` is flattened so the history module takes required host ports (`getActiveExecutionIds`, renderer posting, dialogs, `openPath`, errors) instead of importing `getAllActiveExecutionIds` from agent runtime. Optional chaining on those UI callbacks is removed because they are required dependencies.
> 
> `DesktopSettingsIpcOptions` drops history-specific fields (`resourcesPath`, `runExecution`, `restoreTaskState`, `showErrorMessage`); it only receives `historySettingsController` for dispatch and startup `postHistoryData()`.
> 
> Tests move rerun/delete/clear coverage into `DesktopHistoryHandlers.vitest.mts` and add IPC tests for delegation and startup; the settings IPC suite no longer embeds a full history rerun integration test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a832006db5f951b28d44b0bf11da4785b1de6b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->