### PR TITLE
refactor(webviews): flatten legacy style re-export in fileSelectStyles

### DIFF
--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -15,18 +15,18 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - main view
 import type { LatexDiffsActionDetail } from '@shared/schemas';
-import { designTokens } from '@shared/styles';
+import {
+  compactFormControlStyles,
+  compactIconActionButtonStyles,
+  designTokens,
+} from '@shared/styles';
 import {
   renderIconActionButton,
   renderLabeledActionButtonParts,
 } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
-import {
-  compactActionButtonStyles,
-  compactFormControlStyles,
-  fileSelectLayoutStyles,
-} from '../styles/fileSelectStyles';
+import { fileSelectLayoutStyles } from '../styles/fileSelectStyles';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 type LatexDiffsAction = LatexDiffsActionDetail['action'];
@@ -113,7 +113,7 @@ const COMMIT_MANAGE_ACTIONS: readonly DiffActionSpec[] = [
 export class LatexDiffsSection extends LitElement {
   static override styles = [
     designTokens,
-    compactActionButtonStyles,
+    compactIconActionButtonStyles,
     compactFormControlStyles,
     fileSelectLayoutStyles,
     css`

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -16,6 +16,7 @@
 import { type ZodError } from 'zod';
 
 // Local imports - shared state and schemas
+import { hostBridge } from '@shared/hostBridge';
 import { createWebviewStorage, PersistedState } from '@shared/state';
 import {
   MainViewPersistedStateSchema,
@@ -45,7 +46,6 @@ import {
   workflowAgent$,
   workflowInstruction$,
 } from './mainViewState';
-import { hostBridge } from '@shared/hostBridge';
 
 /**
  * Shared webview storage singleton for the main view.

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -14,15 +14,6 @@ import {
   compactIconActionButtonStyles,
 } from '@shared/styles';
 
-/**
- * Re-exported under the legacy names so existing imports keep working. The
- * canonical definitions live in `@shared/styles/selectStyles` and
- * `@shared/styles/commonViewStyles`; importing from here keeps file-select
- * components from having to pull the full common view / select sheets.
- */
-export const compactActionButtonStyles = compactIconActionButtonStyles;
-export { compactFormControlStyles };
-
 /** Core file-select layout styles. */
 export const fileSelectLayoutStyles = css`
   .file-select {
@@ -191,7 +182,7 @@ const multiFilesStyles = css`
   }
 
   /* .remove-button is a wa-button.action-icon-button now; sizing comes from
-     compactActionButtonStyles. Only the per-row layout shrink survives here. */
+     compactIconActionButtonStyles. Only the per-row layout shrink survives here. */
   .remove-button {
     flex-shrink: 0;
   }
@@ -215,7 +206,7 @@ const dropdownStyles = css`
 
 /** Combined file-select styles for components that need all of them. */
 export const fileSelectStyles = [
-  compactActionButtonStyles,
+  compactIconActionButtonStyles,
   compactFormControlStyles,
   fileSelectLayoutStyles,
   multiFilesStyles,


### PR DESCRIPTION
## Summary

Small, safe simplification pass over `packages/extension/src/settingsView/**` and `packages/extension/src/webview/**`.

The lane is already heavily maintained (recent sweeps like #8368), so most of the pass was verification rather than rewriting: knip found no dead files/exports in this lane, eslint found only one issue, and a broad grep for common anti-patterns (nested ternaries, `parseInt` without radix, `.substring`, `hasOwnProperty`, index-based loops, etc.) came back clean. The one genuine, safe win found:

- `LatexDiffsSection.ts` pulled `compactActionButtonStyles`/`compactFormControlStyles` through a "legacy name" re-export hop in `fileSelectStyles.ts` that existed solely for this one external caller (confirmed via a full-worktree grep — no other consumer used the aliased names). It now imports the canonical `compactIconActionButtonStyles`/`compactFormControlStyles` directly from `@shared/styles`, and the now-unused re-export (plus a stale comment reference to the old name) was removed from `fileSelectStyles.ts`.
- Fixed an `import/order` lint warning in `persistence.ts` (the `hostBridge` import was out of its declared group).

No behavior change: same style objects, same import graph, just one fewer indirection hop.

## Verification

- `npx tsc --noEmit -p packages/extension/tsconfig.json` — clean for this lane. (The aggregate `npm run typecheck` chain currently fails at the repo-root `tsc --noEmit` step on a pre-existing, unrelated issue: this worktree's symlinked `node_modules` is stale relative to a few recent `main` commits that added dependencies — `data-uri-to-buffer` (#8523) and `acorn`/`acorn-walk` (#8519) — neither touched by this PR. Confirmed by running `tsc --noEmit -p packages/extension/tsconfig.json` before and after this change: the only diagnostics are those three missing-module errors, none referencing the files in this PR.)
- `npx eslint packages/extension/src/webview/frontend/components/LatexDiffsSection.ts packages/extension/src/webview/frontend/persistence.ts packages/extension/src/webview/frontend/styles/fileSelectStyles.ts` — clean.
- `npx vitest run --config vitest.config.mjs src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts src/test-kernel/webview/LatexDiffsSectionActions.vitest.mts` — 2 files, 14 tests passed.
- `npx vitest run --config vitest.config.mjs src/test-kernel/webview src/test-kernel/settings` — 23 files, 77 tests passed.

Net change: 3 files, 10 insertions(+), 19 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style import path cleanup and a lint-only import reorder; same style objects and no runtime behavior change.
> 
> **Overview**
> Removes the legacy **`compactActionButtonStyles`** alias from `fileSelectStyles.ts` and has **`LatexDiffsSection`** import **`compactIconActionButtonStyles`** and **`compactFormControlStyles`** from **`@shared/styles`** instead of going through that re-export hop. **`fileSelectStyles`** still bundles the same canonical style objects for file-select components; only comments and import paths change.
> 
> **`persistence.ts`** reorders the **`hostBridge`** import to satisfy **`import/order`** (no logic change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669a4b174db380e0ed2b6ccf6ceb2ab0ba8a0ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->