### PR TITLE
fix(runtime): stop masking persistence failures

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -26,6 +26,7 @@ import {
 import { checkToolInstalled } from '@utils/system';
 import { getComparablePath } from '@utils/files/taskRunStorage';
 import { readPlatformSetting } from '@utils/config/platformSettings';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
   publishCompiledPdfArtifact,
@@ -425,18 +426,31 @@ export class LatexDiffManager {
       buildDir,
       `${path.basename(diffLocation.absolutePath).replace(/\.tex$/i, '')}.pdf`,
     );
-    const artifact =
-      executionId && runDirectory
-        ? await publishCompiledPdfArtifact({
-            runDirectory,
-            executionId,
-            round,
-            displayName: path.basename(diffLocation.absolutePath),
-            source: sourceLocation,
-            compiledPdfPath,
-            pdfStemSuffix,
-          })
-        : null;
+    let artifact: CompiledPdfArtifact | null = null;
+    if (executionId && runDirectory) {
+      try {
+        artifact = await publishCompiledPdfArtifact({
+          runDirectory,
+          executionId,
+          round,
+          displayName: path.basename(diffLocation.absolutePath),
+          source: sourceLocation,
+          compiledPdfPath,
+          pdfStemSuffix,
+        });
+      } catch (error) {
+        this.logger.warn(
+          `Failed to publish latexdiff PDF: ${toErrorMessage(error)}`,
+          {
+            data: {
+              diffFile: diffLocation.absolutePath,
+              compiledPdfPath,
+              error,
+            },
+          },
+        );
+      }
+    }
 
     return { diffLocation, artifact };
   }

--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -1,8 +1,11 @@
 // Standard library imports
 import * as path from 'node:path';
 
-// Local imports - shared schemas
+// Local imports - platform and errors
 import { platform } from '@platform/platform';
+import { isFileNotFoundError } from '@common/errors';
+
+// Local imports - shared schemas
 import type {
   ExecutionId,
   FileLocation,
@@ -74,17 +77,25 @@ async function copyArtifactFile(
 ): Promise<void> {
   const fs = platform().fs;
   await fs.createDirectory(path.dirname(destination));
-  await fs.delete(destination, { recursive: true }).catch(() => {});
+  try {
+    await fs.delete(destination, { recursive: true });
+  } catch (error) {
+    if (!isFileNotFoundError(error)) throw error;
+  }
   await fs.copy(source, destination, { overwrite: true });
 }
 
 export async function publishCompiledPdfArtifact(
   options: PublishCompiledPdfOptions,
 ): Promise<CompiledPdfArtifact | null> {
-  const stats = await platform()
-    .fs.stat(options.compiledPdfPath)
-    .catch(() => null);
-  if (!stats || !isFile(stats.type)) return null;
+  let stats;
+  try {
+    stats = await platform().fs.stat(options.compiledPdfPath);
+  } catch (error) {
+    if (isFileNotFoundError(error)) return null;
+    throw error;
+  }
+  if (!isFile(stats.type)) return null;
 
   const pdfRelativePath = toPdfRelativePath(options);
   const roundRelativePath = path.join(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -415,13 +415,14 @@ export async function executeAgent(
     // Fire-and-forget: generate AI session description from the user's instruction.
     // Triggered at the start so cancelled/errored sessions still get descriptions.
     // Applies to tool-use agents, including subagents, so their progress tabs show
-    // meaningful descriptions in multi-agent pipelines.
-    generateSessionDescription(
+    // meaningful descriptions in multi-agent pipelines. The callee owns its
+    // best-effort failure reporting and never rejects.
+    void generateSessionDescription(
       runExecutionId,
       runStreamId,
       config,
       runSession,
-    ).catch(() => {});
+    );
     const result = await runFlowWithLifecycle(
       ctx,
       async (handle, lifecycle) => {

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -26,6 +26,14 @@ const CHANNEL = 'SessionDescription';
 const MAX_DESCRIPTION_LENGTH = 80;
 const MAX_DESCRIPTION_WORDS = 12;
 
+function warnWithoutRejecting(message: string): void {
+  try {
+    logger.warn(CHANNEL, message);
+  } catch {
+    // Best-effort diagnostics must not make description generation reject.
+  }
+}
+
 /**
  * Normalize a model-generated session description: collapse newlines,
  * strip surrounding quotes/backticks, drop trailing sentence punctuation,
@@ -95,7 +103,7 @@ export async function generateSessionDescription(
 
     const helperResult = await createHelperModelKit();
     if (!helperResult.kit) {
-      logger.warn(CHANNEL, helperResult.reason);
+      warnWithoutRejecting(helperResult.reason);
       return;
     }
 
@@ -123,8 +131,7 @@ export async function generateSessionDescription(
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }
   } catch (err) {
-    logger.warn(
-      CHANNEL,
+    warnWithoutRejecting(
       `Failed to generate session description: ${getSdkErrorMessage(err)}`,
     );
   }

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent output
 
@@ -40,11 +40,90 @@ describe('compiled PDF artifacts', () => {
   }
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       tempDirs
         .splice(0)
         .map((dir) => rm(dir, { recursive: true, force: true })),
     );
+  });
+
+  it('treats a missing compiled PDF as no artifact', async () => {
+    const runDirectory = await makeTempDir();
+
+    await expect(
+      publishCompiledPdfArtifact({
+        runDirectory,
+        executionId: 'missing123',
+        round: 1,
+        displayName: 'missing.tex',
+        source: createExternalLocation(path.join(runDirectory, 'missing.tex')),
+        compiledPdfPath: path.join(runDirectory, 'missing.pdf'),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('propagates unexpected compiled PDF stat failures', async () => {
+    const runDirectory = await makeTempDir();
+    const statError = Object.assign(new Error('stat denied'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(nodeFilesystem, 'stat').mockRejectedValueOnce(statError);
+
+    await expect(
+      publishCompiledPdfArtifact({
+        runDirectory,
+        executionId: 'stat123',
+        round: 1,
+        displayName: 'paper.tex',
+        source: createExternalLocation(path.join(runDirectory, 'paper.tex')),
+        compiledPdfPath: path.join(runDirectory, 'paper.pdf'),
+      }),
+    ).rejects.toBe(statError);
+  });
+
+  it('continues when destination cleanup reports file not found', async () => {
+    const runDirectory = await makeTempDir();
+    const compiledPdfPath = path.join(runDirectory, 'build', 'paper.pdf');
+    await writePdf(compiledPdfPath, 'pdf bytes');
+    vi.spyOn(nodeFilesystem, 'delete').mockRejectedValue(
+      Object.assign(new Error('destination absent'), { code: 'ENOENT' }),
+    );
+
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'delete-missing123',
+      round: 1,
+      displayName: 'paper.tex',
+      source: createExternalLocation(path.join(runDirectory, 'paper.tex')),
+      compiledPdfPath,
+    });
+
+    expect(artifact).not.toBeNull();
+    await expect(readOutput(runDirectory, 'r1', 'paper.pdf')).resolves.toBe(
+      'pdf bytes',
+    );
+  });
+
+  it('propagates unexpected destination cleanup failures', async () => {
+    const runDirectory = await makeTempDir();
+    const compiledPdfPath = path.join(runDirectory, 'build', 'paper.pdf');
+    const deleteError = Object.assign(new Error('delete denied'), {
+      code: 'EACCES',
+    });
+    await writePdf(compiledPdfPath, 'pdf bytes');
+    vi.spyOn(nodeFilesystem, 'delete').mockRejectedValueOnce(deleteError);
+
+    await expect(
+      publishCompiledPdfArtifact({
+        runDirectory,
+        executionId: 'delete123',
+        round: 1,
+        displayName: 'paper.tex',
+        source: createExternalLocation(path.join(runDirectory, 'paper.tex')),
+        compiledPdfPath,
+      }),
+    ).rejects.toBe(deleteError);
   });
 
   it('publishes per-round and latest stable PDF paths', async () => {

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -37,6 +37,7 @@ import {
 const mocks = vi.hoisted(() => ({
   compileLatex2Pdf: vi.fn(async () => ({ ok: true })),
   hasLatexCompiler: vi.fn(async () => true),
+  publishCompiledPdfArtifact: vi.fn(async () => null),
 }));
 
 vi.mock('@latex/texTools', () => ({
@@ -45,6 +46,10 @@ vi.mock('@latex/texTools', () => ({
 
 vi.mock('@latex/latexToolchain', () => ({
   hasLatexCompiler: mocks.hasLatexCompiler,
+}));
+
+vi.mock('@agent/output/compiledPdfArtifacts', () => ({
+  publishCompiledPdfArtifact: mocks.publishCompiledPdfArtifact,
 }));
 
 const storagePath = '/storage';
@@ -122,6 +127,7 @@ describe('workflow LaTeX compile input directories', () => {
   beforeEach(() => {
     mocks.compileLatex2Pdf.mockClear();
     mocks.hasLatexCompiler.mockClear();
+    mocks.publishCompiledPdfArtifact.mockReset().mockResolvedValue(null);
   });
 
   it('derives compile-check input dirs from outputFile.source', async () => {
@@ -344,6 +350,45 @@ describe('workflow LaTeX compile input directories', () => {
       expect.anything(),
       expect.objectContaining({
         extraInputDirs: ['/external/project'],
+      }),
+    );
+  });
+
+  it('keeps a successful diff when publishing its PDF fails', async () => {
+    const executionId = 'latexdiff-publish-failure';
+    await initLatexPlatform({});
+    const trace = logger();
+    const manager = new LatexDiffManager(
+      AgentWorkflowSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+      }),
+      () => ({}),
+      [],
+      trace,
+      'diff-stream',
+      new TaskRunFileService(executionId),
+    );
+    const publishError = new Error('artifact storage unavailable');
+    mocks.publishCompiledPdfArtifact.mockRejectedValueOnce(publishError);
+
+    const result = await diffCompiler(manager).compileDiffIfSuccessful(
+      { success: true, diffFileName: 'main-diff.tex' },
+      runStorageFile(executionId, path.join('r1', 'main.tex')),
+      {
+        absolutePath: path.join(runDir(executionId), 'diff', 'r2'),
+        relativePath: path.join('diff', 'r2'),
+        executionId,
+      },
+      2,
+      runStorageFile(executionId, path.join('r2', 'main.tex')),
+      '-diff',
+    );
+
+    expect(result).toEqual(expect.objectContaining({ artifact: null }));
+    expect(trace.warn).toHaveBeenCalledWith(
+      'Failed to publish latexdiff PDF: artifact storage unavailable',
+      expect.objectContaining({
+        data: expect.objectContaining({ error: publishError }),
       }),
     );
   });

--- a/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionDescription.vitest.ts
@@ -10,6 +10,7 @@ import {
   getSessionDescriptionInstruction,
 } from '@agent/runtime/sessionDescription';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
+import * as logger from '@logger/logUtils';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
@@ -42,6 +43,7 @@ function configFor(category: AgentCategory) {
 
 describe('session description helpers', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -82,6 +84,49 @@ describe('session description helpers', () => {
     expect(mocks.createHelperModelKit).not.toHaveBeenCalled();
     expect(mocks.writeSessionDescription).not.toHaveBeenCalled();
     expect(events).toEqual([]);
+  });
+
+  it('logs helper-model failures without rejecting the fire-and-forget call', async () => {
+    const session = createTestSession();
+    const helperError = new Error('helper unavailable');
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mocks.getAgent.mockReturnValue({ description: 'General chat assistant' });
+    mocks.createHelperModelKit.mockRejectedValueOnce(helperError);
+
+    await expect(
+      generateSessionDescription(
+        'exec-failure' as ExecutionId,
+        'stream-failure' as StreamTabId,
+        configFor(AgentCategory.ToolUse),
+        session,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      'SessionDescription',
+      expect.stringContaining('helper unavailable'),
+    );
+  });
+
+  it('does not reject when the diagnostic sink also fails', async () => {
+    const session = createTestSession();
+    mocks.getAgent.mockReturnValue({ description: 'General chat assistant' });
+    mocks.createHelperModelKit.mockRejectedValueOnce(
+      new Error('helper unavailable'),
+    );
+    vi.spyOn(logger, 'warn').mockImplementation(() => {
+      throw new Error('log sink unavailable');
+    });
+
+    await expect(
+      generateSessionDescription(
+        'exec-log-failure' as ExecutionId,
+        'stream-log-failure' as StreamTabId,
+        configFor(AgentCategory.ToolUse),
+        session,
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it('keeps generating compact descriptions for tool-use runs', async () => {

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -9,6 +9,97 @@ import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
 import { createRecordingHost } from '../agent/progressTestUtils';
 
 describe('AgentCliSessionRegistry', () => {
+  it('logs a rejected session mapping write once without awaiting registration', async () => {
+    const executionId = 'execution-write-failure' as ExecutionId;
+    const writeError = new Error('storage unavailable');
+    const persistSessionId = vi.fn().mockRejectedValueOnce(writeError);
+    const reportPersistenceFailure = vi.fn();
+    const registry = new AgentCliSessionRegistry('test_session_id', {
+      persistSessionId,
+      reportPersistenceFailure,
+    });
+    const executions = new ExecutionRegistry();
+
+    try {
+      expect(
+        registry.register('session-write-failure', {
+          childStreamId: 'child-write-failure' as StreamTabId,
+          executionId,
+          executions,
+        }),
+      ).toBeUndefined();
+
+      await vi.waitFor(() => {
+        expect(reportPersistenceFailure).toHaveBeenCalledOnce();
+      });
+      expect(reportPersistenceFailure).toHaveBeenCalledWith(
+        executionId,
+        writeError,
+      );
+      expect(persistSessionId).toHaveBeenCalledOnce();
+    } finally {
+      registry.release('session-write-failure');
+      executions.dispose();
+    }
+  });
+
+  it('contains a synchronous session mapping write failure', async () => {
+    const executionId = 'execution-sync-write-failure' as ExecutionId;
+    const writeError = new Error('storage unavailable');
+    const persistSessionId = vi.fn(() => {
+      throw writeError;
+    });
+    const reportPersistenceFailure = vi.fn();
+    const registry = new AgentCliSessionRegistry('test_session_id', {
+      persistSessionId,
+      reportPersistenceFailure,
+    });
+    const executions = new ExecutionRegistry();
+
+    expect(
+      registry.register('session-sync-write-failure', {
+        childStreamId: 'child-sync-write-failure' as StreamTabId,
+        executionId,
+        executions,
+      }),
+    ).toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(reportPersistenceFailure).toHaveBeenCalledWith(
+        executionId,
+        writeError,
+      );
+    });
+    expect(registry.lookup('session-sync-write-failure')).toBeDefined();
+    registry.release('session-sync-write-failure');
+    executions.dispose();
+  });
+
+  it('contains diagnostic failures after a rejected mapping write', async () => {
+    const persistSessionId = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('storage unavailable'));
+    const registry = new AgentCliSessionRegistry('test_session_id', {
+      persistSessionId,
+      reportPersistenceFailure: () => {
+        throw new Error('log sink unavailable');
+      },
+    });
+    const executions = new ExecutionRegistry();
+
+    registry.register('session-log-failure', {
+      childStreamId: 'child-log-failure' as StreamTabId,
+      executionId: 'execution-log-failure' as ExecutionId,
+      executions,
+    });
+
+    await vi.waitFor(() => expect(persistSessionId).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(registry.lookup('session-log-failure')).toBeDefined();
+    registry.release('session-log-failure');
+    executions.dispose();
+  });
+
   it('atomically claims a session id and wakes waiters when it becomes active', async () => {
     const registry = new AgentCliSessionRegistry('test_session_id');
     const executions = new ExecutionRegistry();

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -1,6 +1,28 @@
 import { getExecutionStore } from '@agent/storage';
+import { createChannelTrace } from '@agent/trace';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+
+const logger = createChannelTrace('AgentCliSessionRegistry');
+
+interface AgentCliSessionRegistryDependencies {
+  persistSessionId(
+    executionId: ExecutionId,
+    key: string,
+    sessionId: string,
+  ): Promise<void>;
+  reportPersistenceFailure(executionId: ExecutionId, error: unknown): void;
+}
+
+const DEFAULT_DEPENDENCIES: AgentCliSessionRegistryDependencies = {
+  persistSessionId: (executionId, key, sessionId) =>
+    getExecutionStore(executionId).write(key, sessionId),
+  reportPersistenceFailure: (executionId, error) => {
+    logger.debug(`Failed to persist CLI session mapping for ${executionId}`, {
+      data: error,
+    });
+  },
+};
 
 export interface AgentCliSessionEntry {
   childStreamId: StreamTabId;
@@ -19,7 +41,10 @@ type AgentCliSessionState<T> =
 export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
   private readonly sessions = new Map<string, AgentCliSessionState<T>>();
 
-  constructor(private readonly persistedSessionKey: string) {}
+  constructor(
+    private readonly persistedSessionKey: string,
+    private readonly dependencies: AgentCliSessionRegistryDependencies = DEFAULT_DEPENDENCIES,
+  ) {}
 
   /**
    * Atomically reserve an unowned SDK session id. Returns a release handle
@@ -56,9 +81,21 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
     const previous = this.sessions.get(sessionId);
     this.sessions.set(sessionId, { kind: 'active', entry });
     if (previous?.kind === 'reserved') previous.resolve(entry);
-    void getExecutionStore(entry.executionId)
-      .write(this.persistedSessionKey, sessionId)
-      .catch(() => {});
+    void Promise.resolve()
+      .then(() =>
+        this.dependencies.persistSessionId(
+          entry.executionId,
+          this.persistedSessionKey,
+          sessionId,
+        ),
+      )
+      .catch((error) => {
+        try {
+          this.dependencies.reportPersistenceFailure(entry.executionId, error);
+        } catch {
+          // Best-effort diagnostics must not create an unhandled rejection.
+        }
+      });
   }
 
   lookup(sessionId: string): T | undefined {


### PR DESCRIPTION
## Summary

Stop treating unrelated runtime failures as ordinary absence at three agent-runtime boundaries. Compiled PDF publication now ignores only missing files, CLI session mapping persistence reports failures without changing the synchronous in-memory registration contract, and session-description generation owns its documented non-rejecting error path. A failed latexdiff PDF copy is reported at the individual file boundary so it does not discard successful diffs from the rest of the round.

No changelog entry is included because this is internal reliability work with no new user-facing behavior.

## Issue acceptance gates

Closes #8491.

- Removes the redundant empty catch around session-description generation.
- Reports failed persistent CLI session mappings once at debug level while preserving active in-memory registration.
- Treats only file-not-found errors as benign during compiled PDF stat and replacement; permission, I/O, and platform failures now propagate.
- Isolates latexdiff artifact publication failures to one file while retaining its successful diff result.
- Covers synchronous dependency throws, asynchronous rejections, diagnostic-sink failures, and missing-versus-unexpected filesystem errors.

## Single source of truth

- `sessionDescription.ts` owns the complete best-effort, non-rejecting description-generation contract.
- `compiledPdfArtifacts.ts` owns the policy that a missing artifact is absence while other filesystem failures are errors.
- Each output workflow owns the boundary that decides whether artifact-publication failure invalidates its primary result.
- `AgentCliSessionRegistry` owns the split between authoritative in-memory registration and best-effort persisted cross-reference metadata.

## Duplication and abstraction budget

The caller-level fallback in `executeAgent.ts` is deleted. One private dependency interface is added inside `agentCliSessionRegistry.ts` to isolate the persistence and diagnostic boundaries and test both failure modes deterministically; it does not add a public layer or pass-through API. The latexdiff path uses the same per-file isolation policy already established by compile-check output.

## Net elements (R6)

- Files: 0 added, 0 deleted, 9 modified.
- Exported symbols: 0 added, 0 removed.
- Named constructs: 1 private interface added; no classes or enums added.
- Net LoC: +330 overall (+70 production, +260 focused tests).

## Consumer counts (R8)

n/a: no exports, event keys, emit paths, or subscribers are deleted or rerouted.

## Host impact

Extension: Agent runs now expose unexpected PDF publication and persistence failures through existing diagnostics instead of silently masking them. One latexdiff PDF copy failure no longer discards successful results from other files.

Desktop: Shared agent-runtime behavior changes only; no desktop-specific API or UI change.

CLI: External-agent session registration remains synchronous and usable in memory when persistence fails; the failure is now recorded at debug level.

## Scheduled refactoring

None.

## Validation

- `npm run format` (pre-commit hook)
- `npm run typecheck`
- `npm run lint` (0 errors; 51 pre-existing warnings)
- `npm test` (715 files passed, 1 skipped; 6,473 tests passed, 4 skipped before the review follow-up; affected suites rerun afterward)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- Focused Vitest suites for compiled PDF artifacts, LaTeX diff publication, session descriptions, and CLI session registration
- Independent code review followed by a second review after corrections
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation on PDF publication and execution-store writes; behavior is intentional but can surface more diagnostics and rejections on non-ENOENT filesystem failures.
> 
> **Overview**
> Stops swallowing real errors at three agent-runtime boundaries so only **missing files** are treated as absence.
> 
> **Compiled PDF artifacts** (`compiledPdfArtifacts.ts`): `stat` and pre-copy `delete` now return `null` only on file-not-found; permission and other I/O errors propagate. **Latexdiff** (`LatexDiffManager.ts`) catches publish failures, logs a warning, and still returns the diff with `artifact: null`.
> 
> **Session descriptions** (`sessionDescription.ts`): The fire-and-forget helper fully owns best-effort behavior via `warnWithoutRejecting` (logging itself cannot reject). **`executeAgent`** drops the redundant `.catch(() => {})` around `generateSessionDescription`.
> 
> **CLI session registry** (`agentCliSessionRegistry.ts`): In-memory `register` stays synchronous; persisted SDK id writes run async with injectable deps, **debug** logging on failure, and guarded diagnostics so persistence or log-sink errors never become unhandled rejections.
> 
> Focused Vitest coverage added for missing vs unexpected FS errors, latexdiff publish failure, session-description non-rejection, and registry persistence/diagnostic paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfcac5e2dd53a83078e17007e2067ebf3eb3c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->