### PR TITLE
refactor(progress): centralize interaction ownership

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -280,7 +280,7 @@ export class DesktopProgressBridge {
           overrides: {
             retry: {
               show: () => undefined,
-              resolve: () => undefined,
+              dismiss: () => undefined,
             },
             agentProposal: {
               show: (p) =>
@@ -288,7 +288,7 @@ export class DesktopProgressBridge {
                   kind: PERMISSION_KIND.PROPOSAL,
                   data: p,
                 }),
-              resolve: (id) =>
+              dismiss: (id) =>
                 webviewUpdater.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
             },
           },
@@ -657,9 +657,9 @@ export class DesktopProgressBridge {
   }
 
   private clearDesktopSessionMaps(): void {
-    // Drop every pending approval (and proposal payload) without notifying the
-    // webview — the "delete all"/teardown sweep already settles the underlying
-    // approvals through releaseStreamResources/cleanup helpers.
+    // Release every pending approval (and proposal payload) without notifying
+    // the webview. Each handler owns settlement as well as presentation state,
+    // so teardown cannot leave an interaction promise pending.
     for (const handler of Object.values(this.approvalHandlers)) {
       handler.clear();
     }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -186,7 +186,7 @@ export class DesktopProgressBridge {
   private readonly agentProposalController: ProgressViewHost['agentProposalController'];
   private readonly workflowFileActions: ProgressViewHost['workflowFileActionsController'];
   /**
-   * Shown-but-unresolved approval prompts, one {@link ApprovalRequestHandler}
+   * Pending approval prompts, one {@link ApprovalRequestHandler}
    * per kind. These back the shared pending-permissions guard against view
    * switches and the pending-proposal lookup — the same host-agnostic
    * bookkeeping the extension uses, rather than a hand-rolled registry.
@@ -271,7 +271,7 @@ export class DesktopProgressBridge {
         unsupportedCommands(this.progressViewInboundHandlers),
       configureUi: ({ webviewUpdater }) => {
         // The desktop renderer is always attached (no sidebar/editor re-target),
-        // so every show/resolve reaches the webview.
+        // so every show/dismiss reaches the webview.
         const canSend = () => true;
         this.approvalHandlers = buildApprovalRequestHandlerSet({
           webviewUpdater,

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -8,7 +8,6 @@ import {
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
-  type HostInteractionResultByKind,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
@@ -24,7 +23,6 @@ import {
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
-import { assertNever } from '@utils/core';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -32,28 +30,6 @@ import type {
 } from '@platform/interfaces';
 
 import type { DesktopToolEditApprovalController } from './desktopToolEditApproval.js';
-
-type PendingDesktopKind = Exclude<keyof HostInteractionResultByKind, 'retry'>;
-
-interface PendingDesktopMetadataByKind {
-  readonly bash: { readonly streamId?: StreamTabId };
-  readonly plan: { readonly streamId: StreamTabId };
-  readonly proposal: { readonly streamId: StreamTabId };
-  readonly userQuestion: { readonly streamId?: StreamTabId };
-}
-
-type PendingDesktopRegistration<K extends PendingDesktopKind> = {
-  readonly kind: K;
-  readonly cancellationScope?: object;
-} & PendingDesktopMetadataByKind[K];
-
-type PendingDesktopInteraction<K extends PendingDesktopKind> =
-  PendingDesktopRegistration<K> & {
-    settle(result: HostInteractionResultByKind[K]): void;
-  };
-
-type AnyPendingDesktopInteraction =
-  PendingDesktopInteraction<PendingDesktopKind>;
 
 export interface DesktopHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
@@ -84,11 +60,6 @@ export function createDesktopHostInteractions(
 }
 
 class DesktopHostInteractionsImpl implements DesktopHostInteractions {
-  private readonly pendingRequests = new Map<
-    string,
-    AnyPendingDesktopInteraction
-  >();
-
   constructor(private readonly options: DesktopHostInteractionsOptions) {}
 
   requestToolEditApproval(
@@ -114,50 +85,33 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
       allowBypass: true,
       streamId: streamId ?? '',
     };
-    return this.showPending(
-      requestId,
-      { kind: 'bash', streamId, cancellationScope: options?.cancellationScope },
-      () => {
-        this.revealStream(streamId);
-        this.options.getApprovalHandlers().bash.show(payload);
-      },
-    );
+    this.revealStream(streamId);
+    return this.options.getApprovalHandlers().bash.request(payload, {
+      cancellationScope: options?.cancellationScope,
+      cancellationResult: (cause) => cancellationResultFor('bash', cause),
+    });
   }
 
   requestPlanApproval(
     request: HostPlanApprovalRequest,
     options?: HostInteractionOptions,
   ): Promise<PlanApprovalResult> {
-    return this.showPending(
-      request.approvalId,
-      {
-        kind: 'plan',
-        streamId: request.streamId,
-        cancellationScope: options?.cancellationScope,
-      },
-      () => {
-        this.revealStream(request.streamId);
-        this.options.getApprovalHandlers().planApproval.show(request);
-      },
-    );
+    this.revealStream(request.streamId);
+    return this.options.getApprovalHandlers().planApproval.request(request, {
+      cancellationScope: options?.cancellationScope,
+      cancellationResult: (cause) => cancellationResultFor('plan', cause),
+    });
   }
 
   requestAgentProposal(
     request: AgentProposalPermission,
     options?: HostInteractionOptions,
   ): Promise<ProposalResult> {
-    return this.showPending(
-      request.proposalId,
-      {
-        kind: 'proposal',
-        streamId: request.streamId,
-        cancellationScope: options?.cancellationScope,
-      },
-      () => {
-        this.revealStream(request.streamId);
-        this.options.getApprovalHandlers().agentProposal.show(request);
-      },
-    );
+    this.revealStream(request.streamId);
+    return this.options.getApprovalHandlers().agentProposal.request(request, {
+      cancellationScope: options?.cancellationScope,
+      cancellationResult: (cause) => cancellationResultFor('proposal', cause),
+    });
   }
 
   requestRetry(_request: HostRetryRequest): Promise<RetryResult> {
@@ -169,18 +123,12 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     options?: HostInteractionOptions,
   ): Promise<HostUserQuestionResult> {
     const streamId = request.streamId || undefined;
-    return this.showPending(
-      request.requestId,
-      {
-        kind: 'userQuestion',
-        streamId,
-        cancellationScope: options?.cancellationScope,
-      },
-      () => {
-        this.revealStream(streamId);
-        this.options.getApprovalHandlers().userQuestion.show(request);
-      },
-    );
+    this.revealStream(streamId);
+    return this.options.getApprovalHandlers().userQuestion.request(request, {
+      cancellationScope: options?.cancellationScope,
+      cancellationResult: (cause) =>
+        cancellationResultFor('userQuestion', cause),
+    });
   }
 
   openExternalInquiry(
@@ -193,59 +141,51 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
   }
 
   submitBashDecision(requestId: string, decision: BashSettlement): boolean {
-    return this.completePending(
-      requestId,
-      'bash',
-      toBashApprovalResult(decision),
-      () => this.options.getApprovalHandlers().bash.resolve(requestId),
-    );
+    return this.options
+      .getApprovalHandlers()
+      .bash.complete(requestId, toBashApprovalResult(decision));
   }
 
   submitPlanDecision(requestId: string, decision: PlanApprovalResult): boolean {
-    return this.completePending(requestId, 'plan', decision, () =>
-      this.options.getApprovalHandlers().planApproval.resolve(requestId),
-    );
+    return this.options
+      .getApprovalHandlers()
+      .planApproval.complete(requestId, decision);
   }
 
   submitProposalDecision(requestId: string, decision: ProposalResult): boolean {
-    return this.completePending(requestId, 'proposal', decision, () =>
-      this.options.getApprovalHandlers().agentProposal.resolve(requestId),
-    );
+    return this.options
+      .getApprovalHandlers()
+      .agentProposal.complete(requestId, decision);
   }
 
   submitUserQuestionDecision(
     requestId: string,
     decision: UserQuestionSettlement,
   ): boolean {
-    return this.completePending(
-      requestId,
-      'userQuestion',
-      toUserQuestionResult(decision),
-      () => this.options.getApprovalHandlers().userQuestion.resolve(requestId),
-    );
+    return this.options
+      .getApprovalHandlers()
+      .userQuestion.complete(requestId, toUserQuestionResult(decision));
   }
 
   dismissExternalInquiry(requestId: string): void {
-    this.options.getApprovalHandlers().externalInquiry.resolve(requestId);
+    this.options.getApprovalHandlers().externalInquiry.dismiss(requestId);
   }
 
   async approvePendingDelegatedWork(
     streamId: StreamTabId,
     initiatingProposalId: string,
   ): Promise<void> {
-    for (const [requestId, request] of [...this.pendingRequests]) {
-      if (
-        request.streamId !== streamId ||
-        (request.kind === 'proposal' && requestId === initiatingProposalId)
-      ) {
-        continue;
-      }
-      if (request.kind === 'bash') {
-        this.submitBashDecision(requestId, { action: 'approve' });
-      } else if (request.kind === 'proposal') {
-        this.submitProposalDecision(requestId, { action: 'approve' });
-      }
-    }
+    const handlers = this.options.getApprovalHandlers();
+    handlers.bash.completeWhere(
+      (request) => request.streamId === streamId,
+      toBashApprovalResult({ action: 'approve' }),
+    );
+    handlers.agentProposal.completeWhere(
+      (request) =>
+        request.streamId === streamId &&
+        request.proposalId !== initiatingProposalId,
+      { action: 'approve' },
+    );
     await this.options.getToolEditApprovals().approvePendingForStream(streamId);
   }
 
@@ -253,101 +193,59 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     if (selector.kind == null || selector.kind === 'toolEdit') {
       this.options.getToolEditApprovals().cancel(selector);
     }
-    for (const [requestId, request] of [...this.pendingRequests.entries()]) {
-      if (!matchesCancelSelector(request, selector)) continue;
-      this.rejectPending(requestId, request, selector.cause);
-    }
+    const handlers = this.options.getApprovalHandlers();
+    handlers.bash.cancelWhere(
+      (request, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'bash',
+            streamId: request.streamId || undefined,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers.planApproval.cancelWhere(
+      (request, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'plan',
+            streamId: request.streamId,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers.agentProposal.cancelWhere(
+      (request, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'proposal',
+            streamId: request.streamId,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers.userQuestion.cancelWhere(
+      (request, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'userQuestion',
+            streamId: request.streamId || undefined,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
   }
 
   dispose(): void {
     this.cancel({ cause: 'Desktop session disposed.' });
-  }
-
-  private showPending<K extends PendingDesktopKind>(
-    requestId: string,
-    entry: PendingDesktopRegistration<K>,
-    show: () => void,
-  ): Promise<HostInteractionResultByKind[K]> {
-    // Replacement cancellation: a request re-issued under a still-pending id
-    // rejects the stale prompt before the replacement is shown.
-    const replaced = this.pendingRequests.get(requestId);
-    if (replaced) {
-      this.rejectPending(requestId, replaced, 'Approval request was replaced.');
-    }
-    return new Promise<HostInteractionResultByKind[K]>((settle) => {
-      const interaction: PendingDesktopInteraction<K> = {
-        ...entry,
-        settle(result) {
-          settle(result);
-        },
-      };
-      this.pendingRequests.set(requestId, interaction);
-      try {
-        show();
-      } catch (error) {
-        this.pendingRequests.delete(requestId);
-        throw error;
-      }
-    });
-  }
-
-  private rejectPending(
-    requestId: string,
-    request: AnyPendingDesktopInteraction,
-    feedback?: string,
-  ): void {
-    switch (request.kind) {
-      case 'bash':
-        this.completePending(
-          requestId,
-          'bash',
-          cancellationResultFor('bash', feedback),
-          () => this.options.getApprovalHandlers().bash.resolve(requestId),
-        );
-        return;
-      case 'plan':
-        this.completePending(
-          requestId,
-          'plan',
-          cancellationResultFor('plan', feedback),
-          () =>
-            this.options.getApprovalHandlers().planApproval.resolve(requestId),
-        );
-        return;
-      case 'proposal':
-        this.completePending(
-          requestId,
-          'proposal',
-          cancellationResultFor('proposal', feedback),
-          () =>
-            this.options.getApprovalHandlers().agentProposal.resolve(requestId),
-        );
-        return;
-      case 'userQuestion':
-        this.completePending(
-          requestId,
-          'userQuestion',
-          cancellationResultFor('userQuestion', feedback),
-          () =>
-            this.options.getApprovalHandlers().userQuestion.resolve(requestId),
-        );
-        return;
-    }
-    assertNever(request.kind, 'Unhandled desktop interaction kind');
-  }
-
-  private completePending<K extends PendingDesktopKind>(
-    requestId: string,
-    expectedKind: K,
-    value: HostInteractionResultByKind[K],
-    resolveUi: () => void,
-  ): boolean {
-    const pending = this.pendingRequests.get(requestId);
-    if (!pending || pending.kind !== expectedKind) return false;
-    this.pendingRequests.delete(requestId);
-    pending.settle(value);
-    resolveUi();
-    return true;
   }
 
   // Interaction requests surface per-stream (pending badge on the stream

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -1,8 +1,11 @@
 import { nanoid } from 'nanoid';
+import {
+  cancelApprovalRequestHandlers,
+  type ApprovalRequestHandlerSet,
+} from '@controllers/progressView/backend/progressBackendUiConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   cancellationResultFor,
-  matchesCancelSelector,
   type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
@@ -15,6 +18,7 @@ import {
   type PlanApprovalResult,
   type ProposalResult,
   type RetryResult,
+  type SettledInteractionKind,
   type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import {
@@ -23,7 +27,6 @@ import {
 } from '@agent/runtime/hostInteractionResultMappers';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
-import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
@@ -52,6 +55,13 @@ export interface DesktopHostInteractions extends HostInteractions {
   ): boolean;
   dismissExternalInquiry(requestId: string): void;
 }
+
+const DESKTOP_PROGRESS_INTERACTION_KINDS = [
+  'bash',
+  'plan',
+  'proposal',
+  'userQuestion',
+] as const satisfies readonly SettledInteractionKind[];
 
 export function createDesktopHostInteractions(
   options: DesktopHostInteractionsOptions,
@@ -193,54 +203,10 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
     if (selector.kind == null || selector.kind === 'toolEdit') {
       this.options.getToolEditApprovals().cancel(selector);
     }
-    const handlers = this.options.getApprovalHandlers();
-    handlers.bash.cancelWhere(
-      (request, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'bash',
-            streamId: request.streamId || undefined,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers.planApproval.cancelWhere(
-      (request, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'plan',
-            streamId: request.streamId,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers.agentProposal.cancelWhere(
-      (request, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'proposal',
-            streamId: request.streamId,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers.userQuestion.cancelWhere(
-      (request, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'userQuestion',
-            streamId: request.streamId || undefined,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
+    cancelApprovalRequestHandlers(
+      this.options.getApprovalHandlers(),
+      DESKTOP_PROGRESS_INTERACTION_KINDS,
+      selector,
     );
   }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -118,7 +118,7 @@ export class ProgressViewProvider
             retry: {
               show: (p) =>
                 u.showPermission({ kind: PERMISSION_KIND.RETRY, data: p }),
-              resolve: (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
+              dismiss: (id) => u.resolvePermission(PERMISSION_KIND.RETRY, id),
             },
             agentProposal: {
               show: (p) => {
@@ -129,7 +129,7 @@ export class ProgressViewProvider
                 });
                 void this.sendProposalModelOptions(p);
               },
-              resolve: (id) =>
+              dismiss: (id) =>
                 u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
             },
           },

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -9,7 +9,6 @@ import {
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
-  type HostInteractionResultByKind,
   type HostInteractions,
   type HostPlanApprovalRequest,
   type HostRetryRequest,
@@ -31,7 +30,6 @@ import {
   nativeRequestApproval,
 } from '@frontend/approval/nativeToolEditApproval';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
-import { assertNever } from '@utils/core';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
@@ -66,28 +64,9 @@ export interface ExtensionHostInteractions extends HostInteractions {
   dismissExternalInquiry(requestId: string): void;
 }
 
-type PendingKind = keyof HostInteractionResultByKind;
-
-interface PendingExtensionRegistration<K extends PendingKind> {
-  readonly id: string;
-  readonly requestId?: string;
-  readonly kind: K;
-  readonly streamId?: StreamTabId;
-  readonly cancellationScope?: object;
-}
-
-type PendingExtensionInteraction<K extends PendingKind> =
-  PendingExtensionRegistration<K> & {
-    settle(value: HostInteractionResultByKind[K]): void;
-  };
-
-type AnyPendingExtensionInteraction = PendingExtensionInteraction<PendingKind>;
-
 export function createExtensionHostInteractions(
   options: ExtensionHostInteractionsOptions,
 ): ExtensionHostInteractions {
-  const pendingRequests = new Map<string, AnyPendingExtensionInteraction>();
-
   const handlers = () => options.getApprovalHandlers();
 
   // Interaction requests surface per-stream: the request panel is scoped to
@@ -111,133 +90,73 @@ export function createExtensionHostInteractions(
     }
   };
 
-  const showPending = <K extends PendingKind>(
-    pending: PendingExtensionRegistration<K>,
-    show: () => void,
-  ): Promise<HostInteractionResultByKind[K]> => {
-    // Replacement cancellation: a request re-issued under an id that is still
-    // pending dismisses the stale prompt (settling it as a rejection carrying
-    // the replacement cause) before the replacement is shown.
-    const replaced = pendingRequests.get(pending.id);
-    if (replaced) releasePending(replaced, 'Approval request was replaced.');
-    return new Promise<HostInteractionResultByKind[K]>((settle) => {
-      const interaction: PendingExtensionInteraction<K> = {
-        ...pending,
-        settle(value) {
-          settle(value);
-        },
-      };
-      pendingRequests.set(pending.id, interaction);
-      show();
-    });
-  };
-
-  const completePending = <K extends PendingKind>(
-    requestId: string,
-    expectedKind: K,
-    value: HostInteractionResultByKind[K],
-    resolveUi: () => void,
-  ): boolean => {
-    const pending = pendingRequests.get(requestId);
-    if (!pending || pending.kind !== expectedKind) return false;
-    pendingRequests.delete(requestId);
-    pending.settle(value);
-    resolveUi();
-    return true;
-  };
-
-  /** Release a pending interaction with its kind-specific rejection result. */
-  const releasePending = (
-    pending: AnyPendingExtensionInteraction,
-    cause?: string,
-  ): void => {
-    switch (pending.kind) {
-      case 'bash':
-        completePending(
-          pending.id,
-          'bash',
-          cancellationResultFor('bash', cause),
-          () => handlers().bash.resolve(pending.id),
-        );
-        return;
-      case 'plan':
-        completePending(
-          pending.id,
-          'plan',
-          cancellationResultFor('plan', cause),
-          () => handlers().planApproval.resolve(pending.id),
-        );
-        return;
-      case 'proposal':
-        completePending(
-          pending.id,
-          'proposal',
-          cancellationResultFor('proposal', cause),
-          () => handlers().agentProposal.resolve(pending.id),
-        );
-        return;
-      case 'retry':
-        completePending(
-          pending.id,
-          'retry',
-          cancellationResultFor('retry', cause),
-          () => handlers().retry.resolve(pending.id),
-        );
-        return;
-      case 'userQuestion':
-        completePending(
-          pending.id,
-          'userQuestion',
-          cancellationResultFor('userQuestion', cause),
-          () => handlers().userQuestion.resolve(pending.id),
-        );
-        return;
-    }
-    assertNever(pending.kind, 'Unhandled extension interaction kind');
-  };
-
   const cancel = (selector: HostInteractionCancelSelector = {}): void => {
     if (selector.kind == null || selector.kind === 'toolEdit') {
       cancelNativeToolEditApprovals(options.session, selector);
     }
-    for (const pending of [...pendingRequests.values()]) {
-      if (matchesCancelSelector(pending, selector)) {
-        releasePending(pending, selector.cause);
-      }
-    }
+    handlers().bash.cancelWhere(
+      (item, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'bash',
+            streamId: item.streamId || undefined,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers().planApproval.cancelWhere(
+      (item, cancellationScope) =>
+        matchesCancelSelector(
+          { kind: 'plan', streamId: item.streamId, cancellationScope },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers().agentProposal.cancelWhere(
+      (item, cancellationScope) =>
+        matchesCancelSelector(
+          { kind: 'proposal', streamId: item.streamId, cancellationScope },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers().retry.cancelWhere(
+      (item, cancellationScope) =>
+        matchesCancelSelector(
+          { kind: 'retry', streamId: item.streamId, cancellationScope },
+          selector,
+        ),
+      selector.cause,
+    );
+    handlers().userQuestion.cancelWhere(
+      (item, cancellationScope) =>
+        matchesCancelSelector(
+          {
+            kind: 'userQuestion',
+            streamId: item.streamId || undefined,
+            cancellationScope,
+          },
+          selector,
+        ),
+      selector.cause,
+    );
   };
 
   const approvePendingDelegatedWork = async (
     streamId: StreamTabId,
     initiatingProposalId: string,
   ): Promise<void> => {
-    for (const pending of [...pendingRequests.values()]) {
-      if (
-        pending.streamId !== streamId ||
-        (pending.kind === 'proposal' && pending.id === initiatingProposalId)
-      ) {
-        continue;
-      }
-      switch (pending.kind) {
-        case 'bash':
-          completePending(
-            pending.id,
-            'bash',
-            toBashApprovalResult({ action: 'approve' }),
-            () => handlers().bash.resolve(pending.id),
-          );
-          break;
-        case 'proposal':
-          completePending(pending.id, 'proposal', { action: 'approve' }, () =>
-            handlers().agentProposal.resolve(pending.id),
-          );
-          break;
-        case 'plan':
-        case 'retry':
-        case 'userQuestion':
-          break;
-      }
-    }
+    handlers().bash.completeWhere(
+      (item) => item.streamId === streamId,
+      toBashApprovalResult({ action: 'approve' }),
+    );
+    handlers().agentProposal.completeWhere(
+      (item) =>
+        item.streamId === streamId && item.proposalId !== initiatingProposalId,
+      { action: 'approve' },
+    );
     await approveNativeToolEditApprovals(options.session, streamId);
   };
 
@@ -245,8 +164,7 @@ export function createExtensionHostInteractions(
     streamId: StreamTabId,
     requestId: string,
   ): boolean => {
-    const pending = pendingRequests.get(streamId);
-    return pending?.kind === 'retry' && pending.requestId === requestId;
+    return handlers().retry.get(streamId)?.requestId === requestId;
   };
 
   const submitRetryDecision = (
@@ -255,45 +173,30 @@ export function createExtensionHostInteractions(
     decision: RetrySettlement,
   ): boolean => {
     if (!isRetryPending(streamId, requestId)) return false;
-    return completePending(streamId, 'retry', decision, () =>
-      handlers().retry.resolve(streamId),
-    );
+    return handlers().retry.complete(streamId, decision);
   };
 
   const submitBashDecision = (
     requestId: string,
     decision: BashSettlement,
   ): boolean =>
-    completePending(requestId, 'bash', toBashApprovalResult(decision), () =>
-      handlers().bash.resolve(requestId),
-    );
+    handlers().bash.complete(requestId, toBashApprovalResult(decision));
 
   const submitPlanDecision = (
     requestId: string,
     decision: PlanApprovalResult,
-  ): boolean =>
-    completePending(requestId, 'plan', decision, () =>
-      handlers().planApproval.resolve(requestId),
-    );
+  ): boolean => handlers().planApproval.complete(requestId, decision);
 
   const submitProposalDecision = (
     requestId: string,
     decision: ProposalResult,
-  ): boolean =>
-    completePending(requestId, 'proposal', decision, () =>
-      handlers().agentProposal.resolve(requestId),
-    );
+  ): boolean => handlers().agentProposal.complete(requestId, decision);
 
   const submitUserQuestionDecision = (
     requestId: string,
     decision: UserQuestionSettlement,
   ): boolean =>
-    completePending(
-      requestId,
-      'userQuestion',
-      toUserQuestionResult(decision),
-      () => handlers().userQuestion.resolve(requestId),
-    );
+    handlers().userQuestion.complete(requestId, toUserQuestionResult(decision));
 
   return {
     approvePendingDelegatedWork,
@@ -304,7 +207,7 @@ export function createExtensionHostInteractions(
     submitRetryDecision,
     submitUserQuestionDecision,
     dismissExternalInquiry: (requestId) =>
-      handlers().externalInquiry.resolve(requestId),
+      handlers().externalInquiry.dismiss(requestId),
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
       interactionOptions?: HostInteractionOptions,
@@ -322,21 +225,18 @@ export function createExtensionHostInteractions(
       const requestId = `bash-${nanoid()}`;
       const streamId = request.streamId ?? '';
       revealStream(request.streamId);
-      return showPending(
+      return handlers().bash.request(
         {
-          id: requestId,
-          kind: 'bash',
+          requestId,
+          command: request.command,
+          ...(request.cwd ? { cwd: request.cwd } : {}),
+          allowBypass: true,
           streamId,
-          cancellationScope: interactionOptions?.cancellationScope,
         },
-        () =>
-          handlers().bash.show({
-            requestId,
-            command: request.command,
-            ...(request.cwd ? { cwd: request.cwd } : {}),
-            allowBypass: true,
-            streamId,
-          }),
+        {
+          cancellationScope: interactionOptions?.cancellationScope,
+          cancellationResult: (cause) => cancellationResultFor('bash', cause),
+        },
       );
     },
 
@@ -345,15 +245,10 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<PlanApprovalResult> {
       revealStream(request.streamId);
-      return showPending(
-        {
-          id: request.approvalId,
-          kind: 'plan',
-          streamId: request.streamId,
-          cancellationScope: interactionOptions?.cancellationScope,
-        },
-        () => handlers().planApproval.show(request),
-      );
+      return handlers().planApproval.request(request, {
+        cancellationScope: interactionOptions?.cancellationScope,
+        cancellationResult: (cause) => cancellationResultFor('plan', cause),
+      });
     },
 
     requestAgentProposal(
@@ -361,15 +256,10 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<ProposalResult> {
       revealStream(request.streamId);
-      return showPending(
-        {
-          id: request.proposalId,
-          kind: 'proposal',
-          streamId: request.streamId,
-          cancellationScope: interactionOptions?.cancellationScope,
-        },
-        () => handlers().agentProposal.show(request),
-      );
+      return handlers().agentProposal.request(request, {
+        cancellationScope: interactionOptions?.cancellationScope,
+        cancellationResult: (cause) => cancellationResultFor('proposal', cause),
+      });
     },
 
     requestRetry(
@@ -377,16 +267,10 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<RetryResult> {
       revealStream(request.streamId);
-      return showPending(
-        {
-          id: request.streamId,
-          requestId: request.requestId,
-          kind: 'retry',
-          streamId: request.streamId,
-          cancellationScope: interactionOptions?.cancellationScope,
-        },
-        () => handlers().retry.show(request),
-      );
+      return handlers().retry.request(request, {
+        cancellationScope: interactionOptions?.cancellationScope,
+        cancellationResult: (cause) => cancellationResultFor('retry', cause),
+      });
     },
 
     askUserQuestion(
@@ -394,15 +278,11 @@ export function createExtensionHostInteractions(
       interactionOptions?: HostInteractionOptions,
     ): Promise<HostUserQuestionResult> {
       revealStream(request.streamId || undefined);
-      return showPending(
-        {
-          id: request.requestId,
-          kind: 'userQuestion',
-          streamId: request.streamId,
-          cancellationScope: interactionOptions?.cancellationScope,
-        },
-        () => handlers().userQuestion.show(request),
-      );
+      return handlers().userQuestion.request(request, {
+        cancellationScope: interactionOptions?.cancellationScope,
+        cancellationResult: (cause) =>
+          cancellationResultFor('userQuestion', cause),
+      });
     },
 
     async openExternalInquiry(request) {

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -1,9 +1,12 @@
 import { nanoid } from 'nanoid';
 
+import {
+  cancelApprovalRequestHandlers,
+  type ApprovalRequestHandlerSet,
+} from '@controllers/progressView/backend/progressBackendUiConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   cancellationResultFor,
-  matchesCancelSelector,
   type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
@@ -17,6 +20,7 @@ import {
   type ProposalResult,
   type RetryResult,
   type RetrySettlement,
+  type SettledInteractionKind,
   type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import {
@@ -30,7 +34,6 @@ import {
   nativeRequestApproval,
 } from '@frontend/approval/nativeToolEditApproval';
 import type { AgentProposalPermission, StreamTabId } from '@shared/schemas';
-import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
@@ -64,6 +67,14 @@ export interface ExtensionHostInteractions extends HostInteractions {
   dismissExternalInquiry(requestId: string): void;
 }
 
+const EXTENSION_PROGRESS_INTERACTION_KINDS = [
+  'bash',
+  'plan',
+  'proposal',
+  'retry',
+  'userQuestion',
+] as const satisfies readonly SettledInteractionKind[];
+
 export function createExtensionHostInteractions(
   options: ExtensionHostInteractionsOptions,
 ): ExtensionHostInteractions {
@@ -94,53 +105,10 @@ export function createExtensionHostInteractions(
     if (selector.kind == null || selector.kind === 'toolEdit') {
       cancelNativeToolEditApprovals(options.session, selector);
     }
-    handlers().bash.cancelWhere(
-      (item, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'bash',
-            streamId: item.streamId || undefined,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers().planApproval.cancelWhere(
-      (item, cancellationScope) =>
-        matchesCancelSelector(
-          { kind: 'plan', streamId: item.streamId, cancellationScope },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers().agentProposal.cancelWhere(
-      (item, cancellationScope) =>
-        matchesCancelSelector(
-          { kind: 'proposal', streamId: item.streamId, cancellationScope },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers().retry.cancelWhere(
-      (item, cancellationScope) =>
-        matchesCancelSelector(
-          { kind: 'retry', streamId: item.streamId, cancellationScope },
-          selector,
-        ),
-      selector.cause,
-    );
-    handlers().userQuestion.cancelWhere(
-      (item, cancellationScope) =>
-        matchesCancelSelector(
-          {
-            kind: 'userQuestion',
-            streamId: item.streamId || undefined,
-            cancellationScope,
-          },
-          selector,
-        ),
-      selector.cause,
+    cancelApprovalRequestHandlers(
+      handlers(),
+      EXTENSION_PROGRESS_INTERACTION_KINDS,
+      selector,
     );
   };
 

--- a/src/controllers/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/controllers/progressView/backend/ApprovalRequestHandler.ts
@@ -1,92 +1,242 @@
+type PendingPresentation<T> = {
+  readonly mode: 'presentation';
+  readonly item: T;
+};
+
+type PendingInteraction<T, Result> = {
+  readonly mode: 'interaction';
+  readonly item: T;
+  readonly cancellationScope?: object;
+  readonly cancellationResult: (cause?: string) => Result;
+  readonly complete: (result: Result) => void;
+};
+
+type PendingRequest<T, Result> =
+  PendingPresentation<T> | PendingInteraction<T, Result>;
+
+interface ApprovalInteractionOptions<Result> {
+  cancellationScope?: object;
+  cancellationResult: (cause?: string) => Result;
+}
+
+type InteractionPredicate<T> = (
+  item: T,
+  cancellationScope: object | undefined,
+) => boolean;
+
 /**
- * Generic handler for approval/prompt requests with pending state management.
- * Eliminates duplication across tool edit, bash approval, retry, and proposal
- * handlers, and is shared by both the VS Code extension and the desktop host so
- * neither re-implements the pending-approval bookkeeping.
- *
- * The `delivered` set tracks IDs sent to the current webview target so that
- * show() won't duplicate an item that replay() already sent.  replay() always
- * clears the set first — every caller replays because the target changed or
- * lost state, so prior delivery info is meaningless.
+ * Owns the complete lifecycle of one progress-view request kind: payload,
+ * delivery state, replay, optional response callback, cancellation metadata,
+ * and presentation removal.
  */
 export class ApprovalRequestHandler<
   T extends { streamId: string },
   K extends keyof T,
+  Result = never,
 > {
-  private readonly pending = new Map<string, T>();
+  private readonly pending = new Map<string, PendingRequest<T, Result>>();
   /** IDs already sent to the current webview target. */
   private readonly delivered = new Set<string>();
 
   constructor(
     private readonly idField: K,
     private readonly sendShow: (item: T) => void,
-    private readonly sendResolve: (id: string) => void,
+    private readonly sendDismiss: (id: string) => void,
     private readonly canSend: () => boolean,
   ) {}
 
+  /** Present an item that has no response-bearing promise. */
   show(item: T): void {
-    const id = this.setPending(item);
-    if (this.canSend() && !this.delivered.has(id)) {
-      this.delivered.add(id);
-      this.sendShow(item);
+    const id = this.idFor(item);
+    this.removeExisting(id, 'Approval request was replaced.');
+    const entry: PendingPresentation<T> = { mode: 'presentation', item };
+    this.pending.set(id, entry);
+    try {
+      this.deliver(id, entry);
+    } catch (error) {
+      this.rollbackInitialDelivery(id, entry);
+      throw error;
     }
   }
 
-  /** Replace pending data without delivering it until the next replay. */
+  /** Present an item and retain its typed completion callback beside it. */
+  request(
+    item: T,
+    options: ApprovalInteractionOptions<Result>,
+  ): Promise<Result> {
+    const id = this.idFor(item);
+    this.removeExisting(id, 'Approval request was replaced.');
+
+    return new Promise<Result>((complete, reject) => {
+      const entry: PendingInteraction<T, Result> = {
+        mode: 'interaction',
+        item,
+        cancellationScope: options.cancellationScope,
+        cancellationResult: options.cancellationResult,
+        complete,
+      };
+      this.pending.set(id, entry);
+      try {
+        this.deliver(id, entry);
+      } catch (error) {
+        this.rollbackInitialDelivery(id, entry);
+        reject(error);
+      }
+    });
+  }
+
+  /** Replace pending presentation data without delivering until replay. */
   protected setPending(item: T): string {
-    const id = String(item[this.idField]);
-    this.pending.set(id, item);
+    const id = this.idFor(item);
+    this.pending.set(id, { mode: 'presentation', item });
     return id;
   }
 
-  resolve(id: string): void {
-    this.pending.delete(id);
-    this.delivered.delete(id);
-    if (this.canSend()) this.sendResolve(id);
+  /** Complete one response-bearing request and remove its presentation. */
+  complete(id: string, result: Result): boolean {
+    const entry = this.pending.get(id);
+    if (!entry || entry.mode !== 'interaction') return false;
+    return this.completeEntry(id, entry, result, true);
   }
 
-  /** Re-send all pending items. Clears delivery tracking first — the target
-   *  is either new or lost state, so everything must be (re-)delivered. */
+  /** Complete every matching response-bearing request. */
+  completeWhere(predicate: (item: T) => boolean, result: Result): number {
+    let completed = 0;
+    for (const [id, entry] of [...this.pending]) {
+      if (
+        entry.mode === 'interaction' &&
+        predicate(entry.item) &&
+        this.completeEntry(id, entry, result, true)
+      ) {
+        completed += 1;
+      }
+    }
+    return completed;
+  }
+
+  /** Cancel every matching response-bearing request. */
+  cancelWhere(predicate: InteractionPredicate<T>, cause?: string): number {
+    let cancelled = 0;
+    for (const [id, entry] of [...this.pending]) {
+      if (
+        entry.mode === 'interaction' &&
+        predicate(entry.item, entry.cancellationScope) &&
+        this.completeEntry(id, entry, entry.cancellationResult(cause), true)
+      ) {
+        cancelled += 1;
+      }
+    }
+    return cancelled;
+  }
+
+  /** Remove one presentation-only item. */
+  dismiss(id: string): boolean {
+    const entry = this.pending.get(id);
+    if (!entry || entry.mode !== 'presentation') return false;
+    return this.removeEntry(id, entry, true);
+  }
+
+  /** Re-send all pending items to a new or reset target. */
   replay(): void {
     this.delivered.clear();
-    for (const [id, item] of this.pending) {
-      this.delivered.add(id);
-      this.sendShow(item);
+    for (const [id, entry] of this.pending) {
+      this.deliver(id, entry);
     }
   }
 
   get(id: string): T | undefined {
-    return this.pending.get(id);
+    return this.pending.get(id)?.item;
   }
 
   /** Check if any pending item is associated with the given stream. */
   hasPendingForStream(streamId: string): boolean {
-    for (const item of this.pending.values()) {
+    for (const { item } of this.pending.values()) {
       if (!item.streamId || item.streamId === streamId) return true;
     }
     return false;
   }
 
   /**
-   * Silently drop every pending item tied to `streamId` (exact match, so
-   * streamless prompts survive). Unlike resolve(), this does NOT notify the
-   * webview — it only keeps the pending-permissions guard consistent when a
-   * stream is deleted and its prompts were already settled (or are durable,
-   * like external inquiries, and never receive a resolve event).
+   * Silently release every item tied to `streamId`. Response-bearing entries
+   * are cancelled so cleanup can never orphan their promises.
    */
   releaseForStream(streamId: string): void {
-    for (const [id, item] of this.pending) {
-      if (item.streamId === streamId) {
-        this.pending.delete(id);
-        this.delivered.delete(id);
+    for (const [id, entry] of [...this.pending]) {
+      if (entry.item.streamId !== streamId) continue;
+      if (entry.mode === 'interaction') {
+        this.completeEntry(id, entry, entry.cancellationResult(), false);
+      } else {
+        this.removeEntry(id, entry, false);
       }
     }
   }
 
-  /** Silently drop all pending items (and delivery tracking) without notifying
-   *  the webview. Used on a "delete all"/teardown sweep. */
+  /** Silently release all pending items without orphaning interactions. */
   clear(): void {
-    this.pending.clear();
-    this.delivered.clear();
+    for (const [id, entry] of [...this.pending]) {
+      if (entry.mode === 'interaction') {
+        this.completeEntry(id, entry, entry.cancellationResult(), false);
+      } else {
+        this.removeEntry(id, entry, false);
+      }
+    }
+  }
+
+  private idFor(item: T): string {
+    return String(item[this.idField]);
+  }
+
+  private deliver(id: string, entry: PendingRequest<T, Result>): void {
+    if (!this.canSend() || this.delivered.has(id)) return;
+    this.delivered.add(id);
+    try {
+      this.sendShow(entry.item);
+    } catch (error) {
+      if (this.pending.get(id) === entry) this.delivered.delete(id);
+      throw error;
+    }
+  }
+
+  private rollbackInitialDelivery(
+    id: string,
+    entry: PendingRequest<T, Result>,
+  ): void {
+    if (this.pending.get(id) !== entry) return;
+    this.pending.delete(id);
+    this.delivered.delete(id);
+  }
+
+  private removeExisting(id: string, cause: string): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    if (entry.mode === 'interaction') {
+      this.completeEntry(id, entry, entry.cancellationResult(cause), true);
+    } else {
+      this.removeEntry(id, entry, true);
+    }
+  }
+
+  private completeEntry(
+    id: string,
+    entry: PendingInteraction<T, Result>,
+    result: Result,
+    notify: boolean,
+  ): boolean {
+    if (!this.removeEntry(id, entry, false)) return false;
+    entry.complete(result);
+    if (notify && this.canSend()) this.sendDismiss(id);
+    return true;
+  }
+
+  private removeEntry(
+    id: string,
+    entry: PendingRequest<T, Result>,
+    notify: boolean,
+  ): boolean {
+    if (this.pending.get(id) !== entry) return false;
+    this.pending.delete(id);
+    this.delivered.delete(id);
+    if (notify && this.canSend()) this.sendDismiss(id);
+    return true;
   }
 }

--- a/src/controllers/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/controllers/progressView/backend/ApprovalRequestHandler.ts
@@ -85,10 +85,20 @@ export class ApprovalRequestHandler<
     });
   }
 
-  /** Replace pending presentation data without delivering until replay. */
-  protected setPending(item: T): string {
+  /** Stage presentation data for the next replay without delivering it now. */
+  protected stagePresentationForReplay(item: T): string {
     const id = this.idFor(item);
+    const existing = this.pending.get(id);
+    if (existing?.mode === 'interaction') {
+      this.completeEntry(
+        id,
+        existing,
+        existing.cancellationResult('Approval request was replaced.'),
+        false,
+      );
+    }
     this.pending.set(id, { mode: 'presentation', item });
+    this.delivered.delete(id);
     return id;
   }
 

--- a/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
+++ b/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
@@ -87,7 +87,7 @@ export class ExternalInquiryRequestHandler extends ApprovalRequestHandler<
           draft: getOpenTurnDraft(manifest),
           transcript: manifestToTranscript(manifest),
         };
-        this.setPending(
+        this.stagePresentationForReplay(
           manifest.turns.length > 1
             ? { ...basePermission, mode: 'followUp' }
             : { ...basePermission, mode: 'new' },

--- a/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
+++ b/src/controllers/progressView/backend/ExternalInquiryRequestHandler.ts
@@ -18,7 +18,7 @@ const MAX_INQUIRY_THREADS = 100;
 
 export interface ExternalInquiryRequestHandlerOptions {
   show: (permission: ExternalInquiryPermission) => void;
-  resolve: (requestId: string) => void;
+  dismiss: (requestId: string) => void;
   syncThreads: (threads: InquiryThreadUpdatedEvent[]) => void;
   canSend: () => boolean;
   logger?: Pick<AgentTrace, 'debug'>;
@@ -34,7 +34,7 @@ export class ExternalInquiryRequestHandler extends ApprovalRequestHandler<
   'requestId'
 > {
   constructor(private readonly options: ExternalInquiryRequestHandlerOptions) {
-    super('requestId', options.show, options.resolve, options.canSend);
+    super('requestId', options.show, options.dismiss, options.canSend);
   }
 
   override async replay(): Promise<void> {

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -1,10 +1,13 @@
 import type { AgentTrace } from '@agent/trace';
-import type {
-  HostBashApprovalResult,
-  HostUserQuestionResult,
-  PlanApprovalResult,
-  ProposalResult,
-  RetryResult,
+import {
+  type HostBashApprovalResult,
+  matchesCancelSelector,
+  type HostInteractionCancelSelector,
+  type HostUserQuestionResult,
+  type PlanApprovalResult,
+  type ProposalResult,
+  type RetryResult,
+  type SettledInteractionKind,
 } from '@agent/runtime/HostInteractions';
 import type {
   AgentProposalPermission,
@@ -17,6 +20,7 @@ import type {
   UserQuestionPermission,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import { assertNever } from '@utils/core';
 
 import { ApprovalRequestHandler } from './ApprovalRequestHandler';
 import { ExternalInquiryRequestHandler } from './ExternalInquiryRequestHandler';
@@ -56,6 +60,60 @@ export interface ApprovalRequestHandlerSet {
     'requestId',
     HostUserQuestionResult
   >;
+}
+
+function cancelHandler<
+  T extends { streamId: string },
+  K extends keyof T,
+  Result,
+>(
+  handler: ApprovalRequestHandler<T, K, Result>,
+  kind: SettledInteractionKind,
+  selector: HostInteractionCancelSelector,
+): number {
+  return handler.cancelWhere(
+    (item, cancellationScope) =>
+      matchesCancelSelector(
+        {
+          kind,
+          streamId: item.streamId || undefined,
+          cancellationScope,
+        },
+        selector,
+      ),
+    selector.cause,
+  );
+}
+
+/** Cancel the response-bearing progress interactions supported by one host. */
+export function cancelApprovalRequestHandlers(
+  handlers: ApprovalRequestHandlerSet,
+  kinds: readonly SettledInteractionKind[],
+  selector: HostInteractionCancelSelector,
+): number {
+  let cancelled = 0;
+  for (const kind of kinds) {
+    switch (kind) {
+      case 'bash':
+        cancelled += cancelHandler(handlers.bash, kind, selector);
+        break;
+      case 'plan':
+        cancelled += cancelHandler(handlers.planApproval, kind, selector);
+        break;
+      case 'proposal':
+        cancelled += cancelHandler(handlers.agentProposal, kind, selector);
+        break;
+      case 'retry':
+        cancelled += cancelHandler(handlers.retry, kind, selector);
+        break;
+      case 'userQuestion':
+        cancelled += cancelHandler(handlers.userQuestion, kind, selector);
+        break;
+      default:
+        assertNever(kind, 'Unhandled progress interaction kind');
+    }
+  }
+  return cancelled;
 }
 
 type ReplayableApprovalRequestHandlerSet = {
@@ -214,7 +272,7 @@ export interface ProgressBackendUiConfigParams {
  * pending-permissions guard) from a set of {@link ApprovalRequestHandler}s.
  *
  * The tool-edit callbacks delegate to their handler, so host differences live
- * entirely in how each handler is constructed (its show/resolve transport and
+ * entirely in how each handler is constructed (its show/dismiss transport and
  * `canSend` gate) — not in this wiring. The guard checks `hasPendingForStream`
  * across all handlers (see {@link APPROVAL_REQUEST_HANDLER_KEYS}), reusing the
  * handler's empty-streamId-blocks-all rule instead of re-deriving it per host.

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -1,5 +1,12 @@
 import type { AgentTrace } from '@agent/trace';
 import type {
+  HostBashApprovalResult,
+  HostUserQuestionResult,
+  PlanApprovalResult,
+  ProposalResult,
+  RetryResult,
+} from '@agent/runtime/HostInteractions';
+import type {
   AgentProposalPermission,
   BashPermission,
   ExternalInquiryPermission,
@@ -18,21 +25,37 @@ import type { WebviewUpdater } from './WebviewUpdater';
 
 /**
  * The seven pending-approval handlers a progress backend wires. Hosts build
- * each handler with their own show/resolve transport (and `canSend` gate), then
+ * each handler with their own show/dismiss transport (and `canSend` gate), then
  * hand the set to {@link createProgressBackendUiConfig}, which derives the
  * uniform UI callbacks and the pending-permissions guard from them.
  */
 export interface ApprovalRequestHandlerSet {
   toolEdit: ApprovalRequestHandler<ToolEditPermission, 'requestId'>;
-  bash: ApprovalRequestHandler<BashPermission, 'requestId'>;
-  retry: ApprovalRequestHandler<RetryPermission, 'streamId'>;
-  agentProposal: ApprovalRequestHandler<AgentProposalPermission, 'proposalId'>;
-  planApproval: ApprovalRequestHandler<PlanApprovalPermission, 'approvalId'>;
+  bash: ApprovalRequestHandler<
+    BashPermission,
+    'requestId',
+    HostBashApprovalResult
+  >;
+  retry: ApprovalRequestHandler<RetryPermission, 'streamId', RetryResult>;
+  agentProposal: ApprovalRequestHandler<
+    AgentProposalPermission,
+    'proposalId',
+    ProposalResult
+  >;
+  planApproval: ApprovalRequestHandler<
+    PlanApprovalPermission,
+    'approvalId',
+    PlanApprovalResult
+  >;
   externalInquiry: ApprovalRequestHandler<
     ExternalInquiryPermission,
     'requestId'
   >;
-  userQuestion: ApprovalRequestHandler<UserQuestionPermission, 'requestId'>;
+  userQuestion: ApprovalRequestHandler<
+    UserQuestionPermission,
+    'requestId',
+    HostUserQuestionResult
+  >;
 }
 
 type ReplayableApprovalRequestHandlerSet = {
@@ -63,14 +86,14 @@ const APPROVAL_REQUEST_HANDLER_KEYS = Object.keys(
 ) as Array<keyof ApprovalRequestHandlerSet>;
 
 /**
- * Host-specific show/resolve transport for one approval kind. retry and
+ * Host-specific show/dismiss transport for one approval kind. retry and
  * agentProposal differ across hosts (the extension shows a retry panel and
  * upgrades proposals with model/agent dropdowns; the desktop cancels retries
  * and shows a plain proposal), so each host supplies these two directly.
  */
 interface ApprovalHandlerTransport<T> {
   show: (item: T) => void;
-  resolve: (id: string) => void;
+  dismiss: (id: string) => void;
 }
 
 interface ApprovalRequestHandlerOverrides {
@@ -94,12 +117,13 @@ type PermissionData<K extends PermissionPayload['kind']> = Extract<
 function webviewPermissionHandler<
   K extends PermissionPayload['kind'],
   IdField extends keyof PermissionData<K>,
+  Result = never,
 >(
   webviewUpdater: WebviewUpdater,
   canSend: () => boolean,
   kind: K,
   idField: IdField,
-): ApprovalRequestHandler<PermissionData<K>, IdField> {
+): ApprovalRequestHandler<PermissionData<K>, IdField, Result> {
   return new ApprovalRequestHandler(
     idField,
     (data) =>
@@ -123,49 +147,47 @@ export function buildApprovalRequestHandlerSet(
       PERMISSION_KIND.TOOL_EDIT,
       'requestId',
     ),
-    bash: webviewPermissionHandler(
-      webviewUpdater,
-      canSend,
-      PERMISSION_KIND.BASH,
+    bash: webviewPermissionHandler<
+      typeof PERMISSION_KIND.BASH,
       'requestId',
-    ),
-    planApproval: webviewPermissionHandler(
-      webviewUpdater,
-      canSend,
-      PERMISSION_KIND.PLAN_APPROVAL,
+      HostBashApprovalResult
+    >(webviewUpdater, canSend, PERMISSION_KIND.BASH, 'requestId'),
+    planApproval: webviewPermissionHandler<
+      typeof PERMISSION_KIND.PLAN_APPROVAL,
       'approvalId',
-    ),
+      PlanApprovalResult
+    >(webviewUpdater, canSend, PERMISSION_KIND.PLAN_APPROVAL, 'approvalId'),
     externalInquiry: new ExternalInquiryRequestHandler({
       show: (data) =>
         webviewUpdater.showPermission({
           kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
           data,
         }),
-      resolve: (id) =>
+      dismiss: (id) =>
         webviewUpdater.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
       syncThreads: (threads) => webviewUpdater.syncInquiryThreads(threads),
       canSend,
       logger: params.logger,
     }),
-    userQuestion: webviewPermissionHandler(
-      webviewUpdater,
-      canSend,
-      PERMISSION_KIND.USER_QUESTION,
+    userQuestion: webviewPermissionHandler<
+      typeof PERMISSION_KIND.USER_QUESTION,
       'requestId',
-    ),
-    retry: new ApprovalRequestHandler<RetryPermission, 'streamId'>(
+      HostUserQuestionResult
+    >(webviewUpdater, canSend, PERMISSION_KIND.USER_QUESTION, 'requestId'),
+    retry: new ApprovalRequestHandler<RetryPermission, 'streamId', RetryResult>(
       'streamId',
       overrides.retry.show,
-      overrides.retry.resolve,
+      overrides.retry.dismiss,
       canSend,
     ),
     agentProposal: new ApprovalRequestHandler<
       AgentProposalPermission,
-      'proposalId'
+      'proposalId',
+      ProposalResult
     >(
       'proposalId',
       overrides.agentProposal.show,
-      overrides.agentProposal.resolve,
+      overrides.agentProposal.dismiss,
       canSend,
     ),
   };
@@ -204,7 +226,7 @@ export function createProgressBackendUiConfig(
   return {
     callbacks: {
       showToolEditPermission: (p) => handlers.toolEdit.show(p),
-      resolveToolEditPermission: (id) => handlers.toolEdit.resolve(id),
+      resolveToolEditPermission: (id) => handlers.toolEdit.dismiss(id),
       updateToolEditApprovalBypassState: (streamId, bypassActive) => {
         if (canSend()) {
           webviewUpdater.updateBypassState(streamId, 'toolEdit', bypassActive);

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -8,11 +8,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
+  type HostBashApprovalResult,
   matchesCancelSelector,
   type HostInteractionOptions,
   HostInteractions,
   type HostPlanApprovalRequest,
+  type HostUserQuestionResult,
   type PlanApprovalResult,
+  type ProposalResult,
+  type RetryResult,
 } from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
@@ -59,37 +63,50 @@ interface UiEvent {
 }
 
 function createHandlerSet(events: UiEvent[]): ApprovalRequestHandlerSet {
-  const handler = <T extends { streamId: string }, K extends keyof T>(
+  const handler = <
+    T extends { streamId: string },
+    K extends keyof T,
+    Result = never,
+  >(
     kind: string,
     idField: K,
-  ): ApprovalRequestHandler<T, K> =>
-    new ApprovalRequestHandler<T, K>(
+  ): ApprovalRequestHandler<T, K, Result> =>
+    new ApprovalRequestHandler<T, K, Result>(
       idField,
       (item) =>
         events.push({ event: `show:${kind}`, id: String(item[idField]) }),
-      (id) => events.push({ event: `resolve:${kind}`, id }),
+      (id) => events.push({ event: `dismiss:${kind}`, id }),
       () => true,
     );
   return {
     toolEdit: handler<ToolEditPermission, 'requestId'>('toolEdit', 'requestId'),
-    bash: handler<BashPermission, 'requestId'>('bash', 'requestId'),
-    retry: handler<RetryPermission, 'streamId'>('retry', 'streamId'),
-    agentProposal: handler<AgentProposalPermission, 'proposalId'>(
-      'proposal',
+    bash: handler<BashPermission, 'requestId', HostBashApprovalResult>(
+      'bash',
+      'requestId',
+    ),
+    retry: handler<RetryPermission, 'streamId', RetryResult>(
+      'retry',
+      'streamId',
+    ),
+    agentProposal: handler<
+      AgentProposalPermission,
       'proposalId',
-    ),
-    planApproval: handler<PlanApprovalPermission, 'approvalId'>(
-      'plan',
+      ProposalResult
+    >('proposal', 'proposalId'),
+    planApproval: handler<
+      PlanApprovalPermission,
       'approvalId',
-    ),
+      PlanApprovalResult
+    >('plan', 'approvalId'),
     externalInquiry: handler<ExternalInquiryPermission, 'requestId'>(
       'externalInquiry',
       'requestId',
     ),
-    userQuestion: handler<UserQuestionPermission, 'requestId'>(
-      'userQuestion',
+    userQuestion: handler<
+      UserQuestionPermission,
       'requestId',
-    ),
+      HostUserQuestionResult
+    >('userQuestion', 'requestId'),
   };
 }
 

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -4,21 +4,39 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - progress backend
+import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
+
 // Local imports - runtime
 import type {
   BashSettlement,
+  HostBashApprovalResult,
+  HostUserQuestionResult,
   PlanApprovalResult,
   ProposalResult,
+  RetryResult,
   UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 
 // Local imports - shared
-import type { StreamTabId } from '@shared/schemas';
+import type {
+  AgentProposalPermission,
+  BashPermission,
+  ExternalInquiryPermission,
+  PlanApprovalPermission,
+  RetryPermission,
+  StreamTabId,
+  ToolEditPermission,
+  UserQuestionPermission,
+} from '@shared/schemas';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+// Local type imports - progress backend
+import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 
 interface DesktopHostInteractions {
   approvePendingDelegatedWork(
@@ -62,7 +80,7 @@ interface DesktopHostInteractionsModule {
   createDesktopHostInteractions(options: {
     runtimeHost: { emit: (event: string, payload: unknown) => void };
     session: SessionHandle;
-    getApprovalHandlers(): unknown;
+    getApprovalHandlers(): ApprovalRequestHandlerSet;
     getToolEditApprovals(): {
       approvePendingForStream: ReturnType<typeof vi.fn>;
       cancel: ReturnType<typeof vi.fn>;
@@ -71,24 +89,93 @@ interface DesktopHostInteractionsModule {
   }): DesktopHostInteractions;
 }
 
-interface RecordingApprovalHandler {
-  readonly show: ReturnType<typeof vi.fn>;
-  readonly resolve: ReturnType<typeof vi.fn>;
+type ShowSpy<T> = ReturnType<typeof vi.fn<(item: T) => void>>;
+type DismissSpy = ReturnType<typeof vi.fn<(id: string) => void>>;
+
+interface RecordingTransport<T> {
+  readonly show: ShowSpy<T>;
+  readonly dismiss: DismissSpy;
 }
 
-function handler(): RecordingApprovalHandler {
-  return { show: vi.fn(), resolve: vi.fn() };
+interface RecordingApprovalHandlerSet extends ApprovalRequestHandlerSet {
+  readonly transport: {
+    toolEdit: RecordingTransport<ToolEditPermission>;
+    bash: RecordingTransport<BashPermission>;
+    retry: RecordingTransport<RetryPermission>;
+    agentProposal: RecordingTransport<AgentProposalPermission>;
+    planApproval: RecordingTransport<PlanApprovalPermission>;
+    externalInquiry: RecordingTransport<ExternalInquiryPermission>;
+    userQuestion: RecordingTransport<UserQuestionPermission>;
+  };
 }
 
-function createHandlers() {
+function handler<
+  T extends { streamId: string },
+  K extends keyof T,
+  Result = never,
+>(
+  idField: K,
+): {
+  handler: ApprovalRequestHandler<T, K, Result>;
+  transport: RecordingTransport<T>;
+} {
+  const transport = {
+    show: vi.fn<(item: T) => void>(),
+    dismiss: vi.fn<(id: string) => void>(),
+  };
   return {
-    toolEdit: handler(),
-    bash: handler(),
-    retry: handler(),
-    agentProposal: handler(),
-    planApproval: handler(),
-    externalInquiry: handler(),
-    userQuestion: handler(),
+    handler: new ApprovalRequestHandler<T, K, Result>(
+      idField,
+      transport.show,
+      transport.dismiss,
+      () => true,
+    ),
+    transport,
+  };
+}
+
+function createHandlers(): RecordingApprovalHandlerSet {
+  const toolEdit = handler<ToolEditPermission, 'requestId'>('requestId');
+  const bash = handler<BashPermission, 'requestId', HostBashApprovalResult>(
+    'requestId',
+  );
+  const retry = handler<RetryPermission, 'streamId', RetryResult>('streamId');
+  const agentProposal = handler<
+    AgentProposalPermission,
+    'proposalId',
+    ProposalResult
+  >('proposalId');
+  const planApproval = handler<
+    PlanApprovalPermission,
+    'approvalId',
+    PlanApprovalResult
+  >('approvalId');
+  const externalInquiry = handler<ExternalInquiryPermission, 'requestId'>(
+    'requestId',
+  );
+  const userQuestion = handler<
+    UserQuestionPermission,
+    'requestId',
+    HostUserQuestionResult
+  >('requestId');
+
+  return {
+    toolEdit: toolEdit.handler,
+    bash: bash.handler,
+    retry: retry.handler,
+    agentProposal: agentProposal.handler,
+    planApproval: planApproval.handler,
+    externalInquiry: externalInquiry.handler,
+    userQuestion: userQuestion.handler,
+    transport: {
+      toolEdit: toolEdit.transport,
+      bash: bash.transport,
+      retry: retry.transport,
+      agentProposal: agentProposal.transport,
+      planApproval: planApproval.transport,
+      externalInquiry: externalInquiry.transport,
+      userQuestion: userQuestion.transport,
+    },
   };
 }
 
@@ -182,7 +269,7 @@ describe('createDesktopHostInteractions', () => {
       accepted: true,
       userMessage: undefined,
     });
-    expect(handlers.agentProposal.resolve).toHaveBeenCalledWith(
+    expect(handlers.transport.agentProposal.dismiss).toHaveBeenCalledWith(
       'proposal-parallel',
     );
 
@@ -192,7 +279,7 @@ describe('createDesktopHostInteractions', () => {
       }),
     ).toBe(true);
     const streamBRequestId = (
-      handlers.bash.show.mock.calls.find(
+      handlers.transport.bash.show.mock.calls.find(
         ([request]) => request.streamId === 'stream-b',
       )?.[0] as { requestId?: string } | undefined
     )?.requestId;
@@ -236,7 +323,7 @@ describe('createDesktopHostInteractions', () => {
       command: 'echo hi',
       streamId: 'stream-a' as StreamTabId,
     });
-    const requestId = firstShowRequestId(handlers.bash.show);
+    const requestId = firstShowRequestId(handlers.transport.bash.show);
 
     expect(
       interactions.submitPlanDecision(requestId, { action: 'approve' }),
@@ -288,7 +375,7 @@ describe('createDesktopHostInteractions', () => {
       accepted: false,
       userMessage: 'Stream resources released.',
     });
-    expect(handlers.bash.resolve).toHaveBeenCalled();
+    expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
     expect(toolEditApprovals.cancel).toHaveBeenCalledWith({
       streamId: 'stream-a',
       cause: 'Stream resources released.',
@@ -298,7 +385,7 @@ describe('createDesktopHostInteractions', () => {
   it('can cancel synchronously while presenting a request', async () => {
     const handlers = createHandlers();
     const { interactions } = await createInteractions(handlers);
-    handlers.bash.show.mockImplementation(() => {
+    handlers.transport.bash.show.mockImplementation(() => {
       interactions.cancel({
         kind: 'bash',
         streamId: 'stream-sync' as StreamTabId,
@@ -341,7 +428,7 @@ describe('createDesktopHostInteractions', () => {
       command: 'sleep 10',
       streamId: 'stream-a' as StreamTabId,
     });
-    const requestId = firstShowRequestId(handlers.bash.show);
+    const requestId = firstShowRequestId(handlers.transport.bash.show);
 
     expect(
       interactions.submitBashDecision(requestId, { action: 'timeout' }),
@@ -351,7 +438,7 @@ describe('createDesktopHostInteractions', () => {
       accepted: false,
       timedOut: true,
     });
-    expect(handlers.bash.resolve).toHaveBeenCalledWith(requestId);
+    expect(handlers.transport.bash.dismiss).toHaveBeenCalledWith(requestId);
   });
 
   it('preserves typed proposal approval overrides', async () => {
@@ -378,7 +465,9 @@ describe('createDesktopHostInteractions', () => {
       model: 'openai:gpt-5',
       agent: 'configured-agent',
     });
-    expect(handlers.agentProposal.resolve).toHaveBeenCalledWith('proposal-a');
+    expect(handlers.transport.agentProposal.dismiss).toHaveBeenCalledWith(
+      'proposal-a',
+    );
   });
 
   it('cancels all pending requests on dispose with a stable cause', async () => {
@@ -406,7 +495,7 @@ describe('createDesktopHostInteractions', () => {
       action: 'reject',
       feedback: 'Desktop session disposed.',
     });
-    expect(handlers.bash.resolve).toHaveBeenCalled();
-    expect(handlers.planApproval.resolve).toHaveBeenCalled();
+    expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
+    expect(handlers.transport.planApproval.dismiss).toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
@@ -23,6 +23,16 @@ const cancellationResult = (cause?: string): TestResult => ({
   cause,
 });
 
+class TestApprovalRequestHandler extends ApprovalRequestHandler<
+  TestRequest,
+  'requestId',
+  TestResult
+> {
+  stage(item: TestRequest): string {
+    return this.stagePresentationForReplay(item);
+  }
+}
+
 function createHandler(
   options: {
     canSend?: () => boolean;
@@ -32,11 +42,12 @@ function createHandler(
 ) {
   const sendShow = vi.fn(options.sendShow ?? (() => undefined));
   const sendDismiss = vi.fn(options.sendDismiss ?? (() => undefined));
-  const handler = new ApprovalRequestHandler<
-    TestRequest,
+  const handler = new TestApprovalRequestHandler(
     'requestId',
-    TestResult
-  >('requestId', sendShow, sendDismiss, options.canSend ?? (() => true));
+    sendShow,
+    sendDismiss,
+    options.canSend ?? (() => true),
+  );
   return { handler, sendDismiss, sendShow };
 }
 
@@ -135,6 +146,30 @@ describe('ApprovalRequestHandler', () => {
     handler.replay();
     expect(sendShow).not.toHaveBeenCalled();
     expect(sendDismiss).not.toHaveBeenCalled();
+  });
+
+  it('settles an interaction before staging its durable presentation', async () => {
+    const { handler, sendDismiss, sendShow } = createHandler();
+    const result = handler.request(request('same-id', 'stream-a', 'live'), {
+      cancellationResult,
+    });
+
+    expect(handler.stage(request('same-id', 'stream-a', 'durable'))).toBe(
+      'same-id',
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'cancel',
+      cause: 'Approval request was replaced.',
+    });
+    expect(handler.get('same-id')?.label).toBe('durable');
+    expect(sendDismiss).not.toHaveBeenCalled();
+    handler.replay();
+    expect(handler.get('same-id')?.label).toBe('durable');
+    expect(sendShow.mock.calls.map(([item]) => item.label)).toEqual([
+      'live',
+      'durable',
+    ]);
   });
 
   it('replays retained entries once to each newly ready target', async () => {

--- a/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
+
+interface TestRequest {
+  readonly requestId: string;
+  readonly streamId: string;
+  readonly label: string;
+}
+
+type TestResult =
+  | { readonly action: 'approve' }
+  | { readonly action: 'cancel'; readonly cause?: string };
+
+const request = (
+  requestId: string,
+  streamId: string,
+  label = requestId,
+): TestRequest => ({ requestId, streamId, label });
+
+const cancellationResult = (cause?: string): TestResult => ({
+  action: 'cancel',
+  cause,
+});
+
+function createHandler(
+  options: {
+    canSend?: () => boolean;
+    sendShow?: (item: TestRequest) => void;
+    sendDismiss?: (id: string) => void;
+  } = {},
+) {
+  const sendShow = vi.fn(options.sendShow ?? (() => undefined));
+  const sendDismiss = vi.fn(options.sendDismiss ?? (() => undefined));
+  const handler = new ApprovalRequestHandler<
+    TestRequest,
+    'requestId',
+    TestResult
+  >('requestId', sendShow, sendDismiss, options.canSend ?? (() => true));
+  return { handler, sendDismiss, sendShow };
+}
+
+describe('ApprovalRequestHandler', () => {
+  it('removes an interaction before its typed completion and settles once', async () => {
+    const sendDismiss = vi.fn((id: string) => {
+      expect(handler.get(id)).toBeUndefined();
+      expect(handler.complete(id, { action: 'approve' })).toBe(false);
+    });
+    const handler = new ApprovalRequestHandler<
+      TestRequest,
+      'requestId',
+      TestResult
+    >('requestId', vi.fn(), sendDismiss, () => true);
+    const result = handler.request(request('request-a', 'stream-a'), {
+      cancellationResult,
+    });
+
+    expect(handler.complete('request-a', { action: 'approve' })).toBe(true);
+    expect(handler.complete('request-a', { action: 'approve' })).toBe(false);
+
+    await expect(result).resolves.toEqual({ action: 'approve' });
+    expect(sendDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('cancels a duplicate interaction before presenting its replacement', async () => {
+    const events: string[] = [];
+    const { handler } = createHandler({
+      sendShow: (item) => events.push(`show:${item.label}`),
+      sendDismiss: (id) => events.push(`dismiss:${id}`),
+    });
+    const first = handler.request(request('same-id', 'stream-a', 'first'), {
+      cancellationResult: (cause) => {
+        events.push(`cancel:${cause}`);
+        return cancellationResult(cause);
+      },
+    });
+
+    const replacement = handler.request(
+      request('same-id', 'stream-a', 'replacement'),
+      { cancellationResult },
+    );
+
+    await expect(first).resolves.toEqual({
+      action: 'cancel',
+      cause: 'Approval request was replaced.',
+    });
+    expect(events).toEqual([
+      'show:first',
+      'cancel:Approval request was replaced.',
+      'dismiss:same-id',
+      'show:replacement',
+    ]);
+    expect(handler.get('same-id')?.label).toBe('replacement');
+    expect(handler.complete('same-id', { action: 'approve' })).toBe(true);
+    await expect(replacement).resolves.toEqual({ action: 'approve' });
+  });
+
+  it('keeps presentation dismissal distinct from interaction completion', async () => {
+    const { handler, sendDismiss } = createHandler();
+    handler.show(request('presentation', 'stream-a'));
+
+    expect(handler.complete('presentation', { action: 'approve' })).toBe(false);
+    expect(handler.dismiss('presentation')).toBe(true);
+    expect(handler.dismiss('presentation')).toBe(false);
+
+    const result = handler.request(request('interaction', 'stream-a'), {
+      cancellationResult,
+    });
+    expect(handler.dismiss('interaction')).toBe(false);
+    expect(handler.complete('interaction', { action: 'approve' })).toBe(true);
+
+    await expect(result).resolves.toEqual({ action: 'approve' });
+    expect(sendDismiss.mock.calls).toEqual([['presentation'], ['interaction']]);
+  });
+
+  it('rolls back presentation and interaction state when delivery throws', async () => {
+    const sendShow = vi.fn(() => {
+      throw new Error('presentation failed');
+    });
+    const { handler, sendDismiss } = createHandler({ sendShow });
+
+    expect(() => handler.show(request('presentation', 'stream-a'))).toThrow(
+      'presentation failed',
+    );
+    await expect(
+      handler.request(request('interaction', 'stream-a'), {
+        cancellationResult,
+      }),
+    ).rejects.toThrow('presentation failed');
+
+    expect(handler.get('presentation')).toBeUndefined();
+    expect(handler.get('interaction')).toBeUndefined();
+    expect(handler.hasPendingForStream('stream-a')).toBe(false);
+    sendShow.mockClear();
+    handler.replay();
+    expect(sendShow).not.toHaveBeenCalled();
+    expect(sendDismiss).not.toHaveBeenCalled();
+  });
+
+  it('replays retained entries once to each newly ready target', async () => {
+    let canSend = false;
+    const { handler, sendShow } = createHandler({ canSend: () => canSend });
+    const result = handler.request(request('request-a', 'stream-a'), {
+      cancellationResult,
+    });
+
+    expect(sendShow).not.toHaveBeenCalled();
+    canSend = true;
+    handler.replay();
+    expect(sendShow).toHaveBeenCalledTimes(1);
+    handler.replay();
+    expect(sendShow).toHaveBeenCalledTimes(2);
+
+    expect(handler.complete('request-a', { action: 'approve' })).toBe(true);
+    await expect(result).resolves.toEqual({ action: 'approve' });
+    handler.replay();
+    expect(sendShow).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels only interactions matching both stream and cancellation scope', async () => {
+    const { handler } = createHandler();
+    const targetScope = {};
+    const otherScope = {};
+    const target = handler.request(request('target', 'stream-a'), {
+      cancellationScope: targetScope,
+      cancellationResult,
+    });
+    const wrongScope = handler.request(request('wrong-scope', 'stream-a'), {
+      cancellationScope: otherScope,
+      cancellationResult,
+    });
+    const wrongStream = handler.request(request('wrong-stream', 'stream-b'), {
+      cancellationScope: targetScope,
+      cancellationResult,
+    });
+
+    expect(
+      handler.cancelWhere(
+        (item, scope) => item.streamId === 'stream-a' && scope === targetScope,
+        'Scoped cleanup.',
+      ),
+    ).toBe(1);
+    await expect(target).resolves.toEqual({
+      action: 'cancel',
+      cause: 'Scoped cleanup.',
+    });
+    expect(handler.get('wrong-scope')).toBeDefined();
+    expect(handler.get('wrong-stream')).toBeDefined();
+
+    handler.clear();
+    await expect(wrongScope).resolves.toEqual({
+      action: 'cancel',
+      cause: undefined,
+    });
+    await expect(wrongStream).resolves.toEqual({
+      action: 'cancel',
+      cause: undefined,
+    });
+  });
+
+  it('completes every matching interaction without touching peers', async () => {
+    const { handler } = createHandler();
+    const first = handler.request(request('first', 'stream-a'), {
+      cancellationResult,
+    });
+    const second = handler.request(request('second', 'stream-a'), {
+      cancellationResult,
+    });
+    const peer = handler.request(request('peer', 'stream-b'), {
+      cancellationResult,
+    });
+
+    expect(
+      handler.completeWhere((item) => item.streamId === 'stream-a', {
+        action: 'approve',
+      }),
+    ).toBe(2);
+    await expect(first).resolves.toEqual({ action: 'approve' });
+    await expect(second).resolves.toEqual({ action: 'approve' });
+    expect(handler.get('peer')).toBeDefined();
+
+    expect(handler.complete('peer', { action: 'approve' })).toBe(true);
+    await expect(peer).resolves.toEqual({ action: 'approve' });
+  });
+
+  it('releases and clears interactions without orphaning their promises', async () => {
+    const { handler, sendDismiss } = createHandler();
+    const released = handler.request(request('released', 'stream-a'), {
+      cancellationResult,
+    });
+    handler.show(request('released-presentation', 'stream-a'));
+    const retained = handler.request(request('retained', 'stream-b'), {
+      cancellationResult,
+    });
+    handler.show(request('retained-presentation', 'stream-b'));
+
+    handler.releaseForStream('stream-a');
+    await expect(released).resolves.toEqual({
+      action: 'cancel',
+      cause: undefined,
+    });
+    expect(handler.get('released')).toBeUndefined();
+    expect(handler.get('released-presentation')).toBeUndefined();
+    expect(handler.get('retained')).toBeDefined();
+
+    handler.clear();
+    await expect(retained).resolves.toEqual({
+      action: 'cancel',
+      cause: undefined,
+    });
+    expect(handler.get('retained')).toBeUndefined();
+    expect(handler.get('retained-presentation')).toBeUndefined();
+    expect(handler.hasPendingForStream('stream-b')).toBe(false);
+    expect(sendDismiss).not.toHaveBeenCalled();
+  });
+
+  it('isolates identical ids owned by different request kinds', async () => {
+    const first = createHandler();
+    const second = createHandler();
+    const firstResult = first.handler.request(
+      request('shared-id', 'stream-a', 'first-kind'),
+      { cancellationResult },
+    );
+    const secondResult = second.handler.request(
+      request('shared-id', 'stream-a', 'second-kind'),
+      { cancellationResult },
+    );
+
+    expect(first.handler.complete('shared-id', { action: 'approve' })).toBe(
+      true,
+    );
+    await expect(firstResult).resolves.toEqual({ action: 'approve' });
+    expect(second.handler.get('shared-id')?.label).toBe('second-kind');
+
+    expect(second.handler.complete('shared-id', { action: 'approve' })).toBe(
+      true,
+    );
+    await expect(secondResult).resolves.toEqual({ action: 'approve' });
+    expect(first.sendDismiss).toHaveBeenCalledWith('shared-id');
+    expect(second.sendDismiss).toHaveBeenCalledWith('shared-id');
+  });
+});

--- a/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandler.vitest.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - progress view backend
 import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
 
 interface TestRequest {

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  cancelApprovalRequestHandlers,
   createProgressBackendUiConfig,
   replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
@@ -8,6 +9,58 @@ import {
 import type { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
 
 describe('ApprovalRequestHandlerSet helpers', () => {
+  it('routes cancellation through the exact listed interaction handlers', () => {
+    const cancellationScope = {};
+    const request = { streamId: 'stream-1' };
+    const cancelWhere = {
+      bash: vi.fn(),
+      planApproval: vi.fn(),
+      agentProposal: vi.fn(),
+      retry: vi.fn(),
+      userQuestion: vi.fn(),
+    };
+    for (const cancel of Object.values(cancelWhere)) {
+      cancel.mockImplementation((predicate, cause) => {
+        expect(cause).toBe('Session closed.');
+        return predicate(request, cancellationScope) ? 1 : 0;
+      });
+    }
+    const handlers = {
+      bash: { cancelWhere: cancelWhere.bash },
+      planApproval: { cancelWhere: cancelWhere.planApproval },
+      agentProposal: { cancelWhere: cancelWhere.agentProposal },
+      retry: { cancelWhere: cancelWhere.retry },
+      userQuestion: { cancelWhere: cancelWhere.userQuestion },
+    } as unknown as ApprovalRequestHandlerSet;
+    const cases = [
+      ['bash', 'bash'],
+      ['plan', 'planApproval'],
+      ['proposal', 'agentProposal'],
+      ['retry', 'retry'],
+      ['userQuestion', 'userQuestion'],
+    ] as const;
+
+    for (const [kind, handlerKey] of cases) {
+      expect(
+        cancelApprovalRequestHandlers(handlers, [kind], {
+          kind,
+          streamId: 'stream-1',
+          cancellationScope,
+          cause: 'Session closed.',
+        }),
+      ).toBe(1);
+      expect(cancelWhere[handlerKey]).toHaveBeenCalledOnce();
+      for (const cancel of Object.values(cancelWhere)) cancel.mockClear();
+    }
+
+    cancelApprovalRequestHandlers(
+      handlers,
+      ['bash', 'plan', 'proposal', 'userQuestion'],
+      { cause: 'Session closed.' },
+    );
+    expect(cancelWhere.retry).not.toHaveBeenCalled();
+  });
+
   it('replays every pending prompt kind', async () => {
     const replayCalls = {
       toolEdit: vi.fn<() => void>(),

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -3,10 +3,27 @@ import { createTestSession as createIsolatedTestSession } from '@test/support/se
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ApprovalRequestHandler } from '@controllers/progressView/backend/ApprovalRequestHandler';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
+import type {
+  HostBashApprovalResult,
+  HostUserQuestionResult,
+  PlanApprovalResult,
+  ProposalResult,
+  RetryResult,
+} from '@agent/runtime/HostInteractions';
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
-import type { StreamTabId } from '@shared/schemas';
+import type {
+  AgentProposalPermission,
+  BashPermission,
+  ExternalInquiryPermission,
+  PlanApprovalPermission,
+  RetryPermission,
+  StreamTabId,
+  ToolEditPermission,
+  UserQuestionPermission,
+} from '@shared/schemas';
 import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 
 const mocks = vi.hoisted(() => ({
@@ -21,38 +38,94 @@ vi.mock('@frontend/approval/nativeToolEditApproval', () => ({
   nativeRequestApproval: mocks.nativeRequestApproval,
 }));
 
-interface RecordingApprovalHandler {
-  readonly show: ReturnType<typeof vi.fn>;
-  readonly resolve: ReturnType<typeof vi.fn>;
-  readonly replay: ReturnType<typeof vi.fn>;
-  readonly get: ReturnType<typeof vi.fn>;
-  readonly hasPendingForStream: ReturnType<typeof vi.fn>;
-  readonly releaseForStream: ReturnType<typeof vi.fn>;
-  readonly clear: ReturnType<typeof vi.fn>;
+type ShowSpy<T> = ReturnType<typeof vi.fn<(item: T) => void>>;
+type DismissSpy = ReturnType<typeof vi.fn<(id: string) => void>>;
+
+interface RecordingTransport<T> {
+  readonly show: ShowSpy<T>;
+  readonly dismiss: DismissSpy;
 }
 
-function handler(): RecordingApprovalHandler {
-  return {
-    show: vi.fn(),
-    resolve: vi.fn(),
-    replay: vi.fn(),
-    get: vi.fn(),
-    hasPendingForStream: vi.fn(() => false),
-    releaseForStream: vi.fn(),
-    clear: vi.fn(),
+interface RecordingApprovalHandlerSet extends ApprovalRequestHandlerSet {
+  readonly transport: {
+    toolEdit: RecordingTransport<ToolEditPermission>;
+    bash: RecordingTransport<BashPermission>;
+    retry: RecordingTransport<RetryPermission>;
+    agentProposal: RecordingTransport<AgentProposalPermission>;
+    planApproval: RecordingTransport<PlanApprovalPermission>;
+    externalInquiry: RecordingTransport<ExternalInquiryPermission>;
+    userQuestion: RecordingTransport<UserQuestionPermission>;
   };
 }
 
-function createHandlers(): ApprovalRequestHandlerSet {
+function handler<
+  T extends { streamId: string },
+  K extends keyof T,
+  Result = never,
+>(
+  idField: K,
+): {
+  handler: ApprovalRequestHandler<T, K, Result>;
+  transport: RecordingTransport<T>;
+} {
+  const transport = {
+    show: vi.fn<(item: T) => void>(),
+    dismiss: vi.fn<(id: string) => void>(),
+  };
   return {
-    toolEdit: handler(),
-    bash: handler(),
-    retry: handler(),
-    agentProposal: handler(),
-    planApproval: handler(),
-    externalInquiry: handler(),
-    userQuestion: handler(),
-  } as unknown as ApprovalRequestHandlerSet;
+    handler: new ApprovalRequestHandler<T, K, Result>(
+      idField,
+      transport.show,
+      transport.dismiss,
+      () => true,
+    ),
+    transport,
+  };
+}
+
+function createHandlers(): RecordingApprovalHandlerSet {
+  const toolEdit = handler<ToolEditPermission, 'requestId'>('requestId');
+  const bash = handler<BashPermission, 'requestId', HostBashApprovalResult>(
+    'requestId',
+  );
+  const retry = handler<RetryPermission, 'streamId', RetryResult>('streamId');
+  const agentProposal = handler<
+    AgentProposalPermission,
+    'proposalId',
+    ProposalResult
+  >('proposalId');
+  const planApproval = handler<
+    PlanApprovalPermission,
+    'approvalId',
+    PlanApprovalResult
+  >('approvalId');
+  const externalInquiry = handler<ExternalInquiryPermission, 'requestId'>(
+    'requestId',
+  );
+  const userQuestion = handler<
+    UserQuestionPermission,
+    'requestId',
+    HostUserQuestionResult
+  >('requestId');
+
+  return {
+    toolEdit: toolEdit.handler,
+    bash: bash.handler,
+    retry: retry.handler,
+    agentProposal: agentProposal.handler,
+    planApproval: planApproval.handler,
+    externalInquiry: externalInquiry.handler,
+    userQuestion: userQuestion.handler,
+    transport: {
+      toolEdit: toolEdit.transport,
+      bash: bash.transport,
+      retry: retry.transport,
+      agentProposal: agentProposal.transport,
+      planApproval: planApproval.transport,
+      externalInquiry: externalInquiry.transport,
+      userQuestion: userQuestion.transport,
+    },
+  };
 }
 
 function createRuntimeHost() {
@@ -148,7 +221,7 @@ describe('createExtensionHostInteractions', () => {
       accepted: true,
       userMessage: undefined,
     });
-    expect(handlers.agentProposal.resolve).toHaveBeenCalledWith(
+    expect(handlers.transport.agentProposal.dismiss).toHaveBeenCalledWith(
       'proposal-parallel',
     );
     expect(mocks.approveNativeToolEditApprovals).toHaveBeenCalledWith(
@@ -163,7 +236,7 @@ describe('createExtensionHostInteractions', () => {
         action: 'approve',
       }),
     ).toBe(true);
-    const bashShow = handlers.bash.show as unknown as ReturnType<typeof vi.fn>;
+    const bashShow = handlers.transport.bash.show;
     const otherRequestId = firstShowRequestId(bashShow);
     const streamBRequestId = (
       bashShow.mock.calls.find(
@@ -222,7 +295,7 @@ describe('createExtensionHostInteractions', () => {
         },
       },
     });
-    expect(handlers.planApproval.show).toHaveBeenCalledWith({
+    expect(handlers.transport.planApproval.show).toHaveBeenCalledWith({
       approvalId: 'plan-a',
       streamId: 'stream-a',
       goalEnabled: true,
@@ -237,11 +310,42 @@ describe('createExtensionHostInteractions', () => {
     await expect(resultPromise).resolves.toEqual({
       action: 'approve_and_goal',
     });
-    expect(handlers.planApproval.resolve).toHaveBeenCalledWith('plan-a');
+    expect(handlers.transport.planApproval.dismiss).toHaveBeenCalledWith(
+      'plan-a',
+    );
     // The request was settled first-wins: a second resolution finds nothing.
     expect(
       interactions.submitPlanDecision('plan-a', { action: 'approve' }),
     ).toBe(false);
+  });
+
+  it('rejects a request when its show transport fails synchronously', async () => {
+    const handlers = createHandlers();
+    handlers.transport.planApproval.show.mockImplementationOnce(() => {
+      throw new Error('Progress view transport unavailable.');
+    });
+    const interactions = createInteractions({
+      handlers,
+      session: createTestSession(),
+    });
+
+    const resultPromise = interactions.requestPlanApproval?.({
+      approvalId: 'plan-show-failure',
+      streamId: 'stream-a' as StreamTabId,
+      goalEnabled: false,
+      plan: { objective: 'Fail before becoming pending.' },
+    });
+
+    await expect(resultPromise).rejects.toThrow(
+      'Progress view transport unavailable.',
+    );
+    expect(handlers.planApproval.get('plan-show-failure')).toBeUndefined();
+    expect(
+      interactions.submitPlanDecision('plan-show-failure', {
+        action: 'approve',
+      }),
+    ).toBe(false);
+    expect(handlers.transport.planApproval.dismiss).not.toHaveBeenCalled();
   });
 
   it('surfaces retry requests without stealing active-stream focus (#8246)', async () => {
@@ -275,7 +379,7 @@ describe('createExtensionHostInteractions', () => {
         },
       },
     ]);
-    expect(handlers.retry.show).toHaveBeenCalledWith(
+    expect(handlers.transport.retry.show).toHaveBeenCalledWith(
       expect.objectContaining({ streamId: 'failing-subagent' }),
     );
   });
@@ -341,7 +445,7 @@ describe('createExtensionHostInteractions', () => {
     interactions.cancel({ streamId: 'stream-a' as StreamTabId });
 
     await expect(resultPromise).resolves.toEqual({ action: 'cancel' });
-    expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
+    expect(handlers.transport.retry.dismiss).toHaveBeenCalledWith('stream-a');
   });
 
   it('routes tool-edit cancellation through the native approval owner', () => {
@@ -382,7 +486,7 @@ describe('createExtensionHostInteractions', () => {
       accepted: false,
       userMessage: 'Stream resources released.',
     });
-    expect(handlers.bash.resolve).toHaveBeenCalled();
+    expect(handlers.transport.bash.dismiss).toHaveBeenCalled();
   });
 
   it('rejects a resolution whose kind does not match the pending request', async () => {
@@ -396,9 +500,7 @@ describe('createExtensionHostInteractions', () => {
       command: 'echo hi',
       streamId: 'stream-a' as StreamTabId,
     });
-    const requestId = firstShowRequestId(
-      handlers.bash.show as ReturnType<typeof vi.fn>,
-    );
+    const requestId = firstShowRequestId(handlers.transport.bash.show);
 
     // A mismatched kind for the same requestId must not settle the pending
     // bash approval as a plan action would (defends against a caller bug
@@ -442,11 +544,11 @@ describe('createExtensionHostInteractions', () => {
     });
 
     await expect(retryPromise).resolves.toEqual({ action: 'cancel' });
-    expect(handlers.retry.resolve).toHaveBeenCalledWith('stream-a');
+    expect(handlers.transport.retry.dismiss).toHaveBeenCalledWith('stream-a');
 
     // The plan approval on the same stream survives untouched and is still
     // resolvable first-wins.
-    expect(handlers.planApproval.resolve).not.toHaveBeenCalled();
+    expect(handlers.transport.planApproval.dismiss).not.toHaveBeenCalled();
     expect(
       interactions.submitPlanDecision('plan-a', { action: 'approve' }),
     ).toBe(true);
@@ -473,7 +575,7 @@ describe('createExtensionHostInteractions', () => {
       }),
     ).resolves.toEqual({ threadId: 'thread-a' });
 
-    expect(handlers.externalInquiry.show).toHaveBeenCalledWith({
+    expect(handlers.transport.externalInquiry.show).toHaveBeenCalledWith({
       requestId: 'thread-a',
       threadId: 'thread-a',
       question: 'Which convention should be used?',
@@ -482,7 +584,9 @@ describe('createExtensionHostInteractions', () => {
       mode: 'new',
     });
     interactions.dismissExternalInquiry('thread-a');
-    expect(handlers.externalInquiry.resolve).toHaveBeenCalledWith('thread-a');
+    expect(handlers.transport.externalInquiry.dismiss).toHaveBeenCalledWith(
+      'thread-a',
+    );
   });
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
@@ -515,7 +619,9 @@ describe('createExtensionHostInteractions', () => {
       submitted: false,
       feedback: 'No stream owns this question.',
     });
-    expect(handlers.userQuestion.resolve).toHaveBeenCalledWith('question-a');
+    expect(handlers.transport.userQuestion.dismiss).toHaveBeenCalledWith(
+      'question-a',
+    );
     // The cancelled question was released: a later resolution finds nothing.
     expect(
       interactions.submitUserQuestionDecision('question-a', {
@@ -556,7 +662,7 @@ describe('createExtensionHostInteractions', () => {
       submitted: true,
       answers,
     });
-    expect(handlers.userQuestion.resolve).toHaveBeenCalledWith(
+    expect(handlers.transport.userQuestion.dismiss).toHaveBeenCalledWith(
       'question-submit',
     );
   });

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -119,7 +119,7 @@ function createProgressProviderShell(): {
   const syncThreads = vi.fn();
   const handler = new ExternalInquiryRequestHandler({
     show,
-    resolve: vi.fn(),
+    dismiss: vi.fn(),
     syncThreads,
     canSend: () => true,
     logger: { debug: vi.fn() },
@@ -138,7 +138,7 @@ function createReplayShellWithPendingInquiry(): {
   const show = vi.fn<(permission: ExternalInquiryPermission) => void>();
   const handler = new ExternalInquiryRequestHandler({
     show,
-    resolve: vi.fn(),
+    dismiss: vi.fn(),
     syncThreads: vi.fn(),
     canSend: () => true,
     logger: { debug: vi.fn() },


### PR DESCRIPTION
## Summary

- `ApprovalRequestHandler` is now the sole owner of progress request payloads, delivery state, replay, typed completion, cancellation, and dismissal.
- The duplicate extension and desktop pending-interaction registries are gone.
- Genuine host differences remain local to their adapters.
- Presentation-only dismissal remains distinct from response-bearing completion.

## Design

Progress interaction state now has one owner. Each pending entry keeps its payload, cancellation metadata, and typed completion callback together, so replacement, completion, scoped cleanup, replay, and synchronous delivery failure remain atomic.

The extension and desktop adapters translate host-specific behavior without duplicating request correlation or promise settlement. The existing presentation owner is deeper; there is no replacement registry or renamed lifecycle tunnel.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test -- --maxWorkers=2` — 710 files and 6,456 tests passed
- `npm run check:dead-code-ratchet`

Closes #8556
Closes #8545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval/bash/plan/proposal/retry/user-question flows on both hosts; behavior is heavily tested but mistakes could strand or double-settle agent interaction promises.
> 
> **Overview**
> **Centralizes progress approval/interaction state** in `ApprovalRequestHandler` instead of parallel pending maps on the extension and desktop hosts.
> 
> The handler now distinguishes **presentation-only** prompts (`show` / `dismiss`) from **response-bearing** ones (`request` → `complete`, plus `completeWhere` / `cancelWhere`). Each pending entry keeps payload, cancellation scope, and the typed settle callback together, so replacement, scoped cancel, replay, teardown (`clear` / `releaseForStream`), and synchronous show failures stay atomic and cannot leave agent promises hanging.
> 
> **Host adapters** (`extensionHostInteractions`, `desktopHostInteractions`) mostly reveal the stream and forward to the shared handler set; shared **`cancelApprovalRequestHandlers`** routes cancellation by kind. UI wiring renames **`resolve` → `dismiss`** where only the webview panel is cleared. **External inquiry** replay uses **`stagePresentationForReplay`** instead of a separate pending setter.
> 
> Tests add **`ApprovalRequestHandler`** coverage and update host interaction tests to use real handlers with `dismiss` spies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb711de09c4540701e82e65c9a9c6738bc66241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->