### PR TITLE
feat(copilot): show contextual tool invocation messages

### DIFF
--- a/packages/extension/src/frontend/lm/languageModelToolInvocationMessage.ts
+++ b/packages/extension/src/frontend/lm/languageModelToolInvocationMessage.ts
@@ -1,0 +1,49 @@
+// Local imports - core
+import { isObject, tryParseUrl } from '@utils/core';
+import { isNonEmptyString, truncateSummary } from '@utils/text/stringUtils';
+
+export type LanguageModelResearchToolName =
+  'arxiv_search' | 'crossref_search' | 'web_fetch';
+
+const MAX_CONTEXT_LENGTH = 60;
+
+function readInputString(input: unknown, key: string): string | undefined {
+  if (!isObject(input)) return undefined;
+
+  try {
+    const value = input[key];
+    return isNonEmptyString(value) ? value.trim() : undefined;
+  } catch {
+    // Treat unusual objects (such as a throwing Proxy) like malformed input.
+    return undefined;
+  }
+}
+
+function searchMessage(service: string, input: unknown): string {
+  const query = readInputString(input, 'query');
+  return query
+    ? `Searching ${service} for “${truncateSummary(query, MAX_CONTEXT_LENGTH)}”`
+    : `Searching ${service}`;
+}
+
+/** Build the side-effect-free progress text shown before a native LM tool runs. */
+export function buildLanguageModelToolInvocationMessage(
+  toolName: LanguageModelResearchToolName,
+  input: unknown,
+): string {
+  switch (toolName) {
+    case 'arxiv_search':
+      return searchMessage('arXiv', input);
+    case 'crossref_search':
+      return searchMessage('Crossref', input);
+    case 'web_fetch': {
+      const rawUrl = readInputString(input, 'url');
+      const url = rawUrl ? tryParseUrl(rawUrl) : undefined;
+      const host =
+        url?.protocol === 'http:' || url?.protocol === 'https:'
+          ? url.host
+          : undefined;
+      return host ? `Fetching ${host}` : 'Fetching web content';
+    }
+  }
+}

--- a/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
+++ b/packages/extension/src/frontend/lm/registerLanguageModelTools.ts
@@ -16,14 +16,20 @@ import * as logger from '@logger/logUtils';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { getDefaultToolRegistry } from '@tools/registry';
 
+// Local imports - language model tools
+import {
+  buildLanguageModelToolInvocationMessage,
+  type LanguageModelResearchToolName,
+} from './languageModelToolInvocationMessage';
+
 const CHANNEL = 'LanguageModelTools';
 
 /** VS Code tool name (manifest) → canonical TeXRA registry tool name. */
-const LM_TOOL_NAMES: Record<string, string> = {
+const LM_TOOL_NAMES = {
   texra_arxiv_search: 'arxiv_search',
   texra_web_fetch: 'web_fetch',
   texra_crossref_search: 'crossref_search',
-};
+} as const satisfies Record<string, LanguageModelResearchToolName>;
 
 /** Flatten a TeXRA ToolResult into the plain text VS Code chat expects. */
 function toResultText(result: ToolResult): string {
@@ -58,6 +64,16 @@ export function registerLanguageModelTools(
       continue;
     }
     const disposable = lm.registerTool(lmName, {
+      prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<unknown>,
+      ) {
+        return {
+          invocationMessage: buildLanguageModelToolInvocationMessage(
+            toolName,
+            options.input,
+          ),
+        };
+      },
       async invoke(
         options: vscode.LanguageModelToolInvocationOptions<unknown>,
       ) {

--- a/src/test-kernel/frontend/LanguageModelToolInvocationMessage.vitest.ts
+++ b/src/test-kernel/frontend/LanguageModelToolInvocationMessage.vitest.ts
@@ -1,0 +1,47 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - extension frontend
+import { buildLanguageModelToolInvocationMessage } from '@frontend/lm/languageModelToolInvocationMessage';
+
+describe('buildLanguageModelToolInvocationMessage', () => {
+  it('adds validated context and falls back safely for unexpected input', () => {
+    expect(
+      buildLanguageModelToolInvocationMessage('arxiv_search', {
+        query: '  quantum\n  error correction  ',
+      }),
+    ).toBe('Searching arXiv for “quantum error correction”');
+    expect(
+      buildLanguageModelToolInvocationMessage('crossref_search', {
+        query: 'attention is all you need',
+      }),
+    ).toBe('Searching Crossref for “attention is all you need”');
+    expect(
+      buildLanguageModelToolInvocationMessage('web_fetch', {
+        url: 'https://example.com:8443/papers/1',
+      }),
+    ).toBe('Fetching example.com:8443');
+
+    expect(buildLanguageModelToolInvocationMessage('arxiv_search', null)).toBe(
+      'Searching arXiv',
+    );
+    expect(
+      buildLanguageModelToolInvocationMessage('crossref_search', { query: 42 }),
+    ).toBe('Searching Crossref');
+    expect(
+      buildLanguageModelToolInvocationMessage('web_fetch', {
+        url: 'not a valid URL',
+      }),
+    ).toBe('Fetching web content');
+    expect(
+      buildLanguageModelToolInvocationMessage(
+        'crossref_search',
+        Object.defineProperty({}, 'query', {
+          get: () => {
+            throw new Error('unexpected getter');
+          },
+        }),
+      ),
+    ).toBe('Searching Crossref');
+  });
+});


### PR DESCRIPTION
Closes #8532

## Summary

Add native prepareInvocation messages for the three TeXRA research tools exposed to Copilot Chat. arXiv and Crossref show a bounded query preview; web fetch shows a validated HTTP(S) host. Unexpected input falls back to neutral progress text.

Preparation is side-effect-free and does not add confirmation prompts because these tools are read-only.

## Issue acceptance gates

- Every contributed TeXRA LM tool returns contextual invocation text.
- Query and URL context is bounded and validated.
- Unexpected input falls back without throwing.
- Invocation and result behavior remain unchanged.

## Single source of truth

buildLanguageModelToolInvocationMessage owns display text for all three registered research tools.

## Duplication and abstraction budget

One pure helper isolates defensive display formatting from VS Code registration. No dependency or runtime service is added.

## Net elements (R6)

- Files: 3 changed; 2 added; 0 deleted.
- Exported symbols: 1 function and 1 string-union type added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Whole diff: 114 insertions, 2 deletions (including focused coverage).

## Consumer counts (R8)

The helper has one production consumer: registerLanguageModelTools. That registration creates three prepared tool invocations from the same typed name map.

## Host impact

Extension: Copilot Chat shows clearer native progress text for TeXRA research tools.

Desktop: No impact.

CLI: No impact.

## Scheduled refactoring

None.

## Validation

- changed-file ESLint — clean
- root and test-kernel TypeScript checks — clean
- focused invocation-message test — 1 file, 1 test passed
- Prettier and git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes on read-only LM tools; tool execution and results are untouched.
> 
> **Overview**
> Copilot Chat now shows **native progress text** before TeXRA research LM tools run, via VS Code’s `prepareInvocation` hook on the three registered tools (arXiv, Crossref, web fetch).
> 
> A new pure helper **`buildLanguageModelToolInvocationMessage`** centralizes that copy: search tools show a **truncated query** (60 chars); **web_fetch** shows a validated **HTTP(S) host** or a generic “Fetching web content” fallback. Malformed or hostile input (including throwing property getters) is handled defensively so **`invoke` behavior is unchanged**.
> 
> The LM name map is tightened with **`as const satisfies`** for typed tool names. Focused Vitest coverage exercises happy paths and fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2af347914cfc873605fd8312e95b0ec0fb08d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->