### PR TITLE
refactor: type host interaction settlements

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -24,6 +24,7 @@ import {
   type HostInteractionOptions,
   type HostInteractions,
   type HostRetryRequest,
+  type HostUserQuestionResult,
   type PlanApprovalResult,
   type ProposalResult,
   type RetryResult,
@@ -559,11 +560,7 @@ async function requestRetryInteraction(
 async function requestUserQuestionInteraction(
   payload: RuntimeInteractionEventPayloads['showUserQuestion'],
   context: CliContext,
-): Promise<{
-  submitted: boolean;
-  answers?: ApprovalDecision['userQuestionAnswers'];
-  feedback?: string;
-}> {
+): Promise<HostUserQuestionResult> {
   if (!approvalPromptAllowed(context)) {
     return {
       submitted: false,

--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -1,4 +1,5 @@
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
 
 import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
@@ -95,11 +96,12 @@ export function handleUserQuestion(
     }
 
     const submitted = Object.keys(answers).length > 0;
+    const decision: UserQuestionSettlement = submitted
+      ? { action: 'submit', answers }
+      : { action: 'skip', feedback: 'User question skipped by user.' };
     await handleUserQuestionAction({
       requestId: payload.requestId,
-      action: submitted ? 'submit' : 'skip',
-      answers: submitted ? answers : undefined,
-      feedback: submitted ? undefined : 'User question skipped by user.',
+      ...decision,
     });
   })();
 }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -436,8 +436,7 @@ export class DesktopProgressBridge {
         settleProposal: (proposalId, result) => {
           const resolved = this.session.interactions.resolve(proposalId, {
             kind: 'proposal',
-            action: result.action,
-            value: result,
+            decision: result,
           });
           if (!resolved) {
             this.logger.warn(
@@ -515,24 +514,27 @@ export class DesktopProgressBridge {
           handleBashApprovalAction: (message) =>
             void this.session.interactions.resolve(message.requestId, {
               kind: 'bash',
-              action: message.action,
-              feedback: message.feedback,
+              decision:
+                message.action === 'approve'
+                  ? { action: 'approve' }
+                  : { action: 'reject', feedback: message.feedback },
             }),
           handlePlanApprovalAction: (message) => {
             this.session.interactions.resolve(message.approvalId, {
               kind: 'plan',
-              action: message.action,
-              ...(message.action === 'reject' && {
-                feedback: message.feedback,
-              }),
+              decision:
+                message.action === 'reject'
+                  ? { action: 'reject', feedback: message.feedback }
+                  : { action: message.action },
             });
           },
           handleUserQuestionAction: (message) => {
             this.session.interactions.resolve(message.requestId, {
               kind: 'userQuestion',
-              action: message.action,
-              value: message.answers,
-              feedback: message.feedback,
+              decision:
+                message.action === 'submit'
+                  ? { action: 'submit', answers: message.answers }
+                  : { action: message.action, feedback: message.feedback },
             });
             return undefined;
           },

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,12 +1,14 @@
 import { nanoid } from 'nanoid';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
+  cancellationSettlementFor,
   matchesCancelSelector,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
-  type HostInteractionResolution,
+  type HostInteractionResultByKind,
+  type HostInteractionSettlement,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
@@ -17,8 +19,6 @@ import {
 } from '@agent/runtime/HostInteractions';
 import {
   toBashApprovalResult,
-  toPlanApprovalResult,
-  toProposalResult,
   toUserQuestionResult,
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -31,31 +31,27 @@ import type {
 
 import type { DesktopToolEditApprovalController } from './desktopToolEditApproval.js';
 
-type PendingDesktopInteraction =
-  | {
-      kind: 'bash';
-      streamId?: StreamTabId;
-      cancellationScope?: object;
-      settle: (result: HostBashApprovalResult) => void;
-    }
-  | {
-      kind: 'plan';
-      streamId: StreamTabId;
-      cancellationScope?: object;
-      settle: (result: PlanApprovalResult) => void;
-    }
-  | {
-      kind: 'proposal';
-      streamId: StreamTabId;
-      cancellationScope?: object;
-      settle: (result: ProposalResult) => void;
-    }
-  | {
-      kind: 'userQuestion';
-      streamId?: StreamTabId;
-      cancellationScope?: object;
-      settle: (result: HostUserQuestionResult) => void;
-    };
+type PendingDesktopKind = Exclude<keyof HostInteractionResultByKind, 'retry'>;
+
+interface PendingDesktopMetadataByKind {
+  readonly bash: { readonly streamId?: StreamTabId };
+  readonly plan: { readonly streamId: StreamTabId };
+  readonly proposal: { readonly streamId: StreamTabId };
+  readonly userQuestion: { readonly streamId?: StreamTabId };
+}
+
+type PendingDesktopRegistration<K extends PendingDesktopKind> = {
+  readonly kind: K;
+  readonly cancellationScope?: object;
+} & PendingDesktopMetadataByKind[K];
+
+type PendingDesktopInteraction<K extends PendingDesktopKind> =
+  PendingDesktopRegistration<K> & {
+    settle(result: HostInteractionResultByKind[K]): void;
+  };
+
+type AnyPendingDesktopInteraction =
+  PendingDesktopInteraction<PendingDesktopKind>;
 
 export interface DesktopHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
@@ -80,7 +76,7 @@ export function createDesktopHostInteractions(
 class DesktopHostInteractionsImpl implements DesktopHostInteractions {
   private readonly pendingRequests = new Map<
     string,
-    PendingDesktopInteraction
+    AnyPendingDesktopInteraction
   >();
 
   constructor(private readonly options: DesktopHostInteractionsOptions) {}
@@ -186,39 +182,39 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     return Promise.resolve({ threadId: request.threadId });
   }
 
-  /**
-   * `result.kind` must match the pending request's own recorded kind before
-   * it's honored — the same discriminant check the extension host performs
-   * — so a caller bug (or a stale/misrouted resolution) can't be silently
-   * reinterpreted as whatever kind happens to be pending under that
-   * requestId.
-   */
-  resolve(requestId: string, result: HostInteractionResolution): boolean {
-    if (result.kind === 'externalInquiry') {
-      this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
-      return true;
-    }
-
-    const request = this.pendingRequests.get(requestId);
-    if (!request || request.kind !== result.kind) return false;
-    this.pendingRequests.delete(requestId);
-
-    switch (request.kind) {
+  resolve(requestId: string, settlement: HostInteractionSettlement): boolean {
+    switch (settlement.kind) {
       case 'bash':
-        request.settle(toBashApprovalResult(result));
-        this.options.getApprovalHandlers().bash.resolve(requestId);
-        return true;
+        return this.resolvePending(
+          requestId,
+          'bash',
+          toBashApprovalResult(settlement.decision),
+          () => this.options.getApprovalHandlers().bash.resolve(requestId),
+        );
       case 'plan':
-        request.settle(toPlanApprovalResult(result));
-        this.options.getApprovalHandlers().planApproval.resolve(requestId);
-        return true;
+        return this.resolvePending(requestId, 'plan', settlement.decision, () =>
+          this.options.getApprovalHandlers().planApproval.resolve(requestId),
+        );
       case 'proposal':
-        request.settle(toProposalResult(result));
-        this.options.getApprovalHandlers().agentProposal.resolve(requestId);
-        return true;
+        return this.resolvePending(
+          requestId,
+          'proposal',
+          settlement.decision,
+          () =>
+            this.options.getApprovalHandlers().agentProposal.resolve(requestId),
+        );
+      case 'retry':
+        return false;
       case 'userQuestion':
-        request.settle(toUserQuestionResult(result));
-        this.options.getApprovalHandlers().userQuestion.resolve(requestId);
+        return this.resolvePending(
+          requestId,
+          'userQuestion',
+          toUserQuestionResult(settlement.decision),
+          () =>
+            this.options.getApprovalHandlers().userQuestion.resolve(requestId),
+        );
+      case 'externalInquiry':
+        this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
         return true;
     }
   }
@@ -234,33 +230,28 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
       ) {
         continue;
       }
-      if (request.kind === 'bash' || request.kind === 'proposal') {
+      if (request.kind === 'bash') {
         this.resolve(requestId, {
-          kind: request.kind,
-          action: 'approve',
+          kind: 'bash',
+          decision: { action: 'approve' },
+        });
+      } else if (request.kind === 'proposal') {
+        this.resolve(requestId, {
+          kind: 'proposal',
+          decision: { action: 'approve' },
         });
       }
     }
     await this.options.getToolEditApprovals().approvePendingForStream(streamId);
   }
 
-  /**
-   * Cancellation is a synthesized rejection routed through the same
-   * `resolve()`/mapper path a live UI action takes, forwarding the selector's
-   * `cause` as agent-visible feedback — so a cancelled request and a rejected
-   * one settle identically for a given kind.
-   */
   cancel(selector: HostInteractionCancelSelector = {}): void {
     if (selector.kind == null || selector.kind === 'toolEdit') {
       this.options.getToolEditApprovals().cancel(selector);
     }
     for (const [requestId, request] of [...this.pendingRequests.entries()]) {
       if (!matchesCancelSelector(request, selector)) continue;
-      this.resolve(requestId, {
-        kind: request.kind,
-        action: 'reject',
-        feedback: selector.cause,
-      });
+      this.rejectPending(requestId, request, selector.cause);
     }
   }
 
@@ -268,26 +259,25 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     this.cancel({ cause: 'Desktop session disposed.' });
   }
 
-  private showPending<TResult, TEntry extends PendingDesktopInteraction>(
+  private showPending<K extends PendingDesktopKind>(
     requestId: string,
-    entry: Omit<TEntry, 'settle'>,
+    entry: PendingDesktopRegistration<K>,
     show: () => void,
-  ): Promise<TResult> {
+  ): Promise<HostInteractionResultByKind[K]> {
     // Replacement cancellation: a request re-issued under a still-pending id
     // rejects the stale prompt before the replacement is shown.
-    if (this.pendingRequests.has(requestId)) {
-      this.resolve(requestId, {
-        kind: this.pendingRequests.get(requestId)!.kind,
-        action: 'reject',
-        feedback: 'Approval request was replaced.',
-      });
+    const replaced = this.pendingRequests.get(requestId);
+    if (replaced) {
+      this.rejectPending(requestId, replaced, 'Approval request was replaced.');
     }
-    return new Promise<TResult>((resolve) => {
-      const settle = (result: unknown) => resolve(result as TResult);
-      this.pendingRequests.set(requestId, {
+    return new Promise<HostInteractionResultByKind[K]>((settle) => {
+      const interaction: PendingDesktopInteraction<K> = {
         ...entry,
-        settle,
-      } as TEntry);
+        settle(result) {
+          settle(result);
+        },
+      };
+      this.pendingRequests.set(requestId, interaction);
       try {
         show();
       } catch (error) {
@@ -295,6 +285,28 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
         throw error;
       }
     });
+  }
+
+  private rejectPending(
+    requestId: string,
+    request: AnyPendingDesktopInteraction,
+    feedback?: string,
+  ): void {
+    this.resolve(requestId, cancellationSettlementFor(request.kind, feedback));
+  }
+
+  private resolvePending<K extends PendingDesktopKind>(
+    requestId: string,
+    expectedKind: K,
+    value: HostInteractionResultByKind[K],
+    resolveUi: () => void,
+  ): boolean {
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending || pending.kind !== expectedKind) return false;
+    this.pendingRequests.delete(requestId);
+    pending.settle(value);
+    resolveUi();
+    return true;
   }
 
   // Interaction requests surface per-stream (pending badge on the stream

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -439,8 +439,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         settleProposal: (proposalId, result) => {
           const resolved = this.interactions.resolve(proposalId, {
             kind: 'proposal',
-            action: result.action,
-            value: result,
+            decision: result,
           });
           if (!resolved) {
             this.logger.warn(
@@ -581,7 +580,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.interactions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>
         this.interactions.resolveRetry(stream, requestId, {
-          kind: 'retry',
           action: 'retry',
         }),
     });
@@ -640,7 +638,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       data.stream,
       data.requestId,
       {
-        kind: 'retry',
         action: 'retry',
         feedback: data.feedback,
       },
@@ -656,7 +653,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST>,
   ): void {
     this.interactions.resolveRetry(data.stream, data.requestId, {
-      kind: 'retry',
       action: 'cancel',
     });
   }
@@ -666,8 +662,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ): void {
     this.interactions.resolve(data.requestId, {
       kind: 'bash',
-      action: data.action,
-      feedback: data.feedback,
+      decision:
+        data.action === 'approve'
+          ? { action: 'approve' }
+          : { action: 'reject', feedback: data.feedback },
     });
   }
 
@@ -676,9 +674,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ): void {
     this.interactions.resolve(data.requestId, {
       kind: 'userQuestion',
-      action: data.action,
-      value: data.answers,
-      feedback: data.feedback,
+      decision:
+        data.action === 'submit'
+          ? { action: 'submit', answers: data.answers }
+          : { action: data.action, feedback: data.feedback },
     });
   }
 
@@ -808,7 +807,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     if (!started) return;
 
     this.interactions.resolveRetry(data.stream, data.requestId, {
-      kind: 'retry',
       action: 'cancel',
     });
   }
@@ -892,8 +890,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { approvalId, action } = data;
     this.interactions.resolve(approvalId, {
       kind: 'plan',
-      action,
-      feedback: data.feedback,
+      decision:
+        action === 'reject'
+          ? { action: 'reject', feedback: data.feedback }
+          : { action },
     });
   }
 

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -2,26 +2,25 @@ import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
+  cancellationSettlementFor,
   matchesCancelSelector,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
-  type HostInteractionResolution,
+  type HostInteractionResultByKind,
+  type HostInteractionSettlement,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
   type HostUserQuestionResult,
-  type PendingInteractionKind,
   type PlanApprovalResult,
   type ProposalResult,
   type RetryResult,
+  type RetrySettlement,
 } from '@agent/runtime/HostInteractions';
 import {
   toBashApprovalResult,
-  toPlanApprovalResult,
-  toProposalResult,
-  toRetryResult,
   toUserQuestionResult,
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -53,38 +52,31 @@ export interface ExtensionHostInteractions extends HostInteractions {
   resolveRetry(
     streamId: StreamTabId,
     requestId: string,
-    result: HostInteractionResolution,
+    decision: RetrySettlement,
   ): boolean;
 }
 
-type PendingKind = Extract<
-  PendingInteractionKind,
-  'bash' | 'plan' | 'proposal' | 'retry' | 'userQuestion'
->;
+type PendingKind = keyof HostInteractionResultByKind;
 
-interface PendingExtensionInteraction<T> {
+interface PendingExtensionRegistration<K extends PendingKind> {
   readonly id: string;
   readonly requestId?: string;
-  readonly kind: PendingKind;
+  readonly kind: K;
   readonly streamId?: StreamTabId;
   readonly cancellationScope?: object;
-  readonly settle: (value: T) => void;
 }
 
-type PendingExtensionInteractionValue =
-  | HostBashApprovalResult
-  | PlanApprovalResult
-  | ProposalResult
-  | RetryResult
-  | HostUserQuestionResult;
+type PendingExtensionInteraction<K extends PendingKind> =
+  PendingExtensionRegistration<K> & {
+    settle(value: HostInteractionResultByKind[K]): void;
+  };
+
+type AnyPendingExtensionInteraction = PendingExtensionInteraction<PendingKind>;
 
 export function createExtensionHostInteractions(
   options: ExtensionHostInteractionsOptions,
 ): ExtensionHostInteractions {
-  const pendingRequests = new Map<
-    string,
-    PendingExtensionInteraction<PendingExtensionInteractionValue>
-  >();
+  const pendingRequests = new Map<string, AnyPendingExtensionInteraction>();
 
   const handlers = () => options.getApprovalHandlers();
 
@@ -109,28 +101,31 @@ export function createExtensionHostInteractions(
     }
   };
 
-  const showPending = <T extends PendingExtensionInteractionValue>(
-    pending: Omit<PendingExtensionInteraction<T>, 'settle'>,
+  const showPending = <K extends PendingKind>(
+    pending: PendingExtensionRegistration<K>,
     show: () => void,
-  ): Promise<T> => {
+  ): Promise<HostInteractionResultByKind[K]> => {
     // Replacement cancellation: a request re-issued under an id that is still
     // pending dismisses the stale prompt (settling it as a rejection carrying
     // the replacement cause) before the replacement is shown.
     const replaced = pendingRequests.get(pending.id);
     if (replaced) releasePending(replaced, 'Approval request was replaced.');
-    return new Promise<T>((resolve) => {
-      pendingRequests.set(pending.id, {
+    return new Promise<HostInteractionResultByKind[K]>((settle) => {
+      const interaction: PendingExtensionInteraction<K> = {
         ...pending,
-        settle: resolve as (value: PendingExtensionInteractionValue) => void,
-      });
+        settle(value) {
+          settle(value);
+        },
+      };
+      pendingRequests.set(pending.id, interaction);
       show();
     });
   };
 
-  const resolvePending = <T extends PendingExtensionInteractionValue>(
+  const resolvePending = <K extends PendingKind>(
     requestId: string,
-    expectedKind: PendingKind,
-    value: T,
+    expectedKind: K,
+    value: HostInteractionResultByKind[K],
     resolveUi: () => void,
   ): boolean => {
     const pending = pendingRequests.get(requestId);
@@ -141,44 +136,15 @@ export function createExtensionHostInteractions(
     return true;
   };
 
-  /**
-   * Releases a pending interaction as a synthesized rejection, forwarding
-   * `cause` as agent-visible feedback through the same result mappers
-   * `resolve()` uses — so a cancellation and a live UI rejection settle
-   * identically for a given kind.
-   */
+  /** Release a pending interaction with its kind-specific rejection result. */
   const releasePending = (
-    pending: PendingExtensionInteraction<PendingExtensionInteractionValue>,
+    pending: AnyPendingExtensionInteraction,
     cause?: string,
   ): void => {
-    pendingRequests.delete(pending.id);
-    const rejection: HostInteractionResolution = {
-      kind: pending.kind,
-      action: 'reject',
-      feedback: cause,
-    };
-    switch (pending.kind) {
-      case 'bash':
-        handlers().bash.resolve(pending.id);
-        pending.settle(toBashApprovalResult(rejection));
-        break;
-      case 'plan':
-        handlers().planApproval.resolve(pending.id);
-        pending.settle(toPlanApprovalResult(rejection));
-        break;
-      case 'proposal':
-        handlers().agentProposal.resolve(pending.id);
-        pending.settle(toProposalResult(rejection));
-        break;
-      case 'retry':
-        handlers().retry.resolve(pending.id);
-        pending.settle(toRetryResult(rejection));
-        break;
-      case 'userQuestion':
-        handlers().userQuestion.resolve(pending.id);
-        pending.settle(toUserQuestionResult(rejection));
-        break;
-    }
+    settleInteraction(
+      pending.id,
+      cancellationSettlementFor(pending.kind, cause),
+    );
   };
 
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
@@ -208,16 +174,13 @@ export function createExtensionHostInteractions(
           resolvePending(
             pending.id,
             'bash',
-            toBashApprovalResult({ kind: 'bash', action: 'approve' }),
+            toBashApprovalResult({ action: 'approve' }),
             () => handlers().bash.resolve(pending.id),
           );
           break;
         case 'proposal':
-          resolvePending(
-            pending.id,
-            'proposal',
-            toProposalResult({ kind: 'proposal', action: 'approve' }),
-            () => handlers().agentProposal.resolve(pending.id),
+          resolvePending(pending.id, 'proposal', { action: 'approve' }, () =>
+            handlers().agentProposal.resolve(pending.id),
           );
           break;
         case 'plan':
@@ -240,15 +203,49 @@ export function createExtensionHostInteractions(
   const resolveRetry = (
     streamId: StreamTabId,
     requestId: string,
-    result: HostInteractionResolution,
+    decision: RetrySettlement,
   ): boolean => {
     if (!isRetryPending(streamId, requestId)) return false;
-    return resolvePending<RetryResult>(
-      streamId,
-      'retry',
-      toRetryResult(result),
-      () => handlers().retry.resolve(streamId),
+    return resolvePending(streamId, 'retry', decision, () =>
+      handlers().retry.resolve(streamId),
     );
+  };
+
+  const settleInteraction = (
+    requestId: string,
+    settlement: HostInteractionSettlement,
+  ): boolean => {
+    switch (settlement.kind) {
+      case 'bash':
+        return resolvePending(
+          requestId,
+          'bash',
+          toBashApprovalResult(settlement.decision),
+          () => handlers().bash.resolve(requestId),
+        );
+      case 'plan':
+        return resolvePending(requestId, 'plan', settlement.decision, () =>
+          handlers().planApproval.resolve(requestId),
+        );
+      case 'proposal':
+        return resolvePending(requestId, 'proposal', settlement.decision, () =>
+          handlers().agentProposal.resolve(requestId),
+        );
+      case 'retry':
+        return resolvePending(requestId, 'retry', settlement.decision, () =>
+          handlers().retry.resolve(requestId),
+        );
+      case 'userQuestion':
+        return resolvePending(
+          requestId,
+          'userQuestion',
+          toUserQuestionResult(settlement.decision),
+          () => handlers().userQuestion.resolve(requestId),
+        );
+      case 'externalInquiry':
+        handlers().externalInquiry.resolve(requestId);
+        return true;
+    }
   };
 
   return {
@@ -272,7 +269,7 @@ export function createExtensionHostInteractions(
       const requestId = `bash-${nanoid()}`;
       const streamId = request.streamId ?? '';
       revealStream(request.streamId);
-      return showPending<HostBashApprovalResult>(
+      return showPending(
         {
           id: requestId,
           kind: 'bash',
@@ -295,7 +292,7 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<PlanApprovalResult> {
       revealStream(request.streamId);
-      return showPending<PlanApprovalResult>(
+      return showPending(
         {
           id: request.approvalId,
           kind: 'plan',
@@ -311,7 +308,7 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<ProposalResult> {
       revealStream(request.streamId);
-      return showPending<ProposalResult>(
+      return showPending(
         {
           id: request.proposalId,
           kind: 'proposal',
@@ -327,7 +324,7 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<RetryResult> {
       revealStream(request.streamId);
-      return showPending<RetryResult>(
+      return showPending(
         {
           id: request.streamId,
           requestId: request.requestId,
@@ -344,7 +341,7 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<HostUserQuestionResult> {
       revealStream(request.streamId || undefined);
-      return showPending<HostUserQuestionResult>(
+      return showPending(
         {
           id: request.requestId,
           kind: 'userQuestion',
@@ -361,50 +358,7 @@ export function createExtensionHostInteractions(
       return { threadId: request.threadId };
     },
 
-    resolve(requestId: string, result: HostInteractionResolution): boolean {
-      switch (result.kind) {
-        case 'bash':
-          return resolvePending<HostBashApprovalResult>(
-            requestId,
-            'bash',
-            toBashApprovalResult(result),
-            () => handlers().bash.resolve(requestId),
-          );
-        case 'plan':
-          return resolvePending<PlanApprovalResult>(
-            requestId,
-            'plan',
-            toPlanApprovalResult(result),
-            () => handlers().planApproval.resolve(requestId),
-          );
-        case 'proposal':
-          return resolvePending<ProposalResult>(
-            requestId,
-            'proposal',
-            toProposalResult(result),
-            () => handlers().agentProposal.resolve(requestId),
-          );
-        case 'retry':
-          return resolvePending<RetryResult>(
-            requestId,
-            'retry',
-            toRetryResult(result),
-            () => handlers().retry.resolve(requestId),
-          );
-        case 'userQuestion':
-          return resolvePending<HostUserQuestionResult>(
-            requestId,
-            'userQuestion',
-            toUserQuestionResult(result),
-            () => handlers().userQuestion.resolve(requestId),
-          );
-        case 'externalInquiry':
-          handlers().externalInquiry.resolve(requestId);
-          return true;
-        default:
-          return false;
-      }
-    },
+    resolve: settleInteraction,
 
     cancel,
 

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -443,12 +443,16 @@ export function handlePermissionAction(
     }
     case PERMISSION_KIND.USER_QUESTION: {
       const { requestId } = permission.data;
-      postMessage(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION, {
-        requestId,
-        action,
-        feedback,
-        answers,
-      });
+      const message =
+        action === 'submit'
+          ? answers
+            ? { requestId, action, answers }
+            : undefined
+          : action === 'reject' || action === 'skip'
+            ? { requestId, action, feedback }
+            : undefined;
+      if (!message) return;
+      postMessage(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION, message);
       removePrompt(ctx, PERMISSION_KIND.USER_QUESTION, requestId);
       break;
     }

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -19,26 +19,49 @@ export interface HostInteractionOptions {
 }
 
 export type PlanApprovalResult =
-  | { action: 'approve' }
-  | { action: 'approve_and_goal' }
+  | { action: 'approve'; feedback?: never }
+  | { action: 'approve_and_goal'; feedback?: never }
   | { action: 'reject'; feedback?: string }
-  | { action: 'timeout' };
+  | { action: 'timeout'; feedback?: never };
 
 export type ProposalResult =
-  | { action: 'approve'; model?: string; agent?: string }
-  | { action: 'reject'; feedback?: string }
-  | { action: 'setup' }
-  | { action: 'timeout' };
+  | {
+      action: 'approve';
+      model?: string;
+      agent?: string;
+      feedback?: never;
+    }
+  | {
+      action: 'reject';
+      feedback?: string;
+      model?: never;
+      agent?: never;
+    }
+  | {
+      action: 'setup';
+      model?: never;
+      agent?: never;
+      feedback?: never;
+    }
+  | {
+      action: 'timeout';
+      model?: never;
+      agent?: never;
+      feedback?: never;
+    };
+
+export type RetrySettlement =
+  | { action: 'retry'; feedback?: string; reason?: never }
+  | { action: 'cancel'; feedback?: never; reason?: never }
+  | { action: 'timeout'; feedback?: never; reason?: never };
 
 export type RetryResult =
-  | { action: 'retry'; feedback?: string }
-  | { action: 'cancel' }
-  | { action: 'timeout' }
+  | RetrySettlement
   // Policy/headless auto-denial: the retry could not be approved because no
   // human input was available (e.g. `--approval-policy never --no-input`).
   // Distinct from a user `cancel` so retry-exhaustion with no human lands in
   // the `failed` fallback (→ RUN_OUTCOME.FAILED) instead of `cancelled`. See #7331.
-  | { action: 'deny'; reason?: string };
+  | { action: 'deny'; reason?: string; feedback?: never };
 
 export interface HostPlanApprovalRequest {
   readonly approvalId: string;
@@ -83,10 +106,24 @@ export interface HostRetryRequest {
 
 export type HostUserQuestionRequest = UserQuestionPermission;
 
-export interface HostUserQuestionResult {
-  readonly submitted: boolean;
-  readonly answers?: UserQuestionAnswers;
-  readonly feedback?: string;
+export type HostUserQuestionResult =
+  | {
+      readonly submitted: true;
+      readonly answers: UserQuestionAnswers;
+      readonly feedback?: never;
+    }
+  | {
+      readonly submitted: false;
+      readonly feedback?: string;
+      readonly answers?: never;
+    };
+
+export interface HostInteractionResultByKind {
+  readonly bash: HostBashApprovalResult;
+  readonly plan: PlanApprovalResult;
+  readonly proposal: ProposalResult;
+  readonly retry: RetryResult;
+  readonly userQuestion: HostUserQuestionResult;
 }
 
 export type HostExternalInquiryRequest = ExternalInquiryPermission;
@@ -95,12 +132,39 @@ export interface HostExternalInquiryHandle {
   readonly threadId: string;
 }
 
-export interface HostInteractionResolution {
-  readonly kind: string;
-  readonly action: string;
-  readonly feedback?: string;
-  readonly value?: unknown;
-}
+export type BashSettlement =
+  | { readonly action: 'approve'; readonly feedback?: never }
+  | { readonly action: 'reject'; readonly feedback?: string }
+  | { readonly action: 'timeout'; readonly feedback?: never };
+
+export type UserQuestionSettlement =
+  | {
+      readonly action: 'submit';
+      readonly answers: UserQuestionAnswers;
+      readonly feedback?: never;
+    }
+  | {
+      readonly action: 'reject' | 'skip';
+      readonly feedback?: string;
+      readonly answers?: never;
+    };
+
+/** Exact host-to-adapter settlement vocabulary for every interaction kind. */
+export type HostInteractionSettlement = (
+  | { readonly kind: 'bash'; readonly decision: BashSettlement }
+  | { readonly kind: 'plan'; readonly decision: PlanApprovalResult }
+  | { readonly kind: 'proposal'; readonly decision: ProposalResult }
+  | { readonly kind: 'retry'; readonly decision: RetrySettlement }
+  | {
+      readonly kind: 'userQuestion';
+      readonly decision: UserQuestionSettlement;
+    }
+  | { readonly kind: 'externalInquiry'; readonly decision?: never }
+) & {
+  readonly action?: never;
+  readonly feedback?: never;
+  readonly value?: never;
+};
 
 export type PendingInteractionKind =
   | 'toolEdit'
@@ -110,6 +174,45 @@ export type PendingInteractionKind =
   | 'retry'
   | 'userQuestion'
   | 'externalInquiry';
+
+export type SettledInteractionKind = keyof HostInteractionResultByKind;
+
+type SettlementFor<K extends SettledInteractionKind> = Extract<
+  HostInteractionSettlement,
+  { kind: K }
+>;
+
+type CancellationSettlementFactories = {
+  [K in SettledInteractionKind]: (feedback?: string) => SettlementFor<K>;
+};
+
+const cancellationSettlementFactories: CancellationSettlementFactories = {
+  bash: (feedback?: string) => ({
+    kind: 'bash',
+    decision: { action: 'reject', feedback },
+  }),
+  plan: (feedback?: string) => ({
+    kind: 'plan',
+    decision: { action: 'reject', feedback },
+  }),
+  proposal: (feedback?: string) => ({
+    kind: 'proposal',
+    decision: { action: 'reject', feedback },
+  }),
+  retry: () => ({ kind: 'retry', decision: { action: 'cancel' } }),
+  userQuestion: (feedback?: string) => ({
+    kind: 'userQuestion',
+    decision: { action: 'reject', feedback },
+  }),
+};
+
+/** Typed cancellation result shared by every presenting host. */
+export function cancellationSettlementFor<K extends SettledInteractionKind>(
+  kind: K,
+  feedback?: string,
+): SettlementFor<K> {
+  return cancellationSettlementFactories[kind](feedback);
+}
 
 export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
 
@@ -196,7 +299,7 @@ export interface HostInteractions {
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined;
   setApprovalBypassState?(update: HostApprovalBypassStateUpdate): void;
-  resolve(requestId: string, result: HostInteractionResolution): boolean;
+  resolve(requestId: string, settlement: HostInteractionSettlement): boolean;
   /** Settle pending requests matching the selector with their reject/cancel defaults. */
   cancel(selector?: HostInteractionCancelSelector): void;
   dispose?(): void;
@@ -339,9 +442,10 @@ export class SessionHostInteractions implements HostInteractions {
     this.activeAttachment?.interactions.setApprovalBypassState?.(update);
   }
 
-  resolve(requestId: string, result: HostInteractionResolution): boolean {
+  resolve(requestId: string, settlement: HostInteractionSettlement): boolean {
     return (
-      this.activeAttachment?.interactions.resolve(requestId, result) ?? false
+      this.activeAttachment?.interactions.resolve(requestId, settlement) ??
+      false
     );
   }
 

--- a/src/agent/runtime/hostInteractionResultMappers.ts
+++ b/src/agent/runtime/hostInteractionResultMappers.ts
@@ -1,31 +1,17 @@
-/**
- * Shared mapping from the generic `HostInteractionResolution` — used both to
- * settle a live UI action and to synthesize a cancellation/dispose rejection
- * — into each interaction's own typed result.
- *
- * The extension and desktop `HostInteractions` implementations each own their
- * pending-request bookkeeping (that stays host-specific), but they must agree
- * on what a given `{ kind, action, value, feedback }` resolution *means* for
- * the agent. Both hosts call these functions instead of maintaining their own
- * copies, so the two hosts cannot silently re-diverge on that vocabulary.
- */
-
-import type { UserQuestionAnswers } from '@shared/schemas';
+/** Shared conversions for settlements whose public result shape differs. */
 import type {
+  BashSettlement,
   HostBashApprovalResult,
-  HostInteractionResolution,
   HostUserQuestionResult,
-  PlanApprovalResult,
-  ProposalResult,
-  RetryResult,
+  UserQuestionSettlement,
 } from './HostInteractions';
 
 export function toBashApprovalResult(
-  result: HostInteractionResolution,
+  decision: BashSettlement,
 ): HostBashApprovalResult {
   return {
-    accepted: result.action === 'approve',
-    timedOut: result.action === 'timeout' ? true : undefined,
+    accepted: decision.action === 'approve',
+    timedOut: decision.action === 'timeout' ? true : undefined,
     // Deliberate alignment choice, not an oversight: `userMessage` exists to
     // explain a rejection back to the agent (see buildBashApprovalRejectedResult),
     // so it's scoped to the reject action alone. The pre-alignment desktop
@@ -33,75 +19,14 @@ export function toBashApprovalResult(
     // approve carrying a stray note) — that was drift, not a feature; an
     // approved command has no rejection reason to report.
     userMessage:
-      result.action === 'reject' ? result.feedback?.trim() : undefined,
+      decision.action === 'reject' ? decision.feedback?.trim() : undefined,
   };
-}
-
-export function toPlanApprovalResult(
-  result: HostInteractionResolution,
-): PlanApprovalResult {
-  if (result.action === 'approve') return { action: 'approve' };
-  if (result.action === 'approve_and_goal')
-    return { action: 'approve_and_goal' };
-  return { action: 'reject', feedback: result.feedback };
-}
-
-const PROPOSAL_RESULT_ACTIONS: ReadonlySet<ProposalResult['action']> = new Set([
-  'approve',
-  'setup',
-  'reject',
-  'timeout',
-]);
-
-function isProposalResultValue(value: unknown): value is ProposalResult {
-  if (typeof value !== 'object' || value === null) return false;
-  if (!Object.hasOwn(value, 'action')) return false;
-  const { action } = value as { action: unknown };
-  return (
-    typeof action === 'string' &&
-    PROPOSAL_RESULT_ACTIONS.has(action as ProposalResult['action'])
-  );
-}
-
-/**
- * `result.value` may already carry a fully-formed `ProposalResult` (e.g. from
- * `ProgressAgentProposalController.handleAction`); only trust it when its
- * `action` is one this union actually declares, otherwise fall back to
- * `result.action`/`result.feedback` like every other mapper here. A bare
- * pass-through of "any object with an `action` key" would let an unrelated
- * caller shape masquerade as a proposal result.
- */
-export function toProposalResult(
-  result: HostInteractionResolution,
-): ProposalResult {
-  if (isProposalResultValue(result.value)) return result.value;
-  if (result.action === 'setup') return { action: 'setup' };
-  if (result.action === 'approve') return { action: 'approve' };
-  return { action: 'reject', feedback: result.feedback };
-}
-
-export function toRetryResult(result: HostInteractionResolution): RetryResult {
-  return result.action === 'retry'
-    ? { action: 'retry', feedback: result.feedback }
-    : { action: 'cancel' };
 }
 
 export function toUserQuestionResult(
-  result: HostInteractionResolution,
+  decision: UserQuestionSettlement,
 ): HostUserQuestionResult {
-  return {
-    submitted: result.action === 'submit',
-    // Deliberate alignment choice, not an oversight: answers only make sense
-    // once submitted, and feedback is the "why did you decline" text for a
-    // non-submit action — the two are mutually exclusive by what they mean,
-    // not just by which action produced them. The pre-alignment desktop
-    // implementation carried each field whenever its source value/feedback
-    // was truthy, independent of the action, which could report answers on
-    // a decline or feedback on a submission.
-    answers:
-      result.action === 'submit'
-        ? (result.value as UserQuestionAnswers | undefined)
-        : undefined,
-    feedback: result.action === 'submit' ? undefined : result.feedback,
-  };
+  return decision.action === 'submit'
+    ? { submitted: true, answers: decision.answers }
+    : { submitted: false, feedback: decision.feedback };
 }

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -24,7 +24,6 @@ import {
   BASH_APPROVAL_ACTIONS,
   PLAN_APPROVAL_ACTIONS,
   TOOL_EDIT_APPROVAL_ACTIONS,
-  USER_QUESTION_ACTIONS,
   UserQuestionAnswersSchema,
 } from '../prompts';
 import { AgentCategoryFilterSchema, StreamScopedBaseSchema } from './data';
@@ -173,13 +172,28 @@ const ExternalInquiryActionMessageSchema = z.discriminatedUnion('action', [
   }),
 ]);
 
-const UserQuestionActionMessageSchema = z.object({
+const UserQuestionActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION),
   requestId: z.string().min(1),
-  action: z.enum([...USER_QUESTION_ACTIONS, 'skip'] as const),
-  answers: UserQuestionAnswersSchema.optional(),
-  feedback: z.string().optional(),
-});
+};
+
+const UserQuestionActionMessageSchema = z.discriminatedUnion('action', [
+  z.strictObject({
+    ...UserQuestionActionMessageBase,
+    action: z.literal('submit'),
+    answers: UserQuestionAnswersSchema,
+  }),
+  z.strictObject({
+    ...UserQuestionActionMessageBase,
+    action: z.literal('reject'),
+    feedback: z.string().optional(),
+  }),
+  z.strictObject({
+    ...UserQuestionActionMessageBase,
+    action: z.literal('skip'),
+    feedback: z.string().optional(),
+  }),
+]);
 
 const RestoreProposalConfigMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG),

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -145,8 +145,6 @@ export type ExternalInquiryPermission = z.infer<
 // User Question
 // ============================================================================
 
-export const USER_QUESTION_ACTIONS = ['submit', 'reject'] as const;
-
 const UserQuestionOptionSchema = z.strictObject({
   label: z.string().min(1),
   description: z.string().nullish(),

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -94,7 +94,7 @@ describe('human prompt progress events', () => {
     expect(
       explicit.host.interactions?.resolve(show.payload.requestId, {
         kind: 'bash',
-        action: 'approve',
+        decision: { action: 'approve' },
       }),
     ).toBe(true);
 
@@ -152,9 +152,11 @@ describe('human prompt progress events', () => {
     expect(
       explicit.host.interactions?.resolve(show.payload.requestId, {
         kind: 'userQuestion',
-        action: 'submit',
-        value: {
-          'Which path should the agent take?': 'Run the build',
+        decision: {
+          action: 'submit',
+          answers: {
+            'Which path should the agent take?': 'Run the build',
+          },
         },
       }),
     ).toBe(true);
@@ -249,7 +251,7 @@ describe('human prompt progress events', () => {
       expect(
         explicit.host.interactions?.resolve(show.payload.requestId, {
           kind: 'bash',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(approval).resolves.toMatchObject({ accepted: true });

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -185,8 +185,8 @@ export function createRecordingHost(): {
         });
       });
     },
-    resolve: (requestId, result) => {
-      if (result.kind === 'bash') {
+    resolve: (requestId, settlement) => {
+      if (settlement.kind === 'bash') {
         const pending = pendingBashes.get(requestId);
         if (!pending) return false;
         pendingBashes.delete(requestId);
@@ -195,13 +195,15 @@ export function createRecordingHost(): {
           payload: { requestId },
         });
         pending.settle({
-          accepted: result.action === 'approve',
+          accepted: settlement.decision.action === 'approve',
           userMessage:
-            result.action === 'reject' ? result.feedback?.trim() : undefined,
+            settlement.decision.action === 'reject'
+              ? settlement.decision.feedback?.trim()
+              : undefined,
         });
         return true;
       }
-      if (result.kind === 'plan') {
+      if (settlement.kind === 'plan') {
         const pending = pendingPlans.get(requestId);
         if (!pending) return false;
         pendingPlans.delete(requestId);
@@ -209,13 +211,10 @@ export function createRecordingHost(): {
           event: 'resolvePlanApproval',
           payload: { approvalId: requestId },
         });
-        pending.settle({
-          action: result.action as PlanApprovalResult['action'],
-          ...(result.feedback ? { feedback: result.feedback } : {}),
-        } as PlanApprovalResult);
+        pending.settle(settlement.decision);
         return true;
       }
-      if (result.kind === 'proposal') {
+      if (settlement.kind === 'proposal') {
         const pending = pendingProposals.get(requestId);
         if (!pending) return false;
         pendingProposals.delete(requestId);
@@ -223,15 +222,10 @@ export function createRecordingHost(): {
           event: 'resolveAgentProposal',
           payload: { proposalId: requestId },
         });
-        pending.settle(
-          (result.value ?? {
-            action: result.action,
-            ...(result.feedback ? { feedback: result.feedback } : {}),
-          }) as ProposalResult,
-        );
+        pending.settle(settlement.decision);
         return true;
       }
-      if (result.kind === 'retry') {
+      if (settlement.kind === 'retry') {
         const pending = pendingRetries.get(requestId);
         if (!pending) return false;
         pendingRetries.delete(requestId);
@@ -239,13 +233,10 @@ export function createRecordingHost(): {
           event: 'resolveRetryRequest',
           payload: { streamId: requestId },
         });
-        pending.settle({
-          action: result.action as RetryResult['action'],
-          ...(result.feedback ? { feedback: result.feedback } : {}),
-        } as RetryResult);
+        pending.settle(settlement.decision);
         return true;
       }
-      if (result.kind === 'userQuestion') {
+      if (settlement.kind === 'userQuestion') {
         const pending = pendingUserQuestions.get(requestId);
         if (!pending) return false;
         pendingUserQuestions.delete(requestId);
@@ -253,14 +244,17 @@ export function createRecordingHost(): {
           event: 'resolveUserQuestion',
           payload: { requestId },
         });
-        pending.settle({
-          submitted: result.action === 'submit',
-          answers:
-            result.action === 'submit'
-              ? (result.value as HostUserQuestionResult['answers'])
-              : undefined,
-          feedback: result.action === 'submit' ? undefined : result.feedback,
-        });
+        pending.settle(
+          settlement.decision.action === 'submit'
+            ? {
+                submitted: true,
+                answers: settlement.decision.answers,
+              }
+            : {
+                submitted: false,
+                feedback: settlement.decision.feedback,
+              },
+        );
         return true;
       }
       return false;

--- a/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
+++ b/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import { expectTypeOf, it } from 'vitest';
+
+// Local imports - host interactions
+import type {
+  HostInteractionSettlement,
+  HostUserQuestionResult,
+  PlanApprovalResult,
+  ProposalResult,
+  RetrySettlement,
+  UserQuestionSettlement,
+} from '@agent/runtime/HostInteractions';
+
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+
+it('makes contradictory interaction settlements unrepresentable', () => {
+  expectTypeOf<
+    IsAssignable<
+      { kind: 'retry'; decision: { action: 'approve' } },
+      HostInteractionSettlement
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'submit' }, UserQuestionSettlement>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'reject'; answers: { choice: string } },
+      UserQuestionSettlement
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      {
+        kind: 'proposal';
+        decision: { action: 'approve' };
+        value: { action: 'approve' };
+      },
+      HostInteractionSettlement
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { kind: 'externalInquiry'; action: 'submit' },
+      HostInteractionSettlement
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ submitted: true }, HostUserQuestionResult>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { submitted: false; answers: { choice: string } },
+      HostUserQuestionResult
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'approve'; feedback: string }, PlanApprovalResult>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'reject'; model: string }, ProposalResult>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'cancel'; feedback: string }, RetrySettlement>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'cancel'; reason: string }, RetrySettlement>
+  >().toEqualTypeOf<false>();
+});

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -273,8 +273,7 @@ describe('RetryState', () => {
       expect(
         session.interactions.resolve(streamId, {
           kind: 'retry',
-          action: 'retry',
-          feedback: 'try again',
+          decision: { action: 'retry', feedback: 'try again' },
         }),
       ).toBe(true);
 

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -166,14 +166,13 @@ describe('SessionHandle', () => {
       expect(
         b.interactions.resolve('approval:b', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       expect(
         b.interactions.resolve(streamId, {
           kind: 'retry',
-          action: 'retry',
-          feedback: 'retry B',
+          decision: { action: 'retry', feedback: 'retry B' },
         }),
       ).toBe(true);
       await expect(planB).resolves.toEqual({ action: 'approve' });

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -149,15 +149,11 @@ function createControllablePlanAdapter(
         }),
       );
     },
-    resolve(requestId, result) {
+    resolve(requestId, settlement) {
       const entry = pending.get(requestId);
-      if (!entry || result.kind !== 'plan') return false;
+      if (!entry || settlement.kind !== 'plan') return false;
       pending.delete(requestId);
-      entry.settle(
-        result.action === 'approve'
-          ? { action: 'approve' }
-          : { action: 'reject', feedback: result.feedback },
-      );
+      entry.settle(settlement.decision);
       return true;
     },
     cancel(selector = {}) {
@@ -252,7 +248,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     expect(
       target.interactions.resolve('approval:target-owner', {
         kind: 'plan',
-        action: 'approve',
+        decision: { action: 'approve' },
       }),
     ).toBe(true);
     await expect(targetPending).resolves.toEqual({ action: 'approve' });
@@ -330,7 +326,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:unattached', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
@@ -360,7 +356,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:reattach', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
@@ -387,14 +383,14 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         first.interactions.resolve('approval:stale', {
           kind: 'plan',
-          action: 'reject',
+          decision: { action: 'reject' },
         }),
       ).toBe(true);
       await Promise.resolve();
       expect(
         session.interactions.resolve('approval:stale', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
@@ -484,7 +480,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:first-wins', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
@@ -493,7 +489,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:first-wins', {
           kind: 'plan',
-          action: 'reject',
+          decision: { action: 'reject' },
         }),
       ).toBe(false);
     } finally {
@@ -525,7 +521,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:replace', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(second).resolves.toEqual({ action: 'approve' });
@@ -565,13 +561,13 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:cleanup', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(false);
       expect(
         session.interactions.resolve('proposal:cleanup', {
           kind: 'proposal',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(false);
 
@@ -579,7 +575,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('approval:survives', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(surviving).resolves.toEqual({ action: 'approve' });
@@ -615,7 +611,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(
         session.interactions.resolve('proposal:kind-scope', {
           kind: 'proposal',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(pendingProposal).resolves.toMatchObject({

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -205,7 +205,7 @@ describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
       expect(
         b.interactions.resolve('approval:b', {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(true);
       await expect(planB).resolves.toEqual({ action: 'approve' });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -789,3 +789,71 @@ describe('external inquiry action schema', () => {
     expect(results).toEqual([true, true, true, false, false]);
   });
 });
+
+describe('user question action schema', () => {
+  const command = PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION;
+  const requestId = 'question-1';
+
+  it.each([
+    {
+      name: 'submit with answers',
+      message: {
+        command,
+        requestId,
+        action: 'submit',
+        answers: { choice: 'A' },
+      },
+      valid: true,
+    },
+    {
+      name: 'reject with feedback',
+      message: { command, requestId, action: 'reject', feedback: 'Not now' },
+      valid: true,
+    },
+    {
+      name: 'skip without feedback',
+      message: { command, requestId, action: 'skip' },
+      valid: true,
+    },
+    {
+      name: 'submit without answers',
+      message: { command, requestId, action: 'submit' },
+      valid: false,
+    },
+    {
+      name: 'submit with rejection feedback',
+      message: {
+        command,
+        requestId,
+        action: 'submit',
+        answers: { choice: 'A' },
+        feedback: 'contradictory',
+      },
+      valid: false,
+    },
+    {
+      name: 'reject with answers',
+      message: {
+        command,
+        requestId,
+        action: 'reject',
+        answers: { choice: 'A' },
+      },
+      valid: false,
+    },
+    {
+      name: 'skip with answers',
+      message: {
+        command,
+        requestId,
+        action: 'skip',
+        answers: { choice: 'A' },
+      },
+      valid: false,
+    },
+  ])('$name is $valid', ({ message, valid }) => {
+    expect(ProgressViewInboundMessageSchema.safeParse(message).success).toBe(
+      valid,
+    );
+  });
+});

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3202,7 +3202,7 @@ describe('DesktopProgressBridge', () => {
       expect(
         windowB.session.interactions.resolve(approvalId, {
           kind: 'plan',
-          action: 'approve',
+          decision: { action: 'approve' },
         }),
       ).toBe(false);
       // ...neither can B's inbound plan-approval handler...
@@ -3547,7 +3547,7 @@ describe('DesktopProgressBridge', () => {
         expect(
           bridgeB.session.interactions.resolve('plan-rebound', {
             kind: 'plan',
-            action: 'approve',
+            decision: { action: 'approve' },
           }),
         ).toBe(true);
         await expect(planPromise).resolves.toEqual({ action: 'approve' });
@@ -3674,7 +3674,7 @@ describe('DesktopProgressBridge', () => {
         expect(
           bridgeC.session.interactions.resolve('plan-second-window-close', {
             kind: 'plan',
-            action: 'approve',
+            decision: { action: 'approve' },
           }),
         ).toBe(true);
         await expect(approval).resolves.toEqual({ action: 'approve' });
@@ -3771,7 +3771,7 @@ describe('DesktopProgressBridge', () => {
           expect(
             bridgeB.session.interactions.resolve(approvalId, {
               kind: 'plan',
-              action: 'approve',
+              decision: { action: 'approve' },
             }),
           ).toBe(true);
         }

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -5,7 +5,7 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import type { HostInteractionResolution } from '@agent/runtime/HostInteractions';
+import type { HostInteractionSettlement } from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 
@@ -38,7 +38,7 @@ interface DesktopHostInteractions {
     plan: { objective: string };
   }): Promise<unknown>;
   requestAgentProposal(request: unknown): Promise<unknown>;
-  resolve(requestId: string, result: HostInteractionResolution): boolean;
+  resolve(requestId: string, settlement: HostInteractionSettlement): boolean;
   cancel(selector?: {
     streamId?: StreamTabId | null;
     kind?: string;
@@ -178,7 +178,7 @@ describe('createDesktopHostInteractions', () => {
     expect(
       interactions.resolve('proposal-current', {
         kind: 'proposal',
-        action: 'approve',
+        decision: { action: 'approve' },
       }),
     ).toBe(true);
     const streamBRequestId = (
@@ -190,7 +190,7 @@ describe('createDesktopHostInteractions', () => {
     expect(
       interactions.resolve(streamBRequestId!, {
         kind: 'bash',
-        action: 'reject',
+        decision: { action: 'reject' },
       }),
     ).toBe(true);
     await expect(current).resolves.toEqual({ action: 'approve' });
@@ -233,11 +233,17 @@ describe('createDesktopHostInteractions', () => {
     // pending bash approval as a plan action would — matches the extension
     // host's discriminant check.
     expect(
-      interactions.resolve(requestId, { kind: 'plan', action: 'approve' }),
+      interactions.resolve(requestId, {
+        kind: 'plan',
+        decision: { action: 'approve' },
+      }),
     ).toBe(false);
 
     expect(
-      interactions.resolve(requestId, { kind: 'bash', action: 'approve' }),
+      interactions.resolve(requestId, {
+        kind: 'bash',
+        decision: { action: 'approve' },
+      }),
     ).toBe(true);
     await expect(resultPromise).resolves.toEqual({ accepted: true });
     expect(runtimeHost.emit).toHaveBeenCalledWith(
@@ -338,7 +344,10 @@ describe('createDesktopHostInteractions', () => {
     const requestId = firstShowRequestId(handlers.bash.show);
 
     expect(
-      interactions.resolve(requestId, { kind: 'bash', action: 'timeout' }),
+      interactions.resolve(requestId, {
+        kind: 'bash',
+        decision: { action: 'timeout' },
+      }),
     ).toBe(true);
 
     await expect(resultPromise).resolves.toEqual({
@@ -348,7 +357,7 @@ describe('createDesktopHostInteractions', () => {
     expect(handlers.bash.resolve).toHaveBeenCalledWith(requestId);
   });
 
-  it('whitelists only known proposal actions from a pass-through value', async () => {
+  it('preserves typed proposal approval overrides', async () => {
     const handlers = createHandlers();
     const { interactions } = await createInteractions(handlers);
 
@@ -359,21 +368,21 @@ describe('createDesktopHostInteractions', () => {
       agent: 'demo-agent',
     });
 
-    // An unrelated object shape smuggled through `value` (containing an
-    // `action` that isn't a real ProposalResult action) must not be trusted
-    // verbatim — it should fall back to the resolution's own `action`.
     expect(
       interactions.resolve('proposal-a', {
         kind: 'proposal',
-        action: 'reject',
-        value: { action: 'not-a-real-action', foo: 'bar' },
-        feedback: 'Rejected via unrelated caller shape.',
+        decision: {
+          action: 'approve',
+          model: 'openai:gpt-5',
+          agent: 'configured-agent',
+        },
       }),
     ).toBe(true);
 
     await expect(resultPromise).resolves.toEqual({
-      action: 'reject',
-      feedback: 'Rejected via unrelated caller shape.',
+      action: 'approve',
+      model: 'openai:gpt-5',
+      agent: 'configured-agent',
     });
     expect(handlers.agentProposal.resolve).toHaveBeenCalledWith('proposal-a');
   });

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -161,7 +161,7 @@ describe('createExtensionHostInteractions', () => {
     expect(
       interactions.resolve('proposal-current', {
         kind: 'proposal',
-        action: 'approve',
+        decision: { action: 'approve' },
       }),
     ).toBe(true);
     const bashShow = handlers.bash.show as unknown as ReturnType<typeof vi.fn>;
@@ -176,7 +176,7 @@ describe('createExtensionHostInteractions', () => {
     expect(
       interactions.resolve(streamBRequestId!, {
         kind: 'bash',
-        action: 'reject',
+        decision: { action: 'reject' },
       }),
     ).toBe(true);
     await expect(initiatingProposal).resolves.toEqual({ action: 'approve' });
@@ -233,7 +233,7 @@ describe('createExtensionHostInteractions', () => {
     expect(
       interactions.resolve('plan-a', {
         kind: 'plan',
-        action: 'approve_and_goal',
+        decision: { action: 'approve_and_goal' },
       }),
     ).toBe(true);
 
@@ -243,7 +243,10 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-a');
     // The request was settled first-wins: a second resolution finds nothing.
     expect(
-      interactions.resolve('plan-a', { kind: 'plan', action: 'approve' }),
+      interactions.resolve('plan-a', {
+        kind: 'plan',
+        decision: { action: 'approve' },
+      }),
     ).toBe(false);
   });
 
@@ -303,7 +306,6 @@ describe('createExtensionHostInteractions', () => {
     await expect(first).resolves.toEqual({ action: 'cancel' });
     expect(
       interactions.resolveRetry('stream-a' as StreamTabId, 'retry:first', {
-        kind: 'retry',
         action: 'retry',
       }),
     ).toBe(false);
@@ -317,7 +319,7 @@ describe('createExtensionHostInteractions', () => {
       interactions.resolveRetry(
         'stream-a' as StreamTabId,
         'retry:replacement',
-        { kind: 'retry', action: 'retry' },
+        { action: 'retry' },
       ),
     ).toBe(true);
     await expect(replacement).resolves.toEqual({ action: 'retry' });
@@ -404,12 +406,18 @@ describe('createExtensionHostInteractions', () => {
     // bash approval as a plan action would (defends against a caller bug
     // resolving the wrong pending kind under a reused/misrouted requestId).
     expect(
-      interactions.resolve(requestId, { kind: 'plan', action: 'approve' }),
+      interactions.resolve(requestId, {
+        kind: 'plan',
+        decision: { action: 'approve' },
+      }),
     ).toBe(false);
 
     // The correctly-kinded resolution still settles it.
     expect(
-      interactions.resolve(requestId, { kind: 'bash', action: 'approve' }),
+      interactions.resolve(requestId, {
+        kind: 'bash',
+        decision: { action: 'approve' },
+      }),
     ).toBe(true);
     await expect(resultPromise).resolves.toEqual({ accepted: true });
   });
@@ -448,7 +456,10 @@ describe('createExtensionHostInteractions', () => {
     // resolvable first-wins.
     expect(handlers.planApproval.resolve).not.toHaveBeenCalled();
     expect(
-      interactions.resolve('plan-a', { kind: 'plan', action: 'approve' }),
+      interactions.resolve('plan-a', {
+        kind: 'plan',
+        decision: { action: 'approve' },
+      }),
     ).toBe(true);
     await expect(planPromise).resolves.toEqual({ action: 'approve' });
   });
@@ -481,6 +492,10 @@ describe('createExtensionHostInteractions', () => {
       streamId: 'stream-a',
       mode: 'new',
     });
+    expect(interactions.resolve('thread-a', { kind: 'externalInquiry' })).toBe(
+      true,
+    );
+    expect(handlers.externalInquiry.resolve).toHaveBeenCalledWith('thread-a');
   });
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
@@ -518,9 +533,45 @@ describe('createExtensionHostInteractions', () => {
     expect(
       interactions.resolve('question-a', {
         kind: 'userQuestion',
-        action: 'submit',
+        decision: { action: 'submit', answers: { choice: 'unit volume' } },
       }),
     ).toBe(false);
+  });
+
+  it('settles submitted user questions with their answers', async () => {
+    const handlers = createHandlers();
+    const interactions = createInteractions({
+      handlers,
+      session: createTestSession(),
+    });
+
+    const resultPromise = interactions.askUserQuestion?.({
+      requestId: 'question-submit',
+      questions: [
+        {
+          question: 'Which normalization should be used?',
+          options: [{ label: 'Unit volume' }, { label: 'Unit mass' }],
+        },
+      ],
+      allowBypass: false,
+      streamId: 'stream-a' as StreamTabId,
+    });
+    const answers = { normalization: 'unit volume' };
+
+    expect(
+      interactions.resolve('question-submit', {
+        kind: 'userQuestion',
+        decision: { action: 'submit', answers },
+      }),
+    ).toBe(true);
+
+    await expect(resultPromise).resolves.toEqual({
+      submitted: true,
+      answers,
+    });
+    expect(handlers.userQuestion.resolve).toHaveBeenCalledWith(
+      'question-submit',
+    );
   });
 
   it('delegates tool edit approval to the native VS Code port', async () => {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -321,7 +321,6 @@ describe('progress-view onboarding refresh wiring', () => {
       'stream-a',
       'retry-a',
       {
-        kind: 'retry',
         action: 'retry',
         feedback: 'try the other branch',
       },
@@ -330,7 +329,6 @@ describe('progress-view onboarding refresh wiring', () => {
       'stream-a',
       'retry-a',
       {
-        kind: 'retry',
         action: 'cancel',
       },
     );
@@ -386,8 +384,7 @@ describe('progress-view onboarding refresh wiring', () => {
 
     expect(interactions.resolve).toHaveBeenCalledWith('proposal-a', {
       kind: 'proposal',
-      action: 'approve',
-      value: {
+      decision: {
         action: 'approve',
         model: 'gemini31p',
         agent: 'critic',
@@ -418,8 +415,10 @@ describe('progress-view onboarding refresh wiring', () => {
 
     expect(interactions.resolve).toHaveBeenCalledWith('plan-a', {
       kind: 'plan',
-      action: 'reject',
-      feedback: 'state the invariant first',
+      decision: {
+        action: 'reject',
+        feedback: 'state the invariant first',
+      },
     });
   });
 

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type {
-  HostInteractionResolution,
+  HostInteractionSettlement,
   HostInteractions,
 } from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -37,7 +37,7 @@ describe('handleExternalInquiryAction', () => {
   let detach: (() => void) | undefined;
   let resolve: ReturnType<
     typeof vi.fn<
-      (requestId: string, result: HostInteractionResolution) => boolean
+      (requestId: string, settlement: HostInteractionSettlement) => boolean
     >
   >;
 
@@ -46,7 +46,7 @@ describe('handleExternalInquiryAction', () => {
     storageMocks.recordAnswerForOpenTurn.mockResolvedValue(null);
     storageMocks.markDropped.mockResolvedValue(null);
     resolve = vi.fn<
-      (requestId: string, result: HostInteractionResolution) => boolean
+      (requestId: string, settlement: HostInteractionSettlement) => boolean
     >(() => true);
     const interactions: HostInteractions = {
       resolve,
@@ -69,7 +69,6 @@ describe('handleExternalInquiryAction', () => {
 
     expect(resolve).toHaveBeenCalledWith('thread-submit', {
       kind: 'externalInquiry',
-      action: 'submit',
     });
   });
 
@@ -82,8 +81,6 @@ describe('handleExternalInquiryAction', () => {
 
     expect(resolve).toHaveBeenCalledWith('thread-drop', {
       kind: 'externalInquiry',
-      action: 'drop',
-      feedback: 'The question is no longer needed.',
     });
   });
 });

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -95,7 +95,7 @@ describe('PlanTool — update (plan approval)', () => {
     expect(
       host.interactions?.resolve(
         (approval.payload as { approvalId: string }).approvalId,
-        { kind: 'plan', action: 'approve' },
+        { kind: 'plan', decision: { action: 'approve' } },
       ),
     ).toBe(true);
 
@@ -117,7 +117,10 @@ describe('PlanTool — update (plan approval)', () => {
     expect(
       host.interactions?.resolve(
         (approval.payload as { approvalId: string }).approvalId,
-        { kind: 'plan', action: 'reject', feedback: 'Too broad.' },
+        {
+          kind: 'plan',
+          decision: { action: 'reject', feedback: 'Too broad.' },
+        },
       ),
     ).toBe(true);
 
@@ -143,7 +146,7 @@ describe('PlanTool — update (plan approval)', () => {
       expect(
         host.interactions?.resolve(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', action: 'approve_and_goal' },
+          { kind: 'plan', decision: { action: 'approve_and_goal' } },
         ),
       ).toBe(true);
 
@@ -177,7 +180,7 @@ describe('PlanTool — update (plan approval)', () => {
       expect(
         host.interactions?.resolve(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', action: 'approve_and_goal' },
+          { kind: 'plan', decision: { action: 'approve_and_goal' } },
         ),
       ).toBe(true);
 
@@ -218,7 +221,7 @@ describe('PlanTool — update (plan approval)', () => {
       expect(
         host.interactions?.resolve(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', action: 'approve_and_goal' },
+          { kind: 'plan', decision: { action: 'approve_and_goal' } },
         ),
       ).toBe(true);
 
@@ -243,7 +246,7 @@ describe('PlanTool — update (plan approval)', () => {
     expect(
       host.interactions?.resolve(
         (approval.payload as { approvalId: string }).approvalId,
-        { kind: 'plan', action: 'timeout' },
+        { kind: 'plan', decision: { action: 'timeout' } },
       ),
     ).toBe(true);
 

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -68,7 +68,7 @@ describe('WolframTool approval', () => {
     expect(
       explicit.host.interactions?.resolve(show.payload.requestId, {
         kind: 'bash',
-        action: 'approve',
+        decision: { action: 'approve' },
       }),
     ).toBe(true);
 
@@ -87,8 +87,10 @@ describe('WolframTool approval', () => {
     expect(
       explicit.host.interactions?.resolve(show.payload.requestId, {
         kind: 'bash',
-        action: 'reject',
-        feedback: 'Use the requested node check instead.',
+        decision: {
+          action: 'reject',
+          feedback: 'Use the requested node check instead.',
+        },
       }),
     ).toBe(true);
 
@@ -110,7 +112,7 @@ describe('WolframTool approval', () => {
     expect(
       explicit.host.interactions?.resolve(show.payload.requestId, {
         kind: 'bash',
-        action: 'reject',
+        decision: { action: 'reject' },
       }),
     ).toBe(true);
 

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -169,7 +169,6 @@ export async function handleExternalInquiryAction(
     // submits so duplicate/delayed UI actions do not leave a leaked permission.
     session.interactions.resolve(payload.threadId, {
       kind: 'externalInquiry',
-      action: 'submit',
     });
     if (!persisted) {
       logger.warn(
@@ -198,8 +197,6 @@ export async function handleExternalInquiryAction(
   const droppedManifest = await markDropped({ threadId: payload.threadId });
   session.interactions.resolve(payload.threadId, {
     kind: 'externalInquiry',
-    action: 'drop',
-    feedback: payload.feedback,
   });
   if (droppedManifest) {
     await injectContinuationForDroppedThread(

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -7,6 +7,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
 import {
   UserQuestionAnswersSchema,
   UserQuestionPromptSchema,
@@ -34,17 +35,13 @@ const AskUserQuestionInputSchema = z.strictObject({
 
 export type AskUserQuestionInput = z.infer<typeof AskUserQuestionInputSchema>;
 
-export async function handleUserQuestionAction(payload: {
-  requestId: string;
-  action: 'submit' | 'reject' | 'skip';
-  answers?: UserQuestionAnswers;
-  feedback?: string;
-}): Promise<void> {
-  defaultSession().interactions.resolve(payload.requestId, {
+export async function handleUserQuestionAction(
+  payload: { requestId: string } & UserQuestionSettlement,
+): Promise<void> {
+  const { requestId, ...decision } = payload;
+  defaultSession().interactions.resolve(requestId, {
     kind: 'userQuestion',
-    action: payload.action,
-    value: payload.answers,
-    feedback: payload.feedback,
+    decision,
   });
 }
 
@@ -89,7 +86,7 @@ The tool returns a JSON object whose keys are the original question texts and wh
       };
     }
 
-    const answers = UserQuestionAnswersSchema.parse(result.answers ?? {});
+    const answers = UserQuestionAnswersSchema.parse(result.answers);
     if (Object.keys(answers).length === 0) {
       return {
         status: 'executed',


### PR DESCRIPTION
## Summary

- replace the generic `{ kind, action, feedback?, value?: unknown }` settlement bag with exact kind-specific decisions
- key pending result types by interaction kind in both host adapters and pass plan, proposal, and retry decisions through directly
- remove three reconstruction mappers, the proposal runtime whitelist, the user-question cast, duplicated proposal action data, and the now-unused question-action export
- make user-question input/results exact and reject contradictory inbound payloads

Closes #8521.

## Issue acceptance gates

- [x] Impossible kind/action/payload combinations fail TypeScript compilation.
- [x] User-question submit requires answers; reject/skip cannot carry answers.
- [x] Proposal producers no longer duplicate the action outside the typed result.
- [x] No host-interaction settlement field uses `unknown`.
- [x] Redundant plan/proposal/retry mappers and the proposal runtime validator are removed.
- [x] Extension and desktop share the same typed settlement vocabulary.
- [x] Focused tests cover approval, retry, proposal, question, cancellation, timeout, proposal overrides/setup, and inquiry dismissal.
- [x] Format, typecheck, lint, compile, dead-code ratchet, focused tests, and full Vitest pass.

## Single source of truth

`src/agent/runtime/HostInteractions.ts` owns the exact settlement union, kind-to-result map, and kind-correlated cancellation decisions. Hosts retain only presentation and pending-request ownership.

## Duplication and abstraction budget

Removed three typed-result reconstruction functions plus the proposal runtime action whitelist and its `unknown` validation/cast path. Proposal and plan decisions now pass through once instead of being flattened and reconstructed. The user-question schema's explicit discriminants also made its former action tuple dead, so that export is removed.

The new `HostInteractionResultByKind` map owns one invariant: a pending interaction kind determines its promise result. `cancellationSettlementFor` owns the corresponding kind-specific rejection/cancel decision shared by desktop and extension. No pass-through service, registry, or pending-map read API was added.

## Net elements (R6)

- Files: 1 added, 0 deleted; 28 touched.
- Exported symbols: 7 added, 5 deleted, net +2. The additions are exact settlement/result vocabulary plus one shared cancellation function; the deletions are the generic resolution type, three reconstruction mappers, and one dead action tuple.
- Classes/enums: 0 added, 0 deleted. Interface declarations: 3 added, 3 deleted, net 0.
- LoC: +691/-497, net +194. Production is +391/-385 (net +6); tests are +300/-112 (net +188).

## Consumer counts (R8)

Parent-commit grep before rerouting:

- `HostInteractionResolution`: 5 consumer modules and 18 code references outside its defining module; all now use `HostInteractionSettlement` or an exact decision type.
- `toPlanApprovalResult`: 3 call sites across 2 host modules; removed by direct typed pass-through.
- `toProposalResult`: 4 call sites across 2 host modules; removed by direct typed pass-through.
- `toRetryResult`: 3 call sites in the extension host; removed by direct typed pass-through.
- `USER_QUESTION_ACTIONS`: 0 remaining consumers after the inbound schema became explicitly discriminated; removed as dead code.

No event emit key or subscriber path was removed.

## Host impact

Extension: pending promises and resolution are kind-indexed; retry and user-question decisions are exact; UI behavior and first-settlement ownership are preserved.

Desktop: the same settlement vocabulary and kind-indexed pending results replace generic reconstruction; proposal overrides and all existing cancellation behavior are preserved.

CLI: only the shared question result type and human-input decision construction change. The CLI approval adapter and no-op resolution behavior are unchanged.

## Scheduled refactoring

#8537 tracks the remaining generic frontend permission event and permissive inbound schemas as a separate boundary refactor.

## Validation

- `npm run format`
- `CI=true npm run typecheck`
- `CI=true npm run lint` (0 errors; 51 existing warnings)
- `CI=true npm run compile:fast`
- `CI=true npm run check:dead-code-ratchet` (unused exports improved from 210 to 209 after review cleanup)
- focused Vitest: 14 files / 204 tests, plus exactness/schema/extension reruns (35 tests and 69 tests)
- isolated `RunChatSignalOwnership.vitest.mts`: 2/2 passed after a load-induced concurrent timeout
- uncontended `CI=true npm test`: 700 files passed, 1 skipped; 6,306 tests passed, 4 skipped
- independent read-only semantic and stale-API reviews: clean

No changelog entry: this is an internal type/design refactor with no user-visible behavior change.
