### PR TITLE
refactor(tools): centralize file edit flow

### DIFF
--- a/src/test-kernel/tools/FileEditFlow.vitest.ts
+++ b/src/test-kernel/tools/FileEditFlow.vitest.ts
@@ -19,6 +19,7 @@ describe('replaceLiteralMatches', () => {
     ).toEqual({
       content: 'alpha\ndelta\ngamma',
       count: 1,
+      firstMatchLine: 2,
       lineNumbers: [2],
     });
   });
@@ -49,8 +50,21 @@ describe('replaceLiteralMatches', () => {
     ).toEqual({
       content: '$& and $&',
       count: 2,
+      firstMatchLine: 1,
       lineNumbers: [1],
     });
+  });
+
+  it('reports the exact first line of a multi-line match', () => {
+    expect(
+      replaceLiteralMatches({
+        content: 'header\nfirst\nsecond\nfooter',
+        search: 'first\nsecond',
+        replacement: 'joined',
+        mode: 'unique',
+        notFoundError: () => 'missing',
+      }).firstMatchLine,
+    ).toBe(2);
   });
 });
 

--- a/src/test-kernel/tools/FileEditFlow.vitest.ts
+++ b/src/test-kernel/tools/FileEditFlow.vitest.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - tools under test
+import { ToolError } from '@shared/schemas/toolResult';
+import { replaceLiteralMatches } from '@tools/fileEditFlow';
+import { ViewRangeSchema } from '@tools/formatting';
+
+describe('replaceLiteralMatches', () => {
+  it('returns the unique replacement and its 1-based line', () => {
+    expect(
+      replaceLiteralMatches({
+        content: 'alpha\nbeta\ngamma',
+        search: 'beta',
+        replacement: 'delta',
+        mode: 'unique',
+        notFoundError: () => 'missing',
+      }),
+    ).toEqual({
+      content: 'alpha\ndelta\ngamma',
+      count: 1,
+      lineNumbers: [2],
+    });
+  });
+
+  it('reports every matching line through the declared ambiguity error', () => {
+    expect(() =>
+      replaceLiteralMatches({
+        content: 'same\nother same\nsame',
+        search: 'same',
+        replacement: 'new',
+        mode: 'unique',
+        notFoundError: () => 'missing',
+        multipleMatchesError: ({ count, lineNumbers }) =>
+          `${count} matches on ${lineNumbers.join(',')}`,
+      }),
+    ).toThrow(new ToolError('3 matches on 1,2,3'));
+  });
+
+  it('replaces every literal match without interpreting dollar patterns', () => {
+    expect(
+      replaceLiteralMatches({
+        content: 'OLD and OLD',
+        search: 'OLD',
+        replacement: '$&',
+        mode: 'all',
+        notFoundError: () => 'missing',
+      }),
+    ).toEqual({
+      content: '$& and $&',
+      count: 2,
+      lineNumbers: [1],
+    });
+  });
+});
+
+describe('ViewRangeSchema', () => {
+  it('accepts an inclusive 1-based range', () => {
+    expect(ViewRangeSchema.parse([2, 5])).toEqual([2, 5]);
+  });
+
+  it.each([
+    [0, 1],
+    [2, 1],
+    [1, 1.5],
+  ])('rejects invalid range %j', (range) => {
+    expect(ViewRangeSchema.safeParse(range).success).toBe(false);
+  });
+});

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -127,6 +127,29 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(result.output, 'written');
   });
 
+  it('write_file reports the content adjusted during approval', async () => {
+    const tool = new WriteFileTool();
+    let writtenContent: string | undefined;
+
+    WorkspaceFS.exists = async () => true;
+    WorkspaceFS.read = async () => 'old content';
+    WorkspaceFS.write = async (_path: string, content: string) => {
+      writtenContent = content;
+    };
+    testApprovalHandler = async () => ({
+      accepted: true,
+      appliedContent: 'reviewed content',
+    });
+
+    const result = await tool.call({ path: 'doc.txt', content: 'new content' });
+
+    assert.strictEqual(writtenContent, 'reviewed content');
+    assert.match(result.output ?? '', /User adjustments to doc\.txt/);
+    assert.ok(result.userPatch);
+    assert.strictEqual(result.edits?.[0]?.path, 'doc.txt');
+    assert.strictEqual(result.edits?.[0]?.startLine, 1);
+  });
+
   it('write_file rejects when user denies approval', async () => {
     const tool = new WriteFileTool();
     let writeCalled = false;

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -2,24 +2,16 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolError, ToolResult } from '@shared/schemas/toolResult';
-import { requireFileReadForEdit } from '@tools/fileInteractions';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
-  assertWritable,
-  resolveAndFormat,
-  currentToolRoot,
-} from '@tools/pathResolution';
-import { countOccurrences } from '@tools/utils';
-import {
-  appendApprovalDiffNote,
-  requestAndWriteApprovedEdit,
-} from '@tools/approval/toolEditApproval';
-import { WorkspaceFS } from '@utils/files';
+  applyApprovedFileEdit,
+  replaceLiteralMatches,
+  resolveWritableTarget,
+} from '@tools/fileEditFlow';
 import { pluralize } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { replaceAllLiteral, replaceFirstLiteral } from './editPrimitives';
 
 const EditInputSchema = z.strictObject({
   path: z
@@ -49,90 +41,50 @@ export class EditFileTool extends defineTool({
 }) {
   protected async execute(input: EditInput): Promise<ToolResult> {
     const { old_str, new_str, replace_all } = input;
-    const root = currentToolRoot();
-    const { path: resolved, display: displayPath } = resolveAndFormat(
-      input.path,
-      root,
-    );
-    assertWritable(resolved, displayPath);
-    const targetPath = resolved.fsPath;
-
-    if (old_str.length === 0) {
-      throw new ToolError(
-        `old_str must not be empty for ${displayPath}. ` +
-          `Provide the exact text to replace, copied from read_file output (excluding the line-number prefix).`,
-      );
-    }
-
-    const exists = await WorkspaceFS.exists(targetPath);
-    const readGate = requireFileReadForEdit(targetPath, exists);
-    if (readGate) {
-      return readGate;
-    }
-
-    const currentContent = await WorkspaceFS.read(targetPath);
-    const occurrences = countOccurrences(currentContent, old_str);
-
-    if (occurrences === 0) {
-      throw new ToolError(
-        `old_str not found in ${displayPath}.\n` +
-          `To fix:\n` +
-          `- Re-read the file — content may have changed since last read\n` +
-          `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t"); whitespace must match`,
-      );
-    }
-
-    if (!replace_all && occurrences > 1) {
-      throw new ToolError(
-        `old_str matches ${occurrences} locations in ${displayPath}.\n` +
-          `To fix, either:\n` +
-          `- Include more surrounding context to make old_str unique\n` +
-          `- Set replace_all to true to replace every occurrence: { "replace_all": true }`,
-      );
-    }
-
-    // Literal replacement (String.replace would interpret $$, $&, $', `$\``
-    // patterns and corrupt LaTeX/code); see editPrimitives.
-    const updatedContent = replace_all
-      ? replaceAllLiteral(currentContent, old_str, new_str)
-      : replaceFirstLiteral(currentContent, old_str, new_str);
-
-    const outcome = await requestAndWriteApprovedEdit({
-      path: targetPath,
-      displayPath,
-      originalContent: currentContent,
-      proposedContent: updatedContent,
-      sourceTool: 'edit_file',
+    const prepared = await resolveWritableTarget(input.path, {
+      validate: ({ displayPath }) => {
+        if (old_str.length === 0) {
+          throw new ToolError(
+            `old_str must not be empty for ${displayPath}. ` +
+              `Provide the exact text to replace, copied from read_file output (excluding the line-number prefix).`,
+          );
+        }
+      },
     });
-    if ('rejected' in outcome) {
-      return outcome.rejected;
+    if ('blocked' in prepared) {
+      return prepared.blocked;
     }
-    const { approval, appliedContent } = outcome;
+    const { path, displayPath, originalContent } = prepared.target;
 
-    const count = replace_all ? occurrences : 1;
-    const occurrenceWord = pluralize(count, 'occurrence');
-    const replacementSummary = `Replaced ${count} ${occurrenceWord}.`;
-    const summary = `Edited ${displayPath}: replaced ${count} ${occurrenceWord}`;
+    const replacement = replaceLiteralMatches({
+      content: originalContent,
+      search: old_str,
+      replacement: new_str,
+      mode: replace_all ? 'all' : 'unique',
+      notFoundError: () =>
+        `old_str not found in ${displayPath}.\n` +
+        `To fix:\n` +
+        `- Re-read the file — content may have changed since last read\n` +
+        `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t"); whitespace must match`,
+      multipleMatchesError: ({ count }) =>
+        `old_str matches ${count} locations in ${displayPath}.\n` +
+        `To fix, either:\n` +
+        `- Include more surrounding context to make old_str unique\n` +
+        `- Set replace_all to true to replace every occurrence: { "replace_all": true }`,
+    });
 
-    const output = appendApprovalDiffNote(
-      replacementSummary,
+    const occurrenceWord = pluralize(replacement.count, 'occurrence');
+    return applyApprovedFileEdit({
+      path,
       displayPath,
-      updatedContent,
-      appliedContent,
-    );
-
-    return {
-      status: 'executed',
-      summary,
-      output,
-      userPatch: approval.userPatch,
-      edits: [
-        {
-          path: displayPath,
-          lineChanges: approval.lineChanges,
-          startLine: approval.startLine,
-        },
-      ],
-    };
+      originalContent,
+      proposedContent: replacement.content,
+      sourceTool: 'edit_file',
+      startLine: 'approval',
+      present: () => ({
+        summary: `Edited ${displayPath}: replaced ${replacement.count} ${occurrenceWord}`,
+        output: `Replaced ${replacement.count} ${occurrenceWord}.`,
+      }),
+    });
   }
 }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -268,8 +268,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
         return this.readFile(
           executionId,
           rest.join('/'),
-          // Schema enforces length 2; cast since Zod infers number[]
-          input.view_range as [number, number] | undefined,
+          input.view_range ?? undefined,
         );
       case 'workspace-files':
         if (rest.length === 0) {
@@ -278,7 +277,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
         return this.readWorkspaceFile(
           executionId,
           rest.join('/'),
-          input.view_range as [number, number] | undefined,
+          input.view_range ?? undefined,
         );
     }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -68,6 +68,7 @@ import {
   formatFileView,
   paginateToolListing,
   formatPaginationHint,
+  ViewRangeSchema,
 } from './formatting';
 import {
   applyViewRange,
@@ -112,16 +113,9 @@ const ExecutionsToolInputSchema = z.strictObject({
     ),
 
   /** Optional line range [start, end] for large outputs (action="view" only). */
-  view_range: z
-    .array(z.int().min(1))
-    .length(2)
-    .refine(([start, end]) => end >= start, {
-      error: 'view_range[1] must be >= view_range[0]',
-    })
-    .nullish()
-    .describe(
-      'Line range [start, end] for paginating large outputs (action="view" only).',
-    ),
+  view_range: ViewRangeSchema.nullish().describe(
+    'Line range [start, end] for paginating large outputs (action="view" only).',
+  ),
 
   /** Execution IDs to wait on (action="wait" with /executions only). */
   ids: z

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -354,7 +354,7 @@ export class TextEditorTool extends defineTool({
       // patterns and corrupt LaTeX/code); see editPrimitives.
       const newFileContent = replacement.content;
 
-      const replacementLine = replacement.lineNumbers[0] ?? 1;
+      const replacementLine = replacement.firstMatchLine;
       const startLine = Math.max(1, replacementLine - SNIPPET_LINES);
       const endLine =
         replacementLine + SNIPPET_LINES + (newStr.match(/\n/g) ?? []).length;

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -350,8 +350,6 @@ export class TextEditorTool extends defineTool({
           `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${lineNumbers.join(', ')}. Please ensure it is unique`,
       });
 
-      // Literal replacement (String.replace would interpret $$, $&, $', `$\``
-      // patterns and corrupt LaTeX/code); see editPrimitives.
       const newFileContent = replacement.content;
 
       const replacementLine = replacement.firstMatchLine;

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -14,16 +14,11 @@ import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { ToolResult, ToolError } from '@shared/schemas/toolResult';
 import {
-  recordToolFileRead,
-  requireFileReadForEdit,
-} from '@tools/fileInteractions';
-import {
-  appendApprovalDiffNote,
-  requestApprovedEditContent,
-  requestAndWriteApprovedEdit,
-  writeAndRecordApprovedEdit,
-  type ToolEditApprovalResult,
-} from '@tools/approval/toolEditApproval';
+  applyApprovedFileEdit,
+  loadEditableFile,
+  replaceLiteralMatches,
+} from '@tools/fileEditFlow';
+import { recordToolFileRead } from '@tools/fileInteractions';
 import { assertNever } from '@utils/core';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -32,17 +27,13 @@ import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import {
-  findOccurrenceLineNumbers,
-  replaceFirstLiteral,
-} from './editPrimitives';
 import { formatFileView, formatLinesWithNumbers } from './formatting';
 import {
   assertWritable,
   resolveAndFormat,
   currentToolRoot,
 } from './pathResolution';
-import { countOccurrences, requireField } from './utils';
+import { requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
@@ -303,104 +294,26 @@ export class TextEditorTool extends defineTool({
       const proposedContent = isTexFile(filePath)
         ? replacementEngine.applyAll(content)
         : content;
-      const outcome = await requestApprovedEditContent({
+      return applyApprovedFileEdit({
         path: filePath,
         displayPath,
         originalContent: '',
         proposedContent,
         sourceTool: 'text_editor:create',
+        beforeWrite: async () => {
+          const dirPath = path.dirname(filePath);
+          if (dirPath !== '.') {
+            await WorkspaceFS.ensureDir(dirPath);
+          }
+        },
+        present: () => ({
+          summary: `Created file ${displayPath}`,
+          output: `File created successfully at: ${displayPath}`,
+        }),
       });
-      if ('rejected' in outcome) {
-        return outcome.rejected;
-      }
-      const { approval, finalContent } = outcome;
-
-      // Create parent directories if they don't exist
-      const dirPath = path.dirname(filePath);
-      if (dirPath !== '.') {
-        await WorkspaceFS.ensureDir(dirPath);
-      }
-
-      const { appliedContent } = await writeAndRecordApprovedEdit(
-        filePath,
-        '',
-        finalContent,
-      );
-
-      const output = appendApprovalDiffNote(
-        `File created successfully at: ${displayPath}`,
-        displayPath,
-        proposedContent,
-        appliedContent,
-      );
-
-      return {
-        status: 'executed',
-        summary: `Created file ${displayPath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: displayPath, lineChanges: approval.lineChanges }],
-      };
     } catch (error) {
       rethrowWithContext(error, `Error creating file ${displayPath}`);
     }
-  }
-
-  /**
-   * Shared edit prelude for strReplace/insert: gate on read-before-edit, then
-   * read and tab-expand the file. Returns the read-gate ToolResult when the
-   * edit must be blocked, otherwise the file content and its tab-expanded form.
-   */
-  private async prepareEditContent(
-    filePath: string,
-  ): Promise<
-    | { readGate: ToolResult }
-    | { fileContent: string; expandedFileContent: string }
-  > {
-    const exists = await WorkspaceFS.exists(filePath);
-    const readGate = requireFileReadForEdit(filePath, exists);
-    if (readGate) {
-      return { readGate };
-    }
-    const fileContent = await WorkspaceFS.read(filePath);
-    // Expand tabs to 4 spaces for consistent display
-    const expandedFileContent = fileContent.replaceAll('\t', '    ');
-    return { fileContent, expandedFileContent };
-  }
-
-  /**
-   * Shared write tail for strReplace/insert: request approval for the proposed
-   * content, write it, push the prior content onto the undo stack when it
-   * actually changed, and mark the file as read. Returns the rejection
-   * ToolResult when the user declines, otherwise the approval plus the content
-   * landed on disk.
-   */
-  private async approveAndWriteEdit(
-    filePath: string,
-    displayPath: string,
-    fileContent: string,
-    newFileContent: string,
-    sourceTool: 'text_editor:str_replace' | 'text_editor:insert',
-  ): Promise<
-    | { rejected: ToolResult }
-    | { approval: ToolEditApprovalResult; appliedContent: string }
-  > {
-    const outcome = await requestAndWriteApprovedEdit({
-      path: filePath,
-      displayPath,
-      originalContent: fileContent,
-      proposedContent: newFileContent,
-      sourceTool,
-    });
-    if ('rejected' in outcome) {
-      return outcome;
-    }
-    const { approval, appliedContent, baseContent } = outcome;
-    if (appliedContent !== baseContent) {
-      this.addToHistory(filePath, baseContent);
-    }
-
-    return { approval, appliedContent };
   }
 
   private async strReplace(
@@ -410,11 +323,12 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      const prepared = await this.prepareEditContent(filePath);
-      if ('readGate' in prepared) {
-        return prepared.readGate;
+      const loaded = await loadEditableFile(filePath);
+      if ('blocked' in loaded) {
+        return loaded.blocked;
       }
-      const { fileContent, expandedFileContent } = prepared;
+      const fileContent = loaded.originalContent;
+      const expandedFileContent = fileContent.replaceAll('\t', '    ');
 
       const expandedOldStr = oldStr.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
@@ -425,72 +339,51 @@ export class TextEditorTool extends defineTool({
         );
       }
 
-      const occurrences = countOccurrences(expandedFileContent, expandedOldStr);
-
-      if (occurrences === 0) {
-        throw new ToolError(
+      const replacement = replaceLiteralMatches({
+        content: expandedFileContent,
+        search: expandedOldStr,
+        replacement: expandedNewStr,
+        mode: 'unique',
+        notFoundError: () =>
           `No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${displayPath}.`,
-        );
-      }
-
-      if (occurrences > 1) {
-        const lineNumbers = findOccurrenceLineNumbers(
-          expandedFileContent,
-          expandedOldStr,
-        );
-
-        throw new ToolError(
+        multipleMatchesError: ({ lineNumbers }) =>
           `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${lineNumbers.join(', ')}. Please ensure it is unique`,
-        );
-      }
+      });
 
       // Literal replacement (String.replace would interpret $$, $&, $', `$\``
       // patterns and corrupt LaTeX/code); see editPrimitives.
-      const newFileContent = replaceFirstLiteral(
-        expandedFileContent,
-        expandedOldStr,
-        expandedNewStr,
-      );
+      const newFileContent = replacement.content;
 
-      const edit = await this.approveAndWriteEdit(
-        filePath,
-        displayPath,
-        fileContent,
-        newFileContent,
-        'text_editor:str_replace',
-      );
-      if ('rejected' in edit) {
-        return edit.rejected;
-      }
-      const { approval, appliedContent } = edit;
-
-      const textBeforeReplacement =
-        expandedFileContent.split(expandedOldStr)[0];
-      const replacementLine =
-        (textBeforeReplacement.match(/\n/g) ?? []).length + 1;
+      const replacementLine = replacement.lineNumbers[0] ?? 1;
       const startLine = Math.max(1, replacementLine - SNIPPET_LINES);
       const endLine =
         replacementLine + SNIPPET_LINES + (newStr.match(/\n/g) ?? []).length;
 
-      const newFileLines = appliedContent.split('\n');
-      const snippet = newFileLines.slice(startLine - 1, endLine).join('\n');
-
-      const output = this.formatEditOutput(
+      return applyApprovedFileEdit({
+        path: filePath,
         displayPath,
-        snippet,
-        startLine,
-        newFileContent,
-        appliedContent,
-        'Review the changes and make sure they are as expected. Edit the file again if necessary.',
-      );
-
-      return {
-        status: 'executed',
-        summary: `Updated ${displayPath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: displayPath, lineChanges: approval.lineChanges }],
-      };
+        originalContent: fileContent,
+        proposedContent: newFileContent,
+        sourceTool: 'text_editor:str_replace',
+        afterWrite: ({ appliedContent, baseContent }) => {
+          if (appliedContent !== baseContent) {
+            this.addToHistory(filePath, baseContent);
+          }
+        },
+        present: ({ appliedContent }) => {
+          const snippet = appliedContent
+            .split('\n')
+            .slice(startLine - 1, endLine)
+            .join('\n');
+          return {
+            summary: `Updated ${displayPath}`,
+            output:
+              `The file ${displayPath} has been edited. ` +
+              this.makeOutput(snippet, startLine) +
+              'Review the changes and make sure they are as expected. Edit the file again if necessary.',
+          };
+        },
+      });
     } catch (error) {
       rethrowWithContext(error, `Error replacing text in ${displayPath}`);
     }
@@ -503,11 +396,12 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      const prepared = await this.prepareEditContent(filePath);
-      if ('readGate' in prepared) {
-        return prepared.readGate;
+      const loaded = await loadEditableFile(filePath);
+      if ('blocked' in loaded) {
+        return loaded.blocked;
       }
-      const { fileContent, expandedFileContent } = prepared;
+      const fileContent = loaded.originalContent;
+      const expandedFileContent = fileContent.replaceAll('\t', '    ');
 
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
@@ -528,46 +422,38 @@ export class TextEditorTool extends defineTool({
       ];
       const newFileContent = newFileLines.join('\n');
 
-      const edit = await this.approveAndWriteEdit(
-        filePath,
+      return applyApprovedFileEdit({
+        path: filePath,
         displayPath,
-        fileContent,
-        newFileContent,
-        'text_editor:insert',
-      );
-      if ('rejected' in edit) {
-        return edit.rejected;
-      }
-      const { approval, appliedContent } = edit;
-
-      const previewLines = appliedContent.split('\n');
-      const insertIndex = insertLine - 1;
-      const snippetStart = Math.max(0, insertIndex - SNIPPET_LINES);
-      const snippetEnd = Math.min(
-        previewLines.length,
-        insertIndex + newStrLines.length + SNIPPET_LINES,
-      );
-      const snippetText = previewLines
-        .slice(snippetStart, snippetEnd)
-        .join('\n');
-      const startLine = snippetStart + 1;
-
-      const output = this.formatEditOutput(
-        displayPath,
-        snippetText,
-        startLine,
-        newFileContent,
-        appliedContent,
-        'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.',
-      );
-
-      return {
-        status: 'executed',
-        summary: `Inserted text into ${displayPath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: displayPath, lineChanges: approval.lineChanges }],
-      };
+        originalContent: fileContent,
+        proposedContent: newFileContent,
+        sourceTool: 'text_editor:insert',
+        afterWrite: ({ appliedContent, baseContent }) => {
+          if (appliedContent !== baseContent) {
+            this.addToHistory(filePath, baseContent);
+          }
+        },
+        present: ({ appliedContent }) => {
+          const previewLines = appliedContent.split('\n');
+          const insertIndex = insertLine - 1;
+          const snippetStart = Math.max(0, insertIndex - SNIPPET_LINES);
+          const snippetEnd = Math.min(
+            previewLines.length,
+            insertIndex + newStrLines.length + SNIPPET_LINES,
+          );
+          const snippetText = previewLines
+            .slice(snippetStart, snippetEnd)
+            .join('\n');
+          const startLine = snippetStart + 1;
+          return {
+            summary: `Inserted text into ${displayPath}`,
+            output:
+              `The file ${displayPath} has been edited. ` +
+              this.makeOutput(snippetText, startLine) +
+              'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.',
+          };
+        },
+      });
     } catch (error) {
       rethrowWithContext(error, `Error inserting text in ${displayPath}`);
     }
@@ -584,71 +470,33 @@ export class TextEditorTool extends defineTool({
         throw new ToolError(`No edit history found for ${displayPath}.`);
       }
 
-      const exists = await WorkspaceFS.exists(filePath);
-      const readGate = requireFileReadForEdit(filePath, exists);
-      if (readGate) {
-        return readGate;
+      const loaded = await loadEditableFile(filePath);
+      if ('blocked' in loaded) {
+        return loaded.blocked;
       }
 
       const previousContent = history.at(-1)!;
-      const currentContent = await WorkspaceFS.read(filePath);
-
-      const outcome = await requestAndWriteApprovedEdit({
+      return applyApprovedFileEdit({
         path: filePath,
         displayPath,
-        originalContent: currentContent,
+        originalContent: loaded.originalContent,
         proposedContent: previousContent,
         sourceTool: 'text_editor:undo_edit',
+        diffSeparator: '\n',
+        afterWrite: () => {
+          history.pop();
+          if (history.length === 0) {
+            this.fileHistory.delete(key);
+          }
+        },
+        present: ({ appliedContent }) => ({
+          summary: `Undid edit on ${displayPath}`,
+          output: `Last edit to ${displayPath} undone successfully. ${this.makeOutput(appliedContent)}`,
+        }),
       });
-      if ('rejected' in outcome) {
-        return outcome.rejected;
-      }
-      const { approval, appliedContent } = outcome;
-      history.pop();
-
-      if (history.length === 0) {
-        this.fileHistory.delete(key);
-      }
-
-      const baseOutput = `Last edit to ${displayPath} undone successfully. ${this.makeOutput(appliedContent)}`;
-      const output = appendApprovalDiffNote(
-        baseOutput,
-        displayPath,
-        previousContent,
-        appliedContent,
-        '\n',
-      );
-
-      return {
-        status: 'executed',
-        summary: `Undid edit on ${displayPath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: displayPath, lineChanges: approval.lineChanges }],
-      };
     } catch (error) {
       rethrowWithContext(error, `Error undoing edit to ${displayPath}`);
     }
-  }
-
-  /** Build the output message for str_replace/insert commands. */
-  private formatEditOutput(
-    filePath: string,
-    snippetText: string,
-    startLine: number,
-    proposedContent: string,
-    appliedContent: string,
-    reviewNote: string,
-  ): string {
-    const successIntro = `The file ${filePath} has been edited.`;
-    const snippetOutput = this.makeOutput(snippetText, startLine);
-    const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
-    return appendApprovalDiffNote(
-      baseMsg,
-      filePath,
-      proposedContent,
-      appliedContent,
-    );
   }
 
   /**

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -1,21 +1,14 @@
-// Local imports - core
+// Third-party imports
 import { z } from 'zod';
 
-// Internal imports
+// Local imports - tools
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
-import { ToolResult } from '@shared/schemas/toolResult';
-import { requireFileReadForEdit } from '@tools/fileInteractions';
+import type { ToolResult } from '@shared/schemas/toolResult';
 import {
-  assertWritable,
-  resolveAndFormat,
-  currentToolRoot,
-} from '@tools/pathResolution';
-import {
-  appendApprovalDiffNote,
-  requestAndWriteApprovedEdit,
-} from '@tools/approval/toolEditApproval';
-import { WorkspaceFS } from '@utils/files';
+  applyApprovedFileEdit,
+  resolveWritableTarget,
+} from '@tools/fileEditFlow';
 import { countLines } from '@utils/text/stringUtils';
 
 // Local file imports
@@ -37,67 +30,37 @@ export class WriteFileTool extends defineTool({
   schema: WriteInputSchema,
 }) {
   protected async execute(input: WriteInput): Promise<ToolResult> {
-    const root = currentToolRoot();
-    const { path: resolved, display: displayPath } = resolveAndFormat(
-      input.path,
-      root,
-    );
-    assertWritable(resolved, displayPath);
-    const filePath = resolved.fsPath;
-
-    const exists = await WorkspaceFS.exists(filePath);
-    const readGate = requireFileReadForEdit(filePath, exists);
-    if (readGate) {
-      return readGate;
+    const prepared = await resolveWritableTarget(input.path, {
+      missing: 'allow',
+    });
+    if ('blocked' in prepared) {
+      return prepared.blocked;
     }
-
-    const originalContent = exists ? await WorkspaceFS.read(filePath) : '';
-
-    const proposedContent = isTexFile(filePath)
+    const { path, displayPath, exists, originalContent } = prepared.target;
+    const proposedContent = isTexFile(path)
       ? replacementEngine.applyAll(input.content)
       : input.content;
 
-    const outcome = await requestAndWriteApprovedEdit({
-      path: filePath,
+    return applyApprovedFileEdit({
+      path,
       displayPath,
       originalContent,
       proposedContent,
       sourceTool: 'write_file',
+      startLine: 'approval',
+      present: ({ appliedContent }) => {
+        const originalLineCount = countLines(originalContent);
+        const newLineCount = countLines(appliedContent);
+        const action = exists ? 'Overwrote' : 'Created';
+        return {
+          summary: `${action} ${displayPath} (${newLineCount} lines)`,
+          output: 'written',
+          userInstruction:
+            exists && originalLineCount > 0
+              ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
+              : undefined,
+        };
+      },
     });
-    if ('rejected' in outcome) {
-      return outcome.rejected;
-    }
-    const { approval, appliedContent } = outcome;
-
-    const output = appendApprovalDiffNote(
-      'written',
-      displayPath,
-      proposedContent,
-      appliedContent,
-    );
-
-    const originalLineCount = countLines(originalContent);
-    const newLineCount = countLines(appliedContent);
-    const action = exists ? 'Overwrote' : 'Created';
-    const summary = `${action} ${displayPath} (${newLineCount} lines)`;
-    const userInstruction =
-      exists && originalLineCount > 0
-        ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
-        : undefined;
-
-    return {
-      status: 'executed',
-      summary,
-      output,
-      userPatch: approval.userPatch,
-      edits: [
-        {
-          path: displayPath,
-          lineChanges: approval.lineChanges,
-          startLine: approval.startLine,
-        },
-      ],
-      ...(userInstruction && { userInstruction }),
-    };
   }
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -370,7 +370,7 @@ export async function writeApprovedContent(
  * read-before-edit gate. Centralized because every call site paired these two
  * calls by hand and it's an easy one to forget.
  */
-export async function writeAndRecordApprovedEdit(
+async function writeAndRecordApprovedEdit(
   path: string,
   originalContent: string,
   finalContent: string,
@@ -437,7 +437,7 @@ export interface ApprovedEditContent {
  * tool so `sourceTool` is named once and the rejection message stays uniform.
  * Callers own the write/record/post-processing steps, which vary per tool.
  */
-export async function requestApprovedEditContent(request: {
+async function requestApprovedEditContent(request: {
   path: string;
   displayPath: string;
   originalContent: string;
@@ -478,10 +478,9 @@ interface WrittenApprovedEdit extends WriteApprovedContentResult {
  * Full approve-then-write handshake for a proposed edit: request approval,
  * then write the resolved content and record the file as read. Combines
  * `requestApprovedEditContent` + `writeAndRecordApprovedEdit`, the exact
- * pairing every straight-through edit call site (no work needed between
- * approval and write) previously hand-rolled. Callers that must do
- * something between approval and write (e.g. creating parent directories)
- * should compose the two primitives directly instead.
+ * pairing every straight-through edit call site previously hand-rolled.
+ * `beforeWrite` covers work that must happen only after acceptance, such as
+ * creating a new file's parent directory.
  */
 export async function requestAndWriteApprovedEdit(request: {
   path: string;
@@ -489,12 +488,15 @@ export async function requestAndWriteApprovedEdit(request: {
   originalContent: string;
   proposedContent: string;
   sourceTool: string;
+  beforeWrite?: () => void | Promise<void>;
 }): Promise<{ rejected: ToolResult } | WrittenApprovedEdit> {
   const outcome = await requestApprovedEditContent(request);
   if ('rejected' in outcome) {
     return outcome;
   }
   const { approval, finalContent } = outcome;
+
+  await request.beforeWrite?.();
 
   const written = await writeAndRecordApprovedEdit(
     request.path,

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -128,6 +128,8 @@ export function replaceLiteralMatches({
   }
 
   return {
+    // Slice/split-based primitives insert replacement strings verbatim; unlike
+    // String.replace, dollar patterns in LaTeX or code are never interpreted.
     content:
       mode === 'all'
         ? replaceAllLiteral(content, search, replacement)

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -1,0 +1,223 @@
+// Local imports - shared schemas
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+
+// Local imports - tools
+import {
+  findOccurrenceLineNumbers,
+  replaceAllLiteral,
+  replaceFirstLiteral,
+} from '@tools/editPrimitives';
+import { requireFileReadForEdit } from '@tools/fileInteractions';
+import {
+  assertWritable,
+  currentToolRoot,
+  resolveAndFormat,
+} from '@tools/pathResolution';
+import { countOccurrences } from '@tools/utils';
+import {
+  appendApprovalDiffNote,
+  requestAndWriteApprovedEdit,
+  type ToolEditApprovalResult,
+} from '@tools/approval/toolEditApproval';
+import { WorkspaceFS } from '@utils/files';
+
+interface WritableFileTarget {
+  path: string;
+  displayPath: string;
+  exists: boolean;
+  originalContent: string;
+}
+
+type WritableTargetPreparation =
+  { blocked: ToolResult } | { target: WritableFileTarget };
+
+type EditableFileLoad =
+  { blocked: ToolResult } | { exists: boolean; originalContent: string };
+
+interface ResolveWritableTargetOptions {
+  missing?: 'allow' | 'require';
+  validate?: (target: { path: string; displayPath: string }) => void;
+}
+
+/** Apply the shared read-before-edit gate, then load the current content. */
+export async function loadEditableFile(
+  path: string,
+  missing: 'allow' | 'require' = 'require',
+): Promise<EditableFileLoad> {
+  const exists = await WorkspaceFS.exists(path);
+  const blocked = requireFileReadForEdit(path, exists);
+  if (blocked) {
+    return { blocked };
+  }
+
+  return {
+    exists,
+    originalContent:
+      exists || missing === 'require' ? await WorkspaceFS.read(path) : '',
+  };
+}
+
+/** Resolve, authorize, read-gate, and load a workspace file for editing. */
+export async function resolveWritableTarget(
+  inputPath: string,
+  options: ResolveWritableTargetOptions = {},
+): Promise<WritableTargetPreparation> {
+  const { path: resolved, display: displayPath } = resolveAndFormat(
+    inputPath,
+    currentToolRoot(),
+  );
+  assertWritable(resolved, displayPath);
+
+  const path = resolved.fsPath;
+  options.validate?.({ path, displayPath });
+  const loaded = await loadEditableFile(path, options.missing);
+  if ('blocked' in loaded) {
+    return loaded;
+  }
+  return {
+    target: {
+      path,
+      displayPath,
+      ...loaded,
+    },
+  };
+}
+
+interface LiteralMatchContext {
+  count: number;
+  lineNumbers: number[];
+}
+
+interface LiteralReplacementRequest {
+  content: string;
+  search: string;
+  replacement: string;
+  mode: 'unique' | 'all';
+  notFoundError: () => string;
+  multipleMatchesError?: (context: LiteralMatchContext) => string;
+}
+
+interface LiteralReplacement {
+  content: string;
+  count: number;
+  lineNumbers: number[];
+}
+
+/** Apply an exact literal replacement under an explicit match policy. */
+export function replaceLiteralMatches({
+  content,
+  search,
+  replacement,
+  mode,
+  notFoundError,
+  multipleMatchesError,
+}: LiteralReplacementRequest): LiteralReplacement {
+  const count = countOccurrences(content, search);
+  if (count === 0) {
+    throw new ToolError(notFoundError());
+  }
+
+  const lineNumbers = findOccurrenceLineNumbers(content, search);
+  if (mode === 'unique' && count > 1) {
+    if (!multipleMatchesError) {
+      throw new ToolError('The text to replace must be unique.');
+    }
+    throw new ToolError(multipleMatchesError({ count, lineNumbers }));
+  }
+
+  return {
+    content:
+      mode === 'all'
+        ? replaceAllLiteral(content, search, replacement)
+        : replaceFirstLiteral(content, search, replacement),
+    count: mode === 'all' ? count : 1,
+    lineNumbers,
+  };
+}
+
+interface AppliedFileEdit {
+  approval: ToolEditApprovalResult;
+  appliedContent: string;
+  baseContent: string;
+}
+
+interface FileEditPresentation {
+  summary: string;
+  output: string;
+  userInstruction?: string;
+}
+
+interface ApprovedFileEditRequest {
+  path: string;
+  displayPath: string;
+  originalContent: string;
+  proposedContent: string;
+  sourceTool: string;
+  present: (edit: AppliedFileEdit) => FileEditPresentation;
+  beforeWrite?: () => void | Promise<void>;
+  afterWrite?: (edit: AppliedFileEdit) => void | Promise<void>;
+  startLine?: 'approval' | 'omit';
+  diffSeparator?: string;
+}
+
+/**
+ * Apply an approved edit and shape its canonical tool result.
+ *
+ * Callers declare presentation and the few lifecycle hooks that are genuinely
+ * tool-specific; approval, writing, rejection, diff notes, and edit metadata
+ * remain one invariant pipeline.
+ */
+export async function applyApprovedFileEdit({
+  path,
+  displayPath,
+  originalContent,
+  proposedContent,
+  sourceTool,
+  present,
+  beforeWrite,
+  afterWrite,
+  startLine = 'omit',
+  diffSeparator,
+}: ApprovedFileEditRequest): Promise<ToolResult> {
+  const outcome = await requestAndWriteApprovedEdit({
+    path,
+    displayPath,
+    originalContent,
+    proposedContent,
+    sourceTool,
+    beforeWrite,
+  });
+  if ('rejected' in outcome) {
+    return outcome.rejected;
+  }
+
+  const edit: AppliedFileEdit = outcome;
+  await afterWrite?.(edit);
+  const presentation = present(edit);
+  const output = appendApprovalDiffNote(
+    presentation.output,
+    displayPath,
+    proposedContent,
+    edit.appliedContent,
+    diffSeparator,
+  );
+
+  return {
+    status: 'executed',
+    summary: presentation.summary,
+    output,
+    userPatch: edit.approval.userPatch,
+    edits: [
+      {
+        path: displayPath,
+        lineChanges: edit.approval.lineChanges,
+        ...(startLine === 'approval' && {
+          startLine: edit.approval.startLine,
+        }),
+      },
+    ],
+    ...(presentation.userInstruction && {
+      userInstruction: presentation.userInstruction,
+    }),
+  };
+}

--- a/src/tools/fileEditFlow.ts
+++ b/src/tools/fileEditFlow.ts
@@ -100,6 +100,7 @@ interface LiteralReplacementRequest {
 interface LiteralReplacement {
   content: string;
   count: number;
+  firstMatchLine: number;
   lineNumbers: number[];
 }
 
@@ -118,6 +119,7 @@ export function replaceLiteralMatches({
   }
 
   const lineNumbers = findOccurrenceLineNumbers(content, search);
+  const firstMatchIndex = content.indexOf(search);
   if (mode === 'unique' && count > 1) {
     if (!multipleMatchesError) {
       throw new ToolError('The text to replace must be unique.');
@@ -131,6 +133,7 @@ export function replaceLiteralMatches({
         ? replaceAllLiteral(content, search, replacement)
         : replaceFirstLiteral(content, search, replacement),
     count: mode === 'all' ? count : 1,
+    firstMatchLine: content.slice(0, firstMatchIndex).split('\n').length,
     lineNumbers,
   };
 }

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -1,3 +1,13 @@
+// Third-party imports
+import { z } from 'zod';
+
+/** Canonical 1-based inclusive line range for tool view_range fields. */
+export const ViewRangeSchema = z
+  .tuple([z.int().min(1), z.int().min(1)])
+  .refine(([start, end]) => end >= start, {
+    error: 'view_range[1] must be greater than or equal to view_range[0]',
+  });
+
 /** Maximum lines returned in a single file view before truncation. */
 export const READ_FILE_MAX_LINES = 2000;
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -14,16 +14,13 @@ import {
 import { debug } from '@logger/logUtils';
 import { formatBytes, formatRelativeTime } from '@shared/utils/string';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
+import { replaceLiteralMatches } from '@tools/fileEditFlow';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local imports - tool core
 import { defineTool } from '../core/define';
-import {
-  findOccurrenceLineNumbers,
-  replaceFirstLiteral,
-} from '../editPrimitives';
 import {
   recordToolFileRead,
   requireFileReadForEdit,
@@ -33,8 +30,9 @@ import {
   formatLinesWithNumbers,
   formatPaginationHint,
   paginateToolListing,
+  ViewRangeSchema,
 } from '../formatting';
-import { countOccurrences, requireField } from '../utils';
+import { requireField } from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
@@ -67,12 +65,7 @@ const MemoryToolInputSchema = z.strictObject({
   ]),
   path: z.string().nullish(),
   file_text: z.string().nullish(),
-  view_range: z
-    .tuple([z.int().min(1), z.int().min(1)])
-    .refine(([start, end]) => end >= start, {
-      error: 'view_range[1] must be greater than or equal to view_range[0]',
-    })
-    .nullish(),
+  view_range: ViewRangeSchema.nullish(),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
   insert_line: z.int().min(0).nullish(),
@@ -355,23 +348,20 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     if (readGate) return readGate;
 
     const { content, meta } = await this.readMemoryFile(resolvedPath);
-    const occurrences = countOccurrences(content, oldStr);
-    if (occurrences === 0) {
-      throw new ToolError(
+    const replacement = replaceLiteralMatches({
+      content,
+      search: oldStr,
+      replacement: newStr,
+      mode: 'unique',
+      notFoundError: () =>
         `The provided old_str was not found in ${inputPath}. Ensure it matches the file content exactly.`,
-      );
-    }
-
-    if (occurrences > 1) {
-      const lineNumbers = findOccurrenceLineNumbers(content, oldStr);
-      throw new ToolError(
+      multipleMatchesError: ({ lineNumbers }) =>
         `old_str is not unique within ${inputPath} (found in lines ${lineNumbers.join(', ')}). Include more surrounding context to make it unique.`,
-      );
-    }
+    });
 
     // Literal replacement (String.replace would interpret $$, $&, $', `$\``
     // patterns and corrupt LaTeX/content); see editPrimitives.
-    const updated = replaceFirstLiteral(content, oldStr, newStr);
+    const updated = replacement.content;
     await this.writeMemoryFile(resolvedPath, updated, meta);
     recordToolFileRead(inputPath);
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -359,8 +359,6 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
         `old_str is not unique within ${inputPath} (found in lines ${lineNumbers.join(', ')}). Include more surrounding context to make it unique.`,
     });
 
-    // Literal replacement (String.replace would interpret $$, $&, $', `$\``
-    // patterns and corrupt LaTeX/content); see editPrimitives.
     const updated = replacement.content;
     await this.writeMemoryFile(resolvedPath, updated, meta);
     recordToolFileRead(inputPath);


### PR DESCRIPTION
## Summary

Centralize the file-edit tool cluster behind one declarative workflow for target preparation, literal matching, approval, writing, and result metadata.

## Issue acceptance gates

Closes #8499.

- `edit_file`, `write_file`, and all four mutating text-editor commands share one approval/write/result pipeline.
- Text editor and memory literal replacement share one unique/all match policy.
- Identical tuple-based `view_range` contracts in memory and executions share one schema.
- ReadTool's object/array compatibility boundary and TextEditorTool's `-1` EOF contract remain unchanged because normalizing them would change public behavior.
- Multi-line text-editor replacements retain the correct preview line and have regression coverage.

## Single source of truth

`src/tools/fileEditFlow.ts` owns writable-target preparation, the read-before-edit gate, literal match policy, approval/write sequencing, user-adjustment notes, and canonical edit metadata. `ViewRangeSchema` in `src/tools/formatting.ts` owns positive inclusive tuple ranges.

## Duplication and abstraction budget

The new workflow replaces six independently assembled approval tails and deletes TextEditorTool's private preparation/write/result wrappers. Its callbacks expose only genuinely tool-specific presentation and lifecycle work; there is no pass-through host layer. Unique literal matching now has three module consumers (`EditTool`, `TextEditorTool`, and `MemoryTool`).

## Net elements (R6)

- Files: 2 added, 8 modified, 0 deleted.
- Diff: +551 / -463 lines, net +88.
- Exported symbols: +5 (`loadEditableFile`, `resolveWritableTarget`, `replaceLiteralMatches`, `applyApprovedFileEdit`, `ViewRangeSchema`), -2 obsolete approval helpers; net +3.
- Exported classes/interfaces/enums: net 0.

## Consumer counts (R8)

- Removed exports `requestApprovedEditContent` and `writeAndRecordApprovedEdit`: 0 external consumers after migration.
- `applyApprovedFileEdit`: 6 mutation paths.
- `replaceLiteralMatches`: 3 module consumers.
- No event or emit path changed; subscriber counts are n/a.

## Host impact

Extension: Shared tool behavior only; no VS Code imports or extension-specific routing changed.

Desktop: Shared tool behavior only; desktop approval adapters and presentation remain unchanged.

CLI: Shared tool behavior only; CLI approval interaction and rendering remain unchanged.

## Scheduled refactoring

None. The two distinct range contracts remain intentionally separate rather than deferred cleanup.

## Validation

- `npm run format`
- focused Vitest: 3 files, 37 tests; review-fix reruns: 2 files, 17 tests
- `npm run typecheck`
- `npm run lint` (0 errors; pre-existing warnings only)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent edit/write paths and approval behavior across multiple tools; behavior is intended to be preserved but regression risk is real for edit gating, approval, and tool output shape.
> 
> **Overview**
> Introduces **`fileEditFlow.ts`** as the single owner of workspace file mutations: path resolution, read-before-edit gating, literal replace policy, approval → write → read tracking, user-adjustment diff notes, and canonical `ToolResult` edit metadata.
> 
> **`edit_file`**, **`write_file`**, and mutating **`text_editor`** commands (`create`, `str_replace`, `insert`, `undo_edit`) now only supply proposed content, a `present` callback, and optional `beforeWrite` / `afterWrite` hooks instead of hand-rolling approval and result assembly. **`memory`** `str_replace` reuses **`replaceLiteralMatches`** only (no approval pipeline). **`ViewRangeSchema`** is shared by **`executions`** and **`memory`**; **`text_editor`** `view_range` stays on its existing array/EOF contract.
> 
> Approval internals **`requestApprovedEditContent`** and **`writeAndRecordApprovedEdit`** are module-private; **`requestAndWriteApprovedEdit`** gains optional **`beforeWrite`**. Tests cover literal replacement, **`ViewRangeSchema`**, and **`write_file`** reporting reviewer-adjusted content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa468465c9146b935d57f3c2838da85928a90061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->