### PR TITLE
test(relay): update Max model access contract

### DIFF
--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -2,6 +2,7 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
+import { MODEL_CONFIGS } from 'llm-zoo';
 import { describe, it, vi } from 'vitest';
 
 // A retired model whose provider is not in RELAY_PROVIDERS (e.g. 'meta') is
@@ -31,14 +32,28 @@ import {
   FREE_TIER,
   MAX_TIER,
   TIER_CONFIG,
+  ULTRA_ONLY_PROVIDER_SET,
   ULTRA_TIER,
   isModelAllowedForTier,
   isRetiredModelRequest,
 } from '../../../supabase/functions/relay/models';
 
 describe('relay tier model access', () => {
-  it('gives Max full explicit-model access and Ultra passthrough', () => {
-    assert.equal(TIER_CONFIG.tiers.Max?.models, '*');
+  it('limits Max to non-Ultra providers and keeps Ultra passthrough', () => {
+    const maxModels = TIER_CONFIG.tiers.Max?.models;
+    assert.ok(Array.isArray(maxModels));
+    assert.deepEqual(
+      maxModels,
+      Object.values(MODEL_CONFIGS)
+        .filter(
+          (model) =>
+            TIER_CONFIG.providers.includes(model.provider) &&
+            !model.openRouterOnly &&
+            !model.retired &&
+            !ULTRA_ONLY_PROVIDER_SET.has(model.provider.toLowerCase()),
+        )
+        .map((model) => model.name),
+    );
     assert.equal(TIER_CONFIG.tiers.Ultra?.models, '*');
 
     assert.equal(isModelAllowedForTier(MAX_TIER, 'unknown-model'), true);


### PR DESCRIPTION
## Summary

- update the stale Max-tier assertion after #8461 changed the tier config from a wildcard to an explicit list
- derive the expected list from active relay models excluding Ultra-only providers
- retain Ultra passthrough and route-level model-name assertions

Closes #8467

## Context

This is the one-test blocker exposed by PR #8468 CI after #8461 merged into `main`. It is independent of #8468 and intentionally ships separately.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 existing warnings)
- `npx vitest run src/test-kernel/supabase/RelayModelAccess.vitest.ts` (4 passed)
- `npm test` (687 files passed, 1 skipped; 6,170 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modified.
> 
> **Overview**
> Updates the **Max** tier contract test after production config stopped using a wildcard and now exposes an explicit model list.
> 
> The test no longer asserts `TIER_CONFIG.tiers.Max.models === '*'`. It checks that Max models are an array and **deep-equals** the names from `MODEL_CONFIGS` filtered the same way as relay: allowed providers, not `openRouterOnly`, not retired, and not in `ULTRA_ONLY_PROVIDER_SET`. **Ultra** still expects `'*'`, and the existing `isModelAllowedForTier` checks for unknown/null models are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cc06048961bd9f4824fb7e615a9972d8f06536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->