### PR TITLE
fix(cli): clear active dialog drafts on Ctrl-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Ctrl+C clears unfinished chat input before stopping or exiting** — pressing
-  Ctrl+C with a non-empty draft now clears the draft; pressing it again keeps
-  the existing response-stop or exit behavior.
+- **Ctrl+C clears unfinished input before stopping or exiting** — pressing
+  Ctrl+C with text in the chat input or a dialog now clears that text; pressing
+  it again keeps the existing response-stop or exit behavior.
 - **Session navigation uses one persistent list** — `Tab` opens the vertical
   list for the main and delegated sessions; arrow keys select a session,
   `Enter` focuses it, and reopening the list restores the previous selection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### CLI
+
+#### Bug Fixes
+
+- **Ctrl+C clears dialog text before stopping or exiting** — pressing Ctrl+C
+  with text in a foreground dialog now clears that text; pressing it again
+  keeps the existing response-stop or exit behavior.
+
 ## [0.39.5] - 2026-07-15
 
 ### Shared (all surfaces)
@@ -49,9 +59,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Ctrl+C clears unfinished input before stopping or exiting** — pressing
-  Ctrl+C with text in the chat input or a dialog now clears that text; pressing
-  it again keeps the existing response-stop or exit behavior.
+- **Ctrl+C clears unfinished chat input before stopping or exiting** — pressing
+  Ctrl+C with a non-empty draft now clears the draft; pressing it again keeps
+  the existing response-stop or exit behavior.
 - **Session navigation uses one persistent list** — `Tab` opens the vertical
   list for the main and delegated sessions; arrow keys select a session,
   `Enter` focuses it, and reopening the list restores the previous selection.

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -44,6 +44,10 @@ import {
   rewriteKittyEnterInput,
 } from './input/inputKeys';
 import {
+  ActiveDraftScope,
+  createActiveDraftRegistry,
+} from './input/activeDraft';
+import {
   numericFocusTargetForActiveStream,
   resolveChildControlDisplayTargets,
 } from './state/childControls';
@@ -124,6 +128,7 @@ export function App(props: AppProps): React.JSX.Element {
   const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
+  const activeDraftRegistry = useMemo(createActiveDraftRegistry, []);
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
   const agentSelectionAvailable = rootRunStartAvailable;
@@ -403,12 +408,13 @@ export function App(props: AppProps): React.JSX.Element {
     if (key.ctrl && input === 'c') {
       triggerAppCtrlC({
         discardDraft: () =>
-          appDraftDiscardActive({
+          activeDraftRegistry.discard() ||
+          (appDraftDiscardActive({
             inputDisabled,
             reverseSearchOpen,
             sessionListFocused,
           }) &&
-          (inputBarRef.current?.discardDraft() ?? false),
+            (inputBarRef.current?.discardDraft() ?? false)),
         canStopActiveRun,
         onInterruptActive: props.onInterruptActive,
         onExit: exit,
@@ -479,63 +485,68 @@ export function App(props: AppProps): React.JSX.Element {
   });
 
   return (
-    <ConversationRegion
-      agentSelectionAvailable={agentSelectionAvailable}
-      colorEnabled={props.colorEnabled}
-      columns={columns}
-      onTranscriptViewportChange={props.onTranscriptViewportChange}
-      renderFooterChrome={(queuedFollowUpPanelVisible) => (
-        <>
-          <InputBar
-            controlRef={inputBarRef}
-            onSubmit={props.onSubmit}
-            collapseWhenDisabled={!inputBarVisible}
-            disabledMessage={childInputDisabledMessage}
-            disabled={inputDisabled}
-            history={props.history}
-            keyboardActive={!sessionListFocused}
-          />
-          <StatusBar
-            agentSelectionAvailable={agentSelectionAvailable}
-            commandName={props.commandName}
-            foregroundEscapeAction={foregroundEscapeAction({
-              activeFormEscapeAction: activeForm?.escapeAction,
-              approvalKind,
-              childControlEscapeAction,
-              foregroundKind,
-            })}
-            queuedFollowUpPreview={!queuedFollowUpPanelVisible}
-            sessionNavigationAvailable={sessionViews.length > 0}
-            shortcutsActive={focusShortcutsActive}
-            sessionListFocused={sessionListFocused}
-            subagentControlsAvailable={subagentControlsAvailable}
-            taskControlsAvailable={taskControlsAvailable}
-            transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
-          />
-        </>
-      )}
-      renderForegroundSurface={renderForegroundSurface}
-      rows={rows}
-      snapshot={{
-        activeStreamId,
-        foregroundMaxRows,
-        foregroundKind,
-        parentStream,
-        reverseSearchOpen,
-        rootStreamId,
-        slashPaletteOpen,
-        sessionListFocused,
-        sessionViews,
-        selectedSessionId,
-        streams,
-        childExecutionPanelTarget: childControlTargets.tasks,
-        transcriptViewerStreamId,
-      }}
-      onCancelSessionList={cancelSessionList}
-      onFocusSession={focusSession}
-      onSessionSelectionChange={(streamId) =>
-        dispatchSessionListSelection({ kind: 'highlight', streamId })
-      }
-    />
+    <ActiveDraftScope
+      active={foregroundOpen || reverseSearchOpen}
+      registry={activeDraftRegistry}
+    >
+      <ConversationRegion
+        agentSelectionAvailable={agentSelectionAvailable}
+        colorEnabled={props.colorEnabled}
+        columns={columns}
+        onTranscriptViewportChange={props.onTranscriptViewportChange}
+        renderFooterChrome={(queuedFollowUpPanelVisible) => (
+          <>
+            <InputBar
+              controlRef={inputBarRef}
+              onSubmit={props.onSubmit}
+              collapseWhenDisabled={!inputBarVisible}
+              disabledMessage={childInputDisabledMessage}
+              disabled={inputDisabled}
+              history={props.history}
+              keyboardActive={!sessionListFocused}
+            />
+            <StatusBar
+              agentSelectionAvailable={agentSelectionAvailable}
+              commandName={props.commandName}
+              foregroundEscapeAction={foregroundEscapeAction({
+                activeFormEscapeAction: activeForm?.escapeAction,
+                approvalKind,
+                childControlEscapeAction,
+                foregroundKind,
+              })}
+              queuedFollowUpPreview={!queuedFollowUpPanelVisible}
+              sessionNavigationAvailable={sessionViews.length > 0}
+              shortcutsActive={focusShortcutsActive}
+              sessionListFocused={sessionListFocused}
+              subagentControlsAvailable={subagentControlsAvailable}
+              taskControlsAvailable={taskControlsAvailable}
+              transcriptAvailable={(activeSlice?.entries.length ?? 0) > 0}
+            />
+          </>
+        )}
+        renderForegroundSurface={renderForegroundSurface}
+        rows={rows}
+        snapshot={{
+          activeStreamId,
+          foregroundMaxRows,
+          foregroundKind,
+          parentStream,
+          reverseSearchOpen,
+          rootStreamId,
+          slashPaletteOpen,
+          sessionListFocused,
+          sessionViews,
+          selectedSessionId,
+          streams,
+          childExecutionPanelTarget: childControlTargets.tasks,
+          transcriptViewerStreamId,
+        }}
+        onCancelSessionList={cancelSessionList}
+        onFocusSession={focusSession}
+        onSessionSelectionChange={(streamId) =>
+          dispatchSessionListSelection({ kind: 'highlight', streamId })
+        }
+      />
+    </ActiveDraftScope>
   );
 }

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -31,6 +31,7 @@ import {
   withImagePasteTimeout,
   type ImagePasteAttempt,
 } from './imagePasteQueue';
+import { useActiveDraft } from './activeDraft';
 import { textDisplayWidth } from '../render/terminalText';
 
 const ESC_SLASH_PREFIX = '\u001B/';
@@ -442,6 +443,21 @@ export function BaseTextInput(props: BaseTextInputProps): React.JSX.Element {
     },
     [applyEdit],
   );
+
+  const discardDraft = useCallback((): boolean => {
+    const latest = syncLatestExternalValue();
+    if (
+      latest.value.length === 0 &&
+      !imagePasteQueue.hasPending &&
+      !imagePasteQueue.hasDeferredAction
+    ) {
+      return false;
+    }
+    imagePasteQueue.discardPending();
+    applyEdit({ value: '', cursor: 0 });
+    return true;
+  }, [applyEdit, imagePasteQueue, syncLatestExternalValue]);
+  useActiveDraft(discardDraft, focus);
 
   const submitAfterImagePastes = useCallback(
     (handler: (value: string) => void, submitted: string): void => {

--- a/packages/cli/src/chat/tui/input/activeDraft.tsx
+++ b/packages/cli/src/chat/tui/input/activeDraft.tsx
@@ -1,0 +1,61 @@
+// Active text-draft registration for foreground TUI inputs.
+
+// Third-party imports
+import { createContext, useContext, useEffect, type ReactNode } from 'react';
+
+export type DraftDiscarder = () => boolean;
+
+export interface ActiveDraftRegistry {
+  readonly register: (discard: DraftDiscarder) => () => void;
+  readonly discard: () => boolean;
+}
+
+/** Keep the most recently mounted active input as the owner of draft discard. */
+export function createActiveDraftRegistry(): ActiveDraftRegistry {
+  const entries: Array<{ readonly discard: DraftDiscarder }> = [];
+
+  return {
+    register(discard) {
+      const entry = { discard };
+      entries.push(entry);
+      let registered = true;
+      return () => {
+        if (!registered) return;
+        registered = false;
+        const index = entries.indexOf(entry);
+        if (index >= 0) entries.splice(index, 1);
+      };
+    },
+    discard() {
+      return entries.at(-1)?.discard() ?? false;
+    },
+  };
+}
+
+const ActiveDraftContext = createContext<ActiveDraftRegistry | undefined>(
+  undefined,
+);
+
+export function ActiveDraftScope(props: {
+  readonly active: boolean;
+  readonly children: ReactNode;
+  readonly registry: ActiveDraftRegistry;
+}): React.JSX.Element {
+  return (
+    <ActiveDraftContext.Provider
+      value={props.active ? props.registry : undefined}
+    >
+      {props.children}
+    </ActiveDraftContext.Provider>
+  );
+}
+
+/** Register a focused text input with the root Ctrl-C interaction policy. */
+export function useActiveDraft(discard: DraftDiscarder, active: boolean): void {
+  const registry = useContext(ActiveDraftContext);
+
+  useEffect(() => {
+    if (!active || !registry) return;
+    return registry.register(discard);
+  }, [active, discard, registry]);
+}

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -482,7 +482,8 @@ function FreeTextQuestion(props: FreeTextQuestionProps): React.JSX.Element {
     visibleItemCount: visibleOptions.length,
   });
   useInput((input, key) => {
-    // Esc cancels; Ctrl+C is owned by the App's unified handler (exits the app).
+    // Esc cancels; App clears a non-empty answer before applying its usual
+    // Ctrl+C stop or exit behavior.
     if (isEscapeInput(input, key)) {
       props.onCancel();
     }

--- a/src/test-kernel/cli/ActiveDraft.vitest.mts
+++ b/src/test-kernel/cli/ActiveDraft.vitest.mts
@@ -1,0 +1,63 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - TUI input policy
+import { triggerAppCtrlC } from '@cli/chat/tui/appInteractionPolicy';
+import { createActiveDraftRegistry } from '@cli/chat/tui/input/activeDraft';
+
+describe('active foreground draft', () => {
+  it('discards the most recently registered input draft', () => {
+    const registry = createActiveDraftRegistry();
+    const background = vi.fn(() => true);
+    const foreground = vi.fn(() => true);
+
+    registry.register(background);
+    registry.register(foreground);
+
+    expect(registry.discard()).toBe(true);
+    expect(foreground).toHaveBeenCalledOnce();
+    expect(background).not.toHaveBeenCalled();
+  });
+
+  it('restores the previous input when the foreground input unmounts', () => {
+    const registry = createActiveDraftRegistry();
+    const background = vi.fn(() => true);
+    const foreground = vi.fn(() => true);
+    registry.register(background);
+    const unregisterForeground = registry.register(foreground);
+
+    unregisterForeground();
+
+    expect(registry.discard()).toBe(true);
+    expect(background).toHaveBeenCalledOnce();
+    expect(foreground).not.toHaveBeenCalled();
+  });
+
+  it('reports an empty registry without consuming Ctrl-C', () => {
+    const registry = createActiveDraftRegistry();
+
+    expect(registry.discard()).toBe(false);
+  });
+
+  it('clears a dialog draft before the root policy exits', () => {
+    const registry = createActiveDraftRegistry();
+    const onExit = vi.fn();
+    let draft = 'answer in progress';
+    registry.register(() => {
+      if (draft.length === 0) return false;
+      draft = '';
+      return true;
+    });
+
+    expect(
+      triggerAppCtrlC({
+        discardDraft: registry.discard,
+        canStopActiveRun: () => false,
+        onInterruptActive: vi.fn(),
+        onExit,
+      }),
+    ).toBe('clear-draft');
+    expect(draft).toBe('');
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -4,6 +4,12 @@ import { createRequire } from 'node:module';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
+import { BaseTextInput } from '@cli/chat/tui/input/BaseTextInput';
+import {
+  ActiveDraftScope,
+  createActiveDraftRegistry,
+} from '@cli/chat/tui/input/activeDraft';
+import { triggerAppCtrlC } from '@cli/chat/tui/appInteractionPolicy';
 import {
   InputBar,
   submitSlashCommandWhenReady,
@@ -159,6 +165,60 @@ describe('InputBar slash submit', () => {
 });
 
 describe('InputBar draft discard', () => {
+  it('clears a mounted foreground text input before exiting', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const registry = createActiveDraftRegistry();
+    const onExit = vi.fn();
+    let currentValue = 'dialog answer';
+
+    function Harness() {
+      const [value, setValue] = React.useState(currentValue);
+      ink.useInput((input: string, key: { readonly ctrl?: boolean }) => {
+        if (key.ctrl && input === 'c') {
+          triggerAppCtrlC({
+            discardDraft: registry.discard,
+            canStopActiveRun: () => false,
+            onInterruptActive: vi.fn(),
+            onExit,
+          });
+        }
+      });
+      return React.createElement(
+        ActiveDraftScope,
+        { active: true, registry },
+        React.createElement(BaseTextInput, {
+          value,
+          onChange: (next: string) => {
+            currentValue = next;
+            setValue(next);
+          },
+          onSubmit: () => undefined,
+        }),
+      );
+    }
+
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout();
+    const instance = ink.render(React.createElement(Harness), {
+      stdin,
+      stdout,
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('\u0003');
+      await waitFor(() => currentValue === '');
+
+      expect(onExit).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('invalidates an image paste that resolves after the draft is cleared', async () => {
     const imagePasteQueue = new ImagePasteQueue();
     const attempt = imagePasteQueue.beginAttempt();


### PR DESCRIPTION
## Summary

- clears text in the active foreground input on the first Ctrl+C instead of stopping or exiting
- applies the behavior uniformly to user questions, external inquiries, approval feedback, API-key entry, configuration editing, and reverse history search
- preserves the main composer's existing attachment-aware cleanup and the existing second-press stop or exit behavior

## Design

Ink broadcasts each keypress to every mounted input handler, so the root TUI remains the sole owner of Ctrl+C. A foreground input scope now lets the focused `BaseTextInput` register one atomic draft-discard operation with that root policy. This keeps process control out of individual dialogs and makes future foreground text inputs follow the same behavior automatically.

The registry keeps only the active ownership order and removes registrations on unmount. `BaseTextInput` owns text and pending paste cleanup; `App` knows only whether the active draft consumed Ctrl+C. The main composer continues to use its deeper `InputBar` cleanup because it also owns attachments.

## Verification

- mounted Ink regression sends raw Ctrl+C and confirms that dialog text clears without invoking exit
- 10 focused input and policy tests passed
- CLI and test-kernel typechecks passed
- full ESLint and formatting checks passed
- `compile:fast`, CLI architecture checks, and `texra-local:build` passed
- 689 test files passed together (6,224 tests); the timing-sensitive signal-ownership file passed separately (2 tests) after exceeding its fixed 10-second limit under the full local parallel load

Closes #8490

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI input policy change with tests; no auth, persistence, or API surface changes.
> 
> **Overview**
> **Ctrl+C in foreground dialogs now clears typed text first** instead of stopping a run or exiting the app. A second Ctrl+C keeps the existing stop-or-exit behavior.
> 
> The root `App` still owns Ctrl+C, but it now consults an **active draft registry** before the main composer `InputBar`. While a modal, approval flow, `/config` editor, reverse search, or similar surface is open, `ActiveDraftScope` enables registration; focused **`BaseTextInput`** instances register a single `discardDraft` that clears text and pending image-paste state. The **most recently mounted** input wins, so nested foreground UIs discard the right draft on unmount.
> 
> The main chat input path is unchanged: when no foreground draft consumes Ctrl+C, **`InputBar`** still handles attachment-aware cleanup as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2fc9201d5ec2cdd510202a89ebef39d734f2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->