### PR TITLE
refactor(cli): use p-timeout for interactions

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -13,6 +13,8 @@
 // Promise<ToolEditApprovalResult>, not a fire-and-forget event.
 
 import { nanoid } from 'nanoid';
+import pDefer from 'p-defer';
+import pTimeout from 'p-timeout';
 
 import { platform } from '@platform/platform';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -295,7 +297,7 @@ function validTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (timeoutMs == null || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return undefined;
   }
-  return Math.floor(timeoutMs);
+  return Math.max(1, Math.floor(timeoutMs));
 }
 
 /**
@@ -315,30 +317,20 @@ function withInteractionTimeout<T>(
   const timeoutMs = validTimeoutMs(options?.timeoutMs);
   if (timeoutMs == null) return start();
 
-  return new Promise<T>((resolve, reject) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
+  const interaction = pDefer<T>();
+  const timedInteraction = pTimeout(interaction.promise, {
+    milliseconds: timeoutMs,
+    fallback: () => {
       onTimeout();
-      resolve(timeoutResult);
-    }, timeoutMs);
-
-    start().then(
-      (result) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(result);
-      },
-      (error: unknown) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        reject(error);
-      },
-    );
+      return timeoutResult;
+    },
   });
+  try {
+    start().then(interaction.resolve, interaction.reject);
+  } catch (error) {
+    interaction.reject(error);
+  }
+  return timedInteraction;
 }
 
 function createRetryRouteState(): RetryRouteState {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -590,6 +590,20 @@ describe('TUI retry approvals', () => {
     expect(hasCliApprovalDenied(cliContext)).toBe(false);
   });
 
+  it('times out while a retry is still waiting on the keychain', async () => {
+    mocks.lookupApiKey.mockImplementation(() => new Promise(() => undefined));
+
+    const { cliContext, interactions } = tui();
+    const result = interactions.requestRetry?.(
+      relayRetry({ streamId: 'lookup-timeout', provider: 'openai' }),
+      { timeoutMs: 10 },
+    );
+
+    await expect(result).resolves.toEqual({ action: 'timeout' });
+    expect(currentApproval.get()).toBeUndefined();
+    expect(hasCliApprovalDenied(cliContext)).toBe(false);
+  });
+
   it('ignores stale auto-switch lookups after a newer retry replaces them', async () => {
     let resolveFirstLookup: ((value: string | undefined) => void) | undefined;
     mocks.lookupApiKey

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -239,6 +239,26 @@ describe('createTuiHostInteractions().cancel', () => {
 });
 
 describe('HostInteractionOptions.timeoutMs threading', () => {
+  it('accepts a positive fractional timeout', async () => {
+    const interactions = createTuiHostInteractions(host(), context());
+    try {
+      const result = interactions.requestPlanApproval?.(
+        {
+          approvalId: 'approval-fractional-timeout',
+          streamId: 'stream-a',
+          plan,
+          goalEnabled: false,
+        },
+        { timeoutMs: 0.5 },
+      );
+
+      await expect(result).resolves.toEqual({ action: 'timeout' });
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      interactions.dispose?.();
+    }
+  });
+
   it('times out a plan approval that outlives timeoutMs without user input', async () => {
     const interactions = createTuiHostInteractions(host(), context());
     try {


### PR DESCRIPTION
Closes #8515

## Summary

Replace the hand-written TUI interaction timeout state machine with the repository's existing `p-timeout` and `p-defer` dependencies while preserving synchronous approval enqueueing, timeout fallbacks, cleanup, and rejection propagation.

## Issue acceptance gates

- Arm the timeout before interaction work starts.
- Preserve synchronous approval enqueueing.
- Preserve each typed timeout result and queue/retry-route cleanup callback.
- Propagate interaction rejection unchanged.
- Cover a timeout during a hanging keychain lookup.
- Accept every positive finite timeout, including fractional values below 1 ms, by clamping to the timer's 1 ms minimum.

## Single source of truth

`p-timeout` owns timer lifecycle and winner settlement. `withInteractionTimeout` retains only TeXRA's typed fallback and cleanup policy.

## Duplication and abstraction budget

Removes local settled-state, timer, and dual-resolution bookkeeping. No new abstraction is added; `p-defer` is used at the existing function boundary to retain the synchronous-start contract.

## Net elements (R6)

- Files: 3 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Production source: 15 insertions, 23 deletions (net -8).
- Tests: +34 lines.
- Whole diff: 49 insertions, 23 deletions (net +26, entirely from regression coverage after the production deletion).

## Consumer counts (R8)

n/a — no export or event-emission path is deleted or rerouted; all five `withInteractionTimeout` call sites remain unchanged.

## Host impact

Extension: No impact.

Desktop: No impact.

CLI: TUI approval, proposal, retry, and question deadlines use `p-timeout` with existing result shapes and cleanup behavior.

## Scheduled refactoring

None.

## Validation

- `npm run lint` — 0 errors (51 existing warnings)
- `npm run compile:safe`
- `npm test` — 693 files passed, 6,264 tests passed
- targeted TUI approval suites — 33 tests passed after review fix
- `npm run typecheck` after review fix
- `git diff --check`