### PR TITLE
fix(logger): redact output sinks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   opt into deterministic workflow scripts whose completed steps resume after
   interruption and whose progress appears in the existing session view.
 
+#### Bug Fixes
+
+- **Application logs protect provider credentials by default** — extension and
+  SDK-provided log destinations now redact recognizable secrets before writing
+  them, while the local CLI terminal keeps its operator-readable output.
+
 ### CLI
 
 #### Bug Fixes

--- a/docs/proposals/agent-sdk-readiness-audit.md
+++ b/docs/proposals/agent-sdk-readiness-audit.md
@@ -196,13 +196,11 @@ be the highest-leverage addition to this surface.
 
 ### 2.4 Safety: make log redaction opt-out, not opt-in
 
-`redactSecrets` (`src/logger/redaction.ts:84`) is applied only by
-`desktopAppLog.ts`; the default/CLI sinks skip it by design. Any SDK consumer
-wiring a custom `setOutputChannelFactory` that persists logs inherits an
-un-enforced contract and can leak API keys. _Fix:_ make the default sink factory
-redact, with an explicit `{ trusted: true }` opt-out for the operator-terminal
-case. This is the one correctness item worth fixing before any external consumer
-wires a persistent log sink.
+`setOutputChannelFactory` now wraps sinks with `redactSecrets` by default, so an
+SDK consumer cannot accidentally persist provider credentials by omitting a
+host-side convention. The CLI's local operator terminal is the explicit
+`{ trusted: true }` exception; extension and default console sinks remain
+redacted.
 
 ---
 

--- a/docs/proposals/agent-sdk-readiness-audit.md
+++ b/docs/proposals/agent-sdk-readiness-audit.md
@@ -271,8 +271,8 @@ SDK boundary would bypass, not an independent task.)_
 
 1. **Now (mechanical, no behavior change):** 1.1 delete `IModelHandler` shim,
    1.2/1.3 inline the two single-caller helpers. One small PR.
-2. **Next (leak cleanup):** 2.1 xAI clamp override, 2.2 move 4 host-UI ports off
-   `Platform`, 2.4 default-on redaction. Each independently landable.
+2. **Next (leak cleanup):** 2.1 xAI clamp override and 2.2 move 4 host-UI ports
+   off `Platform`. Each independently landable.
 3. **Structural (the actual SDK enablers):** §2.1 curated boundary + §2.2 accept
    `Platform` as an explicit argument to the SDK entrypoint (dissolve the global
    locator). These unlock a real `@texra/core`.

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -262,6 +262,7 @@ export async function initCliPlatform(
   quietPlatformLogs = context.quietLogs;
   setOutputChannelFactory(
     quietPlatformLogs ? () => ({ appendLine: () => undefined }) : null,
+    { trusted: true },
   );
 
   if (!tryPlatform()) {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -9,18 +9,12 @@
  * the VS Code extension provides a factory that returns VS Code
  * `OutputChannel`s, tests/CLI fall back to a console-backed sink.
  *
- * Secret redaction is a host responsibility, by design. This module does NOT
- * redact at emit time — the trade-off is cost/flexibility (most channel output
- * is product-internal and never persisted off-box). Hosts that persist or ship
- * logs off the machine MUST run text through {@link redactSecrets} in their sink
- * (see `desktopAppLog.ts` for the reference redacting wiring) before writing.
- * SDK consumers wiring a custom {@link setOutputChannelFactory} take on the same
- * contract; a sink that forgets it can leak API keys/paths into logs. (The CLI
- * stdout/stderr sinks in `logSinks.ts` are a deliberate non-redacting exception —
- * they target the operator's own terminal, not a persisted/exported artifact.)
+ * Sink output is secret-redacted by default. A host may opt out only for a
+ * trusted operator terminal whose output is neither persisted nor exported.
  */
 import { format } from 'date-fns';
 
+import { redactSecrets } from '@logger/redaction';
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas';
 import { getConfig } from '@utils/config';
 import { serializeError } from '@utils/core';
@@ -43,9 +37,17 @@ interface OutputSink {
 
 type OutputChannelFactory = (name: string) => OutputSink;
 
+export interface OutputChannelFactoryOptions {
+  /** Preserve raw output only for a local operator-controlled terminal. */
+  readonly trusted?: boolean;
+}
+
 const channels = new Map<string, OutputSink>();
 let mainOutputChannel: OutputSink | null = null;
 let outputChannelFactory: OutputChannelFactory | null = null;
+let outputSinksTrusted = false;
+
+const redactingSinks = new WeakMap<OutputSink, OutputSink>();
 
 function getKey(channel: string, isAgent: boolean): string {
   return `${channel}::${isAgent ? 'agent' : 'shared'}`;
@@ -63,9 +65,26 @@ function createConsoleSink(channel: string): OutputSink {
   };
 }
 
+function createRedactingSink(sink: OutputSink): OutputSink {
+  const existing = redactingSinks.get(sink);
+  if (existing) return existing;
+
+  const redactingSink: OutputSink = {
+    appendLine(message) {
+      sink.appendLine(redactSecrets(message));
+    },
+    dispose() {
+      sink.dispose?.();
+    },
+  };
+  redactingSinks.set(sink, redactingSink);
+  return redactingSink;
+}
+
 function createOutputChannel(channel: string, isAgent: boolean): OutputSink {
   const name = isAgent ? `TeXRA ${channel}` : 'TeXRA';
-  return outputChannelFactory?.(name) ?? createConsoleSink(name);
+  const sink = outputChannelFactory?.(name) ?? createConsoleSink(name);
+  return outputSinksTrusted ? sink : createRedactingSink(sink);
 }
 
 function ensureChannel(channel: string, isAgent: boolean): OutputSink {
@@ -183,12 +202,14 @@ export function initialize(channel: string, isAgent = false): void {
 
 export function setOutputChannelFactory(
   factory: OutputChannelFactory | null,
+  options: OutputChannelFactoryOptions = {},
 ): void {
   const sinks = new Set<OutputSink>(channels.values());
   if (mainOutputChannel) sinks.add(mainOutputChannel);
   for (const sink of sinks) sink.dispose?.();
 
   outputChannelFactory = factory;
+  outputSinksTrusted = options.trusted === true;
   channels.clear();
   mainOutputChannel = null;
 }

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -12,8 +12,10 @@
  * Sink output is secret-redacted by default. A host may opt out only for a
  * trusted operator terminal whose output is neither persisted nor exported.
  */
+// Third-party imports
 import { format } from 'date-fns';
 
+// Local imports
 import { redactSecrets } from '@logger/redaction';
 import { LOG_LEVELS, type LogLevel } from '@shared/schemas';
 import { getConfig } from '@utils/config';
@@ -200,6 +202,11 @@ export function initialize(channel: string, isAgent = false): void {
   ensureChannel(channel, isAgent);
 }
 
+/**
+ * Replace the host sink factory and dispose all cached sinks. New sinks redact
+ * secrets unless the host explicitly identifies a local operator terminal as
+ * trusted.
+ */
 export function setOutputChannelFactory(
   factory: OutputChannelFactory | null,
   options: OutputChannelFactoryOptions = {},

--- a/src/logger/redaction.ts
+++ b/src/logger/redaction.ts
@@ -4,6 +4,8 @@ const REDACTED = '[redacted]';
 
 const SECRET_ASSIGNMENT_PATTERN =
   /\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)/gi;
+const JSON_SECRET_PROPERTY_PATTERN =
+  /("(?:[^"\\]|\\.)*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)(?:[^"\\]|\\.)*"\s*:\s*)"(?:[^"\\]|\\.)*"/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=_-]+/g;
 const OPENAI_COMPATIBLE_API_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const GOOGLE_STANDARD_API_KEY_PATTERN = /\bAIza[A-Za-z0-9_-]{20,}\b/g;
@@ -90,6 +92,10 @@ export function redactSecrets(
     .sort((a, b) => b.length - a.length);
 
   let redacted = text
+    .replaceAll(
+      JSON_SECRET_PROPERTY_PATTERN,
+      (_match, property: string) => `${property}"${REDACTED}"`,
+    )
     .replaceAll(
       SECRET_ASSIGNMENT_PATTERN,
       (_match, name: string) => `${name}=${REDACTED}`,

--- a/src/logger/redaction.ts
+++ b/src/logger/redaction.ts
@@ -4,8 +4,9 @@ const REDACTED = '[redacted]';
 
 const SECRET_ASSIGNMENT_PATTERN =
   /\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)/gi;
-const JSON_SECRET_PROPERTY_PATTERN =
-  /("(?:[^"\\]|\\.)*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)(?:[^"\\]|\\.)*"\s*:\s*)"(?:[^"\\]|\\.)*"/gi;
+const JSON_STRING_PROPERTY_PATTERN =
+  /("((?:[^"\\]|\\.)*)"\s*:\s*)"(?:[^"\\]|\\.)*"/g;
+const SECRET_FIELD_NAME_PATTERN = /API[_-]?KEY|TOKEN|SECRET|PASSWORD/i;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=_-]+/g;
 const OPENAI_COMPATIBLE_API_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const GOOGLE_STANDARD_API_KEY_PATTERN = /\bAIza[A-Za-z0-9_-]{20,}\b/g;
@@ -93,8 +94,11 @@ export function redactSecrets(
 
   let redacted = text
     .replaceAll(
-      JSON_SECRET_PROPERTY_PATTERN,
-      (_match, property: string) => `${property}"${REDACTED}"`,
+      JSON_STRING_PROPERTY_PATTERN,
+      (match, property: string, name: string) =>
+        SECRET_FIELD_NAME_PATTERN.test(name)
+          ? `${property}"${REDACTED}"`
+          : match,
     )
     .replaceAll(
       SECRET_ASSIGNMENT_PATTERN,

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -4,6 +4,7 @@ import { UsageLogService } from '@telemetry/UsageLogService';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
+import { setOutputChannelFactory } from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { getSetupPlatform } from '@tools/setup/platform';
@@ -265,6 +266,16 @@ describe('CLI platform init', () => {
     expect(vi.mocked(UsageLogService.dispose)).not.toHaveBeenCalled();
     for (const handler of mocks.shutdownHandlers) await handler();
     expect(vi.mocked(UsageLogService.dispose)).toHaveBeenCalled();
+  });
+
+  it('marks the operator-terminal console sink as trusted', async () => {
+    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+
+    await initCliPlatform(cliContext({ quietLogs: false }));
+
+    expect(vi.mocked(setOutputChannelFactory)).toHaveBeenCalledWith(null, {
+      trusted: true,
+    });
   });
 
   it('installs a CLI agent resume port that delegates to the active handler', async () => {

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -107,12 +107,20 @@ describe('logUtils', () => {
     }));
 
     logger.debug('test', 'request metadata', {
-      data: { authorization: `Bearer ${SECRET}` },
+      data: {
+        authorization: `Bearer ${SECRET}`,
+        password: 'correct horse battery staple',
+        refreshToken: 'opaque-refresh-credential',
+      },
     });
 
     expect(lines).toHaveLength(2);
     expect(lines.join('\n')).not.toContain(SECRET);
+    expect(lines.join('\n')).not.toContain('correct horse battery staple');
+    expect(lines.join('\n')).not.toContain('opaque-refresh-credential');
     expect(lines[1]).toContain('"authorization": "Bearer [redacted]"');
+    expect(lines[1]).toContain('"password": "[redacted]"');
+    expect(lines[1]).toContain('"refreshToken": "[redacted]"');
   });
 
   it('disposes a shared underlying sink exactly once', () => {

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -112,4 +112,16 @@ describe('logUtils', () => {
     expect(lines.join('\n')).not.toContain(SECRET);
     expect(lines[1]).toContain('"authorization": "Bearer [redacted]"');
   });
+
+  it('disposes a shared underlying sink exactly once', () => {
+    const dispose = vi.fn();
+    const sink = { appendLine: vi.fn(), dispose };
+    logger.setOutputChannelFactory(() => sink);
+
+    logger.initialize('shared');
+    logger.initialize('agent', true);
+    logger.setOutputChannelFactory(null);
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
 });

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -111,6 +111,7 @@ describe('logUtils', () => {
         authorization: `Bearer ${SECRET}`,
         password: 'correct horse battery staple',
         refreshToken: 'opaque-refresh-credential',
+        requestId: 'visible-request-id',
       },
     });
 
@@ -121,6 +122,7 @@ describe('logUtils', () => {
     expect(lines[1]).toContain('"authorization": "Bearer [redacted]"');
     expect(lines[1]).toContain('"password": "[redacted]"');
     expect(lines[1]).toContain('"refreshToken": "[redacted]"');
+    expect(lines[1]).toContain('"requestId": "visible-request-id"');
   });
 
   it('disposes a shared underlying sink exactly once', () => {

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as logger from '@logger/logUtils';
 import * as config from '@utils/config';
 
+const SECRET = 'sk-proj-redaction-example-1234567890abcdef';
+
 describe('logUtils', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -45,5 +47,69 @@ describe('logUtils', () => {
     expect(output).not.toContain('[Circular]');
     expect(output).toContain('"first"');
     expect(output).toContain('"second"');
+  });
+
+  it('redacts lines sent to an output sink by default', () => {
+    const lines: string[] = [];
+    logger.setOutputChannelFactory(() => ({
+      appendLine(message: string) {
+        lines.push(message);
+      },
+    }));
+
+    logger.info('test', `OPENAI_API_KEY=${SECRET}`);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toContain(SECRET);
+    expect(lines[0]).toContain('OPENAI_API_KEY=[redacted]');
+  });
+
+  it('preserves the raw line for an explicitly trusted sink', () => {
+    const lines: string[] = [];
+    logger.setOutputChannelFactory(
+      () => ({
+        appendLine(message: string) {
+          lines.push(message);
+        },
+      }),
+      { trusted: true },
+    );
+
+    const rawMessage = `OPENAI_API_KEY=${SECRET}`;
+    logger.info('test', rawMessage);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain(rawMessage);
+    expect(lines[0]).not.toContain('[redacted]');
+  });
+
+  it('redacts lines sent through the default console fallback', () => {
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+    logger.setOutputChannelFactory(null);
+
+    logger.warn('test', `Authorization: Bearer ${SECRET}`);
+
+    expect(consoleInfo).toHaveBeenCalledOnce();
+    const output = String(consoleInfo.mock.calls[0]?.[0]);
+    expect(output).not.toContain(SECRET);
+    expect(output).toContain('Authorization: Bearer [redacted]');
+  });
+
+  it('redacts serialized debug data before sending it to the sink', () => {
+    vi.spyOn(config, 'getConfig').mockReturnValue(true);
+    const lines: string[] = [];
+    logger.setOutputChannelFactory(() => ({
+      appendLine(message: string) {
+        lines.push(message);
+      },
+    }));
+
+    logger.debug('test', 'request metadata', {
+      data: { authorization: `Bearer ${SECRET}` },
+    });
+
+    expect(lines).toHaveLength(2);
+    expect(lines.join('\n')).not.toContain(SECRET);
+    expect(lines[1]).toContain('"authorization": "Bearer [redacted]"');
   });
 });

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Local imports
 import * as logger from '@logger/logUtils';
 import * as config from '@utils/config';
 


### PR DESCRIPTION
## Problem

Logger sinks previously relied on each host to remember secret redaction. An SDK or extension sink that persisted output without that convention could write provider credentials verbatim.

## Change

- Wrap output sinks with `redactSecrets` by default.
- Require the CLI's local operator terminal to opt out explicitly with `{ trusted: true }`.
- Preserve one-argument factory registrations as redacted defaults.
- Deduplicate wrappers so a shared underlying sink is disposed exactly once.
- Document the resolved SDK safety contract and add a user-visible changelog entry.

## Verification

- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm run compile:fast`
- `npm test` (6,424 passed; 4 skipped)
- Focused logger, CLI, trace, inquiry-storage, and desktop-redaction tests
- Independent review: no blocking findings

Closes #8509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default logging behavior for extension and SDK sinks (secrets masked unless explicitly trusted), which is intentional but could hide debugging detail; CLI terminal is explicitly exempt.
> 
> **Overview**
> **Application logs redact provider credentials by default** instead of relying on each host to wrap sinks with `redactSecrets`. `setOutputChannelFactory` now accepts `{ trusted: true }` only for a local operator terminal; the CLI passes that flag so its console stays readable, while custom factories and the default console fallback stay redacted.
> 
> Implementation wraps sinks in `createRedactingSink` (with **WeakMap deduplication** so a shared underlying sink is **disposed once**), wires `redactSecrets` into `logUtils`, and extends redaction to **JSON string properties** whose names look like secrets (so serialized debug payloads lose tokens/passwords while non-secret fields stay visible). Changelog and the agent SDK audit doc are updated to describe opt-out redaction as the resolved contract; new unit tests cover default/trusted/console/debug-data/dispose behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a214b126960e19b74909226756899c5a65e2124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->