### PR TITLE
feat(copilot): support image inputs through VS Code LM

### DIFF
--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -107,13 +107,17 @@ function toVscodeMessage(
   }
 
   return vscode.LanguageModelChatMessage.User(
-    message.content.map((part) =>
-      part.kind === 'text'
-        ? new vscode.LanguageModelTextPart(part.text)
-        : new vscode.LanguageModelToolResultPart(part.callId, [
-            new vscode.LanguageModelTextPart(part.text),
-          ]),
-    ),
+    message.content.map((part) => {
+      if (part.kind === 'text') {
+        return new vscode.LanguageModelTextPart(part.text);
+      }
+      if (part.kind === 'data') {
+        return vscode.LanguageModelDataPart.image(part.data, part.mimeType);
+      }
+      return new vscode.LanguageModelToolResultPart(part.callId, [
+        new vscode.LanguageModelTextPart(part.text),
+      ]);
+    }),
   );
 }
 

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -2,6 +2,7 @@
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
   LanguageModelPortError,
+  type LanguageModelDataPart,
   type LanguageModelMessage,
   type LanguageModelPort,
   type LanguageModelTextPart,
@@ -39,6 +40,9 @@ import type {
   ToolResult,
 } from '@shared/schemas/toolResult';
 
+// Local imports - utilities
+import { getMimeType } from '@utils/files';
+
 // Local imports - model handlers
 import { ModelHandler } from '../ModelHandler';
 import { toVscodeLmTools } from '../toolConversion';
@@ -60,8 +64,10 @@ export interface VscodeLmResponse {
     typeof OPENAI_CHAT_FINISH.STOP | typeof OPENAI_CHAT_FINISH.TOOL_CALLS;
 }
 
-const TEXT_ONLY_ERROR =
-  'VS Code language models currently support text input only in TeXRA. Image, PDF, and audio attachments are not supported.';
+const VISION_UNSUPPORTED_ERROR =
+  'The selected VS Code language model does not support image input.';
+const IMAGE_INPUT_ONLY_ERROR =
+  'VS Code language models support image attachments in TeXRA, but audio and other native file inputs are not supported.';
 
 function joinText(...sections: Array<string | undefined>): string {
   return sections
@@ -153,8 +159,18 @@ function tagVscodeLmError(error: unknown, provider: string): void {
   });
 }
 
-function requireTextOnly(mediaFiles?: readonly FileLocation[]): void {
-  if (mediaFiles?.length) throw new Error(TEXT_ONLY_ERROR);
+function requireSupportedMedia(
+  mediaFiles: readonly FileLocation[] | undefined,
+  supportsVision: boolean,
+): void {
+  if (!mediaFiles?.length) return;
+  if (!supportsVision) throw new Error(VISION_UNSUPPORTED_ERROR);
+
+  const unsupported = mediaFiles.find(({ absolutePath }) => {
+    const mimeType = getMimeType(absolutePath);
+    return mimeType !== 'application/pdf' && !mimeType?.startsWith('image/');
+  });
+  if (unsupported) throw new Error(IMAGE_INPUT_ONLY_ERROR);
 }
 
 function requireLanguageModelPort(): LanguageModelPort {
@@ -175,12 +191,12 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   VscodeLmToolCall,
   LanguageModelPort,
   VscodeLmResponse,
-  never
+  LanguageModelDataPart
 > {
   constructor(config: ModelConfig) {
     super(config);
-    this.capabilities.supportsVision = false;
     this.capabilities.supportsNativeAudio = false;
+    this.capabilities.supportsNativePdf = false;
     this.capabilities.supportsAssistantPrefill = false;
     this.capabilities.supportsTokenCounting = true;
   }
@@ -269,12 +285,15 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     mediaFiles?: FileLocation[],
     systemPrompt?: string,
   ): Promise<LanguageModelMessage[]> {
-    requireTextOnly(mediaFiles);
+    requireSupportedMedia(mediaFiles, this.capabilities.supportsVision);
+    const media = mediaFiles?.length
+      ? await this.createMediaForRound(mediaFiles, 'initial')
+      : [];
     return foldSystemPromptIntoVscodeLmMessages(
       [
         {
           role: 'user',
-          content: [textPart(joinText(userPrefix, userRequest))],
+          content: [textPart(joinText(userPrefix, userRequest)), ...media],
         },
       ],
       systemPrompt,
@@ -286,13 +305,35 @@ export class ModelHandlerVscodeLm extends ModelHandler<
     userMessage: string,
     mediaFiles?: FileLocation[],
   ): Promise<LanguageModelMessage[]> {
-    requireTextOnly(mediaFiles);
-    return [...messages, { role: 'user', content: [textPart(userMessage)] }];
+    requireSupportedMedia(mediaFiles, this.capabilities.supportsVision);
+    const media = mediaFiles?.length
+      ? await this.createMediaForRound(mediaFiles, 'followUp')
+      : [];
+    return [
+      ...messages,
+      { role: 'user', content: [textPart(userMessage), ...media] },
+    ];
   }
 
-  createMediaContent(mediaMessage: MediaEntry[]): never[] {
-    if (mediaMessage.length) throw new Error(TEXT_ONLY_ERROR);
-    return [];
+  createMediaContent(mediaMessage: MediaEntry[]): LanguageModelDataPart[] {
+    return mediaMessage.flatMap((media) => {
+      if (
+        media.media_category !== 'image' ||
+        !media.media_type.startsWith('image/')
+      ) {
+        throw new Error(IMAGE_INPUT_ONLY_ERROR);
+      }
+      if (!media.binary_data) {
+        throw new Error(`Missing binary image data for ${media.file_name}.`);
+      }
+      return [
+        {
+          kind: 'data' as const,
+          data: media.binary_data,
+          mimeType: media.media_type,
+        },
+      ];
+    });
   }
 
   extractResponse(response: VscodeLmResponse): ExtractResponseResult {
@@ -457,11 +498,23 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   }
 
   async addMediaToUserMessage(
-    _messages: LanguageModelMessage[],
+    messages: LanguageModelMessage[],
     mediaFiles: FileLocation[],
   ): Promise<MediaAttachmentKind[]> {
-    requireTextOnly(mediaFiles);
-    return [];
+    requireSupportedMedia(mediaFiles, this.capabilities.supportsVision);
+    if (!mediaFiles.length) return [];
+
+    const index = messages.findLastIndex((message) => message.role === 'user');
+    const message = messages[index];
+    if (message?.role !== 'user') return [];
+
+    const media = await this.createMediaForRound(mediaFiles, 'insert');
+    if (!media.length) return [];
+    messages[index] = {
+      role: 'user',
+      content: [...message.content, ...media],
+    };
+    return this.consumeInsertedAttachmentKinds('insert');
   }
 
   override async estimateTokenCount(

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -94,7 +94,7 @@ function runtimeConfig(
       supportsFunctionCalling: base.capabilities.supportsFunctionCalling,
       supportsReasoning: base.capabilities.supportsReasoning,
       supportsTokenCounting: true,
-      supportsVision: false,
+      supportsVision: base.capabilities.supportsVision,
       supportsSystemPrompt: false,
     },
   };

--- a/src/platform/languageModel.ts
+++ b/src/platform/languageModel.ts
@@ -33,6 +33,13 @@ export interface LanguageModelTextPart {
   readonly text: string;
 }
 
+/** Binary image input passed to an editor-supplied language model. */
+export interface LanguageModelDataPart {
+  readonly kind: 'data';
+  readonly data: Uint8Array;
+  readonly mimeType: string;
+}
+
 export interface LanguageModelToolCallPart {
   readonly kind: 'toolCall';
   readonly callId: string;
@@ -50,7 +57,9 @@ export type LanguageModelMessage =
   | {
       readonly role: 'user';
       readonly content: readonly (
-        LanguageModelTextPart | LanguageModelToolResultPart
+        | LanguageModelTextPart
+        | LanguageModelDataPart
+        | LanguageModelToolResultPart
       )[];
     }
   | {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import { Buffer } from 'node:buffer';
+
 // Third-party imports
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -19,6 +22,7 @@ import {
   ModelHandlerVscodeLm,
 } from '@agent/modelHandlers/vscodelm/modelHandlerVscodeLm';
 import { OPENAI_CHAT_FINISH } from '@agent/types/StopReasonTypes';
+import type { MediaEntry } from '@agent/utils/mediaTypes';
 import {
   detectPartialText,
   isUserAbort,
@@ -27,7 +31,10 @@ import {
 } from '@common/errors/sdkErrorUtils';
 import { isCredentialExhausted, type FileLocation } from '@shared/schemas';
 
-function modelConfig(supportsFunctionCalling = true): ModelConfig {
+function modelConfig(
+  supportsFunctionCalling = true,
+  supportsVision = true,
+): ModelConfig {
   return {
     name: 'copilot-test',
     label: 'Copilot Test',
@@ -41,11 +48,38 @@ function modelConfig(supportsFunctionCalling = true): ModelConfig {
     capabilities: {
       ...DEFAULT_MODEL_CAPABILITIES,
       supportsFunctionCalling,
-      supportsVision: true,
+      supportsVision,
       supportsNativeAudio: true,
     },
     openRouterOnly: false,
   };
+}
+
+const IMAGE_LOCATION: FileLocation = {
+  kind: 'external',
+  absolutePath: '/tmp/figure.png',
+};
+const AUDIO_LOCATION: FileLocation = {
+  kind: 'external',
+  absolutePath: '/tmp/recording.wav',
+};
+
+function mockMediaEntries(
+  handler: ModelHandlerVscodeLm,
+  entries: MediaEntry[],
+) {
+  const processor = (
+    handler as unknown as {
+      mediaProcessor: {
+        loadEntries(
+          mediaFiles: FileLocation[],
+        ): Promise<{ entries: MediaEntry[]; results: [] }>;
+      };
+    }
+  ).mediaProcessor;
+  return vi
+    .spyOn(processor, 'loadEntries')
+    .mockResolvedValue({ entries, results: [] });
 }
 
 function fakePort(
@@ -101,16 +135,77 @@ describe('ModelHandlerVscodeLm messages', () => {
     ]);
   });
 
-  it('rejects image, PDF, and audio attachment input', async () => {
+  it('preserves image bytes across initial, round, and insertion paths', async () => {
     const handler = new ModelHandlerVscodeLm(modelConfig());
-    expect(handler.capabilities.supportsVision).toBe(false);
+    const data = Buffer.from([1, 2, 3, 4]);
+    const loadEntries = mockMediaEntries(handler, [
+      {
+        file_name: 'figure.png',
+        data: data.toString('base64'),
+        binary_data: data,
+        media_type: 'image/png',
+        media_category: 'image',
+      },
+    ]);
+
+    expect(handler.capabilities.supportsVision).toBe(true);
     expect(handler.capabilities.supportsNativeAudio).toBe(false);
+    expect(handler.capabilities.supportsNativePdf).toBe(false);
+
+    const initial = await handler.initializeMessages(
+      'prefix',
+      'request',
+      [IMAGE_LOCATION],
+      'system',
+    );
+    expect(initial).toEqual([
+      {
+        role: 'user',
+        content: [
+          { kind: 'text', text: 'system\n\nprefix\n\nrequest' },
+          { kind: 'data', data, mimeType: 'image/png' },
+        ],
+      },
+    ]);
+
+    const rounds = await handler.createRoundMessages(initial, 'next question', [
+      IMAGE_LOCATION,
+    ]);
+    expect(rounds.at(-1)).toEqual({
+      role: 'user',
+      content: [
+        { kind: 'text', text: 'next question' },
+        { kind: 'data', data, mimeType: 'image/png' },
+      ],
+    });
+
+    const withTrailingAssistant: LanguageModelMessage[] = [
+      ...rounds,
+      { role: 'assistant', content: [{ kind: 'text', text: 'working' }] },
+    ];
+    await expect(
+      handler.addMediaToUserMessage(withTrailingAssistant, [IMAGE_LOCATION]),
+    ).resolves.toEqual(['image']);
+    expect(withTrailingAssistant.at(-2)?.content.at(-1)).toEqual({
+      kind: 'data',
+      data,
+      mimeType: 'image/png',
+    });
+    expect(loadEntries).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects media for non-vision models and rejects audio for vision models', async () => {
+    const textOnlyHandler = new ModelHandlerVscodeLm(modelConfig(true, false));
+    expect(textOnlyHandler.capabilities.supportsVision).toBe(false);
 
     await expect(
-      handler.createRoundMessages([], 'question', [
-        'figure.png' as unknown as FileLocation,
-      ]),
-    ).rejects.toThrow('text input only');
+      textOnlyHandler.createRoundMessages([], 'question', [IMAGE_LOCATION]),
+    ).rejects.toThrow('does not support image input');
+
+    const visionHandler = new ModelHandlerVscodeLm(modelConfig());
+    await expect(
+      visionHandler.initializeMessages('', 'question', [AUDIO_LOCATION]),
+    ).rejects.toThrow('audio and other native file inputs are not supported');
   });
 
   it('does not insert empty text before a tool result', () => {

--- a/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
+++ b/src/test-kernel/frontend/createLanguageModelPort.vitest.ts
@@ -22,6 +22,17 @@ class LanguageModelToolResultPart {
   ) {}
 }
 
+class LanguageModelDataPart {
+  static image(data: Uint8Array, mimeType: string) {
+    return new LanguageModelDataPart(data, mimeType);
+  }
+
+  constructor(
+    public readonly data: Uint8Array,
+    public readonly mimeType: string,
+  ) {}
+}
+
 class LanguageModelChatMessage {
   private constructor(
     public readonly role: 'user' | 'assistant',
@@ -80,6 +91,7 @@ vi.mock('vscode', () => ({
   LanguageModelTextPart,
   LanguageModelToolCallPart,
   LanguageModelToolResultPart,
+  LanguageModelDataPart,
   LanguageModelChatMessage,
   LanguageModelChatToolMode: { Auto: 1, Required: 2 },
   CancellationTokenSource,
@@ -241,7 +253,14 @@ describe('createLanguageModelPort', () => {
         },
         {
           role: 'user',
-          content: [{ kind: 'toolResult', callId: 'call-1', text: 'done' }],
+          content: [
+            {
+              kind: 'data',
+              data: new Uint8Array([1, 2, 3]),
+              mimeType: 'image/png',
+            },
+            { kind: 'toolResult', callId: 'call-1', text: 'done' },
+          ],
         },
       ],
       {
@@ -278,6 +297,7 @@ describe('createLanguageModelPort', () => {
         new LanguageModelToolCallPart('call-1', 'search', { query: 'input' }),
       ]),
       LanguageModelChatMessage.User([
+        LanguageModelDataPart.image(new Uint8Array([1, 2, 3]), 'image/png'),
         new LanguageModelToolResultPart('call-1', [
           new LanguageModelTextPart('done'),
         ]),

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -126,7 +126,7 @@ describe('runtime model registry', () => {
         supportsReasoning: false,
         supportsReasoningEffort: false,
         supportsTokenCounting: true,
-        supportsVision: false,
+        supportsVision: true,
         supportsNativeWebSearch: false,
         supportsNativeCodeExecution: false,
       },


### PR DESCRIPTION
Closes #8530

## Summary

Use the stable VS Code LanguageModelDataPart image API so vision-capable Copilot models can receive TeXRA image attachments. The host-neutral LM port carries image bytes and MIME type, the extension maps them through LanguageModelDataPart.image, and the VS Code LM handler reuses the existing media processor for initial, later-round, and inserted images.

Audio and native PDF input remain disabled. Existing PDF-to-image conversion remains available through the shared media processor.

## Issue acceptance gates

- Preserve the matched model vision capability for discovered Copilot models.
- Carry image bytes and MIME type across the host-neutral port.
- Support initial, later-round, and add-to-last-user image paths.
- Keep non-vision and non-image rejection explicit.
- Preserve text, tool-call, and tool-result behavior.

## Single source of truth

MediaAttachmentProcessor remains the single loader and PDF-to-image boundary. The VS Code bridge owns the conversion from the host-neutral data part to LanguageModelDataPart.image.

## Duplication and abstraction budget

One small host-neutral data-part type is added because core model handling cannot import vscode. No new media loader, dependency, or provider-specific file pipeline is introduced.

## Net elements (R6)

- Files: 7 modified; 0 added; 0 deleted.
- Exported symbols: 1 interface added (LanguageModelDataPart); 0 deleted.
- Classes/interfaces/enums: 1 interface added; 0 deleted.
- Whole diff: 216 insertions, 35 deletions (including focused coverage).

## Consumer counts (R8)

LanguageModelDataPart has two production seams: ModelHandlerVscodeLm creates image parts and createLanguageModelPort maps them to the VS Code API. Three message-entry paths share the existing createMediaForRound pipeline. Existing text and tool consumers remain unchanged.

## Host impact

Extension: Vision-capable Copilot models gain image attachment input.

Desktop: No runtime impact; the host-neutral union compiles but the unavailable LM port remains unchanged.

CLI: No runtime impact; the host-neutral union compiles but the unavailable LM port remains unchanged.

## Scheduled refactoring

Tool-result image attachments remain a separate future feature because TeXRA tool results currently store text in this provider path.

## Validation

- changed-file ESLint — clean
- root and test-kernel TypeScript checks — clean
- focused VS Code LM handler, bridge, and runtime registry tests — 3 files, 40 tests passed
- Prettier and git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Copilot/VS Code LM message pipeline and multimodal validation; mistakes could break requests or send unsupported media, but scope is bounded to the VS Code handler and port mapping with focused tests.
> 
> **Overview**
> Vision-capable **Copilot** models accessed via `vscode.lm` can now receive TeXRA **image** attachments instead of rejecting all media as text-only.
> 
> A host-neutral **`LanguageModelDataPart`** (`kind: 'data'`, bytes + MIME) is added to user message content; the extension maps it to **`LanguageModelDataPart.image`**, and **`ModelHandlerVscodeLm`** loads images through the existing **`createMediaForRound`** path for initial turns, follow-ups, and **`addMediaToUserMessage`**. Validation is capability-aware: non-vision models error on images; vision models still reject **audio** and non-image native inputs (PDF may still be converted upstream). Discovered runtime Copilot configs **preserve** matched base **`supportsVision`** instead of forcing it off.
> 
> Text, tool-call, and tool-result behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cdba8a635806c4d4c19446f7d37a7d848055f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->