### PR TITLE
refactor(tests): dedupe stream-write mocks and temp-dir platform setup

### DIFF
--- a/src/test-kernel/cli/AuthCommand.vitest.mts
+++ b/src/test-kernel/cli/AuthCommand.vitest.mts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
+
 const mocks = vi.hoisted(() => ({
   getCliAuthProfile: vi.fn(),
   initCliPlatform: vi.fn(),
@@ -29,21 +31,6 @@ vi.mock('@cli/runtime/chatgptLogin', async (importOriginal) => {
 });
 
 const { runCli } = await import('@cli/commands/root');
-
-function spyOnStreamWrite(
-  stream: NodeJS.WriteStream,
-  append: (text: string) => void,
-): ReturnType<typeof vi.spyOn> {
-  return vi
-    .spyOn(stream, 'write')
-    .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-      append(String(chunk));
-      const cb = rest.find((arg) => typeof arg === 'function') as
-        ((err?: Error | null) => void) | undefined;
-      cb?.(null);
-      return true;
-    }) as unknown as ReturnType<typeof vi.spyOn>;
-}
 
 describe('CLI auth command', () => {
   let stdout = '';

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import stripAnsi from 'strip-ansi';
 
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   detectUnknownCliCommand,
@@ -1189,24 +1190,12 @@ describe('runCli usage output stream routing', () => {
     });
     stdout = '';
     stderr = '';
-    stdoutSpy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stdout += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
-    stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stderr += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
+      stdout += chunk;
+    });
+    stderrSpy = spyOnStreamWrite(process.stderr, (chunk) => {
+      stderr += chunk;
+    });
     // citty's showUsage writes via console.log; its errors via console.error.
     consoleLogSpy = vi
       .spyOn(console, 'log')

--- a/src/test-kernel/cli/ConfigCommand.vitest.mts
+++ b/src/test-kernel/cli/ConfigCommand.vitest.mts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import { InvalidAgentTeamError } from '@agent/index';
 
 const mocks = vi.hoisted(() => ({
@@ -65,22 +66,8 @@ describe('CLI config command', () => {
       toolUseAgentKeys: [],
       unresolvedNames: [],
     });
-    stdoutSpy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        const callback = rest.find((arg) => typeof arg === 'function') as
-          ((error?: Error | null) => void) | undefined;
-        callback?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
-    stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        const callback = rest.find((arg) => typeof arg === 'function') as
-          ((error?: Error | null) => void) | undefined;
-        callback?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stdoutSpy = spyOnStreamWrite(process.stdout);
+    stderrSpy = spyOnStreamWrite(process.stderr);
   });
 
   afterEach(() => {

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import stripAnsi from 'strip-ansi';
 
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
 import {
   buildDoctorReport,
   doctorExitCode,
@@ -72,15 +73,9 @@ function captureDoctorStdout(
   report: DoctorReport,
 ): string {
   let stdout = '';
-  const stdoutSpy = vi
-    .spyOn(process.stdout, 'write')
-    .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-      stdout += String(chunk);
-      const cb = rest.find((arg) => typeof arg === 'function') as
-        ((error?: Error | null) => void) | undefined;
-      cb?.(null);
-      return true;
-    }) as unknown as ReturnType<typeof vi.spyOn>;
+  const stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
+    stdout += chunk;
+  });
 
   try {
     writeDoctorReport(writeContext, report);

--- a/src/test-kernel/cli/InitCommand.vitest.mts
+++ b/src/test-kernel/cli/InitCommand.vitest.mts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
+
 const mocks = vi.hoisted(() => ({
   getCliModelAccessList: vi.fn(),
   getVisibleAgents: vi.fn(),
@@ -104,24 +106,12 @@ describe('CLI init command', () => {
       ]);
     mocks.initCliPlatform.mockReset().mockResolvedValue(undefined);
     mocks.loadAgents.mockReset().mockResolvedValue(undefined);
-    stdoutSpy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stdout += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
-    stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stderr += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
+      stdout += chunk;
+    });
+    stderrSpy = spyOnStreamWrite(process.stderr, (chunk) => {
+      stderr += chunk;
+    });
   });
 
   afterEach(() => {

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -10,6 +10,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
@@ -169,11 +170,7 @@ describe('executeCliRequest', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it.each(['text', 'json'] as const)(

--- a/src/test-kernel/cli/ToolsCommand.vitest.mts
+++ b/src/test-kernel/cli/ToolsCommand.vitest.mts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { spyOnStreamWrite } from '@test/cli/fixtures/streamWriteSpy';
+
 const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
   readCliToolGuide: vi.fn(),
@@ -43,24 +45,12 @@ describe('CLI tools command', () => {
     });
     mocks.setCliToolEnabled.mockReset().mockResolvedValue(true);
     mocks.spawn.mockReset();
-    stdoutSpy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stdout += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
-    stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
-        stderr += String(chunk);
-        const cb = rest.find((arg) => typeof arg === 'function') as
-          ((err?: Error | null) => void) | undefined;
-        cb?.(null);
-        return true;
-      }) as unknown as ReturnType<typeof vi.spyOn>;
+    stdoutSpy = spyOnStreamWrite(process.stdout, (chunk) => {
+      stdout += chunk;
+    });
+    stderrSpy = spyOnStreamWrite(process.stderr, (chunk) => {
+      stderr += chunk;
+    });
   });
 
   afterEach(() => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -86,7 +86,6 @@ import {
   moveLocalTranscriptToStream,
   resolveLocalTranscriptStreamId,
 } from '@cli/chat/tui/state/transcript';
-import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
@@ -1989,13 +1988,6 @@ describe('CLI transcript state', () => {
 });
 
 describe('subscribeRuntimeHost.updateActiveProcesses', () => {
-  function makeHost(): CliRuntimeHost {
-    return {
-      emit: () => {},
-      close: async () => {},
-    } as unknown as CliRuntimeHost;
-  }
-
   const runningProcessA: ActiveChildInfo = {
     kind: 'process',
     executionId: 'exec-a',

--- a/src/test-kernel/cli/fixtures/streamWriteSpy.ts
+++ b/src/test-kernel/cli/fixtures/streamWriteSpy.ts
@@ -1,0 +1,23 @@
+// Third-party imports
+import { vi } from 'vitest';
+
+/**
+ * Spies on a Node write stream (`process.stdout` / `process.stderr`),
+ * forwarding each chunk to `onChunk` and immediately invoking any completion
+ * callback so call sites that `await stream.write(...)` resolve instead of
+ * hanging.
+ */
+export function spyOnStreamWrite(
+  stream: NodeJS.WriteStream,
+  onChunk: (chunk: string) => void = () => {},
+): ReturnType<typeof vi.spyOn> {
+  return vi
+    .spyOn(stream, 'write')
+    .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+      onChunk(String(chunk));
+      const callback = rest.find((arg) => typeof arg === 'function') as
+        ((error?: Error | null) => void) | undefined;
+      callback?.(null);
+      return true;
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+}

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -34,7 +34,6 @@ import {
   STREAM_PHASE,
   STREAM_STATUS,
   type ExecutionId,
-  type RunOutcome,
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
@@ -2430,7 +2429,7 @@ describe('DesktopProgressBridge', () => {
 
     it('delivers run facts and session facts only to the owning session’s hub subscribers', async () => {
       const pair = await createWindowPair();
-      const { windowA, windowB, registry } = pair;
+      const { windowA, windowB } = pair;
 
       const factKey = (event: SessionEvent): string =>
         event.scope === 'run'

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -1,5 +1,5 @@
 // Node imports
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -12,6 +12,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 
 // Local imports - shared schemas and tools
 import { RUN_OUTCOME, type StreamTabId } from '@shared/schemas';
@@ -272,11 +273,7 @@ describe('createDesktopAgentExecution', () => {
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('write-file-atomic');
     vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('durably registers a sidecar-only legacy claim before removing its source', async () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1,5 +1,4 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { onTestFinished, vi } from 'vitest';
+import { onTestFinished } from 'vitest';
 
 // Local imports - desktop types
 import type { DesktopAgentExecutionHost } from '@desktop/main/desktopAgentExecutionHost';

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -5,7 +5,6 @@ import {
   mkdtemp,
   readlink,
   realpath,
-  rm,
   writeFile,
 } from 'node:fs/promises';
 import * as os from 'node:os';
@@ -21,6 +20,7 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 
 // Local imports - test support
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 
 // Local imports - agent
 import type { AgentTrace } from '@agent/trace';
@@ -145,11 +145,7 @@ describe('DiffFileProcessor line formatting', () => {
 describe('LatexMediaManager PDF compilation', () => {
   afterEach(async () => {
     vi.clearAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('filters nullish compile results before adding media files', async () => {
@@ -271,11 +267,7 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
 
   afterEach(async () => {
     vi.clearAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('extractFiguresFromFiles reuses its resolved baseDir instead of re-resolving it in mirrorFigureDependencies', async () => {

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -9,6 +9,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { installPlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 import {
   createExternalLocation,
   createWorkspaceLocation,
@@ -97,11 +98,7 @@ describe('LaTeXdiffService shadow output', () => {
 
   afterEach(async () => {
     vi.clearAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('writes generated diff sources to the requested output directory', async () => {

--- a/src/test-kernel/latex/OutputDiscovery.vitest.mts
+++ b/src/test-kernel/latex/OutputDiscovery.vitest.mts
@@ -1,10 +1,12 @@
 // Standard library imports
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 
 // `discoverLatestExecutionOutputs` matches a run by agent/model/input and then
 // reads its per-round outputs. Headless `texra run` executions persist those
@@ -78,11 +80,7 @@ describe('discoverLatestExecutionOutputs', () => {
   });
 
   afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('falls back to an on-disk run-dir scan when the stream-tab snapshot is empty', async () => {

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -1,0 +1,45 @@
+// Standard library imports
+import { mkdtemp, rm } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Platform defaults
+import { MemoryStateStore } from '@platform/defaults/memoryState';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import type { Platform } from '@platform/platform';
+
+import { createFakePlatform } from './FakePlatform';
+
+/**
+ * Creates a node-backed `FakePlatform` rooted in a fresh temp directory
+ * (`<tempDir>/workspace` and `<tempDir>/storage`), and records the temp
+ * directory on `tempDirs` for later cleanup via `cleanupTempDirs`.
+ */
+export async function createTempDirPlatform(
+  prefix: string,
+  tempDirs: string[],
+): Promise<Platform> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  const workspaceDir = path.join(tempDir, 'workspace');
+  const storageRoot = path.join(tempDir, 'storage');
+  return createFakePlatform(
+    { workspacePath: workspaceDir },
+    {
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspaceDir),
+      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
+      globalState: new MemoryStateStore(),
+      workspaceState: new MemoryStateStore(),
+    },
+  );
+}
+
+/** Removes every directory recorded by `createTempDirPlatform` (or pushed manually), then clears the list. */
+export async function cleanupTempDirs(tempDirs: string[]): Promise<void> {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+}

--- a/src/test-kernel/traceViewer/replayTrace.vitest.ts
+++ b/src/test-kernel/traceViewer/replayTrace.vitest.ts
@@ -1,16 +1,11 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 import { create } from 'mutative';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import { assembleTrace, StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
@@ -40,21 +35,8 @@ import type { TraceDocument } from '@transcript';
 
 const tempDirs: string[] = [];
 
-async function buildStoragePlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-replay-trace-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildStoragePlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-replay-trace-', tempDirs);
 }
 
 function createContext(initialState: ProgressState): {
@@ -88,9 +70,7 @@ function createContext(initialState: ProgressState): {
 setupPlatform(buildStoragePlatform);
 
 afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
-  );
+  await cleanupTempDirs(tempDirs);
 });
 
 function legacyTrace(

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1,18 +1,13 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import {
-  resolveRunStoragePath,
-  WorkspaceStorageProvider,
-} from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
+import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
 import { getExecutionStore } from '@agent/storage';
@@ -36,21 +31,8 @@ import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function buildSnapshotPlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-snapshot-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildSnapshotPlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-snapshot-', tempDirs);
 }
 
 const STREAM = 'polish@gpt#abc123def' as StreamTabId;
@@ -144,11 +126,7 @@ describe('StreamSnapshotStore', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('persists todos/plan/usage from direct mutators and reassembles them on a fresh store', async () => {

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -10,18 +10,16 @@
  * proves conversation display, chat export, and todos all read through the
  * facade.
  */
-import { mkdtemp, readdir, rm, utimes } from 'node:fs/promises';
-import * as os from 'node:os';
+import { readdir, utimes } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import {
   readCompletedRunConversation,
   readCompletedRunTodos,
@@ -44,21 +42,8 @@ import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function buildArchivePlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-archive-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildArchivePlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-archive-', tempDirs);
 }
 
 function taskState(agent: string, model = 'deepseekproT'): TaskState {
@@ -184,11 +169,7 @@ describe('completedRunArchive facade', () => {
   });
 
   afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('serves conversation, chat export, and todos from the sidecars alone (projections gone)', async () => {

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -1,15 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import {
   resolvePersistedStreamIdForExecution,
   StreamLogStore,
@@ -60,21 +55,8 @@ async function waitForCachedStreamId(
 
 const tempDirs: string[] = [];
 
-async function buildResolverPlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-resolver-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildResolverPlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-resolver-', tempDirs);
 }
 
 function taskState(agent: string, model = 'deepseekproT'): TaskState {
@@ -94,11 +76,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('resolves the sole meta-matched stream without needing a data-presence check', async () => {

--- a/src/test-kernel/transcript/traceAssembler.vitest.ts
+++ b/src/test-kernel/transcript/traceAssembler.vitest.ts
@@ -1,15 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import { assembleTrace, StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -27,21 +22,8 @@ import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function buildStoragePlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-trace-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildStoragePlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-trace-', tempDirs);
 }
 
 function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -69,11 +51,7 @@ describe('assembleTrace', () => {
   setupPlatform(buildStoragePlatform);
 
   afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('assembles a full trace document, deriving streamId from agent/model/executionId', async () => {

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -1,15 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
-
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createFakePlatform } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { MemoryStateStore } from '@platform/defaults/memoryState';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
-import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
+import {
+  cleanupTempDirs,
+  createTempDirPlatform,
+} from '@test/support/tempDirPlatform';
 import { assembleTrace, StreamLogStore } from '@transcript';
 import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
@@ -31,21 +26,8 @@ import type { Platform } from '@platform/platform';
 
 const tempDirs: string[] = [];
 
-async function buildStoragePlatform(): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-trace-viewer-'));
-  tempDirs.push(tempDir);
-  const workspaceDir = path.join(tempDir, 'workspace');
-  const storageRoot = path.join(tempDir, 'storage');
-  return createFakePlatform(
-    { workspacePath: workspaceDir },
-    {
-      fs: nodeFilesystem,
-      workspace: createNodeWorkspace(() => workspaceDir),
-      storage: new WorkspaceStorageProvider(storageRoot, workspaceDir),
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
-    },
-  );
+function buildStoragePlatform(): Promise<Platform> {
+  return createTempDirPlatform('texra-trace-viewer-', tempDirs);
 }
 
 function config(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -73,11 +55,7 @@ describe('trace-viewer TraceDataSchema', () => {
   setupPlatform(buildStoragePlatform);
 
   afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('accepts a real trace document produced by assembleTrace', async () => {

--- a/src/test-kernel/utils/RoundDirOwnership.vitest.ts
+++ b/src/test-kernel/utils/RoundDirOwnership.vitest.ts
@@ -4,7 +4,6 @@ import {
   mkdtemp,
   readFile,
   readlink,
-  rm,
   stat,
   unlink,
   writeFile,
@@ -19,6 +18,7 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { cleanupTempDirs } from '@test/support/tempDirPlatform';
 import {
   AbsoluteFS,
   createWorkspaceLocation,
@@ -53,11 +53,7 @@ function installPlatform(
 
 describe('round-dir ownership and editable .tex inheritance', () => {
   afterEach(async () => {
-    await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   it('snapshots editable .tex on mirror, points r<N>/ symlinks at the snapshot, and the round-output write replaces the symlink with a real file leaving snapshot and workspace untouched', async () => {


### PR DESCRIPTION
## Summary

Consolidate repeated test infrastructure outside the separately owned agent, tools, commands, settings, controller, progress-view, and frontend test lanes.

- Replace six hand-written stdout/stderr write mocks with `spyOnStreamWrite`.
- Replace six identical temporary-platform builders with `createTempDirPlatform`.
- Replace twelve identical temporary-directory cleanup blocks with `cleanupTempDirs`.
- Remove several unused local test helpers, imports, and bindings found by scoped unused-symbol checking.

Production code, test scenarios, assertions, and mock behavior are unchanged.

## Issue acceptance gates

No linked issue. The refactor is complete when the extracted fixtures preserve the existing callback, platform, and cleanup semantics and all affected tests and typechecks pass.

## Single source of truth

`src/test-kernel/cli/fixtures/streamWriteSpy.ts` owns CLI stream-write spying. `src/test-kernel/support/tempDirPlatform.ts` owns the standard node-backed temporary platform and cleanup lifecycle.

## Duplication and abstraction budget

The three new fixture functions replace 24 repeated blocks: 6 stream spies, 6 platform builders, and 12 cleanup blocks. Each fixture has multiple consumers and hides the complete setup/cleanup invariant rather than forwarding to another helper.

## Net elements (R6)

- Files: 24 changed; 2 added, 0 deleted, 22 modified.
- Exported symbols: 3 added (`spyOnStreamWrite`, `createTempDirPlatform`, `cleanupTempDirs`), 0 deleted.
- Classes/interfaces/enums: no changes.
- LoC: 165 additions, 319 deletions, net -154.

## Consumer counts (R8)

- `spyOnStreamWrite`: 6 consumers.
- `createTempDirPlatform`: 6 consumers.
- `cleanupTempDirs`: 12 consumers.
- No event-emission path or existing published export is deleted or rerouted. Removed symbols were unused local test declarations or imports.

## Host impact

Extension: None; test infrastructure only.

Desktop: None; test infrastructure only.

CLI: None; test infrastructure only.

## Scheduled refactoring

None. Similar in-memory state-store classes intentionally remain local because consolidating them would require changing their observable test API and is not a mechanical extraction.

## Validation

- Root TypeScript typecheck: passed.
- Test-kernel TypeScript typecheck: passed.
- Affected test set: 23 files, 495 tests passed.
- GitHub CI is rerun from the rebased branch before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with preserved spy/callback and platform lifecycle semantics; no runtime paths touched.
> 
> **Overview**
> Consolidates repeated **test-kernel** helpers so CLI and storage/transcript suites share one implementation instead of copy-pasted setup.
> 
> **`spyOnStreamWrite`** (`src/test-kernel/cli/fixtures/streamWriteSpy.ts`) centralizes mocking `process.stdout` / `process.stderr` `write`, optional chunk capture, and immediate completion callbacks so async writes do not hang. Six CLI vitest files drop local spy helpers and import this fixture.
> 
> **`createTempDirPlatform`** and **`cleanupTempDirs`** (`src/test-kernel/support/tempDirPlatform.ts`) own the standard node-backed `FakePlatform` temp workspace/storage layout and recursive teardown. Six transcript/trace/replay-style suites replace inline `mkdtemp` + `createFakePlatform` builders; a dozen `afterEach` blocks swap duplicated `Promise.all(rm…)` for `cleanupTempDirs`.
> 
> A few tests only shed unused imports or locals (e.g. unused `registry`, `makeHost`, `RunOutcome`). **No production code, assertions, or mock behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b5a3768da20af2092a3d1dd54e4c999b7746a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->