### PR TITLE
refactor(tools): drop unused exports and use Zod v4 catch idiom

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -30,7 +30,7 @@ const DiagnosticsPathSchema = z
   .min(1)
   .describe('Workspace-relative or absolute file path.');
 
-export const DiagnosticsReadInputSchema = z.strictObject({
+const DiagnosticsReadInputSchema = z.strictObject({
   command: z
     .enum(['list', 'count'])
     .describe('Use "list" for full diagnostics or "count" for a summary.'),

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -66,7 +66,7 @@ const API_TYPE_TO_NAME = {
 
 type TextEditorApiType = keyof typeof API_TYPE_TO_NAME;
 
-export const TextEditorInputSchema = z.strictObject({
+const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
   file_text: z.string().nullish(),

--- a/src/tools/approvalGatedTools.ts
+++ b/src/tools/approvalGatedTools.ts
@@ -27,7 +27,7 @@ const APPROVAL_GATED_TOOL_NAME_LIST = [
   'write_file',
 ] as const satisfies readonly RegisteredToolName[];
 
-export const APPROVAL_GATED_TOOL_NAMES: ReadonlySet<string> = new Set(
+const APPROVAL_GATED_TOOL_NAMES: ReadonlySet<string> = new Set(
   APPROVAL_GATED_TOOL_NAME_LIST,
 );
 

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -38,7 +38,7 @@ export {
 const CODEX_COMMAND_SUMMARY_MAX_LENGTH = 60;
 type ToolUseStatus = NonNullable<ToolUseLog['status']>;
 
-export type CodexFileChange = FileChangeItem['changes'][number];
+type CodexFileChange = FileChangeItem['changes'][number];
 export type CodexCommandToolLogOptions = Pick<
   CommandExecutionItem,
   'command' | 'aggregated_output' | 'exit_code' | 'status'

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -19,7 +19,7 @@ const CHANNEL = 'InlineCommentTool';
 logger.initialize(CHANNEL);
 
 /** A single comment within a thread, as seen by the agent. */
-export interface InlineCommentView {
+interface InlineCommentView {
   author: string;
   body: string;
 }

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -28,7 +28,7 @@ import {
   sumCompletedWorkflowJournalCost,
 } from './workflowScriptRun';
 
-export const WorkflowScriptToolInputSchema = z.strictObject({
+const WorkflowScriptToolInputSchema = z.strictObject({
   agent: z
     .string()
     .min(1)
@@ -45,9 +45,7 @@ export const WorkflowScriptToolInputSchema = z.strictObject({
     .describe('JSON arguments exposed to the script as the global args value.'),
 });
 
-export type WorkflowScriptToolInput = z.infer<
-  typeof WorkflowScriptToolInputSchema
->;
+type WorkflowScriptToolInput = z.infer<typeof WorkflowScriptToolInputSchema>;
 
 function formatWorkflowResult(result: unknown): string {
   if (typeof result === 'string') return result;

--- a/src/tools/executions/summaryFormat.ts
+++ b/src/tools/executions/summaryFormat.ts
@@ -36,7 +36,7 @@ export interface ExecutionSummaryOptions {
  * calling stream — i.e. the caller already receives this subagent's report
  * automatically as a follow-up, so /executions/{id} shouldn't duplicate it.
  */
-export function isCallerParentOfToolUseSubagent(
+function isCallerParentOfToolUseSubagent(
   handle: unknown,
   callerStreamId: StreamTabId | undefined,
 ): boolean {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -79,7 +79,7 @@ import {
 import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import type { Disposable } from '@platform/interfaces';
 
-export const GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY =
+const GITHUB_PR_POLLING_EMIT_CI_STARTED_CONFIG_KEY =
   'texra.git.emitPrCiStartedEvents';
 
 function shouldEmitCIStartedEvents(): boolean {

--- a/src/tools/github/annotationFetchBudget.ts
+++ b/src/tools/github/annotationFetchBudget.ts
@@ -24,8 +24,8 @@
 // rest of the PR polling endpoints under GitHub's primary 5,000/hour limit.
 // Keep it independent of the poll interval so tuning PR_POLL_INTERVAL_MS does
 // not silently raise the hourly ceiling.
-export const MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW = 50;
-export const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 60_000;
+const MAX_PROCESS_ANNOTATION_REQUESTS_PER_WINDOW = 50;
+const ANNOTATION_FETCH_BUDGET_WINDOW_MS = 60_000;
 
 export class AnnotationFetchBudgetExhaustedError extends Error {
   constructor() {

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -15,16 +15,14 @@ import type { PlatformSecrets } from '@platform/secrets';
 export const GITHUB_TOKEN_STORAGE_KEY = 'github.token';
 
 /** Environment variables accepted by GitHub tools, in precedence order. */
-export const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;
+const GITHUB_TOKEN_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'] as const;
 
-export function normalizeGitHubToken(
-  token: string | undefined,
-): string | undefined {
+function normalizeGitHubToken(token: string | undefined): string | undefined {
   const trimmed = token?.trim();
   return trimmed ? trimmed : undefined;
 }
 
-export function getGitHubEnvToken(): string | undefined {
+function getGitHubEnvToken(): string | undefined {
   for (const envVar of GITHUB_TOKEN_ENV_VARS) {
     const token = normalizeGitHubToken(process.env[envVar]);
     if (token) return token;

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -10,14 +10,14 @@
  */
 import { z } from 'zod';
 
-export const GhUserSchema = z.looseObject({
+const GhUserSchema = z.looseObject({
   login: z.string(),
   /** 'User' | 'Bot' | 'Organization' — used by the bot filter to drop CI noise. */
   type: z.string().nullish(),
 });
 export type GhUser = z.infer<typeof GhUserSchema>;
 
-export const GhIssueCommentSchema = z.looseObject({
+const GhIssueCommentSchema = z.looseObject({
   id: z.number(),
   body: z.string().nullable(),
   user: GhUserSchema.nullable(),
@@ -35,7 +35,7 @@ export const GhIssueCommentSchema = z.looseObject({
 });
 export type GhIssueComment = z.infer<typeof GhIssueCommentSchema>;
 
-export const GhReviewCommentSchema = z.looseObject({
+const GhReviewCommentSchema = z.looseObject({
   id: z.number(),
   body: z.string().nullable(),
   user: GhUserSchema.nullable(),
@@ -155,7 +155,7 @@ export type GhIssue = z.infer<typeof GhIssueSchema>;
  * does NOT return `merged` (that's only on the single-PR endpoint), so we
  * rely on `merged_at` to distinguish merged-closed from plain closed.
  */
-export const GhPullsListEntrySchema = z.looseObject({
+const GhPullsListEntrySchema = z.looseObject({
   number: z.number(),
   state: OpenClosedStateSchema,
   title: z.string(),

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -61,11 +61,6 @@ function emitGoalStateChanged(
   });
 }
 
-function normalizeGoalRecord(raw: unknown): Goal | null {
-  const parsedGoal = GoalSchema.safeParse(raw);
-  return parsedGoal.success ? parsedGoal.data : null;
-}
-
 function readRaw(streamId: StreamTabId): Goal | null {
   // tryWorkspaceState — bootstrap-tolerant: read-only paths called before
   // initPlatform() (e.g. early-stream syncs in some tests) return null
@@ -73,7 +68,9 @@ function readRaw(streamId: StreamTabId): Goal | null {
   // does throw, surfacing the misuse.
   const state = tryWorkspaceState();
   if (!state) return null;
-  return normalizeGoalRecord(state.get<unknown>(streamKey(streamId)));
+  return GoalSchema.nullable()
+    .catch(null)
+    .parse(state.get<unknown>(streamKey(streamId)));
 }
 
 async function writeRaw(goal: Goal): Promise<void> {

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -61,7 +61,7 @@ const OpenInquiryTurnSchema = z.object({
   kind: z.literal('open'),
   draft: InquiryDraftSchema.nullish(),
 });
-export type OpenInquiryTurn = z.infer<typeof OpenInquiryTurnSchema>;
+type OpenInquiryTurn = z.infer<typeof OpenInquiryTurnSchema>;
 
 /** Answer recorded and available inline — the steady-state "done" shape. */
 const AnsweredInquiryTurnSchema = z.object({
@@ -72,7 +72,7 @@ const AnsweredInquiryTurnSchema = z.object({
   answerRelativePath: z.string().min(1),
   sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
 });
-export type AnsweredInquiryTurn = z.infer<typeof AnsweredInquiryTurnSchema>;
+type AnsweredInquiryTurn = z.infer<typeof AnsweredInquiryTurnSchema>;
 
 /**
  * Legacy single-shot turn whose answer text still lives only on disk
@@ -89,18 +89,13 @@ const AnsweredUnhydratedInquiryTurnSchema = z.object({
   answeredAt: z.string().nullish(),
   sessionLinks: ExternalInquirySessionLinksSchema.nullish(),
 });
-export type AnsweredUnhydratedInquiryTurn = z.infer<
-  typeof AnsweredUnhydratedInquiryTurnSchema
->;
 
 const CanonicalTurnRecordSchema = z.discriminatedUnion('kind', [
   OpenInquiryTurnSchema,
   AnsweredInquiryTurnSchema,
   AnsweredUnhydratedInquiryTurnSchema,
 ]);
-export type ExternalInquiryTurnRecord = z.infer<
-  typeof CanonicalTurnRecordSchema
->;
+type ExternalInquiryTurnRecord = z.infer<typeof CanonicalTurnRecordSchema>;
 
 /**
  * Raw, untagged shape turns were persisted in prior to this discriminated
@@ -230,7 +225,7 @@ export type ExternalInquiryThreadManifest = z.infer<
 // Mirror types
 // ============================================================================
 
-export interface ExternalInquiryExecutionMirrorPaths {
+interface ExternalInquiryExecutionMirrorPaths {
   executionId: ExecutionId;
   manifestPath: string;
   questionPath: string;

--- a/src/tools/lean/leanServerRegistry.ts
+++ b/src/tools/lean/leanServerRegistry.ts
@@ -19,9 +19,9 @@ import {
 
 import { LEAN_SERVER_MODE_LABELS } from './leanConstants';
 
-export type LeanServerMode = keyof typeof LEAN_SERVER_MODE_LABELS;
+type LeanServerMode = keyof typeof LEAN_SERVER_MODE_LABELS;
 
-export type LeanServerStatus = 'starting' | 'running' | 'error' | 'stopped';
+type LeanServerStatus = 'starting' | 'running' | 'error' | 'stopped';
 
 export interface LeanServerInfo {
   readonly id: string;

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -75,7 +75,7 @@ const CslDateSchema = z.object({
 });
 
 /** Zotero collection metadata returned by `user.groups(true)`. */
-export const BbtCollectionSchema = z.object({
+const BbtCollectionSchema = z.object({
   key: z.string(),
   name: z.string(),
   parentCollection: z.union([z.string(), z.literal(false)]).nullish(),


### PR DESCRIPTION
## Summary

Small, verified-safe cleanup pass over `src/tools/**`:

- Dropped `export` from 20 constants/functions/types across 14 files that
  had zero consumers outside their defining file. Verified with a repo-wide
  `knip --include exports,types` pass, then cross-checked every candidate
  with `rg` across the whole worktree (including `packages/*`) before
  touching it, since `knip`'s default workspace only traces usage from
  repo-root `src/`. Left alone the handful of cases that are deliberate
  public contracts even though currently unconsumed (e.g. the setup-tool
  `SetupPlatform` adapter sub-interfaces, the Lean LSP shape module, and
  `CheckRunsCachePage`, which has an explicit code comment documenting why
  it's exported).
- Deleted one fully dead type alias (`AnsweredUnhydratedInquiryTurn` in
  `externalInquiryStorage.ts`) — its shape is already captured structurally
  by the `ExternalInquiryTurnRecord` union type, and the alias itself was
  never referenced anywhere, including within its own file.
- Replaced a manual `safeParse`-then-ternary wrapper in `goalStore.ts` with
  the project's documented Zod v4 idiom
  (`GoalSchema.nullable().catch(null).parse(...)`), same behavior for every
  input (valid Goal, missing, or malformed all resolve identically to
  before).

All changes are behavior-preserving: no signature, schema shape, or
exported-and-consumed API changed. Net effect in `src/tools/**` vs
`origin/main`: 15 files changed, +28/-40 (net -12 LoC).

## Verification

- `npx tsc --noEmit -p tsconfig.json` (root), `-p tsconfig.test-kernel.json`,
  and the per-package `tsc --noEmit` in `packages/extension`, `packages/cli`,
  and `packages/desktop` (`tsconfig.json` + `tsconfig.main.json`) are all
  clean except for one pre-existing, unrelated error
  (`Cannot find module 'data-uri-to-buffer'` in
  `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts`) caused by
  this worktree's symlinked `node_modules` predating a recent dependency
  addition on `main`; it reproduces identically on an untouched file and is
  outside this lane.
- `npx vitest run --config vitest.config.mjs src/test-kernel/tools`: 535
  passed, 2 pre-existing failures (same missing-package cause as above, not
  introduced by this change).
- Targeted reruns of the specific suites covering every touched file
  (`GitHubAuth`, `GitHubPrTypes`, `PRPollingSource*`, `GoalForget`,
  `GoalStateSubscription`, `GoalStoreConcurrency`, `WorkflowScriptTool`,
  `DiagnosticsTool`, `ToolEditApprovalGate`, `Executions*`,
  `InquiryStorage`, `InquiryReadBoundary`, `InquiryContinuation*`,
  `ExternalInquiryAction`, `LeanServerRegistry`, `InlineCommentTool`,
  `codexConfig`, `codexImport`, `CodexResumeFallback`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export visibility and a localized parse refactor only; no runtime behavior, schema shapes, or consumed APIs are intended to change.
> 
> **Overview**
> **Behavior-preserving cleanup** across `src/tools/**`: many module-local Zod schemas, constants, helpers, and type aliases that had **no importers outside their file** are no longer `export`ed (e.g. `DiagnosticsReadInputSchema`, `TextEditorInputSchema`, `APPROVAL_GATED_TOOL_NAMES`, GitHub `prTypes` schemas, annotation budget constants, auth env-var helpers). **Public APIs that other packages still use** (exported types/schemas, `getGitHubToken`, `isApprovalGatedToolName`, inquiry manifest types, etc.) are unchanged.
> 
> In **`goalStore.ts`**, goal reads drop a `safeParse` wrapper in favor of **`GoalSchema.nullable().catch(null).parse(...)`** so invalid or missing workspace state still resolves to `null` like before.
> 
> In **`externalInquiryStorage.ts`**, the unused **`AnsweredUnhydratedInquiryTurn`** type export is removed; the turn shape remains in the discriminated union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbdc6b46a73c3541ec2fe713618cd4a55c13efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->