### PR TITLE
refactor(desktop): require main-view capabilities

### DIFF
--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -8,12 +8,12 @@ import {
 } from './desktopIpcTypes.js';
 
 export interface DesktopExecutionIpcOptions {
-  executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
+  executeAgent(message: MainViewExecuteMessage): Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
 export function createDesktopExecutionIpc(
-  options: DesktopExecutionIpcOptions = {},
+  options: DesktopExecutionIpcOptions,
 ): DesktopMessageHandler {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
@@ -39,7 +39,7 @@ export function createDesktopExecutionIpc(
           );
           return;
         }
-        return options.executeAgent?.(parsed.data);
+        return options.executeAgent(parsed.data);
       },
     },
     { onAsyncError: options.onAsyncError },

--- a/packages/desktop/src/main/desktopLogIpc.ts
+++ b/packages/desktop/src/main/desktopLogIpc.ts
@@ -10,30 +10,20 @@ import {
 } from '../desktopLogMessages.js';
 
 export interface DesktopLogIpcOptions {
-  readLog?: () => DesktopLogSnapshot;
-  copyLog?: (text: string) => Promise<void>;
-  exportLog?: (text: string) => Promise<void>;
+  readLog(): DesktopLogSnapshot;
+  copyLog(text: string): Promise<void>;
+  exportLog(text: string): Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
 export function createDesktopLogIpc(
   renderer: DesktopRenderer,
-  options: DesktopLogIpcOptions = {},
+  options: DesktopLogIpcOptions,
 ): DesktopMessageHandler {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
-  function readSnapshot(): DesktopLogSnapshot {
-    return (
-      options.readLog?.() ?? {
-        path: undefined,
-        text: 'Desktop log is not available.',
-        truncated: false,
-      }
-    );
-  }
-
   function postSnapshot(): DesktopLogSnapshot {
-    const log = readSnapshot();
+    const log = options.readLog();
     renderer.postToRenderer({
       command: DESKTOP_LOG_COMMANDS.SET_LOG,
       log,
@@ -47,10 +37,10 @@ export function createDesktopLogIpc(
         postSnapshot();
       },
       [DESKTOP_LOG_COMMANDS.COPY_LOG]: () => {
-        void options.copyLog?.(postSnapshot().text).catch(reportAsyncError);
+        void options.copyLog(postSnapshot().text).catch(reportAsyncError);
       },
       [DESKTOP_LOG_COMMANDS.EXPORT_LOG]: () => {
-        void options.exportLog?.(postSnapshot().text).catch(reportAsyncError);
+        void options.exportLog(postSnapshot().text).catch(reportAsyncError);
       },
     },
     { onAsyncError: options.onAsyncError },

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -33,12 +33,12 @@ export interface DesktopMainViewIpcOptions {
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
   onboarding?: DesktopMessageHandler;
-  logs?: DesktopLogIpcOptions;
+  logs: DesktopLogIpcOptions;
   shellActions?: DesktopShellActions;
   modelListRefresh?: PromiseLike<void>;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
   loadStartupOptions?: () => Promise<MainViewStartupOptions>;
-  executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
+  executeAgent(message: MainViewExecuteMessage): Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -49,7 +49,7 @@ export interface DesktopMainViewIpc {
 
 export function installDesktopMainViewIpc(
   window: BrowserWindow,
-  options: DesktopMainViewIpcOptions = {},
+  options: DesktopMainViewIpcOptions,
 ): DesktopMainViewIpc {
   let disposed = false;
   let messageHandlers: DesktopMessageHandler[] = [];

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -24,7 +24,7 @@ interface MainViewIpcModule {
         send(channel: string, message: unknown): void;
       };
     },
-    options?: {
+    options: {
       debugMode?: boolean;
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
       fileSelection?: { handleMessage(message: { command: string }): boolean };
@@ -36,7 +36,16 @@ interface MainViewIpcModule {
         agentOptions: { workflow: unknown[]; toolUse: unknown[] };
         modelOptions: unknown[];
       }>;
-      executeAgent?: (message: unknown) => Promise<void>;
+      logs: {
+        readLog(): {
+          path: string | undefined;
+          text: string;
+          truncated: boolean;
+        };
+        copyLog(text: string): Promise<void>;
+        exportLog(text: string): Promise<void>;
+      };
+      executeAgent(message: unknown): Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -144,6 +153,17 @@ function createWindowMock(
   return { window, webContents };
 }
 
+function createMainViewCommandCapabilities() {
+  return {
+    executeAgent: vi.fn(async (_message: unknown) => {}),
+    logs: {
+      readLog: () => ({ path: undefined, text: '', truncated: false }),
+      copyLog: vi.fn(async (_text: string) => {}),
+      exportLog: vi.fn(async (_text: string) => {}),
+    },
+  };
+}
+
 describe('desktop main-view IPC', () => {
   afterEach(() => {
     vi.doUnmock('electron');
@@ -195,6 +215,7 @@ describe('desktop main-view IPC', () => {
     });
 
     const ipc = installDesktopMainViewIpc(window, {
+      ...createMainViewCommandCapabilities(),
       debugMode: true,
       fileSelection,
       settings,
@@ -462,6 +483,7 @@ describe('desktop main-view IPC', () => {
     const { window, webContents } = createWindowMock(sends);
 
     installDesktopMainViewIpc(window, {
+      ...createMainViewCommandCapabilities(),
       getAuthStatus: async () => ({ authenticated: true }),
       loadStartupOptions: async () => ({
         agentOptions: {
@@ -531,6 +553,7 @@ describe('desktop main-view IPC', () => {
     const { window, webContents } = createWindowMock(sends);
 
     installDesktopMainViewIpc(window, {
+      ...createMainViewCommandCapabilities(),
       modelListRefresh: modelListRefresh.promise,
     });
     rendererListener?.(


### PR DESCRIPTION
## Summary

Require desktop execution and log command capabilities at main-view composition. Execute, request-log, copy-log, and export-log handlers now call required dependencies directly, so a claimed command can no longer silently do nothing because an optional callback was omitted.

Closes #8443.

## Issue acceptance gates

- `createDesktopExecutionIpc` requires and directly invokes `executeAgent`.
- `createDesktopLogIpc` requires and directly invokes `readLog`, `copyLog`, and `exportLog`.
- `DesktopMainViewIpcOptions` requires execution and log capabilities.
- Removed empty factory defaults, optional command calls, and the synthetic unavailable-log fallback.
- Main-view integration tests share typed inert command capabilities and override behavior under assertion.
- Full validation completed successfully.

## Single source of truth

`DesktopMainViewIpcOptions` is the required composition contract, and `packages/desktop/src/main/index.ts` remains the production owner of the concrete execution and log capabilities.

## Duplication and abstraction budget

Removed the shallow `readSnapshot` fallback helper and six optional/default seams across the three factories. Added one test-only capability fixture that centralizes inert callbacks; no new production layer was introduced.

## Net elements (R6)

- Files: 0 added, 0 deleted, 4 modified.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Functions: 1 test helper added, 1 production fallback helper removed, net 0.
- LoC: 38 additions, 25 deletions, net +13 (the explicit test contract accounts for the increase; production code shrinks).

## Consumer counts (R8)

n/a: no event emit path, export, command key, or subscriber route was deleted or rerouted. The existing execute and three log command keys retain the same handlers; only their dependencies became required.

## Host impact

Extension: None.

Desktop: Main-view execution and log actions can no longer be registered in a silent no-op state.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts` (20 passed)
- `npm run check:dead-code-ratchet`
- `npm test` (6,146 passed; 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time and composition-contract tightening on desktop IPC with no auth or data-path changes; production wiring already supplies the required capabilities.
> 
> **Overview**
> Desktop main-view IPC factories now **require** `executeAgent` and log handlers (`readLog`, `copyLog`, `exportLog`) instead of treating them as optional callbacks with empty defaults.
> 
> **`createDesktopExecutionIpc`** and **`createDesktopLogIpc`** no longer accept default options or use optional chaining, so execute and log commands cannot be wired up and then silently no-op. The synthetic “Desktop log is not available” fallback in log IPC is removed; callers must supply real log behavior.
> 
> **`DesktopMainViewIpcOptions`** makes `logs` and `executeAgent` required on **`installDesktopMainViewIpc`**. Main-view integration tests use a shared **`createMainViewCommandCapabilities`** fixture so every install path satisfies the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa6ceee787eac0a0a5ac0ff95fc3eff4b77bdb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->