### PR TITLE
refactor(desktop): require auth host dependencies

### DIFF
--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -59,17 +59,22 @@ export interface DesktopAuthCallbackState {
   clearAwaitingCallback(nonce?: string): Promise<void>;
 }
 
+export interface DesktopAuthHost {
+  openExternalUrl(url: string): Promise<void>;
+  showInfoMessage(message: string): Promise<void> | void;
+  showErrorMessage(message: string): Promise<void> | void;
+  onSessionChanged(): Promise<void> | void;
+}
+
+type DesktopAuthLogger = Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+
 export interface DesktopSupabaseAuthOptions {
   router: DesktopProtocolCallbackRouter;
-  secrets: PlatformSecrets;
-  openExternalUrl(url: string): Promise<void>;
-  showInfoMessage?(message: string): Promise<void> | void;
-  showErrorMessage?(message: string): Promise<void> | void;
-  onSessionChanged?: () => Promise<void> | void;
-  log?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
-  coordinator?: DesktopAuthCoordinator;
-  oauthClient?: DesktopOAuthClient;
-  callbackState?: DesktopAuthCallbackState;
+  coordinator: DesktopAuthCoordinator;
+  callbackState: DesktopAuthCallbackState;
+  oauthClient: DesktopOAuthClient;
+  host: DesktopAuthHost;
+  log: DesktopAuthLogger;
 }
 
 export interface DesktopOAuthClient {
@@ -169,11 +174,7 @@ function isPendingOAuthStateExpired(state: DesktopPendingOAuthState): boolean {
 export function createDesktopSupabaseAuth(
   options: DesktopSupabaseAuthOptions,
 ): DesktopSupabaseAuth {
-  const coordinator =
-    options.coordinator ?? createDesktopAuthCoordinator(options);
-  const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
-  const callbackState =
-    options.callbackState ?? createDesktopAuthCallbackState();
+  const { callbackState, coordinator, host, log, oauthClient } = options;
   const callbackQueue: Array<{
     callback: DesktopProtocolCallback;
     nonce: string;
@@ -260,8 +261,8 @@ export function createDesktopSupabaseAuth(
             activeAttempt = undefined;
           }
           const message = toErrorMessage(error);
-          options.log?.error?.(`Desktop auth callback failed: ${message}`);
-          await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+          log.error(`Desktop auth callback failed: ${message}`);
+          await host.showErrorMessage(`Sign-in failed: ${message}`);
         }
       }
     } finally {
@@ -271,7 +272,7 @@ export function createDesktopSupabaseAuth(
   };
   const subscription = options.router.subscribe((callback) => {
     if (!callbackState.hasPendingSignIn()) {
-      options.log?.debug?.(
+      log.debug(
         'Desktop auth callback ignored because no sign-in is in progress',
       );
       return;
@@ -279,7 +280,7 @@ export function createDesktopSupabaseAuth(
     const callbackNonce =
       new URLSearchParams(callback.query).get('app_nonce') ?? undefined;
     if (!callbackNonce || !callbackState.matchesPendingNonce(callbackNonce)) {
-      options.log?.warn?.(
+      log.warn(
         'Desktop auth callback rejected: nonce mismatch (possible login-CSRF or stale callback)',
       );
       return;
@@ -293,7 +294,7 @@ export function createDesktopSupabaseAuth(
     void callbackState
       .clearAwaitingCallback(callbackNonce)
       .catch((error: unknown) => {
-        options.log?.debug?.(
+        log.debug(
           `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
         );
       });
@@ -303,7 +304,7 @@ export function createDesktopSupabaseAuth(
       generation: claimedAttempt.generation,
     });
     if (isProcessingCallbacks) {
-      options.log?.debug?.(
+      log.debug(
         'Desktop auth callback queued while another callback is being processed',
       );
     }
@@ -344,16 +345,14 @@ export function createDesktopSupabaseAuth(
       }
       if (!ownsAttempt(generation, nonce)) return;
 
-      await options.openExternalUrl(data.url);
-      await options.showInfoMessage?.(
+      await host.openExternalUrl(data.url);
+      await host.showInfoMessage(
         'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
       );
     } catch (error) {
       if (ownsAttempt(generation, nonce)) activeAttempt = undefined;
       await callbackState.clearAwaitingCallback(nonce);
-      await options.showErrorMessage?.(
-        `Sign-in failed: ${toErrorMessage(error)}`,
-      );
+      await host.showErrorMessage(`Sign-in failed: ${toErrorMessage(error)}`);
       throw error;
     }
   };
@@ -392,13 +391,13 @@ export function createDesktopSupabaseAuth(
         await coordinator.clearSession();
       });
       SupabaseClient.setTokenExpiry(null);
-      clearDesktopServerSideKeyCaches(options.log);
+      clearDesktopServerSideKeyCaches(log);
       await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
-        options.log?.warn?.(
+        log.warn(
           `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
         );
       });
-      await options.onSessionChanged?.();
+      await host.onSessionChanged();
     },
 
     dispose() {
@@ -408,9 +407,10 @@ export function createDesktopSupabaseAuth(
   };
 }
 
-export function createDesktopAuthCoordinator(
-  options: Pick<DesktopSupabaseAuthOptions, 'secrets' | 'log'>,
-): DesktopAuthCoordinator {
+export function createDesktopAuthCoordinator(options: {
+  secrets: PlatformSecrets;
+  log: DesktopAuthLogger;
+}): DesktopAuthCoordinator {
   return createHostAuthCoordinator({
     secrets: options.secrets,
     log: createSessionLog(options.log),
@@ -418,7 +418,7 @@ export function createDesktopAuthCoordinator(
 }
 
 export function initializeDesktopServerSideKeyAccess(
-  log: DesktopSupabaseAuthOptions['log'],
+  log: DesktopAuthLogger,
 ): void {
   initializeServerSideKeyAccess(
     {
@@ -433,13 +433,11 @@ export function initializeDesktopServerSideKeyAccess(
   );
 }
 
-function clearDesktopServerSideKeyCaches(
-  log: DesktopSupabaseAuthOptions['log'],
-): void {
+function clearDesktopServerSideKeyCaches(log: DesktopAuthLogger): void {
   try {
     getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
   } catch (error) {
-    log?.debug?.(
+    log.debug(
       `Desktop server-side key cache clear skipped: ${toErrorMessage(error)}`,
     );
   }
@@ -460,9 +458,9 @@ async function processProtocolCallback(
 
   if (!result.success) {
     if (result.isAuthError) {
-      await options.showErrorMessage?.(`Sign-in failed: ${result.error}`);
+      await options.host.showErrorMessage(`Sign-in failed: ${result.error}`);
     } else {
-      options.log?.debug?.(`Desktop auth callback ignored: ${result.error}`);
+      options.log.debug(`Desktop auth callback ignored: ${result.error}`);
     }
     return false;
   }
@@ -478,11 +476,11 @@ async function processProtocolCallback(
 
     clearDesktopServerSideKeyCaches(options.log);
     try {
-      await options.showInfoMessage?.(
+      await options.host.showInfoMessage(
         `Signed in as ${result.session.account.label}`,
       );
     } catch (error) {
-      options.log?.warn?.(
+      options.log.warn(
         `Desktop sign-in notification failed: ${toErrorMessage(error)}`,
       );
     }
@@ -491,9 +489,9 @@ async function processProtocolCallback(
       return false;
     }
     try {
-      await options.onSessionChanged?.();
+      await options.host.onSessionChanged();
     } catch (error) {
-      options.log?.warn?.(
+      options.log.warn(
         `Desktop auth surface refresh failed: ${toErrorMessage(error)}`,
       );
     }
@@ -505,22 +503,20 @@ async function processProtocolCallback(
   });
 }
 
-function createSessionLog(
-  log: Pick<Console, 'debug' | 'info' | 'warn' | 'error'> | undefined,
-): SupabaseSessionLog {
+function createSessionLog(log: DesktopAuthLogger): SupabaseSessionLog {
   return {
-    debug: (source, message) => log?.debug?.(`[${source}] ${message}`),
-    info: (source, message) => log?.info?.(`[${source}] ${message}`),
-    warn: (source, message) => log?.warn?.(`[${source}] ${message}`),
-    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+    debug: (source, message) => log.debug(`[${source}] ${message}`),
+    info: (source, message) => log.info(`[${source}] ${message}`),
+    warn: (source, message) => log.warn(`[${source}] ${message}`),
+    error: (source, message) => log.error(`[${source}] ${message}`),
   };
 }
 
 function createAuthServiceLogger(
-  log: Pick<Console, 'info' | 'error'> | undefined,
+  log: Pick<Console, 'info' | 'error'>,
 ): AuthServiceLogger {
   return {
-    info: (source, message) => log?.info?.(`[${source}] ${message}`),
-    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+    info: (source, message) => log.info(`[${source}] ${message}`),
+    error: (source, message) => log.error(`[${source}] ${message}`),
   };
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -106,6 +106,7 @@ import {
   initializeDesktopServerSideKeyAccess,
   type DesktopAuthCallbackState,
   type DesktopAuthCoordinator,
+  type DesktopAuthHost,
 } from './desktopSupabaseAuth.js';
 import { DESKTOP_DOCS_URL } from '../desktopCommandSurface.js';
 import { reportFatalStartupError } from './fatalStartupError.js';
@@ -470,16 +471,19 @@ function createWindow(options: {
     });
     await onboardingIpcRef.current?.refreshOnboardingFunnel();
   };
-  const desktopAuth = createDesktopSupabaseAuth({
-    router: protocolLifecycle.router,
-    coordinator: options.authCoordinator,
-    secrets: platform().secrets,
-    openExternalUrl: (url) => previewHost.openExternal(url),
+  const desktopAuthHost: DesktopAuthHost = {
+    openExternalUrl: previewHost.openExternal,
     showInfoMessage,
     showErrorMessage,
     onSessionChanged: refreshDesktopAuthSurfaces,
-    log: console,
+  };
+  const desktopAuth = createDesktopSupabaseAuth({
+    router: protocolLifecycle.router,
+    coordinator: options.authCoordinator,
     callbackState: options.authCallbackState,
+    oauthClient: SupabaseClient.getClient(),
+    host: desktopAuthHost,
+    log: console,
   });
   const signInForRemoteAgentCatalog = async (): Promise<boolean> => {
     teamSignInPending = true;

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -14,7 +14,9 @@ import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
   type DesktopAuthCallbackState,
+  type DesktopAuthHost,
   type DesktopOAuthClient,
+  type DesktopSupabaseAuthOptions,
 } from '@desktop/main/desktopSupabaseAuth';
 import type { StateStore } from '@platform/interfaces';
 
@@ -41,17 +43,6 @@ function createCoordinator() {
           }
         : null,
     ),
-  };
-}
-
-function createSecrets() {
-  return {
-    get: vi.fn(async () => undefined),
-    getStored: vi.fn(async () => undefined),
-    set: vi.fn(async () => {}),
-    delete: vi.fn(async () => {}),
-    listStoredKeys: vi.fn(async () => []),
-    getEnv: vi.fn(() => undefined),
   };
 }
 
@@ -104,6 +95,32 @@ function createOAuthClient() {
         error: null,
       })),
     },
+  };
+}
+
+function createAuthHost(
+  overrides: Partial<DesktopAuthHost> = {},
+): DesktopAuthHost {
+  return {
+    openExternalUrl: vi.fn(async () => {}),
+    showInfoMessage: vi.fn(async () => {}),
+    showErrorMessage: vi.fn(async () => {}),
+    onSessionChanged: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function createAuthOptions(
+  overrides: Partial<DesktopSupabaseAuthOptions> = {},
+): DesktopSupabaseAuthOptions {
+  return {
+    router: createDesktopProtocolCallbackRouter(),
+    coordinator: createCoordinator(),
+    callbackState: createDesktopAuthCallbackState(),
+    oauthClient: createOAuthClient(),
+    host: createAuthHost(),
+    log: createLog(),
+    ...overrides,
   };
 }
 
@@ -175,13 +192,14 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
     const openExternalUrl = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        host: createAuthHost({ openExternalUrl }),
+      }),
+    );
 
     await auth.signIn();
 
@@ -227,14 +245,15 @@ describe('desktop Supabase auth', () => {
     const openExternalUrl = vi.fn(async () => {
       events.push('open');
     });
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      callbackState,
-      secrets: createSecrets(),
-      openExternalUrl,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        callbackState,
+        host: createAuthHost({ openExternalUrl }),
+      }),
+    );
 
     await auth.signIn();
 
@@ -247,14 +266,14 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const onSessionChanged = vi.fn(async () => {});
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      onSessionChanged,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        host: createAuthHost({ onSessionChanged }),
+      }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -288,13 +307,9 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator, oauthClient }),
+    );
 
     let completed = false;
     const completion = auth
@@ -324,13 +339,9 @@ describe('desktop Supabase auth', () => {
   it('cancels a waiting sign-in when its window auth is disposed', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator: createCoordinator(),
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, oauthClient }),
+    );
     const completion = auth.signInAndWaitForSession(undefined, {
       timeoutMs: 1_000,
     });
@@ -348,14 +359,9 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator, oauthClient, log }),
+    );
 
     await auth.signIn();
     // Attacker-delivered deeplink carrying valid tokens for another account but
@@ -380,13 +386,9 @@ describe('desktop Supabase auth', () => {
   it('rejects a callback with no nonce while a sign-in is pending', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -406,14 +408,9 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator, log }),
+    );
 
     router.routeUrl(
       'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
@@ -435,14 +432,14 @@ describe('desktop Supabase auth', () => {
     const stateStore = createStateStore();
     const callbackState = createDesktopAuthCallbackState(stateStore);
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      callbackState,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        callbackState,
+      }),
+    );
 
     await auth.signIn();
     auth.dispose();
@@ -455,14 +452,13 @@ describe('desktop Supabase auth', () => {
       }),
     );
 
-    const recreatedAuth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      callbackState: persistedCallbackState,
-    });
+    const recreatedAuth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        callbackState: persistedCallbackState,
+      }),
+    );
 
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledWith(
@@ -483,28 +479,27 @@ describe('desktop Supabase auth', () => {
       const coordinator = createCoordinator();
       const stateStore = createStateStore();
       const oauthClient = createOAuthClient();
-      const auth = createDesktopSupabaseAuth({
-        router,
-        coordinator,
-        oauthClient,
-        secrets: createSecrets(),
-        openExternalUrl: vi.fn(async () => {}),
-        callbackState: createDesktopAuthCallbackState(stateStore),
-      });
+      const auth = createDesktopSupabaseAuth(
+        createAuthOptions({
+          router,
+          coordinator,
+          oauthClient,
+          callbackState: createDesktopAuthCallbackState(stateStore),
+        }),
+      );
 
       await auth.signIn();
       auth.dispose();
 
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
       const expiredCallbackState = createDesktopAuthCallbackState(stateStore);
-      const recreatedAuth = createDesktopSupabaseAuth({
-        router,
-        coordinator,
-        oauthClient: createOAuthClient(),
-        secrets: createSecrets(),
-        openExternalUrl: vi.fn(async () => {}),
-        callbackState: expiredCallbackState,
-      });
+      const recreatedAuth = createDesktopSupabaseAuth(
+        createAuthOptions({
+          router,
+          coordinator,
+          callbackState: expiredCallbackState,
+        }),
+      );
 
       router.routeUrl(
         authCallbackUrl({
@@ -582,15 +577,15 @@ describe('desktop Supabase auth', () => {
     const callbackState = createDesktopAuthCallbackState();
     const oauthClient = createOAuthClient();
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      callbackState,
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        callbackState,
+        log,
+      }),
+    );
 
     await auth.signIn();
     await auth.signOut();
@@ -617,14 +612,9 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const log = createLog();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator, oauthClient, log }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -658,14 +648,14 @@ describe('desktop Supabase auth', () => {
       await callbackProcessing.promise;
       return callbackSessionResult();
     });
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      callbackState,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        callbackState,
+      }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -700,15 +690,14 @@ describe('desktop Supabase auth', () => {
     });
     const onSessionChanged = vi.fn(async () => {});
     const showInfoMessage = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      onSessionChanged,
-      showInfoMessage,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        host: createAuthHost({ onSessionChanged, showInfoMessage }),
+      }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -746,15 +735,15 @@ describe('desktop Supabase auth', () => {
       await storeSession?.(session);
     });
     const onSessionChanged = vi.fn(async () => {});
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      callbackState,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      onSessionChanged,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        callbackState,
+        host: createAuthHost({ onSessionChanged }),
+      }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -809,14 +798,14 @@ describe('desktop Supabase auth', () => {
       const onSessionChanged = vi.fn(async () => {
         await sessionRefresh.promise;
       });
-      const auth = createDesktopSupabaseAuth({
-        router,
-        coordinator,
-        oauthClient,
-        secrets: createSecrets(),
-        openExternalUrl: vi.fn(async () => {}),
-        onSessionChanged,
-      });
+      const auth = createDesktopSupabaseAuth(
+        createAuthOptions({
+          router,
+          coordinator,
+          oauthClient,
+          host: createAuthHost({ onSessionChanged }),
+        }),
+      );
 
       await auth.signIn();
       router.routeUrl(
@@ -857,13 +846,9 @@ describe('desktop Supabase auth', () => {
         await callbackProcessing.promise;
         return callbackSessionResult();
       });
-      const auth = createDesktopSupabaseAuth({
-        router,
-        coordinator,
-        oauthClient,
-        secrets: createSecrets(),
-        openExternalUrl: vi.fn(async () => {}),
-      });
+      const auth = createDesktopSupabaseAuth(
+        createAuthOptions({ router, coordinator, oauthClient }),
+      );
 
       await auth.signIn();
       router.routeUrl(
@@ -891,13 +876,9 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({ router, coordinator, oauthClient }),
+    );
 
     const first = auth.signInAndWaitForSession(undefined, { timeoutMs: 10 });
     await vi.waitFor(() => {
@@ -931,15 +912,15 @@ describe('desktop Supabase auth', () => {
     const showErrorMessage = vi.fn(async () => {});
     const log = createLog();
     const oauthClient = createOAuthClient();
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient,
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      showErrorMessage,
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        router,
+        coordinator,
+        oauthClient,
+        host: createAuthHost({ showErrorMessage }),
+        log,
+      }),
+    );
 
     await auth.signIn();
     router.routeUrl(
@@ -963,17 +944,10 @@ describe('desktop Supabase auth', () => {
   });
 
   it('clears included-access caches on sign-out', async () => {
-    const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const clearAllCaches = vi.fn();
     setServerSideKeyService({ clearAllCaches } as never);
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator,
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(createAuthOptions({ coordinator }));
 
     await auth.signOut();
 
@@ -992,15 +966,13 @@ describe('desktop Supabase auth', () => {
     const coordinator = createCoordinator();
     const onSessionChanged = vi.fn(async () => {});
     const log = createLog();
-    const auth = createDesktopSupabaseAuth({
-      router: createDesktopProtocolCallbackRouter(),
-      coordinator,
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-      onSessionChanged,
-      log,
-    });
+    const auth = createDesktopSupabaseAuth(
+      createAuthOptions({
+        coordinator,
+        host: createAuthHost({ onSessionChanged }),
+        log,
+      }),
+    );
 
     await expect(auth.signOut()).resolves.toBeUndefined();
 
@@ -1029,13 +1001,7 @@ describe('desktop Supabase auth', () => {
         visibility: ['public', 'researcher'],
       },
     ]);
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator: createCoordinator(),
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(createAuthOptions({ router }));
 
     const message = await buildProfileMessage({
       getProviderKeyStatuses: async () => [],
@@ -1070,13 +1036,7 @@ describe('desktop Supabase auth', () => {
     const getAgentsBySource = vi
       .spyOn(agentRegistry, 'getAgentsBySource')
       .mockReturnValue([]);
-    const auth = createDesktopSupabaseAuth({
-      router,
-      coordinator: createCoordinator(),
-      oauthClient: createOAuthClient(),
-      secrets: createSecrets(),
-      openExternalUrl: vi.fn(async () => {}),
-    });
+    const auth = createDesktopSupabaseAuth(createAuthOptions({ router }));
 
     const message = await buildProfileMessage({
       getProviderKeyStatuses: async () => [],


### PR DESCRIPTION
## Summary

- require the desktop auth coordinator, callback state, OAuth client, logger, and UI/lifecycle host at the factory boundary
- compose one typed `DesktopAuthHost` per Electron window and pass it unchanged to desktop authentication
- remove production fallback construction and silent optional calls from sign-in, callback, and sign-out paths
- replace ad hoc test construction with complete typed auth options and host stubs

## Issue acceptance gates

Closes #8440.

All acceptance gates are satisfied: production dependencies are required; browser opening, notifications, and session refresh use one required host; test-only coordinator, callback-state, and OAuth-client fallbacks are removed; auth paths no longer silently omit required effects; and focused plus repository-wide validation passes.

## Single source of truth

`DesktopSupabaseAuthOptions` in `packages/desktop/src/main/desktopSupabaseAuth.ts` owns the complete factory contract. `DesktopAuthHost` owns the browser-opening, notification, and post-auth refresh capabilities, while `main/index.ts` composes its sole production instance.

## Duplication and abstraction budget

The factory previously supported a second hidden construction mode by creating three dependencies and treating four product effects plus logging as optional. That mode forced every auth path to defend against impossible production omissions. The refactor deletes those branches and adds one host interface that expresses the existing Electron-window invariant without adding a wrapper or pass-through layer.

## Net elements (R6)

- Files: 0 added, 0 deleted, 3 modified.
- Exported symbols: 1 interface added (`DesktopAuthHost`); no export removed.
- Named constructs: 1 production host interface added; 1 test-only `createSecrets` helper deleted.
- Net LoC: 226 additions, 266 deletions, net -40.

## Consumer counts (R8)

n/a. No export, event key, emitter, or subscriber path is removed. The deleted option fields were properties of the retained factory options interface and had one production constructor plus focused test constructors, all migrated in this PR.

## Host impact

Extension: none.

Desktop: auth dependencies and UI/lifecycle effects are required at window composition; sign-in, callback, and sign-out behavior remains unchanged for the fully wired production host.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts` (27 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; 50 existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- `npm test` (6,146 passed, 4 skipped)
- `corepack pnpm --filter @texra/desktop typecheck --pretty false`
- `git diff --check`
- independent auth/security review: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of dependency wiring and typing only; OAuth, nonce, and session behavior are unchanged when production passes the same host and clients.
> 
> **Overview**
> Desktop Supabase auth now takes a **fully explicit** factory contract: coordinator, callback state, OAuth client, logger, and a new **`DesktopAuthHost`** (browser open, info/error dialogs, post-session UI refresh) are all **required**—no in-factory defaults for coordinator, OAuth client, or callback state, and no optional chaining on host or log calls.
> 
> **`main/index.ts`** builds one `desktopAuthHost` per window (external URL, dialogs, `refreshDesktopAuthSurfaces`) and passes `SupabaseClient.getClient()` as `oauthClient`. **`createDesktopAuthCoordinator`** is narrowed to `{ secrets, log }` instead of the full auth options bag.
> 
> Tests use **`createAuthOptions`** / **`createAuthHost`** stubs instead of scattered partial options and a removed **`createSecrets`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2899db8104b9403f93ad8d315cb44a6b77b60ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->