### PR TITLE
refactor(tests): dedupe AgentExecutionHandle/message fixture setup

### DIFF
--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -106,6 +106,16 @@ function createAnthropicHandler(
   return new ModelHandlerAnthropic(buildAnthropicConfig(capabilityOverrides));
 }
 
+/** A minimal single-turn "hello" user message, the shape most tests need. */
+function helloMessages(): MessageParam[] {
+  return [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'hello', citations: null }],
+    },
+  ];
+}
+
 type TextBlock = Extract<ContentBlock, { type: 'text' }>;
 
 function assertSingleTextBlock(content: ContentBlock[]): TextBlock {
@@ -929,12 +939,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-6');
 
@@ -978,12 +983,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-8');
 
@@ -1019,12 +1019,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-8');
 
@@ -1053,12 +1048,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-8');
 
@@ -1083,12 +1073,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-6');
 
@@ -1123,12 +1108,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     stubHandlerForTest(handler);
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-sonnet-4-5');
 
@@ -1528,12 +1508,7 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
       },
     } as any;
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
 
     await assert.rejects(
       handler.createResponse({ client, messages, temperature: 0 }),
@@ -1600,12 +1575,7 @@ describe('ModelHandlerAnthropic pre-message_start error handling', () => {
       },
     } as any;
 
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'hello', citations: null }],
-      },
-    ];
+    const messages = helloMessages();
 
     await assert.rejects(
       handler.createResponse({ client, messages, temperature: 0 }),

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -48,6 +48,7 @@ import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
 import {
   STREAM_PHASE,
   type ExecutionId,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 
@@ -62,6 +63,7 @@ function trackChildHandle(
   executionId: ExecutionId,
   parentStreamId: StreamTabId,
   childStreamId: StreamTabId,
+  status: StreamPhase = STREAM_PHASE.RUNNING,
 ): AgentExecutionHandle {
   const handle = new AgentExecutionHandle(
     executionId,
@@ -71,9 +73,7 @@ function trackChildHandle(
     'toolUse',
     { emit: vi.fn() } as never,
   );
-  session.executions.trackAgentExecution(handle, {
-    status: STREAM_PHASE.RUNNING,
-  });
+  session.executions.trackAgentExecution(handle, { status });
   trackedExecutionIds.add(executionId);
   return handle;
 }
@@ -410,17 +410,12 @@ describe('childRunLoop E2E fixtures', () => {
     // Mirrors what a real native turn's runFlowWithLifecycle does: track a
     // fresh handle for this executionId/childStreamId, WAITING, once the
     // turn suspends.
-    const handle = new AgentExecutionHandle(
+    const handle = trackChildHandle(
       executionId,
       parentStreamId,
       childStreamId,
-      'fake',
-      'toolUse',
-      { emit: vi.fn() } as never,
+      STREAM_PHASE.WAITING,
     );
-    session.executions.trackAgentExecution(handle, {
-      status: STREAM_PHASE.WAITING,
-    });
 
     await resolveTurn(1, { kind: 'interim', value: 'first' });
     await vi.waitFor(() =>
@@ -636,17 +631,12 @@ describe('childRunLoop E2E fixtures', () => {
       expect(isChildRunLoopActive(childStreamId)).toBe(true),
     );
 
-    const handle = new AgentExecutionHandle(
+    const handle = trackChildHandle(
       executionId,
       parentStreamId,
       childStreamId,
-      'fake',
-      'toolUse',
-      { emit: vi.fn() } as never,
+      STREAM_PHASE.WAITING,
     );
-    session.executions.trackAgentExecution(handle, {
-      status: STREAM_PHASE.WAITING,
-    });
 
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -6,12 +6,14 @@ import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { getExecutionStore } from '@agent/storage';
 import type { AgentTrace } from '@agent/trace';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   AgentExecutionHandle,
   ExecutionRegistry,
   ProcessExecutionHandle,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/executionRegistry';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { ProcessOutputPoller } from '@agent/runtime/ProcessOutputPoller';
 import {
   SessionEventHub,
@@ -69,26 +71,47 @@ vi.mock('@agent/trace', async (importOriginal) => {
 
 setupPlatform({ workspacePath: '/workspace' });
 
+/** Builds an `AgentExecutionHandle` for a toolUse test-subagent, the shape most tests need. */
+function createHandle(
+  executionId: string,
+  parentStreamId: StreamTabId,
+  childStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
+  overrides: {
+    agentName?: string;
+    category?: AgentCategory;
+    trace?: AgentTrace;
+  } = {},
+): AgentExecutionHandle {
+  return new AgentExecutionHandle(
+    executionId,
+    parentStreamId,
+    childStreamId,
+    overrides.agentName ?? 'test-subagent',
+    overrides.category ?? AgentCategory.ToolUse,
+    runtimeHost,
+    overrides.trace,
+  );
+}
+
 describe('executionRegistry', () => {
   it('observes the current handle, replacements, and removal in order', () => {
     const registry = new ExecutionRegistry();
     const executionId = 'exec-observe-handle';
     const streamId = 'stream-observe-handle' as StreamTabId;
-    const first = new AgentExecutionHandle(
+    const first = createHandle(
       executionId,
       streamId,
       streamId,
-      'first',
-      'workflow',
       createRecordingHost().host,
+      { agentName: 'first', category: AgentCategory.Workflow },
     );
-    const second = new AgentExecutionHandle(
+    const second = createHandle(
       executionId,
       streamId,
       streamId,
-      'second',
-      'workflow',
       createRecordingHost().host,
+      { agentName: 'second', category: AgentCategory.Workflow },
     );
     const registrations: unknown[] = [];
     const detachRegistrations = registry.addRegistrationListener(
@@ -163,13 +186,12 @@ describe('executionRegistry', () => {
     try {
       // Background bash: an AgentExecutionHandle whose attached interrupt
       // handler owns a live OS process (mirrors BashBackgroundSession).
-      const bashHandle = new AgentExecutionHandle(
+      const bashHandle = createHandle(
         bashExecutionId,
         bashParentStreamId,
         bashChildStreamId,
-        'bash',
-        'toolUse',
         explicit.host,
+        { agentName: 'bash' },
       );
       bashHandle.attachInterruptHandler({
         interrupt: bashInterrupt,
@@ -182,12 +204,10 @@ describe('executionRegistry', () => {
       // Ordinary agent execution (e.g. a native-subagent loop's own
       // loop-level interrupt handler): no ownsBackgroundProcess flag, so
       // shutdown drain must leave it alone for restart recovery.
-      const agentHandle = new AgentExecutionHandle(
+      const agentHandle = createHandle(
         agentExecutionId,
         agentParentStreamId,
         agentChildStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       agentHandle.attachInterruptHandler({ interrupt: agentInterrupt });
@@ -233,12 +253,10 @@ describe('executionRegistry', () => {
     const interrupt = vi.fn();
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       handle.attachInterruptHandler({ interrupt });
@@ -268,12 +286,10 @@ describe('executionRegistry', () => {
     const cleanup = vi.fn();
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       registry.track(handle);
@@ -322,14 +338,12 @@ describe('executionRegistry', () => {
     const trace: AgentTrace = { emit: vi.fn() } as unknown as AgentTrace;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
-        trace,
+        { trace },
       );
       registry.track(handle);
       handle.registerWaitingCleanup(() => {});
@@ -389,12 +403,10 @@ describe('executionRegistry', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
       );
       registry.track(handle);
@@ -453,12 +465,10 @@ describe('executionRegistry', () => {
     channelTraceMocks.warn.mockClear();
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
       );
       registry.track(handle);
@@ -505,12 +515,10 @@ describe('executionRegistry', () => {
     const childStreamId = 'child-no-cleanup-kill-test' as StreamTabId;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
       );
       registry.track(handle);
@@ -545,12 +553,10 @@ describe('executionRegistry', () => {
     const cleanup = vi.fn();
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
       );
       registry.track(handle);
@@ -601,12 +607,10 @@ describe('executionRegistry', () => {
           cost: 0,
         },
       });
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         createRecordingHost().host,
       );
       registry.track(handle);
@@ -654,22 +658,19 @@ describe('executionRegistry', () => {
     const childInterrupt = vi.fn();
 
     try {
-      const rootHandle = new AgentExecutionHandle(
+      const rootHandle = createHandle(
         'exec-root-stop-policy-test',
         rootStreamId,
         rootStreamId,
-        'test-root',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-root' },
       );
       rootHandle.attachInterruptHandler({ interrupt: rootInterrupt });
       registry.track(rootHandle);
-      const childHandle = new AgentExecutionHandle(
+      const childHandle = createHandle(
         'exec-child-stop-policy-test',
         rootStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       childHandle.attachInterruptHandler({ interrupt: childInterrupt });
@@ -715,23 +716,20 @@ describe('executionRegistry', () => {
     const grandchildInterrupt = vi.fn();
 
     try {
-      const childHandle = new AgentExecutionHandle(
+      const childHandle = createHandle(
         'exec-child-cascade-test',
         rootStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       childHandle.attachInterruptHandler({ interrupt: childInterrupt });
       registry.track(childHandle);
-      const grandchildHandle = new AgentExecutionHandle(
+      const grandchildHandle = createHandle(
         'exec-grandchild-cascade-test',
         childStreamId,
         grandchildStreamId,
-        'test-grandchild',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-grandchild' },
       );
       grandchildHandle.attachInterruptHandler({
         interrupt: grandchildInterrupt,
@@ -765,23 +763,20 @@ describe('executionRegistry', () => {
     const grandchildInterrupt = vi.fn();
 
     try {
-      const childHandle = new AgentExecutionHandle(
+      const childHandle = createHandle(
         'exec-child-detach-kill-test',
         rootStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       childHandle.attachInterruptHandler({ interrupt: childInterrupt });
       registry.track(childHandle);
-      const grandchildHandle = new AgentExecutionHandle(
+      const grandchildHandle = createHandle(
         'exec-grandchild-detach-kill-test',
         childStreamId,
         grandchildStreamId,
-        'test-grandchild',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-grandchild' },
       );
       grandchildHandle.attachInterruptHandler({
         interrupt: grandchildInterrupt,
@@ -831,33 +826,29 @@ describe('executionRegistry', () => {
     const grandchildInterrupt = vi.fn();
 
     try {
-      const rootHandle = new AgentExecutionHandle(
+      const rootHandle = createHandle(
         'exec-root-detach-stop-policy-test',
         rootStreamId,
         rootStreamId,
-        'test-root',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-root' },
       );
       rootHandle.attachInterruptHandler({ interrupt: rootInterrupt });
       registry.track(rootHandle);
-      const childHandle = new AgentExecutionHandle(
+      const childHandle = createHandle(
         'exec-child-detach-stop-policy-test',
         rootStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
       childHandle.attachInterruptHandler({ interrupt: childInterrupt });
       registry.track(childHandle);
-      const grandchildHandle = new AgentExecutionHandle(
+      const grandchildHandle = createHandle(
         'exec-grandchild-detach-stop-policy-test',
         childStreamId,
         grandchildStreamId,
-        'test-grandchild',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-grandchild' },
       );
       grandchildHandle.attachInterruptHandler({
         interrupt: grandchildInterrupt,
@@ -967,14 +958,7 @@ describe('executionRegistry', () => {
         STREAM_STATUS.WAITING,
       );
       registry.track(
-        new AgentExecutionHandle(
-          executionId,
-          parentStreamId,
-          childStreamId,
-          'test-subagent',
-          'toolUse',
-          explicit.host,
-        ),
+        createHandle(executionId, parentStreamId, childStreamId, explicit.host),
       );
 
       expect(registry.getActiveChildren(parentStreamId).subagents).toEqual([
@@ -998,14 +982,7 @@ describe('executionRegistry', () => {
 
     try {
       registry.trackAgentExecution(
-        new AgentExecutionHandle(
-          executionId,
-          parentStreamId,
-          childStreamId,
-          'test-subagent',
-          'toolUse',
-          explicit.host,
-        ),
+        createHandle(executionId, parentStreamId, childStreamId, explicit.host),
         { status: STREAM_STATUS.RUNNING },
       );
 
@@ -1028,12 +1005,10 @@ describe('executionRegistry', () => {
     const parentStreamId = 'parent-update-agent-status-test' as StreamTabId;
     const childStreamId = 'child-update-agent-status-test' as StreamTabId;
     const executionId = 'exec-update-agent-status-test';
-    const handle = new AgentExecutionHandle(
+    const handle = createHandle(
       executionId,
       parentStreamId,
       childStreamId,
-      'test-subagent',
-      'toolUse',
       explicit.host,
     );
 
@@ -1105,12 +1080,10 @@ describe('executionRegistry', () => {
     const childStreamId = 'child-handle-runtime-host-test' as StreamTabId;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
 
@@ -1157,12 +1130,10 @@ describe('executionRegistry', () => {
     const childStreamId = 'child-session-parent-link-test' as StreamTabId;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
 
@@ -1205,13 +1176,12 @@ describe('executionRegistry', () => {
     };
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         streamId,
         streamId,
-        'test-tool-use',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-tool-use' },
       );
 
       handle.attachToolUseFlow(context);
@@ -1267,24 +1237,22 @@ describe('executionRegistry', () => {
         streamId,
       });
 
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         'exec-manual-compaction-test',
         streamId,
         streamId,
-        'test-tool-use',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-tool-use' },
       );
       handle.attachToolUseFlow(context);
       registry.track(handle);
 
-      const unsupportedHandle = new AgentExecutionHandle(
+      const unsupportedHandle = createHandle(
         'exec-manual-compaction-unsupported-test',
         unsupportedStreamId,
         unsupportedStreamId,
-        'test-tool-use',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-tool-use' },
       );
       unsupportedHandle.attachToolUseFlow(unsupportedContext);
       registry.track(unsupportedHandle);
@@ -1333,13 +1301,12 @@ describe('executionRegistry', () => {
     };
 
     try {
-      const activeHandle = new AgentExecutionHandle(
+      const activeHandle = createHandle(
         'exec-follow-up-active-test',
         activeStreamId,
         activeStreamId,
-        'test-tool-use',
-        'toolUse',
         explicit.host,
+        { agentName: 'test-tool-use' },
       );
       activeHandle.attachToolUseFlow(context);
       registry.track(activeHandle);
@@ -1390,12 +1357,10 @@ describe('executionRegistry', () => {
         STREAM_PHASE.CANCELLED,
       );
       registry.track(
-        new AgentExecutionHandle(
+        createHandle(
           'exec-follow-up-child-test',
           parentStreamId,
           childStreamId,
-          'test-subagent',
-          'toolUse',
           explicit.host,
         ),
       );
@@ -1418,12 +1383,10 @@ describe('executionRegistry', () => {
     const childStreamId = 'child-detach-runtime-host-test' as StreamTabId;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
 
@@ -1464,12 +1427,10 @@ describe('executionRegistry', () => {
       'child-detach-session-parent-link-test' as StreamTabId;
 
     try {
-      const handle = new AgentExecutionHandle(
+      const handle = createHandle(
         executionId,
         parentStreamId,
         childStreamId,
-        'test-subagent',
-        'toolUse',
         explicit.host,
       );
 
@@ -1501,12 +1462,10 @@ describe('executionRegistry', () => {
     const parentStreamId = 'parent-dispose-runtime-host-test' as StreamTabId;
     const childStreamId = 'child-dispose-runtime-host-test' as StreamTabId;
 
-    const handle = new AgentExecutionHandle(
+    const handle = createHandle(
       executionId,
       parentStreamId,
       childStreamId,
-      'test-subagent',
-      'toolUse',
       explicit.host,
     );
 

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -26,12 +26,28 @@ import {
   AgentExecutionHandle,
   ExecutionRegistry,
 } from '@agent/runtime/executionRegistry';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 import { createRecordingHost, recordSessionEvents } from '../progressTestUtils';
 
 const streamId = 'stream:subscription-session' as StreamTabId;
 const childStreamId = 'child:subscription-session' as StreamTabId;
+
+/** Builds a toolUse `search` handle on the shared stream/child stream. */
+function createSearchHandle(
+  executionId: string,
+  runtimeHost: AgentRuntimeHost,
+): AgentExecutionHandle {
+  return new AgentExecutionHandle(
+    executionId,
+    streamId,
+    childStreamId,
+    'search',
+    'toolUse',
+    runtimeHost,
+  );
+}
 
 function createReleaseSource() {
   return {
@@ -70,14 +86,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       session,
     });
     const executionId = 'exec-subscription-session-test';
-    const handle = new AgentExecutionHandle(
-      executionId,
-      streamId,
-      childStreamId,
-      'search',
-      'toolUse',
-      explicit.host,
-    );
+    const handle = createSearchHandle(executionId, explicit.host);
 
     try {
       registry.track(handle);
@@ -130,14 +139,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
         session,
       });
       const executionId = `exec-subscription-${sendResult.status}-event-test`;
-      const handle = new AgentExecutionHandle(
-        executionId,
-        streamId,
-        childStreamId,
-        'search',
-        'toolUse',
-        explicit.host,
-      );
+      const handle = createSearchHandle(executionId, explicit.host);
       sendFollowUpMock.mockResolvedValueOnce(sendResult);
 
       try {
@@ -180,14 +182,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       logger: createLogger(),
     });
     const executionId = 'exec-subscription-current-session-test';
-    const handle = new AgentExecutionHandle(
-      executionId,
-      streamId,
-      childStreamId,
-      'search',
-      'toolUse',
-      explicit.host,
-    );
+    const handle = createSearchHandle(executionId, explicit.host);
 
     try {
       registry.track(handle);
@@ -233,14 +228,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       session,
     });
     const executionId = 'exec-subscription-rejection-test';
-    const handle = new AgentExecutionHandle(
-      executionId,
-      streamId,
-      childStreamId,
-      'search',
-      'toolUse',
-      explicit.host,
-    );
+    const handle = createSearchHandle(executionId, explicit.host);
     const unhandledRejection = vi.fn();
     sendFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
 


### PR DESCRIPTION
## Summary

Simplifies duplicated test setup in the `agent/modelHandlers` and `agent/runtime` test-kernel lane. No test scenarios, assertions, or fixtures were removed or weakened; the changes are mechanical extractions of repeated construction code into small local helpers.

- `src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts`: `new AgentExecutionHandle(...)` was constructed inline with the same 6-7 positional arguments at 33 call sites. Added a local `createHandle(executionId, parentStreamId, childStreamId, runtimeHost, overrides?)` factory (defaults to `agentName: 'test-subagent'`, `category: AgentCategory.ToolUse`) and rewrote every call site to use it, passing only the values that actually vary per test.
- `src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts`: the file already had a `trackChildHandle()` helper used by 5 tests; 2 more tests duplicated its body inline just to pass a different tracked status (`WAITING` instead of the default `RUNNING`). Added an optional `status` parameter to the existing helper and switched both call sites to use it.
- `src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts`: 4 tests built an identical `AgentExecutionHandle` (same `agentName`/`category`/shared module-level stream ids, only `executionId` and the recording host varied). Added a `createSearchHandle(executionId, runtimeHost)` helper.
- `src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts`: 8 tests built an identical single-turn "hello" `MessageParam[]` fixture inline. Added a `helloMessages()` helper next to the file's other small fixture builders.

All four are pure extractions: each call site passes the exact same argument values into the exact same underlying constructor/literal as before, so runtime behavior is unchanged.

Net LoC: **-93** (117 insertions, 210 deletions) across 4 files, measured against `origin/main` after rebasing onto it (the branch picked up 8 unrelated upstream commits, including a `modelHandlerAnthropic.ts` refactor, during this work).

## Verification

- `npx tsc --noEmit -p tsconfig.test-kernel.json` — no new errors from these changes. (Two pre-existing, unrelated missing-dependency errors remain in the environment: `data-uri-to-buffer` in `openAIResponseFileUploads.ts` and `acorn`/`acorn-walk` in `parseScript.ts` — both come from recent `main` commits whose dependencies aren't present in this worktree's symlinked `node_modules`, and predate/are independent of this change.)
- `npx vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts` — 4 files, 80 tests, all passing.
- `eslint` on all four touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test helpers and call-site rewrites in the test-kernel lane; production runtime and agent behavior are untouched.
> 
> **Overview**
> Test-only refactor in four `test-kernel` vitest files: repeated inline setup is pulled into small local helpers so tests stay the same behavior with less noise.
> 
> **`ModelHandlerAnthropic.vitest.ts`** adds `helloMessages()` and uses it in eight tests that previously inlined the same single-turn user `"hello"` `MessageParam[]`.
> 
> **`ExecutionRegistry.vitest.ts`** adds `createHandle(...)` with defaults (`test-subagent`, `AgentCategory.ToolUse`) and optional overrides; ~33 sites stop duplicating `new AgentExecutionHandle(...)`.
> 
> **`ChildRunLoop.vitest.ts`** extends existing `trackChildHandle` with an optional tracked `status` (default `RUNNING`); two tests that needed `WAITING` use the helper instead of duplicating construction + `trackAgentExecution`.
> 
> **`ExecutionSubscriptionBinderSession.vitest.ts`** adds `createSearchHandle(executionId, runtimeHost)` for the shared `search` / `toolUse` handle shape across four tests.
> 
> No production code, assertions, or scenarios change—mechanical deduplication only (~−93 LoC).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cdf84dcc403e3b2eb5992891a9b34f5264eaf75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->