### PR TITLE
refactor(extension): require one recording message protocol

### DIFF
--- a/packages/extension/src/frontend/media/RecordingManager.ts
+++ b/packages/extension/src/frontend/media/RecordingManager.ts
@@ -13,59 +13,28 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 const CHANNEL = 'RecordingManager';
 logger.initialize(CHANNEL);
 
-export interface RecordingManagerConfig {
-  recordingStartedCommand?: string;
-  recordingStoppedCommand?: string;
-  recordingErrorCommand?: string;
-  transcriptionCommand?: string;
-  buildRecordingMessage?: (input: {
-    status: 'started' | 'stopped' | 'error';
-    error?: string;
-  }) => Record<string, unknown>;
-  buildTranscriptionMessage?: (text: string) => Record<string, unknown> | null;
-  progressTitle?: string;
+type RecordingMessageInput =
+  { status: 'started' | 'stopped' } | { status: 'error'; error: string };
+
+interface RecordingManagerConfig {
+  buildRecordingMessage: (
+    input: RecordingMessageInput,
+  ) => Record<string, unknown>;
+  buildTranscriptionMessage: (text: string) => Record<string, unknown>;
+  progressTitle: string;
 }
 
 export class RecordingManager {
-  constructor(
-    private readonly context: vscode.ExtensionContext,
-    private readonly commandConfig: RecordingManagerConfig,
-  ) {}
-
-  private buildRecordingMessage(
-    status: 'started' | 'stopped' | 'error',
-    error?: string,
-  ): Record<string, unknown> | null {
-    if (this.commandConfig.buildRecordingMessage) {
-      return this.commandConfig.buildRecordingMessage({ status, error });
-    }
-
-    const commandMap = {
-      started: this.commandConfig.recordingStartedCommand,
-      stopped: this.commandConfig.recordingStoppedCommand,
-      error: this.commandConfig.recordingErrorCommand,
-    };
-    const command = commandMap[status];
-    if (!command) return null;
-
-    return error ? { command, error } : { command };
-  }
-
-  private buildTranscriptionMessage(
-    text: string,
-  ): Record<string, unknown> | null {
-    if (this.commandConfig.buildTranscriptionMessage) {
-      return this.commandConfig.buildTranscriptionMessage(text);
-    }
-
-    const command = this.commandConfig.transcriptionCommand;
-    return command ? { command, text } : null;
-  }
+  constructor(private readonly commandConfig: RecordingManagerConfig) {}
 
   private notifyError(webview: vscode.Webview, message: string): void {
     void showLoggedMessage(CHANNEL, message);
-    const payload = this.buildRecordingMessage('error', message);
-    if (payload) webview.postMessage(payload);
+    webview.postMessage(
+      this.commandConfig.buildRecordingMessage({
+        status: 'error',
+        error: message,
+      }),
+    );
   }
 
   async start(
@@ -74,8 +43,9 @@ export class RecordingManager {
     try {
       const result = await startRecording();
       if (result.success) {
-        const payload = this.buildRecordingMessage('started');
-        if (payload) webviewView.webview.postMessage(payload);
+        webviewView.webview.postMessage(
+          this.commandConfig.buildRecordingMessage({ status: 'started' }),
+        );
       } else if (result.error) {
         this.notifyError(webviewView.webview, result.error);
       }
@@ -93,15 +63,16 @@ export class RecordingManager {
     const acknowledgeStop = (): void => {
       if (stopAcknowledged) return;
       stopAcknowledged = true;
-      const payload = this.buildRecordingMessage('stopped');
-      if (payload) webviewView.webview.postMessage(payload);
+      webviewView.webview.postMessage(
+        this.commandConfig.buildRecordingMessage({ status: 'stopped' }),
+      );
     };
 
     try {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: this.commandConfig.progressTitle ?? 'Transcribing recording',
+          title: this.commandConfig.progressTitle,
           cancellable: false,
         },
         async () => {
@@ -109,8 +80,9 @@ export class RecordingManager {
           acknowledgeStop();
           const result = await transcriptionPromise;
           if (result.success) {
-            const payload = this.buildTranscriptionMessage(result.text);
-            if (payload) webviewView.webview.postMessage(payload);
+            webviewView.webview.postMessage(
+              this.commandConfig.buildTranscriptionMessage(result.text),
+            );
           } else if (result.error) {
             this.notifyError(webviewView.webview, result.error);
           }

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -98,11 +98,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ) {
     super('ProgressView', { trackActiveView: true });
 
-    this.recordingManager = new RecordingManager(context, {
-      buildRecordingMessage: ({ status, error }) => ({
+    this.recordingManager = new RecordingManager({
+      buildRecordingMessage: (message) => ({
         command: PROGRESS_VIEW_COMMANDS.UPDATE_RECORDING,
-        status,
-        ...(error && { error }),
+        ...message,
       }),
       buildTranscriptionMessage: (text) => ({
         command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -58,11 +58,21 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     private readonly onboarding?: MainViewOnboardingHooks,
   ) {
     super('MainView', { trackActiveView: true });
-    this.recordingManager = new RecordingManager(context, {
-      recordingStartedCommand: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
-      recordingStoppedCommand: MAIN_VIEW_COMMANDS.RECORDING_STOPPED,
-      recordingErrorCommand: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
-      transcriptionCommand: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+    this.recordingManager = new RecordingManager({
+      buildRecordingMessage: (message) => {
+        const command = {
+          started: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
+          stopped: MAIN_VIEW_COMMANDS.RECORDING_STOPPED,
+          error: MAIN_VIEW_COMMANDS.RECORDING_ERROR,
+        }[message.status];
+        return message.status === 'error'
+          ? { command, error: message.error }
+          : { command };
+      },
+      buildTranscriptionMessage: (text) => ({
+        command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
+        text,
+      }),
       progressTitle: 'Transcribing instruction',
     });
     this.fileManager = new FileManager();

--- a/src/test-kernel/frontend/RecordingManager.vitest.mts
+++ b/src/test-kernel/frontend/RecordingManager.vitest.mts
@@ -1,0 +1,90 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  startRecording: vi.fn(),
+  stopRecordingAndTranscribe: vi.fn(),
+  showLoggedMessage: vi.fn(),
+  withProgress: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  ProgressLocation: { Notification: 15 },
+  window: { withProgress: mocks.withProgress },
+}));
+
+vi.mock('@frontend/media/audio', () => ({
+  startRecording: mocks.startRecording,
+  stopRecordingAndTranscribe: mocks.stopRecordingAndTranscribe,
+}));
+
+vi.mock('@frontend/ui/errorHandlingUtils', () => ({
+  showLoggedMessage: mocks.showLoggedMessage,
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  error: vi.fn(),
+  initialize: vi.fn(),
+}));
+
+// Local imports - recording manager
+const { RecordingManager } = await import('@frontend/media/RecordingManager');
+
+describe('RecordingManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.withProgress.mockImplementation((_options, task) => task());
+  });
+
+  it('uses one complete message protocol for recording and transcription', async () => {
+    mocks.startRecording.mockResolvedValue({ success: true });
+    mocks.stopRecordingAndTranscribe.mockResolvedValue({
+      success: true,
+      text: 'transcribed text',
+    });
+    const buildRecordingMessage = vi.fn(
+      (
+        message:
+          | { status: 'started' | 'stopped' }
+          | { status: 'error'; error: string },
+      ) => ({ command: 'recording', ...message }),
+    );
+    const buildTranscriptionMessage = vi.fn((text: string) => ({
+      command: 'transcription',
+      text,
+    }));
+    const postMessage = vi.fn();
+    const view = { webview: { postMessage } } as unknown as vscode.WebviewView;
+    const manager = new RecordingManager({
+      buildRecordingMessage,
+      buildTranscriptionMessage,
+      progressTitle: 'Transcribing test recording',
+    });
+
+    await manager.start(view);
+    await manager.stop(view);
+
+    expect(buildRecordingMessage).toHaveBeenNthCalledWith(1, {
+      status: 'started',
+    });
+    expect(buildRecordingMessage).toHaveBeenNthCalledWith(2, {
+      status: 'stopped',
+    });
+    expect(buildTranscriptionMessage).toHaveBeenCalledWith('transcribed text');
+    expect(mocks.withProgress).toHaveBeenCalledWith(
+      {
+        location: 15,
+        title: 'Transcribing test recording',
+        cancellable: false,
+      },
+      expect.any(Function),
+    );
+    expect(postMessage.mock.calls.map(([message]) => message)).toEqual([
+      { command: 'recording', status: 'started' },
+      { command: 'recording', status: 'stopped' },
+      { command: 'transcription', text: 'transcribed text' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- replace `RecordingManagerConfig`'s two optional message strategies with one required builder protocol
- model recording notifications as a discriminated union so error text is required only for error messages
- remove nullable payload branches, command-string fallback maps, the default title fallback, and an unused `ExtensionContext` dependency
- adapt the main view at its construction boundary; the progress view already used builders
- add focused coverage for start/stop/transcription ordering and the required progress title

Closes #8455

## Single source of truth

Each `RecordingManager` construction now supplies the complete host message protocol. The manager owns recording lifecycle behavior only; callers own their message schema mapping.

## Duplication and abstraction budget

No new production module or exported abstraction is added. The compatibility-shaped command-string mode is deleted rather than renamed, and the private config accepts only fields consumed on every recording lifecycle.

## Net elements

- files: 3 modified, 1 test file added, 0 deleted
- exported symbols: 0 added, 1 unused config interface export removed
- classes/interfaces/enums: 0 added; the config remains private to `RecordingManager.ts`
- production LoC: +44 / -63, net -19
- total LoC including focused test: +134 / -63, net +71

## Consumer counts

- `RecordingManager`: 2 production construction sites, both migrated
- command-string configuration: 1 production consumer removed; 0 remain
- builder protocol: 1 existing production consumer plus 1 migrated consumer; 2 complete consumers remain
- `ExtensionContext` constructor argument: 2 production arguments removed; 0 remain

## Host impact

Extension only. Main-view and progress-view payloads remain unchanged; desktop and CLI do not construct `RecordingManager`.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/frontend/RecordingManager.vitest.mts src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts` (18 passed)
- `npm test` (6,170 passed; 4 skipped)
- `npm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with unchanged main/progress webview payloads; behavior is covered by new unit tests and existing suite.
> 
> **Overview**
> **`RecordingManager`** now requires callers to supply **`buildRecordingMessage`**, **`buildTranscriptionMessage`**, and **`progressTitle`** instead of optional command strings or partial builders. Recording notifications use a discriminated **`RecordingMessageInput`** (`error` is required only when `status` is `'error'`), and the manager always posts the builders’ payloads—no nullable branches, internal command maps, or default progress title.
> 
> **Main view** wiring moves from separate `RECORDING_*` / transcription command fields to inline builders that preserve the same webview commands and shapes. **Progress view** keeps its unified `UPDATE_RECORDING` payload but spreads the status union into the message. The unused **`ExtensionContext`** constructor argument is removed from both sites.
> 
> Adds a focused Vitest that asserts start → stopped ack → transcription **`postMessage`** ordering and the configured progress notification title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e07cb68e202ad15318d917265c4f39d3d0d499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->