### PR TITLE
feat(agent): validate workflow journal costs

### DIFF
--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -119,3 +119,6 @@ return concat(sections, { separator: '\n\n' });
 - The durable progress adapter is implemented in
   `src/tools/delegation/workflowScriptRun.ts`; the future tool must use it so
   phases and script logs appear on the parent run's existing trace tree.
+- Completed journal-call costs can be validated and summed with
+  `sumCompletedWorkflowJournalCost`; the future tool must settle that scalar
+  once through the parent tool-call cost hook.

--- a/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import {
+  readWorkflowScriptCheckpoint,
+  runPersistedWorkflowScript,
+  type WorkflowJournalEntry,
+} from '@agent/workflowScript';
+import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
+import {
+  sumCompletedWorkflowJournalCost,
+  WorkflowJournalCostError,
+} from '@tools/delegation/workflowScriptRun';
+
+const executionId = '7154costtest' as ExecutionId;
+const key = '0000000000000000';
+const meta = `export const meta = {
+  name: 'cost-test',
+  description: 'tests completed workflow journal costs',
+}`;
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+function entry(index: number, result: unknown): WorkflowJournalEntry {
+  return { index, key, result };
+}
+
+function workflowResult(cost: number): unknown {
+  return {
+    category: 'workflow',
+    outcome: RUN_OUTCOME.COMPLETED,
+    outputs: [],
+    compileFailures: [],
+    diffs: [],
+    cost,
+  };
+}
+
+function toolUseResult(cost: number): unknown {
+  return {
+    category: 'toolUse',
+    outcome: RUN_OUTCOME.COMPLETED,
+    response: 'done',
+    files: [],
+    cost,
+  };
+}
+
+beforeEach(() => clearStoreCache());
+
+describe('workflow-script completed journal cost', () => {
+  it('sums canonical workflow and tool-use results independent of entry order', () => {
+    const journal = [
+      entry(4, toolUseResult(0.25)),
+      entry(1, workflowResult(1.5)),
+    ];
+
+    expect(sumCompletedWorkflowJournalCost(journal)).toBe(1.75);
+    expect(sumCompletedWorkflowJournalCost(journal.toReversed())).toBe(1.75);
+  });
+
+  it('uses the final-result default when an older entry omits cost', () => {
+    const result = workflowResult(0) as Record<string, unknown>;
+    delete result.cost;
+
+    expect(sumCompletedWorkflowJournalCost([entry(0, result)])).toBe(0);
+  });
+
+  it.each([
+    ['wrong result shape', entry(3, { cost: 1 })],
+    ['negative cost', entry(7, workflowResult(-1))],
+  ])('rejects %s with the journal index', (_label, invalidEntry) => {
+    expect(() => sumCompletedWorkflowJournalCost([invalidEntry])).toThrow(
+      WorkflowJournalCostError,
+    );
+    expect(() => sumCompletedWorkflowJournalCost([invalidEntry])).toThrow(
+      new RegExp(`entry ${invalidEntry.index}`),
+    );
+  });
+
+  it('produces the same total after a checkpoint replay', async () => {
+    const store = getExecutionStore(executionId);
+    const script = `${meta}
+await agent('first')
+return await agent('second')`;
+    const results = [workflowResult(0.4), toolUseResult(0.6)];
+    const first = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'replay',
+      script,
+      runAgent: async ({ index }) => results[index],
+    });
+
+    clearStoreCache();
+    const runner = vi.fn(() => Promise.reject(new Error('must replay')));
+    const replayed = await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: 'replay',
+      runAgent: runner,
+    });
+
+    expect(runner).not.toHaveBeenCalled();
+    expect(sumCompletedWorkflowJournalCost(first.journal)).toBe(1);
+    expect(sumCompletedWorkflowJournalCost(replayed.journal)).toBe(1);
+  });
+
+  it('can settle completed entries retained after a script failure', async () => {
+    const store = getExecutionStore(executionId);
+    const script = `${meta}
+await agent('completed')
+throw new Error('later failure')`;
+
+    await expect(
+      runPersistedWorkflowScript({
+        store,
+        checkpointId: 'failure',
+        script,
+        runAgent: async () => workflowResult(0.75),
+      }),
+    ).rejects.toThrow('later failure');
+
+    const checkpoint = await readWorkflowScriptCheckpoint(store, 'failure');
+    expect(sumCompletedWorkflowJournalCost(checkpoint?.journal ?? [])).toBe(
+      0.75,
+    );
+  });
+});

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -3,9 +3,11 @@ import type { AgentTrace, StageHandle } from '@agent/trace';
 import {
   runPersistedWorkflowScript,
   type PersistedWorkflowScriptRunOptions,
+  type WorkflowJournalEntry,
   type WorkflowScriptEvent,
   type WorkflowScriptRunResult,
 } from '@agent/workflowScript';
+import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 
 type WorkflowScriptRunWithProgressOptions = Omit<
@@ -16,6 +18,33 @@ type WorkflowScriptRunWithProgressOptions = Omit<
 interface PhaseStage {
   readonly handle: StageHandle;
   failed: boolean;
+}
+
+export class WorkflowJournalCostError extends Error {
+  constructor(index: number, options?: ErrorOptions) {
+    super(
+      `Workflow journal entry ${index} is not an agent final result.`,
+      options,
+    );
+    this.name = 'WorkflowJournalCostError';
+  }
+}
+
+/** Sum completed logical-call cost; failed and cancelled attempts are not journaled. */
+export function sumCompletedWorkflowJournalCost(
+  journal: readonly WorkflowJournalEntry[],
+): number {
+  let total = 0;
+  for (const entry of journal) {
+    const result = AgentFinalResultSchema.safeParse(entry.result);
+    if (!result.success) {
+      throw new WorkflowJournalCostError(entry.index, {
+        cause: result.error,
+      });
+    }
+    total += result.data.cost;
+  }
+  return total;
 }
 
 /** Run a durable workflow script and project its progress onto the parent trace. */


### PR DESCRIPTION
## Summary

- add `sumCompletedWorkflowJournalCost` at the delegation boundary
- validate every durable journal value with the canonical `AgentFinalResultSchema` before accounting
- report malformed data with its journal index instead of silently treating it as zero

Part of #7154.

## Design

The workflow engine keeps `WorkflowJournalEntry.result` generic because it is host-neutral and supports test runners. Production workflow children, however, return durable `AgentFinalResult` values whose `cost` field is the canonical completed-run scalar.

This change keeps that distinction at the boundary. The helper validates and sums completed logical calls only. Its name and documentation deliberately do not call the value total model spend: failed or cancelled attempts can consume tokens without entering the successful-call journal. The future `delegate_workflow_script` tool will settle this scalar once through the existing `recordSubagentCost` hook.

## Verification

- `npm run format`
- workspace type check
- `npm run lint` (0 errors; 51 existing warnings)
- 37 focused workflow integration tests
- full suite: 6,411 passed; five resource-sensitive timing tests failed under concurrent full lint, then QuickJS memory containment, Lean parallelism, and CLI signal ownership all passed in isolated runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive accounting helper and tests at the delegation boundary; no changes to live workflow execution or parent cost settlement yet.
> 
> **Overview**
> Adds **`sumCompletedWorkflowJournalCost`** in `workflowScriptRun.ts` so production can total spend from a durable workflow journal without treating arbitrary `result` blobs as free.
> 
> Each journaled entry is validated with **`AgentFinalResultSchema`** before its `cost` is added; invalid shapes or negative costs throw **`WorkflowJournalCostError`** that names the journal index instead of silently counting zero. The helper only covers **completed** logical calls (failed/cancelled attempts are not journaled).
> 
> Integration tests cover order-independent summing, default cost when omitted, checkpoint replay parity, and partial journals after script failure. The workflow-script README documents that the future **`delegate_workflow_script`** tool should settle this scalar once via the parent tool-call cost hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1fcab42027e4e2feff9c871668792998d79cfe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->