### PR TITLE
refactor(progressView): remove dead code and fix lint warnings

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BaseBypassApprovalPanel.ts
@@ -18,6 +18,12 @@ type BypassPermission = Extract<
   { kind: BypassPermissionKind }
 >;
 
+// `this.permission` is `Extract<PermissionState, { kind: K }>` for the
+// generic `K`; TS cannot distribute that conditional type over the
+// `PermissionState` union while `K` is unresolved, so direct property access
+// on `this.permission` fails to typecheck. Passing it through this
+// concretely-typed helper (bound to the literal `BypassPermissionKind`, not
+// the generic `K`) gives the compiler a resolvable type to check against.
 function canBypassSession({ data }: BypassPermission): boolean {
   return Boolean(data.allowBypass && data.streamId);
 }

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -31,7 +31,6 @@ import {
   AGENT_DECORATORS,
   getAgentCategoryDecorator,
 } from '@shared/utils/icons';
-import { formatResultCount } from '@utils/text/stringUtils';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
@@ -41,6 +40,7 @@ import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
+import { formatResultCount } from '@utils/text/stringUtils';
 import { layoutStyles } from '../styles/logStyles';
 import { streamTabStyles } from './StreamTab.styles';
 import { streamTabsContainerStyles } from './StreamTabsContainer.styles';

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -6,7 +6,6 @@ import type { AgentCategoryFilter } from '@shared/schemas';
  */
 export const ELEMENT_IDS = {
   LOG_CONTENT: 'logContent',
-  LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
   GENERATED_FILES_COLLAPSIBLE: 'generatedFilesCollapsible',
   STREAM_TABS: 'streamTabs',

--- a/packages/extension/src/progressView/frontend/formatters/litTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/litTemplates.ts
@@ -9,7 +9,6 @@ import { html, nothing, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
 
@@ -17,14 +16,5 @@ import { when } from 'lit/directives/when.js';
 export type FormatResult = TemplateResult | null;
 
 // Re-export directives for use in formatter templates
-export {
-  html,
-  nothing,
-  classMap,
-  ifDefined,
-  repeat,
-  styleMap,
-  unsafeHTML,
-  when,
-};
+export { html, nothing, classMap, ifDefined, repeat, unsafeHTML, when };
 export type { TemplateResult };

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -12,6 +12,7 @@ import {
   CodexTodoToolInputSchema,
   CodexTurnToolInputSchema,
 } from '@shared/schemas/codex';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { formatDuration } from '@utils/core';
 
 // Local imports - Lit template utilities
@@ -33,7 +34,6 @@ import {
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 type RenderableSection = TemplateResult | typeof nothing | undefined | null;
 type BadgeData = { iconName: string; label: string };


### PR DESCRIPTION
## Summary

Perform a bounded cleanup of the extension progress view:

- Remove the unused `styleMap` re-export from the local Lit-template module.
- Remove the obsolete `ELEMENT_IDS.LOG_PLACEHOLDER` key after its DOM element and all consumers had already been retired.
- Correct two import-order warnings.
- Document why the generic bypass panel needs a concretely typed helper for TypeScript to narrow its permission union.

The change removes dead public surface and lint noise without changing rendering or approval behavior.

## Issue acceptance gates

No linked issue. The cleanup is complete when both removed surfaces have zero repository consumers, the affected progress-view tests pass, and the extension lane remains lint- and type-correct.

## Single source of truth

Lit directives remain owned by their upstream `lit/directives/*` modules. `UsagePanel.ts`, the only progress-view consumer of `styleMap`, already imports it directly. Active progress-view element IDs remain in `frontend/constants.ts`.

## Duplication and abstraction budget

No abstraction was added. One dead re-export and one dead element-ID property were deleted; the existing narrowing helper is retained and documented because inlining it does not typecheck for the unresolved generic permission kind.

## Net elements (R6)

- Files: 5 modified, 0 added, 0 deleted.
- Exported symbols: 1 removed (`styleMap` from the local Lit-template barrel), 0 added.
- Classes/interfaces/enums: no changes.
- Net LoC: -5 lines (9 additions, 14 deletions).

## Consumer counts (R8)

- `styleMap` through `litTemplates.ts`: 0 consumers. The one actual use imports directly from `lit/directives/style-map.js`.
- `ELEMENT_IDS.LOG_PLACEHOLDER`: 0 consumers.

No event or emit path changes.

## Host impact

Extension: Internal progress-view cleanup only; no user-visible behavior changes.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Focused progress-view Vitest coverage: 4 files, 18 tests passed.
- `npx eslint packages/extension/src/progressView`: passed with no warnings.
- Repository CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removals are confirmed unused; import reorder and comment-only changes do not alter runtime behavior.
> 
> **Overview**
> Small **behavior-preserving** cleanup in the progress view frontend: removes unused surface area and clears lint noise.
> 
> **Dead code:** Drops the unused `ELEMENT_IDS.LOG_PLACEHOLDER` constant and stops re-exporting Lit’s `styleMap` from `litTemplates.ts` (no callers in this lane; consumers that need it import from `lit/directives/style-map.js` directly).
> 
> **Lint:** Reorders imports in `StreamTabs.ts` and `codexToolTemplates.ts` to satisfy `import/order`.
> 
> **Docs:** Adds a short comment in `BaseBypassApprovalPanel.ts` on why session-bypass checks go through `canBypassSession` with a concrete `BypassPermission` type instead of inlining in the generic `canBypass` getter—TypeScript won’t distribute `Extract<PermissionState, { kind: K }>` while `K` is still unresolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d0e5bd2fce345f52d80ad5128eb5eeec1d3219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->