### PR TITLE
refactor(desktop): require settings UI host

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -30,7 +30,6 @@ import {
   buildGitAuthorSettingsMessage,
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
-import { defaultOnError } from './desktopSettingsIpcHelpers.js';
 import {
   createDesktopErrorReporter,
   type DesktopCommandMessage,
@@ -43,6 +42,15 @@ import type { DesktopCrashReportingSettingsController } from './desktopCrashRepo
 import type { DesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import type { DesktopToolingSettingsController } from './desktopToolingSettingsController.js';
 
+export interface DesktopSettingsUiHost {
+  openPath(filePath: string): Promise<void>;
+  revealStream(streamId: string): Promise<void>;
+  showInfoMessage(message: string): Promise<void>;
+  showErrorMessage(message: string): Promise<void>;
+  confirmAction(message: string, confirmLabel?: string): Promise<boolean>;
+  onError(error: unknown): void;
+}
+
 export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
   agentSettingsController: DesktopAgentSettingsController;
@@ -52,13 +60,8 @@ export interface DesktopSettingsIpcOptions {
   toolingSettingsController: DesktopToolingSettingsController;
   state: SettingsStatePorts;
   config: ConfigProvider;
+  ui: DesktopSettingsUiHost;
   sendStartupCatalogData?: boolean;
-  openPath?: (filePath: string) => Promise<void>;
-  /** Route this window to the progress view and select the given stream. */
-  revealStream?: (streamId: string) => Promise<void>;
-  showInfoMessage?: (message: string) => Promise<void>;
-  confirmAction?: (message: string, confirmLabel?: string) => Promise<boolean>;
-  onError?: (error: unknown) => void;
 }
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
@@ -74,12 +77,9 @@ export function createDesktopSettingsIpc(
   const { globalState, workspaceState } = options.state;
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
-  const onError = createDesktopErrorReporter(
-    options.onError ?? defaultOnError,
-    (error) => {
-      void options.showInfoMessage?.(error.reason);
-    },
-  );
+  const onError = createDesktopErrorReporter(options.ui.onError, (error) => {
+    void options.ui.showInfoMessage(error.reason);
+  });
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),
   });
@@ -94,10 +94,9 @@ export function createDesktopSettingsIpc(
     },
     memoryPrompt: {
       confirm: (message, promptOptions) =>
-        options.confirmAction?.(message, promptOptions?.confirmLabel) ??
-        Promise.resolve(true),
+        options.ui.confirmAction(message, promptOptions?.confirmLabel),
       warning: async (message) => {
-        await options.showInfoMessage?.(message);
+        await options.ui.showInfoMessage(message);
       },
     },
   });
@@ -152,12 +151,12 @@ export function createDesktopSettingsIpc(
 
   async function openMemoryFile(input: { storagePath: string }): Promise<void> {
     const resolvedPath = resolveMemoryStoragePath(input.storagePath);
-    await options.openPath?.(StorageFS.fullPath(resolvedPath));
+    await options.ui.openPath(StorageFS.fullPath(resolvedPath));
   }
 
   async function openMemoryFolder(): Promise<void> {
     await StorageFS.ensureDir(resolveMemoryStoragePath());
-    await options.openPath?.(StorageFS.fullPath(resolveMemoryStoragePath()));
+    await options.ui.openPath(StorageFS.fullPath(resolveMemoryStoragePath()));
   }
 
   function postSuperYoloEnabled(): void {
@@ -395,8 +394,7 @@ export function createDesktopSettingsIpc(
     },
     goals: {
       getList: postGoalList,
-      revealStream: (streamId) =>
-        options.revealStream?.(streamId) ?? Promise.resolve(),
+      revealStream: (streamId) => options.ui.revealStream(streamId),
     },
     desktopCrashReporting: options.crashReportingSettingsController.actions,
   };

--- a/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
+++ b/packages/desktop/src/main/desktopSettingsIpcHelpers.ts
@@ -9,10 +9,6 @@ import type { ExternalToolCheckResult } from '@tools/toolAvailability';
  * dashboard request actually arrives.
  */
 
-export function defaultOnError(error: unknown): void {
-  console.error(error);
-}
-
 export async function buildDefaultToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
 ): Promise<ToolDashboardItem[]> {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -72,7 +72,10 @@ import { DefaultDesktopAgentSettingsController } from './desktopAgentSettingsCon
 import { DefaultDesktopCrashReportingSettingsController } from './desktopCrashReportingSettingsController.js';
 import { DefaultDesktopCredentialSettingsController } from './desktopCredentialSettingsController.js';
 import { DesktopHistoryHandlers } from './desktopHistoryHandlers.js';
-import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
+import {
+  createDesktopSettingsIpc,
+  type DesktopSettingsUiHost,
+} from './desktopSettingsIpc.js';
 import {
   buildDefaultToolDashboardItems,
   findToolCommand,
@@ -846,36 +849,9 @@ function createWindow(options: {
       },
       initialization: { initialize: options.initializeCrashReporting },
     });
-  const historySettingsController = new DesktopHistoryHandlers({
-    resourcesPath: options.resourcesPath,
-    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
-    // Rerun and restore use the same host-neutral owners as the extension,
-    // reached through the desktop execution bridge instead of VS Code commands.
-    runExecution: async (request) => {
-      await (await getAgentExecution()).progress.runExecution(request);
-    },
-    restoreTaskState: async (taskState) =>
-      (await getAgentExecution()).progress.restoreTaskState(taskState),
-    getActiveExecutionIds: getAllActiveExecutionIds,
-    openPath: previewHost.openPath,
+  const settingsUi: DesktopSettingsUiHost = {
     showInfoMessage,
     showErrorMessage,
-    onError: reportAsyncError,
-  });
-  const settingsIpc = createDesktopSettingsIpc({
-    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
-    agentSettingsController,
-    crashReportingSettingsController,
-    credentialSettingsController,
-    historySettingsController,
-    toolingSettingsController,
-    state: {
-      globalState: platform().globalState,
-      workspaceState: platform().workspaceState,
-    },
-    config: platform().config,
-    sendStartupCatalogData: true,
-    showInfoMessage,
     confirmAction: async (message, confirmLabel = 'OK') => {
       const result = await dialog.showMessageBox(window, {
         type: 'warning',
@@ -896,6 +872,37 @@ function createWindow(options: {
       }
     },
     onError: reportAsyncError,
+  };
+  const historySettingsController = new DesktopHistoryHandlers({
+    resourcesPath: options.resourcesPath,
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    // Rerun and restore use the same host-neutral owners as the extension,
+    // reached through the desktop execution bridge instead of VS Code commands.
+    runExecution: async (request) => {
+      await (await getAgentExecution()).progress.runExecution(request);
+    },
+    restoreTaskState: async (taskState) =>
+      (await getAgentExecution()).progress.restoreTaskState(taskState),
+    getActiveExecutionIds: getAllActiveExecutionIds,
+    openPath: settingsUi.openPath,
+    showInfoMessage: settingsUi.showInfoMessage,
+    showErrorMessage: settingsUi.showErrorMessage,
+    onError: settingsUi.onError,
+  });
+  const settingsIpc = createDesktopSettingsIpc({
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    agentSettingsController,
+    crashReportingSettingsController,
+    credentialSettingsController,
+    historySettingsController,
+    toolingSettingsController,
+    state: {
+      globalState: platform().globalState,
+      workspaceState: platform().workspaceState,
+    },
+    config: platform().config,
+    ui: settingsUi,
+    sendStartupCatalogData: true,
   });
   settingsIpcRef.current = settingsIpc;
   const progressIpc = createDesktopProgressIpc({

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -16,6 +16,7 @@ import {
   createStubDesktopCrashReportingSettingsController,
   createStubDesktopCredentialSettingsController,
   createStubDesktopHistorySettingsController,
+  createStubDesktopSettingsUiHost,
   createStubDesktopToolingSettingsController,
 } from './desktopSettingsTestSupport';
 import type { StateStore } from '@platform/interfaces';
@@ -50,6 +51,7 @@ type SettingsFixtureOverrides = Omit<
   | 'state'
   | 'config'
   | 'historySettingsController'
+  | 'ui'
   | 'toolingSettingsController'
   | 'postToRenderer'
 > & {
@@ -60,6 +62,7 @@ type SettingsFixtureOverrides = Omit<
   workspaceState?: StateStore;
   config?: DesktopSettingsIpcOptions['config'];
   historySettingsController?: DesktopSettingsIpcOptions['historySettingsController'];
+  ui?: Partial<DesktopSettingsIpcOptions['ui']>;
   toolingSettingsController?: DesktopSettingsIpcOptions['toolingSettingsController'];
   postToRenderer?: DesktopSettingsIpcOptions['postToRenderer'];
 };
@@ -140,6 +143,7 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
     globalState = new MemoryStateStore(),
     workspaceState = new MemoryStateStore(),
     config = new MemoryConfigStore(),
+    ui,
     ...settingsOverrides
   } = overrides;
   const postToRenderer = overrides.postToRenderer ?? (() => undefined);
@@ -171,6 +175,7 @@ function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
       }),
     state: { globalState, workspaceState },
     config,
+    ui: createStubDesktopSettingsUiHost(ui),
     postToRenderer,
   });
   return { globalState, settings, workspaceState };
@@ -446,8 +451,10 @@ describe('desktop settings IPC', () => {
     const revealed: string[] = [];
 
     const { settings } = createSettingsFixture({
-      revealStream: async (streamId) => {
-        revealed.push(streamId);
+      ui: {
+        revealStream: async (streamId) => {
+          revealed.push(streamId);
+        },
       },
     });
 
@@ -590,7 +597,7 @@ describe('desktop settings IPC', () => {
       workspaceState,
       globalState,
       credentialSettingsController,
-      onError: (error) => errors.push(error),
+      ui: { onError: (error) => errors.push(error) },
     });
 
     expect(
@@ -672,7 +679,7 @@ describe('desktop settings IPC', () => {
       workspaceState,
       config,
       sendStartupCatalogData: true,
-      onError: () => undefined,
+      ui: { onError: () => undefined },
     });
 
     expect(
@@ -707,7 +714,7 @@ describe('desktop settings IPC', () => {
 
     const { settings, posted } = createCapturedSettingsFixture({
       config,
-      onError: () => undefined,
+      ui: { onError: () => undefined },
     });
 
     expect(
@@ -752,7 +759,7 @@ describe('desktop settings IPC', () => {
       config: new MemoryConfigStore(),
       sendStartupCatalogData: true,
       credentialSettingsController,
-      onError: () => undefined,
+      ui: { onError: () => undefined },
     });
 
     expect(
@@ -850,6 +857,28 @@ describe('desktop settings IPC', () => {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
       enabled: false,
     });
+  });
+
+  it('requires UI confirmation before deleting memory', async () => {
+    const confirmAction = vi.fn(async () => false);
+    const { settings, posted } = createCapturedSettingsFixture({
+      ui: { confirmAction },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.DELETE_MEMORY,
+        storagePath: 'memory/example.md',
+        displayPath: 'example.md',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(confirmAction).toHaveBeenCalledWith(
+      'Delete "example.md"?',
+      'Delete',
+    );
+    expect(posted).toEqual([]);
   });
 
   it('ignores unsupported or malformed settings messages', async () => {

--- a/src/test-kernel/desktop/desktopSettingsTestSupport.ts
+++ b/src/test-kernel/desktop/desktopSettingsTestSupport.ts
@@ -7,6 +7,7 @@ import type {
   DesktopHistoryOptions,
   DesktopHistorySettingsController,
 } from '@desktop/main/desktopHistoryHandlers';
+import type { DesktopSettingsUiHost } from '@desktop/main/desktopSettingsIpc';
 import type { DesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
 
 // Shared imports - settings controllers
@@ -51,6 +52,20 @@ export function createStubDesktopHistorySettingsController(
       exportChatHtml: noOp,
     },
     postHistoryData: noOp,
+    ...overrides,
+  };
+}
+
+export function createStubDesktopSettingsUiHost(
+  overrides: Partial<DesktopSettingsUiHost> = {},
+): DesktopSettingsUiHost {
+  return {
+    openPath: noOp,
+    revealStream: noOp,
+    showInfoMessage: noOp,
+    showErrorMessage: noOp,
+    confirmAction: async () => true,
+    onError: () => undefined,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Compose one required desktop settings UI host and remove the remaining optional UI callbacks from the settings IPC.

Closes #8432.

## Problem and simpler alternative

The settings factory still accepted five optional UI callbacks even though production always supplied them. Missing callbacks became silent no-ops, console fallback, or an automatic approval for memory deletion; one required typed host makes those dependencies explicit and leaves one behavior path.

## Design

- Add `DesktopSettingsUiHost` with required path opening, stream reveal, info/error notification, confirmation, and error reporting.
- Compose one host object in `main/index.ts`; the extracted history controller from #8431 reuses its relevant capabilities.
- Replace optional settings UI calls with direct calls and remove the unsafe `confirmAction ?? true` behavior.
- Delete the now-unused `defaultOnError` helper.
- Give desktop settings tests one typed UI-host stub and pin cancellation before memory deletion.

## Net elements (R6)

- Files: 5 modified.
- Diff: +100 / -56, net +44.
- Production: +51 / -50, net +1.
- Tests: +49 / -6, net +43.
- Remaining optional UI callback fields on `DesktopSettingsIpcOptions`: 5 to 0.
- New production classes: none; one required six-method port interface.

## Consumer counts (R8)

- Production composition sites: 1 (`main/index.ts`).
- Settings test fixture sites: 1 shared typed stub.
- No command, event, schema, renderer message key, or external package surface changes.

## Host impact

- Desktop: missing UI capabilities now fail at composition/typecheck time; runtime behavior is preserved except that absent confirmation can no longer auto-approve deletion.
- Extension: no change.
- CLI: no change.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; 50 existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only repository ratchet)
- `npm run compile:fast`
- focused desktop settings/history tests: 31 passed
- full Vitest suite: 6,145 passed / 4 skipped across 686 passed files and 1 skipped file
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only wiring refactor with no IPC/schema changes; the only user-visible delta is stricter memory-delete confirmation when the UI host is present (production already supplies it).
> 
> **Overview**
> Desktop settings IPC no longer accepts five optional UI callbacks; it now takes a single required **`DesktopSettingsUiHost`** (`openPath`, `revealStream`, dialogs, **`confirmAction`**, **`onError`**).
> 
> **`main/index.ts`** builds one **`settingsUi`** object (Electron message boxes + progress reveal) and passes it into **`createDesktopSettingsIpc`**; history settings reuse the same open-path and notification hooks. Settings code calls **`options.ui.*`** directly instead of optional chaining, and **`defaultOnError`** is removed.
> 
> **Behavioral fix:** memory deletion always goes through **`confirmAction`**—there is no fallback that treated a missing confirm hook as approval.
> 
> Tests use **`createStubDesktopSettingsUiHost`** and add coverage that canceling delete confirmation leaves memory unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bd82418d870e9760056a3ef035d3a2a558401b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->