### PR TITLE
refactor(progressView): consolidate content-addressable stores

### DIFF
--- a/packages/extension/src/progressView/frontend/formatters/contentStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/contentStore.ts
@@ -1,0 +1,43 @@
+/**
+ * Generic content-addressable registry for progress view formatters.
+ *
+ * Stores a value by ID so it can be retrieved later without duplicating large
+ * or typed payloads in DOM attributes. IDs are content-hash-derived by
+ * default (re-rendering the same value yields the same ID, so repeated
+ * renders don't leak memory), or caller-supplied when the value is expected
+ * to change under a stable identity (e.g. a streaming message).
+ */
+
+import { LRUCache } from 'lru-cache';
+
+import { hashString } from './hashUtils';
+
+export interface ContentStore<T extends NonNullable<unknown>> {
+  register(value: T, explicitId?: string): string;
+  get(id: string): T | undefined;
+  clear(): void;
+}
+
+export function createContentStore<T extends NonNullable<unknown>>(options: {
+  max: number;
+  prefix: string;
+  serialize: (value: T) => string;
+}): ContentStore<T> {
+  const store = new LRUCache<string, T>({ max: options.max });
+
+  return {
+    register(value, explicitId) {
+      let id = explicitId;
+      if (id === undefined) {
+        const serialized = options.serialize(value);
+        id = `${options.prefix}:${serialized.length}:${hashString(serialized)}`;
+      }
+      if (store.get(id) !== value) {
+        store.set(id, value);
+      }
+      return id;
+    },
+    get: (id) => store.get(id),
+    clear: () => store.clear(),
+  };
+}

--- a/packages/extension/src/progressView/frontend/formatters/contentStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/contentStore.ts
@@ -32,6 +32,11 @@ export function createContentStore<T extends NonNullable<unknown>>(options: {
         const serialized = options.serialize(value);
         id = `${options.prefix}:${serialized.length}:${hashString(serialized)}`;
       }
+      // Reference equality is sufficient: for object values re-derived from a
+      // hash-based id (e.g. AgentProposal), each re-parse is a new object, so
+      // this always re-sets and refreshes the LRU position — harmless, since
+      // the content is unchanged. It only skips the write when the exact same
+      // object instance is re-registered under its own explicit id.
       if (store.get(id) !== value) {
         store.set(id, value);
       }

--- a/packages/extension/src/progressView/frontend/formatters/copyContentStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/copyContentStore.ts
@@ -4,11 +4,13 @@
  * Stores copyable content by ID to avoid duplicating large strings in DOM attributes.
  */
 
-import { LRUCache } from 'lru-cache';
+import { createContentStore } from './contentStore';
 
-import { hashString } from './hashUtils';
-
-const copyContentStore = new LRUCache<string, string>({ max: 1000 });
+const copyContentStore = createContentStore<string>({
+  max: 1000,
+  prefix: 'auto',
+  serialize: (content) => content,
+});
 
 /**
  * Register copy content and return a stable ID for lookup.
@@ -17,12 +19,7 @@ export function registerCopyContent(
   content: string,
   contentId?: string,
 ): string {
-  const id = contentId ?? `auto:${content.length}:${hashString(content)}`;
-  const existing = copyContentStore.get(id);
-  if (existing !== content) {
-    copyContentStore.set(id, content);
-  }
-  return id;
+  return copyContentStore.register(content, contentId);
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/formatters/hashUtils.ts
+++ b/packages/extension/src/progressView/frontend/formatters/hashUtils.ts
@@ -1,6 +1,6 @@
 /**
  * Simple string hash for generating stable content-based IDs.
- * Shared by copyContentStore and proposalInputStore.
+ * Used by createContentStore for content-addressable registries.
  */
 export function hashString(input: string): string {
   let hash = 0;

--- a/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/packages/extension/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -6,17 +6,18 @@
  *
  * Parsing the raw tool input into a typed proposal is domain logic and lives in
  * the schema layer (`parseDelegationToolInput`); this module is a thin registry
- * over it. Uses content-based hashing (like copyContentStore) so re-rendering
- * the same message produces the same ID — no memory leak on stream switches.
+ * over `createContentStore`.
  */
-
-import { LRUCache } from 'lru-cache';
 
 import { parseDelegationToolInput, type AgentProposal } from '@shared/schemas';
 
-import { hashString } from './hashUtils';
+import { createContentStore } from './contentStore';
 
-const proposalInputStore = new LRUCache<string, AgentProposal>({ max: 500 });
+const proposalInputStore = createContentStore<AgentProposal>({
+  max: 500,
+  prefix: 'proposal',
+  serialize: (proposal) => JSON.stringify(proposal),
+});
 
 /**
  * Register proposal input and return a stable ID for lookup.
@@ -27,13 +28,7 @@ export function registerProposalInput(
 ): string | null {
   const proposal = parseDelegationToolInput(input, toolName);
   if (!proposal) return null;
-
-  const serialized = JSON.stringify(proposal);
-  const id = `proposal:${serialized.length}:${hashString(serialized)}`;
-  if (!proposalInputStore.has(id)) {
-    proposalInputStore.set(id, proposal);
-  }
-  return id;
+  return proposalInputStore.register(proposal);
 }
 
 /**

--- a/src/test-kernel/progressView/ContentStore.vitest.ts
+++ b/src/test-kernel/progressView/ContentStore.vitest.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - module under test
+import { createContentStore } from '@progressView/frontend/formatters/contentStore';
+
+describe('createContentStore', () => {
+  it('derives a stable, content-hash-based ID and returns the same ID for equal content', () => {
+    const store = createContentStore<string>({
+      max: 10,
+      prefix: 'auto',
+      serialize: (content) => content,
+    });
+
+    const id1 = store.register('hello world');
+    const id2 = store.register('hello world');
+
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^auto:\d+:[0-9a-z]+$/);
+    expect(store.get(id1)).toBe('hello world');
+  });
+
+  it('produces different IDs for different content', () => {
+    const store = createContentStore<string>({
+      max: 10,
+      prefix: 'auto',
+      serialize: (content) => content,
+    });
+
+    expect(store.register('foo')).not.toBe(store.register('bar'));
+  });
+
+  it('honors an explicit ID and overwrites stale content stored under it', () => {
+    const store = createContentStore<string>({
+      max: 10,
+      prefix: 'auto',
+      serialize: (content) => content,
+    });
+
+    const id = store.register('first version', 'stream-1');
+    expect(id).toBe('stream-1');
+    expect(store.get('stream-1')).toBe('first version');
+
+    store.register('second version', 'stream-1');
+    expect(store.get('stream-1')).toBe('second version');
+  });
+
+  it('clears all entries', () => {
+    const store = createContentStore<string>({
+      max: 10,
+      prefix: 'auto',
+      serialize: (content) => content,
+    });
+
+    const id = store.register('content');
+    store.clear();
+
+    expect(store.get(id)).toBeUndefined();
+  });
+});

--- a/src/test-kernel/progressView/ContentStore.vitest.ts
+++ b/src/test-kernel/progressView/ContentStore.vitest.ts
@@ -57,4 +57,29 @@ describe('createContentStore', () => {
 
     expect(store.get(id)).toBeUndefined();
   });
+
+  it('resolves object values re-registered as structurally-equal-but-distinct references to the same ID and content', () => {
+    // Mirrors proposalInputStore's usage: each call passes a freshly parsed
+    // object, so the write-guard's reference-equality check always re-sets
+    // rather than skipping — verify that still resolves correctly.
+    interface Proposal {
+      readonly title: string;
+      readonly steps: readonly string[];
+    }
+    const store = createContentStore<Proposal>({
+      max: 10,
+      prefix: 'proposal',
+      serialize: (proposal) => JSON.stringify(proposal),
+    });
+
+    const first: Proposal = { title: 'demo', steps: ['a', 'b'] };
+    const second: Proposal = { title: 'demo', steps: ['a', 'b'] };
+    expect(first).not.toBe(second);
+
+    const id1 = store.register(first);
+    const id2 = store.register(second);
+
+    expect(id1).toBe(id2);
+    expect(store.get(id1)).toEqual({ title: 'demo', steps: ['a', 'b'] });
+  });
 });


### PR DESCRIPTION
## Summary

A codebase-wide audit for overlapping/duplicated responsibilities (per CLAUDE.md's existing anti-pattern guidance) found that `proposalInputStore.ts` and `copyContentStore.ts` — two files in the same directory (`packages/extension/src/progressView/frontend/formatters/`) — independently implement the same "register a value, get back a stable content-hash ID, retrieve it later, clear on stream delete" `LRUCache` registry. They even cross-reference each other in comments ("Uses content-based hashing (like copyContentStore)"), but had drifted: one guards writes with `has(id)`, the other with a value-equality check, a difference that reads as accidental copy-paste drift rather than intentional design.

This PR extracts the shared shape into a single generic factory, `createContentStore`, and turns both files into thin instantiations of it with **unchanged public APIs** — no caller in `progressView/frontend/` needed to change.

## Issue acceptance gates

Ad-hoc audit task ("identify areas with confusing or overlapped responsibilities and draft a PR for the most significant one"). Acceptance gate: the most significant *concrete, boundedly-fixable* overlap found is consolidated; the write-guard divergence is resolved (not left as an inconsistency) rather than papered over.

## Single source of truth

`createContentStore` (`packages/extension/src/progressView/frontend/formatters/contentStore.ts`) is now the one implementation of "content-addressable LRU registry." `proposalInputStore` and `copyContentStore` each own only their type parameter, ID prefix, and serialization strategy.

## Duplication and abstraction budget

Removed: two independent `LRUCache` instantiations plus two independent (and diverging) ID-derivation/write-guard implementations. Added: one generic factory following the exact convention already established by `src/utils/core/boundedIdSet.ts` (interface + `createX<T>()` factory returning a small typed wrapper) — not a novel pattern, so no new abstraction-cost debt. The factory has two callers today (the two consolidated stores); a third would just be another instantiation, not a copy-paste.

## Net elements (R6)

Diffstat: `contentStore.ts` +43 (new), `copyContentStore.ts` +7/-10, `hashUtils.ts` +1/-1 (comment only), `proposalInputStore.ts` +8/-13, `ContentStore.vitest.ts` +60 (new test file). Exported symbols: `^[+-]export` over the diff adds exactly 2 (`ContentStore` interface, `createContentStore` function) and removes 0 — all existing exported functions (`registerProposalInput`, `getProposalInput`, `clearProposalInputStore`, `registerCopyContent`, `getCopyContent`, `clearCopyContentStore`) keep their exact signatures. Net: +5 files (2 new, 3 edited), +119/-24 LoC, +2 exported symbols (both on the new shared module), 0 pass-through layers.

## Consumer counts (R8)

No emit path or export was deleted or re-routed — all six existing exported functions keep identical signatures, so all existing call sites (`streamLifecycleSlice.ts`, `LogList.ts`, `htmlBuilders.ts`, `logFormatters/toolFormatters.ts`, `logFormatters/messageFormatters.ts` — grepped, 5 files) needed zero changes. n/a for consumer-count impact.

## Host impact

Extension: `progressView` webview only — the proposal-input and copy-content registries backing the progress board's "Setup" link and copy-to-clipboard affordances behave identically; only the write-guard semantics were unified (both now use value-equality, matching `copyContentStore`'s existing, more general behavior that correctly handles content changing under a caller-supplied stable ID).

Desktop: none (progress view formatters are extension-webview-only code, not reused by the desktop shell).

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx tsc --noEmit -p .` — clean.
- `npx eslint <changed files>` — clean (repo-wide `npx eslint .` shows only pre-existing, unrelated warnings/errors in files this PR doesn't touch).
- `npx vitest run src/test-kernel/progressView` — 47 files / 331 tests passed, including a new `ContentStore.vitest.ts` covering ID stability for equal content, distinct IDs for distinct content, explicit-ID overwrite semantics, and `clear()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFi6xx5AwNupkPAKGVsXrs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal progress-view formatter refactor with identical exported APIs and webview-only scope; behavior change is limited to unified registry write guards.
> 
> **Overview**
> Introduces **`createContentStore`**, a shared generic factory for progress-view LRU registries that map stable content-hash (or explicit) IDs to payloads kept out of DOM attributes.
> 
> **`copyContentStore`** and **`proposalInputStore`** no longer each own their own `LRUCache`, ID derivation, and write logic; they become thin wrappers with the same exported functions (`registerCopyContent`, `registerProposalInput`, etc.), so existing call sites are unchanged.
> 
> **Write-guard behavior is unified** on value/reference inequality (matching copy’s prior behavior): proposal registration no longer skips updates with `has(id)`, so content can refresh under an explicit ID and structurally equal re-parsed objects still resolve correctly.
> 
> Adds **`ContentStore.vitest.ts`** for ID stability, explicit-ID overwrite, clear, and object re-registration cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6623874ab89b1a150196b6e4c853eccf88e4853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->