### PR TITLE
fix(openrouter): prefer native usage cost

### DIFF
--- a/src/agent/modelHandlers/openrouter/openRouterUsage.ts
+++ b/src/agent/modelHandlers/openrouter/openRouterUsage.ts
@@ -20,12 +20,19 @@ import type { ChatUsage } from '@openrouter/sdk/models';
 /** Pricing inputs the handler supplies from its `config`/`capabilities`. */
 type OpenRouterPricingConfig = StandardPricingConfig;
 
-/** Computes cost based on token usage and model pricing. */
+/**
+ * Prefer OpenRouter's billed cost for credit-backed requests. BYOK cost is
+ * split between OpenRouter credits and the upstream provider account, so keep
+ * the existing static full-inference estimate for that route.
+ */
 export function computeOpenRouterPrice(
   responseUsage: ChatUsage | null,
   config: OpenRouterPricingConfig,
 ): number {
   if (!responseUsage) return 0;
+  if (responseUsage.isByok !== true && responseUsage.cost != null) {
+    return responseUsage.cost;
+  }
 
   return computeStandardPrice(
     {

--- a/src/test-kernel/agent/modelHandlers/OpenRouterUsage.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenRouterUsage.vitest.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeOpenRouterPrice,
+  normalizeOpenRouterUsage,
+} from '@agent/modelHandlers/openrouter/openRouterUsage';
+import type { ChatUsage } from '@openrouter/sdk/models';
+
+const CONFIG = {
+  inputPrice: 2,
+  outputPrice: 12,
+  cacheDiscountFactor: 0.25,
+};
+
+function usage(fields: Partial<ChatUsage> = {}): ChatUsage {
+  return {
+    promptTokens: 1000,
+    completionTokens: 100,
+    totalTokens: 1100,
+    ...fields,
+  };
+}
+
+const STATIC_PRICE = (1000 * 2 + 100 * 12) / 1e6;
+
+describe('OpenRouter usage pricing', () => {
+  it('prefers native cost and surfaces it through normalization', () => {
+    const raw = usage({ cost: 0.123 });
+
+    expect(computeOpenRouterPrice(raw, CONFIG)).toBe(0.123);
+    expect(normalizeOpenRouterUsage(raw, 50, 'openrouter', CONFIG).cost).toBe(
+      0.123,
+    );
+  });
+
+  it('preserves a native zero cost', () => {
+    expect(computeOpenRouterPrice(usage({ cost: 0 }), CONFIG)).toBe(0);
+  });
+
+  it('keeps static full-inference pricing for BYOK usage', () => {
+    expect(
+      computeOpenRouterPrice(
+        usage({
+          cost: 0.0001,
+          isByok: true,
+          costDetails: {
+            upstreamInferenceCost: 0.5,
+            upstreamInferencePromptCost: 0.3,
+            upstreamInferenceCompletionsCost: 0.2,
+          },
+        }),
+        CONFIG,
+      ),
+    ).toBeCloseTo(STATIC_PRICE, 12);
+  });
+
+  it('falls back to static pricing when native cost is absent', () => {
+    expect(computeOpenRouterPrice(usage(), CONFIG)).toBeCloseTo(
+      STATIC_PRICE,
+      12,
+    );
+  });
+});


### PR DESCRIPTION
Closes #8526

## Summary

Prefer OpenRouter's native billed completion cost for credit-backed requests instead of recomputing it from static model rates. Preserve TeXRA's existing full-inference estimate for BYOK, where spend is split between OpenRouter credits and the user's upstream provider account.

This also preserves native zero-cost responses.

## Issue acceptance gates

- Native non-BYOK cost overrides deliberately different static pricing.
- Native zero is honored.
- BYOK retains the existing static full-inference estimate.
- Nullish native cost falls back to static pricing.
- Normalized usage surfaces the same cost.
- The BYOK policy is recorded in code and tests.

## Single source of truth

`computeOpenRouterPrice` owns route-aware OpenRouter cost selection. OpenRouter's `ChatUsage.cost` is authoritative for credit-backed requests; `computeStandardPrice` remains the compatibility fallback and BYOK estimate.

## Duplication and abstraction budget

No abstraction or dependency is added. The change uses fields already retained on the native SDK usage payload.

## Net elements (R6)

- Files: 1 production file modified; 1 focused test file added.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Production source: 8 insertions, 1 deletion (net +7, including policy documentation).
- Tests: +63 lines.
- Whole diff: 71 insertions, 1 deletion (net +70).

## Consumer counts (R8)

n/a — no export or event-emission path is deleted or rerouted. Both existing `computeOpenRouterPrice` paths (handler price and normalized usage) remain and now share the native-cost policy.

## Host impact

Extension: OpenRouter usage displays actual billed cost for credit-backed requests.

Desktop: Same shared OpenRouter usage behavior.

CLI: Same shared OpenRouter usage behavior.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- focused OpenRouter usage tests — 4 tests passed
- `npm run typecheck`; after fixing the one test fixture type, targeted test-kernel typecheck passed
- `git diff --check`

## References

- OpenRouter response usage schema: https://openrouter.ai/docs/api/reference/overview
- OpenRouter BYOK billing model: https://openrouter.ai/docs/guides/overview/auth/byok

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized billing-display logic with explicit BYOK and fallback behavior and new unit tests; no auth or data-path changes.
> 
> **Overview**
> **OpenRouter credit-backed completions** now report **`ChatUsage.cost`** from the API instead of recomputing spend from static per-model rates, so usage UI matches what OpenRouter actually bills (including **$0** when the API returns zero).
> 
> **BYOK** (`isByok === true`) still uses the existing **`computeStandardPrice`** full-inference estimate, since billed cost is split between OpenRouter credits and the upstream provider. When native **`cost`** is missing, behavior is unchanged: static pricing from token counts and cache/reasoning details.
> 
> Policy lives in **`computeOpenRouterPrice`**, which both the handler and **`normalizeOpenRouterUsage`** already call. New Vitest coverage exercises native cost, zero cost, BYOK static path, and missing-cost fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755928dae6749cc247e8d6353437af6570c3163b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->