### PR TITLE
refactor(tests): dedupe fixture setup in tools/commands test-kernel files

### DIFF
--- a/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
+++ b/src/test-kernel/commands/history/chatExportFormatter.vitest.ts
@@ -8,7 +8,17 @@ import { describe, it } from 'vitest';
 import {
   formatChatAsLatex,
   formatChatAsMarkdown,
+  type ChatExportInput,
 } from '@agent/export/chatExportFormatter';
+
+/** A single-message ChatExportInput fixture wrapping the given content blocks. */
+function assistantChatInput(content: unknown[]): ChatExportInput {
+  return {
+    timestamp: '2026-01-01T00:00:00.000Z',
+    config: {},
+    messages: [{ role: 'assistant', content }],
+  };
+}
 
 describe('formatChatAsMarkdown', () => {
   it('preserves function tool calls in mixed tool_calls arrays', () => {
@@ -126,11 +136,7 @@ describe('formatChatAsMarkdown', () => {
   ])(
     'renders $shape web-fetch fields in Markdown and LaTeX exports',
     ({ block, url, title, content }) => {
-      const input = {
-        timestamp: '2026-01-01T00:00:00.000Z',
-        config: {},
-        messages: [{ role: 'assistant', content: [block] }],
-      };
+      const input = assistantChatInput([block]);
 
       const markdown = formatChatAsMarkdown(input);
       assert.ok(markdown.includes(`**URL:** ${url}`));
@@ -145,38 +151,31 @@ describe('formatChatAsMarkdown', () => {
   );
 
   it('sanitizes web tool URLs before rendering Markdown links', () => {
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
+          type: 'web_search_tool_result',
           content: [
             {
-              type: 'web_search_tool_result',
-              content: [
-                {
-                  type: 'web_search_result',
-                  title: 'unsafe result',
-                  url: 'javascript:alert(1)',
-                },
-                {
-                  type: 'web_search_result',
-                  title: 'safe result',
-                  url: '  https://example.com/search?q=texra  ',
-                },
-              ],
+              type: 'web_search_result',
+              title: 'unsafe result',
+              url: 'javascript:alert(1)',
             },
             {
-              type: 'web_fetch_tool_result',
-              url: 'data:text/html,<script>alert(1)</script>',
-              title: 'unsafe fetch',
-              page_content: 'body',
+              type: 'web_search_result',
+              title: 'safe result',
+              url: '  https://example.com/search?q=texra  ',
             },
           ],
         },
-      ],
-    });
+        {
+          type: 'web_fetch_tool_result',
+          url: 'data:text/html,<script>alert(1)</script>',
+          title: 'unsafe fetch',
+          page_content: 'body',
+        },
+      ]),
+    );
 
     assert.match(markdown, /- unsafe result/);
     assert.match(
@@ -189,33 +188,26 @@ describe('formatChatAsMarkdown', () => {
   });
 
   it('escapes Markdown syntax in web tool titles before rendering Markdown links', () => {
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
+          type: 'web_search_tool_result',
           content: [
             {
-              type: 'web_search_tool_result',
-              content: [
-                {
-                  type: 'web_search_result',
-                  title: 'safe ](javascript:alert(1)) [again',
-                  url: 'https://example.com/search',
-                },
-              ],
-            },
-            {
-              type: 'web_fetch_tool_result',
-              url: 'https://example.com/fetch',
-              title: '[pwn](javascript:alert(1))',
-              page_content: 'body',
+              type: 'web_search_result',
+              title: 'safe ](javascript:alert(1)) [again',
+              url: 'https://example.com/search',
             },
           ],
         },
-      ],
-    });
+        {
+          type: 'web_fetch_tool_result',
+          url: 'https://example.com/fetch',
+          title: '[pwn](javascript:alert(1))',
+          page_content: 'body',
+        },
+      ]),
+    );
 
     assert.ok(
       markdown.includes(
@@ -230,33 +222,20 @@ describe('formatChatAsMarkdown', () => {
 
   it('escapes allowed-scheme URLs before rendering Markdown URL containers', () => {
     const url = 'https://example.com/a) [pwn](javascript:alert(1))';
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
-          content: [
-            {
-              type: 'web_search_tool_result',
-              content: [
-                {
-                  type: 'web_search_result',
-                  title: 'safe result',
-                  url,
-                },
-              ],
-            },
-            {
-              type: 'web_fetch_tool_result',
-              url,
-              title: 'safe fetch',
-              page_content: 'body',
-            },
-          ],
+          type: 'web_search_tool_result',
+          content: [{ type: 'web_search_result', title: 'safe result', url }],
         },
-      ],
-    });
+        {
+          type: 'web_fetch_tool_result',
+          url,
+          title: 'safe fetch',
+          page_content: 'body',
+        },
+      ]),
+    );
 
     assert.ok(
       markdown.includes(
@@ -273,27 +252,16 @@ describe('formatChatAsMarkdown', () => {
 
   it('escapes emphasis/code-span/heading characters in web tool titles', () => {
     const title = '`rm -rf /` *bold* _italic_ # Heading';
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
+          type: 'web_search_tool_result',
           content: [
-            {
-              type: 'web_search_tool_result',
-              content: [
-                {
-                  type: 'web_search_result',
-                  title,
-                  url: 'https://example.com',
-                },
-              ],
-            },
+            { type: 'web_search_result', title, url: 'https://example.com' },
           ],
         },
-      ],
-    });
+      ]),
+    );
 
     assert.ok(
       markdown.includes('\\`rm -rf /\\` \\*bold\\* \\_italic\\_ \\# Heading'),
@@ -305,23 +273,16 @@ describe('formatChatAsMarkdown', () => {
     // Same escapeMarkdownText call as the web_search case above, but through
     // the web_fetch **Title:** container (markdownSpec.ts's second call site).
     const title = '`rm -rf /` *bold* _italic_ # Heading';
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
-          content: [
-            {
-              type: 'web_fetch_tool_result',
-              url: 'https://example.com',
-              title,
-              page_content: 'body',
-            },
-          ],
+          type: 'web_fetch_tool_result',
+          url: 'https://example.com',
+          title,
+          page_content: 'body',
         },
-      ],
-    });
+      ]),
+    );
 
     assert.ok(
       markdown.includes(
@@ -333,21 +294,14 @@ describe('formatChatAsMarkdown', () => {
 
   it('preserves IPv6 host brackets in Markdown link destinations', () => {
     const url = 'http://[::1]:8080/path';
-    const markdown = formatChatAsMarkdown({
-      timestamp: '2026-01-01T00:00:00.000Z',
-      config: {},
-      messages: [
+    const markdown = formatChatAsMarkdown(
+      assistantChatInput([
         {
-          role: 'assistant',
-          content: [
-            {
-              type: 'web_search_tool_result',
-              content: [{ type: 'web_search_result', title: 'ipv6', url }],
-            },
-          ],
+          type: 'web_search_tool_result',
+          content: [{ type: 'web_search_result', title: 'ipv6', url }],
         },
-      ],
-    });
+      ]),
+    );
 
     assert.ok(
       markdown.includes('- [ipv6](http://[::1]:8080/path)'),
@@ -357,38 +311,29 @@ describe('formatChatAsMarkdown', () => {
 
   it('sanitizes web tool URLs before rendering LaTeX links', () => {
     const latex = formatChatAsLatex(
-      {
-        timestamp: '2026-01-01T00:00:00.000Z',
-        config: {},
-        messages: [
-          {
-            role: 'assistant',
-            content: [
-              {
-                type: 'web_search_tool_result',
-                content: [
-                  {
-                    type: 'web_search_result',
-                    title: 'unsafe result',
-                    url: 'vbscript:msgbox(1)',
-                  },
-                  {
-                    type: 'web_search_result',
-                    title: 'safe result',
-                    url: 'https://example.com/path#frag',
-                  },
-                ],
-              },
-              {
-                type: 'web_fetch_tool_result',
-                url: 'file:///etc/passwd',
-                title: 'unsafe fetch',
-                page_content: 'body',
-              },
-            ],
-          },
-        ],
-      },
+      assistantChatInput([
+        {
+          type: 'web_search_tool_result',
+          content: [
+            {
+              type: 'web_search_result',
+              title: 'unsafe result',
+              url: 'vbscript:msgbox(1)',
+            },
+            {
+              type: 'web_search_result',
+              title: 'safe result',
+              url: 'https://example.com/path#frag',
+            },
+          ],
+        },
+        {
+          type: 'web_fetch_tool_result',
+          url: 'file:///etc/passwd',
+          title: 'unsafe fetch',
+          page_content: 'body',
+        },
+      ]),
       '',
     );
 
@@ -405,33 +350,18 @@ describe('formatChatAsMarkdown', () => {
   it('escapes allowed-scheme URLs before rendering LaTeX URL commands', () => {
     const url = String.raw`https://e.test/}\input{/etc/passwd`;
     const latex = formatChatAsLatex(
-      {
-        timestamp: '2026-01-01T00:00:00.000Z',
-        config: {},
-        messages: [
-          {
-            role: 'assistant',
-            content: [
-              {
-                type: 'web_search_tool_result',
-                content: [
-                  {
-                    type: 'web_search_result',
-                    title: 'safe result',
-                    url,
-                  },
-                ],
-              },
-              {
-                type: 'web_fetch_tool_result',
-                url,
-                title: 'safe fetch',
-                page_content: 'body',
-              },
-            ],
-          },
-        ],
-      },
+      assistantChatInput([
+        {
+          type: 'web_search_tool_result',
+          content: [{ type: 'web_search_result', title: 'safe result', url }],
+        },
+        {
+          type: 'web_fetch_tool_result',
+          url,
+          title: 'safe fetch',
+          page_content: 'body',
+        },
+      ]),
       '',
     );
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -7,7 +7,11 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import {
+  createRunContext,
+  withRunContext,
+  type RunContext,
+} from '@agent/runtime/RunContext';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { AgentExecutionHandle } from '@agent/runtime/executionRegistry';
@@ -25,6 +29,7 @@ import {
   executeStableSubagentInBand,
   SubagentDurabilityError,
   SubagentReconciliationError,
+  type InBandSubagentExecutionOptions,
 } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
@@ -85,6 +90,24 @@ function sessionFor(host: AgentRuntimeHost): SessionHandle {
   return session;
 }
 
+/** The run context shared by nearly every case (host/stopAfterCycle/session vary). */
+function parentRunContext(
+  overrides: Partial<{
+    runtimeHost: AgentRuntimeHost;
+    streamId: StreamTabId;
+    stopAfterCycle: boolean;
+    session: SessionHandle;
+  }> = {},
+): RunContext {
+  return createRunContext({
+    runtimeHost: runtimeHost(),
+    streamId: 'parent-stream',
+    executionId: 'parent-exec',
+    model: 'deepseekT',
+    ...overrides,
+  });
+}
+
 /** The shared delegation call used by nearly every case (agent name varies). */
 function callDelegateReview(agent = 'review') {
   return new DelegateAgentTool().call({
@@ -95,6 +118,25 @@ function callDelegateReview(agent = 'review') {
     working_directory: null,
     execution_id: null,
   });
+}
+
+/** The in-band delegation options shared by nearly every case (fields vary). */
+function delegationOptions(
+  overrides: Partial<InBandSubagentExecutionOptions> = {},
+): InBandSubagentExecutionOptions {
+  return {
+    configPayload: {
+      agent: 'review',
+      agentCategory: AgentCategory.ToolUse,
+      model: 'deepseekT',
+    },
+    agentName: 'review',
+    parentExecutionId: 'parent-exec' as ExecutionId,
+    parentStreamId: 'parent-stream' as StreamTabId,
+    runtimeHost: runtimeHost(),
+    session: defaultSession(),
+    ...overrides,
+  };
 }
 
 /**
@@ -200,13 +242,7 @@ describe('headless delegation', () => {
 
   it('awaits child delegation during one-shot tool-use runs', async () => {
     const result = await withRunContext(
-      createRunContext({
-        runtimeHost: runtimeHost(),
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-        stopAfterCycle: true,
-      }),
+      parentRunContext({ stopAfterCycle: true }),
       () => callDelegateReview(),
     );
 
@@ -233,18 +269,7 @@ describe('headless delegation', () => {
   });
 
   it('returns and persists the typed final result for in-band consumers', async () => {
-    const result = await executeSubagentInBand({
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
-      parentExecutionId: 'parent-exec' as ExecutionId,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-    });
+    const result = await executeSubagentInBand(delegationOptions());
 
     expect(result.result).toEqual({
       category: 'toolUse',
@@ -411,19 +436,12 @@ describe('headless delegation', () => {
     );
 
     await expect(
-      executeSubagentInBand({
-        executionId: logicalExecutionId,
-        configPayload: {
-          agent: 'review',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'deepseekT',
-        },
-        agentName: 'review',
-        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-        parentStreamId: 'parent-stream' as StreamTabId,
-        runtimeHost: runtimeHost(),
-        session: defaultSession(),
-      }),
+      executeSubagentInBand(
+        delegationOptions({
+          executionId: logicalExecutionId,
+          parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        }),
+      ),
     ).rejects.toBeInstanceOf(SubagentReconciliationError);
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
@@ -461,19 +479,12 @@ describe('headless delegation', () => {
         return store;
       });
 
-      const completed = await executeSubagentInBand({
-        executionId: logicalExecutionId,
-        configPayload: {
-          agent: 'review',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'deepseekT',
-        },
-        agentName: 'review',
-        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-        parentStreamId: 'parent-stream' as StreamTabId,
-        runtimeHost: runtimeHost(),
-        session: defaultSession(),
-      });
+      const completed = await executeSubagentInBand(
+        delegationOptions({
+          executionId: logicalExecutionId,
+          parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        }),
+      );
 
       expect(completed.executionId).not.toBe(logicalExecutionId);
       expect(mocks.executeAgent).toHaveBeenCalledOnce();
@@ -498,19 +509,10 @@ describe('headless delegation', () => {
     mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
       executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
     );
-    const options = {
+    const options = delegationOptions({
       executionId: logicalExecutionId,
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
       parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-    } as const;
+    });
 
     await expect(executeSubagentInBand(options)).rejects.toBeInstanceOf(
       SubagentDurabilityError,
@@ -528,11 +530,6 @@ describe('headless delegation', () => {
 
   it('uses a new durable attempt after failed and cancelled children', async () => {
     const logicalExecutionId = 'eeeeee555555' as ExecutionId;
-    const configPayload = {
-      agent: 'review',
-      agentCategory: AgentCategory.ToolUse,
-      model: 'deepseekT',
-    };
     const stores = new Map<ExecutionId, Record<string, unknown>>();
     const sequenceStore = stableSequenceStore(logicalExecutionId);
     const priorOutcomes = ['failed', 'cancelled'] as const;
@@ -572,15 +569,12 @@ describe('headless delegation', () => {
       return store;
     });
 
-    const completed = await executeSubagentInBand({
-      executionId: logicalExecutionId,
-      configPayload,
-      agentName: 'review',
-      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-    });
+    const completed = await executeSubagentInBand(
+      delegationOptions({
+        executionId: logicalExecutionId,
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+      }),
+    );
 
     expect(completed.executionId).not.toBe(logicalExecutionId);
     expect(stores.size).toBe(3);
@@ -597,18 +591,7 @@ describe('headless delegation', () => {
     mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
 
     await expect(
-      executeSubagentInBand({
-        configPayload: {
-          agent: 'review',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'deepseekT',
-        },
-        agentName: 'review',
-        parentExecutionId: 'parent-exec' as ExecutionId,
-        parentStreamId: 'parent-stream' as StreamTabId,
-        runtimeHost: runtimeHost(),
-        session: defaultSession(),
-      }),
+      executeSubagentInBand(delegationOptions()),
     ).rejects.toBeInstanceOf(SubagentDurabilityError);
     expect(mocks.writeReport).not.toHaveBeenCalled();
   });
@@ -617,18 +600,7 @@ describe('headless delegation', () => {
     mocks.executeAgent.mockRejectedValueOnce(new Error('review model failed'));
     mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
 
-    const run = executeSubagentInBand({
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
-      parentExecutionId: 'parent-exec' as ExecutionId,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-    });
+    const run = executeSubagentInBand(delegationOptions());
 
     await expect(run).rejects.toMatchObject({
       name: 'SubagentDurabilityError',
@@ -648,18 +620,7 @@ describe('headless delegation', () => {
       } as never),
     );
 
-    const run = executeSubagentInBand({
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
-      parentExecutionId: 'parent-exec' as ExecutionId,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-    });
+    const run = executeSubagentInBand(delegationOptions());
 
     await expect(run).rejects.toMatchObject({
       name: 'SubagentDurabilityError',
@@ -678,20 +639,7 @@ describe('headless delegation', () => {
       touchedFiles: [42],
     });
 
-    await expect(
-      executeSubagentInBand({
-        configPayload: {
-          agent: 'review',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'deepseekT',
-        },
-        agentName: 'review',
-        parentExecutionId: 'parent-exec' as ExecutionId,
-        parentStreamId: 'parent-stream' as StreamTabId,
-        runtimeHost: runtimeHost(),
-        session: defaultSession(),
-      }),
-    ).rejects.toThrow();
+    await expect(executeSubagentInBand(delegationOptions())).rejects.toThrow();
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
     expect(mocks.writeReport).not.toHaveBeenCalled();
   });
@@ -723,20 +671,9 @@ describe('headless delegation', () => {
       };
     });
 
-    const run = executeSubagentInBand({
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
-      parentExecutionId: 'parent-exec' as ExecutionId,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-      signal: controller.signal,
-      onCost,
-    });
+    const run = executeSubagentInBand(
+      delegationOptions({ signal: controller.signal, onCost }),
+    );
     await ready;
     controller.abort(new Error('Workflow stopped.'));
 
@@ -760,19 +697,9 @@ describe('headless delegation', () => {
     });
     mocks.writeResultMeta.mockReturnValueOnce(persistencePending);
 
-    const run = executeSubagentInBand({
-      configPayload: {
-        agent: 'review',
-        agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekT',
-      },
-      agentName: 'review',
-      parentExecutionId: 'parent-exec' as ExecutionId,
-      parentStreamId: 'parent-stream' as StreamTabId,
-      runtimeHost: runtimeHost(),
-      session: defaultSession(),
-      signal: controller.signal,
-    });
+    const run = executeSubagentInBand(
+      delegationOptions({ signal: controller.signal }),
+    );
     await vi.waitFor(() => {
       expect(mocks.writeResultMeta).toHaveBeenCalledOnce();
     });
@@ -796,19 +723,7 @@ describe('headless delegation', () => {
     controller.abort(new Error('Workflow already stopped.'));
 
     await expect(
-      executeSubagentInBand({
-        configPayload: {
-          agent: 'review',
-          agentCategory: AgentCategory.ToolUse,
-          model: 'deepseekT',
-        },
-        agentName: 'review',
-        parentExecutionId: 'parent-exec' as ExecutionId,
-        parentStreamId: 'parent-stream' as StreamTabId,
-        runtimeHost: runtimeHost(),
-        session: defaultSession(),
-        signal: controller.signal,
-      }),
+      executeSubagentInBand(delegationOptions({ signal: controller.signal })),
     ).rejects.toThrow('Workflow already stopped.');
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
@@ -818,15 +733,8 @@ describe('headless delegation', () => {
     // The delegation validates via getVisibleAgent and must hand the resolved
     // entry's source to executeAgent, so getAgentPath resolves the exact
     // (source, name) key instead of re-resolving the ambiguous bare name.
-    await withRunContext(
-      createRunContext({
-        runtimeHost: runtimeHost(),
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-        stopAfterCycle: true,
-      }),
-      () => callDelegateReview(),
+    await withRunContext(parentRunContext({ stopAfterCycle: true }), () =>
+      callDelegateReview(),
     );
 
     expect(mocks.executeAgent).toHaveBeenCalledWith(
@@ -840,15 +748,7 @@ describe('headless delegation', () => {
   });
 
   it('adds a substantive handoff requirement to tool-use subagent instructions', async () => {
-    await withRunContext(
-      createRunContext({
-        runtimeHost: runtimeHost(),
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-      }),
-      () => callDelegateReview(),
-    );
+    await withRunContext(parentRunContext(), () => callDelegateReview());
 
     expect(mocks.executeAgent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -896,16 +796,7 @@ describe('headless delegation', () => {
         tracker: {} as never,
         userInstruction: parentInstruction,
       },
-      () =>
-        withRunContext(
-          createRunContext({
-            runtimeHost: runtimeHost(),
-            streamId: 'parent-stream',
-            executionId: 'parent-exec',
-            model: 'deepseekT',
-          }),
-          () => callDelegateReview(),
-        ),
+      () => withRunContext(parentRunContext(), () => callDelegateReview()),
     );
 
     expect(mocks.executeAgent).toHaveBeenCalledWith(
@@ -951,15 +842,8 @@ describe('headless delegation', () => {
     const result = await withToolFileInteractionContext(
       { tracker: {} as never, hooks: { recordSubagentCost } },
       () =>
-        withRunContext(
-          createRunContext({
-            runtimeHost: runtimeHost(),
-            streamId: 'parent-stream',
-            executionId: 'parent-exec',
-            model: 'deepseekT',
-            stopAfterCycle: true,
-          }),
-          () => callDelegateReview(),
+        withRunContext(parentRunContext({ stopAfterCycle: true }), () =>
+          callDelegateReview(),
         ),
     );
 
@@ -991,15 +875,8 @@ describe('headless delegation', () => {
     const result = await withToolFileInteractionContext(
       { tracker: {} as never, hooks: { recordSubagentCost } },
       () =>
-        withRunContext(
-          createRunContext({
-            runtimeHost: runtimeHost(),
-            streamId: 'parent-stream',
-            executionId: 'parent-exec',
-            model: 'deepseekT',
-            stopAfterCycle: true,
-          }),
-          () => callDelegateReview(),
+        withRunContext(parentRunContext({ stopAfterCycle: true }), () =>
+          callDelegateReview(),
         ),
     );
 
@@ -1016,16 +893,7 @@ describe('headless delegation', () => {
 
     const result = await withToolFileInteractionContext(
       { tracker: {} as never, hooks: { recordSubagentCost } },
-      () =>
-        withRunContext(
-          createRunContext({
-            runtimeHost: runtimeHost(),
-            streamId: 'parent-stream',
-            executionId: 'parent-exec',
-            model: 'deepseekT',
-          }),
-          () => callDelegateReview(),
-        ),
+      () => withRunContext(parentRunContext(), () => callDelegateReview()),
     );
 
     expect(result.summary).toBe("Launched 'review' (async)");
@@ -1036,14 +904,8 @@ describe('headless delegation', () => {
   });
 
   it('keeps interactive delegations asynchronous', async () => {
-    const result = await withRunContext(
-      createRunContext({
-        runtimeHost: runtimeHost(),
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-      }),
-      () => callDelegateReview(),
+    const result = await withRunContext(parentRunContext(), () =>
+      callDelegateReview(),
     );
 
     expect(result.summary).toBe("Launched 'review' (async)");
@@ -1071,13 +933,7 @@ describe('headless delegation', () => {
 
     const session = sessionFor(host);
     const result = await withRunContext(
-      createRunContext({
-        runtimeHost: host,
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-        session,
-      }),
+      parentRunContext({ runtimeHost: host, session }),
       () => callDelegateReview(),
     );
     session.dispose();
@@ -1111,13 +967,7 @@ describe('headless delegation', () => {
 
     const session = sessionFor(host);
     const result = await withRunContext(
-      createRunContext({
-        runtimeHost: host,
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-        session,
-      }),
+      parentRunContext({ runtimeHost: host, session }),
       () => callDelegateReview(),
     );
     session.dispose();
@@ -1147,13 +997,7 @@ describe('headless delegation', () => {
 
     const session = sessionFor(host);
     const result = await withRunContext(
-      createRunContext({
-        runtimeHost: host,
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-        session,
-      }),
+      parentRunContext({ runtimeHost: host, session }),
       () => callDelegateReview(),
     );
     session.dispose();
@@ -1182,14 +1026,8 @@ describe('headless delegation', () => {
           : undefined,
     );
 
-    const result = await withRunContext(
-      createRunContext({
-        runtimeHost: runtimeHost(),
-        streamId: 'parent-stream',
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-      }),
-      () => callDelegateReview('chat'),
+    const result = await withRunContext(parentRunContext(), () =>
+      callDelegateReview('chat'),
     );
 
     expect(result.summary).toBe("Launched 'assistant' (async)");
@@ -1240,12 +1078,7 @@ describe('headless delegation', () => {
     );
 
     await withRunContext(
-      createRunContext({
-        runtimeHost: host,
-        streamId: parentStreamId,
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-      }),
+      parentRunContext({ runtimeHost: host, streamId: parentStreamId }),
       () => callDelegateReview(),
     );
 
@@ -1294,12 +1127,7 @@ describe('headless delegation', () => {
     );
 
     await withRunContext(
-      createRunContext({
-        runtimeHost: host,
-        streamId: parentStreamId,
-        executionId: 'parent-exec',
-        model: 'deepseekT',
-      }),
+      parentRunContext({ runtimeHost: host, streamId: parentStreamId }),
       () => callDelegateReview(),
     );
 

--- a/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts
@@ -124,6 +124,15 @@ async function writeSidecarTodos(
   );
 }
 
+/** Mocks the storage reads for a completed, non-subagent toolUse execution. */
+function mockCompletedExecution(): void {
+  mocks.readMeta.mockResolvedValue({
+    timestamp: '2026-06-15T09:36:02.345Z',
+    category: 'toolUse',
+  });
+  mocks.readConfig.mockResolvedValue(config);
+}
+
 describe('ExecutionsTool', () => {
   setupPlatform({}, { fs: nodeFilesystem });
 
@@ -356,11 +365,7 @@ describe('ExecutionsTool', () => {
           activeForm: 'Reading the sidecar work plan',
         },
       ]);
-      mocks.readMeta.mockResolvedValue({
-        timestamp: '2026-06-15T09:36:02.345Z',
-        category: 'toolUse',
-      });
-      mocks.readConfig.mockResolvedValue(config);
+      mockCompletedExecution();
       mocks.readTodos.mockResolvedValue([
         { content: 'Read the old KV todo', status: 'pending' },
       ]);
@@ -377,11 +382,7 @@ describe('ExecutionsTool', () => {
 
   it('falls back to legacy KV todos when completed summary sidecars are absent', async () => {
     await withTempStorage(async () => {
-      mocks.readMeta.mockResolvedValue({
-        timestamp: '2026-06-15T09:36:02.345Z',
-        category: 'toolUse',
-      });
-      mocks.readConfig.mockResolvedValue(config);
+      mockCompletedExecution();
       mocks.readTodos.mockResolvedValue([
         { content: 'Read the old KV todo', status: 'pending' },
       ]);
@@ -437,11 +438,7 @@ describe('ExecutionsTool', () => {
           activeForm: 'Doing the stale sidecar todo',
         },
       ]);
-      mocks.readMeta.mockResolvedValue({
-        timestamp: '2026-06-15T09:36:02.345Z',
-        category: 'toolUse',
-      });
-      mocks.readConfig.mockResolvedValue(config);
+      mockCompletedExecution();
       mocks.readTodos.mockResolvedValue([
         { content: 'Fresher legacy todo', status: 'completed' },
       ]);
@@ -476,11 +473,7 @@ describe('ExecutionsTool', () => {
       const sidecarMtime = (
         await StorageFS.stat(`${streamDataDir(streamId)}/workPlan.json`)
       ).mtime;
-      mocks.readMeta.mockResolvedValue({
-        timestamp: '2026-06-15T09:36:02.345Z',
-        category: 'toolUse',
-      });
-      mocks.readConfig.mockResolvedValue(config);
+      mockCompletedExecution();
       mocks.readTodos.mockResolvedValue([
         { content: 'Fresher legacy todo', status: 'completed' },
       ]);

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -13,6 +13,7 @@ import {
   WorkPlanState,
 } from '@agent/core/state/AgentWorkspaceState';
 import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import type { PlanApprovalResult } from '@agent/runtime/HostInteractions';
 import { planSummaryLine, type Plan, type StreamTabId } from '@shared/schemas';
 import { GOAL_FEATURE_FLAG_KEY } from '@shared/schemas/goal';
 import {
@@ -26,6 +27,7 @@ import {
   createRecordingHost,
   sessionWithInteractions,
   type RecordedProgressEvent,
+  type RecordingHostDecisions,
 } from '../agent/progressTestUtils';
 
 const plan: Plan = {
@@ -82,6 +84,18 @@ function findPlanApproval(
   return approval!;
 }
 
+/** Submits a plan-approval decision for the request the tool showed. */
+function submitPlanDecision(
+  decisions: RecordingHostDecisions,
+  approval: RecordedProgressEvent,
+  decision: PlanApprovalResult,
+): boolean {
+  return decisions.submitPlan(
+    (approval.payload as { approvalId: string }).approvalId,
+    decision,
+  );
+}
+
 describe('PlanTool — update (plan approval)', () => {
   it('keeps an approved plan in displayed work-plan state and defers steps to the todo tool', async () => {
     await installPlatform(false);
@@ -92,12 +106,9 @@ describe('PlanTool — update (plan approval)', () => {
 
     const approval = findPlanApproval(events);
     expect((approval.payload as { plan: Plan }).plan).toEqual(plan);
-    expect(
-      decisions.submitPlan(
-        (approval.payload as { approvalId: string }).approvalId,
-        { action: 'approve' },
-      ),
-    ).toBe(true);
+    expect(submitPlanDecision(decisions, approval, { action: 'approve' })).toBe(
+      true,
+    );
 
     const result = await resultPromise;
     expect(result.status).toBe('executed');
@@ -115,10 +126,10 @@ describe('PlanTool — update (plan approval)', () => {
 
     const approval = findPlanApproval(events);
     expect(
-      decisions.submitPlan(
-        (approval.payload as { approvalId: string }).approvalId,
-        { action: 'reject', feedback: 'Too broad.' },
-      ),
+      submitPlanDecision(decisions, approval, {
+        action: 'reject',
+        feedback: 'Too broad.',
+      }),
     ).toBe(true);
 
     const result = await resultPromise;
@@ -141,10 +152,9 @@ describe('PlanTool — update (plan approval)', () => {
         true,
       );
       expect(
-        decisions.submitPlan(
-          (approval.payload as { approvalId: string }).approvalId,
-          { action: 'approve_and_goal' },
-        ),
+        submitPlanDecision(decisions, approval, {
+          action: 'approve_and_goal',
+        }),
       ).toBe(true);
 
       const result = await resultPromise;
@@ -175,10 +185,9 @@ describe('PlanTool — update (plan approval)', () => {
     try {
       const approval = findPlanApproval(events);
       expect(
-        decisions.submitPlan(
-          (approval.payload as { approvalId: string }).approvalId,
-          { action: 'approve_and_goal' },
-        ),
+        submitPlanDecision(decisions, approval, {
+          action: 'approve_and_goal',
+        }),
       ).toBe(true);
 
       const result = await resultPromise;
@@ -216,10 +225,9 @@ describe('PlanTool — update (plan approval)', () => {
 
       (platform.config as FakeConfigProvider).set(GOAL_FEATURE_FLAG_KEY, false);
       expect(
-        decisions.submitPlan(
-          (approval.payload as { approvalId: string }).approvalId,
-          { action: 'approve_and_goal' },
-        ),
+        submitPlanDecision(decisions, approval, {
+          action: 'approve_and_goal',
+        }),
       ).toBe(true);
 
       const result = await resultPromise;
@@ -240,12 +248,9 @@ describe('PlanTool — update (plan approval)', () => {
     );
 
     const approval = findPlanApproval(events);
-    expect(
-      decisions.submitPlan(
-        (approval.payload as { approvalId: string }).approvalId,
-        { action: 'timeout' },
-      ),
-    ).toBe(true);
+    expect(submitPlanDecision(decisions, approval, { action: 'timeout' })).toBe(
+      true,
+    );
 
     const result = await resultPromise;
     expect(result.status).toBe('error');


### PR DESCRIPTION
## Summary

Simplify copy-paste-heavy fixtures in four `src/test-kernel/{tools,commands}` test files. No test scenarios, assertions, or coverage were removed; only repeated literal setup was factored into small local helpers used at their existing call sites, and each call site keeps its original overrides explicit.

- `src/test-kernel/tools/DelegationHeadless.vitest.mts`: added `parentRunContext(overrides)` and `delegationOptions(overrides)` to replace ~20 near-identical inline `createRunContext(...)` / `executeSubagentInBand({...})` literals scattered across the file's 32 test cases.
- `src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts`: added `submitPlanDecision(decisions, approval, decision)` to replace the repeated `decisions.submitPlan((approval.payload as {approvalId}).approvalId, ...)` cast used at all six approval-decision call sites.
- `src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts`: added `mockCompletedExecution()` to replace four identical `readMeta`/`readConfig` mock setups for a completed toolUse run (the two call sites with an extra `parentExecutionId` field were left inline, since their shape differs).
- `src/test-kernel/commands/history/chatExportFormatter.vitest.ts`: added `assistantChatInput(content)` to replace the `{timestamp, config: {}, messages: [{role: 'assistant', content}]}` wrapper repeated across 9 of the file's 11 cases; the two cases with a different message shape (`tool_calls` array, top-level `function_call` items) stay inline.

All of this is behavior-preserving: each helper simply returns the same literal previously written inline, with the varying fields passed through as parameters/overrides at each call site.

## Verification

- `npx tsc --noEmit -p tsconfig.test-kernel.json` from the worktree root — 3 pre-existing errors remain (`data-uri-to-buffer`, `acorn`, `acorn-walk` module-resolution failures from commits already on `origin/main`; the shared `node_modules` symlink hasn't been reinstalled since those deps were added). None of the 3 errors reference any file touched in this PR; reproduced identically on `origin/main` before this branch's commits.
- `npx vitest run --config vitest.config.mjs src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts src/test-kernel/commands/history/chatExportFormatter.vitest.ts` — 4 files, 74 tests, all passing.

Net diff vs `origin/main`: +249/-493 (4 files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors with no runtime paths touched; risk is limited to accidental fixture drift, which the unchanged assertions are meant to catch.
> 
> **Overview**
> This PR **only refactors test setup** in four `src/test-kernel` files—no production code, scenarios, or assertions change.
> 
> **`DelegationHeadless.vitest.mts`** adds `parentRunContext(overrides)` and `delegationOptions(overrides)` so dozens of inline `createRunContext` / `executeSubagentInBand` literals collapse to helpers with explicit per-test overrides.
> 
> **`chatExportFormatter.vitest.ts`** adds `assistantChatInput(content)` for the usual single-assistant-message export fixture; cases with `tool_calls` or top-level Responses shapes stay inline.
> 
> **`ExecutionsToolWorkspaceFiles.vitest.ts`** adds `mockCompletedExecution()` for the repeated completed `toolUse` `readMeta`/`readConfig` mock pair (four call sites; differing `parentExecutionId` setups unchanged).
> 
> **`PlanToolWorkPlanState.vitest.ts`** adds `submitPlanDecision(decisions, approval, decision)` to replace the repeated approval-id cast + `decisions.submitPlan` boilerplate at six plan-approval tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3535cded2b2df0fe03dc8e3b054b0eadd024bc96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->