### PR TITLE
feat(agent): bind workflow script outputs in-band

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -8,7 +8,7 @@ import type { OutputState } from '@agent/output/outputState';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import type { LatexMediaManager } from '@latex/LatexMediaManager';
-import type { AgentFileLocation, WorkspaceFileLocation } from '@shared/schemas';
+import type { AgentFileLocation, FileLocation } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
 
 export interface WorkflowOutputPolicy {
@@ -30,6 +30,6 @@ export interface ReflectionServices<
     round: number,
   ) => AgentFileLocation | Promise<AgentFileLocation>;
   readonly workflowOutputPolicy: WorkflowOutputPolicy;
-  readonly baseFiles: WorkspaceFileLocation[];
+  readonly baseFiles: FileLocation[];
   readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,5 +1,3 @@
-import * as path from 'node:path';
-
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
 import { PromptBuilder } from '@agent/prompt';
@@ -32,19 +30,14 @@ import {
   type RoundOutput,
   type RunOutcome,
   type StorageKey,
-  type WorkspaceFileLocation,
+  type FileLocation,
 } from '@shared/schemas';
 import {
   WORKFLOW_DOCUMENT_OUTPUT_EXT,
   WORKFLOW_RAW_OUTPUT_EXT,
 } from '@shared/constants/workflowOutput';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  AbsoluteFS,
-  TaskRunFileService,
-  WorkspaceFS,
-  createWorkspaceLocation,
-} from '@utils/files';
+import { AbsoluteFS, TaskRunFileService } from '@utils/files';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 import { TeXCountNode } from './nodes/TeXCountNode';
@@ -120,13 +113,9 @@ export async function runReflectionFlow<C = unknown>(
   const fileService = new TaskRunFileService(executionId);
   const compatibilityKey = activeModelHandlerCompatibilityKey(modelHandler);
 
-  const baseFiles: WorkspaceFileLocation[] = (
+  const baseFiles: FileLocation[] = (
     config.outputFiles.length > 0 ? config.outputFiles : config.inputFiles
-  ).map((f) => {
-    const absolutePath = path.isAbsolute(f) ? f : WorkspaceFS.fullPath(f);
-    const relativePath = path.isAbsolute(f) ? WorkspaceFS.relativePath(f) : f;
-    return createWorkspaceLocation(absolutePath, relativePath);
-  });
+  ).map((file) => fileService.createLocation(file));
 
   const outputState = createOutputState();
   const xmlManager = new XmlOutputManager(config, logger, fileService);

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -115,7 +115,7 @@ export async function runReflectionFlow<C = unknown>(
 
   const baseFiles: FileLocation[] = (
     config.outputFiles.length > 0 ? config.outputFiles : config.inputFiles
-  ).map((file) => fileService.createLocation(file));
+  ).map((file) => fileService.locateSource(file));
 
   const outputState = createOutputState();
   const xmlManager = new XmlOutputManager(config, logger, fileService);

--- a/src/agent/storage/childRunOutput.ts
+++ b/src/agent/storage/childRunOutput.ts
@@ -1,0 +1,71 @@
+import type { ExecutionId, RunStorageFileLocation } from '@shared/schemas';
+import {
+  inspectRunStorageEntry,
+  runStorageLocationFromAnyAbsolutePath,
+} from '@utils/files/taskRunStorage';
+
+import { getExecutionStore } from './ExecutionKVStore';
+
+/**
+ * Resolve a declared output of a completed direct child run. The absolute path
+ * is only a lookup token; persisted lineage and result metadata are the source
+ * of authority.
+ */
+export async function resolveChildRunOutput(
+  parentExecutionId: ExecutionId,
+  absolutePath: string,
+): Promise<RunStorageFileLocation | undefined> {
+  const reference = runStorageLocationFromAnyAbsolutePath(absolutePath);
+  if (!reference) {
+    throw new Error('Workflow output is not inside task-run storage.');
+  }
+
+  const store = getExecutionStore(reference.executionId);
+  const [meta, resultMeta] = await Promise.all([
+    store.readMeta(),
+    store.readResultMeta(),
+  ]);
+  if (meta?.parentExecutionId !== parentExecutionId) {
+    throw new Error(
+      `Execution ${reference.executionId} is not a direct child of ${parentExecutionId}.`,
+    );
+  }
+  if (
+    resultMeta?.producer !== 'subagent' ||
+    resultMeta.result.category !== 'workflow' ||
+    resultMeta.result.outcome !== 'completed'
+  ) {
+    throw new Error(
+      `Execution ${reference.executionId} has no completed workflow output manifest.`,
+    );
+  }
+
+  const declared = resultMeta.result.outputs.some(
+    (output) =>
+      output.location === 'runStorage' &&
+      output.relativePath.replaceAll('\\', '/') === reference.relativePath,
+  );
+  if (!declared) {
+    throw new Error(
+      `${reference.relativePath} is not a declared output of execution ${reference.executionId}.`,
+    );
+  }
+
+  const entry = await inspectRunStorageEntry(
+    reference.executionId,
+    reference.relativePath,
+  );
+  if (entry.kind === 'file') return entry.location;
+  if (entry.kind === 'symlink') return undefined;
+  if (entry.kind === 'missing') {
+    throw new Error(
+      `Declared output ${reference.relativePath} is missing from execution ${reference.executionId}.`,
+    );
+  }
+  if (entry.kind === 'invalid') {
+    throw new Error(`Invalid declared workflow output: ${entry.reason}`);
+  }
+  throw new Error(
+    `Declared output ${reference.relativePath} is not a regular file.`,
+  );
+}

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -46,3 +46,4 @@ export {
   deriveResumability,
   type ResumabilityDecision,
 } from './resumability';
+export { resolveChildRunOutput } from './childRunOutput';

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -39,9 +39,12 @@ return concat(sections, { separator: '\n\n' });
 ## Boundaries (deliberate for the prototype)
 
 - **Host-agnostic**: the engine never spawns agents itself; hosts inject a
-  `runAgent` callback. Production wiring should use the in-band subagent
-  execution path so the engine consumes the post-flow `AgentFinalResult`
-  envelope — never the XML follow-up delivery string.
+  `runAgent` callback. The production adapter in
+  `src/tools/delegation/workflowScriptAgentRunner.ts` uses the in-band
+  subagent execution path, so the engine consumes the post-flow
+  `AgentFinalResult` envelope — never the XML follow-up delivery string. It
+  also verifies task-run inputs against persisted child lineage and result
+  manifests before passing them to a later stage.
 - **Sandbox**: a fresh QuickJS runtime and context per script, with a CPU
   interrupt deadline, 64 MB heap limit, 1 MB stack limit, dynamic code
   generation disabled, and no `require`/`process`. The WASM module is loaded
@@ -90,11 +93,8 @@ return concat(sections, { separator: '\n\n' });
 
 ## Not yet built (production integration)
 
-- Production `runAgent` wiring that returns the fixed `AgentFinalResult`
-  envelope after workflow diffs have been generated.
-- File hand-off: binding a stage's `outputs` (`OutputFileSummary[]`) as the
-  next stage's `inputFiles` directly from run storage, without an
-  `accept_run_files` round-trip. Domain-specific structures travel as JSON
+- A `delegate_workflow_script` tool, which will invoke the existing production
+  runner and task-run file hand-off. Domain-specific structures travel as JSON
   output files rather than per-call result schemas.
-- A `delegate_workflow_script` tool + journal persistence in the execution
-  KV store, and progress-event bridging onto the existing stream tree.
+- Journal persistence in the execution KV store and progress-event bridging
+  onto the existing stream tree.

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -457,10 +457,10 @@ function normalizeAgentOptions(
   if (source.inputFiles !== undefined) {
     if (
       !Array.isArray(source.inputFiles) ||
-      source.inputFiles.some((file) => typeof file !== 'string')
+      source.inputFiles.some((file) => !isNonEmptyString(file))
     ) {
       throw new Error(
-        'agent() option "inputFiles" must be an array of strings.',
+        'agent() option "inputFiles" must be an array of non-empty strings.',
       );
     }
     options.inputFiles = [...(source.inputFiles as string[])];

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowAgentInvocation } from '@agent/workflowScript';
+import type { LaunchRunContext } from '@agent/runtime/RunContext';
+import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { createWorkflowScriptAgentRunner } from '@tools/delegation/workflowScriptAgentRunner';
+
+const mocks = vi.hoisted(() => ({
+  executeSubagentInBand: vi.fn(),
+  requireVisibleAgent: vi.fn(),
+  selectAvailableDelegationModel: vi.fn(),
+  resolveChildRunOutput: vi.fn(),
+  runStorageLocationFromAnyAbsolutePath: vi.fn(),
+  assertWorkflowFilesExist: vi.fn(),
+}));
+
+vi.mock('@tools/delegation/inBandSubagentExecution', () => ({
+  executeSubagentInBand: mocks.executeSubagentInBand,
+}));
+
+vi.mock('@tools/delegation/proposalFlow', () => ({
+  requireVisibleAgent: mocks.requireVisibleAgent,
+  selectAvailableDelegationModel: mocks.selectAvailableDelegationModel,
+}));
+
+vi.mock('@agent/storage', () => ({
+  resolveChildRunOutput: mocks.resolveChildRunOutput,
+}));
+
+vi.mock('@utils/files/taskRunStorage', () => ({
+  runStorageLocationFromAnyAbsolutePath:
+    mocks.runStorageLocationFromAnyAbsolutePath,
+}));
+
+vi.mock('@tools/delegation/workflowFileValidation', () => ({
+  assertWorkflowFilesExist: mocks.assertWorkflowFilesExist,
+}));
+
+const parentExecutionId = 'aaaaaa111111' as ExecutionId;
+const parentStreamId = 'stream:workflow-script' as StreamTabId;
+const result: AgentFinalResult = {
+  category: 'workflow',
+  outcome: 'completed',
+  outputs: [],
+  compileFailures: [],
+  diffs: [],
+  cost: 0,
+};
+
+function parentContext(): LaunchRunContext {
+  return {
+    kind: 'launch',
+    model: 'parent-model',
+    approvalPromptsUnavailable: true,
+    runtimeUnavailableTools: ['user_question'],
+    runScope: {
+      executionId: parentExecutionId,
+      streamId: parentStreamId,
+      agentName: 'orchestrator',
+      workingDirectory: '/workspace',
+      delegationAgentScope: {
+        workflowAgentKeys: ['builtInWorkflow:correct'],
+        toolUseAgentKeys: ['builtInToolUse:assistant'],
+      },
+      runtimeHost: { emit: vi.fn() } as never,
+      session: { id: 'session' } as never,
+    },
+  };
+}
+
+function invocation(
+  options: WorkflowAgentInvocation['options'] = {},
+): WorkflowAgentInvocation {
+  return {
+    index: 0,
+    prompt: 'Draft the section.',
+    options,
+    signal: new AbortController().signal,
+  };
+}
+
+describe('createWorkflowScriptAgentRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
+      name,
+      source: 'builtInWorkflow',
+      category: 'workflow',
+      path: `/agents/${name}.yml`,
+    }));
+    mocks.selectAvailableDelegationModel.mockResolvedValue('child-model');
+    mocks.assertWorkflowFilesExist.mockResolvedValue(undefined);
+    mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
+    mocks.executeSubagentInBand.mockResolvedValue({
+      executionId: 'bbbbbb222222',
+      result,
+    });
+  });
+
+  it('uses delegation policy and executes a direct in-band child', async () => {
+    const parent = parentContext();
+    const call = invocation({ inputFiles: ['paper.tex'] });
+    const runner = createWorkflowScriptAgentRunner(parent, 'correct');
+
+    await expect(runner(call)).resolves.toBe(result);
+    expect(mocks.requireVisibleAgent).toHaveBeenCalledWith(
+      'workflow',
+      'correct',
+      {
+        workflowAgentKeys: ['builtInWorkflow:correct'],
+        toolUseAgentKeys: ['builtInToolUse:assistant'],
+      },
+    );
+    expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
+      { label: 'Input file', files: ['paper.tex'] },
+    ]);
+    expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
+      parentModel: 'parent-model',
+      agentCategory: 'workflow',
+    });
+    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'correct',
+        parentExecutionId,
+        parentStreamId,
+        signal: call.signal,
+        approvalPromptsUnavailable: true,
+        runtimeUnavailableTools: ['user_question'],
+        configPayload: expect.objectContaining({
+          agent: 'correct',
+          agentSource: 'builtInWorkflow',
+          agentCategory: 'workflow',
+          model: 'child-model',
+          instruction: 'Draft the section.',
+          inputFiles: ['paper.tex'],
+          workingDirectory: '/workspace',
+          delegationAgentScope: {
+            workflowAgentKeys: ['builtInWorkflow:correct'],
+            toolUseAgentKeys: ['builtInToolUse:assistant'],
+          },
+        }),
+      }),
+    );
+  });
+
+  it('honors an explicit agent and binds verified run outputs', async () => {
+    const requested = '/storage/executions/bbbbbb222222/r1/draft.tex';
+    const canonical = '/canonical/executions/bbbbbb222222/r1/draft.tex';
+    mocks.runStorageLocationFromAnyAbsolutePath.mockImplementation((file) =>
+      file === requested ? { kind: 'runStorage' } : undefined,
+    );
+    mocks.resolveChildRunOutput.mockResolvedValue({
+      kind: 'runStorage',
+      absolutePath: canonical,
+      relativePath: 'r1/draft.tex',
+      executionId: 'bbbbbb222222',
+    });
+    const runner = createWorkflowScriptAgentRunner(parentContext(), 'correct');
+
+    await runner(
+      invocation({
+        agentName: 'merge',
+        inputFiles: ['notes.tex', requested],
+      }),
+    );
+
+    expect(mocks.resolveChildRunOutput).toHaveBeenCalledWith(
+      parentExecutionId,
+      requested,
+    );
+    expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
+      { label: 'Input file', files: ['notes.tex'] },
+    ]);
+    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: 'merge',
+        configPayload: expect.objectContaining({
+          inputFiles: ['notes.tex', canonical],
+        }),
+      }),
+    );
+  });
+
+  it('omits declared symlink placeholders from the next child input', async () => {
+    const placeholder = '/storage/executions/bbbbbb222222/r1/unchanged.tex';
+    mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue({
+      kind: 'runStorage',
+    });
+    mocks.resolveChildRunOutput.mockResolvedValue(undefined);
+    const runner = createWorkflowScriptAgentRunner(parentContext(), 'correct');
+
+    await runner(invocation({ inputFiles: [placeholder] }));
+
+    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configPayload: expect.objectContaining({ inputFiles: [] }),
+      }),
+    );
+  });
+});

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -95,6 +95,49 @@ return [a, b]`,
     expect(run.meta.name).toBe('test-flow');
   });
 
+  it('passes typed workflow outputs into the next stage input files', async () => {
+    const outputPath =
+      '/storage/executions/bbbbbb222222/r1/drafted-section.tex';
+    const invocations: WorkflowAgentInvocation[] = [];
+    const run = await runWorkflowScript({
+      script: `${META}
+const drafted = await agent('draft')
+return await agent('merge', {
+  inputFiles: drafted.outputs.map((output) => output.absolutePath),
+})`,
+      runAgent: async (call) => {
+        invocations.push(call);
+        return {
+          category: 'workflow',
+          outcome: 'completed',
+          outputs:
+            call.index === 0
+              ? [
+                  {
+                    round: 1,
+                    relativePath: 'r1/drafted-section.tex',
+                    absolutePath: outputPath,
+                    location: 'runStorage',
+                    originalPath: null,
+                    added: null,
+                    removed: null,
+                  },
+                ]
+              : [],
+          compileFailures: [],
+          diffs: [],
+          cost: 0,
+        };
+      },
+    });
+
+    expect(invocations[1]?.options.inputFiles).toEqual([outputPath]);
+    expect(run.result).toMatchObject({
+      category: 'workflow',
+      outcome: 'completed',
+    });
+  });
+
   it('parallel(): failed thunks resolve to null without aborting siblings', async () => {
     const run = await runWorkflowScript({
       script: `${META}
@@ -352,6 +395,12 @@ return null`,
         runAgent: echoRunner,
       }),
     ).rejects.toThrow(/must be a plain object/);
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('x', { inputFiles: [''] })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/inputFiles.*array of non-empty strings/);
   });
 
   it.each(['schema', 'outputSchema'] as const)(

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -1,8 +1,14 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
+// Standard library imports
+import * as path from 'node:path';
+
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports - platform
+import { FileType, type FileStat } from '@platform/interfaces';
 
 // Local imports
 import { installPlatform } from '@test/support/setupPlatform';
@@ -52,6 +58,32 @@ const streamId = 'stream:accept-run-files' as StreamTabId;
 const workspacePath = '/workspace';
 const storagePath = '/storage';
 
+function runStorageStat(type: number): FileStat {
+  return { type, ctime: 0, mtime: 0, size: 1 };
+}
+
+function setRunStorageEntries(
+  entries: Readonly<Record<string, number>> = {},
+): void {
+  const types = new Map<string, number>([
+    [`executions/${executionId}`, FileType.Directory],
+    ...Object.entries(entries),
+  ]);
+  for (const entry of Object.keys(entries)) {
+    let parent = path.posix.dirname(entry);
+    while (parent !== '.' && parent !== `executions/${executionId}`) {
+      types.set(parent, FileType.Directory);
+      parent = path.posix.dirname(parent);
+    }
+  }
+  StorageFS.exists = async (target) => types.has(target);
+  StorageFS.stat = async (target) => {
+    const type = types.get(target);
+    if (type !== undefined) return runStorageStat(type);
+    throw Object.assign(new Error(`Missing: ${target}`), { code: 'ENOENT' });
+  };
+}
+
 function runAccept(
   tool: AcceptRunFilesTool,
   host: AgentRuntimeHost,
@@ -68,6 +100,7 @@ function runAccept(
 
 describe('accept_run_files progress events', () => {
   let originalStorageExists: typeof StorageFS.exists;
+  let originalStorageStat: typeof StorageFS.stat;
   let originalStorageFullPath: typeof StorageFS.fullPath;
   let originalWorkspaceLocatePath: typeof WorkspaceFS.locatePath;
   let originalWorkspaceExists: typeof WorkspaceFS.exists;
@@ -75,12 +108,12 @@ describe('accept_run_files progress events', () => {
   let originalWorkspaceWrite: typeof WorkspaceFS.write;
   let originalWorkspaceDelete: typeof WorkspaceFS.delete;
   let originalAbsoluteIsFile: typeof AbsoluteFS.isFile;
-  let originalAbsoluteIsSymbolicLink: typeof AbsoluteFS.isSymbolicLink;
   let originalAbsoluteRead: typeof AbsoluteFS.read;
   let originalFlexibleRead: typeof FlexibleFS.read;
 
   beforeEach(async () => {
     originalStorageExists = StorageFS.exists;
+    originalStorageStat = StorageFS.stat;
     originalStorageFullPath = StorageFS.fullPath;
     originalWorkspaceLocatePath = WorkspaceFS.locatePath;
     originalWorkspaceExists = WorkspaceFS.exists;
@@ -88,10 +121,8 @@ describe('accept_run_files progress events', () => {
     originalWorkspaceWrite = WorkspaceFS.write;
     originalWorkspaceDelete = WorkspaceFS.delete;
     originalAbsoluteIsFile = AbsoluteFS.isFile;
-    originalAbsoluteIsSymbolicLink = AbsoluteFS.isSymbolicLink;
     originalAbsoluteRead = AbsoluteFS.read;
     originalFlexibleRead = FlexibleFS.read;
-    AbsoluteFS.isSymbolicLink = async () => false;
     testApprovalHandler = undefined;
     await installTestPlatform();
     cleanupAllApprovals();
@@ -108,6 +139,7 @@ describe('accept_run_files progress events', () => {
 
   afterEach(() => {
     StorageFS.exists = originalStorageExists;
+    StorageFS.stat = originalStorageStat;
     StorageFS.fullPath = originalStorageFullPath;
     WorkspaceFS.locatePath = originalWorkspaceLocatePath;
     WorkspaceFS.exists = originalWorkspaceExists;
@@ -115,7 +147,6 @@ describe('accept_run_files progress events', () => {
     WorkspaceFS.write = originalWorkspaceWrite;
     WorkspaceFS.delete = originalWorkspaceDelete;
     AbsoluteFS.isFile = originalAbsoluteIsFile;
-    AbsoluteFS.isSymbolicLink = originalAbsoluteIsSymbolicLink;
     AbsoluteFS.read = originalAbsoluteRead;
     FlexibleFS.read = originalFlexibleRead;
     testApprovalHandler = undefined;
@@ -135,9 +166,9 @@ describe('accept_run_files progress events', () => {
       },
     );
 
-    StorageFS.exists = async (target) =>
-      target === `executions/${executionId}` ||
-      target === `executions/${executionId}/output.tex`;
+    setRunStorageEntries({
+      [`executions/${executionId}/output.tex`]: FileType.File,
+    });
     WorkspaceFS.exists = async () => false;
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => undefined;
@@ -167,9 +198,9 @@ describe('accept_run_files progress events', () => {
       },
     );
 
-    StorageFS.exists = async (target) =>
-      target === `executions/${executionId}` ||
-      target === `executions/${executionId}/output.tex`;
+    setRunStorageEntries({
+      [`executions/${executionId}/output.tex`]: FileType.File,
+    });
     WorkspaceFS.exists = async () => false;
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => {
@@ -197,7 +228,7 @@ describe('accept_run_files progress events', () => {
     let approvalProposed = '';
     let writes = 0;
 
-    StorageFS.exists = async (target) => target === `executions/${executionId}`;
+    setRunStorageEntries();
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => 'new content';
     WorkspaceFS.write = async () => {
@@ -234,7 +265,7 @@ describe('accept_run_files progress events', () => {
     let approvals = 0;
     let writes = 0;
 
-    StorageFS.exists = async (target) => target === `executions/${executionId}`;
+    setRunStorageEntries();
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => 'same content';
     WorkspaceFS.write = async () => {
@@ -266,18 +297,16 @@ describe('accept_run_files progress events', () => {
     let approvals = 0;
     let writes = 0;
 
-    StorageFS.exists = async (target) =>
-      target === `executions/${executionId}` ||
-      target === `executions/${executionId}/r1/Draft/appendices.tex`;
+    setRunStorageEntries({
+      [`executions/${executionId}/r1/Draft/appendices.tex`]:
+        FileType.SymbolicLink | FileType.File,
+    });
     WorkspaceFS.exists = async () => true;
     WorkspaceFS.read = async () => '';
     WorkspaceFS.write = async () => {
       writes++;
     };
     WorkspaceFS.delete = async () => undefined;
-    AbsoluteFS.isSymbolicLink = async (target) =>
-      target ===
-      `${storagePath}/executions/${executionId}/r1/Draft/appendices.tex`;
     testApprovalHandler = async () => {
       approvals++;
       return { accepted: true };

--- a/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
+++ b/src/test-kernel/agent/storage/ChildRunOutput.vitest.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  clearStoreCache,
+  getExecutionStore,
+  resolveChildRunOutput,
+  type ResultMeta,
+} from '@agent/storage';
+import type { ExecutionId } from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+
+const parentExecutionId = 'aaaaaa111111' as ExecutionId;
+const childExecutionId = 'bbbbbb222222' as ExecutionId;
+const otherParentExecutionId = 'cccccc333333' as ExecutionId;
+const relativePath = 'r1/draft.tex';
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+function completedWorkflowResult(absolutePath: string): ResultMeta {
+  return {
+    producer: 'subagent',
+    agentName: 'draft',
+    wallTimeMs: 10,
+    result: {
+      category: 'workflow',
+      outcome: 'completed',
+      outputs: [
+        {
+          round: 1,
+          relativePath,
+          absolutePath,
+          location: 'runStorage',
+          originalPath: null,
+          added: null,
+          removed: null,
+        },
+      ],
+      compileFailures: [],
+      diffs: [],
+      cost: 0,
+    },
+  };
+}
+
+async function persistCompletedChild(
+  parentId: ExecutionId = parentExecutionId,
+): Promise<string> {
+  const absolutePath = StorageFS.fullPath(
+    `executions/${childExecutionId}/${relativePath}`,
+  );
+  const store = getExecutionStore(childExecutionId);
+  await store.writeMeta({
+    schemaVersion: 1,
+    timestamp: '2026-07-15T00:00:00.000Z',
+    parentExecutionId: parentId,
+    terminalStatus: 'completed',
+    outcome: 'completed',
+  });
+  await store.writeResultMeta(completedWorkflowResult(absolutePath));
+  await StorageFS.ensureDir(`executions/${childExecutionId}/r1`);
+  await StorageFS.write(
+    `executions/${childExecutionId}/${relativePath}`,
+    'draft',
+  );
+  return absolutePath;
+}
+
+describe('resolveChildRunOutput', () => {
+  beforeEach(() => clearStoreCache());
+  afterEach(() => clearStoreCache());
+
+  it('resolves a declared regular output of a completed direct child', async () => {
+    const absolutePath = await persistCompletedChild();
+
+    await expect(
+      resolveChildRunOutput(parentExecutionId, absolutePath),
+    ).resolves.toEqual({
+      kind: 'runStorage',
+      absolutePath,
+      relativePath,
+      executionId: childExecutionId,
+    });
+  });
+
+  it('rejects output references from an unrelated execution tree', async () => {
+    const absolutePath = await persistCompletedChild(otherParentExecutionId);
+
+    await expect(
+      resolveChildRunOutput(parentExecutionId, absolutePath),
+    ).rejects.toThrow('is not a direct child');
+  });
+
+  it('rejects files that are present but absent from the result manifest', async () => {
+    const absolutePath = await persistCompletedChild();
+    const undeclaredPath = absolutePath.replace('draft.tex', 'notes.tex');
+    await StorageFS.write(
+      `executions/${childExecutionId}/r1/notes.tex`,
+      'notes',
+    );
+
+    await expect(
+      resolveChildRunOutput(parentExecutionId, undeclaredPath),
+    ).rejects.toThrow('is not a declared output');
+  });
+
+  it('fails loudly when a declared output has disappeared', async () => {
+    const absolutePath = await persistCompletedChild();
+    await StorageFS.delete(`executions/${childExecutionId}/${relativePath}`);
+
+    await expect(
+      resolveChildRunOutput(parentExecutionId, absolutePath),
+    ).rejects.toThrow('is missing');
+  });
+
+  it('rejects paths outside run storage', async () => {
+    await expect(
+      resolveChildRunOutput(parentExecutionId, '/workspace/draft.tex'),
+    ).rejects.toThrow('not inside task-run storage');
+  });
+});

--- a/src/test-kernel/tools/DelegationAgentScope.vitest.mts
+++ b/src/test-kernel/tools/DelegationAgentScope.vitest.mts
@@ -60,7 +60,7 @@ vi.mock('@agent/index/agentRegistry', () => ({
       : [],
 }));
 
-const { getDelegationAgent, getDelegationAgents } =
+const { getDelegationAgent, getDelegationAgentForScope, getDelegationAgents } =
   await import('@tools/delegationAgentAvailability');
 
 describe('execution-scoped delegation agents', () => {
@@ -80,5 +80,20 @@ describe('execution-scoped delegation agents', () => {
     expect(getDelegationAgents('toolUse')).toEqual([remoteReview]);
     expect(getDelegationAgent('toolUse', 'review')).toBe(remoteReview);
     expect(getDelegationAgent('toolUse', 'custom:review')).toBeUndefined();
+  });
+
+  it('can enforce a captured scope without ambient run context', () => {
+    mocks.context = undefined;
+    const scope = {
+      workflowAgentKeys: [],
+      toolUseAgentKeys: ['remote:review'],
+    };
+
+    expect(getDelegationAgentForScope('toolUse', 'review', scope)).toBe(
+      remoteReview,
+    );
+    expect(
+      getDelegationAgentForScope('toolUse', 'custom:review', scope),
+    ).toBeUndefined();
   });
 });

--- a/src/test-kernel/tools/WorkflowFileValidation.vitest.ts
+++ b/src/test-kernel/tools/WorkflowFileValidation.vitest.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { assertWorkflowFilesExist } from '@tools/delegation/workflowFileValidation';
+import { WorkspaceFS } from '@utils/files';
+
+const originalExists = WorkspaceFS.exists;
+
+describe('assertWorkflowFilesExist', () => {
+  beforeEach(() => {
+    WorkspaceFS.exists = async (file) => file !== 'missing.tex';
+  });
+
+  afterEach(() => {
+    WorkspaceFS.exists = originalExists;
+  });
+
+  it('accepts present files across all workflow input groups', async () => {
+    await expect(
+      assertWorkflowFilesExist([
+        { label: 'Input file', files: ['paper.tex'] },
+        { label: 'Context file', files: ['notes.md'] },
+        { label: 'Media file', files: ['figure.pdf'] },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reports the first missing file with its group label', async () => {
+    await expect(
+      assertWorkflowFilesExist([
+        { label: 'Input file', files: ['paper.tex', 'missing.tex'] },
+        { label: 'Context file', files: ['notes.md'] },
+      ]),
+    ).rejects.toThrow('Input file not found: missing.tex');
+  });
+});

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -1,16 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { FileType, type FileStat } from '@platform/interfaces';
+import { setupPlatform } from '@test/support/setupPlatform';
 import type { ExecutionId } from '@shared/schemas';
 import { StorageFS } from '@utils/files';
 import {
   inspectRunStorageEntry,
   runStorageLocationFromAnyAbsolutePath,
+  TaskRunFileService,
 } from '@utils/files/taskRunStorage';
 
 const executionId = 'abcdef123456' as ExecutionId;
 const originalStat = StorageFS.stat;
 const originalFullPath = StorageFS.fullPath;
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
 
 function fileStat(type: number): FileStat {
   return { type, ctime: 0, mtime: 0, size: 1 };
@@ -190,5 +194,31 @@ describe('inspectRunStorageEntry', () => {
     expect(
       runStorageLocationFromAnyAbsolutePath('/workspace/result.tex'),
     ).toBeUndefined();
+  });
+
+  it('preserves source provenance instead of treating workspace inputs as outputs', () => {
+    const fileService = new TaskRunFileService(executionId);
+
+    expect(fileService.locateSource('draft.tex')).toEqual({
+      kind: 'workspace',
+      absolutePath: '/workspace/draft.tex',
+      relativePath: 'draft.tex',
+    });
+    expect(
+      fileService.locateSource(
+        `/storage/executions/${executionId}/r1/draft.tex`,
+      ),
+    ).toMatchObject({
+      kind: 'runStorage',
+      executionId,
+      relativePath: 'r1/draft.tex',
+    });
+    expect(
+      fileService.locateSource(`/storage/taskRuns/${executionId}/legacy.tex`),
+    ).toMatchObject({
+      kind: 'runStorage',
+      executionId,
+      relativePath: 'legacy.tex',
+    });
   });
 });

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { FileType, type FileStat } from '@platform/interfaces';
+import type { ExecutionId } from '@shared/schemas';
+import { StorageFS } from '@utils/files';
+import {
+  inspectRunStorageEntry,
+  runStorageLocationFromAnyAbsolutePath,
+} from '@utils/files/taskRunStorage';
+
+const executionId = 'abcdef123456' as ExecutionId;
+const originalStat = StorageFS.stat;
+const originalFullPath = StorageFS.fullPath;
+
+function fileStat(type: number): FileStat {
+  return { type, ctime: 0, mtime: 0, size: 1 };
+}
+
+function missing(target: string): Error {
+  return Object.assign(new Error(`Missing: ${target}`), { code: 'ENOENT' });
+}
+
+describe('inspectRunStorageEntry', () => {
+  beforeEach(() => {
+    StorageFS.fullPath = (target) => `/storage/${target}`;
+  });
+
+  afterEach(() => {
+    StorageFS.stat = originalStat;
+    StorageFS.fullPath = originalFullPath;
+  });
+
+  it('returns a canonical location for a regular primary-layout file', async () => {
+    StorageFS.stat = async (target) => {
+      if (target === `executions/${executionId}/r1/draft.tex`) {
+        return fileStat(FileType.File);
+      }
+      if (
+        target === `executions/${executionId}` ||
+        target === `executions/${executionId}/r1`
+      ) {
+        return fileStat(FileType.Directory);
+      }
+      throw missing(target);
+    };
+
+    await expect(
+      inspectRunStorageEntry(executionId, 'r1\\draft.tex'),
+    ).resolves.toEqual({
+      kind: 'file',
+      location: {
+        kind: 'runStorage',
+        absolutePath: `/storage/executions/${executionId}/r1/draft.tex`,
+        relativePath: 'r1/draft.tex',
+        executionId,
+      },
+    });
+  });
+
+  it('falls back to the legacy layout only when the primary entry is absent', async () => {
+    StorageFS.stat = async (target) => {
+      if (target === `taskRuns/${executionId}/result.tex`) {
+        return fileStat(FileType.File);
+      }
+      if (target === `taskRuns/${executionId}`) {
+        return fileStat(FileType.Directory);
+      }
+      throw missing(target);
+    };
+
+    const result = await inspectRunStorageEntry(executionId, 'result.tex');
+
+    expect(result).toMatchObject({
+      kind: 'file',
+      location: {
+        absolutePath: `/storage/taskRuns/${executionId}/result.tex`,
+      },
+    });
+  });
+
+  it.each([
+    { type: FileType.SymbolicLink | FileType.File, kind: 'symlink' },
+    { type: FileType.Directory, kind: 'directory' },
+    { type: FileType.Unknown, kind: 'unsupported' },
+  ] as const)(
+    'classifies a non-bindable entry as $kind',
+    async ({ type, kind }) => {
+      StorageFS.stat = async () => fileStat(type);
+
+      await expect(
+        inspectRunStorageEntry(executionId, 'result.tex'),
+      ).resolves.toMatchObject({ kind });
+    },
+  );
+
+  it('distinguishes missing entries from invalid paths', async () => {
+    StorageFS.stat = async (target) => {
+      throw missing(target);
+    };
+
+    await expect(
+      inspectRunStorageEntry(executionId, 'missing.tex'),
+    ).resolves.toEqual({ kind: 'missing' });
+    await expect(
+      inspectRunStorageEntry(executionId, '../outside.tex'),
+    ).resolves.toMatchObject({ kind: 'invalid' });
+    await expect(
+      inspectRunStorageEntry(executionId, '/outside.tex'),
+    ).resolves.toMatchObject({ kind: 'invalid' });
+  });
+
+  it('rejects a regular file reached through an ancestor symlink', async () => {
+    StorageFS.stat = async (target) => {
+      if (target.endsWith('/link/result.tex')) {
+        return fileStat(FileType.File);
+      }
+      if (target === `executions/${executionId}`) {
+        return fileStat(FileType.Directory);
+      }
+      if (target === `executions/${executionId}/r1`) {
+        return fileStat(FileType.Directory);
+      }
+      if (target === `executions/${executionId}/r1/link`) {
+        return fileStat(FileType.SymbolicLink | FileType.Directory);
+      }
+      throw missing(target);
+    };
+
+    await expect(
+      inspectRunStorageEntry(executionId, 'r1/link/result.tex'),
+    ).resolves.toMatchObject({
+      kind: 'symlink',
+      absolutePath: `/storage/executions/${executionId}/r1/link`,
+    });
+  });
+
+  it('rejects a dangling ancestor symlink before treating the leaf as missing', async () => {
+    const inspected: string[] = [];
+    StorageFS.stat = async (target) => {
+      inspected.push(target);
+      if (target === `executions/${executionId}`) {
+        return fileStat(FileType.Directory);
+      }
+      if (target === `executions/${executionId}/dangling`) {
+        return fileStat(FileType.SymbolicLink | FileType.Unknown);
+      }
+      throw missing(target);
+    };
+
+    await expect(
+      inspectRunStorageEntry(executionId, 'dangling/result.tex'),
+    ).resolves.toMatchObject({
+      kind: 'symlink',
+      absolutePath: `/storage/executions/${executionId}/dangling`,
+    });
+    expect(inspected).not.toContain(
+      `executions/${executionId}/dangling/result.tex`,
+    );
+  });
+
+  it('does not turn storage permission failures into a missing entry', async () => {
+    StorageFS.stat = async () => {
+      throw Object.assign(new Error('Denied'), { code: 'EACCES' });
+    };
+
+    await expect(
+      inspectRunStorageEntry(executionId, 'result.tex'),
+    ).rejects.toThrow('Denied');
+  });
+
+  it('recovers execution identity from current and legacy absolute paths', () => {
+    expect(
+      runStorageLocationFromAnyAbsolutePath(
+        `/storage/executions/${executionId}/r2/result.tex`,
+      ),
+    ).toMatchObject({
+      kind: 'runStorage',
+      executionId,
+      relativePath: 'r2/result.tex',
+    });
+    expect(
+      runStorageLocationFromAnyAbsolutePath(
+        `/storage/taskRuns/${executionId}/result.tex`,
+      ),
+    ).toMatchObject({
+      kind: 'runStorage',
+      executionId,
+      relativePath: 'result.tex',
+    });
+    expect(
+      runStorageLocationFromAnyAbsolutePath('/workspace/result.tex'),
+    ).toBeUndefined();
+  });
+});

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -45,10 +45,8 @@ import { defineTool } from '@tools/core/define';
 // Local imports - utils
 import {
   AbsoluteFS,
-  StorageFS,
   WorkspaceFS,
   FlexibleFS,
-  createRunStorageLocation,
   createWorkspaceLocation,
 } from '@utils/files';
 import { filterNotNull } from '@utils/core';
@@ -56,6 +54,7 @@ import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import {
   findExistingRunStoragePath,
   getOriginalSnapshotPath,
+  inspectRunStorageEntry,
 } from '@utils/files/taskRunStorage';
 
 // ============================================================================
@@ -161,7 +160,6 @@ Optional:
         const { sourceAbsolute, sourceLocation } = await this.resolveSourceFile(
           executionId,
           mapping.path,
-          runDirExists,
         );
 
         const destPath = mapping.original ?? mapping.path;
@@ -339,29 +337,28 @@ Optional:
    * files are written directly to the workspace.
    */
   private async resolveSourceFile(
-    executionId: string,
+    executionId: ExecutionId,
     runPath: string,
-    runDirExists: boolean,
   ): Promise<{ sourceAbsolute: string; sourceLocation: FileLocation }> {
-    // Try run storage first (primary then legacy)
-    if (runDirExists) {
-      const rel = await findExistingRunStoragePath(executionId, runPath);
-      if (rel) {
-        const abs = StorageFS.fullPath(rel);
-        // Symlinks in run storage mean the round didn't emit the file —
-        // it's a stand-in for the `original/` snapshot (or, on pre-fix
-        // runs, the live workspace). Promoting that to the workspace would
-        // propagate non-agent content as if it were agent output.
-        if (await AbsoluteFS.isSymbolicLink(abs)) {
-          throw new ToolError(
-            `Cannot accept ${runPath} from run ${executionId}: the run-storage entry is a symlink, meaning this round did not emit the file. Accepting it would propagate snapshot or workspace content rather than agent output.`,
-          );
-        }
-        return {
-          sourceAbsolute: abs,
-          sourceLocation: createRunStorageLocation(abs, runPath, executionId),
-        };
-      }
+    const entry = await inspectRunStorageEntry(executionId, runPath);
+    if (entry.kind === 'file') {
+      return {
+        sourceAbsolute: entry.location.absolutePath,
+        sourceLocation: entry.location,
+      };
+    }
+    if (entry.kind === 'symlink') {
+      throw new ToolError(
+        `Cannot accept ${runPath} from run ${executionId}: the run-storage entry is a symlink, meaning this round did not emit the file. Accepting it would propagate snapshot or workspace content rather than agent output.`,
+      );
+    }
+    if (entry.kind === 'directory' || entry.kind === 'unsupported') {
+      throw new ToolError(
+        `Cannot accept ${runPath} from run ${executionId}: the run-storage entry is not a regular file.`,
+      );
+    }
+    if (entry.kind === 'invalid') {
+      throw new ToolError(`Cannot accept ${runPath}: ${entry.reason}`);
     }
 
     // Fall back to workspace

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -50,9 +50,7 @@ import { requireRunStream } from '@tools/contextHelpers';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utils
-import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { isNonEmptyString } from '@utils/text/stringUtils';
 
 // Local imports - delegation
 import {
@@ -68,6 +66,7 @@ import {
   WorkflowAgentInputSchema,
   type WorkflowAgentInput,
 } from './delegation/inputFields';
+import { assertWorkflowFilesExist } from './delegation/workflowFileValidation';
 
 export { rejectOversizedBibAttachments } from './delegation/inputFields';
 export type { WorkflowAgentInput };
@@ -144,31 +143,11 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
       agentCategory: AgentCategory.Workflow,
     });
 
-    // Validate all file paths exist (parallel for performance)
-    const toValidate = (
-      arr: string[],
-      label: string,
-    ): { path: string; label: string }[] =>
-      arr.filter(isNonEmptyString).map((path) => ({ path, label }));
-
-    const filesToValidate = [
-      ...toValidate(input.inputFiles, 'Input file'),
-      ...toValidate(input.contextFiles, 'Context file'),
-      ...toValidate(input.mediaFiles, 'Media file'),
-    ];
-
-    const validationResults = await Promise.all(
-      filesToValidate.map(async ({ path, label }) => ({
-        path,
-        label,
-        exists: await WorkspaceFS.exists(path),
-      })),
-    );
-
-    const missing = validationResults.find((r) => !r.exists);
-    if (missing) {
-      throw new Error(`${missing.label} not found: ${missing.path}`);
-    }
+    await assertWorkflowFilesExist([
+      { label: 'Input file', files: input.inputFiles },
+      { label: 'Context file', files: input.contextFiles },
+      { label: 'Media file', files: input.mediaFiles },
+    ]);
 
     const oversizedBibRejection = await rejectOversizedBibAttachments(input);
     if (oversizedBibRejection) return oversizedBibRejection;

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -24,6 +24,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
+import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import {
   isApprovalBypassedForStream,
   proposalApprovals,
@@ -34,7 +35,9 @@ import {
 } from '@tools/delegationModelAvailability';
 import {
   getDelegationAgent,
+  getDelegationAgentForScope,
   getDelegationAgents,
+  getDelegationAgentsForScope,
 } from '@tools/delegationAgentAvailability';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -69,10 +72,17 @@ export async function selectAvailableDelegationModel(input: {
 export function requireVisibleAgent(
   category: AgentCategory,
   name: string,
+  scope?: AgentDelegationScope,
 ): AgentEntry {
-  const agent = getDelegationAgent(category, name);
+  const agent = scope
+    ? getDelegationAgentForScope(category, name, scope)
+    : getDelegationAgent(category, name);
   if (agent) return agent;
-  const available = getDelegationAgents(category)
+  const available = (
+    scope
+      ? getDelegationAgentsForScope(category, scope)
+      : getDelegationAgents(category)
+  )
     .map((a) => a.name)
     .join(', ');
   throw new Error(

--- a/src/tools/delegation/workflowFileValidation.ts
+++ b/src/tools/delegation/workflowFileValidation.ts
@@ -1,0 +1,26 @@
+import { WorkspaceFS } from '@utils/files';
+import { isNonEmptyString } from '@utils/text/stringUtils';
+
+export interface WorkflowFileGroup {
+  readonly label: string;
+  readonly files: readonly string[];
+}
+
+/** Validate workspace-backed workflow inputs before launching a child run. */
+export async function assertWorkflowFilesExist(
+  groups: readonly WorkflowFileGroup[],
+): Promise<void> {
+  const entries = groups.flatMap(({ label, files }) =>
+    files.filter(isNonEmptyString).map((path) => ({ label, path })),
+  );
+  const inspected = await Promise.all(
+    entries.map(async (entry) => ({
+      ...entry,
+      exists: await WorkspaceFS.exists(entry.path),
+    })),
+  );
+  const missing = inspected.find((entry) => !entry.exists);
+  if (missing) {
+    throw new Error(`${missing.label} not found: ${missing.path}`);
+  }
+}

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -1,0 +1,107 @@
+import { resolveChildRunOutput } from '@agent/storage';
+import type {
+  WorkflowAgentRunner,
+  WorkflowAgentInvocation,
+} from '@agent/workflowScript';
+import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import type { LaunchRunContext } from '@agent/runtime/RunContext';
+import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@shared/schemas';
+import { filterNotNullish } from '@utils/core';
+import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/taskRunStorage';
+
+import { executeSubagentInBand } from './inBandSubagentExecution';
+import {
+  requireVisibleAgent,
+  selectAvailableDelegationModel,
+} from './proposalFlow';
+import { assertWorkflowFilesExist } from './workflowFileValidation';
+
+async function resolveInvocationInputFiles(
+  parentExecutionId: LaunchRunContext['runScope']['executionId'],
+  files: readonly string[],
+): Promise<string[]> {
+  const references = files.map((file) => ({
+    file,
+    runStorage: runStorageLocationFromAnyAbsolutePath(file) !== undefined,
+  }));
+  const workspaceFiles = references
+    .filter((reference) => !reference.runStorage)
+    .map((reference) => reference.file);
+  await assertWorkflowFilesExist([
+    { label: 'Input file', files: workspaceFiles },
+  ]);
+  const resolved = await Promise.all(
+    references.map(async ({ file, runStorage }) => {
+      if (!runStorage) return file;
+      return (await resolveChildRunOutput(parentExecutionId, file))
+        ?.absolutePath;
+    }),
+  );
+  return resolved.filter(filterNotNullish);
+}
+
+function inputFilesFrom(
+  invocation: WorkflowAgentInvocation,
+): readonly string[] {
+  return invocation.options.inputFiles ?? [];
+}
+
+/** Build the production `agent()` adapter for one workflow-script run. */
+export function createWorkflowScriptAgentRunner(
+  parent: LaunchRunContext,
+  defaultAgentName: string,
+): WorkflowAgentRunner {
+  const { runScope } = parent;
+  const recordSubagentCost =
+    getCurrentToolCallContext()?.hooks?.recordSubagentCost;
+
+  return async (invocation) => {
+    const requestedAgent = invocation.options.agentName ?? defaultAgentName;
+    const agent = requireVisibleAgent(
+      AgentCategory.Workflow,
+      requestedAgent,
+      runScope.delegationAgentScope ?? undefined,
+    );
+    const [model, inputFiles] = await Promise.all([
+      selectAvailableDelegationModel({
+        parentModel: parent.model,
+        agentCategory: AgentCategory.Workflow,
+      }),
+      resolveInvocationInputFiles(
+        runScope.executionId,
+        inputFilesFrom(invocation),
+      ),
+    ]);
+    const configPayload: AgentConfigPayload = {
+      agent: agent.name,
+      agentSource: agent.source,
+      agentCategory: AgentCategory.Workflow,
+      model,
+      instruction: invocation.prompt,
+      inputFiles,
+      ...(runScope.workingDirectory !== undefined && {
+        workingDirectory: runScope.workingDirectory,
+      }),
+      ...(runScope.delegationAgentScope && {
+        delegationAgentScope: runScope.delegationAgentScope,
+      }),
+    };
+
+    const { result } = await executeSubagentInBand({
+      configPayload,
+      agentName: agent.name,
+      parentExecutionId: runScope.executionId,
+      parentStreamId: runScope.streamId,
+      runtimeHost: runScope.runtimeHost,
+      session: runScope.session,
+      signal: invocation.signal,
+      approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
+      runtimeUnavailableTools: parent.runtimeUnavailableTools,
+      ...(recordSubagentCost && {
+        onCost: (cost: number | undefined) => recordSubagentCost(cost ?? 0),
+      }),
+    });
+    return result;
+  };
+}

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -1,8 +1,5 @@
 import { resolveChildRunOutput } from '@agent/storage';
-import type {
-  WorkflowAgentRunner,
-  WorkflowAgentInvocation,
-} from '@agent/workflowScript';
+import type { WorkflowAgentRunner } from '@agent/workflowScript';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
@@ -41,12 +38,6 @@ async function resolveInvocationInputFiles(
   return resolved.filter(filterNotNullish);
 }
 
-function inputFilesFrom(
-  invocation: WorkflowAgentInvocation,
-): readonly string[] {
-  return invocation.options.inputFiles ?? [];
-}
-
 /** Build the production `agent()` adapter for one workflow-script run. */
 export function createWorkflowScriptAgentRunner(
   parent: LaunchRunContext,
@@ -70,7 +61,7 @@ export function createWorkflowScriptAgentRunner(
       }),
       resolveInvocationInputFiles(
         runScope.executionId,
-        inputFilesFrom(invocation),
+        invocation.options.inputFiles ?? [],
       ),
     ]);
     const configPayload: AgentConfigPayload = {

--- a/src/tools/delegationAgentAvailability.ts
+++ b/src/tools/delegationAgentAvailability.ts
@@ -88,13 +88,19 @@ export function getDelegationAgents(category: AgentCategory): AgentEntry[] {
   return resolveDelegationScopeAgents(activeDelegationScope(), category);
 }
 
-export function getDelegationAgent(
+/** Resolve delegation targets from an explicitly captured run scope. */
+export function getDelegationAgentsForScope(
+  category: AgentCategory,
+  scope: AgentDelegationScope,
+): AgentEntry[] {
+  return resolveDelegationScopeAgents(scope, category);
+}
+
+function findDelegationAgent(
+  agents: readonly AgentEntry[],
   category: AgentCategory,
   identifier: string,
 ): AgentEntry | undefined {
-  const scope = activeDelegationScope();
-  if (!scope) return getWorkspaceVisibleAgent(category, identifier);
-  const agents = getDelegationAgents(category);
   const exact = findAgentByIdentifier(agents, identifier);
   if (exact) return exact;
   const alias = getAgent(identifier, category);
@@ -103,6 +109,28 @@ export function getDelegationAgent(
     agents,
     identifier.includes(':') ? agentKeyOf(alias) : alias.name,
   );
+}
+
+/** Resolve one target from an explicitly captured run scope. */
+export function getDelegationAgentForScope(
+  category: AgentCategory,
+  identifier: string,
+  scope: AgentDelegationScope,
+): AgentEntry | undefined {
+  return findDelegationAgent(
+    getDelegationAgentsForScope(category, scope),
+    category,
+    identifier,
+  );
+}
+
+export function getDelegationAgent(
+  category: AgentCategory,
+  identifier: string,
+): AgentEntry | undefined {
+  const scope = activeDelegationScope();
+  if (!scope) return getWorkspaceVisibleAgent(category, identifier);
+  return getDelegationAgentForScope(category, identifier, scope);
 }
 
 /**

--- a/src/utils/files/runStorageFs.ts
+++ b/src/utils/files/runStorageFs.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs';
 
 import {
   resolveExistingRunStoragePath,
+  resolveLegacyRunStoragePath,
   resolveRunOriginalSnapshotPath,
   resolveRunStoragePath,
   resolveRunStorageRelativePath,
@@ -11,10 +12,15 @@ import {
 } from '@platform/defaults/workspaceStorage';
 import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { type ExecutionId, type RunStorageFileLocation } from '@shared/schemas';
+import {
+  ExecutionIdSchema,
+  type ExecutionId,
+  type RunStorageFileLocation,
+} from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { createRunStorageLocation } from './fileLocation';
+import { isDirectory, isFile, isSymlink } from './fsEntryType';
 import { StorageFS } from './storageFS';
 
 export const CHANNEL = 'taskRunStorage';
@@ -46,6 +52,109 @@ export async function findRunDir(id: ExecutionId): Promise<string | undefined> {
   return rel ? StorageFS.fullPath(rel) : undefined;
 }
 
+export type RunStorageEntryInspection =
+  | { readonly kind: 'file'; readonly location: RunStorageFileLocation }
+  | {
+      readonly kind: 'symlink' | 'directory' | 'unsupported';
+      readonly absolutePath: string;
+    }
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'invalid'; readonly reason: string };
+
+async function storageEntryType(target: string): Promise<number | undefined> {
+  try {
+    return (await StorageFS.stat(target)).type;
+  } catch (error) {
+    if (isFileNotFoundError(error)) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Inspect one execution-relative run-storage entry without following a
+ * workspace-mirror symlink. Primary storage takes precedence over the legacy
+ * layout, matching {@link findExistingRunStoragePath}.
+ */
+export async function inspectRunStorageEntry(
+  executionId: ExecutionId,
+  relativePath: string,
+): Promise<RunStorageEntryInspection> {
+  const posixPath = relativePath.replaceAll('\\', '/');
+  const pathSegments = getPathSegments(posixPath);
+  if (
+    pathSegments.length === 0 ||
+    path.posix.isAbsolute(posixPath) ||
+    path.win32.isAbsolute(relativePath) ||
+    pathSegments.includes('..')
+  ) {
+    return {
+      kind: 'invalid',
+      reason:
+        'Run-storage paths must be non-empty relative paths without parent traversal.',
+    };
+  }
+  const normalizedPath = path.posix.normalize(posixPath);
+
+  const candidates = [
+    {
+      entry: resolveRunStoragePath(executionId, normalizedPath),
+      root: resolveRunStoragePath(executionId),
+    },
+    {
+      entry: resolveLegacyRunStoragePath(executionId, normalizedPath),
+      root: resolveLegacyRunStoragePath(executionId),
+    },
+  ];
+  for (const candidate of candidates) {
+    const ancestors = [candidate.root];
+    let ancestorPath = candidate.root;
+    for (const segment of pathSegments.slice(0, -1)) {
+      ancestorPath = path.join(ancestorPath, segment);
+      ancestors.push(ancestorPath);
+    }
+    let missingAncestor = false;
+    for (const ancestor of ancestors) {
+      const ancestorType = await storageEntryType(ancestor);
+      if (ancestorType === undefined) {
+        missingAncestor = true;
+        break;
+      }
+      if (isSymlink(ancestorType)) {
+        return {
+          kind: 'symlink',
+          absolutePath: StorageFS.fullPath(ancestor),
+        };
+      }
+      if (!isDirectory(ancestorType)) {
+        return {
+          kind: 'unsupported',
+          absolutePath: StorageFS.fullPath(ancestor),
+        };
+      }
+    }
+    if (missingAncestor) continue;
+
+    const type = await storageEntryType(candidate.entry);
+    if (type === undefined) continue;
+    const absolutePath = StorageFS.fullPath(candidate.entry);
+    if (isSymlink(type)) return { kind: 'symlink', absolutePath };
+    if (isFile(type)) {
+      return {
+        kind: 'file',
+        location: createRunStorageLocation(
+          absolutePath,
+          normalizedPath,
+          executionId,
+        ),
+      };
+    }
+    if (isDirectory(type)) return { kind: 'directory', absolutePath };
+    return { kind: 'unsupported', absolutePath };
+  }
+
+  return { kind: 'missing' };
+}
+
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
   await StorageFS.ensureDir(RUNS_STORAGE_DIR);
   await StorageFS.ensureDir(resolveRunStoragePath(id));
@@ -69,6 +178,35 @@ export function runStorageLocationFromAbsolutePath(
   );
   if (!relativePath) return undefined;
   return createRunStorageLocation(absolutePath, relativePath, executionId);
+}
+
+/** Recover execution identity from an absolute path in either run layout. */
+export function runStorageLocationFromAnyAbsolutePath(
+  absolutePath: string,
+): RunStorageFileLocation | undefined {
+  if (!path.isAbsolute(absolutePath)) return undefined;
+
+  const roots = [
+    StorageFS.fullPath(resolveRunStoragePath()),
+    StorageFS.fullPath(resolveLegacyRunStoragePath()),
+  ];
+  for (const root of roots) {
+    const runRelativePath = resolveRunStorageRelativePath(absolutePath, root);
+    if (!runRelativePath) continue;
+
+    const [rawExecutionId, ...entrySegments] = getPathSegments(runRelativePath);
+    const executionId = ExecutionIdSchema.safeParse(rawExecutionId);
+    if (!executionId.success || entrySegments.length === 0) return undefined;
+
+    const relativePath = entrySegments.join('/');
+    return createRunStorageLocation(
+      path.resolve(root, runRelativePath),
+      relativePath,
+      executionId.data,
+    );
+  }
+
+  return undefined;
 }
 
 export async function ensureParentDir(filePath: string): Promise<void> {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -14,6 +14,7 @@ import {
   createExternalLocation,
   createRunStorageLocation,
   createWorkspaceLocation,
+  pathToLocation,
 } from './fileLocation';
 import {
   CHANNEL,
@@ -218,6 +219,14 @@ export class TaskRunFileService {
     return createWorkspaceLocation(
       resolved.absolutePath,
       resolved.relativePath,
+    );
+  }
+
+  /** Preserve the storage provenance of an existing input or comparison base. */
+  public locateSource(inputPath: string): FileLocation {
+    return (
+      runStorageLocationFromAnyAbsolutePath(inputPath) ??
+      pathToLocation(inputPath)
     );
   }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -23,6 +23,8 @@ import {
   getRunDir,
   getOriginalSnapshotPath,
   getRunStorageAbsolutePath,
+  inspectRunStorageEntry,
+  runStorageLocationFromAnyAbsolutePath,
   shouldSkipRelocation,
   snapshotExists,
 } from './runStorageFs';
@@ -46,7 +48,10 @@ export {
   getRunDir,
   findRunDir,
   findExistingRunStoragePath,
+  inspectRunStorageEntry,
+  runStorageLocationFromAnyAbsolutePath,
   runStorageLocationFromAbsolutePath,
+  type RunStorageEntryInspection,
 } from './runStorageFs';
 
 logger.initialize(CHANNEL);
@@ -188,6 +193,9 @@ export class TaskRunFileService {
 
   /** Create a FileLocation for a workflow output file. */
   public createLocation(inputPath: string): FileLocation {
+    const runStorageLocation = runStorageLocationFromAnyAbsolutePath(inputPath);
+    if (runStorageLocation) return runStorageLocation;
+
     const resolved = WorkspaceFS.locatePath(inputPath);
 
     if (resolved.kind === 'external') {


### PR DESCRIPTION
## Summary

Bind workflow-script stage outputs to later subagent invocations through the persisted child-run manifest. The production runner now returns the typed `AgentFinalResult`, validates ordinary workspace inputs through one shared helper, and resolves run-storage inputs only when a completed direct child declared the exact output path.

The resolver treats an absolute path as a lookup token rather than authority. It checks the execution root, every ancestor, and the leaf before use; symlink placeholders are skipped, while undeclared, missing, or non-file outputs fail explicitly. Reflection flows now preserve run-storage provenance instead of relabelling every absolute input as a workspace file.

## Issue acceptance gates

Partial progress on #7154.

- [x] Output-manifest file hand-off through run storage.
- [x] The production workflow-script adapter uses typed in-band child results and propagates cancellation/runtime context.
- [ ] Script and journal persistence for restart recovery remains outside this PR.
- [ ] Progress events on the existing stream tree remains outside this PR.
- [ ] The opt-in `delegate_workflow_script` tool remains outside this PR.

## Single source of truth

`resolveChildRunOutput` owns authorization of a child output for parent reuse. The persisted direct-parent relation and completed result manifest determine whether a path may be consumed; filesystem path shape alone does not.

`inspectRunStorageEntry` owns run-storage entry classification across current and legacy layouts, including ancestor-symlink rejection.

## Duplication and abstraction budget

`assertWorkflowFilesExist` replaces duplicate workspace input validation in direct delegation and workflow-script execution. The new child-output resolver is a boundary module rather than a pass-through layer: it combines lineage, completion, manifest, path-layout, and filesystem checks behind one narrow operation.

Delegation roster lookup now accepts the captured execution scope explicitly, preventing child selection from depending on ambient async context.

## Net elements (R6)

- Files: 7 added, 14 modified, 0 deleted.
- Lines: 1,134 added, 106 deleted; net +1,028, primarily focused tests.
- Exported API: 9 distinct symbols added; no exported symbol removed.
- Constructs: 1 interface and 1 discriminated-union type added; no class or enum added.

## Consumer counts (R8)

n/a. This PR does not delete or reroute an event key or subscriber path.

## Host impact

Extension: No new visible command or default agent behavior. Future workflow-script callers can consume authorized child outputs without workspace symlink placeholders.

Desktop: Same host-neutral runner and storage behavior; no new visible entry point.

CLI: Same host-neutral runner and storage behavior; no new visible entry point.

## Scheduled refactoring

#7154 retains the restart-persistence, progress-bridge, and opt-in tool work.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm test` (6,285 passed, 4 skipped; 697 files passed, 1 skipped)
- `npm run check:dead-code-ratchet`
- Focused workflow-script, storage, delegation-scope, reflection-provenance, and acceptance tests (83 passed)
- Independent review of manifest authority, lineage, roster scope, symlink handling, and error paths; no remaining findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation input resolution and run-storage acceptance with manifest/lineage checks; mistakes could block valid hand-offs or accept wrong files, but symlink and undeclared-output paths fail explicitly.
> 
> **Overview**
> Adds **in-band file hand-off** between workflow-script stages: a later `agent()` call can pass prior child run-storage outputs as `inputFiles`, validated against persisted lineage and the completed workflow result manifest—not raw path trust.
> 
> **`resolveChildRunOutput`** is the authorization gate (direct parent, completed subagent workflow, declared manifest path, regular file vs symlink placeholder). **`createWorkflowScriptAgentRunner`** wires production `runAgent` through in-band subagent execution, resolves workspace vs run-storage inputs, and returns typed **`AgentFinalResult`**.
> 
> **Run-storage inspection** is centralized in **`inspectRunStorageEntry`** and **`runStorageLocationFromAnyAbsolutePath`** (primary/legacy layouts, ancestor symlinks). Reflection flows use **`TaskRunFileService.locateSource`** so base files keep workspace vs run-storage provenance. **`accept_run_files`** and **`delegate_workflow`** adopt the same helpers; workspace input checks move to shared **`assertWorkflowFilesExist`**. Delegation roster lookup can use an **explicit captured scope** (`getDelegationAgentForScope`) instead of ambient async context.
> 
> Workflow scripts now require **non-empty** `inputFiles` strings. Docs/tests cover the runner, resolver, and inspection paths. Journal persistence, progress bridging, and `delegate_workflow_script` remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d262c8cb39a42954ae84fc952c2d0852708afce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->