### PR TITLE
refactor(cli): drop dead exports found by knip in runtime

### DIFF
--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -83,8 +83,8 @@ export interface BuildCliOrchestrationItemsInput {
 }
 
 export type CliModelAccessRoute = 'chatgpt' | 'included' | 'personal';
-export type CliAccountProvider = 'chatgpt' | 'texra';
-export type CliAccountOperation = 'sign-in' | 'switch' | 'sign-out';
+type CliAccountProvider = 'chatgpt' | 'texra';
+type CliAccountOperation = 'sign-in' | 'switch' | 'sign-out';
 
 export interface CliAccountStatus {
   readonly texraSignedIn: boolean;
@@ -318,7 +318,7 @@ function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
   };
 }
 
-export function modelAccessRouteLabel(route: CliModelAccessRoute): string {
+function modelAccessRouteLabel(route: CliModelAccessRoute): string {
   switch (route) {
     case 'chatgpt':
       return 'ChatGPT subscription';

--- a/packages/cli/src/runtime/relayTokensClient.ts
+++ b/packages/cli/src/runtime/relayTokensClient.ts
@@ -10,7 +10,7 @@ import { fetchWithTimeout } from '@auth/SupabaseSession';
 
 const RELAY_TOKENS_REQUEST_TIMEOUT_MS = 30000;
 
-export const RelayTokenInfoSchema = z.object({
+const RelayTokenInfoSchema = z.object({
   id: z.string(),
   name: z.string(),
   token_hint: z.string(),
@@ -22,7 +22,7 @@ export const RelayTokenInfoSchema = z.object({
 });
 export type RelayTokenInfo = z.infer<typeof RelayTokenInfoSchema>;
 
-export const MintedRelayTokenSchema = RelayTokenInfoSchema.omit({
+const MintedRelayTokenSchema = RelayTokenInfoSchema.omit({
   last_used_at: true,
   revoked_at: true,
 }).extend({

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -46,12 +46,6 @@ export type CliToolUseRunResult = Extract<
   { category: 'toolUse' }
 >;
 
-export type PublishedCliRunResult = ExecuteAgentResult extends infer T
-  ? T extends ExecuteAgentResult
-    ? PublishedCliRunResultFor<T>
-    : never
-  : never;
-
 /** Display text for a finished tool-use run: the last response if present,
  *  otherwise a terse status/execution-id summary. */
 export function toolUseResultText(result: CliToolUseRunResult): string {


### PR DESCRIPTION
## What changed

A knip dead-exports sweep of the `packages/cli` workspace (files, exports, types, duplicates) found three residual unused-export findings, all in `packages/cli/src/runtime/`:

- `orchestration.ts`: `CliAccountProvider`, `CliAccountOperation`, and `modelAccessRouteLabel` were exported but only ever referenced inside this same file. Dropped `export` from all three.
- `relayTokensClient.ts`: `RelayTokenInfoSchema` and `MintedRelayTokenSchema` were exported but only used inside this file to build the derived types `RelayTokenInfo` / `MintedRelayToken`, which are the ones `commands/relayTokens.ts` actually imports. Dropped `export` from the two schema consts; the types stay exported unchanged.
- `terminalStatus.ts`: deleted the unused `PublishedCliRunResult` conditional type. `serializeCliRunResult` already inlines the equivalent conditional type directly in its own return signature, so the named alias had no consumers.

No behavior change: this is pure export-surface cleanup (narrowing `export` to file-local, plus deleting one genuinely dead type alias). No runtime logic, no signatures consumed outside these files, no Zod schema shapes changed.

Net LoC: `packages/cli/src` 3 files changed, +5/-11 (net -6 lines) vs `origin/main`.

## Why the rest of the lane was left alone

Beyond the knip findings, I swept the full lane (`packages/cli/src/**` excluding `chat/tui/**`, ~128 `.ts` + a handful of `.tsx` files outside `chat/tui`, ~23k lines): ran `eslint` (clean, 0 warnings on the touched files / repo-wide only pre-existing import-order warnings in files I didn't touch), grepped for nested ternaries (none), TODO/FIXME markers (none), and spot-read the largest files (`dispatch.ts`, `modelAccess.ts`, `history.ts`, `updateChecker.ts`, `installGithubAction.ts`, the approval-policy files, several small runtime utilities). The lane has already been through multiple prior dead-code and refactor passes and reads as deliberately dense with load-bearing comments explaining non-obvious CLI/model-routing/approval behavior; I did not find further changes that were both genuinely simplifying and low-risk enough to make without deeper domain review, so I kept this PR to the verified-safe knip cleanup rather than force a larger, riskier diff.

## Verification

- `node node_modules/typescript/bin/tsc --noEmit -p packages/cli/tsconfig.json` and `... -p tsconfig.test-kernel.json`: both report exactly one pre-existing error (`Cannot find module 'data-uri-to-buffer'` in `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts`), confirmed present identically on `origin/main` via `git stash` before/after comparison — an environment issue (missing hoisted dependency in this worktree's symlinked `node_modules`), unrelated to this change and outside the CLI lane. No other diagnostics, before or after my edit.
- `npx vitest run --config vitest.config.mjs src/test-kernel/cli/` — 139 files, 1783 tests, all passing (covers the touched files: `Orchestration.vitest.mts`, `RelayTokens.vitest.mts`, `RunExecution.vitest.mts`, `WorkflowRunCommand.vitest.mts`, `AgentsRunCommand.vitest.mts`, `MultiAgentRunCommand.vitest.mts`, `chatSessionController.vitest.mts`, `WorkflowOutputResolution.vitest.mts`, `CliRootArgs.vitest.mts`).
- `npx knip --no-progress --include files,exports,types,duplicates --workspace packages/cli` — re-run after the change: all three findings resolved. (One remaining "duplicate exports" finding, `AGENT_RUN_GLOBAL_ARGS`/`ROOT_ROUTING_ARGS` in `commands/_helpers/globalArgs.ts`, is a deliberate two-name alias for the same value used at semantically distinct call sites — left as-is.)
- `node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js packages/cli/src` — 0 errors, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrowing exports and removing an unused type alias only; no logic, schema shapes, or externally consumed signatures change.
> 
> **Overview**
> Knip-driven **export-surface cleanup** in `packages/cli/src/runtime/` with no runtime or API behavior change.
> 
> In **`orchestration.ts`**, `CliAccountProvider`, `CliAccountOperation`, and `modelAccessRouteLabel` are no longer exported—they were only used inside that module.
> 
> In **`relayTokensClient.ts`**, `RelayTokenInfoSchema` and `MintedRelayTokenSchema` are file-local; **`RelayTokenInfo`** and **`MintedRelayToken`** types stay exported for `commands/relayTokens.ts`.
> 
> In **`terminalStatus.ts`**, the unused **`PublishedCliRunResult`** alias is removed because `serializeCliRunResult` already uses the equivalent conditional return type inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a183189cdb9388cab36d28aeb697f2bf5153563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->