### PR TITLE
refactor(desktop): narrow module-internal export surface

### DIFF
--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -20,7 +20,7 @@ import type {
   DesktopMessageHandler,
 } from './desktopIpcTypes.js';
 
-export interface DesktopFileSelectionDialogOptions {
+interface DesktopFileSelectionDialogOptions {
   title: string;
   defaultPath?: string;
   filters: Array<{ name: string; extensions: string[] }>;

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -57,7 +57,7 @@ export interface DesktopGitHost {
   getRecentCommits(): Promise<DesktopGitCommitsResult>;
 }
 
-export interface DesktopGitCommitsResult {
+interface DesktopGitCommitsResult {
   commits: string[];
   isGitRepo: boolean;
 }

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -53,7 +53,7 @@ function defaultReportError(error: unknown): void {
 
 type CommandRunner = (message: DesktopCommandMessage) => void | Promise<void>;
 
-export interface CommandHandlerEntry {
+interface CommandHandlerEntry {
   /** The work to perform when the command matches. */
   run: CommandRunner;
   /**

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -10,7 +10,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { buildDesktopShowPdfMessage } from '../desktopPdfMessages.js';
 
-export interface DesktopShellAdapter {
+interface DesktopShellAdapter {
   openExternal(url: string): Promise<void>;
   openPath(filePath: string): Promise<string>;
 }

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -14,11 +14,11 @@ export interface DesktopProtocolCallback {
   fragment: string;
 }
 
-export interface DesktopProtocolCallbackSubscription {
+interface DesktopProtocolCallbackSubscription {
   dispose(): void;
 }
 
-export type DesktopProtocolCallbackListener = (
+type DesktopProtocolCallbackListener = (
   callback: DesktopProtocolCallback,
 ) => void;
 

--- a/packages/desktop/src/main/desktopSessionProgressBridge.ts
+++ b/packages/desktop/src/main/desktopSessionProgressBridge.ts
@@ -39,7 +39,7 @@ export interface DesktopPresentationPayloads {
   requestShowInstruction: RequestShowInstructionPayload;
 }
 
-export type DesktopPresentationEvent = keyof DesktopPresentationPayloads;
+type DesktopPresentationEvent = keyof DesktopPresentationPayloads;
 
 export interface DesktopSessionProgressBridge {
   /** Handle a desktop-local presentation request from the runtime host. */

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -30,7 +30,7 @@ const FETCH_TIMEOUT_MS = 5000;
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';
 
-export interface DesktopLatestRelease {
+interface DesktopLatestRelease {
   /** Release version with any leading `v` stripped, e.g. `0.40.0`. */
   version: string;
 }

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -3,8 +3,8 @@ import { join, resolve } from 'node:path';
 
 import { app } from 'electron';
 
-import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
 import { DEFAULT_NODE_STORAGE_ROOT } from '@platform/defaults/nodeStorage';
+import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
 import { getWorkspacePathInput } from '@desktop/workspacePath.js';
 
 interface WorkspacePathOptions {

--- a/packages/desktop/src/renderer/rendererPlatform.ts
+++ b/packages/desktop/src/renderer/rendererPlatform.ts
@@ -8,6 +8,6 @@ export function getRendererPlatform(view: Window | null): NodeJS.Platform {
 }
 
 /** Returns the host platform when the browser navigator is inconclusive. */
-export function getDefaultPlatform(): NodeJS.Platform {
+function getDefaultPlatform(): NodeJS.Platform {
   return typeof process === 'undefined' ? 'linux' : process.platform;
 }


### PR DESCRIPTION
## Summary

- Narrowed the export surface of 8 desktop-lane modules: `DesktopFileSelectionDialogOptions`, `DesktopGitCommitsResult`, `CommandHandlerEntry`, `DesktopShellAdapter`, `DesktopProtocolCallbackSubscription`, `DesktopProtocolCallbackListener`, `DesktopPresentationEvent`, `DesktopLatestRelease`, and `getDefaultPlatform` were all `export`ed but never imported from another file. Confirmed with `knip` (both `--workspace packages/desktop` and a full-repo run) and a manual `rg` sweep of the whole worktree, including the dynamic-`import()` test consumers under `src/test-kernel/desktop/*.vitest.mts`, to make sure nothing outside the lane referenced these names. Dropping the `export` keyword is a pure visibility change with no behavior difference.
- Fixed one `eslint import/order` warning in `packages/desktop/src/main/platform/paths.ts` (the only lint warning in the whole lane).

Both changes are behavior-preserving: no signatures, no runtime logic, no wire-format/schema shapes changed.

## Context

I swept the full `packages/desktop/src/**` lane looking for dead code, duplication, and pass-through layers to collapse. `npx jscpd` found 0% duplicated TypeScript in the lane (one unrelated small CSS clone, left alone), and `knip` found no other truly-unused exports once cross-checked against the whole repo — the lane has been through heavy recent refactor activity (visible in `git log`) and most files carry hand-tuned, heavily-commented logic (race-condition guards, CSRF nonce handling, etc.) that isn't a safe target for a low-risk simplification pass. This PR captures the genuinely safe, verified wins found during that sweep.

## Verification

- `npx tsc --noEmit -p packages/desktop/tsconfig.json && npx tsc --noEmit -p packages/desktop/tsconfig.main.json && npx tsc --noEmit -p packages/desktop/tsconfig.preload.json && npx tsc --noEmit -p packages/desktop/tsconfig.renderer.json` — all clean (a pre-existing, unrelated `data-uri-to-buffer`/`acorn` module-resolution gap shows up in `tsconfig.main.json`/`tsconfig.renderer.json` on a clean checkout too, due to hoisting in the shared `node_modules` symlink; confirmed via `git stash` that it's present without any of this PR's changes)
- `npx eslint packages/desktop/src` — clean
- `npx vitest run --config vitest.config.mjs src/test-kernel/desktop/` — 49 test files, 480 tests, all passing

## Net LoC

`git diff origin/main --shortstat`: 9 files changed, 10 insertions(+), 10 deletions(-) (net 0; this is a visibility/lint cleanup, not a line-count reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure export-visibility and import-order edits; no runtime, IPC, or schema changes.
> 
> **Overview**
> Tightens the **public API** of several desktop main/renderer modules by dropping `export` from types and helpers that are only used inside their defining file (dialog options, git commit result shape, IPC handler map entries, shell adapter, protocol callback listener types, presentation event keys, update-check release type, and `getDefaultPlatform`).
> 
> **No signatures or runtime logic change**—this is TypeScript visibility and lint hygiene only. **`paths.ts`** also reorders one import to satisfy `eslint import/order`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0707a7d19d77a9dae917a54de49c6aecef42c458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->