### PR TITLE
refactor(trace-viewer): fix import order in traceDataSchema

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -13,8 +13,8 @@
  */
 import { z } from 'zod';
 
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ExecutionMeta } from '@agent/storage';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory, AgentSourceSchema } from '@shared/schemas/agent';
 import {
   ExecutionIdSchema,


### PR DESCRIPTION
## Summary

I swept `packages/trace-viewer/**` (src/, vite.config.ts, vite.standalone.config.ts,
index.html, CSS) for simplification opportunities. The lane is small and has already
been through several recent simplification/refactor passes (e.g. #8368, #8554), so
there was little dead code, duplication, or indirection left to remove.

- `traceDataSchema.ts`: reordered the two type-only imports (`@agent/storage` before
  `@agent/core/definition/AgentConfig`) to satisfy the repo's `import/order` ESLint
  rule — this was the only ESLint warning in the lane. Import order only, no logic
  or behavior change.

Deliberately left untouched (per lane guidance and my own review):

- `traceDataSchema.ts`'s hand-mirrored `AgentConfig`/`ExecutionMeta` schemas and the
  `_IsExact` compile-time assertion — this duplication is intentional (keeps
  trace-viewer's runtime bundle browser-safe/standalone) and explicitly called out
  as do-not-deduplicate.
- `replayTrace.ts`'s `findRootStageId` / `toStreamLifecycleStatus` legacy-trace
  status-derivation logic — every branch is tied to a specific regression (#7188,
  #7264, #7267, #7291) with matching tests in
  `src/test-kernel/traceViewer/replayTrace.vitest.ts`; the code is already minimal
  for what it needs to distinguish, and rewriting it for brevity would risk
  reintroducing one of those regressions for no LoC win.
- The duplicated `dedupe` alias array between `vite.config.ts` and
  `vite.standalone.config.ts` (and a third copy in `packages/desktop/vite.config.ts`,
  out of lane) — the file comments describe this as an intentional "same recipe"
  copy across three independent build configs; extracting a shared constant for
  only two of the three would create an inconsistent, harder-to-follow pattern for
  a few lines of savings.

## Net elements (R6)

No exported symbols added or removed. Zero net LoC change (1 insertion, 1 deletion —
a line swap).

## Consumer counts (R8)

n/a — no exported symbol's name, signature, or contract changed; only two import
lines within a single file were reordered.

## Verification

- `CI=true corepack pnpm --filter @texra/trace-viewer typecheck` — passed, before
  and after the change.
- `npx vitest run --config vitest.config.mjs src/test-kernel/traceViewer` — 9/9
  passed, before and after.
- `npx vitest run --config vitest.config.mjs src/test-kernel/transcript/traceViewerSchema.vitest.ts`
  (read-only sanity check, outside my lane) — 7/7 passed.
- `npx eslint packages/trace-viewer` — 1 warning before, 0 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic import reorder with no logic, API, or runtime impact.
> 
> **Overview**
> Reorders two **type-only** imports in `traceDataSchema.ts` so `@agent/storage` (`ExecutionMeta`) comes before `@agent/core/definition/AgentConfig`, matching the repo **`import/order`** ESLint rule.
> 
> No schema, runtime, or export changes — behavior and types are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5792655a6595f58f9b0d8cc9b1d248dde6cacd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->