### PR TITLE
refactor: normalize execution listing entries

### DIFF
--- a/packages/cli/src/runtime/chatDefaults.ts
+++ b/packages/cli/src/runtime/chatDefaults.ts
@@ -1,5 +1,9 @@
 import { TEXRA_CONFIG_FILE_NAME } from '@platform/defaults/nodeStorage';
-import { listExecutions } from '@agent/storage';
+import {
+  isUserVisibleExecution,
+  listExecutions,
+  type ExecutionListingEntry,
+} from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { isFileNotFoundError } from '@common/errors';
 import {
@@ -97,19 +101,21 @@ async function loadUserDefaults(): Promise<PartialDefaults> {
 
 async function loadHistoryDefaults(): Promise<PartialDefaults> {
   // An unreadable history listing means no history defaults.
-  const entries = await listExecutions().catch(() => []);
+  const entries: ExecutionListingEntry[] = await listExecutions().catch(
+    () => [],
+  );
   const candidates = toNewestFirstByTimestamp(
-    entries.filter(
+    entries.filter(isUserVisibleExecution).filter(
       (entry) =>
-        entry.agentConfig?.agentCategory === AgentCategory.ToolUse &&
+        entry.agentConfig.agentCategory === AgentCategory.ToolUse &&
         // A multi-agent team run's root is an orchestrator agent, not a
         // sensible default for a plain single-agent chat session.
-        !entry.agentConfig?.cliMultiAgentPresetId,
+        !entry.agentConfig.cliMultiAgentPresetId,
     ),
     (item) => item.timestamp,
   );
   const mostRecent = candidates[0];
-  if (!mostRecent?.agentConfig) return {};
+  if (!mostRecent) return {};
   return {
     model: commandConfigModel(
       parseCliConfigValues({ model: mostRecent.agentConfig.model }),

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -473,27 +473,27 @@ export function formatCliHistoryDetailsText(
 }
 
 async function toCliHistoryEntry(
-  entry: ExecutionListingEntry,
+  entry: Extract<ExecutionListingEntry, { kind: 'agent' }>,
 ): Promise<CliHistoryEntry> {
-  const inputBasename = firstInputBasename(entry.agentConfig);
+  const config = entry.agentConfig;
+  const inputBasename = firstInputBasename(config);
   const resumability = await deriveResumability(entry.id);
-  const resumeData =
-    resumability.resumable && entry.agentConfig
-      ? await readCliToolUseResumeDataForListing(entry.id, entry.agentConfig)
-      : null;
+  const resumeData = resumability.resumable
+    ? await readCliToolUseResumeDataForListing(entry.id, config)
+    : null;
   return {
     id: entry.id,
     timestamp: entry.timestamp,
-    agent: entry.agent,
-    model: resumeData?.snapshot.agentConfig.model ?? entry.model,
+    agent: config.agent,
+    model: resumeData?.snapshot.agentConfig.model ?? config.model,
     status: resolveCliHistoryStatus({
       terminalStatus: entry.terminalStatus,
       resumable: resumeData !== null,
     }),
     inputBasename,
-    category: entry.category,
+    category: entry.runtimeCategory ?? config.agentCategory,
     description: entry.description,
-    teamPresetId: teamPresetId(entry.agentConfig),
+    teamPresetId: teamPresetId(config),
     parentExecutionId: entry.parentExecutionId,
     delegationDepth: entry.delegationDepth,
   };
@@ -503,7 +503,7 @@ function teamPresetId(config: AgentConfig | null): string | undefined {
   return config?.cliMultiAgentPresetId?.trim() || undefined;
 }
 
-function firstInputBasename(config: AgentConfig | null): string {
-  const first = config?.inputFiles.at(0) ?? '';
+function firstInputBasename(config: AgentConfig): string {
+  const first = config.inputFiles.at(0) ?? '';
   return first ? path.basename(first) : '-';
 }

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -20,6 +20,7 @@ import {
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { StorageFS, WorkspaceFS } from '@utils/files';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -37,19 +38,32 @@ const EXECUTION_STORAGE_CONCURRENCY = 32;
 // Public types
 // ============================================================================
 
-export interface ExecutionListingEntry {
+interface ExecutionListingBase {
   id: ExecutionId;
   timestamp: string;
   parentExecutionId?: ExecutionId;
   delegationDepth?: number;
-  agent: string;
-  model: string;
-  agentConfig: AgentConfig | null;
-  category?: string;
   terminalStatus?: string;
   /** AI-generated summary of what the session aimed to accomplish. */
   description?: string;
 }
+
+export type ExecutionListingEntry =
+  | (ExecutionListingBase & {
+      kind: 'agent';
+      agentConfig: AgentConfig;
+      /** Metadata override when it differs from `agentConfig.agentCategory`. */
+      runtimeCategory?: string;
+    })
+  | (ExecutionListingBase & {
+      kind: 'process';
+      agentConfig: AgentConfig;
+    })
+  | (ExecutionListingBase & {
+      kind: 'incomplete';
+      /** Preserved metadata for legacy rows whose config is absent. */
+      runtimeCategory?: string;
+    });
 
 /**
  * True for executions a user should see in a history list — excludes
@@ -62,9 +76,9 @@ export interface ExecutionListingEntry {
  * like `ExecutionsTool` need the raw listing to manage background processes.
  */
 export function isUserVisibleExecution(
-  entry: Pick<ExecutionListingEntry, 'agentConfig' | 'category'>,
-): boolean {
-  return entry.agentConfig !== null && entry.category !== 'process';
+  entry: ExecutionListingEntry,
+): entry is Extract<ExecutionListingEntry, { kind: 'agent' }> {
+  return entry.kind === 'agent';
 }
 
 // ============================================================================
@@ -151,17 +165,31 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
 
         if (!meta) return null;
 
-        return {
+        const base: ExecutionListingBase = {
           id,
           timestamp: meta.timestamp,
           parentExecutionId: meta.parentExecutionId,
           delegationDepth: meta.delegationDepth,
-          agent: cfg?.agent ?? 'unknown',
-          model: cfg?.model ?? 'unknown',
-          agentConfig: cfg ?? null,
-          category: meta.category ?? cfg?.agentCategory,
           terminalStatus: meta.terminalStatus,
           description: meta.description,
+        };
+        if (!cfg) {
+          return {
+            ...base,
+            kind: 'incomplete',
+            runtimeCategory: meta.category,
+          };
+        }
+        if (meta.category === 'process' || isProcessAgent(cfg.agent)) {
+          return { ...base, kind: 'process', agentConfig: cfg };
+        }
+        return {
+          ...base,
+          kind: 'agent',
+          agentConfig: cfg,
+          ...(meta.category && meta.category !== cfg.agentCategory
+            ? { runtimeCategory: meta.category }
+            : {}),
         };
       } catch (error) {
         logger.warn(

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -20,7 +20,6 @@ import {
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
-import { isProcessAgent } from '@shared/streams/agentKind';
 import { StorageFS, WorkspaceFS } from '@utils/files';
 import { filterNotNull, toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -180,7 +179,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
             runtimeCategory: meta.category,
           };
         }
-        if (meta.category === 'process' || isProcessAgent(cfg.agent)) {
+        if (meta.category === 'process') {
           return { ...base, kind: 'process', agentConfig: cfg };
         }
         return {

--- a/src/controllers/settingsView/HistoryMessageBuilder.ts
+++ b/src/controllers/settingsView/HistoryMessageBuilder.ts
@@ -22,7 +22,7 @@ export async function buildHistoryMessage(): Promise<UpdateHistoryMessage> {
   const visibleEntries = entries.filter(isUserVisibleExecution);
   const historyItems = await Promise.all(
     visibleEntries.map(async (entry): Promise<HistoryItem> => {
-      const cfg = entry.agentConfig!;
+      const cfg = entry.agentConfig;
       const base = {
         agent: cfg.agent,
         model: cfg.model,

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -10,11 +10,7 @@ import * as path from 'node:path';
 // Local imports
 import { platform } from '@platform/platform';
 import { StreamSnapshotStore } from '@transcript';
-import { listExecutions } from '@agent/storage';
-import {
-  WORKFLOW_OUTPUT_BASENAME,
-  parseWorkflowOutputRoundDir,
-} from '@shared/constants/workflowOutput';
+import { listExecutions, type ExecutionListingEntry } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
@@ -24,6 +20,10 @@ import type {
   OutputFileInfo,
   RoundIndexed,
 } from '@shared/schemas';
+import {
+  WORKFLOW_OUTPUT_BASENAME,
+  parseWorkflowOutputRoundDir,
+} from '@shared/constants/workflowOutput';
 import {
   WorkspaceFS,
   createRunStorageLocation,
@@ -213,23 +213,31 @@ export async function discoverLatestExecutionOutputs(query: {
     const normalizedInput = path.normalize(query.inputFile);
 
     const candidates = executions
-      .filter((entry) => {
-        if (entry.agent !== query.agent || entry.model !== query.model) {
-          return false;
-        }
-        const entryInput = entry.agentConfig?.inputFiles?.[0];
-        return (
-          typeof entryInput === 'string' &&
-          path.normalize(entryInput) === normalizedInput
-        );
-      })
+      .filter(
+        (entry): entry is Extract<ExecutionListingEntry, { kind: 'agent' }> => {
+          if (
+            entry.kind !== 'agent' ||
+            entry.agentConfig.agent !== query.agent ||
+            entry.agentConfig.model !== query.model
+          ) {
+            return false;
+          }
+          const entryInput = entry.agentConfig.inputFiles[0];
+          return (
+            typeof entryInput === 'string' &&
+            path.normalize(entryInput) === normalizedInput
+          );
+        },
+      )
       .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
     const snapshots = new StreamSnapshotStore();
     for (const candidate of candidates) {
-      const streamId = getStreamTabId(candidate.agent, candidate.model, {
-        executionId: candidate.id,
-      });
+      const streamId = getStreamTabId(
+        candidate.agentConfig.agent,
+        candidate.agentConfig.model,
+        { executionId: candidate.id },
+      );
       const rounds = await snapshots.readOutputFiles(streamId);
       if (rounds && Object.keys(rounds).length > 0) {
         return { executionId: candidate.id, rounds };
@@ -247,7 +255,7 @@ export async function discoverLatestExecutionOutputs(query: {
       const scanned = await scanRunDirForOutputs(
         candidate.id,
         query.inputFile,
-        candidate.agentConfig?.inputFiles?.slice(1),
+        candidate.agentConfig.inputFiles.slice(1),
       );
       if (scanned && Object.keys(scanned).length > 0) {
         return { executionId: candidate.id, rounds: scanned };

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  clearStoreCache,
+  getExecutionStore,
+  isUserVisibleExecution,
+  listExecutions,
+} from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { invalidateListingCache } from '@agent/storage/executionListing';
+import type { ExecutionId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+function config(agent: string): AgentConfig {
+  return {
+    inputFiles: [],
+    contextFiles: [],
+    mediaFiles: [],
+    outputFiles: [],
+    editedFile: null,
+    agent,
+    model: 'deepseekT',
+    instruction: 'Test execution listing.',
+    agentCategory: AgentCategory.ToolUse,
+    editedFiles: [],
+    toolConfig: DEFAULT_TOOL_CONFIG,
+    memories: [],
+    workingDirectory: '/workspace',
+    cliOutputFile: null,
+    cliMultiAgentPresetId: null,
+  };
+}
+
+async function writeExecution(
+  id: ExecutionId,
+  timestamp: string,
+  agentConfig?: AgentConfig,
+  category?: string,
+): Promise<void> {
+  const store = getExecutionStore(id);
+  await store.writeMeta({ timestamp, category });
+  if (agentConfig) await store.writeConfig(agentConfig);
+}
+
+describe('execution listing normalization', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  beforeEach(() => {
+    clearStoreCache();
+    invalidateListingCache();
+  });
+
+  it('uses the config as the canonical source for visible agent fields', async () => {
+    const id = 'aaa111' as ExecutionId;
+    const agentConfig = config('assistant');
+    await writeExecution(
+      id,
+      '2026-07-15T10:00:00.000Z',
+      agentConfig,
+      AgentCategory.ToolUse,
+    );
+
+    const entries = await listExecutions();
+
+    expect(entries).toEqual([
+      {
+        kind: 'agent',
+        id,
+        timestamp: '2026-07-15T10:00:00.000Z',
+        agentConfig,
+      },
+    ]);
+    expect(entries.filter(isUserVisibleExecution)).toHaveLength(1);
+    expect(entries[0]).not.toHaveProperty('agent');
+    expect(entries[0]).not.toHaveProperty('model');
+    expect(entries[0]).not.toHaveProperty('category');
+  });
+
+  it('classifies process and incomplete storage rows explicitly', async () => {
+    const metadataProcessId = 'bbb222' as ExecutionId;
+    const processAgentId = 'ccc333' as ExecutionId;
+    const incompleteId = 'ddd444' as ExecutionId;
+    await writeExecution(
+      metadataProcessId,
+      '2026-07-15T09:00:00.000Z',
+      config('assistant'),
+      'process',
+    );
+    await writeExecution(
+      processAgentId,
+      '2026-07-15T08:00:00.000Z',
+      config('bash'),
+    );
+    await writeExecution(
+      incompleteId,
+      '2026-07-15T07:00:00.000Z',
+      undefined,
+      'legacy',
+    );
+
+    const entries = await listExecutions();
+
+    expect(entries.map(({ kind }) => kind)).toEqual([
+      'process',
+      'process',
+      'incomplete',
+    ]);
+    expect(entries[0]).toMatchObject({
+      kind: 'process',
+      agentConfig: { agent: 'assistant' },
+    });
+    expect(entries[1]).toMatchObject({
+      kind: 'process',
+      agentConfig: { agent: 'bash' },
+    });
+    expect(entries[2]).toEqual({
+      kind: 'incomplete',
+      id: incompleteId,
+      timestamp: '2026-07-15T07:00:00.000Z',
+      runtimeCategory: 'legacy',
+    });
+    expect(entries.filter(isUserVisibleExecution)).toEqual([]);
+  });
+});

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -80,7 +80,7 @@ describe('execution listing normalization', () => {
 
   it('classifies process and incomplete storage rows explicitly', async () => {
     const metadataProcessId = 'bbb222' as ExecutionId;
-    const processAgentId = 'ccc333' as ExecutionId;
+    const customBashAgentId = 'ccc333' as ExecutionId;
     const incompleteId = 'ddd444' as ExecutionId;
     await writeExecution(
       metadataProcessId,
@@ -89,7 +89,7 @@ describe('execution listing normalization', () => {
       'process',
     );
     await writeExecution(
-      processAgentId,
+      customBashAgentId,
       '2026-07-15T08:00:00.000Z',
       config('bash'),
     );
@@ -104,7 +104,7 @@ describe('execution listing normalization', () => {
 
     expect(entries.map(({ kind }) => kind)).toEqual([
       'process',
-      'process',
+      'agent',
       'incomplete',
     ]);
     expect(entries[0]).toMatchObject({
@@ -112,7 +112,7 @@ describe('execution listing normalization', () => {
       agentConfig: { agent: 'assistant' },
     });
     expect(entries[1]).toMatchObject({
-      kind: 'process',
+      kind: 'agent',
       agentConfig: { agent: 'bash' },
     });
     expect(entries[2]).toEqual({
@@ -121,6 +121,6 @@ describe('execution listing normalization', () => {
       timestamp: '2026-07-15T07:00:00.000Z',
       runtimeCategory: 'legacy',
     });
-    expect(entries.filter(isUserVisibleExecution)).toEqual([]);
+    expect(entries.filter(isUserVisibleExecution)).toEqual([entries[1]]);
   });
 });

--- a/src/test-kernel/cli/ChatDefaults.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaults.vitest.mts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 import { listExecutions } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   BUILTIN_DEFAULT_CHAT_AGENT,
@@ -13,6 +14,7 @@ import {
   resolveChatDefaults,
 } from '@cli/runtime/chatDefaults';
 import * as logSinks from '@cli/runtime/logSinks';
+import type { ExecutionId } from '@shared/schemas';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
 /** A missing user config, shaped like a genuine `fs` ENOENT rejection. */
@@ -24,7 +26,8 @@ function enoentError(): NodeJS.ErrnoException {
   return error;
 }
 
-vi.mock('@agent/storage', () => ({
+vi.mock('@agent/storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage')>()),
   listExecutions: vi.fn(async () => []),
 }));
 
@@ -36,14 +39,16 @@ function historyEntry(
   timestamp = '2026-05-21T08:00:00.000Z',
 ) {
   return {
+    kind: 'agent',
+    id: 'abc123' as ExecutionId,
     timestamp,
-    agentConfig: {
+    agentConfig: AgentConfigSchema.parse({
       agent,
       model: 'sonnet46T',
       agentCategory: AgentCategory.ToolUse,
       ...overrides,
-    },
-  } as unknown as Awaited<ReturnType<typeof listExecutions>>[number];
+    }),
+  } satisfies Awaited<ReturnType<typeof listExecutions>>[number];
 }
 
 vi.mock('@utils/files/storageFS', () => ({

--- a/src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts
+++ b/src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts
@@ -14,7 +14,8 @@ vi.mock('@cli/runtime/cliConfig', async (importOriginal) => {
   };
 });
 
-vi.mock('@agent/storage', () => ({
+vi.mock('@agent/storage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage')>()),
   listExecutions: vi.fn(async () => []),
 }));
 

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -175,10 +175,9 @@ describe('CLI history runtime', () => {
   it('formats history list rows with the stable tab-separated text shape', async () => {
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'a1' as ExecutionId,
         timestamp: '2026-05-18T08:00:00.000Z',
-        agent: 'correct',
-        model: 'deepseekT',
         agentConfig: config,
         terminalStatus: 'completed',
       },
@@ -211,28 +210,23 @@ describe('CLI history runtime', () => {
     } as AgentConfig;
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'visible' as ExecutionId,
         timestamp: '2026-05-18T08:00:00.000Z',
-        agent: 'correct',
-        model: 'deepseekT',
         agentConfig: config,
         terminalStatus: 'completed',
       },
       {
+        kind: 'process',
         id: 'bash-process' as ExecutionId,
         timestamp: '2026-05-18T08:01:00.000Z',
-        agent: 'bash',
-        model: 'deepseekT',
         agentConfig: processConfig,
-        category: 'process',
         terminalStatus: 'completed',
       },
       {
+        kind: 'incomplete',
         id: 'configless' as ExecutionId,
         timestamp: '2026-05-18T08:02:00.000Z',
-        agent: 'unknown',
-        model: 'unknown',
-        agentConfig: null,
         terminalStatus: 'completed',
       },
     ]);
@@ -253,10 +247,9 @@ describe('CLI history runtime', () => {
     } as AgentConfig;
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'team1' as ExecutionId,
         timestamp: '2026-05-18T10:00:00.000Z',
-        agent: 'engineer',
-        model: 'sonnet46T',
         agentConfig: teamConfig,
         terminalStatus: 'resumable',
       },
@@ -280,10 +273,9 @@ describe('CLI history runtime', () => {
     } as AgentConfig;
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'chat1' as ExecutionId,
         timestamp: '2026-05-18T11:00:00.000Z',
-        agent: 'assistant',
-        model: 'deepseekT',
         agentConfig: chatConfig,
         terminalStatus: 'resumable',
         description: 'Sketch a proof outline',

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -44,11 +44,14 @@ const { discoverLatestExecutionOutputs } =
 
 function matchingExecution(id: string) {
   return {
+    kind: 'agent',
     id,
-    agent: 'polish',
-    model: 'deepseek',
     timestamp: '2026-01-01T00:00:00.000Z',
-    agentConfig: { inputFiles: ['paper.tex'] },
+    agentConfig: {
+      agent: 'polish',
+      model: 'deepseek',
+      inputFiles: ['paper.tex'],
+    },
   };
 }
 

--- a/src/test-kernel/settings/HistoryHandlers.vitest.ts
+++ b/src/test-kernel/settings/HistoryHandlers.vitest.ts
@@ -29,6 +29,7 @@ describe('settings history handlers', () => {
   it('includes persisted edited files for tool-use history items', async () => {
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'abc123',
         timestamp: '2026-05-31T12:00:00.000Z',
         agentConfig: {
@@ -37,7 +38,6 @@ describe('settings history handlers', () => {
           instruction: 'Check a proof.',
           agentCategory: AgentCategory.ToolUse,
         },
-        category: 'toolUse',
       },
     ]);
     mocks.readWorkspaceFiles.mockResolvedValue(['proofs/lemma.md']);
@@ -63,6 +63,7 @@ describe('settings history handlers', () => {
   it('hides internal process-bookkeeping and configless entries', async () => {
     mocks.listExecutions.mockResolvedValue([
       {
+        kind: 'agent',
         id: 'abc123',
         timestamp: '2026-05-31T12:00:00.000Z',
         agentConfig: {
@@ -71,9 +72,9 @@ describe('settings history handlers', () => {
           instruction: 'Check a proof.',
           agentCategory: AgentCategory.ToolUse,
         },
-        category: 'toolUse',
       },
       {
+        kind: 'process',
         id: 'bash-process',
         timestamp: '2026-05-31T12:01:00.000Z',
         agentConfig: {
@@ -82,12 +83,11 @@ describe('settings history handlers', () => {
           instruction: 'ls -la',
           agentCategory: AgentCategory.ToolUse,
         },
-        category: 'process',
       },
       {
+        kind: 'incomplete',
         id: 'configless',
         timestamp: '2026-05-31T12:02:00.000Z',
-        agentConfig: null,
       },
     ]);
 

--- a/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
+++ b/src/test-kernel/tools/ToolStatusFormatting.vitest.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - storage
 import type { ExecutionListingEntry } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 
 // Local imports - schemas
 import { STATUS_DISPLAY, TODO_STATUS } from '@shared/schemas';
@@ -98,13 +99,16 @@ describe('tool status formatting', () => {
 
   it('renders bash execution history as a process without a model', () => {
     const entry: ExecutionListingEntry = {
+      kind: 'process',
       id: '16c0f3f748e4',
       timestamp: '2026-05-15T23:42:06.000Z',
       parentExecutionId: 'fcf5150d37c6',
-      agent: 'bash',
-      model: 'gemini31p',
-      agentConfig: null,
-      category: 'toolUse',
+      agentConfig: AgentConfigSchema.parse({
+        agent: 'bash',
+        model: 'gemini31p',
+        instruction: 'ls',
+        agentCategory: 'toolUse',
+      }),
       terminalStatus: 'completed',
     };
 

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -15,6 +15,8 @@ export function resolveExecutionDisplayCategory(
   agent: string | undefined,
   category: string | undefined,
 ): string | undefined {
+  // Raw detail reads have not crossed the listing normalization boundary;
+  // normalized listing rows use their discriminated `kind` below instead.
   return isProcessAgent(agent) ? 'process' : category;
 }
 

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -18,6 +18,33 @@ export function resolveExecutionDisplayCategory(
   return isProcessAgent(agent) ? 'process' : category;
 }
 
+function listingDisplay(entry: ExecutionListingEntry): {
+  agent: string;
+  model: string | null;
+  category: string | undefined;
+} {
+  switch (entry.kind) {
+    case 'agent':
+      return {
+        agent: entry.agentConfig.agent,
+        model: entry.agentConfig.model,
+        category: entry.runtimeCategory ?? entry.agentConfig.agentCategory,
+      };
+    case 'process':
+      return {
+        agent: entry.agentConfig.agent,
+        model: null,
+        category: 'process',
+      };
+    case 'incomplete':
+      return {
+        agent: 'unknown',
+        model: entry.runtimeCategory === 'process' ? null : 'unknown',
+        category: entry.runtimeCategory,
+      };
+  }
+}
+
 /** Return paths available for a given agent category. */
 export function getAvailablePaths(
   category?: string,
@@ -76,14 +103,14 @@ export function getExecutionStatusInfo(
 export function formatListingLine(entry: ExecutionListingEntry): string {
   const ts = formatTimestamp(entry.timestamp);
   const info = getExecutionStatusInfo(entry.id, entry.terminalStatus);
-  const category = resolveExecutionDisplayCategory(entry.agent, entry.category);
+  const { agent, model, category } = listingDisplay(entry);
   const categoryTag = category ? `  ${category}` : '';
-  const modelTag = category === 'process' ? '' : `  ${entry.model}`;
+  const modelTag = model == null ? '' : `  ${model}`;
   const parentSuffix = entry.parentExecutionId
     ? `  parent=${entry.parentExecutionId}`
     : '';
   const descSuffix = entry.description ? `  — ${entry.description}` : '';
-  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}${modelTag}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
+  return `${entry.id}  ${ts}  ${agent}${categoryTag}${modelTag}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
 }
 
 function getTodoStatusIcon(status: string | undefined): string {


### PR DESCRIPTION
## Summary

Normalize persisted execution metadata and config once at the storage-listing boundary into explicit `agent`, `process`, and `incomplete` branches. Configured rows now use `AgentConfig` as the sole source for agent/model fields; consumers no longer repeat nullable checks or non-null assertions.

Closes #8483.

## Issue acceptance gates

- [x] Replace the nullable/duplicated listing core with a discriminated union.
- [x] Keep agent/model authoritative in `AgentConfig`.
- [x] Separate runtime metadata overrides from agent category.
- [x] Make `isUserVisibleExecution` a narrowing type predicate and remove the history assertion.
- [x] Update all eight production consumers; onboarding/startup length probes need no branch-specific projection.
- [x] Preserve agent, process, and incomplete presentation behavior.
- [x] Add boundary tests for every union branch and update consumer tests.

## Single source of truth

`src/agent/storage/executionListing.ts` now owns normalization from persisted execution metadata/config into the in-memory listing contract. `AgentConfig` owns configured agent/model data; `kind` owns visibility/runtime classification.

## Duplication and abstraction budget

Removed sibling `agent`, `model`, nullable `agentConfig`, and overloaded `category` fields. Added one discriminated union and one exhaustive formatter projection; each owns a concrete invariant and neither is a pass-through layer.

## Net elements (R6)

- Files: +1 focused storage-boundary test file; 12 modified.
- Exported symbols: 1 flat interface removed, 1 union type added; net 0.
- Production named constructs: +1 private base interface, +1 exhaustive display helper, with the former flat interface replaced by the union; net +2.
- LoC: +285 / -84 overall, net +201; production code is +124 / -54, net +70, while +126 lines are the new all-branch boundary suite.

## Consumer counts (R8)

n/a for emit paths and subscriber keys. `listExecutions()` has 8 production consumer files plus its defining module; all were inspected. Direct `ExecutionListingEntry` references remain in 5 consumer modules plus its definition/barrel.

## Host impact

Extension: History narrowing is assertion-free; onboarding remains a branch-agnostic non-empty probe.

Desktop: Startup onboarding remains a branch-agnostic non-empty probe; persisted storage is unchanged.

CLI: History/default inference consume only visible agent branches and no longer fall back across duplicated fields.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `CI=true npm run compile:fast`
- `CI=true npm run lint` (0 errors; only pre-existing warnings)
- `CI=true npm run check:dead-code-ratchet`
- Focused Vitest: 7 files, 80 tests passed
- `CI=true npm test`
- Review follow-ups: targeted formatter lint, 80 focused tests, both TypeScript projects, and the full 6,224-test suite passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared history/listing contracts across CLI, extension settings, tools, and latexdiff; behavior is intended to be preserved but misclassification at the boundary would affect visibility and display.
> 
> **Overview**
> **`listExecutions()`** now returns a discriminated union (`kind: 'agent' | 'process' | 'incomplete'`) instead of a flat row with duplicated `agent`/`model`, nullable `agentConfig`, and overloaded `category`. Normalization happens once in `executionListing.ts`: configured runs are **`agent`** with required `agentConfig` as the canonical source for agent/model; background bash bookkeeping is **`process`**; missing config is **`incomplete`** with optional `runtimeCategory` for legacy metadata.
> 
> **`isUserVisibleExecution`** is now a type predicate (`kind === 'agent'`), so history and defaults code can drop non-null assertions and nullable field fallbacks.
> 
> Consumers were updated to match: CLI chat defaults and history, settings `HistoryMessageBuilder`, latexdiff output discovery, and **`formatListingLine`** (new exhaustive `listingDisplay` projection). Tests add a storage-boundary suite and refresh mocks to the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afdcac16561b9073db676d2d37fe17a974d29bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->