### PR TITLE
refactor: consolidate filename sanitizers into shared utility

### DIFF
--- a/src/agent/export/chatExport/filenames.ts
+++ b/src/agent/export/chatExport/filenames.ts
@@ -1,5 +1,6 @@
 /** Descriptive filename generation for chat exports. */
 
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 import { isoDateOnly } from '@utils/text/stringUtils';
 
 /**
@@ -37,9 +38,11 @@ export function generateExportFilename(
 }
 
 function sanitizeFilename(name: string): string {
-  return name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9-]/g, '-')
-    .replaceAll(/-+/g, '-')
-    .replaceAll(/^-|-$/g, '');
+  return sanitizePathSegment(name, {
+    lowercase: true,
+    invalidCharPattern: /[^a-z0-9-]/g,
+    replacement: '-',
+    collapseRepeats: true,
+    trimReplacement: true,
+  });
 }

--- a/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts
@@ -7,6 +7,8 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 import { toFile } from '@anthropic-ai/sdk';
 
 // Local imports
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
+
 import { FILES_API_BETA } from './anthropicContextManagement';
 import { wipeBuffer } from '../utils/toolAttachmentUtils';
 
@@ -119,13 +121,13 @@ export async function countPdfPagesFromBuffer(buffer: Buffer): Promise<number> {
  */
 export function sanitizeAnthropicFilename(filename: string): string {
   const baseName = basename(filename) || filename;
-  const trimmed = baseName.trim();
-  const withoutControlChars = Array.from(trimmed, (char) =>
-    char.charCodeAt(0) < 32 ? '_' : char,
-  ).join('');
-  const withoutForbidden = withoutControlChars.replaceAll(/[:<>"|?*\\/]/g, '_');
-  const sanitized = withoutForbidden || 'document.pdf';
-  return sanitized.slice(0, 255);
+  return sanitizePathSegment(baseName.trim(), {
+    // eslint-disable-next-line no-control-regex -- control chars are forbidden in filenames
+    invalidCharPattern: /[\x00-\x1F:<>"|?*\\/]/g,
+    replacement: '_',
+    fallback: 'document.pdf',
+    maxLength: 255,
+  });
 }
 
 interface ReplaceDocumentUploadsResult {

--- a/src/platform/defaults/workspaceStorage.ts
+++ b/src/platform/defaults/workspaceStorage.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { basename, join, normalize, relative } from 'node:path';
 
 import { isPathWithin } from '@utils/core/pathCore';
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 // Local imports - platform
 import type { StorageProvider } from '../interfaces';
@@ -33,12 +34,13 @@ function legacyWorkspaceStorageId(workspacePath: string | undefined): string {
 }
 
 function sanitizeWorkspaceBasename(workspacePath: string): string {
-  return (
-    basename(workspacePath)
-      .replaceAll(/[^A-Za-z0-9._-]/g, '-')
-      .replaceAll(/-+/g, '-')
-      .replaceAll(/^-|-$/g, '') || 'workspace'
-  );
+  return sanitizePathSegment(basename(workspacePath), {
+    invalidCharPattern: /[^A-Za-z0-9._-]/g,
+    replacement: '-',
+    collapseRepeats: true,
+    trimReplacement: true,
+    fallback: 'workspace',
+  });
 }
 
 export function workspaceStorageId(workspacePath: string | undefined): string {

--- a/src/test-kernel/utils/text/SanitizePathSegment.vitest.ts
+++ b/src/test-kernel/utils/text/SanitizePathSegment.vitest.ts
@@ -1,0 +1,65 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
+
+describe('sanitizePathSegment', () => {
+  it('lowercases, replaces disallowed chars, collapses runs, and trims edges', () => {
+    expect(
+      sanitizePathSegment('Claude Sonnet 4.5!!', {
+        lowercase: true,
+        invalidCharPattern: /[^a-z0-9-]/g,
+        replacement: '-',
+        collapseRepeats: true,
+        trimReplacement: true,
+      }),
+    ).toBe('claude-sonnet-4-5');
+  });
+
+  it('falls back to a default when the result is empty', () => {
+    expect(
+      sanitizePathSegment('!!!', {
+        invalidCharPattern: /[^A-Za-z0-9._-]/g,
+        replacement: '-',
+        collapseRepeats: true,
+        trimReplacement: true,
+        fallback: 'workspace',
+      }),
+    ).toBe('workspace');
+  });
+
+  it('returns an empty string when there is no fallback', () => {
+    expect(
+      sanitizePathSegment('!!!', {
+        lowercase: true,
+        invalidCharPattern: /[^a-z0-9-]/g,
+        replacement: '-',
+        collapseRepeats: true,
+        trimReplacement: true,
+      }),
+    ).toBe('');
+  });
+
+  it('replaces without collapsing or trimming when those options are off', () => {
+    expect(
+      sanitizePathSegment('a:b<c>d', {
+        invalidCharPattern: /[:<>"|?*\\/]/g,
+        replacement: '_',
+        fallback: 'document.pdf',
+        maxLength: 255,
+      }),
+    ).toBe('a_b_c_d');
+  });
+
+  it('applies maxLength after fallback substitution', () => {
+    expect(
+      sanitizePathSegment('', {
+        invalidCharPattern: /x/g,
+        replacement: '_',
+        fallback: 'abcdefgh',
+        maxLength: 4,
+      }),
+    ).toBe('abcd');
+  });
+});

--- a/src/utils/text/sanitizePathSegment.ts
+++ b/src/utils/text/sanitizePathSegment.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared shape behind this codebase's several filename/path-segment
+ * sanitizers: replace disallowed characters, optionally collapse repeated
+ * replacement runs, trim replacement characters from the edges, fall back
+ * to a default when nothing survives, and optionally cap the length.
+ */
+
+import escapeRegExp from 'escape-string-regexp';
+
+export interface SanitizePathSegmentOptions {
+  /** Global regex matching characters to replace. */
+  invalidCharPattern: RegExp;
+  /** String to substitute for each match of `invalidCharPattern`. */
+  replacement: string;
+  /** Lowercase the input before sanitizing. */
+  lowercase?: boolean;
+  /** Collapse consecutive replacement characters into a single one. */
+  collapseRepeats?: boolean;
+  /** Trim leading/trailing replacement characters from the result. */
+  trimReplacement?: boolean;
+  /** Value to use if the result is empty after sanitization. */
+  fallback?: string;
+  /** Maximum length of the result, applied last. */
+  maxLength?: number;
+}
+
+export function sanitizePathSegment(
+  input: string,
+  options: SanitizePathSegmentOptions,
+): string {
+  let result = options.lowercase ? input.toLowerCase() : input;
+  result = result.replaceAll(options.invalidCharPattern, options.replacement);
+
+  if (options.replacement) {
+    const escaped = escapeRegExp(options.replacement);
+    if (options.collapseRepeats) {
+      result = result.replaceAll(new RegExp(`${escaped}+`, 'g'), options.replacement);
+    }
+    if (options.trimReplacement) {
+      result = result.replaceAll(
+        new RegExp(`^(?:${escaped})+|(?:${escaped})+$`, 'g'),
+        '',
+      );
+    }
+  }
+
+  if (!result && options.fallback) result = options.fallback;
+  return options.maxLength ? result.slice(0, options.maxLength) : result;
+}

--- a/src/utils/text/sanitizePathSegment.ts
+++ b/src/utils/text/sanitizePathSegment.ts
@@ -34,7 +34,10 @@ export function sanitizePathSegment(
   if (options.replacement) {
     const escaped = escapeRegExp(options.replacement);
     if (options.collapseRepeats) {
-      result = result.replaceAll(new RegExp(`${escaped}+`, 'g'), options.replacement);
+      result = result.replaceAll(
+        new RegExp(`${escaped}+`, 'g'),
+        options.replacement,
+      );
     }
     if (options.trimReplacement) {
       result = result.replaceAll(


### PR DESCRIPTION
## Summary

A codebase-wide sweep for duplicate logic and hand-rolled implementations of native/stdlib functionality found this repo already unusually well-consolidated (nanoid for IDs, `safeParseJson`, shared `debounce`, `structuredClone`, one jittered-backoff implementation, one `RetryState`, provider dispatch through a registry, etc. — all consistently reused). The one clear, verifiable finding: three separate files each hand-rolled the same "replace invalid chars → collapse repeated separators → trim edges → fall back on empty" filename-sanitization logic with different charsets:

- `sanitizeFilename` (`src/agent/export/chatExport/filenames.ts`) — chat export filename parts
- `sanitizeWorkspaceBasename` (`src/platform/defaults/workspaceStorage.ts`) — workspace storage directory basenames
- `sanitizeAnthropicFilename` (`src/agent/modelHandlers/anthropic/anthropicDocumentHandling.ts`) — Anthropic Files API upload names

This PR extracts the shared shape into one parameterized `sanitizePathSegment(input, options)` utility (`src/utils/text/sanitizePathSegment.ts`) and reuses it from all three call sites, preserving each site's exact existing behavior (charset, lowercase/no-lowercase, collapse/trim toggles, fallback string, max length).

A separate, smaller finding (a handful of `JSON.parse`-in-try/catch sites that could route through the existing `safeParseJson` helper) was flagged as low-urgency/low-risk and left out of scope for this PR to keep the diff tight and mechanical.

## Issue acceptance gates

Ad hoc consolidation sweep (no linked issue). Acceptance gate: eliminate the duplicated sanitizer logic without changing observable behavior at any of the three call sites.

## Single source of truth

`sanitizePathSegment` in `src/utils/text/sanitizePathSegment.ts` now owns the replace/collapse/trim/fallback/truncate shape; each call site only supplies its charset and options.

## Duplication and abstraction budget

Removed: three independent inline implementations of the same 4-step sanitization shape (regex replace, collapse-runs, trim-edges, fallback-on-empty), previously duplicated with copy-pasted regex logic. Added: one small, fully parameterized utility with no hidden state, called from exactly 3 sites (plus tests) — not a single-caller extraction.

## Net elements (R6)

- Files: +2 (new utility + its test), 3 modified (call sites)
- Exported symbols: `+export interface SanitizePathSegmentOptions`, `+export function sanitizePathSegment` (2 added, 0 removed — the three original functions were private/unexported and remain private, now just delegating)
- Diffstat: 5 files changed, 139 insertions(+), 18 deletions(-) (bulk of insertions is the new test file)
- Net LoC in non-test source: +31 across 4 files (new 49-line utility offsets the ~18 lines removed from the three call sites; net growth is the parameterization surface, not duplication)

## Consumer counts (R8)

n/a — no emit path, export, or public API surface was deleted or re-routed; the three original private functions keep their names and call sites, only their bodies changed.

## Host impact

Extension: none (shared `src/utils/text/` code, already used by the extension via the same aliases)

Desktop: none

CLI: none

## Scheduled refactoring

None. The lower-priority `JSON.parse`/`safeParseJson` consolidation identified during the sweep is small and low-risk enough to fold into a future pass if desired; no follow-up issue filed.

## Validation

- `npx vitest run src/test-kernel/utils/text/SanitizePathSegment.vitest.ts` — 5 new tests, all pass
- `npx vitest run src/test-kernel/platform/WorkspaceStorage.vitest.ts src/test-kernel/controllers/ChatExportControllerHtml.vitest.ts` — existing tests exercising two of the three refactored call sites, all pass
- `npm run typecheck` — clean across the whole workspace (extension, cli, desktop, trace-viewer)
- `npx eslint` on all changed files — clean
- `npm test` (full suite) — 6229/6230 tests pass; the 1 failure (`SystemUtils.vitest.ts` process-group abort test) is unrelated to this change and reproduces identically on `main` at the same commit in this sandbox (confirmed via `git stash`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRBFwYAcrxak5RVyZhmGz1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with targeted tests; observable naming behavior is intended to be unchanged at all three consumers.
> 
> **Overview**
> Introduces shared **`sanitizePathSegment`** in `src/utils/text/sanitizePathSegment.ts` to centralize replace-invalid-chars, optional collapse/trim, fallback, and max-length behavior behind one options object.
> 
> **Chat export** (`filenames.ts`), **workspace storage IDs** (`workspaceStorage.ts`), and **Anthropic Files API uploads** (`anthropicDocumentHandling.ts`) now call this helper instead of inline regex chains; public/private function names and call sites stay the same, with per-site charset and flags preserved.
> 
> Adds **`SanitizePathSegment.vitest.ts`** with five cases covering the main option combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6dd499f0cdb70fa1461d64dd9833370e4828313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->