### PR TITLE
fix(cli): cap a single output line's rendered width

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -67,21 +67,25 @@ interface ElidedOutput {
   readonly hiddenCount: number;
 }
 
+function capLine(line: string): string {
+  return truncateWithEllipsis(line, OUTPUT_LINE_MAX_CHARS);
+}
+
 function elideOutputLines(lines: readonly string[]): ElidedOutput {
-  const capped = lines.map((line) =>
-    truncateWithEllipsis(line, OUTPUT_LINE_MAX_CHARS),
-  );
   // Only elide when the head + marker + tail form is shorter than the original.
   if (
-    capped.length <=
+    lines.length <=
     OUTPUT_HEAD_LINES + OUTPUT_TAIL_LINES + OUTPUT_MARKER_LINES
   ) {
-    return { head: capped, tail: [], hiddenCount: 0 };
+    return { head: lines.map(capLine), tail: [], hiddenCount: 0 };
   }
+  // Cap only the head/tail lines actually rendered, not every discarded line
+  // in between — this runs on every OutputBlock redraw while a tool streams,
+  // so truncating lines nobody sees would be wasted grapheme-segmentation work.
   return {
-    head: capped.slice(0, OUTPUT_HEAD_LINES),
-    tail: capped.slice(capped.length - OUTPUT_TAIL_LINES),
-    hiddenCount: capped.length - OUTPUT_HEAD_LINES - OUTPUT_TAIL_LINES,
+    head: lines.slice(0, OUTPUT_HEAD_LINES).map(capLine),
+    tail: lines.slice(lines.length - OUTPUT_TAIL_LINES).map(capLine),
+    hiddenCount: lines.length - OUTPUT_HEAD_LINES - OUTPUT_TAIL_LINES,
   };
 }
 

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -54,6 +54,12 @@ export function toolHeaderPreviewBudget(
 const OUTPUT_HEAD_LINES = 6;
 const OUTPUT_TAIL_LINES = 3;
 const OUTPUT_MARKER_LINES = 1;
+// The head/tail budget above only bounds line *count*. A tool's stdout can
+// also be a single, arbitrarily long "line" with no newlines to elide
+// against (e.g. a `rg` match inside a minified bundle) — cap each line's
+// rendered width too, so one pathological line can't blow past the budget
+// it was supposed to be bounded by.
+const OUTPUT_LINE_MAX_CHARS = 2000;
 
 interface ElidedOutput {
   readonly head: readonly string[];
@@ -62,17 +68,20 @@ interface ElidedOutput {
 }
 
 function elideOutputLines(lines: readonly string[]): ElidedOutput {
+  const capped = lines.map((line) =>
+    truncateWithEllipsis(line, OUTPUT_LINE_MAX_CHARS),
+  );
   // Only elide when the head + marker + tail form is shorter than the original.
   if (
-    lines.length <=
+    capped.length <=
     OUTPUT_HEAD_LINES + OUTPUT_TAIL_LINES + OUTPUT_MARKER_LINES
   ) {
-    return { head: lines, tail: [], hiddenCount: 0 };
+    return { head: capped, tail: [], hiddenCount: 0 };
   }
   return {
-    head: lines.slice(0, OUTPUT_HEAD_LINES),
-    tail: lines.slice(lines.length - OUTPUT_TAIL_LINES),
-    hiddenCount: lines.length - OUTPUT_HEAD_LINES - OUTPUT_TAIL_LINES,
+    head: capped.slice(0, OUTPUT_HEAD_LINES),
+    tail: capped.slice(capped.length - OUTPUT_TAIL_LINES),
+    hiddenCount: capped.length - OUTPUT_HEAD_LINES - OUTPUT_TAIL_LINES,
   };
 }
 

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -165,6 +165,23 @@ describe('CLI tool renderer registry', () => {
     `);
   });
 
+  it('caps a single pathologically long output line instead of rendering it whole', () => {
+    const hugeLine = 'x'.repeat(50_000);
+    const entry = toolUse(
+      'bash',
+      { command: "rg -n --fixed-strings 'approved-plan' ~/.nvm" },
+      {
+        headerSummary: "rg -n --fixed-strings 'approved-plan' ~/.nvm",
+        outputText: hugeLine,
+      },
+    );
+
+    const lines = toolUseDisplayLines(entry);
+    expect(lines).toHaveLength(2);
+    expect(lines[1].length).toBeLessThan(2010);
+    expect(lines[1].endsWith('…')).toBe(true);
+  });
+
   it('keeps short bash output whole when elision would not reduce height', () => {
     const entry = toolUse(
       'bash',


### PR DESCRIPTION
## Summary
- Root-caused a user report (texra v0.39.5): asking a docs question in chat mode occasionally dumped a huge wall of raw minified JavaScript into the transcript.
- The immediate trigger was an agent running `rg` across a path that happened to include a globally-installed npm package, whose minified bundle matched — that's a search-scoping/prompt-discipline question, not a rendering bug, and is called out separately for a product decision rather than fixed here.
- The actual rendering bug: `elideOutputLines()` in the CLI TUI only bounds output by **line count** (head 6 / tail 3). A tool result that's almost all on one "line" (no newlines — e.g. a grep match landing inside a minified bundle) sails straight past that budget and renders tens of KB of raw text. Fixed by also capping each line's rendered width (2000 chars, via the existing `truncateWithEllipsis`) before the head/tail slice, so a single pathological line can't blow past the same budget the count-based elision was meant to enforce. Applies uniformly to both the finalized `<Static>` transcript and the live `OutputBlock` renderer, since both route through `elideOutputLines()`.

## Test plan
- [x] `npx vitest run src/test-kernel/cli/ToolRenderers.vitest.mts src/test-kernel/cli/ToolUseRowPatch.vitest.mts` — 17 passed, including a new case for a 50,000-char single-line output
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint packages/cli/src/chat/tui/panes/toolRenderers.tsx src/test-kernel/cli/ToolRenderers.vitest.mts` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change with no auth, data, or execution impact; full output remains on `toolUse.outputText` and in the ctrl+t transcript viewer.
> 
> **Overview**
> Fixes a CLI TUI bug where **tool stdout elision only limited line count** (head/tail), so a single newline-free line (e.g. `rg` hitting a minified bundle) could still paint tens of KB in the transcript.
> 
> **`elideOutputLines()`** now truncates each **rendered** line to **2000 characters** via existing `truncateWithEllipsis`, applied to head/tail slices (and to all lines when count elision does not apply). Middle lines that are dropped by elision are **not** truncated, to avoid wasted work on streaming redraws. Static scrollback and live `OutputBlock` both use this path.
> 
> Adds a test asserting a 50k-character single-line bash output renders under ~2010 chars with a trailing ellipsis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b80b4c9f742c78c9e6129b2b86b81a2914e043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->