### PR TITLE
fix(relay): gate openai/anthropic/google to Ultra tier

### DIFF
--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -79,7 +79,7 @@ import {
   isRetiredModelRequest,
   isModelAllowedForTier,
   FREE_TIER_SUGGESTED_MODEL,
-  ULTRA_ONLY_PROVIDERS,
+  ULTRA_ONLY_PROVIDER_SET,
   ULTRA_TIER,
   FREE_TIER,
   MAX_TIER,
@@ -134,8 +134,6 @@ const OPENAI_GPT5_REASONING_EFFORT_CAPS: Record<string, ReasoningEffortCap> = {
   [FREE_TIER]: 'medium',
   [MAX_TIER]: 'high',
 };
-
-const ULTRA_ONLY_PROVIDER_SET = new Set<string>(ULTRA_ONLY_PROVIDERS);
 
 // Hop-by-hop and auth headers stripped before forwarding to the upstream
 // provider (auth is re-added from the server-side key).

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -37,9 +37,9 @@
  * ============================================================================
  *
  * TIER HIERARCHY (model access):
- * - free: input <= $1.5/M AND output <= $9/M
- * - Max: every model
- * - Ultra: every model
+ * - free: input <= $1.5/M AND output <= $9/M, excluding openai/anthropic/google
+ * - Max: every model except openai/anthropic/google
+ * - Ultra: every model, including openai/anthropic/google (Ultra-only via relay)
  *
  * Authentication: JWT tokens are extracted from SDK auth headers:
  * - OpenAI: Authorization: Bearer {jwt}
@@ -79,6 +79,7 @@ import {
   isRetiredModelRequest,
   isModelAllowedForTier,
   FREE_TIER_SUGGESTED_MODEL,
+  ULTRA_ONLY_PROVIDERS,
   ULTRA_TIER,
   FREE_TIER,
   MAX_TIER,
@@ -133,6 +134,8 @@ const OPENAI_GPT5_REASONING_EFFORT_CAPS: Record<string, ReasoningEffortCap> = {
   [FREE_TIER]: 'medium',
   [MAX_TIER]: 'high',
 };
+
+const ULTRA_ONLY_PROVIDER_SET = new Set<string>(ULTRA_ONLY_PROVIDERS);
 
 // Hop-by-hop and auth headers stripped before forwarding to the upstream
 // provider (auth is re-added from the server-side key).
@@ -595,6 +598,19 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   }
 
   const userTier = profile.tier || FREE_TIER;
+
+  // 6.1. openai/anthropic/google are Ultra-only via relay: free/Max users can
+  // still reach them with their own API keys, just not through relay's
+  // server-side keys. Gated on the URL provider segment, not model name, so
+  // it can't be bypassed by an unrecognized/future model string.
+  if (userTier !== ULTRA_TIER && ULTRA_ONLY_PROVIDER_SET.has(provider)) {
+    return jsonError(
+      `Provider '${provider}' is only available on relay for the Ultra tier. ` +
+        `Switch to your own API key for '${provider}', or upgrade to Ultra.`,
+      403,
+      { providerRestricted: true, provider, requiredTier: ULTRA_TIER },
+    );
+  }
 
   // 6.5. Check monthly spending limit
   const spending = await checkSpendingLimit(relayAdminClient, userId, userTier);

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -6,9 +6,14 @@
  * BOTH its input AND output prices are cheap, so a cheap-input / expensive-output
  * flagship (gemini-3.x-pro at $2/$12, gpt-5 at $1.25/$10) can no longer leak into
  * free on input price alone. See MAX_FREE_INPUT_PRICE / MAX_FREE_OUTPUT_PRICE.
- * - free: input <= $1.5/M AND output <= $9/M
- * - Max: every model (not bounded by the free-tier price ceiling)
+ * - free: input <= $1.5/M AND output <= $9/M, excluding ULTRA_ONLY_PROVIDERS
+ * - Max: every model except ULTRA_ONLY_PROVIDERS (not bounded by the
+ *   free-tier price ceiling)
  * - Ultra: every model
+ *
+ * openai/anthropic/google were made Ultra-only via relay on 2026-07-14 (relay
+ * still proxies them for Ultra; free/Max users can still reach them with
+ * their own API keys, just not through relay's server-side keys).
  */
 
 import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
@@ -63,7 +68,16 @@ interface RelayModel {
   shortName: string;
   apiPattern: string;
   minTier: MinTier;
+  provider: string;
 }
+
+/**
+ * Providers only reachable via relay on the Ultra tier. free/Max users can
+ * still use these providers with their own API keys; they're just not
+ * proxied through relay's server-side keys below Ultra.
+ */
+export const ULTRA_ONLY_PROVIDERS = ['openai', 'anthropic', 'google'] as const;
+const ULTRA_ONLY_PROVIDER_SET = new Set<string>(ULTRA_ONLY_PROVIDERS);
 
 // =============================================================================
 // Tier Assignment Logic
@@ -96,7 +110,7 @@ function getTierFromPrice(inputPrice: number, outputPrice: number): MinTier {
  * an upsell. Kept next to the price ceiling it must satisfy (input <= 1.5,
  * output <= 9).
  */
-export const FREE_TIER_SUGGESTED_MODEL = 'gemini35f';
+export const FREE_TIER_SUGGESTED_MODEL = 'deepseek';
 
 /** Convert llm-zoo model to relay model */
 function toRelayModel(config: ModelConfig): RelayModel {
@@ -104,6 +118,7 @@ function toRelayModel(config: ModelConfig): RelayModel {
     shortName: config.name,
     apiPattern: config.fullName.toLowerCase(),
     minTier: getTierFromPrice(config.inputPrice, config.outputPrice),
+    provider: config.provider,
   };
 }
 
@@ -148,7 +163,11 @@ const RETIRED_MODEL_PATTERNS = Object.values(MODEL_CONFIGS)
 // =============================================================================
 
 const FREE_TIER_SHORT_NAMES = RELAY_MODELS.filter(
-  (m) => m.minTier === FREE_TIER,
+  (m) => m.minTier === FREE_TIER && !ULTRA_ONLY_PROVIDER_SET.has(m.provider),
+).map((m) => m.shortName);
+
+const MAX_TIER_SHORT_NAMES = RELAY_MODELS.filter(
+  (m) => !ULTRA_ONLY_PROVIDER_SET.has(m.provider),
 ).map((m) => m.shortName);
 
 // =============================================================================
@@ -159,7 +178,7 @@ export const TIER_CONFIG: TierModelConfig = {
   providers: [...ALL_PROVIDERS],
   tiers: {
     free: { models: FREE_TIER_SHORT_NAMES },
-    Max: { models: '*' },
+    Max: { models: MAX_TIER_SHORT_NAMES },
     Ultra: { models: '*' },
   },
 };

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -77,7 +77,7 @@ interface RelayModel {
  * proxied through relay's server-side keys below Ultra.
  */
 export const ULTRA_ONLY_PROVIDERS = ['openai', 'anthropic', 'google'] as const;
-const ULTRA_ONLY_PROVIDER_SET = new Set<string>(ULTRA_ONLY_PROVIDERS);
+export const ULTRA_ONLY_PROVIDER_SET = new Set<string>(ULTRA_ONLY_PROVIDERS);
 
 // =============================================================================
 // Tier Assignment Logic
@@ -163,11 +163,13 @@ const RETIRED_MODEL_PATTERNS = Object.values(MODEL_CONFIGS)
 // =============================================================================
 
 const FREE_TIER_SHORT_NAMES = RELAY_MODELS.filter(
-  (m) => m.minTier === FREE_TIER && !ULTRA_ONLY_PROVIDER_SET.has(m.provider),
+  (m) =>
+    m.minTier === FREE_TIER &&
+    !ULTRA_ONLY_PROVIDER_SET.has(m.provider.toLowerCase()),
 ).map((m) => m.shortName);
 
 const MAX_TIER_SHORT_NAMES = RELAY_MODELS.filter(
-  (m) => !ULTRA_ONLY_PROVIDER_SET.has(m.provider),
+  (m) => !ULTRA_ONLY_PROVIDER_SET.has(m.provider.toLowerCase()),
 ).map((m) => m.shortName);
 
 // =============================================================================

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -312,6 +312,10 @@ export function isModelAllowedForTier(
   }
   if (!modelName) return false;
   if (isRetiredModelRequest(modelName)) return false;
+  // Ultra-only-provider enforcement lives at the route level (the URL
+  // provider segment, checked against ULTRA_ONLY_PROVIDER_SET before this
+  // function runs), not here by model name — this stays a blanket allow for
+  // Max.
   if (tier === MAX_TIER) return true;
 
   const models = resolveAllModelsByApiName(modelName);


### PR DESCRIPTION
## Summary
- Free and Max relay users no longer get server-side-key access to openai, anthropic, or google models; they receive a 403 pointing at their own API key or an Ultra upgrade.
- The block is enforced on the URL's `:provider` segment (route level), not by model name, so it can't be bypassed by an unrecognized/future model string. `PROVIDER_CONFIGS`/`ProviderKey` and all routing code are untouched — Ultra still needs full access.
- xai, dashscope, minimax, glm, deepseek, and moonshot are unaffected at every tier.
- Public `/relay/tier-config` model lists updated to match, so client model pickers stay consistent with what's actually enforced. `FREE_TIER_SUGGESTED_MODEL` moves from `gemini35f` to `deepseek` since gemini no longer qualifies for free/Max.
- Already deployed to production (`supabase functions deploy relay --no-verify-jwt`); this PR lands the source-of-truth change in the repo.

## Test plan
- [x] `deno check models.ts` — clean
- [x] `deno check index.ts` — only a pre-existing, unrelated `bodyToSend` type error (confirmed present on unmodified `main` via `git stash`)
- [x] Local `deno eval` smoke test: free/Max tier model lists contain no gemini/gpt/claude entries; `deepseek` resolves as free-tier-allowed; Ultra still resolves `gpt-5`
- [x] Live check against deployed `/relay/tier-config`: free and Max model lists confirmed free of gemini/gpt/claude/haiku/opus/sonnet entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tier access and public `/relay/tier-config` behavior for a large share of relay traffic; enforcement is early and explicit but misconfiguration could surprise Max users expecting those providers on relay.
> 
> **Overview**
> **Relay no longer proxies `openai`, `anthropic`, or `google` for free and Max users** using server-side keys. Those tiers get a **403** on `/relay/:provider/*` when the URL provider segment is one of those three, with guidance to use personal API keys or upgrade to Ultra. **Ultra** is unchanged.
> 
> The restriction is enforced **on the route `provider` parameter**, not on model names, so odd or future model strings cannot bypass it. **`models.ts`** defines `ULTRA_ONLY_PROVIDERS` / `ULTRA_ONLY_PROVIDER_SET`, strips those providers from free and Max model lists in **`TIER_CONFIG`** (Max moves from `models: '*'` to an explicit list), and documents that per-model checks for Max stay permissive because provider gating runs earlier. **`FREE_TIER_SUGGESTED_MODEL`** changes from `gemini35f` to **`deepseek`** so tier-denial hints point at a model still allowed on relay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b62dfe2cd35f2cff68b4bc2548c8f372b60fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->