### PR TITLE
fix(cli): clear chat draft before interrupting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Ctrl+C clears unfinished chat input before stopping or exiting** — pressing
+  Ctrl+C with a non-empty draft now clears the draft; pressing it again keeps
+  the existing response-stop or exit behavior.
 - **Session navigation uses one persistent list** — `Tab` opens the vertical
   list for the main and delegated sessions; arrow keys select a session,
   `Enter` focuses it, and reopening the list restores the previous selection.

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -3351,6 +3351,14 @@ const SCENARIOS = [
     expectExit: true,
   },
   {
+    name: 'ctrl-c-clears-draft',
+    frame: 'viewport',
+    env: { HARNESS_ENTRIES: '4' },
+    keys: ['unfinished draft', ETX],
+    expect: ['Ctrl-C exit'],
+    unexpect: ['unfinished draft'],
+  },
+  {
     name: 'ctrl-c-interrupt-active',
     env: {
       HARNESS_ENTRIES: '4',

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -26,13 +26,14 @@ import {
   foregroundMaxRowsForKind,
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
+  triggerAppCtrlC,
   triggerEscapeInterrupt,
   type EscapeInterruptState,
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { ChildControlPicker } from './modals/ChildControlPicker';
 import { TranscriptViewer } from './modals/TranscriptViewer';
-import { InputBar } from './panes/InputBar';
+import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
 import { currentApproval } from './state/approvalQueue';
@@ -326,6 +327,7 @@ export function App(props: AppProps): React.JSX.Element {
   const pendingEscapeInterruptTimer = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
+  const inputBarRef = useRef<InputBarHandle>(null);
 
   const clearPendingEscapeInterrupt = () => {
     if (pendingEscapeInterruptTimer.current === undefined) return;
@@ -398,15 +400,14 @@ export function App(props: AppProps): React.JSX.Element {
     // path used by terminals that deliver a signal; harnesses can fall back to
     // interrupt-then-exit behavior without duplicating that process lifecycle.
     if (key.ctrl && input === 'c') {
-      if (props.onCtrlC) {
-        props.onCtrlC();
-        return;
-      }
-      if (canStopActiveRun()) {
-        props.onInterruptActive();
-        return;
-      }
-      exit();
+      triggerAppCtrlC({
+        hasDraft: () => inputBarRef.current?.hasDraft() ?? false,
+        clearDraft: () => inputBarRef.current?.clearDraft(),
+        canStopActiveRun,
+        onInterruptActive: props.onInterruptActive,
+        onExit: exit,
+        onCtrlC: props.onCtrlC,
+      });
       return;
     }
 
@@ -480,6 +481,7 @@ export function App(props: AppProps): React.JSX.Element {
       renderFooterChrome={(queuedFollowUpPanelVisible) => (
         <>
           <InputBar
+            controlRef={inputBarRef}
             onSubmit={props.onSubmit}
             collapseWhenDisabled={!inputBarVisible}
             disabledMessage={childInputDisabledMessage}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -17,6 +17,7 @@ import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - TUI surfaces and state
 import {
+  appDraftDiscardActive,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
   approvalVisibleForActiveStream,
@@ -401,8 +402,13 @@ export function App(props: AppProps): React.JSX.Element {
     // interrupt-then-exit behavior without duplicating that process lifecycle.
     if (key.ctrl && input === 'c') {
       triggerAppCtrlC({
-        hasDraft: () => inputBarRef.current?.hasDraft() ?? false,
-        clearDraft: () => inputBarRef.current?.clearDraft(),
+        discardDraft: () =>
+          appDraftDiscardActive({
+            inputDisabled,
+            reverseSearchOpen,
+            sessionListFocused,
+          }) &&
+          (inputBarRef.current?.discardDraft() ?? false),
         canStopActiveRun,
         onInterruptActive: props.onInterruptActive,
         onExit: exit,

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -104,6 +104,38 @@ export function triggerEscapeInterrupt(state: EscapeInterruptState): boolean {
   return true;
 }
 
+export type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
+
+export interface AppCtrlCState {
+  readonly hasDraft: () => boolean;
+  readonly clearDraft: () => void;
+  readonly canStopActiveRun: () => boolean;
+  readonly onInterruptActive: () => void;
+  readonly onExit: () => void;
+  readonly onCtrlC?: () => void;
+}
+
+/** Apply the root TUI's complete Ctrl+C policy from the latest composer state. */
+export function triggerAppCtrlC(state: AppCtrlCState): AppCtrlCAction {
+  if (state.hasDraft()) {
+    state.clearDraft();
+    return 'clear-draft';
+  }
+
+  if (state.onCtrlC) {
+    state.onCtrlC();
+    return 'delegate';
+  }
+
+  if (state.canStopActiveRun()) {
+    state.onInterruptActive();
+    return 'interrupt';
+  }
+
+  state.onExit();
+  return 'exit';
+}
+
 export function digitFromMetaShortcut(value: string): number | undefined {
   return /^[1-9]$/.test(value) ? Number.parseInt(value, 10) : undefined;
 }

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -107,18 +107,28 @@ export function triggerEscapeInterrupt(state: EscapeInterruptState): boolean {
 export type AppCtrlCAction = 'clear-draft' | 'delegate' | 'interrupt' | 'exit';
 
 export interface AppCtrlCState {
-  readonly hasDraft: () => boolean;
-  readonly clearDraft: () => void;
+  readonly discardDraft: () => boolean;
   readonly canStopActiveRun: () => boolean;
   readonly onInterruptActive: () => void;
   readonly onExit: () => void;
   readonly onCtrlC?: () => void;
 }
 
+export function appDraftDiscardActive({
+  inputDisabled,
+  reverseSearchOpen,
+  sessionListFocused,
+}: {
+  readonly inputDisabled: boolean;
+  readonly reverseSearchOpen: boolean;
+  readonly sessionListFocused: boolean;
+}): boolean {
+  return !inputDisabled && !reverseSearchOpen && !sessionListFocused;
+}
+
 /** Apply the root TUI's complete Ctrl+C policy from the latest composer state. */
 export function triggerAppCtrlC(state: AppCtrlCState): AppCtrlCAction {
-  if (state.hasDraft()) {
-    state.clearDraft();
+  if (state.discardDraft()) {
     return 'clear-draft';
   }
 

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -26,7 +26,11 @@ import {
   isUnhandledControlInput,
   metaChordInput,
 } from './inputKeys';
-import { ImagePasteQueue, withImagePasteTimeout } from './imagePasteQueue';
+import {
+  ImagePasteQueue,
+  withImagePasteTimeout,
+  type ImagePasteAttempt,
+} from './imagePasteQueue';
 import { textDisplayWidth } from '../render/terminalText';
 
 const ESC_SLASH_PREFIX = '\u001B/';
@@ -58,7 +62,9 @@ export interface BaseTextInputProps {
   readonly transformPaste?: (text: string) => string;
   /** Ctrl-V handler: probe the OS clipboard for an image. Resolves to the chip
    *  text to insert (e.g. `[Image #1]`) or null when there is no image. */
-  readonly onImagePaste?: () => Promise<string | null>;
+  readonly onImagePaste?: (
+    attempt: ImagePasteAttempt,
+  ) => Promise<string | null>;
   readonly onImagePasteError?: (error: unknown) => void;
   readonly imagePasteQueue?: ImagePasteQueue;
   /** Optional parent-owned value ref for same-tick programmatic draft changes. */
@@ -522,14 +528,17 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
         // Insert the chip at whatever the caret is when the async probe
         // resolves (read from a ref, not a keypress-time snapshot) so typing
         // during the probe isn't clobbered.
+        const attempt = imagePasteQueue.beginAttempt();
         const paste = withImagePasteTimeout(
-          Promise.resolve().then(() => props.onImagePaste?.() ?? null),
+          Promise.resolve().then(() => props.onImagePaste?.(attempt) ?? null),
         )
           .then((chip) => {
-            if (!chip) return;
+            if (!chip || !attempt.isCurrent()) return;
             insertIntoLatestDraft(chip);
           })
-          .catch((err: unknown) => props.onImagePasteError?.(err));
+          .catch((err: unknown) => {
+            if (attempt.isCurrent()) props.onImagePasteError?.(err);
+          });
         imagePasteQueue.track(paste);
         return;
       }

--- a/packages/cli/src/chat/tui/input/imagePasteQueue.ts
+++ b/packages/cli/src/chat/tui/input/imagePasteQueue.ts
@@ -9,9 +9,14 @@ export function withImagePasteTimeout<T>(promise: Promise<T>): Promise<T> {
   });
 }
 
+export interface ImagePasteAttempt {
+  readonly isCurrent: () => boolean;
+}
+
 export class ImagePasteQueue {
   private readonly pending = new Set<Promise<void>>();
   private deferredAction: (() => void) | null = null;
+  private generation = 0;
 
   get hasPending(): boolean {
     return this.pending.size > 0;
@@ -19,6 +24,11 @@ export class ImagePasteQueue {
 
   get hasDeferredAction(): boolean {
     return this.deferredAction !== null;
+  }
+
+  beginAttempt(): ImagePasteAttempt {
+    const generation = this.generation;
+    return { isCurrent: () => generation === this.generation };
   }
 
   track(work: Promise<void>): void {
@@ -43,6 +53,13 @@ export class ImagePasteQueue {
   }
 
   cancelDeferredAction(): void {
+    this.deferredAction = null;
+  }
+
+  /** Detach all work that belongs to a discarded draft. */
+  discardPending(): void {
+    this.generation += 1;
+    this.pending.clear();
     this.deferredAction = null;
   }
 

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -64,8 +64,7 @@ export interface InputBarProps {
 }
 
 export interface InputBarHandle {
-  readonly hasDraft: () => boolean;
-  readonly clearDraft: () => void;
+  readonly discardDraft: () => boolean;
 }
 
 function slashSubmitText(
@@ -160,14 +159,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     clearDraft();
     return { value: '', cursor: 0 };
   }, [clearDraft]);
-  useImperativeHandle(
-    props.controlRef,
-    () => ({
-      clearDraft,
-      hasDraft: () => draftValueRef.current.length > 0,
-    }),
-    [clearDraft],
-  );
+  const discardDraft = useCallback((): boolean => {
+    if (draftValueRef.current.length === 0) return false;
+    clearDraft();
+    return true;
+  }, [clearDraft]);
+  useImperativeHandle(props.controlRef, () => ({ discardDraft }), [
+    discardDraft,
+  ]);
   const replaceSlashTriggerInput = useCallback(
     (input: string, value: string, cursor: number) => {
       if (value === '/' && cursor === 1 && input.startsWith('/')) {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -15,7 +15,10 @@ import {
   DraftAttachmentStore,
   shouldCollapsePaste,
 } from '../input/draftAttachments';
-import { ImagePasteQueue } from '../input/imagePasteQueue';
+import {
+  ImagePasteQueue,
+  type ImagePasteAttempt,
+} from '../input/imagePasteQueue';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { openRegisteredCliSlashForm } from '../commands/slashForms';
@@ -149,9 +152,10 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   // Ref-held so the store survives re-renders and never triggers one itself.
   const attachmentsRef = useRef(new DraftAttachmentStore());
   const clearDraft = useCallback(() => {
+    imagePasteQueue.discardPending();
     setValue('');
     attachmentsRef.current.clear();
-  }, [setValue]);
+  }, [imagePasteQueue, setValue]);
   const clearDraftEdit = useCallback<CursorEdit>(() => {
     clearDraft();
     return { value: '', cursor: 0 };
@@ -189,23 +193,29 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     if (!shouldCollapsePaste(text)) return text;
     return attachmentsRef.current.addPastedText(text);
   }, []);
-  const onImagePaste = useCallback(async (): Promise<string | null> => {
-    try {
-      const result = await attachClipboardImage();
-      if (!result.ok) {
-        setAttachNotice(result.reason);
+  const onImagePaste = useCallback(
+    async (attempt: ImagePasteAttempt): Promise<string | null> => {
+      try {
+        const result = await attachClipboardImage();
+        if (!attempt.isCurrent()) return null;
+        if (!result.ok) {
+          setAttachNotice(result.reason);
+          return null;
+        }
+        return attachmentsRef.current.addPastedImage({
+          path: result.path,
+          mediaType: result.mediaType,
+          displayName: result.displayName,
+        });
+      } catch (error) {
+        if (attempt.isCurrent()) {
+          setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`);
+        }
         return null;
       }
-      return attachmentsRef.current.addPastedImage({
-        path: result.path,
-        mediaType: result.mediaType,
-        displayName: result.displayName,
-      });
-    } catch (error) {
-      setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`);
-      return null;
-    }
-  }, []);
+    },
+    [],
+  );
 
   // Clear the transient paste notice a few seconds after it appears.
   useEffect(() => {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { Box, Text, useInput } from 'ink';
 
 import { writeTextStderr } from '@cli/runtime/logSinks';
@@ -50,6 +56,13 @@ export interface InputBarProps {
   readonly history?: InputHistory;
   /** Whether the input currently owns terminal keys. */
   readonly keyboardActive?: boolean;
+  /** Root-owned handle for draft-aware keyboard policy. */
+  readonly controlRef?: React.Ref<InputBarHandle>;
+}
+
+export interface InputBarHandle {
+  readonly hasDraft: () => boolean;
+  readonly clearDraft: () => void;
 }
 
 function slashSubmitText(
@@ -143,6 +156,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     clearDraft();
     return { value: '', cursor: 0 };
   }, [clearDraft]);
+  useImperativeHandle(
+    props.controlRef,
+    () => ({
+      clearDraft,
+      hasDraft: () => draftValueRef.current.length > 0,
+    }),
+    [clearDraft],
+  );
   const replaceSlashTriggerInput = useCallback(
     (input: string, value: string, cursor: number) => {
       if (value === '/' && cursor === 1 && input.startsWith('/')) {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -160,10 +160,16 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
     return { value: '', cursor: 0 };
   }, [clearDraft]);
   const discardDraft = useCallback((): boolean => {
-    if (draftValueRef.current.length === 0) return false;
+    if (
+      draftValueRef.current.length === 0 &&
+      !imagePasteQueue.hasPending &&
+      !imagePasteQueue.hasDeferredAction
+    ) {
+      return false;
+    }
     clearDraft();
     return true;
-  }, [clearDraft]);
+  }, [clearDraft, imagePasteQueue]);
   useImperativeHandle(props.controlRef, () => ({ discardDraft }), [
     discardDraft,
   ]);

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - TUI interaction policy
 import {
+  appDraftDiscardActive,
   appEscapeInterruptActive,
   appFocusShortcutsActive,
   approvalVisibleForActiveStream,
@@ -66,10 +67,11 @@ function ctrlCFixture({
     events,
     readDraft: () => currentDraft,
     state: {
-      hasDraft: () => currentDraft.length > 0,
-      clearDraft: () => {
+      discardDraft: () => {
+        if (currentDraft.length === 0) return false;
         currentDraft = '';
         events.push('clear');
+        return true;
       },
       canStopActiveRun: () => active,
       onInterruptActive: () => events.push('interrupt'),
@@ -146,6 +148,37 @@ describe('app interaction policy', () => {
     expect(triggerAppCtrlC(fixture.state)).toBe('clear-draft');
     expect(triggerAppCtrlC(fixture.state)).toBe('delegate');
     expect(fixture.events).toEqual(['clear', 'delegate']);
+  });
+
+  it('does not let a background draft consume Ctrl+C', () => {
+    const cases = [
+      {
+        inputDisabled: true,
+        reverseSearchOpen: false,
+        sessionListFocused: false,
+      },
+      {
+        inputDisabled: false,
+        reverseSearchOpen: true,
+        sessionListFocused: false,
+      },
+      {
+        inputDisabled: false,
+        reverseSearchOpen: false,
+        sessionListFocused: true,
+      },
+    ];
+
+    for (const state of cases) {
+      expect(appDraftDiscardActive(state)).toBe(false);
+    }
+    expect(
+      appDraftDiscardActive({
+        inputDisabled: false,
+        reverseSearchOpen: false,
+        sessionListFocused: false,
+      }),
+    ).toBe(true);
   });
 
   it('resolves exhaustive foreground row caps', () => {

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -11,7 +11,9 @@ import {
   foregroundMaxRowsForKind,
   foregroundSurfaceKind,
   shouldDeferEscapeInterruptForMetaChord,
+  triggerAppCtrlC,
   triggerEscapeInterrupt,
+  type AppCtrlCState,
   type EscapeInterruptState,
   type ForegroundSurfaceKind,
 } from '@cli/chat/tui/appInteractionPolicy';
@@ -45,6 +47,38 @@ const escChordHidden = {
   taskControlsAvailable: false,
 } satisfies MetaChordState;
 
+function ctrlCFixture({
+  active,
+  draft,
+  delegate,
+}: {
+  readonly active: boolean;
+  readonly draft: string;
+  readonly delegate?: boolean;
+}): {
+  readonly events: string[];
+  readonly readDraft: () => string;
+  readonly state: AppCtrlCState;
+} {
+  const events: string[] = [];
+  let currentDraft = draft;
+  return {
+    events,
+    readDraft: () => currentDraft,
+    state: {
+      hasDraft: () => currentDraft.length > 0,
+      clearDraft: () => {
+        currentDraft = '';
+        events.push('clear');
+      },
+      canStopActiveRun: () => active,
+      onInterruptActive: () => events.push('interrupt'),
+      onExit: () => events.push('exit'),
+      onCtrlC: delegate ? () => events.push('delegate') : undefined,
+    },
+  };
+}
+
 function bashApproval(streamId?: StreamTabId): PendingApproval {
   return {
     payload: {
@@ -72,6 +106,48 @@ function foregroundInput(
 }
 
 describe('app interaction policy', () => {
+  it('clears a non-empty draft without interrupting an active response', () => {
+    const fixture = ctrlCFixture({ active: true, draft: 'unfinished' });
+
+    expect(triggerAppCtrlC(fixture.state)).toBe('clear-draft');
+    expect(fixture.readDraft()).toBe('');
+    expect(fixture.events).toEqual(['clear']);
+  });
+
+  it('clears a non-empty draft without exiting while idle', () => {
+    const fixture = ctrlCFixture({ active: false, draft: 'unfinished' });
+
+    expect(triggerAppCtrlC(fixture.state)).toBe('clear-draft');
+    expect(fixture.readDraft()).toBe('');
+    expect(fixture.events).toEqual(['clear']);
+  });
+
+  it('interrupts an active response when the draft is empty', () => {
+    const fixture = ctrlCFixture({ active: true, draft: '' });
+
+    expect(triggerAppCtrlC(fixture.state)).toBe('interrupt');
+    expect(fixture.events).toEqual(['interrupt']);
+  });
+
+  it('exits an idle chat when the draft is empty', () => {
+    const fixture = ctrlCFixture({ active: false, draft: '' });
+
+    expect(triggerAppCtrlC(fixture.state)).toBe('exit');
+    expect(fixture.events).toEqual(['exit']);
+  });
+
+  it('delegates the second Ctrl+C after clearing to existing signal policy', () => {
+    const fixture = ctrlCFixture({
+      active: true,
+      draft: 'unfinished',
+      delegate: true,
+    });
+
+    expect(triggerAppCtrlC(fixture.state)).toBe('clear-draft');
+    expect(triggerAppCtrlC(fixture.state)).toBe('delegate');
+    expect(fixture.events).toEqual(['clear', 'delegate']);
+  });
+
   it('resolves exhaustive foreground row caps', () => {
     const surfaceCases = [
       [{ childControlHasItems: false, kind: 'childControls' }, 6],

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -1,7 +1,61 @@
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
-import { submitSlashCommandWhenReady } from '@cli/chat/tui/panes/InputBar';
+import {
+  InputBar,
+  submitSlashCommandWhenReady,
+  type InputBarHandle,
+} from '@cli/chat/tui/panes/InputBar';
+
+const clipboardMock = vi.hoisted(() => ({
+  attachClipboardImage: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/clipboardImage', () => clipboardMock);
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
+
+class FakeStdout extends EventEmitter {
+  readonly isTTY = true;
+  readonly columns = 80;
+  readonly rows = 24;
+  buf = '';
+
+  write(chunk: string): boolean {
+    this.buf += chunk;
+    return true;
+  }
+
+  getColorDepth(): number {
+    return 24;
+  }
+}
+
+class FakeStdin extends EventEmitter {
+  readonly isTTY = true;
+  private readonly chunks: string[] = [];
+
+  write(chunk: string): void {
+    this.chunks.push(chunk);
+    this.emit('readable');
+  }
+
+  read(): string | null {
+    return this.chunks.shift() ?? null;
+  }
+
+  ref(): void {}
+  unref(): void {}
+  pause(): void {}
+  resume(): void {}
+  setEncoding(): void {}
+  setRawMode(): void {}
+}
 
 function deferred(): {
   readonly promise: Promise<void>;
@@ -29,6 +83,20 @@ async function flushPromiseQueue(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for state');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+beforeEach(() => clipboardMock.attachClipboardImage.mockReset());
+afterEach(() => vi.clearAllMocks());
 
 describe('InputBar slash submit', () => {
   it('waits for pending image pastes and submits the latest draft', async () => {
@@ -126,5 +194,82 @@ describe('InputBar draft discard', () => {
     expect(submitted).toEqual([]);
     expect(imagePasteQueue.hasPending).toBe(false);
     expect(imagePasteQueue.hasDeferredAction).toBe(false);
+  });
+
+  it('drops late image, attachment, error, and submit effects in the mounted input', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const firstPaste = deferredValue<{
+      readonly ok: true;
+      readonly path: string;
+      readonly mediaType: string;
+      readonly displayName: string;
+    }>();
+    clipboardMock.attachClipboardImage
+      .mockReturnValueOnce(firstPaste.promise)
+      .mockResolvedValueOnce({
+        ok: true,
+        path: '/tmp/current.png',
+        mediaType: 'image/png',
+        displayName: 'current.png',
+      });
+    const submitted: Array<readonly [string, readonly string[] | undefined]> =
+      [];
+    const controlRef = React.createRef() as {
+      current: InputBarHandle | null;
+    };
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout();
+    const instance = ink.render(
+      React.createElement(InputBar, {
+        controlRef,
+        onSubmit: (value: string, mediaFiles?: readonly string[]) =>
+          submitted.push([value, mediaFiles]),
+      }),
+      {
+        stdin,
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(
+        () =>
+          controlRef.current !== null && stdin.listenerCount('readable') > 0,
+      );
+      stdin.write('unfinished draft');
+      stdin.write('\u0016');
+      await waitFor(
+        () => clipboardMock.attachClipboardImage.mock.calls.length === 1,
+      );
+      stdin.write('\r');
+
+      expect(controlRef.current?.discardDraft()).toBe(true);
+      firstPaste.resolve({
+        ok: true,
+        path: '/tmp/stale.png',
+        mediaType: 'image/png',
+        displayName: 'stale.png',
+      });
+      await flushPromiseQueue();
+
+      expect(submitted).toEqual([]);
+      expect(stdout.buf).not.toContain('[Image #1]');
+      expect(stdout.buf).not.toContain('Image paste failed');
+
+      stdout.buf = '';
+      stdin.write('\u0016');
+      await waitFor(() => stdout.buf.includes('[Image #1]'));
+      expect(stdout.buf).not.toContain('[Image #2]');
+      stdin.write('\r');
+      await waitFor(() => submitted.length === 1);
+
+      expect(submitted).toEqual([['[Image #1]', ['/tmp/current.png']]]);
+    } finally {
+      instance.unmount();
+    }
   });
 });

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -196,7 +196,7 @@ describe('InputBar draft discard', () => {
     expect(imagePasteQueue.hasDeferredAction).toBe(false);
   });
 
-  it('drops late image, attachment, error, and submit effects in the mounted input', async () => {
+  it('discards a pending image submit from an otherwise empty mounted input', async () => {
     const ink = (await import(cliRequire.resolve('ink'))) as any;
     const React = ((await import(cliRequire.resolve('react'))) as any).default;
     const firstPaste = deferredValue<{
@@ -240,7 +240,6 @@ describe('InputBar draft discard', () => {
         () =>
           controlRef.current !== null && stdin.listenerCount('readable') > 0,
       );
-      stdin.write('unfinished draft');
       stdin.write('\u0016');
       await waitFor(
         () => clipboardMock.attachClipboardImage.mock.calls.length === 1,

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -14,6 +14,17 @@ function deferred(): {
   return { promise, resolve };
 }
 
+function deferredValue<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 async function flushPromiseQueue(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -76,5 +87,44 @@ describe('InputBar slash submit', () => {
     await flushPromiseQueue();
 
     expect(submitted).toEqual(['/help [Image #1]']);
+  });
+});
+
+describe('InputBar draft discard', () => {
+  it('invalidates an image paste that resolves after the draft is cleared', async () => {
+    const imagePasteQueue = new ImagePasteQueue();
+    const attempt = imagePasteQueue.beginAttempt();
+    const paste = deferredValue<string>();
+    const inserted: string[] = [];
+
+    imagePasteQueue.track(
+      paste.promise.then((chip) => {
+        if (attempt.isCurrent()) inserted.push(chip);
+      }),
+    );
+    imagePasteQueue.discardPending();
+    paste.resolve('[Image #1]');
+    await paste.promise;
+    await flushPromiseQueue();
+
+    expect(attempt.isCurrent()).toBe(false);
+    expect(inserted).toEqual([]);
+  });
+
+  it('cancels a deferred submit when its pending paste is discarded', async () => {
+    const imagePasteQueue = new ImagePasteQueue();
+    const paste = deferred();
+    const submitted: string[] = [];
+
+    imagePasteQueue.track(paste.promise);
+    imagePasteQueue.deferUntilIdle(() => submitted.push('stale draft'));
+    imagePasteQueue.discardPending();
+    paste.resolve();
+    await paste.promise;
+    await flushPromiseQueue();
+
+    expect(submitted).toEqual([]);
+    expect(imagePasteQueue.hasPending).toBe(false);
+    expect(imagePasteQueue.hasDeferredAction).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary\n\n- clears a non-empty chat draft on the first Ctrl+C instead of stopping the response or exiting\n- preserves the existing stop, delegated signal, and exit behavior when the draft is empty\n- limits draft clearing to the visible composer while it owns keyboard input\n- discards pending image-paste work and deferred submission when a draft is cleared\n\n## Design\n\nThe root interaction policy asks the input component to discard its draft through one atomic handle. The input component owns the text, attachment store, and image-paste queue, so clearing does not leak those details into the root view.\n\nImage-paste attempts carry a generation guard. Discarding a draft invalidates the current generation, detaches pending work, and cancels any Enter action waiting for a clipboard probe. Late clipboard results therefore cannot restore a chip, attachment, error notice, or submission after Ctrl+C.\n\nForeground dialogs, reverse history search, and the session list retain Ctrl+C ownership while they are active; an unseen background draft cannot consume the signal.\n\n## Verification\n\n- full Vitest suite passed with 6,205 tests passed and 4 skipped
- 20 focused policy and input tests passed\n- mounted Ink regression covers late image completion, attachment numbering, deferred Enter, and subsequent submission\n- real PTY scenario confirms one Ctrl+C clears a typed draft without exiting\n- CLI and test-kernel typechecks passed\n- focused ESLint and formatting checks passed\n- independent final review found no actionable issues\n\nCloses #8463

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI keyboard policy and composer cleanup; existing interrupt/exit order preserved when the draft is empty.
> 
> **Overview**
> **Ctrl+C in chat TUI** now clears a non-empty composer draft first; a second press keeps the prior behavior (delegate to SIGINT, stop an active run, or exit when idle).
> 
> The root handler calls **`triggerAppCtrlC`** in `appInteractionPolicy`, which tries draft discard before interrupt/exit/delegate. **`InputBar`** exposes **`discardDraft`** via a ref: it clears text, attachments, and pending image-paste work. **`ImagePasteQueue`** uses generation guards so late clipboard results cannot re-insert chips, show errors, or fire deferred submits after discard.
> 
> Draft clearing only runs when the visible composer owns the keyboard—not when input is disabled, reverse search is open, or the session list is focused. **CHANGELOG**, TUI harness scenario **`ctrl-c-clears-draft`**, and policy/input tests cover the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22f45225e26f60b21456e73e658e9ae987eb6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
