### PR TITLE
refactor(models): narrow OpenAI function tool types

### DIFF
--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -240,7 +240,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     if (tools && tools.length > 0) {
-      request.tools = toOpenAITools(tools) as ChatRequest['tools'];
+      request.tools = toOpenAITools(tools);
       request.toolChoice = 'auto';
     }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -12,7 +12,7 @@ import type {
   ToolUnion,
 } from '@anthropic-ai/sdk/resources/messages';
 import type { Tool as GeminiTool, FunctionDeclaration } from '@google/genai';
-import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { ChatCompletionFunctionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
   WebSearchTool,
@@ -218,8 +218,10 @@ const DYNAMIC_FILTERING_TOOLS = new Set(['web_search', 'web_fetch']);
  * Note: We intentionally don't use zodFunction() here because it doesn't support
  * the unrepresentable option, causing failures with tool schemas that use .transform().
  */
-export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d): ChatCompletionTool => {
+export function toOpenAITools(
+  defs: ToolDefinition[],
+): ChatCompletionFunctionTool[] {
+  return defs.map((d): ChatCompletionFunctionTool => {
     const parameters = toOpenAISchemaObject(d);
     return {
       type: 'function',


### PR DESCRIPTION
Closes #8525

## Summary

Use OpenAI's native `ChatCompletionFunctionTool` type for `toOpenAITools()`, matching the function-only objects the converter actually emits. The narrower SDK type is directly assignable to OpenRouter's function tools, so the request cast is deleted.

Runtime output is unchanged.

## Issue acceptance gates

- Narrow the converter return and map annotation to `ChatCompletionFunctionTool[]`.
- Remove the OpenRouter `ChatRequest['tools']` cast.
- Preserve generated tool payloads.
- Verify against both installed SDK type surfaces.

## Single source of truth

`toOpenAITools()` owns function-tool conversion and now exposes the exact native OpenAI type of its output.

## Duplication and abstraction budget

No abstraction or dependency is added. One unsafe cross-SDK cast is removed.

## Net elements (R6)

- Files: 2 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted; 1 existing return type narrowed.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Whole diff: 6 insertions, 4 deletions (net +2, from multiline exact typing).

## Consumer counts (R8)

`toOpenAITools` has 2 production consumers: the OpenAI Chat handler and the native OpenRouter handler. Both remain; the OpenRouter consumer no longer casts the result. No emit path is changed.

## Host impact

Extension: Compile-time safety improvement only.

Desktop: Compile-time safety improvement only.

CLI: Compile-time safety improvement only.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- `npm run typecheck`
- focused tool-conversion/OpenRouter tests — 3 files, 33 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor on tool conversion and OpenRouter request assembly; no logic or payload changes.
> 
> **Overview**
> **`toOpenAITools()`** is typed to return **`ChatCompletionFunctionTool[]`** instead of the broader **`ChatCompletionTool[]`**, matching the function-only payloads the converter already builds.
> 
> The native OpenRouter chat request no longer needs **`as ChatRequest['tools']`** because that narrower OpenAI SDK type assigns cleanly to OpenRouter’s tools field. **Runtime tool JSON is unchanged**; this is compile-time typing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d66fe8ff3dc6abea9baf8cb9fdd7ecde76c228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->