### PR TITLE
refactor: make permission actions exact

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -31,6 +31,7 @@ import {
   sendFollowupCommand,
 } from '@progressView/frontend/eventHandlers';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
+import type { PermissionActionDetail } from '@progressView/frontend/events';
 import {
   activeStreamId$,
   appState,
@@ -713,7 +714,9 @@ function wireConversation(): void {
   }) as EventListener);
   conversationView.addEventListener('toolbar-command', ((e: CustomEvent) =>
     handleToolbarCommand(e, ctx())) as EventListener);
-  conversationView.addEventListener('permission-action', ((e: CustomEvent) =>
+  conversationView.addEventListener('permission-action', ((
+    e: CustomEvent<PermissionActionDetail>,
+  ) =>
     handlePermissionAction(
       e,
       createHostMessageHandlerContext(),

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -68,6 +68,7 @@ import {
   sendFollowupCommand,
 } from './eventHandlers';
 import { dispatchMessage } from './messageDispatcher';
+import type { PermissionActionDetail } from './events';
 import type {
   FrontendEventHandlerContext,
   MessageHandlerContext,
@@ -372,7 +373,7 @@ export class ProgressApp extends ProgressAppBase {
     handleStreamSwitch(e, this.getEventHandlerContext());
   private onStreamDelete = (e: CustomEvent): void =>
     handleStreamDelete(e, this.getEventHandlerContext());
-  private onPermissionAction = (e: CustomEvent): void =>
+  private onPermissionAction = (e: CustomEvent<PermissionActionDetail>): void =>
     handlePermissionAction(e, this.createMessageHandlerContext());
 
   // Event handlers requiring context

--- a/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseApprovalPanel.ts
@@ -1,0 +1,80 @@
+/** Shared shell and primary action for approval-capable request panels. */
+
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+
+// Side-effect imports - register the approve-split component
+import './ApproveSplitButton';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+// Local imports - progress view events
+import type { ApprovalDecision, ApprovalPermissionKind } from '../events';
+
+export abstract class BaseApprovalPanel<
+  K extends ApprovalPermissionKind,
+> extends BaseFeedbackPanel<K> {
+  /** The panel declares its approval; the base owns dispatch and shortcuts. */
+  protected abstract readonly approvalDecision: ApprovalDecision<K>;
+
+  override handleKeyboardShortcut(key: string): boolean {
+    if (key !== 'y') return super.handleKeyboardShortcut(key);
+    if (this.archived) return false;
+    this.emitAction(this.approvalDecision);
+    return true;
+  }
+
+  /**
+   * Standard approve/reject panel shell. The class structure is the contract
+   * consumed by requestPanelSharedStyles.
+   */
+  protected renderRequestShell(options: {
+    prefix: string;
+    details: TemplateResult;
+    approveTitle: string;
+    rejectTitle: string;
+    leadingActions?: TemplateResult | typeof nothing;
+    middleActions?: TemplateResult | typeof nothing;
+    trailingActions?: TemplateResult | typeof nothing;
+    feedbackPlaceholder?: string;
+    trailing?: TemplateResult | typeof nothing;
+  }): TemplateResult {
+    const { prefix } = options;
+    return html`
+      <div
+        class=${classMap({
+          [prefix]: true,
+          [`${prefix}--feedback-active`]: this.showFeedback,
+        })}
+      >
+        <div class="${prefix}__details">${options.details}</div>
+        <div class="${prefix}__actions">
+          ${options.leadingActions ?? nothing}
+          ${this.renderApproveButton(options.approveTitle)}
+          ${options.middleActions ?? nothing}
+          ${this.renderRejectButton(options.rejectTitle)}
+          ${options.trailingActions ?? nothing}
+        </div>
+        ${this.renderFeedbackSection(
+          `${prefix}__feedback`,
+          `${prefix}__feedback-input`,
+          options.feedbackPlaceholder,
+        )}
+        ${options.trailing ?? nothing}
+      </div>
+    `;
+  }
+
+  protected renderApproveButton(approveTitle: string): TemplateResult {
+    return html`
+      <approve-split-button
+        .approveTitle=${approveTitle}
+        .canBypass=${false}
+        .disabled=${this.archived}
+        @approve=${() => this.emitAction(this.approvalDecision)}
+      ></approve-split-button>
+    `;
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
@@ -1,0 +1,41 @@
+/** Approval panel capability for edit and bash session bypass. */
+
+// Third-party imports
+import { html, type TemplateResult } from 'lit';
+
+// Local imports - progress view events
+import { APPROVE_SESSION_ACTION } from '../events';
+
+// Local imports - base class
+import { BaseApprovalPanel } from './BaseApprovalPanel';
+
+type BypassPermissionKind = 'toolEdit' | 'bash';
+
+export abstract class BaseBypassApprovalPanel<
+  K extends BypassPermissionKind,
+> extends BaseApprovalPanel<K> {
+  protected abstract readonly canBypass: boolean;
+
+  private readonly sessionApprovalDecision = {
+    action: APPROVE_SESSION_ACTION,
+  } as const;
+
+  override handleKeyboardShortcut(key: string): boolean {
+    if (key !== 'a') return super.handleKeyboardShortcut(key);
+    if (this.archived || this.showFeedback || !this.canBypass) return false;
+    this.emitAction(this.sessionApprovalDecision);
+    return true;
+  }
+
+  protected override renderApproveButton(approveTitle: string): TemplateResult {
+    return html`
+      <approve-split-button
+        .approveTitle=${approveTitle}
+        .canBypass=${this.canBypass}
+        .disabled=${this.archived}
+        @approve=${() => this.emitAction(this.approvalDecision)}
+        @approve-session=${() => this.emitAction(this.sessionApprovalDecision)}
+      ></approve-split-button>
+    `;
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
@@ -3,22 +3,35 @@
 // Third-party imports
 import { html, type TemplateResult } from 'lit';
 
-// Local imports - progress view events
-import { APPROVE_SESSION_ACTION } from '../events';
-
 // Local imports - base class
 import { BaseApprovalPanel } from './BaseApprovalPanel';
 
+// Local imports - progress view events
+import { APPROVE_SESSION_ACTION } from '../events';
+
+// Local imports - progress view state
+import type { PermissionState } from '../permissionState';
+
 type BypassPermissionKind = 'toolEdit' | 'bash';
+type BypassPermission = Extract<
+  PermissionState,
+  { kind: BypassPermissionKind }
+>;
+
+function canBypassSession({ data }: BypassPermission): boolean {
+  return Boolean(data.allowBypass && data.streamId);
+}
 
 export abstract class BaseBypassApprovalPanel<
   K extends BypassPermissionKind,
 > extends BaseApprovalPanel<K> {
-  protected abstract readonly canBypass: boolean;
-
   private readonly sessionApprovalDecision = {
     action: APPROVE_SESSION_ACTION,
   } as const;
+
+  private get canBypass(): boolean {
+    return canBypassSession(this.permission);
+  }
 
   override handleKeyboardShortcut(key: string): boolean {
     if (key !== 'a') return super.handleKeyboardShortcut(key);

--- a/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -3,68 +3,27 @@
 // Third-party imports
 import { html, nothing, type TemplateResult } from 'lit';
 import { query, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 
-// Side-effect imports - register WA textarea + the approve-split component
+// Side-effect imports - register WA textarea
 import '@awesome.me/webawesome/dist/components/textarea/textarea.js';
-import './ApproveSplitButton';
 
 // Local imports - shared utilities
-import {
-  FEEDBACK_ELIGIBLE_KINDS,
-  PERMISSION_KIND,
-} from '@shared/utils/uiConstants';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
-
-// Local imports - progress view events
-import { APPROVE_SESSION_ACTION } from '../events';
 
 // Local imports - base class
 import { BaseRequestPanel } from './BaseRequestPanel';
 
-// Local imports - progress view component types
-import type { PermissionState } from '../permissionState';
-
-/**
- * `allowBypass` / `streamId` are structurally present on every permission
- * kind whose schema extends `PermissionBaseSchema` (toolEdit, bash,
- * externalInquiry, userQuestion) — see `src/shared/schemas/prompts.ts`. The
- * remaining kinds (retry, proposal, planApproval) don't carry them at all.
- * `BaseFeedbackPanel` is the shared base for every feedback-eligible panel
- * (all of the above except retry), so it can't be generically constrained to
- * "just the kinds with these fields" — `PlanApprovalRequestPanel` inherits
- * `canBypass` without overriding it. An exhaustive switch here (rather than a
- * cast on `this.permission.data`) keeps the "which kinds have this" list
- * type-checked against the real union instead of hand-rolled.
- */
-function getBypassInfo(permission: PermissionState): {
-  allowBypass?: boolean;
-  streamId?: string;
-} {
-  switch (permission.kind) {
-    case PERMISSION_KIND.TOOL_EDIT:
-    case PERMISSION_KIND.BASH:
-    case PERMISSION_KIND.EXTERNAL_INQUIRY:
-    case PERMISSION_KIND.USER_QUESTION:
-      return {
-        allowBypass: permission.data.allowBypass,
-        streamId: permission.data.streamId,
-      };
-    case PERMISSION_KIND.RETRY:
-    case PERMISSION_KIND.PROPOSAL:
-    case PERMISSION_KIND.PLAN_APPROVAL:
-      return {};
-  }
-}
+// Local imports - progress view events
+import type { FeedbackPermissionKind } from '../events';
 
 export abstract class BaseFeedbackPanel<
-  K extends PermissionState['kind'] = PermissionState['kind'],
+  K extends FeedbackPermissionKind = FeedbackPermissionKind,
 > extends BaseRequestPanel<K> {
   @query('[data-feedback-input]') private feedbackInput?: HTMLElement;
   @state() protected showFeedback = false;
 
   // ===========================================================================
-  // Keyboard shortcuts (common y/n/escape, subclasses add type-specific keys)
+  // Keyboard shortcuts (common n/escape, subclasses add type-specific keys)
   // ===========================================================================
 
   override handleKeyboardShortcut(key: string): boolean {
@@ -72,9 +31,6 @@ export abstract class BaseFeedbackPanel<
     // none of the accelerators should appear to do anything either.
     if (this.archived) return false;
     switch (key) {
-      case 'y':
-        this.emitAction('approve');
-        return true;
       case 'n':
         this.handleRejectAction();
         return true;
@@ -84,11 +40,6 @@ export abstract class BaseFeedbackPanel<
           return true;
         }
         return false;
-      case 'a':
-        // Session-bypass ("Yolo") accelerator. A no-op (returns false) on
-        // prompts that don't allow bypass or while the feedback box is open,
-        // so it only acts on the edit/bash prompts that surface the affordance.
-        return this.handleApproveSessionKey();
       default:
         return this.handleExtraKey(key);
     }
@@ -104,11 +55,6 @@ export abstract class BaseFeedbackPanel<
   // ===========================================================================
 
   protected handleRejectAction(): void {
-    if (!FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind)) {
-      this.emitAction('reject');
-      return;
-    }
-
     if (!this.showFeedback) {
       this.showFeedback = true;
       this.updateComplete.then(() => {
@@ -119,99 +65,10 @@ export abstract class BaseFeedbackPanel<
 
     const feedback = this.getFeedbackValue();
     this.showFeedback = false;
-    this.emitAction('reject', feedback);
-  }
-
-  /**
-   * Standard approve/reject panel shell: the BEM block with its
-   * `--feedback-active` modifier, `__details`, `__actions` (approve/reject
-   * plus optional extra buttons), and `__feedback` section. Keeps the class
-   * structure that `requestPanelSharedStyles` targets defined in one place.
-   */
-  protected renderRequestShell(options: {
-    /** BEM block name, e.g. 'approval-request'. */
-    prefix: string;
-    details: TemplateResult;
-    approveTitle: string;
-    rejectTitle: string;
-    /** Extra action buttons rendered before the approve button. */
-    leadingActions?: TemplateResult | typeof nothing;
-    /** Extra action buttons rendered between approve and reject. */
-    middleActions?: TemplateResult | typeof nothing;
-    /** Extra action buttons rendered after the reject button. */
-    trailingActions?: TemplateResult | typeof nothing;
-    feedbackPlaceholder?: string;
-    /** Content rendered after the feedback section (e.g. an inline diff). */
-    trailing?: TemplateResult | typeof nothing;
-  }): TemplateResult {
-    const { prefix } = options;
-    return html`
-      <div
-        class=${classMap({
-          [prefix]: true,
-          [`${prefix}--feedback-active`]: this.showFeedback,
-        })}
-      >
-        <div class="${prefix}__details">${options.details}</div>
-        <div class="${prefix}__actions">
-          ${options.leadingActions ?? nothing}
-          ${this.renderApproveButton(options.approveTitle)}
-          ${options.middleActions ?? nothing}
-          ${this.renderRejectButton(options.rejectTitle)}
-          ${options.trailingActions ?? nothing}
-        </div>
-        ${this.renderFeedbackSection(
-          `${prefix}__feedback`,
-          `${prefix}__feedback-input`,
-          options.feedbackPlaceholder,
-        )}
-        ${options.trailing ?? nothing}
-      </div>
-    `;
-  }
-
-  protected renderApproveButton(approveTitle: string): TemplateResult {
-    // Declarative: the <approve-split-button> component owns the plain-vs-split
-    // rendering and the menu's keyboard-accessible selection. When the prompt
-    // allows session bypass it surfaces "Yolo (this session)" under the Approve
-    // caret; selecting it (or the `a` shortcut) approves AND auto-approves edits
-    // + bash for the rest of the stream.
-    return html`
-      <approve-split-button
-        .approveTitle=${approveTitle}
-        .canBypass=${this.canBypass}
-        .disabled=${this.archived}
-        @approve=${() => this.emitAction('approve')}
-        @approve-session=${() => this.emitAction(APPROVE_SESSION_ACTION)}
-      ></approve-split-button>
-    `;
-  }
-
-  /**
-   * Whether this prompt advertises the session-bypass ("Yolo") affordance.
-   * Only tool-edit and bash permissions carry `allowBypass`; it is true exactly
-   * when the stream is not already auto-approving (a bypassed stream never
-   * prompts, so a visible prompt always means bypass is currently off). Also
-   * requires a concrete `streamId`: session bypass is per-stream, so without one
-   * there is nothing to scope it to and the button would silently no-op.
-   */
-  protected get canBypass(): boolean {
-    const { allowBypass, streamId } = getBypassInfo(this.permission);
-    return Boolean(allowBypass && streamId);
-  }
-
-  /**
-   * Handle the shared `a` = approve-session shortcut — the keyboard accelerator
-   * for the Approve menu's "Yolo (this session)" item, wired from
-   * `handleKeyboardShortcut`. No-op while the feedback textarea is open (so
-   * typing "a" there is not hijacked) or when the prompt does not allow bypass.
-   */
-  protected handleApproveSessionKey(): boolean {
-    if (this.showFeedback || !this.canBypass) {
-      return false;
-    }
-    this.emitAction(APPROVE_SESSION_ACTION);
-    return true;
+    this.emitAction({
+      action: 'reject',
+      ...(feedback ? { feedback } : {}),
+    });
   }
 
   protected renderRejectButton(rejectTitle: string): TemplateResult {
@@ -230,12 +87,7 @@ export abstract class BaseFeedbackPanel<
     inputClass: string,
     placeholder = 'Why are you rejecting?',
   ): TemplateResult | typeof nothing {
-    if (
-      !this.showFeedback ||
-      !FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind)
-    ) {
-      return nothing;
-    }
+    if (!this.showFeedback) return nothing;
 
     return html`
       <div class=${containerClass}>

--- a/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -6,7 +6,11 @@ import { consume } from '@lit/context';
 import { property } from 'lit/decorators.js';
 
 // Local imports - progress view events
-import { ProgressEvents } from '../events';
+import {
+  ProgressEvents,
+  type PermissionDecision,
+  type PermissionKind,
+} from '../events';
 
 // Local imports - progress view contexts
 import { archivedContext } from '../contexts/streamContexts';
@@ -15,7 +19,7 @@ import { archivedContext } from '../contexts/streamContexts';
 import type { PermissionState } from '../permissionState';
 
 export abstract class BaseRequestPanel<
-  K extends PermissionState['kind'] = PermissionState['kind'],
+  K extends PermissionKind = PermissionKind,
 > extends LitElement {
   @property({ attribute: false }) permission!: Extract<
     PermissionState,
@@ -35,21 +39,10 @@ export abstract class BaseRequestPanel<
   /** Handle keyboard shortcut from container. Returns true if handled. */
   abstract handleKeyboardShortcut(key: string): boolean;
 
-  protected emitAction(
-    action: string,
-    feedback?: string,
-    modelOverride?: string,
-    agentOverride?: string,
-  ): void {
+  protected emitAction(decision: PermissionDecision<K>): void {
     if (this.archived) return;
     this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission: this.permission,
-        action,
-        feedback,
-        modelOverride,
-        agentOverride,
-      }),
+      ProgressEvents.permissionAction(this.permission, decision),
     );
   }
 }

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -21,13 +21,13 @@ import { codeBlockStyles } from '../styles/codeBlockStyles';
 import { buildCodeBlock } from '../formatters/htmlBuilders';
 
 // Local imports - base class
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { BaseBypassApprovalPanel } from './BaseBypassApprovalPanel';
 
 // Local imports - styles
 import { bashRequestPanelStyles } from './BashRequestPanel.styles';
 
 @customElement('bash-request-panel')
-export class BashRequestPanel extends BaseFeedbackPanel<'bash'> {
+export class BashRequestPanel extends BaseBypassApprovalPanel<'bash'> {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -35,6 +35,13 @@ export class BashRequestPanel extends BaseFeedbackPanel<'bash'> {
     requestPanelSharedStyles,
     bashRequestPanelStyles,
   ];
+
+  protected readonly approvalDecision = { action: 'approve' } as const;
+
+  protected get canBypass(): boolean {
+    const { allowBypass, streamId } = this.permission.data;
+    return Boolean(allowBypass && streamId);
+  }
 
   override render(): TemplateResult {
     const data = this.permission.data;

--- a/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BashRequestPanel.ts
@@ -38,11 +38,6 @@ export class BashRequestPanel extends BaseBypassApprovalPanel<'bash'> {
 
   protected readonly approvalDecision = { action: 'approve' } as const;
 
-  protected get canBypass(): boolean {
-    const { allowBypass, streamId } = this.permission.data;
-    return Boolean(allowBypass && streamId);
-  }
-
   override render(): TemplateResult {
     const data = this.permission.data;
 

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -46,7 +46,6 @@ import { createBoundedIdSet } from '@utils/core/boundedIdSet';
 
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 import { externalInquiryPanelStyles } from './ExternalInquiryPanel.styles';
-import { ProgressEvents } from '../events';
 import type { PermissionState } from '../permissionState';
 
 // ── Draft persistence ──
@@ -210,12 +209,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
       return;
     }
     this.writeDraft(ids, this.currentDraft(), { persist: true });
-  }
-
-  override handleKeyboardShortcut(key: string): boolean {
-    // Suppress the parent's 'y' → approve binding (invalid for external inquiry)
-    if (key === 'y') return false;
-    return super.handleKeyboardShortcut(key);
   }
 
   // ── Render ──
@@ -554,9 +547,6 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   }
 
   private handleSubmit(): void {
-    // Bypasses the base class's emitAction chokepoint (dispatches
-    // permission-action directly), so the archived/read-only trace-viewer
-    // guard has to be repeated here.
     if (this.archived) return;
     if (!this.hasAnswer) return;
     const answer = this.answerText.trim();
@@ -564,14 +554,11 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
 
     clearInquiryDraft(getRequestId(this.permission));
 
-    this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission: this.permission,
-        action: INQUIRY_SUBMIT_ACTION,
-        answer,
-        sessionLinks: sessionLinks.length ? sessionLinks : undefined,
-      }),
-    );
+    this.emitAction({
+      action: INQUIRY_SUBMIT_ACTION,
+      answer,
+      ...(sessionLinks.length ? { sessionLinks } : {}),
+    });
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -16,7 +16,7 @@ import {
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - base class
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { BaseApprovalPanel } from './BaseApprovalPanel';
 
 /**
  * Styles for the plan approval request panel. Kept inline (rather than a
@@ -32,7 +32,7 @@ const planApprovalRequestPanelStyles: CSSResult = css`
 `;
 
 @customElement('plan-approval-request-panel')
-export class PlanApprovalRequestPanel extends BaseFeedbackPanel<'planApproval'> {
+export class PlanApprovalRequestPanel extends BaseApprovalPanel<'planApproval'> {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -40,11 +40,13 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel<'planApproval'> 
     planApprovalRequestPanelStyles,
   ];
 
+  protected readonly approvalDecision = { action: 'approve' } as const;
+
   protected override handleExtraKey(key: string): boolean {
     if (key === 'r') {
       const data = this.permission.data;
       if (data.goalEnabled) {
-        this.emitAction('approve_and_goal');
+        this.emitAction({ action: 'approve_and_goal' });
         return true;
       }
     }
@@ -66,7 +68,7 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel<'planApproval'> 
             text: 'Approve & Run',
             title: 'Approve and run this plan autonomously via goal mode (r)',
             action: 'approve_and_goal',
-            onClick: () => this.emitAction('approve_and_goal'),
+            onClick: () => this.emitAction({ action: 'approve_and_goal' }),
           })
         : nothing,
       feedbackPlaceholder: 'Why are you rejecting this plan?',

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -46,7 +46,7 @@ import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { getBasename } from '@utils/core';
 
 // Local imports - base class
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { BaseApprovalPanel } from './BaseApprovalPanel';
 import { proposalRequestPanelStyles } from './ProposalRequestPanel.styles';
 import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
@@ -69,7 +69,7 @@ function readSelectValue(event: Event): string {
 }
 
 @customElement('proposal-request-panel')
-export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
+export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -81,6 +81,10 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
 
   @state() private selectedModel: string | null = null;
   @state() private selectedAgent: string | null = null;
+
+  protected get approvalDecision() {
+    return { action: 'approve' as const, ...this.proposalOverrides };
+  }
 
   // Reset selections only when the proposal's identity changes, so an async
   // permission upsert that just adds dropdown options doesn't wipe the user's
@@ -97,11 +101,17 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
   }
 
   protected override handleExtraKey(key: string): boolean {
-    if (key === 's') {
-      this.emitAction('setup');
-      return true;
+    switch (key) {
+      case 'a':
+        if (this.showFeedback) return false;
+        this.emitAction(this.approveAllDelegatedWorkDecision);
+        return true;
+      case 's':
+        this.emitAction({ action: 'setup' });
+        return true;
+      default:
+        return false;
     }
-    return false;
   }
 
   // Proposals carry a stronger approval action than the edit/bash bypass.
@@ -113,17 +123,11 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
         .approveTitle=${approveTitle}
         .canBypass=${false}
         .canApproveAllDelegatedWork=${true}
-        @approve=${() => this.emitAction('approve')}
+        @approve=${() => this.emitAction(this.approvalDecision)}
         @approve-all-delegated-work=${() =>
-          this.emitAction(APPROVE_ALL_DELEGATED_WORK_ACTION)}
+          this.emitAction(this.approveAllDelegatedWorkDecision)}
       ></approve-split-button>
     `;
-  }
-
-  protected override handleApproveSessionKey(): boolean {
-    if (this.showFeedback) return false;
-    this.emitAction(APPROVE_ALL_DELEGATED_WORK_ACTION);
-    return true;
   }
 
   override render(): TemplateResult {
@@ -203,7 +207,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
         text: 'Setup',
         title: 'Setup (s)',
         action: 'setup',
-        onClick: () => this.emitAction('setup'),
+        onClick: () => this.emitAction({ action: 'setup' }),
       }),
     });
   }
@@ -335,29 +339,26 @@ export class ProposalRequestPanel extends BaseFeedbackPanel<'proposal'> {
     }
   };
 
-  // ===========================================================================
-  // Override emitAction to include model/agent overrides for approve
-  // ===========================================================================
-
-  protected override emitAction(action: string, feedback?: string): void {
-    // Approve-all also accepts this proposal, so it carries the same model and
-    // agent overrides as a plain approval.
-    if (action !== 'approve' && action !== APPROVE_ALL_DELEGATED_WORK_ACTION) {
-      super.emitAction(action, feedback);
-      return;
-    }
+  private get proposalOverrides(): { model?: string; agent?: string } {
     const data = this.permission.data;
     const pickIfChanged = (
       selected: string | null,
       original: string,
     ): string | undefined =>
       selected && selected !== original ? selected : undefined;
-    super.emitAction(
-      action,
-      feedback,
-      pickIfChanged(this.selectedModel, data.model),
-      pickIfChanged(this.selectedAgent, data.agent),
-    );
+    const model = pickIfChanged(this.selectedModel, data.model);
+    const agent = pickIfChanged(this.selectedAgent, data.agent);
+    return {
+      ...(model ? { model } : {}),
+      ...(agent ? { agent } : {}),
+    };
+  }
+
+  private get approveAllDelegatedWorkDecision() {
+    return {
+      action: APPROVE_ALL_DELEGATED_WORK_ACTION,
+      ...this.proposalOverrides,
+    } as const;
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
@@ -1,8 +1,5 @@
 // Local imports - shared utilities
-import {
-  PERMISSION_KIND,
-  type PermissionKind,
-} from '@shared/utils/uiConstants';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view component types
 import type { BaseRequestPanel } from './BaseRequestPanel';
@@ -33,7 +30,7 @@ export function createEmptyPermissionGroups(): PermissionGroups {
   };
 }
 
-const KIND_TO_GROUP: Record<PermissionKind, keyof PermissionGroups> = {
+const KIND_TO_GROUP: Record<PermissionState['kind'], keyof PermissionGroups> = {
   [PERMISSION_KIND.TOOL_EDIT]: 'approval',
   [PERMISSION_KIND.BASH]: 'bash',
   [PERMISSION_KIND.RETRY]: 'retry',

--- a/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -46,16 +46,16 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
     const data = this.permission.data;
     switch (key) {
       case 'r':
-        this.emitAction('retry');
+        this.emitAction({ action: 'retry' });
         return true;
       case 'k':
         if (isCredentialExhausted(data.errorDetails)) {
-          this.emitAction('useOwnApiKey');
+          this.emitAction({ action: 'useOwnApiKey' });
           return true;
         }
         return false;
       case 'escape':
-        this.emitAction('cancel');
+        this.emitAction({ action: 'cancel' });
         return true;
       default:
         return false;
@@ -125,7 +125,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
                 : 'Use your own API key (k)',
               action: 'useOwnApiKey',
               disabled,
-              onClick: () => this.emitAction('useOwnApiKey'),
+              onClick: () => this.emitAction({ action: 'useOwnApiKey' }),
             }),
           )}
           ${renderLabeledActionButton({
@@ -134,7 +134,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
             title: copilotQuotaExhausted ? 'Retry Copilot (r)' : 'Retry (r)',
             action: 'retry',
             disabled,
-            onClick: () => this.emitAction('retry'),
+            onClick: () => this.emitAction({ action: 'retry' }),
           })}
           ${renderLabeledActionButton({
             icon: 'close',
@@ -142,7 +142,7 @@ export class RetryRequestPanel extends BaseRequestPanel<'retry'> {
             title: 'Dismiss (Esc)',
             action: 'cancel',
             disabled,
-            onClick: () => this.emitAction('cancel'),
+            onClick: () => this.emitAction({ action: 'cancel' }),
           })}
         </div>
       </div>

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -26,7 +26,7 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local imports - base class
-import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import { BaseBypassApprovalPanel } from './BaseBypassApprovalPanel';
 
 // Local imports - helpers
 import { monacoLanguageForPath } from './monacoLanguage';
@@ -35,13 +35,20 @@ import { monacoLanguageForPath } from './monacoLanguage';
 import { toolEditRequestPanelStyles } from './ToolEditRequestPanel.styles';
 
 @customElement('tool-edit-request-panel')
-export class ToolEditRequestPanel extends BaseFeedbackPanel<'toolEdit'> {
+export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
   static override styles = [
     designTokens,
     commonViewStyles,
     requestPanelSharedStyles,
     toolEditRequestPanelStyles,
   ];
+
+  protected readonly approvalDecision = { action: 'approve' } as const;
+
+  protected get canBypass(): boolean {
+    const { allowBypass, streamId } = this.permission.data;
+    return Boolean(allowBypass && streamId);
+  }
 
   @state() private inlineDiffOpen = false;
 
@@ -204,8 +211,13 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel<'toolEdit'> {
   ): void => {
     const action =
       (event.detail?.item as HTMLElement & { value?: string })?.value ?? '';
-    if (!action) return;
-    this.emitAction(action);
+    switch (action) {
+      case 'openDiff':
+      case 'showLatexdiff':
+      case 'previewProposed':
+        this.emitAction({ action });
+        break;
+    }
   };
 
   private handleDiffAction = (): void => {
@@ -214,7 +226,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel<'toolEdit'> {
       this.inlineDiffOpen = !this.inlineDiffOpen;
       return;
     }
-    this.emitAction('openDiff');
+    this.emitAction({ action: 'openDiff' });
   };
 
   private hasInlineDiff(data: ToolEditPermission): boolean {

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -45,11 +45,6 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
 
   protected readonly approvalDecision = { action: 'approve' } as const;
 
-  protected get canBypass(): boolean {
-    const { allowBypass, streamId } = this.permission.data;
-    return Boolean(allowBypass && streamId);
-  }
-
   @state() private inlineDiffOpen = false;
 
   protected override handleExtraKey(key: string): boolean {

--- a/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UserQuestionPanel.ts
@@ -27,8 +27,6 @@ import type {
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - progress view events
-import { ProgressEvents } from '../events';
-
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
@@ -230,9 +228,6 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
   }
 
   private submitAnswers(): void {
-    // Bypasses the base class's emitAction chokepoint (dispatches
-    // permission-action directly), so the archived/read-only trace-viewer
-    // guard has to be repeated here.
     if (this.archived) return;
     const data = this.permission.data;
     const answers: UserQuestionAnswers = {};
@@ -250,13 +245,7 @@ export class UserQuestionPanel extends BaseFeedbackPanel<'userQuestion'> {
         : selected[0];
     }
 
-    this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission: this.permission,
-        action: 'submit',
-        answers,
-      }),
-    );
+    this.emitAction({ action: 'submit', answers });
   }
 
   private hasAnyAnswer(data: UserQuestionPermission): boolean {

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -5,6 +5,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
 import {
   type GettingStartedActionDetail,
+  type ProgressViewInboundMessage,
   type StreamTabId,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
@@ -276,29 +277,16 @@ export function handlePermissionAction(
   event: CustomEvent<PermissionActionDetail>,
   ctx: MessageHandlerContext,
 ): void {
-  const {
-    permission,
-    action,
-    feedback,
-    modelOverride,
-    agentOverride,
-    answer,
-    answers,
-    sessionLinks,
-  } = event.detail;
+  const detail = event.detail;
 
-  switch (permission.kind) {
-    case PERMISSION_KIND.TOOL_EDIT:
-    case PERMISSION_KIND.BASH: {
-      const command =
-        permission.kind === PERMISSION_KIND.TOOL_EDIT
-          ? PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
-          : PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION;
+  switch (detail.kind) {
+    case PERMISSION_KIND.TOOL_EDIT: {
+      const { data, decision } = detail;
       // "Yolo (this session)" approves the current request like a normal
       // approve and enables auto-approval (edits + bash) for the rest of the
       // stream — mirroring the toolbar shield and the CLI's `a` = approve
       // session. It never reaches the backend approval protocol.
-      const isYolo = action === APPROVE_SESSION_ACTION;
+      const isYolo = decision.action === APPROVE_SESSION_ACTION;
       if (isYolo) {
         // Enable session bypass BEFORE settling the approval. Webview messages
         // are delivered FIFO and ENABLE_APPROVAL_BYPASS sets the per-stream
@@ -308,66 +296,100 @@ export function handlePermissionAction(
         // inversion-proof: edit and bash bypass can be decoupled on a delegated
         // child stream. The button only renders with a real stream (see
         // canBypass), but guard anyway.
-        const stream = permission.data.streamId;
+        const stream = data.streamId;
         if (stream) {
           postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
             stream,
           });
         }
       }
-      postMessage(command, {
-        requestId: permission.data.requestId,
-        action: isYolo ? 'approve' : action,
-        feedback,
-      });
+      const action = isYolo ? 'approve' : decision.action;
+      postPermissionMessage(
+        decision.action === 'reject'
+          ? {
+              command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+              requestId: data.requestId,
+              action,
+              ...(decision.feedback ? { feedback: decision.feedback } : {}),
+            }
+          : {
+              command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+              requestId: data.requestId,
+              action,
+            },
+      );
       // Only remove for terminal actions (approve/reject/approveSession).
       // Non-terminal actions like openDiff, previewProposed, showLatexdiff
       // just open editors without settling the approval.
-      if (action === 'approve' || action === 'reject' || isYolo) {
-        removePrompt(ctx, permission.kind, permission.data.requestId);
+      if (action === 'approve' || action === 'reject') {
+        removePrompt(ctx, detail.kind, data.requestId);
       }
       break;
     }
-    case PERMISSION_KIND.RETRY:
-      if (action === 'useOwnApiKey') {
+    case PERMISSION_KIND.BASH: {
+      const { data, decision } = detail;
+      const isYolo = decision.action === APPROVE_SESSION_ACTION;
+      if (isYolo && data.streamId) {
+        postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
+          stream: data.streamId,
+        });
+      }
+      postPermissionMessage(
+        decision.action === 'reject'
+          ? {
+              command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+              requestId: data.requestId,
+              action: decision.action,
+              ...(decision.feedback ? { feedback: decision.feedback } : {}),
+            }
+          : {
+              command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+              requestId: data.requestId,
+              action: 'approve',
+            },
+      );
+      removePrompt(ctx, detail.kind, data.requestId);
+      break;
+    }
+    case PERMISSION_KIND.RETRY: {
+      const { data, decision } = detail;
+      if (decision.action === 'useOwnApiKey') {
         // Non-terminal: panel stays open. The extension handler will
         // trigger retry on success, or leave the panel for the user
         // to choose Retry/Dismiss if the user cancels the key picker.
-        const exhaustionReason = permission.data.errorDetails?.exhaustionReason;
+        const exhaustionReason = data.errorDetails?.exhaustionReason;
         postMessage(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
-          stream: permission.data.streamId,
-          requestId: permission.data.requestId,
-          model: permission.data.model,
+          stream: data.streamId,
+          requestId: data.requestId,
+          model: data.model,
           exhaustionReason,
           // Subscription quota exhaustion always means the OpenAI key is the
           // fallback credential, regardless of how the error tagged provider.
           provider:
             exhaustionReason === 'chatgpt-subscription'
               ? 'openai'
-              : permission.data.errorDetails?.provider,
-          viaRelay:
-            permission.data.errorDetails?.isRelayError === true
-              ? true
-              : undefined,
+              : data.errorDetails?.provider,
+          viaRelay: data.errorDetails?.isRelayError === true ? true : undefined,
         });
         break;
       }
-      if (action === 'retry') {
+      if (decision.action === 'retry') {
         postMessage(PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST, {
-          stream: permission.data.streamId,
-          requestId: permission.data.requestId,
-          feedback,
+          stream: data.streamId,
+          requestId: data.requestId,
         });
       } else {
         postMessage(PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST, {
-          stream: permission.data.streamId,
-          requestId: permission.data.requestId,
+          stream: data.streamId,
+          requestId: data.requestId,
         });
       }
       // Optimistic removal
-      removePrompt(ctx, PERMISSION_KIND.RETRY, permission.data.streamId);
+      removePrompt(ctx, PERMISSION_KIND.RETRY, data.streamId);
       break;
+    }
     case PERMISSION_KIND.PROPOSAL: {
+      const { data, decision } = detail;
       // Approve-all accepts this proposal and enables delegated-task approval
       // for the rest of the stream. It never reaches the backend proposal
       // protocol (action stays approve|reject|setup). Enable the bypass BEFORE
@@ -380,81 +402,103 @@ export function handlePermissionAction(
       // auto-resolve the open proposal), and a toggle would then flip bypass back
       // OFF here — the opposite of "enable". Mirrors edit/bash ENABLE_APPROVAL_BYPASS.
       const approveAllDelegatedWork =
-        action === APPROVE_ALL_DELEGATED_WORK_ACTION;
+        decision.action === APPROVE_ALL_DELEGATED_WORK_ACTION;
       if (approveAllDelegatedWork) {
         postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS, {
-          stream: permission.data.streamId,
-          initiatingProposalId: permission.data.proposalId,
+          stream: data.streamId,
+          initiatingProposalId: data.proposalId,
         });
       }
-      postMessage(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
-        proposalId: permission.data.proposalId,
-        action: approveAllDelegatedWork ? 'approve' : action,
-        feedback,
-        model: modelOverride,
-        agent: agentOverride,
-      });
+      const message: ProgressViewInboundMessage =
+        decision.action === 'approve' || approveAllDelegatedWork
+          ? {
+              command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+              proposalId: data.proposalId,
+              action: 'approve',
+              ...(decision.model ? { model: decision.model } : {}),
+              ...(decision.agent ? { agent: decision.agent } : {}),
+            }
+          : decision.action === 'reject'
+            ? {
+                command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+                proposalId: data.proposalId,
+                action: 'reject',
+                ...(decision.feedback ? { feedback: decision.feedback } : {}),
+              }
+            : {
+                command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+                proposalId: data.proposalId,
+                action: 'setup',
+              };
+      postPermissionMessage(message);
       // Optimistic removal — track resolved ID so late SHOW is a no-op
       const removed = removePrompt(
         ctx,
         PERMISSION_KIND.PROPOSAL,
-        permission.data.proposalId,
+        data.proposalId,
       );
       if (!removed) {
-        addResolvedProposalId(permission.data.proposalId);
+        addResolvedProposalId(data.proposalId);
       }
       break;
     }
-    case PERMISSION_KIND.PLAN_APPROVAL:
-      postMessage(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION, {
-        approvalId: permission.data.approvalId,
-        action,
-        feedback,
-      });
-      removePrompt(
-        ctx,
-        PERMISSION_KIND.PLAN_APPROVAL,
-        permission.data.approvalId,
+    case PERMISSION_KIND.PLAN_APPROVAL: {
+      const { data, decision } = detail;
+      postPermissionMessage(
+        decision.action === 'reject'
+          ? {
+              command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+              approvalId: data.approvalId,
+              action: decision.action,
+              ...(decision.feedback ? { feedback: decision.feedback } : {}),
+            }
+          : {
+              command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+              approvalId: data.approvalId,
+              action: decision.action,
+            },
       );
+      removePrompt(ctx, PERMISSION_KIND.PLAN_APPROVAL, data.approvalId);
       break;
+    }
     case PERMISSION_KIND.EXTERNAL_INQUIRY: {
-      const { requestId } = permission.data;
-      // The host now packs `threadId` into `requestId` for the showExternalInquiry
-      // emit; the panel addresses inquiries by their durable thread id.
-      const threadId = (permission.data.threadId ?? requestId) as string;
-      if (action === 'submit' && answer !== undefined) {
-        postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+      const { data, decision } = detail;
+      if (decision.action === 'submit') {
+        postPermissionMessage({
+          command: PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION,
           action: 'submit',
-          threadId,
-          answer,
-          sessionLinks,
+          threadId: data.threadId,
+          answer: decision.answer,
+          ...(decision.sessionLinks
+            ? { sessionLinks: decision.sessionLinks }
+            : {}),
         });
       } else {
-        // 'reject' (and any other non-submit action) → drop the thread.
-        postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+        postPermissionMessage({
+          command: PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION,
           action: 'drop',
-          threadId,
-          feedback,
+          threadId: data.threadId,
+          ...(decision.feedback ? { feedback: decision.feedback } : {}),
         });
       }
-      removePrompt(ctx, PERMISSION_KIND.EXTERNAL_INQUIRY, requestId);
-      clearInquiryDraft(requestId);
+      removePrompt(ctx, PERMISSION_KIND.EXTERNAL_INQUIRY, data.requestId);
+      clearInquiryDraft(data.requestId);
       break;
     }
     case PERMISSION_KIND.USER_QUESTION: {
-      const { requestId } = permission.data;
-      const message =
-        action === 'submit'
-          ? answers
-            ? { requestId, action, answers }
-            : undefined
-          : action === 'reject' || action === 'skip'
-            ? { requestId, action, feedback }
-            : undefined;
-      if (!message) return;
-      postMessage(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION, message);
-      removePrompt(ctx, PERMISSION_KIND.USER_QUESTION, requestId);
+      const { data, decision } = detail;
+      postPermissionMessage({
+        command: PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
+        requestId: data.requestId,
+        ...decision,
+      });
+      removePrompt(ctx, PERMISSION_KIND.USER_QUESTION, data.requestId);
       break;
     }
   }
+}
+
+function postPermissionMessage(message: ProgressViewInboundMessage): void {
+  const { command, ...payload } = message;
+  postMessage(command, payload);
 }

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -91,7 +91,7 @@ type Decision<
 
 type RejectDecision = Decision<'reject', { feedback?: string }>;
 
-export interface PermissionDecisionByKind {
+interface PermissionDecisionByKind {
   toolEdit:
     | Decision<'approve'>
     | Decision<typeof APPROVE_SESSION_ACTION>

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -57,9 +57,8 @@ export interface FollowupCommandDetail {
  * button / `a` shortcut on the edit and bash approval prompts.
  * `handlePermissionAction` decomposes it into a normal approve plus a
  * session-bypass enable, so — unlike `approve` / `reject` / `openDiff` — it
- * never reaches the backend approval protocol (`BASH_APPROVAL_ACTIONS` /
- * `TOOL_EDIT_APPROVAL_ACTIONS` in `@shared/schemas`). Single source of truth
- * shared by the panel that emits it and the handler that consumes it.
+ * never reaches the backend approval protocol. Single source of truth shared
+ * by the panel that emits it and the handler that consumes it.
  */
 export const APPROVE_SESSION_ACTION = 'approveSession';
 
@@ -74,19 +73,97 @@ export const APPROVE_SESSION_ACTION = 'approveSession';
  */
 export const APPROVE_ALL_DELEGATED_WORK_ACTION = 'approveSuperYolo';
 
-export interface PermissionActionDetail {
-  permission: PermissionState;
-  action: string;
-  feedback?: string;
-  modelOverride?: string;
-  agentOverride?: string;
-  /** Answer text from external inquiry panel (submit action only). */
-  answer?: string;
-  /** External chat/thread links captured from the user (submit action only). */
-  sessionLinks?: string[];
-  /** Structured answers from the user-question panel (submit action only). */
-  answers?: UserQuestionAnswers;
+interface PermissionPayloadFields {
+  feedback: string;
+  model: string;
+  agent: string;
+  answer: string;
+  sessionLinks: string[];
+  answers: UserQuestionAnswers;
 }
+
+type Decision<
+  A extends string,
+  Payload extends Partial<PermissionPayloadFields> = object,
+> = { action: A } & Payload & {
+    [K in Exclude<keyof PermissionPayloadFields, keyof Payload>]?: never;
+  };
+
+type RejectDecision = Decision<'reject', { feedback?: string }>;
+
+export interface PermissionDecisionByKind {
+  toolEdit:
+    | Decision<'approve'>
+    | Decision<typeof APPROVE_SESSION_ACTION>
+    | RejectDecision
+    | Decision<'openDiff' | 'showLatexdiff' | 'previewProposed'>;
+  bash:
+    | Decision<'approve'>
+    | Decision<typeof APPROVE_SESSION_ACTION>
+    | RejectDecision;
+  retry: Decision<'retry' | 'useOwnApiKey' | 'cancel'>;
+  proposal:
+    | Decision<
+        'approve',
+        {
+          model?: string;
+          agent?: string;
+        }
+      >
+    | Decision<
+        typeof APPROVE_ALL_DELEGATED_WORK_ACTION,
+        {
+          model?: string;
+          agent?: string;
+        }
+      >
+    | RejectDecision
+    | Decision<'setup'>;
+  planApproval:
+    Decision<'approve'> | Decision<'approve_and_goal'> | RejectDecision;
+  externalInquiry:
+    | Decision<
+        'submit',
+        {
+          answer: string;
+          sessionLinks?: string[];
+        }
+      >
+    | RejectDecision;
+  userQuestion:
+    | Decision<'submit', { answers: UserQuestionAnswers }>
+    | RejectDecision
+    | Decision<'skip', { feedback?: string }>;
+}
+
+export type PermissionKind = keyof PermissionDecisionByKind;
+
+export type PermissionDecision<K extends PermissionKind> =
+  PermissionDecisionByKind[K];
+
+type PermissionKindsWithAction<A extends string> = {
+  [K in PermissionKind]: Extract<
+    PermissionDecisionByKind[K],
+    { action: A }
+  > extends never
+    ? never
+    : K;
+}[PermissionKind];
+
+export type FeedbackPermissionKind = PermissionKindsWithAction<'reject'>;
+export type ApprovalPermissionKind = PermissionKindsWithAction<'approve'>;
+export type ApprovalDecision<K extends ApprovalPermissionKind> = Extract<
+  PermissionDecisionByKind[K],
+  { action: 'approve' }
+>;
+
+/** A permission and the only decisions valid for that permission kind. */
+export type PermissionActionDetail<K extends PermissionKind = PermissionKind> =
+  {
+    [P in K]: Extract<PermissionState, { kind: P }> & {
+      decision: PermissionDecision<P>;
+    };
+  }[K];
 
 /**
  * Detail for file-related actions in ProgressView.
@@ -143,8 +220,10 @@ export const ProgressEvents = {
 
   compileFixerRun: () => createEvent('compile-fixer-run', undefined),
 
-  permissionAction: (detail: PermissionActionDetail) =>
-    createEvent('permission-action', detail),
+  permissionAction: <K extends PermissionKind>(
+    permission: Extract<PermissionState, { kind: K }>,
+    decision: PermissionDecision<K>,
+  ) => createEvent('permission-action', { ...permission, decision }),
 
   groupToggle: (detail: { groupId: string; expanded: boolean }) =>
     createEvent('group-toggle', detail),

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -9,10 +9,11 @@ import type { TaskState } from '@agent/core/state/TaskState';
 import type { AgentProposal, AgentProposalPermission } from '@shared/schemas';
 import type { ProgressAgentProposalActionMessage } from '@shared/schemas/progressView';
 
-type AgentProposalActionInput = Omit<
-  ProgressAgentProposalActionMessage,
-  'command'
->;
+type WithoutCommand<Message> = Message extends unknown
+  ? Omit<Message, 'command'>
+  : never;
+type AgentProposalActionInput =
+  WithoutCommand<ProgressAgentProposalActionMessage>;
 
 export interface ProgressAgentProposalControllerDeps {
   getPendingProposal(proposalId: string): AgentProposalPermission | undefined;
@@ -43,8 +44,6 @@ export class ProgressAgentProposalController {
           ...(input.feedback ? { feedback: input.feedback } : {}),
         });
         return true;
-      default:
-        return false;
     }
   }
 

--- a/src/shared/schemas/progressView/inbound.ts
+++ b/src/shared/schemas/progressView/inbound.ts
@@ -19,13 +19,7 @@ import {
   InquiryDropActionSchema,
   InquirySubmitActionSchema,
 } from '../inquiry';
-import {
-  AgentProposalSchema,
-  BASH_APPROVAL_ACTIONS,
-  PLAN_APPROVAL_ACTIONS,
-  TOOL_EDIT_APPROVAL_ACTIONS,
-  UserQuestionAnswersSchema,
-} from '../prompts';
+import { AgentProposalSchema, UserQuestionAnswersSchema } from '../prompts';
 import { AgentCategoryFilterSchema, StreamScopedBaseSchema } from './data';
 import { GettingStartedActionSchema } from '../mainView/state';
 import { ExhaustionReasonSchema } from '../errors';
@@ -124,38 +118,78 @@ const ShowInformationMessageSchema = z.object({
   text: TrimmedStringSchema,
 });
 
-const ToolEditApprovalActionMessageSchema = z.object({
+const ToolEditActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION),
   requestId: z.string().min(1),
-  action: z.enum(TOOL_EDIT_APPROVAL_ACTIONS),
-  feedback: z.string().optional(),
-});
+};
+const ToolEditApprovalActionMessageSchema = z.discriminatedUnion('action', [
+  z.strictObject({
+    ...ToolEditActionMessageBase,
+    action: z.enum(['approve', 'openDiff', 'showLatexdiff', 'previewProposed']),
+  }),
+  z.strictObject({
+    ...ToolEditActionMessageBase,
+    action: z.literal('reject'),
+    feedback: z.string().optional(),
+  }),
+]);
 
-const BashApprovalActionMessageSchema = z.object({
+const BashActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION),
   requestId: z.string().min(1),
-  action: z.enum(BASH_APPROVAL_ACTIONS),
-  feedback: z.string().optional(),
-});
+};
+const BashApprovalActionMessageSchema = z.discriminatedUnion('action', [
+  z.strictObject({
+    ...BashActionMessageBase,
+    action: z.literal('approve'),
+  }),
+  z.strictObject({
+    ...BashActionMessageBase,
+    action: z.literal('reject'),
+    feedback: z.string().optional(),
+  }),
+]);
 
-const AgentProposalActionMessageSchema = z.object({
+const ProposalActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION),
   proposalId: z.string().min(1),
-  action: z.enum(['approve', 'reject', 'setup']),
-  feedback: z.string().optional(),
-  model: z.string().optional(),
-  agent: z.string().optional(),
-});
+};
+const AgentProposalActionMessageSchema = z.discriminatedUnion('action', [
+  z.strictObject({
+    ...ProposalActionMessageBase,
+    action: z.literal('approve'),
+    model: z.string().optional(),
+    agent: z.string().optional(),
+  }),
+  z.strictObject({
+    ...ProposalActionMessageBase,
+    action: z.literal('reject'),
+    feedback: z.string().optional(),
+  }),
+  z.strictObject({
+    ...ProposalActionMessageBase,
+    action: z.literal('setup'),
+  }),
+]);
 export type ProgressAgentProposalActionMessage = z.infer<
   typeof AgentProposalActionMessageSchema
 >;
 
-const PlanApprovalActionMessageSchema = z.object({
+const PlanActionMessageBase = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION),
   approvalId: z.string().min(1),
-  action: z.enum(PLAN_APPROVAL_ACTIONS),
-  feedback: z.string().optional(),
-});
+};
+const PlanApprovalActionMessageSchema = z.discriminatedUnion('action', [
+  z.strictObject({
+    ...PlanActionMessageBase,
+    action: z.enum(['approve', 'approve_and_goal']),
+  }),
+  z.strictObject({
+    ...PlanActionMessageBase,
+    action: z.literal('reject'),
+    feedback: z.string().optional(),
+  }),
+]);
 
 const ExternalInquiryActionMessageSchema = z.discriminatedUnion('action', [
   InquirySubmitActionSchema.extend({

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -198,29 +198,10 @@ export type UserQuestionPermission = z.infer<
 // Plan Approval
 // ============================================================================
 
-export const PLAN_APPROVAL_ACTIONS = [
-  'approve',
-  'reject',
-  'approve_and_goal',
-] as const;
-export type PlanApprovalAction = (typeof PLAN_APPROVAL_ACTIONS)[number];
+export type PlanApprovalAction = 'approve' | 'reject' | 'approve_and_goal';
 
-// Tool-edit and bash approval action sets live here (the schema layer) so the
-// IPC schema (progressView/inbound) and the runtime approval modules
-// (@tools/approval/*) share one definition. The schema layer has no @tools/
-// @agent imports, so the runtime modules import these without a cycle, and the
-// IPC schema never pulls runtime code into the renderer bundle.
-export const TOOL_EDIT_APPROVAL_ACTIONS = [
-  'approve',
-  'reject',
-  'openDiff',
-  'showLatexdiff',
-  'previewProposed',
-] as const;
 export type ToolEditApprovalAction =
-  (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
-
-export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
+  'approve' | 'reject' | 'openDiff' | 'showLatexdiff' | 'previewProposed';
 
 export const PlanApprovalPermissionSchema = z.strictObject({
   approvalId: z.string(),

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -7,16 +7,3 @@ export const PERMISSION_KIND = {
   EXTERNAL_INQUIRY: 'externalInquiry',
   USER_QUESTION: 'userQuestion',
 } as const;
-
-export type PermissionKind =
-  (typeof PERMISSION_KIND)[keyof typeof PERMISSION_KIND];
-
-/** Permission kinds that support rejection feedback */
-export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
-  PERMISSION_KIND.TOOL_EDIT,
-  PERMISSION_KIND.BASH,
-  PERMISSION_KIND.PROPOSAL,
-  PERMISSION_KIND.PLAN_APPROVAL,
-  PERMISSION_KIND.EXTERNAL_INQUIRY,
-  PERMISSION_KIND.USER_QUESTION,
-]);

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -645,7 +645,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
         {
           command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
           proposalId: 'proposal-1',
-          action: 'setup',
+          action: 'approve',
           agent: 'review',
           model: 'deepseek',
         },
@@ -680,7 +680,7 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     expect(actions.approval.handleAgentProposalAction).toHaveBeenCalledWith({
       command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
       proposalId: 'proposal-1',
-      action: 'setup',
+      action: 'approve',
       agent: 'review',
       model: 'deepseek',
     });
@@ -768,6 +768,102 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     expect(
       actions.approval.onUnsupportedToolEditApproval,
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('permission action schemas', () => {
+  const tool = {
+    command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+    requestId: 'edit-1',
+  };
+  const bash = {
+    command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+    requestId: 'bash-1',
+  };
+  const proposal = {
+    command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+    proposalId: 'proposal-1',
+  };
+  const plan = {
+    command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+    approvalId: 'plan-1',
+  };
+
+  it.each([
+    ['tool approve', { ...tool, action: 'approve' }, true],
+    ['tool reject', { ...tool, action: 'reject', feedback: 'No' }, true],
+    ['tool open diff', { ...tool, action: 'openDiff' }, true],
+    ['tool show latexdiff', { ...tool, action: 'showLatexdiff' }, true],
+    ['tool preview proposed', { ...tool, action: 'previewProposed' }, true],
+    [
+      'tool approve with feedback',
+      { ...tool, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'tool inspection with feedback',
+      { ...tool, action: 'openDiff', feedback: 'x' },
+      false,
+    ],
+    ['tool unknown field', { ...tool, action: 'approve', extra: true }, false],
+    ['bash approve', { ...bash, action: 'approve' }, true],
+    ['bash reject', { ...bash, action: 'reject', feedback: 'No' }, true],
+    ['bash tool action', { ...bash, action: 'openDiff' }, false],
+    [
+      'bash approve with feedback',
+      { ...bash, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    ['bash unknown field', { ...bash, action: 'reject', extra: true }, false],
+    [
+      'proposal approve',
+      { ...proposal, action: 'approve', model: 'm', agent: 'a' },
+      true,
+    ],
+    [
+      'proposal reject',
+      { ...proposal, action: 'reject', feedback: 'No' },
+      true,
+    ],
+    ['proposal setup', { ...proposal, action: 'setup' }, true],
+    [
+      'proposal approve with feedback',
+      { ...proposal, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'proposal reject with model',
+      { ...proposal, action: 'reject', model: 'm' },
+      false,
+    ],
+    [
+      'proposal setup with agent',
+      { ...proposal, action: 'setup', agent: 'a' },
+      false,
+    ],
+    [
+      'proposal unknown field',
+      { ...proposal, action: 'setup', extra: true },
+      false,
+    ],
+    ['plan approve', { ...plan, action: 'approve' }, true],
+    ['plan approve and run', { ...plan, action: 'approve_and_goal' }, true],
+    ['plan reject', { ...plan, action: 'reject', feedback: 'No' }, true],
+    [
+      'plan approve with feedback',
+      { ...plan, action: 'approve', feedback: 'x' },
+      false,
+    ],
+    [
+      'plan run with feedback',
+      { ...plan, action: 'approve_and_goal', feedback: 'x' },
+      false,
+    ],
+    ['plan unknown field', { ...plan, action: 'reject', extra: true }, false],
+  ])('%s parses as %s', (_name, message, valid) => {
+    expect(ProgressViewInboundMessageSchema.safeParse(message).success).toBe(
+      valid,
+    );
   });
 });
 

--- a/src/test-kernel/progressView/BashRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/BashRequestPanel.vitest.mts
@@ -46,19 +46,22 @@ function querySplitButton(element: BashRequestPanel): ApproveSplit | null {
   );
 }
 
-function recordPermissionActions(element: BashRequestPanel): string[] {
-  const actions: string[] = [];
+function recordPermissionActions(
+  element: BashRequestPanel,
+): Array<{ action: string }> {
+  const actions: Array<{ action: string }> = [];
   element.addEventListener('permission-action', (event) => {
-    actions.push((event as CustomEvent<{ action: string }>).detail.action);
+    actions.push(
+      (event as CustomEvent<{ decision: { action: string } }>).detail.decision,
+    );
   });
   return actions;
 }
 
 // Parity with ToolEditRequestPanel: the bash panel gets the Yolo affordance
-// entirely from shared BaseFeedbackPanel logic (`canBypass`, the `a` shortcut in
-// `handleKeyboardShortcut`, and the `<approve-split-button>` in
-// `renderApproveButton`), so these tests guard that the bash panel wires it up
-// — a base-class regression would not be caught by the tool-edit tests alone.
+// entirely from shared BaseBypassApprovalPanel logic, so these tests guard that
+// the bash panel wires it up — a base-class regression would not be caught by
+// the tool-edit tests alone.
 describe('bash-request-panel', () => {
   useLitComponentTestDom(
     () => import('@progressView/frontend/components/BashRequestPanel'),
@@ -95,6 +98,6 @@ describe('bash-request-panel', () => {
     expect(split?.canBypass).toBe(true);
 
     expect(element.handleKeyboardShortcut('a')).toBe(true);
-    expect(actions).toEqual(['approveSession']);
+    expect(actions).toEqual([{ action: 'approveSession' }]);
   });
 });

--- a/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
+++ b/src/test-kernel/progressView/ExternalInquiryPanelTextarea.vitest.mts
@@ -64,7 +64,10 @@ function recordPermissionActions(
 ): Record<string, unknown>[] {
   const actions: Record<string, unknown>[] = [];
   element.addEventListener('permission-action', (event) => {
-    actions.push((event as CustomEvent<Record<string, unknown>>).detail);
+    actions.push(
+      (event as CustomEvent<{ decision: Record<string, unknown> }>).detail
+        .decision,
+    );
   });
   return actions;
 }
@@ -137,7 +140,6 @@ describe('external-inquiry-panel answer/session-link inputs', () => {
 
     expect(actions).toEqual([
       {
-        permission: element.permission,
         action: 'submit',
         answer: 'the answer',
         sessionLinks: ['https://chatgpt.com/c/abc'],

--- a/src/test-kernel/progressView/PermissionActionDetails.vitest.ts
+++ b/src/test-kernel/progressView/PermissionActionDetails.vitest.ts
@@ -1,0 +1,78 @@
+// Third-party imports
+import { expectTypeOf, it } from 'vitest';
+
+// Local imports - progress view events
+import {
+  ProgressEvents,
+  type PermissionActionDetail,
+  type PermissionDecision,
+} from '@progressView/frontend/events';
+
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type DetailFor<K extends PermissionActionDetail['kind']> = Extract<
+  PermissionActionDetail,
+  { kind: K }
+>;
+
+it('makes contradictory permission decisions unrepresentable', () => {
+  expectTypeOf<
+    IsAssignable<{ action: 'approve' }, PermissionDecision<'externalInquiry'>>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'submit' }, PermissionDecision<'userQuestion'>>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'reject'; model: string },
+      PermissionDecision<'proposal'>
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'setup'; agent: string },
+      PermissionDecision<'proposal'>
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'openDiff'; feedback: string },
+      PermissionDecision<'toolEdit'>
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'openDiff' }, PermissionDecision<'bash'>>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'approve'; feedback: string },
+      PermissionDecision<'planApproval'>
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      { action: 'cancel'; feedback: string },
+      PermissionDecision<'retry'>
+    >
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<
+      {
+        kind: 'proposal';
+        data: DetailFor<'proposal'>['data'];
+        decision: { action: 'openDiff' };
+      },
+      PermissionActionDetail
+    >
+  >().toEqualTypeOf<false>();
+});
+
+it('keeps the event factory permission and decision kinds correlated', () => {
+  const invalidFactoryCall = (
+    proposal: Omit<DetailFor<'proposal'>, 'decision'>,
+  ): void => {
+    // @ts-expect-error A proposal cannot emit a tool-edit decision.
+    ProgressEvents.permissionAction(proposal, { action: 'openDiff' });
+  };
+
+  expectTypeOf(invalidFactoryCall).toBeFunction();
+});

--- a/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
+++ b/src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts
@@ -1,0 +1,421 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clearInquiryDraft: vi.fn(),
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({ postMessage: mocks.postMessage }));
+vi.mock('@progressView/frontend/components/ExternalInquiryPanel', () => ({
+  clearInquiryDraft: mocks.clearInquiryDraft,
+}));
+
+// Local imports - progress view
+import { handlePermissionAction } from '@progressView/frontend/eventHandlers';
+import {
+  APPROVE_ALL_DELEGATED_WORK_ACTION,
+  APPROVE_SESSION_ACTION,
+  type PermissionActionDetail,
+  type PermissionDecision,
+} from '@progressView/frontend/events';
+import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
+import type { PermissionState } from '@progressView/frontend/permissionState';
+import { createInitialState } from '@progressView/frontend/store';
+
+// Local imports - shared contracts
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { AgentCategory } from '@shared/schemas';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+
+type PostedCall = [command: string, payload: Record<string, unknown>];
+type PermissionCase = {
+  name: string;
+  detail: PermissionActionDetail;
+  calls: PostedCall[];
+  remains?: boolean;
+  clearedDraft?: string;
+};
+
+const toolData = {
+  requestId: 'tool-1',
+  streamId: 'stream-1',
+  allowBypass: true,
+  path: '/workspace/paper.tex',
+  relativePath: 'paper.tex',
+  sourceTool: 'edit_file',
+  addedLines: 2,
+  removedLines: 1,
+  isLatex: true,
+};
+const bashData = {
+  requestId: 'bash-1',
+  streamId: 'stream-1',
+  allowBypass: true,
+  command: 'npm test',
+};
+const retryData = {
+  requestId: 'retry-1',
+  streamId: 'stream-1',
+  operation: 'stream response',
+  model: 'claude-sonnet',
+};
+const proposalData = {
+  proposalId: 'proposal-1',
+  streamId: 'stream-1',
+  agentCategory: AgentCategory.ToolUse,
+  agent: 'researcher',
+  agentSource: null,
+  model: 'claude-sonnet',
+  instruction: 'Check the references.',
+  memories: [],
+  workingDirectory: null,
+  rootUserInstruction: null,
+};
+const planData = {
+  approvalId: 'plan-1',
+  streamId: 'stream-1',
+  plan: { objective: 'Finish the refactor and verify it.' },
+  goalEnabled: true,
+};
+const inquiryData = {
+  requestId: 'inquiry-1',
+  streamId: 'stream-1',
+  allowBypass: false,
+  mode: 'new' as const,
+  question: 'Which source should I use?',
+  threadId: 'ei_0123456789ab',
+  context: null,
+  suggestSearch: null,
+  attachFiles: null,
+  sessionLinks: null,
+  draft: null,
+  transcript: null,
+};
+const questionData = {
+  requestId: 'question-1',
+  streamId: 'stream-1',
+  allowBypass: false,
+  questions: [
+    {
+      question: 'Choose a format',
+      options: [{ label: 'Short' }, { label: 'Detailed' }],
+    },
+  ],
+  context: null,
+};
+
+const detail = {
+  tool: (decision: PermissionDecision<'toolEdit'>) =>
+    ({ kind: PERMISSION_KIND.TOOL_EDIT, data: toolData, decision }) as const,
+  bash: (decision: PermissionDecision<'bash'>) =>
+    ({ kind: PERMISSION_KIND.BASH, data: bashData, decision }) as const,
+  retry: (decision: PermissionDecision<'retry'>) =>
+    ({ kind: PERMISSION_KIND.RETRY, data: retryData, decision }) as const,
+  proposal: (decision: PermissionDecision<'proposal'>) =>
+    ({
+      kind: PERMISSION_KIND.PROPOSAL,
+      data: proposalData,
+      decision,
+    }) as const,
+  plan: (decision: PermissionDecision<'planApproval'>) =>
+    ({
+      kind: PERMISSION_KIND.PLAN_APPROVAL,
+      data: planData,
+      decision,
+    }) as const,
+  inquiry: (decision: PermissionDecision<'externalInquiry'>) =>
+    ({
+      kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
+      data: inquiryData,
+      decision,
+    }) as const,
+  question: (decision: PermissionDecision<'userQuestion'>) =>
+    ({
+      kind: PERMISSION_KIND.USER_QUESTION,
+      data: questionData,
+      decision,
+    }) as const,
+};
+
+const call = (
+  command: string,
+  payload: Record<string, unknown>,
+): PostedCall => [command, payload];
+
+const actionCases: PermissionCase[] = [
+  {
+    name: 'tool approve',
+    detail: detail.tool({ action: 'approve' }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION, {
+        requestId: 'tool-1',
+        action: 'approve',
+      }),
+    ],
+  },
+  {
+    name: 'tool session approve enables bypass first',
+    detail: detail.tool({ action: APPROVE_SESSION_ACTION }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
+        stream: 'stream-1',
+      }),
+      call(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION, {
+        requestId: 'tool-1',
+        action: 'approve',
+      }),
+    ],
+  },
+  {
+    name: 'tool reject',
+    detail: detail.tool({ action: 'reject', feedback: 'Keep the original.' }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION, {
+        requestId: 'tool-1',
+        action: 'reject',
+        feedback: 'Keep the original.',
+      }),
+    ],
+  },
+  ...(['openDiff', 'showLatexdiff', 'previewProposed'] as const).map(
+    (action): PermissionCase => ({
+      name: `tool ${action} remains open`,
+      detail: detail.tool({ action }),
+      calls: [
+        call(PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION, {
+          requestId: 'tool-1',
+          action,
+        }),
+      ],
+      remains: true,
+    }),
+  ),
+  ...(['approve', 'reject'] as const).map((action): PermissionCase => ({
+    name: `bash ${action}`,
+    detail: detail.bash(
+      action === 'reject'
+        ? { action, feedback: 'Use a safer command.' }
+        : { action },
+    ),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION, {
+        requestId: 'bash-1',
+        action,
+        ...(action === 'reject' ? { feedback: 'Use a safer command.' } : {}),
+      }),
+    ],
+  })),
+  {
+    name: 'bash session approve enables bypass first',
+    detail: detail.bash({ action: APPROVE_SESSION_ACTION }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
+        stream: 'stream-1',
+      }),
+      call(PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION, {
+        requestId: 'bash-1',
+        action: 'approve',
+      }),
+    ],
+  },
+  ...(['retry', 'cancel'] as const).map((action): PermissionCase => ({
+    name: `retry ${action}`,
+    detail: detail.retry({ action }),
+    calls: [
+      call(
+        action === 'retry'
+          ? PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST
+          : PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST,
+        { stream: 'stream-1', requestId: 'retry-1' },
+      ),
+    ],
+  })),
+  {
+    name: 'retry API-key selection remains open',
+    detail: detail.retry({ action: 'useOwnApiKey' }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
+        stream: 'stream-1',
+        requestId: 'retry-1',
+        model: 'claude-sonnet',
+        exhaustionReason: undefined,
+        provider: undefined,
+        viaRelay: undefined,
+      }),
+    ],
+    remains: true,
+  },
+  {
+    name: 'proposal approve',
+    detail: detail.proposal({
+      action: 'approve',
+      model: 'gpt-5',
+      agent: 'reviewer',
+    }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
+        proposalId: 'proposal-1',
+        action: 'approve',
+        model: 'gpt-5',
+        agent: 'reviewer',
+      }),
+    ],
+  },
+  {
+    name: 'proposal delegated approval enables bypass first',
+    detail: detail.proposal({
+      action: APPROVE_ALL_DELEGATED_WORK_ACTION,
+      model: 'gpt-5',
+      agent: 'reviewer',
+    }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS, {
+        stream: 'stream-1',
+        initiatingProposalId: 'proposal-1',
+      }),
+      call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, {
+        proposalId: 'proposal-1',
+        action: 'approve',
+        model: 'gpt-5',
+        agent: 'reviewer',
+      }),
+    ],
+  },
+  ...(
+    [
+      [{ action: 'setup' }, { proposalId: 'proposal-1', action: 'setup' }],
+      [
+        { action: 'reject', feedback: 'Use the existing agent.' },
+        {
+          proposalId: 'proposal-1',
+          action: 'reject',
+          feedback: 'Use the existing agent.',
+        },
+      ],
+    ] as const
+  ).map(([decision, payload]): PermissionCase => ({
+    name: `proposal ${decision.action}`,
+    detail: detail.proposal(decision),
+    calls: [call(PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION, payload)],
+  })),
+  ...(
+    [
+      [{ action: 'approve' }, { approvalId: 'plan-1', action: 'approve' }],
+      [
+        { action: 'approve_and_goal' },
+        { approvalId: 'plan-1', action: 'approve_and_goal' },
+      ],
+      [
+        { action: 'reject', feedback: 'Add verification.' },
+        {
+          approvalId: 'plan-1',
+          action: 'reject',
+          feedback: 'Add verification.',
+        },
+      ],
+    ] as const
+  ).map(([decision, payload]): PermissionCase => ({
+    name: `plan ${decision.action}`,
+    detail: detail.plan(decision),
+    calls: [call(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION, payload)],
+  })),
+  {
+    name: 'external inquiry submit',
+    detail: detail.inquiry({
+      action: 'submit',
+      answer: 'Use the project documentation.',
+      sessionLinks: ['session-7'],
+    }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+        action: 'submit',
+        threadId: 'ei_0123456789ab',
+        answer: 'Use the project documentation.',
+        sessionLinks: ['session-7'],
+      }),
+    ],
+    clearedDraft: 'inquiry-1',
+  },
+  {
+    name: 'external inquiry reject',
+    detail: detail.inquiry({ action: 'reject', feedback: 'Not needed.' }),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+        action: 'drop',
+        threadId: 'ei_0123456789ab',
+        feedback: 'Not needed.',
+      }),
+    ],
+    clearedDraft: 'inquiry-1',
+  },
+  ...(
+    [
+      { action: 'submit', answers: { 'Choose a format': 'Short' } },
+      { action: 'reject', feedback: 'Ask later.' },
+      { action: 'skip', feedback: 'Use the default.' },
+    ] as const
+  ).map((decision): PermissionCase => ({
+    name: `user question ${decision.action}`,
+    detail: detail.question(decision),
+    calls: [
+      call(PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION, {
+        requestId: 'question-1',
+        ...decision,
+      }),
+    ],
+  })),
+];
+
+function permissionFrom(detail: PermissionActionDetail): PermissionState {
+  const { decision: _decision, ...permission } = detail;
+  return permission;
+}
+
+function createContext(permission: PermissionState): {
+  ctx: MessageHandlerContext;
+  permissions: () => PermissionState[];
+} {
+  let state = createInitialState();
+  let permissions = [permission];
+  return {
+    ctx: {
+      getState: () => state,
+      setState: (updater) => {
+        state = updater(state);
+      },
+      setStreamState: () => {},
+      setStreamLogs: () => {},
+      getPermissions: () => permissions,
+      setPermissions: (next) => {
+        permissions = next;
+      },
+      setPlacement: () => {},
+    },
+    permissions: () => permissions,
+  };
+}
+
+describe('permission action event handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(actionCases)('$name', ({ detail, calls, remains, clearedDraft }) => {
+    const permission = permissionFrom(detail);
+    const { ctx, permissions } = createContext(permission);
+
+    handlePermissionAction(
+      { detail } as CustomEvent<PermissionActionDetail>,
+      ctx,
+    );
+
+    expect(mocks.postMessage.mock.calls).toEqual(calls);
+    expect(permissions()).toEqual(remains ? [permission] : []);
+    if (clearedDraft) {
+      expect(mocks.clearInquiryDraft).toHaveBeenCalledWith(clearedDraft);
+    } else {
+      expect(mocks.clearInquiryDraft).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
@@ -77,7 +77,9 @@ function recordPermissionActions(
 ): Array<{ action: string }> {
   const actions: Array<{ action: string }> = [];
   element.addEventListener('permission-action', (event) => {
-    actions.push((event as CustomEvent<{ action: string }>).detail);
+    actions.push(
+      (event as CustomEvent<{ decision: { action: string } }>).detail.decision,
+    );
   });
   return actions;
 }
@@ -115,10 +117,49 @@ describe('proposal-request-panel file-name keyboard activation', () => {
     expect(element.handleKeyboardShortcut('a')).toBe(true);
     expect(element.handleKeyboardShortcut('y')).toBe(true);
 
-    expect(actions.map(({ action }) => action)).toEqual([
-      'approveSuperYolo',
-      'approveSuperYolo',
-      'approve',
+    expect(actions).toEqual([
+      { action: 'approveSuperYolo' },
+      { action: 'approveSuperYolo' },
+      { action: 'approve' },
+    ]);
+  });
+
+  it('attaches selected overrides only to approval decisions', async () => {
+    const permission = createPermission();
+    permission.modelOptions = [
+      { value: 'sonnet', label: 'Sonnet' },
+      { value: 'opus', label: 'Opus' },
+    ];
+    permission.agentOptions = [
+      { value: 'writer', label: 'Writer' },
+      { value: 'reviewer', label: 'Reviewer' },
+    ];
+    const element = await mountPanel(permission);
+    const actions = recordPermissionActions(element);
+    const modelSelect = element.shadowRoot?.querySelector(
+      '.proposal-model-dropdown',
+    ) as HTMLElement & { value?: string };
+    const agentSelect = element.shadowRoot?.querySelector(
+      '.proposal-agent-dropdown',
+    ) as HTMLElement & { value?: string };
+
+    modelSelect.value = 'opus';
+    modelSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    agentSelect.value = 'reviewer';
+    agentSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(element.handleKeyboardShortcut('y')).toBe(true);
+    expect(element.handleKeyboardShortcut('a')).toBe(true);
+    expect(element.handleKeyboardShortcut('s')).toBe(true);
+    expect(element.handleKeyboardShortcut('n')).toBe(true);
+    await element.updateComplete;
+    expect(element.handleKeyboardShortcut('n')).toBe(true);
+
+    expect(actions).toEqual([
+      { action: 'approve', model: 'opus', agent: 'reviewer' },
+      { action: 'approveSuperYolo', model: 'opus', agent: 'reviewer' },
+      { action: 'setup' },
+      { action: 'reject' },
     ]);
   });
 

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -56,10 +56,14 @@ function querySplitButton(element: ToolEditRequestPanel): ApproveSplit | null {
   );
 }
 
-function recordPermissionActions(element: ToolEditRequestPanel): string[] {
-  const actions: string[] = [];
+function recordPermissionActions(
+  element: ToolEditRequestPanel,
+): Array<{ action: string }> {
+  const actions: Array<{ action: string }> = [];
   element.addEventListener('permission-action', (event) => {
-    actions.push((event as CustomEvent<{ action: string }>).detail.action);
+    actions.push(
+      (event as CustomEvent<{ decision: { action: string } }>).detail.decision,
+    );
   });
   return actions;
 }
@@ -132,7 +136,7 @@ describe('tool-edit-request-panel', () => {
     expect(split?.canBypass).toBe(true);
 
     expect(element.handleKeyboardShortcut('a')).toBe(true);
-    expect(actions).toEqual(['approveSession']);
+    expect(actions).toEqual([{ action: 'approveSession' }]);
   });
 
   it('ignores "a" while the rejection feedback box is open', async () => {

--- a/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
+++ b/src/test-kernel/progressView/UserQuestionPanel.vitest.mts
@@ -108,10 +108,24 @@ async function mountPanel(
   return element;
 }
 
-function collectActions(element: UserQuestionPanel): string[] {
-  const actions: string[] = [];
+function collectActions(
+  element: UserQuestionPanel,
+): Array<{ action: string; answers?: Record<string, string | string[]> }> {
+  const actions: Array<{
+    action: string;
+    answers?: Record<string, string | string[]>;
+  }> = [];
   element.addEventListener('permission-action', (event) => {
-    actions.push((event as CustomEvent<{ action: string }>).detail.action);
+    actions.push(
+      (
+        event as CustomEvent<{
+          decision: {
+            action: string;
+            answers?: Record<string, string | string[]>;
+          };
+        }>
+      ).detail.decision,
+    );
   });
   return actions;
 }
@@ -186,7 +200,9 @@ describe('user-question-panel', () => {
 
     const actions = collectActions(element);
     element.handleKeyboardShortcut('y');
-    expect(actions).toEqual(['submit']);
+    expect(actions).toEqual([
+      { action: 'submit', answers: { 'Pick any': ['Red', 'Blue'] } },
+    ]);
   });
 
   it('renders single-select options as wa-radio-group/wa-radio with no native inputs', async () => {
@@ -215,6 +231,8 @@ describe('user-question-panel', () => {
 
     const actions = collectActions(element);
     element.handleKeyboardShortcut('y');
-    expect(actions).toEqual(['submit']);
+    expect(actions).toEqual([
+      { action: 'submit', answers: { 'Pick one': 'No' } },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- replace the generic progress permission event bag and positional optional arguments with a kind-indexed decision union
- split request panels by capability so feedback-only panels cannot inherit approval behavior, while edit and bash panels own session bypass
- enforce strict discriminated inbound schemas for tool, bash, proposal, and plan actions
- remove dead feedback-kind sets and runtime action arrays exposed by the exact contracts
- keep extension and desktop behavior aligned through the shared typed handler

## Design

The top-level permission kind now narrows both its data and its exact decision. Decision arms forbid irrelevant payload keys at compile time, while strict Zod variants reject them at the host boundary. Frontend-only session and delegated-work approvals decompose into an ordinary approval plus an ordered bypass-enable message before reaching the backend protocol.

This removes the BaseRequestPanel positional API, the proposal emitAction override, runtime feedback eligibility checks, fallback handling for impossible inquiry/question actions, and non-distributive proposal input typing.

## Verification

- npm run format
- CI=true npm run typecheck
- CI=true npm run lint (0 errors; 51 existing warnings)
- CI=true npm run compile:fast
- CI=true npm run check:dead-code-ratchet
- 96 focused schema, type, handler, and panel tests
- CI=true npm test: 702 files passed, 1 skipped; 6,359 tests passed, 4 skipped
- independent production and test-gap reviews

No changelog entry: this is an internal contract refactor with no intended user-visible behavior change.

Closes #8537

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all approval and prompt IPC paths and panel shortcuts, but behavior is intended unchanged and guarded by broad schema, handler, and panel tests.
> 
> **Overview**
> Replaces the progress view’s loose **permission-action** payload (a string `action` plus optional side fields) with a **kind-indexed `decision` union**, so each permission type only allows valid actions and payloads at compile time and in events.
> 
> Request panels are split by capability: **feedback-only** behavior stays on `BaseFeedbackPanel`, **approve/reject shells** move to `BaseApprovalPanel`, and **edit/bash session bypass (“Yolo”)** live on `BaseBypassApprovalPanel`. Panels call `emitAction` with a typed decision object instead of positional `emitAction(action, feedback, …)` or ad-hoc `dispatchEvent` bypasses.
> 
> `handlePermissionAction` is rewritten around `detail.kind` + `detail.decision`, building **strict IPC messages** via a shared `postPermissionMessage` helper. Inbound Zod schemas for tool, bash, proposal, and plan actions become **discriminated unions** that reject wrong fields per action (e.g. feedback only on reject). Runtime **action arrays** and **feedback-eligible kind sets** are removed in favor of the new contracts. Extension and desktop wire the same typed `PermissionActionDetail` listener.
> 
> Tests add schema matrix coverage, handler parity cases, and compile-time checks that contradictory decisions are unrepresentable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411b014e8d0d8eba88b3efe6d5df8400c22d7d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->