### PR TITLE
feat(cli): show session list newest-first, below the input box

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -1,5 +1,6 @@
 // Conversation render boundary: static scrollback, live transcript, foreground
-// surfaces, compact side panels, tips, and queued follow-ups above the footer.
+// surfaces, tips, and queued follow-ups above the footer, with the compact
+// side panels below it.
 
 // Third-party imports
 import { Box } from 'ink';
@@ -42,7 +43,7 @@ import type { StreamSlice } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
 // Cap the bottom subagent/todos panels so they never crowd out the
-// conversation or push the input bar off-screen.
+// conversation, even though they now render below the input bar.
 const BOTTOM_PANEL_MAX_ROWS = 10;
 interface ConversationRegionSnapshot {
   readonly activeStreamId: StreamTabId | undefined;

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -243,6 +243,21 @@ export function ConversationRegion({
             </Box>
           ) : null}
         </Box>
+        {tipRowVisible ? (
+          <TipRow
+            agentSelectionAvailable={agentSelectionAvailable}
+            hour={tipHour}
+            responseRunning={activeResponseRunning}
+          />
+        ) : null}
+        {queuedFollowUpPanelVisible ? (
+          <QueuedFollowUpsPanel
+            maxRows={queuedFollowUpPanelRows}
+            messages={queuedFollowUpMessages}
+            width={columns}
+          />
+        ) : null}
+        {renderFooterChrome(queuedFollowUpPanelVisible)}
         {bottomPanelBudget > 0 ? (
           <Box flexDirection="column" overflowY="hidden">
             <SubagentList
@@ -259,21 +274,6 @@ export function ConversationRegion({
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}
-        {tipRowVisible ? (
-          <TipRow
-            agentSelectionAvailable={agentSelectionAvailable}
-            hour={tipHour}
-            responseRunning={activeResponseRunning}
-          />
-        ) : null}
-        {queuedFollowUpPanelVisible ? (
-          <QueuedFollowUpsPanel
-            maxRows={queuedFollowUpPanelRows}
-            messages={queuedFollowUpMessages}
-            width={columns}
-          />
-        ) : null}
-        {renderFooterChrome(queuedFollowUpPanelVisible)}
       </Box>
     </>
   );

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -170,11 +170,17 @@ export function activeStreamTreeEntries(
 ): readonly ActiveStreamTreeEntry[] {
   const root = activeTreeRoot(init);
   if (!root) return [];
-  const ordered = orderedDescendantsFromTree({
-    parent: root,
-    childStreamEntries: init.childStreamEntries,
-    streams: init.streams,
-  });
+  // Newest-first: `orderedDescendantsFromTree` returns children oldest-first
+  // (retained order, then creation order), so the session list and its
+  // Alt+1..9 shortcuts read top-to-bottom from most to least recently
+  // started, keeping the row a user is most likely watching near the top.
+  const ordered = [
+    ...orderedDescendantsFromTree({
+      parent: root,
+      childStreamEntries: init.childStreamEntries,
+      streams: init.streams,
+    }),
+  ].reverse();
   const out: ActiveStreamTreeEntry[] = [];
   if (init.streams.has(root)) out.push({ id: root });
   for (const [index, id] of ordered.entries()) {

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -174,13 +174,11 @@ export function activeStreamTreeEntries(
   // (retained order, then creation order), so the session list and its
   // Alt+1..9 shortcuts read top-to-bottom from most to least recently
   // started, keeping the row a user is most likely watching near the top.
-  const ordered = [
-    ...orderedDescendantsFromTree({
-      parent: root,
-      childStreamEntries: init.childStreamEntries,
-      streams: init.streams,
-    }),
-  ].reverse();
+  const ordered = orderedDescendantsFromTree({
+    parent: root,
+    childStreamEntries: init.childStreamEntries,
+    streams: init.streams,
+  }).toReversed();
   const out: ActiveStreamTreeEntry[] = [];
   if (init.streams.has(root)) out.push({ id: root });
   for (const [index, id] of ordered.entries()) {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -209,7 +209,7 @@ describe('CLI child execution controls', () => {
         streams,
         zeroBasedIndex: 0,
       }),
-    ).toBe('child-c');
+    ).toBe('child-b');
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'root',
@@ -218,7 +218,7 @@ describe('CLI child execution controls', () => {
         streams,
         zeroBasedIndex: 1,
       }),
-    ).toBe('child-b');
+    ).toBe('child-c');
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'root',
@@ -270,7 +270,7 @@ describe('CLI child execution controls', () => {
         streams,
         zeroBasedIndex: 0,
       }),
-    ).toBe('child-b');
+    ).toBe('child-a');
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: 'child-a',
@@ -279,7 +279,7 @@ describe('CLI child execution controls', () => {
         streams,
         zeroBasedIndex: 1,
       }),
-    ).toBe('child-a');
+    ).toBe('child-b');
   });
 
   it('builds subagent and process picker items with stable labels and tails', () => {


### PR DESCRIPTION
## Summary
- The CLI's session/subagent picker listed sessions oldest-first (retained order, then creation order), so the most recently spawned subagent — the one a user is most likely watching — ended up buried at the bottom of a long list. `activeStreamTreeEntries()` now reverses the descendant order so the newest session sits nearest the top; the per-row `shortcutIndex` (Alt+1..9 focus jumps) is assigned after the reversal, so the shortcuts still match what's on screen.
- The session/todos panel rendered above the input bar, pushing the prompt down the screen as sessions accumulated. Moved it below the footer chrome (input bar + status bar) in `ConversationRegion`, so it reads as a status appendix under the prompt.

## Test plan
- [x] `npx vitest run src/test-kernel/cli/StreamViews.vitest.mts src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/SubagentListDisplay.vitest.mts` — 53 passed (updated two Alt+N mapping assertions in `ChildControls.vitest.mts` to match the new order)
- [x] `npx tsc --noEmit -p .` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI layout and display-order changes only; behavior is covered by updated vitest expectations for Alt+N mapping.
> 
> **Overview**
> The CLI session/subagent list and **Alt+1..9** focus jumps now use **newest-first** order: `activeStreamTreeEntries()` reverses descendant ordering so the most recently started session appears at the top, with shortcut indices assigned after that reversal so keys still match on-screen rows.
> 
> **Layout:** In `ConversationRegion`, tips, queued follow-ups, and the footer (input + status) render **above** the compact `SubagentList` / `TodosPlanPanel` block, so growing session lists sit under the prompt instead of pushing it down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e84ef7bf7a9eeca2eb6b4b88009d3e966851da83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->