### PR TITLE
refactor: centralize count pluralization

### DIFF
--- a/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/SkillsListForm.tsx
@@ -7,6 +7,7 @@ import { Box, Text } from 'ink';
 import { formatRuntimeSkillActivation } from '@skills/runtimeSkills';
 import { readCliRuntimeSkills, skillListRecord } from '@cli/runtime/skills';
 import { escapeText } from '@shared/utils/xmlEscape';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { COLOR_WARNING } from '../ui/colors';
 import { KeyHints } from '../ui/KeyHints';
@@ -80,7 +81,7 @@ export function skillSelectItemsForTui(
 
 function skillImportIssueSummary(issueCount: number): string | undefined {
   if (issueCount === 0) return undefined;
-  return `${issueCount} import issue${issueCount === 1 ? '' : 's'}`;
+  return formatResultCount(issueCount, 'import issue');
 }
 
 export function skillsSelectWindow(args: {

--- a/packages/cli/src/chat/tui/forms/configCategories.ts
+++ b/packages/cli/src/chat/tui/forms/configCategories.ts
@@ -1,4 +1,5 @@
 import type { StateSettingEntry } from '@shared/schemas/stateSettings';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import type { SelectItem } from '../ui/Select';
 
@@ -33,6 +34,6 @@ export function buildConfigCategoryItems(
   return [...counts].map(([category, count]) => ({
     value: category,
     label: configCategoryLabel(category),
-    description: `${count} ${count === 1 ? 'setting' : 'settings'}`,
+    description: formatResultCount(count, 'setting'),
   }));
 }

--- a/packages/cli/src/chat/tui/modals/EditApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/EditApproval.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Box, Text, useWindowSize } from 'ink';
 
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { ConfirmCard } from './ConfirmCard';
 import { COLOR_HINT } from '../ui/colors';
@@ -98,7 +99,7 @@ export function editApprovalFeedbackRows({
 }
 
 export function formatEditApprovalHunkCount(count: number): string {
-  return `${count} ${count === 1 ? 'hunk' : 'hunks'}`;
+  return formatResultCount(count, 'hunk');
 }
 
 export function EditApproval(props: EditApprovalProps): React.JSX.Element {

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 // Local imports - shared stream state
 import type { ActiveChildInfo } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and controls
 import {
@@ -107,7 +108,7 @@ function SessionRow({
           <Text dimColor>
             {` · ${[
               hiddenSessionCount > 0
-                ? `+${hiddenSessionCount} session${hiddenSessionCount === 1 ? '' : 's'}`
+                ? `+${formatResultCount(hiddenSessionCount, 'session')}`
                 : undefined,
               processSummary,
             ]
@@ -141,7 +142,7 @@ function ProcessRow({
         <Box flexShrink={0}>
           <Text
             dimColor
-          >{` · +${hiddenProcessCount} more process${hiddenProcessCount === 1 ? '' : 'es'}`}</Text>
+          >{` · +${formatResultCount(hiddenProcessCount, 'more process')}`}</Text>
         </Box>
       ) : null}
     </Box>
@@ -239,7 +240,7 @@ export function SubagentList(
   const hiddenProcessCount = activeProcesses.length - visibleProcesses.length;
   const processSummary =
     hiddenProcessCount > 0 && visibleProcesses.length === 0
-      ? `+${hiddenProcessCount} process${hiddenProcessCount === 1 ? '' : 'es'}`
+      ? `+${formatResultCount(hiddenProcessCount, 'process')}`
       : undefined;
   return (
     <Box

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -10,6 +10,7 @@ import {
   type TodoItem,
   type TodoStatus,
 } from '@shared/schemas';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
   activeStreamId as activeStreamIdSignal,
@@ -209,7 +210,7 @@ export function TodosPlanPanel(
             <Text
               dimColor
               wrap="truncate-end"
-            >{`… +${hiddenCount} more todo/plan item${hiddenCount === 1 ? '' : 's'}`}</Text>
+            >{`… +${formatResultCount(hiddenCount, 'more todo/plan item')}`}</Text>
           </Box>
         ) : null}
       </Box>

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -21,6 +21,7 @@ import {
   formatCompactDuration,
   formatCompactTokenCount,
 } from '@utils/core';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { numberedFollowUpPreview } from '../render/followUpPreview';
 import {
@@ -265,7 +266,7 @@ function pendingInteractionSegment({
 }): StatusBarSegment | undefined {
   if (depth <= 0) return undefined;
   return {
-    text: `${depth} ${kind}${depth === 1 ? '' : 's'}`,
+    text: formatResultCount(depth, kind),
     color: COLOR_WARNING,
     compactPriority: STATUS_BAR_COMPACT_PRIORITY.approvalDepth,
   };
@@ -725,9 +726,7 @@ export function buildStatusBarDisplay(
       // Exiting drops queued follow-ups silently — warn before the user
       // confirms with the second Ctrl-C.
       left.push({
-        text: `${queuedCount} queued follow-up${
-          queuedCount === 1 ? '' : 's'
-        } will be discarded`,
+        text: `${formatResultCount(queuedCount, 'queued follow-up')} will be discarded`,
         color: COLOR_ERROR,
       });
     }

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -5,6 +5,7 @@ import { defineCommand } from 'citty';
 import { assembleTrace, injectStandaloneTrace } from '@transcript';
 import { formatChatAsMarkdown } from '@agent/export/chatExportFormatter';
 import { type ExecutionId } from '@shared/schemas';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { CliExitCode } from '../runtime/exitCodes';
 import {
@@ -42,10 +43,6 @@ export function parseHistoryListLimit(
   if (!/^\d+$/.test(value)) return undefined;
   const limit = Number(value);
   return Number.isSafeInteger(limit) && limit > 0 ? limit : undefined;
-}
-
-function storedExecutionsNoun(count: number): string {
-  return count === 1 ? 'stored execution' : 'stored executions';
 }
 
 async function runHistoryList(
@@ -211,9 +208,7 @@ async function runHistoryDelete(
     });
     if (!preflight.proceed) {
       writeTextStderr(
-        `Refusing to delete ${preflight.count} ${storedExecutionsNoun(
-          preflight.count,
-        )}. Re-run with --yes to confirm.`,
+        `Refusing to delete ${formatResultCount(preflight.count, 'stored execution')}. Re-run with --yes to confirm.`,
       );
       return CliExitCode.Usage;
     }
@@ -242,7 +237,7 @@ async function runHistoryDelete(
 
   let text: string;
   if (result.deleted === 'all') {
-    text = `Deleted ${result.count} ${storedExecutionsNoun(result.count)}.`;
+    text = `Deleted ${formatResultCount(result.count, 'stored execution')}.`;
   } else if (result.found) {
     text = `Deleted execution ${result.id}.`;
   } else {

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -6,6 +6,7 @@ import {
 } from '@agent/index';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { CliUsageError } from './cliContext';
 import { getCliAuthProvider } from './supabaseAuth';
@@ -232,7 +233,7 @@ export function formatCliHiddenAgentsNotice(
 ): string | undefined {
   if (hiddenCount <= 0) return undefined;
   const { categoryArg, catalog } = cliAgentCatalogHint(category);
-  return `Showing visible agents only; ${hiddenCount} hidden agent${hiddenCount === 1 ? '' : 's'} omitted. Use \`texra agents list${categoryArg} --all\` to show the ${catalog}.`;
+  return `Showing visible agents only; ${formatResultCount(hiddenCount, 'hidden agent')} omitted. Use \`texra agents list${categoryArg} --all\` to show the ${catalog}.`;
 }
 
 function cliAgentCatalogHint(category?: AgentCategory): {

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -21,6 +21,7 @@ import {
   TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY,
 } from '@shared/constants/cliRuntime';
 import { extractErrorMessage } from '@utils/errors/errorMessage';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - CLI runtime
 import { CliExitCode } from './exitCodes';
@@ -237,7 +238,7 @@ async function checkModels(
       return pass(
         'models',
         'Models',
-        `${available.length} model${available.length === 1 ? '' : 's'} available.`,
+        `${formatResultCount(available.length, 'model')} available.`,
       );
     }
     return fail(

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -9,6 +9,7 @@ import { teamHostedNamesForPreflight } from '@common/teams/TeamRoster';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { agentKeyOf } from '@shared/schemas/agent';
+import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import {
   AGENT_MODE_PRESETS,
   parseAgentModePresets,
@@ -520,9 +521,7 @@ function availablePresetTeamMemberCount(
 }
 
 function formatAvailableTeamAgentCount(count: number): string {
-  return count === 1
-    ? '1 available team agent'
-    : `${count} available team agents`;
+  return formatResultCount(count, 'available team agent');
 }
 
 function formatPresetAvailabilityForLauncher(
@@ -567,8 +566,7 @@ function launcherAgentKindLabel(
   kind: 'workflow' | 'tool-use',
   count: number,
 ): string {
-  if (kind === 'tool-use') return count === 1 ? 'tool' : 'tools';
-  return count === 1 ? 'workflow' : 'workflows';
+  return pluralize(count, kind === 'tool-use' ? 'tool' : 'workflow');
 }
 
 function agentHasDelegationTools(agent: AgentEntry): boolean {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -1,6 +1,7 @@
 import type { AgentEntry } from '@agent/index';
 import type { ExecutionId } from '@shared/schemas';
 import { agentKeyOf } from '@shared/schemas/agent';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
   cliMultiAgentPresetCanLaunchTeam,
@@ -166,7 +167,7 @@ export function buildCliOrchestrationItems(
     items.push({
       value: { kind: 'browse-resumes' },
       label: 'Resume',
-      description: `${resumeItems.length} resumable ${resumeItems.length === 1 ? 'session' : 'sessions'}`,
+      description: formatResultCount(resumeItems.length, 'resumable session'),
     });
   }
   if (buildCliAgentItems(input.toolUseAgents).length > 0) {

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -22,6 +22,7 @@ import {
 } from '@shared/schemas';
 import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import { assertNever } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - CLI runtime
 import { writeRawStderr } from './logSinks';
@@ -422,8 +423,7 @@ function formatActiveChildren(
   const first = namedChildren[0];
   if (!first) return undefined;
 
-  const plural = kind === 'tool' ? 'tools' : 'subagents';
-  const label = namedChildren.length === 1 ? kind : plural;
+  const label = pluralize(namedChildren.length, kind);
   const suffix =
     namedChildren.length > 1 ? ` +${namedChildren.length - 1}` : '';
   return `${label}: ${first}${suffix}`;

--- a/packages/cli/src/runtime/workflowOutput.ts
+++ b/packages/cli/src/runtime/workflowOutput.ts
@@ -15,6 +15,7 @@ import { getRunDir } from '@utils/files';
 // swap; safe here since these paths come from getSafeDocumentRelativePath /
 // path.relative on the workflow's own generated outputs, never user input.
 import { toPosixPath } from '@utils/core/pathCore';
+import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 
 import { CliUsageError, type CliContext } from './cliContext';
 import { type CliRunResult, type ExecuteAgentResult } from './terminalStatus';
@@ -250,7 +251,7 @@ export async function resolveWorkflowOutput(
     );
     if (missing.length > 0) {
       throw new Error(
-        `Workflow ${terminalStatus} without expected output${missing.length === 1 ? '' : 's'}: ${missing.join(', ')}; copied ${copiedOutputs.length} of ${expectedRelativePaths.length} expected output${expectedRelativePaths.length === 1 ? '' : 's'} to ${targetRoot}.`,
+        `Workflow ${terminalStatus} without expected ${pluralize(missing.length, 'output')}: ${missing.join(', ')}; copied ${copiedOutputs.length} of ${formatResultCount(expectedRelativePaths.length, 'expected output')} to ${targetRoot}.`,
       );
     }
 

--- a/packages/extension/src/commands/review/agentReviewCommands.ts
+++ b/packages/extension/src/commands/review/agentReviewCommands.ts
@@ -33,6 +33,7 @@ import {
 } from '@frontend/ui/errorHandlingUtils';
 import { setReportReviewIssueSink } from '@tools/ReportReviewIssueTool';
 import { WorkspaceFS } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 const CHANNEL = 'AgentReview';
 
@@ -114,7 +115,7 @@ export function registerAgentReviewCommands(
       count > 0
         ? {
             value: count,
-            tooltip: `${count} agent review issue${count === 1 ? '' : 's'}`,
+            tooltip: formatResultCount(count, 'agent review issue'),
           }
         : undefined;
   };

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -48,7 +48,7 @@ import {
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { normalizeLineEndings } from '@utils/text/stringUtils';
+import { normalizeLineEndings, pluralize } from '@utils/text/stringUtils';
 
 const CHANNEL = 'nativeToolEditApproval';
 
@@ -322,7 +322,7 @@ export async function nativeRequestApproval(
     added > 0 && `+${added}`,
     removed > 0 && `-${removed}`,
   ].filter(Boolean);
-  const lineWord = totalChanged === 1 ? 'line' : 'lines';
+  const lineWord = pluralize(totalChanged, 'line');
   const changeSuffix = changeParts.length
     ? ` · ${changeParts.join(' / ')} ${lineWord}`
     : '';

--- a/packages/extension/src/frontend/review/AgentReviewService.ts
+++ b/packages/extension/src/frontend/review/AgentReviewService.ts
@@ -45,6 +45,7 @@ import { AGENT_REVIEW_APPROACHES } from '@shared/schemas/coreSettings';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig, getValidatedConfig } from '@utils/config/configUtils';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   AgentReviewRunController,
   type AgentReviewRunToken,
@@ -330,7 +331,7 @@ class AgentReviewServiceImpl {
         // launch resolves it within tool-use (the config default is Workflow).
         agentCategory: AgentCategory.ToolUse,
         instruction,
-        displayInstruction: `Agent review: diff with ${baseDescription} (${changedFiles.length} file${changedFiles.length === 1 ? '' : 's'})${options.userInstructions ? ' · custom focus' : ''}`,
+        displayInstruction: `Agent review: diff with ${baseDescription} (${formatResultCount(changedFiles.length, 'file')})${options.userInstructions ? ' · custom focus' : ''}`,
         // The instruction's paths are repo-relative; anchor the session's
         // tool calls (read_file, grep, bash) to the repository root, which
         // may sit above the opened workspace folder.
@@ -385,8 +386,7 @@ class AgentReviewServiceImpl {
       if (restored) {
         suffix = ' · showing previous results';
       } else if (this.issues.length > 0) {
-        const plural = this.issues.length === 1 ? '' : 's';
-        suffix = ` · showing the ${this.issues.length} issue${plural} reported before the session ended`;
+        suffix = ` · showing the ${formatResultCount(this.issues.length, 'issue')} reported before the session ended`;
       }
       this.summary = `Review ${verb}${suffix}`;
       logger.warn(CHANNEL, `Agent review session ${verb}`);
@@ -397,7 +397,7 @@ class AgentReviewServiceImpl {
     this.summary =
       count === 0
         ? `No issues found (diff with ${baseDescription})`
-        : `Found ${count} potential issue${count === 1 ? '' : 's'} (diff with ${baseDescription})${truncated ? ' · diff truncated' : ''}`;
+        : `Found ${formatResultCount(count, 'potential issue')} (diff with ${baseDescription})${truncated ? ' · diff truncated' : ''}`;
     logger.info(
       CHANNEL,
       `Agent review (${trigger}): ${count} issue(s) across ${changedFiles.length} changed file(s)`,
@@ -552,7 +552,7 @@ class AgentReviewServiceImpl {
       return;
     }
     void vscode.window.showInformationMessage(
-      `Launched the ${FIX_AGENT} agent to fix ${targets.length} review issue${targets.length === 1 ? '' : 's'}. Run the review again once it finishes.`,
+      `Launched the ${FIX_AGENT} agent to fix ${formatResultCount(targets.length, 'review issue')}. Run the review again once it finishes.`,
     );
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -31,6 +31,7 @@ import {
   AGENT_DECORATORS,
   getAgentCategoryDecorator,
 } from '@shared/utils/icons';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -143,7 +144,7 @@ export class StreamTab extends LitElement {
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
-    const childStreamLabel = `${this.childCount} child stream${this.childCount > 1 ? 's' : ''}`;
+    const childStreamLabel = formatResultCount(this.childCount, 'child stream');
 
     return html`
       <div

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -32,6 +32,7 @@ import { scrollToBottom } from '@shared/utils/dom';
 import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
 import { formatDuration } from '@utils/core';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, GROUP_DOM_IDS } from '../constants';
@@ -343,7 +344,7 @@ export class TaskGroupList extends LitElement {
     label: string;
   }): TemplateResult {
     const revealCount = Math.min(options.hiddenCount, options.step);
-    const suffix = revealCount === 1 ? options.label : `${options.label}s`;
+    const suffix = pluralize(revealCount, options.label);
     return html`
       <div class="log-reveal-row">
         <wa-button

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -23,6 +23,7 @@ import type { ToolEditPermission } from '@shared/schemas';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderDotMeta, type MetaPart } from '@shared/wa/metaStrip';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
+import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
@@ -165,7 +166,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel<'toolEdit'> {
     const added = toCount(request.addedLines);
     const removed = toCount(request.removedLines);
     const total = added + removed;
-    const lineLabel = total === 1 ? 'line' : 'lines';
+    const lineLabel = pluralize(total, 'line');
 
     const parts: string[] = [];
     if (added > 0) parts.push(`+${added}`);

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -28,6 +28,7 @@ import {
 } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
+import { pluralize } from '@utils/text/stringUtils';
 import { AgentSelectionEvents } from './events';
 import { agentSelectionPanelStyles } from './AgentSelectionPanel.styles';
 
@@ -571,7 +572,7 @@ export class AgentSelectionPanel extends LitElement {
       </div>
       <div class="agent-count">
         ${enabledCount}/${this.agents.length}
-        agent${this.agents.length !== 1 ? 's' : ''} in dropdown
+        ${pluralize(this.agents.length, 'agent')} in dropdown
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -22,6 +22,9 @@ import type {
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
 import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/schemas/coreSettings';
 
+// Local imports - utilities
+import { pluralize } from '@utils/text/stringUtils';
+
 // Local imports - settings view components (side-effect: register)
 import '../components/profile/ApiAccessSection';
 import '../components/profile/RelayQuotaMeter';
@@ -344,8 +347,8 @@ export class ModelsTab extends LitElement {
     const status = consentModel
       ? 'VS Code is ready to ask for your consent.'
       : readyCount > 0
-        ? `${readyCount} Copilot model${readyCount === 1 ? ' is' : 's are'} ready.`
-        : `${unavailableCount} Copilot model${unavailableCount === 1 ? ' is' : 's are'} unavailable.`;
+        ? `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`
+        : `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
 
     return html`
       <section id="copilot-access" class="keyless-source">

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -39,6 +39,7 @@ import {
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
 import { AbsoluteFS } from '@utils/files';
+import { formatResultCount } from '@utils/text/stringUtils';
 import type { SettingsAgentVisibilityController } from '@controllers/settingsView/SettingsAgentVisibilityController';
 import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
 import type { SettingsAgentCatalogController } from '@controllers/settingsView/SettingsAgentCatalogController';
@@ -477,7 +478,7 @@ export class AgentHandlers {
       void vscode.window.showInformationMessage(
         unresolvedCount === 0
           ? `Applied "${result.preset.name}" team`
-          : `Applied "${result.preset.name}" with ${unresolvedCount} ${unresolvedCount === 1 ? 'member' : 'members'} still unavailable`,
+          : `Applied "${result.preset.name}" with ${formatResultCount(unresolvedCount, 'member')} still unavailable`,
       );
     } catch (error) {
       await showLoggedErrorMessage(

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -36,6 +36,7 @@ import {
 } from '@utils/files';
 
 import { getConfig } from '@utils/config';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import { BaseWebviewManager } from './BaseWebviewManager';
 
@@ -479,7 +480,7 @@ export class FileManager extends BaseWebviewManager {
     if (attachedCount > 0 && rejectedCount === 0) return;
     if (attachedCount > 0) {
       vscode.window.showInformationMessage(
-        `Attached ${attachedCount} dropped file${attachedCount === 1 ? '' : 's'}; skipped ${rejectedCount} unsupported, folder, or out-of-workspace item${rejectedCount === 1 ? '' : 's'}.`,
+        `Attached ${formatResultCount(attachedCount, 'dropped file')}; skipped ${formatResultCount(rejectedCount, 'unsupported, folder, or out-of-workspace item')}.`,
       );
       return;
     }

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -19,6 +19,7 @@
 import escapeRegExp from 'escape-string-regexp';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { DELIVERY_TAG, DELIVERY_TAGS } from '@shared/deliveryTags';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Derived from the single owned DELIVERY_TAGS list (@shared/deliveryTags),
 // same derivation pattern UserMessage.ts uses for its structured-delivery
@@ -184,7 +185,7 @@ function resultResponsePreview(response: string): string {
 
   const extraLines = lines.length - RESULT_RESPONSE_PREVIEW_LINES;
   const hidden = lineLimited
-    ? `${extraLines} more line${extraLines === 1 ? '' : 's'}`
+    ? formatResultCount(extraLines, 'more line')
     : 'more text';
   return `${preview}\n… ${hidden}; open the subagent transcript for the full response`;
 }

--- a/src/shared/utils/string.ts
+++ b/src/shared/utils/string.ts
@@ -1,6 +1,8 @@
 import { intlFormatDistance } from 'date-fns';
 import prettyBytes from 'pretty-bytes';
 
+import { formatResultCount } from '@utils/text/stringUtils';
+
 const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
   month: 'short',
@@ -39,7 +41,7 @@ export function formatUpdatedDate(
 }
 
 export function formatLineCount(count: number): string {
-  return count === 1 ? '1 line' : `${count} lines`;
+  return formatResultCount(count, 'line');
 }
 
 export function formatBytes(bytes: number): string {

--- a/src/test-kernel/utils/text/StringUtils.vitest.ts
+++ b/src/test-kernel/utils/text/StringUtils.vitest.ts
@@ -6,6 +6,7 @@ import {
   formatTimestamp,
   formatCompactDuration,
   formatCompactTokenCount,
+  formatResultCount,
   objectToLogString,
   pluralize,
   splitContentLines,
@@ -84,6 +85,17 @@ describe('pluralize', () => {
 
   it('honors explicit plural overrides', () => {
     expect(pluralize(2, 'person', 'people')).toBe('people');
+  });
+});
+
+describe('formatResultCount', () => {
+  it('formats singular and library-backed plural counts', () => {
+    expect(formatResultCount(1, 'entry')).toBe('1 entry');
+    expect(formatResultCount(2, 'entry')).toBe('2 entries');
+  });
+
+  it('honors explicit invariant plurals', () => {
+    expect(formatResultCount(2, 'info', 'info')).toBe('2 info');
   });
 });
 

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -10,6 +10,7 @@ import * as logger from '@logger/logUtils';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -245,9 +246,7 @@ export class InlineCommentTool extends defineTool({
           : 'No comment threads are open.',
       };
     }
-    const summary = `${threads.length} comment thread${
-      threads.length === 1 ? '' : 's'
-    }`;
+    const summary = formatResultCount(threads.length, 'comment thread');
     return {
       status: 'executed',
       summary,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -20,6 +20,7 @@ import {
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 const LOOGLE_CHANNEL = 'lean_loogle';
@@ -232,7 +233,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
         query,
         result: {
           status: 'executed',
-          summary: `${hits.length} result${hits.length > 1 ? 's' : ''}`,
+          summary: formatResultCount(hits.length, 'result'),
           output: formatted,
           results: hits,
         },
@@ -301,7 +302,7 @@ Useful for finding the right lemma when you know roughly what type it should hav
     const allFailed = errorCount === queries.length;
     let summary: string;
     if (totalHits > 0) {
-      summary = `${totalHits} result${totalHits > 1 ? 's' : ''} across ${queries.length} queries`;
+      summary = `${formatResultCount(totalHits, 'result')} across ${queries.length} queries`;
     } else if (allFailed) {
       summary = `All ${queries.length} queries failed`;
     } else {

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { formatResultCount } from '@utils/text/stringUtils';
 import {
   countBySeverity,
   formatCounts,
@@ -344,7 +345,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     const goalCount = data.goals.length;
     return {
       status: 'executed',
-      summary: `${goalCount} goal${goalCount > 1 ? 's' : ''}`,
+      summary: formatResultCount(goalCount, 'goal'),
       output: data.rendered,
       goalState: {
         goals: data.goals,

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -12,7 +12,10 @@
  */
 
 import { warn } from '@logger/logUtils';
-import { formatCompactDuration } from '@utils/text/stringUtils';
+import {
+  formatCompactDuration,
+  formatResultCount,
+} from '@utils/text/stringUtils';
 
 import { LEAN_SERVER_MODE_LABELS } from './leanConstants';
 
@@ -153,9 +156,6 @@ export function summarizeLeanServers(
     const toolchain = info.toolchain ? `, ${info.toolchain}` : '';
     return `• ${info.workspaceRoot} (${modeLabel}${toolchain})${statusTail(info, now)}`;
   });
-  const header =
-    list.length === 1
-      ? '1 Lean server registered:'
-      : `${list.length} Lean servers registered:`;
+  const header = `${formatResultCount(list.length, 'Lean server')} registered:`;
   return [header, ...lines].join('\n');
 }

--- a/src/tools/setup/ListApiKeysTool.ts
+++ b/src/tools/setup/ListApiKeysTool.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { apiKeySecretName } from '@model/apiProviders';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -96,7 +97,7 @@ export class ListApiKeysTool extends defineTool({
     if (otherKeys.length > 0) {
       lines.push(
         '',
-        `Other stored secrets: ${otherKeys.length} redacted key name${otherKeys.length === 1 ? '' : 's'}`,
+        `Other stored secrets: ${formatResultCount(otherKeys.length, 'redacted key name')}`,
       );
     }
 
@@ -107,7 +108,7 @@ export class ListApiKeysTool extends defineTool({
 
     return {
       status: 'executed',
-      summary: `${storedKeys.length} stored secret${storedKeys.length === 1 ? '' : 's'}: ${providerSummary}`,
+      summary: `${formatResultCount(storedKeys.length, 'stored secret')}: ${providerSummary}`,
       output: lines.join('\n'),
     };
   }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -15,6 +15,7 @@ import {
 import { debounce, filterNotNull, isObject } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { StorageFS } from '@utils/files/storageFS';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
   isRunningGroupEntry,
@@ -1049,8 +1050,7 @@ export class StreamLogStore {
       const count = parsed.preservedRawEntries.length;
       log.warn(
         LOG_TAG,
-        `Stream ${streamId}: ${count} persisted transcript ` +
-          `entr${count === 1 ? 'y' : 'ies'} did not parse; ` +
+        `Stream ${streamId}: ${formatResultCount(count, 'persisted transcript entry')} did not parse; ` +
           `preserving raw for round-trip on save.`,
       );
     }

--- a/src/utils/diagnostics/diagnosticFormatting.ts
+++ b/src/utils/diagnostics/diagnosticFormatting.ts
@@ -6,6 +6,8 @@
  * and Lean tool diagnostics satisfy this interface.
  */
 
+import { formatResultCount } from '@utils/text/stringUtils';
+
 /**
  * Minimal diagnostic shape required by the formatting functions.
  * Compatible with `vscode.Diagnostic` and `LeanDiagnostic`.
@@ -84,7 +86,7 @@ export function formatCounts(counts: SeverityCounts): string {
   const parts = COUNT_FORMAT_ORDER.filter(({ key }) => counts[key] > 0).map(
     ({ key, label, plural }) => {
       const count = counts[key];
-      return `${count} ${count === 1 ? label : plural}`;
+      return formatResultCount(count, label, plural);
     },
   );
   return parts.length > 0 ? parts.join(', ') : 'No issues';


### PR DESCRIPTION
## Summary

Replace 45 hand-written English count/plural branches with the existing `pluralize()` and `formatResultCount()` helpers backed by the installed `pluralize` package.

## Issue acceptance gates

Fallback/duplication audit finding: remove semantically equivalent local plural suffix rules. All numeric call sites found by the audit were migrated except the documented boundary and grammar cases below.

## Single source of truth

`src/utils/text/stringUtils.ts` owns singular/plural selection and count formatting.

## Duplication and abstraction budget

Forty-five local suffix or singular/plural branches were removed. No abstraction or dependency was added; call sites use the pre-existing shared helpers.

The audit deliberately leaves these cases unchanged:

- the isolated Supabase Deno function, which cannot import the Node-oriented helper
- a persisted XML parser whose count is a string and should not be silently coerced
- sentence-level grammatical branches that also change pronouns, agreement, or meaning

## Net elements (R6)

- files: 33 modified, 0 added, 0 deleted
- exported symbols: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- LoC: 94 added, 64 deleted, net +30; the increase is import lines plus focused helper tests

## Consumer counts (R8)

n/a — no exports or emit paths are deleted or re-routed.

## Host impact

Extension: user-visible count text is unchanged apart from correcting existing zero-count singular forms.

Desktop: shared tool and transcript count text uses the same formatter; no protocol or lifecycle change.

CLI: count text is unchanged apart from correcting existing zero-count singular forms.

## Scheduled refactoring

None.

## Validation

- 45 equivalent replacements across 33 files
- focused regression suites: 228 tests passed
- full repository test suite passed
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (no errors; existing warnings remain)
- `npm run format`
- `git diff --check`
