### PR TITLE
refactor(cli): reuse agent roster UI primitives

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -22,9 +22,11 @@ import {
 } from '@shared/schemas/agentPresets';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
+import { COLOR_ERROR, COLOR_WARNING } from '../ui/colors';
+import { TICK } from '../ui/glyphs';
 import { KeyHints } from '../ui/KeyHints';
 import { Select, type SelectItem } from '../ui/Select';
-import { FormFrame } from './_shared/FormFrame';
+import { FormFrame, renderAsyncListFormTransient } from './_shared/FormFrame';
 import {
   computeSelectWindowSize,
   type SelectWindowSize,
@@ -133,7 +135,7 @@ async function loadRosterData(): Promise<AgentRosterData> {
 
 export function AgentRosterForm(
   props: AgentRosterFormProps,
-): React.JSX.Element {
+): React.JSX.Element | null {
   const [mode, setMode] = useState<AgentRosterFormMode>('overview');
   const [data, setData] = useState<AgentRosterData>();
   const [error, setError] = useState<string>();
@@ -165,11 +167,12 @@ export function AgentRosterForm(
   };
 
   if (!data) {
-    return (
-      <FormFrame title="/config · Agents">
-        <Text>{error ?? 'Loading agent roster...'}</Text>
-      </FormFrame>
-    );
+    return renderAsyncListFormTransient({
+      loading: error === undefined,
+      error,
+      title: '/config · Agents',
+      loadingLabel: 'Loading agent roster...',
+    });
   }
 
   const frame = (
@@ -183,9 +186,9 @@ export function AgentRosterForm(
     });
     return (
       <FormFrame title="/config · Agents" showCloseHint={false}>
-        {error ? <Text color="red">{error}</Text> : null}
+        {error ? <Text color={COLOR_ERROR}>{error}</Text> : null}
         {data.record.missingTeamId ? (
-          <Text color="yellow">
+          <Text color={COLOR_WARNING}>
             Team "{data.record.missingTeamId}" is unavailable; showing all
             agents.
           </Text>
@@ -342,7 +345,7 @@ export function AgentRosterForm(
   return frame(
     agents.map((agent) => ({
       value: agentKeyOf(agent),
-      label: `${selected.has(agentKeyOf(agent)) ? '✓ ' : ''}${agent.name}`,
+      label: `${selected.has(agentKeyOf(agent)) ? `${TICK} ` : ''}${agent.name}`,
       description: agent.description,
     })),
     (value) => {

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -1,13 +1,20 @@
+import { createRequire } from 'node:module';
+
 import { describe, expect, it } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
 import {
+  AgentRosterForm,
   agentRosterSelectWindow,
   buildChatDefaultAgentItems,
   selectedAgentKeys,
   setChatDefaultAgent,
 } from '@cli/chat/tui/forms/AgentRosterForm';
 import { formatCliAgentRoster } from '@cli/runtime/agentRoster';
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
 
 const agents: AgentEntry[] = [
   {
@@ -27,6 +34,16 @@ const agents: AgentEntry[] = [
 ];
 
 describe('AgentRosterForm', () => {
+  it('renders loading through the shared Ink indicator', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const output = ink.renderToString(
+      React.createElement(AgentRosterForm, { onClose: () => undefined }),
+    );
+
+    expect(output).toMatch(/[|/\\-]\s+Loading agent roster\.\.\./);
+  });
+
   it('offers chat defaults only from the effective tool-use roster', () => {
     expect(
       buildChatDefaultAgentItems(agents, ['builtInToolUse:assistant']),


### PR DESCRIPTION
## Summary

Bring `AgentRosterForm` onto the shared Ink presentation primitives used by sibling async-list forms. Loading and initial errors now flow through `renderAsyncListFormTransient`; inline errors and missing-team warnings use semantic palette constants; selected rows use the shared `TICK` glyph.

Closes #8549.

## Issue acceptance gates

- Loading, initial-error, inline-error, warning, and selected-row presentation use shared TUI primitives.
- Roster state, keyboard navigation, and write behavior are unchanged.
- A focused Ink render assertion covers the shared loading row; the existing roster behavior suite remains green.

## Single source of truth

`FormFrame.renderAsyncListFormTransient` owns async-list loading/error presentation, `ui/colors.ts` owns semantic terminal colors, and `ui/glyphs.ts` owns the selected marker.

## Duplication and abstraction budget

Removed a one-off loading/error frame, two literal color choices, and a literal checkmark. No new production abstraction was added; the form now consumes existing owners.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +20 (30 additions, 10 deletions, including the focused render test).

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Agent roster transient and status presentation now matches sibling Ink forms; behavior is unchanged.

## Scheduled refactoring

The broader per-entry TUI layout consolidation remains tracked by #8498 and does not overlap this form-level cleanup.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 existing warnings)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/cli/AgentRosterForm.vitest.mts`
- `npm test` (706 files passed, 1 skipped; 6411 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CLI TUI changes; roster persistence and keyboard behavior are unchanged.
> 
> **Overview**
> **Agent roster config** (`/config · Agents`) now uses the same Ink presentation helpers as other async-list TUI forms, without changing roster reads, writes, or navigation.
> 
> While roster data is still loading—or on the initial load failure—the form delegates to **`renderAsyncListFormTransient`** instead of a custom `FormFrame` + plain text. Inline errors and the missing-team warning use **`COLOR_ERROR`** / **`COLOR_WARNING`**; enabled agents in multi-select lists show the shared **`TICK`** glyph instead of a literal checkmark. The component return type allows **`null`** when the shared transient helper handles the state.
> 
> A new Vitest Ink **`renderToString`** assertion checks that the loading row matches the shared spinner pattern (`Loading agent roster...`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9d1d01bbe4ec06ef93da6628b6fec55bd54899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->