### PR TITLE
refactor(controllers): dedupe progress-view logic, remove dead imports

### DIFF
--- a/src/controllers/progressView/ProgressApiKeyRetryController.ts
+++ b/src/controllers/progressView/ProgressApiKeyRetryController.ts
@@ -28,6 +28,15 @@ interface ProgressApiRoutingSnapshot {
   readonly preferChatGptSubscription: boolean;
 }
 
+function noRetryResult(): ProgressApiKeyRetryResult {
+  return {
+    proceeded: false,
+    retried: false,
+    disabledIncludedModelAccess: false,
+    disabledChatGptSubscription: false,
+  };
+}
+
 export interface ProgressApiKeyRetryControllerDeps {
   providers: readonly ApiProvider[];
   readKey(provider: ApiProvider): Promise<string | undefined>;
@@ -59,12 +68,7 @@ export class ProgressApiKeyRetryController {
       !proceeded ||
       !this.deps.isRetryPending(request.stream, request.requestId)
     ) {
-      return {
-        proceeded: false,
-        retried: false,
-        disabledIncludedModelAccess: false,
-        disabledChatGptSubscription: false,
-      };
+      return noRetryResult();
     }
 
     const before = this.routingSnapshot();
@@ -72,12 +76,7 @@ export class ProgressApiKeyRetryController {
     const retried = this.deps.triggerRetry(request.stream, request.requestId);
     if (!retried) {
       await this.restoreOwnApiKeyRouting(before, prepared);
-      return {
-        proceeded: false,
-        retried: false,
-        disabledIncludedModelAccess: false,
-        disabledChatGptSubscription: false,
-      };
+      return noRetryResult();
     }
     return {
       ...prepared,

--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -1,7 +1,6 @@
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
-  AgentConfigSchema,
   ToolUseAgentConfigSchema,
   type AgentConfig,
 } from '@agent/core/definition/AgentConfig';

--- a/src/controllers/progressView/backend/ApprovalRequestHandler.ts
+++ b/src/controllers/progressView/backend/ApprovalRequestHandler.ts
@@ -172,23 +172,23 @@ export class ApprovalRequestHandler<
    */
   releaseForStream(streamId: string): void {
     for (const [id, entry] of [...this.pending]) {
-      if (entry.item.streamId !== streamId) continue;
-      if (entry.mode === 'interaction') {
-        this.completeEntry(id, entry, entry.cancellationResult(), false);
-      } else {
-        this.removeEntry(id, entry, false);
-      }
+      if (entry.item.streamId === streamId) this.releaseSilently(id, entry);
     }
   }
 
   /** Silently release all pending items without orphaning interactions. */
   clear(): void {
     for (const [id, entry] of [...this.pending]) {
-      if (entry.mode === 'interaction') {
-        this.completeEntry(id, entry, entry.cancellationResult(), false);
-      } else {
-        this.removeEntry(id, entry, false);
-      }
+      this.releaseSilently(id, entry);
+    }
+  }
+
+  /** Release one entry without notifying the webview (dismiss/cancel cleanup). */
+  private releaseSilently(id: string, entry: PendingRequest<T, Result>): void {
+    if (entry.mode === 'interaction') {
+      this.completeEntry(id, entry, entry.cancellationResult(), false);
+    } else {
+      this.removeEntry(id, entry, false);
     }
   }
 

--- a/src/controllers/progressView/backend/restartRepair.ts
+++ b/src/controllers/progressView/backend/restartRepair.ts
@@ -74,6 +74,28 @@ function repairCandidates(
     .map(([streamId]) => streamId);
 }
 
+/** Repair one stream back to WAITING, logging the outcome. */
+function repairToWaiting(
+  streamStatus: StreamStatusMachine,
+  streamId: StreamTabId,
+  statusEmitOptions: StreamStatusEmitOptions | undefined,
+  logger: RestartRepairLogger | undefined,
+): boolean {
+  if (
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.WAITING,
+      STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+      statusEmitOptions,
+    )
+  ) {
+    logger?.debug(`Stream ${streamId} restored to WAITING after restart`);
+    return true;
+  }
+  logger?.warn(`Failed to repair stream ${streamId} to WAITING after restart`);
+  return false;
+}
+
 function transitionToFailedForRestart(
   streamStatus: StreamStatusMachine,
   streamId: StreamTabId,
@@ -207,21 +229,14 @@ export async function repairRestartedStreams(
       if (isWaitingStream) {
         waitingGroupStreams.push(streamId);
         if (
-          options.streamStatus.transition(
+          repairToWaiting(
+            options.streamStatus,
             streamId,
-            STREAM_PHASE.WAITING,
-            STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
             options.statusEmitOptions,
+            options.logger,
           )
         ) {
           waitingStreams.push(streamId);
-          options.logger?.debug(
-            `Stream ${streamId} restored to WAITING after restart`,
-          );
-        } else {
-          options.logger?.warn(
-            `Failed to repair stream ${streamId} to WAITING after restart`,
-          );
         }
       } else {
         orphanedGroupStreams.push(streamId);
@@ -248,21 +263,14 @@ export async function repairRestartedStreams(
     if (isWaitingStream) {
       waitingGroupStreams.push(streamId);
       if (
-        options.streamStatus.transition(
+        repairToWaiting(
+          options.streamStatus,
           streamId,
-          STREAM_PHASE.WAITING,
-          STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
           options.statusEmitOptions,
+          options.logger,
         )
       ) {
         waitingStreams.push(streamId);
-        options.logger?.debug(
-          `Stream ${streamId} restored to WAITING after restart`,
-        );
-      } else {
-        options.logger?.warn(
-          `Failed to repair stream ${streamId} to WAITING after restart`,
-        );
       }
       continue;
     }

--- a/src/controllers/settingsView/SettingsAgentControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsAgentControllerFactory.ts
@@ -21,11 +21,7 @@ import {
   type AgentEntry,
 } from '@agent/index';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
-import {
-  agentKeyOf,
-  type AgentCategory,
-  type AgentSource,
-} from '@shared/schemas/agent';
+import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import { parseAgentModePresets } from '@shared/schemas/agentPresets';
 
 import type { SettingsStatePorts } from '@shared/settingsView/types';

--- a/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressApiKeyRetryController.vitest.ts
@@ -164,6 +164,25 @@ describe('ProgressApiKeyRetryController', () => {
     assert.deepEqual(harness.retries, []);
   });
 
+  it('returns a fresh result when no retry occurs', async () => {
+    const harness = createHarness({
+      keys: { anthropic: 'stored-key' },
+      retryPending: false,
+    });
+    const request = {
+      stream: 'stream-a' as const,
+      requestId: 'retry:stale',
+      provider: 'anthropic' as const,
+      exhaustionReason: 'copilot-subscription' as const,
+    };
+
+    const first = await harness.controller.useOwnApiKey(request);
+    const second = await harness.controller.useOwnApiKey(request);
+
+    assert.notStrictEqual(first, second);
+    assert.deepEqual(first, second);
+  });
+
   it('accepts a changed key from any provider when depletion has no provider hint', async () => {
     const harness = createHarness({
       keys: { openai: 'old-openai', anthropic: undefined },


### PR DESCRIPTION
## Summary

Remove two unused controller imports and give three repeated progress-view decisions one owner each: the empty retry result, silent approval release, and restart-to-waiting repair transition. The retry-result helper returns a fresh object on every call, preserving the original identity semantics.

This is behavior-preserving internal cleanup, so it does not require a changelog entry.

## Issue acceptance gates

No linked issue. The pull request is complete when each repeated block has one local owner, public contracts remain unchanged, and direct controller tests pass.

## Single source of truth

- `noRetryResult()` owns the complete result returned when an API-key retry does not occur.
- `ApprovalRequestHandler.releaseSilently()` owns silent interaction and presentation cleanup.
- `repairToWaiting()` owns the restart repair transition and its associated log messages.

## Duplication and abstraction budget

Each helper replaces two identical in-file blocks and remains private to its module or class. No cross-module layer, wrapper service, or public API is added. A regression test verifies that `noRetryResult()` preserves the former fresh-object behavior.

## Net elements (R6)

- Files: 0 added, 0 deleted, 6 modified.
- Exported symbols: 0 added, 0 removed.
- Classes, interfaces, and enums: none added or removed.
- Net LoC: +21 overall (70 additions, 49 deletions), including 19 lines of regression coverage.

## Consumer counts (R8)

- `noRetryResult()`: 2 callers.
- `releaseSilently()`: 2 callers.
- `repairToWaiting()`: 2 callers.
- No event keys, emit paths, or subscribers are changed.

## Host impact

Extension: Internal progress-view retry, approval cleanup, and restart repair behavior is unchanged.

Desktop: No desktop-specific behavior or API changes.

CLI: No CLI-specific behavior or API changes.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint
- Focused controller and progress-view Vitest suites
- Pre-commit formatting
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with unchanged contracts; low risk aside from ensuring silent approval and restart repair paths behave identically.
> 
> **Overview**
> Internal progress-view cleanup with **no public API or behavior changes**.
> 
> **`noRetryResult()`** centralizes the “no retry” `ProgressApiKeyRetryResult` in `ProgressApiKeyRetryController` (still returns a **new object** each call). A Vitest case locks in that identity semantics.
> 
> **`ApprovalRequestHandler.releaseSilently()`** unifies silent teardown for `releaseForStream` and `clear` (interaction cancel vs presentation remove, no webview notify).
> 
> **`repairToWaiting()`** in `restartRepair.ts` owns the restart-repair transition to `WAITING` plus debug/warn logging, replacing two duplicated blocks.
> 
> Unused imports are dropped in `ProgressFollowUpController` (`AgentConfigSchema`) and `SettingsAgentControllerFactory` (`agentKeyOf`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83aee00e75fb0f91d008c244fc7d51261df9cf2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->