### PR TITLE
feat(cli): show a subagent's own summary in the subagent picker

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -9,13 +9,10 @@ import {
 } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { formatCompactDuration } from '@utils/core';
-import {
-  collapseWhitespace,
-  truncateWithEllipsis,
-} from '@utils/text/stringUtils';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
+import { truncateSummaryToWidth } from '../render/terminalText';
 import {
   activeSubagentsFor,
   childExecutionKey,
@@ -150,50 +147,7 @@ function streamDescription(
   return streamsById.get(child.childStreamId)?.description;
 }
 
-const SUBAGENT_SUMMARY_MAX_CHARS = 100;
-
-/** The subagent's own final reply, already recorded on its stream's
- *  transcript — reused as-is rather than generated fresh for the picker. */
-function streamFinalResponse(
-  child: SubagentChildInfo,
-  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
-): string | undefined {
-  const entries = streamsById.get(child.childStreamId)?.entries;
-  if (!entries) return undefined;
-  for (let i = entries.length - 1; i >= 0; i -= 1) {
-    const entry = entries[i];
-    if (entry.role === 'assistant' && entry.text.trim()) return entry.text;
-  }
-  return undefined;
-}
-
-/** The first user-role entry on the subagent's own stream — its initiating
- *  instruction, already recorded there regardless of whether the run has
- *  produced a final reply yet. */
-function streamFirstInstruction(
-  child: SubagentChildInfo,
-  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
-): string | undefined {
-  const entries = streamsById.get(child.childStreamId)?.entries;
-  return entries?.find((entry) => entry.role === 'user' && entry.text.trim())
-    ?.text;
-}
-
-/** One-line picker summary: the subagent's own final response when it has
- *  one, else the first N characters of its initiating instruction. */
-function streamSummary(
-  child: SubagentChildInfo,
-  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
-): string | undefined {
-  const text =
-    streamFinalResponse(child, streamsById) ??
-    streamFirstInstruction(child, streamsById);
-  if (!text) return undefined;
-  return truncateWithEllipsis(
-    collapseWhitespace(text),
-    SUBAGENT_SUMMARY_MAX_CHARS,
-  );
-}
+const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
 
 const TASK_DETAIL_TRANSCRIPT_COLUMNS = 120;
 
@@ -245,6 +199,14 @@ function buildChildControlItem(
   const statusLabel = childStatusDescription(child.status);
 
   if (child.kind === 'subagent') {
+    const entries = ctx.streamsById.get(child.childStreamId)?.entries;
+    const summary =
+      entries?.findLast(
+        (entry) =>
+          entry.role === 'assistant' && entry.finalized && entry.text.trim(),
+      )?.text ??
+      entries?.find((entry) => entry.role === 'user' && entry.text.trim())
+        ?.text;
     return {
       executionId: child.executionId,
       childStreamId: child.childStreamId,
@@ -254,7 +216,9 @@ function buildChildControlItem(
       description: compactParts([
         statusLabel,
         elapsed ?? undefined,
-        streamSummary(child, ctx.streamsById),
+        summary
+          ? truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)
+          : undefined,
       ]),
       statusLabel,
       elapsed,

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -9,6 +9,10 @@ import {
 } from '@shared/schemas';
 import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
 import { formatCompactDuration } from '@utils/core';
+import {
+  collapseWhitespace,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 // Local imports - CLI state
 import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
@@ -146,6 +150,51 @@ function streamDescription(
   return streamsById.get(child.childStreamId)?.description;
 }
 
+const SUBAGENT_SUMMARY_MAX_CHARS = 100;
+
+/** The subagent's own final reply, already recorded on its stream's
+ *  transcript — reused as-is rather than generated fresh for the picker. */
+function streamFinalResponse(
+  child: SubagentChildInfo,
+  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
+): string | undefined {
+  const entries = streamsById.get(child.childStreamId)?.entries;
+  if (!entries) return undefined;
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    if (entry.role === 'assistant' && entry.text.trim()) return entry.text;
+  }
+  return undefined;
+}
+
+/** The first user-role entry on the subagent's own stream — its initiating
+ *  instruction, already recorded there regardless of whether the run has
+ *  produced a final reply yet. */
+function streamFirstInstruction(
+  child: SubagentChildInfo,
+  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
+): string | undefined {
+  const entries = streamsById.get(child.childStreamId)?.entries;
+  return entries?.find((entry) => entry.role === 'user' && entry.text.trim())
+    ?.text;
+}
+
+/** One-line picker summary: the subagent's own final response when it has
+ *  one, else the first N characters of its initiating instruction. */
+function streamSummary(
+  child: SubagentChildInfo,
+  streamsById: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'entries'>>,
+): string | undefined {
+  const text =
+    streamFinalResponse(child, streamsById) ??
+    streamFirstInstruction(child, streamsById);
+  if (!text) return undefined;
+  return truncateWithEllipsis(
+    collapseWhitespace(text),
+    SUBAGENT_SUMMARY_MAX_CHARS,
+  );
+}
+
 const TASK_DETAIL_TRANSCRIPT_COLUMNS = 120;
 
 function streamEntryTailLines(entry: ConversationEntry): readonly string[] {
@@ -202,7 +251,11 @@ function buildChildControlItem(
       kind: 'subagent',
       label,
       command: streamDescription(child, ctx.streamsById) ?? label,
-      description: compactParts([statusLabel, elapsed ?? undefined]),
+      description: compactParts([
+        statusLabel,
+        elapsed ?? undefined,
+        streamSummary(child, ctx.streamsById),
+      ]),
       statusLabel,
       elapsed,
       killable: ctx.killable,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -455,7 +455,12 @@ describe('CLI child execution controls', () => {
       ]),
     });
 
-    const [item] = buildChildControlItems('root', entries, streams, 'subagents');
+    const [item] = buildChildControlItems(
+      'root',
+      entries,
+      streams,
+      'subagents',
+    );
     expect(item?.description).toBe(
       `running · 3s · Review the introduction for clarity and tone. ${'x'.repeat(53)}…`,
     );

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -376,6 +376,91 @@ describe('CLI child execution controls', () => {
     ]);
   });
 
+  it('shows the subagent own final response as the picker summary', () => {
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'reviewer',
+          childStreamId: 'child-a',
+          status: STREAM_PHASE.WAITING,
+          elapsed: '20s',
+        },
+      ],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: STREAM_PHASE.WAITING,
+            entries: [
+              {
+                id: 'entry-1',
+                role: 'user',
+                text: 'Review the introduction for clarity.',
+                finalized: true,
+              },
+              {
+                id: 'entry-2',
+                role: 'assistant',
+                text: 'Tightened the opening paragraph and fixed two typos.',
+                finalized: true,
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
+      {
+        executionId: 'agent-1',
+        description:
+          'waiting for you · 20s · Tightened the opening paragraph and fixed two typos.',
+      },
+    ]);
+  });
+
+  it('falls back to the first user instruction when no final response exists yet', () => {
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'reviewer',
+          childStreamId: 'child-a',
+          status: 'running',
+          elapsed: '3s',
+        },
+      ],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: 'running',
+            entries: [
+              {
+                id: 'entry-1',
+                role: 'user',
+                text: `Review the introduction for clarity and tone. ${'x'.repeat(100)}`,
+                finalized: true,
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    const [item] = buildChildControlItems('root', entries, streams, 'subagents');
+    expect(item?.description).toBe(
+      `running · 3s · Review the introduction for clarity and tone. ${'x'.repeat(53)}…`,
+    );
+  });
+
   it('derives live elapsed text for running child executions', () => {
     const parentSlice = slice({
       activeProcesses: [

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -449,6 +449,12 @@ describe('CLI child execution controls', () => {
                 text: `Review the introduction for clarity and tone. ${'x'.repeat(100)}`,
                 finalized: true,
               },
+              {
+                id: 'entry-2',
+                role: 'assistant',
+                text: 'Still drafting a response',
+                finalized: false,
+              },
             ],
           }),
         ],


### PR DESCRIPTION
## Summary

Make Alt+S subagent rows explain what each subagent is doing without opening its transcript.

- Show the subagent's last finalized assistant reply when one exists.
- Otherwise show a one-line preview of its initiating user instruction.
- Ignore unfinalized streaming assistant text so the picker does not flicker between partial fragments.
- Truncate summaries to 100 terminal display columns, including correct handling of wide characters.

The existing picker rendering and process/task rows are unchanged.

## Issue acceptance gates

No linked issue. The feature is complete when finalized replies are preferred, active partial replies fall back to the instruction, and summaries remain single-line and width-bounded.

## Single source of truth

The child stream's existing transcript remains the source of both the initiating instruction and finalized response. No generated summary or additional persistence is introduced.

## Duplication and abstraction budget

Summary selection is derived directly in `buildChildControlItem`; no one-caller lookup helpers were added. Width-aware normalization uses the existing `truncateSummaryToWidth` utility.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: no changes.
- LoC: 114 additions, 1 deletion, net +113; 96 additions are focused test coverage.

## Consumer counts (R8)

n/a - no export or event-emission path is changed. The result flows through the existing `ChildControlItem.description` field.

## Host impact

Extension: None.

Desktop: None.

CLI: Alt+S subagent rows gain a stable, width-bounded description of the subagent's instruction or finalized result.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint: passed.
- `src/test-kernel/cli/ChildControls.vitest.mts`: 46 tests passed.
- `corepack pnpm --filter @texra-ai/cli typecheck`: passed.
- GitHub CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display logic on existing `ChildControlItem.description`; no auth, persistence, or export surface changes.
> 
> **Overview**
> **Alt+S subagent picker rows** now append a short transcript preview to each row’s `description` (after status and elapsed), so you can see what a subagent is doing without opening its transcript.
> 
> For subagents, the preview is the **last finalized assistant** message when present; otherwise the **first user** instruction. **Unfinalized** streaming assistant text is skipped to avoid flicker. Text is **truncated to 100 terminal columns** via `truncateSummaryToWidth`. Process/task rows and picker rendering are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a4ee7fcf271b0b1bd0db2e80fc76d7465d6e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->