### PR TITLE
refactor: require settings profile capabilities

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -5,7 +5,7 @@ import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
-import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
+import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -82,7 +82,7 @@ export function createDesktopSettingsIpc(
   const goalController = new SettingsGoalController({
     listGoals: () => GoalStore.list(),
   });
-  const settingsHost = createSettingsViewHost({
+  const settingsHost = new SettingsViewHost({
     state: { workspaceState, globalState },
     respond: options.postToRenderer,
     beforeModelSelectionMessage: () =>

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -17,7 +17,7 @@ import {
   createSettingsViewCommandHandlers,
   type SettingsViewCommandActions,
 } from '@controllers/settingsView/SettingsViewCommandHandlers';
-import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
+import { SettingsProfileHost } from '@controllers/settingsView/SettingsProfileHost';
 import { platform } from '@platform/platform';
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
@@ -108,7 +108,6 @@ import { LatexSettingsHandlers } from './handlers/latexSettingsHandlers';
 import { HistoryHandlers } from './handlers/historyHandlers';
 import { GitHubSubscriptionHandlers } from './handlers/githubSubscriptionHandlers';
 import { ChatGptSubscriptionHandlers } from './handlers/chatgptSubscriptionHandlers';
-import type { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 
 // Re-use the shared type helper for extracting specific message types.
@@ -162,7 +161,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly historyHandlers: HistoryHandlers;
   private readonly githubHandlers: GitHubSubscriptionHandlers;
   private readonly chatgptHandlers: ChatGptSubscriptionHandlers;
-  private readonly settingsHost: SettingsViewHost;
+  private readonly settingsHost: SettingsProfileHost;
   private readonly goalController: SettingsGoalController;
 
   constructor(context: vscode.ExtensionContext) {
@@ -179,7 +178,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // by extension.ts → initializeStateManagers and are still undefined at
     // module load, so destructuring them at top level captures `undefined`
     // and every later globalState.get(...) throws.
-    this.settingsHost = createSettingsViewHost({
+    this.settingsHost = new SettingsProfileHost({
       state: { workspaceState: workspaceSM, globalState: globalSM },
       memoryPrompt: new VscodePromptHost(),
       setMemoryEnabled: setToolUseMemoryEnabled,

--- a/src/controllers/settingsView/SettingsProfileHost.ts
+++ b/src/controllers/settingsView/SettingsProfileHost.ts
@@ -1,0 +1,142 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { SettingsMessageFor } from '@shared/schemas/settingsViewMessages';
+import type { SettingsRespond } from '@shared/settingsView/types';
+
+import {
+  SettingsProfileController,
+  type ApiAccessModeUpdate,
+  type ProviderVscodeSettingUpdateResult,
+  type SettingsProfileConfigValue,
+  type SettingsProfileControllerDeps,
+} from './SettingsProfileController';
+import {
+  SettingsProfileKeyController,
+  type SettingsProfileKeyControllerDeps,
+} from './SettingsProfileKeyController';
+import {
+  SettingsViewHost,
+  type SettingsViewHostOptions,
+} from './SettingsViewHost';
+
+type Awaitable<T> = T | PromiseLike<T>;
+type ApiAccessModeInput = SettingsMessageFor<
+  typeof SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE
+>['mode'];
+
+interface SettingsProfileProviderPorts {
+  readonly setProviderStreaming: (
+    provider: string,
+    enabled: boolean,
+  ) => Awaitable<void>;
+  readonly setProviderEndpoint: (
+    provider: string,
+    endpoint: string,
+  ) => Awaitable<void>;
+  readonly setGlobalStreaming: (enabled: boolean) => Awaitable<void>;
+}
+
+interface SettingsProfileHostOptions extends SettingsViewHostOptions {
+  readonly profile: SettingsProfileControllerDeps;
+  readonly profileKey: SettingsProfileKeyControllerDeps;
+  readonly providerConfig: SettingsProfileProviderPorts;
+}
+
+interface SettingsProfileHostApiAccessModeOptions {
+  readonly respond?: SettingsRespond;
+  readonly afterPost?: (update: ApiAccessModeUpdate) => Awaitable<void>;
+}
+
+/**
+ * Settings-view host with the extension's complete profile capability.
+ * Construction requires every profile port, so profile operations cannot fail
+ * later because a partially configured common host exposed an invalid method.
+ */
+export class SettingsProfileHost extends SettingsViewHost {
+  private readonly profileController: SettingsProfileController;
+  private readonly profileKeyController: SettingsProfileKeyController;
+  private readonly providerConfig: SettingsProfileProviderPorts;
+
+  constructor(options: SettingsProfileHostOptions) {
+    super(options);
+    this.profileController = new SettingsProfileController(options.profile);
+    this.profileKeyController = new SettingsProfileKeyController(
+      options.profileKey,
+    );
+    this.providerConfig = options.providerConfig;
+  }
+
+  async sendProfileData(respond?: SettingsRespond): Promise<void> {
+    await this.post(
+      await this.profileController.buildProfileMessage(),
+      respond,
+    );
+  }
+
+  async setProviderKey(provider: string, apiKey?: string): Promise<void> {
+    if (apiKey != null) {
+      await this.profileKeyController.commitProviderKey(provider, apiKey);
+      return;
+    }
+    await this.profileKeyController.setProviderKey(provider);
+  }
+
+  async removeProviderKey(provider: string): Promise<void> {
+    await this.profileKeyController.removeProviderKey(provider);
+  }
+
+  async openProviderKeyUrl(provider: string): Promise<void> {
+    await this.profileKeyController.openProviderKeyUrl(provider);
+  }
+
+  async setProviderStreaming(
+    provider: string,
+    enabled: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    await this.providerConfig.setProviderStreaming(provider, enabled);
+    await this.sendProfileData(respond);
+  }
+
+  async setProviderEndpoint(
+    provider: string,
+    endpoint: string,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    await this.providerConfig.setProviderEndpoint(provider, endpoint);
+    await this.sendProfileData(respond);
+  }
+
+  async setGlobalStreaming(
+    enabled: boolean,
+    respond?: SettingsRespond,
+  ): Promise<void> {
+    await this.providerConfig.setGlobalStreaming(enabled);
+    await this.sendProfileData(respond);
+  }
+
+  async setApiAccessMode(
+    mode: ApiAccessModeInput,
+    options?: SettingsProfileHostApiAccessModeOptions,
+  ): Promise<ApiAccessModeUpdate> {
+    const update = await this.profileController.setApiAccessMode(mode);
+    await this.sendProfileData(options?.respond);
+    await this.sendModelSelectionData(options?.respond);
+    await options?.afterPost?.(update);
+    return update;
+  }
+
+  getProviderDisplayName(provider: string): string {
+    return this.profileController.getProviderDisplayName(provider);
+  }
+
+  getReliabilitySettings() {
+    return this.profileController.getReliabilitySettings();
+  }
+
+  setProviderVscodeSetting(input: {
+    key: string;
+    value: SettingsProfileConfigValue;
+  }): Promise<ProviderVscodeSettingUpdateResult> {
+    return this.profileController.setProviderVscodeSetting(input);
+  }
+}

--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -17,17 +17,6 @@ import {
   createModelSelectionController,
   type ModelSelectionExtras,
 } from './SettingsModelSelectionControllerFactory';
-import {
-  SettingsProfileController,
-  type ApiAccessModeUpdate,
-  type ProviderVscodeSettingUpdateResult,
-  type SettingsProfileConfigValue,
-  type SettingsProfileControllerDeps,
-} from './SettingsProfileController';
-import {
-  SettingsProfileKeyController,
-  type SettingsProfileKeyControllerDeps,
-} from './SettingsProfileKeyController';
 import type { SettingsMemoryController } from './SettingsMemoryController';
 import type { SettingsModelSelectionController } from './SettingsModelSelectionController';
 
@@ -46,24 +35,6 @@ type SetReasoningLevelInput = Omit<
   SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL>,
   'command'
 >;
-type ApiAccessModeInput = SettingsMessageFor<
-  typeof SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE
->['mode'];
-
-interface SettingsViewHostProviderConfigPorts {
-  readonly isApiProvider?: (provider: string) => boolean;
-  readonly onUnknownProvider?: (provider: string) => Awaitable<void>;
-  readonly setProviderStreaming?: (
-    provider: string,
-    enabled: boolean,
-  ) => Awaitable<void>;
-  readonly setProviderEndpoint?: (
-    provider: string,
-    endpoint: string,
-  ) => Awaitable<void>;
-  readonly setGlobalStreaming?: (enabled: boolean) => Awaitable<void>;
-}
-
 export interface SettingsViewHostOptions {
   readonly state: SettingsStatePorts;
   readonly memoryPrompt: SettingsMemoryControllerFactoryOptions['prompt'];
@@ -71,14 +42,9 @@ export interface SettingsViewHostOptions {
   readonly setMemoryEnabled?: SettingsMemoryControllerFactoryOptions['setMemoryEnabled'];
   readonly modelSelectionExtras?: ModelSelectionExtras;
   readonly beforeModelSelectionMessage?: () => Awaitable<void>;
-  readonly profile?: SettingsProfileControllerDeps;
-  readonly profileKey?: SettingsProfileKeyControllerDeps;
-  readonly providerConfig?: SettingsViewHostProviderConfigPorts;
   readonly controllers?: {
     readonly memory?: SettingsMemoryController;
     readonly modelSelection?: SettingsModelSelectionController;
-    readonly profile?: SettingsProfileController;
-    readonly profileKey?: SettingsProfileKeyController;
   };
 }
 
@@ -87,16 +53,9 @@ export interface SettingsViewHostMutationOptions {
   readonly afterPost?: () => Awaitable<void>;
 }
 
-interface SettingsViewHostApiAccessModeOptions {
-  readonly respond?: SettingsRespond;
-  readonly afterPost?: (update: ApiAccessModeUpdate) => Awaitable<void>;
-}
-
 export class SettingsViewHost {
   readonly memoryController: SettingsMemoryController;
   readonly modelSelectionController: SettingsModelSelectionController;
-  private readonly profileController?: SettingsProfileController;
-  private readonly profileKeyController?: SettingsProfileKeyController;
 
   constructor(private readonly options: SettingsViewHostOptions) {
     this.memoryController =
@@ -112,16 +71,6 @@ export class SettingsViewHost {
         options.state,
         options.modelSelectionExtras,
       );
-    this.profileController =
-      options.controllers?.profile ??
-      (options.profile
-        ? new SettingsProfileController(options.profile)
-        : undefined);
-    this.profileKeyController =
-      options.controllers?.profileKey ??
-      (options.profileKey
-        ? new SettingsProfileKeyController(options.profileKey)
-        : undefined);
   }
 
   async sendMemoryData(respond?: SettingsRespond): Promise<void> {
@@ -227,98 +176,6 @@ export class SettingsViewHost {
     await this.postModelSelectionMutation(options);
   }
 
-  async sendProfileData(respond?: SettingsRespond): Promise<void> {
-    await this.post(
-      await this.requireProfileController().buildProfileMessage(),
-      respond,
-    );
-  }
-
-  async setProviderKey(provider: string, apiKey?: string): Promise<void> {
-    if (!(await this.acceptKnownProvider(provider))) return;
-    const controller = this.requireProfileKeyController();
-    if (apiKey != null) {
-      await controller.commitProviderKey(provider, apiKey);
-      return;
-    }
-    await controller.setProviderKey(provider);
-  }
-
-  async removeProviderKey(provider: string): Promise<void> {
-    if (!(await this.acceptKnownProvider(provider))) return;
-    await this.requireProfileKeyController().removeProviderKey(provider);
-  }
-
-  async openProviderKeyUrl(provider: string): Promise<void> {
-    await this.requireProfileKeyController().openProviderKeyUrl(provider);
-  }
-
-  async setProviderStreaming(
-    provider: string,
-    enabled: boolean,
-    respond?: SettingsRespond,
-  ): Promise<void> {
-    const setProviderStreaming =
-      this.options.providerConfig?.setProviderStreaming;
-    if (!setProviderStreaming) {
-      throw new Error('SettingsViewHost has no provider streaming port.');
-    }
-    await setProviderStreaming(provider, enabled);
-    await this.sendProfileData(respond);
-  }
-
-  async setProviderEndpoint(
-    provider: string,
-    endpoint: string,
-    respond?: SettingsRespond,
-  ): Promise<void> {
-    const setProviderEndpoint =
-      this.options.providerConfig?.setProviderEndpoint;
-    if (!setProviderEndpoint) {
-      throw new Error('SettingsViewHost has no provider endpoint port.');
-    }
-    await setProviderEndpoint(provider, endpoint);
-    await this.sendProfileData(respond);
-  }
-
-  async setGlobalStreaming(
-    enabled: boolean,
-    respond?: SettingsRespond,
-  ): Promise<void> {
-    const setGlobalStreaming = this.options.providerConfig?.setGlobalStreaming;
-    if (!setGlobalStreaming) {
-      throw new Error('SettingsViewHost has no global streaming port.');
-    }
-    await setGlobalStreaming(enabled);
-    await this.sendProfileData(respond);
-  }
-
-  async setApiAccessMode(
-    mode: ApiAccessModeInput,
-    options?: SettingsViewHostApiAccessModeOptions,
-  ): Promise<ApiAccessModeUpdate> {
-    const update = await this.requireProfileController().setApiAccessMode(mode);
-    await this.sendProfileData(options?.respond);
-    await this.sendModelSelectionData(options?.respond);
-    await options?.afterPost?.(update);
-    return update;
-  }
-
-  getProviderDisplayName(provider: string): string {
-    return this.requireProfileController().getProviderDisplayName(provider);
-  }
-
-  getReliabilitySettings() {
-    return this.requireProfileController().getReliabilitySettings();
-  }
-
-  setProviderVscodeSetting(input: {
-    key: string;
-    value: SettingsProfileConfigValue;
-  }): Promise<ProviderVscodeSettingUpdateResult> {
-    return this.requireProfileController().setProviderVscodeSetting(input);
-  }
-
   getVisibleModels(): string[] {
     return this.modelSelectionController.getVisibleModels();
   }
@@ -331,7 +188,7 @@ export class SettingsViewHost {
     await options?.afterPost?.();
   }
 
-  private async post(
+  protected async post(
     message: unknown,
     respond = this.options.respond,
   ): Promise<void> {
@@ -348,31 +205,4 @@ export class SettingsViewHost {
     if (message == null) return;
     await this.post(message, respond);
   }
-
-  private requireProfileController(): SettingsProfileController {
-    if (!this.profileController) {
-      throw new Error('SettingsViewHost has no profile controller.');
-    }
-    return this.profileController;
-  }
-
-  private requireProfileKeyController(): SettingsProfileKeyController {
-    if (!this.profileKeyController) {
-      throw new Error('SettingsViewHost has no profile key controller.');
-    }
-    return this.profileKeyController;
-  }
-
-  private async acceptKnownProvider(provider: string): Promise<boolean> {
-    const isApiProvider = this.options.providerConfig?.isApiProvider;
-    if (!isApiProvider || isApiProvider(provider)) return true;
-    await this.options.providerConfig?.onUnknownProvider?.(provider);
-    return false;
-  }
-}
-
-export function createSettingsViewHost(
-  options: SettingsViewHostOptions,
-): SettingsViewHost {
-  return new SettingsViewHost(options);
 }

--- a/src/test-kernel/controllers/SettingsViewHost.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewHost.vitest.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { SettingsMemoryController } from '@controllers/settingsView/SettingsMemoryController';
 import { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
-import { createSettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
+import { SettingsProfileHost } from '@controllers/settingsView/SettingsProfileHost';
+import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ModelOptionData } from '@shared/schemas';
@@ -122,7 +123,7 @@ function createProfileHost(options: {
   const config = new Map<string, unknown>();
   const globalState = options.globalState ?? createStateStore();
   const secretValues = options.secretValues ?? new Map<string, string>();
-  return createSettingsViewHost({
+  return new SettingsProfileHost({
     state: {
       workspaceState: createStateStore(),
       globalState,
@@ -180,10 +181,11 @@ function createProfileHost(options: {
         options.refreshAfterKeyChange ?? (async () => undefined),
     },
     providerConfig: {
-      isApiProvider: (provider) => provider === 'openai',
-      setProviderStreaming: options.setProviderStreaming,
-      setProviderEndpoint: options.setProviderEndpoint,
-      setGlobalStreaming: options.setGlobalStreaming,
+      setProviderStreaming:
+        options.setProviderStreaming ?? (async () => undefined),
+      setProviderEndpoint:
+        options.setProviderEndpoint ?? (async () => undefined),
+      setGlobalStreaming: options.setGlobalStreaming ?? (async () => undefined),
     },
   });
 }
@@ -194,7 +196,7 @@ describe('SettingsViewHost', () => {
     const modelSelection = createModelSelectionController();
     const messages: unknown[] = [];
     let modelRefreshes = 0;
-    const host = createSettingsViewHost({
+    const host = new SettingsViewHost({
       state: {
         workspaceState: createStateStore(),
         globalState: createStateStore(),
@@ -220,6 +222,7 @@ describe('SettingsViewHost', () => {
     await host.sendModelSelectionData();
     await host.setModelEnabled({ modelName: 'gpt55', enabled: false });
 
+    expect(host).not.toHaveProperty('sendProfileData');
     expect(messages.at(0)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
       enabled: true,


### PR DESCRIPTION
## Summary

Split the shared settings host by real capability instead of exposing extension-only profile methods from every instance. `SettingsViewHost` now owns only the memory/model-selection behavior shared by desktop and extension, while `SettingsProfileHost` requires the complete profile, profile-key, and provider mutation ports at construction.

This removes five delayed capability failures, the optional profile/provider dependency cluster, two production-dead provider-validation hooks, and the shallow `createSettingsViewHost` factory.

Closes #8480.

## Issue acceptance gates

#8480:

- [x] `SettingsViewHostOptions` contains no profile, profile-key, or provider-config optional cluster.
- [x] Desktop constructs only `SettingsViewHost`; profile/provider methods are absent from that object and covered by a focused regression assertion.
- [x] Extension constructs `SettingsProfileHost` with required profile, profile-key, and all three provider mutation ports.
- [x] Removed both `requireProfile*` helpers and all three runtime missing-provider-port branches.
- [x] Removed the production-dead `isApiProvider` / `onUnknownProvider` hook pair.
- [x] Preserved memory, model-selection, profile, key, provider config, and API-access behavior in focused and full suites.
- [x] Consumer counts and net elements are reported below.

## Single source of truth

`SettingsViewHost` owns the memory/model-selection capability shared across hosts. `SettingsProfileHost` owns the complete profile capability and cannot be constructed without its profile controller dependencies, profile-key dependencies, and provider mutation ports.

## Duplication and abstraction budget

No behavior was duplicated: the existing profile methods moved intact behind a required-capability class. One concrete class replaces one shallow exported factory; the new class owns the invariant that every exposed profile operation is valid, while the test-only provider validation branch and five runtime capability assertions are deleted.

## Net elements (R6)

- Files: 1 added, 0 deleted; 5 files touched.
- Exported symbols: `SettingsProfileHost` added; `createSettingsViewHost` deleted; net 0.
- Classes/interfaces/enums: +1 class, +1 internal options interface, 0 enums.
- LoC: 158 additions, 184 deletions; net -26.

## Consumer counts (R8)

No emit path or event key is deleted.

- Production common-host consumers: 1 (`desktopSettingsIpc.ts`).
- Production profile-host consumers: 1 (`SettingsViewMessageHandler.ts`).
- Desktop profile-method consumers through the common host: 0.
- Extension profile/provider methods routed through the profile host: 11 distinct methods.

## Host impact

Extension: construction changes to the required profile-capable type; behavior is unchanged.

Desktop: continues to use the common memory/model host, but no longer receives extension-only profile methods in its object/type surface.

CLI: no impact.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 50 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npm test` (687 passed, 1 skipped files; 6,204 passed, 4 skipped tests)
- `CI=true corepack pnpm exec vitest run src/test-kernel/controllers/SettingsViewHost.vitest.ts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/desktop/desktopSettingsIpc.vitest.ts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- After rebasing onto current `origin/main`: full `npm run typecheck` and focused settings/desktop tests passed.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with behavior preserved per PR validation; touches credential/profile paths in the extension but does not change desktop profile routing (still via credential controller actions).
> 
> **Overview**
> **Splits settings host by capability** so desktop and extension no longer share one object that optionally exposes profile/API-key operations.
> 
> `SettingsViewHost` now only wires **memory and model selection** (shared by desktop and extension). Profile, provider keys, streaming/endpoint ports, and API access mode live on a new **`SettingsProfileHost`** subclass that **requires** `profile`, `profileKey`, and all three `providerConfig` mutations at construction—replacing runtime `requireProfile*` throws and missing-port errors.
> 
> **Consumers:** desktop uses `new SettingsViewHost(...)` (tests assert `sendProfileData` is absent); the VS Code extension uses `new SettingsProfileHost(...)` with full deps. **`createSettingsViewHost`** is removed in favor of direct construction; `post` is **`protected`** for the subclass.
> 
> Removed optional `providerConfig` hooks **`isApiProvider` / `onUnknownProvider`** and the unknown-provider guard on key mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72f38e699b177070477fbbc2e6739dc5e865c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->