### PR TITLE
refactor(progress): separate run and workflow capabilities

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -371,17 +371,10 @@ export class DesktopProgressBridge {
 
   private createProgressViewHost(): ProgressViewHost {
     return new ProgressViewHost({
-      // Shared run-new path (mirrors the extension wiring). Only
-      // `getTaskState` and `executeAgent` matter here: diff/file-operation
-      // actions are routed through `workflowFileActions`/`fileActions`, so
-      // those deps stay unwired.
-      workflowActions: {
+      run: {
         state: {
           getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
           getExecutionId: (stream) => this.getStreamExecutionId(stream),
-          getOutputFiles: (stream) =>
-            this.state.snapshots.getOutputFiles(stream),
-          getKnownWorkspaceOutputPaths: () => new Set(),
         },
         executeAgent: async (request) => {
           const validated = validateExecutionRequest(request);
@@ -393,14 +386,6 @@ export class DesktopProgressBridge {
             return;
           }
           await this.runExecution(validated.request);
-        },
-        runDiff: () => {
-          throw new Error('Desktop diff is routed through workflowFileActions');
-        },
-        runFileOperation: () => {
-          throw new Error(
-            'Desktop file operations are routed through workflowFileActions',
-          );
         },
       },
       workflowFileActions: {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
+import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
 import {
   ProgressFollowUpController,
@@ -72,7 +73,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly recordingManager: RecordingManager;
   private readonly progressHost: ProgressViewHost;
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
-  private readonly workflowActionsController: ProgressViewHost['workflowActionsController'];
+  private readonly workflowActionsController: ProgressWorkflowActionsController;
   private readonly workflowFileActionsController: ProgressViewHost['workflowFileActionsController'];
   private readonly agentProposalController: ProgressViewHost['agentProposalController'];
   private readonly apiKeyRetryController: ProgressApiKeyRetryController;
@@ -106,9 +107,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       progressTitle: 'Transcribing follow-up message',
     });
 
+    this.workflowActionsController = this.createWorkflowActionsController();
     this.progressHost = this.createProgressViewHost();
-    this.workflowActionsController =
-      this.progressHost.workflowActionsController;
     this.workflowFileActionsController =
       this.progressHost.workflowFileActionsController;
     this.agentProposalController = this.progressHost.agentProposalController;
@@ -330,27 +330,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
   private createProgressViewHost(): ProgressViewHost {
     return new ProgressViewHost({
-      workflowActions: {
+      run: {
         state: {
           getTaskState: (stream) =>
             this.provider.state.snapshots.getTaskState(stream),
           getExecutionId: (stream) =>
             this.provider.state.snapshots.getExecutionId(stream),
-          getOutputFiles: (stream) =>
-            this.provider.state.snapshots.getOutputFiles(stream),
-          getKnownWorkspaceOutputPaths: (stream) =>
-            this.provider.state.snapshots.getKnownFilePaths(stream, {
-              workspaceOnly: true,
-            }),
         },
         executeAgent: async (request) => {
           await this.executeValidated(request);
-        },
-        runDiff: async (request) => {
-          await this.runViewCommand('texra.runLatexdiff', [request]);
-        },
-        runFileOperation: async (operation, request) => {
-          await this.runViewCommand(`texra.${operation}`, [request]);
         },
       },
       workflowFileActions: {
@@ -537,6 +525,29 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             this.handleUserQuestionAction(message),
         },
         externalInquiry: {},
+      },
+    });
+  }
+
+  private createWorkflowActionsController(): ProgressWorkflowActionsController {
+    return new ProgressWorkflowActionsController({
+      state: {
+        getTaskState: (stream) =>
+          this.provider.state.snapshots.getTaskState(stream),
+        getExecutionId: (stream) =>
+          this.provider.state.snapshots.getExecutionId(stream),
+        getOutputFiles: (stream) =>
+          this.provider.state.snapshots.getOutputFiles(stream),
+        getKnownWorkspaceOutputPaths: (stream) =>
+          this.provider.state.snapshots.getKnownFilePaths(stream, {
+            workspaceOnly: true,
+          }),
+      },
+      runDiff: async (request) => {
+        await this.runViewCommand('texra.runLatexdiff', [request]);
+      },
+      runFileOperation: async (operation, request) => {
+        await this.runViewCommand(`texra.${operation}`, [request]);
       },
     });
   }

--- a/src/controllers/progressView/ProgressViewHost.ts
+++ b/src/controllers/progressView/ProgressViewHost.ts
@@ -1,3 +1,13 @@
+// Local imports - agent
+import type { ExecutionRequest } from '@agent/core/state/executionRequests';
+import {
+  isWorkflowTaskState,
+  type TaskState,
+} from '@agent/core/state/TaskState';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
 // Local imports - controllers
 import {
   createProgressViewCommandHandlers,
@@ -13,10 +23,6 @@ import {
   ProgressAgentProposalController,
   type ProgressAgentProposalControllerDeps,
 } from './ProgressAgentProposalController';
-import {
-  ProgressWorkflowActionsController,
-  type ProgressWorkflowActionsControllerDeps,
-} from './ProgressWorkflowActionsController';
 import {
   ProgressWorkflowFileActionsController,
   type ProgressWorkflowFileActionsControllerDeps,
@@ -42,15 +48,51 @@ export interface ProgressViewHostCommandOptions {
   readonly externalInquiry: ProgressViewExternalInquiryCommandActions;
 }
 
+interface ProgressViewRunState {
+  getTaskState(stream: StreamTabId): TaskState | undefined;
+  getExecutionId(stream: StreamTabId): string | undefined;
+}
+
+interface ProgressViewRunDependencies {
+  readonly state: ProgressViewRunState;
+  executeAgent(request: ExecutionRequest): Promise<void>;
+}
+
+async function resumeStream(
+  dependencies: ProgressViewRunDependencies,
+  stream: StreamTabId,
+): Promise<void> {
+  const taskState = dependencies.state.getTaskState(stream);
+  if (!taskState) return;
+
+  const executionId = isWorkflowTaskState(taskState)
+    ? dependencies.state.getExecutionId(stream)
+    : undefined;
+
+  await dependencies.executeAgent({
+    config: taskState.agentConfig,
+    ...(executionId && { executionId }),
+  });
+}
+
+async function runNewStream(
+  dependencies: ProgressViewRunDependencies,
+  stream: StreamTabId,
+): Promise<void> {
+  const taskState = dependencies.state.getTaskState(stream);
+  if (!taskState) return;
+
+  await dependencies.executeAgent({ config: taskState.agentConfig });
+}
+
 export interface ProgressViewHostOptions {
-  readonly workflowActions: ProgressWorkflowActionsControllerDeps;
+  readonly run: ProgressViewRunDependencies;
   readonly workflowFileActions: ProgressWorkflowFileActionsControllerDeps;
   readonly agentProposal: ProgressAgentProposalControllerDeps;
   readonly commands: ProgressViewHostCommandOptions;
 }
 
 export class ProgressViewHost {
-  readonly workflowActionsController: ProgressWorkflowActionsController;
   readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
   readonly agentProposalController: ProgressAgentProposalController;
   readonly commandHandlers: ReturnType<
@@ -58,9 +100,6 @@ export class ProgressViewHost {
   >;
 
   constructor(options: ProgressViewHostOptions) {
-    this.workflowActionsController = new ProgressWorkflowActionsController(
-      options.workflowActions,
-    );
     this.workflowFileActionsController =
       new ProgressWorkflowFileActionsController(options.workflowFileActions);
     this.agentProposalController = new ProgressAgentProposalController(
@@ -71,8 +110,8 @@ export class ProgressViewHost {
       run: {
         resumeStream:
           options.commands.resumeStream ??
-          ((stream) => this.workflowActionsController.resume(stream)),
-        runNewStream: (stream) => this.workflowActionsController.runNew(stream),
+          ((stream) => resumeStream(options.run, stream)),
+        runNewStream: (stream) => runNewStream(options.run, stream),
       },
       followUp: options.commands.followUp,
       bypass: options.commands.bypass,

--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -1,6 +1,3 @@
-// Local imports - agent
-import type { ExecutionRequest } from '@agent/core/state/executionRequests';
-
 import {
   isWorkflowTaskState,
   type TaskState,
@@ -46,7 +43,6 @@ interface ProgressWorkflowActionsState {
 
 export interface ProgressWorkflowActionsControllerDeps {
   state: ProgressWorkflowActionsState;
-  executeAgent(request: ExecutionRequest): Promise<void>;
   runDiff(request: WorkflowDiffRequest): Promise<void>;
   runFileOperation(
     operation: WorkflowFileOperation,
@@ -56,27 +52,6 @@ export interface ProgressWorkflowActionsControllerDeps {
 
 export class ProgressWorkflowActionsController {
   constructor(private readonly deps: ProgressWorkflowActionsControllerDeps) {}
-
-  async resume(stream: StreamTabId): Promise<void> {
-    const taskState = this.deps.state.getTaskState(stream);
-    if (!taskState) return;
-
-    const executionId = isWorkflowTaskState(taskState)
-      ? this.deps.state.getExecutionId(stream)
-      : undefined;
-
-    await this.deps.executeAgent({
-      config: taskState.agentConfig,
-      ...(executionId && { executionId }),
-    });
-  }
-
-  async runNew(stream: StreamTabId): Promise<void> {
-    const taskState = this.deps.state.getTaskState(stream);
-    if (!taskState) return;
-
-    await this.deps.executeAgent({ config: taskState.agentConfig });
-  }
 
   async diffStream(stream: StreamTabId): Promise<void> {
     await this.withWorkflowTaskState(stream, async (taskState) => {

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -25,18 +25,14 @@ describe('ProgressViewHost', () => {
     const settledProposals: unknown[] = [];
 
     const host = new ProgressViewHost({
-      workflowActions: {
+      run: {
         state: {
           getTaskState: () => taskState,
           getExecutionId: () => 'exec-1',
-          getOutputFiles: () => ({}),
-          getKnownWorkspaceOutputPaths: () => new Set(),
         },
         executeAgent: async (request) => {
           executed.push(request);
         },
-        runDiff: vi.fn(),
-        runFileOperation: vi.fn(),
       },
       workflowFileActions: {
         state: {
@@ -104,6 +100,10 @@ describe('ProgressViewHost', () => {
       command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
       stream: 'stream-a',
     });
+    await host.commandHandlers[PROGRESS_VIEW_COMMANDS.RESUME]?.({
+      command: PROGRESS_VIEW_COMMANDS.RESUME,
+      stream: 'stream-a',
+    });
     await host.commandHandlers[PROGRESS_VIEW_COMMANDS.OPEN_LABEL]?.({
       command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL,
       label: 'main-thm',
@@ -114,7 +114,10 @@ describe('ProgressViewHost', () => {
       action: 'approve',
     });
 
-    assert.deepEqual(executed, [{ config: taskState.agentConfig }]);
+    assert.deepEqual(executed, [
+      { config: taskState.agentConfig },
+      { config: taskState.agentConfig, executionId: 'exec-1' },
+    ]);
     assert.deepEqual(openedLabels, ['main-thm']);
     assert.deepEqual(infoMessages, ['Label "main-thm" not found.']);
     assert.deepEqual(settledProposals, [

--- a/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressWorkflowActionsController.vitest.ts
@@ -19,32 +19,6 @@ import {
 } from '../support/ProgressControllerHarnesses';
 
 describe('ProgressWorkflowActionsController', () => {
-  it('resumes workflow streams with their execution id', async () => {
-    const taskState = createWorkflowTaskState();
-    const { controller, executed } = createProgressWorkflowActionsHarness({
-      taskStates: new Map([['stream-a', taskState]]),
-      executionIds: new Map([['stream-a', 'exec-123']]),
-    });
-
-    await controller.resume('stream-a');
-
-    assert.deepEqual(executed, [
-      { config: taskState.agentConfig, executionId: 'exec-123' },
-    ]);
-  });
-
-  it('runs a fresh request without the existing execution id', async () => {
-    const taskState = createWorkflowTaskState();
-    const { controller, executed } = createProgressWorkflowActionsHarness({
-      taskStates: new Map([['stream-a', taskState]]),
-      executionIds: new Map([['stream-a', 'exec-123']]),
-    });
-
-    await controller.runNew('stream-a');
-
-    assert.deepEqual(executed, [{ config: taskState.agentConfig }]);
-  });
-
   it('ignores toolbar actions for non-workflow streams', async () => {
     const toolUseState: TaskState = {
       agentConfig: createAgentConfig({

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -18,6 +18,10 @@ import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - test support
 import { FakePromptHost } from '../support/FakeHosts';
+import {
+  createOutputFile,
+  createWorkflowTaskState,
+} from '../support/ProgressControllerHarnesses';
 
 import type * as vscode from 'vscode';
 
@@ -342,6 +346,84 @@ describe('progress-view onboarding refresh wiring', () => {
       action: 'reject',
       feedback: 'state the invariant first',
     });
+  });
+
+  it('routes workflow toolbar actions through extension capabilities', async () => {
+    const provider = createProgressViewProvider();
+    const taskState = createWorkflowTaskState(
+      { outputFiles: ['declared.tex'] },
+      { output: false },
+    );
+    const output = createOutputFile();
+    vi.mocked(provider.state.snapshots.getTaskState).mockReturnValue(taskState);
+    vi.mocked(provider.state.snapshots.getExecutionId).mockReturnValue(
+      'exec-123',
+    );
+    vi.mocked(provider.state.snapshots.getOutputFiles).mockReturnValue({
+      1: [output],
+    });
+    vi.mocked(provider.state.snapshots.getKnownFilePaths).mockReturnValue(
+      new Set(['/workspace/generated.tex', 'extra.tex']),
+    );
+    const handler = createMessageHandler(provider, createExtensionContext());
+    const view = createWebviewView();
+
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DIFF_STREAM, stream: 'stream-a' },
+      view,
+    );
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.PACK_STREAM, stream: 'stream-a' },
+      view,
+    );
+    await handler.handleMessage(
+      { command: PROGRESS_VIEW_COMMANDS.CLEAN_STREAM, stream: 'stream-a' },
+      view,
+    );
+
+    expect(mocks.safeExecuteCommand).toHaveBeenNthCalledWith(
+      1,
+      'texra.runLatexdiff',
+      [
+        {
+          agent: 'correct',
+          model: 'gemini31p',
+          inputFile: 'input.tex',
+          outputFiles: ['declared.tex'],
+          outputFilesActive: false,
+          streamId: 'stream-a',
+          runId: 'exec-123',
+          outputsByRound: { 1: [output] },
+        },
+      ],
+      'ProgressView',
+    );
+    const fileOperationRequest = {
+      streamId: 'stream-a',
+      agent: 'correct',
+      model: 'gemini31p',
+      inputFile: 'input.tex',
+      outputFiles: ['declared.tex', '/workspace/generated.tex', 'extra.tex'],
+      executionId: 'exec-123',
+      skipProgressViewClear: true,
+    };
+    expect(mocks.safeExecuteCommand).toHaveBeenNthCalledWith(
+      2,
+      'texra.pack',
+      [fileOperationRequest],
+      'ProgressView',
+    );
+    expect(mocks.safeExecuteCommand).toHaveBeenNthCalledWith(
+      3,
+      'texra.clean',
+      [fileOperationRequest],
+      'ProgressView',
+    );
+    expect(provider.state.snapshots.getKnownFilePaths).toHaveBeenCalledTimes(2);
+    expect(provider.state.snapshots.getKnownFilePaths).toHaveBeenCalledWith(
+      'stream-a',
+      { workspaceOnly: true },
+    );
   });
 
   it('delegates onboarding refresh through the main view provider', async () => {

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -17,7 +17,6 @@ import {
   AgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';
-import type { ExecutionRequest } from '@agent/core/state/executionRequests';
 import type { TaskState, WorkflowTaskState } from '@agent/core/state/TaskState';
 
 // Local imports - shared
@@ -237,7 +236,6 @@ export interface ProgressWorkflowActionsHarnessOptions {
 
 export interface ProgressWorkflowActionsHarness {
   controller: ProgressWorkflowActionsController;
-  executed: ExecutionRequest[];
   diffs: WorkflowDiffRequest[];
   fileOperations: Array<{
     operation: WorkflowFileOperation;
@@ -248,7 +246,6 @@ export interface ProgressWorkflowActionsHarness {
 export function createProgressWorkflowActionsHarness(
   options: ProgressWorkflowActionsHarnessOptions = {},
 ): ProgressWorkflowActionsHarness {
-  const executed: ExecutionRequest[] = [];
   const diffs: WorkflowDiffRequest[] = [];
   const fileOperations: Array<{
     operation: WorkflowFileOperation;
@@ -264,9 +261,6 @@ export function createProgressWorkflowActionsHarness(
         getKnownWorkspaceOutputPaths: (stream) =>
           new Set(options.knownWorkspaceOutputs?.get(stream) ?? []),
       },
-      executeAgent: async (request) => {
-        executed.push(request);
-      },
       runDiff: async (request) => {
         diffs.push(request);
       },
@@ -274,7 +268,6 @@ export function createProgressWorkflowActionsHarness(
         fileOperations.push({ operation, request });
       },
     }),
-    executed,
     diffs,
     fileOperations,
   };


### PR DESCRIPTION
## Summary

- keep shared run and resume request construction inside `ProgressViewHost`
- construct `ProgressWorkflowActionsController` only in the extension host that supports diff, pack, and clean
- remove desktop empty-state and throwing operation placeholders

Closes #8452

## Issue acceptance gates

- #8452: shared run composition requires only task state, execution ID, and execution
- #8452: extension workflow operations retain their real output and command dependencies
- #8452: desktop no longer supplies `getKnownWorkspaceOutputPaths`, `runDiff`, or `runFileOperation` placeholders
- #8452: desktop unsupported-command declarations remain unchanged
- #8452: focused and repository-wide validation passes

## Single source of truth

`ProgressViewHost` owns shared run request construction. The extension `ProgressViewMessageHandler` owns construction of the diff/pack/clean controller it alone consumes.

## Duplication and abstraction budget

Removed the combined cross-host dependency object and impossible desktop adapters. No new module, class, or exported type was added; the small shared run policy is private to the existing host coordinator.

## Net elements (R6)

- files: 8 modified, 0 added, 0 deleted
- exported symbols: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- LoC: +169 / -107, net +62

## Consumer counts (R8)

- `ProgressWorkflowActionsController.resume`: 1 production consumer rerouted into `ProgressViewHost`
- `ProgressWorkflowActionsController.runNew`: 1 production consumer rerouted into `ProgressViewHost`
- remaining workflow-operation calls: 3 production calls, all in the extension handler (`diffStream` once and `runFileOperation` twice)
- controller construction: 1 production site in the extension plus 1 focused test harness

## Host impact

Extension: unchanged behavior; directly constructs the operation controller for its supported diff, pack, and clean commands.

Desktop: shared run and custom resume behavior are unchanged; impossible operation capabilities are gone.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- focused progress/desktop and extension-composition tests (105 passed)
- `npm test` (6,144 passed, 4 skipped)
- `node scripts/check-dead-code-ratchet.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved on extension and desktop; risk is mainly wiring mistakes on run/resume or toolbar command routing, covered by updated unit and handler tests.
> 
> **Overview**
> **Shared run/resume** is centralized in `ProgressViewHost`: hosts pass a slim `run` dependency (task state, execution id, `executeAgent`), and the host builds **run new** vs **resume** execution requests internally instead of going through `ProgressWorkflowActionsController`.
> 
> **Extension-only workflow toolbar** (diff, pack, clean) is wired by constructing `ProgressWorkflowActionsController` in `ProgressViewMessageHandler` with snapshot/output state and `texra.*` command adapters. **Desktop** no longer supplies stub `runDiff` / `runFileOperation` / `getKnownWorkspaceOutputPaths` on the progress host; unsupported toolbar commands stay on the existing `unsupported(...)` registry.
> 
> `ProgressWorkflowActionsController` drops `resume` / `runNew` and `executeAgent`; tests move run/resume coverage to `ProgressViewHost` and add an integration test that toolbar actions hit the extension commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96b6cef9db4b24a6368a36bc5c5de19a4d1bf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->