### PR TITLE
fix(ui): keep TeXRA status singular and accessible

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -138,6 +138,7 @@ async function refreshApiKeyStatus() {
 
   if (!showReminders) {
     apiKeyStatusBarItem.hide();
+    statusBarItem?.show();
     return;
   }
 
@@ -146,13 +147,18 @@ async function refreshApiKeyStatus() {
   // keys in agreement about whether the first-run CTA should remain visible.
   const exists = await hasAnyUsableSetupCredential();
   if (!exists) {
+    statusBarItem?.hide();
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =
       'Click to run the setup assistant — sign in, use ChatGPT, or add an API key';
     apiKeyStatusBarItem.command = 'texra.runSetupAssistant';
+    apiKeyStatusBarItem.accessibilityInformation = {
+      label: 'TeXRA setup, get started',
+    };
     apiKeyStatusBarItem.show();
   } else {
     apiKeyStatusBarItem.hide();
+    statusBarItem?.show();
   }
 }
 
@@ -628,19 +634,35 @@ export async function activate(context: vscode.ExtensionContext) {
   applyGitAuthorConfig();
 
   statusBarItem = vscode.window.createStatusBarItem(
+    'texra.taskStatus',
     vscode.StatusBarAlignment.Left,
   );
+  statusBarItem.name = 'TeXRA Tasks';
   statusBarItem.command = 'texra.showProgressView';
   statusBarItem.text = '$(bracket-dot) TeXRA: Idle';
   statusBarItem.tooltip = 'Show TeXRA Tasks';
+  statusBarItem.accessibilityInformation = {
+    label: 'TeXRA tasks, idle',
+  };
   statusBarItem.show();
 
   apiKeyStatusBarItem = vscode.window.createStatusBarItem(
+    'texra.setupStatus',
     vscode.StatusBarAlignment.Left,
   );
+  apiKeyStatusBarItem.name = 'TeXRA Setup';
   context.subscriptions.push(apiKeyStatusBarItem);
+  let apiKeyStatusRefreshQueue = Promise.resolve();
+  const queueApiKeyStatusRefresh = (): Promise<void> => {
+    const refresh = apiKeyStatusRefreshQueue.then(refreshApiKeyStatus);
+    // Keep the queue usable after a failed lookup while preserving the error
+    // for this caller. Serial execution ensures the last refresh sees the
+    // newest credential state and is the last one to update the UI.
+    apiKeyStatusRefreshQueue = refresh.catch(() => undefined);
+    return refresh;
+  };
   const safeRefreshApiKeyStatus = () =>
-    refreshApiKeyStatus().catch((err) =>
+    queueApiKeyStatusRefresh().catch((err) =>
       logger.error(
         'extension',
         `API key status refresh failed: ${toErrorMessage(err)}`,
@@ -685,11 +707,20 @@ export async function activate(context: vscode.ExtensionContext) {
     if (!statusBarItem) return;
     const count = statusBarUsageTracker.activeStreamCount;
     if (count > 1) {
-      statusBarItem.text = `$(loading) TeXRA: ${count} active`;
+      statusBarItem.text = `$(loading~spin) TeXRA: ${count} active`;
+      statusBarItem.accessibilityInformation = {
+        label: `TeXRA tasks, ${count} active`,
+      };
     } else if (count === 1) {
-      statusBarItem.text = '$(loading) TeXRA: Running';
+      statusBarItem.text = '$(loading~spin) TeXRA: Running';
+      statusBarItem.accessibilityInformation = {
+        label: 'TeXRA tasks, one active',
+      };
     } else {
       statusBarItem.text = '$(bracket-dot) TeXRA: Idle';
+      statusBarItem.accessibilityInformation = {
+        label: 'TeXRA tasks, idle',
+      };
     }
   };
 
@@ -733,7 +764,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // `activate()`.
     vscode.commands.registerCommand('texra.showMainView', showMainView),
     vscode.commands.registerCommand('texra.refreshApiKeyStatus', async () => {
-      await refreshApiKeyStatus();
+      await queueApiKeyStatusRefresh();
       // Credential facts changed (set/unset API key from any entry point —
       // palette, walkthrough, welcome card), so the onboarding funnel must
       // recompute too: the State 0 card has no other signal when a key is

--- a/packages/extension/src/progressView/index.html
+++ b/packages/extension/src/progressView/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -9,6 +9,7 @@
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${progressStyleUri}" />
+    <title>TeXRA Progress</title>
     <style nonce="${nonce}">
       body {
         padding: 0;
@@ -19,7 +20,7 @@
     </style>
   </head>
   <body>
-    <progress-app></progress-app>
+    <progress-app role="main" aria-label="TeXRA progress"></progress-app>
     <script type="module" nonce="${nonce}" src="${progressBundleUri}"></script>
   </body>
 </html>

--- a/packages/extension/src/settingsView/index.html
+++ b/packages/extension/src/settingsView/index.html
@@ -13,7 +13,7 @@
   </head>
 
   <body>
-    <settings-app></settings-app>
+    <settings-app role="main" aria-label="TeXRA settings"></settings-app>
     <script type="module" nonce="${nonce}" src="${settingsBundleUri}"></script>
   </body>
 </html>

--- a/packages/extension/src/webview/index.html
+++ b/packages/extension/src/webview/index.html
@@ -18,7 +18,7 @@
   </head>
 
   <body>
-    <main-app></main-app>
+    <main-app role="main" aria-label="TeXRA agent"></main-app>
     <script type="module" nonce="${nonce}" src="${mainViewBundleUri}"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #8531

## Summary

Keep TeXRA represented by one status bar item at a time. The setup action now replaces the ordinary task status until a usable credential exists, while configured users and users who disable reminders see the task status.

Both items gain stable IDs, native names, and accessibility labels. Active tasks use the spinning loading icon. The three TeXRA webview documents also gain consistent language, title, and main-landmark metadata.

## Issue acceptance gates

- Never show both TeXRA status items together.
- Preserve setup-versus-configured routing and reminder settings.
- Provide stable native metadata and state-aware accessibility labels.
- Use an animated native progress icon while tasks run.
- Complete missing webview document semantics.

## Single source of truth

refreshApiKeyStatus owns which one of the two internal items is visible. A serialized queue ensures overlapping async refreshes apply credential state in order and recover after failed lookups. Session status updates own the visible task text and accessibility label.

## Duplication and abstraction budget

No abstraction or dependency is added. The existing two items remain because they have different commands and lifecycles, but visibility is mutually exclusive.

## Net elements (R6)

- Files: 4 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Whole diff: 40 insertions, 8 deletions (net +32).

## Consumer counts (R8)

Two internal status items remain: task status and setup status. Exactly one is visible after each credential refresh. Three webview root elements gain document-level landmark metadata.

## Host impact

Extension: Cleaner status bar presence and improved screen-reader/webview semantics.

Desktop: No impact.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- root TypeScript check — clean
- Prettier and git diff --check
- broader webview smoke validation delegated to CI to avoid redundant testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only status bar visibility, accessibility metadata, and webview document semantics; no auth or data-path changes.
> 
> **Overview**
> TeXRA now shows **only one** left status bar entry at a time: `refreshApiKeyStatus` hides the task pill while the setup “Get Started” pill is shown (no credential + reminders on), and restores the task pill when credentials exist or reminders are off.
> 
> Both pills get stable VS Code ids (`texra.taskStatus`, `texra.setupStatus`), display names, and **state-aware** `accessibilityInformation` labels (setup CTA, idle/running/active counts). Running tasks use **`$(loading~spin)`** instead of a static loading icon.
> 
> Credential refreshes are **serialized** via `queueApiKeyStatusRefresh` so overlapping async checks don’t leave the wrong item visible; `texra.refreshApiKeyStatus` uses the same queue.
> 
> The main, progress, and settings webview shells add **`lang="en"`**, document **titles** where missing, and **`role="main"`** + **`aria-label`** on the root custom elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7af3ce58213e26daa2a0d9c22483ecb5ee39284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->