### PR TITLE
refactor(shared): dedupe canonical *Files list fields + fix import order

### DIFF
--- a/src/shared/schemas/fileFields.ts
+++ b/src/shared/schemas/fileFields.ts
@@ -82,12 +82,20 @@ export function migrateLegacyContextFileFields(input: unknown): unknown {
   return obj;
 }
 
-/** The four canonical `*Files` list fields shared by every file-fields schema. */
-const fileListFields = {
+/** The four canonical `*Files` list fields, defaulting to `[]` when absent. */
+export const fileListFields = {
   inputFiles: z.array(z.string()).prefault([]),
   contextFiles: z.array(z.string()).prefault([]),
   mediaFiles: z.array(z.string()).prefault([]),
   outputFiles: z.array(z.string()).prefault([]),
+};
+
+/** The same four `*Files` list fields, required (no default). */
+export const requiredFileListFields = {
+  inputFiles: z.array(z.string()),
+  contextFiles: z.array(z.string()),
+  mediaFiles: z.array(z.string()),
+  outputFiles: z.array(z.string()),
 };
 
 /**

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -9,6 +9,7 @@ import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import {
   UIFileFieldsSchema,
   migrateLegacyContextFileFields,
+  requiredFileListFields,
 } from '../fileFields';
 import {
   DocumentFileTypeSchema,
@@ -183,12 +184,7 @@ const FileOptionsSchema = z.object({
 });
 export type FileOptions = z.infer<typeof FileOptionsSchema>;
 
-const MultiFilesSchema = z.object({
-  inputFiles: z.array(z.string()),
-  contextFiles: z.array(z.string()),
-  mediaFiles: z.array(z.string()),
-  outputFiles: z.array(z.string()),
-});
+const MultiFilesSchema = z.object(requiredFileListFields);
 export type MultiFiles = z.infer<typeof MultiFilesSchema>;
 
 // Enumerates the four `MultiFiles` keys (`inputFiles` / `contextFiles` /

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { AgentCategory, AgentSourceSchema } from './agent';
+import { requiredFileListFields } from './fileFields';
 import { ToolConfigSchema } from './toolConfig';
 
 export const BaseProposalFieldsSchema = z.object({
@@ -19,12 +20,7 @@ export const BaseProposalFieldsSchema = z.object({
   workingDirectory: z.string().nullish(),
 });
 
-const FileFieldsSchema = z.object({
-  inputFiles: z.array(z.string()),
-  contextFiles: z.array(z.string()),
-  mediaFiles: z.array(z.string()),
-  outputFiles: z.array(z.string()),
-});
+const FileFieldsSchema = z.object(requiredFileListFields);
 
 export const WorkflowSpecificFieldsSchema = FileFieldsSchema.extend({
   toolConfig: ToolConfigSchema,

--- a/src/shared/schemas/proposalInput.ts
+++ b/src/shared/schemas/proposalInput.ts
@@ -29,7 +29,7 @@ import { isObject } from '@utils/core';
 import { DEFAULT_AGENT_MODEL } from '../constants/providers';
 import { DELEGATION_TOOL_CATEGORY } from '../constants/delegationTools';
 import { AgentCategory } from './agent';
-import { migrateLegacyContextFileFields } from './fileFields';
+import { fileListFields, migrateLegacyContextFileFields } from './fileFields';
 import {
   ToolUseAgentProposalSchema,
   WorkflowAgentProposalSchema,
@@ -46,10 +46,7 @@ const LenientToolUseProposalSchema = ToolUseAgentProposalSchema.extend({
 
 const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
   model: z.string().prefault(DEFAULT_AGENT_MODEL),
-  inputFiles: z.array(z.string()).prefault([]),
-  contextFiles: z.array(z.string()).prefault([]),
-  mediaFiles: z.array(z.string()).prefault([]),
-  outputFiles: z.array(z.string()).prefault([]),
+  ...fileListFields,
   // toolConfig is inherited from WorkflowAgentProposalSchema (via
   // WorkflowSpecificFieldsSchema) and already object-prefaulted — no override.
 });

--- a/src/shared/settingsView/handlers/approvalHandlers.ts
+++ b/src/shared/settingsView/handlers/approvalHandlers.ts
@@ -7,8 +7,8 @@
  * which lives in `ConfigProvider` rather than workspace state.
  */
 import * as logger from '@logger/logUtils';
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { UpdateApprovalSettingsMessage } from '@shared/schemas/settingsViewMessages';
 import {
   BASH_APPROVAL_CONFIG_KEY,

--- a/src/shared/settingsView/handlers/superYoloHandlers.ts
+++ b/src/shared/settingsView/handlers/superYoloHandlers.ts
@@ -6,8 +6,8 @@
  * host-specific (VS Code config-backed in the extension; absent in the
  * desktop build), so callers supply them.
  */
-import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { NumberVscodeSetting } from '@shared/schemas/profileViewMessages';
 import type { UpdateSuperYoloEnabledMessage } from '@shared/schemas/settingsViewMessages';
 


### PR DESCRIPTION
## Summary

Centralize the four canonical file-list schema fields (`inputFiles`, `contextFiles`, `mediaFiles`, and `outputFiles`) so proposal and main-view schemas cannot drift. The existing defaulted variant and a required variant now each have one definition. Two import-order warnings in adjacent shared settings handlers are also corrected.

This is behavior-preserving internal cleanup, so it does not require a changelog entry.

## Issue acceptance gates

No linked issue. The pull request is complete when every replaced schema keeps the same field types and absent-field behavior, and all affected consumers pass validation.

## Single source of truth

`src/shared/schemas/fileFields.ts` owns both canonical field groups:

- `fileListFields` for schemas where absent lists become empty lists through `.prefault([])`.
- `requiredFileListFields` for schemas where all four lists remain required.

## Duplication and abstraction budget

Twelve repeated field declarations are replaced by two field groups. This introduces no wrapper, factory, or pass-through module. `fileListFields` has three schema consumers and `requiredFileListFields` has two.

## Net elements (R6)

- Files: 0 added, 0 deleted, 6 modified.
- Exported symbols: 2 added, 0 removed (`fileListFields`, `requiredFileListFields`).
- Classes, interfaces, and enums: none added or removed.
- Net LoC: -3 (18 additions, 21 deletions).

## Consumer counts (R8)

- `fileListFields`: 3 schema consumers after the change.
- `requiredFileListFields`: 2 schema consumers after the change.
- No event keys, emit paths, or subscribers are changed.

## Host impact

Extension: Main-view and proposal schemas retain their exact required/defaulted behavior.

Desktop: Shared proposal parsing retains its existing schema shape and defaults.

CLI: Shared proposal parsing retains its existing schema shape and defaults.

## Scheduled refactoring

None.

## Validation

- Changed-file ESLint
- Focused Vitest schema and host-boundary suites
- Full workspace type checking
- `git diff --check`

The earlier Linux CI failure was in the unrelated timing-sensitive `SystemUtils.vitest.ts` descendant-process test. The same test passed on current `main`; this branch has been rebased so CI will validate the current baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only refactor with no runtime or IPC changes; required vs defaulted file-list behavior is preserved at each call site.
> 
> **Overview**
> Centralizes the four canonical `*Files` Zod fields in `fileFields.ts` so main-view, proposal, and lenient workflow proposal parsing cannot drift.
> 
> **`fileListFields`** (exported, `prefault([])`) replaces duplicated defaults in `LenientWorkflowProposalSchema` and continues to back nullable/UI file schemas. **`requiredFileListFields`** replaces inline required arrays in `MultiFilesSchema` and proposal `FileFieldsSchema`.
> 
> Two shared settings handlers only reorder imports (`SETTINGS_VIEW_COMMANDS` before `WorkspaceStateKey`) for lint consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e926ff8f8c44fea87ef50329b186e3d25c264643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->