### PR TITLE
refactor(desktop): require execution host

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -87,7 +87,6 @@ import {
 import type { RegisteredToolName } from '@tools/registry';
 import { DIAGNOSTICS_READ_RUNTIME_CAPABILITY } from '@tools/diagnosticsRuntimeCapabilities';
 import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
-import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -8,7 +8,7 @@ import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform, tryPlatform } from '@platform/platform';
-import { StreamLogStore, StreamSnapshotStore } from '@transcript';
+import { StreamLogStore, type StreamSnapshotStore } from '@transcript';
 import {
   isProgressBackendInteractionEvent,
   type ProgressBackendInteractionPayloads,
@@ -65,7 +65,6 @@ import {
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
-import type { DiffViewHost, ExternalOpener } from '@hosts/uiHosts';
 import type { MainViewExecuteMessage } from '@shared/mainView';
 import {
   STREAM_PHASE,
@@ -114,6 +113,7 @@ import {
   type DesktopPresentationPayloads,
   type DesktopSessionProgressBridge,
 } from './desktopSessionProgressBridge.js';
+import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
 import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
 
@@ -124,13 +124,7 @@ const DESKTOP_UNAVAILABLE_TOOLS: readonly RegisteredToolName[] = [
 ];
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
-  opener?: Pick<ExternalOpener, 'openPath'> & {
-    openBuildDisplay?: BuildDisplayFn;
-  };
-  diff?: Pick<DiffViewHost, 'openDiff'>;
-  confirmAcceptFile?: (message: string) => Promise<boolean>;
-  showErrorMessage?: (message: string) => Promise<void> | void;
-  showInfoMessage?: (message: string) => Promise<void> | void;
+  host: DesktopAgentExecutionHost;
   /**
    * Optional snapshot store wired by the desktop entrypoint. When
    * provided, the bridge persists a slim snapshot of the rail on each
@@ -138,15 +132,7 @@ export interface DesktopAgentExecutionOptions {
    * previously-persisted "ghost" streams in the rail at launch.
    */
   streamSnapshotStore?: DesktopStreamSnapshotStore;
-  progressSnapshotStore?: StreamSnapshotStore;
-  /**
-   * Fired once a run in this window's session reaches a completed terminal
-   * result. Used to recompute the onboarding funnel after a user's first run
-   * (the lifecycle has already persisted `firstRunDone` by the time the
-   * terminal `result` event reaches `session.onResult`), so the renderer leaves
-   * the setup card without waiting for a restart.
-   */
-  onRunCompleted?: () => void;
+  progressSnapshotStore: StreamSnapshotStore;
 }
 
 export interface DesktopAgentExecution {
@@ -169,16 +155,9 @@ interface DesktopRunExecutionOptions {
 export interface DesktopProgressBridgeOptions {
   transcripts: StreamLogStore;
   logger?: AgentTrace;
-  openPath?: (filePath: string, line?: number) => Promise<void>;
-  openBuildDisplay?: BuildDisplayFn;
-  openDiff?: DiffViewHost['openDiff'];
-  confirmAcceptFile?: (message: string) => Promise<boolean>;
-  showInfoMessage?: (message: string) => Promise<void> | void;
-  showErrorMessage?: (message: string) => Promise<void> | void;
+  host: DesktopAgentExecutionHost;
   streamSnapshotStore?: DesktopStreamSnapshotStore;
-  progressSnapshotStore?: StreamSnapshotStore;
-  /** See DesktopAgentExecutionOptions.onRunCompleted. */
-  onRunCompleted?: () => void;
+  progressSnapshotStore: StreamSnapshotStore;
 }
 
 class MemoryProgressStorage implements MementoStorage {
@@ -266,10 +245,7 @@ export class DesktopProgressBridge {
     this.toolEditApprovals = createDesktopToolEditApprovalController({
       runtimeHost: this.runtimeHost,
       session: this.session,
-      openPath: options.openPath,
-      openBuildDisplay: options.openBuildDisplay,
-      openDiff: options.openDiff,
-      showErrorMessage: this.options.showErrorMessage,
+      ui: options.host,
     });
     this.hostInteractions = createDesktopHostInteractions({
       runtimeHost: this.runtimeHost,
@@ -284,7 +260,7 @@ export class DesktopProgressBridge {
     this.backend = new ProgressBackend({
       session: this.session,
       storage: tryPlatform()?.workspaceState ?? new MemoryProgressStorage(),
-      snapshots: options.progressSnapshotStore ?? new StreamSnapshotStore(),
+      snapshots: options.progressSnapshotStore,
       sendMessage: (message) => {
         return this.postToRenderer(message) !== false;
       },
@@ -346,7 +322,7 @@ export class DesktopProgressBridge {
         );
       },
       onShowError: (message) => {
-        void this.options.showErrorMessage?.(message);
+        void this.options.host.showErrorMessage(message);
       },
     });
     const backendSubscription = this.backend.setupEventListeners();
@@ -367,7 +343,7 @@ export class DesktopProgressBridge {
     // still safe — the derivation is idempotent.
     const unsubscribeResult = this.session.onResult((event) => {
       if (event.outcome === 'completed') {
-        this.options.onRunCompleted?.();
+        this.options.host.onRunCompleted();
       }
     });
     this.unsubscribe = () => {
@@ -384,20 +360,10 @@ export class DesktopProgressBridge {
       this.session,
       this.runtimeHost,
     );
-    this.fileActions = new DesktopProgressFileActions(
-      {
-        openPath: options.openPath,
-        openBuildDisplay: options.openBuildDisplay,
-        openDiff: options.openDiff,
-        confirmAcceptFile: options.confirmAcceptFile,
-        showInfoMessage: options.showInfoMessage,
-        showErrorMessage: options.showErrorMessage,
-      },
-      {
-        runExecution: (request) => this.runExecution(request),
-        listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
-      },
-    );
+    this.fileActions = new DesktopProgressFileActions(options.host, {
+      runExecution: (request) => this.runExecution(request),
+      listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
+    });
     this.progressHost = this.createProgressViewHost();
     this.workflowFileActions = this.progressHost.workflowFileActionsController;
     this.agentProposalController = this.progressHost.agentProposalController;
@@ -424,7 +390,7 @@ export class DesktopProgressBridge {
             this.logger.error('Invalid desktop workflow execution request', {
               data: validated.issue,
             });
-            await this.options.showErrorMessage?.(validated.message);
+            await this.options.host.showErrorMessage(validated.message);
             return;
           }
           await this.runExecution(validated.request);
@@ -459,15 +425,15 @@ export class DesktopProgressBridge {
           latexdiffFile: (baseFile, editedFile) =>
             this.runLatexdiffFile(baseFile, editedFile),
           openDirectory: async (directory) => {
-            await this.options.openPath?.(directory);
+            await this.options.host.openPath(directory);
           },
           openLabel: (label) => this.fileActions.findAndOpenLabel(label),
           readFile: (file) => readFile(file, 'utf8'),
           showInfo: async (message) => {
-            await this.options.showInfoMessage?.(message);
+            await this.options.host.showInfoMessage(message);
           },
           showError: async (message) => {
-            await this.options.showErrorMessage?.(message);
+            await this.options.host.showErrorMessage(message);
           },
           logError: (message, error) => {
             this.logger.error(message, {
@@ -542,7 +508,7 @@ export class DesktopProgressBridge {
         },
         file: {
           openFile: async (file, line) => {
-            await this.options.openPath?.(file, line);
+            await this.options.host.openPath(file, line);
           },
           openFileCompile: (file) => this.openFileCompile(file),
         },
@@ -610,7 +576,7 @@ export class DesktopProgressBridge {
           cloneOverleaf: 'Import from Overleaf',
           downloadArxiv: 'Import from arXiv',
         };
-        await this.options.showInfoMessage?.(
+        await this.options.host.showInfoMessage(
           `"${labels[data.action]}" requires the VS Code extension.`,
         );
       },
@@ -625,7 +591,7 @@ export class DesktopProgressBridge {
       webviewReady: () => {},
       // Trivially wireable with existing desktop infrastructure.
       showInformationMessage: (data) => {
-        void this.options.showInfoMessage?.(data.text);
+        void this.options.host.showInfoMessage(data.text);
       },
       restoreProposalConfig: async (data) => {
         await this.agentProposalController.restoreProposalConfig(data.proposal);
@@ -640,7 +606,7 @@ export class DesktopProgressBridge {
         if (!taskState) return;
         const restored = this.restoreTaskState(taskState);
         if (!restored) {
-          await this.options.showErrorMessage?.('Failed to restore state');
+          await this.options.host.showErrorMessage('Failed to restore state');
         }
       },
       compactResponse: unsupported(
@@ -1055,11 +1021,13 @@ export class DesktopProgressBridge {
         // so open the resolved path through the same preview-with-fallback
         // host `openWorkflowOutput` already uses (see runExecution above).
         const data = payload as RequestOpenFilePayload;
-        this.options.openPath?.(data.location.absolutePath).catch((error) => {
-          this.logger.warn('Failed to open requested file on desktop', {
-            data: toLogData(error),
+        this.options.host
+          .openPath(data.location.absolutePath)
+          .catch((error) => {
+            this.logger.warn('Failed to open requested file on desktop', {
+              data: toLogData(error),
+            });
           });
-        });
         return;
       }
       default:
@@ -1216,7 +1184,7 @@ export class DesktopProgressBridge {
         this.logger.error(`Failed to load desktop transcript ${streamId}`, {
           data: toLogData(error),
         });
-        void this.options.showErrorMessage?.(
+        void this.options.host.showErrorMessage(
           `Transcript load failed: ${toErrorMessage(error)}`,
         );
       });
@@ -1263,13 +1231,13 @@ export class DesktopProgressBridge {
       resolveResumeState: async (id) => {
         const resumeState = await this.resolveResumeState(id);
         if (!resumeState) {
-          await this.options.showInfoMessage?.(
+          await this.options.host.showInfoMessage(
             'No persisted run state was found for this stream. Start a new run instead.',
           );
           return undefined;
         }
         if (!resumeState.executionId) {
-          await this.options.showInfoMessage?.(
+          await this.options.host.showInfoMessage(
             'This stream has no persisted execution id. Start a new run instead.',
           );
           return undefined;
@@ -1295,7 +1263,7 @@ export class DesktopProgressBridge {
           { modelHandlerCompatibilityKey },
         ),
       reportNoResumableSession: async () => {
-        await this.options.showInfoMessage?.(
+        await this.options.host.showInfoMessage(
           'This run has no resumable session state. Start a new run instead.',
         );
       },
@@ -1316,7 +1284,7 @@ export class DesktopProgressBridge {
     this.logger.error(`Failed to resume desktop stream ${streamId}`, {
       data: toLogData(error),
     });
-    await this.options.showErrorMessage?.(
+    await this.options.host.showErrorMessage(
       `Resume failed: ${toErrorMessage(error)}`,
     );
   }
@@ -1468,12 +1436,12 @@ export class DesktopProgressBridge {
             },
           });
         }
-        await this.options.showInfoMessage?.(presentation.message);
+        await this.options.host.showInfoMessage(presentation.message);
       }
       return;
     }
 
-    await this.options.showInfoMessage?.(
+    await this.options.host.showInfoMessage(
       'No active session. Start a new agent task to continue.',
     );
   }
@@ -1526,7 +1494,7 @@ export class DesktopProgressBridge {
         // (selectAutoOpenFinalOutput); the desktop host only supplies openPath.
         const output = selectAutoOpenFinalOutput(result);
         if (!output) return;
-        await this.options.openPath?.(output.absolutePath);
+        await this.options.host.openPath(output.absolutePath);
       },
     });
   }
@@ -1582,15 +1550,9 @@ export async function createDesktopAgentExecution(
   const transcripts = await StreamLogStore.open();
   const progress = new DesktopProgressBridge(options.postToRenderer, {
     transcripts,
-    openPath: options.opener?.openPath,
-    openBuildDisplay: options.opener?.openBuildDisplay,
-    openDiff: options.diff?.openDiff,
-    confirmAcceptFile: options.confirmAcceptFile,
-    showInfoMessage: options.showInfoMessage,
-    showErrorMessage: options.showErrorMessage,
+    host: options.host,
     streamSnapshotStore: options.streamSnapshotStore,
     progressSnapshotStore: options.progressSnapshotStore,
-    onRunCompleted: options.onRunCompleted,
   });
 
   return {
@@ -1598,7 +1560,7 @@ export async function createDesktopAgentExecution(
     async handleExecute(message) {
       const preparation = prepareMainViewExecutionRequest(message);
       if (!preparation.valid) {
-        await options.showErrorMessage?.(preparation.message);
+        await options.host.showErrorMessage(preparation.message);
         return;
       }
 

--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -1,0 +1,14 @@
+import type { DiffViewHost } from '@hosts/uiHosts';
+import type { BuildDisplayFn } from '@tools/approval/latexPreview';
+
+/** Required desktop capabilities used throughout an agent execution. */
+export interface DesktopAgentExecutionHost {
+  openPath(filePath: string, line?: number): Promise<void>;
+  openBuildDisplay: BuildDisplayFn;
+  openDiff: DiffViewHost['openDiff'];
+  confirmAcceptFile(message: string): Promise<boolean>;
+  showErrorMessage(message: string): Promise<void> | void;
+  showInfoMessage(message: string): Promise<void> | void;
+  /** Recompute window state derived from a newly completed run. */
+  onRunCompleted(): void;
+}

--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import { appSignals } from '@eventBus/AppSignals';
-import type { DiffViewHost } from '@hosts/uiHosts';
 import { acceptEditedFileReplace } from '@latex/acceptedFileTarget';
 import { openFirstLabelMatch } from '@latex/labelSearch';
 import { LaTeXdiffService } from '@latex/latexdiff';
@@ -19,21 +18,22 @@ import type {
   OutputFileInfo,
   RoundIndexed,
 } from '@shared/schemas';
-import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
   AbsoluteFS,
   createExternalLocation,
   pathToLocation,
 } from '@utils/files';
+import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
 
-export interface DesktopProgressFileActionOptions {
-  openPath?: (filePath: string, line?: number) => Promise<void>;
-  openBuildDisplay?: BuildDisplayFn;
-  openDiff?: DiffViewHost['openDiff'];
-  confirmAcceptFile?: (message: string) => Promise<boolean>;
-  showInfoMessage?: (message: string) => Promise<void> | void;
-  showErrorMessage?: (message: string) => Promise<void> | void;
-}
+type DesktopProgressFileActionUi = Pick<
+  DesktopAgentExecutionHost,
+  | 'openPath'
+  | 'openBuildDisplay'
+  | 'openDiff'
+  | 'confirmAcceptFile'
+  | 'showInfoMessage'
+  | 'showErrorMessage'
+>;
 
 /**
  * Bridge-owned capabilities the file actions reach back into: starting a fresh
@@ -68,29 +68,16 @@ function toFileLocation(filePath: string): FileLocation {
 
 export class DesktopProgressFileActions {
   constructor(
-    private readonly options: DesktopProgressFileActionOptions,
+    private readonly ui: DesktopProgressFileActionUi,
     private readonly host: DesktopProgressFileActionHost,
   ) {}
 
   async openFileCompile(filePath: string): Promise<void> {
-    if (this.options.openBuildDisplay) {
-      await this.options.openBuildDisplay(toFileLocation(filePath));
-      return;
-    }
-    await this.options.showErrorMessage?.(
-      'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
-    );
+    await this.ui.openBuildDisplay(toFileLocation(filePath));
   }
 
   async compareFiles(baseFile: string, editedFile: string): Promise<void> {
-    if (!this.options.openDiff) {
-      await this.options.showErrorMessage?.(
-        'Desktop file comparison is not available in this host yet.',
-      );
-      return;
-    }
-
-    await this.options.openDiff(
+    await this.ui.openDiff(
       { filePath: baseFile },
       { filePath: editedFile },
       `Compare: ${path.basename(editedFile)} <-> ${path.basename(baseFile)}`,
@@ -112,7 +99,7 @@ export class DesktopProgressFileActions {
       },
     });
     if (!validation.valid) {
-      await this.options.showErrorMessage?.(`Merge: ${validation.message}`);
+      await this.ui.showErrorMessage(`Merge: ${validation.message}`);
       return;
     }
     await this.host.runExecution(validation.request);
@@ -130,15 +117,12 @@ export class DesktopProgressFileActions {
         readFile: (location) => readFile(location.absolutePath, 'utf8'),
         writeFile: (location, content) =>
           writeFile(location.absolutePath, content, 'utf8'),
-        confirm: (message) =>
-          this.options.confirmAcceptFile
-            ? this.options.confirmAcceptFile(message)
-            : Promise.resolve(true),
+        confirm: (message) => this.ui.confirmAcceptFile(message),
         emitWritten: (absolutePath) =>
           appSignals.emit('workspaceFilesWritten', {
             absolutePaths: [absolutePath],
           }),
-        showInfo: (message) => this.options.showInfoMessage?.(message),
+        showInfo: (message) => this.ui.showInfoMessage(message),
       },
     );
   }
@@ -171,7 +155,7 @@ export class DesktopProgressFileActions {
     );
 
     if (!result.success || !result.diffFileName) {
-      await this.options.showErrorMessage?.(
+      await this.ui.showErrorMessage(
         result.message ?? 'Failed to generate diff file.',
       );
       return;
@@ -188,7 +172,7 @@ export class DesktopProgressFileActions {
       candidates,
       (file) => readFile(file, 'utf8'),
       async (file) => {
-        await this.options.openPath?.(file);
+        await this.ui.openPath(file);
       },
     );
   }
@@ -252,12 +236,8 @@ export class DesktopProgressFileActions {
     return successes.length > 0;
   }
 
-  /** Open a generated diff file via the LaTeX build display, falling back to the plain opener. */
+  /** Open a generated diff file via the desktop LaTeX build display. */
   private async openDiffOutput(diffFilePath: string): Promise<void> {
-    if (this.options.openBuildDisplay) {
-      await this.options.openBuildDisplay(createExternalLocation(diffFilePath));
-      return;
-    }
-    await this.options.openPath?.(diffFilePath);
+    await this.ui.openBuildDisplay(createExternalLocation(diffFilePath));
   }
 }

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -1,4 +1,4 @@
-import { readFile, rm, writeFile } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { nanoid } from 'nanoid';
@@ -11,10 +11,8 @@ import {
 } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isLatexFile } from '@common/files/fileTypeUtils';
-import type { DiffViewHost } from '@hosts/uiHosts';
 import type { StreamTabId } from '@shared/schemas';
 import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
-import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import {
   previewProposedLatex,
   runLatexdiff,
@@ -23,7 +21,6 @@ import {
 import { writeApprovalTempFiles } from '@tools/approval/tempFileManager';
 import {
   computeLineChangeSummary,
-  computeUserPatch,
   emitToolEditApprovalPrompt,
   registerPendingApproval,
   unregisterPendingApproval,
@@ -34,14 +31,17 @@ import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 import { createTexraTempDir } from './desktopTempDir.js';
+import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
+
+type DesktopToolEditApprovalUi = Pick<
+  DesktopAgentExecutionHost,
+  'openPath' | 'openBuildDisplay' | 'openDiff' | 'showErrorMessage'
+>;
 
 export interface DesktopToolEditApprovalOptions {
   runtimeHost: AgentRuntimeHost;
   session: SessionHandle;
-  openPath?: (filePath: string) => Promise<void>;
-  openBuildDisplay?: BuildDisplayFn;
-  openDiff?: DiffViewHost['openDiff'];
-  showErrorMessage?: (message: string) => Promise<void> | void;
+  ui: DesktopToolEditApprovalUi;
   tempRoot?: string;
 }
 
@@ -188,7 +188,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
         void this.runAction(payload.requestId, () =>
           runLatexdiff(entry, {
             subtype: 'ONLYCHANGEDPAGE',
-            openBuildDisplay: this.options.openBuildDisplay,
+            openBuildDisplay: this.options.ui.openBuildDisplay,
           }),
         );
         return true;
@@ -351,18 +351,14 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   private async previewProposed(
     entry: DesktopPendingToolEditApproval,
   ): Promise<void> {
-    const openBuildDisplay = this.options.openBuildDisplay;
-    if (isLatexFile(entry.request.path) && openBuildDisplay) {
-      await previewProposedLatex(entry, { openBuildDisplay });
+    if (isLatexFile(entry.request.path)) {
+      await previewProposedLatex(entry, {
+        openBuildDisplay: this.options.ui.openBuildDisplay,
+      });
       return;
     }
 
-    if (!this.options.openPath) {
-      await this.report('Desktop preview is unavailable.');
-      return;
-    }
-
-    await this.options.openPath(entry.proposedUri.fsPath);
+    await this.options.ui.openPath(entry.proposedUri.fsPath);
   }
 
   private async approveProposedEdit(
@@ -379,28 +375,12 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   private async openDiffPatch(
     entry: DesktopPendingToolEditApproval,
   ): Promise<void> {
-    if (this.options.openDiff) {
-      await this.options.openDiff(
-        { filePath: entry.originalUri.fsPath },
-        { filePath: entry.proposedUri.fsPath },
-        `Tool edit: ${path.basename(entry.request.path)}`,
-        { preserveFocus: true },
-      );
-      return;
-    }
-
-    if (!this.options.openPath) {
-      await this.report('Desktop diff preview is unavailable.');
-      return;
-    }
-
-    const patch =
-      computeUserPatch(entry.originalContent, entry.proposedContent) ??
-      `No textual changes for ${entry.request.path}.\n`;
-    const diffPath = path.join(entry.tempDir, `${nanoid()}-changes.diff`);
-    await writeFile(diffPath, patch, 'utf8');
-    entry.workspaceTempCleanup.push(() => rm(diffPath, { force: true }));
-    await this.options.openPath(diffPath);
+    await this.options.ui.openDiff(
+      { filePath: entry.originalUri.fsPath },
+      { filePath: entry.proposedUri.fsPath },
+      `Tool edit: ${path.basename(entry.request.path)}`,
+      { preserveFocus: true },
+    );
   }
 
   private cleanupEntry(entry: DesktopPendingToolEditApproval): void {
@@ -413,7 +393,7 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
   }
 
   private async report(message: string): Promise<void> {
-    await this.options.showErrorMessage?.(message);
+    await this.options.ui.showErrorMessage(message);
   }
 }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -122,6 +122,7 @@ import type {
   DesktopAgentExecution,
   DesktopAgentExecutionOptions,
 } from './desktopAgentExecution.js';
+import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
 import type { StreamSnapshotStore } from '@transcript';
 
 const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
@@ -540,10 +541,10 @@ function createWindow(options: {
     ).unref();
   };
   attachRendererConsoleLog(window.webContents);
-  const agentExecutionOptions: DesktopAgentExecutionOptions = {
-    postToRenderer: postToRendererIfAlive,
-    opener: previewHost,
-    diff: createDesktopDiffHost({
+  const agentExecutionHost: DesktopAgentExecutionHost = {
+    openPath: previewHost.openPath,
+    openBuildDisplay: previewHost.openBuildDisplay,
+    openDiff: createDesktopDiffHost({
       openPath: previewHost.openPath,
       // Audit item C / trajectory #18: prefer the in-app overlay
       // (<texra-diff-view> inside a wa-dialog). The external-editor
@@ -562,7 +563,7 @@ function createWindow(options: {
         ipc.postToRenderer(message);
         return true;
       },
-    }),
+    }).openDiff,
     confirmAcceptFile: async (message) => {
       const result = await dialog.showMessageBox(window, {
         type: 'warning',
@@ -575,8 +576,6 @@ function createWindow(options: {
     },
     showInfoMessage,
     showErrorMessage,
-    streamSnapshotStore: options.streamSnapshotStore,
-    progressSnapshotStore: options.progressSnapshotStore,
     // Recompute the onboarding funnel after a run completes so a user's first
     // successful run leaves the setup card without waiting for a restart
     // (the run lifecycle has already persisted firstRunDone). Mirrors the
@@ -584,6 +583,12 @@ function createWindow(options: {
     onRunCompleted: () => {
       void onboardingIpcRef.current?.refreshOnboardingFunnel();
     },
+  };
+  const agentExecutionOptions: DesktopAgentExecutionOptions = {
+    postToRenderer: postToRendererIfAlive,
+    host: agentExecutionHost,
+    streamSnapshotStore: options.streamSnapshotStore,
+    progressSnapshotStore: options.progressSnapshotStore,
   };
   let agentExecution: DesktopAgentExecution | undefined;
   let agentExecutionLoad: Promise<DesktopAgentExecution> | undefined;

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -52,6 +52,7 @@ import {
 
 // Local imports - desktop test support
 import {
+  createStubDesktopAgentExecutionHost,
   disposeAfterTest,
   makeFakeTrace,
   type DesktopAgentExecutionModule,
@@ -213,7 +214,8 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   bridgeModule: DesktopAgentExecutionModule;
   openTranscripts(): Promise<StreamLogStore>;
   ephemeralTranscripts(): StreamLogStore;
-  progressSnapshotStore?: ProgressSnapshotStore;
+  createProgressSnapshotStore(): ProgressSnapshotStore;
+  progressSnapshotStore: ProgressSnapshotStore;
 }> {
   vi.resetModules();
   const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
@@ -372,10 +374,11 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
       workspaceFolders: [],
     },
   }));
-  let progressSnapshotStore: ProgressSnapshotStore | undefined;
+  const { StreamLogStore, StreamSnapshotStore } = await import('@transcript');
+  const createProgressSnapshotStore = (): ProgressSnapshotStore =>
+    new StreamSnapshotStore();
+  const progressSnapshotStore = createProgressSnapshotStore();
   if (options.configureProgressSnapshotStore) {
-    const { StreamSnapshotStore } = await import('@transcript');
-    progressSnapshotStore = new StreamSnapshotStore();
     await progressSnapshotStore.load([]);
     options.configureProgressSnapshotStore(progressSnapshotStore);
     await progressSnapshotStore.flush();
@@ -383,7 +386,6 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   const bridgeModule = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
-  const { StreamLogStore } = await import('@transcript');
   const { initializeDefaultSession } =
     await import('@agent/runtime/SessionHandle');
   initializeDefaultSession({
@@ -391,6 +393,7 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   });
   return {
     bridgeModule,
+    createProgressSnapshotStore,
     openTranscripts: () => StreamLogStore.open(),
     ephemeralTranscripts: () => StreamLogStore.ephemeral('desktop bridge test'),
     progressSnapshotStore,
@@ -416,8 +419,12 @@ async function createBridge(
           : undefined,
         streamSnapshotStore: options.streamSnapshotStore,
         progressSnapshotStore,
-        showErrorMessage: options.showErrorMessage,
-        openPath: options.openPath,
+        host: createStubDesktopAgentExecutionHost({
+          ...(options.showErrorMessage
+            ? { showErrorMessage: options.showErrorMessage }
+            : {}),
+          ...(options.openPath ? { openPath: options.openPath } : {}),
+        }),
       },
     ) as unknown as TestableBridge,
   );
@@ -2933,7 +2940,11 @@ describe('DesktopProgressBridge', () => {
     };
 
     async function createWindowPair(): Promise<WindowPair> {
-      const { bridgeModule, ephemeralTranscripts } = await loadBridgeModule();
+      const {
+        bridgeModule,
+        createProgressSnapshotStore,
+        ephemeralTranscripts,
+      } = await loadBridgeModule();
       // Same registry as the bridge module graph — identity comparisons
       // against process-wide defaults must use this instance, not a
       // statically imported copy from the pre-reset registry.
@@ -2947,7 +2958,9 @@ describe('DesktopProgressBridge', () => {
           },
           {
             transcripts: ephemeralTranscripts(),
+            progressSnapshotStore: createProgressSnapshotStore(),
             streamSnapshotStore: snapshots,
+            host: createStubDesktopAgentExecutionHost(),
           },
         ) as unknown as TestableBridge;
         const session = (bridge as unknown as { session: SessionHandle })
@@ -3346,7 +3359,11 @@ describe('DesktopProgressBridge', () => {
       messages?: unknown[];
     }) {
       let activeExecutionIds: readonly string[] = [];
-      const { bridgeModule, ephemeralTranscripts } = await loadBridgeModule({
+      const {
+        bridgeModule,
+        createProgressSnapshotStore,
+        ephemeralTranscripts,
+      } = await loadBridgeModule({
         activeExecutionIds: () => activeExecutionIds,
       });
       const { AgentExecutionHandle, ProcessExecutionHandle } =
@@ -3357,7 +3374,11 @@ describe('DesktopProgressBridge', () => {
         (message) => {
           messages.push(message);
         },
-        { transcripts: ephemeralTranscripts() },
+        {
+          transcripts: ephemeralTranscripts(),
+          progressSnapshotStore: createProgressSnapshotStore(),
+          host: createStubDesktopAgentExecutionHost(),
+        },
       ) as unknown as TestableBridge & { session: SessionHandle };
       await settleProgressEvents();
       const createHandle = (
@@ -3407,7 +3428,12 @@ describe('DesktopProgressBridge', () => {
           (message) => {
             reopenedMessages.push(message);
           },
-          { transcripts: ephemeralTranscripts(), streamSnapshotStore },
+          {
+            transcripts: ephemeralTranscripts(),
+            progressSnapshotStore: createProgressSnapshotStore(),
+            streamSnapshotStore,
+            host: createStubDesktopAgentExecutionHost(),
+          },
         ) as unknown as TestableBridge & {
           session: SessionHandle;
         };

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -8,6 +8,7 @@ import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 
 // Local imports - desktop test support
 import {
+  createStubDesktopAgentExecutionHost,
   disposeAfterTest,
   makeFakeTrace,
   type DesktopAgentExecutionModule,
@@ -81,12 +82,25 @@ async function createExecution(options: {
   const { createDesktopAgentExecution } = (await import(
     moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
   )) as DesktopAgentExecutionModule;
+  const { StreamSnapshotStore } = await import('@transcript');
   return disposeAfterTest(
     await createDesktopAgentExecution({
       postToRenderer: options.postToRenderer ?? vi.fn(),
-      opener: options.opener,
-      showErrorMessage: options.showErrorMessage,
-      onRunCompleted: options.onRunCompleted,
+      progressSnapshotStore: new StreamSnapshotStore(),
+      host: createStubDesktopAgentExecutionHost({
+        ...(options.opener?.openPath
+          ? { openPath: options.opener.openPath }
+          : {}),
+        ...(options.opener?.openBuildDisplay
+          ? { openBuildDisplay: options.opener.openBuildDisplay }
+          : {}),
+        ...(options.showErrorMessage
+          ? { showErrorMessage: options.showErrorMessage }
+          : {}),
+        ...(options.onRunCompleted
+          ? { onRunCompleted: options.onRunCompleted }
+          : {}),
+      }),
     }),
   );
 }
@@ -322,24 +336,5 @@ describe('createDesktopAgentExecution', () => {
       expect.objectContaining({ absolutePath: '/tmp/output.tex' }),
     );
     expect(opener.openPath).not.toHaveBeenCalled();
-  });
-
-  it('does not fall back to plain file open for compile-file actions', async () => {
-    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
-    const showErrorMessage = vi.fn();
-    const execution = await createExecution({
-      opener,
-      showErrorMessage,
-      prepareMainViewExecutionRequest: vi.fn(() => ({
-        valid: false,
-        message: 'not used',
-      })),
-    });
-
-    await execution.progress.openFileCompile('/tmp/output.tex');
-    expect(opener.openPath).not.toHaveBeenCalled();
-    expect(showErrorMessage).toHaveBeenCalledWith(
-      'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
-    );
   });
 });

--- a/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressFileActions.vitest.mts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
 
+import { createStubDesktopAgentExecutionHost } from './desktopAgentExecutionTestHarness.mjs';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 type DiffOutcome = {
@@ -64,8 +65,7 @@ async function loadFileActions(mocks: {
   };
 }): Promise<{
   actions: FileActionsInstance;
-  openPath: ReturnType<typeof vi.fn>;
-  showErrorMessage: ReturnType<typeof vi.fn>;
+  openBuildDisplay: ReturnType<typeof vi.fn>;
   runLatexdiffForExecution: ReturnType<typeof vi.fn>;
   runDiff: ReturnType<typeof vi.fn>;
 }> {
@@ -118,13 +118,9 @@ async function loadFileActions(mocks: {
     moduleFileUrl(desktopSourcePath('main', 'desktopProgressFileActions.ts'))
   )) as FileActionsModule;
 
-  const openPath = vi.fn();
-  const showErrorMessage = vi.fn();
+  const openBuildDisplay = vi.fn();
   const actions = new module.DesktopProgressFileActions(
-    {
-      openPath,
-      showErrorMessage,
-    },
+    createStubDesktopAgentExecutionHost({ openBuildDisplay }),
     {
       runExecution: vi.fn(),
       listWorkspaceCandidateFiles: vi.fn(async () => []),
@@ -133,8 +129,7 @@ async function loadFileActions(mocks: {
 
   return {
     actions,
-    openPath,
-    showErrorMessage,
+    openBuildDisplay,
     runLatexdiffForExecution,
     runDiff,
   };
@@ -159,7 +154,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       ],
       totalOperations: 1,
     };
-    const { actions, openPath, runLatexdiffForExecution, runDiff } =
+    const { actions, openBuildDisplay, runLatexdiffForExecution, runDiff } =
       await loadFileActions({ outcome });
     const outputsByRound = { 1: [outputInfo('/run/r1/main.tex')] };
 
@@ -181,7 +176,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
       }),
     );
     expect(runDiff).not.toHaveBeenCalled();
-    expect(openPath).toHaveBeenCalledWith('/run/r1/main_diff.tex');
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/run/r1/main_diff.tex',
+    });
   });
 
   it('passes the scan identity (and no rounds) when only a workspace scan is available', async () => {
@@ -195,7 +193,7 @@ describe('DesktopProgressFileActions latexdiff', () => {
       ],
       totalOperations: 1,
     };
-    const { actions, openPath, runLatexdiffForExecution, runDiff } =
+    const { actions, openBuildDisplay, runLatexdiffForExecution, runDiff } =
       await loadFileActions({ outcome });
 
     await actions.runLatexdiffForRun(
@@ -222,11 +220,14 @@ describe('DesktopProgressFileActions latexdiff', () => {
       }),
     );
     expect(runDiff).not.toHaveBeenCalled();
-    expect(openPath).toHaveBeenCalledWith('/workspace/main_diff.tex');
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/workspace/main_diff.tex',
+    });
   });
 
   it('falls back to single-file latexdiff when the shared core finds no operations', async () => {
-    const { actions, openPath, runLatexdiffForExecution, runDiff } =
+    const { actions, openBuildDisplay, runLatexdiffForExecution, runDiff } =
       await loadFileActions({
         outcome: { results: [], totalOperations: 0 },
         fallbackResult: { success: true, diffFileName: 'fallback_diff.tex' },
@@ -242,7 +243,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
 
     expect(runLatexdiffForExecution).toHaveBeenCalledOnce();
     expect(runDiff).toHaveBeenCalledOnce();
-    expect(openPath).toHaveBeenCalledWith('/workspace/fallback_diff.tex');
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/workspace/fallback_diff.tex',
+    });
   });
 
   it('opens every successful diff, not just the first', async () => {
@@ -262,7 +266,9 @@ describe('DesktopProgressFileActions latexdiff', () => {
       ],
       totalOperations: 3,
     };
-    const { actions, openPath, runDiff } = await loadFileActions({ outcome });
+    const { actions, openBuildDisplay, runDiff } = await loadFileActions({
+      outcome,
+    });
 
     await actions.runLatexdiffForRun(
       '/workspace/main.tex',
@@ -272,14 +278,20 @@ describe('DesktopProgressFileActions latexdiff', () => {
       },
     );
 
-    expect(openPath).toHaveBeenCalledWith('/run/r1/main_diff.tex');
-    expect(openPath).toHaveBeenCalledWith('/run/r2/main_diff.tex');
-    expect(openPath).toHaveBeenCalledTimes(2);
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/run/r1/main_diff.tex',
+    });
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/run/r2/main_diff.tex',
+    });
+    expect(openBuildDisplay).toHaveBeenCalledTimes(2);
     expect(runDiff).not.toHaveBeenCalled();
   });
 
   it('falls back to single-file latexdiff when the shared core throws', async () => {
-    const { actions, openPath, runDiff } = await loadFileActions({
+    const { actions, openBuildDisplay, runDiff } = await loadFileActions({
       throws: true,
       fallbackResult: { success: true, diffFileName: 'fallback_diff.tex' },
     });
@@ -294,11 +306,14 @@ describe('DesktopProgressFileActions latexdiff', () => {
     );
 
     expect(runDiff).toHaveBeenCalledOnce();
-    expect(openPath).toHaveBeenCalledWith('/workspace/fallback_diff.tex');
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/workspace/fallback_diff.tex',
+    });
   });
 
   it('falls back to single-file latexdiff when every shared operation failed', async () => {
-    const { actions, openPath, runDiff } = await loadFileActions({
+    const { actions, openBuildDisplay, runDiff } = await loadFileActions({
       outcome: {
         results: [{ success: false, message: 'missing base' }],
         totalOperations: 1,
@@ -315,7 +330,10 @@ describe('DesktopProgressFileActions latexdiff', () => {
     );
 
     expect(runDiff).toHaveBeenCalledOnce();
-    expect(openPath).toHaveBeenCalledWith('/workspace/fallback_diff.tex');
+    expect(openBuildDisplay).toHaveBeenCalledWith({
+      kind: 'external',
+      absolutePath: '/workspace/fallback_diff.tex',
+    });
   });
 
   it('threads the run output files into the shared core for scan resolution', async () => {

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -11,14 +11,10 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
-import type {
-  DiffOptions,
-  DiffSession,
-  DiffSource,
-  DiffViewHost,
-} from '@hosts/uiHosts';
+import type { DiffOptions, DiffSession, DiffSource } from '@hosts/uiHosts';
 import { delay } from '@utils/core';
 
+import { createStubDesktopAgentExecutionHost } from './desktopAgentExecutionTestHarness.mjs';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 import type {
   ToolEditApprovalRequest,
@@ -33,13 +29,7 @@ interface DesktopToolEditApprovalModule {
   createDesktopToolEditApprovalController(options: {
     runtimeHost: AgentRuntimeHost;
     session: SessionHandle;
-    openPath?: (filePath: string) => Promise<void>;
-    openBuildDisplay?: (
-      location: { absolutePath: string },
-      options?: { preserveFocus?: boolean },
-    ) => Promise<void>;
-    openDiff?: DiffViewHost['openDiff'];
-    showErrorMessage?: (message: string) => Promise<void> | void;
+    ui: ReturnType<typeof createStubDesktopAgentExecutionHost>;
     tempRoot?: string;
   }): {
     approvePendingForStream(streamId: string): Promise<void>;
@@ -262,6 +252,7 @@ describe('desktop tool edit approval', () => {
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
         session,
+        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
       });
 
@@ -312,7 +303,7 @@ describe('desktop tool edit approval', () => {
   );
 
   approvalTest(
-    'routes preview and diff actions through desktop temp files before rejection',
+    'routes proposed-file previews through desktop temp files before rejection',
     async () => {
       const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
       const { requestToolEditApproval, desktopModule } =
@@ -326,9 +317,11 @@ describe('desktop tool edit approval', () => {
         runtimeHost,
         session,
         tempRoot,
-        openPath: async (filePath) => {
-          opened.push(filePath);
-        },
+        ui: createStubDesktopAgentExecutionHost({
+          openPath: async (filePath) => {
+            opened.push(filePath);
+          },
+        }),
       });
       useControllerApproval(controller);
       const { shownToolEditPermissions: shown } = runtimeHost;
@@ -371,14 +364,6 @@ describe('desktop tool edit approval', () => {
 
         controller.handleAction({
           requestId: shown[0].requestId,
-          action: 'openDiff',
-        });
-        await vi.waitFor(() => expect(opened).toHaveLength(2));
-        expect(opened[1].endsWith('.diff')).toBe(true);
-        await expect(pathExists(opened[1])).resolves.toBe(true);
-
-        controller.handleAction({
-          requestId: shown[0].requestId,
           action: 'reject',
           feedback: 'not yet',
         });
@@ -388,7 +373,6 @@ describe('desktop tool edit approval', () => {
         });
         await vi.waitFor(async () => {
           await expect(pathExists(opened[0])).resolves.toBe(false);
-          await expect(pathExists(opened[1])).resolves.toBe(false);
         });
       } finally {
         controller.dispose();
@@ -398,7 +382,7 @@ describe('desktop tool edit approval', () => {
   );
 
   approvalTest(
-    'routes diff actions through the injected desktop diff host when available',
+    'routes diff actions through the required desktop diff host',
     async () => {
       const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
       const { requestToolEditApproval, desktopModule } =
@@ -417,8 +401,7 @@ describe('desktop tool edit approval', () => {
         runtimeHost,
         session: createTestSession(),
         tempRoot,
-        openPath,
-        openDiff,
+        ui: createStubDesktopAgentExecutionHost({ openPath, openDiff }),
       });
       useControllerApproval(controller);
       const { shownToolEditPermissions: shown } = runtimeHost;
@@ -469,9 +452,11 @@ describe('desktop tool edit approval', () => {
         runtimeHost,
         session: createTestSession(),
         tempRoot,
-        openPath: async (filePath) => {
-          opened.push(filePath);
-        },
+        ui: createStubDesktopAgentExecutionHost({
+          openPath: async (filePath) => {
+            opened.push(filePath);
+          },
+        }),
       });
       useControllerApproval(controller);
       const { shownToolEditPermissions: shown } = runtimeHost;
@@ -534,12 +519,14 @@ describe('desktop tool edit approval', () => {
         runtimeHost,
         session: createTestSession(),
         tempRoot,
-        openBuildDisplay: async (location, options) => {
-          displayed.push({ absolutePath: location.absolutePath, options });
-        },
-        showErrorMessage: (message) => {
-          messages.push(message);
-        },
+        ui: createStubDesktopAgentExecutionHost({
+          openBuildDisplay: async (location, options) => {
+            displayed.push({ absolutePath: location.absolutePath, options });
+          },
+          showErrorMessage: (message) => {
+            messages.push(message);
+          },
+        }),
       });
       useControllerApproval(controller);
       const { shownToolEditPermissions: shown } = runtimeHost;
@@ -595,6 +582,7 @@ describe('desktop tool edit approval', () => {
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
         session: createTestSession(),
+        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
       });
       useControllerApproval(controller);
@@ -637,6 +625,7 @@ describe('desktop tool edit approval', () => {
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
         session: createTestSession(),
+        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
       });
       useControllerApproval(controller);
@@ -675,6 +664,7 @@ describe('desktop tool edit approval', () => {
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
         session: createTestSession(),
+        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
       });
       useControllerApproval(controller);
@@ -750,6 +740,7 @@ describe('desktop tool edit approval', () => {
       const controller = desktopModule.createDesktopToolEditApprovalController({
         runtimeHost,
         session,
+        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
       });
       useControllerApproval(controller);
@@ -788,6 +779,7 @@ describe('desktop tool edit approval', () => {
     const controller = desktopModule.createDesktopToolEditApprovalController({
       runtimeHost,
       session: createTestSession(),
+      ui: createStubDesktopAgentExecutionHost(),
       tempRoot,
     });
     useControllerApproval(controller);

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { onTestFinished, vi } from 'vitest';
 
+// Local imports - desktop types
+import type { DesktopAgentExecutionHost } from '@desktop/main/desktopAgentExecutionHost';
+
 // Local imports - shared schemas
 import type { RunOutcome } from '@shared/schemas';
 import type { OutputFileSummary } from '@shared/schemas/output';
@@ -32,6 +35,25 @@ export type RunExecutionRequest = (
 export function disposeAfterTest<T extends { dispose(): void }>(value: T): T {
   onTestFinished(() => value.dispose());
   return value;
+}
+
+export function createStubDesktopAgentExecutionHost(
+  overrides: Partial<DesktopAgentExecutionHost> = {},
+): DesktopAgentExecutionHost {
+  return {
+    openPath: async () => undefined,
+    openBuildDisplay: async () => undefined,
+    openDiff: async (original, proposed, title) => ({
+      original,
+      proposed,
+      title,
+    }),
+    confirmAcceptFile: async () => true,
+    showErrorMessage: async () => undefined,
+    showInfoMessage: async () => undefined,
+    onRunCompleted: () => undefined,
+    ...overrides,
+  };
 }
 
 /** Minimal AgentTrace stand-in for bridging terminal results into a session. */


### PR DESCRIPTION
## Summary

- compose one required `DesktopAgentExecutionHost` at the Electron window boundary and pass it unchanged through execution and progress
- require the progress snapshot store while retaining the documented optional stream-snapshot startup policy
- make file actions and tool-edit approvals consume narrow required host views, deleting impossible missing-host branches and their fallback tests
- give desktop tests one typed host stub and explicit in-memory progress stores

## Issue acceptance gates

Closes #8437. All acceptance gates are satisfied: one required composition-root host; no duplicated optional execution/bridge capability bags; required execution, progress, file-action, and tool-edit effects; required invalid-request reporting; required progress snapshots; explicitly optional stream snapshots; and full validation.

## Single source of truth

`packages/desktop/src/main/desktopAgentExecutionHost.ts` owns the desktop execution UI/lifecycle capability contract. `main/index.ts` composes its sole production instance, and the execution factory passes that same instance through to progress and narrow downstream consumers.

## Duplication and abstraction budget

The execution factory, progress bridge, file actions, and tool-edit approvals duplicated the same production capabilities as optional fields, forcing callers through repeated flattening and silent no-op branches. A single required host now represents that invariant, while downstream controllers receive required structural subsets and only the genuinely recoverable stream snapshot resource remains optional.

This removes the unsafe implicit file-accept approval, the test-only progress-store fallback, the plain-file diff fallback, and 21 optional UI/lifecycle calls from the execution bridge.

## Net elements (R6)

- Files: 1 added, 0 deleted, 9 modified.
- Exported symbols (`^[+-]export`): 2 added, 1 deleted, net +1. The additions are the host interface and typed test factory; the deletion is the unused public file-action options bag.
- Named constructs: 1 production interface and 1 test factory added; 1 options interface deleted. Existing execution, bridge, file-action, and tool-edit option shapes were narrowed in place.
- Diffstat after review cleanup: 253 additions, 260 deletions, net -7 LoC.

## Consumer counts (R8)

- Removed export `DesktopProgressFileActionOptions`: 0 external consumers on `origin/main`; its only two references were its declaration and the constructor annotation in the same file.
- New `DesktopAgentExecutionHost`: 4 production import consumers plus 1 test-harness import consumer.
- New `createStubDesktopAgentExecutionHost`: 4 focused desktop test-file consumers.
- No event emit path or subscriber key was removed or rerouted.

## Host impact

Extension: none.

Desktop: required execution UI/lifecycle capabilities and progress snapshots; impossible missing-host fallbacks removed.

CLI: none.

## Scheduled refactoring

#8440 continues the same evidence-backed required-host cleanup for desktop auth; it is not required to complete #8437.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 50 existing warnings outside this change)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- focused desktop execution, file-action, and tool-edit tests: 103 passed
- full Vitest suite: 6,144 passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop file open, diff, compile preview, and tool-edit approval paths by assuming the window always supplies a full host; behavior changes only where optional fallbacks previously ran, not extension/CLI surfaces.
> 
> **Overview**
> **Desktop agent execution** is wired through a single required **`DesktopAgentExecutionHost`** composed once per `BrowserWindow` in `index.ts` (preview, diff, dialogs, accept-file confirm, `onRunCompleted`). The execution factory and progress bridge pass that object through instead of flattening optional `opener` / `diff` / message hooks.
> 
> **Downstream controllers** (`DesktopProgressFileActions`, tool-edit approval) take narrow `Pick<>` slices of the host and call capabilities directly—optional branches for unavailable LaTeX preview, diff host, plain-file diff fallback, and implicit “always accept” file confirm are removed. **`progressSnapshotStore`** is required on the execution/bridge options (no in-bridge default store).
> 
> **Tests** use **`createStubDesktopAgentExecutionHost`** and explicit per-bridge progress snapshot stores; coverage for “host missing” fallbacks is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9f835074abfffc33392e0bd41d8e4b169965fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->