### PR TITLE
test(relay): cover provider tier gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2.0.5
+        with:
+          deno-version: '2.8.3'
+          cache: true
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -93,6 +99,13 @@ jobs:
 
       - name: Lint
         run: pnpm run lint
+
+      - name: Validate relay edge function
+        working-directory: supabase/functions/relay
+        run: |
+          deno check index.ts *_test.ts
+          deno lint
+          deno test --allow-env
 
       - name: Check dead-code ratchet
         run: pnpm run check:dead-code-ratchet

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -379,7 +379,7 @@ function isFutureTimestamp(
 // Hono App
 // =============================================================================
 
-const app = new Hono().basePath('/relay');
+export const app = new Hono().basePath('/relay');
 
 // CORS middleware
 app.use(
@@ -970,4 +970,6 @@ app.notFound((_c) => {
   return jsonError('Invalid path. Expected: /relay/{provider}/{apiPath}', 400);
 });
 
-Deno.serve(app.fetch);
+if (import.meta.main) {
+  Deno.serve(app.fetch);
+}

--- a/supabase/functions/relay/providerTier_test.ts
+++ b/supabase/functions/relay/providerTier_test.ts
@@ -25,18 +25,30 @@ const PROVIDER_API_KEYS = {
   minimax: 'MINIMAX_API_KEY',
   glm: 'GLM_API_KEY',
 } as const;
+const UPSTREAM_ORIGINS = new Set([
+  'https://api.openai.com',
+  'https://api.anthropic.com',
+  'https://generativelanguage.googleapis.com',
+  'https://api.x.ai',
+  'https://api.deepseek.com',
+  'https://api.moonshot.cn',
+  'https://dashscope-intl.aliyuncs.com',
+  'https://api.minimax.io',
+  'https://api.z.ai',
+]);
+const TEST_ENV = {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY: 'anon-key',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  ...Object.fromEntries(
+    Object.values(PROVIDER_API_KEYS).map((envKey) => [envKey, 'provider-key']),
+  ),
+};
 
 type Tier = (typeof TIERS)[number];
 
 interface TierConfigResponse extends TierModelConfig {
   spendingLimits: Record<Tier, number>;
-}
-
-Deno.env.set('SUPABASE_URL', SUPABASE_URL);
-Deno.env.set('SUPABASE_ANON_KEY', 'anon-key');
-Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
-for (const envKey of Object.values(PROVIDER_API_KEYS)) {
-  Deno.env.set(envKey, 'provider-key');
 }
 
 const upstreamRequests: Request[] = [];
@@ -54,11 +66,18 @@ function getTierFromAuthorization(request: Request): Tier {
   return token as Tier;
 }
 
-globalThis.fetch = (input, init): Promise<Response> => {
+function mockFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
   const request = new Request(input, init);
   const url = new URL(request.url);
 
   if (url.origin !== SUPABASE_URL) {
+    assert.ok(
+      UPSTREAM_ORIGINS.has(url.origin),
+      `unexpected upstream: ${url.origin}`,
+    );
     upstreamRequests.push(request);
     return Promise.resolve(new Response(null, { status: 204 }));
   }
@@ -104,11 +123,37 @@ globalThis.fetch = (input, init): Promise<Response> => {
   }
 
   throw new Error(`Unexpected test request: ${request.method} ${request.url}`);
-};
+}
+
+async function withTestEnvironment<T>(run: () => Promise<T>): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = new Map(
+    Object.keys(TEST_ENV).map((key) => [key, Deno.env.get(key)]),
+  );
+
+  for (const [key, value] of Object.entries(TEST_ENV)) {
+    Deno.env.set(key, value);
+  }
+  globalThis.fetch = mockFetch;
+
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+    upstreamRequests.length = 0;
+    for (const [key, value] of originalEnv) {
+      if (value == null) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
+  }
+}
 
 // index.ts starts its server only when it is the entry point, so tests can
 // invoke the same Hono application without opening a listening socket.
-const { app } = await import('./index.ts');
+const { app } = await withTestEnvironment(() => import('./index.ts'));
 
 async function getTierConfig(): Promise<TierConfigResponse> {
   const response = await app.request('/relay/tier-config');
@@ -117,82 +162,92 @@ async function getTierConfig(): Promise<TierConfigResponse> {
 }
 
 Deno.test('gates relay providers by tier at the route boundary', async () => {
-  const config = await getTierConfig();
-  assert.deepEqual(ULTRA_ONLY_PROVIDERS, EXPECTED_ULTRA_ONLY_PROVIDERS);
-  const ultraOnlyProviders = new Set<string>(ULTRA_ONLY_PROVIDERS);
-  assert.deepEqual(
-    config.providers.toSorted(),
-    Object.keys(PROVIDER_API_KEYS).toSorted(),
-  );
-  const ordinaryProviders = config.providers.filter(
-    (provider) => !ultraOnlyProviders.has(provider),
-  );
+  await withTestEnvironment(async () => {
+    const config = await getTierConfig();
+    assert.deepEqual(ULTRA_ONLY_PROVIDERS, EXPECTED_ULTRA_ONLY_PROVIDERS);
+    const ultraOnlyProviders = new Set<string>(EXPECTED_ULTRA_ONLY_PROVIDERS);
+    assert.deepEqual(
+      config.providers.toSorted(),
+      Object.keys(PROVIDER_API_KEYS).toSorted(),
+    );
+    const ordinaryProviders = config.providers.filter(
+      (provider) => !ultraOnlyProviders.has(provider),
+    );
 
-  assert.ok(ordinaryProviders.length > 0);
+    assert.ok(ordinaryProviders.length > 0);
 
-  const cases = TIERS.flatMap((tier) =>
-    config.providers.map((provider) => ({
-      tier,
-      provider,
-      restricted: tier !== 'Ultra' && ultraOnlyProviders.has(provider),
-    })),
-  );
+    const cases = TIERS.flatMap((tier) =>
+      config.providers.map((provider) => ({
+        tier,
+        provider,
+        restricted: tier !== 'Ultra' && ultraOnlyProviders.has(provider),
+      })),
+    );
 
-  for (const testCase of cases) {
-    upstreamRequests.length = 0;
-    const response = await app.request(`/relay/${testCase.provider}/v1/files`, {
-      headers: { authorization: `Bearer ${testCase.tier}-token` },
-    });
+    for (const testCase of cases) {
+      upstreamRequests.length = 0;
+      const response = await app.request(
+        `/relay/${testCase.provider}/v1/files`,
+        {
+          headers: { authorization: `Bearer ${testCase.tier}-token` },
+        },
+      );
 
-    if (testCase.restricted) {
+      if (testCase.restricted) {
+        assert.equal(
+          response.status,
+          403,
+          `${testCase.tier} unexpectedly reached ${testCase.provider}`,
+        );
+        const body = await response.json();
+        assert.equal(body.error.providerRestricted, true);
+        assert.equal(body.error.provider, testCase.provider);
+        assert.equal(body.error.requiredTier, 'Ultra');
+        assert.equal(upstreamRequests.length, 0);
+        continue;
+      }
+
       assert.equal(
         response.status,
-        403,
-        `${testCase.tier} unexpectedly reached ${testCase.provider}`,
+        204,
+        `${testCase.tier} did not pass through ${testCase.provider}`,
       );
-      const body = await response.json();
-      assert.equal(body.error.providerRestricted, true);
-      assert.equal(body.error.provider, testCase.provider);
-      assert.equal(body.error.requiredTier, 'Ultra');
-      assert.equal(upstreamRequests.length, 0);
-      continue;
+      assert.equal(upstreamRequests.length, 1);
     }
-
-    assert.equal(
-      response.status,
-      204,
-      `${testCase.tier} did not pass through ${testCase.provider}`,
-    );
-    assert.equal(upstreamRequests.length, 1);
-  }
+  });
 });
 
 Deno.test(
   'excludes Ultra-only provider models from lower-tier config',
   async () => {
-    const config = await getTierConfig();
+    await withTestEnvironment(async () => {
+      const config = await getTierConfig();
 
-    for (const tier of ['free', 'Max'] as const) {
-      const models = config.tiers[tier]?.models;
-      assert.ok(Array.isArray(models));
+      for (const tier of ['free', 'Max'] as const) {
+        const models = config.tiers[tier]?.models;
+        assert.ok(Array.isArray(models));
 
-      for (const provider of ULTRA_ONLY_PROVIDERS) {
-        const providerModels = Object.values(MODEL_CONFIGS)
-          .filter(
-            (model) =>
-              model.provider.toLowerCase() === provider &&
-              !model.openRouterOnly &&
-              !model.retired,
-          )
-          .map((model) => model.name);
+        for (const provider of EXPECTED_ULTRA_ONLY_PROVIDERS) {
+          const providerModels = Object.values(MODEL_CONFIGS)
+            .filter(
+              (model) =>
+                model.provider.toLowerCase() === provider &&
+                !model.openRouterOnly &&
+                !model.retired,
+            )
+            .map((model) => model.name);
 
-        assert.ok(providerModels.length > 0, `${provider} has no test models`);
-        assert.equal(
-          providerModels.some((model) => models.includes(model)),
-          false,
-          `${tier} config contains a ${provider} model`,
-        );
+          assert.ok(
+            providerModels.length > 0,
+            `${provider} has no test models`,
+          );
+          assert.equal(
+            providerModels.some((model) => models.includes(model)),
+            false,
+            `${tier} config contains a ${provider} model`,
+          );
+        }
       }
-    }
+    });
   },
 );

--- a/supabase/functions/relay/providerTier_test.ts
+++ b/supabase/functions/relay/providerTier_test.ts
@@ -1,0 +1,198 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+// Local imports
+import { ULTRA_ONLY_PROVIDERS, type TierModelConfig } from './models.ts';
+
+const SUPABASE_URL = 'https://supabase.test';
+const TIERS = ['free', 'Max', 'Ultra'] as const;
+const EXPECTED_ULTRA_ONLY_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'google',
+] as const;
+const PROVIDER_API_KEYS = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_API_KEY',
+  xai: 'XAI_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+  moonshot: 'MOONSHOT_API_KEY',
+  dashscope: 'DASHSCOPE_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
+  glm: 'GLM_API_KEY',
+} as const;
+
+type Tier = (typeof TIERS)[number];
+
+interface TierConfigResponse extends TierModelConfig {
+  spendingLimits: Record<Tier, number>;
+}
+
+Deno.env.set('SUPABASE_URL', SUPABASE_URL);
+Deno.env.set('SUPABASE_ANON_KEY', 'anon-key');
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+for (const envKey of Object.values(PROVIDER_API_KEYS)) {
+  Deno.env.set(envKey, 'provider-key');
+}
+
+const upstreamRequests: Request[] = [];
+
+function jsonResponse(body: unknown): Response {
+  return Response.json(body);
+}
+
+function getTierFromAuthorization(request: Request): Tier {
+  const token = request.headers
+    .get('authorization')
+    ?.replace(/^Bearer /, '')
+    .replace(/-token$/, '');
+  assert.ok(TIERS.includes(token as Tier), `unexpected test token: ${token}`);
+  return token as Tier;
+}
+
+globalThis.fetch = (input, init): Promise<Response> => {
+  const request = new Request(input, init);
+  const url = new URL(request.url);
+
+  if (url.origin !== SUPABASE_URL) {
+    upstreamRequests.push(request);
+    return Promise.resolve(new Response(null, { status: 204 }));
+  }
+
+  if (url.pathname === '/auth/v1/user') {
+    const tier = getTierFromAuthorization(request);
+    return Promise.resolve(
+      jsonResponse({
+        id: `user-${tier}`,
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: `${tier.toLowerCase()}@example.com`,
+        app_metadata: {},
+        user_metadata: {},
+        created_at: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+  }
+
+  if (url.pathname === '/rest/v1/profiles') {
+    const tier = getTierFromAuthorization(request);
+    return Promise.resolve(
+      jsonResponse({
+        tier,
+        access_expires_at: null,
+        banned_until: null,
+      }),
+    );
+  }
+
+  if (url.pathname === '/rest/v1/rpc/get_user_monthly_relay_spend') {
+    return Promise.resolve(jsonResponse(0));
+  }
+
+  if (url.pathname === '/rest/v1/rpc/relay_request_gate') {
+    return Promise.resolve(
+      jsonResponse({ allowed: true, slotId: 'test-slot' }),
+    );
+  }
+
+  if (url.pathname === '/rest/v1/rpc/relay_request_release') {
+    return Promise.resolve(jsonResponse(null));
+  }
+
+  throw new Error(`Unexpected test request: ${request.method} ${request.url}`);
+};
+
+// index.ts starts its server only when it is the entry point, so tests can
+// invoke the same Hono application without opening a listening socket.
+const { app } = await import('./index.ts');
+
+async function getTierConfig(): Promise<TierConfigResponse> {
+  const response = await app.request('/relay/tier-config');
+  assert.equal(response.status, 200);
+  return await response.json();
+}
+
+Deno.test('gates relay providers by tier at the route boundary', async () => {
+  const config = await getTierConfig();
+  assert.deepEqual(ULTRA_ONLY_PROVIDERS, EXPECTED_ULTRA_ONLY_PROVIDERS);
+  const ultraOnlyProviders = new Set<string>(ULTRA_ONLY_PROVIDERS);
+  assert.deepEqual(
+    config.providers.toSorted(),
+    Object.keys(PROVIDER_API_KEYS).toSorted(),
+  );
+  const ordinaryProviders = config.providers.filter(
+    (provider) => !ultraOnlyProviders.has(provider),
+  );
+
+  assert.ok(ordinaryProviders.length > 0);
+
+  const cases = TIERS.flatMap((tier) =>
+    config.providers.map((provider) => ({
+      tier,
+      provider,
+      restricted: tier !== 'Ultra' && ultraOnlyProviders.has(provider),
+    })),
+  );
+
+  for (const testCase of cases) {
+    upstreamRequests.length = 0;
+    const response = await app.request(`/relay/${testCase.provider}/v1/files`, {
+      headers: { authorization: `Bearer ${testCase.tier}-token` },
+    });
+
+    if (testCase.restricted) {
+      assert.equal(
+        response.status,
+        403,
+        `${testCase.tier} unexpectedly reached ${testCase.provider}`,
+      );
+      const body = await response.json();
+      assert.equal(body.error.providerRestricted, true);
+      assert.equal(body.error.provider, testCase.provider);
+      assert.equal(body.error.requiredTier, 'Ultra');
+      assert.equal(upstreamRequests.length, 0);
+      continue;
+    }
+
+    assert.equal(
+      response.status,
+      204,
+      `${testCase.tier} did not pass through ${testCase.provider}`,
+    );
+    assert.equal(upstreamRequests.length, 1);
+  }
+});
+
+Deno.test(
+  'excludes Ultra-only provider models from lower-tier config',
+  async () => {
+    const config = await getTierConfig();
+
+    for (const tier of ['free', 'Max'] as const) {
+      const models = config.tiers[tier]?.models;
+      assert.ok(Array.isArray(models));
+
+      for (const provider of ULTRA_ONLY_PROVIDERS) {
+        const providerModels = Object.values(MODEL_CONFIGS)
+          .filter(
+            (model) =>
+              model.provider.toLowerCase() === provider &&
+              !model.openRouterOnly &&
+              !model.retired,
+          )
+          .map((model) => model.name);
+
+        assert.ok(providerModels.length > 0, `${provider} has no test models`);
+        assert.equal(
+          providerModels.some((model) => models.includes(model)),
+          false,
+          `${tier} config contains a ${provider} model`,
+        );
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- exercise provider-tier authorization through the real Hono relay application
- cover free, Max, and Ultra access across every configured provider
- verify lower-tier model configuration excludes OpenAI, Anthropic, and Google models
- run relay Deno checks, lint, and tests in Linux CI

## Design

The relay application is exported for route-level tests and starts its HTTP server only when `index.ts` is the Deno entry point. The test therefore observes the production middleware and handlers without opening a socket or duplicating the gate implementation. An explicit three-provider product contract guards against the production constant and test drifting together.

The test fixture scopes and restores environment variables and `fetch`, and rejects calls to unknown upstream origins. CI uses the repository lockfile with Deno 2.8.3.

## Verification

- `deno check index.ts *_test.ts`
- `deno lint`
- `deno test --allow-env`
- `pnpm vitest run src/test-kernel/supabase/RelayModelAccess.vitest.ts src/test-kernel/supabase/RelayRequestLimits.vitest.ts`
- repository pre-commit format checks

Closes #8469