### PR TITLE
refactor(desktop): require complete shell actions

### DIFF
--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -28,26 +28,14 @@ import {
   type DesktopCommandActions,
 } from '../desktopCommandSurface.js';
 
-export type DesktopShellIpcOptions =
-  DesktopShellActionFactoryOptions | DesktopShellActionInstanceOptions;
-
 export interface DesktopShellActionFactoryOptions {
-  actions?: never;
-  getCustomAgentDirectory?: () => Promise<string>;
-  openExternalUrl?: (url: string) => Promise<void>;
-  openLogFolder?: () => Promise<void>;
-  openPath?: (filePath: string) => Promise<void>;
-  openWorkspaceInNewWindow?: () => Promise<void>;
-  openWorkspaceFolder?: () => Promise<void>;
-  signIn?: () => Promise<void>;
-  /**
-   * Synchronous probe for "is the active workspace a git repo". Used as a
-   * fallback when `getRecentCommits` is not supplied so the desktop still
-   * reports the correct `isGitRepo` state to the renderer banner. When
-   * `getRecentCommits` is wired (production path in `index.ts`), this probe
-   * is unused — the git host's own result is authoritative.
-   */
-  isWorkspaceGitRepo?: () => boolean;
+  getCustomAgentDirectory(): Promise<string>;
+  openExternalUrl(url: string): Promise<void>;
+  openLogFolder(): Promise<void>;
+  openPath(filePath: string): Promise<void>;
+  openWorkspaceInNewWindow(): Promise<void>;
+  openWorkspaceFolder(): Promise<void>;
+  signIn(): Promise<void>;
   /**
    * Async git log host — closes audit item A from
    * `docs/dev/standalone-trajectory-audit.md` (trajectory #16). When
@@ -56,33 +44,29 @@ export interface DesktopShellActionFactoryOptions {
    * swallowed by the host itself; failures surface as `commits: []` plus
    * the best-effort `isGitRepo` boolean.
    */
-  getRecentCommits?: () => Promise<{
+  getRecentCommits(): Promise<{
     commits: string[];
     isGitRepo: boolean;
   }>;
-  showInfoMessage?: (message: string) => Promise<void> | void;
-  onAsyncError?: (error: unknown) => void;
-}
-
-export interface DesktopShellActionInstanceOptions {
-  actions: DesktopShellActions;
-  getCustomAgentDirectory?: never;
-  openPath?: never;
+  showInfoMessage(message: string): Promise<void> | void;
   onAsyncError?: (error: unknown) => void;
 }
 
 export interface DesktopShellActions extends DesktopCommandActions {
   signIn(): void;
   openAgentDirectory(customDirSet?: boolean): void;
+  openDesktopDocs(): void;
+  openLogFolder(): void;
+  openWorkspaceFolder(): void;
+  openWorkspaceInNewWindow(): void;
+  resetMainView(): void;
+  showFirstRunWalkthrough(): void;
   /**
    * Posts the most recent git commits to the renderer in response to
-   * `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS`. When the host has a real
-   * git port wired (`getRecentCommits`), the response includes the actual
-   * `git log` output; otherwise it falls back to an empty list with a
-   * best-effort `isGitRepo` flag derived from `isWorkspaceGitRepo`.
+   * `MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS`.
    */
   sendRecentCommits(): void;
-  showInfoMessage?(message: string): void;
+  showInfoMessage(message: string): void;
 }
 
 const SWITCH_VIEW_ROUTES = {
@@ -93,7 +77,7 @@ const SWITCH_VIEW_ROUTES = {
 
 export function createDesktopShellActions(
   renderer: DesktopRenderer,
-  options: DesktopShellActionFactoryOptions = {},
+  options: DesktopShellActionFactoryOptions,
 ): DesktopShellActions {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
@@ -116,10 +100,6 @@ export function createDesktopShellActions(
   }
 
   async function openCustomAgentDirectory() {
-    if (!options.getCustomAgentDirectory || !options.openPath) {
-      postSettingsRoute(SETTINGS_TAB.AGENTS);
-      return;
-    }
     const customDir = await options.getCustomAgentDirectory();
     await options.openPath(customDir);
   }
@@ -133,26 +113,22 @@ export function createDesktopShellActions(
   }
 
   function openLogFolder() {
-    void options.openLogFolder?.().catch(reportAsyncError);
+    void options.openLogFolder().catch(reportAsyncError);
   }
 
   function openWorkspaceFolder() {
-    void options.openWorkspaceFolder?.().catch(reportAsyncError);
+    void options.openWorkspaceFolder().catch(reportAsyncError);
   }
 
   function openWorkspaceInNewWindow() {
-    void options.openWorkspaceInNewWindow?.().catch(reportAsyncError);
+    void options.openWorkspaceInNewWindow().catch(reportAsyncError);
   }
 
   function openDesktopDocs() {
-    void options.openExternalUrl?.(DESKTOP_DOCS_URL).catch(reportAsyncError);
+    void options.openExternalUrl(DESKTOP_DOCS_URL).catch(reportAsyncError);
   }
 
   function signIn() {
-    if (!options.signIn) {
-      postSettingsRoute(SETTINGS_TAB.MODELS);
-      return;
-    }
     void options.signIn().catch(reportAsyncError);
   }
 
@@ -177,40 +153,27 @@ export function createDesktopShellActions(
           isGitRepo,
         });
       };
-      const { getRecentCommits } = options;
-      if (getRecentCommits) {
-        void getRecentCommits()
-          .then(({ commits, isGitRepo }) => postReply(commits, isGitRepo))
-          .catch((error) => {
-            // The git host swallows expected errors; reaching this catch
-            // is a programmer bug. Log and send a conservative reply so
-            // the launcher banner doesn't hang.
-            reportAsyncError(error);
-            postReply([], false);
-          });
-        return;
-      }
-      // No git host wired (tests / pre-init): best-effort isGitRepo probe.
-      let isGitRepo = false;
-      try {
-        isGitRepo = options.isWorkspaceGitRepo?.() ?? false;
-      } catch (error) {
-        reportAsyncError(error);
-      }
-      postReply([], isGitRepo);
+      void options
+        .getRecentCommits()
+        .then(({ commits, isGitRepo }) => postReply(commits, isGitRepo))
+        .catch((error) => {
+          // The git host swallows expected errors; reaching this catch is a
+          // programmer bug. Log and send a conservative reply so the launcher
+          // banner does not hang.
+          reportAsyncError(error);
+          postReply([], false);
+        });
     },
     showRoute: postRoute,
     showSettings: postSettingsRoute,
     showFirstRunWalkthrough: () => {
       renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
     },
-    showInfoMessage: options.showInfoMessage
-      ? (message) => {
-          void Promise.resolve(options.showInfoMessage!(message)).catch(
-            reportAsyncError,
-          );
-        }
-      : undefined,
+    showInfoMessage: (message) => {
+      void Promise.resolve(options.showInfoMessage(message)).catch(
+        reportAsyncError,
+      );
+    },
   };
 }
 
@@ -264,7 +227,7 @@ function dispatchMainViewInboundOnShell(
       return true;
     case MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION:
       if (message.action === 'openWalkthrough') {
-        actions.showFirstRunWalkthrough?.();
+        actions.showFirstRunWalkthrough();
       } else {
         const labels: Record<typeof message.action, string> = {
           runSetup: 'Run setup assistant',
@@ -272,7 +235,7 @@ function dispatchMainViewInboundOnShell(
           cloneOverleaf: 'Import from Overleaf',
           downloadArxiv: 'Import from arXiv',
         };
-        actions.showInfoMessage?.(
+        actions.showInfoMessage(
           `"${labels[message.action]}" requires the VS Code extension.`,
         );
       }
@@ -288,19 +251,19 @@ function dispatchDesktopLocalOnShell(
 ): boolean {
   switch (message.command) {
     case DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER:
-      actions.openLogFolder?.();
+      actions.openLogFolder();
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
-      actions.openWorkspaceFolder?.();
+      actions.openWorkspaceFolder();
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_IN_NEW_WINDOW:
-      actions.openWorkspaceInNewWindow?.();
+      actions.openWorkspaceInNewWindow();
       return true;
     case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
-      actions.showFirstRunWalkthrough?.();
+      actions.showFirstRunWalkthrough();
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
-      actions.openDesktopDocs?.();
+      actions.openDesktopDocs();
       return true;
     default:
       return false;
@@ -308,14 +271,8 @@ function dispatchDesktopLocalOnShell(
 }
 
 export function createDesktopShellIpc(
-  renderer: DesktopRenderer,
-  options: DesktopShellIpcOptions = {},
+  actions: DesktopShellActions,
 ): DesktopMessageHandler {
-  const actions =
-    options.actions != null
-      ? options.actions
-      : createDesktopShellActions(renderer, options);
-
   return {
     handleMessage(message: DesktopCommandMessage): boolean {
       // Single discriminated-union parse at the entry point. Every shell

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -38,11 +38,10 @@ export interface DesktopShellActionFactoryOptions {
   signIn(): Promise<void>;
   /**
    * Async git log host — closes audit item A from
-   * `docs/dev/standalone-trajectory-audit.md` (trajectory #16). When
-   * provided, the shell forwards the workspace's most recent commits to
-   * the renderer instead of replying with an empty list. Errors are
-   * swallowed by the host itself; failures surface as `commits: []` plus
-   * the best-effort `isGitRepo` boolean.
+   * `docs/dev/standalone-trajectory-audit.md` (trajectory #16). The shell
+   * forwards its recent-commit result to the renderer. The host converts
+   * expected git failures into an empty result with its best-effort
+   * `isGitRepo` value.
    */
   getRecentCommits(): Promise<{
     commits: string[];

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -34,7 +34,7 @@ export interface DesktopMainViewIpcOptions {
   progress?: DesktopProgressIpc;
   onboarding?: DesktopMessageHandler;
   logs: DesktopLogIpcOptions;
-  shellActions?: DesktopShellActions;
+  shellActions: DesktopShellActions;
   modelListRefresh?: PromiseLike<void>;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
   loadStartupOptions?: () => Promise<MainViewStartupOptions>;
@@ -68,12 +68,7 @@ export function installDesktopMainViewIpc(
     debugMode: options.debugMode,
     getTheme: options.getTheme,
   });
-  const shell = createDesktopShellIpc(
-    bridge,
-    options.shellActions == null
-      ? { onAsyncError: options.onAsyncError }
-      : { actions: options.shellActions, onAsyncError: options.onAsyncError },
-  );
+  const shell = createDesktopShellIpc(options.shellActions);
   const execution = createDesktopExecutionIpc({
     executeAgent: options.executeAgent,
     onAsyncError: options.onAsyncError,

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -15,6 +15,9 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 type DesktopShellIpcModule = typeof import('@desktop/main/desktopShellIpc');
+type DesktopShellActionFactoryOptions = Parameters<
+  DesktopShellIpcModule['createDesktopShellActions']
+>[1];
 type DesktopLogIpcModule = typeof import('@desktop/main/desktopLogIpc');
 type DesktopExecutionIpcModule =
   typeof import('@desktop/main/desktopExecutionIpc');
@@ -68,6 +71,34 @@ async function loadDesktopShellIpc(): Promise<DesktopShellIpcModule> {
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopShellIpc.ts'))
   ) as Promise<DesktopShellIpcModule>;
+}
+
+async function createShellHarness(
+  overrides: Partial<DesktopShellActionFactoryOptions> = {},
+) {
+  const { createDesktopShellActions, createDesktopShellIpc } =
+    await loadDesktopShellIpc();
+  const postToRenderer = vi.fn();
+  const actions = createDesktopShellActions(
+    { postToRenderer },
+    {
+      getCustomAgentDirectory: async () => '/agents/custom',
+      openExternalUrl: vi.fn(async () => {}),
+      openLogFolder: vi.fn(async () => {}),
+      openPath: vi.fn(async () => {}),
+      openWorkspaceInNewWindow: vi.fn(async () => {}),
+      openWorkspaceFolder: vi.fn(async () => {}),
+      signIn: vi.fn(async () => {}),
+      getRecentCommits: async () => ({ commits: [], isGitRepo: false }),
+      showInfoMessage: vi.fn(),
+      ...overrides,
+    },
+  );
+  return {
+    actions,
+    postToRenderer,
+    shellIpc: createDesktopShellIpc(actions),
+  };
 }
 
 async function loadDesktopExecutionIpc(): Promise<DesktopExecutionIpcModule> {
@@ -221,17 +252,9 @@ describe('desktop IPC adapters', () => {
     expect(nativeTheme.off).toHaveBeenCalledWith('updated', themeListener);
   });
 
-  it('keeps shell routing and launcher fallbacks in the shell adapter', async () => {
-    const { createDesktopShellIpc } = await loadDesktopShellIpc();
-    const postToRenderer = vi.fn();
+  it('keeps shell routing and launcher actions in the shell adapter', async () => {
     const openPath = vi.fn(async (_filePath: string) => {});
-    const shellIpc = createDesktopShellIpc(
-      { postToRenderer },
-      {
-        getCustomAgentDirectory: async () => '/agents/custom',
-        openPath,
-      },
-    );
+    const { postToRenderer, shellIpc } = await createShellHarness({ openPath });
 
     shellIpc.handleMessage({
       command: COMMON_COMMANDS.SWITCH_VIEW,
@@ -245,6 +268,8 @@ describe('desktop IPC adapters', () => {
     shellIpc.handleMessage({
       command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
     });
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(postToRenderer).toHaveBeenNthCalledWith(1, {
       command: 'desktop:setRoute',
@@ -282,9 +307,9 @@ describe('desktop IPC adapters', () => {
     expect(openPath).toHaveBeenCalledWith('/agents/custom');
 
     postToRenderer.mockClear();
-    createDesktopShellIpc({ postToRenderer }).handleMessage({
+    shellIpc.handleMessage({
       command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
-      customDirSet: true,
+      customDirSet: false,
     });
     expect(postToRenderer).toHaveBeenCalledWith({
       command: 'desktop:setRoute',
@@ -300,16 +325,13 @@ describe('desktop IPC adapters', () => {
     // Closes audit item A: `getRecentCommits` is now a first-class shell
     // option, so the launcher banner sees the actual `git log` output
     // instead of the legacy empty stub.
-    const { createDesktopShellIpc } = await loadDesktopShellIpc();
-    const postToRenderer = vi.fn();
     const getRecentCommits = vi.fn(async () => ({
       commits: ['abc1234: Add feature (2 days ago)'],
       isGitRepo: true,
     }));
-    const shellIpc = createDesktopShellIpc(
-      { postToRenderer },
-      { getRecentCommits },
-    );
+    const { postToRenderer, shellIpc } = await createShellHarness({
+      getRecentCommits,
+    });
 
     expect(
       shellIpc.handleMessage({
@@ -327,32 +349,9 @@ describe('desktop IPC adapters', () => {
     });
   });
 
-  it('falls back to empty list + isWorkspaceGitRepo when no git host is wired', async () => {
-    const { createDesktopShellIpc } = await loadDesktopShellIpc();
-    const postToRenderer = vi.fn();
-    const isWorkspaceGitRepo = vi.fn(() => true);
-    const shellIpc = createDesktopShellIpc(
-      { postToRenderer },
-      { isWorkspaceGitRepo },
-    );
-
-    shellIpc.handleMessage({
-      command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
-    });
-
-    expect(isWorkspaceGitRepo).toHaveBeenCalledOnce();
-    expect(postToRenderer).toHaveBeenCalledWith({
-      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-      commits: [],
-      isGitRepo: true,
-    });
-  });
-
   it('wires the main login banner to desktop sign-in', async () => {
-    const { createDesktopShellIpc } = await loadDesktopShellIpc();
-    const postToRenderer = vi.fn();
     const signIn = vi.fn(async () => {});
-    const shellIpc = createDesktopShellIpc({ postToRenderer }, { signIn });
+    const { postToRenderer, shellIpc } = await createShellHarness({ signIn });
 
     expect(
       shellIpc.handleMessage({
@@ -366,9 +365,7 @@ describe('desktop IPC adapters', () => {
   });
 
   it('rejects shell payloads that fail the MainView inbound schema', async () => {
-    const { createDesktopShellIpc } = await loadDesktopShellIpc();
-    const postToRenderer = vi.fn();
-    const shellIpc = createDesktopShellIpc({ postToRenderer });
+    const { postToRenderer, shellIpc } = await createShellHarness();
 
     // SWITCH_VIEW with an invalid `view` value fails the discriminated-union
     // parse and is no longer dispatched as a real switch — i.e. the single

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -14,6 +14,21 @@ import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
+interface TestDesktopShellActions {
+  showRoute: ReturnType<typeof vi.fn>;
+  showSettings: ReturnType<typeof vi.fn>;
+  signIn: ReturnType<typeof vi.fn>;
+  openAgentDirectory: ReturnType<typeof vi.fn>;
+  openDesktopDocs: ReturnType<typeof vi.fn>;
+  openLogFolder: ReturnType<typeof vi.fn>;
+  openWorkspaceFolder: ReturnType<typeof vi.fn>;
+  openWorkspaceInNewWindow: ReturnType<typeof vi.fn>;
+  resetMainView: ReturnType<typeof vi.fn>;
+  showFirstRunWalkthrough: ReturnType<typeof vi.fn>;
+  sendRecentCommits: ReturnType<typeof vi.fn>;
+  showInfoMessage: ReturnType<typeof vi.fn>;
+}
+
 interface MainViewIpcModule {
   installDesktopMainViewIpc(
     window: {
@@ -30,6 +45,7 @@ interface MainViewIpcModule {
       fileSelection?: { handleMessage(message: { command: string }): boolean };
       settings?: { handleMessage(message: { command: string }): boolean };
       progress?: { handleMessage(message: { command: string }): boolean };
+      shellActions: TestDesktopShellActions;
       modelListRefresh?: PromiseLike<void>;
       getAuthStatus?: () => Promise<{ authenticated: boolean }>;
       loadStartupOptions?: () => Promise<{
@@ -153,6 +169,23 @@ function createWindowMock(
   return { window, webContents };
 }
 
+function createMainViewShellActions(): TestDesktopShellActions {
+  return {
+    showRoute: vi.fn(),
+    showSettings: vi.fn(),
+    signIn: vi.fn(),
+    openAgentDirectory: vi.fn(),
+    openDesktopDocs: vi.fn(),
+    openLogFolder: vi.fn(),
+    openWorkspaceFolder: vi.fn(),
+    openWorkspaceInNewWindow: vi.fn(),
+    resetMainView: vi.fn(),
+    showFirstRunWalkthrough: vi.fn(),
+    sendRecentCommits: vi.fn(),
+    showInfoMessage: vi.fn(),
+  };
+}
+
 function createMainViewCommandCapabilities() {
   return {
     executeAgent: vi.fn(async (_message: unknown) => {}),
@@ -161,6 +194,7 @@ function createMainViewCommandCapabilities() {
       copyLog: vi.fn(async (_text: string) => {}),
       exportLog: vi.fn(async (_text: string) => {}),
     },
+    shellActions: createMainViewShellActions(),
   };
 }
 
@@ -214,8 +248,9 @@ describe('desktop main-view IPC', () => {
       closedListeners.push(listener);
     });
 
+    const capabilities = createMainViewCommandCapabilities();
     const ipc = installDesktopMainViewIpc(window, {
-      ...createMainViewCommandCapabilities(),
+      ...capabilities,
       debugMode: true,
       fileSelection,
       settings,
@@ -296,16 +331,8 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       { command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS },
     );
-    expect(sends).toEqual([
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-          commits: [],
-          isGitRepo: false,
-        },
-      },
-    ]);
+    expect(capabilities.shellActions.sendRecentCommits).toHaveBeenCalledOnce();
+    expect(sends).toEqual([]);
 
     sends.length = 0;
     nativeTheme.shouldUseDarkColors = false;
@@ -337,12 +364,10 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       { command: COMMON_COMMANDS.SWITCH_VIEW, view: 'progress' },
     );
-    expect(sends).toEqual([
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'progress' },
-      },
-    ]);
+    expect(capabilities.shellActions.showRoute).toHaveBeenCalledWith(
+      'progress',
+    );
+    expect(sends).toEqual([]);
 
     sends.length = 0;
     rendererListener?.(
@@ -368,76 +393,36 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       { command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY },
     );
-    expect(sends).toEqual([
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex: SETTINGS_TAB.MODELS,
-        },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          agentSubTab: AgentCategory.ToolUse,
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex: SETTINGS_TAB.AGENTS,
-        },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex: SETTINGS_TAB.MULTI_AGENT,
-        },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex: SETTINGS_TAB.AGENTS,
-        },
-      },
-    ]);
+    expect(capabilities.shellActions.showRoute).toHaveBeenCalledWith(
+      'settings',
+    );
+    expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
+      1,
+      SETTINGS_TAB.MODELS,
+    );
+    expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
+      2,
+      SETTINGS_TAB.AGENTS,
+      AgentCategory.ToolUse,
+    );
+    expect(capabilities.shellActions.showSettings).toHaveBeenNthCalledWith(
+      3,
+      SETTINGS_TAB.MULTI_AGENT,
+    );
+    expect(capabilities.shellActions.openAgentDirectory).toHaveBeenCalledWith(
+      false,
+    );
+    expect(sends).toEqual([]);
 
     sends.length = 0;
     rendererListener?.(
       { sender: webContents },
       { command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY, customDirSet: true },
     );
-    expect(sends).toEqual([
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: { command: 'desktop:setRoute', route: 'settings' },
-      },
-      {
-        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
-        message: {
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex: SETTINGS_TAB.AGENTS,
-        },
-      },
-    ]);
+    expect(capabilities.shellActions.openAgentDirectory).toHaveBeenCalledWith(
+      true,
+    );
+    expect(sends).toEqual([]);
 
     const executeMessage = {
       command: MAIN_VIEW_COMMANDS.EXECUTE,


### PR DESCRIPTION
## Summary

- make the desktop shell action factory require every host capability that production supplies
- pass one complete `DesktopShellActions` object into main-view IPC
- delete the factory-or-instance union, silent missing-host branches, and tests for impossible partial wiring

Closes #8450

## Issue acceptance gates

- #8450: complete shell capabilities are required at the boundary
- #8450: missing opener, sign-in, custom-directory, and recent-commit fallbacks are removed
- #8450: tests use explicit complete fakes
- #8450: typecheck, compile, lint, focused tests, full tests, and dead-code ratchet pass

## Single source of truth

`createDesktopShellActions` owns construction of the complete shell action set; `installDesktopMainViewIpc` only consumes that set.

## Duplication and abstraction budget

Removed the parallel factory-options versus action-instance input shapes and the branching needed to distinguish them. No new production abstraction was added.

## Net elements (R6)

- files: 4 modified, 0 added, 0 deleted
- exported symbols: 2 deleted (`DesktopShellIpcOptions`, `DesktopShellActionInstanceOptions`), 0 added
- classes/interfaces/enums: net 0 interfaces; one production interface deleted and one test fake interface added
- LoC: +159 / -226, net -67

## Consumer counts (R8)

n/a: no event key, emit path, or public command was deleted. `createDesktopShellIpc` retains two call sites: the production installer and its focused adapter harness.

## Host impact

Extension: none.

Desktop: impossible partial shell wiring now fails at compile time; production behavior is unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts` (19 passed, rerun after review fix)
- `npm test` (6,145 passed, 4 skipped)
- `node scripts/check-dead-code-ratchet.mjs`
- `git diff --check`