### PR TITLE
feat(agent): persist workflow script checkpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,10 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
   - `packages/extension/src/common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async, type-guard, math, comparator, URL, and path-basics primitives (`debounce`, `delay`, `filterNotNull`, `clamp`, `byName`, `tryParseUrl`, `normalizeFilePath`, `getBasename`, `getFileStem`); re-exports string primitives from `utils/text/stringUtils` for browser-safe barrel access
-    - `utils/core/boundedIdSet.ts` - `createBoundedIdSet` (LRU-capped `Set<Id>` for "seen id" guards); `utils/core/pathCore.ts` is the sibling Node-only path module
+    - `utils/core/boundedIdSet.ts` - `createBoundedIdSet` (LRU-capped `Set<Id>` for "seen id" guards)
+    - `utils/core/idHash.ts` - Node-only deterministic execution-ID derivation
+    - `utils/core/keyedMutex.ts` - `KeyedMutex` for independently serialized asynchronous work by key
+    - `utils/core/pathCore.ts` - sibling Node-only path module
   - `utils/files/` - Filesystem utilities, rules, and vars
   - `utils/config/` - Settings helpers (`getConfig`, `updateConfig`, `watchConfig`)
   - `utils/system/` - Shell command execution (`execUtils`)

--- a/docs/proposals/workflow-script-engine.md
+++ b/docs/proposals/workflow-script-engine.md
@@ -62,7 +62,9 @@ return await agent('Merge these drafts, unify notation.', {
 ### Primitives
 
 - `agent(prompt, opts?)` → one subagent run; returns the typed result
-  (`null` on failure). Options: `label`, `phase`, `agentName`, `inputFiles`.
+  (`null` on failure). Options: `id`, `label`, `phase`, `agentName`,
+  `inputFiles`. Otherwise-identical calls require distinct `id` values so
+  restart recovery does not depend on scheduling order.
 - `parallel(thunks)` → concurrent barrier; failed thunks resolve to `null`.
 - `pipeline(items, ...stages)` → per-item stage chains with **no barrier**
   between stages (wall-clock = slowest single-item chain, not
@@ -196,8 +198,8 @@ copy, no LLM involvement. Rounds that emitted nothing leave symlinks
 
 Every completed `agent()` call is journaled by (call index, hash of
 prompt+options). Re-running with a prior journal replays matching calls from
-cache and re-runs only edited or new calls; failed calls are not journaled,
-so resume retries them. This extends the existing `persistedFlow` checkpoint
+cache and re-runs only edited or new calls; failed and cancelled calls are not
+journaled, so resume retries them. This extends the existing `persistedFlow` checkpoint
 pattern and is why scripts must be deterministic — `Date.now()` and
 `Math.random()` throw inside the sandbox (pass timestamps via `args`).
 Journals persist in the execution KV store alongside the script text.

--- a/src/agent/storage/resultMeta.ts
+++ b/src/agent/storage/resultMeta.ts
@@ -9,6 +9,7 @@ import {
 } from '@agent/runtime/AgentFinalResult';
 import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
 import {
+  ExecutionIdSchema,
   RUN_OUTCOME,
   RunOutcomeSchema,
   type RunOutcome,
@@ -37,6 +38,8 @@ const CliWorkflowResultMetaSchema = z.strictObject({
 const SubagentResultMetaSchema = z.strictObject({
   producer: z.literal('subagent'),
   agentName: z.string(),
+  /** Durable lineage used to verify a recovered workflow child. */
+  parentExecutionId: ExecutionIdSchema.optional(),
   wallTimeMs: z.number().nonnegative(),
   result: AgentFinalResultSchema,
 });

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -45,6 +45,23 @@ return concat(sections, { separator: '\n\n' });
   `AgentFinalResult` envelope — never the XML follow-up delivery string. It
   also verifies task-run inputs against persisted child lineage and result
   manifests before passing them to a later stage.
+- **Restart-safe checkpoints**: one strict, versioned execution-KV record per
+  tool call stores the script, arguments, and journal atomically. Successful
+  live calls are checkpointed before their results return to the script;
+  parallel writes and overlapping resumes are serialized, malformed state
+  fails loudly, and completed child manifests close the final crash-recovery
+  gap without repeating model work. Each stable child attempt records a
+  reservation before registration and a launch marker before model work, so a
+  failed registration can advance safely while an uncertain launched child is
+  never repeated. The parent records the complete attempt sequence, so deleting
+  an earlier child cannot hide a later completed result. A parent execution has
+  one active runtime owner; the execution KV store is durable state, not a
+  cross-process lock.
+- **Cost ownership**: child costs remain in the persisted typed results. The
+  future tool surface must aggregate the final journal at its tool-result
+  boundary, rather than mutating parent totals during child launch; this keeps
+  live execution, recovered manifests, and journal replay on one accounting
+  path.
 - **Sandbox**: a fresh QuickJS runtime and context per script, with a CPU
   interrupt deadline, 64 MB heap limit, 1 MB stack limit, dynamic code
   generation disabled, and no `require`/`process`. The WASM module is loaded
@@ -72,11 +89,14 @@ return concat(sections, { separator: '\n\n' });
   them (`new Date(timestamp)` stays usable). Resume relies on replaying the
   same call sequence: each `agent()` call is journaled by (call index,
   prompt/options hash), and a rerun with a prior journal replays matching
-  calls from cache, re-running only edited or new calls. Failed calls are
-  not journaled, so resume retries them. Caveat: `agent()` calls made from
+  calls from cache, re-running only edited or new calls. Failed and cancelled
+  calls are not journaled, so resume retries them. Caveat: `agent()` calls made from
   `pipeline()` stages beyond the first get indices in completion order,
   which varies run-to-run — the per-index key check keeps replay safe, but
-  multi-stage pipelines see lower resume cache-hit rates.
+  multi-stage pipelines see lower journal cache-hit rates. Durable child
+  identity instead uses the prompt/options hash, so a shifted journal index
+  does not repeat completed model work. Otherwise-identical calls must provide
+  distinct `id` options; ambiguous duplicates fail before launch.
 - **Budgets**: one concurrency semaphore (default 4) across all `agent()`
   calls, a live-call cap (default 200; journal replays are free), a fan-out cap per
   `parallel()`/`pipeline()` call, and a wall-clock timeout. The cap and
@@ -96,5 +116,4 @@ return concat(sections, { separator: '\n\n' });
 - A `delegate_workflow_script` tool, which will invoke the existing production
   runner and task-run file hand-off. Domain-specific structures travel as JSON
   output files rather than per-call result schemas.
-- Journal persistence in the execution KV store and progress-event bridging
-  onto the existing stream tree.
+- Progress-event bridging onto the existing stream tree.

--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'node:crypto';
+
+const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
+
+/** Build the execution-KV key owned by one workflow invocation. */
+export function workflowScriptCheckpointKvKey(checkpointId: string): string {
+  // JSON.stringify preserves lone UTF-16 surrogates as escapes, unlike direct
+  // UTF-8 encoding, which would conflate them with the replacement character.
+  const digest = createHash('sha256')
+    .update(JSON.stringify(checkpointId))
+    .digest('hex');
+  return `${WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX}${digest}`;
+}
+
+/** True when an execution-KV key is a workflow-script checkpoint. */
+export function isWorkflowScriptCheckpointKvKey(key: string): boolean {
+  return key.startsWith(WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX);
+}

--- a/src/agent/workflowScript/index.ts
+++ b/src/agent/workflowScript/index.ts
@@ -2,6 +2,16 @@ export { parseWorkflowScript, WorkflowScriptParseError } from './parseScript';
 export type { ParsedWorkflowScript } from './parseScript';
 export { runWorkflowScript, WorkflowRunAbortError } from './runWorkflowScript';
 export {
+  readWorkflowScriptCheckpoint,
+  runPersistedWorkflowScript,
+  WorkflowScriptPersistenceError,
+  writeWorkflowScriptCheckpoint,
+} from './persistence';
+export type {
+  PersistedWorkflowScriptRunOptions,
+  WorkflowScriptCheckpoint,
+} from './persistence';
+export {
   WorkflowScriptMetaSchema,
   type WorkflowAgentCallOptions,
   type WorkflowAgentInvocation,

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -1,0 +1,306 @@
+// Third-party imports
+import { z } from 'zod';
+import stableStringify from 'fast-json-stable-stringify';
+
+// Local imports - storage
+import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import { KeyedMutex } from '@utils/core';
+
+// Local imports - workflow script
+import { workflowScriptCheckpointKvKey } from './checkpointKey';
+import { parseWorkflowScript } from './parseScript';
+import { runWorkflowScript } from './runWorkflowScript';
+import type {
+  WorkflowJournalEntry,
+  WorkflowScriptRunOptions,
+  WorkflowScriptRunResult,
+} from './types';
+
+const WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION = 1;
+const JsonValueSchema = z.json();
+
+const PersistedJsonValueSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('undefined') }),
+  z.strictObject({ kind: z.literal('json'), value: JsonValueSchema }),
+]);
+
+const PersistedWorkflowJournalEntrySchema = z.strictObject({
+  index: z.int().nonnegative(),
+  key: z.string().regex(/^[a-f0-9]{16}$/),
+  result: PersistedJsonValueSchema,
+});
+
+const WorkflowScriptCheckpointSchema = z
+  .strictObject({
+    schemaVersion: z.literal(WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION),
+    script: z.string().min(1),
+    args: PersistedJsonValueSchema,
+    journal: z.array(PersistedWorkflowJournalEntrySchema),
+  })
+  .superRefine(({ journal }, context) => {
+    const indices = new Set<number>();
+    for (const entry of journal) {
+      if (indices.has(entry.index)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate workflow journal index ${entry.index}`,
+          path: ['journal'],
+        });
+      }
+      indices.add(entry.index);
+    }
+  });
+
+const CheckpointIdSchema = z.string().min(1).max(256);
+
+type PersistedJsonValue = z.infer<typeof PersistedJsonValueSchema>;
+
+type PersistedWorkflowJournalEntry = z.infer<
+  typeof PersistedWorkflowJournalEntrySchema
+>;
+
+export interface WorkflowScriptCheckpoint {
+  readonly script: string;
+  readonly args: unknown;
+  readonly journal: WorkflowJournalEntry[];
+}
+
+export class WorkflowScriptPersistenceError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'WorkflowScriptPersistenceError';
+  }
+}
+
+function parseCheckpointId(checkpointId: string): string {
+  const parsed = CheckpointIdSchema.safeParse(checkpointId);
+  if (parsed.success) return parsed.data;
+  throw new WorkflowScriptPersistenceError(
+    'Workflow checkpoint id must be a non-empty string of at most 256 characters.',
+    { cause: parsed.error },
+  );
+}
+
+export interface PersistedWorkflowScriptRunOptions extends Omit<
+  WorkflowScriptRunOptions,
+  'script' | 'journal' | 'onJournalEntry'
+> {
+  /** Execution-scoped KV store that owns this invocation's checkpoint. */
+  store: ExecutionKVStore;
+  /** Stable identity, normally the parent tool call id. */
+  checkpointId: string;
+  /** Omit only when resuming the script already stored at checkpointId. */
+  script?: string;
+}
+
+// An execution is owned by one active runtime host. This lock prevents two
+// callers in that host from racing the same checkpoint; execution KV is not a
+// distributed coordination service between separate TeXRA processes.
+const checkpointMutex = new KeyedMutex<string>();
+
+function encodeJsonValue(value: unknown): PersistedJsonValue {
+  return value === undefined
+    ? { kind: 'undefined' }
+    : { kind: 'json', value: JsonValueSchema.parse(value) };
+}
+
+function decodeJsonValue(value: PersistedJsonValue): unknown {
+  return value.kind === 'undefined' ? undefined : value.value;
+}
+
+function persistedValuesEqual(
+  left: PersistedJsonValue,
+  right: PersistedJsonValue,
+): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function encodeJournalEntry(
+  entry: WorkflowJournalEntry,
+): PersistedWorkflowJournalEntry {
+  return {
+    index: entry.index,
+    key: entry.key,
+    result: encodeJsonValue(entry.result),
+  };
+}
+
+function decodeJournalEntry(
+  entry: PersistedWorkflowJournalEntry,
+): WorkflowJournalEntry {
+  return {
+    index: entry.index,
+    key: entry.key,
+    result: decodeJsonValue(entry.result),
+  };
+}
+
+function orderedJournal(
+  entries: Iterable<WorkflowJournalEntry>,
+): WorkflowJournalEntry[] {
+  return [...entries].toSorted((a, b) => a.index - b.index);
+}
+
+/** Read one checkpoint. Absence is legacy-compatible; malformed data fails. */
+export async function readWorkflowScriptCheckpoint(
+  store: ExecutionKVStore,
+  checkpointId: string,
+): Promise<WorkflowScriptCheckpoint | null> {
+  const id = parseCheckpointId(checkpointId);
+  const raw = await store.read(workflowScriptCheckpointKvKey(id));
+  if (raw === undefined) return null;
+
+  const parsed = WorkflowScriptCheckpointSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${id} is malformed.`,
+      { cause: parsed.error },
+    );
+  }
+  const checkpoint = parsed.data;
+  return {
+    script: checkpoint.script,
+    args: decodeJsonValue(checkpoint.args),
+    journal: orderedJournal(checkpoint.journal.map(decodeJournalEntry)),
+  };
+}
+
+/** Atomically replace the script, arguments, and journal for one invocation. */
+export async function writeWorkflowScriptCheckpoint(
+  store: ExecutionKVStore,
+  checkpointId: string,
+  checkpoint: WorkflowScriptCheckpoint,
+): Promise<void> {
+  const id = parseCheckpointId(checkpointId);
+  let persisted: z.infer<typeof WorkflowScriptCheckpointSchema>;
+  try {
+    persisted = WorkflowScriptCheckpointSchema.parse({
+      schemaVersion: WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION,
+      script: checkpoint.script,
+      args: encodeJsonValue(checkpoint.args),
+      journal: orderedJournal(checkpoint.journal).map(encodeJournalEntry),
+    });
+  } catch (error) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${id} cannot be persisted.`,
+      { cause: error },
+    );
+  }
+  await store.write(workflowScriptCheckpointKvKey(id), persisted);
+}
+
+/**
+ * Run or resume a workflow script with a durable execution-scoped journal.
+ * Completed agent calls are persisted before the script can consume them.
+ */
+export async function runPersistedWorkflowScript(
+  options: PersistedWorkflowScriptRunOptions,
+): Promise<WorkflowScriptRunResult> {
+  const checkpointId = parseCheckpointId(options.checkpointId);
+  const lockKey = `${options.store.getExecutionId()}:${checkpointId}`;
+  return checkpointMutex.runExclusive(lockKey, () =>
+    runPersistedWorkflowScriptLocked(options, checkpointId),
+  );
+}
+
+async function runPersistedWorkflowScriptLocked(
+  options: PersistedWorkflowScriptRunOptions,
+  checkpointId: string,
+): Promise<WorkflowScriptRunResult> {
+  const {
+    store,
+    checkpointId: _checkpointId,
+    script: requestedScript,
+    args: requestedArgs,
+    ...runOptions
+  } = options;
+  const prior = await readWorkflowScriptCheckpoint(store, checkpointId);
+  if (
+    prior !== null &&
+    requestedScript !== undefined &&
+    requestedScript !== prior.script
+  ) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${checkpointId} belongs to different script text.`,
+    );
+  }
+  const script = prior?.script ?? requestedScript;
+  if (script === undefined) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${checkpointId} does not exist; a script is required for the first run.`,
+    );
+  }
+  parseWorkflowScript(script);
+
+  let encodedRequestedArgs: PersistedJsonValue;
+  try {
+    encodedRequestedArgs = encodeJsonValue(requestedArgs);
+  } catch (error) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${checkpointId} arguments cannot be persisted.`,
+      { cause: error },
+    );
+  }
+  if (
+    prior !== null &&
+    Object.hasOwn(options, 'args') &&
+    !persistedValuesEqual(encodedRequestedArgs, encodeJsonValue(prior.args))
+  ) {
+    throw new WorkflowScriptPersistenceError(
+      `Workflow checkpoint ${checkpointId} belongs to different arguments.`,
+    );
+  }
+  const args =
+    prior !== null ? prior.args : decodeJsonValue(encodedRequestedArgs);
+
+  const journalByIndex = new Map(
+    (prior?.journal ?? []).map((entry) => [entry.index, entry]),
+  );
+  await writeWorkflowScriptCheckpoint(store, checkpointId, {
+    script,
+    args,
+    journal: orderedJournal(journalByIndex.values()),
+  });
+
+  let acceptingEntries = true;
+  let writeQueue = Promise.resolve();
+  const persistEntry = async (entry: WorkflowJournalEntry): Promise<void> => {
+    if (!acceptingEntries) return;
+    journalByIndex.set(entry.index, entry);
+    const snapshot = orderedJournal(journalByIndex.values());
+    writeQueue = writeQueue.then(() =>
+      writeWorkflowScriptCheckpoint(store, checkpointId, {
+        script,
+        args,
+        journal: snapshot,
+      }),
+    );
+    await writeQueue;
+  };
+
+  try {
+    const result = await runWorkflowScript({
+      ...runOptions,
+      script,
+      args,
+      journal: prior?.journal,
+      onJournalEntry: persistEntry,
+    });
+    acceptingEntries = false;
+    await writeQueue;
+    await writeWorkflowScriptCheckpoint(store, checkpointId, {
+      script,
+      args,
+      journal: result.journal,
+    });
+    return result;
+  } catch (error) {
+    acceptingEntries = false;
+    // L2 cleanup: each journal write is awaited by the engine before it can
+    // continue, so this rejection is the error already leaving the run.
+    // Observe the queue here only to prevent a duplicate unhandled-rejection
+    // report.
+    await writeQueue.catch(() => {});
+    throw error;
+  }
+}

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -161,8 +161,8 @@ const ORCHESTRATION_PRELUDE = `
  * name/message.
  */
 export class WorkflowRunAbortError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'WorkflowRunAbortError';
   }
 }
@@ -191,7 +191,7 @@ function isWorkflowAbort(error: unknown): boolean {
 export async function runWorkflowScript(
   options: WorkflowScriptRunOptions,
 ): Promise<WorkflowScriptRunResult> {
-  const { runAgent, onEvent } = options;
+  const { runAgent, onEvent, onJournalEntry } = options;
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxAgentCalls = options.maxAgentCalls ?? DEFAULT_MAX_AGENT_CALLS;
@@ -212,17 +212,53 @@ export async function runWorkflowScript(
   // no runner keeps consuming quota or emitting events after the run ends.
   const pendingAgentCalls = new Set<Promise<unknown>>();
   let callCounter = 0;
+  const issuedCallKeys = new Set<string>();
   let currentPhase: string | undefined;
+  let fatalRunError: WorkflowRunAbortError | undefined;
 
   const emit = (event: WorkflowScriptEvent) => onEvent?.(event);
+
+  const rememberFatalRunError = (error: unknown): WorkflowRunAbortError => {
+    const fatal =
+      error instanceof WorkflowRunAbortError
+        ? error
+        : new WorkflowRunAbortError(toErrorMessage(error));
+    fatalRunError ??= fatal;
+    runAbort.abort();
+    return fatalRunError;
+  };
+
+  const recordJournalEntry = async (
+    entry: WorkflowJournalEntry,
+    label: string,
+  ): Promise<void> => {
+    journal.set(entry.index, entry);
+    try {
+      await onJournalEntry?.(entry);
+    } catch (error) {
+      const message = `Failed to persist workflow journal entry ${entry.index}: ${toErrorMessage(error)}`;
+      const fatal = rememberFatalRunError(new WorkflowRunAbortError(message));
+      emit({
+        type: 'agent:end',
+        index: entry.index,
+        label,
+        cached: false,
+        error: message,
+      });
+      throw fatal;
+    }
+  };
 
   async function agentPrimitive(
     prompt: unknown,
     rawOptions?: unknown,
   ): Promise<string | undefined> {
     if (runAbort.signal.aborted) {
-      throw new WorkflowRunAbortError(
-        'Workflow run aborted (timeout or call cap); no new agent() calls may start.',
+      throw rememberFatalRunError(
+        fatalRunError ??
+          new WorkflowRunAbortError(
+            'Workflow run aborted (timeout or call cap); no new agent() calls may start.',
+          ),
       );
     }
     if (!isNonEmptyString(prompt)) {
@@ -238,6 +274,14 @@ export async function runWorkflowScript(
       callOptions.label ??
       prompt.slice(0, LABEL_EXCERPT_LENGTH).replaceAll(/\s+/g, ' ').trim();
     const key = journalKey(prompt, callOptions);
+    if (issuedCallKeys.has(key)) {
+      throw rememberFatalRunError(
+        new WorkflowRunAbortError(
+          'Repeated agent() calls with the same prompt and options require distinct non-empty "id" options for restart-safe identity.',
+        ),
+      );
+    }
+    issuedCallKeys.add(key);
 
     const prior = priorEntries.get(index);
     if (prior && prior.key === key) {
@@ -265,9 +309,10 @@ export async function runWorkflowScript(
     if (liveCallCounter > maxAgentCalls) {
       // Abort first so in-flight sibling agents stop consuming quota — the
       // backstop must cancel the fan-out, not just fail this one call.
-      runAbort.abort();
-      throw new WorkflowRunAbortError(
-        `Workflow exceeded the ${maxAgentCalls} live agent-call cap (runaway-loop backstop; journal replays are free).`,
+      throw rememberFatalRunError(
+        new WorkflowRunAbortError(
+          `Workflow exceeded the ${maxAgentCalls} live agent-call cap (runaway-loop backstop; journal replays are free).`,
+        ),
       );
     }
 
@@ -278,12 +323,16 @@ export async function runWorkflowScript(
         // Re-check after waiting for a slot: a timeout/cap abort while this
         // call was queued must not launch fresh model work.
         if (runAbort.signal.aborted) {
-          throw new WorkflowRunAbortError(
-            'Workflow run aborted while this agent() call was queued.',
+          throw rememberFatalRunError(
+            fatalRunError ??
+              new WorkflowRunAbortError(
+                'Workflow run aborted while this agent() call was queued.',
+              ),
           );
         }
         return runAgent({
           index,
+          key,
           prompt,
           options: callOptions,
           signal: runAbort.signal,
@@ -292,7 +341,7 @@ export async function runWorkflowScript(
     } catch (error) {
       // A runner may surface the run abort (it holds runAbort.signal);
       // that must stop the workflow, not degrade into a null agent result.
-      if (isWorkflowAbort(error)) throw error;
+      if (isWorkflowAbort(error)) throw rememberFatalRunError(error);
       // A failed agent resolves to null (callers filter with .filter(Boolean))
       // and is deliberately NOT journaled, so a resume retries it.
       emit({
@@ -322,7 +371,7 @@ export async function runWorkflowScript(
       });
       throw error;
     }
-    journal.set(index, { index, key, result: normalizedResult });
+    await recordJournalEntry({ index, key, result: normalizedResult }, label);
     emit({ type: 'agent:end', index, label, cached: false });
     return payload;
   }
@@ -330,6 +379,7 @@ export async function runWorkflowScript(
   const argsJson = serializeBridgeValue(options.args, 'Workflow args');
 
   let result: unknown;
+  let scriptFailure: { readonly error: unknown } | undefined;
   try {
     result = await runScriptInSandbox(
       body,
@@ -365,6 +415,8 @@ export async function runWorkflowScript(
         onTimeout: () => runAbort.abort(),
       },
     );
+  } catch (error) {
+    scriptFailure = { error };
   } finally {
     // Abort unconditionally once the sandbox returns. This stops in-flight
     // work the script abandoned and makes agentPrimitive reject any late call.
@@ -390,6 +442,12 @@ export async function runWorkflowScript(
       }
     }
   }
+
+  // Guest code may catch an agent() rejection, and an abandoned call can
+  // reject while the final drain is running. Checkpoint failure is a run-level
+  // invariant, so inspect it only after every bounded cleanup opportunity.
+  if (fatalRunError) throw fatalRunError;
+  if (scriptFailure) throw scriptFailure.error;
 
   return {
     meta,
@@ -440,13 +498,14 @@ function normalizeAgentOptions(
   // called with a value that did not come through the bridge.
   const source = structuredClone(raw ?? {}) as Record<string, unknown>;
   const options: WorkflowAgentCallOptions = {};
-  for (const field of ['label', 'phase', 'agentName'] as const) {
+  for (const field of ['id', 'label', 'phase', 'agentName'] as const) {
     const value = source[field];
     if (value === undefined) continue;
-    if (typeof value !== 'string') {
-      throw new Error(`agent() option "${field}" must be a string.`);
+    if (typeof value !== 'string' || (field === 'id' && !value.trim())) {
+      const requirement = field === 'id' ? 'a non-empty string' : 'a string';
+      throw new Error(`agent() option "${field}" must be ${requirement}.`);
     }
-    options[field] = value;
+    options[field] = field === 'id' ? value.trim() : value;
   }
   for (const field of ['schema', 'outputSchema'] as const) {
     if (!Object.hasOwn(source, field)) continue;

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -21,6 +21,8 @@ export type WorkflowScriptMeta = z.infer<typeof WorkflowScriptMetaSchema>;
 
 /** Options accepted by the script-facing `agent()` primitive. */
 export interface WorkflowAgentCallOptions {
+  /** Stable identity when otherwise-identical calls occur more than once. */
+  id?: string;
   /** Display label for progress UIs; defaults to a prompt excerpt. */
   label?: string;
   /** Progress group; defaults to the `phase()` active at call time. */
@@ -34,6 +36,8 @@ export interface WorkflowAgentCallOptions {
 export interface WorkflowAgentInvocation {
   /** 0-based call sequence number; also the journal key position. */
   index: number;
+  /** Stable hash of the prompt and normalized call options. */
+  key: string;
   prompt: string;
   options: WorkflowAgentCallOptions;
   /**
@@ -84,6 +88,12 @@ export interface WorkflowScriptRunOptions {
   concurrency?: number;
   /** Journal from a prior run; per-index key matches return cached results. */
   journal?: WorkflowJournalEntry[];
+  /**
+   * Durable checkpoint hook for a successfully validated live call. The
+   * engine awaits it before the result becomes visible to the script, so a
+   * host restart cannot expose work whose journal entry was never persisted.
+   */
+  onJournalEntry?: (entry: WorkflowJournalEntry) => void | Promise<void>;
   onEvent?: (event: WorkflowScriptEvent) => void;
   /** Wall-clock cap for the whole script. Default 10 minutes. */
   timeoutMs?: number;

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -5,9 +5,14 @@ import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { createWorkflowScriptAgentRunner } from '@tools/delegation/workflowScriptAgentRunner';
+import {
+  SubagentDurabilityError,
+  SubagentReconciliationError,
+} from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
   executeSubagentInBand: vi.fn(),
+  preparedOptions: [] as unknown[],
   requireVisibleAgent: vi.fn(),
   selectAvailableDelegationModel: vi.fn(),
   resolveChildRunOutput: vi.fn(),
@@ -15,9 +20,25 @@ const mocks = vi.hoisted(() => ({
   assertWorkflowFilesExist: vi.fn(),
 }));
 
-vi.mock('@tools/delegation/inBandSubagentExecution', () => ({
-  executeSubagentInBand: mocks.executeSubagentInBand,
-}));
+vi.mock('@tools/delegation/inBandSubagentExecution', () => {
+  class SubagentDurabilityError extends Error {
+    constructor(message: string, options?: ErrorOptions) {
+      super(message, options);
+      this.name = 'SubagentDurabilityError';
+    }
+  }
+  class SubagentReconciliationError extends SubagentDurabilityError {
+    constructor(message: string) {
+      super(message);
+      this.name = 'SubagentReconciliationError';
+    }
+  }
+  return {
+    executeStableSubagentInBand: mocks.executeSubagentInBand,
+    SubagentDurabilityError,
+    SubagentReconciliationError,
+  };
+});
 
 vi.mock('@tools/delegation/proposalFlow', () => ({
   requireVisibleAgent: mocks.requireVisibleAgent,
@@ -74,6 +95,7 @@ function invocation(
 ): WorkflowAgentInvocation {
   return {
     index: 0,
+    key: '0123456789abcdef',
     prompt: 'Draft the section.',
     options,
     signal: new AbortController().signal,
@@ -83,6 +105,7 @@ function invocation(
 describe('createWorkflowScriptAgentRunner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.preparedOptions.length = 0;
     mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
       name,
       source: 'builtInWorkflow',
@@ -92,16 +115,20 @@ describe('createWorkflowScriptAgentRunner', () => {
     mocks.selectAvailableDelegationModel.mockResolvedValue('child-model');
     mocks.assertWorkflowFilesExist.mockResolvedValue(undefined);
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
-    mocks.executeSubagentInBand.mockResolvedValue({
-      executionId: 'bbbbbb222222',
-      result,
+    mocks.executeSubagentInBand.mockImplementation(async (options) => {
+      mocks.preparedOptions.push(await options.prepare());
+      return { executionId: 'bbbbbb222222', result };
     });
   });
 
   it('uses delegation policy and executes a direct in-band child', async () => {
     const parent = parentContext();
     const call = invocation({ inputFiles: ['paper.tex'] });
-    const runner = createWorkflowScriptAgentRunner(parent, 'correct');
+    const runner = createWorkflowScriptAgentRunner(
+      parent,
+      'correct',
+      'tool-call-7',
+    );
 
     await expect(runner(call)).resolves.toBe(result);
     expect(mocks.requireVisibleAgent).toHaveBeenCalledWith(
@@ -120,6 +147,14 @@ describe('createWorkflowScriptAgentRunner', () => {
       agentCategory: 'workflow',
     });
     expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionId: expect.stringMatching(/^[a-f0-9]{24}$/),
+        parentExecutionId,
+        signal: call.signal,
+        prepare: expect.any(Function),
+      }),
+    );
+    expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         agentName: 'correct',
         parentExecutionId,
@@ -156,7 +191,11 @@ describe('createWorkflowScriptAgentRunner', () => {
       relativePath: 'r1/draft.tex',
       executionId: 'bbbbbb222222',
     });
-    const runner = createWorkflowScriptAgentRunner(parentContext(), 'correct');
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
 
     await runner(
       invocation({
@@ -172,7 +211,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Input file', files: ['notes.tex'] },
     ]);
-    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+    expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         agentName: 'merge',
         configPayload: expect.objectContaining({
@@ -188,14 +227,95 @@ describe('createWorkflowScriptAgentRunner', () => {
       kind: 'runStorage',
     });
     mocks.resolveChildRunOutput.mockResolvedValue(undefined);
-    const runner = createWorkflowScriptAgentRunner(parentContext(), 'correct');
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
 
     await runner(invocation({ inputFiles: [placeholder] }));
 
-    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+    expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         configPayload: expect.objectContaining({ inputFiles: [] }),
       }),
     );
+  });
+
+  it('uses one stable child id per workflow call identity', async () => {
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
+
+    await runner(invocation());
+    await runner(invocation());
+    await runner({ ...invocation(), index: 1 });
+    await runner({ ...invocation(), key: 'fedcba9876543210' });
+
+    const executionIds = mocks.executeSubagentInBand.mock.calls.map(
+      ([options]) => options.executionId,
+    );
+    expect(executionIds[0]).toBe(executionIds[1]);
+    expect(executionIds[2]).toBe(executionIds[0]);
+    expect(executionIds[3]).not.toBe(executionIds[0]);
+  });
+
+  it('rejects a cancelled child so the workflow journal can retry it', async () => {
+    mocks.executeSubagentInBand.mockResolvedValueOnce({
+      executionId: 'bbbbbb222222',
+      result: {
+        category: 'toolUse',
+        outcome: 'cancelled',
+        response: '',
+        files: [],
+        cost: 0,
+      },
+    });
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
+
+    await expect(runner(invocation())).rejects.toThrow(
+      'Workflow subagent ended with cancelled outcome.',
+    );
+  });
+
+  it('turns durable reconciliation failures into fatal workflow aborts', async () => {
+    mocks.executeSubagentInBand.mockRejectedValueOnce(
+      new SubagentReconciliationError('incomplete child state'),
+    );
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
+
+    await expect(runner(invocation())).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: 'incomplete child state',
+    });
+  });
+
+  it('turns manifest-write failures into fatal workflow aborts', async () => {
+    const durabilityError = new SubagentDurabilityError(
+      'result manifest unavailable',
+      { cause: new Error('storage offline') },
+    );
+    mocks.executeSubagentInBand.mockRejectedValueOnce(durabilityError);
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+    );
+
+    await expect(runner(invocation())).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: 'result manifest unavailable',
+      cause: durabilityError,
+    });
   });
 });

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -95,6 +95,48 @@ return [a, b]`,
     expect(run.meta.name).toBe('test-flow');
   });
 
+  it('requires explicit identities for otherwise-repeated calls', async () => {
+    const invocations: WorkflowAgentInvocation[] = [];
+    await runWorkflowScript({
+      script: `${META}
+return await parallel([
+  () => agent('same', { id: ' first ' }),
+  () => agent('different'),
+  () => agent('same', { id: 'second' }),
+])`,
+      runAgent: (invocation) => {
+        invocations.push(invocation);
+        return echoRunner(invocation);
+      },
+    });
+
+    expect(invocations.map(({ options }) => options.id)).toEqual([
+      'first',
+      undefined,
+      'second',
+    ]);
+
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await parallel([
+  () => agent('same'),
+  () => agent('same'),
+])`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/require distinct non-empty "id" options/i);
+
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await parallel([
+  () => agent('same', { id: 'same-id' }),
+  () => agent('same', { id: ' same-id ' }),
+])`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/require distinct non-empty "id" options/i);
+  });
+
   it('passes typed workflow outputs into the next stage input files', async () => {
     const outputPath =
       '/storage/executions/bbbbbb222222/r1/drafted-section.tex';
@@ -164,6 +206,65 @@ return await parallel([
     expect(run.result).toEqual([null, 'result:fine']);
     // Only the successful call is journaled, so a resume retries the failure.
     expect(run.journal.map((entry) => entry.index)).toEqual([1]);
+  });
+
+  it('awaits durable journal hooks and excludes failed calls from them', async () => {
+    const order: string[] = [];
+    const run = await runWorkflowScript({
+      script: `${META}return [await agent('boom'), await agent('saved')]`,
+      runAgent: async ({ prompt }) => {
+        if (prompt === 'boom') throw new Error('runner failed');
+        order.push('runner');
+        return 'saved result';
+      },
+      onJournalEntry: async (entry) => {
+        await delay(5);
+        order.push(`checkpoint:${entry.index}`);
+      },
+      onEvent: (event) => {
+        if (event.type === 'agent:end' && !event.error) {
+          order.push(`end:${event.index}`);
+        }
+      },
+    });
+
+    expect(run.result).toEqual([null, 'saved result']);
+    expect(order).toEqual(['runner', 'checkpoint:1', 'end:1']);
+  });
+
+  it('surfaces a late checkpoint failure from an abandoned agent call', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}agent('abandoned'); return 'guest success'`,
+        runAgent: async () => {
+          await delay(5);
+          return 'completed child';
+        },
+        onJournalEntry: async () => {
+          await delay(5);
+          throw new Error('checkpoint offline');
+        },
+      }),
+    ).rejects.toMatchObject({ name: 'WorkflowRunAbortError' });
+  });
+
+  it('does not let a guest error mask a late checkpoint failure', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}agent('abandoned'); throw new Error('guest failed')`,
+        runAgent: async () => {
+          await delay(5);
+          return 'completed child';
+        },
+        onJournalEntry: async () => {
+          await delay(5);
+          throw new Error('checkpoint offline');
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining('checkpoint offline'),
+    });
   });
 
   it('pipeline(): no barrier between stages', async () => {
@@ -970,6 +1071,28 @@ return await parallel([() => agent('x')])`,
         runAgent: runner,
       }),
     ).rejects.toThrow(/runner observed abort/);
+  });
+
+  it('does not let script code suppress a fatal runner abort', async () => {
+    const runner = () => {
+      const abortError = new Error('durable manifest unavailable');
+      abortError.name = 'WorkflowRunAbortError';
+      return Promise.reject(abortError);
+    };
+
+    await expect(
+      runWorkflowScript({
+        script: `${META}
+try {
+  await agent('x')
+} catch {}
+return 'incorrect success'`,
+        runAgent: runner,
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: 'durable manifest unavailable',
+    });
   });
 
   it('removes Intl so scripts cannot read the wall clock implicitly', async () => {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -1,0 +1,406 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  readWorkflowScriptCheckpoint,
+  runPersistedWorkflowScript,
+  WorkflowScriptPersistenceError,
+  writeWorkflowScriptCheckpoint,
+} from '@agent/workflowScript';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { workflowScriptCheckpointKvKey } from '@agent/workflowScript/checkpointKey';
+import type { ExecutionId } from '@shared/schemas';
+import { delay } from '@utils/core';
+
+const executionId = 'aaaaaa111111' as ExecutionId;
+const script = `export const meta = {
+  name: 'durable-flow',
+  description: 'tests durable workflow checkpoints',
+}
+const first = await agent('first')
+const second = await agent('second')
+return [first, second]`;
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+beforeEach(() => clearStoreCache());
+
+describe('workflow-script persistence', () => {
+  it('replays a completed journal after restart without new agent calls', async () => {
+    const store = getExecutionStore(executionId);
+    const firstRunner = vi.fn(async ({ prompt }: { prompt: string }) =>
+      Promise.resolve(`result:${prompt}`),
+    );
+
+    const first = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'call-1',
+      script,
+      runAgent: firstRunner,
+    });
+    expect(firstRunner).toHaveBeenCalledTimes(2);
+    expect(first.journal).toHaveLength(2);
+
+    clearStoreCache();
+    const restartedRunner = vi.fn(() => Promise.reject(new Error('live run')));
+    const restarted = await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: 'call-1',
+      runAgent: restartedRunner,
+    });
+
+    expect(restarted.result).toEqual(['result:first', 'result:second']);
+    expect(restartedRunner).not.toHaveBeenCalled();
+  });
+
+  it('keeps checkpoints isolated by tool call id', async () => {
+    const store = getExecutionStore(executionId);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'call-a',
+      script,
+      runAgent: async () => 'A',
+    });
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'call-b',
+      script,
+      runAgent: async () => 'B',
+    });
+
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'call-a'),
+    ).resolves.toMatchObject({
+      journal: [{ result: 'A' }, { result: 'A' }],
+    });
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'call-b'),
+    ).resolves.toMatchObject({
+      journal: [{ result: 'B' }, { result: 'B' }],
+    });
+  });
+
+  it('treats absence as fresh but rejects malformed present state', async () => {
+    const store = getExecutionStore(executionId);
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'missing'),
+    ).resolves.toBeNull();
+
+    await store.write(workflowScriptCheckpointKvKey('corrupt'), null);
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'corrupt'),
+    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+    await expect(
+      writeWorkflowScriptCheckpoint(store, 'invalid-write', {
+        script,
+        args: undefined,
+        journal: [{ index: 0, key: '0000000000000000', result: () => 1 }],
+      }),
+    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+  });
+
+  it('rejects script drift for an existing tool call id', async () => {
+    const store = getExecutionStore(executionId);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'stable-call',
+      script,
+      runAgent: async () => 'done',
+    });
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'stable-call',
+        script: script.replace('second', 'changed'),
+        runAgent: async () => 'changed',
+      }),
+    ).rejects.toThrow(/different script text/i);
+  });
+
+  it('round-trips an undefined agent result explicitly', async () => {
+    const store = getExecutionStore(executionId);
+    const undefinedScript = `export const meta = {
+  name: 'undefined-result',
+  description: 'persists an undefined result',
+}
+return await agent('none')`;
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'undefined-result',
+      script: undefinedScript,
+      runAgent: async () => undefined,
+    });
+
+    const raw = await store.read<Record<string, unknown>>(
+      workflowScriptCheckpointKvKey('undefined-result'),
+    );
+    expect(raw).toMatchObject({
+      args: { kind: 'undefined' },
+      journal: [{ result: { kind: 'undefined' } }],
+    });
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'undefined-result'),
+    ).resolves.toMatchObject({ journal: [{ result: undefined }] });
+  });
+
+  it('preserves opaque checkpoint ids without normalizing them', async () => {
+    const store = getExecutionStore(executionId);
+    await writeWorkflowScriptCheckpoint(store, ' call-with-space ', {
+      script,
+      args: undefined,
+      journal: [],
+    });
+
+    await expect(
+      readWorkflowScriptCheckpoint(store, ' call-with-space '),
+    ).resolves.toMatchObject({ script, journal: [] });
+    await expect(store.listKeys('workflow-script-')).resolves.toContain(
+      workflowScriptCheckpointKvKey(' call-with-space '),
+    );
+  });
+
+  it('maps maximum-length checkpoint ids to filesystem-safe keys', async () => {
+    const store = getExecutionStore(executionId);
+    const checkpointId = 'x'.repeat(256);
+    const key = workflowScriptCheckpointKvKey(checkpointId);
+
+    expect(Buffer.byteLength(`${encodeURIComponent(key)}.json`)).toBeLessThan(
+      256,
+    );
+    await writeWorkflowScriptCheckpoint(store, checkpointId, {
+      script,
+      args: undefined,
+      journal: [],
+    });
+    await expect(
+      readWorkflowScriptCheckpoint(store, checkpointId),
+    ).resolves.toMatchObject({ script, journal: [] });
+  });
+
+  it('keeps distinct UTF-16 checkpoint ids on distinct keys', () => {
+    expect(workflowScriptCheckpointKvKey('\uD800')).not.toBe(
+      workflowScriptCheckpointKvKey('\uFFFD'),
+    );
+  });
+
+  it('persists arguments and restores them when a restart omits them', async () => {
+    const store = getExecutionStore(executionId);
+    const argsScript = `export const meta = {
+  name: 'args-restart',
+  description: 'restores persisted arguments',
+}
+return await agent(args.topic)`;
+    const firstRunner = vi.fn(async ({ prompt }) => `result:${prompt}`);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'args-restart',
+      script: argsScript,
+      args: { topic: 'geometry' },
+      runAgent: firstRunner,
+    });
+
+    const restarted = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'args-restart',
+      runAgent: vi.fn(() => Promise.reject(new Error('must replay'))),
+    });
+
+    expect(restarted.result).toBe('result:geometry');
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'args-restart'),
+    ).resolves.toMatchObject({ args: { topic: 'geometry' } });
+  });
+
+  it('rejects argument drift for an existing tool call id', async () => {
+    const store = getExecutionStore(executionId);
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'stable-args',
+      script,
+      args: { topic: 'geometry' },
+      runAgent: async () => 'done',
+    });
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'stable-args',
+        args: { topic: 'analysis' },
+        runAgent: async () => 'changed',
+      }),
+    ).rejects.toThrow(/different arguments/i);
+  });
+
+  it('validates arguments before creating a checkpoint or launching an agent', async () => {
+    const store = getExecutionStore(executionId);
+    const runner = vi.fn(async () => 'must not run');
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'invalid-args',
+        script,
+        args: { invalid: () => undefined },
+        runAgent: runner,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+    expect(runner).not.toHaveBeenCalled();
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'invalid-args'),
+    ).resolves.toBeNull();
+  });
+
+  it('serializes overlapping runs for the same checkpoint', async () => {
+    const store = getExecutionStore(executionId);
+    const runner = vi.fn(async ({ prompt }) => {
+      await delay(10);
+      return `result:${prompt}`;
+    });
+
+    const [first, second] = await Promise.all([
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'overlap',
+        script,
+        runAgent: runner,
+      }),
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'overlap',
+        script,
+        runAgent: runner,
+      }),
+    ]);
+
+    expect(first.result).toEqual(second.result);
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('retains completed entries when the script later throws', async () => {
+    const store = getExecutionStore(executionId);
+    const failingScript = `export const meta = {
+  name: 'partial-run',
+  description: 'fails after a completed call',
+}
+await agent('saved')
+throw new Error('script stopped')`;
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'partial-run',
+        script: failingScript,
+        runAgent: async () => 'saved result',
+      }),
+    ).rejects.toThrow('script stopped');
+
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'partial-run'),
+    ).resolves.toMatchObject({
+      script: failingScript,
+      journal: [{ index: 0, result: 'saved result' }],
+    });
+  });
+
+  it('serializes parallel checkpoint writes before a later script failure', async () => {
+    const store = getExecutionStore(executionId);
+    const originalWrite = store.write.bind(store);
+    vi.spyOn(store, 'write').mockImplementation(async (key, value) => {
+      const journal = (value as { journal?: unknown[] }).journal ?? [];
+      if (journal.length === 1) await delay(25);
+      await originalWrite(key, value);
+    });
+    const parallelScript = `export const meta = {
+  name: 'parallel-checkpoint',
+  description: 'tests checkpoint ordering',
+}
+await parallel([() => agent('a'), () => agent('b')])
+throw new Error('stop after fan-out')`;
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'parallel-run',
+        script: parallelScript,
+        runAgent: async ({ prompt }) => prompt,
+      }),
+    ).rejects.toThrow('stop after fan-out');
+
+    const checkpoint = await readWorkflowScriptCheckpoint(
+      store,
+      'parallel-run',
+    );
+    expect(checkpoint?.journal).toHaveLength(2);
+    expect(checkpoint?.journal.map((entry) => entry.index)).toEqual([0, 1]);
+  });
+
+  it('aborts when a completed result cannot be checkpointed', async () => {
+    const store = getExecutionStore(executionId);
+    const originalWrite = store.write.bind(store);
+    vi.spyOn(store, 'write').mockImplementation(async (key, value) => {
+      if ((value as { journal?: unknown[] }).journal?.length === 1) {
+        throw new Error('storage unavailable');
+      }
+      await originalWrite(key, value);
+    });
+
+    const runner = vi.fn(async () => 'completed child');
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'write-failure',
+        script,
+        runAgent: runner,
+      }),
+    ).rejects.toMatchObject({ name: 'WorkflowRunAbortError' });
+    expect(runner).toHaveBeenCalledOnce();
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'write-failure'),
+    ).resolves.toMatchObject({ journal: [] });
+  });
+
+  it('does not launch an agent when the initial checkpoint write fails', async () => {
+    const store = getExecutionStore(executionId);
+    vi.spyOn(store, 'write').mockRejectedValue(new Error('disk full'));
+    const runner = vi.fn(async () => 'should not run');
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'initial-write-failure',
+        script,
+        runAgent: runner,
+      }),
+    ).rejects.toThrow('disk full');
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('does not let script code suppress a checkpoint failure', async () => {
+    const store = getExecutionStore(executionId);
+    const originalWrite = store.write.bind(store);
+    vi.spyOn(store, 'write').mockImplementation(async (key, value) => {
+      if ((value as { journal?: unknown[] }).journal?.length === 1) {
+        throw new Error('checkpoint rejected');
+      }
+      await originalWrite(key, value);
+    });
+    const catchesErrors = `export const meta = {
+  name: 'catch-errors',
+  description: 'tries to catch a checkpoint failure',
+}
+try {
+  await agent('completed')
+} catch {}
+return 'incorrect success'`;
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'caught-write-failure',
+        script: catchesErrors,
+        runAgent: async () => 'child result',
+      }),
+    ).rejects.toMatchObject({ name: 'WorkflowRunAbortError' });
+  });
+});

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -20,7 +20,12 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
-import { executeSubagentInBand } from '@tools/delegation/inBandSubagentExecution';
+import {
+  executeSubagentInBand,
+  executeStableSubagentInBand,
+  SubagentDurabilityError,
+  SubagentReconciliationError,
+} from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
   enableYoloOnChildStream: vi.fn(),
@@ -109,6 +114,38 @@ function mockExecuteAgentErrorOnce(totalCostUsd: number): void {
     await options.onRunError?.(new Error('review model failed'), failed);
     return failed;
   });
+}
+
+const STABLE_PARENT_EXECUTION_ID = 'abcdef123456' as ExecutionId;
+
+function stableAttempt(
+  logicalExecutionId: ExecutionId,
+  phase: 'reserved' | 'launched' | 'retryable' = 'launched',
+) {
+  return {
+    schemaVersion: 1,
+    logicalExecutionId,
+    parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+    phase,
+  } as const;
+}
+
+function stableSequenceStore(logicalExecutionId: ExecutionId, nextAttempt = 0) {
+  let sequence =
+    nextAttempt === 0
+      ? undefined
+      : {
+          schemaVersion: 1 as const,
+          logicalExecutionId,
+          parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+          nextAttempt,
+        };
+  return {
+    read: vi.fn(async () => sequence),
+    write: vi.fn(async (_key: string, value: typeof sequence) => {
+      sequence = value;
+    }),
+  };
 }
 
 describe('headless delegation', () => {
@@ -227,9 +264,334 @@ describe('headless delegation', () => {
     expect(mocks.writeResultMeta).toHaveBeenCalledWith({
       producer: 'subagent',
       agentName: 'review',
+      parentExecutionId: 'parent-exec',
       wallTimeMs: expect.any(Number),
       result: result.result,
     });
+  });
+
+  it('recovers a completed stable child before resolving launch prerequisites', async () => {
+    const stableExecutionId = 'cccccc333333' as ExecutionId;
+    const persistedResult = {
+      category: 'toolUse' as const,
+      outcome: 'completed' as const,
+      response: 'Recovered review.',
+      files: [],
+      cost: 0,
+    };
+    const sequenceStore = stableSequenceStore(stableExecutionId, 1);
+    const childStore = {
+      listKeys: vi
+        .fn()
+        .mockResolvedValue(['stable-subagent-attempt', 'result-meta']),
+      read: vi.fn().mockResolvedValue(stableAttempt(stableExecutionId)),
+      readResultMeta: vi.fn().mockResolvedValue({
+        producer: 'subagent',
+        agentName: 'review',
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        wallTimeMs: 100,
+        result: persistedResult,
+      }),
+    };
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
+      executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
+    );
+    const prepare = vi.fn(() =>
+      Promise.reject(new Error('current agent is unavailable')),
+    );
+
+    await expect(
+      executeStableSubagentInBand({
+        executionId: stableExecutionId,
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        prepare,
+      }),
+    ).resolves.toEqual({
+      executionId: stableExecutionId,
+      result: persistedResult,
+    });
+    expect(prepare).not.toHaveBeenCalled();
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+    expect(mocks.writeResultMeta).not.toHaveBeenCalled();
+  });
+
+  it('recovers a later completed attempt when an earlier child was deleted', async () => {
+    const logicalExecutionId = 'cccccc444444' as ExecutionId;
+    const persistedResult = {
+      category: 'toolUse' as const,
+      outcome: 'completed' as const,
+      response: 'Recovered later attempt.',
+      files: [],
+      cost: 0,
+    };
+    const sequenceStore = stableSequenceStore(logicalExecutionId, 2);
+    const missingStore = {
+      listKeys: vi.fn().mockResolvedValue([]),
+      read: vi.fn().mockResolvedValue(undefined),
+      readResultMeta: vi.fn().mockResolvedValue(null),
+    };
+    const completedStore = {
+      listKeys: vi
+        .fn()
+        .mockResolvedValue(['stable-subagent-attempt', 'result-meta']),
+      read: vi.fn().mockResolvedValue(stableAttempt(logicalExecutionId)),
+      readResultMeta: vi.fn().mockResolvedValue({
+        producer: 'subagent',
+        agentName: 'review',
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        wallTimeMs: 100,
+        result: persistedResult,
+      }),
+    };
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) => {
+      if (executionId === STABLE_PARENT_EXECUTION_ID) return sequenceStore;
+      return executionId === logicalExecutionId ? missingStore : completedStore;
+    });
+    const prepare = vi.fn();
+
+    const recovered = await executeStableSubagentInBand({
+      executionId: logicalExecutionId,
+      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+      prepare,
+    });
+
+    expect(recovered.result).toBe(persistedResult);
+    expect(recovered.executionId).not.toBe(logicalExecutionId);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
+  it('rejects a result manifest with different parent lineage', async () => {
+    const stableExecutionId = 'cccccc555555' as ExecutionId;
+    const sequenceStore = stableSequenceStore(stableExecutionId, 1);
+    const childStore = {
+      listKeys: vi
+        .fn()
+        .mockResolvedValue(['stable-subagent-attempt', 'result-meta']),
+      read: vi.fn().mockResolvedValue(stableAttempt(stableExecutionId)),
+      readResultMeta: vi.fn().mockResolvedValue({
+        producer: 'subagent',
+        agentName: 'review',
+        parentExecutionId: 'deadbeef',
+        wallTimeMs: 100,
+        result: {
+          category: 'toolUse',
+          outcome: 'completed',
+          response: 'Wrong workflow.',
+          files: [],
+          cost: 0,
+        },
+      }),
+    };
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
+      executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
+    );
+
+    await expect(
+      executeStableSubagentInBand({
+        executionId: stableExecutionId,
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        prepare: vi.fn(),
+      }),
+    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
+  it('refuses to repeat an incomplete stable child', async () => {
+    const logicalExecutionId = 'dddddd444444' as ExecutionId;
+    const sequenceStore = stableSequenceStore(logicalExecutionId, 1);
+    const childStore = {
+      listKeys: vi.fn().mockResolvedValue(['meta']),
+      read: vi.fn().mockResolvedValue(undefined),
+      readResultMeta: vi.fn().mockResolvedValue(null),
+    };
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
+      executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
+    );
+
+    await expect(
+      executeSubagentInBand({
+        executionId: logicalExecutionId,
+        configPayload: {
+          agent: 'review',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'deepseekT',
+        },
+        agentName: 'review',
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        parentStreamId: 'parent-stream' as StreamTabId,
+        runtimeHost: runtimeHost(),
+        session: defaultSession(),
+      }),
+    ).rejects.toBeInstanceOf(SubagentReconciliationError);
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.executeAgent).not.toHaveBeenCalled();
+  });
+
+  it.each(['reserved', 'retryable'] as const)(
+    'retries a %s child without a result manifest',
+    async (phase) => {
+      const logicalExecutionId = 'dddddd555555' as ExecutionId;
+      const stores = new Map<ExecutionId, Record<string, unknown>>();
+      const sequenceStore = stableSequenceStore(logicalExecutionId, 1);
+      mocks.getExecutionStore.mockImplementation((id: ExecutionId) => {
+        if (id === STABLE_PARENT_EXECUTION_ID) return sequenceStore;
+        let store = stores.get(id);
+        if (store) return store;
+        store =
+          id === logicalExecutionId
+            ? {
+                listKeys: vi
+                  .fn()
+                  .mockResolvedValue(['stable-subagent-attempt', 'config']),
+                read: vi
+                  .fn()
+                  .mockResolvedValue(stableAttempt(logicalExecutionId, phase)),
+                readResultMeta: vi.fn().mockResolvedValue(null),
+              }
+            : {
+                listKeys: vi.fn().mockResolvedValue([]),
+                read: vi.fn().mockResolvedValue(undefined),
+                readResultMeta: vi.fn().mockResolvedValue(null),
+                write: vi.fn().mockResolvedValue(undefined),
+                writeResultMeta: mocks.writeResultMeta,
+              };
+        stores.set(id, store);
+        return store;
+      });
+
+      const completed = await executeSubagentInBand({
+        executionId: logicalExecutionId,
+        configPayload: {
+          agent: 'review',
+          agentCategory: AgentCategory.ToolUse,
+          model: 'deepseekT',
+        },
+        agentName: 'review',
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        parentStreamId: 'parent-stream' as StreamTabId,
+        runtimeHost: runtimeHost(),
+        session: defaultSession(),
+      });
+
+      expect(completed.executionId).not.toBe(logicalExecutionId);
+      expect(mocks.executeAgent).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('refuses to repeat a completed stable child when its manifest cannot be written', async () => {
+    const logicalExecutionId = 'dddddd666666' as ExecutionId;
+    const sequenceStore = stableSequenceStore(logicalExecutionId);
+    let marker: ReturnType<typeof stableAttempt> | undefined;
+    const write = vi.fn(async (key: string, value: typeof marker) => {
+      if (key === 'stable-subagent-attempt') marker = value;
+    });
+    mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
+    const childStore = {
+      listKeys: vi.fn(async () => (marker ? ['stable-subagent-attempt'] : [])),
+      read: vi.fn(async () => marker),
+      readResultMeta: vi.fn().mockResolvedValue(null),
+      write,
+      writeResultMeta: mocks.writeResultMeta,
+    };
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
+      executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
+    );
+    const options = {
+      executionId: logicalExecutionId,
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+    } as const;
+
+    await expect(executeSubagentInBand(options)).rejects.toBeInstanceOf(
+      SubagentDurabilityError,
+    );
+
+    expect(write).toHaveBeenLastCalledWith(
+      'stable-subagent-attempt',
+      expect.objectContaining({ phase: 'launched' }),
+    );
+    await expect(executeSubagentInBand(options)).rejects.toBeInstanceOf(
+      SubagentReconciliationError,
+    );
+    expect(mocks.executeAgent).toHaveBeenCalledOnce();
+  });
+
+  it('uses a new durable attempt after failed and cancelled children', async () => {
+    const logicalExecutionId = 'eeeeee555555' as ExecutionId;
+    const configPayload = {
+      agent: 'review',
+      agentCategory: AgentCategory.ToolUse,
+      model: 'deepseekT',
+    };
+    const stores = new Map<ExecutionId, Record<string, unknown>>();
+    const sequenceStore = stableSequenceStore(logicalExecutionId);
+    const priorOutcomes = ['failed', 'cancelled'] as const;
+    mocks.getExecutionStore.mockImplementation((id: ExecutionId) => {
+      if (id === STABLE_PARENT_EXECUTION_ID) return sequenceStore;
+      let store = stores.get(id);
+      if (store) return store;
+      const priorOutcome = priorOutcomes[stores.size];
+      store = priorOutcome
+        ? {
+            listKeys: vi
+              .fn()
+              .mockResolvedValue(['stable-subagent-attempt', 'result-meta']),
+            read: vi.fn().mockResolvedValue(stableAttempt(logicalExecutionId)),
+            readResultMeta: vi.fn().mockResolvedValue({
+              producer: 'subagent',
+              agentName: 'review',
+              parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+              wallTimeMs: 100,
+              result: {
+                category: 'toolUse',
+                outcome: priorOutcome,
+                response: '',
+                files: [],
+                cost: 0,
+              },
+            }),
+          }
+        : {
+            listKeys: vi.fn().mockResolvedValue([]),
+            read: vi.fn().mockResolvedValue(undefined),
+            readResultMeta: vi.fn().mockResolvedValue(null),
+            write: vi.fn().mockResolvedValue(undefined),
+            writeResultMeta: mocks.writeResultMeta,
+          };
+      stores.set(id, store);
+      return store;
+    });
+
+    const completed = await executeSubagentInBand({
+      executionId: logicalExecutionId,
+      configPayload,
+      agentName: 'review',
+      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+    });
+
+    expect(completed.executionId).not.toBe(logicalExecutionId);
+    expect(stores.size).toBe(3);
+    expect(mocks.executeAgent).toHaveBeenCalledOnce();
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      completed.executionId,
+      expect.anything(),
+      'review',
+      STABLE_PARENT_EXECUTION_ID,
+    );
   });
 
   it('does not return a typed result when its durable manifest cannot be written', async () => {
@@ -248,8 +610,64 @@ describe('headless delegation', () => {
         runtimeHost: runtimeHost(),
         session: defaultSession(),
       }),
-    ).rejects.toThrow('Failed to persist result for subagent');
+    ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.writeReport).not.toHaveBeenCalled();
+  });
+
+  it('preserves the child failure when its failure manifest cannot be written', async () => {
+    mocks.executeAgent.mockRejectedValueOnce(new Error('review model failed'));
+    mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
+
+    const run = executeSubagentInBand({
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: 'parent-exec' as ExecutionId,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+    });
+
+    await expect(run).rejects.toMatchObject({
+      name: 'SubagentDurabilityError',
+      message: expect.stringContaining('review model failed'),
+      cause: expect.objectContaining({ name: 'AggregateError' }),
+    });
+  });
+
+  it('preserves the child failure when its failure result cannot be constructed', async () => {
+    mocks.executeAgent.mockRejectedValueOnce(
+      new AgentFlowError('review model failed', {
+        category: 'toolUse',
+        outcome: 'failed',
+        executionId: 'child-exec',
+        streamId: 'child-stream',
+        touchedFiles: [42],
+      } as never),
+    );
+
+    const run = executeSubagentInBand({
+      configPayload: {
+        agent: 'review',
+        agentCategory: AgentCategory.ToolUse,
+        model: 'deepseekT',
+      },
+      agentName: 'review',
+      parentExecutionId: 'parent-exec' as ExecutionId,
+      parentStreamId: 'parent-stream' as StreamTabId,
+      runtimeHost: runtimeHost(),
+      session: defaultSession(),
+    });
+
+    await expect(run).rejects.toMatchObject({
+      name: 'SubagentDurabilityError',
+      message: expect.stringContaining('review model failed'),
+      cause: expect.objectContaining({ name: 'AggregateError' }),
+    });
+    expect(mocks.writeResultMeta).not.toHaveBeenCalled();
   });
 
   it('does not rewrite a completed child when typed result construction fails', async () => {

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -559,6 +559,9 @@ describe('ExecutionsTool', () => {
         'workspace-files.json',
         'result-meta.json',
         'child-def456.json',
+        'stable-subagent-attempt.json',
+        'stable-subagent-sequence-abc123.json',
+        'workflow-script-call-1.json',
         `${flowKey(executionId)}.json`,
       ];
       for (const name of kvFiles) {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -12,8 +12,10 @@ import {
   filterNotNullish,
   getBasename,
   getFileStem,
+  KeyedMutex,
   toNewestFirstByTimestamp,
 } from '@utils/core';
+import { deriveExecutionId } from '@utils/core/idHash';
 
 // ---------------------------------------------------------------------------
 // Comparators
@@ -174,6 +176,83 @@ describe('async utilities', () => {
     controller.abort();
 
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});
+
+describe('KeyedMutex', () => {
+  it('serializes operations that use the same key', async () => {
+    const mutex = new KeyedMutex<string>();
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = mutex.runExclusive('shared', async () => {
+      order.push('first:start');
+      await firstBlocked;
+      order.push('first:end');
+    });
+    const second = mutex.runExclusive('shared', async () => {
+      order.push('second');
+    });
+
+    await vi.waitFor(() => expect(order).toEqual(['first:start']));
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first:start', 'first:end', 'second']);
+  });
+
+  it('allows independent keys to run concurrently', async () => {
+    const mutex = new KeyedMutex<string>();
+    const started: string[] = [];
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = mutex.runExclusive('first', async () => {
+      started.push('first');
+      await blocked;
+    });
+    const second = mutex.runExclusive('second', async () => {
+      started.push('second');
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(['first', 'second']));
+    release();
+    await Promise.all([first, second]);
+  });
+
+  it('releases a key when an operation rejects', async () => {
+    const mutex = new KeyedMutex<string>();
+
+    await expect(
+      mutex.runExclusive('shared', async () => {
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+    await expect(
+      mutex.runExclusive('shared', async () => 'recovered'),
+    ).resolves.toBe('recovered');
+  });
+});
+
+describe('deriveExecutionId', () => {
+  it('is stable across identity field order', () => {
+    expect(deriveExecutionId({ parent: 'abc', attempt: 2 })).toBe(
+      deriveExecutionId({ attempt: 2, parent: 'abc' }),
+    );
+  });
+
+  it('returns distinct 24-hex ids for distinct identities', () => {
+    const first = deriveExecutionId({ parent: 'abc', attempt: 1 });
+    const second = deriveExecutionId({ parent: 'abc', attempt: 2 });
+
+    expect(first).toMatch(/^[a-f0-9]{24}$/);
+    expect(second).toMatch(/^[a-f0-9]{24}$/);
+    expect(first).not.toBe(second);
   });
 });
 

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -7,7 +7,12 @@
  * the existing delegation tool.
  */
 
-import { registerExecution, type ResultMeta } from '@agent/storage';
+// Local imports - agent runtime and storage
+import {
+  getExecutionStore,
+  registerExecution,
+  type ResultMeta,
+} from '@agent/storage';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -30,14 +35,25 @@ import {
   buildSubagentFailureResultMeta,
   formatSubagentError,
 } from '@tools/subagentResults';
-import { generateExecutionId } from '@utils/core';
+import { generateExecutionId, KeyedMutex } from '@utils/core';
+import { deriveExecutionId } from '@utils/core/idHash';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
+// Local imports - delegation
 import {
   buildSubagentResult,
   formatBuiltSubagentDelivery,
   type BuiltSubagentResult,
 } from './subagentDeliveryFormat';
+import {
+  readStableSubagentAttempt,
+  readStableSubagentSequence,
+  reservedStableSubagentAttempt,
+  writeStableSubagentAttempt,
+  writeStableSubagentSequence,
+  type StableSubagentAttempt,
+  type StableSubagentSequence,
+} from './stableSubagentAttempt';
 
 const LOG_CHANNEL = 'inBandSubagentExecution';
 logger.initialize(LOG_CHANNEL);
@@ -58,6 +74,19 @@ interface InBandSubagentExecutionBaseOptions {
 /** Options for the typed child API. Direct persisted parentage is required. */
 export interface InBandSubagentExecutionOptions extends InBandSubagentExecutionBaseOptions {
   readonly parentExecutionId: ExecutionId;
+  /** Stable logical-call identity for restart recovery; random when omitted. */
+  readonly executionId?: ExecutionId;
+}
+
+export interface StableInBandSubagentExecutionOptions {
+  /** Cryptographic identity of the prompt/options call, stable across restart. */
+  readonly executionId: ExecutionId;
+  readonly parentExecutionId: ExecutionId;
+  readonly signal?: AbortSignal;
+  /** Resolve mutable launch prerequisites only when no result can be recovered. */
+  readonly prepare: () => Promise<
+    Omit<InBandSubagentExecutionOptions, 'executionId'>
+  >;
 }
 
 /** Legacy delivery callers may still provide a bare one-shot run context. */
@@ -81,6 +110,103 @@ interface CompletedInBandSubagent {
   readonly flowResult: AgentFlowResult;
   readonly built: BuiltSubagentResult;
   readonly delivery?: string;
+}
+
+type StableAttemptInspection =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'advance' }
+  | {
+      readonly kind: 'recovered';
+      readonly result: InBandSubagentExecutionResult;
+    };
+
+export class SubagentDurabilityError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SubagentDurabilityError';
+  }
+}
+
+export class SubagentReconciliationError extends SubagentDurabilityError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SubagentReconciliationError';
+  }
+}
+
+const MAX_STABLE_ATTEMPTS = 1_024;
+
+// Parent execution ownership is process-local. Serialize duplicate dispatches
+// within that owner while durable manifests handle later restart recovery.
+const stableExecutionMutex = new KeyedMutex<ExecutionId>();
+
+function stableAttemptExecutionId(
+  logicalExecutionId: ExecutionId,
+  attempt: number,
+): ExecutionId {
+  if (attempt === 0) return logicalExecutionId;
+  return deriveExecutionId({ attempt, logicalExecutionId });
+}
+
+async function inspectStableAttempt(
+  options: Pick<
+    StableInBandSubagentExecutionOptions,
+    'executionId' | 'parentExecutionId' | 'signal'
+  >,
+  executionId: ExecutionId,
+): Promise<StableAttemptInspection> {
+  const store = getExecutionStore(executionId);
+  let persisted: [string[], StableSubagentAttempt | null, ResultMeta | null];
+  try {
+    persisted = await Promise.all([
+      store.listKeys(),
+      readStableSubagentAttempt(store),
+      store.readResultMeta(),
+    ]);
+  } catch (error) {
+    throw new SubagentReconciliationError(
+      `Failed to inspect persisted subagent ${executionId}.`,
+      { cause: error },
+    );
+  }
+  const [keys, attempt, resultMeta] = persisted;
+  if (keys.length === 0) return { kind: 'absent' };
+  if (
+    !attempt ||
+    attempt.logicalExecutionId !== options.executionId ||
+    attempt.parentExecutionId !== options.parentExecutionId
+  ) {
+    throw new SubagentReconciliationError(
+      `Persisted subagent ${executionId} does not belong to this stable workflow call; refusing to reuse or repeat it.`,
+    );
+  }
+  if (!resultMeta) {
+    if (attempt.phase !== 'launched') return { kind: 'advance' };
+    throw new SubagentReconciliationError(
+      `Cannot reconcile incomplete persisted subagent ${executionId}; refusing to repeat it.`,
+    );
+  }
+  if (attempt.phase === 'reserved') {
+    throw new SubagentReconciliationError(
+      `Persisted subagent ${executionId} has a result without a launch marker; refusing to reuse it.`,
+    );
+  }
+  if (resultMeta.producer !== 'subagent') {
+    throw new SubagentReconciliationError(
+      `Persisted subagent ${executionId} does not match this workflow call; refusing to reuse or repeat it.`,
+    );
+  }
+  if (resultMeta.parentExecutionId !== options.parentExecutionId) {
+    throw new SubagentReconciliationError(
+      `Persisted subagent ${executionId} has different parent lineage; refusing to reuse or repeat it.`,
+    );
+  }
+  if (resultMeta.result.outcome !== 'completed') return { kind: 'advance' };
+  options.signal?.throwIfAborted();
+  return {
+    kind: 'recovered',
+    result: { executionId, result: resultMeta.result },
+  };
 }
 
 function logPersistenceFailure(
@@ -110,10 +236,36 @@ async function persistResultMetaRequired(
 ): Promise<void> {
   const result = await persistChildRunResultMeta(executionId, resultMeta);
   if (result.kind === 'failed') {
-    throw new Error(`Failed to persist result for subagent ${executionId}.`, {
-      cause: result.err,
-    });
+    throw new SubagentDurabilityError(
+      `Failed to persist result for subagent ${executionId}.`,
+      { cause: result.err },
+    );
   }
+}
+
+async function throwRetryableDurabilityError(
+  executionId: ExecutionId,
+  stableAttempt: StableSubagentAttempt | undefined,
+  error: SubagentDurabilityError,
+): Promise<never> {
+  if (!stableAttempt) throw error;
+  try {
+    await writeStableSubagentAttempt(getExecutionStore(executionId), {
+      ...stableAttempt,
+      phase: 'retryable',
+    });
+  } catch (cause) {
+    throw new SubagentDurabilityError(
+      `${error.message} Failed to mark the stable attempt as retryable.`,
+      {
+        cause: new AggregateError(
+          [error, cause],
+          `Subagent ${executionId} durability recovery also failed.`,
+        ),
+      },
+    );
+  }
+  throw error;
 }
 
 async function persistReportBestEffort(
@@ -185,7 +337,9 @@ function createCostSettler(
 async function persistFailure(
   mode: PersistenceMode,
   executionId: ExecutionId,
+  stableAttempt: StableSubagentAttempt | undefined,
   agentName: string,
+  parentExecutionId: ExecutionId | undefined,
   fallbackCategory: AgentFlowResult['category'],
   error: unknown,
   result: AgentFlowResult | undefined,
@@ -193,16 +347,51 @@ async function persistFailure(
   workingDirectory: string | undefined,
 ): Promise<void> {
   const wallTimeMs = Date.now() - startedAt;
-  const resultMeta = buildSubagentFailureResultMeta(
-    agentName,
-    fallbackCategory,
-    result,
-    wallTimeMs,
-  );
+  let resultMeta: ResultMeta;
+  try {
+    resultMeta = buildSubagentFailureResultMeta(
+      agentName,
+      fallbackCategory,
+      result,
+      wallTimeMs,
+      { parentExecutionId },
+    );
+  } catch (cause) {
+    if (mode === 'required-result') {
+      await throwRetryableDurabilityError(
+        executionId,
+        stableAttempt,
+        new SubagentDurabilityError(
+          `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be constructed.`,
+          {
+            cause: new AggregateError(
+              [error, cause],
+              `Subagent ${executionId} execution and result construction both failed.`,
+            ),
+          },
+        ),
+      );
+    }
+    throw cause;
+  }
   if (mode === 'required-result') {
-    // Preserve the execution error even if its diagnostic manifest cannot be
-    // written; a failed call is never journaled by the workflow engine.
-    await persistResultMetaBestEffort(executionId, resultMeta);
+    try {
+      await persistResultMetaRequired(executionId, resultMeta);
+    } catch (cause) {
+      await throwRetryableDurabilityError(
+        executionId,
+        stableAttempt,
+        new SubagentDurabilityError(
+          `Subagent ${executionId} failed (${toErrorMessage(error)}), and its failure result could not be persisted.`,
+          {
+            cause: new AggregateError(
+              [error, cause],
+              `Subagent ${executionId} execution and persistence both failed.`,
+            ),
+          },
+        ),
+      );
+    }
     return;
   }
   const delivery = formatSubagentError(executionId, agentName, error, {
@@ -222,24 +411,48 @@ async function persistFailure(
 async function executeInBand(
   options: InBandSubagentDeliveryOptions,
   mode: PersistenceMode,
+  executionId: ExecutionId,
+  stableAttempt?: StableSubagentAttempt,
 ): Promise<CompletedInBandSubagent> {
   options.signal?.throwIfAborted();
 
   // Lazy import: the agent runtime loads delegation tools through its registry.
   // Keeping this edge lazy avoids closing that registry cycle at module load.
   const { executeAgent } = await import('@agent/runtime/executeAgent');
-  const executionId = generateExecutionId() as ExecutionId;
   const config = AgentConfigSchema.parse(options.configPayload);
   const startedAt = Date.now();
   const workingDirectory = config.workingDirectory ?? undefined;
   const settleCost = createCostSettler(options.onCost);
 
-  await registerExecution(
-    executionId,
-    config,
-    options.agentName,
-    options.parentExecutionId,
-  );
+  try {
+    await registerExecution(
+      executionId,
+      config,
+      options.agentName,
+      options.parentExecutionId,
+    );
+  } catch (cause) {
+    if (mode === 'required-result') {
+      throw new SubagentDurabilityError(
+        `Failed to register subagent ${executionId}.`,
+        { cause },
+      );
+    }
+    throw cause;
+  }
+  if (stableAttempt) {
+    try {
+      await writeStableSubagentAttempt(getExecutionStore(executionId), {
+        ...stableAttempt,
+        phase: 'launched',
+      });
+    } catch (cause) {
+      throw new SubagentDurabilityError(
+        `Failed to mark subagent ${executionId} as launched.`,
+        { cause },
+      );
+    }
+  }
 
   let runError: unknown;
   let detachAbort = (): void => {};
@@ -269,7 +482,9 @@ async function executeInBand(
     await persistFailure(
       mode,
       executionId,
+      stableAttempt,
       options.agentName,
+      options.parentExecutionId,
       config.agentCategory,
       error,
       errorResult,
@@ -287,7 +502,9 @@ async function executeInBand(
     await persistFailure(
       mode,
       executionId,
+      stableAttempt,
       options.agentName,
+      options.parentExecutionId,
       config.agentCategory,
       error,
       flowResult,
@@ -303,22 +520,30 @@ async function executeInBand(
       executionId,
       options.agentName,
       flowResult,
-      { startedAt, workingDirectory },
+      {
+        startedAt,
+        workingDirectory,
+        parentExecutionId: options.parentExecutionId,
+      },
     );
   } catch (error) {
     // The runtime has already finalized this child. A post-flow construction
     // error must not rewrite a completed execution as failed or try to parse
     // the same invalid flow data again through the failure-result builder.
-    if (mode === 'best-effort-delivery') {
-      await persistReportBestEffort(
-        executionId,
-        formatSubagentError(executionId, options.agentName, error, {
-          wallTimeMs: Date.now() - startedAt,
-          workingDirectory,
-          memoryMisses: flowResult.memoryMisses,
-        }),
+    if (mode === 'required-result') {
+      throw new SubagentDurabilityError(
+        `Failed to construct result for subagent ${executionId}.`,
+        { cause: error },
       );
     }
+    await persistReportBestEffort(
+      executionId,
+      formatSubagentError(executionId, options.agentName, error, {
+        wallTimeMs: Date.now() - startedAt,
+        workingDirectory,
+        memoryMisses: flowResult.memoryMisses,
+      }),
+    );
     throw error;
   }
 
@@ -359,18 +584,169 @@ async function executeInBand(
 export async function executeSubagentInBand(
   options: InBandSubagentExecutionOptions,
 ): Promise<InBandSubagentExecutionResult> {
-  const completed = await executeInBand(options, 'required-result');
+  if (options.executionId) {
+    const { executionId, ...launchOptions } = options;
+    return executeStableSubagentInBand({
+      executionId,
+      parentExecutionId: options.parentExecutionId,
+      signal: options.signal,
+      prepare: async () => launchOptions,
+    });
+  }
+  const completed = await executeInBand(
+    options,
+    'required-result',
+    generateExecutionId() as ExecutionId,
+  );
   return {
     executionId: completed.executionId,
     result: completed.built.result,
   };
 }
 
+/** Recover a logical child first; resolve launch-only state only when needed. */
+export async function executeStableSubagentInBand(
+  options: StableInBandSubagentExecutionOptions,
+): Promise<InBandSubagentExecutionResult> {
+  return stableExecutionMutex.runExclusive(options.executionId, async () => {
+    options.signal?.throwIfAborted();
+    // The parent sequence enumerates every reserved child ID. Individual child
+    // markers own launch state, so a deleted early directory cannot become a
+    // reusable hole or hide a later completed result.
+    const parentStore = getExecutionStore(options.parentExecutionId);
+    let sequence: StableSubagentSequence | null;
+    try {
+      sequence = await readStableSubagentSequence(
+        parentStore,
+        options.executionId,
+      );
+    } catch (cause) {
+      throw new SubagentReconciliationError(
+        `Failed to inspect the attempt sequence for subagent ${options.executionId}.`,
+        { cause },
+      );
+    }
+    if (
+      sequence &&
+      (sequence.logicalExecutionId !== options.executionId ||
+        sequence.parentExecutionId !== options.parentExecutionId)
+    ) {
+      throw new SubagentReconciliationError(
+        `Persisted attempt sequence for subagent ${options.executionId} has different ownership.`,
+      );
+    }
+    let nextAttempt = sequence?.nextAttempt ?? 0;
+    if (nextAttempt > MAX_STABLE_ATTEMPTS) {
+      throw new SubagentReconciliationError(
+        `Subagent ${options.executionId} has an invalid durable-attempt count.`,
+      );
+    }
+
+    let unresolved: SubagentReconciliationError | undefined;
+    for (let attempt = 0; attempt < nextAttempt; attempt += 1) {
+      const candidate = stableAttemptExecutionId(options.executionId, attempt);
+      try {
+        const inspection = await inspectStableAttempt(options, candidate);
+        if (inspection.kind === 'recovered') return inspection.result;
+        if (inspection.kind === 'absent') {
+          unresolved ??= new SubagentReconciliationError(
+            `Recorded subagent attempt ${candidate} is missing; refusing to repeat it.`,
+          );
+        }
+      } catch (error) {
+        if (!(error instanceof SubagentReconciliationError)) throw error;
+        unresolved ??= error;
+      }
+    }
+    if (unresolved) throw unresolved;
+
+    let executionId: ExecutionId;
+    let candidateInspection: StableAttemptInspection;
+    while (true) {
+      if (nextAttempt >= MAX_STABLE_ATTEMPTS) {
+        throw new SubagentReconciliationError(
+          `Subagent ${options.executionId} exceeded the ${MAX_STABLE_ATTEMPTS} durable-attempt limit.`,
+        );
+      }
+      executionId = stableAttemptExecutionId(options.executionId, nextAttempt);
+      candidateInspection = await inspectStableAttempt(options, executionId);
+      if (candidateInspection.kind === 'recovered') {
+        return candidateInspection.result;
+      }
+      if (candidateInspection.kind !== 'advance') break;
+      nextAttempt += 1;
+      try {
+        await writeStableSubagentSequence(
+          parentStore,
+          options.executionId,
+          options.parentExecutionId,
+          nextAttempt,
+        );
+      } catch (cause) {
+        throw new SubagentDurabilityError(
+          `Failed to advance the attempt sequence for subagent ${options.executionId}.`,
+          { cause },
+        );
+      }
+    }
+    const attempt = reservedStableSubagentAttempt(
+      options.executionId,
+      options.parentExecutionId,
+    );
+    if (candidateInspection.kind === 'absent') {
+      try {
+        await writeStableSubagentAttempt(
+          getExecutionStore(executionId),
+          attempt,
+        );
+      } catch (cause) {
+        throw new SubagentDurabilityError(
+          `Failed to reserve stable subagent ${executionId}.`,
+          { cause },
+        );
+      }
+    }
+    try {
+      await writeStableSubagentSequence(
+        parentStore,
+        options.executionId,
+        options.parentExecutionId,
+        nextAttempt + 1,
+      );
+    } catch (cause) {
+      throw new SubagentDurabilityError(
+        `Failed to publish stable subagent ${executionId}.`,
+        { cause },
+      );
+    }
+    const prepared = await options.prepare();
+    if (prepared.parentExecutionId !== options.parentExecutionId) {
+      throw new SubagentReconciliationError(
+        `Prepared subagent ${executionId} changed its parent execution.`,
+      );
+    }
+    const completed = await executeInBand(
+      prepared,
+      'required-result',
+      executionId,
+      attempt,
+    );
+    return {
+      executionId: completed.executionId,
+      result: completed.built.result,
+    };
+  });
+}
+
 /** Preserve the existing headless delegation tool's XML/report behavior. */
 export async function executeSubagentForDeliveryInBand(
   options: InBandSubagentDeliveryOptions,
 ): Promise<InBandSubagentDeliveryResult> {
-  const completed = await executeInBand(options, 'best-effort-delivery');
+  const completed = await executeInBand(
+    options,
+    'best-effort-delivery',
+    generateExecutionId() as ExecutionId,
+  );
   if (completed.delivery === undefined) {
     throw new Error('Subagent delivery was not constructed.');
   }

--- a/src/tools/delegation/stableSubagentAttempt.ts
+++ b/src/tools/delegation/stableSubagentAttempt.ts
@@ -1,0 +1,100 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent storage
+import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
+
+const STABLE_SUBAGENT_STATE_SCHEMA_VERSION = 1;
+const STABLE_SUBAGENT_ATTEMPT_KV_KEY = 'stable-subagent-attempt';
+const STABLE_SUBAGENT_SEQUENCE_KEY_PREFIX = 'stable-subagent-sequence-';
+
+const StableSubagentAttemptSchema = z.strictObject({
+  schemaVersion: z.literal(STABLE_SUBAGENT_STATE_SCHEMA_VERSION),
+  logicalExecutionId: ExecutionIdSchema,
+  parentExecutionId: ExecutionIdSchema,
+  phase: z.enum(['reserved', 'launched', 'retryable']),
+});
+
+export type StableSubagentAttempt = z.infer<typeof StableSubagentAttemptSchema>;
+
+const StableSubagentSequenceSchema = z.strictObject({
+  schemaVersion: z.literal(STABLE_SUBAGENT_STATE_SCHEMA_VERSION),
+  logicalExecutionId: ExecutionIdSchema,
+  parentExecutionId: ExecutionIdSchema,
+  nextAttempt: z.int().nonnegative(),
+});
+
+export type StableSubagentSequence = z.infer<
+  typeof StableSubagentSequenceSchema
+>;
+
+function stableSubagentSequenceKvKey(logicalExecutionId: ExecutionId): string {
+  return `${STABLE_SUBAGENT_SEQUENCE_KEY_PREFIX}${logicalExecutionId}`;
+}
+
+export function isStableSubagentStateKvKey(key: string): boolean {
+  return (
+    key === STABLE_SUBAGENT_ATTEMPT_KV_KEY ||
+    key.startsWith(STABLE_SUBAGENT_SEQUENCE_KEY_PREFIX)
+  );
+}
+
+/** Read the parent-owned attempt sequence for one stable logical call. */
+export async function readStableSubagentSequence(
+  store: ExecutionKVStore,
+  logicalExecutionId: ExecutionId,
+): Promise<StableSubagentSequence | null> {
+  const raw = await store.read(stableSubagentSequenceKvKey(logicalExecutionId));
+  return raw === undefined ? null : StableSubagentSequenceSchema.parse(raw);
+}
+
+/** Atomically publish the number of child attempts reserved for this call. */
+export async function writeStableSubagentSequence(
+  store: ExecutionKVStore,
+  logicalExecutionId: ExecutionId,
+  parentExecutionId: ExecutionId,
+  nextAttempt: number,
+): Promise<void> {
+  const sequence = StableSubagentSequenceSchema.parse({
+    schemaVersion: STABLE_SUBAGENT_STATE_SCHEMA_VERSION,
+    logicalExecutionId,
+    parentExecutionId,
+    nextAttempt,
+  });
+  await store.write(
+    stableSubagentSequenceKvKey(sequence.logicalExecutionId),
+    sequence,
+  );
+}
+
+/** Read a stable-call marker. Malformed present state fails validation. */
+export async function readStableSubagentAttempt(
+  store: ExecutionKVStore,
+): Promise<StableSubagentAttempt | null> {
+  const raw = await store.read(STABLE_SUBAGENT_ATTEMPT_KV_KEY);
+  return raw === undefined ? null : StableSubagentAttemptSchema.parse(raw);
+}
+
+/** Atomically replace the stable-call marker before crossing a launch edge. */
+export async function writeStableSubagentAttempt(
+  store: ExecutionKVStore,
+  attempt: StableSubagentAttempt,
+): Promise<void> {
+  await store.write(
+    STABLE_SUBAGENT_ATTEMPT_KV_KEY,
+    StableSubagentAttemptSchema.parse(attempt),
+  );
+}
+
+export function reservedStableSubagentAttempt(
+  logicalExecutionId: ExecutionId,
+  parentExecutionId: ExecutionId,
+): StableSubagentAttempt {
+  return {
+    schemaVersion: STABLE_SUBAGENT_STATE_SCHEMA_VERSION,
+    logicalExecutionId,
+    parentExecutionId,
+    phase: 'reserved',
+  };
+}

--- a/src/tools/delegation/subagentDeliveryFormat.ts
+++ b/src/tools/delegation/subagentDeliveryFormat.ts
@@ -45,6 +45,7 @@ export async function buildSubagentResult(
   options: {
     readonly startedAt: number;
     readonly workingDirectory?: string;
+    readonly parentExecutionId?: ExecutionId;
   },
 ): Promise<BuiltSubagentResult> {
   let diffInfos: Map<string, DiffFileInfo> | undefined;
@@ -81,7 +82,9 @@ export async function buildSubagentResult(
   });
   return {
     result: finalResult,
-    resultMeta: buildSubagentResultMeta(agentName, finalResult, wallTimeMs),
+    resultMeta: buildSubagentResultMeta(agentName, finalResult, wallTimeMs, {
+      parentExecutionId: options.parentExecutionId,
+    }),
     wallTimeMs,
   };
 }

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -1,18 +1,34 @@
+// Local imports - agent runtime and shared utilities
 import { resolveChildRunOutput } from '@agent/storage';
-import type { WorkflowAgentRunner } from '@agent/workflowScript';
-import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import {
+  WorkflowRunAbortError,
+  type WorkflowAgentRunner,
+} from '@agent/workflowScript';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@shared/schemas';
 import { filterNotNullish } from '@utils/core';
+import { deriveExecutionId } from '@utils/core/idHash';
 import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/taskRunStorage';
 
-import { executeSubagentInBand } from './inBandSubagentExecution';
+// Local imports - delegation
+import {
+  executeStableSubagentInBand,
+  SubagentDurabilityError,
+} from './inBandSubagentExecution';
 import {
   requireVisibleAgent,
   selectAvailableDelegationModel,
 } from './proposalFlow';
 import { assertWorkflowFilesExist } from './workflowFileValidation';
+
+function workflowChildExecutionId(
+  parentExecutionId: LaunchRunContext['runScope']['executionId'],
+  checkpointId: string,
+  key: string,
+): LaunchRunContext['runScope']['executionId'] {
+  return deriveExecutionId({ checkpointId, key, parentExecutionId });
+}
 
 async function resolveInvocationInputFiles(
   parentExecutionId: LaunchRunContext['runScope']['executionId'],
@@ -42,57 +58,76 @@ async function resolveInvocationInputFiles(
 export function createWorkflowScriptAgentRunner(
   parent: LaunchRunContext,
   defaultAgentName: string,
+  checkpointId: string,
 ): WorkflowAgentRunner {
   const { runScope } = parent;
-  const recordSubagentCost =
-    getCurrentToolCallContext()?.hooks?.recordSubagentCost;
 
   return async (invocation) => {
-    const requestedAgent = invocation.options.agentName ?? defaultAgentName;
-    const agent = requireVisibleAgent(
-      AgentCategory.Workflow,
-      requestedAgent,
-      runScope.delegationAgentScope ?? undefined,
-    );
-    const [model, inputFiles] = await Promise.all([
-      selectAvailableDelegationModel({
-        parentModel: parent.model,
-        agentCategory: AgentCategory.Workflow,
-      }),
-      resolveInvocationInputFiles(
-        runScope.executionId,
-        invocation.options.inputFiles ?? [],
-      ),
-    ]);
-    const configPayload: AgentConfigPayload = {
-      agent: agent.name,
-      agentSource: agent.source,
-      agentCategory: AgentCategory.Workflow,
-      model,
-      instruction: invocation.prompt,
-      inputFiles,
-      ...(runScope.workingDirectory !== undefined && {
-        workingDirectory: runScope.workingDirectory,
-      }),
-      ...(runScope.delegationAgentScope && {
-        delegationAgentScope: runScope.delegationAgentScope,
-      }),
-    };
-
-    const { result } = await executeSubagentInBand({
-      configPayload,
-      agentName: agent.name,
-      parentExecutionId: runScope.executionId,
-      parentStreamId: runScope.streamId,
-      runtimeHost: runScope.runtimeHost,
-      session: runScope.session,
-      signal: invocation.signal,
-      approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
-      runtimeUnavailableTools: parent.runtimeUnavailableTools,
-      ...(recordSubagentCost && {
-        onCost: (cost: number | undefined) => recordSubagentCost(cost ?? 0),
-      }),
-    });
-    return result;
+    try {
+      const { result } = await executeStableSubagentInBand({
+        executionId: workflowChildExecutionId(
+          runScope.executionId,
+          checkpointId,
+          invocation.key,
+        ),
+        parentExecutionId: runScope.executionId,
+        signal: invocation.signal,
+        prepare: async () => {
+          const requestedAgent =
+            invocation.options.agentName ?? defaultAgentName;
+          const agent = requireVisibleAgent(
+            AgentCategory.Workflow,
+            requestedAgent,
+            runScope.delegationAgentScope ?? undefined,
+          );
+          const [model, inputFiles] = await Promise.all([
+            selectAvailableDelegationModel({
+              parentModel: parent.model,
+              agentCategory: AgentCategory.Workflow,
+            }),
+            resolveInvocationInputFiles(
+              runScope.executionId,
+              invocation.options.inputFiles ?? [],
+            ),
+          ]);
+          const configPayload: AgentConfigPayload = {
+            agent: agent.name,
+            agentSource: agent.source,
+            agentCategory: AgentCategory.Workflow,
+            model,
+            instruction: invocation.prompt,
+            inputFiles,
+            ...(runScope.workingDirectory !== undefined && {
+              workingDirectory: runScope.workingDirectory,
+            }),
+            ...(runScope.delegationAgentScope && {
+              delegationAgentScope: runScope.delegationAgentScope,
+            }),
+          };
+          return {
+            configPayload,
+            agentName: agent.name,
+            parentExecutionId: runScope.executionId,
+            parentStreamId: runScope.streamId,
+            runtimeHost: runScope.runtimeHost,
+            session: runScope.session,
+            signal: invocation.signal,
+            approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
+            runtimeUnavailableTools: parent.runtimeUnavailableTools,
+          };
+        },
+      });
+      if (result.outcome !== 'completed') {
+        throw new Error(
+          `Workflow subagent ended with ${result.outcome} outcome.`,
+        );
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof SubagentDurabilityError) {
+        throw new WorkflowRunAbortError(error.message, { cause: error });
+      }
+      throw error;
+    }
   };
 }

--- a/src/tools/executions/executionKvFiles.ts
+++ b/src/tools/executions/executionKvFiles.ts
@@ -6,8 +6,9 @@
  *
  * The reserved-key vocabulary itself (meta, config, todos, `child-*`, …) is
  * owned by `ExecutionKVStore`; the `flow_*` prefix is owned by
- * `persistedFlow`. This module only strips the on-disk `.json` suffix and
- * defers to those owners rather than re-deriving the vocabulary.
+ * `persistedFlow`; workflow checkpoint keys are owned by `workflowScript`.
+ * This module only strips the on-disk `.json` suffix and defers to those
+ * owners rather than re-deriving the vocabulary.
  *
  * Every real KV entry is written through `KVStore.keyToPath`, which always
  * appends `.json` — so a name without that suffix can never be an internal
@@ -18,10 +19,17 @@
 
 import { isReservedKvKeyName } from '@agent/storage';
 import { FLOW_KEY_PREFIX } from '@agent/node/persistedFlow';
+import { isWorkflowScriptCheckpointKvKey } from '@agent/workflowScript/checkpointKey';
+import { isStableSubagentStateKvKey } from '@tools/delegation/stableSubagentAttempt';
 
 export function isKVFile(name: string): boolean {
   const match = /^(.+)\.json$/.exec(name);
   if (!match) return false;
   const key = match[1];
-  return isReservedKvKeyName(key) || key.startsWith(FLOW_KEY_PREFIX);
+  return (
+    isReservedKvKeyName(key) ||
+    key.startsWith(FLOW_KEY_PREFIX) ||
+    isWorkflowScriptCheckpointKvKey(key) ||
+    isStableSubagentStateKvKey(key)
+  );
 }

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 
-import { Mutex } from 'async-mutex';
 import { z } from 'zod';
 
 import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
@@ -21,6 +20,7 @@ import {
 import { ToolError } from '@shared/schemas/toolResult';
 import {
   isObject,
+  KeyedMutex,
   toNewestFirstByTimestamp,
   unique,
   hexId12,
@@ -261,29 +261,13 @@ export interface PersistedAnsweredTurn {
 // Per-thread write lock
 // ============================================================================
 
-const threadMutexes = new Map<string, Mutex>();
+const threadMutex = new KeyedMutex<string>();
 
-function getThreadMutex(threadId: string): Mutex {
-  let mutex = threadMutexes.get(threadId);
-  if (!mutex) {
-    mutex = new Mutex();
-    threadMutexes.set(threadId, mutex);
-  }
-  return mutex;
-}
-
-// Thread IDs are freshly minted per thread, so the Map would otherwise grow
-// without bound. Evict after each critical section once no waiters remain.
-async function withThreadLock<T>(
+function withThreadLock<T>(
   threadId: string,
-  fn: () => Promise<T>,
+  operation: () => Promise<T>,
 ): Promise<T> {
-  const mutex = getThreadMutex(threadId);
-  try {
-    return await mutex.runExclusive(fn);
-  } finally {
-    if (!mutex.isLocked()) threadMutexes.delete(threadId);
-  }
+  return threadMutex.runExclusive(threadId, operation);
 }
 
 // ============================================================================

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -540,10 +540,14 @@ export function buildSubagentResultMeta(
   agentName: string,
   result: AgentFinalResult,
   wallTimeMs: number,
+  options: { readonly parentExecutionId?: ExecutionId } = {},
 ): SubagentResultMeta {
   return {
     producer: 'subagent',
     agentName,
+    ...(options.parentExecutionId !== undefined && {
+      parentExecutionId: options.parentExecutionId,
+    }),
     wallTimeMs,
     result,
   };
@@ -560,6 +564,7 @@ export function buildSubagentFailureResultMeta(
   fallbackCategory: AgentFlowCategory,
   result: AgentFlowResult | undefined,
   wallTimeMs: number,
+  options: { readonly parentExecutionId?: ExecutionId } = {},
 ): SubagentResultMeta {
   const finalResult = result
     ? buildAgentFinalResult({
@@ -572,5 +577,5 @@ export function buildSubagentFailureResultMeta(
         category: fallbackCategory,
         outcome: 'failed',
       });
-  return buildSubagentResultMeta(agentName, finalResult, wallTimeMs);
+  return buildSubagentResultMeta(agentName, finalResult, wallTimeMs, options);
 }

--- a/src/utils/core/idHash.ts
+++ b/src/utils/core/idHash.ts
@@ -1,0 +1,18 @@
+// Node imports
+import { createHash } from 'node:crypto';
+
+// Third-party imports
+import stableStringify from 'fast-json-stable-stringify';
+
+// Local imports - schemas
+import type { ExecutionId } from '@shared/schemas';
+
+type ExecutionIdentity = Readonly<Record<string, string | number>>;
+
+/** Derive a stable execution ID from named identity fields. */
+export function deriveExecutionId(identity: ExecutionIdentity): ExecutionId {
+  return createHash('sha256')
+    .update(stableStringify(identity))
+    .digest('hex')
+    .slice(0, 24) as ExecutionId;
+}

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -29,6 +29,7 @@ export {
   formatWallTimeSeconds,
   serializeError,
 } from '../text/stringUtils';
+export { KeyedMutex } from './keyedMutex';
 
 // ---------------------------------------------------------------------------
 // typeGuards

--- a/src/utils/core/keyedMutex.ts
+++ b/src/utils/core/keyedMutex.ts
@@ -1,0 +1,26 @@
+// Third-party imports
+import { Mutex } from 'async-mutex';
+
+/** Serialize asynchronous operations independently for each logical key. */
+export class KeyedMutex<Key> {
+  private readonly mutexes = new Map<Key, Mutex>();
+
+  async runExclusive<Result>(
+    key: Key,
+    operation: () => Promise<Result>,
+  ): Promise<Result> {
+    let mutex = this.mutexes.get(key);
+    if (!mutex) {
+      mutex = new Mutex();
+      this.mutexes.set(key, mutex);
+    }
+    try {
+      return await mutex.runExclusive(operation);
+    } finally {
+      // No task can interleave in this synchronous check-and-delete segment.
+      if (this.mutexes.get(key) === mutex && !mutex.isLocked()) {
+        this.mutexes.delete(key);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- persist each workflow-script invocation as one strict, versioned execution-KV checkpoint containing script text, canonical arguments, and the completed-call journal
- serialize overlapping runs and journal writes, reject script/argument drift, and fail loudly on malformed present state
- recover completed typed child manifests before resolving mutable agent/model/file launch prerequisites; retry failed or cancelled attempts under deterministic identities
- make manifest, registration, and reconciliation failures fatal even when sandbox code catches the bridged error
- keep checkpoint key ownership in the workflow-script domain and hide checkpoint files from generated-output listings

## Design

The persistence module owns the complete checkpoint lifecycle behind a small read/write/run API. The workflow engine exposes one awaited journal hook and keeps fatal run errors sticky across the sandbox boundary.

Stable child execution treats the prompt/options hash as the logical call identity. Durable attempts are reconciled under that identity: completed results are reused, failed or cancelled attempts advance to a new deterministic attempt, and partial or mismatched state aborts rather than repeating uncertain work. Mutable launch preparation is lazy, so restart recovery does not depend on the current registry, model availability, or source-file presence.

Child costs remain in persisted typed results. The future opt-in tool will aggregate the final journal at its tool-result boundary, giving live execution, recovered manifests, and journal replay one accounting path rather than mutating parent totals during launch.

A parent execution has one active runtime owner. In-process mutexes prevent duplicate re-entry; execution KV remains durable state rather than a distributed lock.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm test -- --testTimeout=30000` (699 files passed, 1 skipped; 6315 tests passed, 4 skipped)
- focused post-rebase Vitest run (5 files, 124 tests)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`

Part of #7154.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes crash recovery, subagent launch/repeat semantics, and persisted execution state; incorrect reconciliation could skip model work, repeat uncertain runs, or abort workflows on storage failures.
> 
> **Overview**
> Adds **durable workflow-script checkpoints** in execution KV: each invocation stores script text, canonical args, and a versioned journal; completed `agent()` results are persisted via an awaited `onJournalEntry` hook **before** the sandbox can use them, with in-process serialization and loud failures on malformed or drifting script/args.
> 
> **Restart-safe identity** for scripted children: `agent()` accepts optional `id`, passes a stable `key` to the runner, and rejects duplicate prompt/options without distinct ids. Production routing uses `executeStableSubagentInBand` with deterministic child execution IDs, parent-owned attempt sequences, reserve/launch markers, and **reuse of completed manifests** before lazy `prepare()` (model/agent/files). `parentExecutionId` is recorded on subagent result meta for lineage checks; durability/reconciliation errors become fatal `WorkflowRunAbortError` (not null slots or guest `catch`).
> 
> Supporting pieces: `KeyedMutex`, `deriveExecutionId`, checkpoint KV key helpers, and hiding checkpoint/stable-subagent keys from generated execution file listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734726bb590e6d3ff34fce4499896d4b30d7e44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->