### PR TITLE
refactor(settings): use native tool health ring

### DIFF
--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -1,10 +1,10 @@
 /** Tool dashboard showing tool status and installation guides. */
 
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/progress-ring/progress-ring.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
@@ -109,31 +109,11 @@ export class ToolsTab extends LitElement {
         gap: var(--wa-space-xs);
       }
 
-      .tools-health-ring svg {
-        width: 36px;
-        height: 36px;
-        transform: rotate(-90deg);
-      }
-
-      .tools-health-ring__track {
-        fill: none;
-        stroke: var(--wa-color-surface-border);
-        stroke-width: 4;
-      }
-
-      .tools-health-ring__available {
-        fill: none;
-        stroke: var(--color-status-ok);
-        stroke-width: 4;
-        stroke-linecap: round;
-      }
-
-      .tools-health-ring__missing {
-        fill: none;
-        stroke: var(--color-status-error);
-        stroke-width: 4;
-        stroke-linecap: round;
-        transform-origin: 50% 50%;
+      .tools-health-ring wa-progress-ring {
+        --size: 36px;
+        --track-width: 4px;
+        --track-color: var(--wa-color-surface-border);
+        --indicator-color: var(--color-status-ok);
       }
 
       .tools-health-labels {
@@ -336,44 +316,17 @@ export class ToolsTab extends LitElement {
       else if (item.status === 'not-found') missing++;
     }
 
-    // Early return above guarantees items.length > 0.
     const total = items.length;
-    const r = 14;
-    const circ = 2 * Math.PI * r;
-    const availPct = available / total;
-    const missPct = missing / total;
-    const availOffset = circ - circ * availPct;
-    // Missing arc starts after the available arc.
-    const missOffset = circ - circ * missPct;
-    const missRotation = availPct * 360;
+    const availablePercent = (available / total) * 100;
+    const availabilityLabel = `${available} of ${total} tools available`;
 
     return html`
       <div class="tools-summary">
         <div class="tools-health-ring">
-          <svg viewBox="0 0 36 36">
-            <circle class="tools-health-ring__track" cx="18" cy="18" r="${r}" />
-            <circle
-              class="tools-health-ring__available"
-              cx="18"
-              cy="18"
-              r="${r}"
-              stroke-dasharray="${circ}"
-              stroke-dashoffset="${availOffset}"
-            />
-            ${
-              missing > 0
-                ? html`<circle
-                    class="tools-health-ring__missing"
-                    cx="18"
-                    cy="18"
-                    r="${r}"
-                    stroke-dasharray="${circ}"
-                    stroke-dashoffset="${missOffset}"
-                    style=${styleMap({ transform: `rotate(${missRotation}deg)` })}
-                  />`
-                : nothing
-            }
-          </svg>
+          <wa-progress-ring
+            .value=${availablePercent}
+            .label=${availabilityLabel}
+          ></wa-progress-ring>
           <div class="tools-health-labels">
             <span class="tools-summary-stat tools-stat-available">
               ${waIcon('check')} ${available} available

--- a/src/test-kernel/settings/ToolsTab.vitest.ts
+++ b/src/test-kernel/settings/ToolsTab.vitest.ts
@@ -1,0 +1,66 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component and schema types
+import type { ToolsTab } from '@settingsView/frontend/tabs/ToolsTab';
+import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+useLitComponentTestDom(() => import('@settingsView/frontend/tabs/ToolsTab'));
+
+function tool(
+  id: string,
+  status: ToolDashboardItem['status'],
+): ToolDashboardItem {
+  return {
+    id,
+    name: id,
+    category: 'file',
+    description: `${id} description`,
+    tools: [],
+    status,
+    requiresSetup: status !== 'available',
+  };
+}
+
+async function mount(items: ToolDashboardItem[]): Promise<ToolsTab> {
+  const element = document.createElement('tools-tab') as ToolsTab;
+  element.loaded = true;
+  element.items = items;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+describe('tools-tab availability summary', () => {
+  it('uses an accessible Web Awesome progress ring', async () => {
+    const element = await mount([
+      tool('ready', 'available'),
+      tool('missing', 'not-found'),
+    ]);
+    const ring = element.shadowRoot?.querySelector('wa-progress-ring');
+
+    expect(ring).not.toBeNull();
+    expect((ring as { value?: number }).value).toBe(50);
+    expect((ring as { label?: string }).label).toBe('1 of 2 tools available');
+    expect(
+      element.shadowRoot?.querySelector('.tools-health-ring svg'),
+    ).toBeNull();
+    expect(element.shadowRoot?.textContent).toContain('1 available');
+    expect(element.shadowRoot?.textContent).toContain('1 need setup');
+  });
+
+  it('reports complete availability without a missing-state label', async () => {
+    const element = await mount([
+      tool('first', 'available'),
+      tool('second', 'available'),
+    ]);
+    const ring = element.shadowRoot?.querySelector('wa-progress-ring');
+
+    expect((ring as { value?: number }).value).toBe(100);
+    expect((ring as { label?: string }).label).toBe('2 of 2 tools available');
+    expect(element.shadowRoot?.textContent).not.toContain('need setup');
+  });
+});


### PR DESCRIPTION
## Summary

Replace the settings Tools summary's hand-built SVG health ring with Web Awesome's stable `wa-progress-ring`. The summary now declares an availability percentage and assistive label while the shared component owns geometry and progress semantics. Existing available and setup-needed counts remain visible.

Closes #8548.

## Issue acceptance gates

- No hand-drawn SVG remains in the Tools summary.
- The ring uses the locally bundled Web Awesome component and existing theme tokens.
- The component receives an explicit available/total assistive label.
- Focused tests cover partial and complete availability.

## Single source of truth

`wa-progress-ring` now owns circular progress rendering and accessibility semantics. `ToolsTab.renderSummary()` owns only the domain values: available count, total count, and derived percentage.

## Duplication and abstraction budget

Removed custom circumference, offset, rotation, SVG-circle markup, and ring-specific geometry styles. No new wrapper or pass-through abstraction was added.

## Net elements (R6)

- Files: 1 added, 0 deleted, 1 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +19 (78 additions, 59 deletions, including focused tests).

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted.

## Host impact

Extension: Settings Tools summary uses the shared Web Awesome ring; visible counts and tool cards are unchanged.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 existing warnings)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/settings/ToolsTab.vitest.ts`
- `npm test` (706 files passed, 1 skipped; 6405 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI presentation only; no changes to tool detection, exports, or security-sensitive paths.
> 
> **Overview**
> The Settings **Tools** tab availability summary drops the custom dual-arc SVG (circumference, dash offsets, rotation, and `styleMap`) in favor of bundled **`wa-progress-ring`**, styled with existing theme tokens.
> 
> **`renderSummary()`** now passes a single **available/total percentage** and an explicit assistive **label** (e.g. `1 of 2 tools available`); the adjacent **available** / **need setup** text counts are unchanged.
> 
> Adds **`ToolsTab.vitest.ts`** to assert the ring’s `value`/`label`, absence of legacy SVG markup, and full-availability behavior without a missing-state line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d3fe33ae1318b734e5b76a03a0844dd8ccab01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->