### PR TITLE
refactor(extension): dedupe editor-open helper, drop nested ternary

### DIFF
--- a/packages/extension/src/frontend/lm/createLanguageModelPort.ts
+++ b/packages/extension/src/frontend/lm/createLanguageModelPort.ts
@@ -121,6 +121,19 @@ function toVscodeMessage(
   );
 }
 
+function toVscodeToolMode(
+  toolMode: LanguageModelRequestOptions['toolMode'],
+): vscode.LanguageModelChatToolMode | undefined {
+  switch (toolMode) {
+    case undefined:
+      return undefined;
+    case 'required':
+      return vscode.LanguageModelChatToolMode.Required;
+    default:
+      return vscode.LanguageModelChatToolMode.Auto;
+  }
+}
+
 function toVscodeOptions(
   options: LanguageModelRequestOptions,
 ): vscode.LanguageModelChatRequestOptions {
@@ -131,12 +144,7 @@ function toVscodeOptions(
       description: tool.description,
       inputSchema: tool.inputSchema,
     })),
-    toolMode:
-      options.toolMode === undefined
-        ? undefined
-        : options.toolMode === 'required'
-          ? vscode.LanguageModelChatToolMode.Required
-          : vscode.LanguageModelChatToolMode.Auto,
+    toolMode: toVscodeToolMode(options.toolMode),
   };
 }
 

--- a/packages/extension/src/frontend/vscode/vscodeEditor.ts
+++ b/packages/extension/src/frontend/vscode/vscodeEditor.ts
@@ -32,6 +32,31 @@ export function lineToRange(
 }
 
 /**
+ * Show `existingEditor`'s document if one is already open for `uri`,
+ * otherwise open and show `uri` fresh. Shared by `openFileInEditor` and
+ * `ensureFileOpen`, whose only difference is whether an already-open,
+ * already-focused editor can be reused without another `showTextDocument`
+ * call.
+ */
+async function showDocument(
+  uri: vscode.Uri,
+  existingEditor: vscode.TextEditor | undefined,
+  preserveFocus: boolean,
+): Promise<vscode.TextEditor> {
+  if (existingEditor) {
+    return vscode.window.showTextDocument(existingEditor.document, {
+      viewColumn: existingEditor.viewColumn,
+      preserveFocus,
+    });
+  }
+  const document = await vscode.workspace.openTextDocument(uri);
+  return vscode.window.showTextDocument(document, {
+    preview: false,
+    preserveFocus,
+  });
+}
+
+/**
  * Open a file in VS Code editor, optionally positioning cursor at a line.
  * Reuses existing editor if file is already open.
  */
@@ -46,19 +71,7 @@ export async function openFileInEditor(
       (e) => e.document.uri.fsPath === uri.fsPath,
     );
 
-    let editor: vscode.TextEditor;
-    if (existingEditor) {
-      editor = await vscode.window.showTextDocument(existingEditor.document, {
-        viewColumn: existingEditor.viewColumn,
-        preserveFocus,
-      });
-    } else {
-      const document = await vscode.workspace.openTextDocument(uri);
-      editor = await vscode.window.showTextDocument(document, {
-        preview: false,
-        preserveFocus,
-      });
-    }
+    const editor = await showDocument(uri, existingEditor, preserveFocus);
 
     if (line !== undefined) {
       const position = new vscode.Position(
@@ -93,21 +106,10 @@ export async function ensureFileOpen(
     );
     const preserveFocus = options.preserveFocus ?? !existingEditor;
 
-    let editor: vscode.TextEditor;
-    if (existingEditor && preserveFocus) {
-      editor = existingEditor;
-    } else if (existingEditor) {
-      editor = await vscode.window.showTextDocument(existingEditor.document, {
-        viewColumn: existingEditor.viewColumn,
-        preserveFocus,
-      });
-    } else {
-      const document = await vscode.workspace.openTextDocument(uri);
-      editor = await vscode.window.showTextDocument(document, {
-        preview: false,
-        preserveFocus,
-      });
-    }
+    const editor =
+      existingEditor && preserveFocus
+        ? existingEditor
+        : await showDocument(uri, existingEditor, preserveFocus);
 
     if (options.save && editor.document.isDirty) {
       await editor.document.save();


### PR DESCRIPTION
## What changed

- `packages/extension/src/frontend/vscode/vscodeEditor.ts`: `openFileInEditor` and `ensureFileOpen` each independently open-or-reuse the editor for a URI with the exact same "show existing editor's document, otherwise open and show the URI fresh" branch (verified as a real duplicate via `jscpd`). Extracted the shared logic into a private `showDocument` helper both functions call. `ensureFileOpen` keeps its extra fast path (reuse an already-focused editor without calling `showTextDocument` again). No behavior change: same VS Code API calls, same arguments, same order.
- `packages/extension/src/frontend/lm/createLanguageModelPort.ts`: `toVscodeOptions` built its `toolMode` field with a nested ternary (`undefined ? ... : 'required' ? ... : ...`), which CLAUDE.md explicitly flags as an anti-pattern for this repo. Replaced with a small `toVscodeToolMode` switch statement with identical case coverage (`undefined` -> `undefined`, `'required'` -> `Required`, else -> `Auto`).

Both changes are internal refactors within a single file; no exported signatures, call sites, or wire/persisted shapes changed.

## Net LoC

`git diff origin/main --shortstat`: 2 files changed, 44 insertions(+), 34 deletions(-) (net +10 lines, but the vscodeEditor.ts change removes ~15 lines of duplicated branch logic while adding a documented shared helper - the net line count is close to flat because the extracted helper carries its own doc comment).

## Verification

- `npm run typecheck` currently fails at the very first repo-root `tsc --noEmit` step on 3 pre-existing "Cannot find module" errors (`data-uri-to-buffer`, `acorn`, `acorn-walk`) in `src/agent/modelHandlers/openai/openAIResponseFileUploads.ts` and `src/agent/workflowScript/parseScript.ts`. These are outside this lane (`src/agent/`, not `packages/extension/`), confirmed via a controlled before/after comparison (temporarily removing this PR's two-file diff reproduces the identical 3 errors) to be a stale/shared `node_modules` issue unrelated to this change: `acorn`/`acorn-walk` are declared in `package.json` (landed on `main` via #8519) but not present in the shared `node_modules` this worktree symlinks to, and `pnpm install` is off-limits per the task's constraints.
  - Scoped verification instead: `cd packages/extension && ../../node_modules/.bin/tsc --noEmit` reproduces exactly those same 3 pre-existing errors and nothing else - zero errors in `packages/extension` or either changed file.
- `npx vitest run --config vitest.config.mjs src/test-kernel/frontend/createLanguageModelPort.vitest.ts src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` - 2 files, 76 tests, all passing (the former exercises `createLanguageModelPort` directly, including tool-mode conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized readability refactors only; call sites and VS Code API usage are unchanged per the PR intent.
> 
> **Overview**
> Internal refactors in two extension frontend files with **no intended behavior or API changes**.
> 
> In **`vscodeEditor.ts`**, duplicated “reuse visible editor vs open document” logic from `openFileInEditor` and `ensureFileOpen` is moved into a private **`showDocument`** helper. `ensureFileOpen` still skips an extra `showTextDocument` when the file is already open and `preserveFocus` is true.
> 
> In **`createLanguageModelPort.ts`**, the nested ternary that mapped `toolMode` to VS Code’s enum is replaced by **`toVscodeToolMode`** (switch: `undefined` → undefined, `'required'` → Required, otherwise Auto), used from `toVscodeOptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4d706647cbda04614f71d8a57e35552f9f92ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->