### PR TITLE
refactor(desktop): require main-view IPC handlers

### DIFF
--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,5 +1,4 @@
 import type { MainViewExecuteMessage } from '@shared/mainView';
-import { filterNotNullish } from '@utils/core';
 import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
 import {
@@ -29,10 +28,10 @@ import type { MainViewStartupOptions } from '@controllers/mainView/MainViewStart
 export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
   getTheme?: () => DesktopTheme;
-  fileSelection?: DesktopFileSelection;
-  settings?: DesktopSettingsIpc;
-  progress?: DesktopProgressIpc;
-  onboarding?: DesktopMessageHandler;
+  fileSelection: DesktopFileSelection;
+  settings: DesktopSettingsIpc;
+  progress: DesktopProgressIpc;
+  onboarding: DesktopMessageHandler;
   logs: DesktopLogIpcOptions;
   shellActions: DesktopShellActions;
   modelListRefresh?: PromiseLike<void>;
@@ -94,7 +93,7 @@ export function installDesktopMainViewIpc(
     logs,
     shell,
     execution,
-  ].filter(filterNotNullish);
+  ];
 
   function dispose(): void {
     if (disposed) return;

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -42,9 +42,10 @@ interface MainViewIpcModule {
     options: {
       debugMode?: boolean;
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
-      fileSelection?: { handleMessage(message: { command: string }): boolean };
-      settings?: { handleMessage(message: { command: string }): boolean };
-      progress?: { handleMessage(message: { command: string }): boolean };
+      fileSelection: { handleMessage(message: { command: string }): boolean };
+      settings: { handleMessage(message: { command: string }): boolean };
+      progress: { handleMessage(message: { command: string }): boolean };
+      onboarding: { handleMessage(message: { command: string }): boolean };
       shellActions: TestDesktopShellActions;
       modelListRefresh?: PromiseLike<void>;
       getAuthStatus?: () => Promise<{ authenticated: boolean }>;
@@ -187,8 +188,15 @@ function createMainViewShellActions(): TestDesktopShellActions {
 }
 
 function createMainViewCommandCapabilities() {
+  const createUnhandledCapability = () => ({
+    handleMessage: vi.fn(() => false),
+  });
   return {
     executeAgent: vi.fn(async (_message: unknown) => {}),
+    fileSelection: createUnhandledCapability(),
+    settings: createUnhandledCapability(),
+    progress: createUnhandledCapability(),
+    onboarding: createUnhandledCapability(),
     logs: {
       readLog: () => ({ path: undefined, text: '', truncated: false }),
       copyLog: vi.fn(async (_text: string) => {}),


### PR DESCRIPTION
## Summary

- require the file-selection, settings, progress, and onboarding handlers at the desktop main-view composition boundary
- construct the handler chain directly instead of filtering nullable capabilities
- move no-op handler convenience into the desktop IPC test fixture

This makes incomplete production wiring a TypeScript error instead of a silently ignored command path.

Closes #8464

## Design

The production composition root already supplies all four handlers. Their optional types represented no supported runtime mode and leaked test convenience into the production contract. Genuinely optional startup defaults remain unchanged.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts` (3 passed)
- `npm test` (687 files passed, 1 skipped; 6,170 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time contract tightening only; production already passes all four handlers and behavior is unchanged when wiring is complete.
> 
> **Overview**
> **Tightens the desktop main-view IPC composition contract** so `fileSelection`, `settings`, `progress`, and `onboarding` are **required** on `DesktopMainViewIpcOptions` instead of optional.
> 
> The handler chain in `installDesktopMainViewIpc` is built as a fixed array of those dependencies plus startup, view state, logs, shell, and execution—**no `filterNotNullish`**, so missing production wiring fails at compile time rather than dropping handlers at runtime.
> 
> Desktop IPC tests supply **no-op `handleMessage` stubs** for the four handlers via `createMainViewCommandCapabilities`, keeping test convenience out of the production API. Other optional options (`getTheme`, `modelListRefresh`, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf57574355ec7c392629814ffb63c3ace6663b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->