### PR TITLE
refactor(agent): localize xAI reasoning validation

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -737,23 +737,12 @@ export abstract class ModelHandler<
   }
 
   /**
-   * Validates reasoning effort based on provider-specific support
-   * @param effort The reasoning effort level to validate
-   * @returns Valid reasoning effort string for the current provider
+   * Normalizes a reasoning-effort value for the concrete handler.
+   * Provider handlers override this hook when their API supports a narrower
+   * vocabulary.
    */
   protected validateReasoningEffort(effort: string): string {
-    if (this.config.provider !== ModelProvider.XAI) return effort;
-    // Current Grok reasoning models (grok-4.3 / grok-4.5) document
-    // low/medium/high (docs.x.ai reasoning guide); xhigh only exists on the
-    // multi-agent variant where it means agent count, so clamp it to high.
-    if (effort === 'low' || effort === 'medium' || effort === 'high') {
-      return effort;
-    }
-
-    this.logger.warn(
-      `xAI models only support 'low', 'medium', or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
-    );
-    return 'high';
+    return effort;
   }
 
   /**

--- a/src/agent/modelHandlers/openai/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerXAI.ts
@@ -12,8 +12,8 @@ import type { ChatCompletion } from 'openai/resources/chat/completions';
  *
  * Note: the legacy grok-4 generation (deprecated May 2026) rejected the
  * reasoning_effort parameter outright. Current reasoning models (grok-4.3,
- * grok-4.5) document low/medium/high effort control — see
- * validateReasoningEffort in the base class for the clamp.
+ * grok-4.5) document low/medium/high effort control; this handler normalizes
+ * unsupported effort levels before sending them to xAI.
  *
  * processThinkingBlock is inherited from ModelHandlerOpenAI which already
  * extracts reasoning_content from the response message.
@@ -21,6 +21,18 @@ import type { ChatCompletion } from 'openai/resources/chat/completions';
  * usageProvider and toolCallProvider inherit from base class via config.provider.
  */
 export class ModelHandlerXAI extends ModelHandlerOpenAI {
+  protected override validateReasoningEffort(effort: string): string {
+    // xhigh only exists on the multi-agent variant, where it means agent count.
+    if (effort === 'low' || effort === 'medium' || effort === 'high') {
+      return effort;
+    }
+
+    this.logger.warn(
+      `xAI models only support 'low', 'medium', or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
+    );
+    return 'high';
+  }
+
   /** Extracts response text and usage statistics from API response. */
   override extractResponse(
     responseObject: ChatCompletion,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -150,6 +150,20 @@ describe('ModelHandlerOpenRouterNative reasoning-level override', () => {
       assert.equal(handler.supportsReasoningLevelOverride, expected);
     },
   );
+
+  it('preserves xhigh for xAI models routed through OpenRouter', () => {
+    class TestableHandler extends ModelHandlerOpenRouterNative {
+      validateReasoningEffortForTest(effort: string): string {
+        return this.validateReasoningEffort(effort);
+      }
+    }
+
+    const handler = new TestableHandler(
+      buildConfig({ provider: ModelProvider.XAI }),
+    );
+
+    assert.equal(handler.validateReasoningEffortForTest('xhigh'), 'xhigh');
+  });
 });
 
 describe('ModelHandlerOpenRouterNative retry ownership', () => {


### PR DESCRIPTION
## Summary

- make the shared model-handler reasoning normalizer provider-neutral
- move xAI's `low | medium | high` validation and above-high clamp into `ModelHandlerXAI`
- verify that xAI models routed through OpenRouter retain OpenRouter's broader `xhigh` vocabulary

Closes #8507

## Issue acceptance gates

- [x] `ModelHandler.validateReasoningEffort` is an identity default
- [x] direct xAI requests still clamp unsupported effort levels to `high`
- [x] the xAI rule is owned by `ModelHandlerXAI`
- [x] the sibling GPT-5 rule in `getEffectiveReasoningEffort` is unchanged
- [x] OpenRouter does not acquire an xAI-specific branch

## Single source of truth

Before this change, the abstract base knew the xAI API's reasoning vocabulary while the xAI handler contained no corresponding policy. After this change, the concrete xAI handler is the sole owner of that provider rule. The abstract base exposes only the overridable normalization hook.

## Duplication and abstraction budget

No new production type, helper, module, or service was added. The existing override point is used directly. The xAI rule moved without duplication; sibling DeepSeek and GLM overrides remain unchanged.

## Net elements

- production methods added: 1 override
- production methods removed: 0
- provider branches removed from the shared base: 1
- tests added: 1
- files changed: 3
- net lines: +15

## Consumer counts

- `validateReasoningEffort` remains one protected hook used by the OpenAI-compatible and OpenRouter request paths
- concrete overrides: DeepSeek, GLM, xAI
- the base implementation now has no provider dependency

## Host impact

None. This changes model-handler ownership only; CLI, extension, desktop, and persisted formats are unaffected.

## Scheduled refactoring

None. The target ownership is complete in this PR.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused Vitest: 4 files, 32 tests passed
- full Vitest: 711 files passed, 1 skipped; 6,446 tests passed, 4 skipped
- Prettier and `git diff --check`
- independent review: no actionable findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of reasoning-effort normalization with behavior preserved for direct xAI vs OpenRouter; no auth, persistence, or API surface changes.
> 
> **Overview**
> **xAI reasoning normalization** now lives only on `ModelHandlerXAI` instead of branching on `ModelProvider.XAI` in the shared `ModelHandler` base.
> 
> `ModelHandler.validateReasoningEffort` is a pass-through default; direct xAI calls still accept `low` / `medium` / `high` and map anything else (e.g. `xhigh`) to `high` with the same warning. **OpenRouter** paths use `ModelHandlerOpenRouterNative`, which inherits the identity default—so xAI models routed through OpenRouter keep broader effort values like `xhigh` instead of being clamped by base-class xAI rules.
> 
> A Vitest case asserts that OpenRouter + `ModelProvider.XAI` preserves `xhigh`. GPT-5 tier capping in `getEffectiveReasoningEffort` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c4630b353cc35f70aef453a337f2e6e71d182f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->