### PR TITLE
refactor(extension): delete retired auth registration shim

### DIFF
--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -25,7 +25,6 @@ import {
   registerSettingsViewCommands,
   initializeSettingsViewProvider,
 } from '@commands/settings';
-import { registerAuthCommands } from '@commands/auth';
 import {
   createExtensionCommandActions,
   registerExtensionCommandRegistry,
@@ -49,7 +48,6 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerPackCommands(context);
   registerCleanCommands(context);
   registerMergeCommands(context);
-  registerAuthCommands(context);
   registerStateRestoreCommand(context);
   registerSettingsViewCommands(context);
   registerCompareCommands(context);

--- a/packages/extension/src/commands/auth/index.ts
+++ b/packages/extension/src/commands/auth/index.ts
@@ -1,19 +1,3 @@
-import type * as vscode from 'vscode';
-
-/**
- * Register authentication-related commands.
- *
- * `texra.auth.signIn`, `texra.auth.signOut`, and `texra.auth.viewProfile`
- * are now dispatched through the shared command registry (see #3771 and
- * `extensionCommandSurface.ts`), so this function is intentionally a
- * no-op kept around for the import call site in `commands.ts`.
- */
-export function registerAuthCommands(
-  _context: vscode.ExtensionContext,
-): vscode.Disposable[] {
-  return [];
-}
-
 // Re-export AUTH_COMMANDS for external use
 export { AUTH_COMMANDS } from '@auth/constants';
 export { getAuthStatus, signIn, signOut, viewProfile } from './authCommands';


### PR DESCRIPTION
## Summary

- remove the retired `registerAuthCommands` no-op and its stale caller
- preserve the auth barrel's constants and real auth actions
- keep authentication command registration exclusively in the shared extension command registry

Closes #8454

## Issue acceptance gates

- #8454: no `registerAuthCommands` symbol or call remains
- #8454: sign-in, sign-out, and profile commands remain registered once through `registerExtensionCommandRegistry`
- #8454: existing auth barrel consumers remain unchanged
- #8454: focused and repository-wide validation passes

## Single source of truth

`registerExtensionCommandRegistry` remains the sole authentication command-registration path. The auth barrel now exports only values and actions that consumers use.

## Duplication and abstraction budget

This change deletes a circular compatibility arrangement: the no-op existed only for its stale call site, and the call site existed only to invoke the no-op. It adds no replacement abstraction.

## Net elements

- files: 2 modified, 0 added, 0 deleted
- exported symbols: 0 added, 1 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- LoC: +0 / -18, net -18

## Consumer counts

- `registerAuthCommands`: 1 production call removed; 0 consumers remain
- shared extension command registry: 1 production registration path retained
- auth barrel constants/actions: existing consumers retained without rewiring

## Host impact

Extension: command behavior is unchanged; only an ignored no-op call is removed.

Desktop and CLI: none.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- command catalog and registry tests (66 passed)
- `npm test` (6,169 passed, 4 skipped)
- `node scripts/check-dead-code-ratchet.mjs`
- `git diff --check`
- repository search confirms no `registerAuthCommands` reference remains

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral no-op removal with auth registration unchanged on the existing registry path.
> 
> **Overview**
> Removes the **no-op** `registerAuthCommands` shim and its call from `registerCommands`, so auth commands are not registered through a second, empty path.
> 
> **Sign-in, sign-out, and profile** stay registered only via `registerExtensionCommandRegistry` / `extensionCommandSurface`. The `@commands/auth` barrel still re-exports `AUTH_COMMANDS` and the real `signIn` / `signOut` / `viewProfile` handlers for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240a1cf21289ec26d873040117483f5e032b9c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->