### PR TITLE
refactor(workflow): parse scripts with Acorn

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "@supabase/supabase-js": "2.110.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "acorn": "^8.17.0",
+    "acorn-walk": "^8.3.5",
     "arxiv-client": "^0.0.9",
     "async-mutex": "^0.5.0",
     "bibtex": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      acorn:
+        specifier: ^8.17.0
+        version: 8.17.0
+      acorn-walk:
+        specifier: ^8.3.5
+        version: 8.3.5
       arxiv-client:
         specifier: ^0.0.9
         version: 0.0.9
@@ -2929,6 +2935,10 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -8561,6 +8571,10 @@ snapshots:
       acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.17.0
 

--- a/src/agent/workflowScript/parseScript.ts
+++ b/src/agent/workflowScript/parseScript.ts
@@ -1,5 +1,7 @@
 import * as vm from 'node:vm';
 
+import { parse, type Node, type Program } from 'acorn';
+import { full as walkAst } from 'acorn-walk';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -19,49 +21,112 @@ export interface ParsedWorkflowScript {
   body: string;
 }
 
-const META_PATTERN = /export\s+const\s+meta\s*=\s*\{/;
+interface ExportedMetaDeclaration {
+  declarationStart: number;
+  literalStart: number;
+  literalEnd: number;
+}
+
+function parseProgram(source: string): Program {
+  try {
+    return parse(source, {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      allowReturnOutsideFunction: true,
+    });
+  } catch (error) {
+    throw new WorkflowScriptParseError(
+      `Invalid workflow script syntax: ${toErrorMessage(error)}`,
+    );
+  }
+}
+
+function rejectsModuleLoading(program: Program): boolean {
+  let rejected = false;
+  walkAst(program, (node: Node) => {
+    if (node.type === 'ImportDeclaration' || node.type === 'ImportExpression') {
+      rejected = true;
+      return;
+    }
+    const moduleLoad = node as Node & {
+      callee?: Node & { name?: string };
+      tag?: Node & { name?: string };
+    };
+    if (
+      (node.type === 'CallExpression' &&
+        moduleLoad.callee?.type === 'Identifier' &&
+        moduleLoad.callee.name === 'require') ||
+      (node.type === 'TaggedTemplateExpression' &&
+        moduleLoad.tag?.type === 'Identifier' &&
+        moduleLoad.tag.name === 'require')
+    ) {
+      rejected = true;
+    }
+  });
+  return rejected;
+}
+
+function exportedMetaDeclaration(
+  program: Program,
+): ExportedMetaDeclaration | undefined {
+  const first = program.body[0];
+  if (first?.type !== 'ExportNamedDeclaration' || !first.declaration) {
+    return undefined;
+  }
+  const declaration = first.declaration;
+  if (
+    declaration.type !== 'VariableDeclaration' ||
+    declaration.kind !== 'const'
+  ) {
+    return undefined;
+  }
+  const [meta, ...extraDeclarations] = declaration.declarations;
+  if (
+    extraDeclarations.length > 0 ||
+    meta?.id.type !== 'Identifier' ||
+    meta.id.name !== 'meta' ||
+    meta.init?.type !== 'ObjectExpression'
+  ) {
+    return undefined;
+  }
+  return {
+    declarationStart: declaration.start,
+    literalStart: meta.init.start,
+    literalEnd: meta.init.end,
+  };
+}
 
 /**
  * Statically validates a workflow script: extracts and zod-parses the
  * `export const meta = {...}` literal (evaluated in a bare realm so it must
  * be self-contained), and rejects module imports. The body is not executed.
  *
- * All structural scanning (import ban, meta anchoring, brace matching) runs
- * on a masked copy of the source with string/comment contents blanked, so
- * prose like "you can mention require() here" in prompts or comments is not
- * a false positive. The import ban is an early, readable error, not the
- * security boundary — the sandbox realm has no `require`, and dynamic
- * `import()` fails there at runtime (no dynamic-import callback is wired).
+ * Acorn owns tokenization and structural scanning so strings, comments, regex
+ * literals, and modern syntax cannot confuse the import ban or meta offsets.
+ * The import ban is an early, readable error, not the security boundary — the
+ * sandbox realm has no `require`, and dynamic `import()` fails there at runtime
+ * (no dynamic-import callback is wired).
  */
 export function parseWorkflowScript(source: string): ParsedWorkflowScript {
-  const masked = maskStringsAndComments(source);
+  const program = parseProgram(source);
 
-  if (
-    /(^|[^.\w])require\s*\(/.test(masked) ||
-    /^\s*import[\s(]/m.test(masked) ||
-    /[^\w.]import\s*\(/.test(masked)
-  ) {
+  if (rejectsModuleLoading(program)) {
     throw new WorkflowScriptParseError(
       'Workflow scripts cannot import modules; use only the injected primitives (agent, parallel, pipeline, concat, log, phase, args).',
     );
   }
 
-  const match = META_PATTERN.exec(masked);
-  if (!match || /\S/.test(masked.slice(0, match.index))) {
+  const metaDeclaration = exportedMetaDeclaration(program);
+  if (!metaDeclaration) {
     throw new WorkflowScriptParseError(
       'Workflow script must begin with `export const meta = { name, description, ... }` (only whitespace/comments may precede it).',
     );
   }
-  // META_PATTERN ends in `\{`, so the literal opens at the match's last char.
-  const braceStart = match.index + match[0].length - 1;
-  const braceEnd = findMatchingBrace(masked, braceStart);
-  if (braceEnd < 0) {
-    throw new WorkflowScriptParseError(
-      'Unterminated meta object literal in workflow script.',
-    );
-  }
 
-  const literal = source.slice(braceStart, braceEnd + 1);
+  const literal = source.slice(
+    metaDeclaration.literalStart,
+    metaDeclaration.literalEnd,
+  );
   let rawMeta: unknown;
   try {
     // Bare realm with code generation disabled: a non-literal meta
@@ -88,86 +153,7 @@ export function parseWorkflowScript(source: string): ParsedWorkflowScript {
   }
 
   const body =
-    source.slice(0, match.index) +
-    source.slice(match.index).replace(/^export\s+/, '');
+    source.slice(0, program.body[0]?.start ?? 0) +
+    source.slice(metaDeclaration.declarationStart);
   return { meta: parsed.data, body };
-}
-
-/**
- * Returns the source with the contents of string literals (including whole
- * template literals) and comments blanked to spaces, preserving length and
- * newlines so indices map 1:1 onto the original. Code inside template
- * interpolations is blanked too — an import hidden there still fails at
- * runtime in the sandbox, so the static ban deliberately stays simple.
- */
-function maskStringsAndComments(source: string): string {
-  // split('') keeps UTF-16 units so indices map 1:1 onto the original.
-  // [...source] would iterate code points and shorten the mask after any
-  // astral character (e.g. an emoji in a meta description), shifting every
-  // later match/brace offset.
-  const out = source.split('');
-  const blank = (from: number, to: number) => {
-    for (let k = from; k < to && k < out.length; k++) {
-      if (out[k] !== '\n') out[k] = ' ';
-    }
-  };
-  let i = 0;
-  while (i < source.length) {
-    const char = source[i];
-    const next = source[i + 1];
-    if (char === '/' && next === '/') {
-      const newline = source.indexOf('\n', i);
-      const stop = newline < 0 ? source.length : newline;
-      blank(i, stop);
-      i = stop;
-      continue;
-    }
-    if (char === '/' && next === '*') {
-      const close = source.indexOf('*/', i + 2);
-      const stop = close < 0 ? source.length : close + 2;
-      blank(i, stop);
-      i = stop;
-      continue;
-    }
-    if (char === '"' || char === "'" || char === '`') {
-      const end = skipString(source, i);
-      blank(i + 1, end - 1);
-      i = end;
-      continue;
-    }
-    i += 1;
-  }
-  return out.join('');
-}
-
-/**
- * Finds the brace matching `masked[openIndex]`. Operates on masked source,
- * where string/comment contents are already spaces, so a plain depth count
- * suffices. Returns -1 if unbalanced.
- */
-function findMatchingBrace(masked: string, openIndex: number): number {
-  let depth = 0;
-  for (let i = openIndex; i < masked.length; i++) {
-    if (masked[i] === '{') depth += 1;
-    if (masked[i] === '}') {
-      depth -= 1;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
-}
-
-/** Returns the index just past the closing quote of the string at `start`. */
-function skipString(source: string, start: number): number {
-  const quote = source[start];
-  let i = start + 1;
-  while (i < source.length) {
-    if (source[i] === '\\') {
-      i += 2;
-      continue;
-    }
-    if (source[i] === quote) return i + 1;
-    i += 1;
-  }
-  return source.length;
 }

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -57,6 +57,25 @@ describe('parseWorkflowScript', () => {
     expect(() =>
       parseWorkflowScript(`import fs from 'node:fs'\n${META}`),
     ).toThrow(/cannot import/);
+    expect(() =>
+      parseWorkflowScript(`${META}return import('node:fs')`),
+    ).toThrow(/cannot import/);
+    expect(() =>
+      parseWorkflowScript(`${META}return require\`node:fs\``),
+    ).toThrow(/cannot import/);
+  });
+
+  it('does not confuse regex literals with module loading or structure', () => {
+    const { body } = parseWorkflowScript(
+      `${META}const pattern = /require\\s*\\(.*[{}]/\nreturn pattern.test('x')`,
+    );
+    expect(body).toContain('/require\\s*\\(.*[{}]/');
+  });
+
+  it('keeps top-level return and await valid after AST parsing', () => {
+    expect(() =>
+      parseWorkflowScript(`${META}return await agent('x')`),
+    ).not.toThrow();
   });
 
   it('rejects meta whose accessors would hang host-side validation', () => {


### PR DESCRIPTION
Closes #8514

## Summary

Replace the workflow-script string/comment/brace scanner with Acorn AST parsing. Static validation now handles regex literals and modern JavaScript syntax without maintaining a partial lexer, while preserving VM evaluation and Zod validation for metadata.

## Issue acceptance gates

- AST-parse workflow scripts with `sourceType: 'module'` and top-level `return` support.
- Require the first statement to be a single `export const meta = { ... }` declaration.
- Reject static imports, dynamic imports, direct `require(...)` calls, and tagged-template `require` forms through AST nodes.
- Preserve VM timeout, code-generation restrictions, and Zod validation.
- Cover regex literals, dynamic imports, tagged-template require, and top-level `return await`.

## Single source of truth

`parseWorkflowScript` in `src/agent/workflowScript/parseScript.ts` owns workflow-script structure validation; Acorn owns JavaScript tokenization and AST structure.

## Duplication and abstraction budget

Deletes the handwritten string/comment masker, brace matcher, and string skipper. The three replacement helpers each own a distinct parser boundary: syntax errors, module-loading detection, and exported-meta shape extraction.

## Net elements (R6)

- Files: 4 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/enums: 0 added; 0 deleted.
- Internal interfaces: +1.
- Production source: 91 insertions, 105 deletions (net -14).
- Tests: +19 lines.
- Dependency metadata/lockfile: +16 lines.
- Whole diff: 126 insertions, 105 deletions (net +21, including tests and lockfile).

## Consumer counts (R8)

n/a — no export or event-emission path is deleted or rerouted; the existing `parseWorkflowScript` export and its consumers are unchanged.

## Host impact

Extension: Workflow scripts receive stricter and more accurate static parsing.

Desktop: Same shared workflow-script behavior as the extension.

CLI: Same shared workflow-script behavior as other hosts.

## Scheduled refactoring

None.

## Validation

- `npm run lint` — 0 errors (51 existing warnings)
- `npm run compile:safe`
- `npm test` — 693 files passed, 6,265 tests passed
- targeted workflow-script suites — 59 tests passed after review fix
- `npm run typecheck` after review fix
- `git diff --check`