### PR TITLE
refactor(progress): hoist fact-error wrapping to dispatch sites

### DIFF
--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -128,116 +128,94 @@ export class ProgressFactApplier {
   private progressThrottleTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingProgressUpdates = new Map<StreamTabId, ConversationProgress>();
 
-  /** Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive. */
+  /**
+   * Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive.
+   * Handlers hold only their own logic — `handleRunFact` wraps each dispatch in
+   * `applyFact` once, deriving the error context from the fact type.
+   */
   private readonly runFactHandlers: RunFactHandlers = {
     usage: (streamId, event) => {
       const payload = toUpdateStreamUsagePayload(event.data, streamId);
       if (payload) {
-        this.applyFact('failed to handle usage fact', () =>
-          this.handleUpdateStreamUsage(payload),
-        );
+        this.handleUpdateStreamUsage(payload);
       }
     },
     'run.config': (_streamId, event) => {
-      this.applyFact('failed to handle run.config fact', () =>
-        this.handleSetTaskState({
-          streamId: event.streamId,
-          executionId: event.executionId,
-          taskState: agentConfigToTaskState(event.config),
-        }),
-      );
+      this.handleSetTaskState({
+        streamId: event.streamId,
+        executionId: event.executionId,
+        taskState: agentConfigToTaskState(event.config),
+      });
     },
     status: (_streamId, event) => {
-      this.applyFact('failed to handle status fact', () =>
-        this.setStreamStatus(
-          event.streamId,
-          event.phase,
-          event.previousPhase,
-          event.substate,
-        ),
+      this.setStreamStatus(
+        event.streamId,
+        event.phase,
+        event.previousPhase,
+        event.substate,
       );
     },
     updateTodos: (_streamId, event) => {
-      this.applyFact('failed to handle updateTodos fact', () =>
-        this.handleUpdateTodos(event),
-      );
+      this.handleUpdateTodos(event);
     },
     updatePlan: (_streamId, event) => {
-      this.applyFact('failed to handle updatePlan fact', () =>
-        this.handleUpdatePlan(event),
-      );
+      this.handleUpdatePlan(event);
     },
     addOutputFiles: (_streamId, event) => {
-      this.applyFact('failed to handle addOutputFiles fact', () =>
-        this.handleAddOutputFiles(event),
-      );
+      this.handleAddOutputFiles(event);
     },
     updateMissingOutputs: (_streamId, event) => {
-      this.applyFact('failed to handle updateMissingOutputs fact', () =>
-        this.handleUpdateMissingOutputs(event),
-      );
+      this.handleUpdateMissingOutputs(event);
     },
     updateCompileFailures: (_streamId, event) => {
-      this.applyFact('failed to handle updateCompileFailures fact', () =>
-        this.handleUpdateCompileFailures(event),
-      );
+      this.handleUpdateCompileFailures(event);
     },
     goalPaused: () => {
       // No progress-view state change; listed only to keep the run-fact type
       // set exhaustive (it stays in the subscription filter for parity).
     },
     'conversation.progress': (streamId, event) => {
-      this.applyFact('failed to handle conversation.progress fact', () =>
-        this.handleUpdateConversationProgress({
-          streamId,
-          progress: event.progress,
-        }),
-      );
+      this.handleUpdateConversationProgress({
+        streamId,
+        progress: event.progress,
+      });
     },
     'stage.start': (streamId, event) => {
       if (event.kind !== 'round') return;
-      this.applyFact('failed to handle stage.start fact', () =>
-        this.handleUpdateRoundStage({
-          streamId,
-          roundStage: {
-            index: event.index ?? 0,
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
-        }),
-      );
+      this.handleUpdateRoundStage({
+        streamId,
+        roundStage: {
+          index: event.index ?? 0,
+          ...(event.total !== undefined && event.total > 0
+            ? { total: event.total }
+            : {}),
+        },
+      });
     },
     'child.activity': (_streamId, event) => {
       if (event.kind === 'subagents') {
-        this.applyFact('failed to handle subagent activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeSubagents',
-            countField: 'finishedSubagentCount',
-            next: [...event.children],
-          }),
-        );
+        this.updateActiveChildren(event.parentStreamId, {
+          activeField: 'activeSubagents',
+          countField: 'finishedSubagentCount',
+          next: [...event.children],
+        });
         return;
       }
       if (event.kind === 'processes') {
-        this.applyFact('failed to handle process activity fact', () =>
-          this.updateActiveChildren(event.parentStreamId, {
-            activeField: 'activeProcesses',
-            countField: 'finishedProcessCount',
-            next: [...event.processes],
-          }),
-        );
+        this.updateActiveChildren(event.parentStreamId, {
+          activeField: 'activeProcesses',
+          countField: 'finishedProcessCount',
+          next: [...event.processes],
+        });
       }
     },
     'process.output': (_streamId, event) => {
-      this.applyFact('failed to handle process.output fact', () =>
-        this.handleUpdateProcessOutput({
-          parentStreamId: event.parentStreamId,
-          executionId: event.executionId,
-          stdout: event.stdout,
-          stderr: event.stderr,
-        }),
-      );
+      this.handleUpdateProcessOutput({
+        parentStreamId: event.parentStreamId,
+        executionId: event.executionId,
+        stdout: event.stdout,
+        stderr: event.stderr,
+      });
     },
   };
 
@@ -296,55 +274,45 @@ export class ProgressFactApplier {
   }
 
   handleSessionFact(fact: SessionFact): void {
+    this.applyFact(`failed to handle ${fact.type} fact`, () =>
+      this.dispatchSessionFact(fact),
+    );
+  }
+
+  private dispatchSessionFact(fact: SessionFact): void {
     switch (fact.type) {
       case 'goalStateChanged':
         return;
       case 'inquiryThreadUpdated':
-        this.applyFact('failed to handle inquiryThreadUpdated fact', () =>
-          this.handleInquiryThreadUpdated(fact.payload),
-        );
+        this.handleInquiryThreadUpdated(fact.payload);
         return;
       case 'clearMissingOutputs':
-        this.applyFact('failed to handle clearMissingOutputs fact', () =>
-          this.handleClearMissingOutputs(fact.payload),
-        );
+        this.handleClearMissingOutputs(fact.payload);
         return;
       case 'updateQueuedFollowUps':
-        this.applyFact('failed to handle updateQueuedFollowUps fact', () =>
-          this.handleUpdateQueuedFollowUps(fact.payload),
-        );
+        this.handleUpdateQueuedFollowUps(fact.payload);
         return;
       case 'followUpSent':
         return;
       case 'setActiveStream':
-        this.applyFact('failed to handle setActiveStream fact', () =>
-          this.handleSetActiveStream(fact.payload),
-        );
+        this.handleSetActiveStream(fact.payload);
         return;
       case 'updateStreamDescription':
-        this.applyFact('failed to handle updateStreamDescription fact', () =>
-          this.handleUpdateStreamDescription(fact.payload),
-        );
+        this.handleUpdateStreamDescription(fact.payload);
         return;
       case 'updateStreamStatus':
-        this.applyFact('failed to handle updateStreamStatus fact', () =>
-          this.setStreamStatus(
-            fact.payload.streamId,
-            fact.payload.status,
-            fact.payload.previousStatus,
-            fact.payload.substate,
-          ),
+        this.setStreamStatus(
+          fact.payload.streamId,
+          fact.payload.status,
+          fact.payload.previousStatus,
+          fact.payload.substate,
         );
         return;
       case 'setParentStream':
-        this.applyFact('failed to handle setParentStream fact', () =>
-          this.handleSetParentStream(fact.payload),
-        );
+        this.handleSetParentStream(fact.payload);
         return;
       case 'removeStream':
-        this.applyFact('failed to handle removeStream fact', () =>
-          this.deleteStream(fact.payload.streamId),
-        );
+        this.deleteStream(fact.payload.streamId);
         return;
     }
     assertNever(fact, 'Unhandled progress-view session fact');
@@ -360,7 +328,11 @@ export class ProgressFactApplier {
         (streamId: StreamTabId, event: AgentEvent) => void
       >
     >;
-    handlers[event.type]?.(streamId, event);
+    const handler = handlers[event.type];
+    if (!handler) return;
+    this.applyFact(`failed to handle ${event.type} fact`, () =>
+      handler(streamId, event),
+    );
   }
 
   private applyFact(context: string, handle: () => void | Promise<void>): void {

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -111,7 +111,7 @@ type RunFactHandlers = {
   [K in RunFactType]: (
     streamId: StreamTabId,
     event: Extract<AgentEvent, { type: K }>,
-  ) => void;
+  ) => void | Promise<void>;
 };
 
 function getDefaultProgressStreamControls(): ProgressStreamControls {
@@ -312,22 +312,15 @@ export class ProgressFactApplier {
     >;
     const handler = handlers[event.type];
     if (!handler) return;
-    this.applyFact(this.runFactErrorContext(event), () =>
-      handler(streamId, event),
-    );
-  }
-
-  /**
-   * Error context for a run fact. Every type derives its context from
-   * `event.type`, except `child.activity` — the one fact whose failure context
-   * was historically keyed on `event.kind` (subagents vs processes), preserved
-   * here so those failures stay distinguishable in logs.
-   */
-  private runFactErrorContext(event: AgentEvent): string {
-    if (event.type === 'child.activity') {
-      return `failed to handle ${event.kind} activity fact`;
-    }
-    return `failed to handle ${event.type} fact`;
+    // Every type derives its context from `event.type`, except `child.activity`
+    // — the one fact whose failure context was historically keyed on
+    // `event.kind` (subagents vs processes), preserved so those failures stay
+    // distinguishable in logs.
+    const context =
+      event.type === 'child.activity'
+        ? `failed to handle ${event.kind} activity fact`
+        : `failed to handle ${event.type} fact`;
+    this.applyFact(context, () => handler(streamId, event));
   }
 
   private applyFact(context: string, handle: () => void | Promise<void>): void {

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -130,59 +130,48 @@ export class ProgressFactApplier {
 
   /**
    * Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive.
-   * Handlers hold only their own logic — `handleRunFact` wraps each dispatch in
-   * `applyFact` once, deriving the error context from the fact type.
+   * Handlers hold only their own logic and RETURN it — `handleRunFact` wraps
+   * each dispatch in `applyFact` once. Returning (rather than discarding) the
+   * call keeps async handlers' promises flowing to `applyFact`, so a rejection
+   * after an await is still logged instead of becoming an unhandled rejection.
    */
   private readonly runFactHandlers: RunFactHandlers = {
     usage: (streamId, event) => {
       const payload = toUpdateStreamUsagePayload(event.data, streamId);
-      if (payload) {
-        this.handleUpdateStreamUsage(payload);
-      }
+      if (payload) return this.handleUpdateStreamUsage(payload);
     },
-    'run.config': (_streamId, event) => {
+    'run.config': (_streamId, event) =>
       this.handleSetTaskState({
         streamId: event.streamId,
         executionId: event.executionId,
         taskState: agentConfigToTaskState(event.config),
-      });
-    },
-    status: (_streamId, event) => {
+      }),
+    status: (_streamId, event) =>
       this.setStreamStatus(
         event.streamId,
         event.phase,
         event.previousPhase,
         event.substate,
-      );
-    },
-    updateTodos: (_streamId, event) => {
-      this.handleUpdateTodos(event);
-    },
-    updatePlan: (_streamId, event) => {
-      this.handleUpdatePlan(event);
-    },
-    addOutputFiles: (_streamId, event) => {
-      this.handleAddOutputFiles(event);
-    },
-    updateMissingOutputs: (_streamId, event) => {
-      this.handleUpdateMissingOutputs(event);
-    },
-    updateCompileFailures: (_streamId, event) => {
-      this.handleUpdateCompileFailures(event);
-    },
+      ),
+    updateTodos: (_streamId, event) => this.handleUpdateTodos(event),
+    updatePlan: (_streamId, event) => this.handleUpdatePlan(event),
+    addOutputFiles: (_streamId, event) => this.handleAddOutputFiles(event),
+    updateMissingOutputs: (_streamId, event) =>
+      this.handleUpdateMissingOutputs(event),
+    updateCompileFailures: (_streamId, event) =>
+      this.handleUpdateCompileFailures(event),
     goalPaused: () => {
       // No progress-view state change; listed only to keep the run-fact type
       // set exhaustive (it stays in the subscription filter for parity).
     },
-    'conversation.progress': (streamId, event) => {
+    'conversation.progress': (streamId, event) =>
       this.handleUpdateConversationProgress({
         streamId,
         progress: event.progress,
-      });
-    },
+      }),
     'stage.start': (streamId, event) => {
       if (event.kind !== 'round') return;
-      this.handleUpdateRoundStage({
+      return this.handleUpdateRoundStage({
         streamId,
         roundStage: {
           index: event.index ?? 0,
@@ -194,29 +183,27 @@ export class ProgressFactApplier {
     },
     'child.activity': (_streamId, event) => {
       if (event.kind === 'subagents') {
-        this.updateActiveChildren(event.parentStreamId, {
+        return this.updateActiveChildren(event.parentStreamId, {
           activeField: 'activeSubagents',
           countField: 'finishedSubagentCount',
           next: [...event.children],
         });
-        return;
       }
       if (event.kind === 'processes') {
-        this.updateActiveChildren(event.parentStreamId, {
+        return this.updateActiveChildren(event.parentStreamId, {
           activeField: 'activeProcesses',
           countField: 'finishedProcessCount',
           next: [...event.processes],
         });
       }
     },
-    'process.output': (_streamId, event) => {
+    'process.output': (_streamId, event) =>
       this.handleUpdateProcessOutput({
         parentStreamId: event.parentStreamId,
         executionId: event.executionId,
         stdout: event.stdout,
         stderr: event.stderr,
-      });
-    },
+      }),
   };
 
   constructor(
@@ -274,48 +261,43 @@ export class ProgressFactApplier {
   }
 
   handleSessionFact(fact: SessionFact): void {
-    this.applyFact(`failed to handle ${fact.type} fact`, () =>
-      this.dispatchSessionFact(fact),
-    );
-  }
-
-  private dispatchSessionFact(fact: SessionFact): void {
-    switch (fact.type) {
-      case 'goalStateChanged':
-        return;
-      case 'inquiryThreadUpdated':
-        this.handleInquiryThreadUpdated(fact.payload);
-        return;
-      case 'clearMissingOutputs':
-        this.handleClearMissingOutputs(fact.payload);
-        return;
-      case 'updateQueuedFollowUps':
-        this.handleUpdateQueuedFollowUps(fact.payload);
-        return;
-      case 'followUpSent':
-        return;
-      case 'setActiveStream':
-        this.handleSetActiveStream(fact.payload);
-        return;
-      case 'updateStreamDescription':
-        this.handleUpdateStreamDescription(fact.payload);
-        return;
-      case 'updateStreamStatus':
-        this.setStreamStatus(
-          fact.payload.streamId,
-          fact.payload.status,
-          fact.payload.previousStatus,
-          fact.payload.substate,
-        );
-        return;
-      case 'setParentStream':
-        this.handleSetParentStream(fact.payload);
-        return;
-      case 'removeStream':
-        this.deleteStream(fact.payload.streamId);
-        return;
-    }
-    assertNever(fact, 'Unhandled progress-view session fact');
+    // Wrap once, and RETURN each case so async handlers' promises reach
+    // `applyFact` (a discarded promise would let a post-await rejection escape
+    // `withEventErrorHandling`'s thenable check as an unhandled rejection). The
+    // switch is inlined here rather than in a single-caller helper, mirroring
+    // `handleRunFact`'s inline table lookup. `assertNever` stays inside the
+    // wrapper — an unreachable exhaustiveness guard that would only ever be
+    // logged, never thrown, and the union is closed so it never fires.
+    this.applyFact(`failed to handle ${fact.type} fact`, () => {
+      switch (fact.type) {
+        case 'goalStateChanged':
+          return;
+        case 'inquiryThreadUpdated':
+          return this.handleInquiryThreadUpdated(fact.payload);
+        case 'clearMissingOutputs':
+          return this.handleClearMissingOutputs(fact.payload);
+        case 'updateQueuedFollowUps':
+          return this.handleUpdateQueuedFollowUps(fact.payload);
+        case 'followUpSent':
+          return;
+        case 'setActiveStream':
+          return this.handleSetActiveStream(fact.payload);
+        case 'updateStreamDescription':
+          return this.handleUpdateStreamDescription(fact.payload);
+        case 'updateStreamStatus':
+          return this.setStreamStatus(
+            fact.payload.streamId,
+            fact.payload.status,
+            fact.payload.previousStatus,
+            fact.payload.substate,
+          );
+        case 'setParentStream':
+          return this.handleSetParentStream(fact.payload);
+        case 'removeStream':
+          return this.deleteStream(fact.payload.streamId);
+      }
+      assertNever(fact, 'Unhandled progress-view session fact');
+    });
   }
 
   handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
@@ -325,14 +307,27 @@ export class ProgressFactApplier {
     const handlers = this.runFactHandlers as Partial<
       Record<
         AgentEvent['type'],
-        (streamId: StreamTabId, event: AgentEvent) => void
+        (streamId: StreamTabId, event: AgentEvent) => void | Promise<void>
       >
     >;
     const handler = handlers[event.type];
     if (!handler) return;
-    this.applyFact(`failed to handle ${event.type} fact`, () =>
+    this.applyFact(this.runFactErrorContext(event), () =>
       handler(streamId, event),
     );
+  }
+
+  /**
+   * Error context for a run fact. Every type derives its context from
+   * `event.type`, except `child.activity` — the one fact whose failure context
+   * was historically keyed on `event.kind` (subagents vs processes), preserved
+   * here so those failures stay distinguishable in logs.
+   */
+  private runFactErrorContext(event: AgentEvent): string {
+    if (event.type === 'child.activity') {
+      return `failed to handle ${event.kind} activity fact`;
+    }
+    return `failed to handle ${event.type} fact`;
   }
 
   private applyFact(context: string, handle: () => void | Promise<void>): void {

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -316,10 +316,11 @@ export class ProgressFactApplier {
     // — the one fact whose failure context was historically keyed on
     // `event.kind` (subagents vs processes), preserved so those failures stay
     // distinguishable in logs.
-    const context =
-      event.type === 'child.activity'
-        ? `failed to handle ${event.kind} activity fact`
-        : `failed to handle ${event.type} fact`;
+    let context = `failed to handle ${event.type} fact`;
+    if (event.type === 'child.activity') {
+      const activityKind = event.kind === 'subagents' ? 'subagent' : 'process';
+      context = `failed to handle ${activityKind} activity fact`;
+    }
     this.applyFact(context, () => handler(streamId, event));
   }
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1601,6 +1601,50 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('propagates async fact-handler promises to the error wrapper', async () => {
+    const { backend } = createRecordingBackend();
+    const stream = 'tool-stream' as StreamTabId;
+
+    // A tracking thenable: `withEventErrorHandling` does
+    // `Promise.resolve(result).catch(...)`, which adopts (calls `.then` on) the
+    // handler's result only when the dispatch wrapper actually RETURNED it. A
+    // block-bodied handler that discarded the promise would hand
+    // `withEventErrorHandling` `undefined`, leaving this untouched — and a
+    // post-await rejection would then escape logging as an unhandled rejection.
+    // Both `setStreamStatus` callers (the run-fact `status` path and the
+    // session-fact `updateStreamStatus` path) are covered.
+    let adopted = 0;
+    const tracking: PromiseLike<void> = {
+      then(onFulfilled, onRejected) {
+        adopted += 1;
+        return Promise.resolve().then(onFulfilled, onRejected);
+      },
+    };
+    vi.spyOn(backend.factApplier, 'setStreamStatus').mockReturnValue(
+      tracking as Promise<void>,
+    );
+
+    try {
+      backend.factApplier.handleRunFact(stream, {
+        type: 'status',
+        streamId: stream,
+        phase: STREAM_PHASE.RUNNING,
+        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      });
+      backend.factApplier.handleSessionFact({
+        type: 'updateStreamStatus',
+        payload: { streamId: stream, status: STREAM_PHASE.RUNNING },
+      });
+
+      // Thenable adoption runs on a microtask; flush before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(adopted).toBe(2);
+    } finally {
+      backend.dispose();
+    }
+  });
+
   it('revalidates and syncs the active stream when status registration changes the filter', async () => {
     const { backend, messages } = createRecordingBackend();
 


### PR DESCRIPTION
## Summary

Move progress-fact error handling from 21 repeated handler wrappers to the two run/session dispatch boundaries. Each handler now contains only its domain action, while the dispatch boundary owns error reporting and asynchronous promise adoption.

The final implementation preserves the historical `subagent`/`process` diagnostic wording and returns asynchronous handler results so post-`await` failures remain caught rather than becoming unhandled rejections.

## Issue acceptance gates

No linked issue. The refactor is complete when error context remains specific, synchronous and asynchronous failures use the shared boundary, and focused regression coverage demonstrates promise adoption for both run and session facts.

## Single source of truth

`handleRunFact` and `handleSessionFact` now own progress-fact error context and dispatch-level failure handling. Individual fact handlers own only their state changes.

## Duplication and abstraction budget

Removed 21 repeated `applyFact(...)` wrappers. No pass-through method or single-caller helper was added: the session switch and the `child.activity` diagnostic special case remain inline at their dispatch sites.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: no changes.
- Classes/interfaces/enums: no changes. `RunFactHandlers` now explicitly permits `void | Promise<void>`.
- LoC: 150 additions, 145 deletions, net +5. The test adds 44 lines; production source is net -39 lines.

## Consumer counts (R8)

n/a - no export or event-emission path is removed or rerouted. The private `applyFact` method goes from 21 internal callers to 2 dispatch callers.

## Host impact

Extension: Progress-fact failures retain their existing diagnostics and shared logging path.

Desktop: None; this controller is not a desktop host integration.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint: passed.
- `src/test-kernel/progressView/ProgressBackend.vitest.ts`: 37 tests passed.
- The regression test covers thenable adoption through both run-fact and session-fact dispatch.
- GitHub CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to error-boundary placement and async promise plumbing; behavior and log context are preserved with regression coverage.
> 
> **Overview**
> **Progress fact error handling** is centralized at `handleRunFact` and `handleSessionFact` instead of ~21 per-handler `applyFact` wrappers. Individual run/session handlers now only perform their state/webview work and **return** results (including promises).
> 
> That return path matters because `withEventErrorHandling` only attaches `.catch` when the dispatch wrapper passes through a thenable—discarded async results would otherwise surface as unhandled rejections after `await`. `RunFactHandlers` is updated to allow `void | Promise<void>`, and **`child.activity`** still logs **subagent** vs **process** failure context at the run dispatch boundary.
> 
> A focused vitest asserts both the run `status` and session `updateStreamStatus` paths adopt mocked `setStreamStatus` thenables through the shared wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5191a219279a0d582e94a25a7b8459ac708c2e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->