### PR TITLE
refactor(progress): canonicalize stream metadata

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -681,7 +681,7 @@ export class DesktopProgressBridge {
   private getStreamExecutionId(streamId: StreamTabId): ExecutionId | undefined {
     return (
       this.state.snapshots.getExecutionId(streamId) ??
-      this.state.getStreamHints(streamId).executionId
+      this.state.getStreamMetadata(streamId).executionId
     );
   }
 
@@ -1055,7 +1055,7 @@ export class DesktopProgressBridge {
    * Goals panel (issue #7751 FS6) so jumping from a goal entry to its owning
    * run works the same way on both hosts.
    *
-   * Resolves category via `buildStreamInfo` (persisted config/hints), not
+   * Resolves category via `buildStreamInfo` (canonical stream metadata), not
    * `getStreamState()`'s ephemeral session-only kind, so a goal-owned stream
    * restored from `workspaceState` that hasn't emitted a live fact yet this
    * session still matches the current filter instead of unconditionally
@@ -1354,9 +1354,7 @@ export class DesktopProgressBridge {
     if (!runState) return undefined;
 
     this.state.streamLogs.ensureStream(streamId);
-    this.state.updateStreamHints(streamId, {
-      agentCategory: runState.agentCategory,
-    });
+    this.state.refreshStreamMetadataFromSnapshot(streamId);
 
     const parentStreamId = this.state.snapshots.getParentStreamId(streamId);
     return {

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -178,7 +178,7 @@ class DesktopSessionProgressBridgeImpl implements DesktopSessionProgressBridge {
       if (this.liveStreams.has(snapshot.streamId)) continue;
       this.restoredStreams.set(snapshot.streamId, snapshot);
       this.opts.state.streamLogs.ensureStream(snapshot.streamId);
-      this.opts.state.updateStreamHints(snapshot.streamId, {
+      this.opts.state.updateStreamMetadata(snapshot.streamId, {
         agent: snapshot.agent,
         agentCategory: snapshot.agentCategory,
         inputFile: snapshot.inputFile,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -266,9 +266,11 @@ export class ProgressFactApplier {
   private handleRunningTransition(
     streamId: StreamTabId,
   ): AgentCategory | undefined {
-    const knownCategory = this.getStreamCategory(streamId);
-    const category = knownCategory ?? AgentCategory.Workflow;
+    const provisionalCategory = this.getStreamCategory(streamId);
     this.state.resetStreamMetadataForRun(streamId);
+    const knownCategory =
+      this.getStreamCategory(streamId) ?? provisionalCategory;
+    const category = knownCategory ?? AgentCategory.Workflow;
     this.state.getOrCreateStreamState(streamId, category);
     this.state.resetFinishedChildCounters(streamId);
     this.pendingProgressUpdates.delete(streamId);

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -3,7 +3,6 @@ import {
   type LogContentExtras,
 } from '@controllers/progressView/backend/WebviewUpdater';
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
-import { pickAgentCategory } from '@controllers/progressView/backend/streamTabInfo';
 import {
   ProgressViewState,
   type ActiveStreamId,
@@ -269,7 +268,7 @@ export class ProgressFactApplier {
   ): AgentCategory | undefined {
     const knownCategory = this.getStreamCategory(streamId);
     const category = knownCategory ?? AgentCategory.Workflow;
-    this.state.clearStreamHints(streamId);
+    this.state.resetStreamMetadataForRun(streamId);
     this.state.getOrCreateStreamState(streamId, category);
     this.state.resetFinishedChildCounters(streamId);
     this.pendingProgressUpdates.delete(streamId);
@@ -375,7 +374,7 @@ export class ProgressFactApplier {
     streamId,
     description,
   }: UpdateStreamDescriptionPayload): void {
-    this.state.snapshots.setDescription(streamId, description);
+    this.state.setStreamDescription(streamId, description);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateStreamDescription(streamId, description);
     }
@@ -385,7 +384,7 @@ export class ProgressFactApplier {
     childStreamId,
     parentStreamId,
   }: SetParentStreamPayload): void {
-    this.state.snapshots.setParentStream(childStreamId, parentStreamId);
+    this.state.setStreamParent(childStreamId, parentStreamId);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateParentStream(
         childStreamId,
@@ -525,16 +524,16 @@ export class ProgressFactApplier {
     const wasKnownStream = this.state.streamLogs.has(streamId);
     const previousFilter = this.state.agentCategoryFilter;
     this.state.streamLogs.ensureStream(streamId);
-    // Only pass defined hint fields — spreading {key: undefined} over existing
-    // hints would clear previously-set values (isRemote).
-    const hints = {
+    // Only pass fields the event actually knows; omitted fields retain the
+    // canonical metadata already owned by ProgressViewState.
+    const metadata = {
       ...(payload.agentCategory !== undefined && {
         agentCategory: payload.agentCategory,
       }),
       ...(isRemote !== undefined && { isRemote }),
     };
-    if (Object.keys(hints).length > 0) {
-      this.state.updateStreamHints(streamId, hints);
+    if (Object.keys(metadata).length > 0) {
+      this.state.updateStreamMetadata(streamId, metadata);
     }
     // Resolve category: use payload hint, fall back to existing stream state.
     // Approval flows (proposal, tool-edit, bash) emit without agentCategory;
@@ -627,7 +626,7 @@ export class ProgressFactApplier {
 
     // Legacy compatibility payload. The snapshot store derives the current
     // config and run descriptor from this but no longer writes meta.taskState.
-    this.state.snapshots.setTaskState(streamId, taskState, executionId);
+    this.state.setStreamTaskState(streamId, taskState, executionId);
 
     if (isActiveStream) {
       this.maybeUpdateFilterForCategory(category);
@@ -960,8 +959,7 @@ export class ProgressFactApplier {
   }
 
   private getStreamCategory(streamId: StreamTabId): AgentCategory | undefined {
-    const config = this.state.snapshots.getRunConfig(streamId);
-    return pickAgentCategory(config, this.state.getStreamHints(streamId));
+    return this.state.getStreamMetadata(streamId).agentCategory;
   }
 
   getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -5,6 +5,7 @@ import { StreamSnapshotStore, type StreamLogStore } from '@transcript';
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { TaskState } from '@agent/core/state/TaskState';
 import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
@@ -13,16 +14,15 @@ import {
 } from '@agent/runtime/SessionHandle';
 import {
   AgentCategoryFilterSchema,
-  ContextStateDataSchema,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   type RunOutcome,
-  StreamTabInfoBaseSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
   type ContextStateData,
+  type ExecutionId,
   type RoundStage,
   type StreamTabId,
 } from '@shared/schemas';
@@ -42,27 +42,26 @@ import type { MementoStorage } from '@controllers/progressView/backend/persisten
  *  mirroring `StreamSnapshotStore`'s own per-stream disk-read concurrency. */
 const LEGACY_INSTRUCTION_BACKFILL_CONCURRENCY = 8;
 
-/** Ephemeral stream metadata hints, displayed before TaskState is fully populated. */
-const StreamHintsSchema = StreamTabInfoBaseSchema.pick({
-  agent: true,
-  agentCategory: true,
-  inputFile: true,
-  isRemote: true,
-  creationTimestamp: true,
-  executionId: true,
-  parentStreamId: true,
-  description: true,
-}).partial();
-
-export type StreamHints = z.infer<typeof StreamHintsSchema>;
+/** Canonical current metadata used by every progress-view stream consumer. */
+export interface ProgressStreamMetadata {
+  agent?: string;
+  agentCategory?: AgentCategory;
+  inputFile?: string;
+  isRemote?: boolean;
+  creationTimestamp: number;
+  executionId?: ExecutionId;
+  parentStreamId?: StreamTabId;
+  description?: string;
+  model?: string;
+  instruction?: string;
+  workingDirectory?: string;
+}
 
 /** Ephemeral session state per stream (not persisted). */
-const StreamSessionStateSchema = z.object({
-  hints: StreamHintsSchema.prefault({}),
-  contextState: ContextStateDataSchema.nullable().prefault(null),
-});
-
-type StreamSessionState = z.output<typeof StreamSessionStateSchema>;
+interface StreamSessionState {
+  metadata: ProgressStreamMetadata;
+  contextState: ContextStateData | null;
+}
 
 /** Active stream identifier, or empty string when no stream is selected. */
 export type ActiveStreamId = StreamTabId | '';
@@ -218,38 +217,106 @@ export class ProgressViewState {
 
   // -- Ephemeral session state ------------------------------------------------
 
-  private getOrCreateSession(stream: StreamTabId): StreamSessionState {
+  private getOrCreateSession(
+    stream: StreamTabId,
+    creationTimestamp?: number,
+  ): StreamSessionState {
     let state = this._sessionState.get(stream);
     if (!state) {
-      state = StreamSessionStateSchema.parse({});
+      state = {
+        metadata: {
+          creationTimestamp:
+            this.streamLogs.getFirstTimestamp(stream) ??
+            creationTimestamp ??
+            Date.now(),
+        },
+        contextState: null,
+      };
       this._sessionState.set(stream, state);
     }
     return state;
   }
 
-  updateStreamHints(streamTabId: StreamTabId, hints: StreamHints): void {
-    const state = this.getOrCreateSession(streamTabId);
-    const creationTimestamp =
-      state.hints.creationTimestamp ?? hints.creationTimestamp ?? Date.now();
-    state.hints = StreamHintsSchema.parse({
-      ...state.hints,
-      ...hints,
-      creationTimestamp,
-    });
-  }
-
-  getStreamHints(streamTabId: StreamTabId): StreamHints {
-    return this._sessionState.get(streamTabId)?.hints ?? {};
-  }
-
-  clearStreamHints(streamTabId: StreamTabId): void {
-    const state = this._sessionState.get(streamTabId);
-    if (state) {
-      state.hints =
-        state.hints.creationTimestamp === undefined
-          ? {}
-          : { creationTimestamp: state.hints.creationTimestamp };
+  private applySnapshotMetadata(
+    stream: StreamTabId,
+    metadata: ProgressStreamMetadata,
+  ): void {
+    const config = this.snapshots.getRunConfig(stream);
+    if (config) {
+      metadata.agent = config.agent;
+      metadata.agentCategory = config.agentCategory;
+      metadata.inputFile = config.inputFiles?.at(0) ?? metadata.inputFile;
+      metadata.model = config.model;
+      metadata.instruction = config.instruction;
+      metadata.workingDirectory = config.workingDirectory ?? undefined;
     }
+
+    metadata.executionId =
+      this.snapshots.getExecutionId(stream) ?? metadata.executionId;
+    metadata.parentStreamId =
+      this.snapshots.getParentStreamId(stream) ?? metadata.parentStreamId;
+    metadata.description =
+      this.snapshots.getDescription(stream) ?? metadata.description;
+  }
+
+  /**
+   * Apply metadata known before durable task state catches up. Snapshot-owned
+   * fields are re-applied here so late events cannot override authoritative
+   * config, execution, hierarchy, or description data.
+   */
+  updateStreamMetadata(
+    stream: StreamTabId,
+    patch: Partial<ProgressStreamMetadata>,
+  ): void {
+    const state = this.getOrCreateSession(stream, patch.creationTimestamp);
+    const creationTimestamp = state.metadata.creationTimestamp;
+    Object.assign(state.metadata, patch, { creationTimestamp });
+    this.applySnapshotMetadata(stream, state.metadata);
+  }
+
+  /** Re-apply newly loaded snapshot authority without changing live-only data. */
+  refreshStreamMetadataFromSnapshot(stream: StreamTabId): void {
+    const metadata = this.getOrCreateSession(stream).metadata;
+    this.applySnapshotMetadata(stream, metadata);
+  }
+
+  /**
+   * Start a run from durable metadata, retaining only the tab's original
+   * creation time from its previous provisional/live record.
+   */
+  resetStreamMetadataForRun(stream: StreamTabId): void {
+    const state = this.getOrCreateSession(stream);
+    state.metadata = {
+      creationTimestamp: state.metadata.creationTimestamp,
+    };
+    this.applySnapshotMetadata(stream, state.metadata);
+  }
+
+  getStreamMetadata(stream: StreamTabId): Readonly<ProgressStreamMetadata> {
+    return this.getOrCreateSession(stream).metadata;
+  }
+
+  setStreamTaskState(
+    stream: StreamTabId,
+    taskState: TaskState,
+    executionId?: ExecutionId,
+  ): void {
+    this.snapshots.setTaskState(stream, taskState, executionId);
+    this.refreshStreamMetadataFromSnapshot(stream);
+  }
+
+  setStreamParent(
+    stream: StreamTabId,
+    parent: StreamTabId | null | undefined,
+  ): void {
+    this.snapshots.setParentStream(stream, parent);
+    const metadata = this.getOrCreateSession(stream).metadata;
+    metadata.parentStreamId = parent ?? undefined;
+  }
+
+  setStreamDescription(stream: StreamTabId, description: string): void {
+    this.snapshots.setDescription(stream, description);
+    this.getOrCreateSession(stream).metadata.description = description;
   }
 
   // todos/plan are owned + persisted by StreamSnapshotStore (workPlan.json).
@@ -376,6 +443,9 @@ export class ProgressViewState {
     }
 
     await this.snapshots.load(streamIds);
+    for (const stream of streamIds) {
+      this.resetStreamMetadataForRun(stream);
+    }
 
     const restoredLegacyInstructionCount =
       await this.backfillLegacyWorkflowInstructions(streamIds);

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -270,7 +270,7 @@ export class ProgressViewState {
   ): void {
     const state = this.getOrCreateSession(stream, patch.creationTimestamp);
     const creationTimestamp = state.metadata.creationTimestamp;
-    Object.assign(state.metadata, patch, { creationTimestamp });
+    state.metadata = { ...state.metadata, ...patch, creationTimestamp };
     this.applySnapshotMetadata(stream, state.metadata);
   }
 
@@ -292,8 +292,18 @@ export class ProgressViewState {
     this.applySnapshotMetadata(stream, state.metadata);
   }
 
+  /**
+   * Read effective metadata, creating the ephemeral record when needed. Once
+   * the transcript has entries, its actual first timestamp replaces any
+   * provisional or restored timestamp used before the log became available.
+   */
   getStreamMetadata(stream: StreamTabId): Readonly<ProgressStreamMetadata> {
-    return this.getOrCreateSession(stream).metadata;
+    const metadata = this.getOrCreateSession(stream).metadata;
+    const firstTimestamp = this.streamLogs.getFirstTimestamp(stream);
+    if (firstTimestamp !== undefined) {
+      metadata.creationTimestamp = firstTimestamp;
+    }
+    return metadata;
   }
 
   setStreamTaskState(

--- a/src/controllers/progressView/backend/streamInfoUtils.ts
+++ b/src/controllers/progressView/backend/streamInfoUtils.ts
@@ -2,7 +2,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
 import { filterNotNull } from '@utils/core';
 import { peekWorktreeInfo, resolveWorktreeInfo } from '@utils/git/worktreeInfo';
-import { buildStreamTabInfo, pickAgentCategory } from './streamTabInfo';
+import { buildStreamTabInfo } from './streamTabInfo';
 import { compareByNewestCreationTime } from './streamOrdering';
 import type { ProgressViewState } from './state/ProgressViewState';
 
@@ -43,20 +43,13 @@ export function buildStreamInfo(
   id: string,
   filter: AgentCategoryFilter,
 ): StreamTabInfo | null {
-  const hints = state.getStreamHints(id);
-  const config = state.snapshots.getRunConfig(id);
+  const metadata = state.getStreamMetadata(id);
 
   // Determine category and check filter
-  const rawCategory = pickAgentCategory(config, hints);
-  const category = matchesFilter(rawCategory, filter);
+  const category = matchesFilter(metadata.agentCategory, filter);
   if (category === null) return null;
 
-  const creationTimestamp =
-    state.streamLogs.getFirstTimestamp(id) ??
-    hints.creationTimestamp ??
-    Date.now();
-
-  const workingDirectory = config?.workingDirectory;
+  const workingDirectory = metadata.workingDirectory;
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);
@@ -65,13 +58,7 @@ export function buildStreamInfo(
 
   return buildStreamTabInfo({
     streamId: id,
-    config,
-    hints,
-    creationTimestamp,
-    executionId: state.snapshots.getExecutionId(id) ?? hints.executionId,
-    parentStreamId:
-      state.snapshots.getParentStreamId(id) ?? hints.parentStreamId,
-    description: state.snapshots.getDescription(id) ?? hints.description,
+    metadata,
     worktreeInfo,
   });
 }

--- a/src/controllers/progressView/backend/streamTabInfo.ts
+++ b/src/controllers/progressView/backend/streamTabInfo.ts
@@ -1,46 +1,19 @@
 import * as path from 'node:path';
 
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isRemoteAgent } from '@agent/index/agentRegistry';
 import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import type { StreamTabInfo, WorktreeInfo } from '@shared/schemas';
 import { AgentCategory, getCleanAgentName } from '@shared/schemas/agent';
 import { isProcessAgent } from '@shared/streams/agentKind';
+import type { ProgressStreamMetadata } from './state/ProgressViewState';
 
 export interface StreamTabInfoInputs {
   streamId: string;
-  /** Live taskState's config — preferred source of truth when available. */
-  config?: AgentConfig;
-  /** Fallback hints (e.g. for hydrated ghost streams without taskState). */
-  hints?: {
-    agent?: string;
-    agentCategory?: AgentCategory;
-    inputFile?: string;
-    isRemote?: boolean;
-  };
-  creationTimestamp: number;
-  executionId?: string;
-  parentStreamId?: string;
-  description?: string;
+  metadata: Readonly<ProgressStreamMetadata>;
   /** Pre-resolved worktree context (branch, dirty, PR). Callers that have
    *  asynchronously resolved this pass it in so the stream tab can render a
    *  worktree chip without async work in this builder. */
   worktreeInfo?: WorktreeInfo;
-}
-
-/**
- * Single owner of the two-source `config`/`hints` agentCategory lookup shared
- * by `buildStreamTabInfo`, `buildStreamInfo` (streamInfoUtils.ts), and
- * `getStreamCategory` (ProgressFactApplier.ts). Live `config` wins over the
- * fallback `hints`. Deliberately undefined-preserving (no default baked in)
- * — `getStreamCategory` needs that variant; callers that want a concrete
- * category layer `?? AgentCategory.Workflow` on top.
- */
-export function pickAgentCategory(
-  config: Pick<AgentConfig, 'agentCategory'> | undefined,
-  hints: { agentCategory?: AgentCategory } | undefined,
-): AgentCategory | undefined {
-  return config?.agentCategory ?? hints?.agentCategory;
 }
 
 /**
@@ -53,12 +26,12 @@ export function pickAgentCategory(
  * `desktopAgentExecution.buildStreamInfo` (desktop).
  */
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
-  const { streamId, config, hints, creationTimestamp } = inputs;
+  const { streamId, metadata } = inputs;
 
-  const category = pickAgentCategory(config, hints) ?? AgentCategory.Workflow;
+  const category = metadata.agentCategory ?? AgentCategory.Workflow;
 
-  const inputFile = config?.inputFiles?.[0] ?? hints?.inputFile ?? '';
-  const rawAgentName = config?.agent ?? hints?.agent ?? streamId.split('@')[0];
+  const inputFile = metadata.inputFile ?? '';
+  const rawAgentName = metadata.agent ?? streamId.split('@')[0];
   const agentName = getCleanAgentName(rawAgentName);
 
   // Workflow agents include the input filename in the tab label so users
@@ -72,20 +45,18 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model`
   // is the schema's prefault, not a real inference model — omit so the
   // tab footer doesn't lie.
-  const resolvedAgent = config?.agent ?? hints?.agent ?? agentName;
+  const resolvedAgent = metadata.agent ?? agentName;
   const processAgent = isProcessAgent(resolvedAgent);
 
   // Surface the full untruncated command for process streams (description
   // is capped for tab/tooltip rendering).
   const command =
-    processAgent && config?.instruction ? config.instruction : undefined;
+    processAgent && metadata.instruction ? metadata.instruction : undefined;
 
-  // Hint takes precedence: the runtime/event layer sometimes knows
-  // remote-ness (e.g. setActiveStream payload) before the agent registry
-  // is loaded, in which case `isRemoteAgent` would return false for a
-  // genuinely remote agent.
+  // Canonical host-known status takes precedence because setActiveStream can
+  // identify a remote run before its agent is present in the registry.
   const isRemote =
-    hints?.isRemote ?? (rawAgentName ? isRemoteAgent(rawAgentName) : false);
+    metadata.isRemote ?? (rawAgentName ? isRemoteAgent(rawAgentName) : false);
 
   // Worktree context comes from one of two sources, in order:
   //   1. An explicit hint passed in by the caller (already resolved branch /
@@ -94,8 +65,8 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   //      minimal chip carrying just the path until async resolution lands.
   const worktree: WorktreeInfo | undefined =
     inputs.worktreeInfo ??
-    (config?.workingDirectory
-      ? { workingDirectory: config.workingDirectory }
+    (metadata.workingDirectory
+      ? { workingDirectory: metadata.workingDirectory }
       : undefined);
 
   const base = {
@@ -105,10 +76,10 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     agentCategory: category,
     isRemote,
     inputFile,
-    creationTimestamp,
-    executionId: inputs.executionId,
-    parentStreamId: inputs.parentStreamId,
-    description: inputs.description,
+    creationTimestamp: metadata.creationTimestamp,
+    executionId: metadata.executionId,
+    parentStreamId: metadata.parentStreamId,
+    description: metadata.description,
     worktree,
   };
 
@@ -117,9 +88,9 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     : {
         ...base,
         kind: 'agent',
-        model: config?.model,
-        modelLabel: config?.model
-          ? (getRuntimeModelConfig(config.model)?.label ?? config.model)
+        model: metadata.model,
+        modelLabel: metadata.model
+          ? (getRuntimeModelConfig(metadata.model)?.label ?? metadata.model)
           : undefined,
       };
 }

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -285,10 +285,9 @@ export type WorktreeInfo = z.infer<typeof WorktreeInfoSchema>;
 
 /**
  * Fields shared by every stream tab regardless of what's running underneath
- * it — split out (rather than folded into the discriminated union below) so
- * consumers that only need the common metadata (e.g. `StreamHintsSchema` in
- * `ProgressViewState.ts`) can `.pick()` from a plain object schema; Zod's
- * discriminated unions don't support `.pick()`/`.partial()` directly.
+ * it — split out rather than folded into the discriminated union below so
+ * consumers can validate the common fields directly; Zod's discriminated
+ * unions don't support `.pick()`/`.partial()`.
  */
 export const StreamTabInfoBaseSchema = z.object({
   name: z.string(),

--- a/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts
@@ -90,7 +90,7 @@ function makeMockState(overrides: Record<string, any> = {}): any {
   return {
     activeStream: '',
     streamLogs: createStreamLogs(),
-    updateStreamHints: vi.fn(),
+    updateStreamMetadata: vi.fn(),
     snapshots: {
       getTaskState: vi.fn(() => undefined),
       getRunConfig: vi.fn(() => undefined),
@@ -101,7 +101,7 @@ function makeMockState(overrides: Record<string, any> = {}): any {
       setTaskState: vi.fn(),
       read: vi.fn(async () => ({})),
     },
-    getStreamHints: vi.fn(() => ({})),
+    getStreamMetadata: vi.fn(() => ({ creationTimestamp: 0 })),
     ...overrides,
   };
 }
@@ -230,14 +230,14 @@ describe('DesktopSessionProgressBridge', () => {
       }
     });
 
-    it('seeds stream hints and log entries from the snapshot', () => {
+    it('seeds canonical stream metadata and log entries from the snapshot', () => {
       const ensureStream = vi.fn();
-      const updateStreamHints = vi.fn();
+      const updateStreamMetadata = vi.fn();
 
       const bridge = createBridge({
         state: makeMockState({
           streamLogs: createStreamLogs({ ensureStream }),
-          updateStreamHints,
+          updateStreamMetadata,
         }),
         streamSnapshotStore: createSnapshotStore({
           hydrated: [
@@ -256,7 +256,7 @@ describe('DesktopSessionProgressBridge', () => {
 
       try {
         expect(ensureStream).toHaveBeenCalledWith('ghost-seeded');
-        expect(updateStreamHints).toHaveBeenCalledWith('ghost-seeded', {
+        expect(updateStreamMetadata).toHaveBeenCalledWith('ghost-seeded', {
           agent: 'proofreader',
           agentCategory: AgentCategory.Workflow,
           inputFile: 'paper.tex',

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1419,7 +1419,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream('tool-stream');
-      backend.state.updateStreamHints('tool-stream', {
+      backend.state.updateStreamMetadata('tool-stream', {
         agentCategory: AgentCategory.ToolUse,
       });
       backend.state.getOrCreateStreamState(
@@ -1461,12 +1461,12 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.snapshots.setTaskState(
+      backend.state.setStreamTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         'abc123' as ExecutionId,
       );
-      backend.state.updateStreamHints(stream, {
+      backend.state.updateStreamMetadata(stream, {
         agentCategory: AgentCategory.ToolUse,
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
@@ -1523,7 +1523,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.updateStreamHints(stream, {
+      backend.state.updateStreamMetadata(stream, {
         agentCategory: AgentCategory.ToolUse,
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
@@ -1551,12 +1551,12 @@ describe('ProgressBackend', () => {
       await backend.state.snapshots.load([]);
       backend.state.streamLogs.ensureStream(stream);
       backend.state.activeStream = stream;
-      backend.state.snapshots.setTaskState(
+      backend.state.setStreamTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         'abc123' as ExecutionId,
       );
-      backend.state.updateStreamHints(stream, {
+      backend.state.updateStreamMetadata(stream, {
         agentCategory: AgentCategory.ToolUse,
       });
       backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
@@ -1606,7 +1606,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream('tool-stream');
-      backend.state.updateStreamHints('tool-stream', {
+      backend.state.updateStreamMetadata('tool-stream', {
         agentCategory: AgentCategory.ToolUse,
       });
       backend.state.getOrCreateStreamState(
@@ -1616,14 +1616,14 @@ describe('ProgressBackend', () => {
       backend.state.activeStream = 'tool-stream';
       backend.state.agentCategoryFilter = 'toolUse';
       backend.state.streamLogs.ensureStream('workflow-existing');
-      backend.state.updateStreamHints('workflow-existing', {
+      backend.state.updateStreamMetadata('workflow-existing', {
         agentCategory: AgentCategory.Workflow,
       });
       backend.state.getOrCreateStreamState(
         'workflow-existing',
         AgentCategory.Workflow,
       );
-      backend.state.updateStreamHints('workflow-stream', {
+      backend.state.updateStreamMetadata('workflow-stream', {
         agentCategory: AgentCategory.Workflow,
       });
       vi.spyOn(backend.state, 'pickValidActiveStream').mockReturnValue(
@@ -1664,34 +1664,50 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('agrees on the resolved agentCategory across the filter, tab-render, and sync-content paths (#7583)', async () => {
-    // Regression test for the config/hints agentCategory single-owner fix:
-    // buildStreamInfos (matchesFilter + buildStreamTabInfo, streamInfoUtils.ts
-    // / streamTabInfo.ts) and syncStreamContent (getStreamCategory,
-    // ProgressFactApplier.ts) must resolve the same category from the same
-    // config/hints inputs, even when hints deliberately disagree with the
-    // live config.
+  it('keeps task-state metadata canonical across filtering, rendering, and sync content', async () => {
     const { backend, messages } = createRecordingBackend();
     const stream = 'search@deepseek#de5711c' as StreamTabId;
+    const executionId = 'de5711c' as ExecutionId;
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.snapshots.setTaskState(
+      backend.state.updateStreamMetadata(stream, {
+        agent: 'provisional-workflow',
+        agentCategory: AgentCategory.Workflow,
+        inputFile: 'draft.tex',
+        isRemote: true,
+        creationTimestamp: 123,
+      });
+      backend.state.setStreamTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
-        'de5711c' as ExecutionId,
+        executionId,
       );
-      // Stale hint disagrees with the live config on purpose — config must
-      // win consistently everywhere the category is resolved.
-      backend.state.updateStreamHints(stream, {
+      // A late provisional event cannot replace task-state authority.
+      backend.state.updateStreamMetadata(stream, {
+        agent: 'late-workflow',
         agentCategory: AgentCategory.Workflow,
+      });
+
+      expect(backend.state.getStreamMetadata(stream)).toMatchObject({
+        agent: 'search',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekproT',
+        isRemote: true,
+        creationTimestamp: 123,
+        executionId,
       });
 
       const toolUseInfos = buildStreamInfos(backend.state, 'toolUse');
       expect(toolUseInfos.map((info) => info.name)).toContain(stream);
-      expect(
-        toolUseInfos.find((info) => info.name === stream)?.agentCategory,
-      ).toBe(AgentCategory.ToolUse);
+      expect(toolUseInfos.find((info) => info.name === stream)).toMatchObject({
+        agent: 'search',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekproT',
+        isRemote: true,
+        creationTimestamp: 123,
+        executionId,
+      });
 
       const workflowInfos = buildStreamInfos(backend.state, 'workflow');
       expect(workflowInfos.map((info) => info.name)).not.toContain(stream);
@@ -1719,7 +1735,7 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([stream]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.snapshots.setTaskState(
+      backend.state.setStreamTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1727,6 +1727,39 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('promotes the transcript first timestamp into canonical metadata', () => {
+    const { backend } = createRecordingBackend();
+    const stream = 'timestamp-stream' as StreamTabId;
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.updateStreamMetadata(stream, { creationTimestamp: 500 });
+      expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(
+        500,
+      );
+
+      backend.state.streamLogs.append(stream, {
+        id: 'first-entry',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 100,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'first transcript entry',
+      });
+
+      expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(
+        100,
+      );
+      expect(
+        buildStreamInfos(backend.state, 'all').find(
+          (streamInfo) => streamInfo.name === stream,
+        ),
+      ).toMatchObject({ name: stream, creationTimestamp: 100 });
+    } finally {
+      backend.dispose();
+    }
+  });
+
   it('deletes the execution directory named by stream metadata when a stream is cleared', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966a' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1461,15 +1461,15 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      // Simulate persistence receiving run.config before progress state sees
+      // the RUNNING transition. The transition boundary must refresh the
+      // durable category before replacing stale execution state.
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         'abc123' as ExecutionId,
       );
-      backend.state.updateStreamMetadata(stream, {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+      backend.state.getOrCreateStreamState(stream, AgentCategory.Workflow);
       backend.state.updateStreamState(stream, (prev) => ({
         ...prev,
         conversationProgress: { toolCallCount: 7 },

--- a/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts
@@ -137,8 +137,10 @@ describe('progress view snapshot hydration', () => {
     state.snapshots.addUsage(stream, runId, usage);
     state.snapshots.setTodos(stream, [todo]);
     state.snapshots.setPlan(stream, plan);
-    state.snapshots.setParentStream(stream, parentStream);
-    state.updateStreamHints(stream, { agentCategory: AgentCategory.ToolUse });
+    state.setStreamParent(stream, parentStream);
+    state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.ToolUse,
+    });
     state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
     state.updateStreamState(stream, (prev) => ({
       ...prev,

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -4,11 +4,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, expect, it } from 'vitest';
 import { compareByNewestCreationTime } from '@controllers/progressView/backend/streamOrdering';
-import {
-  buildStreamTabInfo,
-  pickAgentCategory,
-} from '@controllers/progressView/backend/streamTabInfo';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { buildStreamTabInfo } from '@controllers/progressView/backend/streamTabInfo';
 import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
 
 // ---------------------------------------------------------------------------
@@ -53,59 +49,29 @@ describe('buildStreamTabInfo', () => {
   it('classifies stream-id-derived bash child streams as process agents', () => {
     const info = buildStreamTabInfo({
       streamId: 'bash@tool#exec:child-stream',
-      hints: {
+      metadata: {
         agentCategory: AgentCategory.ToolUse,
+        creationTimestamp: 1,
       },
-      creationTimestamp: 1,
     });
 
     expect(info.label).toBe('bash');
     expect(info.agent).toBe('bash');
     expect(info.kind).toBe('process');
   });
-});
 
-// ---------------------------------------------------------------------------
-// pickAgentCategory — single owner of the config/hints agentCategory
-// precedence (issue #7583). Regression coverage for the desync scenario:
-// `matchesFilter`/`buildStreamInfo` (streamInfoUtils.ts), `buildStreamTabInfo`
-// (streamTabInfo.ts), and `getStreamCategory` (ProgressFactApplier.ts) must
-// all resolve the same category for the same config/hints inputs.
-// ---------------------------------------------------------------------------
-
-describe('pickAgentCategory', () => {
-  it('prefers a live config category over the hint fallback', () => {
-    expect(
-      pickAgentCategory(
-        { agentCategory: AgentCategory.ToolUse },
-        { agentCategory: AgentCategory.Workflow },
-      ),
-    ).toBe(AgentCategory.ToolUse);
-  });
-
-  it('falls back to hints when config is absent', () => {
-    expect(
-      pickAgentCategory(undefined, { agentCategory: AgentCategory.ToolUse }),
-    ).toBe(AgentCategory.ToolUse);
-  });
-
-  it('returns undefined (no default) when both sources are empty', () => {
-    expect(pickAgentCategory(undefined, undefined)).toBeUndefined();
-    expect(pickAgentCategory(undefined, {})).toBeUndefined();
-  });
-
-  it('agrees with buildStreamTabInfo, which layers the Workflow default on top', () => {
-    const config = { agentCategory: AgentCategory.ToolUse } as AgentConfig;
-    const hints = { agentCategory: AgentCategory.Workflow };
-
+  it('renders the canonical category and remote status without source precedence', () => {
     const info = buildStreamTabInfo({
       streamId: 'search@deepseek#exec',
-      config,
-      hints,
-      creationTimestamp: 1,
+      metadata: {
+        agent: 'search',
+        agentCategory: AgentCategory.ToolUse,
+        isRemote: true,
+        creationTimestamp: 1,
+      },
     });
 
-    expect(pickAgentCategory(config, hints)).toBe(AgentCategory.ToolUse);
-    expect(info.agentCategory).toBe(pickAgentCategory(config, hints));
+    expect(info.agentCategory).toBe(AgentCategory.ToolUse);
+    expect(info.isRemote).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Replace the progress view's parallel `config` and `hints` metadata sources with one canonical `ProgressStreamMetadata` record owned by `ProgressViewState`.

Early host and runtime facts update that record through one boundary. Durable task-state and snapshot writes refresh the same record before filtering or rendering can observe it. This removes the field-by-field precedence logic and the `pickAgentCategory` resolver instead of renaming the old hydration model.

Closes #8476.

## Issue acceptance gates

- Rendering and filtering now accept one canonical metadata record, not a `config`/`hints` pair.
- `ProgressViewState` owns effective agent, category, input, remote status, timestamps, execution hierarchy, description, model, instruction, and working-directory metadata.
- Durable task state is applied at the write boundary, so late provisional events cannot create a contradictory effective category or agent.
- Removed `pickAgentCategory`, `StreamHints`, their schemas, and all fallback chains from progress rendering.
- Added coverage for provisional-event to task-state transitions, late-event protection, restored desktop streams without live task state, filter/render/sync agreement, and remote status.
- Extension and desktop consumers use the same `buildStreamTabInfo` input.

## Single source of truth

`ProgressViewState.ProgressStreamMetadata` is the single effective metadata record for progress-view consumers. `StreamSnapshotStore` remains the persistence mechanism; `ProgressViewState` synchronizes persistence-owned fields into the canonical record at load and write boundaries.

## Duplication and abstraction budget

Removed the two-source `config`/`hints` input shape, three category-resolution call sites, the standalone `pickAgentCategory` precedence helper, and duplicate fallback expressions for execution, parent, description, creation time, input, model, and working directory.

The new state methods own one invariant: early metadata may fill gaps, while durable snapshot metadata remains authoritative. They are boundary operations rather than pass-through managers.

## Net elements (R6)

- Files: 11 modified, 0 added, 0 deleted.
- Exported symbols: +1 (`ProgressStreamMetadata`), -2 (`StreamHints`, `pickAgentCategory`), net -1.
- Type constructs: +2 interfaces (one exported canonical record and one private session record), -2 type aliases; no classes or enums added.
- Net LoC: +52 (264 insertions, 212 deletions), including expanded transition and timestamp coverage.

## Consumer counts (R8)

- `pickAgentCategory`: 3 production consumers rerouted to canonical metadata; helper deleted.
- `getStreamHints` / `updateStreamHints` / `clearStreamHints`: 7 production call sites rerouted; APIs deleted.
- No event emit path or subscriber key changed.

## Host impact

Extension: Shared progress filtering, tab rendering, content sync, parent, description, and task-state paths consume canonical metadata.

Desktop: Restored streams and resume metadata feed the same canonical state; desktop tab rendering remains shared with the extension.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/streamInfoUtils.vitest.ts src/test-kernel/progressView/ProgressViewWorkPlanHydration.vitest.ts src/test-kernel/desktop/DesktopSessionProgressBridge.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (142 passed before review fixes)
- `npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/streamInfoUtils.vitest.ts` (39 passed after review fixes)
- `npm test` (6,195 passed, 4 skipped after review fixes)
