### PR TITLE
refactor(cli): centralize transcript entry layout

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -26,7 +26,6 @@ import {
   type ChildStreamEntries,
 } from '../state/childExecutions';
 import { streamViewForId } from '../state/streamViews';
-import { transcriptEntryLines } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { COLOR_HINT } from '../ui/colors';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
@@ -36,13 +35,13 @@ import {
   nextRenderableTranscriptEntry,
   userPromptAwaitsLiveContinuation,
 } from './transcriptEntries';
+import { TranscriptEntry } from './TranscriptEntry';
 import {
-  ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
-  PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
-  TranscriptEntry,
   USER_ENTRY_MARGIN_BOTTOM_ROWS,
-  USER_ENTRY_MARGIN_TOP_ROWS,
-} from './TranscriptEntry';
+  transcriptColumns,
+  transcriptEntryLayout,
+  transcriptEntryLayoutRows,
+} from './transcriptEntryLayout';
 
 export type StaticTranscriptItem =
   | {
@@ -118,7 +117,7 @@ function SessionHeaderBlock({
   readonly meta: SessionMeta;
   readonly width?: number;
 }): React.JSX.Element {
-  const columns = Math.max(1, Math.floor(width ?? 80));
+  const columns = transcriptColumns(width);
   if (compact) {
     return (
       <Box paddingX={1}>
@@ -195,31 +194,12 @@ function staticTranscriptItemRowCount(
       ? COMPACT_SESSION_HEADER_ROWS
       : FULL_SESSION_HEADER_ROWS;
   }
-  // Compact budgeting can over-count tool rows because the transcript viewer
-  // keeps full tool output while the static scrollback renderer elides it.
-  const cols = Math.max(1, Math.floor(width ?? 80));
-  const isUserBand =
-    item.entry.role === 'user' && !isInquiryContinuationText(item.entry.text);
-  const isPaddedPrefixRow =
-    item.entry.role === 'user' || item.entry.role === 'error';
-  // Pass cols-2 for user/error entries: transcriptEntryLines subtracts the
-  // 2-char prefix internally, so the effective wrap width is cols-4,
-  // matching the paddingX={1} + prefix geometry of the renderer.
-  const lines = transcriptEntryLines(
-    item.entry,
-    isPaddedPrefixRow ? Math.max(1, cols - 2) : cols,
-  ).length;
-  let marginRows = 0;
-  if (isUserBand) {
-    marginRows =
-      USER_ENTRY_MARGIN_TOP_ROWS +
-      (item.userBottomMarginRows ?? USER_ENTRY_MARGIN_BOTTOM_ROWS);
-  } else if (item.entry.role === 'assistant') {
-    marginRows = ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS;
-  } else if (item.entry.role === 'process') {
-    marginRows = PROCESS_ENTRY_MARGIN_BOTTOM_ROWS;
-  }
-  return lines + marginRows;
+  return transcriptEntryLayoutRows(
+    transcriptEntryLayout(item.entry, {
+      userBottomMarginRows: item.userBottomMarginRows,
+      width,
+    }),
+  );
 }
 
 function staticUserBottomMarginRows({
@@ -346,7 +326,7 @@ export function StaticConversationTranscript({
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly width?: number;
 }): React.JSX.Element {
-  const normalizedWidth = Math.max(1, Math.floor(width ?? 80));
+  const normalizedWidth = transcriptColumns(width);
   const streams = useSignal(streamsSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -196,6 +196,7 @@ function staticTranscriptItemRowCount(
   }
   return transcriptEntryLayoutRows(
     transcriptEntryLayout(item.entry, {
+      mode: 'scrollback-budget',
       userBottomMarginRows: item.userBottomMarginRows,
       width,
     }),

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -15,12 +15,13 @@ import {
   toolUseDisplayLines,
   UniversalToolRow,
 } from './toolRenderers';
+import { transcriptColumns } from './transcriptEntryLayout';
 
 export function filledToolUseDisplayText(
   toolUse: NormalizedToolUse,
   width?: number,
 ): string {
-  const cols = Math.max(1, Math.floor(width ?? 80));
+  const cols = transcriptColumns(width);
   return fillRows(toolUseDisplayLines(toolUse).join('\n'), cols);
 }
 

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -165,6 +165,12 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   readonly fillWidth?: boolean;
   readonly userBottomMarginRows?: number;
 }): React.JSX.Element {
+  if (entry.role === 'tool') {
+    return (
+      <ToolUseRow fillWidth={fillWidth} toolUse={entry.toolUse} width={width} />
+    );
+  }
+
   const layout = transcriptEntryLayout(entry, {
     colorEnabled,
     mode: 'scrollback',
@@ -173,14 +179,6 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   });
 
   switch (entry.role) {
-    case 'tool':
-      return (
-        <ToolUseRow
-          fillWidth={fillWidth}
-          toolUse={entry.toolUse}
-          width={width}
-        />
-      );
     case 'process':
       return (
         <ProcessEntryRow

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -229,6 +229,7 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   const layout = boundedTranscriptEntryLayout(
     transcriptEntryLayout(entry, {
       colorEnabled,
+      maxRows,
       mode: 'bounded',
       width,
     }),

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -1,209 +1,120 @@
-// Per-entry renderers shared by the `<Static>` finalized transcript and the
-// bounded live region. Finalized assistant text flows through the ANSI
-// markdown renderer; the live tail stays plain text to avoid re-parsing a
-// growing document on every chunk.
+// Per-entry Ink presentation. Geometry and text rows come from
+// transcriptEntryLayout; this module adds only role-specific styling and rich
+// widgets.
 
+// Third-party imports
 import { memo } from 'react';
 import { Box, Text } from 'ink';
 
-import { COLOR_ERROR, COLOR_HINT } from '../ui/colors';
+// Local imports - CLI TUI rendering
 import { Markdown } from '../render/Markdown';
-import { renderAnsiMarkdown } from '../render/ansiMarkdown';
-import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { fillRows } from '../render/terminalText';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
-import {
-  ERROR_ENTRY_PREFIX,
-  STATUS_DOT,
-  USER_ENTRY_PREFIX,
-} from '../ui/glyphs';
-import { isInquiryContinuationText } from './transcriptEntries';
+import { COLOR_ERROR, COLOR_HINT } from '../ui/colors';
+import { STATUS_DOT } from '../ui/glyphs';
 import { childStatusColor } from './SubagentListDisplay';
 import { ToolUseRow } from './ToolUseRow';
-import { toolUseDisplayLines } from './toolRenderers';
+import {
+  LIVE_TAIL_ROWS,
+  boundedTranscriptEntryLayout,
+  transcriptEntryLayout,
+  type TranscriptEntryLayout,
+} from './transcriptEntryLayout';
+import { isInquiryContinuationText } from './transcriptEntries';
 import type {
   CompletedProcessTranscript,
   ConversationEntry,
 } from '../state/cliState';
 
-export const USER_ENTRY_MARGIN_TOP_ROWS = 1;
-export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
-export const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
-export const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
-
-// Terminal columns available to an entry's text. Padded boxes (paddingX={1})
-// inset one column on each side, so those rows pass `inset = 2`; full-width
-// rows pass no inset. A missing width defaults to 80 columns.
-function entryCols(width: number | undefined, inset = 0): number {
-  return Math.max(1, Math.floor(width ?? 80) - inset);
-}
-
-function prefixedWrappedLines(
-  text: string,
-  cols: number,
-  prefix = USER_ENTRY_PREFIX,
+function displayLines(
+  layout: TranscriptEntryLayout,
+  fillWidth: boolean | undefined,
 ): readonly string[] {
-  const continuationPrefix = ' '.repeat(prefix.length);
-  return wrapAnsiToWidth(text, Math.max(1, cols - prefix.length))
-    .split('\n')
-    .map(
-      (line, index) => `${index === 0 ? prefix : continuationPrefix}${line}`,
+  return fillWidth === true
+    ? fillRows(layout.lines.join('\n'), layout.columns).split('\n')
+    : layout.lines;
+}
+
+function PlainEntryRows({
+  colorEnabled,
+  entry,
+  fillWidth,
+  layout,
+}: {
+  readonly colorEnabled?: boolean;
+  readonly entry: ConversationEntry;
+  readonly fillWidth?: boolean;
+  readonly layout: TranscriptEntryLayout;
+}): React.JSX.Element {
+  const lines = displayLines(layout, fillWidth);
+  const paddingX = layout.inset / 2;
+  const boxProps = {
+    flexDirection: 'column' as const,
+    marginBottom: layout.marginBottomRows,
+    marginTop: layout.marginTopRows,
+    paddingX,
+  };
+
+  if (entry.role === 'user' && isInquiryContinuationText(entry.text)) {
+    return (
+      <Box {...boxProps}>
+        {lines.map((line, index) => (
+          <Text
+            key={index}
+            color={
+              colorEnabled !== false && index === 0 ? COLOR_HINT : undefined
+            }
+            dimColor={colorEnabled !== false && index > 0}
+          >
+            {line}
+          </Text>
+        ))}
+      </Box>
     );
-}
+  }
 
-function displayRows({
-  lines,
-  fillWidth,
-  width,
-}: {
-  readonly lines: readonly string[];
-  readonly fillWidth?: boolean;
-  readonly width: number;
-}): string {
-  const text = lines.join('\n');
-  return fillWidth === true ? fillRows(text, width) : text;
-}
-
-export function compactPrefixedDisplayRows({
-  fillWidth,
-  maxRows,
-  prefix = USER_ENTRY_PREFIX,
-  text,
-  width,
-}: {
-  readonly fillWidth?: boolean;
-  readonly maxRows?: number;
-  readonly prefix?: string;
-  readonly text: string;
-  readonly width: number;
-}): string {
-  const cols = Math.max(1, Math.floor(width));
-  const lines = prefixedWrappedLines(text, cols, prefix);
-  return displayRows({
-    fillWidth,
-    lines: maxRows === undefined ? lines : boundedLines(lines, maxRows),
-    width: cols,
-  });
-}
-
-function boundedDisplayRows({
-  lines,
-  maxRows,
-  width,
-}: {
-  readonly lines: readonly string[];
-  readonly maxRows: number;
-  readonly width: number;
-}): string {
-  return fillRows(boundedLines(lines, maxRows).join('\n'), width);
-}
-
-function UserEntryRow({
-  entry,
-  colorEnabled,
-  marginTopRows = USER_ENTRY_MARGIN_TOP_ROWS,
-  marginBottomRows = USER_ENTRY_MARGIN_BOTTOM_ROWS,
-  maxRows,
-  width,
-}: {
-  readonly entry: ConversationEntry;
-  readonly colorEnabled?: boolean;
-  readonly marginTopRows?: number;
-  readonly marginBottomRows?: number;
-  readonly maxRows?: number;
-  readonly width?: number;
-}): React.JSX.Element {
-  // Mark a user turn with a reverse-video band (theme-adaptive via reverse
-  // video), inset one column from each terminal edge — the same gutter the
-  // error/tool/process rows get from their padded boxes — with a blank row
-  // above and below so the turn breathes. Finalized transcript rows are
-  // normally print-once; a width change remounts the enclosing `<Static>` so
-  // patched Ink replaces the accumulated rows at the current width. The `› `
-  // chevron is 2 cols; row estimators add the exported margin constants
-  // alongside their wrapped-line count.
-  const cols = entryCols(width, 2);
   return (
-    <Box marginTop={marginTopRows} marginBottom={marginBottomRows} paddingX={1}>
-      <Text inverse={colorEnabled !== false}>
-        {compactPrefixedDisplayRows({
-          fillWidth: true,
-          maxRows,
-          text: entry.text,
-          width: cols,
-        })}
+    <Box {...boxProps}>
+      <Text
+        color={entry.role === 'error' ? COLOR_ERROR : undefined}
+        inverse={entry.role === 'user' && colorEnabled !== false}
+      >
+        {lines.join('\n')}
       </Text>
-    </Box>
-  );
-}
-
-function InquiryContinuationRow({
-  entry,
-  fillWidth,
-  colorEnabled,
-  maxRows,
-  width,
-}: {
-  readonly entry: ConversationEntry;
-  readonly fillWidth?: boolean;
-  readonly colorEnabled?: boolean;
-  readonly maxRows?: number;
-  readonly width?: number;
-}): React.JSX.Element {
-  // Same one-column gutter as the user band so both `› ` chevrons align.
-  const cols = entryCols(width, 2);
-  const wrappedLines = prefixedWrappedLines(entry.text, cols);
-  const lines =
-    maxRows === undefined ? wrappedLines : boundedLines(wrappedLines, maxRows);
-  const displayLines =
-    fillWidth === true ? fillRows(lines.join('\n'), cols).split('\n') : lines;
-  return (
-    <Box flexDirection="column" paddingX={1}>
-      {displayLines.map((line, index) => (
-        <Text
-          key={index}
-          color={colorEnabled !== false && index === 0 ? COLOR_HINT : undefined}
-          dimColor={colorEnabled !== false && index > 0}
-        >
-          {line}
-        </Text>
-      ))}
     </Box>
   );
 }
 
 function ProcessEntryRow({
   fillWidth,
+  layout,
   process,
-  width,
 }: {
   readonly fillWidth?: boolean;
+  readonly layout: TranscriptEntryLayout;
   readonly process: CompletedProcessTranscript;
-  readonly width?: number;
 }): React.JSX.Element {
   if (fillWidth === true) {
-    const cols = entryCols(width, 2);
-    return (
-      <Box
-        marginBottom={PROCESS_ENTRY_MARGIN_BOTTOM_ROWS}
-        paddingX={1}
-        flexDirection="column"
-      >
-        <Text>
-          {fillRows(completedProcessDisplayLines(process).join('\n'), cols)}
-        </Text>
-      </Box>
-    );
+    const entry: ConversationEntry = {
+      finalized: true,
+      id: process.executionId,
+      process,
+      role: 'process',
+      text: '',
+    };
+    return <PlainEntryRows entry={entry} fillWidth layout={layout} />;
   }
 
-  // Same status→color owner as the live SubagentList rows, so a cancelled or
-  // stopped child finalizes with the neutral dot instead of a green one.
+  // Same status-to-color owner as the live SubagentList rows, so a cancelled
+  // or stopped child finalizes with the neutral dot instead of a green one.
   const color = childStatusColor(process.status);
   const [, ...tailLines] = completedProcessDisplayLines(process);
   return (
     <Box
-      marginBottom={PROCESS_ENTRY_MARGIN_BOTTOM_ROWS}
-      paddingX={1}
       flexDirection="column"
+      marginBottom={layout.marginBottomRows}
+      marginTop={layout.marginTopRows}
+      paddingX={layout.inset / 2}
     >
       <Box>
         <Text color={color}>{STATUS_DOT} </Text>
@@ -231,10 +142,8 @@ function ProcessEntryRow({
   );
 }
 
-// The entry renderers are memoized: stream sync keeps unchanged entry
-// objects reference-identical across ticks (see `renderLogEntry`'s
-// `entriesEqual` reuse), so a streaming delta re-wraps only the entry that
-// actually changed instead of every pending row on each 16ms tick.
+// Entry objects stay reference-identical across stream ticks, so memoization
+// limits wrapping and Markdown work to the entry that actually changed.
 export const TranscriptEntry = memo(function TranscriptEntry({
   entry,
   width,
@@ -248,41 +157,14 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   readonly fillWidth?: boolean;
   readonly userBottomMarginRows?: number;
 }): React.JSX.Element {
+  const layout = transcriptEntryLayout(entry, {
+    colorEnabled,
+    mode: 'scrollback',
+    userBottomMarginRows,
+    width,
+  });
+
   switch (entry.role) {
-    case 'user':
-      if (isInquiryContinuationText(entry.text)) {
-        return (
-          <InquiryContinuationRow
-            entry={entry}
-            fillWidth={fillWidth}
-            colorEnabled={colorEnabled}
-            width={width}
-          />
-        );
-      }
-      return (
-        <UserEntryRow
-          entry={entry}
-          colorEnabled={colorEnabled}
-          marginBottomRows={userBottomMarginRows}
-          width={width}
-        />
-      );
-    case 'error': {
-      const cols = entryCols(width, 2);
-      return (
-        <Box paddingX={1}>
-          <Text color={COLOR_ERROR}>
-            {compactPrefixedDisplayRows({
-              fillWidth,
-              prefix: ERROR_ENTRY_PREFIX,
-              text: entry.text,
-              width: cols,
-            })}
-          </Text>
-        </Box>
-      );
-    }
     case 'tool':
       return (
         <ToolUseRow
@@ -295,76 +177,35 @@ export const TranscriptEntry = memo(function TranscriptEntry({
       return (
         <ProcessEntryRow
           fillWidth={fillWidth}
+          layout={layout}
           process={entry.process}
-          width={width}
+        />
+      );
+    case 'assistant':
+      return (
+        <Box
+          marginBottom={layout.marginBottomRows}
+          marginTop={layout.marginTopRows}
+        >
+          <Markdown
+            content={entry.text}
+            width={layout.columns}
+            colorEnabled={colorEnabled}
+            fillWidth={fillWidth}
+          />
+        </Box>
+      );
+    default:
+      return (
+        <PlainEntryRows
+          colorEnabled={colorEnabled}
+          entry={entry}
+          fillWidth={fillWidth}
+          layout={layout}
         />
       );
   }
-  return (
-    <Box marginBottom={ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS}>
-      <Markdown
-        content={entry.text}
-        width={width}
-        colorEnabled={colorEnabled}
-        fillWidth={fillWidth}
-      />
-    </Box>
-  );
 });
-
-function boundedLines(
-  lines: readonly string[],
-  maxRows: number,
-): readonly string[] {
-  return lines.slice(-Math.max(1, maxRows));
-}
-
-// Slice raw text to a tail window before wrapping: ~2 screen widths per
-// visible row covers worst-case wrapping without making the wrap O(text) on
-// every streaming delta. liveAssistantDisplayLines applies this window and is
-// shared by the live renderers and viewport row estimator.
-function tailWindow(text: string, cols: number, tailRows: number): string {
-  const budget = Math.max(1, cols) * tailRows * 2;
-  return text.length > budget ? text.slice(-budget) : text;
-}
-
-export function liveAssistantDisplayLines({
-  rows,
-  text,
-  width,
-}: {
-  readonly rows: number;
-  readonly text: string;
-  readonly width?: number;
-}): readonly string[] {
-  const cols = entryCols(width);
-  return wrapAnsiToWidth(tailWindow(text, cols, rows), cols)
-    .split('\n')
-    .slice(-Math.max(1, rows));
-}
-
-export function boundedAssistantDisplayLines({
-  colorEnabled,
-  finalized,
-  rows,
-  text,
-  width,
-}: {
-  readonly colorEnabled?: boolean;
-  readonly finalized: boolean;
-  readonly rows: number;
-  readonly text: string;
-  readonly width?: number;
-}): readonly string[] {
-  const cols = entryCols(width);
-  if (!finalized) {
-    return liveAssistantDisplayLines({ rows, text, width: cols });
-  }
-  return boundedLines(
-    renderAnsiMarkdown(text, { width: cols, colorEnabled }).split('\n'),
-    rows,
-  );
-}
 
 export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   colorEnabled,
@@ -377,109 +218,23 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   readonly maxRows: number;
   readonly width?: number;
 }): React.JSX.Element {
-  const rows = Math.max(1, maxRows);
-  if (entry.role === 'assistant') {
-    const cols = entryCols(width);
-    // Streaming overflow stays plain for speed. Finalized overflow renders
-    // cached Markdown first and then takes the visible tail.
-    return (
-      <Box flexDirection="column">
-        <Text>
-          {displayRows({
-            fillWidth: true,
-            lines: boundedAssistantDisplayLines({
-              colorEnabled,
-              finalized: entry.finalized,
-              rows,
-              text: entry.text,
-              width: cols,
-            }),
-            width: cols,
-          })}
-        </Text>
-      </Box>
-    );
-  }
-  if (entry.role === 'user') {
-    if (isInquiryContinuationText(entry.text)) {
-      return (
-        <InquiryContinuationRow
-          entry={entry}
-          fillWidth
-          colorEnabled={colorEnabled}
-          maxRows={rows}
-          width={width}
-        />
-      );
-    }
-
-    const includeMargins = rows >= 3;
-    const marginRows = includeMargins
-      ? USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS
-      : 0;
-    return (
-      <UserEntryRow
-        entry={entry}
-        colorEnabled={colorEnabled}
-        marginTopRows={includeMargins ? USER_ENTRY_MARGIN_TOP_ROWS : 0}
-        marginBottomRows={includeMargins ? USER_ENTRY_MARGIN_BOTTOM_ROWS : 0}
-        maxRows={Math.max(1, rows - marginRows)}
-        width={width}
-      />
-    );
-  }
-  if (entry.role === 'tool') {
-    const cols = entryCols(width, 2);
-    return (
-      <Box flexDirection="column" paddingX={1}>
-        <Text>
-          {boundedDisplayRows({
-            lines: toolUseDisplayLines(entry.toolUse),
-            maxRows: rows,
-            width: cols,
-          })}
-        </Text>
-      </Box>
-    );
-  }
-  if (entry.role === 'process') {
-    const cols = entryCols(width, 2);
-    return (
-      <Box flexDirection="column" paddingX={1}>
-        <Text>
-          {boundedDisplayRows({
-            lines: completedProcessDisplayLines(entry.process),
-            maxRows: rows,
-            width: cols,
-          })}
-        </Text>
-      </Box>
-    );
-  }
-
-  const prefix =
-    entry.role === 'error' ? ERROR_ENTRY_PREFIX : USER_ENTRY_PREFIX;
-  const color = entry.role === 'error' ? COLOR_ERROR : undefined;
-  const cols = entryCols(width, 2);
+  const layout = boundedTranscriptEntryLayout(
+    transcriptEntryLayout(entry, {
+      colorEnabled,
+      mode: 'bounded',
+      width,
+    }),
+    maxRows,
+  );
   return (
-    <Box paddingX={1}>
-      <Text color={color}>
-        {compactPrefixedDisplayRows({
-          fillWidth: true,
-          maxRows: rows,
-          prefix,
-          text: entry.text,
-          width: cols,
-        })}
-      </Text>
-    </Box>
+    <PlainEntryRows
+      colorEnabled={colorEnabled}
+      entry={entry}
+      fillWidth
+      layout={layout}
+    />
   );
 });
-
-// Cap the live tail so a multi-megabyte assistant buffer doesn't re-wrap
-// every chunk. The static `<Static>` transcript owns the full history; we
-// only need enough characters here to fill a typical viewport.
-export const LIVE_TAIL_ROWS = 24;
 
 export const LiveTranscriptEntry = memo(function LiveTranscriptEntry({
   entry,
@@ -488,15 +243,9 @@ export const LiveTranscriptEntry = memo(function LiveTranscriptEntry({
   readonly entry: ConversationEntry;
   readonly width?: number;
 }): React.JSX.Element {
-  const cols = entryCols(width);
-  const rows = liveAssistantDisplayLines({
-    rows: LIVE_TAIL_ROWS,
-    text: entry.text,
-    width: cols,
-  });
-  return (
-    <Box flexDirection="column">
-      <Text>{fillRows(rows.join('\n'), cols)}</Text>
-    </Box>
+  const layout = boundedTranscriptEntryLayout(
+    transcriptEntryLayout(entry, { mode: 'live', width }),
+    LIVE_TAIL_ROWS,
   );
+  return <PlainEntryRows entry={entry} fillWidth layout={layout} />;
 });

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -46,7 +46,15 @@ function PlainEntryRows({
   readonly fillWidth?: boolean;
   readonly layout: TranscriptEntryLayout;
 }): React.JSX.Element {
-  const lines = displayLines(layout, fillWidth);
+  const isInquiryContinuation =
+    entry.role === 'user' && isInquiryContinuationText(entry.text);
+  // User turns are full-width inverse bands in both static and live panes.
+  // Inquiry continuations remain ordinary prefixed rows and only fill when
+  // their bounded caller requests it.
+  const lines = displayLines(
+    layout,
+    fillWidth === true || (entry.role === 'user' && !isInquiryContinuation),
+  );
   const paddingX = layout.inset / 2;
   const boxProps = {
     flexDirection: 'column' as const,
@@ -55,7 +63,7 @@ function PlainEntryRows({
     paddingX,
   };
 
-  if (entry.role === 'user' && isInquiryContinuationText(entry.text)) {
+  if (isInquiryContinuation) {
     return (
       <Box {...boxProps}>
         {lines.map((line, index) => (

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -101,6 +101,8 @@ export interface ToolRenderer {
   readonly key: string;
   matches(toolUse: NormalizedToolUse): boolean;
   render(toolUse: NormalizedToolUse): React.JSX.Element;
+  /** Text geometry for budgeting and plain projections. Keep one line for
+   *  every visually distinct row emitted by `render`. */
   displayLines(
     toolUse: NormalizedToolUse,
     options?: DisplayLineOptions,

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -478,14 +478,9 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     visibleOutput.length === 0 &&
     !patchGroups &&
     !toolUse.isError;
-  const hasDetails =
-    visibleOutput.length > 0 ||
-    (patchGroups?.length ?? 0) > 0 ||
-    toolUse.isError ||
-    showNoOutput;
 
   return (
-    <Box flexDirection="column" marginBottom={hasDetails ? 1 : 0}>
+    <Box flexDirection="column" marginBottom={toolUseMarginBottomRows(toolUse)}>
       <Box flexDirection="row" flexWrap="nowrap">
         <Text color={color} dimColor={!color}>
           {STATUS_DOT}{' '}
@@ -631,4 +626,10 @@ export function toolUseDisplayLines(
   }
   cached[slot] = lines;
   return lines;
+}
+
+/** Tool detail rows are separated from the next conversation entry. Derive
+ *  that geometry from the same display-line model used by row budgeting. */
+export function toolUseMarginBottomRows(toolUse: NormalizedToolUse): 0 | 1 {
+  return toolUseDisplayLines(toolUse).length > 1 ? 1 : 0;
 }

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -182,13 +182,17 @@ function entryLines(
       const lines = toolUseDisplayLines(entry.toolUse, {
         elide: mode !== 'viewer' && mode !== 'scrollback-budget',
       });
-      // The live rich renderer keeps each tool display line on one terminal
-      // row. Other modes paint the descriptor's text projection directly.
-      return mode === 'live' ? lines : wrapDisplayLines(lines, columns);
+      // Rich rows and their bounded fallback keep each display line on one
+      // terminal row. Other modes paint the wrapped text projection directly.
+      return mode === 'live' || mode === 'bounded'
+        ? lines
+        : wrapDisplayLines(lines, columns);
     }
     case 'process': {
       const lines = completedProcessDisplayLines(entry.process);
-      return mode === 'live' ? lines : wrapDisplayLines(lines, columns);
+      return mode === 'live' || mode === 'bounded'
+        ? lines
+        : wrapDisplayLines(lines, columns);
     }
     default: {
       const geometry = ROLE_GEOMETRY[entry.role];

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -21,7 +21,8 @@ const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 export const LIVE_TAIL_ROWS = 24;
 
 type TranscriptEntryRole = ConversationEntry['role'];
-type TranscriptEntryLayoutMode = 'bounded' | 'live' | 'scrollback' | 'viewer';
+type TranscriptEntryLayoutMode =
+  'bounded' | 'live' | 'scrollback' | 'scrollback-budget' | 'viewer';
 
 interface RoleGeometry {
   readonly firstPrefix: string;
@@ -156,7 +157,6 @@ function entryLines(
   columns: number,
   colorEnabled: boolean | undefined,
 ): readonly string[] {
-  const geometry = ROLE_GEOMETRY[entry.role];
   switch (entry.role) {
     case 'assistant':
       if (mode === 'live' || (mode === 'bounded' && !entry.finalized)) {
@@ -166,29 +166,35 @@ function entryLines(
           width: columns,
         });
       }
-      return mode === 'scrollback' || mode === 'bounded'
+      return mode === 'scrollback' ||
+        mode === 'scrollback-budget' ||
+        mode === 'bounded'
         ? renderAnsiMarkdown(entry.text, {
             width: columns,
             colorEnabled,
           }).split('\n')
         : wrapWithPrefix(entry.text, columns, '', '');
-    case 'tool':
-      return wrapDisplayLines(
-        toolUseDisplayLines(entry.toolUse, { elide: mode !== 'viewer' }),
-        columns,
-      );
-    case 'process':
-      return wrapDisplayLines(
-        completedProcessDisplayLines(entry.process),
-        columns,
-      );
-    default:
+    case 'tool': {
+      const lines = toolUseDisplayLines(entry.toolUse, {
+        elide: mode !== 'viewer' && mode !== 'scrollback-budget',
+      });
+      // The live rich renderer keeps each tool display line on one terminal
+      // row. Other modes paint the descriptor's text projection directly.
+      return mode === 'live' ? lines : wrapDisplayLines(lines, columns);
+    }
+    case 'process': {
+      const lines = completedProcessDisplayLines(entry.process);
+      return mode === 'live' ? lines : wrapDisplayLines(lines, columns);
+    }
+    default: {
+      const geometry = ROLE_GEOMETRY[entry.role];
       return wrapWithPrefix(
         entry.text,
         columns,
         geometry.firstPrefix,
         geometry.continuationPrefix,
       );
+    }
   }
 }
 

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -1,0 +1,267 @@
+// Declarative conversation-entry geometry shared by Ink renderers, viewport
+// budgeting, static scrollback, and the plain-text transcript viewer.
+
+import { renderAnsiMarkdown } from '../render/ansiMarkdown';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
+import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
+import {
+  ERROR_ENTRY_PREFIX,
+  TOOL_OUTPUT_CORNER,
+  USER_ENTRY_PREFIX,
+} from '../ui/glyphs';
+import { isInquiryContinuationText } from './transcriptEntries';
+import { toolUseDisplayLines, toolUseMarginBottomRows } from './toolRenderers';
+import type { ConversationEntry } from '../state/cliState';
+
+const DEFAULT_TRANSCRIPT_COLUMNS = 80;
+const USER_ENTRY_MARGIN_TOP_ROWS = 1;
+export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
+const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
+const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
+export const LIVE_TAIL_ROWS = 24;
+
+type TranscriptEntryRole = ConversationEntry['role'];
+type TranscriptEntryLayoutMode = 'bounded' | 'live' | 'scrollback' | 'viewer';
+
+interface RoleGeometry {
+  readonly firstPrefix: string;
+  readonly continuationPrefix: string;
+  readonly inset: number;
+  readonly marginBottomRows: number;
+  readonly marginTopRows: number;
+}
+
+const ROLE_GEOMETRY = {
+  assistant: {
+    firstPrefix: '',
+    continuationPrefix: '',
+    inset: 0,
+    marginBottomRows: ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
+    marginTopRows: 0,
+  },
+  error: {
+    firstPrefix: ERROR_ENTRY_PREFIX,
+    continuationPrefix: ' '.repeat(ERROR_ENTRY_PREFIX.length),
+    inset: 2,
+    marginBottomRows: 0,
+    marginTopRows: 0,
+  },
+  process: {
+    firstPrefix: '',
+    continuationPrefix: '',
+    inset: 2,
+    marginBottomRows: PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
+    marginTopRows: 0,
+  },
+  tool: {
+    firstPrefix: '',
+    continuationPrefix: '',
+    inset: 0,
+    marginBottomRows: 0,
+    marginTopRows: 0,
+  },
+  user: {
+    firstPrefix: USER_ENTRY_PREFIX,
+    continuationPrefix: ' '.repeat(USER_ENTRY_PREFIX.length),
+    inset: 2,
+    marginBottomRows: USER_ENTRY_MARGIN_BOTTOM_ROWS,
+    marginTopRows: USER_ENTRY_MARGIN_TOP_ROWS,
+  },
+} as const satisfies Record<TranscriptEntryRole, RoleGeometry>;
+
+export interface TranscriptEntryLayout extends RoleGeometry {
+  readonly columns: number;
+  readonly lines: readonly string[];
+  readonly role: TranscriptEntryRole;
+}
+
+export function transcriptColumns(
+  width: number | undefined,
+  inset = 0,
+): number {
+  return Math.max(
+    1,
+    Math.floor(
+      width == null || !Number.isFinite(width)
+        ? DEFAULT_TRANSCRIPT_COLUMNS
+        : width,
+    ) - inset,
+  );
+}
+
+function wrapWithPrefix(
+  body: string,
+  columns: number,
+  firstPrefix: string,
+  continuationPrefix: string,
+): readonly string[] {
+  const width = Math.max(1, columns - firstPrefix.length);
+  return wrapAnsiToWidth(body, width)
+    .split('\n')
+    .map(
+      (line, index) =>
+        `${index === 0 ? firstPrefix : continuationPrefix}${line}`,
+    );
+}
+
+const CORNER_PREFIX = `${TOOL_OUTPUT_CORNER} `;
+
+function leadingWhitespacePrefix(line: string): string {
+  return line.match(/^\s+/)?.[0] ?? '';
+}
+
+function wrapDisplayLine(line: string, columns: number): readonly string[] {
+  if (line.startsWith(CORNER_PREFIX)) {
+    return wrapWithPrefix(
+      line.slice(CORNER_PREFIX.length),
+      columns,
+      CORNER_PREFIX,
+      ' '.repeat(CORNER_PREFIX.length),
+    );
+  }
+  const prefix = leadingWhitespacePrefix(line);
+  return wrapWithPrefix(line.slice(prefix.length), columns, prefix, prefix);
+}
+
+function wrapDisplayLines(
+  lines: readonly string[],
+  columns: number,
+): readonly string[] {
+  return lines.flatMap((line) => wrapDisplayLine(line, columns));
+}
+
+function tailWindow(text: string, columns: number, tailRows: number): string {
+  const budget = Math.max(1, columns) * tailRows * 2;
+  return text.length > budget ? text.slice(-budget) : text;
+}
+
+export function liveAssistantDisplayLines({
+  rows,
+  text,
+  width,
+}: {
+  readonly rows: number;
+  readonly text: string;
+  readonly width?: number;
+}): readonly string[] {
+  const columns = transcriptColumns(width);
+  return wrapAnsiToWidth(tailWindow(text, columns, rows), columns)
+    .split('\n')
+    .slice(-Math.max(1, rows));
+}
+
+function entryLines(
+  entry: ConversationEntry,
+  mode: TranscriptEntryLayoutMode,
+  columns: number,
+  colorEnabled: boolean | undefined,
+): readonly string[] {
+  const geometry = ROLE_GEOMETRY[entry.role];
+  switch (entry.role) {
+    case 'assistant':
+      if (mode === 'live' || (mode === 'bounded' && !entry.finalized)) {
+        return liveAssistantDisplayLines({
+          rows: LIVE_TAIL_ROWS,
+          text: entry.text,
+          width: columns,
+        });
+      }
+      return mode === 'scrollback' || mode === 'bounded'
+        ? renderAnsiMarkdown(entry.text, {
+            width: columns,
+            colorEnabled,
+          }).split('\n')
+        : wrapWithPrefix(entry.text, columns, '', '');
+    case 'tool':
+      return wrapDisplayLines(
+        toolUseDisplayLines(entry.toolUse, { elide: mode !== 'viewer' }),
+        columns,
+      );
+    case 'process':
+      return wrapDisplayLines(
+        completedProcessDisplayLines(entry.process),
+        columns,
+      );
+    default:
+      return wrapWithPrefix(
+        entry.text,
+        columns,
+        geometry.firstPrefix,
+        geometry.continuationPrefix,
+      );
+  }
+}
+
+export function transcriptEntryLayout(
+  entry: ConversationEntry,
+  {
+    colorEnabled,
+    mode = 'scrollback',
+    userBottomMarginRows,
+    width,
+  }: {
+    readonly colorEnabled?: boolean;
+    readonly mode?: TranscriptEntryLayoutMode;
+    readonly userBottomMarginRows?: number;
+    readonly width?: number;
+  } = {},
+): TranscriptEntryLayout {
+  const base = ROLE_GEOMETRY[entry.role];
+  // The bounded tool fallback historically uses a one-column Ink gutter; the
+  // rich unbounded tool renderer owns its own per-line indentation.
+  const inset = entry.role === 'tool' && mode === 'bounded' ? 2 : base.inset;
+  const isInquiryContinuation =
+    entry.role === 'user' && isInquiryContinuationText(entry.text);
+  const marginTopRows = isInquiryContinuation ? 0 : base.marginTopRows;
+  const marginBottomRows =
+    entry.role === 'tool'
+      ? toolUseMarginBottomRows(entry.toolUse)
+      : isInquiryContinuation
+        ? 0
+        : entry.role === 'user'
+          ? (userBottomMarginRows ?? base.marginBottomRows)
+          : base.marginBottomRows;
+  // The ctrl+t viewer is a full-width text projection with no Ink padding;
+  // its lines still share role prefixes and wrapping rules with the layout.
+  const columns = transcriptColumns(width, mode === 'viewer' ? 0 : inset);
+  return {
+    ...base,
+    columns,
+    lines: entryLines(entry, mode, columns, colorEnabled),
+    inset,
+    marginBottomRows,
+    marginTopRows,
+    role: entry.role,
+  };
+}
+
+export function transcriptEntryLayoutRows(
+  layout: TranscriptEntryLayout,
+): number {
+  return (
+    Math.max(1, layout.lines.length) +
+    layout.marginTopRows +
+    layout.marginBottomRows
+  );
+}
+
+export function boundedTranscriptEntryLayout(
+  layout: TranscriptEntryLayout,
+  maxRows: number,
+): TranscriptEntryLayout {
+  const rows = Math.max(1, maxRows);
+  // Existing bounded process/tool rows omit their unbounded separators; user
+  // bands retain margins whenever one content row still fits.
+  const marginRows =
+    layout.role === 'user' ? layout.marginTopRows + layout.marginBottomRows : 0;
+  const includeMargins = rows > marginRows;
+  const contentRows = Math.max(1, rows - (includeMargins ? marginRows : 0));
+  return {
+    ...layout,
+    lines: layout.lines.slice(-contentRows),
+    marginBottomRows:
+      layout.role === 'user' && includeMargins ? layout.marginBottomRows : 0,
+    marginTopRows:
+      layout.role === 'user' && includeMargins ? layout.marginTopRows : 0,
+  };
+}

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -156,12 +156,16 @@ function entryLines(
   mode: TranscriptEntryLayoutMode,
   columns: number,
   colorEnabled: boolean | undefined,
+  maxRows: number | undefined,
 ): readonly string[] {
   switch (entry.role) {
     case 'assistant':
       if (mode === 'live' || (mode === 'bounded' && !entry.finalized)) {
         return liveAssistantDisplayLines({
-          rows: LIVE_TAIL_ROWS,
+          rows:
+            mode === 'bounded' && maxRows !== undefined
+              ? Math.max(1, maxRows)
+              : LIVE_TAIL_ROWS,
           text: entry.text,
           width: columns,
         });
@@ -202,11 +206,13 @@ export function transcriptEntryLayout(
   entry: ConversationEntry,
   {
     colorEnabled,
+    maxRows,
     mode = 'scrollback',
     userBottomMarginRows,
     width,
   }: {
     readonly colorEnabled?: boolean;
+    readonly maxRows?: number;
     readonly mode?: TranscriptEntryLayoutMode;
     readonly userBottomMarginRows?: number;
     readonly width?: number;
@@ -233,7 +239,7 @@ export function transcriptEntryLayout(
   return {
     ...base,
     columns,
-    lines: entryLines(entry, mode, columns, colorEnabled),
+    lines: entryLines(entry, mode, columns, colorEnabled, maxRows),
     inset,
     marginBottomRows,
     marginTopRows,

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -30,19 +30,14 @@ function estimateLiveTranscriptEntryRows(
   entry: ConversationEntry,
   width?: number,
 ): number {
-  // Live assistant text streams as raw wrapped lines (no Markdown parse)
-  // and has no trailing margin row. Pre-slice to the same tail window
-  // LiveTranscriptEntry paints, then cap at LIVE_TAIL_ROWS — so a
-  // multi-MB reply never gets split in full just for an estimate that
-  // discards everything above the tail.
-  if (entry.role === 'assistant') {
-    return estimateEntryRows(() =>
-      transcriptEntryLayoutRows(
-        transcriptEntryLayout(entry, { mode: 'live', width }),
-      ),
-    );
-  }
-  return estimateTranscriptEntryRows(entry, width);
+  // Live mode captures the pending-pane paint contract: assistant text uses
+  // its capped raw tail, while rich tool/process rows keep one descriptor
+  // line per terminal row instead of being reflowed like plain projections.
+  return estimateEntryRows(() =>
+    transcriptEntryLayoutRows(
+      transcriptEntryLayout(entry, { mode: 'live', width }),
+    ),
+  );
 }
 
 export interface TranscriptEntrySelection {

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -1,20 +1,10 @@
 // Pure viewport math for bounded pending transcript panes.
 
-import { renderAnsiMarkdown } from '../render/ansiMarkdown';
-import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import {
-  ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS,
-  LIVE_TAIL_ROWS,
-  PROCESS_ENTRY_MARGIN_BOTTOM_ROWS,
-  USER_ENTRY_MARGIN_BOTTOM_ROWS,
-  USER_ENTRY_MARGIN_TOP_ROWS,
-  liveAssistantDisplayLines,
-} from './TranscriptEntry';
-import {
-  isInquiryContinuationText,
-  isRenderableTranscriptEntry,
-} from './transcriptEntries';
-import { toolUseDisplayLines } from './toolRenderers';
+  transcriptEntryLayout,
+  transcriptEntryLayoutRows,
+} from './transcriptEntryLayout';
+import { isRenderableTranscriptEntry } from './transcriptEntries';
 import type { ConversationEntry } from '../state/cliState';
 
 const FAILED_ENTRY_ESTIMATE_ROWS = 1;
@@ -27,61 +17,18 @@ function estimateEntryRows(computeRows: () => number): number {
   }
 }
 
-function estimateWrappedRows(text: string, width: number): number {
-  const cols = Math.max(1, width);
-  const lines = text.length > 0 ? text.split('\n') : [''];
-  return lines.reduce(
-    (sum, line) => sum + Math.max(1, Math.ceil(line.length / cols)),
-    0,
-  );
-}
-
 export function estimateTranscriptEntryRows(
   entry: ConversationEntry,
-  width = 80,
+  width?: number,
 ): number {
-  if (entry.role === 'tool') {
-    const toolUse = entry.toolUse;
-    return estimateEntryRows(() => {
-      const lines = toolUseDisplayLines(toolUse);
-      return lines.length + (lines.length > 1 ? 1 : 0);
-    });
-  }
-  if (entry.role === 'process') {
-    const process = entry.process;
-    return estimateEntryRows(() => {
-      return (
-        Math.max(1, completedProcessDisplayLines(process).length) +
-        PROCESS_ENTRY_MARGIN_BOTTOM_ROWS
-      );
-    });
-  }
-  if (entry.role === 'assistant') {
-    return estimateEntryRows(() => {
-      const rendered = renderAnsiMarkdown(entry.text, { width });
-      return (
-        Math.max(1, rendered.split('\n').length) +
-        ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS
-      );
-    });
-  }
-  if (entry.role === 'user' || entry.role === 'error') {
-    // Both roles render inside a paddingX={1} box plus a 2-col prefix
-    // (`› ` / `! `), so text wraps to `width - 4`.
-    const textRows = estimateWrappedRows(entry.text, Math.max(1, width - 4));
-    const marginRows =
-      entry.role === 'user' && !isInquiryContinuationText(entry.text)
-        ? USER_ENTRY_MARGIN_TOP_ROWS + USER_ENTRY_MARGIN_BOTTOM_ROWS
-        : 0;
-    return textRows + marginRows;
-  }
-
-  return estimateWrappedRows(entry.text, width) + 1;
+  return estimateEntryRows(() =>
+    transcriptEntryLayoutRows(transcriptEntryLayout(entry, { width })),
+  );
 }
 
 function estimateLiveTranscriptEntryRows(
   entry: ConversationEntry,
-  width = 80,
+  width?: number,
 ): number {
   // Live assistant text streams as raw wrapped lines (no Markdown parse)
   // and has no trailing margin row. Pre-slice to the same tail window
@@ -89,14 +36,11 @@ function estimateLiveTranscriptEntryRows(
   // multi-MB reply never gets split in full just for an estimate that
   // discards everything above the tail.
   if (entry.role === 'assistant') {
-    return estimateEntryRows(() => {
-      const cols = Math.max(1, width);
-      return liveAssistantDisplayLines({
-        rows: LIVE_TAIL_ROWS,
-        text: entry.text,
-        width: cols,
-      }).length;
-    });
+    return estimateEntryRows(() =>
+      transcriptEntryLayoutRows(
+        transcriptEntryLayout(entry, { mode: 'live', width }),
+      ),
+    );
   }
   return estimateTranscriptEntryRows(entry, width);
 }
@@ -112,7 +56,7 @@ export interface TranscriptEntrySelection {
 export function selectTranscriptEntriesForViewport(
   entries: readonly ConversationEntry[],
   maxRows: number,
-  width = 80,
+  width?: number,
 ): TranscriptEntrySelection {
   if (!Number.isFinite(maxRows) || maxRows <= 0) {
     return { entries: [], rowLimits: new Map(), usedRows: 0 };

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -3,52 +3,9 @@
 // live region — which slice tool output to a head+tail preview — this renders
 // every line so the viewer is the place to read the complete output.
 
-import { wrapAnsiToWidth } from '../render/ansiWrap';
-import { completedProcessDisplayLines } from './completedProcessTranscript';
 import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
-import { toolUseDisplayLines } from '../panes/toolRenderers';
-import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
+import { transcriptEntryLayout } from '../panes/transcriptEntryLayout';
 import type { ConversationEntry, StreamSlice } from './cliState';
-
-/** Gutter that opens a wrapped tool-output line (corner glyph + space). */
-const CORNER_PREFIX = `${TOOL_OUTPUT_CORNER} `;
-
-/** Soft-wrap `body` to `cols`, prefixing the first wrapped line with
- *  `firstPrefix` and every continuation line with `contPrefix` (spaces matching
- *  the first prefix by default, for a hanging indent). */
-function wrapWithPrefix(
-  body: string,
-  cols: number,
-  firstPrefix = '',
-  contPrefix = ' '.repeat(firstPrefix.length),
-): string[] {
-  const width = Math.max(1, cols - firstPrefix.length);
-  return wrapAnsiToWidth(body, width)
-    .split('\n')
-    .map((line, index) => `${index === 0 ? firstPrefix : contPrefix}${line}`);
-}
-
-function leadingWhitespacePrefix(line: string): string {
-  return line.match(/^\s+/)?.[0] ?? '';
-}
-
-function wrapDisplayLine(line: string, cols: number): string[] {
-  if (line.startsWith(CORNER_PREFIX)) {
-    return wrapWithPrefix(
-      line.slice(CORNER_PREFIX.length),
-      cols,
-      CORNER_PREFIX,
-    );
-  }
-  // Repeat any leading indentation on every wrapped line so nested output keeps
-  // its shape.
-  const prefix = leadingWhitespacePrefix(line);
-  return wrapWithPrefix(line.slice(prefix.length), cols, prefix, prefix);
-}
-
-function wrapLines(lines: readonly string[], cols: number): string[] {
-  return lines.flatMap((line) => wrapDisplayLine(line, cols));
-}
 
 // Wrapped-line cache keyed by the immutable entry object. Entries are
 // replaced (never mutated in place) when their content changes, so hits are
@@ -81,21 +38,10 @@ function computeTranscriptEntryLines(
   entry: ConversationEntry,
   cols: number,
 ): readonly string[] {
-  switch (entry.role) {
-    case 'tool':
-      return wrapLines(
-        toolUseDisplayLines(entry.toolUse, { elide: false }),
-        cols,
-      );
-    case 'process':
-      return wrapLines(completedProcessDisplayLines(entry.process), cols);
-    case 'user':
-      return wrapWithPrefix(entry.text, cols, '› ');
-    case 'error':
-      return wrapWithPrefix(entry.text, cols, '! ');
-    default:
-      return wrapWithPrefix(entry.text, cols);
-  }
+  return transcriptEntryLayout(entry, {
+    mode: 'viewer',
+    width: cols,
+  }).lines;
 }
 
 function isCompactToolEntry(

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -438,6 +438,26 @@ describe('CLI conversation transcript splitting', () => {
     );
   });
 
+  it('budgets live rich tool rows without reflowing their display lines', () => {
+    const base = toolEntry('t1', TOOL_USE_STATUS.COMPLETED);
+    const tool: ConversationEntry = {
+      ...base,
+      toolUse: {
+        ...base.toolUse,
+        input: { command: 'x'.repeat(80) },
+      },
+    };
+    const liveLayout = transcriptEntryLayout(tool, {
+      mode: 'live',
+      width: 20,
+    });
+
+    expect(liveLayout.lines).toHaveLength(2);
+    expect(selectTranscriptEntriesForViewport([tool], 20, 20).usedRows).toBe(
+      transcriptEntryLayoutRows(liveLayout),
+    );
+  });
+
   it('budgets live user prompt bands with their margin rows', () => {
     const user = entry('u1', 'user', 'why do you write as a latex?', true);
 
@@ -746,6 +766,47 @@ describe('CLI conversation transcript splitting', () => {
         width: 80,
       }).map((item) => item.id),
     ).toEqual(['session-header', 'p1']);
+  });
+
+  it('keeps full tool output as the conservative static-header budget', () => {
+    const tool = {
+      ...toolEntry(
+        't1',
+        TOOL_USE_STATUS.COMPLETED,
+        Array.from({ length: 20 }, (_, index) => `line ${index}`).join('\n'),
+      ),
+      finalized: true,
+    } satisfies ConversationEntry;
+    const renderedRows = transcriptEntryLayoutRows(
+      transcriptEntryLayout(tool, { mode: 'scrollback', width: 80 }),
+    );
+    const budgetRows = transcriptEntryLayoutRows(
+      transcriptEntryLayout(tool, {
+        mode: 'scrollback-budget',
+        width: 80,
+      }),
+    );
+    expect(budgetRows).toBeGreaterThan(renderedRows);
+
+    const withoutHeader = appendStaticTranscriptItems({
+      scrollbackStreamId: STREAM_ID,
+      currentItems: [],
+      streams: streamsFromEntries(STREAM_ID, [tool]),
+      meta: SESSION_META,
+      maxRows: 0,
+      width: 80,
+    });
+    expect(withoutHeader.map((item) => item.id)).toEqual(['t1']);
+    expect(
+      appendStaticTranscriptItems({
+        scrollbackStreamId: STREAM_ID,
+        currentItems: withoutHeader,
+        streams: streamsFromEntries(STREAM_ID, [tool]),
+        meta: SESSION_META,
+        maxRows: renderedRows + 4,
+        width: 80,
+      }).map((item) => item.id),
+    ).toEqual(['t1']);
   });
 
   it('budgets user band margins before inserting compact static headers', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -468,6 +468,27 @@ describe('CLI conversation transcript splitting', () => {
     );
   });
 
+  it('keeps bounded rich display rows unwrapped', () => {
+    const baseTool = toolEntry('t1', TOOL_USE_STATUS.COMPLETED, 'x'.repeat(40));
+    const baseProcess = processEntry('p1');
+    const process: ConversationEntry = {
+      ...baseProcess,
+      process: {
+        ...baseProcess.process,
+        tailLines: ['y'.repeat(40)],
+      },
+    };
+
+    for (const item of [baseTool, process]) {
+      const live = transcriptEntryLayout(item, { mode: 'live', width: 20 });
+      const bounded = boundedTranscriptEntryLayout(
+        transcriptEntryLayout(item, { mode: 'bounded', width: 20 }),
+        10,
+      );
+      expect(bounded.lines).toEqual(live.lines);
+    }
+  });
+
   it('budgets live user prompt bands with their margin rows', () => {
     const user = entry('u1', 'user', 'why do you write as a latex?', true);
 

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -379,6 +379,16 @@ describe('CLI conversation transcript splitting', () => {
     expect(finalizedTail).toContain('bold tail marker');
     expect(finalizedTail).not.toContain('**bold tail marker**');
     expect(streamingTail).toContain('**bold tail marker**');
+
+    const cappedStreamingTail = boundedTranscriptEntryLayout(
+      transcriptEntryLayout(entry('tail', 'assistant', 'x'.repeat(25), false), {
+        maxRows: 1,
+        mode: 'bounded',
+        width: 10,
+      }),
+      1,
+    );
+    expect(cappedStreamingTail.lines).toEqual(['x'.repeat(10)]);
   });
 
   it('budgets live assistant display-math rows with the live renderer', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -7,10 +7,11 @@ import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   LIVE_TAIL_ROWS,
-  boundedAssistantDisplayLines,
-  compactPrefixedDisplayRows,
+  boundedTranscriptEntryLayout,
   liveAssistantDisplayLines,
-} from '@cli/chat/tui/panes/TranscriptEntry';
+  transcriptEntryLayout,
+  transcriptEntryLayoutRows,
+} from '@cli/chat/tui/panes/transcriptEntryLayout';
 import { formatRenderError } from '@cli/chat/tui/panes/EntryErrorBoundary';
 import {
   isInquiryContinuationText,
@@ -352,20 +353,28 @@ describe('CLI conversation transcript splitting', () => {
       '\n',
     );
 
-    const finalizedTail = boundedAssistantDisplayLines({
-      colorEnabled: false,
-      finalized: true,
-      rows: 1,
+    const assistant = (finalized: boolean): ConversationEntry => ({
+      finalized,
+      id: finalized ? 'finalized' : 'streaming',
+      role: 'assistant',
       text,
-      width: 80,
-    }).join('\n');
-    const streamingTail = boundedAssistantDisplayLines({
-      colorEnabled: false,
-      finalized: false,
-      rows: 1,
-      text,
-      width: 80,
-    }).join('\n');
+    });
+    const finalizedTail = boundedTranscriptEntryLayout(
+      transcriptEntryLayout(assistant(true), {
+        colorEnabled: false,
+        mode: 'bounded',
+        width: 80,
+      }),
+      1,
+    ).lines.join('\n');
+    const streamingTail = boundedTranscriptEntryLayout(
+      transcriptEntryLayout(assistant(false), {
+        colorEnabled: false,
+        mode: 'bounded',
+        width: 80,
+      }),
+      1,
+    ).lines.join('\n');
 
     expect(finalizedTail).toContain('bold tail marker');
     expect(finalizedTail).not.toContain('**bold tail marker**');
@@ -399,24 +408,34 @@ describe('CLI conversation transcript splitting', () => {
     expect(selected.rowLimits.has('a1')).toBe(false);
   });
 
-  it('pads compact prefixed rows to the viewport width', () => {
-    expect(
-      compactPrefixedDisplayRows({
-        fillWidth: true,
-        prefix: '! ',
-        text: 'bad',
-        width: 8,
-      }),
-    ).toBe('! bad   ');
-    expect(
-      compactPrefixedDisplayRows({
-        fillWidth: true,
-        maxRows: 1,
-        prefix: '! ',
-        text: 'abcdef',
-        width: 6,
-      }),
-    ).toBe('  ef  ');
+  it('derives prefixes, insets, margins, and row counts from one layout', () => {
+    const user = entry('u1', 'user', 'x'.repeat(77), true);
+    const userLayout = transcriptEntryLayout(user, { width: 80 });
+    expect(userLayout).toMatchObject({
+      columns: 78,
+      continuationPrefix: '  ',
+      firstPrefix: '› ',
+      inset: 2,
+      marginBottomRows: 1,
+      marginTopRows: 1,
+    });
+    expect(userLayout.lines).toHaveLength(2);
+    expect(transcriptEntryLayoutRows(userLayout)).toBe(4);
+    expect(estimateTranscriptEntryRows(user, 80)).toBe(
+      transcriptEntryLayoutRows(userLayout),
+    );
+
+    const tool = toolEntry('t1', TOOL_USE_STATUS.COMPLETED, 'one\ntwo');
+    const toolLayout = transcriptEntryLayout(tool, { width: 80 });
+    expect(toolLayout).toMatchObject({
+      columns: 80,
+      inset: 0,
+      marginBottomRows: 1,
+      marginTopRows: 0,
+    });
+    expect(estimateTranscriptEntryRows(tool, 80)).toBe(
+      transcriptEntryLayoutRows(toolLayout),
+    );
   });
 
   it('budgets live user prompt bands with their margin rows', () => {


### PR DESCRIPTION
## Summary

- introduce one declarative per-entry layout model for role prefixes, continuation prefixes, insets, margins, wrapped lines, and normalized terminal width
- derive static scrollback budgets, live viewport estimates, bounded rows, Ink presentation geometry, and Ctrl-T transcript lines from that model
- derive tool separation margins from the same tool display lines and remove the duplicated role switches and row estimators
- preserve specialized color, Markdown, process, diff, and tool rendering as presentation-only concerns

## Design

The previous structure encoded conversation geometry independently in three render paths, the transcript projection, and two row estimators. This made scrollback ownership depend on hand-synchronized magic offsets. `transcriptEntryLayout` is now the single geometry owner; renderers add styling without redefining layout, and bounded rendering applies a declarative cap policy to the same descriptor.

The richer tool renderer remains specialized because its colored `DiffView` rows are not a lossless projection of plain strings. This PR unifies its row-separation geometry and display-line source without replacing the structured diff widget with a weaker abstraction.

## Net elements (R6)

- Files: 1 added, 0 deleted, and 7 modified (8 files total).
- Export declarations in the raw diff: 9 added and 8 removed (net +1); 3 are ownership-preserving relocations.
- Type constructs: 4 added (3 internal types/interfaces and 1 exported interface), 0 removed.
- LoC: 584 added and 587 deleted (net -3).

## Consumer counts (R8)

The removed public layout helpers/constants have no remaining external consumers:

- `ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS`: 0
- `PROCESS_ENTRY_MARGIN_BOTTOM_ROWS`: 0
- `USER_ENTRY_MARGIN_TOP_ROWS`: 0
- `compactPrefixedDisplayRows`: 0
- `boundedAssistantDisplayLines`: 0

Counts were verified by repository-wide `rg`; the first three names remain private implementation constants in the new layout owner, but have zero imports/callers outside it.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/cli/StaticBandResize.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (173 tests)
- `npm run check:dead-code-ratchet`

Closes #8498

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal scrollback, live viewport row math, and tool elision budgets across multiple render paths; regressions would show as clipped or mis-ordered transcript UI, though coverage was expanded in ConversationPane tests.
> 
> **Overview**
> **Centralizes CLI transcript geometry** in a new `transcriptEntryLayout` module so prefixes, insets, margins, column width, and per-mode line generation are defined once instead of duplicated across Ink renderers, viewport estimators, static scrollback budgeting, and the Ctrl+T plain-text viewer.
> 
> `TranscriptEntry` is trimmed to **presentation only** (Markdown, colors, rich tool/process widgets); bounded and live panes consume the same layout descriptors via `boundedTranscriptEntryLayout`. Static row counting uses **`scrollback-budget`** mode (conservative tool line counts with elision) separately from on-screen scrollback rendering. **Tool bottom margins** now come from `toolUseMarginBottomRows`, aligned with `toolUseDisplayLines` row budgeting.
> 
> Viewport estimation in `transcriptViewport` and viewer lines in `transcriptLines` both delegate to the shared layout API; tests in `ConversationPane.vitest.mts` assert parity between estimates, bounded/live behavior, and static header budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6d53d4773a93351f091ad7b37ae24dcab1096f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->