### PR TITLE
refactor(tests): dedupe boilerplate in controllers/progressView test suites

### DIFF
--- a/src/test-kernel/controllers/AgentRosterController.vitest.ts
+++ b/src/test-kernel/controllers/AgentRosterController.vitest.ts
@@ -323,7 +323,7 @@ describe('AgentRosterController', () => {
     });
   });
 
-  it('matches source-qualified custom selections by exact identity', async () => {
+  it('matches source-qualified custom selections by exact identity', () => {
     const duplicateAgents: Record<AgentCategory, AgentRosterEntry[]> = {
       workflow: [],
       toolUse: [

--- a/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
+++ b/src/test-kernel/controllers/OnboardingFunnel.vitest.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   deriveOnboardingFunnelState,
   planOnboardingFunnelTransition,
+  type OnboardingFunnelInputs,
+  type OnboardingFunnelState,
+  type OnboardingFunnelTransition,
 } from '@controllers/onboarding/onboardingFunnel';
 import {
   backfillFirstRunDone,
@@ -29,173 +32,105 @@ function fakeStateStore(initial: Record<string, unknown> = {}): StateStore {
 }
 
 describe('deriveOnboardingFunnelState', () => {
-  it('is needs-credential only without a credential and without a decline', () => {
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: false,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toBe('needs-credential');
-  });
-
-  it('a deliberate skip suppresses State 0', () => {
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: false,
-        declined: true,
-        firstRunDone: false,
-      }),
-    ).toBe('done');
-  });
-
-  it('credential present + first run pending → setup owns the session', () => {
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: true,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toBe('setup');
-    // A stale declined flag never blocks State 1 once a credential exists.
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: true,
-        declined: true,
-        firstRunDone: false,
-      }),
-    ).toBe('setup');
-  });
-
-  it('a completed first run means the normal product', () => {
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: true,
-        declined: false,
-        firstRunDone: true,
-      }),
-    ).toBe('done');
-    expect(
-      deriveOnboardingFunnelState({
-        hasCredential: false,
-        declined: false,
-        firstRunDone: true,
-      }),
-    ).toBe('done');
+  it.each<[string, OnboardingFunnelInputs, OnboardingFunnelState]>([
+    [
+      'is needs-credential only without a credential and without a decline',
+      { hasCredential: false, declined: false, firstRunDone: false },
+      'needs-credential',
+    ],
+    [
+      'a deliberate skip suppresses State 0',
+      { hasCredential: false, declined: true, firstRunDone: false },
+      'done',
+    ],
+    [
+      'credential present + first run pending → setup owns the session',
+      { hasCredential: true, declined: false, firstRunDone: false },
+      'setup',
+    ],
+    [
+      'a stale declined flag never blocks State 1 once a credential exists',
+      { hasCredential: true, declined: true, firstRunDone: false },
+      'setup',
+    ],
+    [
+      'a completed first run with a credential means the normal product',
+      { hasCredential: true, declined: false, firstRunDone: true },
+      'done',
+    ],
+    [
+      'a completed first run without a credential means the normal product',
+      { hasCredential: false, declined: false, firstRunDone: true },
+      'done',
+    ],
+  ])('%s', (_name, inputs, expected) => {
+    expect(deriveOnboardingFunnelState(inputs)).toBe(expected);
   });
 });
 
 describe('planOnboardingFunnelTransition', () => {
-  it('in-session State 0 → 1: selects the setup agent but never auto-runs', () => {
-    expect(
-      planOnboardingFunnelTransition('needs-credential', {
-        hasCredential: true,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'setup',
-      selectSetupAgent: true,
-      clearDeclined: false,
-    });
-  });
-
-  it('plain activation in State 1 (previous undefined): selects but never auto-runs', () => {
-    expect(
-      planOnboardingFunnelTransition(undefined, {
-        hasCredential: true,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'setup',
-      selectSetupAgent: true,
-      clearDeclined: false,
-    });
-  });
-
-  it('a refresh already in State 1 never re-selects (user agent switches survive)', () => {
-    expect(
-      planOnboardingFunnelTransition('setup', {
-        hasCredential: true,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'setup',
-      selectSetupAgent: false,
-      clearDeclined: false,
-    });
-  });
-
-  it('skipped user who later configures a credential: re-enters State 1, clears the skip, no auto-run', () => {
-    expect(
-      planOnboardingFunnelTransition('done', {
-        hasCredential: true,
-        declined: true,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'setup',
-      selectSetupAgent: true,
-      clearDeclined: true,
-    });
-  });
-
-  it('first run already done: credential arrival lands in State 2 with no setup actions', () => {
-    expect(
-      planOnboardingFunnelTransition('needs-credential', {
-        hasCredential: true,
-        declined: false,
-        firstRunDone: true,
-      }),
-    ).toEqual({
-      state: 'done',
-      selectSetupAgent: false,
-      clearDeclined: false,
-    });
-  });
-
-  it('first run already done: missing credentials stay in State 2', () => {
-    expect(
-      planOnboardingFunnelTransition('needs-credential', {
-        hasCredential: false,
-        declined: false,
-        firstRunDone: true,
-      }),
-    ).toEqual({
-      state: 'done',
-      selectSetupAgent: false,
-      clearDeclined: false,
-    });
-  });
-
-  it('State 0 holds while no credential exists', () => {
-    expect(
-      planOnboardingFunnelTransition('needs-credential', {
-        hasCredential: false,
-        declined: false,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'needs-credential',
-      selectSetupAgent: false,
-      clearDeclined: false,
-    });
-  });
-
-  it('skip while in State 0: moves to done without setup actions', () => {
-    expect(
-      planOnboardingFunnelTransition('needs-credential', {
-        hasCredential: false,
-        declined: true,
-        firstRunDone: false,
-      }),
-    ).toEqual({
-      state: 'done',
-      selectSetupAgent: false,
-      clearDeclined: false,
-    });
+  it.each<
+    [
+      string,
+      OnboardingFunnelState | undefined,
+      OnboardingFunnelInputs,
+      OnboardingFunnelTransition,
+    ]
+  >([
+    [
+      'in-session State 0 → 1: selects the setup agent but never auto-runs',
+      'needs-credential',
+      { hasCredential: true, declined: false, firstRunDone: false },
+      { state: 'setup', selectSetupAgent: true, clearDeclined: false },
+    ],
+    [
+      'plain activation in State 1 (previous undefined): selects but never auto-runs',
+      undefined,
+      { hasCredential: true, declined: false, firstRunDone: false },
+      { state: 'setup', selectSetupAgent: true, clearDeclined: false },
+    ],
+    [
+      'a refresh already in State 1 never re-selects (user agent switches survive)',
+      'setup',
+      { hasCredential: true, declined: false, firstRunDone: false },
+      { state: 'setup', selectSetupAgent: false, clearDeclined: false },
+    ],
+    [
+      'skipped user who later configures a credential: re-enters State 1, clears the skip, no auto-run',
+      'done',
+      { hasCredential: true, declined: true, firstRunDone: false },
+      { state: 'setup', selectSetupAgent: true, clearDeclined: true },
+    ],
+    [
+      'first run already done: credential arrival lands in State 2 with no setup actions',
+      'needs-credential',
+      { hasCredential: true, declined: false, firstRunDone: true },
+      { state: 'done', selectSetupAgent: false, clearDeclined: false },
+    ],
+    [
+      'first run already done: missing credentials stay in State 2',
+      'needs-credential',
+      { hasCredential: false, declined: false, firstRunDone: true },
+      { state: 'done', selectSetupAgent: false, clearDeclined: false },
+    ],
+    [
+      'State 0 holds while no credential exists',
+      'needs-credential',
+      { hasCredential: false, declined: false, firstRunDone: false },
+      {
+        state: 'needs-credential',
+        selectSetupAgent: false,
+        clearDeclined: false,
+      },
+    ],
+    [
+      'skip while in State 0: moves to done without setup actions',
+      'needs-credential',
+      { hasCredential: false, declined: true, firstRunDone: false },
+      { state: 'done', selectSetupAgent: false, clearDeclined: false },
+    ],
+  ])('%s', (_name, previous, inputs, expected) => {
+    expect(planOnboardingFunnelTransition(previous, inputs)).toEqual(expected);
   });
 });
 

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -137,41 +137,35 @@ function parseSendFollowUpMessage(message: unknown): SendFollowUpMessage {
   return parsed;
 }
 
+function expectDispatched(
+  message: ProgressViewInboundMessage,
+  handlers: ProgressViewInboundHandlerRegistry,
+): void {
+  expect(dispatchProgressViewInbound(message, handlers)).toBe(true);
+}
+
 describe('createProgressViewCommandHandlers', () => {
   it('routes lifecycle commands to host actions', () => {
     const actions = createActions();
     const handlers = createProgressViewCommandHandlers(actions);
 
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, stream: 'stream-a' },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS, filter: 'all' },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM, stream: 'stream-b' },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.STOP_STREAM, stream: 'stream-c' },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, stream: 'stream-a' },
+      handlers,
+    );
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS, filter: 'all' },
+      handlers,
+    );
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM, stream: 'stream-b' },
+      handlers,
+    );
+    expectDispatched({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL }, handlers);
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.STOP_STREAM, stream: 'stream-c' },
+      handlers,
+    );
 
     expect(actions.lifecycle.setActiveStream).toHaveBeenCalledWith('stream-a');
     expect(actions.lifecycle.setAgentFilter).toHaveBeenCalledWith('all');
@@ -184,18 +178,14 @@ describe('createProgressViewCommandHandlers', () => {
     const actions = createActions();
     const handlers = createProgressViewCommandHandlers(actions);
 
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.RESUME, stream: 'stream-a' },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.RUN_NEW, stream: 'stream-b' },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.RESUME, stream: 'stream-a' },
+      handlers,
+    );
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.RUN_NEW, stream: 'stream-b' },
+      handlers,
+    );
 
     expect(actions.run.resumeStream).toHaveBeenCalledWith('stream-a');
     expect(actions.run.runNewStream).toHaveBeenCalledWith('stream-b');
@@ -205,91 +195,73 @@ describe('createProgressViewCommandHandlers', () => {
     const actions = createActions();
     const handlers = createProgressViewCommandHandlers(actions);
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
-          file: 'paper.tex',
-          line: 12,
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
-          file: 'paper.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
-          stream: 'stream-a',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
-          file: 'edited.tex',
-          base: 'paper.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
-          file: 'edited.tex',
-          base: 'paper.tex',
-          prev: 'previous.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
-          file: 'edited.tex',
-          base: 'paper.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
-          file: 'edited.tex',
-          base: 'paper.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
-          file: 'edited.tex',
-          base: 'paper.tex',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL, label: 'thm:main' },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: 'paper.tex',
+        line: 12,
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
+        file: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
+        stream: 'stream-a',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
+        file: 'edited.tex',
+        base: 'paper.tex',
+        prev: 'previous.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+        file: 'edited.tex',
+        base: 'paper.tex',
+      },
+      handlers,
+    );
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL, label: 'thm:main' },
+      handlers,
+    );
 
     expect(actions.file.openFile).toHaveBeenCalledWith('paper.tex', 12);
     expect(actions.file.openFileCompile).toHaveBeenCalledWith('paper.tex');
@@ -409,15 +381,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       createActions({ bypass: { runtimeHost: host, showInfo } }),
     );
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
-          stream,
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+        stream,
+      },
+      handlers,
+    );
     await Promise.resolve();
 
     expect(isApprovalBypassedForStream(stream)).toBe(true);
@@ -432,15 +402,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       'YOLO mode enabled: Tool actions and bash commands will be auto-approved for this stream.',
     );
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
-          stream,
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
+        stream,
+      },
+      handlers,
+    );
     await Promise.resolve();
 
     expect(isApprovalBypassedForStream(stream)).toBe(false);
@@ -466,15 +434,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       }),
     );
     try {
-      expect(
-        dispatchProgressViewInbound(
-          {
-            command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
-            stream,
-          },
-          handlers,
-        ),
-      ).toBe(true);
+      expectDispatched(
+        {
+          command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+          stream,
+        },
+        handlers,
+      );
       await Promise.resolve();
 
       expect(isApprovalBypassedForStream(stream, owner)).toBe(true);
@@ -502,12 +468,10 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     expect(isApprovalBypassedForStream(stream)).toBe(true);
     expect(isBashApprovalBypassedForStream(stream)).toBe(false);
 
-    expect(
-      dispatchProgressViewInbound(
-        { command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, stream },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      { command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, stream },
+      handlers,
+    );
     await Promise.resolve();
 
     expect(isApprovalBypassedForStream(stream)).toBe(true);
@@ -526,15 +490,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     });
     const handlers = createProgressViewCommandHandlers(actions);
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
-          stream,
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+        stream,
+      },
+      handlers,
+    );
     await Promise.resolve();
 
     expect(proposalApprovals().isBypassed(stream)).toBe(true);
@@ -554,16 +516,14 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       'Task, file-edit, and command auto-approval enabled for this stream.',
     );
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS,
-          stream,
-          initiatingProposalId: 'proposal-current',
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS,
+        stream,
+        initiatingProposalId: 'proposal-current',
+      },
+      handlers,
+    );
     await Promise.resolve();
     expect(proposalApprovals().isBypassed(stream)).toBe(true);
     expect(isApprovalBypassedForStream(stream)).toBe(true);
@@ -573,15 +533,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       'proposal-current',
     );
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
-          stream,
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
+        stream,
+      },
+      handlers,
+    );
     await Promise.resolve();
 
     expect(proposalApprovals().isBypassed(stream)).toBe(false);
@@ -605,60 +563,50 @@ describe('createProgressViewCommandHandlers - approvals', () => {
     const actions = createActions();
     const handlers = createProgressViewCommandHandlers(actions);
 
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-          requestId: 'edit-1',
-          action: 'approve',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
-          requestId: 'bash-1',
-          action: 'reject',
-          feedback: 'needs a smaller command',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
-          approvalId: 'plan-1',
-          action: 'approve_and_goal',
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
-          requestId: 'question-1',
-          action: 'submit',
-          answers: { answer: 'yes' },
-        },
-        handlers,
-      ),
-    ).toBe(true);
-    expect(
-      dispatchProgressViewInbound(
-        {
-          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-          proposalId: 'proposal-1',
-          action: 'approve',
-          agent: 'review',
-          model: 'deepseek',
-        },
-        handlers,
-      ),
-    ).toBe(true);
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+        requestId: 'edit-1',
+        action: 'approve',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+        requestId: 'bash-1',
+        action: 'reject',
+        feedback: 'needs a smaller command',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+        approvalId: 'plan-1',
+        action: 'approve_and_goal',
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.USER_QUESTION_ACTION,
+        requestId: 'question-1',
+        action: 'submit',
+        answers: { answer: 'yes' },
+      },
+      handlers,
+    );
+    expectDispatched(
+      {
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-1',
+        action: 'approve',
+        agent: 'review',
+        model: 'deepseek',
+      },
+      handlers,
+    );
 
     await Promise.resolve();
 

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -206,7 +206,7 @@ describe('SettingsProfileController', () => {
     );
   });
 
-  it('defaults reliability settings to DEFAULT_CORE_SETTINGS.model.retry (no drift from the catalog)', async () => {
+  it('defaults reliability settings to DEFAULT_CORE_SETTINGS.model.retry (no drift from the catalog)', () => {
     const { controller } = createController();
 
     const reliabilitySettings = controller.getReliabilitySettings();

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -432,7 +432,7 @@ describe('createExtensionHostInteractions', () => {
     expect(handlers.transport.planApproval.dismiss).not.toHaveBeenCalled();
   });
 
-  it('surfaces retry requests without stealing active-stream focus (#8246)', async () => {
+  it('surfaces retry requests without stealing active-stream focus (#8246)', () => {
     const handlers = createHandlers();
     const session = createTestSession();
     const sessionEvents = recordSessionEvents(session);

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1665,7 +1665,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('keeps task-state metadata canonical across filtering, rendering, and sync content', async () => {
+  it('keeps task-state metadata canonical across filtering, rendering, and sync content', () => {
     const { backend, messages } = createRecordingBackend();
     const stream = 'search@deepseek#de5711c' as StreamTabId;
     const executionId = 'de5711c' as ExecutionId;

--- a/src/test-kernel/progressView/TerminalOutput.vitest.ts
+++ b/src/test-kernel/progressView/TerminalOutput.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -8,49 +8,45 @@ useLitComponentTestDom(
   () => import('@progressView/frontend/components/TerminalOutput'),
 );
 
-describe('terminal-output text update planning', () => {
-  it('writes only the appended suffix when output grows', async () => {
-    const { planTerminalTextUpdate } =
-      await import('@progressView/frontend/components/TerminalOutput');
+// Loaded after useLitComponentTestDom's beforeAll installs the jsdom globals
+// this module touches at import time.
+let planTerminalTextUpdate: typeof import('@progressView/frontend/components/TerminalOutput').planTerminalTextUpdate;
+let countTerminalRows: typeof import('@progressView/frontend/components/TerminalOutput').countTerminalRows;
+let nextTerminalRowCount: typeof import('@progressView/frontend/components/TerminalOutput').nextTerminalRowCount;
 
+beforeAll(async () => {
+  ({ planTerminalTextUpdate, countTerminalRows, nextTerminalRowCount } =
+    await import('@progressView/frontend/components/TerminalOutput'));
+});
+
+describe('terminal-output text update planning', () => {
+  it('writes only the appended suffix when output grows', () => {
     expect(planTerminalTextUpdate('alpha\n', 'alpha\nbeta\n')).toEqual({
       reset: false,
       textToWrite: 'beta\n',
     });
   });
 
-  it('falls back to a reset when retained output is replaced', async () => {
-    const { planTerminalTextUpdate } =
-      await import('@progressView/frontend/components/TerminalOutput');
-
+  it('falls back to a reset when retained output is replaced', () => {
     expect(planTerminalTextUpdate('alpha\nbeta\n', 'beta\n')).toEqual({
       reset: true,
       textToWrite: 'beta\n',
     });
   });
 
-  it('counts terminal rows without allocating split arrays', async () => {
-    const { countTerminalRows } =
-      await import('@progressView/frontend/components/TerminalOutput');
-
+  it('counts terminal rows without allocating split arrays', () => {
     expect(countTerminalRows('')).toBe(1);
     expect(countTerminalRows('one')).toBe(1);
     expect(countTerminalRows('one\ntwo\n')).toBe(3);
   });
 
-  it('updates row count incrementally for appended output', async () => {
-    const { nextTerminalRowCount, planTerminalTextUpdate } =
-      await import('@progressView/frontend/components/TerminalOutput');
-
+  it('updates row count incrementally for appended output', () => {
     const updatePlan = planTerminalTextUpdate('alpha\n', 'alpha\nbeta\ngamma');
 
     expect(nextTerminalRowCount(2, updatePlan)).toBe(3);
   });
 
-  it('recounts rows when output is reset after trimming', async () => {
-    const { nextTerminalRowCount, planTerminalTextUpdate } =
-      await import('@progressView/frontend/components/TerminalOutput');
-
+  it('recounts rows when output is reset after trimming', () => {
     const updatePlan = planTerminalTextUpdate('alpha\nbeta\n', 'beta\ngamma\n');
 
     expect(nextTerminalRowCount(3, updatePlan)).toBe(3);

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
 import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
@@ -15,11 +15,30 @@ useLitComponentTestDom(() =>
   ]),
 );
 
+// Loaded after useLitComponentTestDom's beforeAll installs the jsdom globals
+// these modules touch at import time.
+let formatToolUseTemplate: typeof import('@progressView/frontend/formatters/logFormatters/toolFormatters').formatToolUseTemplate;
+let formatLogEntry: typeof import('@progressView/frontend/formatters').formatLogEntry;
+let getToolTimeoutMs: typeof import('@progressView/frontend/formatters/logFormatters/toolFormatters/helpers').getToolTimeoutMs;
+let formatBannerContentTemplate: typeof import('@progressView/frontend/formatters/logFormatters/bannerFormatters').formatBannerContentTemplate;
+let formatErrorTemplate: typeof import('@progressView/frontend/formatters/logFormatters/messageFormatters').formatErrorTemplate;
+let render: typeof import('lit').render;
+
+beforeAll(async () => {
+  ({ formatToolUseTemplate } =
+    await import('@progressView/frontend/formatters/logFormatters/toolFormatters'));
+  ({ formatLogEntry } = await import('@progressView/frontend/formatters'));
+  ({ getToolTimeoutMs } =
+    await import('@progressView/frontend/formatters/logFormatters/toolFormatters/helpers'));
+  ({ formatBannerContentTemplate } =
+    await import('@progressView/frontend/formatters/logFormatters/bannerFormatters'));
+  ({ formatErrorTemplate } =
+    await import('@progressView/frontend/formatters/logFormatters/messageFormatters'));
+  ({ render } = await import('lit'));
+});
+
 describe('tool-use formatter', () => {
-  it('renders workflow-script delegation details without proposal or journal data', async () => {
-    const { formatToolUseTemplate } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-    const { render } = await import('lit');
+  it('renders workflow-script delegation details without proposal or journal data', () => {
     const script = `export const meta = {
   name: 'Literature synthesis',
   phases: [{ title: 'Collect' }, { title: 'Compare' }],
@@ -85,10 +104,7 @@ return { papers, question: args.question };`;
     expect(container.querySelector('.proposal-banner-setup')).toBeNull();
   });
 
-  it('shows explicit null workflow-script arguments as JSON', async () => {
-    const { formatToolUseTemplate } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-    const { render } = await import('lit');
+  it('shows explicit null workflow-script arguments as JSON', () => {
     const message: LogMessageData = {
       id: 'workflow-script-null-args',
       text: '',
@@ -114,10 +130,7 @@ return { papers, question: args.question };`;
     ).toBe('null');
   });
 
-  it('keeps streamed bash output out of the collapsed error summary', async () => {
-    const { formatToolUseTemplate } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-    const { render } = await import('lit');
+  it('keeps streamed bash output out of the collapsed error summary', () => {
     const stdout = Array.from(
       { length: 20 },
       (_, i) => `[${i}/100] Built Mathlib.Example.Module${i}`,
@@ -158,10 +171,7 @@ return { papers, question: args.question };`;
     expect(container.querySelector('details')).toBeNull();
   });
 
-  it('renders write_file cards even when compact logs omit content', async () => {
-    const { formatLogEntry } =
-      await import('@progressView/frontend/formatters');
-    const { render } = await import('lit');
+  it('renders write_file cards even when compact logs omit content', () => {
     const message: LogMessageData = {
       id: 'write-file-compact',
       text: '',
@@ -183,12 +193,7 @@ return { papers, question: args.question };`;
     expect(container.textContent).not.toContain('Failed to render');
   });
 
-  it('caps executions wait timeout displays at the tool maximum', async () => {
-    const { formatToolUseTemplate } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-    const { getToolTimeoutMs } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters/helpers');
-    const { render } = await import('lit');
+  it('caps executions wait timeout displays at the tool maximum', () => {
     const input = {
       path: '/executions/abc123',
       action: 'wait',
@@ -248,9 +253,6 @@ function dispatchActivationKeydown(target: EventTarget, key: 'Enter' | ' ') {
 
 describe('wa-details summary controls: activation does not toggle the panel', () => {
   it('clicking the proposal-restore-link ("Setup") button does not toggle the panel, and the click still bubbles to an outer delegated handler', async () => {
-    const { formatToolUseTemplate } =
-      await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-    const { render } = await import('lit');
     const message: LogMessageData = {
       id: 'proposal-1',
       text: '',
@@ -295,9 +297,6 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
   it.each(['Enter', ' '] as const)(
     'keydown %j on the proposal-restore-link does not toggle the panel',
     async (key) => {
-      const { formatToolUseTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/toolFormatters');
-      const { render } = await import('lit');
       const message: LogMessageData = {
         id: 'proposal-2',
         text: '',
@@ -334,9 +333,6 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
   it.each(['Enter', ' '] as const)(
     'keydown %j on the copy button does not toggle the panel',
     async (key) => {
-      const { formatBannerContentTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/bannerFormatters');
-      const { render } = await import('lit');
       const message: LogMessageData = {
         id: 'thinking-1',
         text: 'some thinking content',
@@ -372,9 +368,6 @@ describe('wa-details summary controls: activation does not toggle the panel', ()
   it.each(['Enter', ' '] as const)(
     'keydown %j on the error banner copy button does not toggle the panel',
     async (key) => {
-      const { formatErrorTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/messageFormatters');
-      const { render } = await import('lit');
       const message: LogMessageData = {
         id: 'error-1',
         text: 'something failed',

--- a/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
+++ b/src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts
@@ -6,7 +6,7 @@
  * and must still render legitimate links normally.
  */
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
 import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
@@ -14,10 +14,25 @@ import { LOG_LEVELS, type LogMessageData } from '@shared/schemas';
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
+type WebFormatters =
+  typeof import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
+
 useLitComponentTestDom(
   () =>
     import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters'),
 );
+
+// Loaded after useLitComponentTestDom's beforeAll installs the jsdom globals
+// these modules touch at import time.
+let formatWebSearchTemplate: WebFormatters['formatWebSearchTemplate'];
+let formatWebFetchTemplate: WebFormatters['formatWebFetchTemplate'];
+let render: typeof import('lit').render;
+
+beforeAll(async () => {
+  ({ formatWebSearchTemplate, formatWebFetchTemplate } =
+    await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters'));
+  ({ render } = await import('lit'));
+});
 
 function webSearchMessage(url: string): LogMessageData {
   return {
@@ -59,29 +74,19 @@ const DANGEROUS_URLS = [
 
 describe('web-search/web-fetch formatters: URL scheme sanitization', () => {
   describe('web_search results', () => {
-    it.each(DANGEROUS_URLS)(
-      'never renders %s as a clickable href',
-      async (url) => {
-        const { formatWebSearchTemplate } =
-          await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
-        const { render } = await import('lit');
+    it.each(DANGEROUS_URLS)('never renders %s as a clickable href', (url) => {
+      const container = document.createElement('div');
+      render(formatWebSearchTemplate(webSearchMessage(url)), container);
 
-        const container = document.createElement('div');
-        render(formatWebSearchTemplate(webSearchMessage(url)), container);
+      // The single result carries only a dangerous URL, so it must render
+      // as inert text — no anchor at all, not merely an anchor with a
+      // neutralized href.
+      expect(container.querySelectorAll('a').length).toBe(0);
+      // The result should still be visible (as inert text), just not linked.
+      expect(container.textContent).toContain('Click me');
+    });
 
-        // The single result carries only a dangerous URL, so it must render
-        // as inert text — no anchor at all, not merely an anchor with a
-        // neutralized href.
-        expect(container.querySelectorAll('a').length).toBe(0);
-        // The result should still be visible (as inert text), just not linked.
-        expect(container.textContent).toContain('Click me');
-      },
-    );
-
-    it('renders a legitimate https URL as a real clickable href', async () => {
-      const { formatWebSearchTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
-      const { render } = await import('lit');
+    it('renders a legitimate https URL as a real clickable href', () => {
       const url = 'https://example.com/article?id=42';
 
       const container = document.createElement('div');
@@ -101,10 +106,7 @@ describe('web-search/web-fetch formatters: URL scheme sanitization', () => {
       expect(container.querySelector('details')).toBeNull();
     });
 
-    it('renders a mailto URL as a real clickable href', async () => {
-      const { formatWebSearchTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
-      const { render } = await import('lit');
+    it('renders a mailto URL as a real clickable href', () => {
       const url = 'mailto:someone@example.com';
 
       const container = document.createElement('div');
@@ -116,26 +118,16 @@ describe('web-search/web-fetch formatters: URL scheme sanitization', () => {
   });
 
   describe('web_fetch payloads', () => {
-    it.each(DANGEROUS_URLS)(
-      'never renders %s as a clickable href',
-      async (url) => {
-        const { formatWebFetchTemplate } =
-          await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
-        const { render } = await import('lit');
+    it.each(DANGEROUS_URLS)('never renders %s as a clickable href', (url) => {
+      const container = document.createElement('div');
+      render(formatWebFetchTemplate(webFetchMessage(url)), container);
 
-        const container = document.createElement('div');
-        render(formatWebFetchTemplate(webFetchMessage(url)), container);
+      // The "URL:" section is only rendered when a safe URL survives
+      // sanitization, so a dangerous URL must produce no anchor at all.
+      expect(container.querySelectorAll('a').length).toBe(0);
+    });
 
-        // The "URL:" section is only rendered when a safe URL survives
-        // sanitization, so a dangerous URL must produce no anchor at all.
-        expect(container.querySelectorAll('a').length).toBe(0);
-      },
-    );
-
-    it('renders a legitimate https URL as a real clickable href', async () => {
-      const { formatWebFetchTemplate } =
-        await import('@progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters');
-      const { render } = await import('lit');
+    it('renders a legitimate https URL as a real clickable href', () => {
       const url = 'https://example.com/doc.pdf';
 
       const container = document.createElement('div');


### PR DESCRIPTION
## What changed

- `ProgressViewCommandHandlers.vitest.ts`: extracted an `expectDispatched()` helper for the ~28 repeated `expect(dispatchProgressViewInbound(...)).toBe(true)` blocks. Same dispatch call, same assertion, one line per call site instead of seven.
- `OnboardingFunnel.vitest.ts`: converted the `deriveOnboardingFunnelState` and `planOnboardingFunnelTransition` describe blocks to `it.each` tables. Every existing input/output pair is preserved as its own test case (test count went from 12 to 14 individual assertions surfaced as distinct cases, since a couple of the original `it` blocks bundled two `expect` calls together).
- `WebFormattersUrlSanitization.vitest.mts`, `ToolUseFormatter.vitest.mts`, `TerminalOutput.vitest.ts`: these each re-ran the identical `await import(...)` inside every test to defer loading the module under test until after `useLitComponentTestDom`'s `beforeAll` installs the jsdom globals. Replaced the per-test imports with one `beforeAll` (registered after that hook, so timing is unchanged) that resolves the bindings once.
- `AgentRosterController.vitest.ts`, `SettingsProfileController.vitest.ts`, `ExtensionHostInteractions.vitest.mts`, `ProgressBackend.vitest.ts`: dropped `async` from one test callback each that no longer awaits anything (in `ProgressBackend`/`ToolUseFormatter` these were leftover from the import hoisting above; in the other two files they were already dead ceremony, confirmed by an AST-ish brace-balanced scan of every `it`/`it.each` body in the lane, not just a text grep).

All of this is behavior-preserving: no assertion was deleted, no scenario was dropped, and the dynamic-import timing relative to the jsdom setup hook is unchanged (same `beforeAll` registration order).

## Net LoC

9 files changed: +377 / -513 (net -136 lines), measured against origin/main scoped to the changed files (`git diff --shortstat origin/main -- <9 files>`).

## Verification

- `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx tsc --noEmit` (root) — clean
- `npx vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts src/test-kernel/controllers/OnboardingFunnel.vitest.ts src/test-kernel/controllers/AgentRosterController.vitest.ts src/test-kernel/controllers/SettingsProfileController.vitest.ts src/test-kernel/progressView/WebFormattersUrlSanitization.vitest.mts src/test-kernel/progressView/ToolUseFormatter.vitest.mts src/test-kernel/progressView/TerminalOutput.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/progressView/ProgressBackend.vitest.ts` — 9 files, 170 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors with preserved assertions and import timing; no application or runtime code paths change.
> 
> **Overview**
> This PR **refactors test-only code** across nine Vitest files; production behavior is unchanged.
> 
> **Progress view command routing** — `ProgressViewCommandHandlers.vitest.ts` adds `expectDispatched()` so repeated `dispatchProgressViewInbound` + `toBe(true)` checks collapse to one-liners.
> 
> **Onboarding funnel** — `OnboardingFunnel.vitest.ts` replaces many separate `it` blocks with `it.each` tables for `deriveOnboardingFunnelState` and `planOnboardingFunnelTransition`, keeping the same inputs/outputs (some cases that bundled two expects are now separate named rows).
> 
> **Lit/jsdom formatter tests** — `TerminalOutput.vitest.ts`, `ToolUseFormatter.vitest.mts`, and `WebFormattersUrlSanitization.vitest.mts` hoist dynamic `import()` into a shared `beforeAll` (still after `useLitComponentTestDom`’s setup) instead of re-importing inside every test; tests become synchronous where they only assert on loaded bindings.
> 
> **Misc cleanup** — Removes unnecessary `async` from a few tests that no longer `await` (`AgentRosterController`, `SettingsProfileController`, `ExtensionHostInteractions`, `ProgressBackend`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d992c81b4de80533c3b4f7e07fb071d4b07dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->