### PR TITLE
refactor(cli): require normalized context fields

### DIFF
--- a/packages/cli/src/commands/_helpers/context.ts
+++ b/packages/cli/src/commands/_helpers/context.ts
@@ -15,8 +15,8 @@ export async function contextFromArgs(
   const context = await buildCliContext({
     globalArgs: pickGlobalArgs(args, { skillSourcePaths }),
   });
-  if (context.quietLogs !== true) {
-    for (const warning of context.configWarnings ?? []) {
+  if (!context.quietLogs) {
+    for (const warning of context.configWarnings) {
       writeTextStderr(`WARN ${warning}`);
     }
   }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -242,11 +242,7 @@ const configEditCommand = defineCliCommand({
   args: { ...GLOBAL_ARGS },
   run: async (context) => {
     const ambient = readCliAmbientState();
-    if (
-      !ambient.stdinIsTty ||
-      !(context.stdoutIsTty ?? ambient.stdoutIsTty) ||
-      context.termIsDumb
-    ) {
+    if (!ambient.stdinIsTty || !context.stdoutIsTty || context.termIsDumb) {
       throw new CliUsageError(
         'Interactive configuration requires a terminal. Use `texra config show` or `texra config agents` in scripts.',
       );

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -33,33 +33,35 @@ export interface CliPromptRequest {
   readonly prompt: string;
 }
 
+/** Fully normalized CLI state produced by {@link buildCliContext}. */
 export interface CliContext {
   readonly cwd: string;
   readonly mode: CliMode;
   readonly outputFormat: CliOutputFormat;
   readonly approvalPolicy: CliApprovalPolicy;
   readonly helperModel?: string;
+  /** Absent until the invocation or initialized platform selects a mode. */
   readonly apiMode?: CliApiMode;
-  readonly quietLogs?: boolean;
+  readonly quietLogs: boolean;
   readonly renderRunProgress?: boolean;
-  readonly stdoutIsTty?: boolean;
-  readonly termIsDumb?: boolean;
-  readonly stderrIsTty?: boolean;
+  readonly stdoutIsTty: boolean;
+  readonly termIsDumb: boolean;
+  readonly stderrIsTty: boolean;
   /** Color allowed when writing to stdout. */
-  readonly stdoutColorEnabled?: boolean;
+  readonly stdoutColorEnabled: boolean;
   /** Color allowed when writing to stderr. */
-  readonly stderrColorEnabled?: boolean;
+  readonly stderrColorEnabled: boolean;
   /** Back-compat alias for `stderrColorEnabled`. */
   readonly colorEnabled: boolean;
-  readonly commandName?: string;
+  readonly commandName: string;
   readonly version: string;
   readonly resourcesPath: string;
-  readonly cliConfig?: CliConfigValues;
+  readonly cliConfig: CliConfigValues;
   readonly configFilePath?: string;
-  readonly configWarnings?: readonly string[];
+  readonly configWarnings: readonly string[];
   readonly envAgent?: string;
   readonly envModel?: string;
-  readonly skillSourceOptions?: SkillSourceOptions;
+  readonly skillSourceOptions: SkillSourceOptions;
   readonly approvalPrompt?: (request: CliPromptRequest) => Promise<string>;
 }
 

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -308,12 +308,12 @@ async function checkConfig(context: CliContext): Promise<DoctorCheck> {
       'Optional defaults may be placed in .texra/config.json.',
     );
   }
-  if ((context.configWarnings ?? []).length > 0) {
+  if (context.configWarnings.length > 0) {
     return warn(
       'config',
       'Config',
       `Workspace config has warnings: ${context.configFilePath}`,
-      context.configWarnings?.join(' '),
+      context.configWarnings.join(' '),
     );
   }
   const workspaceConfig = workspaceTexraConfigPath(context.cwd);
@@ -417,12 +417,8 @@ export function writeDoctorReport(
   // report goes to stdout, a failing one to stderr (clig.dev). Using a single
   // stderr-keyed gate leaked ANSI into `doctor | cat` and stripped color from
   // `doctor 2>/dev/null` on a TTY.
-  const stdoutColorEnabled =
-    context.stdoutColorEnabled ??
-    (context.colorEnabled && context.stdoutIsTty === true);
-  const stderrColorEnabled =
-    context.stderrColorEnabled ??
-    (context.colorEnabled && context.stderrIsTty === true);
+  const stdoutColorEnabled = context.stdoutColorEnabled;
+  const stderrColorEnabled = context.stderrColorEnabled;
   const colorEnabled = report.ok ? stdoutColorEnabled : stderrColorEnabled;
   const text = formatDoctorText(report, createCliStyle(colorEnabled));
   if (report.ok) {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -259,7 +259,7 @@ export async function initCliPlatform(
     Pick<CliContext, 'quietLogs'> & { skipIncludedModelAccess?: boolean },
 ): Promise<void> {
   cliWorkspaceCwd = context.cwd;
-  quietPlatformLogs = context.quietLogs ?? false;
+  quietPlatformLogs = context.quietLogs;
   setOutputChannelFactory(
     quietPlatformLogs ? () => ({ appendLine: () => undefined }) : null,
   );

--- a/packages/cli/src/runtime/resumeExecution.ts
+++ b/packages/cli/src/runtime/resumeExecution.ts
@@ -23,7 +23,7 @@ export async function runResumeExecution(
 ): Promise<number> {
   const terminalFailure = interactiveTerminalFailure(context);
   if (terminalFailure) {
-    const commandName = context.commandName || 'texra';
+    const commandName = context.commandName;
     const runCommand = `${commandName} run`;
     writeTextStderr(
       formatInteractiveTerminalFailure(terminalFailure, {

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -69,7 +69,7 @@ export interface RunProgressRendererInit {
 export function shouldRenderRunProgress(
   context: Pick<CliContext, 'outputFormat' | 'quietLogs'>,
 ): boolean {
-  return context.quietLogs !== true && context.outputFormat !== 'ndjson';
+  return !context.quietLogs && context.outputFormat !== 'ndjson';
 }
 
 export function createRunProgressRenderer(

--- a/packages/cli/src/runtime/terminalRequirements.ts
+++ b/packages/cli/src/runtime/terminalRequirements.ts
@@ -1,14 +1,18 @@
-import type { CliContext } from './cliContext';
-
 export type InteractiveTerminalFailureReason = 'headless' | 'dumb-terminal';
 
+interface InteractiveTerminalContext {
+  readonly mode: 'headless' | 'interactive';
+  readonly stdoutIsTty?: boolean;
+  readonly termIsDumb?: boolean;
+}
+
 export function interactiveTerminalFailure(
-  context: Pick<CliContext, 'mode' | 'stdoutIsTty' | 'termIsDumb'>,
+  context: InteractiveTerminalContext,
 ): InteractiveTerminalFailureReason | undefined {
-  if (context.mode === 'headless' || context.stdoutIsTty !== true) {
+  if (context.mode === 'headless' || !context.stdoutIsTty) {
     return 'headless';
   }
-  if (context.termIsDumb === true) return 'dumb-terminal';
+  if (context.termIsDumb) return 'dumb-terminal';
   return undefined;
 }
 

--- a/src/test-kernel/cli/AgentsCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsCommand.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
 
@@ -39,21 +40,10 @@ vi.mock('@cli/runtime/agents', async (importOriginal) => ({
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
+  return createTestCliContext({
     renderRunProgress: true,
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 describe('CLI agents command', () => {

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -70,21 +71,10 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
+  return createTestCliContext({
     renderRunProgress: true,
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 describe('CLI agents run command', () => {

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -10,6 +10,7 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
@@ -36,18 +37,13 @@ import {
 import { requestToolEditApproval } from '@tools/approval/toolEditApproval';
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/tmp',
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
     version: 'test',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 function useCliHostInteractions(

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -198,6 +198,7 @@ function cliContext(
     resourcesPath: '/tmp/resources',
     version: '0.0.0-test',
     quietLogs: true,
+    skillSourceOptions: {},
     ...overrides,
   };
 }

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import stripAnsi from 'strip-ansi';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   detectUnknownCliCommand,
@@ -54,21 +55,10 @@ import { pickGlobalArgs } from '@cli/runtime/globalArgs';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
+  return createTestCliContext({
     renderRunProgress: true,
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 function storedConfig(

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import stripAnsi from 'strip-ansi';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import {
   buildDoctorReport,
   doctorExitCode,
@@ -12,15 +13,10 @@ import {
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 
-const context: CliContext = {
+const context: CliContext = createTestCliContext({
   cwd: '/workspace',
-  mode: 'headless',
-  outputFormat: 'text',
-  approvalPolicy: 'never',
-  colorEnabled: false,
-  version: '0.0.0',
   resourcesPath: '/resources',
-};
+});
 
 const directory = {
   isDirectory: () => true,

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -81,6 +81,7 @@ vi.mock('@cli/runtime/initPlatform', () => ({
 import { parseHistoryListLimit, runHistoryExport } from '@cli/commands/history';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { TraceDocument } from '@transcript';
 import {
   cliHistoryNdjsonRecords,
@@ -1352,15 +1353,10 @@ describe('CLI history runtime', () => {
       const trace = makeTrace('a1');
 
       function makeContext(resourcesPath: string): CliContext {
-        return {
+        return createTestCliContext({
           cwd: '/workspace',
-          mode: 'headless',
-          outputFormat: 'text',
-          approvalPolicy: 'never',
-          colorEnabled: false,
-          version: '0.0.0',
           resourcesPath,
-        };
+        });
       }
 
       beforeEach(() => {

--- a/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessRoutes.vitest.mts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import {
   contextForCliModelAccess,
   readCliModelAccessStatus,
   selectCliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoutes';
-import type { CliContext } from '@cli/runtime/cliContext';
 
 const mocks = vi.hoisted(() => ({
   getCodexStatus: vi.fn(),
@@ -45,7 +45,7 @@ vi.mock('@cli/runtime/chatgptLogin', () => ({
   signInCliChatGpt: mocks.signInCliChatGpt,
 }));
 
-const context = { apiMode: 'personal' } as CliContext;
+const context = createTestCliContext({ apiMode: 'personal' });
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
@@ -112,21 +113,10 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
+  return createTestCliContext({
     renderRunProgress: true,
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 function mockExpandedRunInputs(inputs: {

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { ExecutionId } from '@shared/schemas';
 
@@ -35,20 +36,16 @@ vi.mock('@cli/chat/tui/runChatTui', () => ({
 const EXECUTION_ID = 'exec-1' as ExecutionId;
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
+  return createTestCliContext({
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
     stdoutIsTty: true,
     stderrIsTty: true,
     stdoutColorEnabled: true,
     stderrColorEnabled: true,
     colorEnabled: true,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 function resumableResolution() {

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import type { CliContext } from '@cli/runtime/cliContext';
@@ -178,7 +179,7 @@ vi.mock('@cli/chat/chatSessionController', async (importOriginal) => {
   };
 });
 
-const INTERACTIVE_CONTEXT: CliContext = {
+const INTERACTIVE_CONTEXT: CliContext = createTestCliContext({
   cwd: '/tmp/texra-chat',
   mode: 'interactive',
   outputFormat: 'text',
@@ -193,7 +194,7 @@ const INTERACTIVE_CONTEXT: CliContext = {
   commandName: 'texra',
   version: '0.0.0',
   resourcesPath: '/tmp/resources',
-};
+});
 
 function deferred(): { readonly promise: Promise<void>; resolve(): void } {
   let resolvePromise = (): void => undefined;

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -9,6 +9,7 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
@@ -107,19 +108,7 @@ vi.mock('@cli/runtime/logSinks', () => ({
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
-    ...overrides,
-  };
+  return createTestCliContext(overrides);
 }
 
 function baseRequest(): Parameters<typeof executeCliRequest>[0] {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type {
   RuntimePresentationEvent,
@@ -35,21 +36,15 @@ vi.mock('@agent/index', () => ({
 }));
 
 function context(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
+  return createTestCliContext({
     mode: 'interactive',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
     renderRunProgress: true,
     stderrIsTty: true,
     stdoutColorEnabled: true,
     stderrColorEnabled: true,
     colorEnabled: true,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 type RuntimePresentationNdjsonPolicy =

--- a/src/test-kernel/cli/SetupCommand.vitest.mts
+++ b/src/test-kernel/cli/SetupCommand.vitest.mts
@@ -32,18 +32,15 @@ vi.mock('@cli/runtime/initPlatform', () => ({
   initInteractiveCliPlatform: mocks.initInteractiveCliPlatform,
 }));
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { runSetup } from '@cli/commands/setup';
 import { CliExitCode } from '@cli/runtime/exitCodes';
-import type { CliContext } from '@cli/runtime/cliContext';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 
-const INTERACTIVE_CONTEXT = {
+const INTERACTIVE_CONTEXT = createTestCliContext({
   mode: 'interactive',
   stdoutIsTty: true,
-  termIsDumb: false,
-  stdoutColorEnabled: false,
-  colorEnabled: false,
-} as unknown as CliContext;
+});
 
 describe('texra setup combined flow', () => {
   beforeEach(() => {
@@ -63,7 +60,7 @@ describe('texra setup combined flow', () => {
       const exit = await runSetup({
         ...INTERACTIVE_CONTEXT,
         mode: 'headless',
-      } as CliContext);
+      });
       expect(exit).toBe(CliExitCode.Usage);
       expect(mocks.initInteractiveCliPlatform).not.toHaveBeenCalled();
       expect(mocks.runCliOnboarding).not.toHaveBeenCalled();

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -5,6 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import * as codexAuth from '@auth/codex';
 import { handleTuiSlashCommand } from '@cli/chat/tui/commands/handleSlashCommand';
 import { type SlashCommandContext } from '@cli/chat/tui/commands/handlers/slashContext';
@@ -55,18 +56,14 @@ function createSession(): TuiSession {
 }
 
 function createCliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/tmp/workspace',
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
     stdoutIsTty: true,
-    termIsDumb: false,
-    colorEnabled: false,
     version: '0.0.0-test',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 function createContext(

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -40,6 +40,7 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({ secrets: mocks.secrets }),
 }));
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
@@ -62,15 +63,13 @@ import {
 import { setGoalSessionBashAutoApproval } from '@tools/goal';
 
 function context(): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/work',
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
-    colorEnabled: false,
     version: 'test',
     resourcesPath: '/resources',
-  };
+  });
 }
 
 function host(): CliRuntimeHost {

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -9,6 +9,7 @@ vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: vi.fn(),
 }));
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import {
   clearApprovals,
   currentApproval,
@@ -24,15 +25,13 @@ import {
 } from '@shared/schemas';
 
 function context(): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/work',
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
-    colorEnabled: false,
     version: 'test',
     resourcesPath: '/resources',
-  };
+  });
 }
 
 function host(): CliRuntimeHost {

--- a/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
+++ b/src/test-kernel/cli/WorkflowOutputResolution.vitest.mts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   expectedOutputFilesForOutputDir,
@@ -29,17 +30,11 @@ async function makeTempDir(): Promise<string> {
 }
 
 function testContext(cwd: string): CliContext {
-  return {
+  return createTestCliContext({
     cwd,
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
     version: 'test',
     resourcesPath: cwd,
-  };
+  });
 }
 
 function workflowResult(

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { CliExitCode } from '@cli/runtime/exitCodes';
@@ -87,21 +88,10 @@ vi.mock('@cli/runtime/workflowInputs', () => ({
 }));
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    cwd: '/tmp/project',
-    mode: 'headless',
-    outputFormat: 'text',
-    approvalPolicy: 'never',
-    quietLogs: false,
+  return createTestCliContext({
     renderRunProgress: true,
-    stderrIsTty: false,
-    stdoutColorEnabled: false,
-    stderrColorEnabled: false,
-    colorEnabled: false,
-    version: '0.0.0',
-    resourcesPath: '/tmp/resources',
     ...overrides,
-  };
+  });
 }
 
 describe('CLI workflow run command', () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -118,6 +118,7 @@ vi.mock('@cli/runtime/sessionResume', () => ({
 }));
 
 import { StreamSnapshotStore } from '@transcript';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import type { ResumeStreamPorts } from '@agent/runtime/resolveAndResumeStream';
@@ -169,10 +170,9 @@ function makeSession(overrides: Partial<TuiSession> = {}): TuiSession {
 }
 
 function makeSessionContext(): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/tmp/test',
     mode: 'interactive',
-    outputFormat: 'text',
     approvalPolicy: 'ask',
     stdoutIsTty: true,
     stderrIsTty: true,
@@ -182,7 +182,7 @@ function makeSessionContext(): CliContext {
     helperModel: 'test-model',
     commandName: 'chat',
     apiMode: 'included',
-  } as CliContext;
+  });
 }
 
 describe('CLI terminal outcome resolution', () => {

--- a/src/test-kernel/cli/cliModelResolution.vitest.mts
+++ b/src/test-kernel/cli/cliModelResolution.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import {
   buildHeadlessRunContext,
   selectCliRunModel,
@@ -48,15 +49,10 @@ const KNOWN_MODEL = 'gpt5';
 const OTHER_MODEL = 'claudeSonnet';
 
 function makeContext(partial: Partial<CliContext> = {}): CliContext {
-  return {
+  return createTestCliContext({
     cwd: '/tmp',
-    colorEnabled: false,
-    mode: 'headless',
-    outputFormat: 'text',
-    stderrIsTty: false,
-    quietLogs: false,
     ...partial,
-  } as CliContext;
+  });
 }
 
 const runConfig = (model: string): CliConfigValues => ({ run: { model } });

--- a/src/test-kernel/cli/fixtures/cliContext.ts
+++ b/src/test-kernel/cli/fixtures/cliContext.ts
@@ -1,0 +1,29 @@
+// Local imports - CLI runtime
+import type { CliContext } from '@cli/runtime/cliContext';
+
+const BASE_CLI_CONTEXT = {
+  cwd: '/tmp/project',
+  mode: 'headless',
+  outputFormat: 'text',
+  approvalPolicy: 'never',
+  quietLogs: false,
+  stdoutIsTty: false,
+  termIsDumb: false,
+  stderrIsTty: false,
+  stdoutColorEnabled: false,
+  stderrColorEnabled: false,
+  colorEnabled: false,
+  commandName: 'texra',
+  version: '0.0.0',
+  resourcesPath: '/tmp/resources',
+  cliConfig: {},
+  configWarnings: [],
+  skillSourceOptions: {},
+} satisfies CliContext;
+
+/** Creates a complete post-normalization CLI context for tests. */
+export function createTestCliContext(
+  overrides: Partial<CliContext> = {},
+): CliContext {
+  return { ...BASE_CLI_CONTEXT, ...overrides };
+}


### PR DESCRIPTION
## Summary

- make values normalized by `buildCliContext()` required in the post-build `CliContext` contract
- remove redundant terminal, color, warning, logging, and command-name fallback paths
- centralize complete CLI test contexts and remove every `as CliContext` assertion

## Issue acceptance gates

Closes #8447.

- `CliContext` now distinguishes normalized required state from genuinely optional state; `apiMode` intentionally remains optional
- full-context consumers use values already settled by `buildCliContext()` directly
- type checking, zero-error lint, CLI-focused tests, full tests, build, and dead-code ratchet pass

## Single source of truth

`buildCliContext()` is the normalization boundary and `CliContext` is its truthful post-normalization contract. Terminal capability helpers keep a smaller structural input only where onboarding also consumes them before a full context is required.

## Duplication and abstraction budget

A single `createTestCliContext()` fixture owns the complete normalized test invariant and replaces repeated partial object literals plus six unsafe `as CliContext` assertions. The fixture is consumed by 20 test modules; its `satisfies CliContext` declaration makes every future required field a compile-time canary.

## Net elements (R6)

- Files: +1 / -0; 29 existing files modified
- Exported symbols: +1 / -0 (test-only `createTestCliContext`)
- Interfaces: +1 / -0 (private `InteractiveTerminalContext`)
- Classes/enums: +0 / -0
- LoC: +120 / -189, net -69

## Consumer counts (R8)

n/a: no production emit path or export was deleted or rerouted. The new test-only fixture has 20 consuming test modules plus its defining file.

## Host impact

Extension: none.

Desktop: none.

CLI: normalized context fields are required after construction; dead defensive fallbacks are removed without changing runtime values.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; repository baseline warnings only)
- `npm test` (6,146 passed, 4 skipped)
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli` (1,750 passed)
- `npm run check:dead-code-ratchet`
- `npm run check:test-loc-growth` (existing warn-only repository baseline)