### PR TITLE
fix(cli): print the ChatGPT sign-in link even after opening the browser

### DIFF
--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -75,12 +75,15 @@ export async function signInCliChatGpt(
   return loginWithLoopback({
     coordinator,
     openBrowser: async (url) => {
-      if (!init.noBrowser) {
+      if (!init.noBrowser && (await tryOpenBrowser(url))) {
+        // Always print the link even after a successful launch: the
+        // loopback callback accepts the redirect from any browser, so a
+        // user whose ChatGPT session lives elsewhere can just copy it from
+        // the terminal instead of needing `--no-browser` ahead of time.
         options.writeProgress(
-          'Opening your browser to sign in with ChatGPT...',
+          `Opening your browser to sign in with ChatGPT. Using a different browser? Open this URL there instead:\n${url}`,
         );
-        const opened = await tryOpenBrowser(url);
-        if (opened) return;
+        return;
       }
       options.writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
     },

--- a/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
+++ b/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  codexCoordinator: vi.fn(() => ({})),
+  loginWithLoopback: vi.fn(),
+  tryOpenBrowser: vi.fn(),
+}));
+
+vi.mock('@auth/codex', () => ({
+  codexCoordinator: mocks.codexCoordinator,
+  loginWithDeviceCode: vi.fn(),
+  loginWithLoopback: mocks.loginWithLoopback,
+  setPreferCodexSubscription: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/browser', () => ({
+  tryOpenBrowser: mocks.tryOpenBrowser,
+}));
+
+const { signInCliChatGpt } = await import('@cli/runtime/chatgptLogin');
+
+function loopbackSession() {
+  return {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+describe('signInCliChatGpt browser choice', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prints the sign-in link even after a successful browser launch', async () => {
+    mocks.tryOpenBrowser.mockResolvedValue(true);
+    mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize?x=1');
+      return loopbackSession();
+    });
+    const progress: string[] = [];
+
+    await signInCliChatGpt(
+      { device: false, noBrowser: false },
+      { writeProgress: (message) => progress.push(message) },
+    );
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]).toContain('https://auth.openai.com/authorize?x=1');
+    expect(progress[0]).toContain('different browser');
+  });
+
+  it('prints only the URL when the browser fails to launch', async () => {
+    mocks.tryOpenBrowser.mockResolvedValue(false);
+    mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize?x=2');
+      return loopbackSession();
+    });
+    const progress: string[] = [];
+
+    await signInCliChatGpt(
+      { device: false, noBrowser: false },
+      { writeProgress: (message) => progress.push(message) },
+    );
+
+    expect(progress).toEqual([
+      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=2',
+    ]);
+  });
+
+  it('skips the launch attempt and prints the URL with --no-browser', async () => {
+    mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize?x=3');
+      return loopbackSession();
+    });
+    const progress: string[] = [];
+
+    await signInCliChatGpt(
+      { device: false, noBrowser: true },
+      { writeProgress: (message) => progress.push(message) },
+    );
+
+    expect(mocks.tryOpenBrowser).not.toHaveBeenCalled();
+    expect(progress).toEqual([
+      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=3',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- `signInCliChatGpt` (`packages/cli/src/runtime/chatgptLogin.ts`) only showed the ChatGPT sign-in URL when the browser launch failed or `--no-browser` was passed.
- The loopback OAuth callback accepts the redirect from *any* browser, so a user whose ChatGPT session lives in a different browser than the OS default previously had no way to grab the link without knowing to pass `--no-browser` ahead of time.
- Now the link is always printed alongside the auto-launch message, so it's copyable straight from the terminal regardless of outcome.
- This is the CLI-side counterpart to #8465 (VS Code extension). Same shared `signInCliChatGpt`/`loginWithLoopback` path covers all CLI entry points: the TUI Account menu ("Sign in with ChatGPT"), `/login chatgpt`, `/subscription on`, and the headless `texra chatgpt login` command.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Added `src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts` covering: successful launch (link still printed), failed launch (URL-only fallback unchanged), and `--no-browser` (URL-only, launch never attempted)
- [x] Existing CLI auth tests (`SlashCommandDispatch`, `ChatGptSubscriptionDetection`, `BrowserLaunch`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to CLI progress messages during OAuth; auth flow and tokens are unchanged.
> 
> **Overview**
> **Loopback ChatGPT sign-in** now always surfaces the authorize URL in the terminal when the default browser opens successfully, not only when launch fails or `--no-browser` is used.
> 
> `signInCliChatGpt` reorders the `openBrowser` callback so a successful `tryOpenBrowser` shows a message that includes the URL and hints that another browser can be used—matching the fact that loopback OAuth accepts the redirect from any browser. Failed launch and `--no-browser` still emit the URL-only progress text unchanged.
> 
> Adds `ChatgptLoginBrowser.vitest.mts` with coverage for successful launch (link + copy hint), failed launch, and `--no-browser` (no launch attempt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0318f0ea6caebcfddf6caca5918232e1f7437d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->