### PR TITLE
fix(cli): use subscription-capped context window in status bar

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -6,6 +6,8 @@ import {
   metaChordLabel,
 } from '@cli/runtime/shortcutLabels';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { resolveProviderCapabilities } from '@model/providerCapabilities';
+import { getRuntimeModelConfig } from '@model/runtimeModelRegistry';
 import {
   type RoundStage,
   type StreamPhase,
@@ -130,6 +132,28 @@ interface StatusBarDisplay {
   readonly bindings: string;
 }
 
+// ChatGPT/Codex-subscription turns run under a smaller enforced context
+// window than the model's raw API contextWindow (see providerCapabilities.ts).
+// `usage.usageRoute` is stamped by the handler that produced this specific
+// snapshot, so it's ground truth for *this* usage regardless of what the CLI
+// is currently configured to use — and resolveProviderCapabilities() only
+// ever stamps 'chatgpt-subscription' when useOpenRouter was false for that
+// turn, so passing `false` here isn't an assumption, it's already implied.
+function effectiveContextWindow(
+  usage: TokenUsageStats,
+  model: string,
+): number | undefined {
+  if (usage.usageRoute === 'chatgpt-subscription') {
+    const config = getRuntimeModelConfig(model);
+    const capped = config
+      ? resolveProviderCapabilities({ model: config, useOpenRouter: false })
+          ?.contextWindow
+      : undefined;
+    if (capped) return capped;
+  }
+  return MODEL_CONFIGS[model]?.contextWindow;
+}
+
 function formatUsage(
   usage: TokenUsageStats | undefined,
   model: string,
@@ -144,7 +168,7 @@ function formatUsage(
   if (used <= 0) return undefined;
 
   const base = { compactPriority: STATUS_BAR_COMPACT_PRIORITY.usage };
-  const contextWindow = MODEL_CONFIGS[model]?.contextWindow;
+  const contextWindow = effectiveContextWindow(usage, model);
   if (!contextWindow || contextWindow <= 0) {
     return { ...base, text: formatCompactTokenCount(used), color: 'dim' };
   }

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -476,9 +476,7 @@ describe('CLI StatusBar display model', () => {
       }),
     );
 
-    expect(display.left.map(statusBarSegmentText)).toContain(
-      '187k/1.1M (18%)',
-    );
+    expect(display.left.map(statusBarSegmentText)).toContain('187k/1.1M (18%)');
   });
 
   it('caps the context window to the subscription budget for chatgpt-subscription usage', () => {
@@ -497,9 +495,7 @@ describe('CLI StatusBar display model', () => {
 
     // gpt-5.6's Codex subscription budget caps to 500k
     // (CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW), not the raw 1.05M API window.
-    expect(display.left.map(statusBarSegmentText)).toContain(
-      '187k/500k (37%)',
-    );
+    expect(display.left.map(statusBarSegmentText)).toContain('187k/500k (37%)');
   });
 
   it('keeps critical controls visible in narrow subagent sessions', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -467,6 +467,41 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Alt-1..9 focus');
   });
 
+  it('shows the raw registry context window for non-subscription usage', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        model: 'gpt56',
+        usage: { inputTokens: 187_000, outputTokens: 4_000, cost: 0 },
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toContain(
+      '187k/1.1M (18%)',
+    );
+  });
+
+  it('caps the context window to the subscription budget for chatgpt-subscription usage', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        model: 'gpt56',
+        usage: {
+          inputTokens: 187_000,
+          outputTokens: 4_000,
+          cost: 0,
+          usageRoute: 'chatgpt-subscription',
+        },
+      }),
+    );
+
+    // gpt-5.6's Codex subscription budget caps to 500k
+    // (CODEX_GPT56_SUBSCRIPTION_CONTEXT_WINDOW), not the raw 1.05M API window.
+    expect(display.left.map(statusBarSegmentText)).toContain(
+      '187k/500k (37%)',
+    );
+  });
+
   it('keeps critical controls visible in narrow subagent sessions', () => {
     const display = buildStatusBarDisplay(
       statusInput({


### PR DESCRIPTION
## Summary
- `formatUsage()` in the CLI status bar read the raw llm-zoo `MODEL_CONFIGS[model].contextWindow` (the full API ceiling), so a ChatGPT/Codex-subscription session displayed e.g. `187k/1.1M (18%)` instead of the actual enforced subscription budget.
- The correct, capped value is already computed by `resolveProviderCapabilities()` and used by the agent runtime (`getEffectiveContextWindow()`) and the VS Code extension's UsagePanel — the CLI was the only surface not consulting it, so the two surfaces disagreed for the same session.
- Fix: `formatUsage()` now checks `usage.usageRoute === 'chatgpt-subscription'` (ground truth for that specific usage snapshot) and, when set, resolves the subscription-capped window via `resolveProviderCapabilities()` instead of the raw registry value. Non-subscription sessions are unaffected.

## Test plan
- [x] `npx vitest run src/test-kernel/cli/StatusBar.vitest.mts` — 54 passed, including two new cases (raw window for non-subscription usage, capped window for `chatgpt-subscription` usage)
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint packages/cli/src/chat/tui/panes/statusBarDisplay.ts src/test-kernel/cli/StatusBar.vitest.mts` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in status bar formatting with tests; no auth, billing, or request-path behavior.
> 
> **Overview**
> The CLI status bar **token usage** segment (`formatUsage`) now uses a subscription-aware context ceiling instead of always reading the raw `MODEL_CONFIGS` API window.
> 
> When `usage.usageRoute` is **`chatgpt-subscription`**, it resolves the enforced budget via `getRuntimeModelConfig` + `resolveProviderCapabilities` (e.g. `187k/500k (37%)` for gpt-5.6 instead of `187k/1.1M (18%)`). Other routes still use the registry window unchanged.
> 
> Vitest adds two cases covering non-subscription vs subscription usage display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a911a5107ba17b50ffca4b42420b0a3aa2693a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->