### PR TITLE
fix(cli): preserve React Compiler coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate CLI React Compiler
+        run: pnpm --filter @texra-ai/cli smoke:react-compiler
+
       - name: Type check
         run: pnpm run typecheck
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -128,7 +128,7 @@ export function App(props: AppProps): React.JSX.Element {
   const transcriptViewerOpen = transcriptViewerStreamId !== undefined;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
-  const activeDraftRegistry = useMemo(createActiveDraftRegistry, []);
+  const activeDraftRegistry = useMemo(() => createActiveDraftRegistry(), []);
   const canStopActiveRun =
     props.canStopActiveRun ?? props.canInterruptActiveRun;
   const agentSelectionAvailable = rootRunStartAvailable;


### PR DESCRIPTION
## Summary

- restores React Compiler output for the CLI `App` with an inline `useMemo` initializer
- moves the compiler smoke into pull-request validation as an explicit, cheap gate

## Design issue

The production component and its compiler contract had drifted apart: React Compiler 1.0 rejects a direct function reference as the `useMemo` initializer, silently skips the whole component, and leaves runtime behavior correct but optimization absent. The existing smoke detected that state, but only through a main-only runtime job. The component now uses the compiler-supported declarative form, and the contract is checked before merge.

## Validation

- `npm run format`
- `npm run lint` — 0 errors, 51 existing warnings
- `npm run compile:fast`
- `npm test -- --maxWorkers=2` — 709 passed files, 6,446 passed tests
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `corepack pnpm --filter @texra-ai/cli smoke:react-compiler`
- `corepack pnpm --filter @texra-ai/cli validate:run`
- focused ActiveDraft and InputBar tests — 10 passed

Closes #8557

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral-equivalent `useMemo` tweak plus an early CI smoke; no auth, data, or runtime semantics change beyond restoring compiler output.
> 
> **Overview**
> Restores **React Compiler** optimization on the CLI TUI root **`App`** by changing the `activeDraftRegistry` `useMemo` initializer from a bare function reference to an inline `() => createActiveDraftRegistry()` — the form React Compiler 1.0 accepts instead of silently skipping the whole component.
> 
> Adds a **Validate CLI React Compiler** step to the Linux PR **`validate`** job (`pnpm --filter @texra-ai/cli smoke:react-compiler`), so the compiler contract is enforced on every code PR before typecheck/lint, not only via the main-only runtime **`validate:run`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130db6a19f9dc849e0aad4cfd09ace39dbf4fcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->