### PR TITLE
refactor(desktop): require onboarding capabilities

### DIFF
--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -28,7 +28,7 @@ export interface DesktopOnboardingIpcOptions {
    * keys, or any provider API key). Async because both the relay auth check
    * and the secrets read can involve disk/network I/O.
    */
-  hasCredential?: () => boolean | Promise<boolean>;
+  hasCredential: () => boolean | Promise<boolean>;
   /**
    * Resolves once the host's one-shot first-run backfill has settled. The first
    * funnel derivation waits for it so a returning veteran isn't transiently
@@ -37,17 +37,17 @@ export interface DesktopOnboardingIpcOptions {
    */
   readyGate?: Promise<void>;
   /** Post SET_SELECTED_AGENT to the renderer when entering State 1. */
-  selectSetupAgent?: () => Promise<void>;
+  selectSetupAgent: () => Promise<void>;
   /** Launch the setup conversation when the user clicks "Run Setup". */
-  kickoffSetup?: () => Promise<void>;
+  kickoffSetup: () => Promise<void>;
   /** Run ChatGPT sign-in flow from the welcome card. */
-  signInWithChatGpt?: () => Promise<void>;
+  signInWithChatGpt: () => Promise<void>;
   /**
    * Open the getting-started walkthrough from the State 0 welcome card. The
    * desktop shell can't host the VS Code walkthrough, so the host wires this to
    * the closest analog: opening the desktop getting-started docs externally.
    */
-  openGettingStarted?: () => Promise<void>;
+  openGettingStarted: () => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -58,7 +58,7 @@ export interface DesktopOnboardingIpc extends DesktopMessageHandler {
 
 export function createDesktopOnboardingIpc(
   renderer: DesktopRenderer,
-  options: DesktopOnboardingIpcOptions = {},
+  options: DesktopOnboardingIpcOptions,
 ): DesktopOnboardingIpc {
   const state = options.state ?? platform().globalState;
   let previousFunnelState: OnboardingFunnelState | undefined;
@@ -88,9 +88,9 @@ export function createDesktopOnboardingIpc(
     if (options.readyGate) {
       await options.readyGate.catch(() => undefined);
     }
-    const hasCredential = options.hasCredential
-      ? await Promise.resolve(options.hasCredential()).catch(() => false)
-      : false;
+    const hasCredential = await Promise.resolve(options.hasCredential()).catch(
+      () => false,
+    );
     const flags = readOnboardingFlags(state);
     const transition = planOnboardingFunnelTransition(previousFunnelState, {
       hasCredential,
@@ -107,7 +107,7 @@ export function createDesktopOnboardingIpc(
       await setOnboardingDeclined(state, false);
     }
     if (transition.selectSetupAgent) {
-      await options.selectSetupAgent?.();
+      await options.selectSetupAgent();
     }
     // Entering State 1 only selects the setup agent and paints the setup card;
     // it never auto-starts the setup conversation. The user launches setup
@@ -125,7 +125,7 @@ export function createDesktopOnboardingIpc(
     // completion, which must NOT block the serialized funnel-refresh chain —
     // otherwise a later "skip setup" / sign-out / credential-removal refresh
     // would queue behind the entire setup run, leaving the card stuck on 'setup'.
-    void Promise.resolve(options.kickoffSetup?.())
+    void Promise.resolve(options.kickoffSetup())
       .catch(() => {
         // Swallow — the kickoff handler already surfaced the error to the user.
       })
@@ -173,7 +173,7 @@ export function createDesktopOnboardingIpc(
   }
 
   async function runSetup(): Promise<void> {
-    await options.selectSetupAgent?.();
+    await options.selectSetupAgent();
     // Route through the shared guard so a double-click of "Run Setup" can't
     // launch a second concurrent run.
     startSetupKickoff();
@@ -181,12 +181,12 @@ export function createDesktopOnboardingIpc(
   }
 
   async function signInWithChatGpt(): Promise<void> {
-    await options.signInWithChatGpt?.();
+    await options.signInWithChatGpt();
     await refreshOnboardingFunnel();
   }
 
   async function openGettingStarted(): Promise<void> {
-    await options.openGettingStarted?.();
+    await options.openGettingStarted();
   }
 
   return {

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -32,9 +32,24 @@ type DesktopViewStateIpcModule =
 type DesktopOnboardingOptions = NonNullable<
   Parameters<DesktopOnboardingIpcModule['createDesktopOnboardingIpc']>[1]
 >;
-type OnboardingHarnessOptions = Omit<DesktopOnboardingOptions, 'state'> & {
+type OnboardingHarnessOptions = Partial<
+  Omit<DesktopOnboardingOptions, 'state'>
+> & {
   seed?: Readonly<Record<string, unknown>>;
 };
+
+function createOnboardingCapabilities(): Omit<
+  DesktopOnboardingOptions,
+  'state' | 'readyGate' | 'onAsyncError'
+> {
+  return {
+    hasCredential: () => false,
+    selectSetupAgent: async () => {},
+    kickoffSetup: async () => {},
+    signInWithChatGpt: async () => {},
+    openGettingStarted: async () => {},
+  };
+}
 
 // The WEBVIEW_READY / run-setup handlers trigger refreshOnboardingFunnel as a
 // fire-and-forget task whose chain (readyGate → credential probe →
@@ -123,7 +138,11 @@ async function createOnboardingHarness({
   const postToRenderer = vi.fn();
   const onboarding = createDesktopOnboardingIpc(
     { postToRenderer },
-    { ...options, state: memory.state },
+    {
+      ...createOnboardingCapabilities(),
+      ...options,
+      state: memory.state,
+    },
   );
   return {
     ...memory,


### PR DESCRIPTION
## Summary

Require every production capability used by the desktop onboarding IPC adapter. Claimed onboarding commands now call explicit dependencies directly, and an omitted credential probe can no longer silently force the funnel into `needs-credential`.

Tests keep concise per-case overrides through one complete typed inert capability fixture.

Closes #8445.

## Issue acceptance gates

- #8445: the credential probe and all renderer-command callbacks are required.
- The adapter no longer defaults its options to `{}`.
- Claimed onboarding actions call required capabilities without optional chaining.
- Credential-probe rejection still falls back to `false`.
- Focused onboarding coverage and all repository validation gates pass.

## Single source of truth

`DesktopOnboardingIpcOptions` now owns the complete host capability contract for desktop onboarding actions. The desktop composition root supplies the real implementations; the test harness supplies one complete typed fixture.

## Duplication and abstraction budget

Removed five independent runtime optionality paths. Added one private test fixture that owns the repeated inert onboarding capability set; no production abstraction or pass-through layer was added.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: net 0; the existing options interface is narrowed in place.
- Functions: 1 private test helper added, 0 production helpers added.
- Net LoC: +19 (35 additions, 16 deletions), entirely from making the test capability contract explicit; production is net 0 LoC.

## Consumer counts (R8)

n/a: no command key, route, emit path, or export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: Missing onboarding action wiring is now a TypeScript error instead of a claimed command that silently no-ops. Production already supplies all required capabilities.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck -- --pretty false`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts` (17 passed)
- `npm run check:dead-code-ratchet`
- `npm test` (6,146 passed; 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-level and call-site tightening only; production already passes full capabilities, with unchanged rejection-to-false credential behavior.
> 
> **Overview**
> **Desktop onboarding IPC** now treats host wiring as a required contract instead of optional callbacks with silent fallbacks.
> 
> `DesktopOnboardingIpcOptions` makes `hasCredential`, `selectSetupAgent`, `kickoffSetup`, `signInWithChatGpt`, and `openGettingStarted` mandatory; `createDesktopOnboardingIpc` no longer defaults `options` to `{}`. The adapter always runs the credential probe (rejections still map to `false`) and invokes those capabilities directly—no optional chaining—so a missing host hook is a compile-time error rather than a no-op that could wrongly leave the funnel in `needs-credential`.
> 
> Tests spread a single `createOnboardingCapabilities()` inert fixture through `createOnboardingHarness`, with per-case overrides still allowed via `Partial` options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb38b247944eb829693ae44d340bc5b566be24f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->