### PR TITLE
refactor(desktop): unify settings startup

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -61,7 +61,6 @@ export interface DesktopSettingsIpcOptions {
   state: SettingsStatePorts;
   config: ConfigProvider;
   ui: DesktopSettingsUiHost;
-  sendStartupCatalogData?: boolean;
 }
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
@@ -417,13 +416,7 @@ export function createDesktopSettingsIpc(
             command: SETTINGS_VIEW_COMMANDS.SET_UNSUPPORTED_COMMANDS,
             commands: unsupportedCommands(settingsHandlers),
           });
-          if (options.sendStartupCatalogData) {
-            runAsync(postInitialSettingsData());
-          } else {
-            postGitAuthorSettings();
-            options.toolingSettingsController.postLatexConfigValues();
-            postGoalList();
-          }
+          runAsync(postInitialSettingsData());
         }
         return false;
       }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -902,7 +902,6 @@ function createWindow(options: {
     },
     config: platform().config,
     ui: settingsUi,
-    sendStartupCatalogData: true,
   });
   settingsIpcRef.current = settingsIpc;
   const progressIpc = createDesktopProgressIpc({

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -255,6 +255,7 @@ describe('desktop settings IPC', () => {
         view: 'settings',
       }),
     ).toBe(false);
+    await flushAsyncWork();
     // First post is the derived capability broadcast (commands this host's
     // registry declares `unsupported(...)`); asserted structurally rather
     // than as an exact list so it doesn't need updating every time a
@@ -265,23 +266,19 @@ describe('desktop settings IPC', () => {
         SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS,
       ]),
     });
-    expect(posted.slice(1)).toEqual([
-      {
-        command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
-        markCommits: DEFAULT_GIT_MARK_COMMITS,
-        authorName: 'TeXRA Bot',
-        authorEmail: 'bot@example.com',
-        worktreeSupport: false,
-      },
-      {
-        command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
-        values: {},
-      },
-      {
-        command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
-        items: [],
-      },
-    ]);
+    expect(
+      posted.find(
+        (message) =>
+          commandOf(message) ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      ),
+    ).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      markCommits: DEFAULT_GIT_MARK_COMMITS,
+      authorName: 'TeXRA Bot',
+      authorEmail: 'bot@example.com',
+      worktreeSupport: false,
+    });
   }, 15_000);
 
   it('delegates agent-selection commands to the required controller', async () => {
@@ -429,6 +426,7 @@ describe('desktop settings IPC', () => {
       command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
       view: 'settings',
     });
+    await flushAsyncWork();
     const capabilities = posted[0] as { commands?: string[] };
     expect(capabilities.commands).not.toContain(
       SETTINGS_VIEW_COMMANDS.GET_GOAL_LIST,
@@ -678,7 +676,6 @@ describe('desktop settings IPC', () => {
       toolingSettingsController,
       workspaceState,
       config,
-      sendStartupCatalogData: true,
       ui: { onError: () => undefined },
     });
 
@@ -757,7 +754,6 @@ describe('desktop settings IPC', () => {
     const { settings, posted } = createCapturedSettingsFixture({
       ...state,
       config: new MemoryConfigStore(),
-      sendStartupCatalogData: true,
       credentialSettingsController,
       ui: { onError: () => undefined },
     });


### PR DESCRIPTION
## Summary

Remove the desktop settings startup mode flag and always run the production startup sequence when the settings view becomes ready.

Closes #8433.

## Problem and simpler alternative

`sendStartupCatalogData?: boolean` exposed a test-only runtime mode: production always passed `true`, while omission skipped most startup domains and exercised a protocol production never used. One unconditional `postInitialSettingsData()` path removes the duplicate partial sequence; typed controller stubs keep tests fast without changing production control flow.

## Design

- Delete `sendStartupCatalogData` from `DesktopSettingsIpcOptions` and the Electron composition root.
- Replace the conditional ready path with one `runAsync(postInitialSettingsData())` call.
- Remove the duplicate Git/LaTeX/goals-only branch.
- Update readiness tests to await startup work and assert the relevant messages without assuming the obsolete partial protocol.
- Preserve the existing non-blocking model-refresh test and all domain-startup assertions.

## Net elements (R6)

- Files: 3 modified.
- Diff: +16 / -28, net -12.
- Production: +1 / -9, net -8.
- Tests: +15 / -19, net -4.
- Optional constructor fields: -1.
- Startup control-flow branches: -1.

## Consumer counts (R8)

- Production values of the removed flag: 1, always `true`.
- Explicit test values of the removed flag: 2, both `true`.
- No command, event, schema, renderer message key, or external package surface changes.

## Host impact

- Desktop: settings readiness now has one startup protocol, matching the only production behavior that existed.
- Extension: no change.
- CLI: no change.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run lint` (0 errors; 50 existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (warn-only repository ratchet)
- `npm run compile:fast`
- focused desktop settings tests: 17 passed
- full Vitest suite: 6,145 passed / 4 skipped across 686 passed files and 1 skipped file
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production already always enabled full startup; this is a control-flow cleanup with no IPC or schema changes.
> 
> **Overview**
> **Removes the desktop-only `sendStartupCatalogData` option** and the alternate “partial” settings bootstrap that only pushed Git author, LaTeX config, and goals when the flag was omitted.
> 
> When the settings webview signals **WEBVIEW_READY**, the host **always** schedules **`postInitialSettingsData()`** (unsupported-command broadcast unchanged). The Electron main process no longer passes `sendStartupCatalogData: true` because that path is now the only one.
> 
> Tests **await async startup** after readiness and assert individual outbound messages (e.g. Git author) instead of assuming the old partial post order or passing the removed flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84ad82e7affafbc8f8213f8e4af563991d22c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->