### PR TITLE
refactor(memory): reuse shared byte formatting

### DIFF
--- a/packages/cli/src/runtime/memory.ts
+++ b/packages/cli/src/runtime/memory.ts
@@ -1,12 +1,9 @@
 import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
 import type { MemoryViewItem } from '@shared/schemas';
+import { formatBytes } from '@shared/utils/string';
 import { MEMORY_DISPLAY_ROOT } from '@tools/memory/constants';
 import { loadMemoryPreview } from '@tools/memory/memoryFileSystem';
-import {
-  displayToStoragePath,
-  formatSize,
-  toDisplayPath,
-} from '@tools/memory/memoryUtils';
+import { displayToStoragePath, toDisplayPath } from '@tools/memory/memoryUtils';
 import { filterNotNullish, normalizeFilePath } from '@utils/core';
 import {
   formatLocaleTimestamp,
@@ -30,7 +27,7 @@ function formatModifiedDate(value: string): string {
 export function cliMemoryItemDescription(item: MemoryViewItem): string {
   const parts = [
     item.pinned ? 'pinned' : undefined,
-    formatSize(item.size),
+    formatBytes(item.size),
     formatModifiedDate(item.mtime),
     item.modifiedBy ? `by ${item.modifiedBy}` : undefined,
   ].filter(filterNotNullish);

--- a/src/test-kernel/cli/CliMemory.vitest.mts
+++ b/src/test-kernel/cli/CliMemory.vitest.mts
@@ -22,7 +22,7 @@ describe('CLI memory formatting', () => {
     const description = cliMemoryItemDescription(item);
 
     expect(description).toContain('pinned');
-    expect(description).toContain('2.0K');
+    expect(description).toContain('2 KiB');
     expect(description).toContain('by researcher');
   });
 

--- a/src/tools/executions/fileListingFormat.ts
+++ b/src/tools/executions/fileListingFormat.ts
@@ -6,7 +6,7 @@
  * source entries with differently-named directory flags.
  */
 
-import { formatSize } from '../memory/memoryUtils';
+import { formatBytes } from '@shared/utils/string';
 
 export interface SizedEntry {
   readonly path: string;
@@ -19,7 +19,7 @@ export function formatSizedEntryLines(
   entries: readonly SizedEntry[],
 ): string[] {
   return entries.map((entry) => {
-    const sizeStr = entry.isDir ? '<dir>' : formatSize(entry.size);
+    const sizeStr = entry.isDir ? '<dir>' : formatBytes(entry.size);
     return `${sizeStr.padStart(8)}  ${entry.path}`;
   });
 }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -12,7 +12,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { debug } from '@logger/logUtils';
-import { formatRelativeTime } from '@shared/utils/string';
+import { formatBytes, formatRelativeTime } from '@shared/utils/string';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -43,7 +43,7 @@ import {
   DIRECTORY_LISTING_DEPTH,
   shouldSkipEntry,
 } from './constants';
-import { toDisplayPath, formatSize, displayToStoragePath } from './memoryUtils';
+import { displayToStoragePath, toDisplayPath } from './memoryUtils';
 import {
   parseFrontmatter,
   buildFile,
@@ -554,7 +554,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
             );
           }
         }
-        return `${formatSize(entry.size)}\t${age}\t${by}\t${display}`;
+        return `${formatBytes(entry.size)}\t${age}\t${by}\t${display}`;
       }),
     );
   }

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -18,21 +18,6 @@ export function toDisplayPath(storagePath: string): string {
   return relativeToDisplayPath(relative);
 }
 
-export function formatSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-
-  const units = ['K', 'M', 'G', 'T'];
-  let value = bytes / 1024;
-  let unitIndex = 0;
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-  return `${value.toFixed(1)}${units[unitIndex]}`;
-}
-
 export function displayToStoragePath(displayPath: string): string {
   if (
     displayPath !== MEMORY_DISPLAY_ROOT &&


### PR DESCRIPTION
Closes #8518

## Summary

Delete the memory-specific byte formatter and route CLI memory descriptions, memory-tool listings, and execution file listings through the existing shared `pretty-bytes` formatter.

User-visible sizes now use explicit binary units consistently, for example `2 KiB` instead of `2.0K`.

## Issue acceptance gates

- Remove `memoryUtils.formatSize`.
- Reuse `formatBytes(bytes)` from `src/shared/utils/string.ts`.
- Update all three production consumers.
- Preserve directory markers and listing alignment.
- Update the existing CLI memory-format assertion.

## Single source of truth

`src/shared/utils/string.ts::formatBytes`, backed by the existing `pretty-bytes` dependency, owns user-facing byte formatting.

## Duplication and abstraction budget

Deletes a 15-line duplicate formatter. No dependency or abstraction is added.

## Net elements (R6)

- Files: 5 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 1 deleted (`formatSize`).
- Classes/interfaces/enums: 0 added; 0 deleted.
- Production source: 8 insertions, 26 deletions (net -18).
- Tests: 1 insertion, 1 deletion.
- Whole diff: 9 insertions, 27 deletions (net -18).

## Consumer counts (R8)

Before deletion, `formatSize` had 3 production consumers: CLI memory descriptions, memory-tool directory listings, and execution file listings. All 3 are rerouted to `formatBytes`; post-change `formatSize` grep count is 0.

## Host impact

Extension: Memory and execution listings use explicit binary byte units.

Desktop: Same shared listing behavior.

CLI: Memory descriptions use explicit binary byte units.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- `npm run typecheck`
- focused CLI memory and execution-listing tests — 2 files, 27 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting consolidation with no auth, data, or API behavior changes; minor string output differences in listings.
> 
> **Overview**
> Removes the duplicate `formatSize` helper from memory utilities and wires **CLI memory descriptions**, **memory-tool directory listings**, and **execution/workspace file listings** through the shared `formatBytes` helper (`pretty-bytes` with binary units).
> 
> **User-visible change:** sizes now show explicit binary units (e.g. **`2 KiB`** instead of **`2.0K`**). Directory markers (`<dir>`) and right-aligned listing layout are unchanged. The CLI memory test expectation is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004df7a8f015c00027e0680f8b8a61080597e6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->