### PR TITLE
refactor: make stream content sync explicit

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -1,148 +1,71 @@
-import { create, type Draft } from 'mutative';
-
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import { sumUsageStats } from '@shared/schemas';
+import {
+  AgentCategory,
+  sumUsageStats,
+  type StreamContentRenderPayload,
+} from '@shared/schemas';
 
 import {
-  isToolUseState,
-  isWorkflowState,
-  type StreamState,
-  type ToolUseStreamState,
-  type WorkflowStreamState,
-} from '../store';
-import { updateParentStreamId } from '../stateUtils';
+  updateParentStreamId,
+  updateToolUseState,
+  updateWorkflowState,
+} from '../stateUtils';
 import type { HandlerRegistry } from '../messageHandlerTypes';
 
-const isRunUsageOwner = (
-  state: StreamState,
-): state is ToolUseStreamState | WorkflowStreamState =>
-  isToolUseState(state) || isWorkflowState(state);
-
-/**
- * Apply `mutate` to `draft` only when `prev` (the pre-mutation snapshot the
- * union was narrowed from) satisfies `guard`. Centralizes the single
- * necessarily-unsafe cast — `mutative`'s `Draft<T>` can't be narrowed from a
- * guard on the un-drafted `prev` — instead of repeating it at every call site.
- */
-function withDraftKind<S extends StreamState>(
-  draft: Draft<StreamState>,
-  prev: StreamState,
-  guard: (state: StreamState) => state is S,
-  mutate: (typedDraft: Draft<S>) => void,
-): void {
-  if (guard(prev)) mutate(draft as Draft<S>);
+function activeStateFields(data: StreamContentRenderPayload) {
+  if (!data.activeState) return {};
+  const { conversationProgress, roundStage, badges } = data.activeState;
+  return {
+    conversationProgress,
+    roundStage: roundStage ?? undefined,
+    activeSubagents: badges.activeSubagents,
+    finishedSubagentCount: badges.finishedSubagentCount,
+    activeProcesses: badges.activeProcesses,
+    finishedProcessCount: badges.finishedProcessCount,
+  };
 }
 
-// `HandlerRegistry` is now exhaustive (every ProgressView outbound command
-// needs a real handler or `unsupported(...)` — see `@shared/utils/dispatcher`).
-// This slice only owns a subset, so it's typed as a `satisfies Partial<...>`
-// subset rather than the full registry; `messageDispatcher.ts` spreads all
-// slices together and is the actual exhaustiveness checkpoint TypeScript
-// enforces.
+// `HandlerRegistry` is exhaustive across the assembled dispatcher. This slice
+// owns only stream-content synchronization.
 export const syncHandlers = {
   [PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT]: (data, ctx) => {
-    if (!data.stream || data.action === 'clear') return;
+    if (data.action === 'clear') return;
 
-    const hasWorkflowFiles =
-      data.workflowFiles !== undefined ||
-      data.workflowMissingOutputs !== undefined ||
-      data.workflowCompileFailures !== undefined;
-    const hasTaskData =
-      data.todos !== undefined ||
-      data.plan !== undefined ||
-      data.queuedFollowUps !== undefined;
-    const hasMeta =
-      data.conversationProgress !== undefined ||
-      'roundStage' in data ||
-      data.badges !== undefined;
-    const hasRunUsage = data.runUsage !== undefined;
-    const hasContext = data.contextState !== undefined;
+    const runUsage = { ...data.runUsage };
+    const sessionUsage = sumUsageStats(Object.values(runUsage));
 
-    if (
-      hasWorkflowFiles ||
-      hasTaskData ||
-      hasMeta ||
-      hasRunUsage ||
-      hasContext
-    ) {
-      ctx.setStreamState(data.stream, (prev) =>
-        create(prev, (draft) => {
-          // contextState is a base field shared by workflow and tool-use.
-          if (hasContext) {
-            draft.contextState = data.contextState;
-          }
-
-          if (hasWorkflowFiles) {
-            withDraftKind(draft, prev, isWorkflowState, (d) => {
-              // Replace (not merge) so a clean operation that shrinks the
-              // backend's set is reflected after a tab switch — Object.assign
-              // would leak stale rounds.
-              if (data.workflowFiles) d.files = { ...data.workflowFiles };
-              if (data.workflowMissingOutputs) {
-                d.missingOutputs = { ...data.workflowMissingOutputs };
-              }
-              if (data.workflowCompileFailures) {
-                d.compileFailures = { ...data.workflowCompileFailures };
-              }
-            });
-          }
-
-          // runUsage is per-run for both workflow and tool-use; derive the
-          // sum into sessionUsage so the UI always shows cumulative totals.
-          // Replace (not merge) so a clean operation that shrinks the backend's
-          // run set is reflected — Object.assign would leak stale entries and
-          // over-count sessionUsage.
-          if (hasRunUsage && data.runUsage) {
-            withDraftKind(draft, prev, isRunUsageOwner, (d) => {
-              d.runUsage = { ...data.runUsage };
-              d.sessionUsage = sumUsageStats(Object.values(d.runUsage));
-            });
-          }
-
-          if (hasTaskData) {
-            withDraftKind(draft, prev, isToolUseState, (d) => {
-              if (data.todos) d.todos = data.todos;
-              if (data.plan !== undefined) d.plan = data.plan;
-              if (data.queuedFollowUps)
-                d.queuedFollowUps = data.queuedFollowUps;
-            });
-          }
-
-          // Hydrate toggle bypass state on tab switch
-          withDraftKind(draft, prev, isToolUseState, (d) => {
-            if (data.toolEditBypass !== undefined)
-              d.toolEditBypass = data.toolEditBypass;
-            if (data.superYoloBypass !== undefined)
-              d.superYoloBypass = data.superYoloBypass;
-            // Treat goalActive as the source of truth: when it is
-            // explicitly set, also overwrite status/objective. JSON drops
-            // `undefined`, so the absence of these fields when active=false
-            // is expected and means "clear them".
-            if (data.goalActive !== undefined) {
-              d.goalActive = data.goalActive;
-              d.goalStatus = data.goalStatus;
-              d.goalObjective = data.goalObjective;
-            }
-          });
-
-          if (data.conversationProgress) {
-            draft.conversationProgress = data.conversationProgress;
-          }
-          if ('roundStage' in data) {
-            draft.roundStage = data.roundStage ?? undefined;
-          }
-          if (data.badges) {
-            draft.activeSubagents = data.badges.activeSubagents;
-            draft.finishedSubagentCount = data.badges.finishedSubagentCount;
-            draft.activeProcesses = data.badges.activeProcesses;
-            draft.finishedProcessCount = data.badges.finishedProcessCount;
-          }
-        }),
-      );
+    if (data.kind === AgentCategory.Workflow) {
+      updateWorkflowState(ctx, data.stream, (prev) => ({
+        ...prev,
+        ...activeStateFields(data),
+        runUsage,
+        sessionUsage,
+        files: { ...data.outputs.files },
+        missingOutputs: { ...data.outputs.missing },
+        compileFailures: { ...data.outputs.compileFailures },
+      }));
+    } else {
+      const { workPlan, controls } = data;
+      updateToolUseState(ctx, data.stream, (prev) => ({
+        ...prev,
+        ...activeStateFields(data),
+        runUsage,
+        sessionUsage,
+        todos: workPlan.todos,
+        plan: workPlan.plan,
+        queuedFollowUps: workPlan.queuedFollowUps,
+        toolEditBypass: controls.toolEditBypass,
+        superYoloBypass: controls.superYoloBypass,
+        goalActive: controls.goal.active,
+        goalStatus: controls.goal.active ? controls.goal.status : undefined,
+        goalObjective: controls.goal.active
+          ? controls.goal.objective
+          : undefined,
+      }));
     }
 
-    if (data.parentStreamId !== undefined) {
-      updateParentStreamId(ctx, data.stream as string, data.parentStreamId);
+    if (data.activeState) {
+      updateParentStreamId(ctx, data.stream, data.activeState.parentStreamId);
     }
   },
 } satisfies Partial<HandlerRegistry>;

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -1,3 +1,4 @@
+// Shared imports
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AgentCategory,
@@ -5,6 +6,7 @@ import {
   type StreamContentRenderPayload,
 } from '@shared/schemas';
 
+// Local imports
 import {
   updateParentStreamId,
   updateToolUseState,

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -1,6 +1,7 @@
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
 import type { MessageHandlerContext } from '@progressView/frontend/messageHandlerTypes';
 import {
+  AgentCategory,
   executionStatusToRunOutcome,
   STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
@@ -11,6 +12,7 @@ import {
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewOutboundMessage } from '@shared/schemas/progressView';
+import { buildStreamContentSync } from '@shared/streams/streamContentSync';
 import { isProcessAgent } from '@shared/streams/agentKind';
 import { isObject } from '@utils/core';
 import type { TraceDocument } from '@transcript';
@@ -197,19 +199,32 @@ export function replayTrace(
   };
   dispatchMessage(logDelta, ctx);
 
-  const syncContent: SyncStreamContentMessage = {
-    command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+  const syncSnapshot = {
     stream: trace.streamId,
     runUsage: snapshot.runUsage,
-    todos: snapshot.todos,
-    plan: snapshot.plan,
-    queuedFollowUps: [],
-    // Workflow-only display fields (empty records/arrays for tool-use
-    // traces) — the same rename the desktop ghost-stream restore path uses
-    // (packages/desktop/src/main/desktopSessionProgressBridge.ts).
-    workflowFiles: snapshot.outputFilesByRound,
-    workflowMissingOutputs: snapshot.missingOutputsByRound,
-    workflowCompileFailures: snapshot.compileFailuresByRound,
+  };
+  const syncPayload =
+    trace.config.agentCategory === AgentCategory.Workflow
+      ? buildStreamContentSync({
+          ...syncSnapshot,
+          kind: AgentCategory.Workflow,
+          files: snapshot.outputFilesByRound,
+          missingOutputs: snapshot.missingOutputsByRound,
+          compileFailures: snapshot.compileFailuresByRound,
+        })
+      : buildStreamContentSync({
+          ...syncSnapshot,
+          kind: AgentCategory.ToolUse,
+          todos: snapshot.todos,
+          plan: snapshot.plan,
+          queuedFollowUps: [],
+          toolEditBypass: false,
+          superYoloBypass: false,
+          goal: { active: false },
+        });
+  const syncContent: SyncStreamContentMessage = {
+    command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+    ...syncPayload,
   };
   dispatchMessage(syncContent, ctx);
 }

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -39,23 +39,6 @@ export type ProgressViewMessageSender = (
 ) => void;
 
 /**
- * Extra content to include with log updates.
- * All fields are optional to support incremental updates.
- *
- * NOTE: Status/todos/instruction are sent as separate messages rather than
- * batched here. This ensures critical UI feedback (status) isn't blocked by
- * potentially large log payloads and provides fault isolation.
- */
-export type LogContentExtras = Pick<
-  SyncStreamContentPayload,
-  | 'workflowFiles'
-  | 'workflowMissingOutputs'
-  | 'workflowCompileFailures'
-  | 'runUsage'
-  | 'contextState'
->;
-
-/**
  * Manages webview updates for the progress view.
  * Provides a clean interface for updating different parts of the webview
  * without coupling business logic to DOM operations.
@@ -383,10 +366,7 @@ export class WebviewUpdater {
     });
   }
 
-  /**
-   * Send a single batched content sync message combining logs, todos, follow-ups,
-   * and instruction. Used on tab switch to replace 4 separate messages with 1.
-   */
+  /** Sends one complete, kind-specific content snapshot for a stream tab. */
   sendSyncStreamContent(payload: SyncStreamContentPayload): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -775,7 +775,11 @@ export class ProgressFactApplier {
 
     this.webviewBridge.syncStream(stream);
 
-    const kind = this.getStreamCategory(stream) ?? AgentCategory.Workflow;
+    const existingState = this.state.getStreamState(stream);
+    const kind =
+      this.getStreamCategory(stream) ??
+      existingState?.kind ??
+      AgentCategory.Workflow;
 
     const activeState = includeActiveState
       ? this.toActiveStreamContentSync(

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -1,7 +1,4 @@
-import {
-  WebviewUpdater,
-  type LogContentExtras,
-} from '@controllers/progressView/backend/WebviewUpdater';
+import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
 import {
   ProgressViewState,
@@ -44,6 +41,7 @@ import {
 } from '@shared/schemas';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
+import { buildStreamContentSync } from '@shared/streams/streamContentSync';
 import { assertNever, mapToRecord } from '@utils/core';
 
 import { withEventErrorHandling } from './errorHandling';
@@ -61,13 +59,16 @@ export type ProgressEventSubscription = {
   dispose(): void;
 };
 
-export interface ProgressStreamControls {
+interface ProgressStreamBypassControls {
   toolEditBypass: boolean;
   superYoloBypass: boolean;
-  goalActive: boolean;
-  goalStatus?: GoalStatus;
-  goalObjective?: string;
 }
+
+export type ProgressStreamControls = ProgressStreamBypassControls &
+  (
+    | { goalActive: false }
+    | { goalActive: true; goalStatus: GoalStatus; goalObjective: string }
+  );
 
 export type GetProgressStreamControls = (
   stream: StreamTabId,
@@ -766,68 +767,73 @@ export class ProgressFactApplier {
 
     if (!stream) {
       // Clear the stream surface when no stream is active.
-      this.webviewUpdater.sendSyncStreamContent({
-        stream: '',
-        action: 'clear',
-        todos: [],
-        plan: null,
-        queuedFollowUps: [],
-      });
+      this.webviewUpdater.sendSyncStreamContent(
+        buildStreamContentSync({ action: 'clear' }),
+      );
       return;
     }
 
     this.webviewBridge.syncStream(stream);
 
-    const extras = this.buildStreamSyncExtras(stream);
-    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
-    const queuedFollowUps = this.state.followUps.getAll(stream);
-    const agentCategory = this.getStreamCategory(stream);
+    const kind = this.getStreamCategory(stream) ?? AgentCategory.Workflow;
 
-    // Optionally include active-stream state (replaces syncActiveStreamState).
-    let conversationProgress: ConversationProgress | undefined;
-    let roundStage: StreamExecutionState['roundStage'] | undefined;
-    let badges: StreamBadgeSnapshot | undefined;
-    let parentStreamId: StreamTabId | undefined;
-    if (includeActiveState) {
-      const streamState = this.state.getStreamState(stream);
-      if (streamState) {
-        conversationProgress = streamState.conversationProgress;
-        roundStage = streamState.roundStage;
-        badges = this.toBadgeSnapshot(streamState);
-      }
-      parentStreamId = this.state.snapshots.getParentStreamId(stream);
+    const activeState = includeActiveState
+      ? this.toActiveStreamContentSync(
+          stream,
+          this.state.getOrCreateStreamState(stream, kind),
+        )
+      : undefined;
+
+    const shared = {
+      stream,
+      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
+      activeState,
+    };
+
+    if (kind === AgentCategory.Workflow) {
+      this.webviewUpdater.sendSyncStreamContent(
+        buildStreamContentSync({
+          ...shared,
+          kind,
+          files: this.state.snapshots.getOutputFiles(stream),
+          missingOutputs: this.state.snapshots.getMissingOutputs(stream),
+          compileFailures: this.state.snapshots.getCompileFailures(stream),
+        }),
+      );
+      return;
     }
 
-    // Always include toggle/goal state so buttons render correctly on tab switch.
-    const streamControls = this.getStreamControls(stream);
-
-    this.webviewUpdater.sendSyncStreamContent({
-      stream,
-      action: 'render',
-      ...extras,
-      todos,
-      plan,
-      queuedFollowUps,
-      agentCategory,
-      conversationProgress,
-      roundStage: includeActiveState ? (roundStage ?? null) : undefined,
-      badges,
-      parentStreamId,
-      ...streamControls,
-    });
+    const { todos, plan } = this.state.snapshots.getWorkPlan(stream);
+    const controls = this.getStreamControls(stream);
+    this.webviewUpdater.sendSyncStreamContent(
+      buildStreamContentSync({
+        ...shared,
+        kind,
+        todos,
+        plan,
+        queuedFollowUps: this.state.followUps.getAll(stream),
+        toolEditBypass: controls.toolEditBypass,
+        superYoloBypass: controls.superYoloBypass,
+        goal: controls.goalActive
+          ? {
+              active: true,
+              status: controls.goalStatus,
+              objective: controls.goalObjective,
+            }
+          : { active: false },
+      }),
+    );
   }
 
-  private buildStreamSyncExtras(stream: StreamTabId): LogContentExtras {
+  private toActiveStreamContentSync(
+    stream: StreamTabId,
+    state: StreamExecutionState,
+  ) {
     return {
-      // Workflow files/missing outputs are flat (one run per tab), already in
-      // the canonical round-indexed record shape the webview consumes.
-      workflowFiles: this.state.snapshots.getOutputFiles(stream),
-      workflowMissingOutputs: this.state.snapshots.getMissingOutputs(stream),
-      workflowCompileFailures: this.state.snapshots.getCompileFailures(stream),
-      // Per-run usage map — shared by workflow and tool-use. Frontend derives
-      // sessionUsage as the sum so cumulative totals survive resume.
-      runUsage: mapToRecord(this.state.snapshots.getRunUsage(stream)),
-      contextState: this.state.getContextState(stream),
+      conversationProgress: state.conversationProgress,
+      roundStage: state.roundStage ?? null,
+      badges: this.toBadgeSnapshot(state),
+      parentStreamId: this.state.snapshots.getParentStreamId(stream) ?? null,
     };
   }
 

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -21,7 +21,6 @@ import {
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
-  type ContextStateData,
   type ExecutionId,
   type RoundStage,
   type StreamTabId,
@@ -60,7 +59,6 @@ export interface ProgressStreamMetadata {
 /** Ephemeral session state per stream (not persisted). */
 interface StreamSessionState {
   metadata: ProgressStreamMetadata;
-  contextState: ContextStateData | null;
 }
 
 /** Active stream identifier, or empty string when no stream is selected. */
@@ -230,7 +228,6 @@ export class ProgressViewState {
             creationTimestamp ??
             Date.now(),
         },
-        contextState: null,
       };
       this._sessionState.set(stream, state);
     }
@@ -330,10 +327,6 @@ export class ProgressViewState {
   }
 
   // todos/plan are owned + persisted by StreamSnapshotStore (workPlan.json).
-
-  getContextState(stream: StreamTabId): ContextStateData | undefined {
-    return this._sessionState.get(stream)?.contextState ?? undefined;
-  }
 
   // -- Ephemeral execution state ----------------------------------------------
 

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -1,6 +1,5 @@
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
-import { isGoalInFlight } from '@shared/schemas/goal';
 import {
   isApprovalBypassedForStream,
   proposalApprovals,
@@ -13,13 +12,17 @@ export function getProgressStreamControls(
   session?: SessionHandle,
 ): ProgressStreamControls {
   const goal = GoalStore.getForStream(streamId);
-  const goalActive = isGoalInFlight(goal);
-  return {
+  const bypasses = {
     toolEditBypass: isApprovalBypassedForStream(streamId, session),
     superYoloBypass: proposalApprovals(session).isBypassed(streamId),
-    goalActive,
-    ...(goalActive && goal
-      ? { goalStatus: goal.status, goalObjective: goal.objective }
-      : {}),
+  };
+  if (!goal) {
+    return { ...bypasses, goalActive: false };
+  }
+  return {
+    ...bypasses,
+    goalActive: true,
+    goalStatus: goal.status,
+    goalObjective: goal.objective,
   };
 }

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -12,6 +12,7 @@ import {
 } from '@shared/utils/dispatcher';
 import { ThemeSchema } from '../commonViewMessages';
 import { GoalStatusSchema } from '../goal';
+import { AgentCategory } from '../agent';
 
 import { StreamTabIdSchema } from '../identifiers';
 import { StreamLogEntrySchema, StreamLogTextDeltaSchema } from '../log';
@@ -41,7 +42,6 @@ import {
 } from '../streamState';
 import { PlanSchema } from '../plan';
 import { TodoItemSchema } from '../todo';
-import { ContextStateDataSchema } from '../contextManagement';
 import { RunUsageMapSchema, TokenUsageStatsSchema } from '../usage';
 import {
   AgentCategoryFilterSchema,
@@ -291,46 +291,98 @@ export const UpdateInquiryThreadMessageSchema = z.object({
   thread: InquiryThreadUpdatedEventSchema,
 });
 
-export const SyncStreamContentMessageSchema = z.object({
+const StreamContentRenderFields = {
   command: z.literal(PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
-  stream: z.union([StreamTabIdSchema, z.literal('')]),
-  action: z.enum(['render', 'clear']).optional(),
-  // Workflow flat files (one run per tab)
-  workflowFiles: roundIndexedRecord(OutputFileInfoSchema).optional(),
-  workflowMissingOutputs: roundIndexedRecord(z.string()).optional(),
-  workflowCompileFailures: roundIndexedRecord(CompileFailureSchema).optional(),
-  // Per-run usage map — used by both workflow and tool-use so resume
-  // correctly accumulates. Frontend derives sessionUsage as the sum.
-  runUsage: RunUsageMapSchema.optional(),
-  contextState: ContextStateDataSchema.optional(),
-  todos: z.array(TodoItemSchema),
-  plan: PlanSchema.nullable(),
-  queuedFollowUps: z.array(z.string()),
-  agentCategory: z.string().optional(),
-  // Tab-switch state (R2: replaces separate syncActiveStreamState messages)
-  conversationProgress: ConversationProgressSchema.optional(),
-  roundStage: RoundStageSchema.nullable().optional(),
-  badges: z
-    .object({
-      activeSubagents: z.array(ActiveChildInfoSchema),
-      finishedSubagentCount: z.number(),
-      activeProcesses: z.array(ActiveChildInfoSchema),
-      finishedProcessCount: z.number(),
+  action: z.literal('render'),
+  stream: StreamTabIdSchema,
+  // Per-run usage is shared by both stream kinds. The frontend derives the
+  // cumulative session total from this canonical map.
+  runUsage: RunUsageMapSchema,
+  // Active state is all-or-nothing. Partial tab-activation snapshots would
+  // preserve unrelated stale fields in the frontend.
+  activeState: z
+    .strictObject({
+      conversationProgress: ConversationProgressSchema,
+      roundStage: RoundStageSchema.nullable(),
+      badges: z.strictObject({
+        activeSubagents: z.array(ActiveChildInfoSchema),
+        finishedSubagentCount: z.number(),
+        activeProcesses: z.array(ActiveChildInfoSchema),
+        finishedProcessCount: z.number(),
+      }),
+      parentStreamId: StreamTabIdSchema.nullable(),
     })
     .optional(),
-  parentStreamId: StreamTabIdSchema.optional(),
-  // Toggle bypass state (hydrated on tab switch so toggles display correctly)
-  toolEditBypass: z.boolean().optional(),
-  superYoloBypass: z.boolean().optional(),
-  goalActive: z.boolean().optional(),
-  goalStatus: GoalStatusSchema.optional(),
-  goalObjective: z.string().optional(),
+};
+
+const ClearStreamContentMessageSchema = z.strictObject({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
+  action: z.literal('clear'),
 });
 
-export type SyncStreamContentPayload = Omit<
-  z.infer<typeof SyncStreamContentMessageSchema>,
-  'command'
+const WorkflowStreamContentMessageSchema = z.strictObject({
+  ...StreamContentRenderFields,
+  kind: z.literal(AgentCategory.Workflow),
+  outputs: z.strictObject({
+    files: roundIndexedRecord(OutputFileInfoSchema),
+    missing: roundIndexedRecord(z.string()),
+    compileFailures: roundIndexedRecord(CompileFailureSchema),
+  }),
+});
+
+const GoalSyncSchema = z.discriminatedUnion('active', [
+  z.strictObject({ active: z.literal(false) }),
+  z.strictObject({
+    active: z.literal(true),
+    status: GoalStatusSchema,
+    objective: z.string(),
+  }),
+]);
+
+const ToolUseStreamContentMessageSchema = z.strictObject({
+  ...StreamContentRenderFields,
+  kind: z.literal(AgentCategory.ToolUse),
+  workPlan: z.strictObject({
+    todos: z.array(TodoItemSchema),
+    plan: PlanSchema.nullable(),
+    queuedFollowUps: z.array(z.string()),
+  }),
+  controls: z.strictObject({
+    toolEditBypass: z.boolean(),
+    superYoloBypass: z.boolean(),
+    goal: GoalSyncSchema,
+  }),
+});
+
+/** Full tab snapshots, expressed as the only three valid transport states. */
+const RenderStreamContentMessageSchema = z.discriminatedUnion('kind', [
+  WorkflowStreamContentMessageSchema,
+  ToolUseStreamContentMessageSchema,
+]);
+
+export const SyncStreamContentMessageSchema = z.discriminatedUnion('action', [
+  ClearStreamContentMessageSchema,
+  RenderStreamContentMessageSchema,
+]);
+
+type WithoutCommand<T> = T extends unknown ? Omit<T, 'command'> : never;
+
+export type SyncStreamContentPayload = WithoutCommand<
+  z.infer<typeof SyncStreamContentMessageSchema>
 >;
+
+export type WorkflowStreamContentPayload = Extract<
+  SyncStreamContentPayload,
+  { action: 'render'; kind: typeof AgentCategory.Workflow }
+>;
+
+export type ToolUseStreamContentPayload = Extract<
+  SyncStreamContentPayload,
+  { action: 'render'; kind: typeof AgentCategory.ToolUse }
+>;
+
+export type StreamContentRenderPayload =
+  WorkflowStreamContentPayload | ToolUseStreamContentPayload;
 
 const GoalActiveUpdatedMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED),

--- a/src/shared/streams/streamContentSync.ts
+++ b/src/shared/streams/streamContentSync.ts
@@ -1,3 +1,4 @@
+// Shared imports
 import {
   AgentCategory,
   type ActiveChildInfo,

--- a/src/shared/streams/streamContentSync.ts
+++ b/src/shared/streams/streamContentSync.ts
@@ -1,0 +1,111 @@
+import {
+  AgentCategory,
+  type ActiveChildInfo,
+  type CompileFailure,
+  type ConversationProgress,
+  type GoalStatus,
+  type OutputFileInfo,
+  type Plan,
+  type RoundIndexed,
+  type RoundStage,
+  type StreamTabId,
+  type SyncStreamContentPayload,
+  type TokenUsageStats,
+  type TodoItem,
+  type ToolUseStreamContentPayload,
+  type WorkflowStreamContentPayload,
+} from '../schemas';
+
+interface ClearStreamContentSync {
+  action: 'clear';
+}
+
+interface ActiveStreamContentSync {
+  conversationProgress: ConversationProgress;
+  roundStage: RoundStage | null;
+  badges: {
+    activeSubagents: ActiveChildInfo[];
+    finishedSubagentCount: number;
+    activeProcesses: ActiveChildInfo[];
+    finishedProcessCount: number;
+  };
+  parentStreamId: StreamTabId | null;
+}
+
+interface StreamContentSyncBase {
+  stream: StreamTabId;
+  runUsage: Record<string, TokenUsageStats>;
+  activeState?: ActiveStreamContentSync;
+}
+
+interface WorkflowStreamContentSync extends StreamContentSyncBase {
+  kind: typeof AgentCategory.Workflow;
+  files: RoundIndexed<OutputFileInfo>;
+  missingOutputs: RoundIndexed<string>;
+  compileFailures: RoundIndexed<CompileFailure>;
+}
+
+interface ToolUseStreamContentSync extends StreamContentSyncBase {
+  kind: typeof AgentCategory.ToolUse;
+  todos: TodoItem[];
+  plan: Plan | null;
+  queuedFollowUps: string[];
+  toolEditBypass: boolean;
+  superYoloBypass: boolean;
+  goal:
+    { active: false } | { active: true; status: GoalStatus; objective: string };
+}
+
+export type StreamContentSyncSnapshot =
+  ClearStreamContentSync | WorkflowStreamContentSync | ToolUseStreamContentSync;
+
+/** Projects canonical state into one of the three valid transport variants. */
+export function buildStreamContentSync(
+  snapshot: ClearStreamContentSync,
+): Extract<SyncStreamContentPayload, { action: 'clear' }>;
+export function buildStreamContentSync(
+  snapshot: WorkflowStreamContentSync,
+): WorkflowStreamContentPayload;
+export function buildStreamContentSync(
+  snapshot: ToolUseStreamContentSync,
+): ToolUseStreamContentPayload;
+export function buildStreamContentSync(
+  snapshot: StreamContentSyncSnapshot,
+): SyncStreamContentPayload {
+  if ('action' in snapshot) return snapshot;
+
+  const { stream, runUsage, activeState } = snapshot;
+  const shared = {
+    action: 'render' as const,
+    stream,
+    runUsage,
+    ...(activeState ? { activeState } : {}),
+  };
+
+  if (snapshot.kind === AgentCategory.Workflow) {
+    return {
+      ...shared,
+      kind: snapshot.kind,
+      outputs: {
+        files: snapshot.files,
+        missing: snapshot.missingOutputs,
+        compileFailures: snapshot.compileFailures,
+      },
+    };
+  }
+
+  return {
+    ...shared,
+    kind: snapshot.kind,
+    workPlan: {
+      todos: snapshot.todos,
+      plan: snapshot.plan,
+      queuedFollowUps: snapshot.queuedFollowUps,
+    },
+    controls: {
+      toolEditBypass: snapshot.toolEditBypass,
+      superYoloBypass: snapshot.superYoloBypass,
+      goal: snapshot.goal,
+    },
+  };
+}

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -180,6 +180,8 @@ type CreateBridgeOptions = {
 
 type ProgressMessage = {
   command?: string;
+  action?: string;
+  kind?: string;
   activeStream?: string;
   stream?: string;
   streamId?: string;
@@ -193,6 +195,13 @@ type ProgressMessage = {
   streams?: Array<{ name: string; creationTimestamp: number }>;
   streamStates?: Record<string, unknown>;
   streamState?: unknown;
+  runUsage?: Record<string, unknown>;
+  outputs?: {
+    files: Record<string, unknown>;
+    missing: Record<string, unknown>;
+    compileFailures: Record<string, unknown>;
+  };
+  activeState?: unknown;
 };
 
 /** Shared fixture for the tool-use "search" agentConfig used across several
@@ -2158,6 +2167,25 @@ describe('DesktopProgressBridge', () => {
     expect(messages[1]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
       activeStream: 'first',
+    });
+    expect(messages[2]).toMatchObject({
+      command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+      action: 'render',
+      stream: 'first',
+      kind: AgentCategory.Workflow,
+      runUsage: {},
+      outputs: { files: {}, missing: {}, compileFailures: {} },
+      activeState: {
+        conversationProgress: { toolCallCount: 0 },
+        roundStage: null,
+        badges: {
+          activeSubagents: [],
+          finishedSubagentCount: 0,
+          activeProcesses: [],
+          finishedProcessCount: 0,
+        },
+        parentStreamId: null,
+      },
     });
     expect(messages[3]).toMatchObject({
       command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,

--- a/src/test-kernel/progressView/ProcessOutputState.vitest.ts
+++ b/src/test-kernel/progressView/ProcessOutputState.vitest.ts
@@ -419,10 +419,20 @@ describe('process output frontend state', () => {
         command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
         stream: streamId,
         action: 'render',
-        todos: [],
-        plan: null,
-        queuedFollowUps: [],
-        roundStage: null,
+        kind: AgentCategory.Workflow,
+        runUsage: {},
+        outputs: { files: {}, missing: {}, compileFailures: {} },
+        activeState: {
+          conversationProgress: { toolCallCount: 0 },
+          roundStage: null,
+          badges: {
+            activeSubagents: [],
+            finishedSubagentCount: 0,
+            activeProcesses: [],
+            finishedProcessCount: 0,
+          },
+          parentStreamId: null,
+        },
       } satisfies ProgressViewOutboundMessage),
     ) as ProgressViewOutboundMessage;
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1658,6 +1658,7 @@ describe('ProgressBackend', () => {
       ).toMatchObject({
         stream: 'workflow-existing',
         action: 'render',
+        kind: AgentCategory.Workflow,
       });
     } finally {
       backend.dispose();
@@ -1720,7 +1721,7 @@ describe('ProgressBackend', () => {
       expect(sync).toMatchObject({
         stream,
         action: 'render',
-        agentCategory: AgentCategory.ToolUse,
+        kind: AgentCategory.ToolUse,
       });
     } finally {
       backend.dispose();

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -28,6 +28,7 @@ import {
   dispatchProgressViewOutbound,
   MainViewMessageSchema,
   ProgressViewOutboundMessageSchema,
+  SyncStreamContentMessageSchema,
   type ProgressViewOutboundHandlerRegistry,
 } from '@shared/schemas';
 import {
@@ -37,21 +38,100 @@ import {
   unsupported,
 } from '@shared/utils/dispatcher';
 
-/** Every command in the real outbound schema, including nested unions (UPDATE_PERMISSION). */
+interface DiscriminatedSchemaNode {
+  shape?: { command: { value: string } };
+  options?: readonly DiscriminatedSchemaNode[];
+}
+
+function collectCommands(
+  schema: DiscriminatedSchemaNode,
+  commands: Set<string>,
+): void {
+  if (schema.shape) commands.add(schema.shape.command.value);
+  for (const option of schema.options ?? []) {
+    collectCommands(option, commands);
+  }
+}
+
+/** Every command in the real outbound schema, including nested unions. */
 function outboundCommands(): string[] {
   const commands = new Set<string>();
-  for (const opt of ProgressViewOutboundMessageSchema.options as Array<{
-    shape?: { command: { value: string } };
-    options?: Array<{ shape: { command: { value: string } } }>;
-  }>) {
-    if (opt.shape) {
-      commands.add(opt.shape.command.value);
-    } else if (opt.options) {
-      for (const sub of opt.options) commands.add(sub.shape.command.value);
-    }
-  }
+  collectCommands(
+    ProgressViewOutboundMessageSchema as unknown as DiscriminatedSchemaNode,
+    commands,
+  );
   return [...commands];
 }
+
+describe('SyncStreamContentMessageSchema', () => {
+  const workflow = {
+    command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+    action: 'render',
+    stream: 'workflow-stream',
+    kind: 'workflow',
+    runUsage: {},
+    outputs: { files: {}, missing: {}, compileFailures: {} },
+    activeState: {
+      conversationProgress: { toolCallCount: 0 },
+      roundStage: null,
+      badges: {
+        activeSubagents: [],
+        finishedSubagentCount: 0,
+        activeProcesses: [],
+        finishedProcessCount: 0,
+      },
+      parentStreamId: null,
+    },
+  } as const;
+  const toolUse = {
+    command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+    action: 'render',
+    stream: 'tool-stream',
+    kind: 'toolUse',
+    runUsage: {},
+    workPlan: { todos: [], plan: null, queuedFollowUps: [] },
+    controls: {
+      toolEditBypass: false,
+      superYoloBypass: false,
+      goal: { active: false },
+    },
+  } as const;
+
+  it.each([
+    { command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT, action: 'clear' },
+    workflow,
+    toolUse,
+  ])('accepts an exact transport variant', (message) => {
+    expect(SyncStreamContentMessageSchema.safeParse(message).success).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    {
+      command: PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+      action: 'clear',
+      stream: '',
+    },
+    { ...workflow, workPlan: toolUse.workPlan },
+    { ...toolUse, outputs: workflow.outputs },
+    {
+      ...workflow,
+      activeState: { conversationProgress: { toolCallCount: 1 } },
+    },
+    {
+      ...toolUse,
+      controls: {
+        ...toolUse.controls,
+        goal: { active: true },
+      },
+    },
+  ])('rejects a contradictory transport state', (message) => {
+    expect(SyncStreamContentMessageSchema.safeParse(message).success).toBe(
+      false,
+    );
+  });
+});
 
 function createSpyContext(initialState: ProgressState = createInitialState()): {
   ctx: MessageHandlerContext;

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -222,6 +222,45 @@ describe('progress view stream-content projection', () => {
     expect(messages[0]).not.toHaveProperty('controls');
   });
 
+  it('preserves a provisional tool-use execution across metadata reset', async () => {
+    const state = await createLoadedState();
+    const { messages, updater, bridge } = createSyncCapture();
+    const handler = new ProgressFactApplier(
+      state,
+      updater,
+      bridge,
+      () => false,
+    );
+
+    state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    // Running-transition setup preserves the provisional kind in execution
+    // state while reset metadata awaits a canonical run config.
+    state.resetStreamMetadataForRun(stream);
+    state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+    expect(state.getStreamMetadata(stream).agentCategory).toBeUndefined();
+    state.updateStreamState(stream, (prev) => ({
+      ...prev,
+      conversationProgress: { toolCallCount: 3 },
+      activeSubagents: [activeSubagent],
+    }));
+    messages.length = 0;
+
+    handler.syncStreamContent(stream, { includeActiveState: true });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      action: 'render',
+      stream,
+      kind: AgentCategory.ToolUse,
+      activeState: {
+        conversationProgress: { toolCallCount: 3 },
+        badges: { activeSubagents: [activeSubagent] },
+      },
+    });
+  });
+
   it('projects clear without placeholder stream content', async () => {
     const state = await createLoadedState();
     const { messages, updater, bridge } = createSyncCapture();

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -120,8 +120,8 @@ function createSyncCapture(): SyncCapture {
   return { messages, updater, bridge };
 }
 
-describe('progress view snapshot hydration', () => {
-  it('syncs the durable display snapshot from the shared progress-view backend', async () => {
+describe('progress view stream-content projection', () => {
+  it('projects the tool-use snapshot and active state', async () => {
     const state = await createLoadedState();
     const { messages, updater, bridge } = createSyncCapture();
     const handler = new ProgressFactApplier(
@@ -131,9 +131,6 @@ describe('progress view snapshot hydration', () => {
       () => false,
     );
 
-    state.snapshots.addOutputFiles(stream, { 1: [outputFile] });
-    state.snapshots.updateMissingOutputs(stream, { 1: ['paper.pdf'] });
-    state.snapshots.updateCompileFailures(stream, { 1: [compileFailure] });
     state.snapshots.addUsage(stream, runId, usage);
     state.snapshots.setTodos(stream, [todo]);
     state.snapshots.setPlan(stream, plan);
@@ -156,37 +153,88 @@ describe('progress view snapshot hydration', () => {
     expect(messages.at(-1)).toMatchObject({
       stream,
       action: 'render',
-      workflowFiles: {
-        1: [outputFile],
-      },
-      workflowMissingOutputs: {
-        1: ['paper.pdf'],
-      },
-      workflowCompileFailures: {
-        1: [compileFailure],
-      },
+      kind: AgentCategory.ToolUse,
       runUsage: {
         [runId]: usage,
       },
-      todos: [todo],
-      plan,
-      queuedFollowUps: [],
-      agentCategory: AgentCategory.ToolUse,
-      conversationProgress: { toolCallCount: 5 },
-      roundStage: { index: 2 },
-      badges: {
-        activeSubagents: [activeSubagent],
-        finishedSubagentCount: 2,
-        activeProcesses: [],
-        finishedProcessCount: 0,
+      workPlan: {
+        todos: [todo],
+        plan,
+        queuedFollowUps: [],
       },
-      parentStreamId: parentStream,
+      controls: {
+        toolEditBypass: false,
+        superYoloBypass: false,
+        goal: { active: false },
+      },
+      activeState: {
+        conversationProgress: { toolCallCount: 5 },
+        roundStage: { index: 2 },
+        badges: {
+          activeSubagents: [activeSubagent],
+          finishedSubagentCount: 2,
+          activeProcesses: [],
+          finishedProcessCount: 0,
+        },
+        parentStreamId: parentStream,
+      },
     });
     expect(state.snapshots.getWorkPlan(stream)).toEqual({
       todos: [todo],
       plan,
       planSummary: 'Hydrate plan and todo state from one backend owner.',
     });
+  });
+
+  it('projects workflow outputs without tool-use capabilities', async () => {
+    const state = await createLoadedState();
+    const { messages, updater, bridge } = createSyncCapture();
+    const handler = new ProgressFactApplier(
+      state,
+      updater,
+      bridge,
+      () => false,
+    );
+
+    state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.Workflow,
+    });
+    state.snapshots.addOutputFiles(stream, { 1: [outputFile] });
+    state.snapshots.updateMissingOutputs(stream, { 1: ['paper.pdf'] });
+    state.snapshots.updateCompileFailures(stream, { 1: [compileFailure] });
+    state.snapshots.addUsage(stream, runId, usage);
+
+    handler.syncStreamContent(stream);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      action: 'render',
+      stream,
+      kind: AgentCategory.Workflow,
+      runUsage: { [runId]: usage },
+      outputs: {
+        files: { 1: [outputFile] },
+        missing: { 1: ['paper.pdf'] },
+        compileFailures: { 1: [compileFailure] },
+      },
+    });
+    expect(messages[0]).not.toHaveProperty('workPlan');
+    expect(messages[0]).not.toHaveProperty('controls');
+  });
+
+  it('projects clear without placeholder stream content', async () => {
+    const state = await createLoadedState();
+    const { messages, updater, bridge } = createSyncCapture();
+    const handler = new ProgressFactApplier(
+      state,
+      updater,
+      bridge,
+      () => false,
+    );
+
+    handler.syncStreamContent('');
+
+    expect(messages).toEqual([{ action: 'clear' }]);
   });
 
   it('includes host-provided stream controls in synced content', async () => {
@@ -210,16 +258,25 @@ describe('progress view snapshot hydration', () => {
       },
     );
 
+    state.updateStreamMetadata(controlledStream, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+
     handler.syncStreamContent(controlledStream);
 
     expect(messages.at(-1)).toMatchObject({
       stream: controlledStream,
       action: 'render',
-      toolEditBypass: true,
-      superYoloBypass: true,
-      goalActive: true,
-      goalStatus: 'active',
-      goalObjective: 'Keep making progress.',
+      kind: AgentCategory.ToolUse,
+      controls: {
+        toolEditBypass: true,
+        superYoloBypass: true,
+        goal: {
+          active: true,
+          status: 'active',
+          objective: 'Keep making progress.',
+        },
+      },
     });
   });
 });

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -120,6 +120,55 @@ function legacyTrace(
 }
 
 describe('replayTrace legacy-status fallback (issue #7188)', () => {
+  it('replays workflow content without tool-use state', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const trace = legacyTrace(undefined);
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed).toMatchObject({
+      kind: AgentCategory.Workflow,
+      files: {},
+      missingOutputs: {},
+      compileFailures: {},
+    });
+    expect(replayed).not.toHaveProperty('todos');
+  });
+
+  it('replays tool-use content without workflow output state', () => {
+    const { ctx, getState } = createContext(createInitialState());
+    const workflow = legacyTrace(undefined);
+    const trace: TraceDocument = {
+      ...workflow,
+      config: AgentConfigSchema.parse({
+        agent: 'correct',
+        model: 'gemini35f',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      snapshot: StreamSnapshotSchema.parse({
+        streamId: workflow.streamId,
+        todos: [
+          {
+            content: 'Replay the plan',
+            status: 'pending',
+            activeForm: 'Replaying the plan',
+          },
+        ],
+      }),
+    };
+
+    replayTrace(trace, ctx);
+
+    const replayed = getState().streamStates.get(trace.streamId);
+    expect(replayed).toMatchObject({
+      kind: AgentCategory.ToolUse,
+      todos: [{ content: 'Replay the plan' }],
+      plan: null,
+    });
+    expect(replayed).not.toHaveProperty('files');
+  });
+
   it('derives failed status from a real exported legacy trace without snapshot.status', async () => {
     const executionId = 'abc124' as ExecutionId;
     const config = AgentConfigSchema.parse({


### PR DESCRIPTION
## Summary

`SYNC_STREAM_CONTENT` now describes exactly three states: clear, workflow render, or tool-use render. Workflow outputs, tool-use work plans and controls, and complete activation state are separated by the schema instead of inferred from optional field combinations.

A host-neutral projector is the sole constructor for live extension/desktop snapshots and trace replay. The frontend reducer follows the union directly with immutable kind-specific updates. Backend `contextState` storage and projection, which had no writer, are removed while the active log-derived frontend context state remains.

Closes #8546.

## Issue acceptance gates

- Strict schema tests accept all exact variants and reject fake clear fields, cross-kind capability fields, partial activation state, and incomplete active goals.
- Clear carries no empty stream, todos, plan, or follow-up placeholders.
- Workflow and tool-use render payloads expose only their own capabilities.
- Frontend handling contains no `Draft` cast, field-presence reconstruction, or stream cast.
- Live backend, desktop, trace replay, work-plan, process-output, and schema tests cover the new contract.
- Provisional tool-use state remains authoritative while canonical run metadata is temporarily absent.
- The repository typecheck, compile, lint, full Vitest suite, and dead-code ratchet are green.

## Single source of truth

`SyncStreamContentMessageSchema` owns the valid transport states. `buildStreamContentSync` in `src/shared/streams/streamContentSync.ts` owns their construction for both live progress and archived trace replay.

## Duplication and abstraction budget

The change removes two independent payload constructors and the frontend's five `has*` inference groups. The new projector owns one invariant: every source snapshot becomes one schema-valid transport variant. It is not a pass-through layer; it maps canonical flat state into capability-specific nested payloads and is shared by both real producers.

Dead plumbing removed: `LogContentExtras`, backend `StreamSessionState.contextState`, its initializer/getter, and the unused goal-liveness predicate branch.

## Net elements (R6)

- Files: 1 added, 1 renamed, 12 modified.
- Diff: +673 / -319 lines; production code is +362 / -272 (net +90), with the remainder in contract and host coverage.
- Exported symbols: net +4 (`WorkflowStreamContentPayload`, `ToolUseStreamContentPayload`, `StreamContentRenderPayload`, `StreamContentSyncSnapshot`, and `buildStreamContentSync` added; `LogContentExtras` removed; existing exports retained with stricter definitions).
- Classes/enums: no change. Interfaces: 7 added and 1 removed, net +6; five model the projector's source union, one models recursive test schema traversal, and one replaces the former exported boolean property bag internally.

## Consumer counts (R8)

- `buildStreamContentSync`: 2 production consumers (live progress backend and trace replay).
- `SYNC_STREAM_CONTENT`: 1 shared frontend reducer consumed by both extension and desktop renderers.
- Removed `getContextState`: 1 former producer call, 0 writers, 0 remaining consumers.

## Host impact

Extension: Receives and reduces strict kind-specific snapshots through the existing progress dispatcher.

Desktop: Uses the same live backend/projector and shared reducer; a desktop execution test asserts the complete workflow and activation payload.

CLI: No runtime or UI behavior change.

## Scheduled refactoring

The broader architecture sweep continues independently in #8544 and #8545. Neither is required for this contract.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` — 0 errors, existing 51-warning baseline
- `npm run compile:fast`
- Focused Vitest suites — 153 initial tests, 101 staged-review tests, and 126 review-fix tests
- `npm test` after review fixes — 708 files passed, 1 skipped; 6,432 tests passed, 4 skipped
- `npm run check:dead-code-ratchet` — all counts at or below baseline
