### PR TITLE
refactor: consolidate duplicated logic in error, logger, CLI, and desktop code

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/nunjucks": "^3.2.6",
     "@types/pluralize": "^0.0.33",
     "@types/proper-lockfile": "^4.1.4",
+    "@types/semver": "^7.7.1",
     "@types/shell-quote": "^1.7.5",
     "@types/sortablejs": "^1.15.9",
     "@types/turndown": "^5.0.6",

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -2,7 +2,6 @@ import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { gt as semverGt, valid as semverValid } from 'semver';
 import { z } from 'zod';
 
 import { JsonStore } from '@platform/defaults/jsonStore';
@@ -10,6 +9,11 @@ import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { executeCommand } from '@utils/system/execUtils';
+import {
+  DAILY_UPDATE_CHECK_INTERVAL_MS,
+  isNewerSemverVersion,
+  UPDATE_CHECK_SKIP_ENV,
+} from '@utils/system/semverUpdateCheck';
 
 import {
   cliEnvValue,
@@ -35,30 +39,14 @@ const CLI_HOMEBREW_FORMULA = 'texra';
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
 const HOMEBREW_COMMAND_TIMEOUT_MS = 10000;
-const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 /**
  * Check for a new release at most once per day, matching the desktop update
- * checker's cadence (see `desktopUpdateChecker.ts`'s `CHECK_INTERVAL_MS`).
+ * checker's cadence (see `desktopUpdateChecker.ts`).
  */
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CHECK_INTERVAL_MS = DAILY_UPDATE_CHECK_INTERVAL_MS;
 
 /** Package manager the running binary was installed with. */
 export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
-
-/**
- * True when `latest` is strictly newer than `current`, using full semver
- * precedence (a plain release outranks any prerelease of the same `x.y.z`, and
- * prereleases compare numerically — so `1.2.0-rc.10` correctly beats
- * `1.2.0-rc.2`). Unparseable inputs yield `false` so a malformed registry
- * response can never push a bogus update prompt. The leading `v` some tags
- * carry is tolerated by `semver`.
- */
-export function isNewerVersion(latest: string, current: string): boolean {
-  const a = semverValid(latest.trim(), { loose: true });
-  const b = semverValid(current.trim(), { loose: true });
-  if (!a || !b) return false;
-  return semverGt(a, b);
-}
 
 /**
  * Guess the package manager from the path the binary runs out of. Homebrew and
@@ -352,7 +340,7 @@ export async function checkCliUpdateAvailable({
 
   const { version, refreshed } = await fetchLatest();
   const latest =
-    version !== undefined && isNewerVersion(version, currentVersion)
+    version !== undefined && isNewerSemverVersion(version, currentVersion)
       ? version
       : undefined;
   if (latest !== undefined) await notify(latest);

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -1,6 +1,9 @@
-import { gt as semverGt, valid as semverValid } from 'semver';
-
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import {
+  DAILY_UPDATE_CHECK_INTERVAL_MS,
+  isNewerSemverVersion,
+  UPDATE_CHECK_SKIP_ENV,
+} from '@utils/system/semverUpdateCheck';
 import type { StateStore } from '@platform/interfaces';
 
 /**
@@ -27,27 +30,11 @@ export const DESKTOP_RELEASES_PAGE_URL =
 const GITHUB_USER_AGENT = 'TeXRA-Desktop';
 const FETCH_TIMEOUT_MS = 5000;
 /** Poll at most once per day so a normal multi-launch day makes one request. */
-const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
-const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
+const CHECK_INTERVAL_MS = DAILY_UPDATE_CHECK_INTERVAL_MS;
 
 interface DesktopLatestRelease {
   /** Release version with any leading `v` stripped, e.g. `0.40.0`. */
   version: string;
-}
-
-/**
- * True when `latest` is strictly newer than `current` under semver
- * precedence. Unparseable input yields `false` so a malformed API response
- * can never trigger a bogus update notification.
- */
-export function isNewerDesktopVersion(
-  latest: string,
-  current: string,
-): boolean {
-  const a = semverValid(latest.trim(), { loose: true });
-  const b = semverValid(current.trim(), { loose: true });
-  if (!a || !b) return false;
-  return semverGt(a, b);
 }
 
 /** Fetch the latest release's version, or undefined on any failure. */
@@ -143,7 +130,7 @@ async function runDesktopUpdateCheck({
   // Notify at most once per release version; a matching-or-older release just
   // refreshes the throttle stamp below.
   if (
-    isNewerDesktopVersion(release.version, currentVersion) &&
+    isNewerSemverVersion(release.version, currentVersion) &&
     globalState.get<string>(
       GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
     ) !== release.version

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -30,10 +30,6 @@ export const apiKeyCommands = {
   removeApiKey: 'texra.removeApiKey',
 };
 
-function refreshApiKeyUI(): Promise<void> {
-  return refreshApiKeyCaches(getSetupPlatform());
-}
-
 /**
  * Delegates the write/delete/confirm/notify sequence to the same controller
  * settingsView's Profile tab uses, so the two surfaces can't drift apart on
@@ -57,7 +53,7 @@ function createProfileKeyController(): SettingsProfileKeyController {
     setSecret: (key, value) => SecretManager.set(key, value),
     deleteSecret: (key) => SecretManager.delete(key),
     refreshAfterKeyChange: async () => {
-      await refreshApiKeyUI();
+      await refreshApiKeyCaches(getSetupPlatform());
       const view = await getMainWebview();
       const anyKeyExists = await SecretManager.anyApiKeyExists();
       view?.webview.postMessage({

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -10,13 +10,13 @@ import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { invalidateApiKeyCache } from '@model/apiProviders';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import {
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_URLS,
 } from '@shared/constants/providers';
+import { refreshApiKeyCaches } from '@tools/setup/apiKeyHelpers';
+import { getSetupPlatform } from '@tools/setup/platform';
 import {
   getProviderDisplayName,
   getProviderKeyUrl,
@@ -30,11 +30,8 @@ export const apiKeyCommands = {
   removeApiKey: 'texra.removeApiKey',
 };
 
-async function refreshApiKeyUI(): Promise<void> {
-  invalidateModelOptionsCache();
-  invalidateApiKeyCache();
-  await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-  await vscode.commands.executeCommand('texra.refreshAllOptions');
+function refreshApiKeyUI(): Promise<void> {
+  return refreshApiKeyCaches(getSetupPlatform());
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -22,7 +22,8 @@ import type {
 } from '@agent/runtime/ExecutionHandle';
 import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import { classifyAgentError, isAbortError } from '@common/errors';
+import { classifyAgentError } from '@common/errors';
+import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
   RUN_OUTCOME,
   type ExecutionId,
@@ -251,7 +252,7 @@ function isCleanInterruption(
   signal: AbortSignal,
   loop: ChildRunInterruptible,
 ): boolean {
-  return signal.aborted || loop.isInterrupted() || isAbortError(err);
+  return signal.aborted || loop.isInterrupted() || isUserAbort(err);
 }
 
 /** Log a turn summary (duration + token usage) to the child stream. */

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -1,8 +1,3 @@
-/** True for an AbortController-style cancellation error. */
-export function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === 'AbortError';
-}
-
 /** Check if an error represents a file-not-found condition. */
 export function isFileNotFoundError(err: unknown): boolean {
   const code = (err as { code?: string })?.code;

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -10,7 +10,6 @@
  */
 export { formatError } from './errorFormatUtils';
 export {
-  isAbortError,
   isFileNotFoundError,
   isModuleNotFoundError,
   isNotADirectoryError,

--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -1,7 +1,9 @@
 import prettyMilliseconds from 'pretty-ms';
 
-import { isObject, isString } from '@utils/core';
+import { isObject } from '@utils/core';
 import { capitalize } from '@utils/text/stringUtils';
+
+import { pickNumberField, pickStringField } from './errorInspection';
 
 /**
  * Detection + formatting for the ChatGPT-subscription (Codex backend) usage
@@ -22,20 +24,6 @@ import { capitalize } from '@utils/text/stringUtils';
 export interface ChatGptSubscriptionLimit {
   readonly planType?: string;
   readonly resetsInSeconds?: number;
-}
-
-function pickStringField(value: unknown, key: string): string | undefined {
-  if (!isObject(value)) return undefined;
-  const field = value[key];
-  return isString(field) && field.trim().length > 0 ? field : undefined;
-}
-
-function pickNumberField(value: unknown, key: string): number | undefined {
-  if (!isObject(value)) return undefined;
-  const field = value[key];
-  return typeof field === 'number' && Number.isFinite(field)
-    ? field
-    : undefined;
 }
 
 /**

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -4,6 +4,24 @@ import { isObject, isString } from '@utils/core';
 
 import { pickStatus } from './sdkErrorKinds';
 
+/** Pick a non-blank string field off an error-body object. Shared by the
+ *  relay/ChatGPT-subscription/credit-depletion body detectors, which all read
+ *  loosely-typed provider JSON. */
+export function pickStringField(v: unknown, key: string): string | undefined {
+  if (!isObject(v)) return undefined;
+  const value = (v as Record<string, unknown>)[key];
+  return isString(value) && value.trim().length > 0 ? value : undefined;
+}
+
+/** Pick a finite-number field off an error-body object. See {@link pickStringField}. */
+export function pickNumberField(v: unknown, key: string): number | undefined {
+  if (!isObject(v)) return undefined;
+  const value = (v as Record<string, unknown>)[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
 export function safeGetReasonPhrase(statusCode: number): string | undefined {
   try {

--- a/src/common/errors/sdkError/relayDetection.ts
+++ b/src/common/errors/sdkError/relayDetection.ts
@@ -1,6 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import { isObject, isString } from '@utils/core';
 
+import { pickStringField } from './errorInspection';
+
 /**
  * Maps Anthropic error type strings to their corresponding HTTP status codes.
  * Used to recover the status code when SDK error objects lose it
@@ -79,12 +81,6 @@ export function isRelayMonthlyLimitMessage(
   return (
     message?.toLowerCase().includes('monthly spending limit reached') ?? false
   );
-}
-
-function pickStringField(v: unknown, key: string): string | undefined {
-  if (!isObject(v)) return undefined;
-  const value = (v as Record<string, unknown>)[key];
-  return isString(value) ? value : undefined;
 }
 
 /** True when the upstream provider returned a credit/quota exhaustion body.

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -14,6 +14,7 @@
  */
 // Third-party imports
 import { format } from 'date-fns';
+import safeStringify from 'safe-stable-stringify';
 
 // Local imports
 import { redactSecrets } from '@logger/redaction';
@@ -131,12 +132,7 @@ function writeLine(
   if (data === null || data === undefined) return;
   if (!isDebugModeEnabled()) return;
 
-  const normalizedData = normalizeLogData(data);
-  sink.appendLine(
-    typeof normalizedData === 'string'
-      ? normalizedData
-      : JSON.stringify(normalizedData, null, 2),
-  );
+  sink.appendLine(normalizeLogData(data));
 }
 
 export type ChannelWriter = (
@@ -158,34 +154,19 @@ export function createChannelWriter(
     writeLine(level, channel, isAgent, message, data);
 }
 
-/** Errors don't survive `JSON.stringify`, so flatten them before emit. */
-function normalizeLogData(
-  data: unknown,
-  seen = new WeakSet<object>(),
-): unknown {
-  if (data instanceof Error) return serializeError(data);
-  if (Array.isArray(data)) {
-    if (seen.has(data)) return '[Circular]';
-    seen.add(data);
-    const result = data.map((item) => normalizeLogData(item, seen));
-    seen.delete(data);
-    return result;
-  }
-  if (typeof data !== 'object' || data === null) return data;
-
-  const prototype = Object.getPrototypeOf(data);
-  if (prototype !== Object.prototype && prototype !== null) return data;
-  if (seen.has(data)) return '[Circular]';
-  seen.add(data);
-
-  const result = Object.fromEntries(
-    Object.entries(data).map(([key, value]) => [
-      key,
-      normalizeLogData(value, seen),
-    ]),
+/** Errors don't survive `JSON.stringify`, so flatten them before emit.
+ *  `safe-stable-stringify` already handles circular references (rendered as
+ *  `"[Circular]"`, matching the prior hand-rolled walker); this only adds the
+ *  Error → plain-object mapping on top via its replacer hook. */
+function normalizeLogData(data: unknown): string {
+  if (typeof data !== 'object' || data === null) return String(data);
+  return (
+    safeStringify(
+      data,
+      (_key, value) => (value instanceof Error ? serializeError(value) : value),
+      2,
+    ) ?? String(data)
   );
-  seen.delete(data);
-  return result;
 }
 
 function logAt(

--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -7,7 +7,6 @@ import {
   fetchLatestCliVersion,
   fetchLatestHomebrewFormulaVersion,
   formatUpdateCommand,
-  isNewerVersion,
   isPackageManagerInstall,
 } from '@cli/runtime/updateChecker';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -27,27 +26,6 @@ class MemoryStateStore {
     }
   }
 }
-
-describe('isNewerVersion', () => {
-  it('compares numerically across all components', () => {
-    expect(isNewerVersion('1.0.0', '0.9.9')).toBe(true);
-    expect(isNewerVersion('0.39.0', '0.38.2')).toBe(true);
-    expect(isNewerVersion('0.38.3', '0.38.2')).toBe(true);
-    expect(isNewerVersion('0.38.2', '0.38.2')).toBe(false);
-    expect(isNewerVersion('0.38.1', '0.38.2')).toBe(false);
-  });
-
-  it('ranks a release above its prerelease but not vice versa', () => {
-    expect(isNewerVersion('1.2.0', '1.2.0-rc.1')).toBe(true);
-    expect(isNewerVersion('1.2.0-rc.1', '1.2.0')).toBe(false);
-    expect(isNewerVersion('1.2.0-rc.2', '1.2.0-rc.1')).toBe(true);
-  });
-
-  it('returns false when either version is unparseable', () => {
-    expect(isNewerVersion('1.0.0', 'unknown')).toBe(false);
-    expect(isNewerVersion('latest', '1.0.0')).toBe(false);
-  });
-});
 
 describe('detectInstallMethod', () => {
   it('recognizes pnpm, yarn, and bun global layouts', () => {

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -26,7 +26,6 @@ interface DesktopLatestRelease {
 
 interface DesktopUpdateCheckerModule {
   DESKTOP_RELEASES_PAGE_URL: string;
-  isNewerDesktopVersion(latest: string, current: string): boolean;
   checkForDesktopUpdate(options: {
     currentVersion: string;
     globalState: MemoryStateStore;
@@ -45,23 +44,6 @@ async function loadDesktopUpdateChecker(): Promise<DesktopUpdateCheckerModule> {
 }
 
 describe('desktop update checker', () => {
-  describe('isNewerDesktopVersion', () => {
-    it('is true only when latest strictly outranks current', async () => {
-      const { isNewerDesktopVersion } = await loadDesktopUpdateChecker();
-
-      expect(isNewerDesktopVersion('0.40.0', '0.39.3')).toBe(true);
-      expect(isNewerDesktopVersion('0.39.3', '0.39.3')).toBe(false);
-      expect(isNewerDesktopVersion('0.38.0', '0.39.3')).toBe(false);
-    });
-
-    it('treats unparseable versions as not newer', async () => {
-      const { isNewerDesktopVersion } = await loadDesktopUpdateChecker();
-
-      expect(isNewerDesktopVersion('not-a-version', '0.39.3')).toBe(false);
-      expect(isNewerDesktopVersion('0.40.0', 'not-a-version')).toBe(false);
-    });
-  });
-
   it('exposes a known-constant releases page URL (never opens API-provided URLs)', async () => {
     const { DESKTOP_RELEASES_PAGE_URL } = await loadDesktopUpdateChecker();
 

--- a/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
+++ b/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNewerSemverVersion } from '@utils/system/semverUpdateCheck';
+
+describe('isNewerSemverVersion', () => {
+  it('compares numerically across all components', () => {
+    expect(isNewerSemverVersion('1.0.0', '0.9.9')).toBe(true);
+    expect(isNewerSemverVersion('0.39.0', '0.38.2')).toBe(true);
+    expect(isNewerSemverVersion('0.38.3', '0.38.2')).toBe(true);
+    expect(isNewerSemverVersion('0.38.2', '0.38.2')).toBe(false);
+    expect(isNewerSemverVersion('0.38.1', '0.38.2')).toBe(false);
+  });
+
+  it('ranks a release above its prerelease but not vice versa', () => {
+    expect(isNewerSemverVersion('1.2.0', '1.2.0-rc.1')).toBe(true);
+    expect(isNewerSemverVersion('1.2.0-rc.1', '1.2.0')).toBe(false);
+    expect(isNewerSemverVersion('1.2.0-rc.2', '1.2.0-rc.1')).toBe(true);
+  });
+
+  it('returns false when either version is unparseable', () => {
+    expect(isNewerSemverVersion('1.0.0', 'unknown')).toBe(false);
+    expect(isNewerSemverVersion('latest', '1.0.0')).toBe(false);
+    expect(isNewerSemverVersion('not-a-version', '0.39.3')).toBe(false);
+    expect(isNewerSemverVersion('0.40.0', 'not-a-version')).toBe(false);
+  });
+});

--- a/src/tools/setup/apiKeyHelpers.ts
+++ b/src/tools/setup/apiKeyHelpers.ts
@@ -43,8 +43,10 @@ export async function refreshApiKeyCaches(
   invalidateApiKeyCache();
   const commands = platform.commands;
   if (!commands) return;
-  await Promise.all([
-    commands.invoke('texra.refreshApiKeyStatus').catch(() => undefined),
-    commands.invoke('texra.refreshAllOptions').catch(() => undefined),
+  // Credential changes must remain successful when a host cannot refresh its
+  // status surfaces; the next ordinary refresh will reconcile stale UI.
+  await Promise.allSettled([
+    commands.invoke('texra.refreshApiKeyStatus'),
+    commands.invoke('texra.refreshAllOptions'),
   ]);
 }

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -5,3 +5,4 @@ export * from './platformPaths';
 export * from './binaryResolver';
 export * from './wslDetect';
 export * from './workspaceInfo';
+export * from './semverUpdateCheck';

--- a/src/utils/system/semverUpdateCheck.ts
+++ b/src/utils/system/semverUpdateCheck.ts
@@ -1,0 +1,26 @@
+import { gt as semverGt, valid as semverValid } from 'semver';
+
+/**
+ * True when `latest` is strictly newer than `current`, using full semver
+ * precedence (a plain release outranks any prerelease of the same `x.y.z`, and
+ * prereleases compare numerically — so `1.2.0-rc.10` correctly beats
+ * `1.2.0-rc.2`). Unparseable inputs yield `false` so a malformed
+ * registry/release response can never push a bogus update prompt. The
+ * leading `v` some tags carry is tolerated by `semver`.
+ *
+ * Shared by the CLI (`updateChecker.ts`) and desktop (`desktopUpdateChecker.ts`)
+ * update checks, which otherwise poll different sources on the same daily
+ * cadence and notify through the same env-var kill switch.
+ */
+export function isNewerSemverVersion(latest: string, current: string): boolean {
+  const a = semverValid(latest.trim(), { loose: true });
+  const b = semverValid(current.trim(), { loose: true });
+  if (!a || !b) return false;
+  return semverGt(a, b);
+}
+
+/** Poll for updates at most once per day. */
+export const DAILY_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Env var that disables both the CLI's and desktop's update checks. */
+export const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';


### PR DESCRIPTION
## Summary

Consolidate five verified duplicate implementations found by the fallback and abstraction audit:

- CLI and desktop update checks now share semver comparison, polling interval, and opt-out environment variable.
- Extension API-key changes use the same cache invalidation and status refresh path as setup tools.
- Log normalization uses the installed circular-safe stable stringifier instead of a recursive object walker.
- Provider error inspection shares one blank-rejecting string/number field reader.
- Child-run cancellation uses the canonical user-abort predicate.

The only intentional behavior alignments are stricter rejection of blank provider fields, broader recognition of genuine user aborts, and best-effort UI refresh after a credential mutation.

## Issue acceptance gates

No linked issue. Every touched duplicate has one implementation, all removed symbols have migrated consumers, and fallback behavior is explicit at its owning boundary.

## Single source of truth

- `src/utils/system/semverUpdateCheck.ts`: update comparison and cadence constants.
- `src/tools/setup/apiKeyHelpers.ts`: credential-cache invalidation and status refresh.
- `src/common/errors/sdkError/errorInspection.ts`: provider-body primitive field extraction.
- `src/common/errors/sdkError/errorPatterns.ts`: user-abort classification.
- `safe-stable-stringify`: circular-safe log serialization.

## Duplication and abstraction budget

Removed two semver comparators, one cache-refresh sequence, one string-field reader, one recursive normalization walker, and one abort predicate. The new semver module has CLI and desktop consumers. The extension's former one-caller refresh wrapper is removed.

## Net elements (R6)

- Files: 18 changed; 2 added, 2 deleted, 14 modified.
- Exported symbols: 6 added and 3 removed. The barrel re-export exposes the three semver exports as one source module.
- Classes/interfaces/enums: no changes.
- LoC: 120 additions, 155 deletions, net -35.

## Consumer counts (R8)

- `isAbortError`: 1 consumer migrated to `isUserAbort`.
- `isNewerVersion`: 1 production consumer migrated to `isNewerSemverVersion`.
- `isNewerDesktopVersion`: 1 production consumer migrated to `isNewerSemverVersion`.
- Relay-local `pickStringField`: 1 consumer module migrated to the shared helper.
- No event or subscription path changes.

## Host impact

Extension: Credential changes share one cache refresh path. Status-command failures are explicitly best-effort: the credential mutation succeeds and the next normal refresh reconciles stale UI.

Desktop: Update comparison and cadence use the shared system helper; behavior is unchanged.

CLI: Update comparison and cadence use the shared system helper; behavior is unchanged.

## Scheduled refactoring

None. Deeper model-handler and capability consolidation remains outside this bounded audit change.

## Validation

- Changed-file ESLint: passed.
- Focused semver, logger, child-run, and key-controller tests: 4 files, 32 tests passed.
- Earlier full workspace typecheck and lint passed.
- GitHub CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly internal deduplication with bounded behavior shifts (stricter blank provider fields, broader user-abort detection, best-effort UI refresh after key changes); update and credential paths remain best-effort as before.
> 
> **Overview**
> This PR **removes parallel copies** of the same logic across CLI, desktop, extension, logging, and SDK error handling, routing callers through a small set of shared modules.
> 
> **Update checks:** CLI and desktop now import `isNewerSemverVersion`, the daily poll interval, and `TEXRA_NO_UPDATE_CHECK` from `semverUpdateCheck.ts` instead of each defining their own semver helpers and constants. Semver tests live in one focused suite.
> 
> **API keys:** The extension’s `setApiKey` / `removeApiKey` path calls `refreshApiKeyCaches(getSetupPlatform())` like setup tools, dropping a local invalidation wrapper. Status refresh commands use **`Promise.allSettled`** so a failed VS Code refresh does not block a successful credential write.
> 
> **Logging:** Debug log payloads use **`safe-stable-stringify`** (with an Error replacer) instead of a hand-rolled circular walker.
> 
> **Provider errors:** `pickStringField` / `pickNumberField` are centralized in `errorInspection.ts` for relay, ChatGPT subscription, and credit-depletion detectors; string fields now **reject blank** values.
> 
> **Agent runtime:** Child-run clean interruptions use **`isUserAbort`** from SDK error utilities instead of barrel **`isAbortError`** (removed from `errorPredicates`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90875680882f937b0a32add2b027ee9088fbd5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->