### PR TITLE
refactor: make response cycle phases explicit

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -58,8 +58,8 @@ import type { ResponseCycleServices } from './CycleServices';
 const CycleFieldsSchema = BaseCycleFieldsSchema.extend({
   /** Whether output file exists */
   outputExists: z.boolean(),
-  /** Agent output location (nullable for native nesting compatibility) */
-  outputLocation: AgentFileLocationSchema.nullable(),
+  /** Agent output location selected before this cycle starts. */
+  outputLocation: AgentFileLocationSchema,
   /** Processed response text */
   processedResponse: z.string().optional(),
 });
@@ -111,7 +111,7 @@ class ResponsePrepNode<C> extends BaseNode<
   async prep(shared: ResponseCycleShared): Promise<ResponsePrepResult> {
     const { prompt, userVarChannels, checkInterruption } = this.services;
     const interrupted = checkInterruption();
-    const exists = await FlexibleFS.exists(shared.outputLocation!);
+    const exists = await FlexibleFS.exists(shared.outputLocation);
     const systemPrompt = interrupted
       ? undefined
       : await getSystemPromptWithRules(prompt.systemPrompt, {
@@ -140,7 +140,7 @@ class ResponsePrepNode<C> extends BaseNode<
     await saveCycleDebug(shared.messages, 'messages', this.services, {
       continuationCount: round.continuationCount,
       baseName: 'response',
-      outputFile: shared.outputLocation!.relativePath,
+      outputFile: shared.outputLocation.relativePath,
     });
 
     return FlowTransition.DEFAULT;
@@ -191,17 +191,19 @@ type ProcessNodeResult = SkippableNodeResult<ProcessResult>;
 /**
  * Data extracted by prep() for continuation decision.
  */
-interface ContinuationPrepResult {
-  shouldSkip: boolean;
+interface ContinuationPrepData {
   interrupted: boolean;
-  stopReason?: ProviderStopReason;
-  processedResponse?: string;
+  stopReason: ProviderStopReason;
+  processedResponse: string;
 }
+
+type ContinuationPrepResult = SkippableNodeResult<ContinuationPrepData>;
 
 type ContinuationNodeResult = SkippableNodeResult<{
   shouldEndTurn: boolean;
   shouldStop: boolean;
   shouldContinue: boolean;
+  reachedTokenLimit: boolean;
 }>;
 
 export function responseCycleToolsForModel<C>(
@@ -369,7 +371,7 @@ class ResponseProcessNode<C> extends BaseNode<
     workspace.assembly.accumulatedOutput = result.updatedAccumulatedOutput;
     shared.processedResponse = result.processedResponse;
 
-    const outputLocation = shared.outputLocation!;
+    const { outputLocation } = shared;
     const connector = result.bestConnector;
 
     await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
@@ -469,39 +471,39 @@ class ResponseContinuationNode<C> extends BaseNode<
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ContinuationPrepResult> {
-    const shouldSkip =
-      shared.shouldStop || !shared.stopReason || !shared.processedResponse;
-
-    const interrupted = !shouldSkip && this.services.checkInterruption();
+    if (shared.shouldStop || !shared.stopReason || !shared.processedResponse) {
+      return { kind: 'skipped' };
+    }
 
     return {
-      shouldSkip,
-      interrupted,
-      stopReason: shared.stopReason ?? undefined,
-      processedResponse: shared.processedResponse,
+      kind: 'success',
+      value: {
+        interrupted: this.services.checkInterruption(),
+        stopReason: shared.stopReason,
+        processedResponse: shared.processedResponse,
+      },
     };
   }
 
   async exec(prepRes: ContinuationPrepResult): Promise<ContinuationNodeResult> {
     const { round, run, modelHandler, setting } = this.services;
 
-    if (prepRes.shouldSkip) {
+    if (prepRes.kind === 'skipped') {
       return { kind: 'skipped' };
     }
 
-    if (prepRes.interrupted) {
+    const { interrupted, stopReason, processedResponse } = prepRes.value;
+    if (interrupted) {
       return {
         kind: 'success',
         value: {
           shouldEndTurn: false,
           shouldStop: true,
           shouldContinue: false,
+          reachedTokenLimit: false,
         },
       };
     }
-
-    const stopReason = prepRes.stopReason!;
-    const processedResponse = prepRes.processedResponse!;
 
     const { endTurn: shouldEndTurn, shouldStop } =
       modelHandler.checkStopConditions(
@@ -517,16 +519,22 @@ class ResponseContinuationNode<C> extends BaseNode<
       processedResponse,
       setting,
     );
+    const reachedTokenLimit = isTokenLimitStopReason(stopReason);
 
     return {
       kind: 'success',
-      value: { shouldEndTurn, shouldStop, shouldContinue },
+      value: {
+        shouldEndTurn,
+        shouldStop,
+        shouldContinue,
+        reachedTokenLimit,
+      },
     };
   }
 
   async post(
     shared: ResponseCycleShared,
-    prepRes: ContinuationPrepResult,
+    _prepRes: ContinuationPrepResult,
     execRes: ContinuationNodeResult,
   ): Promise<string | undefined> {
     const { round, workspace, logger, modelHandler, setting, config } =
@@ -538,11 +546,11 @@ class ResponseContinuationNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
-    const { shouldEndTurn, shouldStop, shouldContinue } = execRes.value;
+    const { shouldEndTurn, shouldStop, shouldContinue, reachedTokenLimit } =
+      execRes.value;
     shared.endTurn = shouldEndTurn;
     shared.shouldStop = shouldStop;
 
-    const reachedTokenLimit = isTokenLimitStopReason(prepRes.stopReason);
     if (shouldStop || !(shouldContinue || reachedTokenLimit)) {
       return FlowTransition.COMPLETE;
     }
@@ -600,7 +608,7 @@ export function createResponseCycleFlow<C>(): Flow<
     getDebugFileOptions: (shared, services) => ({
       continuationCount: services.round.continuationCount,
       baseName: 'response',
-      outputFile: shared.outputLocation!.relativePath,
+      outputFile: shared.outputLocation.relativePath,
     }),
   });
   const processNode = new ResponseProcessNode<C>();

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -16,11 +16,14 @@ import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { ensureError } from '@utils/errors/errorMessage';
 
-import type { ReflectionFlowShared } from '../ReflectionFlowState';
+import type {
+  ReflectionFlowShared,
+  RoundContext,
+} from '../ReflectionFlowState';
 import type { ReflectionServices } from '../ReflectionServices';
 
 interface CyclePrepInput {
-  shared: ReflectionFlowShared;
+  context: RoundContext;
   outputLocation: AgentFileLocation;
   run: AgentRunStateSnapshot;
   workspace: AgentWorkspaceState;
@@ -61,7 +64,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     const round = context.stateRoundSnapshot;
 
     return {
-      shared,
+      context,
       outputLocation: await this.services.getOutputFileLocation(
         shared.currentRound,
       ),
@@ -72,8 +75,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
   }
 
   async exec(prepRes: CyclePrepInput): Promise<CycleOutcome> {
-    const { shared } = prepRes;
-    const context = shared.context!; // Validated in prep()
+    const { context } = prepRes;
 
     const [outputAlreadyComplete, initializedMessages] =
       await this.services.modelHandler.initializeOutputAndPrefill(
@@ -190,8 +192,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
     shared.workspaceSnapshot = prepRes.workspace.toSnapshot({
       excludeAssemblyStrings: true,
     });
-    shared.conversation = shared.context!.messages;
-    shared.roundStateSnapshots.push(shared.context!.stateRoundSnapshot);
+    shared.conversation = prepRes.context.messages;
+    shared.roundStateSnapshots.push(prepRes.context.stateRoundSnapshot);
 
     return FlowTransition.DEFAULT;
   }

--- a/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
+++ b/src/test-kernel/agent/ReflectionOutputLocation.vitest.ts
@@ -45,6 +45,7 @@ describe('reflection output location resolution', () => {
       relativePath: 'output.xml',
     };
     let resolvedRound: number | undefined;
+    const shared = reflectionShared();
     const node = new ResponseCycleNode().setServices({
       getOutputFileLocation: async (round: number) => {
         resolvedRound = round;
@@ -53,9 +54,11 @@ describe('reflection output location resolution', () => {
       },
     } as unknown as ReflectionServices);
 
-    const prep = await node.prep(reflectionShared());
+    const prep = await node.prep(shared);
 
     expect(resolvedRound).toBe(1);
+    expect(prep.context).toBe(shared.context);
+    expect(prep).not.toHaveProperty('shared');
     expect(prep.outputLocation).toBe(outputLocation);
   });
 });

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -1,0 +1,156 @@
+// Third-party imports
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+// Local imports - response cycle
+import {
+  createResponseCycleFlow,
+  type ResponseCycleShared,
+} from '@agent/core/flows/ResponseCycleFlow';
+import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import type { AgentFileLocation } from '@shared/schemas';
+
+const outputLocation: AgentFileLocation = {
+  kind: 'workspace',
+  absolutePath: '/tmp/output.xml',
+  relativePath: 'output.xml',
+};
+
+function createShared(
+  overrides: Partial<ResponseCycleShared> = {},
+): ResponseCycleShared {
+  return {
+    messages: [],
+    shouldStop: false,
+    endTurn: false,
+    outputExists: true,
+    outputLocation,
+    ...overrides,
+  };
+}
+
+function getContinuationNode() {
+  const prepNode = createResponseCycleFlow().start;
+  const invocationNode = prepNode.getNextNode();
+  const processNode = invocationNode?.getNextNode();
+  const continuationNode = processNode?.getNextNode();
+  if (!continuationNode) {
+    throw new Error('Response cycle continuation node is not wired');
+  }
+  return continuationNode;
+}
+
+function createServices(interrupted = false) {
+  const round = { continuationCount: 0 };
+  const checkInterruption = vi.fn(() => interrupted);
+  const checkStopConditions = vi.fn(() => ({
+    endTurn: false,
+    shouldStop: false,
+  }));
+  const shouldContinue = vi.fn(() => false);
+  const addContinueMessage = vi.fn();
+  const services = {
+    checkInterruption,
+    round,
+    run: {},
+    setting: {},
+    config: {},
+    workspace: {},
+    logger: { info: vi.fn() },
+    modelHandler: {
+      checkStopConditions,
+      shouldContinue,
+      addContinueMessage,
+    },
+  } as unknown as ResponseCycleServices<unknown>;
+
+  return {
+    services,
+    round,
+    checkInterruption,
+    checkStopConditions,
+    shouldContinue,
+    addContinueMessage,
+  };
+}
+
+describe('response cycle continuation phases', () => {
+  it('requires an output location in cycle-local state', () => {
+    expectTypeOf<
+      ResponseCycleShared['outputLocation']
+    >().toEqualTypeOf<AgentFileLocation>();
+  });
+
+  it('skips before interruption checks when no processed response is ready', async () => {
+    const shared = createShared();
+    const harness = createServices();
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(prepResult).toEqual({ kind: 'skipped' });
+    expect(execResult).toEqual({ kind: 'skipped' });
+    expect(harness.checkInterruption).not.toHaveBeenCalled();
+    expect(shared).toMatchObject({ shouldStop: true, endTurn: false });
+    expect(action).toBe(FlowTransition.COMPLETE);
+  });
+
+  it('continues token-limited output even when the model declines continuation', async () => {
+    const shared = createShared({
+      stopReason: 'length',
+      processedResponse: 'partial response',
+    });
+    const harness = createServices();
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(prepResult).toEqual({
+      kind: 'success',
+      value: {
+        interrupted: false,
+        stopReason: 'length',
+        processedResponse: 'partial response',
+      },
+    });
+    expect(harness.checkStopConditions).toHaveBeenCalledWith(
+      'length',
+      'partial response',
+      harness.round,
+      {},
+      {},
+    );
+    expect(harness.shouldContinue).toHaveBeenCalledWith(
+      'length',
+      'partial response',
+      harness.services.setting,
+    );
+    expect(harness.shouldContinue).toHaveReturnedWith(false);
+    expect(harness.round.continuationCount).toBe(1);
+    expect(harness.addContinueMessage).toHaveBeenCalledOnce();
+    expect(action).toBe(FlowTransition.CONTINUE);
+  });
+
+  it('turns a ready response into a completed stop when interrupted', async () => {
+    const shared = createShared({
+      stopReason: 'stop',
+      processedResponse: 'complete response',
+    });
+    const harness = createServices(true);
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(harness.checkStopConditions).not.toHaveBeenCalled();
+    expect(harness.shouldContinue).not.toHaveBeenCalled();
+    expect(shared).toMatchObject({ shouldStop: true, endTurn: false });
+    expect(harness.addContinueMessage).not.toHaveBeenCalled();
+    expect(action).toBe(FlowTransition.COMPLETE);
+  });
+});


### PR DESCRIPTION
## Summary

Make response-cycle phase guarantees explicit in types instead of recovering them with nine non-null assertions.

- Require the cycle-local output location that callers already select before starting a cycle.
- Represent continuation prep as skipped or ready, with stop reason and processed response required only in the ready arm.
- Carry the validated round context through prep instead of passing the full reflection shared store and asserting later.
- Preserve skip, interruption, token-limit continuation, and finalization behavior with focused tests.

Closes #8513.

## Issue acceptance gates

- Removed all nine targeted non-null assertions from `ResponseCycleFlow.ts` and `ResponseCycleNode.ts`.
- `ResponseCycleShared.outputLocation` is required while the outer reflection state remains nullable before round setup.
- Continuation prep is a discriminated `SkippableNodeResult`; ready data requires `stopReason` and `processedResponse`.
- `CyclePrepInput` carries a validated `RoundContext`, not the whole mutable reflection shared store.
- Added focused type and runtime tests for the new phase contracts and behavior-preserving edge cases.

All acceptance gates in #8513 are satisfied.

## Single source of truth

The response-cycle shared schema owns cycle-local readiness. `ResponseCycleNode.prep()` owns the transition from nullable outer reflection state to the required cycle input.

## Duplication and abstraction budget

Removed repeated assertion-based recovery of the same phase guarantees. The continuation path reuses the existing `SkippableNodeResult` union; the only new production construct is a local ready-data interface, with no new module or pass-through layer.

## Net elements (R6)

- Files: 1 test file added, 3 files modified, 0 deleted.
- Exported symbols: +0 / -0.
- Classes/enums: +0 / -0.
- Interfaces/type aliases: +2 / -1 (net +1 local construct).
- LoC: +204 / -35 (net +169), comprising +10 production LoC and +159 test LoC.

## Consumer counts (R8)

n/a — no event path or exported symbol is deleted or rerouted. The response-cycle flow has one production creator, `ResponseCycleNode`.

## Host impact

Extension: Shared agent runs use the stricter internal phase types; no UI or protocol change.

Desktop: Same shared runtime behavior; no desktop-specific change.

CLI: Same shared runtime behavior; no CLI-specific change.

## Scheduled refactoring

None. #8521 is a separate audited settlement-data issue, not required by this change.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; 51 existing warnings outside this diff)
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json --pretty false`
- `npm run check:dead-code-ratchet`
- Focused Vitest: 4 files, 13 tests passed (also repeated after rebasing onto current `origin/main`)
- Full Vitest before the non-overlapping rebase: 695 files passed, 1 skipped; 6,274 tests passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal typing and control-flow clarity in the agent response cycle with behavior-preserving tests; no auth, API, or persistence contract changes.
> 
> **Overview**
> **Makes response-cycle phase guarantees explicit in types** so callers no longer rely on non-null assertions for output location, continuation inputs, and round context.
> 
> `ResponseCycleShared.outputLocation` is **required** on cycle-local state (outer reflection state can still be nullable until prep). Prep/process/debug paths use `shared.outputLocation` directly without `!`.
> 
> **Continuation prep** is modeled as `SkippableNodeResult`: when `shouldStop`, `stopReason`, or `processedResponse` are missing, prep/exec skip **before** `checkInterruption`. The ready arm always carries `stopReason` and `processedResponse`. **`reachedTokenLimit`** is computed in continuation `exec` and returned with the other continuation flags (instead of re-reading stop reason in `post`).
> 
> **Reflection `ResponseCycleNode`** passes a validated **`RoundContext`** through `CyclePrepInput` instead of the full shared store, and updates conversation/round snapshots from `prepRes.context` after the cycle.
> 
> **Tests** assert the required output-location type, async output resolution + prep shape, and continuation edge cases (skip, token-limit continue when `shouldContinue` is false, interrupt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d09e237eb862fe9f922954178148c35ebb3bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->