### PR TITLE
fix(approvals): resolve bash/tool-edit bypass across stream ancestry

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -426,6 +426,23 @@ export function createChatSessionController(
             lifecycleStarted = true;
           },
           onStreamResolved: (resolvedStreamId) => {
+            // Each chat round mints a fresh root StreamTabId (new
+            // executionId), so bash/tool-edit/super-YOLO bypass — which is
+            // keyed per stream — would otherwise reset every round even
+            // though the user is continuing the same conversation. Link the
+            // new round's stream to the previous one so bypass resolution
+            // (see `registerStreamParent`) falls through to whatever the
+            // prior round had, unless this round sets its own explicit value.
+            const previousRootStreamId = rootStreamId.get();
+            if (
+              previousRootStreamId &&
+              previousRootStreamId !== resolvedStreamId
+            ) {
+              defaultSession().approvals.registerStreamParent(
+                resolvedStreamId,
+                previousRootStreamId,
+              );
+            }
             session.streamId = resolvedStreamId;
             publishChatTuiRunState(session);
             rootStreamId.set(resolvedStreamId);

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -35,6 +35,12 @@ export type ApprovalBypassEvent =
  * Single implementation behind the tool-edit, bash, and proposal (super-YOLO)
  * bypass toggles, so set/toggle/clear semantics and UI notification stay
  * uniform across approval kinds.
+ *
+ * A stream with no explicit bypass value of its own defers to its ancestor
+ * chain (see `resolveParent`) rather than defaulting straight to `false` —
+ * this is what lets a delegated subagent stream, or the next round of a CLI
+ * conversation, inherit a bypass its predecessor turned on, without a
+ * one-shot copy that misses toggles made after the child/round was created.
  */
 export interface StreamApprovalBypass {
   isBypassed(streamId: StreamTabId): boolean;
@@ -57,6 +63,7 @@ export interface StreamApprovalBypass {
 
 export function createStreamApprovalBypass(
   event: ApprovalBypassEvent,
+  resolveParent: (streamId: StreamTabId) => StreamTabId | undefined,
 ): StreamApprovalBypass {
   const byStream = new Map<StreamTabId, boolean>();
 
@@ -74,7 +81,15 @@ export function createStreamApprovalBypass(
 
   return {
     isBypassed(streamId) {
-      return byStream.get(streamId) ?? false;
+      const seen = new Set<StreamTabId>();
+      let current: StreamTabId | undefined = streamId;
+      while (current && !seen.has(current)) {
+        const explicit = byStream.get(current);
+        if (explicit !== undefined) return explicit;
+        seen.add(current);
+        current = resolveParent(current);
+      }
+      return false;
     },
     setBypass,
     toggleBypass(streamId, runtimeHost) {
@@ -120,6 +135,7 @@ export interface StreamApprovalControllerOptions<
 > {
   rejectionResult: () => R;
   bypassEvent: ApprovalBypassEvent;
+  resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
 }
 
 export function createStreamApprovalController<R extends { accepted: boolean }>(
@@ -145,7 +161,10 @@ export function createStreamApprovalController<R extends { accepted: boolean }>(
     unregisterPending(id) {
       pending.delete(id);
     },
-    bypass: createStreamApprovalBypass(options.bypassEvent),
+    bypass: createStreamApprovalBypass(
+      options.bypassEvent,
+      options.resolveParent,
+    ),
     enqueue<T>(
       streamId: StreamTabId | undefined,
       run: () => Promise<T>,
@@ -197,6 +216,19 @@ export interface SessionApprovals {
    */
   readonly proposal: StreamApprovalBypass;
   /**
+   * Record that `childStreamId` descends from `parentStreamId` for bypass
+   * resolution purposes: `toolEdit`/`bash`/`proposal.isBypassed(childStreamId)`
+   * will defer to the parent's bypass state whenever the child has no
+   * explicit value of its own. Used for delegated subagent streams (parent =
+   * the orchestrator stream) and, in the CLI, successive conversation rounds
+   * (parent = the previous round's root stream) — both mint a fresh
+   * `StreamTabId` that would otherwise start every bypass kind ungated.
+   */
+  registerStreamParent(
+    childStreamId: StreamTabId,
+    parentStreamId: StreamTabId,
+  ): void;
+  /**
    * Reject every pending approval and clear all bypass + proposal state for
    * this session. Used by session teardown and the session-wide
    * `cleanupAllApprovals` sweep.
@@ -205,25 +237,38 @@ export interface SessionApprovals {
 }
 
 export function createSessionApprovals(): SessionApprovals {
+  const parentOf = new Map<StreamTabId, StreamTabId>();
+  const resolveParent = (streamId: StreamTabId): StreamTabId | undefined =>
+    parentOf.get(streamId);
+
   const toolEdit = createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateToolEditApprovalBypassState',
+    resolveParent,
   });
   const bash = createStreamApprovalController<HostBashApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateBashApprovalBypassState',
+    resolveParent,
   });
-  const proposal = createStreamApprovalBypass('updateSuperYoloBypassState');
+  const proposal = createStreamApprovalBypass(
+    'updateSuperYoloBypassState',
+    resolveParent,
+  );
   return {
     toolEdit,
     bash,
     proposal,
+    registerStreamParent(childStreamId, parentStreamId) {
+      parentOf.set(childStreamId, parentStreamId);
+    },
     rejectAndClearAll() {
       toolEdit.rejectAllPending();
       bash.rejectAllPending();
       toolEdit.bypass.clearAll();
       bash.bypass.clearAll();
       proposal.clearAll();
+      parentOf.clear();
     },
   };
 }

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -279,9 +279,10 @@ export function createSessionApprovals(): SessionApprovals {
     },
     forgetStreamAncestry(streamId) {
       parentOf.delete(streamId);
-      for (const [child, parent] of parentOf) {
-        if (parent === streamId) parentOf.delete(child);
-      }
+      const orphaned = [...parentOf]
+        .filter(([, parent]) => parent === streamId)
+        .map(([child]) => child);
+      for (const child of orphaned) parentOf.delete(child);
     },
     rejectAndClearAll() {
       toolEdit.rejectAllPending();

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -29,6 +29,15 @@ export type ApprovalBypassEvent =
   | 'updateBashApprovalBypassState'
   | 'updateSuperYoloBypassState';
 
+/** The three independently-tracked bypass kinds `SessionApprovals` owns. */
+export type BypassAncestryKind = 'toolEdit' | 'bash' | 'proposal';
+
+const ALL_BYPASS_ANCESTRY_KINDS: readonly BypassAncestryKind[] = [
+  'toolEdit',
+  'bash',
+  'proposal',
+];
+
 /**
  * Per-stream bypass state bound to the progress event that announces it.
  *
@@ -223,24 +232,33 @@ export interface SessionApprovals {
   readonly proposal: StreamApprovalBypass;
   /**
    * Record that `childStreamId` descends from `parentStreamId` for bypass
-   * resolution purposes: `toolEdit`/`bash`/`proposal.isBypassed(childStreamId)`
-   * will defer to the parent's bypass state whenever the child has no
-   * explicit value of its own. Used for delegated subagent streams (parent =
-   * the orchestrator stream) and, in the CLI, successive conversation rounds
-   * (parent = the previous round's root stream) — both mint a fresh
-   * `StreamTabId` that would otherwise start every bypass kind ungated.
+   * resolution purposes: each bypass kind named in `kinds` will defer to the
+   * parent's bypass state whenever the child has no explicit value of its
+   * own. Ancestry is tracked separately per kind — linking `bash` does NOT
+   * also let the child inherit `toolEdit` or `proposal` bypass — so a
+   * delegation that only wants bash to follow the parent can't accidentally
+   * grant tool-edit or super-YOLO auto-approval too.
+   *
+   * Used for delegated subagent streams (parent = the orchestrator stream,
+   * `kinds: ['bash']` — tool-edit YOLO is granted separately and explicitly
+   * via `enableYoloOnChildStream` when a delegation asks for it) and, in the
+   * CLI, successive conversation rounds (parent = the previous round's root
+   * stream, all kinds — a CLI round should carry forward whichever bypasses
+   * were on) — both mint a fresh `StreamTabId` that would otherwise start
+   * every bypass kind ungated.
    */
   registerStreamParent(
     childStreamId: StreamTabId,
     parentStreamId: StreamTabId,
+    kinds?: readonly BypassAncestryKind[],
   ): void;
   /**
-   * Drop `streamId` from the ancestry graph: both its own parent link and
-   * any child that named it as parent. Called on per-stream teardown
-   * (`cleanupApprovalsForStream`) so a torn-down stream can't linger as a
-   * live ancestor — without this, a still-running child would keep
-   * resolving its bypass through a parent whose own bypass state was just
-   * cleared, silently changing the child's effective bypass.
+   * Drop `streamId` from the ancestry graph (all kinds): both its own parent
+   * links and any child that named it as parent. Called on per-stream
+   * teardown (`cleanupApprovalsForStream`) so a torn-down stream can't
+   * linger as a live ancestor — without this, a still-running child would
+   * keep resolving its bypass through a parent whose own bypass state was
+   * just cleared, silently changing the child's effective bypass.
    */
   forgetStreamAncestry(streamId: StreamTabId): void;
   /**
@@ -252,37 +270,55 @@ export interface SessionApprovals {
 }
 
 export function createSessionApprovals(): SessionApprovals {
-  const parentOf = new Map<StreamTabId, StreamTabId>();
-  const resolveParent = (streamId: StreamTabId): StreamTabId | undefined =>
-    parentOf.get(streamId);
+  // One ancestry graph per bypass kind — deliberately NOT shared — so that
+  // e.g. linking `bash` ancestry for a delegated subagent can never let it
+  // also inherit `toolEdit` or `proposal` bypass from the same parent.
+  const parentOf: Record<BypassAncestryKind, Map<StreamTabId, StreamTabId>> = {
+    toolEdit: new Map(),
+    bash: new Map(),
+    proposal: new Map(),
+  };
+  const resolveParentFor =
+    (kind: BypassAncestryKind) =>
+    (streamId: StreamTabId): StreamTabId | undefined =>
+      parentOf[kind].get(streamId);
 
   const toolEdit = createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateToolEditApprovalBypassState',
-    resolveParent,
+    resolveParent: resolveParentFor('toolEdit'),
   });
   const bash = createStreamApprovalController<HostBashApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateBashApprovalBypassState',
-    resolveParent,
+    resolveParent: resolveParentFor('bash'),
   });
   const proposal = createStreamApprovalBypass(
     'updateSuperYoloBypassState',
-    resolveParent,
+    resolveParentFor('proposal'),
   );
   return {
     toolEdit,
     bash,
     proposal,
-    registerStreamParent(childStreamId, parentStreamId) {
-      parentOf.set(childStreamId, parentStreamId);
+    registerStreamParent(
+      childStreamId,
+      parentStreamId,
+      kinds = ALL_BYPASS_ANCESTRY_KINDS,
+    ) {
+      for (const kind of kinds) {
+        parentOf[kind].set(childStreamId, parentStreamId);
+      }
     },
     forgetStreamAncestry(streamId) {
-      parentOf.delete(streamId);
-      const orphaned = [...parentOf]
-        .filter(([, parent]) => parent === streamId)
-        .map(([child]) => child);
-      for (const child of orphaned) parentOf.delete(child);
+      for (const kind of ALL_BYPASS_ANCESTRY_KINDS) {
+        const graph = parentOf[kind];
+        graph.delete(streamId);
+        const orphaned = [...graph]
+          .filter(([, parent]) => parent === streamId)
+          .map(([child]) => child);
+        for (const child of orphaned) graph.delete(child);
+      }
     },
     rejectAndClearAll() {
       toolEdit.rejectAllPending();
@@ -290,7 +326,7 @@ export function createSessionApprovals(): SessionApprovals {
       toolEdit.bypass.clearAll();
       bash.bypass.clearAll();
       proposal.clearAll();
-      parentOf.clear();
+      for (const kind of ALL_BYPASS_ANCESTRY_KINDS) parentOf[kind].clear();
     },
   };
 }

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -67,6 +67,18 @@ export function createStreamApprovalBypass(
 ): StreamApprovalBypass {
   const byStream = new Map<StreamTabId, boolean>();
 
+  function resolve(streamId: StreamTabId): boolean {
+    const seen = new Set<StreamTabId>();
+    let current: StreamTabId | undefined = streamId;
+    while (current && !seen.has(current)) {
+      const explicit = byStream.get(current);
+      if (explicit !== undefined) return explicit;
+      seen.add(current);
+      current = resolveParent(current);
+    }
+    return false;
+  }
+
   const setBypass: StreamApprovalBypass['setBypass'] = (
     streamId,
     enabled,
@@ -80,20 +92,14 @@ export function createStreamApprovalBypass(
   };
 
   return {
-    isBypassed(streamId) {
-      const seen = new Set<StreamTabId>();
-      let current: StreamTabId | undefined = streamId;
-      while (current && !seen.has(current)) {
-        const explicit = byStream.get(current);
-        if (explicit !== undefined) return explicit;
-        seen.add(current);
-        current = resolveParent(current);
-      }
-      return false;
-    },
+    isBypassed: resolve,
     setBypass,
     toggleBypass(streamId, runtimeHost) {
-      const next = !byStream.get(streamId);
+      // Flip the *resolved* (ancestry-aware) state, not just this stream's
+      // own explicit entry — otherwise a stream inheriting `true` from a
+      // parent would toggle to an explicit `true` on the first press (no
+      // visible change) instead of turning bypass off.
+      const next = !resolve(streamId);
       setBypass(streamId, next, runtimeHost);
       return next;
     },
@@ -229,6 +235,15 @@ export interface SessionApprovals {
     parentStreamId: StreamTabId,
   ): void;
   /**
+   * Drop `streamId` from the ancestry graph: both its own parent link and
+   * any child that named it as parent. Called on per-stream teardown
+   * (`cleanupApprovalsForStream`) so a torn-down stream can't linger as a
+   * live ancestor — without this, a still-running child would keep
+   * resolving its bypass through a parent whose own bypass state was just
+   * cleared, silently changing the child's effective bypass.
+   */
+  forgetStreamAncestry(streamId: StreamTabId): void;
+  /**
    * Reject every pending approval and clear all bypass + proposal state for
    * this session. Used by session teardown and the session-wide
    * `cleanupAllApprovals` sweep.
@@ -261,6 +276,12 @@ export function createSessionApprovals(): SessionApprovals {
     proposal,
     registerStreamParent(childStreamId, parentStreamId) {
       parentOf.set(childStreamId, parentStreamId);
+    },
+    forgetStreamAncestry(streamId) {
+      parentOf.delete(streamId);
+      for (const [child, parent] of parentOf) {
+        if (parent === streamId) parentOf.delete(child);
+      }
     },
     rejectAndClearAll() {
       toolEdit.rejectAllPending();

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -14,6 +14,7 @@ import {
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
+  setToolEditApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
 } from '@tools/approval';
 import { currentSession } from '@agent/runtime/SessionHandle';
@@ -141,5 +142,25 @@ describe('child subagent stream approval inheritance', () => {
     cleanupApprovalsForStream(parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('does not let bash ancestry also grant tool-edit or proposal bypass', () => {
+    // Bugbot #3e336d8a (high severity): ancestry used to be one shared graph
+    // for all three bypass kinds, so linking a child for bash inheritance
+    // silently let it inherit tool-edit YOLO too whenever the parent had it
+    // on — even without `enableYoloOnChild`. Each kind must have its own
+    // independent ancestry graph.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-toolEdit-on' as StreamTabId;
+    const child = 'stream:child-bash-only-ancestry' as StreamTabId;
+    setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+
+    inheritBashBypassOnChildStream(child, parent);
+
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+    // No ancestry link was registered for 'toolEdit', so the child stays
+    // gated even though the parent has tool-edit YOLO on.
+    expect(isApprovalBypassedForStream(child)).toBe(false);
   });
 });

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -8,11 +8,13 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupAllApprovals,
+  cleanupApprovalsForStream,
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
+  toggleBashApprovalSessionBypass,
 } from '@tools/approval';
 import { currentSession } from '@agent/runtime/SessionHandle';
 
@@ -105,5 +107,39 @@ describe('child subagent stream approval inheritance', () => {
     setBashApprovalSessionBypass(roundTwo, false, host, { silent: true });
     expect(isBashApprovalBypassedForStream(roundTwo)).toBe(false);
     expect(isBashApprovalBypassedForStream(roundOne)).toBe(true);
+  });
+
+  it('toggling a stream that only inherits bypass turns it off on the first press', () => {
+    // Bugbot #9555956b: toggle used to flip the stream's own (unset) explicit
+    // entry — `!undefined` — landing on an explicit `true` that looked like
+    // no-op to the user. It must flip the *resolved* state instead.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-toggle' as StreamTabId;
+    const child = 'stream:child-toggle' as StreamTabId;
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+    inheritBashBypassOnChildStream(child, parent);
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+
+    const first = toggleBashApprovalSessionBypass(child, host);
+    expect(first).toBe(false);
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
+    // The parent's own bypass is untouched by the child's toggle.
+    expect(isBashApprovalBypassedForStream(parent)).toBe(true);
+  });
+
+  it('detaches a child from a torn-down parent instead of leaving it inheriting through a dead stream', () => {
+    // Bugbot #9df28eca: per-stream cleanup used to clear only the parent's
+    // own bypass entries, leaving the ancestry link intact so a live child
+    // silently changed effective bypass the moment the parent's tab closed.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-torn-down' as StreamTabId;
+    const child = 'stream:child-survives-parent' as StreamTabId;
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+    inheritBashBypassOnChildStream(child, parent);
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+
+    cleanupApprovalsForStream(parent);
+
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
   });
 });

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -14,6 +14,7 @@ import {
   isBashApprovalBypassedForStream,
   setBashApprovalSessionBypass,
 } from '@tools/approval';
+import { currentSession } from '@agent/runtime/SessionHandle';
 
 import { createRecordingHost } from '../progressTestUtils';
 
@@ -67,5 +68,42 @@ describe('child subagent stream approval inheritance', () => {
 
     expect(isApprovalBypassedForStream(child)).toBe(true);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('picks up a parent bash bypass toggled after the child stream already started', () => {
+    // Regression for the "YOLO forgotten after one round" bug: inheritance
+    // used to be a one-shot copy taken at child-creation time, so a bypass
+    // enabled on the parent afterwards never reached an already-running
+    // child. It must now resolve live off the ancestry link.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-late-toggle' as StreamTabId;
+    const child = 'stream:child-late-toggle' as StreamTabId;
+
+    inheritBashBypassOnChildStream(child, parent);
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
+
+    setBashApprovalSessionBypass(parent, true, host, { silent: true });
+
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+  });
+
+  it('lets a conversation round inherit bypass from the previous round via the session-level ancestry link', () => {
+    // Mirrors the CLI: every chat round mints a brand-new root StreamTabId,
+    // so bypass must be carried forward explicitly (see
+    // chatSessionController.ts's onStreamResolved) rather than assumed to
+    // survive on the same stream id.
+    const { host } = createRecordingHost();
+    const roundOne = 'stream:round-1' as StreamTabId;
+    const roundTwo = 'stream:round-2' as StreamTabId;
+
+    setBashApprovalSessionBypass(roundOne, true, host, { silent: true });
+    currentSession().approvals.registerStreamParent(roundTwo, roundOne);
+
+    expect(isBashApprovalBypassedForStream(roundTwo)).toBe(true);
+
+    // An explicit toggle on the later round still wins over the inherited one.
+    setBashApprovalSessionBypass(roundTwo, false, host, { silent: true });
+    expect(isBashApprovalBypassedForStream(roundTwo)).toBe(false);
+    expect(isBashApprovalBypassedForStream(roundOne)).toBe(true);
   });
 });

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -111,9 +111,9 @@ describe('child subagent stream approval inheritance', () => {
   });
 
   it('toggling a stream that only inherits bypass turns it off on the first press', () => {
-    // Bugbot #9555956b: toggle used to flip the stream's own (unset) explicit
-    // entry — `!undefined` — landing on an explicit `true` that looked like
-    // no-op to the user. It must flip the *resolved* state instead.
+    // Toggle used to flip the stream's own (unset) explicit entry —
+    // `!undefined` — landing on an explicit `true` that looked like a no-op
+    // to the user. It must flip the *resolved* state instead.
     const { host } = createRecordingHost();
     const parent = 'stream:parent-toggle' as StreamTabId;
     const child = 'stream:child-toggle' as StreamTabId;
@@ -129,9 +129,9 @@ describe('child subagent stream approval inheritance', () => {
   });
 
   it('detaches a child from a torn-down parent instead of leaving it inheriting through a dead stream', () => {
-    // Bugbot #9df28eca: per-stream cleanup used to clear only the parent's
-    // own bypass entries, leaving the ancestry link intact so a live child
-    // silently changed effective bypass the moment the parent's tab closed.
+    // Per-stream cleanup used to clear only the parent's own bypass
+    // entries, leaving the ancestry link intact so a live child silently
+    // changed effective bypass the moment the parent's tab closed.
     const { host } = createRecordingHost();
     const parent = 'stream:parent-torn-down' as StreamTabId;
     const child = 'stream:child-survives-parent' as StreamTabId;
@@ -145,11 +145,11 @@ describe('child subagent stream approval inheritance', () => {
   });
 
   it('does not let bash ancestry also grant tool-edit or proposal bypass', () => {
-    // Bugbot #3e336d8a (high severity): ancestry used to be one shared graph
-    // for all three bypass kinds, so linking a child for bash inheritance
-    // silently let it inherit tool-edit YOLO too whenever the parent had it
-    // on — even without `enableYoloOnChild`. Each kind must have its own
-    // independent ancestry graph.
+    // Ancestry used to be one shared graph for all three bypass kinds, so
+    // linking a child for bash inheritance silently let it inherit tool-edit
+    // YOLO too whenever the parent had it on — even without
+    // `enableYoloOnChild`. Each kind must have its own independent ancestry
+    // graph.
     const { host } = createRecordingHost();
     const parent = 'stream:parent-toolEdit-on' as StreamTabId;
     const child = 'stream:child-bash-only-ancestry' as StreamTabId;

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -32,6 +32,7 @@ export function cleanupApprovalsForStream(
   toolEdit.bypass.clearForStream(streamId);
   bash.bypass.clearForStream(streamId);
   proposal.clearForStream(streamId);
+  session.approvals.forgetStreamAncestry(streamId);
   session.interactions.cancel({
     streamId,
     cause: 'Stream resources released.',

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -524,7 +524,13 @@ export function inheritBashBypassOnChildStream(
   session: SessionHandle = currentSession(),
 ): void {
   if (parentStreamId) {
-    session.approvals.registerStreamParent(childStreamId, parentStreamId);
+    // Scoped to 'bash' only — ancestry is tracked per bypass kind, so this
+    // cannot also let the child inherit tool-edit or super-YOLO bypass from
+    // the parent. Those are granted separately and explicitly (see
+    // `enableYoloOnChildStream`) when a delegation asks for them.
+    session.approvals.registerStreamParent(childStreamId, parentStreamId, [
+      'bash',
+    ]);
   }
 }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -505,23 +505,26 @@ export async function requestAndWriteApprovedEdit(request: {
 }
 
 /**
- * Mirror the parent stream's bash-approval bypass onto a freshly resolved child
- * subagent stream, independent of any tool-edit auto-approval.
+ * Link a freshly resolved child subagent stream to its parent for bash-bypass
+ * resolution, independent of any tool-edit auto-approval.
  *
- * A child delegated by a parent that auto-runs bash should auto-run bash too. If
- * the parent's bash is still gated this is a no-op — fresh child streams default
- * to gated — so the child matches the parent either way. Kept separate from the
- * tool-edit YOLO flag to respect the CLI's distinct AUTO-BASH / AUTO-APPROVE
- * grants: a parent with AUTO-BASH but edits still gated still propagates bash.
+ * A child delegated by a parent that auto-runs bash should auto-run bash too —
+ * and should keep doing so even if the parent's bash bypass is toggled on
+ * *after* the child stream already started, since this registers a live
+ * ancestry link rather than copying the parent's bypass value once at child
+ * creation (see `registerStreamParent`). If the parent's bash is still gated
+ * the child stays gated too — fresh streams default to gated either way.
+ * Kept separate from the tool-edit YOLO flag to respect the CLI's distinct
+ * AUTO-BASH / AUTO-APPROVE grants: a parent with AUTO-BASH but edits still
+ * gated still propagates bash.
  */
 export function inheritBashBypassOnChildStream(
   childStreamId: StreamTabId,
   parentStreamId?: StreamTabId,
   session: SessionHandle = currentSession(),
 ): void {
-  const bashBypass = session.approvals.bash.bypass;
-  if (parentStreamId && bashBypass.isBypassed(parentStreamId)) {
-    bashBypass.setBypass(childStreamId, true);
+  if (parentStreamId) {
+    session.approvals.registerStreamParent(childStreamId, parentStreamId);
   }
 }
 


### PR DESCRIPTION
## Summary
- Bash/tool-edit/super-YOLO bypass ("YOLO") was a one-shot snapshot copied at the instant a new stream was created, with no live link back to whichever stream the user actually toggled it on — so it appeared to reset after one round of conversation.
- Extension: a delegated subagent stream copied its parent's bypass once at creation, so toggling YOLO afterward (or spawning a later sibling subagent) never picked it up.
- CLI: every chat round mints a brand-new root stream id, so bypass had nothing to attach to on the next turn.
- Fix: `SessionApprovals` now tracks a shared per-session ancestry map (`registerStreamParent`); `isBypassed()` walks up from a stream to its parent whenever the stream has no explicit bypass value of its own, instead of defaulting straight to `false`. An explicit toggle at any level still wins over an inherited one. Delegated subagents register the orchestrator as parent; each new CLI chat round registers the previous round's stream as parent.

## Test plan
- [x] `tsc --noEmit` (root, `tsconfig.test-kernel.json`, and `packages/cli`) — clean
- [x] `ChildStreamYoloInheritance.vitest.ts` — 6/6 pass, including 2 new regression tests: bypass toggled *after* the child stream already exists, and round-to-round inheritance via the session-level ancestry link (with explicit-override-wins coverage)
- [x] Full approval-suite sweep (`vitest -t "pproval"`) — 224/224 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auto-approval is resolved for bash, edits, and delegation across streams; behavior is security-sensitive but scoped and heavily tested.
> 
> **Overview**
> **Approval bypass (bash, tool-edit, super-YOLO) now follows a per-stream ancestry chain** instead of a one-shot copy when a new stream is created. `isBypassed()` walks parents when a stream has no explicit value; **toggle** flips the resolved state so inherited bypass can be turned off on the first press.
> 
> `SessionApprovals` adds **`registerStreamParent`** / **`forgetStreamAncestry`** with **separate graphs per bypass kind** (bash ancestry does not imply tool-edit or proposal). Stream teardown calls **`forgetStreamAncestry`** so children do not keep inheriting from cleared parents.
> 
> **CLI:** each new chat round links its root stream to the previous round in `onStreamResolved`. **Delegated subagents:** `inheritBashBypassOnChildStream` registers bash-only parent links instead of copying bypass at creation time.
> 
> Regression coverage expands in `ChildStreamYoloInheritance.vitest.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620c1736a7ebb86020f28c36ffa9a4f698044d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->