### PR TITLE
refactor(cli-tui): dedupe width/offset math, drop nested ternary

### DIFF
--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -1,7 +1,8 @@
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
-import { KEY_HINT_SEPARATOR } from '../ui/KeyHints';
+import { KEY_HINT_SEPARATOR, keyHintText } from '../ui/KeyHints';
 import { isEscapeInput } from '../input/inputKeys';
+import { textDisplayWidth } from '../render/terminalText';
 
 export type ConfirmCardKeyAction =
   'approve' | 'reject' | 'approveAlways' | 'feedback' | 'ignore';
@@ -89,16 +90,10 @@ export function confirmCardFeedbackHints(): ConfirmCardHintAction[] {
   ];
 }
 
+// Reuses the canonical `keyHintText` projection (see its doc comment) so this
+// measures exactly what KeyHints renders, instead of re-deriving the format.
 function hintColumns(hints: readonly ConfirmCardHintAction[]): number {
-  return hints.reduce(
-    (width, hint, index) =>
-      width +
-      (index === 0 ? 0 : KEY_HINT_SEPARATOR.length) +
-      hint.key.length +
-      1 +
-      hint.action.length,
-    0,
-  );
+  return textDisplayWidth(hints.map(keyHintText).join(KEY_HINT_SEPARATOR));
 }
 
 function hintsFit(

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -288,13 +288,22 @@ function statusBarSegmentsWidth(segments: readonly StatusBarSegment[]): number {
   );
 }
 
+// Shared by every width-aware layout below: the row width minus the status
+// bar's fixed horizontal padding, or undefined when the width itself is
+// unknown (tests/headless runs).
+function statusBarInnerWidth(width: number | undefined): number | undefined {
+  return width === undefined
+    ? undefined
+    : Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
+}
+
 function fitPendingExitStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
   width: number | undefined,
 ): readonly StatusBarSegment[] {
-  if (width === undefined) return segments;
+  const innerWidth = statusBarInnerWidth(width);
+  if (innerWidth === undefined) return segments;
 
-  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
   const fitted = [...segments];
   while (fitted.length > 2 && statusBarSegmentsWidth(fitted) > innerWidth) {
     fitted.pop();
@@ -320,8 +329,8 @@ function rightStatusBudget(
   segments: readonly StatusBarSegment[],
   width: number | undefined,
 ): number | undefined {
-  if (width === undefined) return undefined;
-  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
+  const innerWidth = statusBarInnerWidth(width);
+  if (innerWidth === undefined) return undefined;
   return Math.max(
     0,
     innerWidth -
@@ -334,9 +343,13 @@ function fitStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
   width: number | undefined,
 ): readonly StatusBarSegment[] {
-  if (width === undefined) return segments;
-  const innerWidth = Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
-  if (statusBarSegmentsWidth(segments) <= innerWidth) return segments;
+  const innerWidth = statusBarInnerWidth(width);
+  if (
+    innerWidth === undefined ||
+    statusBarSegmentsWidth(segments) <= innerWidth
+  ) {
+    return segments;
+  }
 
   const compacted = [...segments];
   const priorities = [
@@ -704,6 +717,43 @@ const BYPASS_BADGES: ReadonlyArray<{
   { field: 'toolEdit', text: 'AUTO-EDIT', badgeColor: COLOR_WARNING },
 ];
 
+// Which text occupies the bindings row is a priority order, not a single
+// condition: an active pending-exit prompt always wins, then the session
+// list, then any other foreground surface, and only then the normal chat
+// shortcuts.
+function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
+  if (input.pendingExitHint && input.pendingExitResumeId) {
+    return `Resume this session with: ${formatResumeCommand(
+      input.commandName,
+      input.pendingExitResumeId,
+      { approvalPolicy: input.approvalPolicy },
+    )}`;
+  }
+
+  const maxColumns = statusBarInnerWidth(input.width);
+  if (input.sessionListFocused) {
+    return sessionListBindingsText(input.ctrlCAction ?? 'exit', maxColumns);
+  }
+  if (input.shortcutsActive === false) {
+    return foregroundBindingsText(
+      input.ctrlCAction ?? 'exit',
+      maxColumns,
+      input.foregroundEscapeAction,
+    );
+  }
+  return statusBarBindingsText(
+    input.taskControlsAvailable ?? true,
+    input.agentSelectionAvailable ?? false,
+    input.subagentControlsAvailable,
+    input.sessionNavigationAvailable,
+    input.shortcutModifierLabel,
+    input.shiftEnterNewline,
+    input.transcriptAvailable,
+    input.ctrlCAction,
+    maxColumns,
+  );
+}
+
 export function buildStatusBarDisplay(
   input: StatusBarDisplayInput,
 ): StatusBarDisplay {
@@ -824,40 +874,6 @@ export function buildStatusBarDisplay(
           rightStatusBudget(fittedLeft, input.width),
         )
       : undefined,
-    bindings:
-      input.pendingExitHint && input.pendingExitResumeId
-        ? `Resume this session with: ${formatResumeCommand(
-            input.commandName,
-            input.pendingExitResumeId,
-            { approvalPolicy: input.approvalPolicy },
-          )}`
-        : input.sessionListFocused
-          ? sessionListBindingsText(
-              input.ctrlCAction ?? 'exit',
-              input.width === undefined
-                ? undefined
-                : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
-            )
-          : input.shortcutsActive === false
-            ? foregroundBindingsText(
-                input.ctrlCAction ?? 'exit',
-                input.width === undefined
-                  ? undefined
-                  : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
-                input.foregroundEscapeAction,
-              )
-            : statusBarBindingsText(
-                input.taskControlsAvailable ?? true,
-                input.agentSelectionAvailable ?? false,
-                input.subagentControlsAvailable,
-                input.sessionNavigationAvailable,
-                input.shortcutModifierLabel,
-                input.shiftEnterNewline,
-                input.transcriptAvailable,
-                input.ctrlCAction,
-                input.width === undefined
-                  ? undefined
-                  : Math.max(0, input.width - STATUS_BAR_HORIZONTAL_PADDING),
-              ),
+    bindings: resolveStatusBarBindings(input),
   };
 }

--- a/packages/cli/src/chat/tui/render/scrollBounds.ts
+++ b/packages/cli/src/chat/tui/render/scrollBounds.ts
@@ -13,6 +13,15 @@ export interface ScrollBoundedRows<T> {
   readonly visibleRows: readonly T[];
 }
 
+// Shared by both offset functions below: with one row reserved (for an
+// overflow marker or scroll-status row), how far content can scroll.
+function maxOffsetReservingOneRow(
+  maxDisplayLines: number,
+  totalLines: number,
+): number {
+  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+}
+
 export function maxScrollableRowOffset({
   compactRows,
   maxDisplayLines,
@@ -25,7 +34,7 @@ export function maxScrollableRowOffset({
   if (maxDisplayLines <= compactRows || totalLines <= maxDisplayLines) {
     return 0;
   }
-  return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+  return maxOffsetReservingOneRow(maxDisplayLines, totalLines);
 }
 
 export function scrollBoundedRows<T>({
@@ -99,7 +108,7 @@ export function compactAwareMaxScrollOffset({
 }): number {
   if (maxDisplayLines <= 0) return 0;
   if (maxDisplayLines <= compactRows && totalLines > maxDisplayLines) {
-    return Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1));
+    return maxOffsetReservingOneRow(maxDisplayLines, totalLines);
   }
 
   return maxScrollableRowOffset({ compactRows, maxDisplayLines, totalLines });


### PR DESCRIPTION
## Summary

Small, targeted simplifications in `packages/cli/src/chat/tui/**`, found after a
full sweep of the lane (knip unused-export scan, eslint, and a manual pass over
the largest/logic-heaviest files). The lane was already very clean (knip found
zero unused exports/files, eslint reported zero issues), so this focuses on two
concrete, high-confidence issues rather than a broad rewrite:

- `panes/statusBarDisplay.ts`: the `bindings` field of `buildStatusBarDisplay`
  was chosen by a 4-way nested ternary (an explicit anti-pattern per
  `CLAUDE.md`), and the "row width minus horizontal padding" formula was
  hand-repeated inline at three of its four branches plus three other
  functions in the same file. Extracted `resolveStatusBarBindings()` as an
  explicit priority-ordered if/else chain, and factored the repeated formula
  into `statusBarInnerWidth()`, now shared by all four call sites. Same
  priority order, same clamping, no behavior change.
- `modals/ConfirmCardState.ts`: `hintColumns()` hand-reimplemented the same
  "join key hints with the separator and measure" logic that
  `childControlPickerHints.ts` already does correctly via the canonical
  `keyHintText()` + `textDisplayWidth()`. Routed it through the same
  projection instead of re-deriving the `"key action"` format assumption in a
  second place — this also fixes a latent staleness risk called out in
  `keyHintText`'s own doc comment (width math must "measure exactly what
  renders").
- `render/scrollBounds.ts`: `maxScrollableRowOffset` and
  `compactAwareMaxScrollOffset` both inlined the identical
  `Math.max(0, totalLines - Math.max(1, maxDisplayLines - 1))` formula.
  Factored into `maxOffsetReservingOneRow()`, called from both.

All three changes are internal-only refactors: no exported signatures, prop
shapes, or the Static/live-region ownership, resize-repaint, or sync-teardown
paths were touched.

Net LoC vs the branch's merge-base with `origin/main` (which has moved forward
independently since this branch was cut, so `git diff origin/main --shortstat`
alone is not representative): 3 files changed, 74 insertions(+), 54
deletions(-), net +20. The nested-ternary fix intentionally adds a few lines
(a named function + explanatory comment) in exchange for removing the
anti-pattern explicitly called out in this repo's style rules and eliminating
3x duplicated width-formula inlining; the other two changes are straightforward
net deletions of duplicated logic.

## Verification

- `npm run typecheck` from the worktree root: green for every file this PR
  touches. The chain also reports one pre-existing, unrelated failure —
  `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts(11,33): error
  TS2307: Cannot find module 'data-uri-to-buffer'` — confirmed present on a
  clean `git stash` of this branch before any of these edits (missing
  transitive dependency hoist in this machine's `node_modules`, unrelated to
  `packages/cli/src/chat/tui`). `corepack pnpm --filter @texra-ai/cli
  typecheck` (part of the same chain) reproduces only that same single error,
  confirming no new type errors from these changes.
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/` — full CLI
  test-kernel suite: 139 files / 1783 tests, all passing, including the
  suites that exercise the touched code directly or through its consumers
  (`StatusBar.vitest.mts`, `ConfirmCardState.vitest.mts`,
  `ConfirmCardRowsBudget.vitest.mts`, `PlanApproval.vitest.mts`,
  `BashApproval.vitest.mts`, `EditApproval.vitest.mts`,
  `RetryRequest.vitest.mts`, `TuiApprovalRetry.vitest.mts`,
  `DiffView.vitest.mts`, `ExternalInquiry.vitest.mts`,
  `AgentProposal.vitest.mts`).
- `npx eslint packages/cli/src/chat/tui` — zero issues, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only refactors in TUI display math with preserved priority order and existing test coverage; no auth, I/O, or public contract changes.
> 
> **Overview**
> Internal CLI TUI refactors only—no exported APIs or behavior changes intended.
> 
> **Status bar:** Replaces the four-way nested ternary that chose `bindings` in `buildStatusBarDisplay` with `resolveStatusBarBindings()`, an explicit priority chain (pending-exit resume hint → session list → foreground panel → normal shortcuts). Pulls the repeated “terminal width minus horizontal padding” calculation into `statusBarInnerWidth()` for bindings and the existing left-segment fitters.
> 
> **Confirm card hints:** `hintColumns()` now measures hint rows the same way as other modals—`keyHintText` joined with `KEY_HINT_SEPARATOR` and `textDisplayWidth`—instead of hand-counting key/action lengths.
> 
> **Scroll bounds:** `maxScrollableRowOffset` and `compactAwareMaxScrollOffset` share `maxOffsetReservingOneRow()` for the “reserve one row for overflow/status” max-offset formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92331a0895a4c6331bead7afeeb872a2541f4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->