### PR TITLE
refactor(supabase): dedupe edge-client construction and session payload shape

### DIFF
--- a/supabase/functions/_shared/edgeClients.ts
+++ b/supabase/functions/_shared/edgeClients.ts
@@ -1,0 +1,14 @@
+/** Shared Supabase client construction for edge functions. */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/** Stateless server client (no token refresh, no persisted session). */
+export function createEdgeClient(
+  url: string | undefined,
+  key: string | undefined,
+): SupabaseClient<any> | null {
+  if (!url || !key) return null;
+  return createClient<any>(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}

--- a/supabase/functions/_shared/goTrueSession.ts
+++ b/supabase/functions/_shared/goTrueSession.ts
@@ -39,3 +39,27 @@ export async function mintGoTrueSession(
 
   return data.session;
 }
+
+/**
+ * Session payload shared by GoTrue-session-minting auth endpoints
+ * (auth-github /exchange, /refresh and auth-device /token). Returns a plain
+ * object type (not a named interface) so it stays structurally assignable to
+ * the `Record<string, unknown>` body param of `versionedJsonResponse`.
+ */
+export function sessionResponseBody(session: Session) {
+  return {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_at: session.expires_at,
+    expires_in: session.expires_in,
+    token_type: session.token_type,
+    user: {
+      id: session.user.id,
+      email: session.user.email,
+      user_metadata: {
+        avatar_url: session.user.user_metadata?.avatar_url,
+        user_name: session.user.user_metadata?.user_name,
+      },
+    },
+  };
+}

--- a/supabase/functions/auth-device/index.ts
+++ b/supabase/functions/auth-device/index.ts
@@ -29,12 +29,16 @@
  */
 
 import { Hono, type Context as HonoContext } from '@hono/hono';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseApprovalDecision } from './approvalRequest.ts';
 import { authenticateJwt, bearerToken } from '../_shared/auth.ts';
 import { getCorsHeaders, handleCors } from '../_shared/cors.ts';
 import { randomBase64Url } from '../_shared/crypto.ts';
-import { mintGoTrueSession } from '../_shared/goTrueSession.ts';
+import { createEdgeClient } from '../_shared/edgeClients.ts';
+import {
+  mintGoTrueSession,
+  sessionResponseBody,
+} from '../_shared/goTrueSession.ts';
 import { sha256Hex } from '../_shared/relayCiToken.ts';
 import { versionedJsonResponse } from '../_shared/responses.ts';
 
@@ -73,17 +77,6 @@ const USER_CODE_INSERT_ATTEMPTS = 4;
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
-
-/** Stateless server client (no token refresh, no persisted session). */
-function createEdgeClient(
-  url: string | undefined,
-  key: string | undefined,
-): SupabaseClient<any> | null {
-  if (!url || !key) return null;
-  return createClient<any>(url, key, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
 
 const adminSupabase = createEdgeClient(supabaseUrl, supabaseServiceKey);
 const anonSupabase = createEdgeClient(supabaseUrl, supabaseAnonKey);
@@ -408,21 +401,7 @@ app.post('/token', async (c) => {
     return versionedJsonResponse(
       c.req.raw,
       VERSION,
-      {
-        access_token: session.access_token,
-        refresh_token: session.refresh_token,
-        expires_at: session.expires_at,
-        expires_in: session.expires_in,
-        token_type: session.token_type,
-        user: {
-          id: session.user.id,
-          email: session.user.email,
-          user_metadata: {
-            avatar_url: session.user.user_metadata?.avatar_url,
-            user_name: session.user.user_metadata?.user_name,
-          },
-        },
-      },
+      sessionResponseBody(session),
       200,
     );
   } catch (error) {

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -22,17 +22,17 @@
  */
 
 import { Hono, type Context as HonoContext } from '@hono/hono';
-import {
-  createClient,
-  type Session,
-  type SupabaseClient,
-} from '@supabase/supabase-js';
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
 import { handleCors } from '../_shared/cors.ts';
+import { createEdgeClient } from '../_shared/edgeClients.ts';
 import {
   checkEmailDomain,
   checkGitHubAccountAge,
 } from '../_shared/emailPolicy.ts';
-import { mintGoTrueSession } from '../_shared/goTrueSession.ts';
+import {
+  mintGoTrueSession,
+  sessionResponseBody,
+} from '../_shared/goTrueSession.ts';
 import { versionedJsonResponse } from '../_shared/responses.ts';
 
 // =============================================================================
@@ -49,19 +49,8 @@ const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
 
-const adminSupabase =
-  supabaseUrl && supabaseServiceKey
-    ? createClient<any>(supabaseUrl, supabaseServiceKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      })
-    : null;
-
-const anonSupabase =
-  supabaseUrl && supabaseAnonKey
-    ? createClient<any>(supabaseUrl, supabaseAnonKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      })
-    : null;
+const adminSupabase = createEdgeClient(supabaseUrl, supabaseServiceKey);
+const anonSupabase = createEdgeClient(supabaseUrl, supabaseAnonKey);
 
 // =============================================================================
 // Types
@@ -131,21 +120,7 @@ function sessionResponse(c: Context, session: Session) {
   return versionedJsonResponse(
     c.req.raw,
     VERSION,
-    {
-      access_token: session.access_token,
-      refresh_token: session.refresh_token,
-      expires_at: session.expires_at,
-      expires_in: session.expires_in,
-      token_type: session.token_type,
-      user: {
-        id: session.user.id,
-        email: session.user.email,
-        user_metadata: {
-          avatar_url: session.user.user_metadata?.avatar_url,
-          user_name: session.user.user_metadata?.user_name,
-        },
-      },
-    },
+    sessionResponseBody(session),
     200,
   );
 }

--- a/supabase/functions/relay-tokens/index.ts
+++ b/supabase/functions/relay-tokens/index.ts
@@ -20,10 +20,11 @@
  */
 
 import { Hono, type Context as HonoContext } from '@hono/hono';
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { authenticateJwt, bearerToken } from '../_shared/auth.ts';
 import { handleCors } from '../_shared/cors.ts';
 import { randomBase64Url } from '../_shared/crypto.ts';
+import { createEdgeClient } from '../_shared/edgeClients.ts';
 import { RELAY_CI_TOKEN_PREFIX, sha256Hex } from '../_shared/relayCiToken.ts';
 import { versionedJsonResponse } from '../_shared/responses.ts';
 
@@ -49,12 +50,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
-const adminSupabase =
-  supabaseUrl && supabaseServiceKey
-    ? createClient<any>(supabaseUrl, supabaseServiceKey, {
-        auth: { autoRefreshToken: false, persistSession: false },
-      })
-    : null;
+const adminSupabase = createEdgeClient(supabaseUrl, supabaseServiceKey);
 
 // =============================================================================
 // Hono App


### PR DESCRIPTION
## What changed

Swept `supabase/functions/**` for provably safe simplifications under the
ultra-conservative bar for this lane (no gating/ban/cap/wire-shape changes).
The only genuine, provable duplication found was two exact, byte-identical
blocks repeated across auth functions:

- **`createEdgeClient` (Supabase client construction).** The same
  null-guarded `createClient(url, key, { auth: { autoRefreshToken: false,
  persistSession: false } })` pattern was defined once as a local function in
  `auth-device/index.ts` and repeated inline (as ternaries) twice in
  `auth-github/index.ts` and once in `relay-tokens/index.ts`. Folded into a
  single `createEdgeClient()` in new `supabase/functions/_shared/edgeClients.ts`,
  used by all three call sites (4 total construction sites).
- **GoTrue session response payload.** The
  `{ access_token, refresh_token, expires_at, expires_in, token_type, user:
  {...} }` object was built inline, identically, in `auth-github`'s
  `sessionResponse()` and in `auth-device`'s `/token` route. Folded into
  `sessionResponseBody(session)` in `supabase/functions/_shared/goTrueSession.ts`.

Both extractions are behavior-preserving: identical null checks, identical
`createClient` options object, identical response field set and values (byte
comparison done before extracting). No request/response shape, gating logic,
env var, CORS header, or `deno.lock`/`deno.json` pin was touched.

Everything else in the lane (relay tier/spending/gate enforcement,
before-user-created signup gating, auth-bridge, log-usage validation, all
Deno test files) was read end to end and left untouched — no other
provably-dead code, unused imports, or exact duplicates were found there;
that logic is either single-instance or has meaningful per-function
differences (e.g. `get-agent-config`/`log-usage`'s `createClient` calls omit
the `auth` options object, so they are not the same pattern and were left
alone).

## Net elements (R6)

- Added: `createEdgeClient` (exported from new `_shared/edgeClients.ts`),
  `sessionResponseBody` (exported from `_shared/goTrueSession.ts`) — 2 new
  exports.
- Removed: the local `createEdgeClient` function in `auth-device/index.ts`
  (was file-private, not exported) — 1 local helper removed, folded into the
  shared one.
- Both new exports have multiple real call sites (`createEdgeClient`: 3 files,
  4 call sites; `sessionResponseBody`: 2 files, 2 call sites), so this is DRY
  extraction, not a single-caller helper.

## Consumer counts (R8)

- `createEdgeClient`: called from `auth-device/index.ts` (x2),
  `auth-github/index.ts` (x2), `relay-tokens/index.ts` (x1) — grepped across
  the whole worktree, no other callers.
- `sessionResponseBody`: called from `auth-github/index.ts` (x1, inside
  `sessionResponse()` which itself backs both `/exchange` and `/refresh`) and
  `auth-device/index.ts` (x1, inside `/token`) — grepped across the whole
  worktree, no other callers.

## Net LoC

5 files changed, 57 insertions(+), 69 deletions(-) → **net -12 LoC** versus
`origin/main` merge-base.

## Verification

- `deno check index.ts` (deno 2.8.3) run from each of the 8 function
  directories (`auth-bridge`, `auth-device`, `auth-github`,
  `before-user-created`, `get-agent-config`, `log-usage`, `relay-tokens`,
  `relay`) — all pass, both before editing (baseline) and after.
- `deno check` on every `*_test.ts` file in the lane
  (`auth-device/approvalRequest_test.ts`,
  `before-user-created/webhookVerification_test.ts`,
  `log-usage/usageValidation_test.ts`, `relay/enforcement_test.ts`,
  `relay/providerTier_test.ts`) — all pass.
- `deno test --allow-env --allow-net --no-check enforcement_test.ts
  providerTier_test.ts` in `supabase/functions/relay` — 8/8 pass.
- `npx vitest run --config vitest.config.mjs src/test-kernel/supabase` — 54/54
  pass, both before and after (this suite doesn't touch `_shared`, so it's a
  baseline-parity check for the untouched `relay/*` logic).
- Manual runtime smoke test (outside the repo, not committed) confirming
  `sessionResponseBody()` and `createEdgeClient()` produce output identical
  to the removed inline code for representative inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in auth edge functions; session and client construction logic is unchanged, only centralized.
> 
> **Overview**
> Pulls duplicated Supabase edge setup into **`_shared`**: **`createEdgeClient`** centralizes the null-guarded stateless `createClient` pattern used by **`auth-device`**, **`auth-github`**, and **`relay-tokens`**, replacing a local helper and repeated inline ternaries.
> 
> Adds **`sessionResponseBody`** next to **`mintGoTrueSession`** so **`auth-github`** (`/exchange`, `/refresh`) and **`auth-device`** (`/token`) return the same GoTrue session JSON from one builder instead of copy-pasted objects.
> 
> No intended changes to env handling, CORS, gating, or client-visible response fields—net **-12 LoC** of mechanical DRY.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12fbb6c903bb2cc5c987b9dd297bdf4a0b3abf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->