### PR TITLE
refactor(desktop): require auth host dependencies

### DIFF
--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -59,17 +59,22 @@ export interface DesktopAuthCallbackState {
   clearAwaitingCallback(nonce?: string): Promise<void>;
 }
 
-export interface DesktopSupabaseAuthOptions {
-  router: DesktopProtocolCallbackRouter;
-  secrets: PlatformSecrets;
+type DesktopAuthLog = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+
+export interface DesktopSupabaseAuthHost {
   openExternalUrl(url: string): Promise<void>;
-  showInfoMessage?(message: string): Promise<void> | void;
-  showErrorMessage?(message: string): Promise<void> | void;
-  onSessionChanged?: () => Promise<void> | void;
-  log?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
-  coordinator?: DesktopAuthCoordinator;
-  oauthClient?: DesktopOAuthClient;
-  callbackState?: DesktopAuthCallbackState;
+  showInfoMessage(message: string): Promise<void> | void;
+  showErrorMessage(message: string): Promise<void> | void;
+  onSessionChanged(): Promise<void> | void;
+}
+
+interface DesktopSupabaseAuthOptions {
+  router: DesktopProtocolCallbackRouter;
+  coordinator: DesktopAuthCoordinator;
+  oauthClient: DesktopOAuthClient;
+  callbackState: DesktopAuthCallbackState;
+  host: DesktopSupabaseAuthHost;
+  log: DesktopAuthLog;
 }
 
 export interface DesktopOAuthClient {
@@ -169,11 +174,8 @@ function isPendingOAuthStateExpired(state: DesktopPendingOAuthState): boolean {
 export function createDesktopSupabaseAuth(
   options: DesktopSupabaseAuthOptions,
 ): DesktopSupabaseAuth {
-  const coordinator =
-    options.coordinator ?? createDesktopAuthCoordinator(options);
-  const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
-  const callbackState =
-    options.callbackState ?? createDesktopAuthCallbackState();
+  const { callbackState, coordinator, host, log, oauthClient, router } =
+    options;
   const callbackQueue: Array<{
     callback: DesktopProtocolCallback;
     nonce: string;
@@ -246,7 +248,8 @@ export function createDesktopSupabaseAuth(
           const success = await processProtocolCallback(
             coordinator,
             queued.callback,
-            options,
+            host,
+            log,
             () => ownsAttempt(queued.generation, queued.nonce),
             runAuthCommit,
           );
@@ -260,8 +263,8 @@ export function createDesktopSupabaseAuth(
             activeAttempt = undefined;
           }
           const message = toErrorMessage(error);
-          options.log?.error?.(`Desktop auth callback failed: ${message}`);
-          await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+          log.error(`Desktop auth callback failed: ${message}`);
+          await host.showErrorMessage(`Sign-in failed: ${message}`);
         }
       }
     } finally {
@@ -269,9 +272,9 @@ export function createDesktopSupabaseAuth(
       if (callbackQueue.length > 0) void processCallbackQueue();
     }
   };
-  const subscription = options.router.subscribe((callback) => {
+  const subscription = router.subscribe((callback) => {
     if (!callbackState.hasPendingSignIn()) {
-      options.log?.debug?.(
+      log.debug(
         'Desktop auth callback ignored because no sign-in is in progress',
       );
       return;
@@ -279,7 +282,7 @@ export function createDesktopSupabaseAuth(
     const callbackNonce =
       new URLSearchParams(callback.query).get('app_nonce') ?? undefined;
     if (!callbackNonce || !callbackState.matchesPendingNonce(callbackNonce)) {
-      options.log?.warn?.(
+      log.warn(
         'Desktop auth callback rejected: nonce mismatch (possible login-CSRF or stale callback)',
       );
       return;
@@ -293,7 +296,7 @@ export function createDesktopSupabaseAuth(
     void callbackState
       .clearAwaitingCallback(callbackNonce)
       .catch((error: unknown) => {
-        options.log?.debug?.(
+        log.debug(
           `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
         );
       });
@@ -303,7 +306,7 @@ export function createDesktopSupabaseAuth(
       generation: claimedAttempt.generation,
     });
     if (isProcessingCallbacks) {
-      options.log?.debug?.(
+      log.debug(
         'Desktop auth callback queued while another callback is being processed',
       );
     }
@@ -344,16 +347,14 @@ export function createDesktopSupabaseAuth(
       }
       if (!ownsAttempt(generation, nonce)) return;
 
-      await options.openExternalUrl(data.url);
-      await options.showInfoMessage?.(
+      await host.openExternalUrl(data.url);
+      await host.showInfoMessage(
         'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
       );
     } catch (error) {
       if (ownsAttempt(generation, nonce)) activeAttempt = undefined;
       await callbackState.clearAwaitingCallback(nonce);
-      await options.showErrorMessage?.(
-        `Sign-in failed: ${toErrorMessage(error)}`,
-      );
+      await host.showErrorMessage(`Sign-in failed: ${toErrorMessage(error)}`);
       throw error;
     }
   };
@@ -392,13 +393,13 @@ export function createDesktopSupabaseAuth(
         await coordinator.clearSession();
       });
       SupabaseClient.setTokenExpiry(null);
-      clearDesktopServerSideKeyCaches(options.log);
+      clearDesktopServerSideKeyCaches(log);
       await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
-        options.log?.warn?.(
+        log.warn(
           `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
         );
       });
-      await options.onSessionChanged?.();
+      await host.onSessionChanged();
     },
 
     dispose() {
@@ -408,9 +409,10 @@ export function createDesktopSupabaseAuth(
   };
 }
 
-export function createDesktopAuthCoordinator(
-  options: Pick<DesktopSupabaseAuthOptions, 'secrets' | 'log'>,
-): DesktopAuthCoordinator {
+export function createDesktopAuthCoordinator(options: {
+  secrets: PlatformSecrets;
+  log: DesktopAuthLog;
+}): DesktopAuthCoordinator {
   return createHostAuthCoordinator({
     secrets: options.secrets,
     log: createSessionLog(options.log),
@@ -418,7 +420,7 @@ export function createDesktopAuthCoordinator(
 }
 
 export function initializeDesktopServerSideKeyAccess(
-  log: DesktopSupabaseAuthOptions['log'],
+  log: DesktopAuthLog,
 ): void {
   initializeServerSideKeyAccess(
     {
@@ -433,13 +435,11 @@ export function initializeDesktopServerSideKeyAccess(
   );
 }
 
-function clearDesktopServerSideKeyCaches(
-  log: DesktopSupabaseAuthOptions['log'],
-): void {
+function clearDesktopServerSideKeyCaches(log: DesktopAuthLog): void {
   try {
     getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
   } catch (error) {
-    log?.debug?.(
+    log.debug(
       `Desktop server-side key cache clear skipped: ${toErrorMessage(error)}`,
     );
   }
@@ -448,7 +448,8 @@ function clearDesktopServerSideKeyCaches(
 async function processProtocolCallback(
   coordinator: DesktopAuthCoordinator,
   callback: DesktopProtocolCallback,
-  options: DesktopSupabaseAuthOptions,
+  host: DesktopSupabaseAuthHost,
+  log: DesktopAuthLog,
   ownsAttempt: () => boolean,
   runAuthCommit: <T>(commit: () => Promise<T>) => Promise<T>,
 ): Promise<boolean> {
@@ -460,9 +461,9 @@ async function processProtocolCallback(
 
   if (!result.success) {
     if (result.isAuthError) {
-      await options.showErrorMessage?.(`Sign-in failed: ${result.error}`);
+      await host.showErrorMessage(`Sign-in failed: ${result.error}`);
     } else {
-      options.log?.debug?.(`Desktop auth callback ignored: ${result.error}`);
+      log.debug(`Desktop auth callback ignored: ${result.error}`);
     }
     return false;
   }
@@ -476,26 +477,22 @@ async function processProtocolCallback(
       return false;
     }
 
-    clearDesktopServerSideKeyCaches(options.log);
+    clearDesktopServerSideKeyCaches(log);
     try {
-      await options.showInfoMessage?.(
+      await host.showInfoMessage(
         `Signed in as ${result.session.account.label}`,
       );
     } catch (error) {
-      options.log?.warn?.(
-        `Desktop sign-in notification failed: ${toErrorMessage(error)}`,
-      );
+      log.warn(`Desktop sign-in notification failed: ${toErrorMessage(error)}`);
     }
     if (!ownsAttempt()) {
       await coordinator.clearSession();
       return false;
     }
     try {
-      await options.onSessionChanged?.();
+      await host.onSessionChanged();
     } catch (error) {
-      options.log?.warn?.(
-        `Desktop auth surface refresh failed: ${toErrorMessage(error)}`,
-      );
+      log.warn(`Desktop auth surface refresh failed: ${toErrorMessage(error)}`);
     }
     if (!ownsAttempt()) {
       await coordinator.clearSession();
@@ -505,22 +502,20 @@ async function processProtocolCallback(
   });
 }
 
-function createSessionLog(
-  log: Pick<Console, 'debug' | 'info' | 'warn' | 'error'> | undefined,
-): SupabaseSessionLog {
+function createSessionLog(log: DesktopAuthLog): SupabaseSessionLog {
   return {
-    debug: (source, message) => log?.debug?.(`[${source}] ${message}`),
-    info: (source, message) => log?.info?.(`[${source}] ${message}`),
-    warn: (source, message) => log?.warn?.(`[${source}] ${message}`),
-    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+    debug: (source, message) => log.debug(`[${source}] ${message}`),
+    info: (source, message) => log.info(`[${source}] ${message}`),
+    warn: (source, message) => log.warn(`[${source}] ${message}`),
+    error: (source, message) => log.error(`[${source}] ${message}`),
   };
 }
 
 function createAuthServiceLogger(
-  log: Pick<Console, 'info' | 'error'> | undefined,
+  log: Pick<DesktopAuthLog, 'info' | 'error'>,
 ): AuthServiceLogger {
   return {
-    info: (source, message) => log?.info?.(`[${source}] ${message}`),
-    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+    info: (source, message) => log.info(`[${source}] ${message}`),
+    error: (source, message) => log.error(`[${source}] ${message}`),
   };
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -106,6 +106,7 @@ import {
   initializeDesktopServerSideKeyAccess,
   type DesktopAuthCallbackState,
   type DesktopAuthCoordinator,
+  type DesktopSupabaseAuthHost,
 } from './desktopSupabaseAuth.js';
 import { DESKTOP_DOCS_URL } from '../desktopCommandSurface.js';
 import { reportFatalStartupError } from './fatalStartupError.js';
@@ -470,16 +471,19 @@ function createWindow(options: {
     });
     await onboardingIpcRef.current?.refreshOnboardingFunnel();
   };
-  const desktopAuth = createDesktopSupabaseAuth({
-    router: protocolLifecycle.router,
-    coordinator: options.authCoordinator,
-    secrets: platform().secrets,
+  const desktopAuthHost: DesktopSupabaseAuthHost = {
     openExternalUrl: (url) => previewHost.openExternal(url),
     showInfoMessage,
     showErrorMessage,
     onSessionChanged: refreshDesktopAuthSurfaces,
-    log: console,
+  };
+  const desktopAuth = createDesktopSupabaseAuth({
+    router: protocolLifecycle.router,
+    coordinator: options.authCoordinator,
+    oauthClient: SupabaseClient.getClient(),
     callbackState: options.authCallbackState,
+    host: desktopAuthHost,
+    log: console,
   });
   const signInForRemoteAgentCatalog = async (): Promise<boolean> => {
     teamSignInPending = true;

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -9,12 +9,15 @@ import { setServerSideKeyService } from '@auth/serverKeys';
 import {
   createDesktopProtocolCallbackRouter,
   parseDesktopProtocolCallback,
+  type DesktopProtocolCallbackRouter,
 } from '@desktop/main/desktopProtocolCallbacks';
 import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
   type DesktopAuthCallbackState,
+  type DesktopAuthCoordinator,
   type DesktopOAuthClient,
+  type DesktopSupabaseAuthHost,
 } from '@desktop/main/desktopSupabaseAuth';
 import type { StateStore } from '@platform/interfaces';
 
@@ -44,17 +47,6 @@ function createCoordinator() {
   };
 }
 
-function createSecrets() {
-  return {
-    get: vi.fn(async () => undefined),
-    getStored: vi.fn(async () => undefined),
-    set: vi.fn(async () => {}),
-    delete: vi.fn(async () => {}),
-    listStoredKeys: vi.fn(async () => []),
-    getEnv: vi.fn(() => undefined),
-  };
-}
-
 function createLog() {
   return {
     debug: vi.fn(),
@@ -62,6 +54,41 @@ function createLog() {
     warn: vi.fn(),
     error: vi.fn(),
   };
+}
+
+interface DesktopAuthTestOptions extends Partial<DesktopSupabaseAuthHost> {
+  router: DesktopProtocolCallbackRouter;
+  coordinator: DesktopAuthCoordinator;
+  oauthClient: DesktopOAuthClient;
+  callbackState?: DesktopAuthCallbackState;
+  log?: ReturnType<typeof createLog>;
+}
+
+function createTestAuth(options: DesktopAuthTestOptions) {
+  const {
+    router,
+    coordinator,
+    oauthClient,
+    callbackState = createDesktopAuthCallbackState(),
+    log = createLog(),
+    openExternalUrl = vi.fn(async () => {}),
+    showInfoMessage = vi.fn(),
+    showErrorMessage = vi.fn(),
+    onSessionChanged = vi.fn(),
+  } = options;
+  return createDesktopSupabaseAuth({
+    router,
+    coordinator,
+    oauthClient,
+    callbackState,
+    host: {
+      openExternalUrl,
+      showInfoMessage,
+      showErrorMessage,
+      onSessionChanged,
+    },
+    log,
+  });
 }
 
 function callbackSessionResult() {
@@ -175,11 +202,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
     const openExternalUrl = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl,
     });
 
@@ -227,12 +253,11 @@ describe('desktop Supabase auth', () => {
     const openExternalUrl = vi.fn(async () => {
       events.push('open');
     });
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
       callbackState,
-      secrets: createSecrets(),
       openExternalUrl,
     });
 
@@ -247,11 +272,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const onSessionChanged = vi.fn(async () => {});
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
     });
@@ -288,11 +312,10 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 
@@ -324,11 +347,10 @@ describe('desktop Supabase auth', () => {
   it('cancels a waiting sign-in when its window auth is disposed', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator: createCoordinator(),
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
     const completion = auth.signInAndWaitForSession(undefined, {
@@ -348,11 +370,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
     });
@@ -380,11 +401,10 @@ describe('desktop Supabase auth', () => {
   it('rejects a callback with no nonce while a sign-in is pending', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 
@@ -406,11 +426,10 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
     });
@@ -435,11 +454,10 @@ describe('desktop Supabase auth', () => {
     const stateStore = createStateStore();
     const callbackState = createDesktopAuthCallbackState(stateStore);
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
     });
@@ -455,11 +473,10 @@ describe('desktop Supabase auth', () => {
       }),
     );
 
-    const recreatedAuth = createDesktopSupabaseAuth({
+    const recreatedAuth = createTestAuth({
       router,
       coordinator,
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState: persistedCallbackState,
     });
@@ -483,11 +500,10 @@ describe('desktop Supabase auth', () => {
       const coordinator = createCoordinator();
       const stateStore = createStateStore();
       const oauthClient = createOAuthClient();
-      const auth = createDesktopSupabaseAuth({
+      const auth = createTestAuth({
         router,
         coordinator,
         oauthClient,
-        secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
         callbackState: createDesktopAuthCallbackState(stateStore),
       });
@@ -497,11 +513,10 @@ describe('desktop Supabase auth', () => {
 
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
       const expiredCallbackState = createDesktopAuthCallbackState(stateStore);
-      const recreatedAuth = createDesktopSupabaseAuth({
+      const recreatedAuth = createTestAuth({
         router,
         coordinator,
         oauthClient: createOAuthClient(),
-        secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
         callbackState: expiredCallbackState,
       });
@@ -582,11 +597,10 @@ describe('desktop Supabase auth', () => {
     const callbackState = createDesktopAuthCallbackState();
     const oauthClient = createOAuthClient();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
       log,
@@ -617,11 +631,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const log = createLog();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
     });
@@ -658,11 +671,10 @@ describe('desktop Supabase auth', () => {
       await callbackProcessing.promise;
       return callbackSessionResult();
     });
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
     });
@@ -700,11 +712,10 @@ describe('desktop Supabase auth', () => {
     });
     const onSessionChanged = vi.fn(async () => {});
     const showInfoMessage = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
       showInfoMessage,
@@ -746,12 +757,11 @@ describe('desktop Supabase auth', () => {
       await storeSession?.(session);
     });
     const onSessionChanged = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
       callbackState,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
     });
@@ -809,11 +819,10 @@ describe('desktop Supabase auth', () => {
       const onSessionChanged = vi.fn(async () => {
         await sessionRefresh.promise;
       });
-      const auth = createDesktopSupabaseAuth({
+      const auth = createTestAuth({
         router,
         coordinator,
         oauthClient,
-        secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
         onSessionChanged,
       });
@@ -857,11 +866,10 @@ describe('desktop Supabase auth', () => {
         await callbackProcessing.promise;
         return callbackSessionResult();
       });
-      const auth = createDesktopSupabaseAuth({
+      const auth = createTestAuth({
         router,
         coordinator,
         oauthClient,
-        secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
       });
 
@@ -891,11 +899,10 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 
@@ -931,11 +938,10 @@ describe('desktop Supabase auth', () => {
     const showErrorMessage = vi.fn(async () => {});
     const log = createLog();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient,
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       showErrorMessage,
       log,
@@ -967,11 +973,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const clearAllCaches = vi.fn();
     setServerSideKeyService({ clearAllCaches } as never);
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator,
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 
@@ -992,11 +997,10 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const onSessionChanged = vi.fn(async () => {});
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router: createDesktopProtocolCallbackRouter(),
       coordinator,
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
       log,
@@ -1029,11 +1033,10 @@ describe('desktop Supabase auth', () => {
         visibility: ['public', 'researcher'],
       },
     ]);
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator: createCoordinator(),
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 
@@ -1070,11 +1073,10 @@ describe('desktop Supabase auth', () => {
     const getAgentsBySource = vi
       .spyOn(agentRegistry, 'getAgentsBySource')
       .mockReturnValue([]);
-    const auth = createDesktopSupabaseAuth({
+    const auth = createTestAuth({
       router,
       coordinator: createCoordinator(),
       oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
     });
 


### PR DESCRIPTION
## Summary

Make desktop Supabase auth dependencies explicit at the desktop composition root. The auth factory now receives one required host for browser, notification, and session-refresh effects plus required coordinator, OAuth client, callback state, and logger dependencies; its production fallback constructors and silent optional calls are gone.

Closes #8440.

## Issue acceptance gates

- Required production dependencies: coordinator, OAuth client, callback state, auth host, and logger are all required by the factory type.
- Required typed host: external URL opening, info/error notifications, and session refresh are one `DesktopSupabaseAuthHost` contract.
- Removed fallback construction: the factory no longer creates its own coordinator, OAuth client, or callback state.
- Removed silent optional effects: every product effect and logging call is direct.
- Typed tests: a local typed fixture supplies inert host methods and cases explicitly override behavior under assertion.
- Full validation completed successfully.

## Single source of truth

`createWindow` in `packages/desktop/src/main/index.ts` owns production composition. `DesktopSupabaseAuthHost` is the auth factory boundary for desktop UI and lifecycle effects.

## Duplication and abstraction budget

Removed the parallel production/test construction modes, the test-only secrets stub, and repeated optional-call branching. Added one host interface that owns the invariant that desktop auth always has browser, notification, and session-refresh capabilities; it is consumed directly rather than wrapped by another pass-through layer.

## Net elements (R6)

- Files: 0 added, 0 deleted, 3 modified.
- Exported symbols: 1 added (`DesktopSupabaseAuthHost`), 1 removed (`DesktopSupabaseAuthOptions` export), net 0.
- Classes/interfaces/enums: 1 interface added, net +1.
- LoC: 128 additions, 127 deletions, net +1.

## Consumer counts (R8)

- Removed `DesktopSupabaseAuthOptions` export: 0 external consumers before removal (`rg` found only its declaration and internal factory use).
- New `DesktopSupabaseAuthHost`: 2 type consumers, the desktop composition root and desktop auth tests.
- No event emit path or runtime command key was deleted or rerouted.

## Host impact

Extension: None.

Desktop: Auth composition is explicit; runtime behavior is preserved and missing effects can no longer be silently ignored.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts` (27 passed)
- `npm run check:dead-code-ratchet`
- `npm test` (6,146 passed; 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: auth behavior is intended to stay the same while making missing host/logger wiring a compile-time error instead of a silent no-op at runtime.
> 
> **Overview**
> Desktop Supabase auth composition is tightened so **all production wiring happens at the desktop root** instead of inside the factory with silent defaults.
> 
> **`createDesktopSupabaseAuth`** now requires **`coordinator`**, **`oauthClient`**, **`callbackState`**, **`host`**, and **`log`**—it no longer builds its own coordinator/OAuth client/callback state or treats UI hooks as optional. Browser open, info/error dialogs, and post-session UI refresh are grouped behind a new exported **`DesktopSupabaseAuthHost`**; logging uses a required **`DesktopAuthLog`** with direct calls (no `?.` skips).
> 
> **`createWindow`** in `index.ts` supplies that host (preview external URLs, message boxes, `refreshDesktopAuthSurfaces`) and passes **`SupabaseClient.getClient()`** explicitly. Tests use a **`createTestAuth`** helper with inert host defaults instead of a **`secrets`** stub on the factory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19fed45db5aaedfcd58470f8802ce790705fa272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->