### PR TITLE
refactor(ui): dedup CLI picker windowing and standardize tool card tooltips

### DIFF
--- a/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
+++ b/packages/cli/src/chat/tui/modals/ChildControlPicker.tsx
@@ -9,7 +9,7 @@ import { Box, Text, useInput } from 'ink';
 import type { StreamTabId } from '@shared/schemas';
 
 // Local imports - CLI state and UI
-import { clamp, clampIndex } from '@utils/core';
+import { clampIndex } from '@utils/core';
 
 import {
   CHILD_CONTROL_MODE_COPY,
@@ -27,8 +27,10 @@ import { COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
 import {
   nextWrappingHighlightIndex,
+  visibleSelectRange,
   SELECT_LABEL_MAX_COLS,
 } from '../ui/Select';
+import { computeSelectWindowSize } from '../forms/_shared/selectWindow';
 import { compactPickerOverflowText } from '../render/overflowText';
 import {
   activeSubagentsFor,
@@ -183,7 +185,7 @@ export function computePickerListLayout({
   readonly scopeLineCount: number;
 }): PickerListLayout {
   const rows = Math.max(0, availableRows ?? 18);
-  const fixedRows =
+  const chromeRows =
     2 + // border
     1 + // title
     Math.max(0, scopeLineCount) +
@@ -191,29 +193,22 @@ export function computePickerListLayout({
     Math.max(0, extraListRowCount) +
     Math.max(0, hintsMarginRows) +
     1; // hints row
-  const rowBudget = Math.max(1, rows - fixedRows);
-  const windowStart = (count: number): number => {
-    const lastStart = Math.max(0, itemCount - count);
-    return clamp(highlight - Math.floor(count / 2), 0, lastStart);
-  };
-  let visibleCount = Math.min(itemCount, rowBudget);
-  for (let i = 0; i < 2; i += 1) {
-    const start = windowStart(visibleCount);
-    const end = start + visibleCount;
-    const markerRows =
-      rowBudget >= 3 ? (start > 0 ? 1 : 0) + (end < itemCount ? 1 : 0) : 0;
-    visibleCount =
-      itemCount === 0 ? 0 : clamp(rowBudget - markerRows, 1, itemCount);
-  }
-  const start = windowStart(visibleCount);
-  const end = start + visibleCount;
-  const markerRowsAllowed = rowBudget >= visibleCount + 1;
+  const { maxVisibleItems, showOverflow } = computeSelectWindowSize({
+    availableRows: rows,
+    itemCount,
+    chromeRows,
+  });
+  const { start, end } = visibleSelectRange({
+    itemCount,
+    highlight,
+    maxVisibleItems,
+  });
   return {
     end,
-    hiddenAfter: markerRowsAllowed ? Math.max(0, itemCount - end) : 0,
-    hiddenBefore: markerRowsAllowed ? start : 0,
+    hiddenAfter: showOverflow ? Math.max(0, itemCount - end) : 0,
+    hiddenBefore: showOverflow ? start : 0,
     start,
-    visibleCount,
+    visibleCount: end - start,
   };
 }
 

--- a/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/packages/extension/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -6,6 +6,7 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
 import '@awesome.me/webawesome/dist/components/tag/tag.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -313,14 +314,17 @@ export class ToolCard extends LitElement {
             this.item.installCommand
               ? html`
                   <wa-button
+                    id="tool-install-btn-${this.item.id}"
                     appearance="filled"
                     variant="brand"
                     size="small"
                     @click=${() => this.runCommand('install')}
-                    title=${this.item.installCommand}
                   >
                     ${waIcon('terminal', { slot: 'start' })} Install in Terminal
                   </wa-button>
+                  <wa-tooltip for="tool-install-btn-${this.item.id}"
+                    >${this.item.installCommand}</wa-tooltip
+                  >
                 `
               : nothing
           }
@@ -328,14 +332,17 @@ export class ToolCard extends LitElement {
             this.item.authCommand
               ? html`
                   <wa-button
+                    id="tool-auth-btn-${this.item.id}"
                     appearance=${secondaryAppearance}
                     variant=${secondaryVariant}
                     size="small"
                     @click=${() => this.runCommand('auth')}
-                    title=${this.item.authCommand}
                   >
                     ${waIcon('right-to-bracket', { slot: 'start' })} Sign in
                   </wa-button>
+                  <wa-tooltip for="tool-auth-btn-${this.item.id}"
+                    >${this.item.authCommand}</wa-tooltip
+                  >
                 `
               : nothing
           }
@@ -437,16 +444,19 @@ export class ToolCard extends LitElement {
           this.item.tools.length > 0
             ? html`
                 <div class="tool-ids">
-                  ${this.item.tools.map(
-                    (tool) =>
-                      html`<wa-badge
+                  ${this.item.tools.map((tool, index) => {
+                    const badgeId = `tool-id-badge-${this.item.id}-${index}`;
+                    return html`<wa-badge
+                        id=${badgeId}
                         class="tool-id-tag"
                         variant="neutral"
                         appearance="filled"
-                        title=${tool.description ?? tool.name}
                         >${tool.name}</wa-badge
-                      >`,
-                  )}
+                      >
+                      <wa-tooltip for=${badgeId}
+                        >${tool.description ?? tool.name}</wa-tooltip
+                      >`;
+                  })}
                 </div>
               `
             : nothing


### PR DESCRIPTION
## Summary

A UI-consistency review of the webview frontends and CLI Ink TUI found two concrete, spread-out inconsistencies (most icon/badge/spinner consolidation work had already landed). This PR fixes both:

- **CLI**: `ChildControlPicker.tsx`'s `computePickerListLayout` reimplemented the fit-and-center row-budget algorithm (windowing math + iterative marker-row convergence) that every `/`-form list already shares via `computeSelectWindowSize` + `visibleSelectRange` in `ui/Select.tsx` / `forms/_shared/selectWindow.ts`. It was the one picker that never migrated onto the shared primitive.
- **Webview**: `ToolCard.ts` used a bare `title=` attribute for supplementary hover text on its install/auth buttons and tool-id badges, while the equivalent case elsewhere (`StreamHeader.ts`'s toolbar buttons and chips) already uses `<wa-tooltip for=...>`. Aligned `ToolCard` to the same convention.

## Issue acceptance gates

No linked issue — follow-up from a UI-consistency audit. Gates satisfied:

- `ChildControlPicker`'s row-budget/windowing behavior is delegated to the same helpers used by `AgentListForm`, `ModelListForm`, etc., instead of a second hand-rolled implementation.
- `ToolCard`'s buttons/badges use `<wa-tooltip>` for supplementary hover text, matching `StreamHeader`'s established pattern; purely decorative icon-only titles (e.g. the status icon) were left untouched since that's the documented-intentional case.

## Single source of truth

`computeSelectWindowSize` (row-fit) + `visibleSelectRange` (centered windowing) in `packages/cli/src/chat/tui/ui/Select.tsx` / `forms/_shared/selectWindow.ts` now own row-budget windowing for every list/picker in the CLI TUI, including `ChildControlPicker`.

## Duplication and abstraction budget

No new abstraction added. `ChildControlPicker`'s ~25-line hand-rolled fit/center loop is deleted in favor of the two existing shared helpers. `ToolCard` gains no new component — it imports and uses the same `wa-tooltip` custom element already used by `StreamHeader.ts` and 7 other files.

## Net elements (R6)

- Files changed: 2; files added/deleted: 0.
- Exported symbols: 0 added, 0 removed (`computePickerListLayout`'s signature and return shape are unchanged).
- Classes/interfaces/enums: 0 added, 0 removed.
- Whole diff: 35 insertions, 30 deletions (net +5).

## Consumer counts (R8)

n/a — no export or emit path was deleted or rerouted. `computePickerListLayout` keeps its existing single in-file consumer; `ToolCard`'s render output changes are presentational only (no new/removed public API).

## Host impact

Extension: `ToolCard` (Settings → Tools tab) shows install/auth-command and tool-id hover text via `<wa-tooltip>` instead of the native browser title tooltip — same information, consistent presentation with the rest of the settings UI.

Desktop: No impact.

CLI: `ChildControlPicker`'s visible/hidden item windowing is now computed via the same algorithm as every other list form. In edge cases where only one overflow marker ("... N more" but not "... N earlier") would be needed, the picker now reserves a row for both markers rather than packing one extra item in — this trades a very small amount of density for consistency with every other picker in the app, which already behaves this way.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` (root + all workspace packages) — clean
- `npm run lint` — 0 errors (51 pre-existing warnings, none new)
- `npx vitest run src/test-kernel/cli/` — 139 files, 1779 tests passed
- `npm test` (full suite) — 710/711 files, 6439/6449 tests passed; the one failure (`SystemUtils.vitest.ts` process-group-abort test) reproduces identically on `main` with no changes applied — a pre-existing sandbox/environment limitation, unrelated to this change
- Prettier — clean, no changes needed

**Not independently verified**: the `wa-tooltip` visual behavior in `ToolCard.ts` was not manually verified in a running VS Code webview (no browser/extension-host available in this environment). The change follows the exact `wa-tooltip[for=]` pattern already working in `StreamHeader.ts`, with per-instance unique IDs to avoid collisions across repeated `ToolCard`/badge instances, but a manual pass in the Tools settings tab is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019MUWpMjoFVLf6cDM3UorpK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational and layout-consistency changes only; minor CLI edge-case list density trade-off, no API or security impact.
> 
> **Overview**
> **CLI:** `computePickerListLayout` in `ChildControlPicker` drops its local fit-and-center loop and uses `computeSelectWindowSize` plus `visibleSelectRange`, matching other list forms. Overflow markers follow the shared `showOverflow` rule (both “earlier” and “more” rows when needed, not a custom single-marker case).
> 
> **Extension:** Settings **Tools** `ToolCard` shows install/auth commands and tool-id descriptions via `<wa-tooltip for=...>` with per-control ids, instead of native `title=`, aligned with `StreamHeader` and similar settings components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3959965f98fb2fba04dc26fa513653b01cd3360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->