### PR TITLE
fix(desktop): report notification failures

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -77,7 +77,7 @@ export function createDesktopSettingsIpc(
   // Commands declared `unsupported(...)` in settingsHandlers below surface as
   // a visible info dialog instead of a console-only error log.
   const onError = createDesktopErrorReporter(options.ui.onError, (error) => {
-    void options.ui.showInfoMessage(error.reason);
+    void options.ui.showInfoMessage(error.reason).catch(options.ui.onError);
   });
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -467,6 +467,45 @@ describe('desktop settings IPC', () => {
     expect(revealed).toEqual(['goal-owning-stream']);
   });
 
+  it('shows unsupported-command reasons without reporting an error', async () => {
+    const showInfoMessage = vi.fn(async () => undefined);
+    const onError = vi.fn();
+    const { settings } = createSettingsFixture({
+      ui: { showInfoMessage, onError },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(showInfoMessage).toHaveBeenCalledWith(
+      'No VS Code settings in the desktop app.',
+    );
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure to show an unsupported-command reason', async () => {
+    const failure = new Error('notification failed');
+    const showInfoMessage = vi.fn(async () => Promise.reject(failure));
+    const onError = vi.fn();
+    const { settings } = createSettingsFixture({
+      ui: { showInfoMessage, onError },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
   it('delegates Tools and LaTeX commands to the required controller', async () => {
     const baseController = createStubDesktopToolingSettingsController();
     const toggle = vi.fn(async () => undefined);


### PR DESCRIPTION
## Summary

Route failures from the desktop settings unsupported-command notification to the required desktop error reporter.

Closes #8436.

## Problem

Desktop settings commands deliberately marked unsupported are shown through a native information message. That asynchronous notification was started without observing its result, so a native notification failure could become an unhandled rejection.

## Design

The unsupported-command path remains distinct from ordinary errors: a successful information message is not sent to the generic reporter. Only rejection of the information-message promise is passed to the existing required `onError` port. This preserves the current user-visible behavior and keeps one error-reporting owner.

## Validation

- Focused desktop settings tests: 19 passed
- Type checking passed
- Lint: 0 errors; 50 existing warnings
- Prettier and `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change on a desktop-only notification path with tests; no auth, data, or shared runtime behavior changes.
> 
> **Overview**
> When desktop settings routes an **unsupported** command to a native info dialog, the `showInfoMessage` promise is now **`.catch`’d** through the existing `onError` reporter so a failed notification cannot become an **unhandled rejection**.
> 
> Successful info messages are unchanged—they still do not hit the generic error reporter. Two focused IPC tests cover the happy path and notification failure forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920f60ff9ee0527d7d5817a7bfa6ce678800237e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->