### PR TITLE
refactor(extension): remove retired auth registration shim

### DIFF
--- a/packages/extension/src/commands.ts
+++ b/packages/extension/src/commands.ts
@@ -25,7 +25,6 @@ import {
   registerSettingsViewCommands,
   initializeSettingsViewProvider,
 } from '@commands/settings';
-import { registerAuthCommands } from '@commands/auth';
 import {
   createExtensionCommandActions,
   registerExtensionCommandRegistry,
@@ -49,7 +48,6 @@ export function registerCommands(context: vscode.ExtensionContext): void {
   registerPackCommands(context);
   registerCleanCommands(context);
   registerMergeCommands(context);
-  registerAuthCommands(context);
   registerStateRestoreCommand(context);
   registerSettingsViewCommands(context);
   registerCompareCommands(context);

--- a/packages/extension/src/commands/auth/index.ts
+++ b/packages/extension/src/commands/auth/index.ts
@@ -1,19 +1,3 @@
-import type * as vscode from 'vscode';
-
-/**
- * Register authentication-related commands.
- *
- * `texra.auth.signIn`, `texra.auth.signOut`, and `texra.auth.viewProfile`
- * are now dispatched through the shared command registry (see #3771 and
- * `extensionCommandSurface.ts`), so this function is intentionally a
- * no-op kept around for the import call site in `commands.ts`.
- */
-export function registerAuthCommands(
-  _context: vscode.ExtensionContext,
-): vscode.Disposable[] {
-  return [];
-}
-
 // Re-export AUTH_COMMANDS for external use
 export { AUTH_COMMANDS } from '@auth/constants';
 export { getAuthStatus, signIn, signOut, viewProfile } from './authCommands';


### PR DESCRIPTION
## Summary

- delete the `registerAuthCommands()` no-op retained only for its stale caller
- remove the ignored registration call from the extension command composition root
- keep the auth barrel's real command constants and action exports unchanged

Auth commands continue to register through the shared extension command registry; this removes a second registration-shaped path that performed no work.

Closes #8454

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/commands/CommandCatalog.vitest.ts src/test-kernel/commands/CommandRegistry.vitest.ts src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` (66 passed)
- `npm test` (6,169 passed; 4 skipped)
- `npm run check:dead-code-ratchet`
- `git diff --check`

## Scope

- 2 files modified
- 18 lines deleted
- no files, exports, or runtime branches added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code cleanup only—no new registration paths or auth behavior changes.
> 
> **Overview**
> Removes the legacy **`registerAuthCommands()`** path from extension startup: the no-op implementation in `commands/auth/index.ts` is deleted and the call is dropped from **`registerCommands()`** in `commands.ts`.
> 
> **`signIn`**, **`signOut`**, and **`viewProfile`** are unchanged at runtime—they still register via the shared **`registerExtensionCommandRegistry`** / **`extensionCommandSurface`** handler map. The auth module barrel continues to re-export **`AUTH_COMMANDS`** and the auth action helpers for that surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af7bffd6443798cba56b3b0d0171d53d0dcad81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->