### PR TITLE
fix(openai): decode standards-compliant data URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "async-mutex": "^0.5.0",
     "bibtex": "^0.9.0",
     "content-disposition": "^2.0.1",
+    "data-uri-to-buffer": "^6.0.2",
     "date-fns": "^4.4.0",
     "deepmerge": "^4.3.1",
     "delay": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       content-disposition:
         specifier: ^2.0.1
         version: 2.0.1
+      data-uri-to-buffer:
+        specifier: ^6.0.2
+        version: 6.0.2
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -3431,6 +3434,10 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -9126,6 +9133,8 @@ snapshots:
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
 
   data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:

--- a/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseFileUploads.ts
@@ -8,6 +8,7 @@
 import { Buffer } from 'node:buffer';
 import * as path from 'node:path';
 
+import { dataUriToBuffer } from 'data-uri-to-buffer';
 import OpenAI, {
   APIConnectionTimeoutError,
   APIError as OpenAIAPIError,
@@ -21,7 +22,7 @@ import { isNonEmptyString } from '@utils/core';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 
 import { loadAttachmentBuffer, wipeBuffer } from '../utils/toolAttachmentUtils';
-import { parseDataUrl, toDataUrl } from '../support/dataUrl';
+import { toDataUrl } from '../support/dataUrl';
 import { reportMediaAttachmentFailure } from '../support/mediaAttachmentPolicy';
 import { isInputFileContent, isMessageItem } from './openAIResponseContent';
 import type {
@@ -105,10 +106,10 @@ async function replaceFileDataWithUpload(
   let buffer: Buffer | undefined;
 
   try {
-    const parsed = parseDataUrl(fileData);
-    const payload = parsed ? parsed.base64Data : fileData;
-
-    buffer = Buffer.from(payload, 'base64');
+    buffer =
+      fileData.slice(0, 5).toLowerCase() === 'data:'
+        ? Buffer.from(dataUriToBuffer(fileData).buffer)
+        : Buffer.from(fileData, 'base64');
     const uploadedFile = await client.files.create({
       file: await toFile(buffer!, filename),
       purpose: 'assistants',

--- a/src/agent/modelHandlers/support/dataUrl.ts
+++ b/src/agent/modelHandlers/support/dataUrl.ts
@@ -1,21 +1,7 @@
-// Shared helpers for building and parsing `data:` URLs used across model
-// handlers to inline base64-encoded media/documents in provider requests.
+// Shared helper for building `data:` URLs used across model handlers to inline
+// base64-encoded media/documents in provider requests.
 
 /** Builds a `data:` URL from a MIME type and base64-encoded payload. */
 export function toDataUrl(mediaType: string, base64Data: string): string {
   return `data:${mediaType};base64,${base64Data}`;
-}
-
-/**
- * Parses a `data:<mediaType>;base64,<data>` URL into its parts. `mediaType`
- * captures everything up to the `;base64,` marker, including any extra
- * parameters (e.g. `application/pdf;charset=utf-8`). Returns `undefined` if
- * the string doesn't match the expected base64 data URL shape.
- */
-export function parseDataUrl(
-  dataUrl: string,
-): { mediaType: string; base64Data: string } | undefined {
-  const match = /^data:(.+?);base64,(.+)$/s.exec(dataUrl);
-  if (!match) return undefined;
-  return { mediaType: match[1], base64Data: match[2] };
 }

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseFileUploads.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseFileUploads.vitest.ts
@@ -1,0 +1,109 @@
+import { Buffer } from 'node:buffer';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import { uploadInlineInputFiles } from '@agent/modelHandlers/openai/openAIResponseFileUploads';
+import type OpenAI from 'openai';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
+
+interface TestInputFile {
+  type: 'input_file';
+  filename?: string;
+  file_data?: string;
+  file_id?: string;
+}
+
+function inputFileMessage(fileData: string): {
+  content: TestInputFile;
+  message: ResponseInputItem;
+} {
+  const content: TestInputFile = {
+    type: 'input_file',
+    filename: 'paper.pdf',
+    file_data: fileData,
+  };
+  return {
+    content,
+    message: {
+      type: 'message',
+      role: 'user',
+      content: [content],
+    } as unknown as ResponseInputItem,
+  };
+}
+
+function uploadClient(): {
+  client: OpenAI;
+  create: ReturnType<typeof vi.fn>;
+  uploadedBytes: () => Buffer | undefined;
+} {
+  let bytes: Buffer | undefined;
+  const create = vi.fn(async ({ file }: { file: File }) => {
+    bytes = Buffer.from(await file.arrayBuffer());
+    return { id: 'file-1' };
+  });
+  return {
+    client: { files: { create } } as unknown as OpenAI,
+    create,
+    uploadedBytes: () => bytes,
+  };
+}
+
+const logger = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+} as unknown as AgentTrace;
+
+async function upload(client: OpenAI, message: ResponseInputItem) {
+  await uploadInlineInputFiles(client, [message], {
+    openRouterRouting: false,
+    logger,
+  });
+}
+
+describe('uploadInlineInputFiles data URLs', () => {
+  it('decodes parameters and percent-encoded base64 padding', async () => {
+    const { content, message } = inputFileMessage(
+      'data:application/pdf;charset=utf-8;base64,SGVsbG8%3D',
+    );
+    const { client, uploadedBytes } = uploadClient();
+
+    await upload(client, message);
+
+    expect(uploadedBytes()?.toString()).toBe('Hello');
+    expect(content).toEqual({ type: 'input_file', file_id: 'file-1' });
+  });
+
+  it('preserves the raw-base64 fallback', async () => {
+    const { message } = inputFileMessage('SGVsbG8=');
+    const { client, uploadedBytes } = uploadClient();
+
+    await upload(client, message);
+
+    expect(uploadedBytes()?.toString()).toBe('Hello');
+  });
+
+  it('rejects malformed data URLs without mutating the input', async () => {
+    const fileData = 'data:application/pdf;base64';
+    const { content, message } = inputFileMessage(fileData);
+    const { client, create } = uploadClient();
+
+    await expect(upload(client, message)).rejects.toThrow(TypeError);
+    expect(create).not.toHaveBeenCalled();
+    expect(content).toEqual({
+      type: 'input_file',
+      filename: 'paper.pdf',
+      file_data: fileData,
+    });
+  });
+
+  it('uploads an empty data URL payload', async () => {
+    const { message } = inputFileMessage('data:application/pdf;base64,');
+    const { client, uploadedBytes } = uploadClient();
+
+    await upload(client, message);
+
+    expect(uploadedBytes()).toHaveLength(0);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/DataUrl.vitest.ts
@@ -1,43 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseDataUrl, toDataUrl } from '@agent/modelHandlers/support/dataUrl';
+import { toDataUrl } from '@agent/modelHandlers/support/dataUrl';
 
 describe('toDataUrl', () => {
   it('builds a data URL from a media type and base64 payload', () => {
     expect(toDataUrl('application/pdf', 'ABC123')).toBe(
       'data:application/pdf;base64,ABC123',
     );
-  });
-});
-
-describe('parseDataUrl', () => {
-  it('parses a simple media type and base64 payload', () => {
-    expect(parseDataUrl('data:application/pdf;base64,ABC123')).toEqual({
-      mediaType: 'application/pdf',
-      base64Data: 'ABC123',
-    });
-  });
-
-  it('parses a media type with extra parameters before the base64 marker', () => {
-    expect(
-      parseDataUrl('data:application/pdf;charset=utf-8;base64,ABC123'),
-    ).toEqual({
-      mediaType: 'application/pdf;charset=utf-8',
-      base64Data: 'ABC123',
-    });
-  });
-
-  it('returns undefined for a raw base64 string with no data URL prefix', () => {
-    expect(parseDataUrl('ABC123')).toBeUndefined();
-  });
-
-  it('returns undefined for a ";base64," separator without the "data:" prefix', () => {
-    // Documents an intentional behavior change from the original inline
-    // openAIResponseFileUploads.ts extraction, which used a plain
-    // `indexOf(';base64,')` and would have matched this input. The sole
-    // caller always receives proper `data:` URLs from the OpenAI Response
-    // API, so the stricter contract is safe there; this test exists so the
-    // narrowing is documented rather than silently relied upon.
-    expect(parseDataUrl('something;base64,ABC123')).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #8516

## Summary

Replace the local OpenAI inline-file data-URL regex with `data-uri-to-buffer` at the upload boundary. Data URLs are decoded once into upload bytes, while raw base64 remains supported.

The dependency is pinned to `^6.0.2`, the newest line compatible with TeXRA's current CommonJS/`moduleResolution: node` typecheck. The actively maintained package's v8 conditional exports require a newer TypeScript module-resolution mode; using v6 avoids a local declaration shim or repo-wide compiler change.

## Issue acceptance gates

- Decode RFC 2397 data URLs with the maintained package.
- Support parameters and percent-encoded base64 padding.
- Preserve raw-base64 input.
- Reject malformed `data:` URLs without mutating the input.
- Accept empty data-URL payloads.
- Preserve the existing upload buffer wipe in `finally`.

## Single source of truth

`replaceFileDataWithUpload` is the sole decode boundary for OpenAI inline files; `data-uri-to-buffer` owns data-URL parsing. The shared `toDataUrl` helper remains the sole encoder.

## Duplication and abstraction budget

Deletes the single-caller `parseDataUrl` wrapper and its regex. No replacement wrapper is added.

## Net elements (R6)

- Files: 5 modified; 1 test file added; 0 deleted.
- Exported symbols: 0 added; 1 deleted (`parseDataUrl`).
- Classes/interfaces/enums: 0 production additions.
- Production source: 8 insertions, 21 deletions (net -13).
- Tests: 110 insertions, 33 deletions (net +77).
- Dependency metadata/lockfile: +10 lines.
- Whole diff: 128 insertions, 54 deletions (net +74, primarily focused boundary coverage).

## Consumer counts (R8)

Before deletion, `parseDataUrl` had exactly 1 production consumer (`openAIResponseFileUploads.ts`) and 1 test suite. The production consumer is rerouted directly to `dataUriToBuffer`; the wrapper-only tests are replaced by upload-boundary tests. Post-change grep count: 0.

## Host impact

Extension: OpenAI Responses file uploads correctly decode standards-compliant data URLs.

Desktop: Same shared OpenAI upload behavior.

CLI: Same shared OpenAI upload behavior.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- `npm run compile:safe`
- focused OpenAI/data-URL tests — 3 files, 35 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how inline file bytes are derived before OpenAI upload; wrong decoding could corrupt uploads, though behavior is tightened and covered by new tests.
> 
> **Overview**
> **OpenAI Responses inline file uploads** now decode `file_data` through `data-uri-to-buffer` at `replaceFileDataWithUpload` instead of the removed local `parseDataUrl` regex. Strings starting with `data:` become upload bytes via the library (RFC 2397, extra MIME parameters, percent-encoded padding); non–data-URL strings still use raw base64. Malformed `data:` URLs throw without calling the Files API or changing the content object.
> 
> The shared `dataUrl` module keeps only **`toDataUrl`** for encoding. **`parseDataUrl`** and its tests are dropped in favor of **`OpenAIResponseFileUploads.vitest.ts`** boundary tests. Dependency **`data-uri-to-buffer@^6.0.2`** is added for CJS/older module resolution compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8b41b87da58855dde8962482fbd9efcbbfc8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->