### PR TITLE
fix(agent): retry and time out Kimi token estimation requests

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -1,13 +1,19 @@
 import { z } from 'zod';
+import ky from 'ky';
+import { AbortError } from 'p-retry';
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
 import type { ToolDefinition } from '@model';
+import { joinAbortSignal, retryTransientFetch } from '@tools/timeouts';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import type OpenAI from 'openai';
 
 /**
  * Moonshot API `fullName`s shared by more than one TeXRA registry entry — a
@@ -76,6 +82,9 @@ const KimiTokenEstimateResponseSchema = z.object({
   data: z.object({ total_tokens: z.number() }),
 });
 
+const KIMI_TOKEN_ESTIMATE_TIMEOUT_MS = 20_000; // 20 s
+const KIMI_TOKEN_ESTIMATE_RETRIES = 2;
+
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
  * Kimi K2 Thinking models return reasoning_content automatically when streaming.
@@ -103,7 +112,8 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
   protected override readonly convertContentToStringUnlessVision = true;
 
   protected override getThinkingParameter():
-    { type: 'enabled' | 'disabled' } | undefined {
+    | { type: 'enabled' | 'disabled' }
+    | undefined {
     // See AMBIGUOUS_THINKING_DEFAULT_FULLNAMES: these wire names default to
     // thinking-enabled on the Moonshot API, so the non-reasoning registry
     // entry must explicitly turn it off.
@@ -170,43 +180,59 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
    * Estimates token count using Kimi's native token counting API.
    * This provides accurate token counts for Moonshot models.
    *
+   * Retries transient failures (timeouts, 5xx, 429 rate limits, dropped
+   * connections) with jittered backoff via {@link retryTransientFetch} — the
+   * same pattern every other network-boundary call in this codebase uses —
+   * and joins `options.signal` so an interrupted run aborts an in-flight
+   * request instead of waiting out the timeout.
+   *
    * @param messages The messages to count tokens for.
+   * @param options Cancellation signal for the owning run.
    * @returns Promise resolving to the total token count.
    * @see https://platform.moonshot.cn/docs/api/tokenization
    */
   override async estimateTokenCount(
     messages: ChatCompletionMessageParam[],
+    options?: TokenCountOptions<OpenAI>,
   ): Promise<number> {
     const apiKey = await this.getApiKey();
     const baseUrl = this.getBaseUrl() ?? 'https://api.moonshot.ai/v1';
 
-    const response = await fetch(`${baseUrl}/tokenizers/estimate-token-count`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
+    return retryTransientFetch(
+      async () => {
+        const raw = await ky
+          .post(`${baseUrl}/tokenizers/estimate-token-count`, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            json: { model: this.config.fullName, messages },
+            timeout: false,
+            signal: joinAbortSignal(
+              KIMI_TOKEN_ESTIMATE_TIMEOUT_MS,
+              options?.signal,
+            ),
+            retry: 0,
+          })
+          .json<unknown>();
+
+        const parsed = KimiTokenEstimateResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          throw new AbortError(
+            new Error(
+              `Kimi token estimation returned an unexpected response shape: ${z.prettifyError(parsed.error)}`,
+            ),
+          );
+        }
+        return parsed.data.data.total_tokens;
       },
-      body: JSON.stringify({
-        model: this.config.fullName,
-        messages,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `Kimi token estimation failed (${response.status}): ${errorText}`,
-      );
-    }
-
-    const parsed = KimiTokenEstimateResponseSchema.safeParse(
-      await response.json().catch(() => null),
+      {
+        retries: KIMI_TOKEN_ESTIMATE_RETRIES,
+        minTimeout: 1000,
+        cancelSignal: options?.signal,
+        onFailedAttempt: ({ error, retriesLeft }) => {
+          this.logger.debug(
+            `Kimi token estimation failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
+          );
+        },
+      },
     );
-    if (!parsed.success) {
-      throw new Error(
-        `Kimi token estimation returned an unexpected response shape: ${z.prettifyError(parsed.error)}`,
-      );
-    }
-    return parsed.data.data.total_tokens;
   }
 }

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -112,8 +112,7 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
   protected override readonly convertContentToStringUnlessVision = true;
 
   protected override getThinkingParameter():
-    | { type: 'enabled' | 'disabled' }
-    | undefined {
+    { type: 'enabled' | 'disabled' } | undefined {
     // See AMBIGUOUS_THINKING_DEFAULT_FULLNAMES: these wire names default to
     // thinking-enabled on the Moonshot API, so the non-reasoning registry
     // entry must explicitly turn it off.

--- a/src/agent/modelHandlers/openai/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerKimi.ts
@@ -1,14 +1,10 @@
 import { z } from 'zod';
-import ky from 'ky';
-import { AbortError } from 'p-retry';
 import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { TokenCountOptions } from '@agent/types/ModelHandlerContracts';
 import type { ToolDefinition } from '@model';
-import { joinAbortSignal, retryTransientFetch } from '@tools/timeouts';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
@@ -179,11 +175,9 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
    * Estimates token count using Kimi's native token counting API.
    * This provides accurate token counts for Moonshot models.
    *
-   * Retries transient failures (timeouts, 5xx, 429 rate limits, dropped
-   * connections) with jittered backoff via {@link retryTransientFetch} — the
-   * same pattern every other network-boundary call in this codebase uses —
-   * and joins `options.signal` so an interrupted run aborts an in-flight
-   * request instead of waiting out the timeout.
+   * The OpenAI-compatible client owns transient retry policy (408, 409, 429,
+   * 5xx, network failures, and Retry-After) and applies the timeout per
+   * attempt. The owning run's signal cancels requests and retry delays.
    *
    * @param messages The messages to count tokens for.
    * @param options Cancellation signal for the owning run.
@@ -194,44 +188,20 @@ export class ModelHandlerKimi extends ReasoningModelHandlerOpenAI {
     messages: ChatCompletionMessageParam[],
     options?: TokenCountOptions<OpenAI>,
   ): Promise<number> {
-    const apiKey = await this.getApiKey();
-    const baseUrl = this.getBaseUrl() ?? 'https://api.moonshot.ai/v1';
+    const client = options?.client ?? (await this.getClient());
+    const raw = await client.post<unknown>('/tokenizers/estimate-token-count', {
+      body: { model: this.config.fullName, messages },
+      maxRetries: KIMI_TOKEN_ESTIMATE_RETRIES,
+      timeout: KIMI_TOKEN_ESTIMATE_TIMEOUT_MS,
+      signal: options?.signal,
+    });
 
-    return retryTransientFetch(
-      async () => {
-        const raw = await ky
-          .post(`${baseUrl}/tokenizers/estimate-token-count`, {
-            headers: { Authorization: `Bearer ${apiKey}` },
-            json: { model: this.config.fullName, messages },
-            timeout: false,
-            signal: joinAbortSignal(
-              KIMI_TOKEN_ESTIMATE_TIMEOUT_MS,
-              options?.signal,
-            ),
-            retry: 0,
-          })
-          .json<unknown>();
-
-        const parsed = KimiTokenEstimateResponseSchema.safeParse(raw);
-        if (!parsed.success) {
-          throw new AbortError(
-            new Error(
-              `Kimi token estimation returned an unexpected response shape: ${z.prettifyError(parsed.error)}`,
-            ),
-          );
-        }
-        return parsed.data.data.total_tokens;
-      },
-      {
-        retries: KIMI_TOKEN_ESTIMATE_RETRIES,
-        minTimeout: 1000,
-        cancelSignal: options?.signal,
-        onFailedAttempt: ({ error, retriesLeft }) => {
-          this.logger.debug(
-            `Kimi token estimation failed (${retriesLeft} retries left): ${toErrorMessage(error)}`,
-          );
-        },
-      },
-    );
+    const parsed = KimiTokenEstimateResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new Error(
+        `Kimi token estimation returned an unexpected response shape: ${z.prettifyError(parsed.error)}`,
+      );
+    }
+    return parsed.data.data.total_tokens;
   }
 }

--- a/src/test-kernel/agent/modelHandlers/KimiTokenEstimation.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/KimiTokenEstimation.vitest.ts
@@ -1,0 +1,151 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import OpenAI from 'openai';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - handler under test
+import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
+
+function buildHandler(): ModelHandlerKimi {
+  const config: ModelConfig = {
+    name: 'kimi-test',
+    label: 'Kimi Test',
+    fullName: 'kimi-k2.5',
+    shortName: 'kimi-test',
+    provider: ModelProvider.MOONSHOT,
+    maxOutputTokens: 8192,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  };
+  return new ModelHandlerKimi(config);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'retry-after-ms': '0',
+    },
+  });
+}
+
+describe('Kimi token estimation', () => {
+  it('uses the authenticated SDK client with bounded native retries', async () => {
+    const controller = new AbortController();
+    const post = vi.fn(async () => ({ data: { total_tokens: 37 } }));
+
+    const total = await buildHandler().estimateTokenCount(
+      [{ role: 'user', content: 'count this' }],
+      {
+        client: { post } as unknown as OpenAI,
+        signal: controller.signal,
+      },
+    );
+
+    assert.equal(total, 37);
+    expect(post).toHaveBeenCalledWith('/tokenizers/estimate-token-count', {
+      body: {
+        model: 'kimi-k2.5',
+        messages: [{ role: 'user', content: 'count this' }],
+      },
+      maxRetries: 2,
+      timeout: 20_000,
+      signal: controller.signal,
+    });
+  });
+
+  it('retries 408 and 429 responses before succeeding', async () => {
+    const responses = [
+      jsonResponse({ error: 'timeout' }, 408),
+      jsonResponse({ error: 'rate limited' }, 429),
+      jsonResponse({ data: { total_tokens: 41 } }),
+    ];
+    const fetchMock = vi.fn<typeof fetch>(async () => responses.shift()!);
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://api.moonshot.test/v1',
+      fetch: fetchMock,
+    });
+
+    assert.equal(
+      await buildHandler().estimateTokenCount(
+        [{ role: 'user', content: 'retry' }],
+        { client },
+      ),
+      41,
+    );
+    assert.equal(fetchMock.mock.calls.length, 3);
+  });
+
+  it('does not retry a permanent 400 response', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      jsonResponse({ error: 'bad request' }, 400),
+    );
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://api.moonshot.test/v1',
+      fetch: fetchMock,
+    });
+
+    await assert.rejects(
+      buildHandler().estimateTokenCount(
+        [{ role: 'user', content: 'invalid' }],
+        { client },
+      ),
+    );
+    assert.equal(fetchMock.mock.calls.length, 1);
+  });
+
+  it('rejects a malformed successful response without another request', async () => {
+    const post = vi.fn(async () => ({ data: { tokens: 37 } }));
+
+    await assert.rejects(
+      buildHandler().estimateTokenCount(
+        [{ role: 'user', content: 'malformed' }],
+        { client: { post } as unknown as OpenAI },
+      ),
+      /unexpected response shape/,
+    );
+    assert.equal(post.mock.calls.length, 1);
+  });
+
+  it('aborts an active request without retrying', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn<typeof fetch>(
+      async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => reject(init.signal?.reason),
+            { once: true },
+          );
+        }),
+    );
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://api.moonshot.test/v1',
+      fetch: fetchMock,
+    });
+    const pending = buildHandler().estimateTokenCount(
+      [{ role: 'user', content: 'cancel' }],
+      { client, signal: controller.signal },
+    );
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    controller.abort(new Error('cancelled'));
+
+    await assert.rejects(pending);
+    assert.equal(fetchMock.mock.calls.length, 1);
+  });
+});

--- a/src/test-kernel/tools/TransientHttpError.vitest.ts
+++ b/src/test-kernel/tools/TransientHttpError.vitest.ts
@@ -54,7 +54,8 @@ describe('isTransientHttpError', () => {
     ).toBe(false);
   });
 
-  it('treats rate limits and 5xx server errors as transient', () => {
+  it('treats request timeouts, rate limits, and 5xx errors as transient', () => {
+    expect(isTransientHttpError(kyErrorWithStatus(408))).toBe(true);
     expect(isTransientHttpError(kyErrorWithStatus(429))).toBe(true);
     expect(isTransientHttpError(kyErrorWithStatus(500))).toBe(true);
     expect(isTransientHttpError(kyErrorWithStatus(503))).toBe(true);

--- a/src/tools/timeouts.ts
+++ b/src/tools/timeouts.ts
@@ -53,8 +53,8 @@ export function isTimeoutError(error: unknown): boolean {
 /**
  * Whether an HTTP request error is transient (worth retrying).
  *
- * Transient = timeout, network-level failure (no response received), 429
- * rate limit, or 5xx server error.
+ * Transient = timeout, network-level failure (no response received), 408
+ * request timeout, 429 rate limit, or 5xx server error.
  * Permanent = other 4xx responses and non-network errors.
  *
  * Only safe to use for idempotent requests (GET / read-only RPC); retrying
@@ -63,7 +63,11 @@ export function isTimeoutError(error: unknown): boolean {
 export function isTransientHttpError(error: unknown): boolean {
   if (isTimeoutError(error)) return true;
   if (error instanceof HTTPError) {
-    return error.response.status === 429 || error.response.status >= 500;
+    return (
+      error.response.status === 408 ||
+      error.response.status === 429 ||
+      error.response.status >= 500
+    );
   }
   // Network-level failure from the underlying fetch — connection reset, DNS
   // hiccup, socket hang-up. `fetch` surfaces these as a `TypeError`, but a bare


### PR DESCRIPTION
## Summary

Kimi token estimation previously used a bare request without a bounded failure policy or run cancellation. This PR sends the Moonshot-compatible token-count request through the existing authenticated OpenAI client and relies on the SDK's native request policy:

- 20-second timeout per attempt
- up to 2 retries for the SDK's transient classes, including HTTP 408, 409, 429, 5xx, connection failures, and `Retry-After`
- immediate cancellation through the run's `AbortSignal`
- no retry for ordinary 4xx responses or malformed successful responses

The shared transient HTTP classifier is also corrected to include HTTP 408 for the remaining non-SDK request sites.

## Issue acceptance gates

No linked issue. The reliability gate is covered by real HTTP-boundary tests: transient 408 then 429 responses recover on the third request, a 400 response is attempted once, a malformed 200 response is attempted once, and active cancellation aborts without retry.

## Single source of truth

The OpenAI SDK owns retry timing, `Retry-After` interpretation, timeout handling, request authentication, and cancellation for this OpenAI-compatible endpoint. `ModelHandlerKimi` supplies only endpoint-specific path, body, and response validation.

The existing `isTransientHttpError` helper remains the shared policy for non-SDK callers and now consistently recognizes HTTP 408.

## Duplication and abstraction budget

The custom `ky` plus `p-retry` composition from the earlier PR revision was removed. No new retry wrapper or client was introduced. The handler consumes the already constructed OpenAI client, including a client passed through `TokenCountOptions`.

## Net elements (R6)

4 files changed, 178 insertions, 27 deletions, net +151 lines. No exported symbol, class, interface, factory, or schema was added or removed.

151 added lines are focused network-boundary regression tests. The production handler is net smaller than the earlier custom retry revision.

## Consumer counts (R8)

- `ModelHandlerKimi.estimateTokenCount`: existing override; its existing OpenAI-path caller supplies the optional client and cancellation signal.
- `isTransientHttpError`: 17 source/test call sites after this change; no caller migration or emit-path change.
- No export, event emit path, or compatibility alias was added, removed, or rerouted.

## Host impact

- CLI: Kimi token estimation no longer hangs indefinitely and stops with run cancellation.
- Extension: same shared model-handler improvement.
- Desktop: same shared model-handler improvement.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint
- `corepack pnpm exec vitest run src/test-kernel/agent/modelHandlers/KimiTokenEstimation.vitest.ts src/test-kernel/tools/TransientHttpError.vitest.ts` — 13 passed
- `corepack pnpm typecheck`
