### PR TITLE
refactor(models): remove dead export and fix import order

### DIFF
--- a/src/agent/modelHandlers/openai/openAIResponseErrors.ts
+++ b/src/agent/modelHandlers/openai/openAIResponseErrors.ts
@@ -6,11 +6,11 @@ import {
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
-import type { Response } from 'openai/resources/responses/responses';
 import type { ProviderError } from '@shared/schemas';
 
 // Local imports - model handlers
 import { tagOpenAISdkError } from './openAISdkError';
+import type { Response } from 'openai/resources/responses/responses';
 
 interface OpenAIBackgroundResumeError {
   providerError: ProviderError;

--- a/src/model/codexSubscriptionRouting.ts
+++ b/src/model/codexSubscriptionRouting.ts
@@ -9,7 +9,6 @@
  * request time in the handler and in the async availability context, so the
  * conversation-compatibility key can stay sync.
  */
-import type { ModelConfig } from 'llm-zoo';
 
 import {
   isCodexSubscriptionToolUseOnly,
@@ -21,6 +20,7 @@ import {
   resolveProviderCapabilities,
   type ProviderCapabilityProfile,
 } from './providerCapabilities';
+import type { ModelConfig } from 'llm-zoo';
 
 export function resolveCodexSubscriptionCapabilities(
   config: ModelConfig,

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -195,13 +195,6 @@ export function runtimeModelAccess(
   return runtimeModels.get(model)?.access;
 }
 
-/** Native reference for a discovered model; absent for static model ids. */
-export function getRuntimeModelReference(
-  model: string,
-): LanguageModelReference | undefined {
-  return runtimeModels.get(model)?.reference;
-}
-
 /** Direct-key model represented by an editor-supplied subscription model. */
 export function getRuntimeModelDirectFallback(
   model: string,


### PR DESCRIPTION
## Summary

Remove the unused `getRuntimeModelReference` export and correct two type-import ordering warnings. No runtime behavior changes.

## Issue acceptance gates

No linked issue. This maintenance cleanup is complete when the deleted export has zero consumers and the touched model tests and lint checks pass.

## Single source of truth

The internal `runtimeModels` map in `src/model/runtimeModelRegistry.ts` remains the single owner of discovered runtime-model state.

## Duplication and abstraction budget

No abstraction or duplication is added. One unused accessor is removed.

## Net elements (R6)

- Files: 0 added, 0 deleted, 3 modified.
- Exported symbols: 0 added, 1 deleted (`getRuntimeModelReference`).
- Classes/interfaces/enums: 0 added, 0 deleted.
- LoC: 2 additions, 9 deletions, net -7.

## Consumer counts (R8)

- `getRuntimeModelReference`: 1 definition and 0 consumers before the change; 0 definitions and 0 consumers on this branch.
- No emit path changes.

## Host impact

Extension: No behavior change; the deleted export had zero consumers.

Desktop: No behavior change.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint: passed without warnings.
- Focused model tests: 3 files, 27 tests passed.
- Previous broader `src/test-kernel/model` run: 91 tests passed.
- GitHub CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maintenance-only: one unused export removed and import reordering; no logic, auth, or data-path changes.
> 
> **Overview**
> Removes the unused **`getRuntimeModelReference`** export from `runtimeModelRegistry.ts`; internal `reference` data on runtime entries is unchanged and still used (e.g. `requestRuntimeModelAccess`).
> 
> Reorders **`import type`** lines in `openAIResponseErrors.ts` and `codexSubscriptionRouting.ts` to satisfy import-order lint rules. No runtime or API behavior changes beyond dropping the dead export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d95d6a696546fd2857a104e61e22a77b071070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->