### PR TITLE
refactor(desktop): require progress bridge source

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -33,15 +33,20 @@ interface DesktopProgressIpcBridge {
   completeWebviewReady(): Promise<void>;
 }
 
+type DesktopProgressSource =
+  | { kind: 'eager'; progress: DesktopProgressIpcBridge }
+  | {
+      kind: 'lazy';
+      get(): DesktopProgressIpcBridge | undefined;
+      ensure(): Promise<DesktopProgressIpcBridge>;
+    };
+
 export interface DesktopProgressIpcOptions {
-  progress?: DesktopProgressIpcBridge;
-  getProgress?: () => DesktopProgressIpcBridge | undefined;
-  ensureProgress?: () => Promise<DesktopProgressIpcBridge>;
+  source: DesktopProgressSource;
   /** Called for a recognized command that wasn't dispatched to a real
-   *  handler — either the matched registry entry is `unsupported(...)`
-   *  (`reason` set to its message), or the progress bridge isn't
-   *  constructed yet (`reason` undefined). A schema-invalid message never
-   *  reaches this callback; `handleMessage` returns `false` for it instead. */
+   *  handler. A matched `unsupported(...)` registry entry supplies its
+   *  message as `reason`. A schema-invalid message never reaches this
+   *  callback; `handleMessage` returns `false` for it instead. */
   onUnsupportedCommand?: (
     message: ProgressViewInboundMessage,
     reason?: string,
@@ -72,8 +77,19 @@ export function createDesktopProgressIpc(
       console.warn(
         `Unsupported desktop Progress command: ${message.command}${reason ? ` (${reason})` : ''}`,
       ));
-  const getProgress = () => options.getProgress?.() ?? options.progress;
-  const ensureProgress = options.ensureProgress;
+
+  function withProgress(run: (progress: DesktopProgressIpcBridge) => void) {
+    if (options.source.kind === 'eager') {
+      run(options.source.progress);
+      return;
+    }
+    const progress = options.source.get();
+    if (progress) {
+      run(progress);
+      return;
+    }
+    void options.source.ensure().then(run).catch(reportAsyncError);
+  }
 
   // Splits a dispatch's onError callback: an UnsupportedCommandError (a
   // registry entry declared `unsupported(...)`) is captured for
@@ -113,41 +129,20 @@ export function createDesktopProgressIpc(
       // handlers in the chain still receive them.
       if (command === PROGRESS_VIEW_COMMANDS.WEBVIEW_READY) {
         if (!isProgressWebviewReadyMessage(message)) return false;
-        const progress = getProgress();
-        if (progress) {
+        withProgress((progress) => {
           void progress.completeWebviewReady().catch(reportAsyncError);
-        } else if (ensureProgress) {
-          void ensureProgress()
-            .then((loaded) => loaded.completeWebviewReady())
-            .catch(reportAsyncError);
-        }
+        });
         return false;
       }
       if (passThroughCommands.has(command)) return false;
 
-      const progress = getProgress();
-      if (!progress && ensureProgress) {
-        void ensureProgress()
-          .then((loaded) => {
-            dispatchAndReport(
-              message,
-              loaded.progressViewInboundHandlers,
-              result.data,
-            );
-          })
-          .catch(reportAsyncError);
-        return true;
-      }
-      if (!progress) {
-        onUnsupportedCommand(result.data);
-        return true;
-      }
-
-      dispatchAndReport(
-        message,
-        progress.progressViewInboundHandlers,
-        result.data,
-      );
+      withProgress((progress) => {
+        dispatchAndReport(
+          message,
+          progress.progressViewInboundHandlers,
+          result.data,
+        );
+      });
       return true;
     },
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -914,8 +914,11 @@ function createWindow(options: {
   });
   settingsIpcRef.current = settingsIpc;
   const progressIpc = createDesktopProgressIpc({
-    getProgress: () => agentExecution?.progress,
-    ensureProgress: async () => (await getAgentExecution()).progress,
+    source: {
+      kind: 'lazy',
+      get: () => agentExecution?.progress,
+      ensure: async () => (await getAgentExecution()).progress,
+    },
     onAsyncError: reportAsyncError,
     // A registry entry declared `unsupported(...)` carries a user-facing
     // reason; fall back to a generic message for a truly unrecognized

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -37,14 +37,18 @@ interface DesktopProgressIpcBridgeStub {
 
 interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
-    progress?: DesktopProgressIpcBridgeStub;
-    getProgress?: () => DesktopProgressIpcBridgeStub | undefined;
+    source:
+      | { kind: 'eager'; progress: DesktopProgressIpcBridgeStub }
+      | {
+          kind: 'lazy';
+          get(): DesktopProgressIpcBridgeStub | undefined;
+          ensure(): Promise<DesktopProgressIpcBridgeStub>;
+        };
     onUnsupportedCommand?: (
       message: { command: string },
       reason?: string,
     ) => void;
     onAsyncError?: (error: unknown) => void;
-    ensureProgress?: () => Promise<DesktopProgressIpcBridgeStub>;
   }): {
     handleMessage(
       message: { command: string } & Record<string, unknown>,
@@ -68,6 +72,10 @@ function createProgress(
   };
 }
 
+function eagerSource(progress: DesktopProgressIpcBridgeStub) {
+  return { kind: 'eager' as const, progress };
+}
+
 describe('desktop Progress IPC', () => {
   let createDesktopProgressIpc: DesktopProgressIpcModule['createDesktopProgressIpc'];
   beforeEach(async () => {
@@ -76,7 +84,7 @@ describe('desktop Progress IPC', () => {
 
   it('syncs Progress state on readiness while allowing shared view-state handling', async () => {
     const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ progress });
+    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -91,7 +99,7 @@ describe('desktop Progress IPC', () => {
 
   it('ignores main-view readiness broadcasts for Progress prompt replay', async () => {
     const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ progress });
+    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -106,7 +114,11 @@ describe('desktop Progress IPC', () => {
   it('replays pending prompts after lazy Progress readiness load', async () => {
     const progress = createProgress();
     const ipc = createDesktopProgressIpc({
-      ensureProgress: async () => progress,
+      source: {
+        kind: 'lazy',
+        get: () => undefined,
+        ensure: async () => progress,
+      },
     });
 
     expect(
@@ -125,7 +137,7 @@ describe('desktop Progress IPC', () => {
     const progress = createProgress({
       [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: switchStream,
     });
-    const ipc = createDesktopProgressIpc({ progress });
+    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -139,10 +151,35 @@ describe('desktop Progress IPC', () => {
     });
   });
 
+  it('loads a lazy Progress bridge before dispatching recognized commands', async () => {
+    const switchStream = vi.fn();
+    const progress = createProgress({
+      [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: switchStream,
+    });
+    const ensure = vi.fn(async () => progress);
+    const ipc = createDesktopProgressIpc({
+      source: { kind: 'lazy', get: () => undefined, ensure },
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+    expect(switchStream).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+      stream: 'run-1',
+    });
+  });
+
   it('consumes recognized but unhandled commands with an explicit warning path', async () => {
     const onUnsupportedCommand = vi.fn();
     const ipc = createDesktopProgressIpc({
-      progress: createProgress(),
+      source: eagerSource(createProgress()),
       onUnsupportedCommand,
     });
 
@@ -161,7 +198,7 @@ describe('desktop Progress IPC', () => {
   it('leaves shell-level pass-through commands for sibling desktop handlers', async () => {
     const onUnsupportedCommand = vi.fn();
     const ipc = createDesktopProgressIpc({
-      progress: createProgress(),
+      source: eagerSource(createProgress()),
       onUnsupportedCommand,
     });
 
@@ -178,9 +215,11 @@ describe('desktop Progress IPC', () => {
     const error = new Error('dispatch failed');
     const onAsyncError = vi.fn();
     const ipc = createDesktopProgressIpc({
-      progress: createProgress({
-        [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: () => Promise.reject(error),
-      }),
+      source: eagerSource(
+        createProgress({
+          [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: () => Promise.reject(error),
+        }),
+      ),
       onAsyncError,
     });
 
@@ -201,7 +240,10 @@ describe('desktop Progress IPC', () => {
       completeWebviewReady: vi.fn(() => Promise.reject(error)),
       progressViewInboundHandlers: fillRegistry(),
     };
-    const ipc = createDesktopProgressIpc({ progress, onAsyncError });
+    const ipc = createDesktopProgressIpc({
+      source: eagerSource(progress),
+      onAsyncError,
+    });
 
     expect(
       ipc.handleMessage({
@@ -215,7 +257,9 @@ describe('desktop Progress IPC', () => {
   });
 
   it('ignores invalid Progress IPC payloads', async () => {
-    const ipc = createDesktopProgressIpc({ progress: createProgress() });
+    const ipc = createDesktopProgressIpc({
+      source: eagerSource(createProgress()),
+    });
 
     expect(ipc.handleMessage({ command: 'not-a-progress-command' })).toBe(
       false,


### PR DESCRIPTION
## Summary

Replace the independent optional progress, getProgress, and ensureProgress fields with one required eager-or-lazy bridge source. Bridge acquisition now has one local owner for readiness replay and command dispatch, and the invalid no-source unsupported-command path is gone.

Closes #8472

## Issue acceptance gates

- Creating desktop Progress IPC without a bridge source is now a TypeScript error.
- Eager and lazy acquisition are the only representable modes.
- Conflicting direct, getter, and loader combinations cannot compile.
- Production lazy loading, readiness replay, eager routing, and lazy command dispatch are covered.
- Typecheck, lint, compile, focused tests, full tests, formatting, and the dead-code ratchet pass.

## Single source of truth

DesktopProgressIpcOptions.source owns the bridge acquisition mode. Its discriminant determines whether the bridge is already present or must be read and loaded lazily.

## Duplication and abstraction budget

Removed two copies of optional get-or-ensure branching and the runtime precedence between getProgress and progress. Added one local withProgress helper, used by both readiness replay and command dispatch, which owns the eager/lazy acquisition invariant. The eagerSource test helper replaces eight repeated test literals.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- LoC: 97 added, 55 deleted, net +42. The net addition is the discriminated-union contract plus lazy-dispatch coverage that makes invalid acquisition states unrepresentable.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed; 1 internal type alias added.

## Consumer counts (R8)

n/a: no emit path or exported symbol is deleted or rerouted. Repository search finds one production createDesktopProgressIpc call site and one focused dynamic-import test module; both are updated in this PR.

## Host impact

Extension: none.

Desktop: bridge acquisition becomes a required eager/lazy contract; runtime behavior is preserved for the production lazy source.

CLI: none.

## Scheduled refactoring

None.

## Validation

- npm run format
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors; 50 existing warnings)
- npx vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts (10 passed)
- npm test (687 files passed, 1 skipped; 6171 tests passed, 4 skipped)
- npm run check:dead-code-ratchet
- git diff --check