### PR TITLE
refactor(desktop): narrow progress bridge registry ownership

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -77,7 +77,6 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
-import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { unsupported, unsupportedCommands } from '@shared/utils/dispatcher';
 import {
@@ -112,6 +111,7 @@ import {
   type DesktopPresentationPayloads,
   type DesktopSessionProgressBridge,
 } from './desktopSessionProgressBridge.js';
+import type { DesktopProgressInboundHandlerRegistry } from './desktopProgressIpc.js';
 import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
 import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 import type { DesktopStreamSnapshotStore } from './desktopStreamSnapshot.js';
@@ -206,7 +206,7 @@ export class DesktopProgressBridge {
   private readonly restartRepair: Promise<void>;
 
   readonly runtimeHost: AgentRuntimeHost;
-  readonly progressViewInboundHandlers: ProgressViewInboundHandlerRegistry;
+  readonly progressViewInboundHandlers: DesktopProgressInboundHandlerRegistry;
 
   /**
    * This window's own session. Each desktop BrowserWindow gets a fresh one so
@@ -544,7 +544,7 @@ export class DesktopProgressBridge {
     });
   }
 
-  private createProgressViewInboundHandlers(): ProgressViewInboundHandlerRegistry {
+  private createProgressViewInboundHandlers(): DesktopProgressInboundHandlerRegistry {
     return {
       ...this.progressHost.commandHandlers,
       // Getting-started actions from the progress empty-state. openWalkthrough
@@ -564,15 +564,6 @@ export class DesktopProgressBridge {
           `"${labels[data.action]}" requires the VS Code extension.`,
         );
       },
-      // These are intercepted in desktopProgressIpc.ts's passThroughCommands
-      // (theme/debug-mode/switch-view) or handled before dispatch even
-      // reaches this registry (webview-ready), so these entries are never
-      // actually invoked — they exist only to satisfy the exhaustive
-      // registry type.
-      setTheme: () => {},
-      setDebugMode: () => {},
-      switchView: () => {},
-      webviewReady: () => {},
       // Trivially wireable with existing desktop infrastructure.
       showInformationMessage: (data) => {
         void this.options.host.showInfoMessage(data.text);

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -2,6 +2,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewInbound,
   ProgressViewInboundMessageSchema,
+  type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 import { UnsupportedCommandError } from '@shared/utils/dispatcher';
@@ -11,12 +12,26 @@ import {
   type DesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
-import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
-type DesktopProgressIpcBridge = Pick<
-  DesktopProgressBridge,
-  'progressViewInboundHandlers' | 'completeWebviewReady'
+const PASS_THROUGH_COMMANDS = [
+  PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
+  PROGRESS_VIEW_COMMANDS.THEME_SET,
+  PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,
+] as const;
+
+type DesktopProgressIpcOwnedCommand =
+  | typeof PROGRESS_VIEW_COMMANDS.WEBVIEW_READY
+  | (typeof PASS_THROUGH_COMMANDS)[number];
+
+export type DesktopProgressInboundHandlerRegistry = Omit<
+  ProgressViewInboundHandlerRegistry,
+  DesktopProgressIpcOwnedCommand
 >;
+
+interface DesktopProgressIpcBridge {
+  readonly progressViewInboundHandlers: DesktopProgressInboundHandlerRegistry;
+  completeWebviewReady(): Promise<void>;
+}
 
 export interface DesktopProgressIpcOptions {
   progress?: DesktopProgressIpcBridge;
@@ -36,11 +51,7 @@ export interface DesktopProgressIpcOptions {
 
 export type DesktopProgressIpc = DesktopMessageHandler;
 
-const passThroughCommands = new Set<string>([
-  PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
-  PROGRESS_VIEW_COMMANDS.THEME_SET,
-  PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,
-]);
+const passThroughCommands: ReadonlySet<string> = new Set(PASS_THROUGH_COMMANDS);
 
 function isProgressWebviewReadyMessage(
   message: DesktopCommandMessage,
@@ -70,17 +81,24 @@ export function createDesktopProgressIpc(
   // as a generic error.
   function dispatchAndReport(
     message: DesktopCommandMessage,
-    handlers: Parameters<typeof dispatchProgressViewInbound>[1],
+    handlers: DesktopProgressInboundHandlerRegistry,
     parsed: ProgressViewInboundMessage,
   ): boolean {
     let unsupportedReason: string | undefined;
-    const handled = dispatchProgressViewInbound(message, handlers, (error) => {
-      if (error instanceof UnsupportedCommandError) {
-        unsupportedReason = error.reason;
-        return;
-      }
-      reportAsyncError(error);
-    });
+    // handleMessage returns before this point for every omitted command. The
+    // shared dispatcher cannot express that runtime narrowing because it
+    // parses the raw message itself, so keep the assertion at this boundary.
+    const handled = dispatchProgressViewInbound(
+      message,
+      handlers as ProgressViewInboundHandlerRegistry,
+      (error) => {
+        if (error instanceof UnsupportedCommandError) {
+          unsupportedReason = error.reason;
+          return;
+        }
+        reportAsyncError(error);
+      },
+    );
     if (!handled) onUnsupportedCommand(parsed, unsupportedReason);
     return handled;
   }


### PR DESCRIPTION
## Summary

- derive the desktop bridge registry from the full progress registry minus the four commands owned by `desktopProgressIpc`
- delete never-invoked theme, debug-mode, switch-view, and webview-ready handlers from `DesktopAgentExecution`
- make the existing pass-through command tuple the single runtime/type source for three omitted keys
- remove the type-only dependency from the IPC adapter back to the concrete execution bridge
- retain one documented assertion after the adapter's runtime guards because the shared dispatcher reparses raw input

Closes #8456

## Single source of truth

`PASS_THROUGH_COMMANDS` owns the three sibling-handler commands. `webviewReady` remains explicitly owned by the adapter's readiness branch. The downstream registry is derived from those four keys and remains exhaustive for every other progress command.

## Duplication and abstraction budget

This adds one exported type projection used by the desktop bridge and one private structural bridge interface, replacing a `Pick` of the concrete execution class. No runtime capability manifest or alternate dispatcher is added. The sole assertion is isolated at the checked IPC boundary rather than spreading partial registries or optional handlers through the codebase.

## Net elements

- files: 2 modified, 0 added, 0 deleted
- exported symbols: 1 type added, 0 removed
- classes/interfaces/enums: 1 private interface added, 0 runtime classes/enums added
- LoC: +38 / -29, net +9
- dead runtime handlers: 4 removed

## Consumer counts

- `DesktopProgressInboundHandlerRegistry`: 1 production producer and 1 production consumer
- `PASS_THROUGH_COMMANDS`: 1 runtime set projection and 1 type projection
- omitted handlers: 4 production no-op entries removed; 0 remain
- downstream progress commands: all non-omitted schema commands still require a handler or `unsupported(...)`

## Host impact

Desktop only. Extension retains its complete progress registry. Desktop readiness and theme/debug/switch pass-through behavior are unchanged.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (86 passed)
- `npm test` (6,170 passed; 4 skipped)
- `npm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only typing/refactor with unchanged readiness and pass-through behavior; no auth, data, or extension host changes.
> 
> **Overview**
> Desktop progress IPC now **owns** `webviewReady`, theme, debug-mode, and switch-view handling; the execution bridge registry is typed as the full progress registry **minus** those four commands via `DesktopProgressInboundHandlerRegistry`.
> 
> **Removed** four no-op stub handlers (`setTheme`, `setDebugMode`, `switchView`, `webviewReady`) from `DesktopProgressBridge` that existed only to satisfy the exhaustive shared type. **`PASS_THROUGH_COMMANDS`** is the single source for the three pass-through command keys at both runtime and in the type projection.
> 
> The IPC layer no longer depends on the concrete `DesktopProgressBridge` type—it uses a small structural `DesktopProgressIpcBridge` interface. One documented `as ProgressViewInboundHandlerRegistry` cast remains at the dispatch boundary because the shared dispatcher reparses raw messages and cannot express the runtime narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3a50031270337f4e2404591cc7c755ec97fde2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->