### PR TITLE
fix(relay): correlate upstream timeout failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ All notable changes to this project will be documented in this file.
 
 - **OpenAI-compatible conversations no longer stop unexpectedly** — valid
   answers now continue to completion instead of being interrupted.
-- **Relay failures can be traced without exposing request content** — provider
-  responses now include a correlation identifier that can be shared with
-  support when a request fails before or during its response.
+- **Relay failures can be traced without exposing request content** — relay
+  responses now include a correlation identifier that support can use to
+  investigate failures before or during a model response.
 
 ### Extension (VS Code)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 
 - **OpenAI-compatible conversations no longer stop unexpectedly** — valid
   answers now continue to completion instead of being interrupted.
+- **Relay failures can be traced without exposing request content** — provider
+  responses now include a correlation identifier that can be shared with
+  support when a request fails before or during its response.
 
 ### Extension (VS Code)
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -4,6 +4,10 @@ import { ModelProvider } from 'llm-zoo';
 
 // Local imports - core utilities
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
+import {
+  ChatCompletionStream,
+  type ContentDeltaEvent,
+} from 'openai/lib/ChatCompletionStream';
 import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
 
 // Local imports - agent components
@@ -23,6 +27,7 @@ import type {
 } from '@agent/types/IModelHandler';
 import {
   buildErrorLogData,
+  detectRequestId,
   isMissingFinishReasonError,
   handleStreamingFailure,
   trackStreamConnect,
@@ -90,10 +95,7 @@ import type {
   ChatCompletionMessageParam,
   ChatCompletionMessageToolCall,
   ChatCompletionToolMessageParam,
-  ChatCompletionStreamParams,
 } from 'openai/resources/chat/completions';
-import type { ContentDeltaEvent } from 'openai/lib/ChatCompletionStream';
-
 type ChatCompletionRequestBase = Omit<
   ChatCompletionCreateParamsStreaming,
   'stream' | 'stream_options'
@@ -104,6 +106,7 @@ type ChatCompletionRequestWithThinking = ChatCompletionRequestBase & {
 type ChatCompletionSummaryParams = ChatCompletionCreateParamsNonStreaming & {
   thinking?: { type: 'enabled' | 'disabled' };
 };
+type ErrorWithRequestId = Error & { request_id?: string };
 
 /**
  * DeepSeek's official (non-OpenRouter) chat API caps `max_tokens` well below
@@ -388,17 +391,16 @@ export class ModelHandlerOpenAI<
     const thinking = this.createThinkingStream();
     const output = this.createOutputStream();
 
-    const streamParams: ChatCompletionStreamParams = {
+    const streamParams: ChatCompletionCreateParamsStreaming = {
       ...baseParams,
       stream: true,
       stream_options: { include_usage: true },
     };
 
-    const stream = await client.chat.completions.stream(streamParams, {
-      signal,
-    });
-    const connect = trackStreamConnect(stream);
     const streamingAggregator = this.createStreamingAggregator();
+    let requestId: string | undefined;
+    let stream: ChatCompletionStream | undefined;
+    let connect: ReturnType<typeof trackStreamConnect> | undefined;
 
     const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
       if (delta) {
@@ -416,16 +418,15 @@ export class ModelHandlerOpenAI<
       }
     };
 
-    stream.on('content.delta', onContentDelta);
-    stream.on('chunk', onChunk);
-
-    const cleanup = (): void => {
-      connect.cleanup();
-      stream.off('content.delta', onContentDelta);
-      stream.off('chunk', onChunk);
-    };
-
     try {
+      const request = client.chat.completions.create(streamParams, { signal });
+      const { data, response } = await request.withResponse();
+      requestId = detectRequestId({ headers: response.headers });
+      stream = ChatCompletionStream.fromReadableStream(data.toReadableStream());
+      connect = trackStreamConnect(stream);
+      stream.on('content.delta', onContentDelta);
+      stream.on('chunk', onChunk);
+
       let finalResponse = await this.awaitFinalResponse(
         stream,
         streamingAggregator,
@@ -465,14 +466,18 @@ export class ModelHandlerOpenAI<
         // the tail.
         partialTail: () =>
           extractOpenAIPartialTail(
-            stream.currentChatCompletionSnapshot,
+            stream?.currentChatCompletionSnapshot,
             PARTIAL_TEXT_TAIL_MAX,
           ),
-        retryEligible: (tail) => connect.isConnected() || tail.length > 0,
+        retryEligible: (tail) =>
+          (connect?.isConnected() ?? false) || tail.length > 0,
         decorateError: (err, tail) => {
           // Tag at the boundary so abort identity survives wrapping and
           // minification (mirrors the Anthropic stream catch).
           tagOpenAISdkError(err, this.config.provider);
+          if (requestId && err instanceof Error) {
+            (err as ErrorWithRequestId).request_id = requestId;
+          }
           // Aborts are control flow; log at debug, skip warn.
           if (!isUserAbort(err)) {
             this.logger.warn('Stream failed', {
@@ -486,7 +491,9 @@ export class ModelHandlerOpenAI<
         },
       });
     } finally {
-      cleanup();
+      connect?.cleanup();
+      stream?.off('content.delta', onContentDelta);
+      stream?.off('chunk', onChunk);
     }
   }
 

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -401,6 +401,8 @@ export class ModelHandlerOpenAI<
     let requestId: string | undefined;
     let stream: ChatCompletionStream | undefined;
     let connect: ReturnType<typeof trackStreamConnect> | undefined;
+    const abortReconstructedStream = () => stream?.abort();
+    signal?.addEventListener('abort', abortReconstructedStream, { once: true });
 
     const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
       if (delta) {
@@ -423,6 +425,7 @@ export class ModelHandlerOpenAI<
       const { data, response } = await request.withResponse();
       requestId = detectRequestId({ headers: response.headers });
       stream = ChatCompletionStream.fromReadableStream(data.toReadableStream());
+      if (signal?.aborted) stream.abort();
       connect = trackStreamConnect(stream);
       stream.on('content.delta', onContentDelta);
       stream.on('chunk', onChunk);
@@ -491,6 +494,7 @@ export class ModelHandlerOpenAI<
         },
       });
     } finally {
+      signal?.removeEventListener('abort', abortReconstructedStream);
       connect?.cleanup();
       stream?.off('content.delta', onContentDelta);
       stream?.off('chunk', onChunk);

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -164,13 +164,19 @@ export function detectRequestId(err: unknown): string | undefined {
     headers?: HeaderBag;
   };
 
+  const relayRequestId = getHeaderValue(
+    candidate.headers,
+    'x-relay-request-id',
+  );
+  if (relayRequestId) return relayRequestId;
+
   const directId =
     candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
 
-  // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
+  // Try provider headers after the relay-specific correlation id.
   return (
     getHeaderValue(candidate.headers, 'request-id') ??
     getHeaderValue(candidate.headers, 'x-request-id')

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -31,7 +31,7 @@ export {
   trackStreamConnect,
 } from './sdkError/streamFailure';
 
-export { detectStatusCode } from './sdkError/errorInspection';
+export { detectRequestId, detectStatusCode } from './sdkError/errorInspection';
 
 export {
   PARTIAL_TEXT_TAIL_MAX,

--- a/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
@@ -1,0 +1,87 @@
+// Third-party imports
+import OpenAI from 'openai';
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent model handlers
+import { noopTrace } from '@agent/trace';
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
+
+// Local imports - common errors
+import { normalizeProviderError } from '@common/errors/sdkErrorUtils';
+
+class TestModelHandlerOpenAI extends ModelHandlerOpenAI {
+  runStreaming(client: OpenAI) {
+    return this.executeStreamingChat(client, {
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+  }
+}
+
+function createHandler(): TestModelHandlerOpenAI {
+  const handler = new TestModelHandlerOpenAI({
+    name: 'test-openai',
+    label: 'Test OpenAI',
+    fullName: 'gpt-test',
+    shortName: 'gpt-test',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 128_000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: false,
+      supportsTokenCounting: false,
+    },
+    openRouterOnly: true,
+  });
+  handler.setLogger(noopTrace);
+  return handler;
+}
+
+describe('OpenAI relay stream correlation', () => {
+  it('retains the relay request id when the response body fails', async () => {
+    const bodyError = new Error('response body failed');
+    const chunk = new TextEncoder().encode(
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}\n\n',
+    );
+    let pullCount = 0;
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://relay.test/openai/v1',
+      maxRetries: 0,
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (pullCount === 0) {
+                pullCount += 1;
+                controller.enqueue(chunk);
+                return;
+              }
+              controller.error(bodyError);
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'text/event-stream',
+              'x-relay-request-id': 'relay-123',
+            },
+          },
+        ),
+    });
+
+    let caught: unknown;
+    try {
+      await createHandler().runStreaming(client);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({ request_id: 'relay-123' });
+    expect(normalizeProviderError(caught).requestId).toBe('relay-123');
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
@@ -8,14 +8,21 @@ import { noopTrace } from '@agent/trace';
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 
 // Local imports - common errors
-import { normalizeProviderError } from '@common/errors/sdkErrorUtils';
+import {
+  isUserAbort,
+  normalizeProviderError,
+} from '@common/errors/sdkErrorUtils';
 
 class TestModelHandlerOpenAI extends ModelHandlerOpenAI {
-  runStreaming(client: OpenAI) {
-    return this.executeStreamingChat(client, {
-      model: 'gpt-test',
-      messages: [{ role: 'user', content: 'hello' }],
-    });
+  runStreaming(client: OpenAI, signal?: AbortSignal) {
+    return this.executeStreamingChat(
+      client,
+      {
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+      signal,
+    );
   }
 }
 
@@ -83,5 +90,63 @@ describe('OpenAI relay stream correlation', () => {
 
     expect(caught).toMatchObject({ request_id: 'relay-123' });
     expect(normalizeProviderError(caught).requestId).toBe('relay-123');
+  });
+
+  it('preserves user aborts after response headers and a partial chunk', async () => {
+    const abortController = new AbortController();
+    let resolveFirstChunk: (() => void) | undefined;
+    const firstChunk = new Promise<void>((resolve) => {
+      resolveFirstChunk = resolve;
+    });
+    const chunk = new TextEncoder().encode(
+      'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}\n\n',
+    );
+    let sentChunk = false;
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://relay.test/openai/v1',
+      maxRetries: 0,
+      fetch: async (_input, init) => {
+        let bodyController:
+          ReadableStreamDefaultController<Uint8Array> | undefined;
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            bodyController = controller;
+          },
+          pull(controller) {
+            if (!sentChunk) {
+              sentChunk = true;
+              controller.enqueue(chunk);
+              resolveFirstChunk?.();
+              return;
+            }
+            return new Promise<void>(() => {});
+          },
+        });
+        init?.signal?.addEventListener(
+          'abort',
+          () =>
+            bodyController?.error(new DOMException('aborted', 'AbortError')),
+          { once: true },
+        );
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    });
+
+    const run = createHandler().runStreaming(client, abortController.signal);
+    await firstChunk;
+    abortController.abort();
+
+    let caught: unknown;
+    try {
+      await run;
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isUserAbort(caught)).toBe(true);
   });
 });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -186,6 +186,18 @@ describe('formatProviderHttpError', () => {
     expect(formatted.requestId).toBe('req-anthropic');
   });
 
+  it('prefers relay correlation ids over provider request ids', () => {
+    const err = withHeaders(new UnknownSdkApiError('relay timed out'), {
+      'request-id': 'req-anthropic',
+      'x-relay-request-id': 'relay-123',
+    });
+    Object.assign(err, { request_id: 'req-anthropic' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.requestId).toBe('relay-123');
+  });
+
   it('does not infer OpenAI from generic x-request-id headers', () => {
     const err = withHeaders(
       new UnknownSdkApiError('openai-compatible gateway failed'),

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -15,6 +15,9 @@ import {
 } from '../../../supabase/functions/relay/requestLimits';
 import {
   acquireRelayRequestSlot,
+  classifyPreHeaderFailure,
+  getRelayRequestBytes,
+  getUpstreamRequestId,
   releaseWhenStreamCloses,
 } from '../../../supabase/functions/relay/requestGate';
 import { getRequestLimits } from '../../../supabase/functions/relay/models';
@@ -354,6 +357,72 @@ describe('relay free-tier request limits', () => {
     assert.equal(releases, 1);
   });
 
+  it('classifies failures before upstream headers arrive', () => {
+    const timeout = new Error('timed out');
+    timeout.name = 'TimeoutError';
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+
+    assert.equal(classifyPreHeaderFailure(timeout), 'pre_headers_timeout');
+    assert.equal(classifyPreHeaderFailure(abort), 'pre_headers_timeout');
+    assert.equal(
+      classifyPreHeaderFailure(new TypeError('fetch failed')),
+      'pre_headers_failure',
+    );
+  });
+
+  it('measures buffered relay request bytes without reading content', () => {
+    assert.equal(getRelayRequestBytes('a€', null), 4);
+    assert.equal(getRelayRequestBytes(new Uint8Array([0, 1, 2]), '999'), 3);
+    assert.equal(getRelayRequestBytes(byteStream([]), '60000'), 60_000);
+    assert.equal(getRelayRequestBytes(byteStream([]), null), null);
+    assert.equal(getRelayRequestBytes(undefined, null), 0);
+  });
+
+  it('extracts provider request ids without replacing them', () => {
+    assert.equal(
+      getUpstreamRequestId(
+        new Headers({
+          'request-id': 'req-anthropic',
+          'x-request-id': 'req-compatible',
+        }),
+      ),
+      'req-anthropic',
+    );
+    assert.equal(
+      getUpstreamRequestId(new Headers({ 'x-goog-request-id': 'req-google' })),
+      'req-google',
+    );
+    assert.equal(getUpstreamRequestId(new Headers()), null);
+  });
+
+  it('reports upstream response-body failures and releases the slot', async () => {
+    const upstreamError = new Error('response body failed');
+    let observedError: unknown;
+    let releases = 0;
+    const failingBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(upstreamError);
+      },
+    });
+    const wrapped = await releaseWhenStreamCloses(
+      failingBody,
+      async () => {
+        releases += 1;
+      },
+      undefined,
+      0,
+      (error) => {
+        observedError = error;
+      },
+    );
+    if (wrapped === null) assert.fail('expected wrapped stream');
+
+    await assert.rejects(wrapped.getReader().read(), upstreamError);
+    assert.equal(observedError, upstreamError);
+    assert.equal(releases, 1);
+  });
+
   it('uses the same slot id for gate refresh and release RPCs', async () => {
     const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
     const client = {
@@ -538,11 +607,16 @@ describe('relay free-tier request limits', () => {
       });
       if (!slot.allowed) assert.fail('expected slot to be allowed');
 
+      let upstreamBodyFailures = 0;
+
       const wrapped = await releaseWhenStreamCloses(
         byteStream([new Uint8Array([1])]),
         slot.release,
         slot.refresh,
         10,
+        () => {
+          upstreamBodyFailures += 1;
+        },
       );
       if (wrapped === null) assert.fail('expected wrapped stream');
 
@@ -558,6 +632,7 @@ describe('relay free-tier request limits', () => {
         reader.read(),
         /relay_request_refresh did not find request slot/,
       );
+      assert.equal(upstreamBodyFailures, 0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../supabase/functions/relay/diagnostics';
 import {
   acquireRelayRequestSlot,
-  releaseAfterUpstreamFailure,
+  releaseRelaySlotSafely,
   releaseWhenStreamCloses,
 } from '../../../supabase/functions/relay/requestGate';
 import {
@@ -434,7 +434,8 @@ describe('relay free-tier request limits', () => {
   });
 
   it('measures buffered relay request bytes without reading content', () => {
-    assert.equal(getRelayRequestBytes('a€', null), 4);
+    assert.equal(getRelayRequestBytes('a€😀', null), 8);
+    assert.equal(getRelayRequestBytes('\ud800', null), 3);
     assert.equal(getRelayRequestBytes(new Uint8Array([0, 1, 2]), '999'), 3);
     assert.equal(getRelayRequestBytes(byteStream([]), '60000'), 60_000);
     assert.equal(getRelayRequestBytes(byteStream([]), null), null);
@@ -468,11 +469,11 @@ describe('relay free-tier request limits', () => {
     const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
-      await releaseAfterUpstreamFailure(async () => {
+      await releaseRelaySlotSafely(async () => {
         throw new Error('release failed with sensitive details');
       });
       assert.deepEqual(errorLog.mock.calls, [
-        ['[RELAY] Failed to release request slot after upstream failure'],
+        ['[RELAY] Failed to release request slot'],
       ]);
     } finally {
       errorLog.mockRestore();
@@ -500,6 +501,23 @@ describe('relay free-tier request limits', () => {
 
     await assert.rejects(wrapped.getReader().read(), upstreamError);
     assert.equal(releases, 1);
+  });
+
+  it('preserves bodyless upstream responses when slot release fails', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const wrapped = await releaseWhenStreamCloses(null, async () => {
+        throw new Error('release failed');
+      });
+
+      assert.equal(wrapped, null);
+      assert.deepEqual(errorLog.mock.calls, [
+        ['[RELAY] Failed to release request slot'],
+      ]);
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
   it('preserves upstream errors and slot release when the observer throws', async () => {
@@ -554,7 +572,7 @@ describe('relay free-tier request limits', () => {
 
       await assert.rejects(wrapped.getReader().read(), upstreamError);
       assert.deepEqual(errorLog.mock.calls, [
-        ['[RELAY] Failed to release request slot after upstream failure'],
+        ['[RELAY] Failed to release request slot'],
       ]);
     } finally {
       errorLog.mockRestore();

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -17,6 +17,7 @@ import {
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
+  logRelayFailure,
   RELAY_REQUEST_ID_HEADER,
   withRelayErrorRequestId,
 } from '../../../supabase/functions/relay/diagnostics';
@@ -388,6 +389,38 @@ describe('relay free-tier request limits', () => {
       getCanonicalRelayModelName('prompt-or-secret@example.com'),
       null,
     );
+  });
+
+  it('sanitizes the complete structured failure log', () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      logRelayFailure({
+        relayRequestId: 'relay-123',
+        provider: 'anthropic',
+        model: 'prompt-or-secret@example.com',
+        requestBytes: 60_000,
+        elapsedMs: 390_000,
+        failurePhase: 'response_body_failure',
+        upstreamRequestId: 'https://secret.example/prompt',
+      });
+
+      const serialized = String(errorLog.mock.calls[0]?.[0]);
+      assert.equal(serialized.includes('prompt-or-secret@example.com'), false);
+      assert.equal(serialized.includes('secret.example'), false);
+      assert.deepEqual(JSON.parse(serialized.slice('[RELAY] '.length)), {
+        event: 'upstream_failure',
+        relayRequestId: 'relay-123',
+        provider: 'anthropic',
+        model: null,
+        requestBytes: 60_000,
+        elapsedMs: 390_000,
+        failurePhase: 'response_body_failure',
+        upstreamRequestId: null,
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
   it('exposes relay-generated error ids through the SDK request-id contract', () => {

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -764,9 +764,14 @@ describe('relay free-tier request limits', () => {
       if (!slot.allowed) assert.fail('expected slot to be allowed');
 
       let upstreamBodyFailures = 0;
+      const pendingBody = new ReadableStream<Uint8Array>({
+        pull() {
+          return new Promise<void>(() => {});
+        },
+      });
 
       const wrapped = await releaseWhenStreamCloses(
-        byteStream([new Uint8Array([1])]),
+        pendingBody,
         slot.release,
         slot.refresh,
         10,
@@ -776,6 +781,12 @@ describe('relay free-tier request limits', () => {
       );
       if (wrapped === null) assert.fail('expected wrapped stream');
 
+      const reader = wrapped.getReader();
+      const pendingRead = reader.read();
+      const rejectedRead = assert.rejects(
+        pendingRead,
+        /relay_request_refresh did not find request slot/,
+      );
       await vi.advanceTimersByTimeAsync(10);
       assert.deepEqual(calls, [
         'relay_request_gate',
@@ -783,11 +794,7 @@ describe('relay free-tier request limits', () => {
         'relay_request_release',
       ]);
 
-      const reader = wrapped.getReader();
-      await assert.rejects(
-        reader.read(),
-        /relay_request_refresh did not find request slot/,
-      );
+      await rejectedRead;
       assert.equal(upstreamBodyFailures, 0);
     } finally {
       vi.useRealTimers();

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -423,6 +423,41 @@ describe('relay free-tier request limits', () => {
     assert.equal(releases, 1);
   });
 
+  it('preserves upstream errors and slot release when the observer throws', async () => {
+    const upstreamError = new Error('response body failed');
+    const observerError = new Error('sensitive observer details');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let releases = 0;
+    const failingBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(upstreamError);
+      },
+    });
+
+    try {
+      const wrapped = await releaseWhenStreamCloses(
+        failingBody,
+        async () => {
+          releases += 1;
+        },
+        undefined,
+        0,
+        () => {
+          throw observerError;
+        },
+      );
+      if (wrapped === null) assert.fail('expected wrapped stream');
+
+      await assert.rejects(wrapped.getReader().read(), upstreamError);
+      assert.equal(releases, 1);
+      assert.deepEqual(errorLog.mock.calls, [
+        ['[RELAY] Upstream body failure observer failed'],
+      ]);
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+
   it('uses the same slot id for gate refresh and release RPCs', async () => {
     const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
     const client = {

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -14,10 +14,12 @@ import {
   readRequestBodyWithinSizeLimit,
 } from '../../../supabase/functions/relay/requestLimits';
 import {
-  acquireRelayRequestSlot,
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
+} from '../../../supabase/functions/relay/diagnostics';
+import {
+  acquireRelayRequestSlot,
   releaseWhenStreamCloses,
 } from '../../../supabase/functions/relay/requestGate';
 import { getRequestLimits } from '../../../supabase/functions/relay/models';
@@ -398,7 +400,6 @@ describe('relay free-tier request limits', () => {
 
   it('reports upstream response-body failures and releases the slot', async () => {
     const upstreamError = new Error('response body failed');
-    let observedError: unknown;
     let releases = 0;
     const failingBody = new ReadableStream<Uint8Array>({
       pull(controller) {
@@ -412,14 +413,11 @@ describe('relay free-tier request limits', () => {
       },
       undefined,
       0,
-      (error) => {
-        observedError = error;
-      },
+      () => {},
     );
     if (wrapped === null) assert.fail('expected wrapped stream');
 
     await assert.rejects(wrapped.getReader().read(), upstreamError);
-    assert.equal(observedError, upstreamError);
     assert.equal(releases, 1);
   });
 

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -17,12 +17,18 @@ import {
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
+  RELAY_REQUEST_ID_HEADER,
+  withRelayErrorRequestId,
 } from '../../../supabase/functions/relay/diagnostics';
 import {
   acquireRelayRequestSlot,
+  releaseAfterUpstreamFailure,
   releaseWhenStreamCloses,
 } from '../../../supabase/functions/relay/requestGate';
-import { getRequestLimits } from '../../../supabase/functions/relay/models';
+import {
+  getCanonicalRelayModelName,
+  getRequestLimits,
+} from '../../../supabase/functions/relay/models';
 import { isModelFreeRelayPath } from '../../../supabase/functions/relay/paths';
 
 function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
@@ -373,6 +379,27 @@ describe('relay free-tier request limits', () => {
     );
   });
 
+  it('uses only registry-owned model identifiers in diagnostics', () => {
+    assert.equal(
+      getCanonicalRelayModelName('anthropic/claude-sonnet-4-6'),
+      'claude-sonnet-4-6',
+    );
+    assert.equal(
+      getCanonicalRelayModelName('prompt-or-secret@example.com'),
+      null,
+    );
+  });
+
+  it('exposes relay-generated error ids through the SDK request-id contract', () => {
+    const response = withRelayErrorRequestId(
+      new Response(null, { status: 504 }),
+      'relay-123',
+    );
+
+    assert.equal(response.headers.get(RELAY_REQUEST_ID_HEADER), 'relay-123');
+    assert.equal(response.headers.get('x-request-id'), 'relay-123');
+  });
+
   it('measures buffered relay request bytes without reading content', () => {
     assert.equal(getRelayRequestBytes('a€', null), 4);
     assert.equal(getRelayRequestBytes(new Uint8Array([0, 1, 2]), '999'), 3);
@@ -396,6 +423,27 @@ describe('relay free-tier request limits', () => {
       'req-google',
     );
     assert.equal(getUpstreamRequestId(new Headers()), null);
+    assert.equal(
+      getUpstreamRequestId(
+        new Headers({ 'x-request-id': 'https://secret.example/prompt' }),
+      ),
+      null,
+    );
+  });
+
+  it('does not let slot release failures replace upstream failures', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await releaseAfterUpstreamFailure(async () => {
+        throw new Error('release failed with sensitive details');
+      });
+      assert.deepEqual(errorLog.mock.calls, [
+        ['[RELAY] Failed to release request slot after upstream failure'],
+      ]);
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
   it('reports upstream response-body failures and releases the slot', async () => {
@@ -450,6 +498,30 @@ describe('relay free-tier request limits', () => {
       assert.equal(releases, 1);
       assert.deepEqual(errorLog.mock.calls, [
         ['[RELAY] Upstream body failure observer failed'],
+      ]);
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+
+  it('preserves upstream errors when slot release also fails', async () => {
+    const upstreamError = new Error('response body failed');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const failingBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(upstreamError);
+      },
+    });
+
+    try {
+      const wrapped = await releaseWhenStreamCloses(failingBody, async () => {
+        throw new Error('release failed');
+      });
+      if (wrapped === null) assert.fail('expected wrapped stream');
+
+      await assert.rejects(wrapped.getReader().read(), upstreamError);
+      assert.deepEqual(errorLog.mock.calls, [
+        ['[RELAY] Failed to release request slot after upstream failure'],
       ]);
     } finally {
       errorLog.mockRestore();

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -1,0 +1,43 @@
+export type RelayFailurePhase =
+  'pre_headers_timeout' | 'pre_headers_failure' | 'response_body_failure';
+
+const UPSTREAM_REQUEST_ID_HEADERS = [
+  'request-id',
+  'x-request-id',
+  'x-goog-request-id',
+] as const;
+
+type RelayRequestBody =
+  string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
+
+export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
+  return error instanceof Error &&
+    (error.name === 'TimeoutError' || error.name === 'AbortError')
+    ? 'pre_headers_timeout'
+    : 'pre_headers_failure';
+}
+
+export function getUpstreamRequestId(headers: Headers): string | null {
+  for (const header of UPSTREAM_REQUEST_ID_HEADERS) {
+    const requestId = headers.get(header)?.trim();
+    if (requestId) return requestId;
+  }
+  return null;
+}
+
+export function getRelayRequestBytes(
+  body: RelayRequestBody,
+  contentLength: string | null,
+): number | null {
+  if (body == null) return 0;
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).byteLength;
+  }
+  if (body instanceof Uint8Array) return body.byteLength;
+
+  if (contentLength == null || contentLength.trim() === '') return null;
+  const parsedLength = Number(contentLength);
+  return Number.isSafeInteger(parsedLength) && parsedLength >= 0
+    ? parsedLength
+    : null;
+}

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -1,3 +1,5 @@
+import { getCanonicalRelayModelName } from './models.ts';
+
 export type RelayFailurePhase =
   'pre_headers_timeout' | 'pre_headers_failure' | 'response_body_failure';
 
@@ -12,6 +14,16 @@ const SAFE_REQUEST_ID_RE = /^[A-Za-z0-9._:-]{1,200}$/;
 
 type RelayRequestBody =
   string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
+
+export interface RelayFailureDiagnostic {
+  relayRequestId: string;
+  provider: string;
+  model: string | null;
+  requestBytes: number | null;
+  elapsedMs: number;
+  failurePhase: RelayFailurePhase;
+  upstreamRequestId: string | null;
+}
 
 /** Attach the relay id to a relay-generated error using both its specific
  * header and the standard request-id header understood by SDK clients. */
@@ -31,10 +43,26 @@ export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
     : 'pre_headers_failure';
 }
 
+function sanitizeRequestId(requestId: string | null): string | null {
+  const trimmed = requestId?.trim();
+  return trimmed && SAFE_REQUEST_ID_RE.test(trimmed) ? trimmed : null;
+}
+
+export function logRelayFailure(diagnostic: RelayFailureDiagnostic): void {
+  console.error(
+    `[RELAY] ${JSON.stringify({
+      event: 'upstream_failure',
+      ...diagnostic,
+      model: getCanonicalRelayModelName(diagnostic.model),
+      upstreamRequestId: sanitizeRequestId(diagnostic.upstreamRequestId),
+    })}`,
+  );
+}
+
 export function getUpstreamRequestId(headers: Headers): string | null {
   for (const header of UPSTREAM_REQUEST_ID_HEADERS) {
-    const requestId = headers.get(header)?.trim();
-    if (requestId && SAFE_REQUEST_ID_RE.test(requestId)) return requestId;
+    const requestId = sanitizeRequestId(headers.get(header));
+    if (requestId) return requestId;
   }
   return null;
 }

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -1,14 +1,28 @@
 export type RelayFailurePhase =
   'pre_headers_timeout' | 'pre_headers_failure' | 'response_body_failure';
 
+export const RELAY_REQUEST_ID_HEADER = 'x-relay-request-id';
+
 const UPSTREAM_REQUEST_ID_HEADERS = [
   'request-id',
   'x-request-id',
   'x-goog-request-id',
 ] as const;
+const SAFE_REQUEST_ID_RE = /^[A-Za-z0-9._:-]{1,200}$/;
 
 type RelayRequestBody =
   string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
+
+/** Attach the relay id to a relay-generated error using both its specific
+ * header and the standard request-id header understood by SDK clients. */
+export function withRelayErrorRequestId(
+  response: Response,
+  relayRequestId: string,
+): Response {
+  response.headers.set(RELAY_REQUEST_ID_HEADER, relayRequestId);
+  response.headers.set('x-request-id', relayRequestId);
+  return response;
+}
 
 export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
   return error instanceof Error &&
@@ -20,7 +34,7 @@ export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
 export function getUpstreamRequestId(headers: Headers): string | null {
   for (const header of UPSTREAM_REQUEST_ID_HEADERS) {
     const requestId = headers.get(header)?.trim();
-    if (requestId) return requestId;
+    if (requestId && SAFE_REQUEST_ID_RE.test(requestId)) return requestId;
   }
   return null;
 }

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -15,6 +15,30 @@ const SAFE_REQUEST_ID_RE = /^[A-Za-z0-9._:-]{1,200}$/;
 type RelayRequestBody =
   string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
 
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    const codeUnit = value.charCodeAt(i);
+    if (codeUnit < 0x80) {
+      bytes += 1;
+    } else if (codeUnit < 0x800) {
+      bytes += 2;
+    } else if (
+      codeUnit >= 0xd800 &&
+      codeUnit <= 0xdbff &&
+      i + 1 < value.length &&
+      value.charCodeAt(i + 1) >= 0xdc00 &&
+      value.charCodeAt(i + 1) <= 0xdfff
+    ) {
+      bytes += 4;
+      i += 1;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
 export interface RelayFailureDiagnostic {
   relayRequestId: string;
   provider: string;
@@ -72,9 +96,7 @@ export function getRelayRequestBytes(
   contentLength: string | null,
 ): number | null {
   if (body == null) return 0;
-  if (typeof body === 'string') {
-    return new TextEncoder().encode(body).byteLength;
-  }
+  if (typeof body === 'string') return utf8ByteLength(body);
   if (body instanceof Uint8Array) return body.byteLength;
 
   if (contentLength == null || contentLength.trim() === '') return null;

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -102,7 +102,11 @@ import {
 } from './requestLimits.ts';
 import {
   acquireRelayRequestSlot,
+  classifyPreHeaderFailure,
+  getRelayRequestBytes,
+  getUpstreamRequestId,
   releaseWhenStreamCloses,
+  type RelayFailurePhase,
 } from './requestGate.ts';
 
 // =============================================================================
@@ -118,6 +122,7 @@ const RELAY_VERSION = '1.10.0';
 
 // Upstream request timeout (390s to fit within Supabase's 400s wall clock limit)
 const UPSTREAM_TIMEOUT_MS = 390000;
+const RELAY_REQUEST_ID_HEADER = 'x-relay-request-id';
 
 // Env and the service-role client are fixed at cold start; no per-request state.
 // Public metadata remains available without the service role, but proxy routes
@@ -176,6 +181,16 @@ interface ProviderConfig {
   baseUrl: string;
   envKey: string;
   authType: AuthType;
+}
+
+interface RelayFailureDiagnostic {
+  relayRequestId: string;
+  provider: string;
+  model: string | null;
+  requestBytes: number | null;
+  elapsedMs: number;
+  failurePhase: RelayFailurePhase;
+  upstreamRequestId: string | null;
 }
 
 type ProviderKey =
@@ -249,6 +264,20 @@ function getEnabledProviders(): string[] {
   return Object.entries(PROVIDER_CONFIGS)
     .filter(([, config]) => Deno.env.get(config.envKey))
     .map(([name]) => name);
+}
+
+function logRelayFailure(diagnostic: RelayFailureDiagnostic): void {
+  console.error(
+    `[RELAY] ${JSON.stringify({
+      event: 'upstream_failure',
+      ...diagnostic,
+    })}`,
+  );
+}
+
+function withRelayRequestId(response: Response, relayRequestId: string) {
+  response.headers.set(RELAY_REQUEST_ID_HEADER, relayRequestId);
+  return response;
 }
 
 /**
@@ -394,7 +423,12 @@ app.use(
       'x-stainless-runtime',
       'x-stainless-runtime-version',
     ],
-    exposeHeaders: ['content-length', 'content-type', 'x-request-id'],
+    exposeHeaders: [
+      'content-length',
+      'content-type',
+      'x-request-id',
+      RELAY_REQUEST_ID_HEADER,
+    ],
     maxAge: 86400,
   }),
 );
@@ -835,26 +869,48 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   // 11. Forward request with timeout
   let upstreamResponse: Response;
+  const bodyToSend =
+    c.req.method === 'GET' ? undefined : (requestBody ?? c.req.raw.body);
+  const relayRequestId = crypto.randomUUID();
+  const requestBytes = getRelayRequestBytes(
+    bodyToSend,
+    c.req.raw.headers.get('content-length'),
+  );
+  const upstreamStartedAt = performance.now();
   try {
-    const bodyToSend =
-      c.req.method === 'GET' ? undefined : (requestBody ?? c.req.raw.body);
-
     upstreamResponse = await fetch(targetUrl, {
       method: c.req.method,
       headers: upstreamHeaders,
-      body: bodyToSend,
+      // The buffered body owns its ArrayBuffer, although its existing public
+      // type predates typed-array buffer generics in newer TypeScript versions.
+      body: bodyToSend as BodyInit | null | undefined,
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch (error) {
+    const failurePhase = classifyPreHeaderFailure(error);
+    logRelayFailure({
+      relayRequestId,
+      provider,
+      model: modelName,
+      requestBytes,
+      elapsedMs: Math.round(performance.now() - upstreamStartedAt),
+      failurePhase,
+      upstreamRequestId: null,
+    });
     await releaseRelaySlot?.();
-    if (
-      error instanceof Error &&
-      (error.name === 'TimeoutError' || error.name === 'AbortError')
-    ) {
-      return jsonError('Upstream request timed out', 504);
+    if (failurePhase === 'pre_headers_timeout') {
+      return withRelayRequestId(
+        jsonError('Upstream request timed out', 504),
+        relayRequestId,
+      );
     }
-    throw error;
+    return withRelayRequestId(
+      jsonError('Internal server error', 500),
+      relayRequestId,
+    );
   }
+
+  const upstreamRequestId = getUpstreamRequestId(upstreamResponse.headers);
 
   if (upstreamResponse.status >= 400) {
     console.error(
@@ -871,6 +927,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   });
 
   responseHeaders.set('X-Accel-Buffering', 'no');
+  responseHeaders.set(RELAY_REQUEST_ID_HEADER, relayRequestId);
 
   // FUTURE: SSE keepalive injection to prevent proxy idle timeouts.
   //
@@ -898,6 +955,18 @@ app.all('/:provider{[^/]+}/*', async (c) => {
         upstreamResponse.body,
         releaseRelaySlot,
         refreshRelaySlot ?? undefined,
+        undefined,
+        () => {
+          logRelayFailure({
+            relayRequestId,
+            provider,
+            model: modelName,
+            requestBytes,
+            elapsedMs: Math.round(performance.now() - upstreamStartedAt),
+            failurePhase: 'response_body_failure',
+            upstreamRequestId,
+          });
+        },
       )
     : upstreamResponse.body;
 

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -110,7 +110,7 @@ import {
 } from './diagnostics.ts';
 import {
   acquireRelayRequestSlot,
-  releaseAfterUpstreamFailure,
+  releaseRelaySlotSafely,
   releaseWhenStreamCloses,
 } from './requestGate.ts';
 
@@ -877,7 +877,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
       failurePhase,
       upstreamRequestId: null,
     });
-    await releaseAfterUpstreamFailure(releaseRelaySlot);
+    await releaseRelaySlotSafely(releaseRelaySlot);
     if (failurePhase === 'pre_headers_timeout') {
       return withRelayErrorRequestId(
         jsonError('Upstream request timed out', 504),

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -74,6 +74,7 @@ import { resolveRelayCredential } from '../_shared/relayCiToken.ts';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
+  getCanonicalRelayModelName,
   getSpendingLimit,
   getRequestLimits,
   isRetiredModelRequest,
@@ -104,10 +105,13 @@ import {
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
+  RELAY_REQUEST_ID_HEADER,
   type RelayFailurePhase,
+  withRelayErrorRequestId,
 } from './diagnostics.ts';
 import {
   acquireRelayRequestSlot,
+  releaseAfterUpstreamFailure,
   releaseWhenStreamCloses,
 } from './requestGate.ts';
 
@@ -124,7 +128,6 @@ const RELAY_VERSION = '1.10.0';
 
 // Upstream request timeout (390s to fit within Supabase's 400s wall clock limit)
 const UPSTREAM_TIMEOUT_MS = 390000;
-const RELAY_REQUEST_ID_HEADER = 'x-relay-request-id';
 
 // Env and the service-role client are fixed at cold start; no per-request state.
 // Public metadata remains available without the service role, but proxy routes
@@ -275,11 +278,6 @@ function logRelayFailure(diagnostic: RelayFailureDiagnostic): void {
       ...diagnostic,
     })}`,
   );
-}
-
-function withRelayRequestId(response: Response, relayRequestId: string) {
-  response.headers.set(RELAY_REQUEST_ID_HEADER, relayRequestId);
-  return response;
 }
 
 /**
@@ -874,6 +872,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   const bodyToSend =
     c.req.method === 'GET' ? undefined : (requestBody ?? c.req.raw.body);
   const relayRequestId = crypto.randomUUID();
+  const diagnosticModel = getCanonicalRelayModelName(modelName);
   const requestBytes = getRelayRequestBytes(
     bodyToSend,
     c.req.raw.headers.get('content-length'),
@@ -893,20 +892,20 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     logRelayFailure({
       relayRequestId,
       provider,
-      model: modelName,
+      model: diagnosticModel,
       requestBytes,
       elapsedMs: Math.round(performance.now() - upstreamStartedAt),
       failurePhase,
       upstreamRequestId: null,
     });
-    await releaseRelaySlot?.();
+    await releaseAfterUpstreamFailure(releaseRelaySlot);
     if (failurePhase === 'pre_headers_timeout') {
-      return withRelayRequestId(
+      return withRelayErrorRequestId(
         jsonError('Upstream request timed out', 504),
         relayRequestId,
       );
     }
-    return withRelayRequestId(
+    return withRelayErrorRequestId(
       jsonError('Internal server error', 500),
       relayRequestId,
     );
@@ -962,7 +961,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
           logRelayFailure({
             relayRequestId,
             provider,
-            model: modelName,
+            model: diagnosticModel,
             requestBytes,
             elapsedMs: Math.round(performance.now() - upstreamStartedAt),
             failurePhase: 'response_body_failure',

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -101,12 +101,14 @@ import {
   readRequestBodyWithinSizeLimit,
 } from './requestLimits.ts';
 import {
-  acquireRelayRequestSlot,
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
-  releaseWhenStreamCloses,
   type RelayFailurePhase,
+} from './diagnostics.ts';
+import {
+  acquireRelayRequestSlot,
+  releaseWhenStreamCloses,
 } from './requestGate.ts';
 
 // =============================================================================

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -74,7 +74,6 @@ import { resolveRelayCredential } from '../_shared/relayCiToken.ts';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
-  getCanonicalRelayModelName,
   getSpendingLimit,
   getRequestLimits,
   isRetiredModelRequest,
@@ -105,8 +104,8 @@ import {
   classifyPreHeaderFailure,
   getRelayRequestBytes,
   getUpstreamRequestId,
+  logRelayFailure,
   RELAY_REQUEST_ID_HEADER,
-  type RelayFailurePhase,
   withRelayErrorRequestId,
 } from './diagnostics.ts';
 import {
@@ -188,16 +187,6 @@ interface ProviderConfig {
   authType: AuthType;
 }
 
-interface RelayFailureDiagnostic {
-  relayRequestId: string;
-  provider: string;
-  model: string | null;
-  requestBytes: number | null;
-  elapsedMs: number;
-  failurePhase: RelayFailurePhase;
-  upstreamRequestId: string | null;
-}
-
 type ProviderKey =
   | 'openai'
   | 'anthropic'
@@ -269,15 +258,6 @@ function getEnabledProviders(): string[] {
   return Object.entries(PROVIDER_CONFIGS)
     .filter(([, config]) => Deno.env.get(config.envKey))
     .map(([name]) => name);
-}
-
-function logRelayFailure(diagnostic: RelayFailureDiagnostic): void {
-  console.error(
-    `[RELAY] ${JSON.stringify({
-      event: 'upstream_failure',
-      ...diagnostic,
-    })}`,
-  );
 }
 
 /**
@@ -872,7 +852,6 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   const bodyToSend =
     c.req.method === 'GET' ? undefined : (requestBody ?? c.req.raw.body);
   const relayRequestId = crypto.randomUUID();
-  const diagnosticModel = getCanonicalRelayModelName(modelName);
   const requestBytes = getRelayRequestBytes(
     bodyToSend,
     c.req.raw.headers.get('content-length'),
@@ -892,7 +871,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
     logRelayFailure({
       relayRequestId,
       provider,
-      model: diagnosticModel,
+      model: modelName,
       requestBytes,
       elapsedMs: Math.round(performance.now() - upstreamStartedAt),
       failurePhase,
@@ -961,7 +940,7 @@ app.all('/:provider{[^/]+}/*', async (c) => {
           logRelayFailure({
             relayRequestId,
             provider,
-            model: diagnosticModel,
+            model: modelName,
             requestBytes,
             elapsedMs: Math.round(performance.now() - upstreamStartedAt),
             failurePhase: 'response_body_failure',

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -282,6 +282,15 @@ function resolveAllModelsByApiName(modelName: string): RelayModel[] {
   return exactMatches.length > 0 ? exactMatches : boundaryMatches;
 }
 
+/** Return a registry-owned model identifier suitable for diagnostics.
+ * Unknown and caller-defined model text must not enter logs. */
+export function getCanonicalRelayModelName(
+  modelName: string | null,
+): string | null {
+  if (!modelName) return null;
+  return resolveAllModelsByApiName(modelName).at(0)?.apiPattern ?? null;
+}
+
 export function isRetiredModelRequest(modelName: string): boolean {
   const name = normalizeModelName(modelName);
   const modelPart = stripProviderPrefix(name);

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -32,6 +32,18 @@ export type RelayRequestSlot =
 
 export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
 
+export type RelayFailurePhase =
+  'pre_headers_timeout' | 'pre_headers_failure' | 'response_body_failure';
+
+const UPSTREAM_REQUEST_ID_HEADERS = [
+  'request-id',
+  'x-request-id',
+  'x-goog-request-id',
+] as const;
+
+type RelayRequestBody =
+  string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
+
 class RelayRequestSlotLostError extends Error {
   constructor() {
     super('relay_request_refresh did not find request slot');
@@ -58,6 +70,38 @@ function parseGateDecision(data: unknown): GateDecision {
 
 function didRefreshSlot(data: unknown): boolean {
   return isJsonRecord(data) && data.refreshed === true;
+}
+
+export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
+  return error instanceof Error &&
+    (error.name === 'TimeoutError' || error.name === 'AbortError')
+    ? 'pre_headers_timeout'
+    : 'pre_headers_failure';
+}
+
+export function getUpstreamRequestId(headers: Headers): string | null {
+  for (const header of UPSTREAM_REQUEST_ID_HEADERS) {
+    const requestId = headers.get(header)?.trim();
+    if (requestId) return requestId;
+  }
+  return null;
+}
+
+export function getRelayRequestBytes(
+  body: RelayRequestBody,
+  contentLength: string | null,
+): number | null {
+  if (body == null) return 0;
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).byteLength;
+  }
+  if (body instanceof Uint8Array) return body.byteLength;
+
+  if (contentLength == null || contentLength.trim() === '') return null;
+  const parsedLength = Number(contentLength);
+  return Number.isSafeInteger(parsedLength) && parsedLength >= 0
+    ? parsedLength
+    : null;
 }
 
 function once(release: () => Promise<void>): () => Promise<void> {
@@ -156,6 +200,7 @@ export async function releaseWhenStreamCloses(
   release: () => Promise<void>,
   refresh?: () => Promise<void>,
   refreshIntervalMs = RELAY_SLOT_REFRESH_INTERVAL_MS,
+  onUpstreamBodyError?: (error: unknown) => void,
 ): Promise<ReadableStream<Uint8Array> | null> {
   if (body === null) {
     await release();
@@ -195,21 +240,25 @@ export async function releaseWhenStreamCloses(
       );
     },
     async pull(controller) {
+      let readResult: ReadableStreamReadResult<Uint8Array>;
       try {
-        const { done, value } = await reader.read();
-        if (leaseError) {
-          throw leaseError;
-        }
-        if (done) {
-          controller.close();
-          await releaseOnce();
-          return;
-        }
-        controller.enqueue(value);
+        readResult = await reader.read();
       } catch (error) {
+        onUpstreamBodyError?.(error);
         await releaseOnce();
         throw error;
       }
+
+      if (leaseError) {
+        await releaseOnce();
+        throw leaseError;
+      }
+      if (readResult.done) {
+        controller.close();
+        await releaseOnce();
+        return;
+      }
+      controller.enqueue(readResult.value);
     },
     async cancel(reason) {
       try {

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -207,13 +207,15 @@ export async function releaseWhenStreamCloses(
       try {
         readResult = await reader.read();
       } catch (error) {
-        try {
-          onUpstreamBodyError?.();
-        } catch {
-          console.error('[RELAY] Upstream body failure observer failed');
+        if (!leaseError) {
+          try {
+            onUpstreamBodyError?.();
+          } catch {
+            console.error('[RELAY] Upstream body failure observer failed');
+          }
         }
         await releaseRelaySlotSafely(releaseOnce);
-        throw error;
+        throw leaseError ?? error;
       }
 
       if (leaseError) {

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -244,7 +244,11 @@ export async function releaseWhenStreamCloses(
       try {
         readResult = await reader.read();
       } catch (error) {
-        onUpstreamBodyError?.(error);
+        try {
+          onUpstreamBodyError?.(error);
+        } catch {
+          console.error('[RELAY] Upstream body failure observer failed');
+        }
         await releaseOnce();
         throw error;
       }

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -69,6 +69,20 @@ function once(release: () => Promise<void>): () => Promise<void> {
   };
 }
 
+/** Release a slot without allowing a release failure to replace the upstream
+ * failure that the caller is already handling. */
+export async function releaseAfterUpstreamFailure(
+  release: (() => Promise<void>) | null | undefined,
+): Promise<void> {
+  try {
+    await release?.();
+  } catch {
+    console.error(
+      '[RELAY] Failed to release request slot after upstream failure',
+    );
+  }
+}
+
 function startStreamLeaseRefresh(
   refresh: (() => Promise<void>) | undefined,
   intervalMs: number,
@@ -205,7 +219,7 @@ export async function releaseWhenStreamCloses(
         } catch {
           console.error('[RELAY] Upstream body failure observer failed');
         }
-        await releaseOnce();
+        await releaseAfterUpstreamFailure(releaseOnce);
         throw error;
       }
 

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -69,17 +69,15 @@ function once(release: () => Promise<void>): () => Promise<void> {
   };
 }
 
-/** Release a slot without allowing a release failure to replace the upstream
- * failure that the caller is already handling. */
-export async function releaseAfterUpstreamFailure(
+/** Release a slot without allowing bookkeeping failure to replace the
+ * upstream response or error that the caller is already handling. */
+export async function releaseRelaySlotSafely(
   release: (() => Promise<void>) | null | undefined,
 ): Promise<void> {
   try {
     await release?.();
   } catch {
-    console.error(
-      '[RELAY] Failed to release request slot after upstream failure',
-    );
+    console.error('[RELAY] Failed to release request slot');
   }
 }
 
@@ -173,7 +171,7 @@ export async function releaseWhenStreamCloses(
   onUpstreamBodyError?: () => void,
 ): Promise<ReadableStream<Uint8Array> | null> {
   if (body === null) {
-    await release();
+    await releaseRelaySlotSafely(release);
     return null;
   }
 
@@ -190,15 +188,10 @@ export async function releaseWhenStreamCloses(
     leaseError = error instanceof Error ? error : new Error(String(error));
     stopRefreshing();
     streamController?.error(leaseError);
-    void reader
-      .cancel(leaseError)
-      .then(releaseOnce, releaseOnce)
-      .catch((releaseError) => {
-        console.error(
-          '[RELAY] Failed to release request slot after lease loss:',
-          releaseError,
-        );
-      });
+    void reader.cancel(leaseError).then(
+      () => releaseRelaySlotSafely(releaseOnce),
+      () => releaseRelaySlotSafely(releaseOnce),
+    );
   };
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -219,17 +212,17 @@ export async function releaseWhenStreamCloses(
         } catch {
           console.error('[RELAY] Upstream body failure observer failed');
         }
-        await releaseAfterUpstreamFailure(releaseOnce);
+        await releaseRelaySlotSafely(releaseOnce);
         throw error;
       }
 
       if (leaseError) {
-        await releaseOnce();
+        await releaseRelaySlotSafely(releaseOnce);
         throw leaseError;
       }
       if (readResult.done) {
         controller.close();
-        await releaseOnce();
+        await releaseRelaySlotSafely(releaseOnce);
         return;
       }
       controller.enqueue(readResult.value);
@@ -238,7 +231,7 @@ export async function releaseWhenStreamCloses(
       try {
         await reader.cancel(reason);
       } finally {
-        await releaseOnce();
+        await releaseRelaySlotSafely(releaseOnce);
       }
     },
   });

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -32,18 +32,6 @@ export type RelayRequestSlot =
 
 export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
 
-export type RelayFailurePhase =
-  'pre_headers_timeout' | 'pre_headers_failure' | 'response_body_failure';
-
-const UPSTREAM_REQUEST_ID_HEADERS = [
-  'request-id',
-  'x-request-id',
-  'x-goog-request-id',
-] as const;
-
-type RelayRequestBody =
-  string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
-
 class RelayRequestSlotLostError extends Error {
   constructor() {
     super('relay_request_refresh did not find request slot');
@@ -70,38 +58,6 @@ function parseGateDecision(data: unknown): GateDecision {
 
 function didRefreshSlot(data: unknown): boolean {
   return isJsonRecord(data) && data.refreshed === true;
-}
-
-export function classifyPreHeaderFailure(error: unknown): RelayFailurePhase {
-  return error instanceof Error &&
-    (error.name === 'TimeoutError' || error.name === 'AbortError')
-    ? 'pre_headers_timeout'
-    : 'pre_headers_failure';
-}
-
-export function getUpstreamRequestId(headers: Headers): string | null {
-  for (const header of UPSTREAM_REQUEST_ID_HEADERS) {
-    const requestId = headers.get(header)?.trim();
-    if (requestId) return requestId;
-  }
-  return null;
-}
-
-export function getRelayRequestBytes(
-  body: RelayRequestBody,
-  contentLength: string | null,
-): number | null {
-  if (body == null) return 0;
-  if (typeof body === 'string') {
-    return new TextEncoder().encode(body).byteLength;
-  }
-  if (body instanceof Uint8Array) return body.byteLength;
-
-  if (contentLength == null || contentLength.trim() === '') return null;
-  const parsedLength = Number(contentLength);
-  return Number.isSafeInteger(parsedLength) && parsedLength >= 0
-    ? parsedLength
-    : null;
 }
 
 function once(release: () => Promise<void>): () => Promise<void> {
@@ -200,7 +156,7 @@ export async function releaseWhenStreamCloses(
   release: () => Promise<void>,
   refresh?: () => Promise<void>,
   refreshIntervalMs = RELAY_SLOT_REFRESH_INTERVAL_MS,
-  onUpstreamBodyError?: (error: unknown) => void,
+  onUpstreamBodyError?: () => void,
 ): Promise<ReadableStream<Uint8Array> | null> {
   if (body === null) {
     await release();
@@ -245,7 +201,7 @@ export async function releaseWhenStreamCloses(
         readResult = await reader.read();
       } catch (error) {
         try {
-          onUpstreamBodyError?.(error);
+          onUpstreamBodyError?.();
         } catch {
           console.error('[RELAY] Upstream body failure observer failed');
         }


### PR DESCRIPTION
## Summary

- attach a relay-owned correlation identifier to upstream responses and relay-generated errors
- distinguish failures before response headers from failures while consuming the response body
- log bounded diagnostics without request content, caller-defined model text, credentials, user identifiers, or request URLs
- preserve the original upstream outcome when diagnostics or request-slot release also fail
- propagate relay identifiers through the existing client `ProviderError.requestId` contract, including OpenAI response-body failures after headers arrive

## Design

Relay diagnostics now have one owner in `diagnostics.ts`; request gating remains responsible only for request-slot lifecycle. Model names are mapped back to registry-owned identifiers before logging, upstream request identifiers use a bounded safe format, and UTF-8 request size is measured without allocating another body copy.

The OpenAI chat handler uses the SDK public `create(...).withResponse()` and `ChatCompletionStream.fromReadableStream()` APIs to retain response metadata while preserving the SDK stream aggregator. The caller abort signal is bridged to the reconstructed stream so cancellation identity and source cleanup remain intact.

The 390-second timeout is unchanged because the hosted runtime has an approximately 400-second hard lifetime. This PR supplies the evidence needed for the next routing or infrastructure decision; it does not claim to support longer streams.

## Verification

- focused relay, SDK-error, failing OpenAI stream, and post-header abort suites (100 tests)
- root and test-kernel TypeScript checks
- changed-file ESLint (0 warnings, 0 errors)
- repository `npm run lint` (0 errors; 50 existing warnings)
- `deno check index.ts diagnostics.ts models.ts requestGate.ts`
- `deno lint index.ts diagnostics.ts models.ts requestGate.ts`

## Follow-up required

After deployment, one single-attempt large uncached workflow request must be correlated across the returned relay identifier, Supabase execution logs, and provider telemetry. That observation remains necessary before choosing a longer-running runtime, early rejection policy, or provider-specific asynchronous route.

Refs #7022