### PR TITLE
refactor(agent): remove model handler type indirection

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -1,5 +1,6 @@
 import type { AgentTrace } from '@agent/trace';
-import type { IModelHandler, SdkToolCall } from '@agent/types/IModelHandler';
+import type { IModelHandler } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type {

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -8,7 +8,8 @@ import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState'
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
-import type { IModelHandler, SdkToolCall } from '@agent/types/IModelHandler';
+import type { IModelHandler } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { TaskRunFileService } from '@utils/files';
 

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -5,7 +5,7 @@ import {
   endToolUseCard,
   startToolUseCard,
 } from '@agent/trace';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import {
   extractToolAttachments,
   type ExtractedToolAttachments,

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -4,7 +4,7 @@ import { logWebFetch, logWebSearch } from '@agent/trace';
 import { recordCycleMetrics } from '@agent/core/state/AgentState';
 import { extractModelResponse } from '@agent/core/flows/CommonCycleTypes';
 import { appendFollowUpAsUserMessage } from '@agent/followUp/followUpMessages';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { ServerToolContentBlock } from '@agent/types/ServerToolTypes';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports - core flow primitives
 import { BaseCycleFieldsSchema } from '@agent/core/flows/CommonCycleTypes';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import { NormalizedUsageSchema } from '@agent/types/NormalizedUsage';
 
 /**

--- a/src/agent/core/flows/toolUseRound/toolCallParsing.ts
+++ b/src/agent/core/flows/toolUseRound/toolCallParsing.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { AgentTrace } from '@agent/trace';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,

--- a/src/agent/followUp/followUpMessages.ts
+++ b/src/agent/followUp/followUpMessages.ts
@@ -1,5 +1,6 @@
 import type { AgentTrace } from '@agent/trace';
-import type { IModelHandler, SdkToolCall } from '@agent/types/IModelHandler';
+import type { IModelHandler } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import {
   countMediaFilesNeedingVision,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -601,13 +601,12 @@ export abstract class ModelHandler<
    * is a provider-wire-format fact (there's a reasoning channel to preserve
    * across the whole family's API), not a per-model reasoning toggle.
    * `ModelHandlerGLM` overrides it back to `false` even for its
-   * reasoning-capable variants (`glm45`, `glm52`). And Grok reasoning models
-   * (`grok43`, `grok3-`; see {@link isGrokReasoningModel}) never override this
-   * at all, staying at this `false` default, via `ModelHandlerXAI`. Folding
-   * this into `supportsReasoning` would wrongly force batching on
-   * non-reasoning DeepSeek/Kimi/MiniMax variants and wrongly skip it for
-   * reasoning Grok models. Stays an overridable getter: genuinely per-provider
-   * behavior, not a foldable predicate.
+   * reasoning-capable variants (`glm45`, `glm52`). Grok reasoning models
+   * (`grok43`, `grok3-`) likewise stay at this `false` default through
+   * `ModelHandlerXAI`. Folding this into `supportsReasoning` would wrongly
+   * force batching on non-reasoning DeepSeek/Kimi/MiniMax variants and wrongly
+   * skip it for reasoning Grok models. Stays an overridable getter: genuinely
+   * per-provider behavior, not a foldable predicate.
    */
   get requiresBatchedParallelToolResults(): boolean {
     return false;
@@ -733,15 +732,6 @@ export abstract class ModelHandler<
   get isOReasoningModel(): boolean {
     return (
       this.config.provider === ModelProvider.OPENAI &&
-      this.capabilities.supportsReasoning
-    );
-  }
-
-  /** Runtime combinator (provider identity × reasoning capability); see
-   * {@link isOReasoningModel}. */
-  get isGrokReasoningModel(): boolean {
-    return (
-      this.config.provider === ModelProvider.XAI &&
       this.capabilities.supportsReasoning
     );
   }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -33,7 +33,7 @@ import type {
   ExtractResponseResult,
   AnthropicToolCall,
   TokenCountOptions,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   attachStreamDiagnostics,
   handleStreamingFailure,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -29,7 +29,7 @@ import type {
   ExtractResponseResult,
   GoogleToolCall,
   TokenCountOptions,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   handleStreamingFailure,
   takeTail,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -29,7 +29,7 @@ import type {
   ExtractResponseResult,
   GoogleToolCall,
   TokenCountOptions,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   detectStatusCode,
   attachPartialText,

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -13,7 +13,7 @@ import type {
   CreateResponseResult,
   ExtractResponseResult,
   SdkToolCall,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
 import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';

--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -2,7 +2,7 @@
 import { ReasoningEffort } from 'llm-zoo';
 
 // Local file imports
-import type { DeepSeekToolCall } from '@agent/types/IModelHandler';
+import type { DeepSeekToolCall } from '@agent/types/ModelHandlerContracts';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -24,7 +24,7 @@ import type {
   ExtractResponseResult,
   DeepSeekToolCall,
   OpenAIToolCall,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   buildErrorLogData,
   detectRequestId,
@@ -297,7 +297,10 @@ export class ModelHandlerOpenAI<
    * can't drift apart.
    */
   protected get configuresEndTagStopSequence(): boolean {
-    return !this.isOReasoningModel && !this.isGrokReasoningModel;
+    const isGrokReasoningModel =
+      this.config.provider === ModelProvider.XAI &&
+      this.capabilities.supportsReasoning;
+    return !this.isOReasoningModel && !isGrokReasoningModel;
   }
 
   protected buildChatBaseParams(

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -25,7 +25,7 @@ import type {
   ExtractResponseResult,
   OpenAIResponseToolCall,
   TokenCountOptions,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   attachContextWindowError,
   buildErrorLogData,

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import type { ExtractResponseResult } from '@agent/types/IModelHandler';
+import type { ExtractResponseResult } from '@agent/types/ModelHandlerContracts';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { ChatCompletion } from 'openai/resources/chat/completions';
 

--- a/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/reasoningModelHandlerOpenAI.ts
@@ -2,7 +2,7 @@
 import type {
   DeepSeekToolCall,
   OpenAIToolCall,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 
 // Type imports

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -19,7 +19,7 @@ import type {
   CreateResponseResult,
   ExtractResponseResult,
   OpenRouterToolCall,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import {
   detectStatusCode,
   handleStreamingFailure,

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -19,7 +19,7 @@ import type {
   ExtractResponseResult,
   TokenCountOptions,
   VscodeLmToolCall,
-} from '@agent/types/IModelHandler';
+} from '@agent/types/ModelHandlerContracts';
 import { OPENAI_CHAT_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -471,23 +471,36 @@ async function createModelHandlerForResolvedCompatibilityKey(
   // Responses-shaped models the user has opted to drive through their
   // subscription instead of an API key. Gated on the key not being the
   // validation override so the package-validation gate still wins.
-  if (
+  const codexSubscriptionEligible =
     options.allowCodexSubscriptionOverride &&
     compatibilityKey !== 'ModelHandlerValidation' &&
     resolveCodexSubscriptionCapabilitiesForAgentCategory(
       config,
       useOpenRouter,
       options.agentCategory,
-    ) &&
-    (await isCodexSessionRoutableForAgent())
-  ) {
-    logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');
-    const { ModelHandlerCodex } =
-      await import('@agent/modelHandlers/openai/modelHandlerCodex');
-    return finalizeModelHandler(
-      new ModelHandlerCodex(config),
-      'ModelHandlerOpenAIResponse',
-    );
+    ) !== null;
+  if (codexSubscriptionEligible) {
+    let codexSessionRoutable: boolean;
+    try {
+      codexSessionRoutable = await isCodexSessionRoutable();
+    } catch (error) {
+      if (error instanceof CodexAuthError) {
+        throw new AgentError(formatCodexAuthUnavailableMessage(error), {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+
+    if (codexSessionRoutable) {
+      logger.debug(CHANNEL, 'Using ChatGPT subscription (Codex) Handler');
+      const { ModelHandlerCodex } =
+        await import('@agent/modelHandlers/openai/modelHandlerCodex');
+      return finalizeModelHandler(
+        new ModelHandlerCodex(config),
+        'ModelHandlerOpenAIResponse',
+      );
+    }
   }
 
   if (
@@ -565,19 +578,5 @@ async function createModelHandlerForResolvedCompatibilityKey(
         route.compatibilityKey,
       );
     }
-  }
-}
-
-/** Classify retryable/config preflight failures for the agent lifecycle. */
-async function isCodexSessionRoutableForAgent(): Promise<boolean> {
-  try {
-    return await isCodexSessionRoutable();
-  } catch (error) {
-    if (error instanceof CodexAuthError) {
-      throw new AgentError(formatCodexAuthUnavailableMessage(error), {
-        cause: error,
-      });
-    }
-    throw error;
   }
 }

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -1,32 +1,12 @@
 // Local imports - agent components
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import type {
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas/toolResult';
 import type { ProviderMessage } from './ProviderMessage';
-import type { SdkToolCall } from './ModelHandlerContracts';
-
-// Re-exported for existing consumers of this module. These plain data
-// contracts live in `./ModelHandlerContracts` (not here) because
-// `ModelHandler.ts` needs them too, and importing them from this file would
-// recreate the ModelHandler.ts <-> IModelHandler.ts cycle this module exists
-// to avoid — see the note on `IModelHandler` below.
-export type {
-  TokenCountOptions,
-  CreateResponseOptions,
-  CreateResponseResult,
-  ExtractResponseResult,
-  OpenAIToolCall,
-  DeepSeekToolCall,
-  OpenAIResponseToolCall,
-  GoogleToolCall,
-  AnthropicToolCall,
-  OpenRouterToolCall,
-  VscodeLmToolCall,
-  SdkToolCall,
-} from './ModelHandlerContracts';
 
 /**
  * Common port implemented by all model handlers.

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -15,7 +15,7 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ITool } from '@agent/core/tools/ToolTypes';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -8,7 +8,7 @@ import {
 import type { AgentTrace } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
-import type { GoogleToolCall } from '@agent/types/IModelHandler';
+import type { GoogleToolCall } from '@agent/types/ModelHandlerContracts';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import * as configModule from '@utils/config/configUtils';
 import type { Interactions } from '@google/genai';

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -48,7 +48,7 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import type { SdkToolCall } from '@agent/types/IModelHandler';
+import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
 
 // Internal imports
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -11,7 +11,7 @@ import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 // Local imports - model handlers
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { extractToolAttachments } from '@agent/core/tools/toolAttachmentExtraction';
-import type { OpenAIResponseToolCall } from '@agent/types/IModelHandler';
+import type { OpenAIResponseToolCall } from '@agent/types/ModelHandlerContracts';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 
 // Local imports - tools


### PR DESCRIPTION
## Summary

- routes model data-contract imports directly to `ModelHandlerContracts.ts` instead of through `IModelHandler.ts`
- removes the one-use Grok reasoning predicate from the abstract model-handler surface
- moves the one-use Codex routability error translation next to its route decision

## Issue acceptance gates

Closes #8506.

- all 22 former contract consumers name `ModelHandlerContracts` directly
- the load-bearing `IModelHandler` port remains intact
- `isGrokReasoningModel` is removed from the base class and evaluated at its only call site
- `isCodexSessionRoutableForAgent` is removed and its error translation remains at the only route that uses it

## Single source of truth

`src/agent/types/ModelHandlerContracts.ts` is now the only export location for provider tool-call, response option/result, and token-counting contracts. `IModelHandler.ts` exports only the model-handler port it owns.

## Duplication and abstraction budget

No abstraction was added. The change removes one re-export block, one base-class getter, and one private wrapper. The Codex translation remains explicit at the route boundary; the Grok predicate remains a local expression at the stop-sequence decision.

## Net elements (R6)

- files: 25 changed; none added or deleted
- diffstat: +60 / -85, net -25 lines
- exported symbols: 13 re-exported contract names removed from `IModelHandler.ts`; all remain exported from their owning module
- class/function surface: one getter and one private function removed; none added
- classes/interfaces/enums: no definitions added or removed

## Consumer counts (R8)

- former `IModelHandler` module consumers: 22; only 3 true port consumers remain
- `ModelHandlerContracts` consumers: 24 total, comprising the 22 migrated consumers plus `ModelHandler.ts` and `IModelHandler.ts`
- `isGrokReasoningModel`: 1 caller moved inline, then 0 exported/member consumers
- `isCodexSessionRoutableForAgent`: 1 caller moved inline, then 0 consumers
- no event or emit path changed

## Host impact

Extension: none; type-only import routing and shared model-handler internals.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. #8507 separately owns the provider-specific xAI reasoning-effort clamp.

## Validation

- targeted Prettier and `git diff --check`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused Vitest suites: 77 tests passed
- full Vitest suite: 711 files passed, 1 skipped; 6,445 tests passed, 4 skipped
- independent review: no correctness, layering, public-surface, or style findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only import moves and local inlining with no runtime behavior change beyond the same Codex auth translation living at the factory call site.
> 
> **Overview**
> **Import layering:** Provider tool-call, response, and token-count types now import from `ModelHandlerContracts.ts` instead of the `IModelHandler` re-export barrel. `IModelHandler.ts` keeps only the handler port type; the large `export type { … }` block is removed.
> 
> **Model handler surface:** `isGrokReasoningModel` is dropped from `ModelHandler`; `modelHandlerOpenAI` inlines the same XAI + `supportsReasoning` check for `configuresEndTagStopSequence`. Related base-class comments are tightened.
> 
> **Codex routing:** `isCodexSessionRoutableForAgent` is removed; `ModelFactory` calls `isCodexSessionRoutable()` directly in the subscription branch and maps `CodexAuthError` to `AgentError` there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d970fe09703a380533bd28575f9f2bf659f7c996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->