### PR TITLE
refactor: remove impossible tool-edit action fallback

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -503,14 +503,6 @@ export class DesktopProgressBridge {
             ),
           handleToolEditApprovalAction: (message) =>
             this.toolEditApprovals.handleAction(message),
-          onUnsupportedToolEditApproval: (message) => {
-            this.logger.warn('Unsupported desktop tool-edit approval action', {
-              data: {
-                requestId: message.requestId,
-                action: message.action,
-              },
-            });
-          },
           handleBashApprovalAction: (message) =>
             void this.session.interactions.resolve(message.requestId, {
               kind: 'bash',

--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -52,7 +52,7 @@ export interface DesktopToolEditApprovalController {
     requestId: string;
     action: ToolEditApprovalAction;
     feedback?: string;
-  }): boolean;
+  }): void;
   requestApproval(
     request: ToolEditApprovalRequest,
     options?: HostInteractionOptions,
@@ -160,30 +160,30 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     requestId: string;
     action: ToolEditApprovalAction;
     feedback?: string;
-  }): boolean {
+  }): void {
     const entry = this.pending.get(payload.requestId);
-    if (!entry || entry.isSettled()) return true;
+    if (!entry || entry.isSettled()) return;
 
     switch (payload.action) {
       case 'approve':
         void this.runAction(payload.requestId, () =>
           this.approveProposedEdit(payload.requestId, entry),
         );
-        return true;
+        return;
       case 'reject':
         this.settle(payload.requestId, {
           accepted: false,
           userMessage: payload.feedback?.trim() || undefined,
         });
-        return true;
+        return;
       case 'openDiff':
         void this.runAction(payload.requestId, () => this.openDiffPatch(entry));
-        return true;
+        return;
       case 'previewProposed':
         void this.runAction(payload.requestId, () =>
           this.previewProposed(entry),
         );
-        return true;
+        return;
       case 'showLatexdiff':
         void this.runAction(payload.requestId, () =>
           runLatexdiff(entry, {
@@ -191,10 +191,9 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
             openBuildDisplay: this.options.ui.openBuildDisplay,
           }),
         );
-        return true;
-      default:
-        return false;
+        return;
     }
+    payload.action satisfies never;
   }
 
   async approvePendingForStream(streamId: StreamTabId): Promise<void> {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -519,10 +519,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
               stream,
               initiatingProposalId,
             ),
-          handleToolEditApprovalAction: async (message) => {
-            await handleProgressViewToolEditApprovalAction(message);
-            return true;
-          },
+          handleToolEditApprovalAction:
+            handleProgressViewToolEditApprovalAction,
           handleBashApprovalAction: (message) =>
             this.handleBashApprovalAction(message),
           handlePlanApprovalAction: (message) =>

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -94,12 +94,7 @@ export interface ProgressViewApprovalCommandActions {
     message: ProgressViewMessage<
       typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
     >,
-  ): boolean | Promise<boolean>;
-  onUnsupportedToolEditApproval?(
-    message: ProgressViewMessage<
-      typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION
-    >,
-  ): void;
+  ): void | Promise<void>;
   handleBashApprovalAction(
     message: ProgressViewMessage<
       typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION
@@ -284,19 +279,8 @@ export function createProgressViewCommandHandlers(
       await reportDelegatedWorkApproval(true);
     },
 
-    [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) => {
-      const handled = approval.handleToolEditApprovalAction(data);
-      if (handled instanceof Promise) {
-        return handled.then((result) => {
-          if (result === false) {
-            approval.onUnsupportedToolEditApproval?.(data);
-          }
-        });
-      }
-      if (handled === false) {
-        approval.onUnsupportedToolEditApproval?.(data);
-      }
-    },
+    [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]: (data) =>
+      approval.handleToolEditApprovalAction(data),
     [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: async (data) => {
       await approval.handleBashApprovalAction(data);
     },

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -90,8 +90,7 @@ function createActions(
     },
     approval: {
       approvePendingDelegatedWork: vi.fn(async () => undefined),
-      handleToolEditApprovalAction: vi.fn().mockReturnValue(true),
-      onUnsupportedToolEditApproval: vi.fn(),
+      handleToolEditApprovalAction: vi.fn(),
       handleBashApprovalAction: vi.fn(),
       handlePlanApprovalAction: vi.fn(),
       handleUserQuestionAction: vi.fn(),
@@ -684,90 +683,6 @@ describe('createProgressViewCommandHandlers - approvals', () => {
       agent: 'review',
       model: 'deepseek',
     });
-    expect(
-      actions.approval.onUnsupportedToolEditApproval,
-    ).not.toHaveBeenCalled();
-  });
-
-  it('reports unsupported tool-edit approval actions when the host returns false', async () => {
-    const actions = createActions();
-    actions.approval.handleToolEditApprovalAction = vi.fn(() => false);
-    const handlers = createProgressViewCommandHandlers(actions);
-
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-          requestId: 'edit-2',
-          action: 'openDiff',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-
-    await Promise.resolve();
-
-    expect(actions.approval.onUnsupportedToolEditApproval).toHaveBeenCalledWith(
-      {
-        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-        requestId: 'edit-2',
-        action: 'openDiff',
-      },
-    );
-  });
-
-  it('reports unsupported tool-edit approval actions from async host results', async () => {
-    const actions = createActions();
-    actions.approval.handleToolEditApprovalAction = vi.fn(() =>
-      Promise.resolve(false),
-    );
-    const handlers = createProgressViewCommandHandlers(actions);
-
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-          requestId: 'edit-3',
-          action: 'approve',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-
-    await Promise.resolve();
-
-    expect(actions.approval.onUnsupportedToolEditApproval).toHaveBeenCalledWith(
-      {
-        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-        requestId: 'edit-3',
-        action: 'approve',
-      },
-    );
-  });
-
-  it('does not report unsupported tool-edit approval actions from async handled results', async () => {
-    const actions = createActions();
-    actions.approval.handleToolEditApprovalAction = vi.fn(() =>
-      Promise.resolve(true),
-    );
-    const handlers = createProgressViewCommandHandlers(actions);
-
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-          requestId: 'edit-4',
-          action: 'reject',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-
-    await Promise.resolve();
-
-    expect(
-      actions.approval.onUnsupportedToolEditApproval,
-    ).not.toHaveBeenCalled();
   });
 });
 

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -12,6 +12,7 @@ import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInte
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { DiffOptions, DiffSession, DiffSource } from '@hosts/uiHosts';
+import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import { delay } from '@utils/core';
 
 import { createStubDesktopAgentExecutionHost } from './desktopAgentExecutionTestHarness.mjs';
@@ -40,9 +41,9 @@ interface DesktopToolEditApprovalModule {
     }): void;
     handleAction(payload: {
       requestId: string;
-      action: string;
+      action: ToolEditApprovalAction;
       feedback?: string;
-    }): boolean;
+    }): void;
     requestApproval(
       request: ToolEditApprovalRequest,
     ): Promise<ToolEditApprovalResult>;
@@ -238,6 +239,7 @@ describe('desktop tool edit approval', () => {
     for (const session of testSessions.splice(0)) session.dispose();
     vi.doUnmock('@utils/config/configUtils');
     vi.doUnmock('@agent/runtime/RunContext');
+    vi.doUnmock('@tools/approval/latexPreview');
     vi.doUnmock('@utils/files');
     vi.restoreAllMocks();
   });
@@ -478,12 +480,10 @@ describe('desktop tool edit approval', () => {
         await vi.waitFor(() => expect(opened).toHaveLength(1));
         await writeFile(opened[0], 'beta\nwith user edits\nand more\n', 'utf8');
 
-        expect(
-          controller.handleAction({
-            requestId: shown[0].requestId,
-            action: 'approve',
-          }),
-        ).toBe(true);
+        controller.handleAction({
+          requestId: shown[0].requestId,
+          action: 'approve',
+        });
 
         await expect(resultPromise).resolves.toMatchObject({
           accepted: true,
@@ -493,6 +493,71 @@ describe('desktop tool edit approval', () => {
         await vi.waitFor(async () => {
           await expect(pathExists(opened[0])).resolves.toBe(false);
         });
+      } finally {
+        controller.dispose();
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  approvalTest(
+    'routes LaTeX diff inspection without settling the request',
+    async () => {
+      const runLatexdiff = vi.fn(async () => {});
+      vi.doMock('@tools/approval/latexPreview', async () => {
+        const actual = await vi.importActual<
+          typeof import('@tools/approval/latexPreview')
+        >('@tools/approval/latexPreview');
+        return { ...actual, runLatexdiff };
+      });
+
+      const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
+      const { requestToolEditApproval, desktopModule } =
+        await loadApprovalModules();
+      const runtimeHost = createRecordingRuntimeHost();
+      const openBuildDisplay = vi.fn(async () => {});
+      const controller = desktopModule.createDesktopToolEditApprovalController({
+        runtimeHost,
+        session: createTestSession(),
+        tempRoot,
+        ui: createStubDesktopAgentExecutionHost({ openBuildDisplay }),
+      });
+      useControllerApproval(controller);
+      const { shownToolEditPermissions: shown } = runtimeHost;
+
+      try {
+        const resultPromise = requestToolEditApproval({
+          path: '/workspace/main.tex',
+          originalContent: 'old\n',
+          proposedContent: 'new\n',
+          sourceTool: 'write_file',
+        });
+        await vi.waitFor(() => expect(shown).toHaveLength(1));
+        let settled = false;
+        void resultPromise.then(() => {
+          settled = true;
+        });
+
+        controller.handleAction({
+          requestId: shown[0].requestId,
+          action: 'showLatexdiff',
+        });
+
+        await vi.waitFor(() => expect(runLatexdiff).toHaveBeenCalledOnce());
+        expect(runLatexdiff).toHaveBeenCalledWith(
+          expect.objectContaining({ requestId: shown[0].requestId }),
+          {
+            subtype: 'ONLYCHANGEDPAGE',
+            openBuildDisplay,
+          },
+        );
+        expect(settled).toBe(false);
+
+        controller.handleAction({
+          requestId: shown[0].requestId,
+          action: 'reject',
+        });
+        await expect(resultPromise).resolves.toMatchObject({ accepted: false });
       } finally {
         controller.dispose();
         await rm(tempRoot, { recursive: true, force: true });
@@ -770,42 +835,4 @@ describe('desktop tool edit approval', () => {
       }
     },
   );
-
-  approvalTest('returns false for unknown approval actions', async () => {
-    const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-    const { requestToolEditApproval, desktopModule } =
-      await loadApprovalModules();
-    const runtimeHost = createRecordingRuntimeHost();
-    const controller = desktopModule.createDesktopToolEditApprovalController({
-      runtimeHost,
-      session: createTestSession(),
-      ui: createStubDesktopAgentExecutionHost(),
-      tempRoot,
-    });
-    useControllerApproval(controller);
-    const { shownToolEditPermissions: shown } = runtimeHost;
-
-    try {
-      const resultPromise = requestToolEditApproval({
-        path: '/workspace/unknown-action.tex',
-        originalContent: 'old\n',
-        proposedContent: 'new\n',
-        sourceTool: 'write_file',
-      });
-      await vi.waitFor(() => expect(shown).toHaveLength(1));
-
-      expect(
-        controller.handleAction({
-          requestId: shown[0].requestId,
-          action: 'unexpected',
-        }),
-      ).toBe(false);
-
-      controller.dispose();
-      await expect(resultPromise).resolves.toMatchObject({ accepted: false });
-    } finally {
-      controller.dispose();
-      await rm(tempRoot, { recursive: true, force: true });
-    }
-  });
 });


### PR DESCRIPTION
## Summary

- Trust the strict tool-edit action schema after IPC parsing instead of carrying an impossible boolean "unsupported action" result through every host.
- Route the shared command directly to a `void | Promise<void>` host action and make the desktop switch compile-time exhaustive.
- Remove the unreachable desktop warning callback and tests that fabricated invalid actions/results.
- Retain controller-level behavior coverage for all five valid actions, including non-terminal LaTeX diff inspection.

## Issue acceptance gates

Closes #8541.

- All five validated actions retain behavior coverage: approve, reject, openDiff, previewProposed, and showLatexdiff.
- No unsupported-action boolean, callback, warning, or fabricated invalid-action test remains.
- Type checking, lint, focused approval tests, the full Vitest suite, compilation, and the dead-code ratchet pass.

## Single source of truth

`ToolEditApprovalActionMessageSchema` at the IPC boundary and its inferred `ToolEditApprovalAction` union now exclusively define valid actions. Downstream handlers trust that closed contract.

## Duplication and abstraction budget

No abstraction was added. The change deletes a parallel error channel, sync-versus-Promise branching, a host callback, and tests devoted solely to impossible values. The existing shared dispatcher continues to own async error reporting.

## Net elements (R6)

- Files: 6 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted; one interface member removed.
- LoC: +88 / -173, net -85.

## Consumer counts (R8)

- `onUnsupportedToolEditApproval`: 4 production references and 5 test references before; 0 after.
- `TOOL_EDIT_APPROVAL_ACTION`: one shared command handler and two host adapters before and after; all remain connected.
- `handleToolEditApprovalAction`: the two host producers and the shared dispatch consumer remain; only the result type changes from boolean to void.

## Host impact

Extension: directly supplies the existing async tool-edit handler; no behavior change.

Desktop: controller handles the exact five-action union exhaustively and no longer reports unreachable unknown actions.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `CI=true npm run typecheck`
- `CI=true npm run lint` (0 errors; 51 existing warnings)
- `CI=true npm run compile:fast`
- `CI=true npm run check:dead-code-ratchet`
- `CI=true npm test` (702 files passed, 1 skipped; 6,356 tests passed, 4 skipped)
- Focused command-handler, desktop approval, and desktop execution suites (130 tests passed)
- Final desktop approval suite after fifth-action coverage (10 tests passed)
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- Independent read-only subagent review: no remaining actionable findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of approval routing with no auth or persistence changes; behavior for the five schema-valid actions is preserved and re-tested.
> 
> **Overview**
> Tool-edit approval IPC is treated as a **closed contract** after schema validation: hosts no longer return a boolean “handled vs unsupported,” and the shared progress command handler forwards `TOOL_EDIT_APPROVAL_ACTION` straight to the host without sync/async branching or `onUnsupportedToolEditApproval` warnings.
> 
> **Desktop** `handleAction` is now `void` with an exhaustive switch over the five `ToolEditApprovalAction` values (`satisfies never` instead of a `default` that returned `false`). **Extension** wires the existing async handler directly. Tests drop fabricated invalid-action paths and add coverage that **`showLatexdiff`** runs LaTeX diff inspection without settling the pending approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755dcb821c3a45dbcc3e665b31a35845db796084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->