### PR TITLE
refactor: remove session response tunnel

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -26,6 +26,7 @@ import {
   type HostInteractionOptions,
   type HostInteractions,
   type HostRetryRequest,
+  type HostUserQuestionRequest,
   type HostUserQuestionResult,
   type PlanApprovalResult,
   type ProposalResult,
@@ -247,7 +248,6 @@ export function createTuiHostInteractions(
       return openExternalInquiryInteraction(request, context);
     },
     setApprovalBypassState: setTuiApprovalBypassState,
-    resolve: () => false,
     cancel(selector: HostInteractionCancelSelector = {}) {
       // Retry routes live outside the modal queue (the pre-queue auto-switch
       // lookup), so a retry-kind or unfiltered cancel must settle them too —
@@ -550,7 +550,7 @@ async function requestRetryInteraction(
 }
 
 async function requestUserQuestionInteraction(
-  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
+  payload: HostUserQuestionRequest,
   context: CliContext,
 ): Promise<HostUserQuestionResult> {
   if (!approvalPromptAllowed(context)) {

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -1,5 +1,6 @@
 import { structuredPatch } from 'diff';
 
+import type { HostUserQuestionRequest } from '@agent/runtime/HostInteractions';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
   agentProposalCategoryLabel,
@@ -209,7 +210,7 @@ export function formatToolEditApprovalSummary(
 }
 
 export function formatUserQuestionPrompt(
-  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
+  payload: HostUserQuestionRequest,
 ): string {
   return payload.questions
     .map((question, index) => {

--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -1,20 +1,13 @@
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
-
-import { handleUserQuestionAction } from '@tools/userQuestion';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 import { type CliContext } from '../cliContext';
-import { parseUserQuestionAnswer } from '../userQuestionAnswer';
 
 import {
   type CliApprovalPromptHooks,
   approvalPromptAllowed,
   humanInputDenialFeedback,
-  markApprovalDenied,
-  queueCliApprovalQuestion,
 } from './approvalPolicy';
-import { formatUserQuestionPrompt } from './approvalSummaries';
 
 const NON_TUI_EXTERNAL_INQUIRY_FEEDBACK =
   'External inquiry is not available in non-TUI CLI runs: inquiry answers ' +
@@ -47,61 +40,4 @@ export function handleExternalInquiry(
     threadId,
     feedback: NON_TUI_EXTERNAL_INQUIRY_FEEDBACK,
   });
-}
-
-export function handleUserQuestion(
-  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
-  context: CliContext,
-  hooks: CliApprovalPromptHooks = {},
-): void {
-  if (!approvalPromptAllowed(context)) {
-    const feedback = humanInputDenialFeedback(
-      context,
-      'User question requires human input; yolo mode cannot synthesize an answer.',
-    );
-    void handleUserQuestionAction({
-      requestId: payload.requestId,
-      action: 'skip',
-      feedback,
-    });
-    return;
-  }
-
-  void (async () => {
-    const answers: Record<string, string | string[]> = {};
-    try {
-      for (const question of payload.questions) {
-        hooks.beforePrompt?.();
-        const answer = await queueCliApprovalQuestion(context, {
-          kind: 'approval',
-          summary: payload.context
-            ? `${payload.context}\n\n${formatUserQuestionPrompt({
-                ...payload,
-                questions: [question],
-              })}`
-            : formatUserQuestionPrompt({ ...payload, questions: [question] }),
-          prompt: 'Answer (blank to skip): ',
-        });
-        const parsed = parseUserQuestionAnswer(answer, question);
-        if (parsed != null) answers[question.question] = parsed;
-      }
-    } catch {
-      markApprovalDenied(context);
-      await handleUserQuestionAction({
-        requestId: payload.requestId,
-        action: 'skip',
-        feedback: 'CLI user question prompt failed.',
-      });
-      return;
-    }
-
-    const submitted = Object.keys(answers).length > 0;
-    const decision: UserQuestionSettlement = submitted
-      ? { action: 'submit', answers }
-      : { action: 'skip', feedback: 'User question skipped by user.' };
-    await handleUserQuestionAction({
-      requestId: payload.requestId,
-      ...decision,
-    });
-  })();
 }

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -7,6 +7,7 @@ import type {
   HostBashApprovalResult,
   HostInteractions,
   HostRetryRequest,
+  HostUserQuestionRequest,
   HostUserQuestionResult,
   PlanApprovalResult,
   ProposalResult,
@@ -42,10 +43,7 @@ import {
   formatToolEditApprovalSummary,
 } from './approval/approvalSummaries';
 import { summarizeApprovalEvent } from './approval/eventDispatch';
-import {
-  handleExternalInquiry,
-  handleUserQuestion,
-} from './approval/humanInputHandlers';
+import { handleExternalInquiry } from './approval/humanInputHandlers';
 import { parseUserQuestionAnswer } from './userQuestionAnswer';
 
 export {
@@ -155,7 +153,7 @@ function toRetryResult(
 }
 
 async function askHeadlessUserQuestion(
-  payload: RuntimeInteractionEventPayloads['showUserQuestion'],
+  payload: HostUserQuestionRequest,
   context: CliContext,
   hooks: CliApprovalPromptHooks,
 ): Promise<HostUserQuestionResult> {
@@ -272,7 +270,6 @@ export function createHeadlessCliHostInteractions(
       });
       return { threadId: request.threadId };
     },
-    resolve: () => false,
     // Headless requests decide inline (policy or prompt hooks) — there is no
     // pending registry to cancel into.
     cancel: () => {},
@@ -290,15 +287,6 @@ export function handleCliApprovalEvent<
   if (event === 'showExternalInquiry') {
     handleExternalInquiry(
       payload as RuntimeInteractionEventPayloads['showExternalInquiry'],
-      context,
-      hooks,
-    );
-    return true;
-  }
-
-  if (event === 'showUserQuestion') {
-    handleUserQuestion(
-      payload as RuntimeInteractionEventPayloads['showUserQuestion'],
       context,
       hooks,
     );

--- a/packages/cli/src/runtime/approvalEvents.ts
+++ b/packages/cli/src/runtime/approvalEvents.ts
@@ -12,7 +12,6 @@ export const CLI_DECISION_APPROVAL_EVENTS = [
 
 export const CLI_HUMAN_INPUT_APPROVAL_EVENTS = [
   'showExternalInquiry',
-  'showUserQuestion',
 ] as const satisfies readonly (keyof RuntimeInteractionEventPayloads)[];
 
 export const CLI_APPROVAL_EVENTS = [
@@ -26,7 +25,6 @@ export const CLI_APPROVAL_EVENT_KIND = {
   showAgentProposal: 'proposal',
   showRetryRequest: 'retry',
   showExternalInquiry: 'externalInquiry',
-  showUserQuestion: 'userQuestion',
 } as const satisfies Record<CliApprovalEvent, string>;
 
 export type CliDecisionApprovalEvent =

--- a/packages/cli/src/runtime/userQuestionAnswer.ts
+++ b/packages/cli/src/runtime/userQuestionAnswer.ts
@@ -1,8 +1,8 @@
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import type { UserQuestionPrompt } from '@shared/schemas';
 
 export function parseUserQuestionAnswer(
   raw: string,
-  question: RuntimeInteractionEventPayloads['showUserQuestion']['questions'][number],
+  question: UserQuestionPrompt,
 ): string | string[] | undefined {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -434,10 +434,10 @@ export class DesktopProgressBridge {
           this.approvalHandlers.agentProposal.get(proposalId),
         restoreTaskState: async (taskState) => this.restoreTaskState(taskState),
         settleProposal: (proposalId, result) => {
-          const resolved = this.session.interactions.resolve(proposalId, {
-            kind: 'proposal',
-            decision: result,
-          });
+          const resolved = this.hostInteractions.submitProposalDecision(
+            proposalId,
+            result,
+          );
           if (!resolved) {
             this.logger.warn(
               `No pending desktop host interaction found for proposal: ${proposalId}`,
@@ -504,35 +504,34 @@ export class DesktopProgressBridge {
           handleToolEditApprovalAction: (message) =>
             this.toolEditApprovals.handleAction(message),
           handleBashApprovalAction: (message) =>
-            void this.session.interactions.resolve(message.requestId, {
-              kind: 'bash',
-              decision:
-                message.action === 'approve'
-                  ? { action: 'approve' }
-                  : { action: 'reject', feedback: message.feedback },
-            }),
+            void this.hostInteractions.submitBashDecision(
+              message.requestId,
+              message.action === 'approve'
+                ? { action: 'approve' }
+                : { action: 'reject', feedback: message.feedback },
+            ),
           handlePlanApprovalAction: (message) => {
-            this.session.interactions.resolve(message.approvalId, {
-              kind: 'plan',
-              decision:
-                message.action === 'reject'
-                  ? { action: 'reject', feedback: message.feedback }
-                  : { action: message.action },
-            });
+            this.hostInteractions.submitPlanDecision(
+              message.approvalId,
+              message.action === 'reject'
+                ? { action: 'reject', feedback: message.feedback }
+                : { action: message.action },
+            );
           },
           handleUserQuestionAction: (message) => {
-            this.session.interactions.resolve(message.requestId, {
-              kind: 'userQuestion',
-              decision:
-                message.action === 'submit'
-                  ? { action: 'submit', answers: message.answers }
-                  : { action: message.action, feedback: message.feedback },
-            });
+            this.hostInteractions.submitUserQuestionDecision(
+              message.requestId,
+              message.action === 'submit'
+                ? { action: 'submit', answers: message.answers }
+                : { action: message.action, feedback: message.feedback },
+            );
             return undefined;
           },
         },
         externalInquiry: {
           session: this.session,
+          dismiss: (threadId) =>
+            this.hostInteractions.dismissExternalInquiry(threadId),
         },
       },
     });

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,14 +1,14 @@
 import { nanoid } from 'nanoid';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
-  cancellationSettlementFor,
+  cancellationResultFor,
   matchesCancelSelector,
+  type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
   type HostInteractionResultByKind,
-  type HostInteractionSettlement,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
@@ -16,6 +16,7 @@ import {
   type PlanApprovalResult,
   type ProposalResult,
   type RetryResult,
+  type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import {
   toBashApprovalResult,
@@ -23,6 +24,7 @@ import {
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -65,6 +67,14 @@ export interface DesktopHostInteractions extends HostInteractions {
     streamId: StreamTabId,
     initiatingProposalId: string,
   ): Promise<void>;
+  submitBashDecision(requestId: string, decision: BashSettlement): boolean;
+  submitPlanDecision(requestId: string, decision: PlanApprovalResult): boolean;
+  submitProposalDecision(requestId: string, decision: ProposalResult): boolean;
+  submitUserQuestionDecision(
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean;
+  dismissExternalInquiry(requestId: string): void;
 }
 
 export function createDesktopHostInteractions(
@@ -182,41 +192,41 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     return Promise.resolve({ threadId: request.threadId });
   }
 
-  resolve(requestId: string, settlement: HostInteractionSettlement): boolean {
-    switch (settlement.kind) {
-      case 'bash':
-        return this.resolvePending(
-          requestId,
-          'bash',
-          toBashApprovalResult(settlement.decision),
-          () => this.options.getApprovalHandlers().bash.resolve(requestId),
-        );
-      case 'plan':
-        return this.resolvePending(requestId, 'plan', settlement.decision, () =>
-          this.options.getApprovalHandlers().planApproval.resolve(requestId),
-        );
-      case 'proposal':
-        return this.resolvePending(
-          requestId,
-          'proposal',
-          settlement.decision,
-          () =>
-            this.options.getApprovalHandlers().agentProposal.resolve(requestId),
-        );
-      case 'retry':
-        return false;
-      case 'userQuestion':
-        return this.resolvePending(
-          requestId,
-          'userQuestion',
-          toUserQuestionResult(settlement.decision),
-          () =>
-            this.options.getApprovalHandlers().userQuestion.resolve(requestId),
-        );
-      case 'externalInquiry':
-        this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
-        return true;
-    }
+  submitBashDecision(requestId: string, decision: BashSettlement): boolean {
+    return this.completePending(
+      requestId,
+      'bash',
+      toBashApprovalResult(decision),
+      () => this.options.getApprovalHandlers().bash.resolve(requestId),
+    );
+  }
+
+  submitPlanDecision(requestId: string, decision: PlanApprovalResult): boolean {
+    return this.completePending(requestId, 'plan', decision, () =>
+      this.options.getApprovalHandlers().planApproval.resolve(requestId),
+    );
+  }
+
+  submitProposalDecision(requestId: string, decision: ProposalResult): boolean {
+    return this.completePending(requestId, 'proposal', decision, () =>
+      this.options.getApprovalHandlers().agentProposal.resolve(requestId),
+    );
+  }
+
+  submitUserQuestionDecision(
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean {
+    return this.completePending(
+      requestId,
+      'userQuestion',
+      toUserQuestionResult(decision),
+      () => this.options.getApprovalHandlers().userQuestion.resolve(requestId),
+    );
+  }
+
+  dismissExternalInquiry(requestId: string): void {
+    this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
   }
 
   async approvePendingDelegatedWork(
@@ -231,15 +241,9 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
         continue;
       }
       if (request.kind === 'bash') {
-        this.resolve(requestId, {
-          kind: 'bash',
-          decision: { action: 'approve' },
-        });
+        this.submitBashDecision(requestId, { action: 'approve' });
       } else if (request.kind === 'proposal') {
-        this.resolve(requestId, {
-          kind: 'proposal',
-          decision: { action: 'approve' },
-        });
+        this.submitProposalDecision(requestId, { action: 'approve' });
       }
     }
     await this.options.getToolEditApprovals().approvePendingForStream(streamId);
@@ -292,10 +296,47 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     request: AnyPendingDesktopInteraction,
     feedback?: string,
   ): void {
-    this.resolve(requestId, cancellationSettlementFor(request.kind, feedback));
+    switch (request.kind) {
+      case 'bash':
+        this.completePending(
+          requestId,
+          'bash',
+          cancellationResultFor('bash', feedback),
+          () => this.options.getApprovalHandlers().bash.resolve(requestId),
+        );
+        return;
+      case 'plan':
+        this.completePending(
+          requestId,
+          'plan',
+          cancellationResultFor('plan', feedback),
+          () =>
+            this.options.getApprovalHandlers().planApproval.resolve(requestId),
+        );
+        return;
+      case 'proposal':
+        this.completePending(
+          requestId,
+          'proposal',
+          cancellationResultFor('proposal', feedback),
+          () =>
+            this.options.getApprovalHandlers().agentProposal.resolve(requestId),
+        );
+        return;
+      case 'userQuestion':
+        this.completePending(
+          requestId,
+          'userQuestion',
+          cancellationResultFor('userQuestion', feedback),
+          () =>
+            this.options.getApprovalHandlers().userQuestion.resolve(requestId),
+        );
+        return;
+    }
+    assertNever(request.kind, 'Unhandled desktop interaction kind');
   }
 
-  private resolvePending<K extends PendingDesktopKind>(
+  private completePending<K extends PendingDesktopKind>(
     requestId: string,
     expectedKind: K,
     value: HostInteractionResultByKind[K],

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -437,10 +437,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           );
         },
         settleProposal: (proposalId, result) => {
-          const resolved = this.interactions.resolve(proposalId, {
-            kind: 'proposal',
-            decision: result,
-          });
+          const resolved = this.interactions.submitProposalDecision(
+            proposalId,
+            result,
+          );
           if (!resolved) {
             this.logger.warn(
               this.channel,
@@ -528,7 +528,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           handleUserQuestionAction: (message) =>
             this.handleUserQuestionAction(message),
         },
-        externalInquiry: {},
+        externalInquiry: {
+          dismiss: (threadId) =>
+            this.interactions.dismissExternalInquiry(threadId),
+        },
       },
     });
   }
@@ -577,7 +580,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       isRetryPending: (stream, requestId) =>
         this.interactions.isRetryPending(stream, requestId),
       triggerRetry: (stream, requestId) =>
-        this.interactions.resolveRetry(stream, requestId, {
+        this.interactions.submitRetryDecision(stream, requestId, {
           action: 'retry',
         }),
     });
@@ -632,7 +635,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleRetryStreamRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
   ): Promise<void> {
-    const resolved = this.interactions.resolveRetry(
+    const resolved = this.interactions.submitRetryDecision(
       data.stream,
       data.requestId,
       {
@@ -650,7 +653,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private handleCancelRetryRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST>,
   ): void {
-    this.interactions.resolveRetry(data.stream, data.requestId, {
+    this.interactions.submitRetryDecision(data.stream, data.requestId, {
       action: 'cancel',
     });
   }
@@ -658,25 +661,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private handleBashApprovalAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION>,
   ): void {
-    this.interactions.resolve(data.requestId, {
-      kind: 'bash',
-      decision:
-        data.action === 'approve'
-          ? { action: 'approve' }
-          : { action: 'reject', feedback: data.feedback },
-    });
+    this.interactions.submitBashDecision(
+      data.requestId,
+      data.action === 'approve'
+        ? { action: 'approve' }
+        : { action: 'reject', feedback: data.feedback },
+    );
   }
 
   private handleUserQuestionAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION>,
   ): void {
-    this.interactions.resolve(data.requestId, {
-      kind: 'userQuestion',
-      decision:
-        data.action === 'submit'
-          ? { action: 'submit', answers: data.answers }
-          : { action: data.action, feedback: data.feedback },
-    });
+    this.interactions.submitUserQuestionDecision(
+      data.requestId,
+      data.action === 'submit'
+        ? { action: 'submit', answers: data.answers }
+        : { action: data.action, feedback: data.feedback },
+    );
   }
 
   private async handleUseOwnApiKey(
@@ -804,7 +805,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       );
     if (!started) return;
 
-    this.interactions.resolveRetry(data.stream, data.requestId, {
+    this.interactions.submitRetryDecision(data.stream, data.requestId, {
       action: 'cancel',
     });
   }
@@ -886,13 +887,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
   ): void {
     const { approvalId, action } = data;
-    this.interactions.resolve(approvalId, {
-      kind: 'plan',
-      decision:
-        action === 'reject'
-          ? { action: 'reject', feedback: data.feedback }
-          : { action },
-    });
+    this.interactions.submitPlanDecision(
+      approvalId,
+      action === 'reject'
+        ? { action: 'reject', feedback: data.feedback }
+        : { action },
+    );
   }
 
   // ============================================================

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -2,14 +2,14 @@ import { nanoid } from 'nanoid';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
-  cancellationSettlementFor,
+  cancellationResultFor,
   matchesCancelSelector,
+  type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
   type HostInteractionResultByKind,
-  type HostInteractionSettlement,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
@@ -18,6 +18,7 @@ import {
   type ProposalResult,
   type RetryResult,
   type RetrySettlement,
+  type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import {
   toBashApprovalResult,
@@ -30,6 +31,7 @@ import {
   nativeRequestApproval,
 } from '@frontend/approval/nativeToolEditApproval';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -49,11 +51,19 @@ export interface ExtensionHostInteractions extends HostInteractions {
     initiatingProposalId: string,
   ): Promise<void>;
   isRetryPending(streamId: StreamTabId, requestId: string): boolean;
-  resolveRetry(
+  submitBashDecision(requestId: string, decision: BashSettlement): boolean;
+  submitPlanDecision(requestId: string, decision: PlanApprovalResult): boolean;
+  submitProposalDecision(requestId: string, decision: ProposalResult): boolean;
+  submitRetryDecision(
     streamId: StreamTabId,
     requestId: string,
     decision: RetrySettlement,
   ): boolean;
+  submitUserQuestionDecision(
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean;
+  dismissExternalInquiry(requestId: string): void;
 }
 
 type PendingKind = keyof HostInteractionResultByKind;
@@ -122,7 +132,7 @@ export function createExtensionHostInteractions(
     });
   };
 
-  const resolvePending = <K extends PendingKind>(
+  const completePending = <K extends PendingKind>(
     requestId: string,
     expectedKind: K,
     value: HostInteractionResultByKind[K],
@@ -141,10 +151,49 @@ export function createExtensionHostInteractions(
     pending: AnyPendingExtensionInteraction,
     cause?: string,
   ): void => {
-    settleInteraction(
-      pending.id,
-      cancellationSettlementFor(pending.kind, cause),
-    );
+    switch (pending.kind) {
+      case 'bash':
+        completePending(
+          pending.id,
+          'bash',
+          cancellationResultFor('bash', cause),
+          () => handlers().bash.resolve(pending.id),
+        );
+        return;
+      case 'plan':
+        completePending(
+          pending.id,
+          'plan',
+          cancellationResultFor('plan', cause),
+          () => handlers().planApproval.resolve(pending.id),
+        );
+        return;
+      case 'proposal':
+        completePending(
+          pending.id,
+          'proposal',
+          cancellationResultFor('proposal', cause),
+          () => handlers().agentProposal.resolve(pending.id),
+        );
+        return;
+      case 'retry':
+        completePending(
+          pending.id,
+          'retry',
+          cancellationResultFor('retry', cause),
+          () => handlers().retry.resolve(pending.id),
+        );
+        return;
+      case 'userQuestion':
+        completePending(
+          pending.id,
+          'userQuestion',
+          cancellationResultFor('userQuestion', cause),
+          () => handlers().userQuestion.resolve(pending.id),
+        );
+        return;
+    }
+    assertNever(pending.kind, 'Unhandled extension interaction kind');
   };
 
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
@@ -171,7 +220,7 @@ export function createExtensionHostInteractions(
       }
       switch (pending.kind) {
         case 'bash':
-          resolvePending(
+          completePending(
             pending.id,
             'bash',
             toBashApprovalResult({ action: 'approve' }),
@@ -179,7 +228,7 @@ export function createExtensionHostInteractions(
           );
           break;
         case 'proposal':
-          resolvePending(pending.id, 'proposal', { action: 'approve' }, () =>
+          completePending(pending.id, 'proposal', { action: 'approve' }, () =>
             handlers().agentProposal.resolve(pending.id),
           );
           break;
@@ -200,58 +249,62 @@ export function createExtensionHostInteractions(
     return pending?.kind === 'retry' && pending.requestId === requestId;
   };
 
-  const resolveRetry = (
+  const submitRetryDecision = (
     streamId: StreamTabId,
     requestId: string,
     decision: RetrySettlement,
   ): boolean => {
     if (!isRetryPending(streamId, requestId)) return false;
-    return resolvePending(streamId, 'retry', decision, () =>
+    return completePending(streamId, 'retry', decision, () =>
       handlers().retry.resolve(streamId),
     );
   };
 
-  const settleInteraction = (
+  const submitBashDecision = (
     requestId: string,
-    settlement: HostInteractionSettlement,
-  ): boolean => {
-    switch (settlement.kind) {
-      case 'bash':
-        return resolvePending(
-          requestId,
-          'bash',
-          toBashApprovalResult(settlement.decision),
-          () => handlers().bash.resolve(requestId),
-        );
-      case 'plan':
-        return resolvePending(requestId, 'plan', settlement.decision, () =>
-          handlers().planApproval.resolve(requestId),
-        );
-      case 'proposal':
-        return resolvePending(requestId, 'proposal', settlement.decision, () =>
-          handlers().agentProposal.resolve(requestId),
-        );
-      case 'retry':
-        return resolvePending(requestId, 'retry', settlement.decision, () =>
-          handlers().retry.resolve(requestId),
-        );
-      case 'userQuestion':
-        return resolvePending(
-          requestId,
-          'userQuestion',
-          toUserQuestionResult(settlement.decision),
-          () => handlers().userQuestion.resolve(requestId),
-        );
-      case 'externalInquiry':
-        handlers().externalInquiry.resolve(requestId);
-        return true;
-    }
-  };
+    decision: BashSettlement,
+  ): boolean =>
+    completePending(requestId, 'bash', toBashApprovalResult(decision), () =>
+      handlers().bash.resolve(requestId),
+    );
+
+  const submitPlanDecision = (
+    requestId: string,
+    decision: PlanApprovalResult,
+  ): boolean =>
+    completePending(requestId, 'plan', decision, () =>
+      handlers().planApproval.resolve(requestId),
+    );
+
+  const submitProposalDecision = (
+    requestId: string,
+    decision: ProposalResult,
+  ): boolean =>
+    completePending(requestId, 'proposal', decision, () =>
+      handlers().agentProposal.resolve(requestId),
+    );
+
+  const submitUserQuestionDecision = (
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean =>
+    completePending(
+      requestId,
+      'userQuestion',
+      toUserQuestionResult(decision),
+      () => handlers().userQuestion.resolve(requestId),
+    );
 
   return {
     approvePendingDelegatedWork,
     isRetryPending,
-    resolveRetry,
+    submitBashDecision,
+    submitPlanDecision,
+    submitProposalDecision,
+    submitRetryDecision,
+    submitUserQuestionDecision,
+    dismissExternalInquiry: (requestId) =>
+      handlers().externalInquiry.resolve(requestId),
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
       interactionOptions?: HostInteractionOptions,
@@ -357,8 +410,6 @@ export function createExtensionHostInteractions(
       handlers().externalInquiry.show(request);
       return { threadId: request.threadId };
     },
-
-    resolve: settleInteraction,
 
     cancel,
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -149,23 +149,6 @@ export type UserQuestionSettlement =
       readonly answers?: never;
     };
 
-/** Exact host-to-adapter settlement vocabulary for every interaction kind. */
-export type HostInteractionSettlement = (
-  | { readonly kind: 'bash'; readonly decision: BashSettlement }
-  | { readonly kind: 'plan'; readonly decision: PlanApprovalResult }
-  | { readonly kind: 'proposal'; readonly decision: ProposalResult }
-  | { readonly kind: 'retry'; readonly decision: RetrySettlement }
-  | {
-      readonly kind: 'userQuestion';
-      readonly decision: UserQuestionSettlement;
-    }
-  | { readonly kind: 'externalInquiry'; readonly decision?: never }
-) & {
-  readonly action?: never;
-  readonly feedback?: never;
-  readonly value?: never;
-};
-
 export type PendingInteractionKind =
   | 'toolEdit'
   | 'bash'
@@ -177,41 +160,30 @@ export type PendingInteractionKind =
 
 export type SettledInteractionKind = keyof HostInteractionResultByKind;
 
-type SettlementFor<K extends SettledInteractionKind> = Extract<
-  HostInteractionSettlement,
-  { kind: K }
->;
-
-type CancellationSettlementFactories = {
-  [K in SettledInteractionKind]: (feedback?: string) => SettlementFor<K>;
+type CancellationResultFactories = {
+  [K in SettledInteractionKind]: (
+    feedback?: string,
+  ) => HostInteractionResultByKind[K];
 };
 
-const cancellationSettlementFactories: CancellationSettlementFactories = {
-  bash: (feedback?: string) => ({
-    kind: 'bash',
-    decision: { action: 'reject', feedback },
+const cancellationResultFactories: CancellationResultFactories = {
+  bash: (feedback) => ({
+    accepted: false,
+    timedOut: undefined,
+    userMessage: feedback?.trim(),
   }),
-  plan: (feedback?: string) => ({
-    kind: 'plan',
-    decision: { action: 'reject', feedback },
-  }),
-  proposal: (feedback?: string) => ({
-    kind: 'proposal',
-    decision: { action: 'reject', feedback },
-  }),
-  retry: () => ({ kind: 'retry', decision: { action: 'cancel' } }),
-  userQuestion: (feedback?: string) => ({
-    kind: 'userQuestion',
-    decision: { action: 'reject', feedback },
-  }),
+  plan: (feedback) => ({ action: 'reject', feedback }),
+  proposal: (feedback) => ({ action: 'reject', feedback }),
+  retry: () => ({ action: 'cancel' }),
+  userQuestion: (feedback) => ({ submitted: false, feedback }),
 };
 
 /** Typed cancellation result shared by every presenting host. */
-export function cancellationSettlementFor<K extends SettledInteractionKind>(
+export function cancellationResultFor<K extends SettledInteractionKind>(
   kind: K,
   feedback?: string,
-): SettlementFor<K> {
-  return cancellationSettlementFactories[kind](feedback);
+): HostInteractionResultByKind[K] {
+  return cancellationResultFactories[kind](feedback);
 }
 
 export type ApprovalBypassKind = 'bash' | 'toolEdit' | 'superYolo';
@@ -299,7 +271,6 @@ export interface HostInteractions {
     request: HostExternalInquiryRequest,
   ): Promise<HostExternalInquiryHandle> | undefined;
   setApprovalBypassState?(update: HostApprovalBypassStateUpdate): void;
-  resolve(requestId: string, settlement: HostInteractionSettlement): boolean;
   /** Settle pending requests matching the selector with their reject/cancel defaults. */
   cancel(selector?: HostInteractionCancelSelector): void;
   dispose?(): void;
@@ -440,13 +411,6 @@ export class SessionHostInteractions implements HostInteractions {
 
   setApprovalBypassState(update: HostApprovalBypassStateUpdate): void {
     this.activeAttachment?.interactions.setApprovalBypassState?.(update);
-  }
-
-  resolve(requestId: string, settlement: HostInteractionSettlement): boolean {
-    return (
-      this.activeAttachment?.interactions.resolve(requestId, settlement) ??
-      false
-    );
   }
 
   cancel(selector: HostInteractionCancelSelector = {}): void {
@@ -680,8 +644,6 @@ function createHostInteractionsForwarder(
     openExternalInquiry: (request) => target()?.openExternalInquiry?.(request),
     setApprovalBypassState: (update) =>
       target()?.setApprovalBypassState?.(update),
-    resolve: (requestId, result) =>
-      target()?.resolve(requestId, result) ?? false,
     cancel: (selector = {}) => {
       const interactions = target();
       if (!interactions) return;

--- a/src/agent/runtime/runtimeInteractionEvents.ts
+++ b/src/agent/runtime/runtimeInteractionEvents.ts
@@ -6,7 +6,6 @@ import type {
   RetryPermission,
   StreamTabId,
   ToolEditPermission,
-  UserQuestionPermission,
 } from '@shared/schemas';
 
 /**
@@ -36,7 +35,6 @@ export interface RuntimeInteractionEventPayloads {
   showAgentProposal: AgentProposalPermission;
   showPlanApproval: PlanApprovalPermission;
   showExternalInquiry: ExternalInquiryPermission;
-  showUserQuestion: UserQuestionPermission;
 }
 
 export type RuntimeInteractionEvent = keyof RuntimeInteractionEventPayloads;
@@ -52,7 +50,6 @@ const RUNTIME_INTERACTION_EVENTS = [
   'showAgentProposal',
   'showPlanApproval',
   'showExternalInquiry',
-  'showUserQuestion',
 ] as const satisfies readonly RuntimeInteractionEvent[];
 
 const RuntimeInteractionEventSet: ReadonlySet<string> = new Set(

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -14,7 +14,10 @@ import {
   setDelegatedWorkApprovalBypasses,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
-import { handleExternalInquiryAction } from '@tools/inquiry';
+import {
+  continueExternalInquiryAction,
+  persistExternalInquiryAction,
+} from '@tools/inquiry';
 import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 
 // Local imports - utilities
@@ -119,10 +122,12 @@ export interface ProgressViewApprovalCommandActions {
 
 export interface ProgressViewExternalInquiryCommandActions {
   /**
-   * Forwarded to the inquiry submit/drop settle path. Desktop scopes it to its
-   * window session; the extension omits it so the module default applies.
+   * Continuation owner. Desktop scopes it to its window session; the extension
+   * omits it so the module default applies.
    */
   session?: SessionHandle;
+  /** Remove the completed inquiry from progress presentation state. */
+  dismiss(threadId: string): void;
 }
 
 export interface ProgressViewCommandActions {
@@ -303,7 +308,9 @@ export function createProgressViewCommandHandlers(
         });
         return;
       }
-      await handleExternalInquiryAction(data, externalInquiry);
+      const transition = await persistExternalInquiryAction(data);
+      externalInquiry.dismiss(data.threadId);
+      await continueExternalInquiryAction(transition, externalInquiry);
     },
   } satisfies Partial<ProgressViewInboundHandlerRegistry>;
 }

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -47,7 +47,6 @@ function installTestPlatform(): Promise<void> {
         }
         return handler(request);
       },
-      resolve: () => false,
       cancel: () => undefined,
     });
   });

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -47,7 +47,6 @@ function installTestPlatform(): Promise<void> {
         }
         return handler(request);
       },
-      resolve: () => false,
       cancel: () => undefined,
     });
   });
@@ -92,9 +91,8 @@ describe('human prompt progress events', () => {
       'showBashPermission',
     );
     expect(
-      explicit.host.interactions?.resolve(show.payload.requestId, {
-        kind: 'bash',
-        decision: { action: 'approve' },
+      explicit.decisions.submitBash(show.payload.requestId, {
+        action: 'approve',
       }),
     ).toBe(true);
 
@@ -150,13 +148,10 @@ describe('human prompt progress events', () => {
       'showUserQuestion',
     );
     expect(
-      explicit.host.interactions?.resolve(show.payload.requestId, {
-        kind: 'userQuestion',
-        decision: {
-          action: 'submit',
-          answers: {
-            'Which path should the agent take?': 'Run the build',
-          },
+      explicit.decisions.submitUserQuestion(show.payload.requestId, {
+        action: 'submit',
+        answers: {
+          'Which path should the agent take?': 'Run the build',
         },
       }),
     ).toBe(true);
@@ -249,9 +244,8 @@ describe('human prompt progress events', () => {
         'showBashPermission',
       );
       expect(
-        explicit.host.interactions?.resolve(show.payload.requestId, {
-          kind: 'bash',
-          decision: { action: 'approve' },
+        explicit.decisions.submitBash(show.payload.requestId, {
+          action: 'approve',
         }),
       ).toBe(true);
       await expect(approval).resolves.toMatchObject({ accepted: true });

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -3,6 +3,7 @@ import type { AgentEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   matchesCancelSelector,
+  type BashSettlement,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractions,
@@ -10,7 +11,9 @@ import {
   type PendingInteractionKind,
   type PlanApprovalResult,
   type ProposalResult,
+  type RetrySettlement,
   type RetryResult,
+  type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
@@ -26,9 +29,8 @@ import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 /**
  * Loosely-typed recording of host emissions. The recording host also encodes
- * typed `HostInteractions` requests/resolutions as legacy-style show/resolve
- * entries (including keys that no longer exist on the frozen production map),
- * so the vocabulary is a plain string.
+ * typed `HostInteractions` requests and test-owned decisions as legacy-style
+ * show/resolve entries, so the vocabulary is a plain string.
  */
 export type RecordedProgressEvent = {
   event: string;
@@ -37,6 +39,17 @@ export type RecordedProgressEvent = {
 
 export interface RecordingProgressSink {
   emit(event: string, payload: unknown): void;
+}
+
+export interface RecordingHostDecisions {
+  submitBash(requestId: string, decision: BashSettlement): boolean;
+  submitPlan(requestId: string, decision: PlanApprovalResult): boolean;
+  submitProposal(requestId: string, decision: ProposalResult): boolean;
+  submitRetry(requestId: string, decision: RetrySettlement): boolean;
+  submitUserQuestion(
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean;
 }
 
 export function recordSessionEvents(
@@ -76,6 +89,7 @@ export function runEventsOfType<T extends AgentEvent['type']>(
 export function createRecordingHost(): {
   events: RecordedProgressEvent[];
   interactions: HostInteractions;
+  decisions: RecordingHostDecisions;
   host: AgentRuntimeHost & RecordingProgressSink;
 } {
   const events: RecordedProgressEvent[] = [];
@@ -113,6 +127,71 @@ export function createRecordingHost(): {
         },
       });
     }
+  };
+  const decisions: RecordingHostDecisions = {
+    submitBash(requestId, decision) {
+      const pending = pendingBashes.get(requestId);
+      if (!pending) return false;
+      pendingBashes.delete(requestId);
+      events.push({
+        event: 'resolveBashPermission',
+        payload: { requestId },
+      });
+      pending.settle({
+        accepted: decision.action === 'approve',
+        userMessage:
+          decision.action === 'reject' ? decision.feedback?.trim() : undefined,
+      });
+      return true;
+    },
+    submitPlan(requestId, decision) {
+      const pending = pendingPlans.get(requestId);
+      if (!pending) return false;
+      pendingPlans.delete(requestId);
+      events.push({
+        event: 'resolvePlanApproval',
+        payload: { approvalId: requestId },
+      });
+      pending.settle(decision);
+      return true;
+    },
+    submitProposal(requestId, decision) {
+      const pending = pendingProposals.get(requestId);
+      if (!pending) return false;
+      pendingProposals.delete(requestId);
+      events.push({
+        event: 'resolveAgentProposal',
+        payload: { proposalId: requestId },
+      });
+      pending.settle(decision);
+      return true;
+    },
+    submitRetry(requestId, decision) {
+      const pending = pendingRetries.get(requestId);
+      if (!pending) return false;
+      pendingRetries.delete(requestId);
+      events.push({
+        event: 'resolveRetryRequest',
+        payload: { streamId: requestId },
+      });
+      pending.settle(decision);
+      return true;
+    },
+    submitUserQuestion(requestId, decision) {
+      const pending = pendingUserQuestions.get(requestId);
+      if (!pending) return false;
+      pendingUserQuestions.delete(requestId);
+      events.push({
+        event: 'resolveUserQuestion',
+        payload: { requestId },
+      });
+      pending.settle(
+        decision.action === 'submit'
+          ? { submitted: true, answers: decision.answers }
+          : { submitted: false, feedback: decision.feedback },
+      );
+      return true;
+    },
   };
   const interactions: HostInteractions = {
     requestBashApproval: (request) => {
@@ -185,80 +264,6 @@ export function createRecordingHost(): {
         });
       });
     },
-    resolve: (requestId, settlement) => {
-      if (settlement.kind === 'bash') {
-        const pending = pendingBashes.get(requestId);
-        if (!pending) return false;
-        pendingBashes.delete(requestId);
-        events.push({
-          event: 'resolveBashPermission',
-          payload: { requestId },
-        });
-        pending.settle({
-          accepted: settlement.decision.action === 'approve',
-          userMessage:
-            settlement.decision.action === 'reject'
-              ? settlement.decision.feedback?.trim()
-              : undefined,
-        });
-        return true;
-      }
-      if (settlement.kind === 'plan') {
-        const pending = pendingPlans.get(requestId);
-        if (!pending) return false;
-        pendingPlans.delete(requestId);
-        events.push({
-          event: 'resolvePlanApproval',
-          payload: { approvalId: requestId },
-        });
-        pending.settle(settlement.decision);
-        return true;
-      }
-      if (settlement.kind === 'proposal') {
-        const pending = pendingProposals.get(requestId);
-        if (!pending) return false;
-        pendingProposals.delete(requestId);
-        events.push({
-          event: 'resolveAgentProposal',
-          payload: { proposalId: requestId },
-        });
-        pending.settle(settlement.decision);
-        return true;
-      }
-      if (settlement.kind === 'retry') {
-        const pending = pendingRetries.get(requestId);
-        if (!pending) return false;
-        pendingRetries.delete(requestId);
-        events.push({
-          event: 'resolveRetryRequest',
-          payload: { streamId: requestId },
-        });
-        pending.settle(settlement.decision);
-        return true;
-      }
-      if (settlement.kind === 'userQuestion') {
-        const pending = pendingUserQuestions.get(requestId);
-        if (!pending) return false;
-        pendingUserQuestions.delete(requestId);
-        events.push({
-          event: 'resolveUserQuestion',
-          payload: { requestId },
-        });
-        pending.settle(
-          settlement.decision.action === 'submit'
-            ? {
-                submitted: true,
-                answers: settlement.decision.answers,
-              }
-            : {
-                submitted: false,
-                feedback: settlement.decision.feedback,
-              },
-        );
-        return true;
-      }
-      return false;
-    },
     cancel: (selector = {}) => cancelWhere(selector),
     dispose: () => cancelWhere({}),
   };
@@ -320,6 +325,7 @@ export function createRecordingHost(): {
   } as AgentRuntimeHost & RecordingProgressSink;
   return {
     events,
+    decisions,
     interactions,
     host,
   };

--- a/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
+++ b/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
@@ -1,25 +1,21 @@
 // Third-party imports
-import { expectTypeOf, it } from 'vitest';
+import { expect, expectTypeOf, it } from 'vitest';
 
 // Local imports - host interactions
-import type {
-  HostInteractionSettlement,
-  HostUserQuestionResult,
-  PlanApprovalResult,
-  ProposalResult,
-  RetrySettlement,
-  UserQuestionSettlement,
+import {
+  cancellationResultFor,
+  type HostBashApprovalResult,
+  type HostUserQuestionResult,
+  type PlanApprovalResult,
+  type ProposalResult,
+  type RetryResult,
+  type RetrySettlement,
+  type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 
 type IsAssignable<From, To> = [From] extends [To] ? true : false;
 
-it('makes contradictory interaction settlements unrepresentable', () => {
-  expectTypeOf<
-    IsAssignable<
-      { kind: 'retry'; decision: { action: 'approve' } },
-      HostInteractionSettlement
-    >
-  >().toEqualTypeOf<false>();
+it('makes contradictory interaction decisions unrepresentable', () => {
   expectTypeOf<
     IsAssignable<{ action: 'submit' }, UserQuestionSettlement>
   >().toEqualTypeOf<false>();
@@ -27,22 +23,6 @@ it('makes contradictory interaction settlements unrepresentable', () => {
     IsAssignable<
       { action: 'reject'; answers: { choice: string } },
       UserQuestionSettlement
-    >
-  >().toEqualTypeOf<false>();
-  expectTypeOf<
-    IsAssignable<
-      {
-        kind: 'proposal';
-        decision: { action: 'approve' };
-        value: { action: 'approve' };
-      },
-      HostInteractionSettlement
-    >
-  >().toEqualTypeOf<false>();
-  expectTypeOf<
-    IsAssignable<
-      { kind: 'externalInquiry'; action: 'submit' },
-      HostInteractionSettlement
     >
   >().toEqualTypeOf<false>();
   expectTypeOf<
@@ -66,4 +46,28 @@ it('makes contradictory interaction settlements unrepresentable', () => {
   expectTypeOf<
     IsAssignable<{ action: 'cancel'; reason: string }, RetrySettlement>
   >().toEqualTypeOf<false>();
+});
+
+it("returns each interaction kind's exact cancellation result", () => {
+  expectTypeOf(
+    cancellationResultFor('bash'),
+  ).toEqualTypeOf<HostBashApprovalResult>();
+  expectTypeOf(
+    cancellationResultFor('plan'),
+  ).toEqualTypeOf<PlanApprovalResult>();
+  expectTypeOf(
+    cancellationResultFor('proposal'),
+  ).toEqualTypeOf<ProposalResult>();
+  expectTypeOf(cancellationResultFor('retry')).toEqualTypeOf<RetryResult>();
+  expectTypeOf(
+    cancellationResultFor('userQuestion'),
+  ).toEqualTypeOf<HostUserQuestionResult>();
+});
+
+it('normalizes bash cancellation feedback like an explicit rejection', () => {
+  expect(cancellationResultFor('bash', '  reason  ')).toEqual({
+    accepted: false,
+    timedOut: undefined,
+    userMessage: 'reason',
+  });
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -105,7 +105,6 @@ async function withRetryRunContext<T>(
       agentName: 'retry-test',
       session: sessionWithInteractions({
         requestRetry,
-        resolve: () => false,
         cancel: () => {},
       }),
     }),
@@ -271,9 +270,9 @@ describe('RetryState', () => {
       );
 
       expect(
-        session.interactions.resolve(streamId, {
-          kind: 'retry',
-          decision: { action: 'retry', feedback: 'try again' },
+        recording.decisions.submitRetry(streamId, {
+          action: 'retry',
+          feedback: 'try again',
         }),
       ).toBe(true);
 

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -164,15 +164,12 @@ describe('SessionHandle', () => {
 
       // ...while B's remain live and resolvable through B's own port.
       expect(
-        b.interactions.resolve('approval:b', {
-          kind: 'plan',
-          decision: { action: 'approve' },
-        }),
+        hostB.decisions.submitPlan('approval:b', { action: 'approve' }),
       ).toBe(true);
       expect(
-        b.interactions.resolve(streamId, {
-          kind: 'retry',
-          decision: { action: 'retry', feedback: 'retry B' },
+        hostB.decisions.submitRetry(streamId, {
+          action: 'retry',
+          feedback: 'retry B',
         }),
       ).toBe(true);
       await expect(planB).resolves.toEqual({ action: 'approve' });

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -15,7 +15,10 @@ import {
   type PlanApprovalResult,
 } from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import { createDesktopHostInteractions } from '@desktop/main/desktopHostInteractions';
+import {
+  createDesktopHostInteractions,
+  type DesktopHostInteractions,
+} from '@desktop/main/desktopHostInteractions';
 import {
   AgentCategory,
   type AgentProposal,
@@ -94,7 +97,7 @@ function createPortSession(): {
   session: SessionHandle;
   uiEvents: UiEvent[];
   emitted: string[];
-  interactions: HostInteractions;
+  interactions: DesktopHostInteractions;
 } {
   const uiEvents: UiEvent[] = [];
   const emitted: string[] = [];
@@ -149,13 +152,6 @@ function createControllablePlanAdapter(
         }),
       );
     },
-    resolve(requestId, settlement) {
-      const entry = pending.get(requestId);
-      if (!entry || settlement.kind !== 'plan') return false;
-      pending.delete(requestId);
-      entry.settle(settlement.decision);
-      return true;
-    },
     cancel(selector = {}) {
       for (const [requestId, entry] of pending) {
         if (
@@ -175,7 +171,14 @@ function createControllablePlanAdapter(
     },
     dispose,
   };
-  return { interactions, requests, dispose };
+  const submit = (requestId: string, decision: PlanApprovalResult): boolean => {
+    const entry = pending.get(requestId);
+    if (!entry) return false;
+    pending.delete(requestId);
+    entry.settle(decision);
+    return true;
+  };
+  return { interactions, requests, submit, dispose };
 }
 
 describe('session.interactions request bookkeeping (coordinator fold)', () => {
@@ -245,12 +248,9 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       cause: 'Session disposed.',
       cancellationScope: expect.any(Object),
     });
-    expect(
-      target.interactions.resolve('approval:target-owner', {
-        kind: 'plan',
-        decision: { action: 'approve' },
-      }),
-    ).toBe(true);
+    expect(adapter.submit('approval:target-owner', { action: 'approve' })).toBe(
+      true,
+    );
     await expect(targetPending).resolves.toEqual({ action: 'approve' });
     target.dispose();
   });
@@ -268,7 +268,6 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
           settle = resolve;
           source.dispose();
         }),
-      resolve: () => false,
       cancel,
     });
     source.useHostInteractions(target.interactions.createForwarder());
@@ -297,7 +296,6 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     const session = createTestSession();
     const dispose = vi.fn();
     session.useHostInteractions({
-      resolve: () => false,
       cancel: () => {
         throw new Error('cancel failed');
       },
@@ -323,12 +321,9 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
 
       session.useHostInteractions(adapter.interactions);
       expect(adapter.requests).toHaveLength(1);
-      expect(
-        session.interactions.resolve('approval:unattached', {
-          kind: 'plan',
-          decision: { action: 'approve' },
-        }),
-      ).toBe(true);
+      expect(adapter.submit('approval:unattached', { action: 'approve' })).toBe(
+        true,
+      );
       await expect(pending).resolves.toEqual({ action: 'approve' });
     } finally {
       session.dispose();
@@ -353,12 +348,9 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
 
       session.useHostInteractions(second.interactions);
       expect(second.requests).toHaveLength(1);
-      expect(
-        session.interactions.resolve('approval:reattach', {
-          kind: 'plan',
-          decision: { action: 'approve' },
-        }),
-      ).toBe(true);
+      expect(second.submit('approval:reattach', { action: 'approve' })).toBe(
+        true,
+      );
       await expect(pending).resolves.toEqual({ action: 'approve' });
     } finally {
       session.dispose();
@@ -380,19 +372,9 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       detach();
       session.useHostInteractions(second.interactions);
 
-      expect(
-        first.interactions.resolve('approval:stale', {
-          kind: 'plan',
-          decision: { action: 'reject' },
-        }),
-      ).toBe(true);
+      expect(first.submit('approval:stale', { action: 'reject' })).toBe(true);
       await Promise.resolve();
-      expect(
-        session.interactions.resolve('approval:stale', {
-          kind: 'plan',
-          decision: { action: 'approve' },
-        }),
-      ).toBe(true);
+      expect(second.submit('approval:stale', { action: 'approve' })).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
     } finally {
       session.dispose();
@@ -460,7 +442,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
   });
 
   it('resolves a plan approval first-wins through the session slot', async () => {
-    const { session, uiEvents, emitted } = createPortSession();
+    const { session, uiEvents, emitted, interactions } = createPortSession();
     try {
       const pending = session.interactions.requestPlanApproval({
         approvalId: 'approval:first-wins',
@@ -478,18 +460,16 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       });
 
       expect(
-        session.interactions.resolve('approval:first-wins', {
-          kind: 'plan',
-          decision: { action: 'approve' },
+        interactions.submitPlanDecision('approval:first-wins', {
+          action: 'approve',
         }),
       ).toBe(true);
       await expect(pending).resolves.toEqual({ action: 'approve' });
 
       // First-wins: a second resolution finds nothing pending.
       expect(
-        session.interactions.resolve('approval:first-wins', {
-          kind: 'plan',
-          decision: { action: 'reject' },
+        interactions.submitPlanDecision('approval:first-wins', {
+          action: 'reject',
         }),
       ).toBe(false);
     } finally {
@@ -498,7 +478,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
   });
 
   it('rejects the stale request when the same id is re-requested (replacement)', async () => {
-    const { session, uiEvents } = createPortSession();
+    const { session, uiEvents, interactions } = createPortSession();
     try {
       const first = session.interactions.requestPlanApproval({
         approvalId: 'approval:replace',
@@ -519,9 +499,8 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       ).toHaveLength(2);
 
       expect(
-        session.interactions.resolve('approval:replace', {
-          kind: 'plan',
-          decision: { action: 'approve' },
+        interactions.submitPlanDecision('approval:replace', {
+          action: 'approve',
         }),
       ).toBe(true);
       await expect(second).resolves.toEqual({ action: 'approve' });
@@ -531,7 +510,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
   });
 
   it('a stream-scoped cancel settles every pending request for that stream only', async () => {
-    const { session } = createPortSession();
+    const { session, interactions } = createPortSession();
     const otherStreamId = 'stream:interactions-other' as StreamTabId;
     try {
       const pendingPlan = session.interactions.requestPlanApproval({
@@ -559,23 +538,20 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
         action: 'reject',
       });
       expect(
-        session.interactions.resolve('approval:cleanup', {
-          kind: 'plan',
-          decision: { action: 'approve' },
+        interactions.submitPlanDecision('approval:cleanup', {
+          action: 'approve',
         }),
       ).toBe(false);
       expect(
-        session.interactions.resolve('proposal:cleanup', {
-          kind: 'proposal',
-          decision: { action: 'approve' },
+        interactions.submitProposalDecision('proposal:cleanup', {
+          action: 'approve',
         }),
       ).toBe(false);
 
       // The other stream's request is untouched and still resolvable.
       expect(
-        session.interactions.resolve('approval:survives', {
-          kind: 'plan',
-          decision: { action: 'approve' },
+        interactions.submitPlanDecision('approval:survives', {
+          action: 'approve',
         }),
       ).toBe(true);
       await expect(surviving).resolves.toEqual({ action: 'approve' });
@@ -585,7 +561,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
   });
 
   it('a kind-scoped cancel settles only that kind on the stream', async () => {
-    const { session } = createPortSession();
+    const { session, interactions } = createPortSession();
     try {
       const pendingPlan = session.interactions.requestPlanApproval({
         approvalId: 'approval:kind-scope',
@@ -609,9 +585,8 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
 
       // The proposal on the same stream is untouched and still resolvable.
       expect(
-        session.interactions.resolve('proposal:kind-scope', {
-          kind: 'proposal',
-          decision: { action: 'approve' },
+        interactions.submitProposalDecision('proposal:kind-scope', {
+          action: 'approve',
         }),
       ).toBe(true);
       await expect(pendingProposal).resolves.toMatchObject({

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -203,10 +203,7 @@ describe('cleanupAllApprovals scope (SDK Step 7d PR 3)', () => {
       await expect(planA).resolves.toEqual({ action: 'reject' });
       // Session B's request is untouched and still resolvable.
       expect(
-        b.interactions.resolve('approval:b', {
-          kind: 'plan',
-          decision: { action: 'approve' },
-        }),
+        hostB.decisions.submitPlan('approval:b', { action: 'approve' }),
       ).toBe(true);
       await expect(planB).resolves.toEqual({ action: 'approve' });
     } finally {

--- a/src/test-kernel/cli/ApprovalEvents.vitest.mts
+++ b/src/test-kernel/cli/ApprovalEvents.vitest.mts
@@ -17,7 +17,6 @@ describe('CLI approval event taxonomy', () => {
       'showAgentProposal',
       'showRetryRequest',
       'showExternalInquiry',
-      'showUserQuestion',
     ]);
 
     const decisionEvents: ReadonlySet<string> = new Set(
@@ -33,7 +32,7 @@ describe('CLI approval event taxonomy', () => {
     expect(isCliDecisionApprovalEvent('showExternalInquiry')).toBe(false);
 
     expect(isCliApprovalEvent('showExternalInquiry')).toBe(true);
-    expect(isCliApprovalEvent('showUserQuestion')).toBe(true);
+    expect(isCliApprovalEvent('showUserQuestion')).toBe(false);
     expect(isCliApprovalEvent('updateStreamStatus')).toBe(false);
   });
 
@@ -43,6 +42,5 @@ describe('CLI approval event taxonomy', () => {
     expect(cliApprovalEventKind('showAgentProposal')).toBe('proposal');
     expect(cliApprovalEventKind('showRetryRequest')).toBe('retry');
     expect(cliApprovalEventKind('showExternalInquiry')).toBe('externalInquiry');
-    expect(cliApprovalEventKind('showUserQuestion')).toBe('userQuestion');
   });
 });

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -28,6 +28,12 @@ import {
 } from '@tools/approval';
 import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
 
+const externalInquiryMocks = vi.hoisted(() => ({
+  continueExternalInquiryAction: vi.fn(),
+  persistExternalInquiryAction: vi.fn(),
+}));
+
+vi.mock('@tools/inquiry', () => externalInquiryMocks);
 vi.mock('@utils/files/pastedImageUtils', () => ({
   savePastedImageBase64: vi.fn(),
 }));
@@ -96,7 +102,9 @@ function createActions(
       handleUserQuestionAction: vi.fn(),
       handleAgentProposalAction: vi.fn(),
     },
-    externalInquiry: {},
+    externalInquiry: {
+      dismiss: vi.fn(),
+    },
     ...overrides,
   };
 }
@@ -786,6 +794,11 @@ describe('external inquiry action schema', () => {
   const command = PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION;
   const threadId = 'ei_123456789abc';
 
+  beforeEach(() => {
+    externalInquiryMocks.continueExternalInquiryAction.mockReset();
+    externalInquiryMocks.persistExternalInquiryAction.mockReset();
+  });
+
   it("requires each action variant's own fields", () => {
     const results = [
       { command, action: 'submit', threadId, answer: 'Confirmed' },
@@ -799,6 +812,50 @@ describe('external inquiry action schema', () => {
 
     expect(results).toEqual([true, true, true, false, false]);
   });
+
+  it.each([
+    {
+      name: 'submit',
+      message: { command, action: 'submit' as const, threadId, answer: 'Yes' },
+    },
+    {
+      name: 'drop',
+      message: { command, action: 'drop' as const, threadId },
+    },
+  ])(
+    'persists, dismisses, then continues a $name action',
+    async ({ message }) => {
+      const order: string[] = [];
+      const transition = { kind: 'stale' as const, threadId };
+      externalInquiryMocks.persistExternalInquiryAction.mockImplementation(
+        async () => {
+          order.push('persist');
+          return transition;
+        },
+      );
+      const dismiss = vi.fn(() => {
+        order.push('dismiss');
+      });
+      externalInquiryMocks.continueExternalInquiryAction.mockImplementation(
+        async () => {
+          order.push('continue');
+        },
+      );
+      const actions = createActions({ externalInquiry: { dismiss } });
+      const handlers = createProgressViewCommandHandlers(actions);
+
+      await assertSupported(handlers[command])(message);
+
+      expect(order).toEqual(['persist', 'dismiss', 'continue']);
+      expect(
+        externalInquiryMocks.persistExternalInquiryAction,
+      ).toHaveBeenCalledWith(message);
+      expect(dismiss).toHaveBeenCalledWith(threadId);
+      expect(
+        externalInquiryMocks.continueExternalInquiryAction,
+      ).toHaveBeenCalledWith(transition, actions.externalInquiry);
+    },
+  );
 });
 
 describe('user question action schema', () => {

--- a/src/test-kernel/controllers/ProgressViewHost.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewHost.vitest.ts
@@ -92,7 +92,9 @@ describe('ProgressViewHost', () => {
           handlePlanApprovalAction: vi.fn(),
           handleUserQuestionAction: vi.fn(),
         },
-        externalInquiry: {},
+        externalInquiry: {
+          dismiss: vi.fn(),
+        },
       },
     });
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -19,6 +19,7 @@ import {
   TaskStateSchema,
   type WorkflowTaskState,
 } from '@agent/core/state/TaskState';
+import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
@@ -67,6 +68,12 @@ type Bridge = {
 };
 
 type TestableBridge = Bridge & {
+  hostInteractions: {
+    submitPlanDecision(
+      requestId: string,
+      decision: PlanApprovalResult,
+    ): boolean;
+  };
   runtimeHost: {
     interactions?: {
       requestPlanApproval?: (request: {
@@ -3226,11 +3233,10 @@ describe('DesktopProgressBridge', () => {
         ),
       ).toEqual([]);
 
-      // B's session port cannot settle A's pending approval...
+      // B's response port cannot settle A's pending approval...
       expect(
-        windowB.session.interactions.resolve(approvalId, {
-          kind: 'plan',
-          decision: { action: 'approve' },
+        windowB.bridge.hostInteractions.submitPlanDecision(approvalId, {
+          action: 'approve',
         }),
       ).toBe(false);
       // ...neither can B's inbound plan-approval handler...
@@ -3573,9 +3579,8 @@ describe('DesktopProgressBridge', () => {
 
         // Window B resolves the retained run's pending interaction.
         expect(
-          bridgeB.session.interactions.resolve('plan-rebound', {
-            kind: 'plan',
-            decision: { action: 'approve' },
+          bridgeB.hostInteractions.submitPlanDecision('plan-rebound', {
+            action: 'approve',
           }),
         ).toBe(true);
         await expect(planPromise).resolves.toEqual({ action: 'approve' });
@@ -3700,10 +3705,10 @@ describe('DesktopProgressBridge', () => {
           );
         });
         expect(
-          bridgeC.session.interactions.resolve('plan-second-window-close', {
-            kind: 'plan',
-            decision: { action: 'approve' },
-          }),
+          bridgeC.hostInteractions.submitPlanDecision(
+            'plan-second-window-close',
+            { action: 'approve' },
+          ),
         ).toBe(true);
         await expect(approval).resolves.toEqual({ action: 'approve' });
       } finally {
@@ -3797,9 +3802,8 @@ describe('DesktopProgressBridge', () => {
 
         for (const approvalId of ['plan-before-close', 'plan-while-closed']) {
           expect(
-            bridgeB.session.interactions.resolve(approvalId, {
-              kind: 'plan',
-              decision: { action: 'approve' },
+            bridgeB.hostInteractions.submitPlanDecision(approvalId, {
+              action: 'approve',
             }),
           ).toBe(true);
         }

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -5,7 +5,12 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - runtime
-import type { HostInteractionSettlement } from '@agent/runtime/HostInteractions';
+import type {
+  BashSettlement,
+  PlanApprovalResult,
+  ProposalResult,
+  UserQuestionSettlement,
+} from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 
@@ -38,7 +43,13 @@ interface DesktopHostInteractions {
     plan: { objective: string };
   }): Promise<unknown>;
   requestAgentProposal(request: unknown): Promise<unknown>;
-  resolve(requestId: string, settlement: HostInteractionSettlement): boolean;
+  submitBashDecision(requestId: string, decision: BashSettlement): boolean;
+  submitPlanDecision(requestId: string, decision: PlanApprovalResult): boolean;
+  submitProposalDecision(requestId: string, decision: ProposalResult): boolean;
+  submitUserQuestionDecision(
+    requestId: string,
+    decision: UserQuestionSettlement,
+  ): boolean;
   cancel(selector?: {
     streamId?: StreamTabId | null;
     kind?: string;
@@ -176,9 +187,8 @@ describe('createDesktopHostInteractions', () => {
     );
 
     expect(
-      interactions.resolve('proposal-current', {
-        kind: 'proposal',
-        decision: { action: 'approve' },
+      interactions.submitProposalDecision('proposal-current', {
+        action: 'approve',
       }),
     ).toBe(true);
     const streamBRequestId = (
@@ -188,9 +198,8 @@ describe('createDesktopHostInteractions', () => {
     )?.requestId;
     expect(streamBRequestId).toBeDefined();
     expect(
-      interactions.resolve(streamBRequestId!, {
-        kind: 'bash',
-        decision: { action: 'reject' },
+      interactions.submitBashDecision(streamBRequestId!, {
+        action: 'reject',
       }),
     ).toBe(true);
     await expect(current).resolves.toEqual({ action: 'approve' });
@@ -218,7 +227,7 @@ describe('createDesktopHostInteractions', () => {
     expect(toolEditApprovals.requestApproval).toHaveBeenCalledWith(request);
   });
 
-  it('rejects a resolution whose kind does not match the pending request', async () => {
+  it('rejects a plan decision for a pending bash request', async () => {
     const handlers = createHandlers();
     const { interactions, runtimeHost, sessionEvents } =
       await createInteractions(handlers);
@@ -229,21 +238,12 @@ describe('createDesktopHostInteractions', () => {
     });
     const requestId = firstShowRequestId(handlers.bash.show);
 
-    // A mismatched kind under the same requestId must not settle the
-    // pending bash approval as a plan action would — matches the extension
-    // host's discriminant check.
     expect(
-      interactions.resolve(requestId, {
-        kind: 'plan',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitPlanDecision(requestId, { action: 'approve' }),
     ).toBe(false);
 
     expect(
-      interactions.resolve(requestId, {
-        kind: 'bash',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitBashDecision(requestId, { action: 'approve' }),
     ).toBe(true);
     await expect(resultPromise).resolves.toEqual({ accepted: true });
     expect(runtimeHost.emit).toHaveBeenCalledWith(
@@ -344,10 +344,7 @@ describe('createDesktopHostInteractions', () => {
     const requestId = firstShowRequestId(handlers.bash.show);
 
     expect(
-      interactions.resolve(requestId, {
-        kind: 'bash',
-        decision: { action: 'timeout' },
-      }),
+      interactions.submitBashDecision(requestId, { action: 'timeout' }),
     ).toBe(true);
 
     await expect(resultPromise).resolves.toEqual({
@@ -369,13 +366,10 @@ describe('createDesktopHostInteractions', () => {
     });
 
     expect(
-      interactions.resolve('proposal-a', {
-        kind: 'proposal',
-        decision: {
-          action: 'approve',
-          model: 'openai:gpt-5',
-          agent: 'configured-agent',
-        },
+      interactions.submitProposalDecision('proposal-a', {
+        action: 'approve',
+        model: 'openai:gpt-5',
+        agent: 'configured-agent',
       }),
     ).toBe(true);
 

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -159,9 +159,8 @@ describe('createExtensionHostInteractions', () => {
     expect(initiatingProposal).toBeDefined();
     expect(otherStream).toBeDefined();
     expect(
-      interactions.resolve('proposal-current', {
-        kind: 'proposal',
-        decision: { action: 'approve' },
+      interactions.submitProposalDecision('proposal-current', {
+        action: 'approve',
       }),
     ).toBe(true);
     const bashShow = handlers.bash.show as unknown as ReturnType<typeof vi.fn>;
@@ -174,9 +173,8 @@ describe('createExtensionHostInteractions', () => {
     expect(streamBRequestId).toBeDefined();
     expect(otherRequestId).not.toBe(streamBRequestId);
     expect(
-      interactions.resolve(streamBRequestId!, {
-        kind: 'bash',
-        decision: { action: 'reject' },
+      interactions.submitBashDecision(streamBRequestId!, {
+        action: 'reject',
       }),
     ).toBe(true);
     await expect(initiatingProposal).resolves.toEqual({ action: 'approve' });
@@ -231,9 +229,8 @@ describe('createExtensionHostInteractions', () => {
       plan: { objective: 'Prove the compactness lemma.' },
     });
     expect(
-      interactions.resolve('plan-a', {
-        kind: 'plan',
-        decision: { action: 'approve_and_goal' },
+      interactions.submitPlanDecision('plan-a', {
+        action: 'approve_and_goal',
       }),
     ).toBe(true);
 
@@ -243,10 +240,7 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-a');
     // The request was settled first-wins: a second resolution finds nothing.
     expect(
-      interactions.resolve('plan-a', {
-        kind: 'plan',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitPlanDecision('plan-a', { action: 'approve' }),
     ).toBe(false);
   });
 
@@ -305,9 +299,13 @@ describe('createExtensionHostInteractions', () => {
 
     await expect(first).resolves.toEqual({ action: 'cancel' });
     expect(
-      interactions.resolveRetry('stream-a' as StreamTabId, 'retry:first', {
-        action: 'retry',
-      }),
+      interactions.submitRetryDecision(
+        'stream-a' as StreamTabId,
+        'retry:first',
+        {
+          action: 'retry',
+        },
+      ),
     ).toBe(false);
     expect(
       interactions.isRetryPending(
@@ -316,7 +314,7 @@ describe('createExtensionHostInteractions', () => {
       ),
     ).toBe(true);
     expect(
-      interactions.resolveRetry(
+      interactions.submitRetryDecision(
         'stream-a' as StreamTabId,
         'retry:replacement',
         { action: 'retry' },
@@ -406,18 +404,12 @@ describe('createExtensionHostInteractions', () => {
     // bash approval as a plan action would (defends against a caller bug
     // resolving the wrong pending kind under a reused/misrouted requestId).
     expect(
-      interactions.resolve(requestId, {
-        kind: 'plan',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitPlanDecision(requestId, { action: 'approve' }),
     ).toBe(false);
 
     // The correctly-kinded resolution still settles it.
     expect(
-      interactions.resolve(requestId, {
-        kind: 'bash',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitBashDecision(requestId, { action: 'approve' }),
     ).toBe(true);
     await expect(resultPromise).resolves.toEqual({ accepted: true });
   });
@@ -456,10 +448,7 @@ describe('createExtensionHostInteractions', () => {
     // resolvable first-wins.
     expect(handlers.planApproval.resolve).not.toHaveBeenCalled();
     expect(
-      interactions.resolve('plan-a', {
-        kind: 'plan',
-        decision: { action: 'approve' },
-      }),
+      interactions.submitPlanDecision('plan-a', { action: 'approve' }),
     ).toBe(true);
     await expect(planPromise).resolves.toEqual({ action: 'approve' });
   });
@@ -492,9 +481,7 @@ describe('createExtensionHostInteractions', () => {
       streamId: 'stream-a',
       mode: 'new',
     });
-    expect(interactions.resolve('thread-a', { kind: 'externalInquiry' })).toBe(
-      true,
-    );
+    interactions.dismissExternalInquiry('thread-a');
     expect(handlers.externalInquiry.resolve).toHaveBeenCalledWith('thread-a');
   });
 
@@ -531,9 +518,9 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
     // The cancelled question was released: a later resolution finds nothing.
     expect(
-      interactions.resolve('question-a', {
-        kind: 'userQuestion',
-        decision: { action: 'submit', answers: { choice: 'unit volume' } },
+      interactions.submitUserQuestionDecision('question-a', {
+        action: 'submit',
+        answers: { choice: 'unit volume' },
       }),
     ).toBe(false);
   });
@@ -559,9 +546,9 @@ describe('createExtensionHostInteractions', () => {
     const answers = { normalization: 'unit volume' };
 
     expect(
-      interactions.resolve('question-submit', {
-        kind: 'userQuestion',
-        decision: { action: 'submit', answers },
+      interactions.submitUserQuestionDecision('question-submit', {
+        action: 'submit',
+        answers,
       }),
     ).toBe(true);
 

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -52,8 +52,12 @@ function createHostInteractions(
   return {
     approvePendingDelegatedWork: vi.fn(async () => undefined),
     isRetryPending: vi.fn(() => false),
-    resolveRetry: vi.fn(() => false),
-    resolve: vi.fn(() => false),
+    submitBashDecision: vi.fn(() => false),
+    submitPlanDecision: vi.fn(() => false),
+    submitProposalDecision: vi.fn(() => false),
+    submitRetryDecision: vi.fn(() => false),
+    submitUserQuestionDecision: vi.fn(() => false),
+    dismissExternalInquiry: vi.fn(),
     cancel: vi.fn(),
     ...overrides,
   };
@@ -290,7 +294,7 @@ describe('progress-view onboarding refresh wiring', () => {
 
   it('routes retry request actions through host interactions', async () => {
     const interactions = createHostInteractions({
-      resolveRetry: vi.fn(() => true),
+      submitRetryDecision: vi.fn(() => true),
     });
     const directHandler = createMessageHandler(
       createProgressViewProvider(),
@@ -317,7 +321,7 @@ describe('progress-view onboarding refresh wiring', () => {
       createWebviewView(),
     );
 
-    expect(interactions.resolveRetry).toHaveBeenCalledWith(
+    expect(interactions.submitRetryDecision).toHaveBeenCalledWith(
       'stream-a',
       'retry-a',
       {
@@ -325,7 +329,7 @@ describe('progress-view onboarding refresh wiring', () => {
         feedback: 'try the other branch',
       },
     );
-    expect(interactions.resolveRetry).toHaveBeenCalledWith(
+    expect(interactions.submitRetryDecision).toHaveBeenCalledWith(
       'stream-a',
       'retry-a',
       {
@@ -342,7 +346,7 @@ describe('progress-view onboarding refresh wiring', () => {
       provider,
       context,
       prompt,
-      createHostInteractions({ resolveRetry: vi.fn(() => false) }),
+      createHostInteractions({ submitRetryDecision: vi.fn(() => false) }),
     );
 
     await handler.handleMessage(
@@ -362,7 +366,7 @@ describe('progress-view onboarding refresh wiring', () => {
 
   it('routes agent proposal actions through host interactions', async () => {
     const interactions = createHostInteractions({
-      resolve: vi.fn(() => true),
+      submitProposalDecision: vi.fn(() => true),
     });
     const handler = createMessageHandler(
       createProgressViewProvider(),
@@ -382,19 +386,19 @@ describe('progress-view onboarding refresh wiring', () => {
       createWebviewView(),
     );
 
-    expect(interactions.resolve).toHaveBeenCalledWith('proposal-a', {
-      kind: 'proposal',
-      decision: {
+    expect(interactions.submitProposalDecision).toHaveBeenCalledWith(
+      'proposal-a',
+      {
         action: 'approve',
         model: 'gemini31p',
         agent: 'critic',
       },
-    });
+    );
   });
 
   it('routes plan approval actions through host interactions', async () => {
     const interactions = createHostInteractions({
-      resolve: vi.fn(() => true),
+      submitPlanDecision: vi.fn(() => true),
     });
     const handler = createMessageHandler(
       createProgressViewProvider(),
@@ -413,12 +417,9 @@ describe('progress-view onboarding refresh wiring', () => {
       createWebviewView(),
     );
 
-    expect(interactions.resolve).toHaveBeenCalledWith('plan-a', {
-      kind: 'plan',
-      decision: {
-        action: 'reject',
-        feedback: 'state the invariant first',
-      },
+    expect(interactions.submitPlanDecision).toHaveBeenCalledWith('plan-a', {
+      action: 'reject',
+      feedback: 'state the invariant first',
     });
   });
 

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -64,7 +64,7 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
     const sessionA = createTestSession();
     const sessionB = createTestSession();
     const cancelA = vi.fn();
-    sessionA.useHostInteractions({ resolve: () => false, cancel: cancelA });
+    sessionA.useHostInteractions({ cancel: cancelA });
     const settled = new Set<string>();
 
     try {

--- a/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
+++ b/src/test-kernel/tools/ConcurrentToolEditApprovalHandlers.vitest.ts
@@ -72,12 +72,10 @@ describe('Concurrent session tool edit approval handlers', () => {
     const sessionB = createTestSession();
     sessionA.useHostInteractions({
       requestToolEditApproval: handlerA,
-      resolve: () => false,
       cancel: () => undefined,
     });
     sessionB.useHostInteractions({
       requestToolEditApproval: handlerB,
-      resolve: () => false,
       cancel: () => undefined,
     });
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -73,7 +73,6 @@ function runtimeHost(): AgentRuntimeHost {
   return {
     emit: vi.fn(),
     interactions: {
-      resolve: vi.fn(() => false),
       cancel: vi.fn(),
     } satisfies HostInteractions,
   };

--- a/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryAction.vitest.ts
@@ -2,14 +2,9 @@
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type {
-  HostInteractionSettlement,
-  HostInteractions,
-} from '@agent/runtime/HostInteractions';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 
 const storageMocks = vi.hoisted(() => ({
@@ -34,53 +29,46 @@ vi.mock('@tools/inquiry/externalInquiryStorage', () => storageMocks);
 vi.mock('@tools/inquiry/inquiryContinuation', () => continuationMocks);
 
 describe('handleExternalInquiryAction', () => {
-  let detach: (() => void) | undefined;
-  let resolve: ReturnType<
-    typeof vi.fn<
-      (requestId: string, settlement: HostInteractionSettlement) => boolean
-    >
-  >;
-
   beforeEach(() => {
     vi.clearAllMocks();
     storageMocks.recordAnswerForOpenTurn.mockResolvedValue(null);
     storageMocks.markDropped.mockResolvedValue(null);
-    resolve = vi.fn<
-      (requestId: string, settlement: HostInteractionSettlement) => boolean
-    >(() => true);
-    const interactions: HostInteractions = {
-      resolve,
-      cancel: () => {},
-    };
-    detach = defaultSession().useHostInteractions(interactions);
   });
 
-  afterEach(() => {
-    detach?.();
-    detach = undefined;
-  });
+  it('persists and continues submit actions', async () => {
+    const manifest = { status: 'answered' };
+    storageMocks.recordAnswerForOpenTurn.mockResolvedValue({ manifest });
 
-  it('resolves extension submit actions through the default session', async () => {
     await handleExternalInquiryAction({
       action: 'submit',
       threadId: 'thread-submit',
       answer: 'A proof follows by compactness.',
     });
 
-    expect(resolve).toHaveBeenCalledWith('thread-submit', {
-      kind: 'externalInquiry',
+    expect(storageMocks.recordAnswerForOpenTurn).toHaveBeenCalledWith({
+      threadId: 'thread-submit',
+      answer: 'A proof follows by compactness.',
+      sessionLinks: undefined,
     });
+    expect(
+      continuationMocks.injectContinuationForAnsweredThread,
+    ).toHaveBeenCalledWith('thread-submit', manifest, undefined);
   });
 
-  it('resolves extension drop actions through the default session', async () => {
+  it('persists and continues drop actions', async () => {
+    const manifest = { status: 'dropped' };
+    storageMocks.markDropped.mockResolvedValue(manifest);
+
     await handleExternalInquiryAction({
       action: 'drop',
       threadId: 'thread-drop',
-      feedback: 'The question is no longer needed.',
     });
 
-    expect(resolve).toHaveBeenCalledWith('thread-drop', {
-      kind: 'externalInquiry',
+    expect(storageMocks.markDropped).toHaveBeenCalledWith({
+      threadId: 'thread-drop',
     });
+    expect(
+      continuationMocks.injectContinuationForDroppedThread,
+    ).toHaveBeenCalledWith('thread-drop', manifest, undefined);
   });
 });

--- a/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
+++ b/src/test-kernel/tools/ExternalInquiryHostInteractionRejection.vitest.ts
@@ -17,7 +17,6 @@ function createRuntimeHostWithRejectingInteraction(
   return {
     emit: () => {},
     interactions: {
-      resolve: () => false,
       cancel: () => {},
       openExternalInquiry: () => Promise.reject(reason),
     },

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -51,7 +51,7 @@ async function installPlatform(flagOn: boolean): Promise<Platform> {
 }
 
 function startPlanUpdate(streamId: StreamTabId, objective: string) {
-  const { events, host, interactions } = createRecordingHost();
+  const { decisions, events, host, interactions } = createRecordingHost();
   const session = sessionWithInteractions(interactions);
   const workPlanState = new WorkPlanState();
   const tool = new PlanTool();
@@ -71,7 +71,7 @@ function startPlanUpdate(streamId: StreamTabId, objective: string) {
     () => tool.call({ command: 'update', objective }),
   );
 
-  return { resultPromise, events, host, session, workPlanState };
+  return { decisions, resultPromise, events, session, workPlanState };
 }
 
 function findPlanApproval(
@@ -85,7 +85,7 @@ function findPlanApproval(
 describe('PlanTool — update (plan approval)', () => {
   it('keeps an approved plan in displayed work-plan state and defers steps to the todo tool', async () => {
     await installPlatform(false);
-    const { resultPromise, events, host, workPlanState } = startPlanUpdate(
+    const { decisions, resultPromise, events, workPlanState } = startPlanUpdate(
       'stream:plan-approve' as StreamTabId,
       plan.objective,
     );
@@ -93,9 +93,9 @@ describe('PlanTool — update (plan approval)', () => {
     const approval = findPlanApproval(events);
     expect((approval.payload as { plan: Plan }).plan).toEqual(plan);
     expect(
-      host.interactions?.resolve(
+      decisions.submitPlan(
         (approval.payload as { approvalId: string }).approvalId,
-        { kind: 'plan', decision: { action: 'approve' } },
+        { action: 'approve' },
       ),
     ).toBe(true);
 
@@ -108,19 +108,16 @@ describe('PlanTool — update (plan approval)', () => {
 
   it('clears a rejected plan from displayed work-plan state', async () => {
     await installPlatform(false);
-    const { resultPromise, events, host, workPlanState } = startPlanUpdate(
+    const { decisions, resultPromise, events, workPlanState } = startPlanUpdate(
       'stream:plan-reject' as StreamTabId,
       plan.objective,
     );
 
     const approval = findPlanApproval(events);
     expect(
-      host.interactions?.resolve(
+      decisions.submitPlan(
         (approval.payload as { approvalId: string }).approvalId,
-        {
-          kind: 'plan',
-          decision: { action: 'reject', feedback: 'Too broad.' },
-        },
+        { action: 'reject', feedback: 'Too broad.' },
       ),
     ).toBe(true);
 
@@ -134,7 +131,7 @@ describe('PlanTool — update (plan approval)', () => {
     const streamId = 'stream:plan-goal' as StreamTabId;
     await installPlatform(true);
 
-    const { resultPromise, events, host, session } = startPlanUpdate(
+    const { decisions, resultPromise, events, session } = startPlanUpdate(
       streamId,
       plan.objective,
     );
@@ -144,9 +141,9 @@ describe('PlanTool — update (plan approval)', () => {
         true,
       );
       expect(
-        host.interactions?.resolve(
+        decisions.submitPlan(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', decision: { action: 'approve_and_goal' } },
+          { action: 'approve_and_goal' },
         ),
       ).toBe(true);
 
@@ -171,16 +168,16 @@ describe('PlanTool — update (plan approval)', () => {
     await installPlatform(true);
 
     const existing = await GoalStore.start(streamId, 'Old objective');
-    const { resultPromise, events, host, session } = startPlanUpdate(
+    const { decisions, resultPromise, events, session } = startPlanUpdate(
       streamId,
       followUpPlan.objective,
     );
     try {
       const approval = findPlanApproval(events);
       expect(
-        host.interactions?.resolve(
+        decisions.submitPlan(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', decision: { action: 'approve_and_goal' } },
+          { action: 'approve_and_goal' },
         ),
       ).toBe(true);
 
@@ -207,7 +204,7 @@ describe('PlanTool — update (plan approval)', () => {
     const platform = await installPlatform(true);
 
     try {
-      const { resultPromise, events, host } = startPlanUpdate(
+      const { decisions, resultPromise, events } = startPlanUpdate(
         streamId,
         plan.objective,
       );
@@ -219,9 +216,9 @@ describe('PlanTool — update (plan approval)', () => {
 
       (platform.config as FakeConfigProvider).set(GOAL_FEATURE_FLAG_KEY, false);
       expect(
-        host.interactions?.resolve(
+        decisions.submitPlan(
           (approval.payload as { approvalId: string }).approvalId,
-          { kind: 'plan', decision: { action: 'approve_and_goal' } },
+          { action: 'approve_and_goal' },
         ),
       ).toBe(true);
 
@@ -237,16 +234,16 @@ describe('PlanTool — update (plan approval)', () => {
 
   it('clears a timed-out plan from displayed work-plan state', async () => {
     await installPlatform(false);
-    const { resultPromise, events, host, workPlanState } = startPlanUpdate(
+    const { decisions, resultPromise, events, workPlanState } = startPlanUpdate(
       'stream:plan-timeout' as StreamTabId,
       plan.objective,
     );
 
     const approval = findPlanApproval(events);
     expect(
-      host.interactions?.resolve(
+      decisions.submitPlan(
         (approval.payload as { approvalId: string }).approvalId,
-        { kind: 'plan', decision: { action: 'timeout' } },
+        { action: 'timeout' },
       ),
     ).toBe(true);
 

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -56,7 +56,6 @@ async function installPlatform(
       }
       return handler(request);
     },
-    resolve: () => false,
     cancel: () => undefined,
   });
 }

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -66,9 +66,8 @@ describe('WolframTool approval', () => {
     });
 
     expect(
-      explicit.host.interactions?.resolve(show.payload.requestId, {
-        kind: 'bash',
-        decision: { action: 'approve' },
+      explicit.decisions.submitBash(show.payload.requestId, {
+        action: 'approve',
       }),
     ).toBe(true);
 
@@ -85,12 +84,9 @@ describe('WolframTool approval', () => {
 
     const { explicit, result, show } = await dispatchWolfram(streamId, '2+2');
     expect(
-      explicit.host.interactions?.resolve(show.payload.requestId, {
-        kind: 'bash',
-        decision: {
-          action: 'reject',
-          feedback: 'Use the requested node check instead.',
-        },
+      explicit.decisions.submitBash(show.payload.requestId, {
+        action: 'reject',
+        feedback: 'Use the requested node check instead.',
       }),
     ).toBe(true);
 
@@ -110,9 +106,8 @@ describe('WolframTool approval', () => {
       'Factor[n^7 - n]',
     );
     expect(
-      explicit.host.interactions?.resolve(show.payload.requestId, {
-        kind: 'bash',
-        decision: { action: 'reject' },
+      explicit.decisions.submitBash(show.payload.requestId, {
+        action: 'reject',
       }),
     ).toBe(true);
 

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -152,40 +152,43 @@ export type InquiryInput = z.infer<typeof InquiryInputSchema>;
 // Action handler (called by the host when the panel submits/drops)
 // ============================================================================
 
-export async function handleExternalInquiryAction(
+export type ExternalInquiryTransition =
+  | {
+      readonly kind: 'answered';
+      readonly threadId: InquiryActionMessage['threadId'];
+      readonly manifest: ExternalInquiryThreadManifest;
+    }
+  | {
+      readonly kind: 'dropped';
+      readonly threadId: InquiryActionMessage['threadId'];
+      readonly manifest: ExternalInquiryThreadManifest;
+    }
+  | {
+      readonly kind: 'stale';
+      readonly threadId: InquiryActionMessage['threadId'];
+    };
+
+/** Persist one terminal inquiry action without reaching into host presentation. */
+export async function persistExternalInquiryAction(
   payload: InquiryActionMessage,
-  options: { session?: SessionHandle } = {},
-): Promise<void> {
-  const session = options.session ?? defaultSession();
+): Promise<ExternalInquiryTransition> {
   if (payload.action === 'submit') {
     const persisted = await recordAnswerForOpenTurn({
       threadId: payload.threadId,
       answer: payload.answer,
       sessionLinks: payload.sessionLinks ?? undefined,
     });
-    // Removes the inquiry card from `ApprovalRequestHandler.pending`; without
-    // this the request would replay on next webview load and the stream would
-    // be reported as having pending permissions forever. Emit even for stale
-    // submits so duplicate/delayed UI actions do not leave a leaked permission.
-    session.interactions.resolve(payload.threadId, {
-      kind: 'externalInquiry',
-    });
     if (!persisted) {
       logger.warn(
         `Inquiry submit ignored: thread ${payload.threadId} has no open turn.`,
       );
-      return;
+      return { kind: 'stale', threadId: payload.threadId };
     }
-    // Pass the manifest we just wrote so the injector doesn't re-read from
-    // disk — a concurrent follow-up `ask` from another stream could flip
-    // the status back to `open` between writes and would otherwise cause
-    // the continuation to silently drop.
-    await injectContinuationForAnsweredThread(
-      payload.threadId,
-      persisted.manifest,
-      options.session,
-    );
-    return;
+    return {
+      kind: 'answered',
+      threadId: payload.threadId,
+      manifest: persisted.manifest,
+    };
   }
 
   // drop — only flips status if the thread is still open; see markDropped.
@@ -195,21 +198,54 @@ export async function handleExternalInquiryAction(
     });
   }
   const droppedManifest = await markDropped({ threadId: payload.threadId });
-  session.interactions.resolve(payload.threadId, {
-    kind: 'externalInquiry',
-  });
   if (droppedManifest) {
-    await injectContinuationForDroppedThread(
-      payload.threadId,
-      droppedManifest,
-      options.session,
-    );
-  } else {
-    logger.warn(
-      `Inquiry drop ignored: thread ${payload.threadId} is no longer open ` +
-        `(stale/duplicate drop after submit?). Skipping continuation.`,
-    );
+    return {
+      kind: 'dropped',
+      threadId: payload.threadId,
+      manifest: droppedManifest,
+    };
   }
+  logger.warn(
+    `Inquiry drop ignored: thread ${payload.threadId} is no longer open ` +
+      `(stale/duplicate drop after submit?). Skipping continuation.`,
+  );
+  return { kind: 'stale', threadId: payload.threadId };
+}
+
+/** Deliver the continuation represented by a completed durable transition. */
+export async function continueExternalInquiryAction(
+  transition: ExternalInquiryTransition,
+  options: { session?: SessionHandle } = {},
+): Promise<void> {
+  switch (transition.kind) {
+    case 'answered':
+      // Use the manifest just written so a concurrent follow-up cannot flip
+      // storage back to `open` before this continuation observes the answer.
+      await injectContinuationForAnsweredThread(
+        transition.threadId,
+        transition.manifest,
+        options.session,
+      );
+      return;
+    case 'dropped':
+      await injectContinuationForDroppedThread(
+        transition.threadId,
+        transition.manifest,
+        options.session,
+      );
+      return;
+    case 'stale':
+      return;
+  }
+}
+
+/** Persist and continue an inquiry action for hosts without progress UI. */
+export async function handleExternalInquiryAction(
+  payload: InquiryActionMessage,
+  options: { session?: SessionHandle } = {},
+): Promise<void> {
+  const transition = await persistExternalInquiryAction(payload);
+  await continueExternalInquiryAction(transition, options);
 }
 
 // ============================================================================

--- a/src/tools/inquiry/index.ts
+++ b/src/tools/inquiry/index.ts
@@ -1,4 +1,5 @@
 export {
+  continueExternalInquiryAction,
   ExternalInquiryTool,
-  handleExternalInquiryAction,
+  persistExternalInquiryAction,
 } from './ExternalInquiryTool';

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -7,7 +7,6 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import type { UserQuestionSettlement } from '@agent/runtime/HostInteractions';
 import {
   UserQuestionAnswersSchema,
   UserQuestionPromptSchema,
@@ -34,16 +33,6 @@ const AskUserQuestionInputSchema = z.strictObject({
 });
 
 export type AskUserQuestionInput = z.infer<typeof AskUserQuestionInputSchema>;
-
-export async function handleUserQuestionAction(
-  payload: { requestId: string } & UserQuestionSettlement,
-): Promise<void> {
-  const { requestId, ...decision } = payload;
-  defaultSession().interactions.resolve(requestId, {
-    kind: 'userQuestion',
-    decision,
-  });
-}
 
 export class AskUserQuestionTool extends defineTool({
   name: 'ask_user_question',

--- a/src/tools/userQuestion/index.ts
+++ b/src/tools/userQuestion/index.ts
@@ -1,4 +1,1 @@
-export {
-  AskUserQuestionTool,
-  handleUserQuestionAction,
-} from './UserQuestionTool';
+export { AskUserQuestionTool } from './UserQuestionTool';


### PR DESCRIPTION
## Summary

- remove `HostInteractions.resolve` from the runtime port, session owner, and forwarding adapter
- route bash, plan, proposal, retry, and user-question decisions through exact extension and desktop presentation actions
- separate external-inquiry persistence, presentation dismissal, and continuation delivery
- remove CLI dummy resolvers and the dead `showUserQuestion` compatibility event route
- return cancellation results directly instead of wrapping and re-decoding a generic settlement union

## Design

Runtime sessions now own request buffering, host rebinding, cancellation, and result promises only. Concrete progress adapters own response correlation. External inquiry exposes a durable transition value so the progress command path can dismiss the card after persistence and before continuation delivery, while CLI hosts compose the same domain transition without progress UI.

This is the first implementation slice of #8545. The existing host-specific presentation maps remain for the follow-up consolidation into `ApprovalRequestHandler`; no replacement registry or renamed response tunnel is introduced here.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 existing warnings)
- `npm run compile:fast`
- `npm test` (708 files passed, 1 skipped; 6,435 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet`
- post-rebase focused boundary suite (6 files, 89 tests)

Refs #8545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across runtime approval plumbing, desktop/extension progress handlers, and CLI human-input routing; behavior changes are localized but mistakes could strand pending approvals or mishandle inquiry continuations.
> 
> **Overview**
> Removes **`HostInteractions.resolve`** and the **`HostInteractionSettlement`** union from the runtime session port. Pending interactions are still buffered and cancelled in the coordinator; **extension and desktop** now settle UI actions via explicit **`submit*Bash/Plan/Proposal/Retry/UserQuestion*Decision`** helpers (and **`dismissExternalInquiry`**) instead of a kind-tagged tunnel through `session.interactions`.
> 
> **Cancellation** uses **`cancellationResultFor`**, returning each interaction’s concrete result type directly rather than wrapping and re-decoding settlements.
> 
> **External inquiry** is split into **`persistExternalInquiryAction`**, host **`dismiss`**, and **`continueExternalInquiryAction`** so progress UI can clear the card after persistence and before async continuation; headless/CLI paths compose the same transition without calling `resolve`.
> 
> **CLI** drops the **`showUserQuestion`** compatibility event route and the async **`handleUserQuestion`** handler; user questions flow through **`HostInteractions.askUserQuestion`** (TUI queue / headless prompts). Dummy **`resolve: () => false`** stubs are removed from TUI and headless adapters.
> 
> **`showUserQuestion`** is removed from **`RuntimeInteractionEventPayloads`**; **`handleUserQuestionAction`** is removed from the user-question tool module. Tests use **`RecordingHostDecisions.submit*`** instead of **`interactions.resolve`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fea0d12a3af0c3cfeb1e593d8d3b5c90f2469d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->