### PR TITLE
refactor(tests): dedupe copy-pasted fixture setup in agent test-kernel

### DIFF
--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -52,6 +52,21 @@ const baseConfig = {
   toolConfig: DEFAULT_TOOL_CONFIG,
 } as AgentConfig;
 
+function resultMeta(outcome: string, response: string) {
+  return {
+    producer: 'subagent',
+    agentName: 'reviewer',
+    wallTimeMs: 20,
+    result: {
+      category: 'toolUse',
+      outcome,
+      response,
+      files: [],
+      cost: 0.1,
+    },
+  };
+}
+
 describe('execution lifecycle', () => {
   setupPlatform({ workspacePath: '/workspace/root' });
 
@@ -96,18 +111,9 @@ describe('execution lifecycle', () => {
       terminalStatus: EXECUTION_STATUS.COMPLETED,
       outcome: 'completed',
     });
-    mocks.readResultMeta.mockResolvedValue({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'Interim result.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    mocks.readResultMeta.mockResolvedValue(
+      resultMeta('completed', 'Interim result.'),
+    );
 
     await writeTerminalStatus(executionId, EXECUTION_STATUS.INTERRUPTED);
 
@@ -129,48 +135,21 @@ describe('execution lifecycle', () => {
       terminalStatus: EXECUTION_STATUS.INTERRUPTED,
       outcome: RUN_OUTCOME.CANCELLED,
     });
-    mocks.readResultMeta.mockResolvedValue({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.COMPLETED,
-        response: 'Interim result.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    mocks.readResultMeta.mockResolvedValue(
+      resultMeta(RUN_OUTCOME.COMPLETED, 'Interim result.'),
+    );
 
     await synchronizeAgentResultOutcome(executionId, RUN_OUTCOME.CANCELLED);
 
-    expect(mocks.writeResultMeta).toHaveBeenCalledWith({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: RUN_OUTCOME.CANCELLED,
-        response: 'Interim result.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    expect(mocks.writeResultMeta).toHaveBeenCalledWith(
+      resultMeta(RUN_OUTCOME.CANCELLED, 'Interim result.'),
+    );
   });
 
   it('does not change the result outcome when execution metadata is missing', async () => {
-    mocks.readResultMeta.mockResolvedValue({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'Finished.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    mocks.readResultMeta.mockResolvedValue(
+      resultMeta('completed', 'Finished.'),
+    );
 
     await synchronizeAgentResultOutcome(
       'missing-terminal-meta' as ExecutionId,
@@ -189,18 +168,9 @@ describe('execution lifecycle', () => {
       terminalStatus: EXECUTION_STATUS.COMPLETED,
       outcome: 'completed',
     });
-    mocks.readResultMeta.mockResolvedValue({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'Finished.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    mocks.readResultMeta.mockResolvedValue(
+      resultMeta('completed', 'Finished.'),
+    );
     mocks.writeMeta.mockRejectedValueOnce(new Error('disk full'));
 
     const executionId = 'failed-terminal-write' as ExecutionId;
@@ -333,18 +303,9 @@ describe('execution lifecycle', () => {
       timestamp: '2026-07-10T00:00:00.000Z',
       outcome: RUN_OUTCOME.CANCELLED,
     });
-    mocks.readResultMeta.mockResolvedValue({
-      producer: 'subagent',
-      agentName: 'reviewer',
-      wallTimeMs: 20,
-      result: {
-        category: 'toolUse',
-        outcome: 'completed',
-        response: 'Interim result.',
-        files: [],
-        cost: 0.1,
-      },
-    });
+    mocks.readResultMeta.mockResolvedValue(
+      resultMeta('completed', 'Interim result.'),
+    );
     mocks.writeResultMeta.mockRejectedValueOnce(error);
 
     try {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -82,6 +82,23 @@ const VALID_TOOL_USE_SHARED = {
 };
 type ToolUseSetupContext = Parameters<ToolUseFlowSetupCallback>[0];
 
+// Most flow-record fixtures below persist a fresh run/workspace snapshot
+// with only the current model and (occasionally) a transient override
+// varying between cases.
+function defaultStateSlices(
+  model = 'gpt54',
+  transient: Record<string, string> = {},
+) {
+  return {
+    runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
+    workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+    userChannels: {
+      input: Object.freeze({ MODEL: model }),
+      transient,
+    },
+  };
+}
+
 function createTaggedModelHandler(
   compatibilityKey: ModelHandlerCompatibilityKey,
 ): RunToolUseFlowInput['modelHandler'] {
@@ -207,14 +224,7 @@ describe('retrieveSessionResumeData', () => {
       shared: {
         messages: [],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: { MODEL: 'gpt55' },
-          },
-        },
+        stateSlices: defaultStateSlices('gpt54', { MODEL: 'gpt55' }),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -242,14 +252,7 @@ describe('retrieveSessionResumeData', () => {
       shared: {
         messages: [],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -281,14 +284,7 @@ describe('retrieveSessionResumeData', () => {
           },
         ],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gemini35f' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices('gemini35f'),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -322,14 +318,7 @@ describe('retrieveSessionResumeData', () => {
             },
           ],
           shouldSkipCycle: false,
-          stateSlices: {
-            runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-            workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-            userChannels: {
-              input: Object.freeze({ MODEL: 'gpt54' }),
-              transient: {},
-            },
-          },
+          stateSlices: defaultStateSlices(),
         },
       },
       createdAt: new Date().toISOString(),
@@ -367,14 +356,7 @@ describe('retrieveSessionResumeData', () => {
           { role: 'user', content: 'Continue the flat legacy conversation.' },
         ],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -403,14 +385,7 @@ describe('retrieveSessionResumeData', () => {
       shared: {
         messages: [],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -452,14 +427,7 @@ describe('retrieveSessionResumeData', () => {
       shared: {
         messages: [],
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       nodes: [],
@@ -939,14 +907,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         // Pass-through field the boundary's ToolUseSessionSnapshot contract
         // does not carry -- must survive the consumer's self-heal write.
         systemPrompt: 'You are a helpful assistant.',
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
     };
     await getExecutionStore(executionId).write(flowKey(executionId), {
@@ -1003,14 +964,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         messages: [{ role: 'user', content: 'Continue.' }],
         modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       cursor: { nextNodeId: WAIT_NODE_CURSOR },
@@ -1066,14 +1020,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         messages: [{ role: 'user', content: 'Continue.' }],
         modelHandlerCompatibilityKey: persistedCompatibilityKey,
         shouldSkipCycle: false,
-        stateSlices: {
-          runStateSnapshot: AgentRunStateSnapshotSchema.parse({}),
-          workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-          userChannels: {
-            input: Object.freeze({ MODEL: 'gpt54' }),
-            transient: {},
-          },
-        },
+        stateSlices: defaultStateSlices(),
       },
       createdAt: new Date().toISOString(),
       cursor: { nextNodeId: WAIT_NODE_CURSOR },

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -90,6 +90,14 @@ function parentContext(): LaunchRunContext {
   };
 }
 
+function defaultRunner(): ReturnType<typeof createWorkflowScriptAgentRunner> {
+  return createWorkflowScriptAgentRunner(
+    parentContext(),
+    'correct',
+    'tool-call-7',
+  );
+}
+
 function invocation(
   options: WorkflowAgentInvocation['options'] = {},
 ): WorkflowAgentInvocation {
@@ -122,13 +130,8 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('uses delegation policy and executes a direct in-band child', async () => {
-    const parent = parentContext();
     const call = invocation({ inputFiles: ['paper.tex'] });
-    const runner = createWorkflowScriptAgentRunner(
-      parent,
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await expect(runner(call)).resolves.toBe(result);
     expect(mocks.requireVisibleAgent).toHaveBeenCalledWith(
@@ -191,11 +194,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       relativePath: 'r1/draft.tex',
       executionId: 'bbbbbb222222',
     });
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await runner(
       invocation({
@@ -227,11 +226,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       kind: 'runStorage',
     });
     mocks.resolveChildRunOutput.mockResolvedValue(undefined);
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await runner(invocation({ inputFiles: [placeholder] }));
 
@@ -243,11 +238,7 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('uses one stable child id per workflow call identity', async () => {
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await runner(invocation());
     await runner(invocation());
@@ -273,11 +264,7 @@ describe('createWorkflowScriptAgentRunner', () => {
         cost: 0,
       },
     });
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await expect(runner(invocation())).rejects.toThrow(
       'Workflow subagent ended with cancelled outcome.',
@@ -288,11 +275,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     mocks.executeSubagentInBand.mockRejectedValueOnce(
       new SubagentReconciliationError('incomplete child state'),
     );
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await expect(runner(invocation())).rejects.toMatchObject({
       name: 'WorkflowRunAbortError',
@@ -306,11 +289,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       { cause: new Error('storage offline') },
     );
     mocks.executeSubagentInBand.mockRejectedValueOnce(durabilityError);
-    const runner = createWorkflowScriptAgentRunner(
-      parentContext(),
-      'correct',
-      'tool-call-7',
-    );
+    const runner = defaultRunner();
 
     await expect(runner(invocation())).rejects.toMatchObject({
       name: 'WorkflowRunAbortError',

--- a/src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts
+++ b/src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts
@@ -5,6 +5,7 @@ import {
   setToolUseSharedModel,
 } from '@agent/implementations/flows/tooluse/modelSwitchState';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
+import { toolUseRunShared } from '../progressTestUtils';
 
 describe('tool-use model switch state helpers', () => {
   it('prefers the transient model over the launch model', () => {
@@ -36,11 +37,6 @@ describe('tool-use model switch state helpers', () => {
   });
 
   it('returns false when the flow has not reached resumable state', () => {
-    expect(
-      setToolUseSharedModel(
-        { messages: [], shouldSkipCycle: false, stateSlices: null },
-        'gpt55',
-      ),
-    ).toBe(false);
+    expect(setToolUseSharedModel(toolUseRunShared(), 'gpt55')).toBe(false);
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -16,6 +16,29 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
+/**
+ * Fields identical across every `ToolUseRoundServices` fixture below --
+ * only `modelHandler`, `session`, `setting`, and `toolRegistry` vary per
+ * scenario, so those stay inline at each call site.
+ */
+function baseRoundServices(traceLabel: string) {
+  return {
+    checkInterruption: () => false,
+    client: {},
+    config: { agent: 'test-agent', model: 'test-model' },
+    fileService: {
+      createLocation: (filePath: string) => ({ absolutePath: filePath }),
+    },
+    logger: createRunTrace(traceLabel, StreamLogStore.ephemeral('test')).trace,
+    prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
+    run: AgentRunStateSnapshotSchema.parse({}),
+    setAbortController: () => {},
+    streamStatus: new StreamStatusMachine(),
+    userVarChannels: { input: {}, transient: {} },
+    workspace: AgentWorkspaceState.create(),
+  };
+}
+
 describe('ToolUseRoundFlow queued follow-ups', () => {
   it('attaches media from follow-ups queued at round start', async () => {
     const createUserFollowUpMessages = vi.fn(
@@ -28,16 +51,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     const addMediaToUserMessage = vi.fn(async () => []);
 
     const services = {
-      checkInterruption: () => false,
-      client: {},
-      config: { agent: 'test-agent', model: 'test-model' },
-      fileService: {
-        createLocation: (filePath: string) => ({ absolutePath: filePath }),
-      },
-      logger: createRunTrace(
-        'ToolUseRoundFollowUpMedia',
-        StreamLogStore.ephemeral('test'),
-      ).trace,
+      ...baseRoundServices('ToolUseRoundFollowUpMedia'),
       modelHandler: {
         addMediaToUserMessage,
         capabilities: { supportsVision: true },
@@ -45,8 +59,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
         createUserFollowUpMessages,
         setOutputStreaming: vi.fn(),
       },
-      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
-      run: AgentRunStateSnapshotSchema.parse({}),
       session: {
         hasQueuedFollowUp: () => true,
         waitForFollowUp: async () => ({
@@ -60,12 +72,8 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
           synthetic: false,
         }),
       },
-      setAbortController: () => {},
       setting: { temperature: 0, tools: [] },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({}),
-      userVarChannels: { input: {}, transient: {} },
-      workspace: AgentWorkspaceState.create(),
     } as unknown as ToolUseRoundServices;
 
     const shared = createShared([]);
@@ -165,16 +173,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     );
 
     const services = {
-      checkInterruption: () => false,
-      client: {},
-      config: { agent: 'test-agent', model: 'test-model' },
-      fileService: {
-        createLocation: (filePath: string) => ({ absolutePath: filePath }),
-      },
-      logger: createRunTrace(
-        'ToolUseRoundBlankToolResult',
-        StreamLogStore.ephemeral('test'),
-      ).trace,
+      ...baseRoundServices('ToolUseRoundBlankToolResult'),
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
@@ -213,14 +212,10 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
         processThinkingBlock: () => null,
         setOutputStreaming: vi.fn(),
       },
-      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
-      run: AgentRunStateSnapshotSchema.parse({}),
       session: {
         hasQueuedFollowUp: () => false,
       },
-      setAbortController: () => {},
       setting: { temperature: 0, tools: [{ name: 'again' }] },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         again: {
           call: vi.fn(async () => ({
@@ -230,8 +225,6 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
           definition: { name: 'again' },
         } as never,
       }),
-      userVarChannels: { input: {}, transient: {} },
-      workspace: AgentWorkspaceState.create(),
     } as unknown as ToolUseRoundServices;
 
     return { createResponse, createUserFollowUpMessages, services };
@@ -378,16 +371,7 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
     }));
 
     const services = {
-      checkInterruption: () => false,
-      client: {},
-      config: { agent: 'test-agent', model: 'test-model' },
-      fileService: {
-        createLocation: (filePath: string) => ({ absolutePath: filePath }),
-      },
-      logger: createRunTrace(
-        'ToolUseRoundSystemPrompt',
-        StreamLogStore.ephemeral('test'),
-      ).trace,
+      ...baseRoundServices('ToolUseRoundSystemPrompt'),
       modelHandler: {
         addMediaToUserMessage: vi.fn(async () => []),
         capabilities: { supportsVision: true },
@@ -414,15 +398,9 @@ describe('ToolUseRoundFlow queued follow-ups', () => {
         requiresPerCallSystemPrompt,
         setOutputStreaming: vi.fn(),
       },
-      prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
-      run: AgentRunStateSnapshotSchema.parse({}),
       session: { hasQueuedFollowUp: () => false },
-      setAbortController: () => {},
       setting: { temperature: 0, tools: [] },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({}),
-      userVarChannels: { input: {}, transient: {} },
-      workspace: AgentWorkspaceState.create(),
     } as unknown as ToolUseRoundServices;
 
     return { createResponse, services };

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -36,6 +36,7 @@ import { GoalStore } from '@tools/goal';
 import {
   recordSessionEvents,
   runEventsOfType,
+  toolUseRunShared,
   withTestRunContext,
 } from '../progressTestUtils';
 
@@ -95,11 +96,7 @@ function createWaitNodeServices(
 
 describe('ToolUseWaitNode', () => {
   it('always suspends a subagent cycle at WAITING, carrying its turn facts', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
 
@@ -140,11 +137,7 @@ describe('ToolUseWaitNode', () => {
     // and symmetrically. A follow-up already queued is the child-run loop's
     // concern (it resumes immediately instead of genuinely waiting) — not
     // something the flow itself should special-case.
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
 
@@ -167,11 +160,7 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('advances a drained child-loop batch once without reading the session queue', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const waitForFollowUp = vi.fn();
     const createUserFollowUpMessages = vi.fn(
@@ -236,11 +225,7 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('stops instead of suspending when stopAfterCycle is set (headless in-band subagent)', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
 
     const services = createWaitNodeServices({
@@ -264,11 +249,7 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('stops immediately on interruption instead of suspending a subagent', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
 
     const services = createWaitNodeServices({
@@ -292,11 +273,9 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('fires the root-only onIdle notification every cycle without suspending', async () => {
-    const shared: ToolUseRunShared = {
+    const shared: ToolUseRunShared = toolUseRunShared({
       messages: [{ role: 'assistant', content: 'partial response' } as never],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    });
     const onIdle = vi.fn();
     const runtimeHost = { emit: vi.fn() };
     let waitCalls = 0;
@@ -323,11 +302,7 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('warns when follow-up media cannot be attached to a non-vision model', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const info = vi.fn();
     const warn = vi.fn();
     const addMediaToUserMessage = vi.fn(async () => []);
@@ -385,11 +360,7 @@ describe('ToolUseWaitNode', () => {
   });
 
   it('logs follow-up markers reported by provider insertion', async () => {
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const info = vi.fn();
     const runtimeHost = { emit: vi.fn() };
     const logger = Object.assign(new TraceEmitter(), {
@@ -443,12 +414,9 @@ describe('ToolUseWaitNode', () => {
 
     await GoalStore.start(streamId, 'finish the refactor');
 
-    const shared: ToolUseRunShared = {
+    const shared: ToolUseRunShared = toolUseRunShared({
       lastError: { message: 'cycle failed', userRetryable: false },
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    });
     const runtimeHost = { emit: vi.fn() };
     const logger = new TraceEmitter();
     const hub = new SessionEventHub();
@@ -510,11 +478,7 @@ describe('ToolUseWaitNode', () => {
 
     await GoalStore.start(streamId, 'Finish the autonomous proof audit.');
 
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const createUserFollowUpMessages = vi.fn(
       async (
         messages: ProviderMessage[],
@@ -594,11 +558,7 @@ describe('ToolUseWaitNode', () => {
       'Keep solving the hard problem until verification is complete.',
     );
 
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const createUserFollowUpMessages = vi.fn(
       async (
         messages: ProviderMessage[],
@@ -744,11 +704,7 @@ describe('ToolUseWaitNode', () => {
   it('updates the injected stream status owner while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
     const streamStatus = new StreamStatusMachine();
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const createUserFollowUpMessages = vi.fn(async () => []);
     const runtimeHost = { emit: vi.fn() };
     const services = createWaitNodeServices({

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -8,7 +8,7 @@ import type {
   WaitExecResult,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import { withTestRunContext } from '../progressTestUtils';
+import { toolUseRunShared, withTestRunContext } from '../progressTestUtils';
 
 function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},
@@ -46,11 +46,7 @@ describe('ToolUseWaitNode follow-up transcript logging (regression: #7508 patter
       >
     ).mockRejectedValue(new Error('follow-up append failed'));
     const node = new ToolUseWaitNode().setServices(services);
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const execRes: WaitExecResult = {
       kind: 'continue',
@@ -72,11 +68,7 @@ describe('ToolUseWaitNode follow-up transcript logging (regression: #7508 patter
   it('still logs exactly once per follow-up on the success path', async () => {
     const services = buildServices();
     const node = new ToolUseWaitNode().setServices(services);
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const execRes: WaitExecResult = {
       kind: 'continue',
@@ -98,11 +90,7 @@ describe('ToolUseWaitNode follow-up transcript logging (regression: #7508 patter
       >
     ).mockRejectedValue(new Error('boom'));
     const node = new ToolUseWaitNode().setServices(services);
-    const shared: ToolUseRunShared = {
-      messages: [],
-      shouldSkipCycle: false,
-      stateSlices: null,
-    };
+    const shared: ToolUseRunShared = toolUseRunShared();
     const runtimeHost = { emit: vi.fn() };
     const execRes: WaitExecResult = {
       kind: 'continue',

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -82,6 +82,15 @@ function outputFile(
   };
 }
 
+/** Seeds a single round-0 `main.tex` output -- the common single-file case. */
+function seedMainTexOutput(executionId: ExecutionId) {
+  const outputState = createOutputState();
+  ensureRoundData(outputState, 0).outputs = [
+    outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
+  ];
+  return outputState;
+}
+
 function logger(): AgentTrace {
   return {
     debug: vi.fn(),
@@ -117,10 +126,7 @@ describe('runCompileCheck', () => {
     // before compileLatex2Pdf is ever invoked.
     await initLatexPlatform({});
 
-    const outputState = createOutputState();
-    ensureRoundData(outputState, 0).outputs = [
-      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
-    ];
+    const outputState = seedMainTexOutput(executionId);
 
     const result = await runCompileCheck(
       {
@@ -196,10 +202,7 @@ describe('runCompileCheck', () => {
     ).join('\n');
     mocks.compileLatex2Pdf.mockResolvedValue({ ok: false, logTail });
 
-    const outputState = createOutputState();
-    ensureRoundData(outputState, 0).outputs = [
-      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
-    ];
+    const outputState = seedMainTexOutput(executionId);
 
     const result = await runCompileCheck(
       {
@@ -242,10 +245,7 @@ describe('runCompileCheck', () => {
       logTail: lines.join('\n'),
     });
 
-    const outputState = createOutputState();
-    ensureRoundData(outputState, 0).outputs = [
-      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
-    ];
+    const outputState = seedMainTexOutput(executionId);
 
     const result = await runCompileCheck(
       {
@@ -281,10 +281,7 @@ describe('runCompileCheck', () => {
       logTail: 'stale failure log',
     });
 
-    const outputState = createOutputState();
-    ensureRoundData(outputState, 0).outputs = [
-      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
-    ];
+    const outputState = seedMainTexOutput(executionId);
     const ctx = {
       fileService: new TaskRunFileService(executionId),
       outputState,
@@ -327,10 +324,7 @@ describe('runCompileCheck', () => {
       [legacyLogPath]: 'Compile check failed for main.tex (pre-upgrade)\n',
     });
 
-    const outputState = createOutputState();
-    ensureRoundData(outputState, 0).outputs = [
-      outputFile(executionId, path.join('r0', 'main.tex'), 'main.tex', 0),
-    ];
+    const outputState = seedMainTexOutput(executionId);
 
     const result = await runCompileCheck(
       {

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -1,5 +1,6 @@
 // Local imports
 import type { AgentEvent } from '@agent/trace';
+import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   matchesCancelSelector,
@@ -74,6 +75,21 @@ export function sessionFactPayloads<T extends SessionFact['type']>(
     payloads.push(entry.event.payload);
   }
   return payloads;
+}
+
+/**
+ * The `ToolUseRunShared` baseline every wait/round node test starts from:
+ * no messages, no pending cycle skip, no persisted state slices yet.
+ */
+export function toolUseRunShared(
+  overrides: Partial<ToolUseRunShared> = {},
+): ToolUseRunShared {
+  return {
+    messages: [],
+    shouldSkipCycle: false,
+    stateSlices: null,
+    ...overrides,
+  };
 }
 
 export function runEventsOfType<T extends AgentEvent['type']>(

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -14,6 +14,7 @@ import {
   collectReviewDiff,
   isPathInChangeSet,
   listBaseBranchCandidates,
+  type CollectReviewDiffOptions,
 } from '@agent/review/reviewDiff';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -93,25 +94,33 @@ describe('collectReviewDiff (real git repository)', () => {
     await rm(repo, { recursive: true, force: true });
   });
 
+  /** Runs `collectReviewDiff` against the fixture repo and unwraps a success. */
+  async function collectDiffOrFail(
+    options: Partial<CollectReviewDiffOptions> & { includeUntracked: boolean },
+  ) {
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeSubmodules: true,
+      ...options,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected collectReviewDiff to succeed');
+    return result.value;
+  }
+
   it('diffs a feature branch against main and includes untracked files', async () => {
     await git('checkout', '-b', 'feature');
     await writeFile(path.join(repo, 'paper.tex'), 'changed line\n');
     await writeFile(path.join(repo, 'scratch.txt'), 'untracked content\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: true,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseDescription).toBe('main branch (main)');
-    expect(result.value.diff).toContain('-original line');
-    expect(result.value.diff).toContain('+changed line');
-    expect(result.value.diff).toContain('+untracked content');
-    expect(result.value.changedFiles).toEqual(['paper.tex', 'scratch.txt']);
-    expect(result.value.truncated).toBe(false);
-    expect(await realpath(result.value.repoRoot)).toBe(await realpath(repo));
+    const value = await collectDiffOrFail({ includeUntracked: true });
+    expect(value.baseDescription).toBe('main branch (main)');
+    expect(value.diff).toContain('-original line');
+    expect(value.diff).toContain('+changed line');
+    expect(value.diff).toContain('+untracked content');
+    expect(value.changedFiles).toEqual(['paper.tex', 'scratch.txt']);
+    expect(value.truncated).toBe(false);
+    expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
   });
 
   it('ignores inherited interactive git environment variables', async () => {
@@ -123,12 +132,7 @@ describe('collectReviewDiff (real git repository)', () => {
       await git('checkout', '-b', 'feature');
       await writeFile(path.join(repo, 'paper.tex'), 'changed line\n');
 
-      const result = await collectReviewDiff({
-        cwd: repo,
-        includeUntracked: false,
-        includeSubmodules: true,
-      });
-      expect(result.ok).toBe(true);
+      await collectDiffOrFail({ includeUntracked: false });
     } finally {
       if (previousPager === undefined) delete process.env.PAGER;
       else process.env.PAGER = previousPager;
@@ -145,19 +149,13 @@ describe('collectReviewDiff (real git repository)', () => {
       `start-of-big-file\n${'x'.repeat(300 * 1024)}\n`,
     );
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: true,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.diff).toContain('+start-of-big-file');
+    const value = await collectDiffOrFail({ includeUntracked: true });
+    expect(value.diff).toContain('+start-of-big-file');
     // The 200 KB per-file prefix exceeds the overall diff cap, so the
     // global truncation applies and the result stays bounded.
-    expect(result.value.truncated).toBe(true);
-    expect(result.value.diff).toContain('[... diff truncated for review]');
-    expect(result.value.diff.length).toBeLessThan(200 * 1024);
+    expect(value.truncated).toBe(true);
+    expect(value.diff).toContain('[... diff truncated for review]');
+    expect(value.diff.length).toBeLessThan(200 * 1024);
   });
 
   it('falls back to the origin remote-tracking branch when no local main exists', async () => {
@@ -168,15 +166,9 @@ describe('collectReviewDiff (real git repository)', () => {
     await git('branch', '-D', 'main');
     await writeFile(path.join(repo, 'paper.tex'), 'changed line\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: false,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseDescription).toBe('main branch (origin/main)');
-    expect(result.value.diff).toContain('+changed line');
+    const value = await collectDiffOrFail({ includeUntracked: false });
+    expect(value.baseDescription).toBe('main branch (origin/main)');
+    expect(value.diff).toContain('+changed line');
   });
 
   it('resolves the repository root when run from a subdirectory', async () => {
@@ -184,60 +176,39 @@ describe('collectReviewDiff (real git repository)', () => {
     await mkdir(path.join(repo, 'sub'));
     await writeFile(path.join(repo, 'sub', 'note.txt'), 'untracked content\n');
 
-    const result = await collectReviewDiff({
+    const value = await collectDiffOrFail({
       cwd: path.join(repo, 'sub'),
       includeUntracked: true,
-      includeSubmodules: true,
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(await realpath(result.value.repoRoot)).toBe(await realpath(repo));
-    expect(result.value.changedFiles).toEqual(['sub/note.txt']);
+    expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
+    expect(value.changedFiles).toEqual(['sub/note.txt']);
   });
 
   it('omits untracked files when disabled', async () => {
     await git('checkout', '-b', 'feature');
     await writeFile(path.join(repo, 'scratch.txt'), 'untracked content\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: false,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.diff).toBe('');
-    expect(result.value.changedFiles).toEqual([]);
+    const value = await collectDiffOrFail({ includeUntracked: false });
+    expect(value.diff).toBe('');
+    expect(value.changedFiles).toEqual([]);
   });
 
   it('reviews uncommitted changes when on the main branch', async () => {
     await writeFile(path.join(repo, 'paper.tex'), 'edited on main\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: false,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseDescription).toContain('uncommitted changes');
-    expect(result.value.diff).toContain('+edited on main');
+    const value = await collectDiffOrFail({ includeUntracked: false });
+    expect(value.baseDescription).toContain('uncommitted changes');
+    expect(value.diff).toContain('+edited on main');
   });
 
   it('reviews the latest commit when on main with a clean tree', async () => {
     await writeFile(path.join(repo, 'paper.tex'), 'committed on main\n');
     await git('commit', '-am', 'second');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: false,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseDescription).toContain('latest commit');
-    expect(result.value.diff).toContain('+committed on main');
-    expect(result.value.diff).toContain('-original line');
+    const value = await collectDiffOrFail({ includeUntracked: false });
+    expect(value.baseDescription).toContain('latest commit');
+    expect(value.diff).toContain('+committed on main');
+    expect(value.diff).toContain('-original line');
   });
 
   it('diffs against a chosen base branch (merge-base) from the picker', async () => {
@@ -251,20 +222,16 @@ describe('collectReviewDiff (real git repository)', () => {
     await git('checkout', '-b', 'feature');
     await writeFile(path.join(repo, 'paper.tex'), 'feature line\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
+    const value = await collectDiffOrFail({
       includeUntracked: false,
-      includeSubmodules: true,
       baseBranch: 'develop',
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
     // Merge-base with develop is the initial commit, so develop's own work
     // is not part of the review — only the feature change is.
-    expect(result.value.baseDescription).toBe('branch develop');
-    expect(result.value.diff).toContain('+feature line');
-    expect(result.value.diff).not.toContain('develop work');
-    expect(result.value.changedFiles).toEqual(['paper.tex']);
+    expect(value.baseDescription).toBe('branch develop');
+    expect(value.diff).toContain('+feature line');
+    expect(value.diff).not.toContain('develop work');
+    expect(value.changedFiles).toEqual(['paper.tex']);
   });
 
   it('diffs against an explicitly chosen remote ref even on the matching local branch', async () => {
@@ -275,18 +242,14 @@ describe('collectReviewDiff (real git repository)', () => {
     await writeFile(path.join(repo, 'paper.tex'), 'second unpushed commit\n');
     await git('commit', '-am', 'second unpushed');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
+    const value = await collectDiffOrFail({
       includeUntracked: false,
-      includeSubmodules: true,
       baseBranch: 'origin/main',
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseDescription).toBe('branch origin/main');
-    expect(result.value.diff).toContain('+first unpushed commit');
-    expect(result.value.diff).toContain('+second unpushed commit');
-    expect(result.value.changedFiles).toEqual(['notes.txt', 'paper.tex']);
+    expect(value.baseDescription).toBe('branch origin/main');
+    expect(value.diff).toContain('+first unpushed commit');
+    expect(value.diff).toContain('+second unpushed commit');
+    expect(value.changedFiles).toEqual(['notes.txt', 'paper.tex']);
   });
 
   it('fails clearly when the chosen base branch does not exist', async () => {
@@ -312,31 +275,21 @@ describe('collectReviewDiff (real git repository)', () => {
     await git('commit', '-am', 'second');
     await writeFile(path.join(repo, 'notes.txt'), 'dirty after commit\n');
 
-    const result = await collectReviewDiff({
-      cwd: repo,
+    const value = await collectDiffOrFail({
       includeUntracked: false,
-      includeSubmodules: true,
       baseRef: previousHead,
       baseDescription: 'previous commit on main',
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.baseRef).toBe(previousHead);
-    expect(result.value.baseDescription).toBe('previous commit on main');
-    expect(result.value.diff).toContain('+committed on main');
-    expect(result.value.diff).toContain('+dirty after commit');
-    expect(result.value.changedFiles).toEqual(['notes.txt', 'paper.tex']);
+    expect(value.baseRef).toBe(previousHead);
+    expect(value.baseDescription).toBe('previous commit on main');
+    expect(value.diff).toContain('+committed on main');
+    expect(value.diff).toContain('+dirty after commit');
+    expect(value.changedFiles).toEqual(['notes.txt', 'paper.tex']);
   });
 
   it('reports no changes on main with a clean tree and no parent commit', async () => {
-    const result = await collectReviewDiff({
-      cwd: repo,
-      includeUntracked: false,
-      includeSubmodules: true,
-    });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.diff).toBe('');
+    const value = await collectDiffOrFail({ includeUntracked: false });
+    expect(value.diff).toBe('');
   });
 
   it('fails with a reason outside a git repository', async () => {


### PR DESCRIPTION
## Summary

Sweep of `src/test-kernel/agent/**` (excluding `modelHandlers/` and `runtime/`) to remove copy-pasted setup blocks. All changes extract a small local helper that reproduces the exact object each call site built before; no assertions were changed, weakened, or removed.

- `progressTestUtils.ts`: added `toolUseRunShared()`, the `{ messages: [], shouldSkipCycle: false, stateSlices: null }` baseline that was duplicated 14 times across `ToolUseWaitNode.vitest.ts`, `ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts`, and `ModelSwitchState.vitest.ts`.
- `RegisterExecutionWorkspaceDirectory.vitest.ts`: `resultMeta(outcome, response)` replaces 5 copy-pasted `readResultMeta` payloads.
- `SessionResumeRetrieval.vitest.ts`: `defaultStateSlices(model, transient)` replaces 10 copy-pasted `stateSlices` fixtures (the 3 cases with custom run/workspace snapshots stay inline).
- `WorkflowScriptAgentRunner.vitest.ts`: `defaultRunner()` replaces 7 identical `createWorkflowScriptAgentRunner(parentContext(), 'correct', 'tool-call-7')` calls.
- `ToolUseRoundFollowUpMedia.vitest.ts`: `baseRoundServices(traceLabel)` factors out the `ToolUseRoundServices` fields identical across all three fixtures, leaving only `modelHandler`/`session`/`setting`/`toolRegistry` inline per scenario.
- `output/CompileCheck.vitest.ts`: `seedMainTexOutput(executionId)` replaces 5 copy-pasted single-file round-0 output-state setups (the chunk.tex, two-file collision, and relativePath-reuse cases stay inline).
- `review/AgentReviewDiff.vitest.ts`: `collectDiffOrFail(options)` replaces the `collectReviewDiff` + `expect(result.ok).toBe(true)` + narrowing-return boilerplate repeated at 10 call sites (the two `ok: false` cases are untouched).

Net: 10 files changed, +215/-447 (-232 LoC).

## Verification

- `npx tsc --noEmit -p tsconfig.test-kernel.json` -- clean except one pre-existing, out-of-lane error (`src/agent/modelHandlers/openai/openAIResponseFileUploads.ts` cannot find `data-uri-to-buffer`), confirmed present on `origin/main` before any of these changes and unrelated to this lane.
- `npx vitest run --config vitest.config.mjs <all 9 touched test files>` -- 107/107 tests passing.

## Notes

This worktree's `node_modules` is a symlink into the primary checkout, which predates `origin/main`'s recently-added `acorn` dependency (#8519). Rebasing this branch onto current `origin/main` therefore breaks module resolution for two unrelated files (`WorkflowScriptAgentRunner.vitest.ts`, `SessionResumeRetrieval.vitest.ts`) purely as a local-environment artifact -- not a real conflict. This PR is intentionally left based a few commits behind `origin/main` (no overlapping files) so every change here stays fully verified; a normal merge/rebase at merge time will pick up `acorn` from a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactoring with behavior-preserving helpers; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR **deduplicates repeated test setup** under `src/test-kernel/agent/**` by extracting small local helpers that build the same objects each call site used before. **No production code changes** and **no assertion changes**—only less boilerplate (~232 fewer lines).
> 
> Shared additions include **`toolUseRunShared()`** in `progressTestUtils.ts` for the default `ToolUseRunShared` baseline (replacing many inline `{ messages: [], shouldSkipCycle: false, stateSlices: null }` blocks), plus file-specific helpers: **`resultMeta`**, **`defaultStateSlices`**, **`defaultRunner`**, **`baseRoundServices`**, **`seedMainTexOutput`**, and **`collectDiffOrFail`** for review-diff success paths. Cases that need custom snapshots or failure paths stay inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157981b9296440b6123e6389dd261f50dabed9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->