### PR TITLE
fix(runtime): make terminal finalization durability failures observable

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -8,11 +8,7 @@
 import PQueue from 'p-queue';
 
 import { StreamSnapshotStore } from '@transcript';
-import {
-  getExecutionStore,
-  registerExecution,
-  writeTerminalStatus,
-} from '@agent/storage';
+import { getExecutionStore, registerExecution } from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -31,6 +27,7 @@ import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import { CliExitCode } from '@cli/runtime/exitCodes';
+import { finalizeCliExecutionOrThrow } from '@cli/runtime/executionFinalization';
 import { readCliMultiAgentPresetName } from '@cli/runtime/multiAgentPresets';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -169,7 +166,11 @@ export async function markRegisteredChatExecutionError(
   },
 ): Promise<void> {
   if (!options.executionRegistered || options.agentSettled) return;
-  await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+  await finalizeCliExecutionOrThrow(
+    executionId,
+    EXECUTION_STATUS.ERROR,
+    'delete',
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -27,7 +27,10 @@ import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { type CliContext } from '@cli/runtime/cliContext';
 import { approvalPromptsUnavailable } from '@cli/runtime/approvalPolicyAvailability';
 import { CliExitCode } from '@cli/runtime/exitCodes';
-import { finalizeCliExecutionOrThrow } from '@cli/runtime/executionFinalization';
+import {
+  finalizeCliExecution,
+  type CliFinalizationFailureReporter,
+} from '@cli/runtime/executionFinalization';
 import { readCliMultiAgentPresetName } from '@cli/runtime/multiAgentPresets';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
 import {
@@ -163,13 +166,15 @@ export async function markRegisteredChatExecutionError(
   options: {
     readonly executionRegistered: boolean;
     readonly agentSettled: boolean;
+    readonly reportFinalizationFailure: CliFinalizationFailureReporter;
   },
 ): Promise<void> {
   if (!options.executionRegistered || options.agentSettled) return;
-  await finalizeCliExecutionOrThrow(
+  await finalizeCliExecution(
     executionId,
     EXECUTION_STATUS.ERROR,
     'delete',
+    options.reportFinalizationFailure,
   );
 }
 
@@ -345,6 +350,12 @@ export function createChatSessionController(
       : CliExitCode.AgentError;
   };
 
+  // Durability failures remain visible even when the user intentionally
+  // stopped the run and the primary run error is therefore suppressed.
+  const reportFinalizationFailure = (error: Error): void => {
+    appendLocalErrorTranscript(toErrorMessage(error));
+  };
+
   // Build the runtime host shared by start and resume: attach the
   // terminal-result toast and the TUI approval pipeline, and return a
   // `finalize` teardown that both run promises invoke from their `.finally`.
@@ -440,6 +451,7 @@ export function createChatSessionController(
         await markRegisteredChatExecutionError(executionId, {
           executionRegistered,
           agentSettled,
+          reportFinalizationFailure,
         });
         reportRunFailure(error);
       })

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -165,11 +165,11 @@ export async function markRegisteredChatExecutionError(
   executionId: ExecutionId,
   options: {
     readonly executionRegistered: boolean;
-    readonly agentSettled: boolean;
+    readonly lifecycleStarted: boolean;
     readonly reportFinalizationFailure: CliFinalizationFailureReporter;
   },
 ): Promise<void> {
-  if (!options.executionRegistered || options.agentSettled) return;
+  if (!options.executionRegistered || options.lifecycleStarted) return;
   await finalizeCliExecution(
     executionId,
     EXECUTION_STATUS.ERROR,
@@ -411,7 +411,7 @@ export function createChatSessionController(
       setupRunHost(sessionContext);
     const executionId = generateExecutionId();
     let executionRegistered = false;
-    let agentSettled = false;
+    let lifecycleStarted = false;
     session.executionId = executionId;
 
     const runPromise = registerFreshChatExecution(executionId, config)
@@ -422,6 +422,9 @@ export function createChatSessionController(
           enforceCategory: true,
           approvalPromptsUnavailable: approvalsUnavailable,
           runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+          onRun: () => {
+            lifecycleStarted = true;
+          },
           onStreamResolved: (resolvedStreamId) => {
             session.streamId = resolvedStreamId;
             publishChatTuiRunState(session);
@@ -437,7 +440,6 @@ export function createChatSessionController(
         });
       })
       .then((result) => {
-        agentSettled = true;
         session.runExitCode = runOutcomeExitCode(
           result.outcome,
           sessionContext,
@@ -450,7 +452,7 @@ export function createChatSessionController(
       .catch(async (error: unknown) => {
         await markRegisteredChatExecutionError(executionId, {
           executionRegistered,
-          agentSettled,
+          lifecycleStarted,
           reportFinalizationFailure,
         });
         reportRunFailure(error);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -10,7 +10,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
-import { finalizeCliExecutionOrThrow } from '../runtime/executionFinalization';
+import { finalizeCliExecution } from '../runtime/executionFinalization';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
@@ -157,10 +157,12 @@ export async function runWorkflowAgent(
           return CliExitCode.Interrupted;
         }
 
-        await finalizeCliExecutionOrThrow(
+        await finalizeCliExecution(
           executionId,
           EXECUTION_STATUS.ERROR,
           'delete',
+          (finalizationError) =>
+            writeTextStderr(`Warning: ${toErrorMessage(finalizationError)}`),
         );
         writeErrorStderr(error);
         return CliExitCode.AgentError;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1,8 +1,4 @@
-import {
-  buildCliWorkflowResultMeta,
-  getExecutionStore,
-  writeTerminalStatus,
-} from '@agent/storage';
+import { buildCliWorkflowResultMeta, getExecutionStore } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
@@ -14,6 +10,7 @@ import {
   type CliContext,
 } from '../runtime/cliContext';
 import { CliExitCode } from '../runtime/exitCodes';
+import { finalizeCliExecutionOrThrow } from '../runtime/executionFinalization';
 import { writeErrorStderr, writeTextStderr } from '../runtime/logSinks';
 import {
   buildHeadlessRunContext,
@@ -160,7 +157,11 @@ export async function runWorkflowAgent(
           return CliExitCode.Interrupted;
         }
 
-        await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+        await finalizeCliExecutionOrThrow(
+          executionId,
+          EXECUTION_STATUS.ERROR,
+          'delete',
+        );
         writeErrorStderr(error);
         return CliExitCode.AgentError;
       }

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -13,17 +13,29 @@ export async function finalizeCliExecution(
   flowRecord: FinalizeExecutionInput['flowRecord'],
   reportFailure: CliFinalizationFailureReporter,
 ): Promise<void> {
-  const result = await finalizeExecution({
-    executionId,
-    terminalStatus,
-    flowRecord,
-  });
+  let result: Awaited<ReturnType<typeof finalizeExecution>>;
+  try {
+    result = await finalizeExecution({
+      executionId,
+      terminalStatus,
+      flowRecord,
+    });
+  } catch (error) {
+    reportFailure(
+      new Error(
+        `Execution finalization failed unexpectedly for ${executionId}: ${toErrorMessage(error)}`,
+        { cause: error },
+      ),
+    );
+    return;
+  }
   if (result.status === 'durable') return;
 
-  reportFailure(
-    new Error(
-      `Failed to persist ${terminalStatus.toLowerCase()} status for execution ${executionId}: ${toErrorMessage(result.error)}`,
-      { cause: result.error },
-    ),
-  );
+  const message =
+    result.stage === 'flow-record-delete'
+      ? `Persisted ${terminalStatus.toLowerCase()} status for execution ${executionId}, but failed to delete its flow record: ${toErrorMessage(result.error)}`
+      : result.stage === 'terminal-status-and-flow-record-delete'
+        ? `Failed to persist ${terminalStatus.toLowerCase()} status and delete the flow record for execution ${executionId}: ${toErrorMessage(result.error)}`
+        : `Failed to persist ${terminalStatus.toLowerCase()} status for execution ${executionId}: ${toErrorMessage(result.error)}`;
+  reportFailure(new Error(message, { cause: result.error }));
 }

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -1,0 +1,15 @@
+import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
+
+/** Apply the CLI's strict policy for execution finalization failures. */
+export async function finalizeCliExecutionOrThrow(
+  executionId: FinalizeExecutionInput['executionId'],
+  terminalStatus: string,
+  flowRecord: FinalizeExecutionInput['flowRecord'],
+): Promise<void> {
+  const result = await finalizeExecution({
+    executionId,
+    terminalStatus,
+    flowRecord,
+  });
+  if (result.status === 'failed') throw result.error;
+}

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -1,15 +1,29 @@
 import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
-/** Apply the CLI's strict policy for execution finalization failures. */
-export async function finalizeCliExecutionOrThrow(
+export type CliFinalizationFailureReporter = (error: Error) => void;
+
+/**
+ * Finalize an execution without replacing the caller's primary result or error.
+ * The required reporter keeps durability failures observable at the host boundary.
+ */
+export async function finalizeCliExecution(
   executionId: FinalizeExecutionInput['executionId'],
   terminalStatus: string,
   flowRecord: FinalizeExecutionInput['flowRecord'],
+  reportFailure: CliFinalizationFailureReporter,
 ): Promise<void> {
   const result = await finalizeExecution({
     executionId,
     terminalStatus,
     flowRecord,
   });
-  if (result.status === 'failed') throw result.error;
+  if (result.status === 'durable') return;
+
+  reportFailure(
+    new Error(
+      `Failed to persist ${terminalStatus.toLowerCase()} status for execution ${executionId}: ${toErrorMessage(result.error)}`,
+      { cause: result.error },
+    ),
+  );
 }

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -1,4 +1,5 @@
 import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
+import type { ExecutionStatus } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export type CliFinalizationFailureReporter = (error: Error) => void;
@@ -10,7 +11,7 @@ type FailedFinalizationResult = Extract<
 function finalizationFailureMessage(
   result: FailedFinalizationResult,
   executionId: FinalizeExecutionInput['executionId'],
-  terminalStatus: string,
+  terminalStatus: ExecutionStatus,
 ): string {
   const status = terminalStatus.toLowerCase();
   const detail = toErrorMessage(result.error);
@@ -30,7 +31,7 @@ function finalizationFailureMessage(
  */
 export async function finalizeCliExecution(
   executionId: FinalizeExecutionInput['executionId'],
-  terminalStatus: string,
+  terminalStatus: ExecutionStatus,
   flowRecord: FinalizeExecutionInput['flowRecord'],
   reportFailure: CliFinalizationFailureReporter,
 ): Promise<void> {

--- a/packages/cli/src/runtime/executionFinalization.ts
+++ b/packages/cli/src/runtime/executionFinalization.ts
@@ -2,6 +2,27 @@ import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export type CliFinalizationFailureReporter = (error: Error) => void;
+type FailedFinalizationResult = Extract<
+  Awaited<ReturnType<typeof finalizeExecution>>,
+  { readonly status: 'failed' }
+>;
+
+function finalizationFailureMessage(
+  result: FailedFinalizationResult,
+  executionId: FinalizeExecutionInput['executionId'],
+  terminalStatus: string,
+): string {
+  const status = terminalStatus.toLowerCase();
+  const detail = toErrorMessage(result.error);
+  switch (result.stage) {
+    case 'flow-record-delete':
+      return `Persisted ${status} status for execution ${executionId}, but failed to delete its flow record: ${detail}`;
+    case 'terminal-status-and-flow-record-delete':
+      return `Failed to persist ${status} status and delete the flow record for execution ${executionId}: ${detail}`;
+    case 'terminal-status':
+      return `Failed to persist ${status} status for execution ${executionId}: ${detail}`;
+  }
+}
 
 /**
  * Finalize an execution without replacing the caller's primary result or error.
@@ -31,11 +52,10 @@ export async function finalizeCliExecution(
   }
   if (result.status === 'durable') return;
 
-  const message =
-    result.stage === 'flow-record-delete'
-      ? `Persisted ${terminalStatus.toLowerCase()} status for execution ${executionId}, but failed to delete its flow record: ${toErrorMessage(result.error)}`
-      : result.stage === 'terminal-status-and-flow-record-delete'
-        ? `Failed to persist ${terminalStatus.toLowerCase()} status and delete the flow record for execution ${executionId}: ${toErrorMessage(result.error)}`
-        : `Failed to persist ${terminalStatus.toLowerCase()} status for execution ${executionId}: ${toErrorMessage(result.error)}`;
+  const message = finalizationFailureMessage(
+    result,
+    executionId,
+    terminalStatus,
+  );
   reportFailure(new Error(message, { cause: result.error }));
 }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -16,7 +16,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
-import { finalizeCliExecutionOrThrow } from './executionFinalization';
+import { finalizeCliExecution } from './executionFinalization';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
@@ -108,10 +108,12 @@ export async function executeCliConfig<
   const { result } = execution;
 
   if (expectedCategory !== undefined && result.category !== expectedCategory) {
-    await finalizeCliExecutionOrThrow(
+    await finalizeCliExecution(
       executionId,
       EXECUTION_STATUS.ERROR,
       'delete',
+      (finalizationError) =>
+        writeTextStderr(`Warning: ${toErrorMessage(finalizationError)}`),
     );
     writeTextStderr(
       categoryMismatchMessage ??
@@ -209,25 +211,25 @@ export async function executeCliRequest(
     : undefined;
   let shutdownInterrupted = false;
   let shutdownFinalizationFailureReported = false;
-  const reportShutdownFinalizationFailure = (error: unknown): void => {
+  const reportFinalizationFailure = (error: unknown): void => {
+    interactionHost.emit('requestShowError', {
+      message: toErrorMessage(error),
+    });
+  };
+  const reportShutdownFinalizationFailure = (error: Error): void => {
     if (shutdownFinalizationFailureReported) return;
     shutdownFinalizationFailureReported = true;
-    interactionHost.emit('requestShowError', {
-      message: `Failed to persist interrupted status for execution ${ownedExecutionId}: ${toErrorMessage(error)}`,
-    });
+    reportFinalizationFailure(error);
   };
   const disposeShutdownStatus = ownedExecutionId
     ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
         shutdownInterrupted = true;
-        try {
-          await finalizeCliExecutionOrThrow(
-            ownedExecutionId,
-            EXECUTION_STATUS.INTERRUPTED,
-            'preserve',
-          );
-        } catch (error) {
-          reportShutdownFinalizationFailure(error);
-        }
+        await finalizeCliExecution(
+          ownedExecutionId,
+          EXECUTION_STATUS.INTERRUPTED,
+          'preserve',
+          reportShutdownFinalizationFailure,
+        );
       })
     : undefined;
   const invoke = (): Promise<ExecuteAgentResult> =>
@@ -271,10 +273,11 @@ export async function executeCliRequest(
       !invokeSettledOk &&
       !(err instanceof AgentError)
     ) {
-      await finalizeCliExecutionOrThrow(
+      await finalizeCliExecution(
         request.executionId,
         EXECUTION_STATUS.ERROR,
         'delete',
+        reportFinalizationFailure,
       );
     }
     // Only a classified, already-handled AgentError resolves to a non-zero
@@ -289,15 +292,12 @@ export async function executeCliRequest(
     // If the run settles while shutdown is in progress, keep the
     // signal-owned interrupted status as the final write.
     if (shutdownInterrupted && ownedExecutionId) {
-      try {
-        await finalizeCliExecutionOrThrow(
-          ownedExecutionId,
-          EXECUTION_STATUS.INTERRUPTED,
-          'preserve',
-        );
-      } catch (error) {
-        reportShutdownFinalizationFailure(error);
-      }
+      await finalizeCliExecution(
+        ownedExecutionId,
+        EXECUTION_STATUS.INTERRUPTED,
+        'preserve',
+        reportShutdownFinalizationFailure,
+      );
     }
     detachResultToast();
     detachRunProgressRenderer();

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -232,12 +232,16 @@ export async function executeCliRequest(
         );
       })
     : undefined;
+  let lifecycleStarted = false;
   const invoke = (): Promise<ExecuteAgentResult> =>
     runAgent(request, {
       runtimeHost: interactionHost,
       session,
       enforceCategory: options.enforceCategory,
       registerExecution: options.registerExecution,
+      onRun: () => {
+        lifecycleStarted = true;
+      },
       stopAfterCycle: options.stopAfterCycle,
       approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
       runtimeUnavailableTools: [
@@ -271,7 +275,7 @@ export async function executeCliRequest(
       options.markErrorOnThrow &&
       request.executionId &&
       !invokeSettledOk &&
-      !(err instanceof AgentError)
+      !lifecycleStarted
     ) {
       await finalizeCliExecution(
         request.executionId,

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -207,14 +207,20 @@ export async function executeCliRequest(
     ? request.executionId
     : undefined;
   let shutdownInterrupted = false;
+  let shutdownFinalizationError: unknown;
   const disposeShutdownStatus = ownedExecutionId
     ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
         shutdownInterrupted = true;
-        await finalizeCliExecutionOrThrow(
-          ownedExecutionId,
-          EXECUTION_STATUS.INTERRUPTED,
-          'preserve',
-        );
+        try {
+          await finalizeCliExecutionOrThrow(
+            ownedExecutionId,
+            EXECUTION_STATUS.INTERRUPTED,
+            'preserve',
+          );
+          shutdownFinalizationError = undefined;
+        } catch (error) {
+          shutdownFinalizationError = error;
+        }
       })
     : undefined;
   const invoke = (): Promise<ExecuteAgentResult> =>
@@ -252,7 +258,12 @@ export async function executeCliRequest(
       : trackedInvoke());
     runResult = { ok: true, result };
   } catch (err) {
-    if (options.markErrorOnThrow && request.executionId && !invokeSettledOk) {
+    if (
+      options.markErrorOnThrow &&
+      request.executionId &&
+      !invokeSettledOk &&
+      !(err instanceof AgentError)
+    ) {
       await finalizeCliExecutionOrThrow(
         request.executionId,
         EXECUTION_STATUS.ERROR,
@@ -271,11 +282,16 @@ export async function executeCliRequest(
     // If the run settles while shutdown is in progress, keep the
     // signal-owned interrupted status as the final write.
     if (shutdownInterrupted && ownedExecutionId) {
-      await finalizeCliExecutionOrThrow(
-        ownedExecutionId,
-        EXECUTION_STATUS.INTERRUPTED,
-        'preserve',
-      );
+      try {
+        await finalizeCliExecutionOrThrow(
+          ownedExecutionId,
+          EXECUTION_STATUS.INTERRUPTED,
+          'preserve',
+        );
+        shutdownFinalizationError = undefined;
+      } catch (error) {
+        shutdownFinalizationError = error;
+      }
     }
     detachResultToast();
     detachRunProgressRenderer();
@@ -291,6 +307,10 @@ export async function executeCliRequest(
     } finally {
       await interactionHost.close();
     }
+  }
+
+  if (shutdownFinalizationError !== undefined) {
+    throw shutdownFinalizationError;
   }
 
   if (!runResult.ok) {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,7 +1,6 @@
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { tryPlatform } from '@platform/platform';
 import { flushPendingRunTraces, StreamSnapshotStore } from '@transcript';
-import { writeTerminalStatus } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -16,6 +15,7 @@ import { generateExecutionId } from '@utils/core';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
+import { finalizeCliExecutionOrThrow } from './executionFinalization';
 import { attachCliSessionProgressProjection } from './sessionProgressSubscription';
 import { initializeHeadlessTranscriptSession } from './transcriptSession';
 import { createCliRuntimeHost, type CliRuntimeHost } from './runtimeHost';
@@ -107,7 +107,11 @@ export async function executeCliConfig<
   const { result } = execution;
 
   if (expectedCategory !== undefined && result.category !== expectedCategory) {
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
+    await finalizeCliExecutionOrThrow(
+      executionId,
+      EXECUTION_STATUS.ERROR,
+      'delete',
+    );
     writeTextStderr(
       categoryMismatchMessage ??
         `Agent resolved to a non ${expectedCategory} run.`,
@@ -206,9 +210,10 @@ export async function executeCliRequest(
   const disposeShutdownStatus = ownedExecutionId
     ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
         shutdownInterrupted = true;
-        await writeTerminalStatus(
+        await finalizeCliExecutionOrThrow(
           ownedExecutionId,
           EXECUTION_STATUS.INTERRUPTED,
+          'preserve',
         );
       })
     : undefined;
@@ -248,7 +253,11 @@ export async function executeCliRequest(
     runResult = { ok: true, result };
   } catch (err) {
     if (options.markErrorOnThrow && request.executionId && !invokeSettledOk) {
-      await writeTerminalStatus(request.executionId, EXECUTION_STATUS.ERROR);
+      await finalizeCliExecutionOrThrow(
+        request.executionId,
+        EXECUTION_STATUS.ERROR,
+        'delete',
+      );
     }
     // Only a classified, already-handled AgentError resolves to a non-zero
     // exit code here; anything else (e.g. registerExecution disk I/O,
@@ -262,7 +271,11 @@ export async function executeCliRequest(
     // If the run settles while shutdown is in progress, keep the
     // signal-owned interrupted status as the final write.
     if (shutdownInterrupted && ownedExecutionId) {
-      await writeTerminalStatus(ownedExecutionId, EXECUTION_STATUS.INTERRUPTED);
+      await finalizeCliExecutionOrThrow(
+        ownedExecutionId,
+        EXECUTION_STATUS.INTERRUPTED,
+        'preserve',
+      );
     }
     detachResultToast();
     detachRunProgressRenderer();

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -330,6 +330,9 @@ export async function executeCliRequest(
     };
   }
 
-  const outcome = await readCliRunOutcome(runResult.result);
+  const outcome = await readCliRunOutcome(
+    runResult.result,
+    reportFinalizationFailure,
+  );
   return { ok: true, result: { ...runResult.result, outcome } };
 }

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -12,6 +12,7 @@ import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { AgentError } from '@common/errors';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { approvalPromptsUnavailable } from './approvalPolicyAvailability';
 import { createHeadlessCliHostInteractions } from './approvalAdapter';
@@ -207,7 +208,14 @@ export async function executeCliRequest(
     ? request.executionId
     : undefined;
   let shutdownInterrupted = false;
-  let shutdownFinalizationError: unknown;
+  let shutdownFinalizationFailureReported = false;
+  const reportShutdownFinalizationFailure = (error: unknown): void => {
+    if (shutdownFinalizationFailureReported) return;
+    shutdownFinalizationFailureReported = true;
+    interactionHost.emit('requestShowError', {
+      message: `Failed to persist interrupted status for execution ${ownedExecutionId}: ${toErrorMessage(error)}`,
+    });
+  };
   const disposeShutdownStatus = ownedExecutionId
     ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
         shutdownInterrupted = true;
@@ -217,9 +225,8 @@ export async function executeCliRequest(
             EXECUTION_STATUS.INTERRUPTED,
             'preserve',
           );
-          shutdownFinalizationError = undefined;
         } catch (error) {
-          shutdownFinalizationError = error;
+          reportShutdownFinalizationFailure(error);
         }
       })
     : undefined;
@@ -288,9 +295,8 @@ export async function executeCliRequest(
           EXECUTION_STATUS.INTERRUPTED,
           'preserve',
         );
-        shutdownFinalizationError = undefined;
       } catch (error) {
-        shutdownFinalizationError = error;
+        reportShutdownFinalizationFailure(error);
       }
     }
     detachResultToast();
@@ -307,10 +313,6 @@ export async function executeCliRequest(
     } finally {
       await interactionHost.close();
     }
-  }
-
-  if (shutdownFinalizationError !== undefined) {
-    throw shutdownFinalizationError;
   }
 
   if (!runResult.ok) {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -9,6 +9,7 @@ import {
   legacyEndGroupStatusForOutcome,
   runOutcomeToExecutionStatus,
 } from '@shared/streams/streamStatus';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { hasCliApprovalDenied } from './approvalAdapter';
 import { CliExitCode } from './exitCodes';
@@ -103,7 +104,18 @@ export function runOutcomeExitCode(
 
 export async function readCliRunOutcome(
   result: ExecuteAgentResult,
+  reportReadFailure?: (error: Error) => void,
 ): Promise<RunOutcome> {
-  const meta = await getExecutionStore(result.executionId).readMeta();
-  return meta?.outcome ?? result.outcome;
+  try {
+    const meta = await getExecutionStore(result.executionId).readMeta();
+    return meta?.outcome ?? result.outcome;
+  } catch (error) {
+    reportReadFailure?.(
+      new Error(
+        `Could not verify the persisted outcome for execution ${result.executionId}; using the current run outcome: ${toErrorMessage(error)}`,
+        { cause: error },
+      ),
+    );
+    return result.outcome;
+  }
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -20,7 +20,6 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import {
   PersistedFlowStateError,
-  flowKey,
   readPersistedFlowRecord,
 } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
@@ -360,14 +359,8 @@ export async function runReflectionFlow<C = unknown>(
     outcome = RUN_OUTCOME.FAILED;
     throw error;
   } finally {
-    if (outcome === RUN_OUTCOME.COMPLETED) {
-      try {
-        await kv.delete(flowKey(executionId));
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
-
+    // AgentRunLifecycle owns terminal metadata and flow-record disposition as
+    // one storage finalization. This flow only determines its outcome.
     runSession.interactions.cancel({ streamId, cause: 'Run ended.' });
   }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -89,6 +89,8 @@ export interface RunToolUseFlowInput<
   ) => void;
   /** Runtime feature registry for auto-injected tools. */
   toolInjections?: ToolInjectionRegistry;
+  /** Reports whether terminal finalization should retain the resume record. */
+  onFlowRecordDisposition?: (disposition: 'preserve' | 'delete') => void;
 }
 
 export interface RunToolUseFlowResult {
@@ -587,8 +589,9 @@ export async function runToolUseFlow<C = unknown>(
       preserveFlowRecord && !persistenceRecoveryPending;
 
     if (preservationReason) logger.debug(preservationReason);
-    // AgentRunLifecycle applies the terminal metadata and flow-record policy
-    // through one storage finalization after this flow reports its outcome.
+    input.onFlowRecordDisposition?.(preserveFlowRecord ? 'preserve' : 'delete');
+    // AgentRunLifecycle applies this policy with terminal metadata through one
+    // storage finalization after the flow reports its outcome.
 
     // Recovery failures preserve the unread record but release the rebuilt
     // live queue. The resume wrapper owns the drained batch and restores it

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -586,15 +586,9 @@ export async function runToolUseFlow<C = unknown>(
     const preserveFollowUpQueue =
       preserveFlowRecord && !persistenceRecoveryPending;
 
-    if (preservationReason) {
-      logger.debug(preservationReason);
-    } else {
-      try {
-        await kv.delete(flowKey(executionId));
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+    if (preservationReason) logger.debug(preservationReason);
+    // AgentRunLifecycle applies the terminal metadata and flow-record policy
+    // through one storage finalization after this flow reports its outcome.
 
     // Recovery failures preserve the unread record but release the rebuilt
     // live queue. The resume wrapper owns the drained batch and restores it

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -1,5 +1,5 @@
 import { platform } from '@platform/platform';
-import { getExecutionStore, writeTerminalStatus } from '@agent/storage';
+import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
 import {
   logSdkError,
   type AgentTrace,
@@ -7,7 +7,6 @@ import {
   type StageHandle,
 } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
-import { flowKey } from '@agent/node/persistedFlow';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AGENT_ERROR_OUTCOME,
@@ -84,12 +83,13 @@ export interface FinalizeRunTerminalParams {
    * bash) omit it so their per-turn results stay out of the host result plane.
    */
   readonly trace?: AgentTrace;
-  /**
-   * Persist the outcome projection to execution history (best-effort). Callers
-   * that own a richer persistence block (background bash writes result meta,
-   * report, and status together) pass false.
-   */
-  readonly persistTerminalStatus: boolean;
+  /** Durable execution-state action owned by the storage finalizer. */
+  readonly persistence:
+    | { readonly kind: 'skip' }
+    | {
+        readonly kind: 'finalize';
+        readonly flowRecord: FinalizeExecutionInput['flowRecord'];
+      };
   /**
    * Delivery hook (subagent onError) run after the result settles and before
    * untrack, so the parent still sees this child as active while the
@@ -124,11 +124,23 @@ export async function finalizeRunTerminal(
   // live registration to clear in the common case — this guards a future
   // caller that registers one outside that branch.
   handle.clearWaitingCleanup();
-  if (params.persistTerminalStatus) {
-    await writeTerminalStatus(
-      handle.executionId,
-      projectRunOutcome(outcome).executionStatus,
-    ).catch(() => {});
+  if (params.persistence.kind === 'finalize') {
+    const finalization = await finalizeExecution({
+      executionId: handle.executionId,
+      terminalStatus: projectRunOutcome(outcome).executionStatus,
+      flowRecord: params.persistence.flowRecord,
+    });
+    if (finalization.status === 'failed') {
+      logger.warn('Failed to finalize durable execution state', {
+        data: {
+          agentIdentifier: handle.agentName,
+          executionId: handle.executionId,
+          stage: finalization.stage,
+          terminalStatusPersisted: finalization.terminalStatusPersisted,
+          error: finalization.error,
+        },
+      });
+    }
   }
   if (params.stage) {
     try {
@@ -313,7 +325,14 @@ export async function runFlowWithLifecycle(
       isSubagent: options?.isSubagent ?? false,
       stage: ctx.parentStage,
       trace: ctx.logger,
-      persistTerminalStatus: true,
+      persistence: {
+        kind: 'finalize',
+        // Completed runs have no resume state left to retain. Failed and
+        // cancelled runs keep their last flow record for diagnosis or resume;
+        // terminal metadata still prevents failed runs from being resumed.
+        flowRecord:
+          arm.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve',
+      },
       ...arm,
     });
   try {
@@ -342,15 +361,6 @@ export async function runFlowWithLifecycle(
       const parentStageId = ctx.parentStage.id;
       handle.registerWaitingCleanup(() => {
         session.followUps.release(streamId);
-        // Best-effort: this deletes the persisted flow-record for a run that
-        // is already being torn down and has no caller left awaiting this
-        // closure (it only fires from a later kill, well after the original
-        // request context is gone) — a failed delete just leaves a stale
-        // record on disk, not a correctness gap, so there is nothing useful
-        // to propagate an error to.
-        void getExecutionStore(executionId)
-          .delete(flowKey(executionId))
-          .catch(() => {});
         // Close this turn's "Run: ..." transcript group so a killed suspended
         // subagent doesn't leave it stuck at `running` forever (every other
         // terminal path reaches this via `finalizeRunTerminal`'s stage end,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -424,6 +424,11 @@ export async function runFlowWithLifecycle(
       });
       return result;
     }
+    // Persist the terminal fact before any supplementary UX state. In
+    // particular, a completed tool-use flow must not remain resumable while an
+    // onboarding write is pending.
+    await finalizeTerminal({ outcome: result.outcome });
+
     // Onboarding funnel (PRD: agent-native onboarding): State 1 ends when any
     // real run completes. The setup conversation itself doesn't count, but the
     // demo it delegates does (subagent runs land here too). Best-effort: a
@@ -442,13 +447,6 @@ export async function runFlowWithLifecycle(
       }
     }
 
-    // The flow's outcome is the canonical terminal fact; the finalizer owns
-    // every projection of it. No other layer may re-derive these. Success
-    // has no delivery hook: a native subagent's own turn value IS the
-    // strategy's returned result (see childRunLoop.ts), so there is nothing
-    // left to deliver here — only a subagent failure needs the caller to
-    // format and route an error (see the catch arm's `onError` below).
-    await finalizeTerminal({ outcome: result.outcome });
     logger.debug(`Task completed with outcome: ${result.outcome}`);
     return result;
   } catch (err) {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -60,6 +60,13 @@ export interface RunFlowLifecycleOptions {
   onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
+export type FlowRecordDisposition = FinalizeExecutionInput['flowRecord'];
+
+/** Private control channel through which a flow reports its retention policy. */
+export interface FlowLifecycleControl {
+  setFlowRecordDisposition(disposition: FlowRecordDisposition): void;
+}
+
 export interface FinalizeRunTerminalParams {
   /** Live handle for this terminal attempt; its settled flag is the exactly-once guard. */
   readonly handle: AgentExecutionHandle;
@@ -280,7 +287,10 @@ function emitRunStart(ctx: AgentLaunchContext): void {
  */
 export async function runFlowWithLifecycle(
   ctx: AgentLaunchContext,
-  runner: (handle: AgentExecutionHandle) => Promise<AgentRuntimeFlowResult>,
+  runner: (
+    handle: AgentExecutionHandle,
+    lifecycle: FlowLifecycleControl,
+  ) => Promise<AgentRuntimeFlowResult>,
   options?: RunFlowLifecycleOptions,
 ): Promise<AgentRuntimeFlowResult> {
   const { streamId, executionId, runtimeHost, session } = ctx.runScope;
@@ -304,6 +314,12 @@ export async function runFlowWithLifecycle(
   // missed the emitRunStart() `run.config` below and replays it from here (#8258).
   handle.initialRunFacts = { config: ctx.config };
   session.executions.track(handle);
+  let flowRecordDisposition: FlowRecordDisposition | undefined;
+  const lifecycleControl: FlowLifecycleControl = {
+    setFlowRecordDisposition(disposition): void {
+      flowRecordDisposition = disposition;
+    },
+  };
   // Expose the live handle to the launcher (F-2). Guarded: neither a synchronous
   // throw nor an async rejection from a consumer callback may abort the run.
   if (options?.onRun) {
@@ -337,11 +353,11 @@ export async function runFlowWithLifecycle(
       trace: ctx.logger,
       persistence: {
         kind: 'finalize',
-        // Completed runs have no resume state left to retain. Failed and
-        // cancelled runs keep their last flow record for diagnosis or resume;
-        // terminal metadata still prevents failed runs from being resumed.
+        // Tool-use flows report the exact recovery decision through the
+        // private lifecycle control. Other flows retain the historical policy.
         flowRecord:
-          arm.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve',
+          flowRecordDisposition ??
+          (arm.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve'),
       },
       ...arm,
     });
@@ -356,7 +372,7 @@ export async function runFlowWithLifecycle(
     if (!handle.hasPendingInterrupt) transitionRunStart(ctx);
     let result: AgentRuntimeFlowResult;
     try {
-      result = await runner(handle);
+      result = await runner(handle, lifecycleControl);
     } finally {
       handle.closePendingInterruptWindow();
     }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -105,6 +105,11 @@ export interface FinalizeRunTerminalParams {
   readonly deliver?: () => void | Promise<void>;
 }
 
+export interface FinalizeRunTerminalResult {
+  readonly event: ResultEvent;
+  readonly terminalStatusPersisted: boolean;
+}
+
 /**
  * The single owner of terminal run choreography, shared by the run lifecycle
  * arms below, the agent-CLI session loop, and child stream tabs
@@ -119,7 +124,7 @@ export interface FinalizeRunTerminalParams {
  */
 export async function finalizeRunTerminal(
   params: FinalizeRunTerminalParams,
-): Promise<ResultEvent | undefined> {
+): Promise<FinalizeRunTerminalResult | undefined> {
   const { handle, outcome } = params;
   if (!handle.claimTerminalFinalize()) return undefined;
   // This run is terminating, not suspending: drop any waiting-cleanup
@@ -131,6 +136,7 @@ export async function finalizeRunTerminal(
   // live registration to clear in the common case — this guards a future
   // caller that registers one outside that branch.
   handle.clearWaitingCleanup();
+  let terminalStatusPersisted = false;
   if (params.persistence.kind === 'finalize') {
     try {
       const finalization = await finalizeExecution({
@@ -149,6 +155,7 @@ export async function finalizeRunTerminal(
           },
         });
       }
+      terminalStatusPersisted = finalization.terminalStatusPersisted;
     } catch (error) {
       logger.warn('Execution finalizer rejected unexpectedly', {
         data: {
@@ -218,7 +225,7 @@ export async function finalizeRunTerminal(
       data: { agentIdentifier: handle.agentName, error: cleanupErr },
     });
   }
-  return event;
+  return { event, terminalStatusPersisted };
 }
 
 function transitionRunStart(ctx: AgentLaunchContext): void {
@@ -342,7 +349,7 @@ export async function runFlowWithLifecycle(
     outcome: RunOutcome;
     error?: ResultEvent['error'];
     deliver?: () => void | Promise<void>;
-  }): Promise<ResultEvent | undefined> =>
+  }): Promise<FinalizeRunTerminalResult | undefined> =>
     finalizeRunTerminal({
       handle,
       executions: session.executions,

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -125,19 +125,29 @@ export async function finalizeRunTerminal(
   // caller that registers one outside that branch.
   handle.clearWaitingCleanup();
   if (params.persistence.kind === 'finalize') {
-    const finalization = await finalizeExecution({
-      executionId: handle.executionId,
-      terminalStatus: projectRunOutcome(outcome).executionStatus,
-      flowRecord: params.persistence.flowRecord,
-    });
-    if (finalization.status === 'failed') {
-      logger.warn('Failed to finalize durable execution state', {
+    try {
+      const finalization = await finalizeExecution({
+        executionId: handle.executionId,
+        terminalStatus: projectRunOutcome(outcome).executionStatus,
+        flowRecord: params.persistence.flowRecord,
+      });
+      if (finalization.status === 'failed') {
+        logger.warn('Failed to finalize durable execution state', {
+          data: {
+            agentIdentifier: handle.agentName,
+            executionId: handle.executionId,
+            stage: finalization.stage,
+            terminalStatusPersisted: finalization.terminalStatusPersisted,
+            error: finalization.error,
+          },
+        });
+      }
+    } catch (error) {
+      logger.warn('Execution finalizer rejected unexpectedly', {
         data: {
           agentIdentifier: handle.agentName,
           executionId: handle.executionId,
-          stage: finalization.stage,
-          terminalStatusPersisted: finalization.terminalStatusPersisted,
-          error: finalization.error,
+          error,
         },
       });
     }

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -67,6 +67,13 @@ export interface FlowLifecycleControl {
   setFlowRecordDisposition(disposition: FlowRecordDisposition): void;
 }
 
+export type RunTerminalPersistence =
+  | { readonly kind: 'skip' }
+  | {
+      readonly kind: 'finalize';
+      readonly flowRecord: FinalizeExecutionInput['flowRecord'];
+    };
+
 export interface FinalizeRunTerminalParams {
   /** Live handle for this terminal attempt; its settled flag is the exactly-once guard. */
   readonly handle: AgentExecutionHandle;
@@ -91,12 +98,7 @@ export interface FinalizeRunTerminalParams {
    */
   readonly trace?: AgentTrace;
   /** Durable execution-state action owned by the storage finalizer. */
-  readonly persistence:
-    | { readonly kind: 'skip' }
-    | {
-        readonly kind: 'finalize';
-        readonly flowRecord: FinalizeExecutionInput['flowRecord'];
-      };
+  readonly persistence: RunTerminalPersistence;
   /**
    * Delivery hook (subagent onError) run after the result settles and before
    * untrack, so the parent still sees this child as active while the

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -663,7 +663,7 @@ export function startChildRunLoop<TTurn>(
           failed: sawTurnFailure,
           cancelled: loop.isInterrupted(),
           stage: sessionStage,
-          persistTerminalStatus: true,
+          persistence: { kind: 'finalize', flowRecord: 'delete' },
         });
       } else {
         // Native: every GENUINE terminal turn already finalized its own

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -23,10 +23,11 @@ import type {
 import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { classifyAgentError, isAbortError } from '@common/errors';
-import type {
-  ExecutionId,
-  StreamTabId,
-  SubagentProgressUpdate,
+import {
+  RUN_OUTCOME,
+  type ExecutionId,
+  type StreamTabId,
+  type SubagentProgressUpdate,
 } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 
@@ -701,7 +702,11 @@ export function startChildRunLoop<TTurn>(
                   }
                 : undefined,
             isSubagent: true,
-            persistTerminalStatus: true,
+            persistence: {
+              kind: 'finalize',
+              flowRecord:
+                outcome === RUN_OUTCOME.CANCELLED ? 'preserve' : 'delete',
+            },
           });
           // No turn result follows an interruption between turns. Only this
           // path may relabel the latest interim envelope; ordinary terminal

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -711,7 +711,7 @@ export function startChildRunLoop<TTurn>(
           // No turn result follows an interruption between turns. Only this
           // path may relabel the latest interim envelope; ordinary terminal
           // turns persist their own result after runFlowWithLifecycle returns.
-          if (finalized && loop.isInterrupted()) {
+          if (finalized?.terminalStatusPersisted && loop.isInterrupted()) {
             await synchronizeAgentResultOutcome(executionId, outcome);
           }
         }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -44,7 +44,10 @@ import {
   withExecutionRunContext,
   type AgentLaunchContext,
 } from './AgentLaunchContext';
-import { runFlowWithLifecycle } from './AgentRunLifecycle';
+import {
+  runFlowWithLifecycle,
+  type FlowLifecycleControl,
+} from './AgentRunLifecycle';
 import {
   AgentFlowError,
   buildOptionalFlowResultFields,
@@ -149,6 +152,7 @@ function assertAllowedWaitingResult(
 async function runToolUseAgent(
   ctx: AgentLaunchContext,
   handle: AgentExecutionHandle,
+  lifecycle: FlowLifecycleControl,
   setting: AgentToolUseSetting,
   options: Pick<
     ExecuteAgentOptions,
@@ -183,6 +187,8 @@ async function runToolUseAgent(
           ctx,
           options.onFollowUpConsumed,
         ),
+        onFlowRecordDisposition: (disposition) =>
+          lifecycle.setFlowRecordDisposition(disposition),
         onModelChanged: (modelHandler) => {
           // The tool-use flow already wrote services.config.model
           // (=== ctx.config.model, same object), so the live model is updated
@@ -425,7 +431,7 @@ export async function executeAgent(
     ).catch(() => {});
     const result = await runFlowWithLifecycle(
       ctx,
-      async (handle) => {
+      async (handle, lifecycle) => {
         // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
         if (executionId) await ensureRunDir(executionId);
         logger.info(`Starting task execution (streamId: ${runStreamId})`);
@@ -450,7 +456,7 @@ export async function executeAgent(
         });
 
         if (setting.agentCategory === AgentCategory.ToolUse) {
-          return runToolUseAgent(ctx, handle, setting, options);
+          return runToolUseAgent(ctx, handle, lifecycle, setting, options);
         }
         return runReflectionAgent(ctx, handle, setting);
       },
@@ -551,7 +557,7 @@ export async function resumeToolUseFromSnapshot(
     const isSubagent = delegationDepth > 0;
     const result = await runFlowWithLifecycle(
       ctx,
-      async (handle) => {
+      async (handle, lifecycle) => {
         const result = await runToolUseFlow(
           {
             ...ctx,
@@ -571,6 +577,8 @@ export async function resumeToolUseFromSnapshot(
               ctx,
               options.onFollowUpConsumed,
             ),
+            onFlowRecordDisposition: (disposition) =>
+              lifecycle.setFlowRecordDisposition(disposition),
           },
           undefined,
           (flowContext) => {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -6,10 +6,10 @@
  */
 
 import {
+  finalizeExecution,
   synchronizeAgentResultOutcome,
-  writeTerminalStatus,
 } from '@agent/storage';
-import type { ResultEvent } from '@agent/trace';
+import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
@@ -40,6 +40,8 @@ import {
 } from './ExecutionHandle';
 import { ProcessOutputPoller } from './ProcessOutputPoller';
 import { SessionEventHub } from './SessionEventHub';
+
+const logger = createChannelTrace('executionRegistry');
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {
@@ -911,18 +913,34 @@ export class ExecutionRegistry {
     handle.trace?.emit(cancelledResult);
     this.publishResult?.(cancelledResult, handle.childStreamId);
     handle.settleResult(cancelledResult);
-    const statusWrite = writeTerminalStatus(
-      handle.executionId,
-      projectRunOutcome(RUN_OUTCOME.CANCELLED).executionStatus,
-    );
+    const finalization = finalizeExecution({
+      executionId: handle.executionId,
+      terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED).executionStatus,
+      flowRecord: 'delete',
+    });
     // No later result write is guaranteed here, including during RESUMING:
     // the resume can fail before installing its own handle, while this method
     // untracks the suspended one below. Align the interim envelope only after
     // durable terminal metadata exists. A turn that does continue will replace
     // it with its own result.
-    void statusWrite.then(() =>
-      synchronizeAgentResultOutcome(handle.executionId, RUN_OUTCOME.CANCELLED),
-    );
+    void finalization.then((result) => {
+      if (result.status === 'failed') {
+        logger.warn('Failed to finalize stopped waiting execution', {
+          data: {
+            executionId: handle.executionId,
+            stage: result.stage,
+            terminalStatusPersisted: result.terminalStatusPersisted,
+            error: result.error,
+          },
+        });
+      }
+      if (result.terminalStatusPersisted) {
+        void synchronizeAgentResultOutcome(
+          handle.executionId,
+          RUN_OUTCOME.CANCELLED,
+        );
+      }
+    });
     this.untrackHandle(handle);
     this.cancelStreamStatus(handle.childStreamId, handle);
     return true;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -923,24 +923,30 @@ export class ExecutionRegistry {
     // untracks the suspended one below. Align the interim envelope only after
     // durable terminal metadata exists. A turn that does continue will replace
     // it with its own result.
-    void finalization.then((result) => {
-      if (result.status === 'failed') {
-        logger.warn('Failed to finalize stopped waiting execution', {
-          data: {
-            executionId: handle.executionId,
-            stage: result.stage,
-            terminalStatusPersisted: result.terminalStatusPersisted,
-            error: result.error,
-          },
+    void finalization
+      .then((result) => {
+        if (result.status === 'failed') {
+          logger.warn('Failed to finalize stopped waiting execution', {
+            data: {
+              executionId: handle.executionId,
+              stage: result.stage,
+              terminalStatusPersisted: result.terminalStatusPersisted,
+              error: result.error,
+            },
+          });
+        }
+        if (result.terminalStatusPersisted) {
+          void synchronizeAgentResultOutcome(
+            handle.executionId,
+            RUN_OUTCOME.CANCELLED,
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        logger.warn('Waiting-execution finalizer rejected unexpectedly', {
+          data: { executionId: handle.executionId, error },
         });
-      }
-      if (result.terminalStatusPersisted) {
-        void synchronizeAgentResultOutcome(
-          handle.executionId,
-          RUN_OUTCOME.CANCELLED,
-        );
-      }
-    });
+      });
     this.untrackHandle(handle);
     this.cancelStreamStatus(handle.childStreamId, handle);
     return true;

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -208,7 +208,7 @@ export interface ExecutionKVStore {
  */
 class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   constructor(private readonly executionId: ExecutionId) {
-    super(resolveRunStoragePath(executionId));
+    super(resolveRunStoragePath(executionId), { throwOnErrors: true });
   }
 
   async clear(): Promise<void> {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -234,8 +234,14 @@ export type FinalizeExecutionResult =
   | {
       status: 'failed';
       error: unknown;
-      stage: 'terminal-status' | 'flow-record-delete';
-      terminalStatusPersisted: boolean;
+      stage: 'terminal-status';
+      terminalStatusPersisted: false;
+    }
+  | {
+      status: 'failed';
+      error: unknown;
+      stage: 'flow-record-delete';
+      terminalStatusPersisted: true;
     };
 
 /** Persist terminal metadata, then apply the requested flow-record policy. */

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -17,6 +17,7 @@ import {
   RUN_OUTCOME,
   executionStatusToRunOutcome,
   type ExecutionId,
+  type ExecutionStatus,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
@@ -215,7 +216,7 @@ export async function synchronizeAgentResultOutcome(
  */
 export async function writeTerminalStatus(
   executionId: ExecutionId,
-  status: string,
+  status: ExecutionStatus,
 ): Promise<void> {
   const outcome = executionStatusToRunOutcome(status);
   await enqueueMetaUpdate(executionId, () => ({
@@ -225,28 +226,29 @@ export async function writeTerminalStatus(
 }
 
 export interface FinalizeExecutionInput {
-  executionId: ExecutionId;
-  terminalStatus: string;
-  flowRecord: 'preserve' | 'delete';
+  readonly executionId: ExecutionId;
+  readonly terminalStatus: ExecutionStatus;
+  readonly flowRecord: 'preserve' | 'delete';
 }
 
 export type FinalizeExecutionResult =
   | {
-      status: 'durable';
-      terminalStatusPersisted: true;
-      flowRecord: 'preserved' | 'deleted';
+      readonly status: 'durable';
+      readonly terminalStatusPersisted: true;
+      readonly flowRecord: 'preserved' | 'deleted';
     }
   | {
-      status: 'failed';
-      error: unknown;
-      stage: 'terminal-status' | 'terminal-status-and-flow-record-delete';
-      terminalStatusPersisted: false;
+      readonly status: 'failed';
+      readonly error: unknown;
+      readonly stage:
+        'terminal-status' | 'terminal-status-and-flow-record-delete';
+      readonly terminalStatusPersisted: false;
     }
   | {
-      status: 'failed';
-      error: unknown;
-      stage: 'flow-record-delete';
-      terminalStatusPersisted: true;
+      readonly status: 'failed';
+      readonly error: unknown;
+      readonly stage: 'flow-record-delete';
+      readonly terminalStatusPersisted: true;
     };
 
 /** Persist terminal metadata, then apply the requested flow-record policy. */

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -208,7 +208,11 @@ export async function synchronizeAgentResultOutcome(
   }
 }
 
-/** Persist a terminal status and its canonical outcome projection. */
+/**
+ * Persist a terminal status and its canonical outcome projection.
+ * @deprecated Use {@link finalizeExecution} so flow-record disposition and
+ * durability failures are handled together.
+ */
 export async function writeTerminalStatus(
   executionId: ExecutionId,
   status: string,
@@ -255,6 +259,8 @@ export async function finalizeExecution({
     await writeTerminalStatus(executionId, terminalStatus);
   } catch (error) {
     const outcome = executionStatusToRunOutcome(terminalStatus);
+    // A terminal COMPLETED/FAILED result must never retain a resumable flow,
+    // even when the caller requested preservation before the status write failed.
     const deleteToFailClosed =
       flowRecord === 'delete' ||
       outcome === RUN_OUTCOME.COMPLETED ||

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -14,6 +14,7 @@ import { flowKey } from '@agent/node/persistedFlow';
 
 import * as logger from '@logger/logUtils';
 import {
+  RUN_OUTCOME,
   executionStatusToRunOutcome,
   type ExecutionId,
   type RunOutcome,
@@ -234,7 +235,7 @@ export type FinalizeExecutionResult =
   | {
       status: 'failed';
       error: unknown;
-      stage: 'terminal-status';
+      stage: 'terminal-status' | 'terminal-status-and-flow-record-delete';
       terminalStatusPersisted: false;
     }
   | {
@@ -253,6 +254,26 @@ export async function finalizeExecution({
   try {
     await writeTerminalStatus(executionId, terminalStatus);
   } catch (error) {
+    const outcome = executionStatusToRunOutcome(terminalStatus);
+    const deleteToFailClosed =
+      flowRecord === 'delete' ||
+      outcome === RUN_OUTCOME.COMPLETED ||
+      outcome === RUN_OUTCOME.FAILED;
+    if (deleteToFailClosed) {
+      try {
+        await getExecutionStore(executionId).delete(flowKey(executionId));
+      } catch (deleteError) {
+        return {
+          status: 'failed',
+          error: new AggregateError(
+            [error, deleteError],
+            `Terminal metadata and flow deletion failed for ${executionId}`,
+          ),
+          stage: 'terminal-status-and-flow-record-delete',
+          terminalStatusPersisted: false,
+        };
+      }
+    }
     return {
       status: 'failed',
       error,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -10,6 +10,7 @@
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { getAgent, isAgentRegistryReady } from '@agent/index/agentRegistry';
+import { flowKey } from '@agent/node/persistedFlow';
 
 import * as logger from '@logger/logUtils';
 import {
@@ -84,7 +85,9 @@ function enqueueMetaUpdate(
   const next = prev.then(async () => {
     const store = getExecutionStore(executionId);
     const existing = await store.readMeta();
-    if (!existing) return;
+    if (!existing) {
+      throw new Error(`Execution metadata not found for ${executionId}`);
+    }
     await store.writeMeta({ ...existing, ...updater(existing) });
     invalidateListingCache();
   });
@@ -142,16 +145,14 @@ export async function registerExecution(
 }
 
 /**
- * Persist supplementary metadata fields on an existing execution.
+ * Persist supplementary metadata fields on an existing execution as a
+ * best-effort operation.
  * Serialized with other meta updates for the same execution to prevent
  * read-modify-write races (e.g. between terminal status and description).
- * Never throws: storage failures are swallowed and logged so callers'
- * lifecycle logic (registry untrack, follow-up delivery) always runs — even
- * for fields like terminal status that are the resumability/status source of
- * truth, not incidental bookkeeping. Callers must not add their own
- * `.catch()` around this; it can never reject.
+ * Never throws because these fields are caches or presentation metadata, not
+ * lifecycle state. Authoritative metadata must use enqueueMetaUpdate directly.
  */
-async function persistMetaField(
+async function persistSupplementaryMetaFieldsBestEffort(
   executionId: ExecutionId,
   fields: Partial<ExecutionMeta>,
   what: string,
@@ -212,11 +213,71 @@ export async function writeTerminalStatus(
   status: string,
 ): Promise<void> {
   const outcome = executionStatusToRunOutcome(status);
-  await persistMetaField(
-    executionId,
-    { terminalStatus: status, ...(outcome && { outcome }) },
-    'terminal status',
-  );
+  await enqueueMetaUpdate(executionId, () => ({
+    terminalStatus: status,
+    ...(outcome && { outcome }),
+  }));
+}
+
+export interface FinalizeExecutionInput {
+  executionId: ExecutionId;
+  terminalStatus: string;
+  flowRecord: 'preserve' | 'delete';
+}
+
+export type FinalizeExecutionResult =
+  | {
+      status: 'durable';
+      terminalStatusPersisted: true;
+      flowRecord: 'preserved' | 'deleted';
+    }
+  | {
+      status: 'failed';
+      error: unknown;
+      stage: 'terminal-status' | 'flow-record-delete';
+      terminalStatusPersisted: boolean;
+    };
+
+/** Persist terminal metadata, then apply the requested flow-record policy. */
+export async function finalizeExecution({
+  executionId,
+  terminalStatus,
+  flowRecord,
+}: FinalizeExecutionInput): Promise<FinalizeExecutionResult> {
+  try {
+    await writeTerminalStatus(executionId, terminalStatus);
+  } catch (error) {
+    return {
+      status: 'failed',
+      error,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    };
+  }
+
+  if (flowRecord === 'preserve') {
+    return {
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'preserved',
+    };
+  }
+
+  try {
+    await getExecutionStore(executionId).delete(flowKey(executionId));
+    return {
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      error,
+      stage: 'flow-record-delete',
+      terminalStatusPersisted: true,
+    };
+  }
 }
 
 /** Persist an AI-generated session description on an existing execution's metadata. */
@@ -224,7 +285,11 @@ export async function writeSessionDescription(
   executionId: ExecutionId,
   description: string,
 ): Promise<void> {
-  await persistMetaField(executionId, { description }, 'session description');
+  await persistSupplementaryMetaFieldsBestEffort(
+    executionId,
+    { description },
+    'session description',
+  );
 }
 
 /**
@@ -237,5 +302,9 @@ export async function writeExecutionStreamId(
   executionId: ExecutionId,
   streamId: StreamTabId,
 ): Promise<void> {
-  await persistMetaField(executionId, { streamId }, 'execution stream id');
+  await persistSupplementaryMetaFieldsBestEffort(
+    executionId,
+    { streamId },
+    'execution stream id',
+  );
 }

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -25,8 +25,11 @@ export {
   resolveExecutionWorkspaceFilePath,
 } from './executionWorkspaceFiles';
 export {
+  finalizeExecution,
   registerExecution,
   synchronizeAgentResultOutcome,
+  type FinalizeExecutionInput,
+  type FinalizeExecutionResult,
   writeTerminalStatus,
   writeSessionDescription,
 } from './executionLifecycle';

--- a/src/controllers/progressView/backend/restartRepair.ts
+++ b/src/controllers/progressView/backend/restartRepair.ts
@@ -1,6 +1,8 @@
 import {
+  finalizeExecution as defaultFinalizeExecution,
   synchronizeAgentResultOutcome as defaultSynchronizeResultOutcome,
-  writeTerminalStatus as defaultWriteTerminalStatus,
+  type FinalizeExecutionInput,
+  type FinalizeExecutionResult,
 } from '@agent/storage/executionLifecycle';
 import type {
   StreamStatusEmitOptions,
@@ -37,10 +39,9 @@ export interface RestartRepairOptions {
   /** Retry terminal metadata after an earlier repair already moved a stream to FAILED. */
   retryFailedStreams?: boolean;
   statusEmitOptions?: StreamStatusEmitOptions;
-  writeTerminalStatus?: (
-    executionId: ExecutionId,
-    status: string,
-  ) => Promise<void>;
+  finalizeExecution?: (
+    input: FinalizeExecutionInput,
+  ) => Promise<FinalizeExecutionResult>;
   /** Align the latest persisted envelope after terminal metadata is durable. */
   synchronizeResultOutcome?: (
     executionId: ExecutionId,
@@ -109,10 +110,9 @@ function transitionToFailedForRestart(
 async function writeFailedTerminalStatuses(
   streamIds: readonly StreamTabId[],
   executionIds: ReadonlyMap<StreamTabId, ExecutionId>,
-  writeTerminalStatus: (
-    executionId: ExecutionId,
-    status: string,
-  ) => Promise<void>,
+  finalizeExecution: (
+    input: FinalizeExecutionInput,
+  ) => Promise<FinalizeExecutionResult>,
   synchronizeResultOutcome: (
     executionId: ExecutionId,
     outcome: RunOutcome,
@@ -125,7 +125,13 @@ async function writeFailedTerminalStatuses(
     return executionId ? [{ streamId, executionId }] : [];
   });
   const results = await Promise.allSettled(
-    writes.map(({ executionId }) => writeTerminalStatus(executionId, status)),
+    writes.map(({ executionId }) =>
+      finalizeExecution({
+        executionId,
+        terminalStatus: status,
+        flowRecord: 'delete',
+      }),
+    ),
   );
 
   const updated: ExecutionId[] = [];
@@ -136,11 +142,25 @@ async function writeFailedTerminalStatuses(
   for (const [index, result] of results.entries()) {
     const { streamId, executionId } = writes[index];
     if (result.status === 'fulfilled') {
-      updated.push(executionId);
-      synchronizationWrites.push({ streamId, executionId });
+      const finalization = result.value;
+      if (finalization.status === 'failed') {
+        logger?.warn('Failed to finalize restart-repair execution', {
+          data: {
+            streamId,
+            executionId,
+            stage: finalization.stage,
+            terminalStatusPersisted: finalization.terminalStatusPersisted,
+            error: finalization.error,
+          },
+        });
+      }
+      if (finalization.terminalStatusPersisted) {
+        updated.push(executionId);
+        synchronizationWrites.push({ streamId, executionId });
+      }
       continue;
     }
-    logger?.warn('Failed to persist restart-repair terminal status', {
+    logger?.warn('Restart-repair finalization rejected unexpectedly', {
       data: { streamId, executionId, error: result.reason },
     });
   }
@@ -289,7 +309,7 @@ export async function repairRestartedStreams(
   const terminalStatusUpdated = await writeFailedTerminalStatuses(
     failedStreams,
     options.executionIds,
-    options.writeTerminalStatus ?? defaultWriteTerminalStatus,
+    options.finalizeExecution ?? defaultFinalizeExecution,
     options.synchronizeResultOutcome ?? defaultSynchronizeResultOutcome,
     options.logger,
   );

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { flowKey } from '@agent/node/persistedFlow';
 import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
@@ -12,6 +13,7 @@ import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 const mocks = vi.hoisted(() => ({
   getExecutionStore: vi.fn(),
+  delete: vi.fn(),
   readMeta: vi.fn(),
   readResultMeta: vi.fn(),
   writeConfig: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock('@agent/storage/executionListing', () => ({
 }));
 
 import {
+  finalizeExecution,
   registerExecution,
   synchronizeAgentResultOutcome,
   writeTerminalStatus,
@@ -55,6 +58,7 @@ describe('execution lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getExecutionStore.mockReturnValue({
+      delete: mocks.delete,
       readMeta: mocks.readMeta,
       readResultMeta: mocks.readResultMeta,
       writeConfig: mocks.writeConfig,
@@ -63,6 +67,7 @@ describe('execution lifecycle', () => {
     });
     mocks.readMeta.mockResolvedValue(null);
     mocks.readResultMeta.mockResolvedValue(null);
+    mocks.delete.mockResolvedValue(undefined);
     mocks.writeConfig.mockResolvedValue(undefined);
     mocks.writeMeta.mockResolvedValue(undefined);
     mocks.writeResultMeta.mockResolvedValue(undefined);
@@ -177,7 +182,7 @@ describe('execution lifecycle', () => {
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
   });
 
-  it('does not change the result outcome when terminal metadata cannot be written', async () => {
+  it('rejects when terminal metadata cannot be written', async () => {
     mocks.readMeta.mockResolvedValue({
       schemaVersion: 1,
       timestamp: '2026-07-10T00:00:00.000Z',
@@ -199,11 +204,104 @@ describe('execution lifecycle', () => {
     mocks.writeMeta.mockRejectedValueOnce(new Error('disk full'));
 
     const executionId = 'failed-terminal-write' as ExecutionId;
-    await writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED);
-    await synchronizeAgentResultOutcome(executionId, RUN_OUTCOME.CANCELLED);
+    await expect(
+      writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED),
+    ).rejects.toThrow('disk full');
 
     expect(mocks.readResultMeta).not.toHaveBeenCalled();
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
+  });
+
+  it('finalizes durably while preserving the flow record', async () => {
+    const executionId = 'preserved-flow' as ExecutionId;
+    mocks.readMeta.mockResolvedValue({
+      schemaVersion: 1,
+      timestamp: '2026-07-10T00:00:00.000Z',
+    });
+
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
+
+    expect(result).toEqual({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'preserved',
+    });
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('finalizes durably after deleting the flow record', async () => {
+    const executionId = 'deleted-flow' as ExecutionId;
+    mocks.readMeta.mockResolvedValue({
+      schemaVersion: 1,
+      timestamp: '2026-07-10T00:00:00.000Z',
+    });
+
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+      flowRecord: 'delete',
+    });
+
+    expect(result).toEqual({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
+  });
+
+  it('does not delete the flow record when terminal metadata fails', async () => {
+    const executionId = 'metadata-failed-flow' as ExecutionId;
+    const error = new Error('metadata disk full');
+    mocks.readMeta.mockRejectedValueOnce(error);
+
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      error,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+    expect(mocks.delete).not.toHaveBeenCalled();
+  });
+
+  it('reports durable terminal metadata when flow deletion fails', async () => {
+    const executionId = 'flow-delete-failed' as ExecutionId;
+    const error = new Error('flow delete failed');
+    mocks.readMeta.mockResolvedValue({
+      schemaVersion: 1,
+      timestamp: '2026-07-10T00:00:00.000Z',
+    });
+    mocks.delete.mockRejectedValueOnce(error);
+
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      error,
+      stage: 'flow-record-delete',
+      terminalStatusPersisted: true,
+    });
+    expect(mocks.writeMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalStatus: EXECUTION_STATUS.ERROR,
+        outcome: RUN_OUTCOME.FAILED,
+      }),
+    );
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
   });
 
   it('warns when the persisted result outcome cannot be reconciled', async () => {

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -254,7 +254,7 @@ describe('execution lifecycle', () => {
     expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
   });
 
-  it('does not delete the flow record when terminal metadata fails', async () => {
+  it('deletes the flow record when failed terminal metadata cannot persist', async () => {
     const executionId = 'metadata-failed-flow' as ExecutionId;
     const error = new Error('metadata disk full');
     mocks.readMeta.mockRejectedValueOnce(error);
@@ -271,7 +271,27 @@ describe('execution lifecycle', () => {
       stage: 'terminal-status',
       terminalStatusPersisted: false,
     });
-    expect(mocks.delete).not.toHaveBeenCalled();
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
+  });
+
+  it('reports when terminal metadata and fail-closed flow deletion both fail', async () => {
+    const executionId = 'metadata-and-flow-failed' as ExecutionId;
+    mocks.readMeta.mockRejectedValueOnce(new Error('metadata disk full'));
+    mocks.delete.mockRejectedValueOnce(new Error('flow delete failed'));
+
+    const result = await finalizeExecution({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'preserve',
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      stage: 'terminal-status-and-flow-record-delete',
+      terminalStatusPersisted: false,
+      error: expect.any(AggregateError),
+    });
+    expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
   });
 
   it('reports durable terminal metadata when flow deletion fails', async () => {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -119,6 +119,9 @@ async function runPersistedFlow(
   options: {
     readonly isSubagent?: boolean;
     readonly onIdle?: () => void;
+    readonly onFlowRecordDisposition?: (
+      disposition: 'preserve' | 'delete',
+    ) => void;
   } = {},
 ): Promise<RunToolUseFlowResult> {
   const config = snapshot?.agentConfig ?? CONFIG;
@@ -158,6 +161,7 @@ async function runPersistedFlow(
           ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
           isSubagent: options.isSubagent ?? true,
           onIdle: options.onIdle,
+          onFlowRecordDisposition: options.onFlowRecordDisposition,
           toolInjections: new ToolInjectionRegistry(),
         },
         new MapToolRegistry({}),
@@ -716,6 +720,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const readSpy = vi.spyOn(store, 'read');
     const deleteSpy = vi.spyOn(store, 'delete');
     const releaseSpy = vi.spyOn(session.followUps, 'release');
+    const dispositions: Array<'preserve' | 'delete'> = [];
 
     try {
       const result = await runPersistedFlow(
@@ -724,11 +729,13 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         undefined,
         (flowContext) => flowContext.interrupt(),
         session,
+        { onFlowRecordDisposition: (value) => dispositions.push(value) },
       );
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(readSpy).not.toHaveBeenCalled();
-      expect(deleteSpy).toHaveBeenCalledWith(flowKey(executionId));
+      expect(deleteSpy).not.toHaveBeenCalledWith(flowKey(executionId));
+      expect(dispositions).toEqual(['delete']);
       expect(releaseSpy).toHaveBeenCalledWith(streamId);
     } finally {
       readSpy.mockRestore();
@@ -841,14 +848,23 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         throw abortError;
       });
     const deleteSpy = vi.spyOn(store, 'delete');
+    const dispositions: Array<'preserve' | 'delete'> = [];
 
     try {
       await expect(
-        runPersistedFlow(executionId, streamId, snapshot, (context) => {
-          flowContext = context;
-        }),
+        runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          (context) => {
+            flowContext = context;
+          },
+          undefined,
+          { onFlowRecordDisposition: (value) => dispositions.push(value) },
+        ),
       ).rejects.toBe(abortError);
       expect(deleteSpy).not.toHaveBeenCalledWith(flowKey(executionId));
+      expect(dispositions).toEqual(['preserve']);
       expect(await store.read<FlowRecord>(flowKey(executionId))).toMatchObject({
         cursor: { nextNodeId: 'start' },
         shared: { shouldSkipCycle: true },

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -12,6 +12,7 @@ import {
 } from '@test/helpers/streamStatusTestUtils';
 import { platform } from '@platform/platform';
 import { installPlatform } from '@test/support/setupPlatform';
+import type { FinalizeExecutionResult } from '@agent/storage';
 import { noopTrace, TraceEmitter } from '@agent/trace';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import {
@@ -50,16 +51,37 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createRecordingHost, recordSessionEvents } from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
-  writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
+  finalizeExecution: vi.fn(
+    async (input: {
+      flowRecord: 'preserve' | 'delete';
+    }): Promise<FinalizeExecutionResult> => ({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: input.flowRecord === 'delete' ? 'deleted' : 'preserved',
+    }),
+  ),
   synchronizeAgentResultOutcome: vi.fn().mockResolvedValue(undefined),
-  deleteFlowRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+const channelTraceMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
-  writeTerminalStatus: storageMocks.writeTerminalStatus,
+  finalizeExecution: storageMocks.finalizeExecution,
   synchronizeAgentResultOutcome: storageMocks.synchronizeAgentResultOutcome,
-  getExecutionStore: () => ({ delete: storageMocks.deleteFlowRecord }),
 }));
+
+vi.mock('@agent/trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/trace')>();
+  return {
+    ...actual,
+    createChannelTrace: vi.fn(() => ({
+      ...actual.noopTrace,
+      warn: channelTraceMocks.warn,
+    })),
+  };
+});
 
 async function initLifecycleTestPlatform(firstRunDone: boolean) {
   await installPlatform({
@@ -425,7 +447,7 @@ describe('runFlowWithLifecycle', () => {
       'lifecycle-subagent-waiting',
     );
     const onError = vi.fn();
-    storageMocks.writeTerminalStatus.mockClear();
+    storageMocks.finalizeExecution.mockClear();
 
     try {
       const result = await runFlowWithLifecycle(
@@ -446,7 +468,7 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      expect(storageMocks.writeTerminalStatus).not.toHaveBeenCalled();
+      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
       expect(onError).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
       expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
@@ -546,7 +568,7 @@ describe('runFlowWithLifecycle', () => {
       ctx.runScope.session.transcripts,
       'update',
     );
-    storageMocks.deleteFlowRecord.mockClear();
+    storageMocks.finalizeExecution.mockClear();
 
     try {
       const result = await runFlowWithLifecycle(
@@ -563,7 +585,7 @@ describe('runFlowWithLifecycle', () => {
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
       expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
       expect(followUpsRelease).not.toHaveBeenCalled();
-      expect(storageMocks.deleteFlowRecord).not.toHaveBeenCalled();
+      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
       // The fixture's ctx.logger is noopTrace, and the run handle carries it
       // as its trace channel.
       const traceEmit = vi.spyOn(noopTrace, 'emit');
@@ -609,9 +631,11 @@ describe('runFlowWithLifecycle', () => {
         STREAM_PHASE.CANCELLED,
       );
       expect(followUpsRelease).toHaveBeenCalledWith(streamId);
-      expect(storageMocks.deleteFlowRecord).toHaveBeenCalledWith(
-        `flow_${executionId}`,
-      );
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
+        executionId,
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        flowRecord: 'delete',
+      });
       // The kill path never resumes, so the per-suspension parent stage must
       // be closed here rather than dangling open forever. `ctx.parentStage`
       // is already desubscribed by this point (disposeTrace ran in the
@@ -668,7 +692,7 @@ describe('runFlowWithLifecycle', () => {
         `outcome-${expected.outcome}`,
       );
       const stageEnd = vi.spyOn(ctx.parentStage, 'end');
-      storageMocks.writeTerminalStatus.mockClear();
+      storageMocks.finalizeExecution.mockClear();
 
       try {
         const result = await runFlowWithLifecycle(ctx, async () => ({
@@ -679,10 +703,12 @@ describe('runFlowWithLifecycle', () => {
         }));
 
         expect(result.outcome).toBe(expected.outcome);
-        expect(storageMocks.writeTerminalStatus).toHaveBeenCalledWith(
+        expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
           executionId,
-          expected.terminal,
-        );
+          terminalStatus: expected.terminal,
+          flowRecord:
+            expected.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve',
+        });
         // The stage closes with the literal outcome — no
         // legacyEndGroupStatusForOutcome fold at this production call site.
         expect(stageEnd).toHaveBeenCalledWith(expected.outcome);
@@ -698,7 +724,7 @@ describe('runFlowWithLifecycle', () => {
       'outcome-thrown-abort',
     );
     const stageEnd = vi.spyOn(ctx.parentStage, 'end');
-    storageMocks.writeTerminalStatus.mockClear();
+    storageMocks.finalizeExecution.mockClear();
 
     try {
       const result = await runFlowWithLifecycle(ctx, async () => {
@@ -706,10 +732,11 @@ describe('runFlowWithLifecycle', () => {
       });
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(storageMocks.writeTerminalStatus).toHaveBeenCalledWith(
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
         executionId,
-        EXECUTION_STATUS.INTERRUPTED,
-      );
+        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        flowRecord: 'preserve',
+      });
       expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.CANCELLED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
@@ -722,7 +749,7 @@ describe('runFlowWithLifecycle', () => {
       'outcome-thrown-error',
     );
     const stageEnd = vi.spyOn(ctx.parentStage, 'end');
-    storageMocks.writeTerminalStatus.mockClear();
+    storageMocks.finalizeExecution.mockClear();
 
     try {
       await expect(
@@ -731,10 +758,11 @@ describe('runFlowWithLifecycle', () => {
         }),
       ).rejects.toThrow('model exploded');
 
-      expect(storageMocks.writeTerminalStatus).toHaveBeenCalledWith(
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
         executionId,
-        EXECUTION_STATUS.ERROR,
-      );
+        terminalStatus: EXECUTION_STATUS.ERROR,
+        flowRecord: 'preserve',
+      });
       expect(stageEnd).toHaveBeenCalledWith(RUN_OUTCOME.FAILED);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
     } finally {
@@ -821,14 +849,19 @@ describe('finalizeRunTerminal', () => {
     );
     const untrack = vi.fn();
     const traceEmit = vi.spyOn(noopTrace, 'emit');
-    storageMocks.writeTerminalStatus.mockClear();
+    storageMocks.finalizeExecution.mockClear();
     // Park the first caller at its persist await so the second caller arrives
     // while the first has not yet emitted or settled anything.
     let releasePersist: (() => void) | undefined;
-    storageMocks.writeTerminalStatus.mockImplementationOnce(
+    storageMocks.finalizeExecution.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          releasePersist = resolve;
+        new Promise((resolve) => {
+          releasePersist = () =>
+            resolve({
+              status: 'durable' as const,
+              terminalStatusPersisted: true as const,
+              flowRecord: 'deleted' as const,
+            });
         }),
     );
 
@@ -841,8 +874,8 @@ describe('finalizeRunTerminal', () => {
         outcome: RUN_OUTCOME.COMPLETED,
         isSubagent: false,
         trace: noopTrace,
-        persistTerminalStatus: true,
-      };
+        persistence: { kind: 'finalize', flowRecord: 'delete' },
+      } as const;
 
       const first = finalizeRunTerminal(params);
       const second = finalizeRunTerminal(params);
@@ -859,7 +892,7 @@ describe('finalizeRunTerminal', () => {
         executionId,
         streamId,
       });
-      expect(storageMocks.writeTerminalStatus).toHaveBeenCalledTimes(1);
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledTimes(1);
       // The stream-status transition also emits on the trace; the terminal
       // `result` event itself must be published exactly once.
       expect(
@@ -872,6 +905,67 @@ describe('finalizeRunTerminal', () => {
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     } finally {
       traceEmit.mockRestore();
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('settles and untracks once while reporting terminal metadata failure', async () => {
+    const executionId = 'exec-finalize-metadata-failure';
+    const streamId = 'stream-finalize-metadata-failure' as StreamTabId;
+    const streamStatus = new StreamStatusMachine();
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      streamId,
+      'test-agent',
+      'toolUse',
+      createRecordingHost().host,
+      noopTrace,
+    );
+    const untrack = vi.fn();
+    const durabilityError = new Error('metadata disk write failed');
+    storageMocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+      error: durabilityError,
+    });
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
+
+      const event = await finalizeRunTerminal({
+        handle,
+        executions: { untrack },
+        streamStatus,
+        outcome: RUN_OUTCOME.FAILED,
+        isSubagent: false,
+        trace: noopTrace,
+        persistence: { kind: 'finalize', flowRecord: 'preserve' },
+      });
+
+      expect(event).toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+        executionId,
+      });
+      await expect(handle.result).resolves.toBe(event);
+      expect(untrack).toHaveBeenCalledExactlyOnceWith(executionId);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+      expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
+        'Failed to finalize durable execution state',
+        {
+          data: {
+            agentIdentifier: 'test-agent',
+            executionId,
+            stage: 'terminal-status',
+            terminalStatusPersisted: false,
+            error: durabilityError,
+          },
+        },
+      );
+    } finally {
       clearStreamStatusForTest(streamStatus, streamId);
     }
   });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -887,10 +887,13 @@ describe('finalizeRunTerminal', () => {
       const event = await first;
 
       expect(event).toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.COMPLETED,
-        executionId,
-        streamId,
+        terminalStatusPersisted: true,
+        event: {
+          type: 'result',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        },
       });
       expect(storageMocks.finalizeExecution).toHaveBeenCalledTimes(1);
       // The stream-status transition also emits on the trace; the terminal
@@ -901,7 +904,7 @@ describe('finalizeRunTerminal', () => {
         ),
       ).toHaveLength(1);
       expect(untrack).toHaveBeenCalledTimes(1);
-      await expect(handle.result).resolves.toBe(event);
+      await expect(handle.result).resolves.toBe(event?.event);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     } finally {
       traceEmit.mockRestore();
@@ -946,11 +949,14 @@ describe('finalizeRunTerminal', () => {
       });
 
       expect(event).toMatchObject({
-        type: 'result',
-        outcome: RUN_OUTCOME.FAILED,
-        executionId,
+        terminalStatusPersisted: false,
+        event: {
+          type: 'result',
+          outcome: RUN_OUTCOME.FAILED,
+          executionId,
+        },
       });
-      await expect(handle.result).resolves.toBe(event);
+      await expect(handle.result).resolves.toBe(event?.event);
       expect(untrack).toHaveBeenCalledExactlyOnceWith(executionId);
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
       expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -242,6 +242,39 @@ describe('runFlowWithLifecycle', () => {
     });
   }
 
+  it('persists terminal state before updating onboarding state', async () => {
+    const fake = await initLifecycleTestPlatform(false);
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'terminal-before-onboarding',
+      'assistant',
+    );
+    const updateOnboarding = vi.spyOn(fake.globalState, 'update');
+    storageMocks.finalizeExecution.mockClear();
+
+    try {
+      await runFlowWithLifecycle(ctx, async () => ({
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.COMPLETED,
+        executionId,
+        streamId,
+      }));
+
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledOnce();
+      expect(updateOnboarding).toHaveBeenCalledWith(
+        GlobalStateKey.ONBOARDING_FIRST_RUN_DONE,
+        true,
+      );
+      expect(
+        storageMocks.finalizeExecution.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        updateOnboarding.mock.invocationCallOrder[0] ??
+          Number.POSITIVE_INFINITY,
+      );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
   it('finalizes the status machine owned by the run session', async () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'lifecycle-status-owner',

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -13,10 +13,18 @@ import pDefer, { type DeferredPromise } from 'p-defer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  finalizeExecution: vi.fn(),
+  synchronizeAgentResultOutcome: vi.fn(),
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
   enqueueChildRunFollowUp: vi.fn(),
   wakeChildRunFollowUp: vi.fn(),
+}));
+
+vi.mock('@agent/storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage')>()),
+  finalizeExecution: mocks.finalizeExecution,
+  synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
@@ -141,6 +149,12 @@ function createFakeStrategy(): FakeStrategyHandle {
 beforeEach(() => {
   session = defaultSession();
   vi.clearAllMocks();
+  mocks.finalizeExecution.mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  });
+  mocks.synchronizeAgentResultOutcome.mockResolvedValue(undefined);
   mocks.persistChildRunReport.mockImplementation(async (_id, msg: string) => {
     return { kind: 'persisted' as const, msg };
   });
@@ -360,7 +374,7 @@ describe('childRunLoop E2E fixtures', () => {
     expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1);
   });
 
-  it('stop between turns (native, no ChildStream) settles and untracks the dangling handle — no ghost subagent', async () => {
+  it('stop between turns settles without result sync when terminal metadata fails', async () => {
     // Regression: for a native strategy (no ChildStream — each turn owns its
     // own AgentExecutionHandle via runFlowWithLifecycle, not the loop), a
     // stop landing BETWEEN turns interrupts the loop through the run handle
@@ -374,6 +388,12 @@ describe('childRunLoop E2E fixtures', () => {
     const parentStreamId = 'parent' as StreamTabId;
     const executionId = 'exec-ghost-handle-stop' as ExecutionId;
     const { strategy, resolveTurn } = createFakeStrategy();
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: new Error('metadata disk full'),
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
 
     startChildRunLoop({
       childStreamId,
@@ -422,6 +442,7 @@ describe('childRunLoop E2E fixtures', () => {
     // Untracked: no longer resumable — a later delegate_agent(execution_id=…)
     // would correctly report "not found" instead of finding a ghost handle.
     expect(session.executions.getHandle(executionId)).toBeUndefined();
+    expect(mocks.synchronizeAgentResultOutcome).not.toHaveBeenCalled();
   });
 
   it('reattaches the loop interrupt handler immediately when a turn settles, before delivery (Copilot review: no interrupt gap during delivery)', async () => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -34,6 +34,39 @@ import {
   sessionFactPayloads,
 } from '../progressTestUtils';
 
+const storageMocks = vi.hoisted(() => ({
+  finalizeExecution: vi.fn(),
+  synchronizeAgentResultOutcome: vi.fn(),
+}));
+
+const channelTraceMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock('@agent/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/storage')>();
+  storageMocks.finalizeExecution.mockImplementation(actual.finalizeExecution);
+  storageMocks.synchronizeAgentResultOutcome.mockImplementation(
+    actual.synchronizeAgentResultOutcome,
+  );
+  return {
+    ...actual,
+    finalizeExecution: storageMocks.finalizeExecution,
+    synchronizeAgentResultOutcome: storageMocks.synchronizeAgentResultOutcome,
+  };
+});
+
+vi.mock('@agent/trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/trace')>();
+  return {
+    ...actual,
+    createChannelTrace: vi.fn(() => ({
+      ...actual.noopTrace,
+      warn: channelTraceMocks.warn,
+    })),
+  };
+});
+
 setupPlatform({ workspacePath: '/workspace' });
 
 describe('executionRegistry', () => {
@@ -333,6 +366,127 @@ describe('executionRegistry', () => {
         outcome: RUN_OUTCOME.CANCELLED,
         executionId,
       });
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('settles and untracks a waiting handle when terminal metadata persistence fails', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const executionId = 'exec-waiting-kill-metadata-failure' as ExecutionId;
+    const parentStreamId =
+      'parent-waiting-kill-metadata-failure' as StreamTabId;
+    const childStreamId = 'child-waiting-kill-metadata-failure' as StreamTabId;
+    const durabilityError = new Error('metadata disk write failed');
+    storageMocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+      error: durabilityError,
+    });
+    storageMocks.synchronizeAgentResultOutcome.mockClear();
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(() => {});
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      await expect(handle.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+        executionId,
+      });
+      expect(registry.getHandle(executionId)).toBeUndefined();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
+      await vi.waitFor(() => {
+        expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
+          'Failed to finalize stopped waiting execution',
+          {
+            data: {
+              executionId,
+              stage: 'terminal-status',
+              terminalStatusPersisted: false,
+              error: durabilityError,
+            },
+          },
+        );
+      });
+      expect(storageMocks.synchronizeAgentResultOutcome).not.toHaveBeenCalled();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('synchronizes a waiting stop when only flow-record deletion fails', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const executionId = 'exec-waiting-kill-flow-delete-failure' as ExecutionId;
+    const parentStreamId =
+      'parent-waiting-kill-flow-delete-failure' as StreamTabId;
+    const childStreamId =
+      'child-waiting-kill-flow-delete-failure' as StreamTabId;
+    const cleanupError = new Error('flow delete failed');
+    storageMocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      stage: 'flow-record-delete',
+      terminalStatusPersisted: true,
+      error: cleanupError,
+    });
+    storageMocks.synchronizeAgentResultOutcome.mockResolvedValueOnce(undefined);
+    storageMocks.synchronizeAgentResultOutcome.mockClear();
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      const handle = new AgentExecutionHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        'test-subagent',
+        'toolUse',
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(() => {});
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(
+          storageMocks.synchronizeAgentResultOutcome,
+        ).toHaveBeenCalledExactlyOnceWith(executionId, RUN_OUTCOME.CANCELLED);
+      });
+      expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
+        'Failed to finalize stopped waiting execution',
+        {
+          data: {
+            executionId,
+            stage: 'flow-record-delete',
+            terminalStatusPersisted: true,
+            error: cleanupError,
+          },
+        },
+      );
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -40,11 +40,15 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createRecordingHost } from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
-  writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
+  finalizeExecution: vi.fn().mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  }),
 }));
 
 vi.mock('@agent/storage', () => ({
-  writeTerminalStatus: storageMocks.writeTerminalStatus,
+  finalizeExecution: storageMocks.finalizeExecution,
 }));
 
 function initTestPlatform(): Promise<void> {

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -38,11 +38,15 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createRecordingHost } from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
-  writeTerminalStatus: vi.fn().mockResolvedValue(undefined),
+  finalizeExecution: vi.fn().mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  }),
 }));
 
 vi.mock('@agent/storage', () => ({
-  writeTerminalStatus: storageMocks.writeTerminalStatus,
+  finalizeExecution: storageMocks.finalizeExecution,
 }));
 
 let counter = 0;

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -5,6 +5,7 @@ import {
   clearStoreCache,
   deriveResumability,
   EXECUTION_META_SCHEMA_VERSION,
+  finalizeExecution,
   getExecutionStore,
   RESUMABILITY_CAUSE,
 } from '@agent/storage';
@@ -83,6 +84,34 @@ describe('deriveResumability', () => {
     const executionId = 'failed-with-flow' as ExecutionId;
     await writeTerminalStatus(executionId, EXECUTION_STATUS.ERROR);
     await writeFlow(executionId);
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.TERMINAL_FAILED,
+      terminalStatus: EXECUTION_STATUS.ERROR,
+    });
+  });
+
+  it('stays non-resumable when terminal metadata persists but flow deletion fails', async () => {
+    const executionId = 'failed-finalization-with-flow' as ExecutionId;
+    await writeMeta(executionId, {});
+    await writeFlow(executionId);
+    const store = getExecutionStore(executionId);
+    vi.spyOn(store, 'delete').mockRejectedValueOnce(
+      new Error('flow delete failed'),
+    );
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        terminalStatus: EXECUTION_STATUS.ERROR,
+        flowRecord: 'delete',
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      stage: 'flow-record-delete',
+      terminalStatusPersisted: true,
+    });
 
     await expect(deriveResumability(executionId)).resolves.toMatchObject({
       resumable: false,

--- a/src/test-kernel/agent/storage/Resumability.vitest.ts
+++ b/src/test-kernel/agent/storage/Resumability.vitest.ts
@@ -120,6 +120,33 @@ describe('deriveResumability', () => {
     });
   });
 
+  it('fails closed when terminal metadata fails for a failed execution', async () => {
+    const executionId = 'failed-terminal-metadata-with-flow' as ExecutionId;
+    await writeMeta(executionId, {});
+    await writeFlow(executionId);
+    const store = getExecutionStore(executionId);
+    vi.spyOn(store, 'writeMeta').mockRejectedValueOnce(
+      new Error('metadata disk full'),
+    );
+
+    await expect(
+      finalizeExecution({
+        executionId,
+        terminalStatus: EXECUTION_STATUS.ERROR,
+        flowRecord: 'preserve',
+      }),
+    ).resolves.toMatchObject({
+      status: 'failed',
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    await expect(deriveResumability(executionId)).resolves.toMatchObject({
+      resumable: false,
+      cause: RESUMABILITY_CAUSE.MISSING_FLOW,
+    });
+  });
+
   it('marks interrupted executions with a valid flow record as resumable', async () => {
     const executionId = 'interrupted-with-flow' as ExecutionId;
     await writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED);

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -26,7 +26,11 @@ vi.mock('@agent/index', () => ({
 }));
 
 vi.mock('@agent/storage', () => ({
-  writeTerminalStatus: vi.fn(),
+  finalizeExecution: vi.fn().mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  }),
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -39,7 +39,11 @@ vi.mock('@agent/index', () => ({
 }));
 
 vi.mock('@agent/storage', () => ({
-  writeTerminalStatus: vi.fn(),
+  finalizeExecution: vi.fn().mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  }),
 }));
 
 vi.mock('@cli/runtime/initPlatform', () => ({

--- a/src/test-kernel/cli/RunChatRegistration.vitest.mts
+++ b/src/test-kernel/cli/RunChatRegistration.vitest.mts
@@ -9,8 +9,8 @@ import {
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
+  finalizeExecution: vi.fn(),
   registerExecution: vi.fn(),
-  writeTerminalStatus: vi.fn(),
 }));
 
 vi.mock('@agent/storage', async () => {
@@ -18,16 +18,20 @@ vi.mock('@agent/storage', async () => {
     await vi.importActual<typeof import('@agent/storage')>('@agent/storage');
   return {
     ...actual,
+    finalizeExecution: mocks.finalizeExecution,
     registerExecution: mocks.registerExecution,
-    writeTerminalStatus: mocks.writeTerminalStatus,
   };
 });
 
 describe('CLI chat execution registration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.finalizeExecution.mockResolvedValue({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
     mocks.registerExecution.mockResolvedValue(undefined);
-    mocks.writeTerminalStatus.mockResolvedValue(undefined);
   });
 
   it('registers fresh chat executions so resume/history can resolve them', async () => {
@@ -63,10 +67,11 @@ describe('CLI chat execution registration', () => {
       agentSettled: false,
     });
 
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
       executionId,
-      EXECUTION_STATUS.ERROR,
-    );
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
   });
 
   it('does not mark launch errors before registration succeeds', async () => {
@@ -77,7 +82,7 @@ describe('CLI chat execution registration', () => {
       agentSettled: false,
     });
 
-    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('does not overwrite terminal status after the agent has settled', async () => {
@@ -88,6 +93,6 @@ describe('CLI chat execution registration', () => {
       agentSettled: true,
     });
 
-    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/cli/RunChatRegistration.vitest.mts
+++ b/src/test-kernel/cli/RunChatRegistration.vitest.mts
@@ -126,4 +126,49 @@ describe('CLI chat execution registration', () => {
       }),
     );
   });
+
+  it('reports unexpected finalizer rejections without rejecting the caller', async () => {
+    const persistenceError = new Error('finalizer contract failure');
+    mocks.finalizeExecution.mockRejectedValueOnce(persistenceError);
+
+    await expect(
+      markRegisteredChatExecutionError('registered' as ExecutionId, {
+        executionRegistered: true,
+        agentSettled: false,
+        reportFinalizationFailure: mocks.reportFinalizationFailure,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.reportFinalizationFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message:
+          'Execution finalization failed unexpectedly for registered: finalizer contract failure',
+        cause: persistenceError,
+      }),
+    );
+  });
+
+  it('distinguishes flow-record cleanup failures from terminal writes', async () => {
+    const cleanupError = new Error('flow record is locked');
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: cleanupError,
+      stage: 'flow-record-delete',
+      terminalStatusPersisted: true,
+    });
+
+    await markRegisteredChatExecutionError('registered' as ExecutionId, {
+      executionRegistered: true,
+      agentSettled: false,
+      reportFinalizationFailure: mocks.reportFinalizationFailure,
+    });
+
+    expect(mocks.reportFinalizationFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message:
+          'Persisted error status for execution registered, but failed to delete its flow record: flow record is locked',
+        cause: cleanupError,
+      }),
+    );
+  });
 });

--- a/src/test-kernel/cli/RunChatRegistration.vitest.mts
+++ b/src/test-kernel/cli/RunChatRegistration.vitest.mts
@@ -65,7 +65,7 @@ describe('CLI chat execution registration', () => {
 
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: true,
-      agentSettled: false,
+      lifecycleStarted: false,
       reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
@@ -81,19 +81,19 @@ describe('CLI chat execution registration', () => {
 
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: false,
-      agentSettled: false,
+      lifecycleStarted: false,
       reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 
-  it('does not overwrite terminal status after the agent has settled', async () => {
+  it('does not overwrite terminal status after the lifecycle starts', async () => {
     const executionId = 'completed' as ExecutionId;
 
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: true,
-      agentSettled: true,
+      lifecycleStarted: true,
       reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
@@ -113,7 +113,7 @@ describe('CLI chat execution registration', () => {
     await expect(
       markRegisteredChatExecutionError(executionId, {
         executionRegistered: true,
-        agentSettled: false,
+        lifecycleStarted: false,
         reportFinalizationFailure: mocks.reportFinalizationFailure,
       }),
     ).resolves.toBeUndefined();
@@ -134,7 +134,7 @@ describe('CLI chat execution registration', () => {
     await expect(
       markRegisteredChatExecutionError('registered' as ExecutionId, {
         executionRegistered: true,
-        agentSettled: false,
+        lifecycleStarted: false,
         reportFinalizationFailure: mocks.reportFinalizationFailure,
       }),
     ).resolves.toBeUndefined();
@@ -159,7 +159,7 @@ describe('CLI chat execution registration', () => {
 
     await markRegisteredChatExecutionError('registered' as ExecutionId, {
       executionRegistered: true,
-      agentSettled: false,
+      lifecycleStarted: false,
       reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 

--- a/src/test-kernel/cli/RunChatRegistration.vitest.mts
+++ b/src/test-kernel/cli/RunChatRegistration.vitest.mts
@@ -10,6 +10,7 @@ import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   finalizeExecution: vi.fn(),
+  reportFinalizationFailure: vi.fn(),
   registerExecution: vi.fn(),
 }));
 
@@ -65,6 +66,7 @@ describe('CLI chat execution registration', () => {
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: true,
       agentSettled: false,
+      reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
     expect(mocks.finalizeExecution).toHaveBeenCalledWith({
@@ -80,6 +82,7 @@ describe('CLI chat execution registration', () => {
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: false,
       agentSettled: false,
+      reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
@@ -91,8 +94,36 @@ describe('CLI chat execution registration', () => {
     await markRegisteredChatExecutionError(executionId, {
       executionRegistered: true,
       agentSettled: true,
+      reportFinalizationFailure: mocks.reportFinalizationFailure,
     });
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+  });
+
+  it('reports finalization failures without rejecting the chat error path', async () => {
+    const executionId = 'registered' as ExecutionId;
+    const persistenceError = new Error('terminal metadata disk full');
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: persistenceError,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    await expect(
+      markRegisteredChatExecutionError(executionId, {
+        executionRegistered: true,
+        agentSettled: false,
+        reportFinalizationFailure: mocks.reportFinalizationFailure,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.reportFinalizationFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message:
+          'Failed to persist error status for execution registered: terminal metadata disk full',
+        cause: persistenceError,
+      }),
+    );
   });
 });

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -516,27 +516,16 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
-  it('surfaces a terminal-state durability failure instead of reporting a handled run error', async () => {
+  it('does not finalize a classified run failure a second time', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
-    const persistenceError = new Error('terminal metadata write failed');
     mocks.runAgent.mockRejectedValueOnce(new AgentError('provider boom'));
-    mocks.finalizeExecution.mockResolvedValueOnce({
-      status: 'failed',
-      error: persistenceError,
-      stage: 'terminal-status',
-      terminalStatusPersisted: false,
-    });
 
     await expect(
       executeCliRequest(request, cliContext(), { markErrorOnThrow: true }),
-    ).rejects.toBe(persistenceError);
+    ).resolves.toEqual({ ok: false, exitCode: CliExitCode.AgentError });
 
-    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
-      executionId: 'exec-1',
-      terminalStatus: EXECUTION_STATUS.ERROR,
-      flowRecord: 'delete',
-    });
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -577,12 +566,7 @@ describe('executeCliRequest', () => {
     });
 
     expect(result).toEqual({ ok: false, exitCode: CliExitCode.AgentError });
-    // markErrorOnThrow still records the terminal status, same as before.
-    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
-      executionId: 'exec-1',
-      terminalStatus: EXECUTION_STATUS.ERROR,
-      flowRecord: 'delete',
-    });
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -688,6 +672,44 @@ describe('executeCliRequest', () => {
       terminalStatus: EXECUTION_STATUS.INTERRUPTED,
       flowRecord: 'preserve',
     });
+  });
+
+  it('closes the runtime host when shutdown finalization fails', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const platform = createFakePlatform();
+    initPlatform(platform);
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const persistenceError = new Error('terminal metadata disk full');
+    mocks.finalizeExecution.mockResolvedValue({
+      status: 'failed',
+      error: persistenceError,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+    let resolveRun:
+      | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
+      | undefined;
+    mocks.runAgent.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRun = resolve;
+      }),
+    );
+
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await Promise.resolve();
+    await platform.lifecycle.runShutdown();
+    resolveRun?.({
+      category: 'toolUse',
+      executionId: 'exec-1',
+      outcome: 'completed',
+      streamId: 'stream-1',
+    });
+
+    await expect(run).rejects.toBe(persistenceError);
+    expect(mocks.finalizeExecution).toHaveBeenCalledTimes(2);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
   it('removes the shutdown status hook after owned executions finish', async () => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -35,7 +35,7 @@ const mocks = vi.hoisted(() => ({
   readCliRunOutcome: vi.fn(),
   runAgent: vi.fn(),
   writeTextStderr: vi.fn(),
-  writeTerminalStatus: vi.fn(),
+  finalizeExecution: vi.fn(),
 }));
 
 const tempDirs: string[] = [];
@@ -80,7 +80,7 @@ vi.mock('@agent/runtime/runAgent', () => ({
 
 vi.mock('@agent/storage', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage')>()),
-  writeTerminalStatus: mocks.writeTerminalStatus,
+  finalizeExecution: mocks.finalizeExecution,
 }));
 
 vi.mock('@cli/runtime/runtimeHost', () => ({
@@ -147,6 +147,11 @@ function stubRunExecutionDeps(): void {
     close: mocks.close,
   });
   mocks.readCliRunOutcome.mockResolvedValue('completed');
+  mocks.finalizeExecution.mockResolvedValue({
+    status: 'durable',
+    terminalStatusPersisted: true,
+    flowRecord: 'deleted',
+  });
   mocks.runAgent.mockResolvedValue({
     category: 'toolUse',
     executionId: 'exec-1',
@@ -503,10 +508,35 @@ describe('executeCliRequest', () => {
       executeCliRequest(request, cliContext(), { markErrorOnThrow: true }),
     ).rejects.toBe(error);
 
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
-      'exec-1',
-      EXECUTION_STATUS.ERROR,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a terminal-state durability failure instead of reporting a handled run error', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const request = baseRequest();
+    const persistenceError = new Error('terminal metadata write failed');
+    mocks.runAgent.mockRejectedValueOnce(new AgentError('provider boom'));
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: persistenceError,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    await expect(
+      executeCliRequest(request, cliContext(), { markErrorOnThrow: true }),
+    ).rejects.toBe(persistenceError);
+
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -529,10 +559,11 @@ describe('executeCliRequest', () => {
       }),
     ).rejects.toBe(cleanupError);
 
-    expect(mocks.writeTerminalStatus).not.toHaveBeenCalledWith(
-      'exec-1',
-      EXECUTION_STATUS.ERROR,
-    );
+    expect(mocks.finalizeExecution).not.toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -547,10 +578,11 @@ describe('executeCliRequest', () => {
 
     expect(result).toEqual({ ok: false, exitCode: CliExitCode.AgentError });
     // markErrorOnThrow still records the terminal status, same as before.
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
-      'exec-1',
-      EXECUTION_STATUS.ERROR,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
@@ -628,10 +660,11 @@ describe('executeCliRequest', () => {
     await Promise.resolve();
     await platform.lifecycle.runShutdown();
 
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
-      'exec-1',
-      EXECUTION_STATUS.INTERRUPTED,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
 
     resolveRun?.({
       category: 'toolUse',
@@ -649,11 +682,12 @@ describe('executeCliRequest', () => {
         streamId: 'stream-1',
       },
     });
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledTimes(2);
-    expect(mocks.writeTerminalStatus).toHaveBeenLastCalledWith(
-      'exec-1',
-      EXECUTION_STATUS.INTERRUPTED,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledTimes(2);
+    expect(mocks.finalizeExecution).toHaveBeenLastCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
   });
 
   it('removes the shutdown status hook after owned executions finish', async () => {
@@ -666,10 +700,10 @@ describe('executeCliRequest', () => {
     await executeCliRequest(request, cliContext(), {
       registerExecution: true,
     });
-    mocks.writeTerminalStatus.mockClear();
+    mocks.finalizeExecution.mockClear();
     await platform.lifecycle.runShutdown();
 
-    expect(mocks.writeTerminalStatus).not.toHaveBeenCalled();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 });
 
@@ -790,10 +824,11 @@ describe('executeCliConfig', () => {
     });
 
     expect(result).toMatchObject({ ok: false });
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
-      expect.any(String),
-      EXECUTION_STATUS.ERROR,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: expect.any(String),
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
     expect(mocks.writeTextStderr).toHaveBeenCalledWith('wrong category');
     expect(mocks.close).toHaveBeenCalledOnce();
   });

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -332,6 +332,30 @@ describe('executeCliRequest', () => {
     );
   });
 
+  it('reports outcome read failures without rejecting a successful run', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const readError = new Error('metadata read failed');
+    mocks.readCliRunOutcome.mockImplementationOnce(
+      async (
+        result: { readonly outcome: string },
+        reportReadFailure: (error: Error) => void,
+      ) => {
+        reportReadFailure(readError);
+        return result.outcome;
+      },
+    );
+
+    await expect(
+      executeCliRequest(baseRequest(), cliContext()),
+    ).resolves.toMatchObject({
+      ok: true,
+      result: { outcome: 'completed' },
+    });
+    expect(mocks.emit).toHaveBeenCalledWith('requestShowError', {
+      message: 'metadata read failed',
+    });
+  });
+
   it('persists headless stream sidecars from session events', async () => {
     await installStoragePlatform();
     const { executeCliRequest } = await import('@cli/runtime/runExecution');

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -26,6 +26,7 @@ import { SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES } from '@tools/setup/platform';
 
 const mocks = vi.hoisted(() => ({
   close: vi.fn(),
+  emit: vi.fn(),
   detachRunProgressRenderer: vi.fn(),
   detachSessionProgressProjection: vi.fn(),
   createHeadlessCliHostInteractions: vi.fn(),
@@ -141,7 +142,7 @@ function stubRunExecutionDeps(): void {
     dispose: mocks.disposeHostInteractions,
   });
   mocks.createCliRuntimeHost.mockReturnValue({
-    emit: vi.fn(),
+    emit: mocks.emit,
     attachRunProgressRenderer: vi.fn(() => mocks.detachRunProgressRenderer),
     prepareInteractivePrompt: mocks.prepareInteractivePrompt,
     close: mocks.close,
@@ -700,15 +701,29 @@ describe('executeCliRequest', () => {
     });
     await Promise.resolve();
     await platform.lifecycle.runShutdown();
+    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('requestShowError', {
+      message:
+        'Failed to persist interrupted status for execution exec-1: terminal metadata disk full',
+    });
     resolveRun?.({
       category: 'toolUse',
       executionId: 'exec-1',
       outcome: 'completed',
       streamId: 'stream-1',
     });
+    mocks.readCliRunOutcome.mockResolvedValueOnce('cancelled');
 
-    await expect(run).rejects.toBe(persistenceError);
+    await expect(run).resolves.toEqual({
+      ok: true,
+      result: {
+        category: 'toolUse',
+        executionId: 'exec-1',
+        outcome: 'cancelled',
+        streamId: 'stream-1',
+      },
+    });
     expect(mocks.finalizeExecution).toHaveBeenCalledTimes(2);
+    expect(mocks.emit).toHaveBeenCalledTimes(1);
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -517,6 +517,30 @@ describe('executeCliRequest', () => {
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves an unexpected run error when terminal persistence also fails', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    const error = new Error('workspace state unavailable');
+    const persistenceError = new Error('terminal metadata disk full');
+    mocks.runAgent.mockRejectedValueOnce(error);
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: persistenceError,
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    await expect(
+      executeCliRequest(baseRequest(), cliContext(), {
+        markErrorOnThrow: true,
+      }),
+    ).rejects.toBe(error);
+
+    expect(mocks.emit).toHaveBeenCalledWith('requestShowError', {
+      message:
+        'Failed to persist error status for execution exec-1: terminal metadata disk full',
+    });
+  });
+
   it('does not finalize a classified run failure a second time', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
@@ -868,5 +892,39 @@ describe('executeCliConfig', () => {
     });
     expect(mocks.writeTextStderr).toHaveBeenCalledWith('wrong category');
     expect(mocks.close).toHaveBeenCalledOnce();
+  });
+
+  it('reports category finalization failures and still returns the mismatch', async () => {
+    const { AgentCategory } =
+      await import('@agent/core/definition/AgentDataclass');
+    const { executeCliConfig } = await import('@cli/runtime/runExecution');
+    mocks.runAgent.mockResolvedValueOnce({
+      category: AgentCategory.Workflow,
+      executionId: 'exec-1',
+      outcome: 'completed',
+      outputs: [],
+      compileFailures: [],
+    });
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: new Error('terminal metadata disk full'),
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    await expect(
+      executeCliConfig(toolUseConfig(), cliContext(), {
+        expectedCategory: AgentCategory.ToolUse,
+        categoryMismatchMessage: 'wrong category',
+      }),
+    ).resolves.toEqual({ ok: false, exitCode: CliExitCode.AgentError });
+
+    expect(mocks.writeTextStderr).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(
+        /^Warning: Failed to persist error status for execution .+: terminal metadata disk full$/,
+      ),
+    );
+    expect(mocks.writeTextStderr).toHaveBeenNthCalledWith(2, 'wrong category');
   });
 });

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -544,7 +544,12 @@ describe('executeCliRequest', () => {
   it('does not finalize a classified run failure a second time', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
-    mocks.runAgent.mockRejectedValueOnce(new AgentError('provider boom'));
+    mocks.runAgent.mockImplementationOnce(
+      async (_request: unknown, options: { readonly onRun?: () => void }) => {
+        options.onRun?.();
+        throw new AgentError('provider boom');
+      },
+    );
 
     await expect(
       executeCliRequest(request, cliContext(), { markErrorOnThrow: true }),
@@ -552,6 +557,23 @@ describe('executeCliRequest', () => {
 
     expect(mocks.finalizeExecution).not.toHaveBeenCalled();
     expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('finalizes a classified launch failure before the lifecycle starts', async () => {
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    mocks.runAgent.mockRejectedValueOnce(new AgentError('model not found'));
+
+    await expect(
+      executeCliRequest(baseRequest(), cliContext(), {
+        markErrorOnThrow: true,
+      }),
+    ).resolves.toEqual({ ok: false, exitCode: CliExitCode.AgentError });
+
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
   });
 
   it('keeps a completed run terminal status when wrap cleanup fails after invoke succeeded (#7863)', async () => {
@@ -584,7 +606,12 @@ describe('executeCliRequest', () => {
   it('resolves a classified run failure to a non-zero exit code without rethrowing', async () => {
     const { executeCliRequest } = await import('@cli/runtime/runExecution');
     const request = baseRequest();
-    mocks.runAgent.mockRejectedValueOnce(new AgentError('provider boom'));
+    mocks.runAgent.mockImplementationOnce(
+      async (_request: unknown, options: { readonly onRun?: () => void }) => {
+        options.onRun?.();
+        throw new AgentError('provider boom');
+      },
+    );
 
     const result = await executeCliRequest(request, cliContext(), {
       markErrorOnThrow: true,

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -14,13 +14,13 @@ const mocks = vi.hoisted(() => {
   return {
     executeCliConfig: vi.fn(),
     emitCliResult: vi.fn(),
+    finalizeExecution: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
     isAuthenticated: vi.fn(),
     resolveCliLaunchAgent: vi.fn(),
     selectCliRunModel: vi.fn(),
     writeResultMeta: vi.fn(),
-    writeTerminalStatus: vi.fn(),
   };
 });
 
@@ -29,7 +29,7 @@ vi.mock('@agent/storage', async (importOriginal) => ({
   getExecutionStore: vi.fn(() => ({
     writeResultMeta: mocks.writeResultMeta,
   })),
-  writeTerminalStatus: mocks.writeTerminalStatus,
+  finalizeExecution: mocks.finalizeExecution,
 }));
 
 vi.mock('@agent/index', () => ({
@@ -97,6 +97,11 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
 describe('CLI workflow run command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.finalizeExecution.mockResolvedValue({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
     mocks.resolveCliLaunchAgent.mockResolvedValue({
       name: 'polish',
       category: AgentCategory.Workflow,
@@ -574,10 +579,11 @@ describe('CLI workflow run command', () => {
         cost: 0,
       },
     });
-    expect(mocks.writeTerminalStatus).toHaveBeenCalledWith(
-      'exec-copy-fail',
-      EXECUTION_STATUS.ERROR,
-    );
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-copy-fail',
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
   });
 
   it('uses the resolved terminal outcome in the persisted envelope', async () => {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -20,7 +20,9 @@ const mocks = vi.hoisted(() => {
     isAuthenticated: vi.fn(),
     resolveCliLaunchAgent: vi.fn(),
     selectCliRunModel: vi.fn(),
+    writeErrorStderr: vi.fn(),
     writeResultMeta: vi.fn(),
+    writeTextStderr: vi.fn(),
   };
 });
 
@@ -73,6 +75,11 @@ vi.mock('@cli/runtime/agents', async (importOriginal) => ({
 
 vi.mock('@cli/runtime/runExecution', () => ({
   executeCliConfig: mocks.executeCliConfig,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeErrorStderr: mocks.writeErrorStderr,
+  writeTextStderr: mocks.writeTextStderr,
 }));
 
 vi.mock('@cli/runtime/workflowInputs', () => ({
@@ -584,6 +591,55 @@ describe('CLI workflow run command', () => {
       terminalStatus: EXECUTION_STATUS.ERROR,
       flowRecord: 'delete',
     });
+  });
+
+  it('keeps a copy error primary when execution finalization also fails', async () => {
+    mocks.executeCliConfig.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-copy-fail',
+      result: {
+        category: AgentCategory.Workflow,
+        executionId: 'exec-copy-fail',
+        streamId: 'stream-copy-fail',
+        outcome: RUN_OUTCOME.COMPLETED,
+        outputs: [
+          {
+            round: 1,
+            relativePath: 'r1/paper.tex',
+            absolutePath: '/missing/run/r1/paper.tex',
+            location: 'runStorage',
+            originalPath: '/workspace/paper.tex',
+            added: null,
+            removed: null,
+          },
+        ],
+        compileFailures: [],
+      },
+    });
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: new Error('terminal metadata disk full'),
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+
+    const { runWorkflowAgent } = await import('@cli/commands/workflow');
+    await expect(
+      runWorkflowAgent(cliContext(), {
+        agent: 'polish',
+        inputFiles: ['paper.tex'],
+        contextFiles: [],
+        output: 'polished.tex',
+        instruction: '',
+      }),
+    ).resolves.toBe(CliExitCode.AgentError);
+
+    expect(mocks.writeTextStderr).toHaveBeenCalledWith(
+      'Warning: Failed to persist error status for execution exec-copy-fail: terminal metadata disk full',
+    );
+    expect(mocks.writeErrorStderr).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ code: 'ENOENT' }),
+    );
   });
 
   it('uses the resolved terminal outcome in the persisted envelope', async () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -9,6 +9,7 @@ import pDefer from 'p-defer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  finalizeExecution: vi.fn(),
   stopAgentStream: vi.fn(),
   workspaceGet: vi.fn(),
   getExecutionStore: vi.fn(),
@@ -37,9 +38,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@agent/storage', () => ({
+  finalizeExecution: mocks.finalizeExecution,
   getExecutionStore: mocks.getExecutionStore,
   registerExecution: vi.fn(),
-  writeTerminalStatus: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
@@ -378,6 +379,12 @@ describe('chatTuiCanStartRootRun', () => {
 
 describe('createChatSessionController', () => {
   beforeEach(() => {
+    mocks.finalizeExecution.mockReset();
+    mocks.finalizeExecution.mockResolvedValue({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
     mocks.stopAgentStream.mockReset();
     mocks.workspaceGet.mockReset();
     mocks.workspaceGet.mockReturnValue(false);

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -501,6 +501,35 @@ describe('createChatSessionController', () => {
     expect(session.runExitCode).toBe(CliExitCode.Success);
   });
 
+  it('does not delete a flow after the run lifecycle has taken ownership', async () => {
+    const session = makeSession();
+    mocks.executeAgent.mockImplementationOnce(
+      async (
+        _config: unknown,
+        _executionId: unknown,
+        options: { readonly onRun?: () => void },
+      ) => {
+        options.onRun?.();
+        throw new Error('recovery remains resumable');
+      },
+    );
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    ctrl.startRootRun({
+      agent: 'chat',
+      model: 'gpt54',
+      instruction: 'Continue the recoverable proof.',
+      workingDirectory: '/tmp/test',
+      agentCategory: 'toolUse',
+    });
+    await session.runPromise;
+
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+    expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledWith(
+      'recovery remains resumable',
+    );
+  });
+
   it('canStartRootRun() delegates to chatTuiCanStartRootRun(session)', () => {
     const session = makeSession();
     const ctrl = createChatSessionController(makeInit({ session }));

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -9,7 +9,9 @@ import pDefer from 'p-defer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  executeAgent: vi.fn(),
   finalizeExecution: vi.fn(),
+  registerExecution: vi.fn(),
   stopAgentStream: vi.fn(),
   workspaceGet: vi.fn(),
   getExecutionStore: vi.fn(),
@@ -40,7 +42,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', () => ({
   finalizeExecution: mocks.finalizeExecution,
   getExecutionStore: mocks.getExecutionStore,
-  registerExecution: vi.fn(),
+  registerExecution: mocks.registerExecution,
 }));
 
 vi.mock('@agent/runtime/resolveAndResumeStream', () => ({
@@ -52,7 +54,7 @@ vi.mock('@agent/runtime/resumeQueuedToolUse', () => ({
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
-  executeAgent: vi.fn(),
+  executeAgent: mocks.executeAgent,
   resumeToolUseFromSnapshot: mocks.resumeToolUseFromSnapshot,
 }));
 
@@ -379,12 +381,21 @@ describe('chatTuiCanStartRootRun', () => {
 
 describe('createChatSessionController', () => {
   beforeEach(() => {
+    mocks.executeAgent.mockReset();
+    mocks.executeAgent.mockResolvedValue({
+      category: 'toolUse',
+      executionId: 'exec-start',
+      outcome: RUN_OUTCOME.COMPLETED,
+      streamId: 'stream-start',
+    });
     mocks.finalizeExecution.mockReset();
     mocks.finalizeExecution.mockResolvedValue({
       status: 'durable',
       terminalStatusPersisted: true,
       flowRecord: 'deleted',
     });
+    mocks.registerExecution.mockReset();
+    mocks.registerExecution.mockResolvedValue(undefined);
     mocks.stopAgentStream.mockReset();
     mocks.workspaceGet.mockReset();
     mocks.workspaceGet.mockReturnValue(false);
@@ -456,6 +467,38 @@ describe('createChatSessionController', () => {
     expect(typeof ctrl.resume).toBe('function');
     expect(typeof ctrl.stop).toBe('function');
     expect(typeof ctrl.canStartRootRun).toBe('function');
+  });
+
+  it('shows durability failures without turning an intentional stop into an error', async () => {
+    const run = pDefer<never>();
+    const session = makeSession();
+    mocks.executeAgent.mockReturnValueOnce(run.promise);
+    mocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'failed',
+      error: new Error('terminal metadata disk full'),
+      stage: 'terminal-status',
+      terminalStatusPersisted: false,
+    });
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    ctrl.startRootRun({
+      agent: 'chat',
+      model: 'gpt54',
+      instruction: 'Check the draft.',
+      workingDirectory: '/tmp/test',
+      agentCategory: 'toolUse',
+    });
+    await vi.waitFor(() => expect(mocks.executeAgent).toHaveBeenCalledOnce());
+    ctrl.stop();
+    run.reject(new Error('run stopped'));
+    await session.runPromise;
+
+    expect(mocks.appendLocalErrorTranscript).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(
+        /^Failed to persist error status for execution .+: terminal metadata disk full$/,
+      ),
+    );
+    expect(session.runExitCode).toBe(CliExitCode.Success);
   });
 
   it('canStartRootRun() delegates to chatTuiCanStartRootRun(session)', () => {

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -210,19 +210,30 @@ describe('CLI terminal outcome resolution', () => {
     ).resolves.toBe(RUN_OUTCOME.CANCELLED);
   });
 
-  it('surfaces storage failures instead of masking them', async () => {
+  it('reports an outcome read failure and retains the completed run', async () => {
+    const reportReadFailure = vi.fn();
     mocks.getExecutionStore.mockReturnValue({
       readMeta: vi.fn().mockRejectedValue(new Error('metadata read failed')),
     });
 
     await expect(
-      readCliRunOutcome({
-        category: 'toolUse',
-        executionId: 'broken-storage',
-        outcome: RUN_OUTCOME.COMPLETED,
-        streamId: 'broken-storage',
-      } as Parameters<typeof readCliRunOutcome>[0]),
-    ).rejects.toThrow('metadata read failed');
+      readCliRunOutcome(
+        {
+          category: 'toolUse',
+          executionId: 'broken-storage',
+          outcome: RUN_OUTCOME.COMPLETED,
+          streamId: 'broken-storage',
+        } as Parameters<typeof readCliRunOutcome>[0],
+        reportReadFailure,
+      ),
+    ).resolves.toBe(RUN_OUTCOME.COMPLETED);
+    expect(reportReadFailure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        message:
+          'Could not verify the persisted outcome for execution broken-storage; using the current run outcome: metadata read failed',
+        cause: expect.any(Error),
+      }),
+    );
   });
 });
 

--- a/src/test-kernel/progressView/RestartRepair.vitest.ts
+++ b/src/test-kernel/progressView/RestartRepair.vitest.ts
@@ -39,6 +39,14 @@ function seedWaiting(
   );
 }
 
+function createDurableFinalizer() {
+  return vi.fn(async () => ({
+    status: 'durable' as const,
+    terminalStatusPersisted: true as const,
+    flowRecord: 'deleted' as const,
+  }));
+}
+
 describe('repairRestartedStreams', () => {
   it('repairs resumable running streams to WAITING with neutral group closure', async () => {
     const streamId = 'stream-waiting' as StreamTabId;
@@ -49,14 +57,14 @@ describe('repairRestartedStreams', () => {
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
         status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
-    const writeTerminalStatus = vi.fn();
+    const finalizeExecution = createDurableFinalizer();
 
     const result = await repairRestartedStreams({
       streamStatus,
       waitingStreams: new Set([streamId]),
       executionIds: new Map([[streamId, executionId]]),
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       now: 123,
     });
 
@@ -73,7 +81,7 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.CANCELLED,
       123,
     );
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('repairs resumable streams without an in-memory phase and closes their groups', async () => {
@@ -84,7 +92,7 @@ describe('repairRestartedStreams', () => {
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
         status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
-    const writeTerminalStatus = vi.fn();
+    const finalizeExecution = createDurableFinalizer();
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -92,7 +100,7 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       now: 234,
     });
 
@@ -103,7 +111,7 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.CANCELLED,
       234,
     );
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('closes non-waiting candidates without an in-memory phase without terminalizing them', async () => {
@@ -114,7 +122,7 @@ describe('repairRestartedStreams', () => {
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
         status === RUN_OUTCOME.FAILED ? [...streamIds] : [],
     );
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -122,7 +130,7 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       now: 345,
     });
 
@@ -139,7 +147,7 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.FAILED,
       345,
     );
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('closes waiting groups even when the current phase is not repairable', async () => {
@@ -156,7 +164,7 @@ describe('repairRestartedStreams', () => {
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
         status === RUN_OUTCOME.CANCELLED ? [...streamIds] : [],
     );
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -164,7 +172,7 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       now: 456,
     });
 
@@ -181,7 +189,7 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.CANCELLED,
       456,
     );
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('repairs non-resumable running streams to FAILED and writes terminal meta', async () => {
@@ -193,7 +201,7 @@ describe('repairRestartedStreams', () => {
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
         status === RUN_OUTCOME.FAILED ? [...streamIds] : [],
     );
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
     const synchronizeResultOutcome = vi.fn(async () => undefined);
 
     const result = await repairRestartedStreams({
@@ -201,7 +209,7 @@ describe('repairRestartedStreams', () => {
       waitingStreams: new Set(),
       executionIds: new Map([[streamId, executionId]]),
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       synchronizeResultOutcome,
       now: 456,
     });
@@ -219,10 +227,11 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.FAILED,
       456,
     );
-    expect(writeTerminalStatus).toHaveBeenCalledWith(
+    expect(finalizeExecution).toHaveBeenCalledWith({
       executionId,
-      EXECUTION_STATUS.ERROR,
-    );
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
     expect(synchronizeResultOutcome).toHaveBeenCalledWith(
       executionId,
       RUN_OUTCOME.FAILED,
@@ -234,7 +243,7 @@ describe('repairRestartedStreams', () => {
     const executionId = 'execution-failed-close-error' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
     seedRunning(streamStatus, streamId);
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
 
     await expect(
       repairRestartedStreams({
@@ -244,12 +253,12 @@ describe('repairRestartedStreams', () => {
         closeRunningGroups: async () => {
           throw new Error('group close failed');
         },
-        writeTerminalStatus,
+        finalizeExecution,
       }),
     ).rejects.toThrow('group close failed');
 
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('writes failed terminal meta when retrying an already failed repair', async () => {
@@ -257,7 +266,7 @@ describe('repairRestartedStreams', () => {
     const executionId = 'execution-failed-retry' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
     seedRunning(streamStatus, streamId);
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
 
     await expect(
       repairRestartedStreams({
@@ -267,11 +276,11 @@ describe('repairRestartedStreams', () => {
         closeRunningGroups: async () => {
           throw new Error('group close failed');
         },
-        writeTerminalStatus,
+        finalizeExecution,
       }),
     ).rejects.toThrow('group close failed');
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
 
     const closeRunningGroups = vi.fn(
       async (streamIds: readonly StreamTabId[], status: RunOutcome) =>
@@ -285,7 +294,7 @@ describe('repairRestartedStreams', () => {
       repairStreams: [streamId],
       retryFailedStreams: true,
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
       now: 567,
     });
 
@@ -299,10 +308,11 @@ describe('repairRestartedStreams', () => {
       RUN_OUTCOME.FAILED,
       567,
     );
-    expect(writeTerminalStatus).toHaveBeenCalledWith(
+    expect(finalizeExecution).toHaveBeenCalledWith({
       executionId,
-      EXECUTION_STATUS.ERROR,
-    );
+      terminalStatus: EXECUTION_STATUS.ERROR,
+      flowRecord: 'delete',
+    });
   });
 
   it('does not retry historical failed streams unless retry is requested', async () => {
@@ -318,7 +328,7 @@ describe('repairRestartedStreams', () => {
     const closeRunningGroups = vi.fn(
       async (streamIds: readonly StreamTabId[]) => [...streamIds],
     );
-    const writeTerminalStatus = vi.fn(async () => undefined);
+    const finalizeExecution = createDurableFinalizer();
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -326,7 +336,7 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
       closeRunningGroups,
-      writeTerminalStatus,
+      finalizeExecution,
     });
 
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
@@ -336,7 +346,93 @@ describe('repairRestartedStreams', () => {
       terminalStatusUpdated: [],
     });
     expect(closeRunningGroups).not.toHaveBeenCalled();
-    expect(writeTerminalStatus).not.toHaveBeenCalled();
+    expect(finalizeExecution).not.toHaveBeenCalled();
+  });
+
+  it('does not report or synchronize terminal status when metadata persistence fails', async () => {
+    const streamId = 'stream-metadata-failure' as StreamTabId;
+    const executionId = 'execution-metadata-failure' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const durabilityError = new Error('metadata disk write failed');
+    const finalizeExecution = vi.fn(async () => ({
+      status: 'failed' as const,
+      stage: 'terminal-status' as const,
+      terminalStatusPersisted: false as const,
+      error: durabilityError,
+    }));
+    const synchronizeResultOutcome = vi.fn(async () => undefined);
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      closeRunningGroups: async (streamIds) => [...streamIds],
+      finalizeExecution,
+      synchronizeResultOutcome,
+      logger,
+    });
+
+    expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+    expect(result.terminalStatusUpdated).toEqual([]);
+    expect(synchronizeResultOutcome).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      'Failed to finalize restart-repair execution',
+      {
+        data: {
+          streamId,
+          executionId,
+          stage: 'terminal-status',
+          terminalStatusPersisted: false,
+          error: durabilityError,
+        },
+      },
+    );
+  });
+
+  it('reports flow cleanup failure but synchronizes durable terminal metadata', async () => {
+    const streamId = 'stream-flow-delete-failure' as StreamTabId;
+    const executionId = 'execution-flow-delete-failure' as ExecutionId;
+    const streamStatus = new StreamStatusMachine();
+    seedRunning(streamStatus, streamId);
+    const cleanupError = new Error('flow delete failed');
+    const finalizeExecution = vi.fn(async () => ({
+      status: 'failed' as const,
+      stage: 'flow-record-delete' as const,
+      terminalStatusPersisted: true as const,
+      error: cleanupError,
+    }));
+    const synchronizeResultOutcome = vi.fn(async () => undefined);
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    const result = await repairRestartedStreams({
+      streamStatus,
+      waitingStreams: new Set(),
+      executionIds: new Map([[streamId, executionId]]),
+      closeRunningGroups: async (streamIds) => [...streamIds],
+      finalizeExecution,
+      synchronizeResultOutcome,
+      logger,
+    });
+
+    expect(result.terminalStatusUpdated).toEqual([executionId]);
+    expect(synchronizeResultOutcome).toHaveBeenCalledExactlyOnceWith(
+      executionId,
+      RUN_OUTCOME.FAILED,
+    );
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      'Failed to finalize restart-repair execution',
+      {
+        data: {
+          streamId,
+          executionId,
+          stage: 'flow-record-delete',
+          terminalStatusPersisted: true,
+          error: cleanupError,
+        },
+      },
+    );
   });
 
   it('can terminalize stale WAITING streams through the resume choreography', async () => {
@@ -351,7 +447,7 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       repairStreams: [streamId],
       closeRunningGroups: async (streamIds) => [...streamIds],
-      writeTerminalStatus: vi.fn(async () => undefined),
+      finalizeExecution: createDurableFinalizer(),
     });
 
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -20,6 +20,7 @@ import {
 } from 'llm-zoo';
 import { createRunTrace, StreamLogStore } from '@transcript';
 import type { AgentEvent } from '@agent/trace';
+import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type {
   AgentPrompt,
@@ -53,7 +54,11 @@ import type { SdkToolCall } from '@agent/types/IModelHandler';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { BashTool } from '@tools/bash';
 import { TaskRunFileService } from '@utils/files';
@@ -631,6 +636,60 @@ describe('BashTool', () => {
       clearStreamStatusForTest(defaultSession().status, parentStreamId);
       defaultSession().followUps.release(parentStreamId);
     }
+  });
+
+  it('finalizes background execution when supplementary result metadata fails', async () => {
+    let resolveCommand: ((result: ExecResult) => void) | undefined;
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCommand = resolve;
+        }),
+    );
+    await installPlatform({
+      workspacePath: '/workspace',
+      config: { 'texra.toolUse.requireBashApproval': false },
+    });
+    const parentStreamId = 'bash-result-meta-failure' as StreamTabId;
+    const { host } = createRecordingHost();
+    const recorded = recordSessionEvents(defaultSession().events);
+
+    const launchResult = await withToolEnvironment(
+      {
+        run: { runtimeHost: host, streamId: parentStreamId },
+        call: { tracker: new FileInteractionState() },
+      },
+      () =>
+        new BashTool().call({
+          command: 'make build',
+          run_in_background: true,
+        }),
+    );
+    const executionId = /Execution ID: (\S+)/.exec(
+      String(launchResult.output ?? ''),
+    )?.[1];
+    assert.ok(executionId, JSON.stringify(launchResult));
+    const store = getExecutionStore(executionId);
+    vi.spyOn(store, 'writeResultMeta').mockRejectedValueOnce(
+      new Error('result metadata disk full'),
+    );
+
+    resolveCommand?.({
+      success: true,
+      stdout: 'done\n',
+      stderr: '',
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    await vi.waitFor(async () => {
+      assert.equal(
+        (await store.readMeta())?.terminalStatus,
+        EXECUTION_STATUS.COMPLETED,
+      );
+    });
+    recorded.detach();
+    defaultSession().followUps.release(parentStreamId);
   });
 
   it('accepts optional command descriptions without passing them to the shell', async () => {

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -27,13 +27,13 @@ const mocks = vi.hoisted(() => ({
   enqueueChildRunFollowUp: vi.fn(),
   wakeChildRunFollowUp: vi.fn(),
   executeAgent: vi.fn(),
+  finalizeExecution: vi.fn(),
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
   readConfig: vi.fn(),
   resumeToolUseFromSnapshot: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
   synchronizeAgentResultOutcome: vi.fn(),
-  writeTerminalStatus: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
@@ -42,9 +42,9 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 }));
 
 vi.mock('@agent/storage', () => ({
+  finalizeExecution: mocks.finalizeExecution,
   getExecutionStore: vi.fn(() => ({ readConfig: mocks.readConfig })),
   synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
-  writeTerminalStatus: mocks.writeTerminalStatus,
 }));
 
 vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
@@ -95,8 +95,12 @@ describe('NativeToolUseStrategy', () => {
     mocks.wakeChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
     mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
+    mocks.finalizeExecution.mockResolvedValue({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
     mocks.synchronizeAgentResultOutcome.mockResolvedValue(undefined);
-    mocks.writeTerminalStatus.mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -6,9 +6,9 @@ import { tryPlatform } from '@platform/platform';
 
 // Local imports - agent
 import {
+  finalizeExecution,
   getExecutionStore,
   registerExecution,
-  writeTerminalStatus,
 } from '@agent/storage';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
@@ -476,10 +476,12 @@ export class BashTool extends defineTool({
             timedOut: result.timedOut ?? false,
             command,
           });
-          await writeTerminalStatus(
+          const finalization = await finalizeExecution({
             executionId,
-            backgroundBashTerminalStatus(result.success),
-          );
+            terminalStatus: backgroundBashTerminalStatus(result.success),
+            flowRecord: 'delete',
+          });
+          if (finalization.status === 'failed') throw finalization.error;
           await store.writeReport(msg);
         } catch (err: unknown) {
           logBackgroundFailure('persist', err);
@@ -492,10 +494,12 @@ export class BashTool extends defineTool({
       const { error } = outcome;
       const msg = formatBashError(executionId, command, error);
       try {
-        await writeTerminalStatus(
+        const finalization = await finalizeExecution({
           executionId,
-          backgroundBashTerminalStatus(false),
-        );
+          terminalStatus: backgroundBashTerminalStatus(false),
+          flowRecord: 'delete',
+        });
+        if (finalization.status === 'failed') throw finalization.error;
         await getExecutionStore(executionId).writeReport(msg);
       } catch (err: unknown) {
         logBackgroundFailure('persist', err);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -466,8 +466,8 @@ export class BashTool extends defineTool({
             : 0,
         );
 
+        const store = getExecutionStore(executionId);
         try {
-          const store = getExecutionStore(executionId);
           await store.writeResultMeta({
             producer: 'backgroundBash',
             exitCode: result.exitCode ?? (result.success ? 0 : 1),
@@ -476,15 +476,23 @@ export class BashTool extends defineTool({
             timedOut: result.timedOut ?? false,
             command,
           });
+        } catch (err: unknown) {
+          logBackgroundFailure('persist result metadata', err);
+        }
+        try {
           const finalization = await finalizeExecution({
             executionId,
             terminalStatus: backgroundBashTerminalStatus(result.success),
             flowRecord: 'delete',
           });
           if (finalization.status === 'failed') throw finalization.error;
+        } catch (err: unknown) {
+          logBackgroundFailure('finalize execution', err);
+        }
+        try {
           await store.writeReport(msg);
         } catch (err: unknown) {
-          logBackgroundFailure('persist', err);
+          logBackgroundFailure('persist report', err);
         }
 
         await deliverAndFinalize(msg, { wallTimeMs, error, autoClose: true });
@@ -500,9 +508,13 @@ export class BashTool extends defineTool({
           flowRecord: 'delete',
         });
         if (finalization.status === 'failed') throw finalization.error;
+      } catch (err: unknown) {
+        logBackgroundFailure('finalize execution', err);
+      }
+      try {
         await getExecutionStore(executionId).writeReport(msg);
       } catch (err: unknown) {
-        logBackgroundFailure('persist', err);
+        logBackgroundFailure('persist report', err);
       }
 
       await deliverAndFinalize(msg, { error, autoClose: true });

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -4,7 +4,10 @@ import type { AgentTrace, StageHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { finalizeRunTerminal } from '@agent/runtime/AgentRunLifecycle';
+import {
+  finalizeRunTerminal,
+  type RunTerminalPersistence,
+} from '@agent/runtime/AgentRunLifecycle';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   currentSession,
@@ -50,11 +53,8 @@ interface FinalizeChildStreamOptions {
   cancelled?: boolean;
   /** Session stage closed with the derived outcome (agent-CLI loop's stage). */
   stage?: Pick<StageHandle, 'end'>;
-  /**
-   * Persist the outcome projection to execution history. Callers that own a
-   * richer persistence block (background bash) leave this unset.
-   */
-  persistTerminalStatus?: boolean;
+  /** Durable execution-state action; background bash owns its richer block. */
+  persistence?: RunTerminalPersistence;
   /** Remove the child stream tab from the progress view once finalized. */
   autoClose?: boolean;
 }
@@ -265,10 +265,7 @@ async function finalizeChildStream(
     stage: options?.stage,
     // No trace emit: child-stream results must stay out of `session.onResult`
     // (host toast) consumers — the loop already presents them as follow-ups.
-    persistence:
-      options?.persistTerminalStatus === true
-        ? { kind: 'finalize', flowRecord: 'delete' }
-        : { kind: 'skip' },
+    persistence: options?.persistence ?? { kind: 'skip' },
   });
   disposeTrace();
 

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -265,7 +265,10 @@ async function finalizeChildStream(
     stage: options?.stage,
     // No trace emit: child-stream results must stay out of `session.onResult`
     // (host toast) consumers — the loop already presents them as follow-ups.
-    persistTerminalStatus: options?.persistTerminalStatus === true,
+    persistence:
+      options?.persistTerminalStatus === true
+        ? { kind: 'finalize', flowRecord: 'delete' }
+        : { kind: 'skip' },
   });
   disposeTrace();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core execution lifecycle, resumability, and terminal persistence across agent runtime, CLI, and storage with fail-closed semantics when disk writes fail.
> 
> **Overview**
> Terminal execution cleanup is consolidated behind **`finalizeExecution`**, which writes terminal metadata and applies flow-record **preserve** or **delete** in one step, with staged failure results instead of silent best-effort writes.
> 
> **Agent runtime** routes lifecycle, registry kills, child streams, and tool-use flows through this path: flows report disposition via `onFlowRecordDisposition` / `FlowLifecycleControl` rather than deleting flow keys themselves; `finalizeRunTerminal` runs **before** onboarding side effects on success; result-outcome sync and restart repair only run when `terminalStatusPersisted` is true.
> 
> **CLI** adds `finalizeCliExecution` to report persistence failures without changing primary exit codes; chat TUI uses `lifecycleStarted` (via `onRun`) so pre-lifecycle errors finalize but in-flight runs do not double-write; shutdown and outcome-read failures surface through stderr or host error events.
> 
> **Storage** makes strict terminal meta updates throw; supplementary meta stays best-effort; execution KV stores use `throwOnErrors: true`; completed/failed terminal write failures attempt fail-closed flow deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd734976118e10fd16968847ef3c073a5b94ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary

- Makes terminal execution metadata writes strict and centralizes metadata with flow-record disposition.
- Fails closed when completed or failed terminal metadata cannot be persisted, while preserving explicit partial-failure diagnostics.
- Synchronizes results and restart repairs only after terminal persistence is confirmed.
- Separates supplementary background and CLI persistence so it cannot suppress terminal finalization.
- Reports CLI shutdown durability failures immediately and exactly once.

## Design

The storage finalizer writes terminal metadata before applying the flow-record retention policy. Tool-use flows report that policy, while storage owns the writes.

If terminal metadata cannot be written for a completed or failed execution, finalization attempts to delete the flow record so stale state is not offered as an ordinary resumable session. If both writes fail, the result identifies both failed stages with an aggregate error; no process can durably prevent a stale resume when neither storage operation succeeds.

Runtime cleanup remains non-throwing so executions still settle and unregister, but each durability failure is observable through one structured error event.

## Verification

- All source, test-kernel, extension, CLI, trace-viewer, and desktop typechecks passed.
- Lint passed with 0 errors and 50 existing warnings.
- The extension and all three webviews built successfully.
- The full Vitest suite passed with 6,193 tests passed and 4 skipped.
- A final parallel rerun had two CLI signal timeouts under load; their isolated rerun passed 2 of 2.
- All 28 targeted execution tests passed.
- The dead-code ratchet passed.
- An independent final review found no actionable issues.

Closes #8459
