### PR TITLE
refactor: simplify agent creator orchestration

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -9,7 +9,7 @@ import {
   type AgentCreatorUI,
   type CreatorConfig,
   TOOL_GROUPS,
-  createAgentCreatorFlow,
+  runAgentCreator,
 } from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
 import { renderAgentTemplateString } from '@agent/templates/agentTemplateRenderer';
 import { settleQuickInput } from '@commands/_shared/quickInputUtils';
@@ -227,8 +227,7 @@ export async function handleCreateAgentWithAI(
 ): Promise<void> {
   try {
     const config = await loadCreatorConfig(context);
-    const flow = createAgentCreatorFlow(buildVSCodeUI());
-    await flow.run({ config, category });
+    await runAgentCreator(config, category, buildVSCodeUI());
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to create agent', err);
   }

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -1,10 +1,9 @@
 import * as path from 'node:path';
 
 import * as nunjucks from 'nunjucks';
+import pRetry from 'p-retry';
 import { z } from 'zod';
 
-import { Node, Flow } from '@agent/node';
-import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
   AgentWorkflowSettingSchema,
   AgentToolUseSettingSchema,
@@ -50,16 +49,6 @@ interface AgentBlueprint {
   aiVars: Record<string, string>;
   fallbackTemplate: string;
   fallbackVars: Record<string, string>;
-}
-
-/** Mutable shared state flowing through the agent creation flow. */
-export interface AgentCreatorShared {
-  config: CreatorConfig;
-  category: AgentCategory;
-  agentName?: string;
-  description?: string;
-  blueprint?: AgentBlueprint;
-  yamlContent?: string;
 }
 
 export interface ToolGroup {
@@ -183,7 +172,7 @@ export function suggestToolGroups(description: string): string[] {
 
 /**
  * All host-specific operations injected by the VS Code command layer.
- * Allows the flow and nodes to run without importing vscode.
+ * Keeps the creation workflow independent of VS Code.
  */
 export interface AgentCreatorUI {
   promptAgentName(categoryLabel: string): Promise<string | undefined>;
@@ -237,272 +226,180 @@ function getSchemaReference(category: AgentCategory): string {
 }
 
 function buildSchemaRef(settingsSchema: z.ZodObject<z.ZodRawShape>): string {
+  const schemaOptions = {
+    target: 'draft-2020-12',
+    unrepresentable: 'any',
+    io: 'input',
+  } as const;
   return [
     '## Agent YAML Schema (JSON Schema)',
     '',
     '### settings',
-    JSON.stringify(z.toJSONSchema(settingsSchema), null, 2),
+    JSON.stringify(z.toJSONSchema(settingsSchema, schemaOptions), null, 2),
     '',
     '### prompts',
-    JSON.stringify(z.toJSONSchema(AgentPromptSchema), null, 2),
+    JSON.stringify(z.toJSONSchema(AgentPromptSchema, schemaOptions), null, 2),
   ].join('\n');
 }
 
-// ── Nodes ───────────────────────────────────────────────────
+// ── Creation stages ─────────────────────────────────────────
 
-class GatherInputNode extends Node<AgentCreatorShared> {
-  constructor(private ui: AgentCreatorUI) {
-    super();
-  }
+async function buildAgentBlueprint(
+  config: CreatorConfig,
+  category: AgentCategory,
+  agentName: string,
+  description: string,
+  ui: AgentCreatorUI,
+): Promise<AgentBlueprint | undefined> {
+  const base = { AGENT_NAME: agentName, DESCRIPTION: description };
 
-  async prep(shared: AgentCreatorShared) {
-    return {
-      category: shared.category,
-      categoryLabel: shared.category === 'toolUse' ? 'Tool Use' : 'Workflow',
-    };
-  }
-
-  async exec(prepRes: { category: AgentCategory; categoryLabel: string }) {
-    const agentName = await this.ui.promptAgentName(prepRes.categoryLabel);
-    if (!agentName) return undefined;
-
-    const description = await this.ui.promptDescription(
-      `New ${prepRes.categoryLabel} Agent: ${agentName}`,
-      DESCRIPTION_PROMPTS[prepRes.category],
+  if (category === 'toolUse') {
+    const picked = await ui.pickTools(
+      agentName,
+      description,
+      suggestToolGroups(description),
     );
-    if (!description) return undefined;
-
-    return { agentName, description };
-  }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: { agentName: string; description: string } | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.agentName = execRes.agentName;
-    shared.description = execRes.description;
-    return shared.category;
-  }
-}
-
-/**
- * Builds the {@link AgentBlueprint} for the category chosen upstream. Both
- * categories share the same prep/post and the same `AGENT_NAME`/`DESCRIPTION`
- * render vars; only `toolUse` runs the tool-pick step and contributes the
- * tool-derived vars. The tool pick happens before the target directory is
- * resolved so cancelling it short-circuits without side effects.
- */
-class BlueprintNode extends Node<AgentCreatorShared> {
-  constructor(private ui: AgentCreatorUI) {
-    super();
-  }
-
-  async prep(shared: AgentCreatorShared) {
+    if (!picked) return undefined;
+    const targetDir = await ui.getCustomAgentDir();
     return {
-      category: shared.category,
-      agentName: shared.agentName!,
-      description: shared.description!,
-      config: shared.config,
-    };
-  }
-
-  async exec(prepRes: {
-    category: AgentCategory;
-    agentName: string;
-    description: string;
-    config: CreatorConfig;
-  }): Promise<AgentBlueprint | undefined> {
-    const { category, agentName, description, config } = prepRes;
-    const base = { AGENT_NAME: agentName, DESCRIPTION: description };
-
-    if (category === 'toolUse') {
-      const picked = await this.ui.pickTools(
-        agentName,
-        description,
-        suggestToolGroups(description),
-      );
-      if (!picked) return undefined;
-      const targetDir = await this.ui.getCustomAgentDir();
-      return {
-        category: 'toolUse',
-        agentName,
-        filePath: path.join(targetDir, `${agentName}.yaml`),
-        aiVars: {
-          ...base,
-          SELECTED_TOOLS: picked.tools.join(', '),
-          SELECTED_GROUPS: picked.groups.join(', '),
-        },
-        fallbackTemplate: config.templates.toolUse,
-        fallbackVars: {
-          ...base,
-          TOOLS_YAML: picked.tools.map((t) => `    - ${t}`).join('\n'),
-        },
-      };
-    }
-
-    const targetDir = await this.ui.getCustomAgentDir();
-    return {
-      category: 'workflow',
+      category: 'toolUse',
       agentName,
       filePath: path.join(targetDir, `${agentName}.yaml`),
-      aiVars: { ...base },
-      fallbackTemplate: config.templates.workflowSingle,
-      fallbackVars: { ...base },
+      aiVars: {
+        ...base,
+        SELECTED_TOOLS: picked.tools.join(', '),
+        SELECTED_GROUPS: picked.groups.join(', '),
+      },
+      fallbackTemplate: config.templates.toolUse,
+      fallbackVars: {
+        ...base,
+        TOOLS_YAML: picked.tools.map((tool) => `    - ${tool}`).join('\n'),
+      },
     };
   }
 
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    execRes: AgentBlueprint | undefined,
-  ): Promise<string | undefined> {
-    if (!execRes) return 'cancel';
-    shared.blueprint = execRes;
-    return FlowTransition.DEFAULT;
-  }
+  const targetDir = await ui.getCustomAgentDir();
+  return {
+    category: 'workflow',
+    agentName,
+    filePath: path.join(targetDir, `${agentName}.yaml`),
+    aiVars: { ...base },
+    fallbackTemplate: config.templates.workflowSingle,
+    fallbackVars: { ...base },
+  };
 }
 
-interface GeneratePrepResult {
-  config: CreatorConfig;
-  blueprint: AgentBlueprint;
-}
+async function generateAgentYaml(
+  config: CreatorConfig,
+  blueprint: AgentBlueprint,
+  ui: AgentCreatorUI,
+): Promise<string> {
+  let lastValidationError: string | undefined;
 
-class GenerateNode extends Node<AgentCreatorShared> {
-  private lastValidationError?: string;
+  try {
+    return await pRetry(
+      async () => {
+        const helperResult = await createHelperModelKit();
+        if (!helperResult.kit) {
+          throw new Error(helperResult.reason);
+        }
 
-  constructor(private ui: AgentCreatorUI) {
-    super(AI_GENERATION_ATTEMPTS);
-  }
+        const prompts = config[blueprint.category];
+        const schemaRef = getSchemaReference(blueprint.category);
+        const renderVars = {
+          ...PASSTHROUGH,
+          ...blueprint.aiVars,
+        };
+        const systemPrompt =
+          nunjucksEnv.renderString(prompts.systemPrompt, renderVars) +
+          '\n' +
+          schemaRef;
 
-  async prep(shared: AgentCreatorShared): Promise<GeneratePrepResult> {
-    return { config: shared.config, blueprint: shared.blueprint! };
-  }
+        let userMessage = nunjucksEnv.renderString(
+          prompts.userRequest,
+          renderVars,
+        );
+        if (lastValidationError) {
+          userMessage +=
+            '\n' +
+            nunjucksEnv.renderString(config.retryPrompts[blueprint.category], {
+              VALIDATION_ERROR: lastValidationError,
+            });
+        }
 
-  async exec(prepRes: GeneratePrepResult): Promise<string> {
-    const { config, blueprint } = prepRes;
-    const helperResult = await createHelperModelKit();
-    if (!helperResult.kit) {
-      throw new Error(helperResult.reason);
-    }
-
-    const prompts = config[blueprint.category];
-    const schemaRef = getSchemaReference(blueprint.category);
-    const renderVars = {
-      ...PASSTHROUGH,
-      ...blueprint.aiVars,
-    };
-    const systemPrompt =
-      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) +
-      '\n' +
-      schemaRef;
-
-    let userMessage = nunjucksEnv.renderString(prompts.userRequest, renderVars);
-    if (this.lastValidationError) {
-      userMessage +=
-        '\n' +
-        nunjucksEnv.renderString(config.retryPrompts[blueprint.category], {
-          VALIDATION_ERROR: this.lastValidationError,
+        const text = await runHelperModelCompletion(helperResult.kit, {
+          userPrompt: userMessage,
+          systemPrompt,
         });
-    }
+        if (!isNonEmptyString(text)) {
+          throw new Error('Model returned no text');
+        }
 
-    const text = await runHelperModelCompletion(helperResult.kit, {
-      userPrompt: userMessage,
-      systemPrompt,
-    });
+        const extracted = extractTextFromTag(text, 'yaml');
+        const candidate = (extracted || text).trim();
+        try {
+          validateAgentYamlContent(candidate);
+        } catch (error) {
+          lastValidationError = toErrorMessage(error);
+          throw new Error(`Generated YAML was invalid: ${lastValidationError}`);
+        }
 
-    if (!isNonEmptyString(text)) {
-      throw new Error('Model returned no text');
-    }
-
-    const extracted = extractTextFromTag(text, 'yaml');
-    const candidate = (extracted || text).trim();
-    try {
-      validateAgentYamlContent(candidate);
-    } catch (err) {
-      this.lastValidationError = toErrorMessage(err);
-      throw new Error(
-        `Generated YAML was invalid: ${this.lastValidationError}`,
-      );
-    }
-
-    logger.info(
-      CHANNEL,
-      `AI generation succeeded for ${blueprint.category} agent`,
+        logger.info(
+          CHANNEL,
+          `AI generation succeeded for ${blueprint.category} agent`,
+        );
+        return candidate;
+      },
+      {
+        retries: AI_GENERATION_ATTEMPTS - 1,
+        minTimeout: 0,
+        factor: 1,
+        randomize: false,
+      },
     );
-    return candidate;
-  }
-
-  async execFallback(
-    prepRes: GeneratePrepResult,
-    error: Error,
-  ): Promise<string> {
+  } catch (error) {
     logger.warn(
       CHANNEL,
-      `AI generation failed, using template: ${error.message}`,
+      `AI generation failed, using template: ${toErrorMessage(error)}`,
     );
-    const { blueprint } = prepRes;
     // Route through the shared renderer so both the Settings "new from
     // template" flow and this fallback produce byte-identical output for
     // matching inputs.
-    return this.ui.renderTemplate(
+    return ui.renderTemplate(
       blueprint.fallbackTemplate,
       blueprint.fallbackVars,
     );
   }
-
-  async post(
-    shared: AgentCreatorShared,
-    _prepRes: unknown,
-    yamlContent: string,
-  ): Promise<string | undefined> {
-    shared.yamlContent = yamlContent;
-    return FlowTransition.DEFAULT;
-  }
 }
 
-class RegisterNode extends Node<AgentCreatorShared> {
-  constructor(private ui: AgentCreatorUI) {
-    super();
-  }
-
-  async prep(shared: AgentCreatorShared) {
-    return { blueprint: shared.blueprint!, yamlContent: shared.yamlContent! };
-  }
-
-  async exec(prepRes: { blueprint: AgentBlueprint; yamlContent: string }) {
-    const { blueprint, yamlContent } = prepRes;
-    await AbsoluteFS.write(blueprint.filePath, yamlContent);
-    this.ui.showCreatedInfo(blueprint.filePath);
-    await this.ui.promptAddToConfig(
-      blueprint.agentName,
-      false,
-      blueprint.category,
-    );
-    await this.ui.openCreatedFile(blueprint.filePath);
-  }
-
-  async post(): Promise<string | undefined> {
-    return FlowTransition.DEFAULT;
-  }
-}
-
-// ── Flow ────────────────────────────────────────────────────
-
-export function createAgentCreatorFlow(
+/** Run the complete agent-creation wizard, stopping without side effects when cancelled. */
+export async function runAgentCreator(
+  config: CreatorConfig,
+  category: AgentCategory,
   ui: AgentCreatorUI,
-): Flow<AgentCreatorShared> {
-  const gatherInput = new GatherInputNode(ui);
-  const blueprint = new BlueprintNode(ui);
-  const generate = new GenerateNode(ui);
-  const register = new RegisterNode(ui);
+): Promise<void> {
+  const categoryLabel = category === 'toolUse' ? 'Tool Use' : 'Workflow';
+  const agentName = await ui.promptAgentName(categoryLabel);
+  if (!agentName) return;
 
-  gatherInput.on('workflow', blueprint);
-  gatherInput.on('toolUse', blueprint);
+  const description = await ui.promptDescription(
+    `New ${categoryLabel} Agent: ${agentName}`,
+    DESCRIPTION_PROMPTS[category],
+  );
+  if (!description) return;
 
-  blueprint.next(generate);
-  generate.next(register);
+  const blueprint = await buildAgentBlueprint(
+    config,
+    category,
+    agentName,
+    description,
+    ui,
+  );
+  if (!blueprint) return;
 
-  return new Flow<AgentCreatorShared>(gatherInput);
+  const yamlContent = await generateAgentYaml(config, blueprint, ui);
+  await AbsoluteFS.write(blueprint.filePath, yamlContent);
+  ui.showCreatedInfo(blueprint.filePath);
+  await ui.promptAddToConfig(agentName, false, category);
+  await ui.openCreatedFile(blueprint.filePath);
 }

--- a/src/test-kernel/agent/AgentCreatorOrchestration.vitest.ts
+++ b/src/test-kernel/agent/AgentCreatorOrchestration.vitest.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type AgentCreatorUI,
+  type CreatorConfig,
+  runAgentCreator,
+} from '@agent/implementations/flows/agentCreator/agentCreatorFlow';
+import { AbsoluteFS } from '@utils/files';
+
+const mocks = vi.hoisted(() => ({
+  createHelperModelKit: vi.fn(),
+  runHelperModelCompletion: vi.fn(),
+  validateAgentYamlContent: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/helperModel', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/helperModel')>()),
+  createHelperModelKit: mocks.createHelperModelKit,
+  runHelperModelCompletion: mocks.runHelperModelCompletion,
+}));
+
+vi.mock('@agent/runtime/agentLoad', async (importActual) => ({
+  ...(await importActual<typeof import('@agent/runtime/agentLoad')>()),
+  validateAgentYamlContent: mocks.validateAgentYamlContent,
+}));
+
+const CONFIG: CreatorConfig = {
+  workflow: {
+    systemPrompt: 'Create {{ AGENT_NAME }} for {{ DESCRIPTION }}.',
+    userRequest: 'Generate workflow {{ AGENT_NAME }}.',
+  },
+  toolUse: {
+    systemPrompt: 'Create {{ AGENT_NAME }} for {{ DESCRIPTION }}.',
+    userRequest: 'Tools={{ SELECTED_TOOLS }}; Groups={{ SELECTED_GROUPS }}.',
+  },
+  retryPrompts: {
+    workflow: 'Retry workflow: {{ VALIDATION_ERROR }}',
+    toolUse: 'Retry tool use: {{ VALIDATION_ERROR }}',
+  },
+  templates: {
+    workflowSingle: 'workflow fallback',
+    toolUse: 'tool-use fallback',
+  },
+};
+
+function createUi(
+  events: string[] = [],
+  overrides: Partial<AgentCreatorUI> = {},
+): AgentCreatorUI {
+  return {
+    promptAgentName: vi.fn(async () => 'editor'),
+    promptDescription: vi.fn(async () => 'Edit documents'),
+    pickTools: vi.fn(async () => ({ tools: ['edit_file'], groups: [] })),
+    getCustomAgentDir: vi.fn(async () => '/agents'),
+    showCreatedInfo: vi.fn(() => events.push('show')),
+    promptAddToConfig: vi.fn(async () => {
+      events.push('register');
+    }),
+    openCreatedFile: vi.fn(async () => {
+      events.push('open');
+    }),
+    renderTemplate: vi.fn(() => 'fallback yaml'),
+    ...overrides,
+  };
+}
+
+describe('agent creator orchestration', () => {
+  beforeEach(() => {
+    mocks.createHelperModelKit.mockReset();
+    mocks.runHelperModelCompletion.mockReset();
+    mocks.validateAgentYamlContent.mockReset();
+    mocks.createHelperModelKit.mockResolvedValue({
+      kit: { modelName: 'test' },
+    });
+    mocks.runHelperModelCompletion.mockResolvedValue(
+      '<yaml>generated: true</yaml>',
+    );
+    mocks.validateAgentYamlContent.mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a workflow agent and preserves registration side-effect order', async () => {
+    const events: string[] = [];
+    const ui = createUi(events);
+    vi.spyOn(AbsoluteFS, 'write').mockImplementation(async () => {
+      events.push('write');
+    });
+
+    await runAgentCreator(CONFIG, 'workflow', ui);
+
+    expect(ui.promptAgentName).toHaveBeenCalledWith('Workflow');
+    expect(ui.promptDescription).toHaveBeenCalledWith(
+      'New Workflow Agent: editor',
+      expect.stringContaining('What should this agent do?'),
+    );
+    expect(ui.pickTools).not.toHaveBeenCalled();
+    expect(AbsoluteFS.write).toHaveBeenCalledWith(
+      '/agents/editor.yaml',
+      'generated: true',
+    );
+    expect(ui.promptAddToConfig).toHaveBeenCalledWith(
+      'editor',
+      false,
+      'workflow',
+    );
+    expect(ui.openCreatedFile).toHaveBeenCalledWith('/agents/editor.yaml');
+    expect(events).toEqual(['write', 'show', 'register', 'open']);
+  });
+
+  it('passes selected tool metadata into tool-use generation', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi([], {
+      promptAgentName: vi.fn(async () => 'researcher'),
+      promptDescription: vi.fn(async () => 'Search papers and edit files'),
+      pickTools: vi.fn(async () => ({
+        tools: ['web_search', 'write_file'],
+        groups: ['Web & Search', 'File Operations'],
+      })),
+    });
+
+    await runAgentCreator(CONFIG, 'toolUse', ui);
+
+    expect(ui.pickTools).toHaveBeenCalledWith(
+      'researcher',
+      'Search papers and edit files',
+      expect.arrayContaining([
+        'File Operations',
+        'Web & Search',
+        'Academic Research',
+      ]),
+    );
+    expect(mocks.runHelperModelCompletion).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userPrompt:
+          'Tools=web_search, write_file; Groups=Web & Search, File Operations.',
+        systemPrompt: expect.stringContaining(
+          'Create researcher for Search papers and edit files.',
+        ),
+      }),
+    );
+    expect(ui.promptAddToConfig).toHaveBeenCalledWith(
+      'researcher',
+      false,
+      'toolUse',
+    );
+  });
+
+  it('stops before description when name selection is cancelled', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi([], {
+      promptAgentName: vi.fn(async () => undefined),
+    });
+
+    await runAgentCreator(CONFIG, 'workflow', ui);
+
+    expect(ui.promptDescription).not.toHaveBeenCalled();
+    expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
+    expect(AbsoluteFS.write).not.toHaveBeenCalled();
+  });
+
+  it('stops before generation when description is cancelled', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi([], {
+      promptDescription: vi.fn(async () => undefined),
+    });
+
+    await runAgentCreator(CONFIG, 'workflow', ui);
+
+    expect(ui.getCustomAgentDir).not.toHaveBeenCalled();
+    expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
+    expect(AbsoluteFS.write).not.toHaveBeenCalled();
+  });
+
+  it('stops tool-use creation before filesystem access when tool selection is cancelled', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi([], {
+      pickTools: vi.fn(async () => undefined),
+    });
+
+    await runAgentCreator(CONFIG, 'toolUse', ui);
+
+    expect(ui.getCustomAgentDir).not.toHaveBeenCalled();
+    expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
+    expect(AbsoluteFS.write).not.toHaveBeenCalled();
+    expect(ui.promptAddToConfig).not.toHaveBeenCalled();
+  });
+
+  it('includes the validation error in the second generation attempt', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi();
+    mocks.runHelperModelCompletion
+      .mockResolvedValueOnce('<yaml>invalid</yaml>')
+      .mockResolvedValueOnce('<yaml>valid: true</yaml>');
+    mocks.validateAgentYamlContent
+      .mockImplementationOnce(() => {
+        throw new Error('missing prompts');
+      })
+      .mockImplementationOnce(() => undefined);
+
+    await runAgentCreator(CONFIG, 'workflow', ui);
+
+    expect(mocks.runHelperModelCompletion).toHaveBeenCalledTimes(2);
+    expect(mocks.runHelperModelCompletion.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        userPrompt: expect.stringContaining('Retry workflow: missing prompts'),
+      }),
+    );
+    expect(AbsoluteFS.write).toHaveBeenCalledWith(
+      '/agents/editor.yaml',
+      'valid: true',
+    );
+  });
+
+  it('uses the deterministic template after both generation attempts fail', async () => {
+    vi.spyOn(AbsoluteFS, 'write').mockResolvedValue(undefined);
+    const ui = createUi();
+    mocks.runHelperModelCompletion.mockRejectedValue(
+      new Error('model unavailable'),
+    );
+
+    await runAgentCreator(CONFIG, 'workflow', ui);
+
+    expect(mocks.createHelperModelKit).toHaveBeenCalledTimes(2);
+    expect(mocks.runHelperModelCompletion).toHaveBeenCalledTimes(2);
+    expect(ui.renderTemplate).toHaveBeenCalledWith('workflow fallback', {
+      AGENT_NAME: 'editor',
+      DESCRIPTION: 'Edit documents',
+    });
+    expect(AbsoluteFS.write).toHaveBeenCalledWith(
+      '/agents/editor.yaml',
+      'fallback yaml',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- replace the four-node agent-creation graph with one sequential, typed coordinator
- remove the optional phase-state bag and all five non-null assertions
- preserve cancellation boundaries, the two-attempt AI validation retry, deterministic template fallback, and successful write/register/open ordering
- generate the model-facing JSON Schema with the established `unrepresentable: 'any'` input policy so custom tool definitions do not force every attempt into fallback
- add direct orchestration coverage for workflow and tool-use creation

Closes #8486

## Issue acceptance gates

- [x] No non-null assertions remain for agent-creator phase data.
- [x] The shallow shared-state graph and its impossible optional combinations are removed.
- [x] Config, category, and UI dependencies enter through the single `runAgentCreator` call.
- [x] Name, description, and tool-selection cancellation stop before filesystem/settings side effects.
- [x] AI validation retries once with the validation error, then uses the deterministic template fallback.
- [x] Success writes the file, offers config registration, and opens the file in the original order.
- [x] Focused tests cover workflow, tool-use, cancellation, retry, fallback, and registration ordering.
- [x] Production consumer and net-element counts are reported below.

## Single source of truth

`runAgentCreator` now owns the wizard sequence. `generateAgentYaml` owns the only behavior that needs retry state.

## Duplication and abstraction budget

Removed four shallow PocketFlow node classes, four repeated UI constructor injections, the shared optional phase-state interface, and prep/post pass-through methods. Added no new class, service layer, or generic state abstraction; the two private helpers own blueprint construction and generation retry behavior.

## Net elements (R6)

- Files: 1 added, 2 modified, 0 deleted.
- Exported symbols: 1 added, 2 deleted (net -1).
- Classes/interfaces/enums: 0 added, 4 classes and 2 interfaces deleted (net -6).
- Top-level functions: 3 added, 1 deleted (net +2); the added functions replace the deleted classes and their lifecycle methods.
- Production LoC: 145 added, 249 deleted (net -104).
- Total LoC including focused tests: 383 added, 249 deleted (net +134).

## Consumer counts (R8)

n/a: no event, emit path, subscriber key, or externally consumed protocol changed. The deleted flow factory had exactly 1 production consumer, `agentCreatorCommands.ts`, which now calls `runAgentCreator`.

## Host impact

Extension: sole production caller; wizard behavior is preserved while orchestration becomes direct and type-safe.

Desktop: none; no production consumer.

CLI: none; no production consumer.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `CI=true npm run compile:fast`
- `CI=true npm run lint` (0 errors; 51 pre-existing warnings)
- `CI=true corepack pnpm exec tsc --noEmit --pretty false`
- `CI=true corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `CI=true npm run check:dead-code-ratchet`
- focused Vitest: 2 files, 17 tests passed
- full `CI=true npm test`: 694 files passed, 1 skipped; 6,270 tests passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of extension-only agent-creation wizard with preserved behavior and strong new orchestration tests; no auth, security, or shared runtime protocol changes.
> 
> **Overview**
> Replaces the four-node PocketFlow graph (`GatherInput`, `Blueprint`, `Generate`, `Register`) with a single sequential **`runAgentCreator`** coordinator and private helpers **`buildAgentBlueprint`** / **`generateAgentYaml`**, removing **`AgentCreatorShared`**, **`createAgentCreatorFlow`**, and non-null assertions on phase state.
> 
> The VS Code command now calls **`runAgentCreator(config, category, buildVSCodeUI())`** directly. AI generation retries use **`pRetry`** (same two-attempt validation retry, then deterministic template fallback). Model-facing JSON Schema is built with **`unrepresentable: 'any'`** and **`io: 'input'`** so custom tool shapes do not spuriously fail validation.
> 
> Adds **`AgentCreatorOrchestration.vitest.ts`** covering workflow vs tool-use paths, cancellation before side effects, retry prompt content, fallback, and write → notify → register → open ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0740bb20c5aff93497d9238daa48767ebdcca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->