### PR TITLE
refactor(agent): prune unused exports across core, runtime, and storage

### DIFF
--- a/src/agent/core/definition/AgentDataclass.ts
+++ b/src/agent/core/definition/AgentDataclass.ts
@@ -30,7 +30,7 @@ const filePatternsContainEntryFields = {
   varName: z.string(),
 };
 
-export const AgentSettingBaseSchema = z.strictObject({
+const AgentSettingBaseSchema = z.strictObject({
   temperature: temperatureField.prefault(1.0),
   requiredFiles: requiredFilesField.prefault({}),
   requiredFilesInternal: requiredFilesField.prefault({}),
@@ -150,7 +150,7 @@ const RawAgentSettingInputSchema = z.strictObject({
  * Raw YAML settings. This schema validates field shapes without materialising
  * defaults, so inherited child blocks only override fields the author wrote.
  */
-export const AgentSettingInputSchema = z.preprocess(
+const AgentSettingInputSchema = z.preprocess(
   stripLegacySettingFields,
   RawAgentSettingInputSchema,
 );
@@ -171,7 +171,7 @@ export const AgentPromptSchema = z.strictObject({
 export type AgentPrompt = z.infer<typeof AgentPromptSchema>;
 
 /** Partial prompts as they appear in YAML before inheritance and defaults. */
-export const AgentPromptInputSchema = z.strictObject({
+const AgentPromptInputSchema = z.strictObject({
   systemPrompt: z.string().optional(),
   userPrefix: z.string().optional(),
   userRequest: z.union([z.string(), z.array(z.string())]).optional(),

--- a/src/agent/followUp/ToolFileInteractionContext.ts
+++ b/src/agent/followUp/ToolFileInteractionContext.ts
@@ -17,7 +17,7 @@ import {
 
 /** Optional lifecycle callbacks a tool call may be given, grouped since they
  *  vary together by call site rather than independently. */
-export interface ToolCallHooks {
+interface ToolCallHooks {
   /** Called by tools with approval flows to trigger in-progress log after approval. */
   onExecutionReady?: () => void;
   /** Called by tools to push partial output for live streaming to the UI. */

--- a/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
+++ b/src/agent/implementations/flows/agentCreator/agentCreatorFlow.ts
@@ -163,7 +163,7 @@ export const TOOL_GROUPS: Record<string, ToolGroup> = {
  * Tool groups whose keywords match `description`. `File Operations` is
  * always included as a safe baseline for any tool-use agent.
  */
-export function suggestToolGroups(description: string): string[] {
+function suggestToolGroups(description: string): string[] {
   const lower = description.toLowerCase();
   const suggested = new Set<string>(['File Operations']);
   for (const [name, group] of Object.entries(TOOL_GROUPS)) {

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -23,7 +23,7 @@ import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerC
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { RetryErrorInfoSchema } from '@shared/schemas';
 
-export const StateSlicesSchema = z.object({
+const StateSlicesSchema = z.object({
   runStateSnapshot: AgentRunStateSnapshotSchema,
   workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
   userChannels: UserVariableChannelsSchema,

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -20,8 +20,6 @@ export { toRemoteAgentProfileData } from './remoteAgentProfileData';
 export {
   AgentRosterController,
   InvalidAgentTeamError,
-  type AgentRosterControllerDeps,
-  type AgentRosterSnapshot,
 } from '../roster/AgentRosterController';
 
 export {
@@ -48,7 +46,6 @@ export {
   // Visible agents (for dropdowns and tools)
   getVisibleAgents,
   createWorkspaceAgentRosterController,
-  resolveDelegationScopeAgents,
   // Canonical name-or-key identity matcher (shared by out-of-registry callers)
   findAgentByIdentifier,
   // All built-in delegating team roots (relay-served + bundled)

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -60,7 +60,7 @@ export interface RunFlowLifecycleOptions {
   onRun?: (handle: AgentRunHandle) => void | Promise<void>;
 }
 
-export type FlowRecordDisposition = FinalizeExecutionInput['flowRecord'];
+type FlowRecordDisposition = FinalizeExecutionInput['flowRecord'];
 
 /** Private control channel through which a flow reports its retention policy. */
 export interface FlowLifecycleControl {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -57,7 +57,7 @@ export interface StopAgentStreamOptions {
   readonly runtimeHost?: AgentRuntimeHost;
 }
 
-export type StopAgentChildPolicy = 'cascade' | 'detach';
+type StopAgentChildPolicy = 'cascade' | 'detach';
 
 export type StopAgentStreamResult =
   | {

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -24,7 +24,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { HostBashApprovalResult } from './HostInteractions';
 
 /** Progress events that announce per-stream approval-bypass changes. */
-export type ApprovalBypassEvent =
+type ApprovalBypassEvent =
   | 'updateToolEditApprovalBypassState'
   | 'updateBashApprovalBypassState'
   | 'updateSuperYoloBypassState';
@@ -70,7 +70,7 @@ export interface StreamApprovalBypass {
   clearAll(): void;
 }
 
-export function createStreamApprovalBypass(
+function createStreamApprovalBypass(
   event: ApprovalBypassEvent,
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined,
 ): StreamApprovalBypass {
@@ -121,13 +121,13 @@ export function createStreamApprovalBypass(
   };
 }
 
-export interface PendingApproval<R extends { accepted: boolean }> {
+interface PendingApproval<R extends { accepted: boolean }> {
   streamId?: StreamTabId;
   isSettled: () => boolean;
   settle: (result: R) => void;
 }
 
-export interface StreamApprovalController<R extends { accepted: boolean }> {
+interface StreamApprovalController<R extends { accepted: boolean }> {
   registerPending(id: string, entry: PendingApproval<R>): void;
   unregisterPending(id: string): void;
   bypass: StreamApprovalBypass;
@@ -145,15 +145,13 @@ export interface StreamApprovalController<R extends { accepted: boolean }> {
   rejectAllPending(): void;
 }
 
-export interface StreamApprovalControllerOptions<
-  R extends { accepted: boolean },
-> {
+interface StreamApprovalControllerOptions<R extends { accepted: boolean }> {
   rejectionResult: () => R;
   bypassEvent: ApprovalBypassEvent;
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
 }
 
-export function createStreamApprovalController<R extends { accepted: boolean }>(
+function createStreamApprovalController<R extends { accepted: boolean }>(
   options: StreamApprovalControllerOptions<R>,
 ): StreamApprovalController<R> {
   const pending = new Map<string, PendingApproval<R>>();

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -26,12 +26,10 @@ export {
 } from './executionWorkspaceFiles';
 export {
   finalizeExecution,
-  hasPersistedParent,
   registerExecution,
   synchronizeAgentResultOutcome,
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
-  writeTerminalStatus,
   writeSessionDescription,
 } from './executionLifecycle';
 export {

--- a/src/agent/types/ProviderMessage.ts
+++ b/src/agent/types/ProviderMessage.ts
@@ -35,7 +35,7 @@ export type ProviderMessage =
  * instead of being silently trusted and surfacing as a confusing error deep
  * inside a model handler.
  */
-export const ProviderMessageSchema = z.custom<ProviderMessage>(
+const ProviderMessageSchema = z.custom<ProviderMessage>(
   (value): value is ProviderMessage =>
     typeof value === 'object' &&
     value !== null &&

--- a/src/agent/workflowScript/index.ts
+++ b/src/agent/workflowScript/index.ts
@@ -1,5 +1,4 @@
 export { parseWorkflowScript, WorkflowScriptParseError } from './parseScript';
-export type { ParsedWorkflowScript } from './parseScript';
 export { runWorkflowScript, WorkflowRunAbortError } from './runWorkflowScript';
 export {
   readWorkflowScriptCheckpoint,
@@ -7,18 +6,11 @@ export {
   WorkflowScriptPersistenceError,
   writeWorkflowScriptCheckpoint,
 } from './persistence';
+export type { PersistedWorkflowScriptRunOptions } from './persistence';
 export type {
-  PersistedWorkflowScriptRunOptions,
-  WorkflowScriptCheckpoint,
-} from './persistence';
-export {
-  WorkflowScriptMetaSchema,
-  type WorkflowAgentCallOptions,
-  type WorkflowAgentInvocation,
-  type WorkflowAgentRunner,
-  type WorkflowJournalEntry,
-  type WorkflowScriptEvent,
-  type WorkflowScriptMeta,
-  type WorkflowScriptRunOptions,
-  type WorkflowScriptRunResult,
+  WorkflowAgentInvocation,
+  WorkflowAgentRunner,
+  WorkflowJournalEntry,
+  WorkflowScriptEvent,
+  WorkflowScriptRunResult,
 } from './types';

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const WorkflowScriptPhaseSchema = z.object({
+const WorkflowScriptPhaseSchema = z.object({
   title: z.string().min(1),
   detail: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

Narrow the public surface of `src/agent/**` to the API that the repository actually consumes.

- Remove unused barrel re-exports from the agent roster, storage, and workflow-script entry points.
- Keep module implementation schemas, helper functions, and internal types private when no other module imports them.
- Preserve the deliberately broad trace-event SDK contract, even where present repository consumers do not exercise every member.

No runtime logic, schema shape, function signature, or direct-path import changes.

## Issue acceptance gates

No linked issue. This is a bounded dead-export cleanup: every removed export has zero consumers through the removed surface, and all retained direct-path consumers continue to compile and pass their tests.

## Single source of truth

Each affected symbol remains defined in its existing domain module. The agent roster, storage, and workflow-script barrels now expose only the subset intended for barrel consumers; implementation-only symbols remain private to their defining modules.

## Duplication and abstraction budget

No abstraction was added. The change deletes 27 accidental exports and re-exports without adding wrappers, aliases, compatibility shims, or replacement paths.

## Net elements (R6)

- Files: 12 modified, 0 added, 0 deleted.
- Exported symbols: 27 removed, 0 added.
- Classes/interfaces/enums: no definitions added or deleted; 5 interfaces and 7 type/schema declarations become module-private.
- Net LoC: -15 lines (22 additions, 37 deletions).

## Consumer counts (R8)

Every removed public surface has zero consumers. Definitions and internal or direct-path consumers remain unchanged.

- Module-private exports, 0 external consumers each: `AgentSettingBaseSchema`, `AgentSettingInputSchema`, `AgentPromptInputSchema`, `ToolCallHooks`, `suggestToolGroups`, `StateSlicesSchema`, `FlowRecordDisposition`, `StopAgentChildPolicy`, `ApprovalBypassEvent`, `createStreamApprovalBypass`, `PendingApproval`, `StreamApprovalController`, `StreamApprovalControllerOptions`, `createStreamApprovalController`, `ProviderMessageSchema`, and `WorkflowScriptPhaseSchema`.
- `@agent/index` barrel, 0 consumers each through the barrel: `AgentRosterControllerDeps`, `AgentRosterSnapshot`, and `resolveDelegationScopeAgents`. Existing direct imports remain.
- `@agent/storage` barrel, 0 consumers each through the barrel: `hasPersistedParent` and `writeTerminalStatus`. Existing direct imports from `executionLifecycle` remain.
- `@agent/workflowScript` barrel, 0 consumers each through the barrel: `ParsedWorkflowScript`, `WorkflowScriptCheckpoint`, `WorkflowScriptMetaSchema`, `WorkflowAgentCallOptions`, `WorkflowScriptMeta`, and `WorkflowScriptRunOptions`. Their definitions and internal direct imports remain.

## Host impact

Extension: No behavior or host integration changes.

Desktop: No behavior or host integration changes.

CLI: No behavior or host integration changes.

## Scheduled refactoring

None. The trace-event exports remain intentionally untouched because that module documents an SDK contract broader than current internal consumers.

## Validation

- Focused Vitest coverage for the touched agent, runtime, storage, roster, approval, and workflow-script modules: 36 files, 440 tests passed.
- `CI=true corepack pnpm typecheck`: passed across the root, test kernel, extension, CLI, trace viewer, and desktop projects.
- Repository CI is rerun from the rebased branch before merge.
