### PR TITLE
feat(agent): add opt-in workflow script tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Shared (all surfaces)
+
+#### New Features
+
+- **Custom agents can run resumable multi-agent workflows** — agent authors can
+  opt into deterministic workflow scripts whose completed steps resume after
+  interruption and whose progress appears in the existing session view.
+
 ### CLI
 
 #### Bug Fixes

--- a/packages/cli/scripts/build-harness.mjs
+++ b/packages/cli/scripts/build-harness.mjs
@@ -27,7 +27,8 @@ try {
     // relative to `import.meta.url`, which esbuild bundling breaks.
     external: ['fsevents', 'clipboardy'],
     jsx: 'automatic',
-    loader: { '.tsx': 'tsx', '.ts': 'ts' },
+    // Keep the harness build graph faithful to the production CLI bundle.
+    loader: { '.tsx': 'tsx', '.ts': 'ts', '.wasm': 'binary' },
     alias: { 'react-devtools-core': reactDevtoolsStub },
     outfile,
     banner: {

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -59,6 +59,12 @@ recommended groups at the bottom are a good starting point.
 - `delegate_workflow` — delegate to a workflow agent for whole-document
   operations. Pass `agent`, `model`, `instruction`, `inputFiles`. Returns
   asynchronously via the follow-up queue.
+- `delegate_workflow_script` — advanced opt-in tool for a durable sequence of
+  workflow-agent calls with predetermined branching and fan-out. Pass a default
+  `agent`, the complete `script`, and optional JSON `args`. The script begins
+  with `export const meta = { name, description }` and can use `agent`, `phase`,
+  `log`, `parallel`, `pipeline`, and `concat`. It is intentionally absent from
+  the recommended orchestrator set.
 - `delegate_agent` — delegate to another tool-use agent. Pass `agent`,
   `model`, and `instruction` for a fresh run, or `execution_id` +
   `instruction` to resume a WAITING subagent.

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -120,13 +120,11 @@ export const DIFF_MARKER_THRESHOLD = 2;
 // Tool output patterns for filtering trivial responses
 export const TRIVIAL_WRITE_OUTPUT = 'written';
 
-/** Workflow-script delegation has a dedicated progress-view presentation. */
-export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME = 'delegate_workflow_script';
-
 /**
  * Friendly display labels for tool names that shouldn't be shown verbatim.
  */
 export const TOOL_LABEL_MAP: Record<string, string> = {
+  delegate_workflow_script: 'Workflow script',
   codex_patch: 'Codex Files',
   codex_thread: 'Codex Thread',
   codex_todo: 'Codex Plan',
@@ -196,7 +194,7 @@ export const TOOL_ICON_MAP: Record<string, string> = {
 
   // Workflow/delegation (includes legacy names for historical log entries)
   delegate_workflow: 'list-tree',
-  [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: 'list-tree',
+  delegate_workflow_script: 'list-tree',
   delegate_agent: 'account',
   propose_workflow: 'list-tree',
   propose_agent: 'account',

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -120,6 +120,9 @@ export const DIFF_MARKER_THRESHOLD = 2;
 // Tool output patterns for filtering trivial responses
 export const TRIVIAL_WRITE_OUTPUT = 'written';
 
+/** Workflow-script delegation has a dedicated progress-view presentation. */
+export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME = 'delegate_workflow_script';
+
 /**
  * Friendly display labels for tool names that shouldn't be shown verbatim.
  */
@@ -193,6 +196,7 @@ export const TOOL_ICON_MAP: Record<string, string> = {
 
   // Workflow/delegation (includes legacy names for historical log entries)
   delegate_workflow: 'list-tree',
+  [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: 'list-tree',
   delegate_agent: 'account',
   propose_workflow: 'list-tree',
   propose_agent: 'account',

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -17,7 +17,10 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 // Local imports - shared utilities
 import type { LogMessageData } from '@shared/schemas';
 import { normalizeToolUseData } from '@shared/toolUse';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import {
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATION_TOOL_CATEGORY,
+} from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import { isObject } from '@utils/core';
@@ -44,11 +47,7 @@ import {
 } from '../htmlBuilders';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage } from '../parseUtils';
-import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
-  TOOL_LABEL_MAP,
-  TRIVIAL_WRITE_OUTPUT,
-} from '../constants';
+import { TOOL_LABEL_MAP, TRIVIAL_WRITE_OUTPUT } from '../constants';
 
 import {
   buildBannerContent,
@@ -196,9 +195,10 @@ export function formatToolUseTemplate(
   const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp} .timeoutMs=${toolTimeoutMs ?? 0}></tool-timer>` : undefined;
 
   // Delegation banner extras: setup link (shown in summary row)
-  const isProposalBearingDelegation =
-    DELEGATION_TOOLS.has(toolName) &&
-    toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME;
+  const isProposalBearingDelegation = Object.hasOwn(
+    DELEGATION_TOOL_CATEGORY,
+    toolName,
+  );
   const proposalId =
     isProposalBearingDelegation && !isInProgress
       ? registerProposalInput(input, toolName)

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -44,7 +44,11 @@ import {
 } from '../htmlBuilders';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage } from '../parseUtils';
-import { TOOL_LABEL_MAP, TRIVIAL_WRITE_OUTPUT } from '../constants';
+import {
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  TOOL_LABEL_MAP,
+  TRIVIAL_WRITE_OUTPUT,
+} from '../constants';
 
 import {
   buildBannerContent,
@@ -140,6 +144,7 @@ export function formatToolUseTemplate(
     isWriteTool && outputText.trim() === TRIVIAL_WRITE_OUTPUT;
   if (
     outputText &&
+    toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME &&
     !toolName.startsWith('mcp:') &&
     toolDisplayKind(toolName) !== 'read' &&
     !isTrivialWriteOutput
@@ -191,9 +196,11 @@ export function formatToolUseTemplate(
   const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp} .timeoutMs=${toolTimeoutMs ?? 0}></tool-timer>` : undefined;
 
   // Delegation banner extras: setup link (shown in summary row)
-  const isDelegation = DELEGATION_TOOLS.has(toolName);
+  const isProposalBearingDelegation =
+    DELEGATION_TOOLS.has(toolName) &&
+    toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME;
   const proposalId =
-    isDelegation && !isInProgress
+    isProposalBearingDelegation && !isInProgress
       ? registerProposalInput(input, toolName)
       : null;
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -29,6 +29,7 @@ import {
   extractCodeOnlyInput,
 } from '@progressView/frontend/formatters/parseUtils';
 import {
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   TOOL_CODE_LANGUAGES,
   getLanguageFromPath,
 } from '@progressView/frontend/formatters/constants';
@@ -329,6 +330,73 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
+function omitWorkflowJournal(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(omitWorkflowJournal);
+  if (!isObject(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) =>
+      key === 'journal' ? [] : [[key, omitWorkflowJournal(entry)] as const],
+    ),
+  );
+}
+
+function buildWorkflowScriptSections(
+  ctx: ToolSectionContext,
+): TemplateResult[] {
+  const { input, parsedOutput } = ctx;
+  if (!isObject(input)) {
+    return [
+      buildToolUseSection(
+        'Input:',
+        wrapInPre('Workflow script input is unavailable.'),
+      ),
+    ];
+  }
+
+  const sections: TemplateResult[] = [];
+  if (typeof input.agent === 'string') {
+    // prettier-ignore
+    sections.push(buildToolUseSection('Agent:', html`<code class="execution-id">${input.agent}</code>`));
+  }
+
+  if (typeof input.script === 'string') {
+    sections.push(
+      buildToolSection('Script:', input.script, {
+        language: 'javascript',
+        extraClass: 'tool-command-input',
+      }),
+    );
+  }
+
+  if (Object.hasOwn(input, 'args')) {
+    const args = input.args === undefined ? null : input.args;
+    sections.push(
+      buildToolSection('Args:', JSON.stringify(args, null, 2), {
+        language: 'json',
+      }),
+    );
+  }
+
+  const rawResult =
+    isObject(parsedOutput) && Object.hasOwn(parsedOutput, 'output')
+      ? parsedOutput.output
+      : parsedOutput;
+  const publicResult = omitWorkflowJournal(rawResult);
+  const { text: resultText, language: resultLanguage } =
+    stringifyWithLanguage(publicResult);
+  if (resultText) {
+    sections.push(
+      buildToolSection('Result:', resultText, {
+        language: resultLanguage,
+        extraClass: 'tool-output-full',
+      }),
+    );
+  }
+
+  return sections;
+}
+
 function buildSpecializedSections(ctx: ToolSectionContext): TemplateResult[] {
   const { toolName, input } = ctx;
   const content =
@@ -491,6 +559,10 @@ const TOOL_SECTION_BUILDERS: Array<{
   {
     match: (ctx) => ctx.toolName === 'accept_run_files' && isObject(ctx.input),
     build: buildAcceptRunFilesSections,
+  },
+  {
+    match: (ctx) => ctx.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+    build: buildWorkflowScriptSections,
   },
   {
     match: (ctx) => DELEGATION_TOOLS.has(ctx.toolName) && isObject(ctx.input),

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -29,7 +29,6 @@ import {
   extractCodeOnlyInput,
 } from '@progressView/frontend/formatters/parseUtils';
 import {
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   TOOL_CODE_LANGUAGES,
   getLanguageFromPath,
 } from '@progressView/frontend/formatters/constants';
@@ -38,7 +37,10 @@ import {
   CodexMcpToolOutputSchema,
   type CodexMcpToolOutput,
 } from '@shared/schemas/codex';
-import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import {
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  DELEGATION_TOOLS,
+} from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
@@ -330,17 +332,6 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
-function omitWorkflowJournal(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(omitWorkflowJournal);
-  if (!isObject(value)) return value;
-
-  return Object.fromEntries(
-    Object.entries(value).flatMap(([key, entry]) =>
-      key === 'journal' ? [] : [[key, omitWorkflowJournal(entry)] as const],
-    ),
-  );
-}
-
 function buildWorkflowScriptSections(
   ctx: ToolSectionContext,
 ): TemplateResult[] {
@@ -378,13 +369,9 @@ function buildWorkflowScriptSections(
     );
   }
 
-  const rawResult =
-    isObject(parsedOutput) && Object.hasOwn(parsedOutput, 'output')
-      ? parsedOutput.output
-      : parsedOutput;
-  const publicResult = omitWorkflowJournal(rawResult);
+  const rawResult = isObject(parsedOutput) ? parsedOutput.output : parsedOutput;
   const { text: resultText, language: resultLanguage } =
-    stringifyWithLanguage(publicResult);
+    stringifyWithLanguage(rawResult);
   if (resultText) {
     sections.push(
       buildToolSection('Result:', resultText, {

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -11,9 +11,10 @@ import {
   type ExtractedToolAttachments,
 } from '@agent/core/tools/toolAttachmentExtraction';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
+import type { FileLocation } from '@shared/schemas';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 
 // Local imports - logging
-import type { FileLocation } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import { isNonEmptyString, createSemaphore } from '@utils/core';
@@ -36,6 +37,7 @@ const SLOW_TOOLS = new Set([
   'web_fetch',
   'web_search',
   'executions',
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
 ]);
 
 /** Tools that defer in-progress logging until after approval. */
@@ -367,6 +369,7 @@ export class ToolUseDispatchNode<C> extends Node<
         {
           tracker: options.workspace.interactions,
           workPlanState: options.workspace.workPlan,
+          trace: options.logger,
           userInstruction:
             options.config.rootUserInstruction ?? this._currentUserInstruction,
           toolCallId: call.callId,

--- a/src/agent/followUp/ToolFileInteractionContext.ts
+++ b/src/agent/followUp/ToolFileInteractionContext.ts
@@ -2,6 +2,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 // Type imports
+import type { AgentTrace } from '@agent/trace';
 import type {
   FileInteractionState,
   WorkPlanState,
@@ -35,6 +36,8 @@ export interface ToolCallHooks {
 export interface ToolCallContext {
   toolCallId?: string;
   tracker: FileInteractionState;
+  /** Parent trace used to project nested tool activity onto the same stream tree. */
+  trace?: AgentTrace;
   /** User instruction that led to this tool call, when available. */
   userInstruction?: string;
   /** Plan and todo progress state. Absent in contexts without work-plan support. */

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -16,6 +16,7 @@ import {
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { buildUserVarPassthrough } from '@agent/utils/userVars';
 import * as logger from '@logger/logUtils';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isNonEmptyString } from '@utils/text/stringUtils';
@@ -133,6 +134,7 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
     description: 'Delegate tasks to other agents and manage executions',
     tools: [
       'delegate_workflow',
+      DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
       'delegate_agent',
       'executions',
       'accept_run_files',

--- a/src/agent/runtime/agentToolResolution.ts
+++ b/src/agent/runtime/agentToolResolution.ts
@@ -28,7 +28,7 @@ import * as logUtils from '@logger/logUtils';
 import type { ToolDefinition } from '@model';
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
-  DELEGATION_TOOL_CATEGORY,
+  DELEGATION_AVAILABILITY_CATEGORY,
   hasDelegationTool,
 } from '@shared/constants/delegationTools';
 import type { AgentCategory } from '@shared/schemas/agent';
@@ -92,7 +92,7 @@ async function availableDelegationModelNamesForTools(
   }
   const categories = new Set(
     tools
-      .map((tool) => DELEGATION_TOOL_CATEGORY[tool.name])
+      .map((tool) => DELEGATION_AVAILABILITY_CATEGORY[tool.name])
       .filter((category): category is AgentCategory => category !== undefined),
   );
 
@@ -208,7 +208,7 @@ function runtimeNarrowToolDefinition(
 /**
  * Refresh a delegation tool's "Available models:", "Available agents:", and
  * "Git worktree support:" lines from current state. A tool with no
- * `DELEGATION_TOOL_CATEGORY` entry returns untouched at the early guard.
+ * `DELEGATION_AVAILABILITY_CATEGORY` entry returns untouched at the early guard.
  * `availableModelNames` is `undefined` only when the resolved list held no
  * delegation tool at all, so in that case every tool reaching this function is a
  * non-delegation tool that returns early — `category` and `availableModelNames`
@@ -220,7 +220,7 @@ function annotateDelegationTool(
   availableModelNames:
     ReadonlyMap<AgentCategory, readonly string[]> | null | undefined,
 ): ToolDefinition {
-  const category = DELEGATION_TOOL_CATEGORY[tool.name];
+  const category = DELEGATION_AVAILABILITY_CATEGORY[tool.name];
   if (!category) return tool;
   const categoryModelNames =
     availableModelNames instanceof Map

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -111,14 +111,15 @@ return concat(sections, { separator: '\n\n' });
   which already resolves to `null` with its own `agent:end` event) is
   logged via a `log` event before the slot becomes `null`.
 
-## Not yet built (production integration)
+## Production integration
 
-- A `delegate_workflow_script` tool, which will invoke the existing production
-  runner and task-run file hand-off. Domain-specific structures travel as JSON
-  output files rather than per-call result schemas.
-- The durable progress adapter is implemented in
-  `src/tools/delegation/workflowScriptRun.ts`; the future tool must use it so
-  phases and script logs appear on the parent run's existing trace tree.
-- Completed journal-call costs can be validated and summed with
-  `sumCompletedWorkflowJournalCost`; the future tool must settle that scalar
-  once through the parent tool-call cost hook.
+The opt-in `delegate_workflow_script` tool composes the production in-band
+subagent runner, durable checkpoint store, task-run file hand-off, progress
+projection, parent cancellation, and completed-journal cost settlement. It is
+registered but absent from every default agent configuration; explicitly adding
+the tool to an agent is the consent boundary for automated workflow fan-out.
+
+Domain-specific structures should travel as JSON output files rather than
+per-call result schemas. Cost settlement covers completed logical calls retained
+in the journal; failed or cancelled attempts can consume additional quota before
+they become durable.

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -398,6 +398,9 @@ export async function runWorkflowScript(
   }
 
   const argsJson = serializeBridgeValue(options.args, 'Workflow args');
+  const abortFromParent = () => runAbort.abort(options.signal?.reason);
+  options.signal?.addEventListener('abort', abortFromParent, { once: true });
+  if (options.signal?.aborted) abortFromParent();
 
   let result: unknown;
   let scriptFailure: { readonly error: unknown } | undefined;
@@ -433,12 +436,14 @@ export async function runWorkflowScript(
       {
         timeoutMs,
         filename: `${meta.name}.workflow.js`,
+        signal: options.signal,
         onTimeout: () => runAbort.abort(),
       },
     );
   } catch (error) {
     scriptFailure = { error };
   } finally {
+    options.signal?.removeEventListener('abort', abortFromParent);
     // Abort unconditionally once the sandbox returns. This stops in-flight
     // work the script abandoned and makes agentPrimitive reject any late call.
     runAbort.abort();

--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -32,6 +32,8 @@ export interface SandboxOptions {
   /** Wall-clock cap for the whole (async) script run. */
   timeoutMs: number;
   filename: string;
+  /** Parent cancellation signal for immediate guest preemption. */
+  signal?: AbortSignal;
   /** Fired exactly once when the wall-clock timeout is first observed. */
   onTimeout?: () => void;
 }
@@ -239,7 +241,14 @@ interface GuestOutcome {
 type SandboxSettlement =
   | { readonly kind: 'outcome'; readonly outcome: GuestOutcome }
   | { readonly kind: 'host-failure'; readonly error: Error }
+  | { readonly kind: 'aborted'; readonly error: Error }
   | { readonly kind: 'timeout' };
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted', 'AbortError');
+}
 
 /**
  * Evaluates a workflow body in a fresh preemptible QuickJS runtime. The WASM
@@ -251,7 +260,9 @@ export async function runScriptInSandbox(
   bridge: SandboxHostBridge,
   options: SandboxOptions,
 ): Promise<unknown> {
+  if (options.signal?.aborted) throw abortError(options.signal);
   const quickJs = await getQuickJsModule();
+  if (options.signal?.aborted) throw abortError(options.signal);
   const deadline = performance.now() + options.timeoutMs;
   let active = true;
   let interruptRequested = false;
@@ -288,6 +299,13 @@ export async function runScriptInSandbox(
     }
     wake();
   };
+  const markAborted = () => {
+    interruptRequested = true;
+    if (settlement === undefined && options.signal) {
+      settlement = { kind: 'aborted', error: abortError(options.signal) };
+    }
+    wake();
+  };
 
   const runtime = quickJs.newRuntime({
     memoryLimitBytes: QUICKJS_MEMORY_LIMIT_BYTES,
@@ -309,6 +327,8 @@ export async function runScriptInSandbox(
   }
   const pendingHostPromises = new Set<QuickJSDeferredPromise>();
   const timeout = setTimeout(markTimedOut, options.timeoutMs);
+  options.signal?.addEventListener('abort', markAborted, { once: true });
+  if (options.signal?.aborted) markAborted();
 
   try {
     installHostBridge(
@@ -378,6 +398,8 @@ export async function runScriptInSandbox(
           return settlement.outcome.value;
         case 'host-failure':
           throw settlement.error;
+        case 'aborted':
+          throw settlement.error;
         case 'timeout':
           throw timeoutError(options);
         case undefined:
@@ -388,10 +410,12 @@ export async function runScriptInSandbox(
     }
   } catch (error) {
     if (settlement?.kind === 'timeout') throw timeoutError(options);
+    if (settlement?.kind === 'aborted') throw settlement.error;
     throw error;
   } finally {
     active = false;
     clearTimeout(timeout);
+    options.signal?.removeEventListener('abort', markAborted);
     wake();
     try {
       for (const deferred of pendingHostPromises) deferred.dispose();

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -85,6 +85,8 @@ export interface WorkflowScriptRunOptions {
   /** Exposed verbatim to the script as the global `args`. */
   args?: unknown;
   runAgent: WorkflowAgentRunner;
+  /** Parent cancellation signal; aborts guest execution and active agents. */
+  signal?: AbortSignal;
   /** Max concurrently running agent() calls. Default 4. */
   concurrency?: number;
   /** Journal from a prior run; per-index key matches return cached results. */

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -1,5 +1,8 @@
 import { AgentCategory } from '../schemas/agent';
 
+export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME =
+  'delegate_workflow_script' as const;
+
 /**
  * Tools that delegate work to sub-agents.
  *
@@ -10,6 +13,7 @@ import { AgentCategory } from '../schemas/agent';
  */
 export const DELEGATION_TOOLS: ReadonlySet<string> = new Set([
   'delegate_workflow',
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   'delegate_agent',
   'resume_agent',
   'propose_workflow',
@@ -29,6 +33,14 @@ export const DELEGATION_TOOL_CATEGORY: Readonly<Record<string, AgentCategory>> =
     delegate_agent: AgentCategory.ToolUse,
     propose_agent: AgentCategory.ToolUse,
   };
+
+/** Delegation tools whose descriptions receive live roster/model annotations. */
+export const DELEGATION_AVAILABILITY_CATEGORY: Readonly<
+  Record<string, AgentCategory>
+> = {
+  ...DELEGATION_TOOL_CATEGORY,
+  [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: AgentCategory.Workflow,
+};
 
 /** True when any of the given tool names is a delegation tool. */
 export function hasDelegationTool(

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -90,7 +90,7 @@ function dispatchHarness(opts: HarnessOptions) {
   } as unknown as ToolUseRoundServices<unknown>;
   const node = new ToolUseDispatchNode<unknown>();
   node.setServices(services);
-  return { node, dispose: () => runTrace.dispose() };
+  return { node, trace: runTrace.trace, dispose: () => runTrace.dispose() };
 }
 
 /** prep() then the batch executor, mirroring Node's _run sequence. */
@@ -129,6 +129,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
 
   it('preserves the unwrapped root instruction across nested delegation', async () => {
     let observedInstruction: string | undefined;
+    let observedTrace: unknown;
     const inspectContext: ITool = {
       definition: {
         name: 'inspect_context',
@@ -136,11 +137,13 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
         parameters: {},
       },
       async call(): Promise<ToolResult> {
-        observedInstruction = getCurrentToolCallContext()?.userInstruction;
+        const context = getCurrentToolCallContext();
+        observedInstruction = context?.userInstruction;
+        observedTrace = context?.trace;
         return { status: 'executed', output: 'ok' };
       },
     } as ITool;
-    const { node, dispose } = dispatchHarness({
+    const { node, trace, dispose } = dispatchHarness({
       tools: { inspect_context: inspectContext },
       rootUserInstruction: 'Do not use files or external tools.',
     });
@@ -152,6 +155,7 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
         'Wrapped child instruction with prior handoff boilerplate.',
       );
       assert.equal(observedInstruction, 'Do not use files or external tools.');
+      assert.equal(observedTrace, trace);
     } finally {
       dispose();
     }

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -1097,6 +1097,34 @@ return 'incorrect success'`,
     });
   });
 
+  it('aborts guest execution and the active child from a parent signal', async () => {
+    const controller = new AbortController();
+    let childSignal: AbortSignal | undefined;
+    const run = runWorkflowScript({
+      script: `${META}return await agent('wait')`,
+      signal: controller.signal,
+      runAgent: (invocation) => {
+        childSignal = invocation.signal;
+        return new Promise((_resolve, reject) => {
+          invocation.signal.addEventListener(
+            'abort',
+            () => reject(invocation.signal.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    await vi.waitFor(() => expect(childSignal).toBeDefined());
+
+    controller.abort(new DOMException('parent stopped', 'AbortError'));
+
+    await expect(run).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'parent stopped',
+    });
+    expect(childSignal?.aborted).toBe(true);
+  });
+
   it('removes Intl so scripts cannot read the wall clock implicitly', async () => {
     await expect(
       runWorkflowScript({

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -25,8 +25,10 @@ describe('tool-use formatter', () => {
   phases: [{ title: 'Collect' }, { title: 'Compare' }],
 };
 
-const papers = await parallel(args.paperIds, async (paperId) =>
-  agent(\`Read and assess \${paperId}\`, { label: paperId }),
+const papers = await parallel(
+  args.paperIds.map((paperId) => () =>
+    agent(\`Read and assess \${paperId}\`, { label: paperId }),
+  ),
 );
 return { papers, question: args.question };`;
     const message: LogMessageData = {
@@ -46,9 +48,10 @@ return { papers, question: args.question };`;
           },
         },
         output: {
-          result: { compared: 2 },
-          agentCalls: 2,
-          journal: [{ index: 0, key: 'private-key', result: 'private-result' }],
+          status: 'executed',
+          summary:
+            "Completed workflow script 'Literature synthesis' (2 agent calls)",
+          output: JSON.stringify({ compared: 2 }),
         },
       },
     };
@@ -77,9 +80,8 @@ return { papers, question: args.question };`;
     expect(argsBlock?.querySelector('code')?.textContent).toContain(
       '"question": "Which assumptions differ?"',
     );
-    expect(container.textContent).toContain('compared: 2');
+    expect(container.textContent).toContain('"compared":2');
     expect(container.textContent).not.toContain('journal');
-    expect(container.textContent).not.toContain('private-key');
     expect(container.querySelector('.proposal-banner-setup')).toBeNull();
   });
 

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -16,6 +16,102 @@ useLitComponentTestDom(() =>
 );
 
 describe('tool-use formatter', () => {
+  it('renders workflow-script delegation details without proposal or journal data', async () => {
+    const { formatToolUseTemplate } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
+    const { render } = await import('lit');
+    const script = `export const meta = {
+  name: 'Literature synthesis',
+  phases: [{ title: 'Collect' }, { title: 'Compare' }],
+};
+
+const papers = await parallel(args.paperIds, async (paperId) =>
+  agent(\`Read and assess \${paperId}\`, { label: paperId }),
+);
+return { papers, question: args.question };`;
+    const message: LogMessageData = {
+      id: 'workflow-script',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'delegate_workflow_script',
+        input: {
+          agent: 'research',
+          script,
+          args: {
+            paperIds: ['2401.00001', '2401.00002'],
+            question: 'Which assumptions differ?',
+          },
+        },
+        output: {
+          result: { compared: 2 },
+          agentCalls: 2,
+          journal: [{ index: 0, key: 'private-key', result: 'private-result' }],
+        },
+      },
+    };
+
+    const container = document.createElement('div');
+    render(formatToolUseTemplate(message, { defaultOpen: true }), container);
+
+    const details = container.querySelector('wa-details.tool-use-details') as
+      (HTMLElement & { open: boolean }) | null;
+    const scriptBlock = container.querySelector(
+      '.code-block[data-language="javascript"]',
+    );
+    const argsBlock = container.querySelector(
+      '.code-block[data-language="json"]',
+    );
+    const labels = [...container.querySelectorAll('.tool-use-sublabel')].map(
+      (label) => label.textContent,
+    );
+
+    expect(details?.open).toBe(true);
+    expect(container.querySelector('wa-icon[name="list-tree"]')).not.toBeNull();
+    expect(labels).toEqual(['Agent:', 'Script:', 'Args:', 'Result:']);
+    expect(container.textContent).toContain('research');
+    expect(scriptBlock?.querySelector('code')?.textContent).toBe(script);
+    expect(scriptBlock?.textContent).toContain('JavaScript');
+    expect(argsBlock?.querySelector('code')?.textContent).toContain(
+      '"question": "Which assumptions differ?"',
+    );
+    expect(container.textContent).toContain('compared: 2');
+    expect(container.textContent).not.toContain('journal');
+    expect(container.textContent).not.toContain('private-key');
+    expect(container.querySelector('.proposal-banner-setup')).toBeNull();
+  });
+
+  it('shows explicit null workflow-script arguments as JSON', async () => {
+    const { formatToolUseTemplate } =
+      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
+    const { render } = await import('lit');
+    const message: LogMessageData = {
+      id: 'workflow-script-null-args',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'delegate_workflow_script',
+        input: {
+          agent: 'research',
+          script: 'export const meta = { name: "One call" };\nreturn null;',
+          args: null,
+        },
+      },
+    };
+
+    const container = document.createElement('div');
+    render(formatToolUseTemplate(message), container);
+
+    expect(
+      container.querySelector('.code-block[data-language="json"] code')
+        ?.textContent,
+    ).toBe('null');
+  });
+
   it('keeps streamed bash output out of the collapsed error summary', async () => {
     const { formatToolUseTemplate } =
       await import('@progressView/frontend/formatters/logFormatters/toolFormatters');

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { TraceEmitter } from '@agent/trace';
+import { runPersistedWorkflowScript } from '@agent/workflowScript';
+import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
+import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import type { LaunchRunContext } from '@agent/runtime/RunContext';
+import { withRunContext } from '@agent/runtime/RunContext';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  DELEGATION_AVAILABILITY_CATEGORY,
+  DELEGATION_TOOL_CATEGORY,
+  DELEGATION_TOOLS,
+} from '@shared/constants/delegationTools';
+import { getDefaultToolRegistry } from '@tools/registry';
+import { WorkflowScriptTool } from '@tools/delegation/WorkflowScriptTool';
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+const executionId = '7154scripttool' as ExecutionId;
+const streamId = 'stream:workflow-script-tool' as StreamTabId;
+const script = `export const meta = {
+  name: 'tool-test',
+  description: 'tests the workflow script tool',
+}
+return await agent('saved call')`;
+const finalResult: AgentFinalResult = {
+  category: 'workflow',
+  outcome: 'completed',
+  outputs: [],
+  compileFailures: [],
+  diffs: [],
+  cost: 0.42,
+};
+
+function parentContext(): LaunchRunContext {
+  return {
+    kind: 'launch',
+    model: 'parent-model',
+    runScope: {
+      executionId,
+      streamId,
+      agentName: 'orchestrator',
+      runtimeHost: { emit: vi.fn() } as never,
+      session: { id: 'workflow-script-test' } as never,
+    },
+  };
+}
+
+async function callTool(options?: {
+  readonly checkpointId?: string;
+  readonly script?: string;
+  readonly recordCost?: (cost: number) => void;
+  readonly signal?: AbortSignal;
+  readonly trace?: TraceEmitter;
+  readonly args?: unknown;
+}) {
+  return withRunContext(parentContext(), () =>
+    withToolFileInteractionContext(
+      {
+        tracker: {} as never,
+        toolCallId: options?.checkpointId ?? 'tool-call',
+        trace: options?.trace ?? new TraceEmitter(),
+        signal: options?.signal,
+        hooks: { recordSubagentCost: options?.recordCost ?? vi.fn() },
+      },
+      () =>
+        new WorkflowScriptTool().call({
+          agent: 'correct',
+          script: options?.script ?? script,
+          args: options?.args,
+        }),
+    ),
+  );
+}
+
+beforeEach(() => clearStoreCache());
+
+describe('WorkflowScriptTool', () => {
+  it('is registered and classified without becoming a proposal tool', () => {
+    expect(getDefaultToolRegistry().has('delegate_workflow_script')).toBe(true);
+    expect(DELEGATION_TOOLS.has('delegate_workflow_script')).toBe(true);
+    expect(DELEGATION_AVAILABILITY_CATEGORY.delegate_workflow_script).toBe(
+      'workflow',
+    );
+    expect(DELEGATION_TOOL_CATEGORY.delegate_workflow_script).toBeUndefined();
+  });
+
+  it('rejects invalid JSON arguments at the schema boundary', async () => {
+    const result = await new WorkflowScriptTool().call({
+      agent: 'correct',
+      script,
+      args: { invalid: undefined },
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.diagnostics).toMatchObject({ type: 'validation_error' });
+  });
+
+  it('requires a launched tool context and parent trace', async () => {
+    const outside = await new WorkflowScriptTool().call({
+      agent: 'correct',
+      script,
+    });
+    expect(outside).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('active launched agent session'),
+    });
+
+    const missingTrace = await withRunContext(parentContext(), () =>
+      withToolFileInteractionContext(
+        { tracker: {} as never, toolCallId: 'missing-trace' },
+        () => new WorkflowScriptTool().call({ agent: 'correct', script }),
+      ),
+    );
+    expect(missingTrace).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('parent progress trace'),
+    });
+
+    const missingCallId = await withRunContext(parentContext(), () =>
+      withToolFileInteractionContext(
+        { tracker: {} as never, trace: new TraceEmitter() },
+        () => new WorkflowScriptTool().call({ agent: 'correct', script }),
+      ),
+    );
+    expect(missingCallId).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('tool call id'),
+    });
+  });
+
+  it('replays a checkpoint and settles completed child cost exactly once', async () => {
+    const checkpointId = 'replay-cost';
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId,
+      script,
+      runAgent: async () => finalResult,
+    });
+    clearStoreCache();
+    const recordCost = vi.fn();
+
+    const result = await callTool({ checkpointId, recordCost });
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      summary: "Completed workflow script 'tool-test' (1 agent call)",
+    });
+    expect(result.output).toContain('"category": "workflow"');
+    expect(recordCost).toHaveBeenCalledTimes(1);
+    expect(recordCost).toHaveBeenCalledWith(0.42);
+  });
+
+  it('passes JSON arguments through and formats a zero-call result', async () => {
+    const recordCost = vi.fn();
+    const result = await callTool({
+      checkpointId: 'args-result',
+      script: `export const meta = {
+  name: 'arguments',
+  description: 'returns its arguments',
+}
+return args`,
+      args: { question: 'What is conserved?' },
+      recordCost,
+    });
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      summary: "Completed workflow script 'arguments' (0 agent calls)",
+      output: expect.stringContaining('"question": "What is conserved?"'),
+    });
+    expect(recordCost).toHaveBeenCalledTimes(1);
+    expect(recordCost).toHaveBeenCalledWith(0);
+  });
+
+  it('settles a retained journal when later script code fails', async () => {
+    const checkpointId = 'partial-failure';
+    const failingScript = `export const meta = {
+  name: 'tool-test',
+  description: 'tests retained journal settlement',
+}
+await agent('saved call')
+throw new Error('script failed after replay')`;
+    await expect(
+      runPersistedWorkflowScript({
+        store: getExecutionStore(executionId),
+        checkpointId,
+        script: failingScript,
+        runAgent: async () => finalResult,
+      }),
+    ).rejects.toThrow('script failed after replay');
+    clearStoreCache();
+    const recordCost = vi.fn();
+
+    const result = await callTool({
+      checkpointId,
+      recordCost,
+      script: failingScript,
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('script failed after replay'),
+    });
+    expect(recordCost).toHaveBeenCalledTimes(1);
+    expect(recordCost).toHaveBeenCalledWith(0.42);
+  });
+
+  it('fails closed on malformed journal costs without recording a scalar', async () => {
+    const checkpointId = 'malformed-cost';
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId,
+      script,
+      runAgent: async () => ({ not: 'an agent result' }),
+    });
+    clearStoreCache();
+    const recordCost = vi.fn();
+
+    const result = await callTool({ checkpointId, recordCost });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: expect.stringContaining(
+        'Workflow journal entry 0 is not an agent final result',
+      ),
+    });
+    expect(recordCost).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -1,0 +1,133 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent runtime
+import { getExecutionStore } from '@agent/storage';
+import {
+  readWorkflowScriptCheckpoint,
+  type WorkflowJournalEntry,
+  type WorkflowScriptRunResult,
+} from '@agent/workflowScript';
+import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
+
+// Local imports - shared schemas
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import type { ToolResult } from '@shared/schemas/toolResult';
+
+// Local imports - tools
+import { defineTool } from '@tools/core/define';
+
+// Local imports - utilities
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { formatResultCount } from '@utils/text/stringUtils';
+
+// Local imports - delegation
+import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
+import {
+  runPersistedWorkflowScriptWithProgress,
+  sumCompletedWorkflowJournalCost,
+} from './workflowScriptRun';
+
+export const WorkflowScriptToolInputSchema = z.strictObject({
+  agent: z
+    .string()
+    .min(1)
+    .describe('Default workflow agent used when agent() omits agentName.'),
+  script: z
+    .string()
+    .min(1)
+    .describe(
+      'Complete workflow script source, beginning with an export const meta object.',
+    ),
+  args: z
+    .json()
+    .nullish()
+    .describe('JSON arguments exposed to the script as the global args value.'),
+});
+
+export type WorkflowScriptToolInput = z.infer<
+  typeof WorkflowScriptToolInputSchema
+>;
+
+function formatWorkflowResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  return JSON.stringify(result, null, 2) ?? 'undefined';
+}
+
+/** Execute a durable, deterministic workflow script from an opted-in agent. */
+export class WorkflowScriptTool extends defineTool({
+  name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  description: `Run a deterministic JavaScript workflow that coordinates one or more workflow agents. Use this when the complete fan-out, pipeline, and join structure is known in advance and should resume safely after interruption. The script must start with export const meta = { name, description } and may call agent(prompt, options), phase(title), log(message), parallel(thunks), pipeline(items, ...stages), and concat(parts, options). Its final return value is delivered as this tool's result.
+
+Available agents: loaded from the active roster at runtime.
+
+The agent field is the default for agent() calls; a call may select another visible workflow agent with options.agentName. Model selection follows the active model access mode automatically. Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.`,
+  schema: WorkflowScriptToolInputSchema,
+}) {
+  protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {
+    const contexts = getCurrentToolContexts();
+    if (contexts?.runContext?.kind !== 'launch') {
+      throw new Error(
+        'delegate_workflow_script requires an active launched agent session.',
+      );
+    }
+    const { runContext: parent, callContext } = contexts;
+    const checkpointId = callContext.toolCallId;
+    if (!checkpointId) {
+      throw new Error(
+        'delegate_workflow_script requires a tool call id for durable resume.',
+      );
+    }
+    if (!callContext.trace) {
+      throw new Error(
+        'delegate_workflow_script requires the parent progress trace.',
+      );
+    }
+
+    const store = getExecutionStore(parent.runScope.executionId);
+    let costSettled = false;
+    const settleCost = (journal: readonly WorkflowJournalEntry[]): void => {
+      if (costSettled) return;
+      const cost = sumCompletedWorkflowJournalCost(journal);
+      costSettled = true;
+      callContext.hooks?.recordSubagentCost?.(cost);
+    };
+
+    let run: WorkflowScriptRunResult;
+    try {
+      run = await runPersistedWorkflowScriptWithProgress(callContext.trace, {
+        store,
+        checkpointId,
+        script: input.script,
+        args: input.args,
+        signal: callContext.signal,
+        runAgent: createWorkflowScriptAgentRunner(
+          parent,
+          input.agent,
+          checkpointId,
+        ),
+      });
+    } catch (runError) {
+      try {
+        const checkpoint = await readWorkflowScriptCheckpoint(
+          store,
+          checkpointId,
+        );
+        settleCost(checkpoint?.journal ?? []);
+      } catch (settlementError) {
+        throw new AggregateError(
+          [runError, settlementError],
+          `Workflow script failed: ${toErrorMessage(runError)} Cost settlement also failed: ${toErrorMessage(settlementError)}`,
+        );
+      }
+      throw runError;
+    }
+
+    settleCost(run.journal);
+    return {
+      status: 'executed',
+      summary: `Completed workflow script '${run.meta.name}' (${formatResultCount(run.agentCalls, 'agent call')})`,
+      output: formatWorkflowResult(run.result),
+    };
+  }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,6 +9,7 @@ import {
 } from '@model/ToolDefinition';
 
 // Local imports - shared tools
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { CanonicalToolDisplayName } from '@shared/tools/toolKind';
 
 // Local imports - tools
@@ -56,6 +57,7 @@ import {
   LeanLoogleTool,
 } from './lean';
 import { WorkflowAgentTool, DelegateAgentTool } from './DelegationTools';
+import { WorkflowScriptTool } from './delegation/WorkflowScriptTool';
 import { ExecutionsTool } from './ExecutionsTool';
 import { AcceptRunFilesTool } from './AcceptRunFilesTool';
 import { ExternalInquiryTool } from './inquiry';
@@ -129,6 +131,7 @@ function createDefaultTools() {
     codex: new CodexTool(),
     [CLAUDE_AGENT_NAME]: new ClaudeAgentTool(),
     delegate_workflow: new WorkflowAgentTool(),
+    [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME]: new WorkflowScriptTool(),
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),
     accept_run_files: new AcceptRunFilesTool(),


### PR DESCRIPTION
## Summary

- Adds the opt-in `delegate_workflow_script` tool without enabling it for any default agent.
- Composes the existing persisted workflow runner, in-band workflow agents, task-run file hand-off, progress tree, and parent cost hook at one tool boundary.
- Propagates parent cancellation into QuickJS and active child runs.
- Presents the script, arguments, result, and progress in the extension without treating the tool as a single-agent proposal.

## Design

Before this change, the production runner, progress adapter, and strict journal-cost helper existed but had no model-facing boundary. A tool could not obtain the parent trace, and the sandbox had only its own timeout signal.

After this change, the tool-call context carries the existing parent trace and cancellation signal. The new tool owns checkpoint identity, result formatting, and one-time settlement of completed journal-call cost. Proposal reconstruction remains governed by the proposal-category map, while a separate availability map supplies the live workflow roster and model access information.

Explicit inclusion in a custom agent definition is the consent boundary for automated fan-out. The tool is registered and selectable in the agent creator, but remains absent from bundled and recommended agent configurations.

Cost settlement deliberately covers completed logical calls retained in the journal. Failed or cancelled attempts can consume additional model quota before they become durable.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 existing warnings)
- `npm run compile:fast`
- `npm test` (6,428 passed; 4 skipped)
- Focused workflow, dispatch, registry, catalog, and progress-view tests (136 passed before final rebase; 100 affected tests passed after rebase)

Closes #7154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new delegation surface that can launch many workflow subagents with durable checkpoints and cost settlement; mistakes in journal handling or cancellation could affect billing, run state, or parent sessions.
> 
> **Overview**
> Adds an **opt-in** `delegate_workflow_script` tool so custom agents can run **durable, resumable** JavaScript workflows that fan out to workflow agents with predetermined `parallel` / `pipeline` structure. The tool is **registered** and selectable in agent creation, but **not** enabled on default or recommended orchestrator configs—explicit tool inclusion is the consent boundary for automated multi-agent fan-out.
> 
> The new tool wires the existing persisted workflow runner, checkpoint store, in-band workflow agents, progress projection onto the **parent** trace, parent **cancellation**, and **one-time** settlement of completed journal costs. Tool-call context now carries the parent `trace` and `signal`; dispatch treats the tool as slow-running and passes trace into nested runs.
> 
> **QuickJS sandbox** and `runWorkflowScript` honor parent `AbortSignal` for immediate guest preemption. **Progress UI** gets dedicated formatting (script, args, result) without proposal “Setup” links or raw tool-output dumps. Delegation constants split **proposal-bearing** tools from **availability** annotations so workflow-script gets live roster/model lines but not proposal reconstruction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692348bb75b233ef9c66737e7021e39df66d57b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->