### PR TITLE
feat(agent): add typed in-band child execution

### DIFF
--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -14,8 +14,13 @@ import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import type { HostInteractions } from '@agent/runtime/HostInteractions';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
-import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import {
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
+import { executeSubagentInBand } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
   enableYoloOnChildStream: vi.fn(),
@@ -28,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   isProposalBypassed: vi.fn(),
   registerExecution: vi.fn(),
   writeReport: vi.fn(),
+  writeResultMeta: vi.fn(),
   computeModelOptionsData: vi.fn(),
 }));
 
@@ -133,8 +139,10 @@ describe('headless delegation', () => {
     mocks.isApprovalBypassedForStream.mockReturnValue(false);
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.writeReport.mockResolvedValue(undefined);
+    mocks.writeResultMeta.mockResolvedValue(undefined);
     mocks.getExecutionStore.mockReturnValue({
       writeReport: mocks.writeReport,
+      writeResultMeta: mocks.writeResultMeta,
     });
     mocks.executeAgent.mockResolvedValue({
       category: 'toolUse',
@@ -186,6 +194,207 @@ describe('headless delegation', () => {
     expect(result.output).toContain('<response>');
     expect(result.output).toContain('The proof is correct.');
     expect(mocks.writeReport).toHaveBeenCalledWith(result.output);
+  });
+
+  it('returns and persists the typed final result for in-band consumers', async () => {
+    const result = await executeSubagentInBand({
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: 'parent-exec' as ExecutionId,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+    });
+
+    expect(result.result).toEqual({
+      category: 'toolUse',
+      outcome: 'completed',
+      response: 'The proof is correct.',
+      files: [],
+      cost: 0,
+    });
+    expect(mocks.writeReport).not.toHaveBeenCalled();
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      result.executionId,
+      expect.objectContaining({ agent: 'review' }),
+      'review',
+      'parent-exec',
+    );
+    expect(mocks.writeResultMeta).toHaveBeenCalledWith({
+      producer: 'subagent',
+      agentName: 'review',
+      wallTimeMs: expect.any(Number),
+      result: result.result,
+    });
+  });
+
+  it('does not return a typed result when its durable manifest cannot be written', async () => {
+    mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
+
+    await expect(
+      executeSubagentInBand({
+        configPayload: {
+          agent: 'review',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'deepseekT',
+        },
+        agentName: 'review',
+        parentExecutionId: 'parent-exec' as ExecutionId,
+        parentStreamId: 'parent-stream' as StreamTabId,
+        runtimeHost: runtimeHost(),
+        session: defaultSession(),
+      }),
+    ).rejects.toThrow('Failed to persist result for subagent');
+    expect(mocks.writeReport).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite a completed child when typed result construction fails', async () => {
+    mocks.executeAgent.mockResolvedValueOnce({
+      category: 'toolUse',
+      outcome: 'completed',
+      executionId: 'child-exec',
+      streamId: 'child-stream',
+      touchedFiles: [42],
+    });
+
+    await expect(
+      executeSubagentInBand({
+        configPayload: {
+          agent: 'review',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'deepseekT',
+        },
+        agentName: 'review',
+        parentExecutionId: 'parent-exec' as ExecutionId,
+        parentStreamId: 'parent-stream' as StreamTabId,
+        runtimeHost: runtimeHost(),
+        session: defaultSession(),
+      }),
+    ).rejects.toThrow();
+    expect(mocks.writeResultMeta).not.toHaveBeenCalled();
+    expect(mocks.writeReport).not.toHaveBeenCalled();
+  });
+
+  it('interrupts the live child when the in-band caller aborts', async () => {
+    const controller = new AbortController();
+    const onCost = vi.fn();
+    let childReady!: () => void;
+    let childInterrupted!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      childReady = resolve;
+    });
+    const interrupted = new Promise<void>((resolve) => {
+      childInterrupted = resolve;
+    });
+    const interrupt = vi.fn(() => {
+      childInterrupted();
+      return true;
+    });
+    mocks.executeAgent.mockImplementationOnce(async (_config, _id, options) => {
+      await options.onRun?.({ interrupt } as never);
+      childReady();
+      await interrupted;
+      return {
+        category: 'toolUse',
+        outcome: 'cancelled',
+        executionId: 'child-exec',
+        streamId: 'child-stream',
+      };
+    });
+
+    const run = executeSubagentInBand({
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: 'parent-exec' as ExecutionId,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+      signal: controller.signal,
+      onCost,
+    });
+    await ready;
+    controller.abort(new Error('Workflow stopped.'));
+
+    await expect(run).rejects.toThrow('Workflow stopped.');
+    expect(interrupt).toHaveBeenCalledOnce();
+    expect(onCost).toHaveBeenCalledOnce();
+    expect(mocks.writeResultMeta).toHaveBeenCalledOnce();
+    expect(mocks.writeResultMeta).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        producer: 'subagent',
+        result: expect.objectContaining({ outcome: 'cancelled' }),
+      }),
+    );
+  });
+
+  it('keeps the completed child result when cancellation arrives during persistence', async () => {
+    const controller = new AbortController();
+    let finishPersistence!: () => void;
+    const persistencePending = new Promise<void>((resolve) => {
+      finishPersistence = resolve;
+    });
+    mocks.writeResultMeta.mockReturnValueOnce(persistencePending);
+
+    const run = executeSubagentInBand({
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: 'parent-exec' as ExecutionId,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => {
+      expect(mocks.writeResultMeta).toHaveBeenCalledOnce();
+    });
+    controller.abort(new Error('Workflow stopped after child completion.'));
+    finishPersistence();
+
+    await expect(run).rejects.toThrow(
+      'Workflow stopped after child completion.',
+    );
+    expect(mocks.writeResultMeta).toHaveBeenCalledOnce();
+    expect(mocks.writeResultMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        producer: 'subagent',
+        result: expect.objectContaining({ outcome: 'completed' }),
+      }),
+    );
+  });
+
+  it('does not register a child when the in-band caller is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('Workflow already stopped.'));
+
+    await expect(
+      executeSubagentInBand({
+        configPayload: {
+          agent: 'review',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'deepseekT',
+        },
+        agentName: 'review',
+        parentExecutionId: 'parent-exec' as ExecutionId,
+        parentStreamId: 'parent-stream' as StreamTabId,
+        runtimeHost: runtimeHost(),
+        session: defaultSession(),
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('Workflow already stopped.');
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
   });
 
   it('carries the validated agent source to executeAgent for source-pinned launch', async () => {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -1,0 +1,382 @@
+/**
+ * In-band native subagent execution for callers that consume a typed result.
+ *
+ * This is the synchronous counterpart to `childRunLoop`: it owns child
+ * registration, execution, post-flow artifact construction, result persistence,
+ * and caller cancellation. XML presentation remains in a separate adapter for
+ * the existing delegation tool.
+ */
+
+import { registerExecution, type ResultMeta } from '@agent/storage';
+import {
+  AgentConfigSchema,
+  type AgentConfigPayload,
+} from '@agent/core/definition/AgentConfig';
+import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import {
+  getAgentFlowErrorResult,
+  type AgentFlowResult,
+} from '@agent/runtime/AgentFlowResult';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRunHandle } from '@agent/runtime/executionRegistry';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import * as logger from '@logger/logUtils';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  persistChildRunReport,
+  persistChildRunResultMeta,
+} from '@tools/childRunDelivery';
+import {
+  buildSubagentFailureResultMeta,
+  formatSubagentError,
+} from '@tools/subagentResults';
+import { generateExecutionId } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import {
+  buildSubagentResult,
+  formatBuiltSubagentDelivery,
+  type BuiltSubagentResult,
+} from './subagentDeliveryFormat';
+
+const LOG_CHANNEL = 'inBandSubagentExecution';
+logger.initialize(LOG_CHANNEL);
+
+interface InBandSubagentExecutionBaseOptions {
+  readonly configPayload: AgentConfigPayload;
+  readonly agentName: string;
+  readonly parentStreamId: StreamTabId;
+  readonly runtimeHost: AgentRuntimeHost;
+  readonly session: SessionHandle;
+  readonly approvalPromptsUnavailable?: boolean;
+  readonly runtimeUnavailableTools?: readonly string[];
+  readonly signal?: AbortSignal;
+  readonly onStreamResolved?: (streamId: StreamTabId) => void;
+  readonly onCost?: (totalCostUsd: number | undefined) => void | Promise<void>;
+}
+
+/** Options for the typed child API. Direct persisted parentage is required. */
+export interface InBandSubagentExecutionOptions extends InBandSubagentExecutionBaseOptions {
+  readonly parentExecutionId: ExecutionId;
+}
+
+/** Legacy delivery callers may still provide a bare one-shot run context. */
+export interface InBandSubagentDeliveryOptions extends InBandSubagentExecutionBaseOptions {
+  readonly parentExecutionId?: ExecutionId;
+}
+
+export interface InBandSubagentExecutionResult {
+  readonly executionId: ExecutionId;
+  readonly result: AgentFinalResult;
+}
+
+export interface InBandSubagentDeliveryResult extends InBandSubagentExecutionResult {
+  readonly delivery: string;
+}
+
+type PersistenceMode = 'required-result' | 'best-effort-delivery';
+
+interface CompletedInBandSubagent {
+  readonly executionId: ExecutionId;
+  readonly flowResult: AgentFlowResult;
+  readonly built: BuiltSubagentResult;
+  readonly delivery?: string;
+}
+
+function logPersistenceFailure(
+  kind: 'report' | 'result manifest',
+  executionId: ExecutionId,
+  error: unknown,
+): void {
+  logger.warn(
+    LOG_CHANNEL,
+    `Failed to persist subagent ${kind} for ${executionId}: ${toErrorMessage(error)}`,
+  );
+}
+
+async function persistResultMetaBestEffort(
+  executionId: ExecutionId,
+  resultMeta: ResultMeta,
+): Promise<void> {
+  const result = await persistChildRunResultMeta(executionId, resultMeta);
+  if (result.kind === 'failed') {
+    logPersistenceFailure('result manifest', executionId, result.err);
+  }
+}
+
+async function persistResultMetaRequired(
+  executionId: ExecutionId,
+  resultMeta: ResultMeta,
+): Promise<void> {
+  const result = await persistChildRunResultMeta(executionId, resultMeta);
+  if (result.kind === 'failed') {
+    throw new Error(`Failed to persist result for subagent ${executionId}.`, {
+      cause: result.err,
+    });
+  }
+}
+
+async function persistReportBestEffort(
+  executionId: ExecutionId,
+  report: string,
+): Promise<void> {
+  const result = await persistChildRunReport(executionId, report);
+  if (result.kind === 'failed') {
+    logPersistenceFailure('report', executionId, result.err);
+  }
+}
+
+async function persistDeliveryBestEffort(
+  executionId: ExecutionId,
+  delivery: string,
+  resultMeta: ResultMeta,
+): Promise<void> {
+  const [reportResult, metaResult] = await Promise.all([
+    persistChildRunReport(executionId, delivery),
+    persistChildRunResultMeta(executionId, resultMeta),
+  ]);
+  if (reportResult.kind === 'failed') {
+    logPersistenceFailure('report', executionId, reportResult.err);
+  }
+  if (metaResult.kind === 'failed') {
+    logPersistenceFailure('result manifest', executionId, metaResult.err);
+  }
+}
+
+/** Bind caller cancellation to the live child while its flow is running. */
+function bindAbortSignal(
+  signal: AbortSignal | undefined,
+  handle: AgentRunHandle,
+): () => void {
+  if (!signal) return () => {};
+  const interrupt = (): void => {
+    handle.interrupt();
+  };
+  if (signal.aborted) {
+    interrupt();
+    return () => {};
+  }
+  signal.addEventListener('abort', interrupt, { once: true });
+  return () => signal.removeEventListener('abort', interrupt);
+}
+
+function createCostSettler(
+  onCost: InBandSubagentExecutionBaseOptions['onCost'],
+): (totalCostUsd: number | undefined) => void {
+  let settled = false;
+  return (totalCostUsd) => {
+    if (settled) return;
+    settled = true;
+    try {
+      const observed = onCost?.(totalCostUsd);
+      void Promise.resolve(observed).catch((error: unknown) => {
+        logger.warn(LOG_CHANNEL, 'Subagent cost observer rejected', {
+          data: error,
+        });
+      });
+    } catch (error) {
+      logger.warn(LOG_CHANNEL, 'Subagent cost observer failed', {
+        data: error,
+      });
+    }
+  };
+}
+
+async function persistFailure(
+  mode: PersistenceMode,
+  executionId: ExecutionId,
+  agentName: string,
+  fallbackCategory: AgentFlowResult['category'],
+  error: unknown,
+  result: AgentFlowResult | undefined,
+  startedAt: number,
+  workingDirectory: string | undefined,
+): Promise<void> {
+  const wallTimeMs = Date.now() - startedAt;
+  const resultMeta = buildSubagentFailureResultMeta(
+    agentName,
+    fallbackCategory,
+    result,
+    wallTimeMs,
+  );
+  if (mode === 'required-result') {
+    // Preserve the execution error even if its diagnostic manifest cannot be
+    // written; a failed call is never journaled by the workflow engine.
+    await persistResultMetaBestEffort(executionId, resultMeta);
+    return;
+  }
+  const delivery = formatSubagentError(executionId, agentName, error, {
+    wallTimeMs,
+    workingDirectory,
+    memoryMisses: result?.memoryMisses,
+  });
+  await persistDeliveryBestEffort(executionId, delivery, resultMeta);
+}
+
+/**
+ * Execute one child and construct its terminal typed result. Once
+ * `executeAgent` returns, the child's outcome is fixed: later caller
+ * cancellation may reject the waiting workflow stage, but it never rewrites
+ * the completed child's manifest.
+ */
+async function executeInBand(
+  options: InBandSubagentDeliveryOptions,
+  mode: PersistenceMode,
+): Promise<CompletedInBandSubagent> {
+  options.signal?.throwIfAborted();
+
+  // Lazy import: the agent runtime loads delegation tools through its registry.
+  // Keeping this edge lazy avoids closing that registry cycle at module load.
+  const { executeAgent } = await import('@agent/runtime/executeAgent');
+  const executionId = generateExecutionId() as ExecutionId;
+  const config = AgentConfigSchema.parse(options.configPayload);
+  const startedAt = Date.now();
+  const workingDirectory = config.workingDirectory ?? undefined;
+  const settleCost = createCostSettler(options.onCost);
+
+  await registerExecution(
+    executionId,
+    config,
+    options.agentName,
+    options.parentExecutionId,
+  );
+
+  let runError: unknown;
+  let detachAbort = (): void => {};
+  let flowResult: AgentFlowResult;
+  try {
+    flowResult = await executeAgent(config, executionId, {
+      runtimeHost: options.runtimeHost,
+      session: options.session,
+      isSubagent: true,
+      enforceCategory: true,
+      parentStreamId: options.parentStreamId,
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      stopAfterCycle: true,
+      onStreamResolved: options.onStreamResolved,
+      onRunError: (error) => {
+        runError = error;
+      },
+      onRun: (handle) => {
+        detachAbort();
+        detachAbort = bindAbortSignal(options.signal, handle);
+      },
+    });
+  } catch (error) {
+    const errorResult = getAgentFlowErrorResult(error);
+    settleCost(errorResult?.totalCostUsd);
+    await persistFailure(
+      mode,
+      executionId,
+      options.agentName,
+      config.agentCategory,
+      error,
+      errorResult,
+      startedAt,
+      workingDirectory,
+    );
+    throw error;
+  } finally {
+    detachAbort();
+  }
+
+  settleCost(flowResult.totalCostUsd);
+  if (flowResult.outcome === 'failed') {
+    const error = runError ?? new Error('Subagent ended with failed outcome.');
+    await persistFailure(
+      mode,
+      executionId,
+      options.agentName,
+      config.agentCategory,
+      error,
+      flowResult,
+      startedAt,
+      workingDirectory,
+    );
+    throw error;
+  }
+
+  let built: BuiltSubagentResult;
+  try {
+    built = await buildSubagentResult(
+      executionId,
+      options.agentName,
+      flowResult,
+      { startedAt, workingDirectory },
+    );
+  } catch (error) {
+    // The runtime has already finalized this child. A post-flow construction
+    // error must not rewrite a completed execution as failed or try to parse
+    // the same invalid flow data again through the failure-result builder.
+    if (mode === 'best-effort-delivery') {
+      await persistReportBestEffort(
+        executionId,
+        formatSubagentError(executionId, options.agentName, error, {
+          wallTimeMs: Date.now() - startedAt,
+          workingDirectory,
+          memoryMisses: flowResult.memoryMisses,
+        }),
+      );
+    }
+    throw error;
+  }
+
+  let delivery: string | undefined;
+  if (mode === 'required-result') {
+    await persistResultMetaRequired(executionId, built.resultMeta);
+  } else {
+    try {
+      delivery = formatBuiltSubagentDelivery(
+        executionId,
+        options.agentName,
+        flowResult,
+        built,
+        workingDirectory,
+      );
+    } catch (error) {
+      await persistResultMetaBestEffort(executionId, built.resultMeta);
+      await persistReportBestEffort(
+        executionId,
+        formatSubagentError(executionId, options.agentName, error, {
+          wallTimeMs: built.wallTimeMs,
+          workingDirectory,
+          memoryMisses: flowResult.memoryMisses,
+        }),
+      );
+      throw error;
+    }
+    await persistDeliveryBestEffort(executionId, delivery, built.resultMeta);
+  }
+
+  // Post-flow artifact construction deliberately reaches a terminal record.
+  // Cancellation observed here rejects the caller without changing that record.
+  options.signal?.throwIfAborted();
+  return { executionId, flowResult, built, delivery };
+}
+
+/** Run a direct child and return the durable, XML-free result envelope. */
+export async function executeSubagentInBand(
+  options: InBandSubagentExecutionOptions,
+): Promise<InBandSubagentExecutionResult> {
+  const completed = await executeInBand(options, 'required-result');
+  return {
+    executionId: completed.executionId,
+    result: completed.built.result,
+  };
+}
+
+/** Preserve the existing headless delegation tool's XML/report behavior. */
+export async function executeSubagentForDeliveryInBand(
+  options: InBandSubagentDeliveryOptions,
+): Promise<InBandSubagentDeliveryResult> {
+  const completed = await executeInBand(options, 'best-effort-delivery');
+  if (completed.delivery === undefined) {
+    throw new Error('Subagent delivery was not constructed.');
+  }
+  return {
+    executionId: completed.executionId,
+    result: completed.built.result,
+    delivery: completed.delivery,
+  };
+}

--- a/src/tools/delegation/subagentDeliveryFormat.ts
+++ b/src/tools/delegation/subagentDeliveryFormat.ts
@@ -1,12 +1,14 @@
 /**
- * Shared terminal-result formatting for native subagent strategies
- * (tool-use and workflow): compute workflow diffs (when applicable), then
- * format both the delivery XML and the structured result manifest from the
- * same diff pass so neither strategy pays for diff computation twice.
+ * Shared terminal-result construction for native subagent strategies
+ * (tool-use and workflow). The typed result owns workflow diff construction;
+ * XML formatting is a separate boundary operation over that same result.
  */
 
 import type { ResultMeta } from '@agent/storage';
-import { buildAgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import {
+  buildAgentFinalResult,
+  type AgentFinalResult,
+} from '@agent/runtime/AgentFinalResult';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
@@ -22,14 +24,21 @@ import {
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const LOG_CHANNEL = 'subagentDelivery';
+type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
+
+export interface BuiltSubagentResult {
+  readonly result: AgentFinalResult;
+  readonly resultMeta: SubagentResultMeta;
+  readonly wallTimeMs: number;
+}
 
 /**
- * Format a subagent result for delivery to the orchestrator.
+ * Build a subagent's typed terminal result and persistence record.
  * For workflow results, computes latexdiffs and writes them as files to the
  * execution's run directory first — the delivery references diff file paths
  * so the orchestrator can read them on demand via /executions/{id}/files/.
  */
-export async function subagentDeliveryMessage(
+export async function buildSubagentResult(
   executionId: ExecutionId,
   agentName: string,
   result: AgentFlowResult,
@@ -37,7 +46,7 @@ export async function subagentDeliveryMessage(
     readonly startedAt: number;
     readonly workingDirectory?: string;
   },
-): Promise<{ msg: string; resultMeta: ResultMeta }> {
+): Promise<BuiltSubagentResult> {
   let diffInfos: Map<string, DiffFileInfo> | undefined;
   let diffsUnavailable: string | undefined;
   if (result.category === 'workflow' && result.outputs.length > 0) {
@@ -71,12 +80,52 @@ export async function subagentDeliveryMessage(
     diffsUnavailable,
   });
   return {
-    msg: formatSubagentDelivery(agentName, finalResult, {
-      executionId,
-      memoryMisses: result.memoryMisses,
-      wallTimeMs,
-      workingDirectory: options.workingDirectory,
-    }),
+    result: finalResult,
     resultMeta: buildSubagentResultMeta(agentName, finalResult, wallTimeMs),
+    wallTimeMs,
+  };
+}
+
+/** Build the model-facing XML only at the follow-up/tool-result boundary. */
+export function formatBuiltSubagentDelivery(
+  executionId: ExecutionId,
+  agentName: string,
+  result: AgentFlowResult,
+  built: BuiltSubagentResult,
+  workingDirectory?: string,
+): string {
+  return formatSubagentDelivery(agentName, built.result, {
+    executionId,
+    memoryMisses: result.memoryMisses,
+    wallTimeMs: built.wallTimeMs,
+    workingDirectory,
+  });
+}
+
+/** Build both representations for asynchronous child-delivery strategies. */
+export async function subagentDeliveryMessage(
+  executionId: ExecutionId,
+  agentName: string,
+  result: AgentFlowResult,
+  options: {
+    readonly startedAt: number;
+    readonly workingDirectory?: string;
+  },
+): Promise<{ msg: string; resultMeta: SubagentResultMeta }> {
+  const built = await buildSubagentResult(
+    executionId,
+    agentName,
+    result,
+    options,
+  );
+  return {
+    msg: formatBuiltSubagentDelivery(
+      executionId,
+      agentName,
+      result,
+      built,
+      options.workingDirectory,
+    ),
+    resultMeta: built.resultMeta,
   };
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -8,17 +8,12 @@
  */
 
 // Local imports - agent
-import type { ResultMeta } from '@agent/storage';
 import { registerExecution } from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { currentSession } from '@agent/runtime/SessionHandle';
-import {
-  getAgentFlowErrorResult,
-  type AgentFlowResult,
-} from '@agent/runtime/AgentFlowResult';
 import {
   getRunContextExecutionId,
   getRunContextRuntimeHost,
@@ -42,21 +37,13 @@ import {
   enableYoloOnChildStream,
   inheritBashBypassOnChildStream,
 } from '@tools/approval';
-import {
-  buildSubagentFailureResultMeta,
-  formatSubagentError,
-} from '@tools/subagentResults';
-import {
-  persistChildRunReport,
-  persistChildRunResultMeta,
-} from '@tools/childRunDelivery';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-// Local imports - utils
-import { subagentDeliveryMessage } from './subagentDeliveryFormat';
+import { executeSubagentForDeliveryInBand } from './inBandSubagentExecution';
+
 // `createNativeToolUseStrategy`/`createNativeWorkflowStrategy` are lazy-
-// imported below, alongside `executeAgent` — both strategy modules import
+// imported below. Both strategy modules import
 // `@agent/runtime/executeAgent` (directly, or transitively via
 // `resumeQueuedToolUseSnapshot`), which pulls in `runToolUseFlow.ts` ->
 // `@tools/registry`. An eager import here would close the same
@@ -79,32 +66,8 @@ interface ApprovalMeta {
   requestedAgent?: string;
 }
 
-/** Persist a subagent's report and result manifest, logging (not throwing) on failure. */
-async function persistSubagentDeliveryBestEffort(
-  executionId: ExecutionId,
-  msg: string,
-  resultMeta: ResultMeta,
-): Promise<void> {
-  const [reportResult, metaResult] = await Promise.all([
-    persistChildRunReport(executionId, msg),
-    persistChildRunResultMeta(executionId, resultMeta),
-  ]);
-  if (reportResult.kind === 'failed') {
-    logger.warn(
-      LOG_CHANNEL,
-      `Failed to persist subagent report for ${executionId}: ${toErrorMessage(reportResult.err)}`,
-    );
-  }
-  if (metaResult.kind === 'failed') {
-    logger.warn(
-      LOG_CHANNEL,
-      `Failed to persist subagent result manifest for ${executionId}: ${toErrorMessage(metaResult.err)}`,
-    );
-  }
-}
-
 /**
- * Execute a subagent asynchronously.
+ * Execute a subagent through the delegation tool boundary.
  * Pre-generates executionId so all IDs (tool return, XML delivery, error)
  * are consistent and usable with the executions tool.
  *
@@ -117,10 +80,6 @@ export async function executeSubagent(
   orchestratorStreamId: StreamTabId,
   options?: { enableYoloOnChild?: boolean; approvalMeta?: ApprovalMeta },
 ): Promise<ToolResult> {
-  // Lazy import: the delegation tool runs agents, and the agent runtime loads
-  // this tool through the registry. Same intentional recursion pattern as the
-  // dynamic RemoteAgentLoader import in agentRegistry.
-  const { executeAgent } = await import('@agent/runtime/executeAgent');
   const parentContext = tryUseRunContext();
   const runtimeHost = getRunContextRuntimeHost(parentContext);
   if (!parentContext || !runtimeHost) {
@@ -150,8 +109,6 @@ export async function executeSubagent(
     recordSubagentCost?.(totalCostUsd ?? 0);
   }
 
-  const executionId = generateExecutionId();
-  const startedAt = Date.now();
   const delegationAgentScope =
     parentContext.kind === 'launch'
       ? parentContext.runScope.delegationAgentScope
@@ -161,14 +118,6 @@ export async function executeSubagent(
     ...(delegationAgentScope ? { delegationAgentScope } : {}),
   };
   const workingDirectory = childConfigPayload.workingDirectory ?? undefined;
-
-  const syntheticConfig = AgentConfigSchema.parse(childConfigPayload);
-  await registerExecution(
-    executionId,
-    syntheticConfig,
-    agentName,
-    parentExecutionId,
-  );
 
   const inheritChildStreamApprovals = (resolvedStreamId: StreamTabId): void => {
     // Bash bypass follows the parent regardless of edit-YOLO, so a bash-only
@@ -180,80 +129,45 @@ export async function executeSubagent(
   };
 
   if (parentContext.stopAfterCycle) {
-    const failureResult = async (
-      err: unknown,
-      result?: AgentFlowResult,
-    ): Promise<ToolResult> => {
-      const wallTimeMs = Date.now() - startedAt;
-      const msg = formatSubagentError(executionId, agentName, err, {
-        wallTimeMs,
-        workingDirectory,
-        memoryMisses: result?.memoryMisses,
-      });
-      // Keep the failed run's data (partial outputs, category, cost) in the
-      // manifest, matching the async error path.
-      await persistSubagentDeliveryBestEffort(
-        executionId,
-        msg,
-        buildSubagentFailureResultMeta(
-          agentName,
-          syntheticConfig.agentCategory,
-          result,
-          wallTimeMs,
-        ),
-      );
-      return {
-        status: 'error',
-        summary: `Subagent '${agentName}' failed`,
-        error: toErrorMessage(err),
-      };
-    };
     try {
-      let subagentError: unknown;
-      const result = await executeAgent(childConfigPayload, executionId, {
+      const { result, delivery } = await executeSubagentForDeliveryInBand({
+        configPayload: childConfigPayload,
+        agentName,
+        parentExecutionId,
+        parentStreamId: orchestratorStreamId,
         runtimeHost,
         session: parentSession,
-        isSubagent: true,
-        enforceCategory: true,
-        parentStreamId: orchestratorStreamId,
         approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
         runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
-        stopAfterCycle: true,
         onStreamResolved: inheritChildStreamApprovals,
-        onRunError: (err) => {
-          subagentError = err;
-        },
+        onCost: settleSubagentCost,
       });
-      settleSubagentCost(result.totalCostUsd);
-      if (result.outcome === 'failed') {
-        return failureResult(
-          subagentError ?? 'Subagent ended with failed outcome.',
-          result,
-        );
-      }
-      const { msg, resultMeta } = await subagentDeliveryMessage(
-        executionId,
-        agentName,
-        result,
-        { startedAt, workingDirectory },
-      );
-      await persistSubagentDeliveryBestEffort(executionId, msg, resultMeta);
       return {
         status: 'executed',
         summary:
           result.outcome === 'cancelled'
             ? `Cancelled '${agentName}'`
             : `Completed '${agentName}'`,
-        output: msg,
+        output: delivery,
       };
     } catch (err) {
-      // AgentFlowError carries the failed run's result — keep its category,
-      // partial outputs, and cost in the failure manifest for chaining.
-      const errorResult = getAgentFlowErrorResult(err);
-      settleSubagentCost(errorResult?.totalCostUsd);
-      return failureResult(err, errorResult);
+      return {
+        status: 'error',
+        summary: `Subagent '${agentName}' failed`,
+        error: toErrorMessage(err),
+      };
     }
   }
+
+  const executionId = generateExecutionId();
+  const startedAt = Date.now();
+  const syntheticConfig = AgentConfigSchema.parse(childConfigPayload);
+  await registerExecution(
+    executionId,
+    syntheticConfig,
+    agentName,
+    parentExecutionId,
+  );
 
   const isToolUse = childConfigPayload.agentCategory === AgentCategory.ToolUse;
   // Must match the id `buildAgentLaunchContext` actually reserves for this


### PR DESCRIPTION
## Summary

Add the typed in-band child-execution primitive required by the workflow-script engine. Direct workflow callers now receive a durable `AgentFinalResult` after post-flow artifact construction, while the existing headless delegation tool retains its XML/report adapter.

Cancellation is bound to the live child handle. Once the child runtime returns, its terminal outcome is fixed: cancellation may reject the waiting workflow stage, but cannot rewrite a completed child manifest.

## Issue acceptance gates

Advances #7154.

Satisfied in this PR:

- Run a direct child in-band with ordinary `parentExecutionId` lineage.
- Return the post-flow `AgentFinalResult` rather than an XML delivery string.
- Require durable result-manifest persistence before the typed call succeeds.
- Propagate caller cancellation to the live child run handle.
- Preserve the existing one-shot delegation tool's XML/report behavior.
- Keep typed result construction independent of presentation formatting.

Still intentionally outside this PR:

- Resolve script `agentName` and `inputFiles` into child configurations.
- Bind prior-stage output manifests through run storage.
- Persist workflow scripts and journals for restart recovery.
- Bridge workflow-script events to the stream tree.
- Register the opt-in `delegate_workflow_script` tool.

## Single source of truth

`executeSubagentInBand` now owns direct child registration, execution, cancellation, typed result construction, and required manifest persistence. `buildSubagentResult` owns the one post-flow conversion from `AgentFlowResult` to `AgentFinalResult`; XML is produced separately by `formatBuiltSubagentDelivery`.

## Duplication and abstraction budget

The former `stopAfterCycle` branch in `subagentExecution.ts` duplicated execution, failure-manifest, persistence, cost, and delivery choreography. It is replaced by one deep in-band module.

The second exported adapter, `executeSubagentForDeliveryInBand`, exists only to preserve the legacy tool boundary. It selects best-effort XML/report persistence; it does not duplicate child execution.

## Net elements (R6)

- Files: 1 added, 3 modified, 0 deleted.
- Exports: 9 added, 0 removed.
- Types: 7 interfaces added; 0 classes and 0 enums added.
- Total LoC: 681 added, 127 removed, net +554.
- Production LoC: 471 added, 126 removed, net +345.
- Test LoC: 210 added, 1 removed, net +209.

The production increase encodes the two explicit contracts that were previously entangled: durable typed execution and best-effort model-facing delivery. The test increase covers lineage, durable persistence, live cancellation, post-terminal cancellation races, construction failures, and the unchanged headless adapter.

## Consumer counts (R8)

n/a. No event key, emit path, or existing export was removed.

## Host impact

Extension: No host-specific change; future workflow-tool wiring can consume the shared typed API.

Desktop: No host-specific change; the API uses the injected runtime host and session.

CLI: Existing one-shot/headless delegation behavior remains XML-facing. The typed API is ready for later workflow-script integration.

## Scheduled refactoring

#7154 remains open for file hand-off, workflow journal persistence, progress bridging, and the opt-in tool surface.

## Validation

- `npm run format`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm run compile:safe`
- `npm test`: 692 files passed, 1 skipped; 6258 tests passed, 4 skipped
- Focused delegation/child-run regression set: 6 files, 71 tests passed
- Independent subagent review: no remaining merge-blocking correctness issues
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches child execution, durable result manifests, and cancellation races in core delegation paths; headless behavior is preserved via an adapter but logic moved into a new ~380-line module.
> 
> **Overview**
> Introduces **`executeSubagentInBand`** for workflow-style callers that need a durable **`AgentFinalResult`** (with required **`writeResultMeta`**) instead of XML tool output. **`executeSubagentForDeliveryInBand`** keeps the headless delegation path on best-effort report + manifest persistence.
> 
> **`subagentDeliveryFormat`** now builds the typed result once via **`buildSubagentResult`**; XML is applied separately through **`formatBuiltSubagentDelivery`**. The one-shot **`stopAfterCycle`** branch in **`subagentExecution`** delegates to the new module instead of inlining **`executeAgent`**, failure manifests, and delivery persistence.
> 
> Cancellation is wired to the live child handle; after the child flow finishes, abort only rejects the waiter and does not change an already-written completed manifest. Tests cover persistence failures, post-flow construction errors, abort races, and pre-abort short-circuit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cbf5236734210015f9d6b951164badd579c059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->