### PR TITLE
fix(cli): bound terminal resize listeners

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -92,10 +92,7 @@ import {
 } from '../src/chat/tui/state/focusedChildFollowUp';
 import { formatCliSessionStatus } from '../src/chat/tui/sessionStatus';
 import { notify } from '../src/chat/tui/notifications/terminalNotifier';
-import {
-  installTuiStdoutListenerLimit,
-  tuiOutputStreamForColor,
-} from '../src/chat/tui/render/noColorOutput';
+import { tuiOutputStreamForColor } from '../src/chat/tui/render/noColorOutput';
 import { createTuiViewportController } from '../src/chat/tui/render/tuiViewportController';
 import {
   clearApprovals,
@@ -1979,9 +1976,6 @@ function handleHarnessCtrlC(): void {
   void exitHarness(0);
 }
 
-const restoreStdoutListenerLimit = installTuiStdoutListenerLimit(
-  process.stdout,
-);
 function renderHarnessApp(): React.JSX.Element {
   return (
     <App
@@ -2034,7 +2028,6 @@ async function exitHarness(exitCode: number): Promise<void> {
   try {
     await tryPlatform()?.lifecycle.runShutdown();
   } finally {
-    restoreStdoutListenerLimit();
     process.exit(exitCode);
   }
 }

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -47,8 +47,8 @@ export const ToolUseRow = memo(function ToolUseRow({
 
   const renderer = pickToolRenderer(toolUse);
   return renderer ? (
-    renderer.render(toolUse)
+    renderer.render(toolUse, width)
   ) : (
-    <UniversalToolRow toolUse={toolUse} />
+    <UniversalToolRow toolUse={toolUse} width={width} />
   );
 });

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -1,7 +1,7 @@
 // Third-party imports
 import { useMemo } from 'react';
 
-import { Box, Text, useWindowSize } from 'ink';
+import { Box, Text } from 'ink';
 
 // Local imports - shared schemas and utilities
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
@@ -113,7 +113,7 @@ export interface DisplayLineOptions {
 export interface ToolRenderer {
   readonly key: string;
   matches(toolUse: NormalizedToolUse): boolean;
-  render(toolUse: NormalizedToolUse): React.JSX.Element;
+  render(toolUse: NormalizedToolUse, width?: number): React.JSX.Element;
   /** Text geometry for budgeting and plain projections. Keep one line for
    *  every visually distinct row emitted by `render`. */
   displayLines(
@@ -374,15 +374,16 @@ const PATCH_PREVIEW_INDENT = 4;
 
 function PatchPreview({
   groups,
+  width,
 }: {
   readonly groups: readonly InlinePatchGroup[];
+  readonly width?: number;
 }): React.JSX.Element {
   // The diff sits under two nested `paddingLeft={2}` boxes; derive its width
   // from the real terminal so the full-row bands fill exactly the available
   // columns instead of padding to a fixed default and wrapping on narrow
   // terminals. `DiffView` floors this at its own minimum.
-  const { columns } = useWindowSize();
-  const diffWidth = columns - PATCH_PREVIEW_INDENT;
+  const diffWidth = (width ?? MAX_HEADER_PREVIEW) - PATCH_PREVIEW_INDENT;
   return (
     <Box flexDirection="column" paddingLeft={2}>
       {groups.map((group, index) => (
@@ -447,6 +448,7 @@ function CornerLine({
 
 interface ToolRowProps {
   readonly toolUse: NormalizedToolUse;
+  readonly width?: number;
   readonly displayName?: string;
   readonly fallbackName?: string;
   readonly previewColor?: typeof COLOR_HINT;
@@ -465,7 +467,7 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
     showExitCode = false,
     preferInputPreview = false,
   } = props;
-  const { columns } = useWindowSize();
+  const columns = props.width;
   const color = statusColor(toolUse);
   const name =
     (props.displayName ?? displayToolName(toolUse.toolName)) ||
@@ -508,7 +510,9 @@ function ToolRow(props: ToolRowProps): React.JSX.Element {
         ) : null}
       </Box>
       <OutputBlock lines={visibleOutput} />
-      {patchGroups ? <PatchPreview groups={patchGroups} /> : null}
+      {patchGroups ? (
+        <PatchPreview groups={patchGroups} width={columns} />
+      ) : null}
       {toolUse.isError && exitCode !== undefined ? (
         <CornerLine color={COLOR_ERROR}>{`exit ${exitCode}`}</CornerLine>
       ) : null}
@@ -529,10 +533,12 @@ export function UniversalToolRow({
   toolUse,
   displayName,
   showOutput,
+  width,
 }: {
   readonly toolUse: NormalizedToolUse;
   readonly displayName?: string;
   readonly showOutput?: boolean;
+  readonly width?: number;
 }): React.JSX.Element {
   return (
     <ToolRow
@@ -540,6 +546,7 @@ export function UniversalToolRow({
       displayName={displayName}
       showPatch={true}
       showOutput={showOutput}
+      width={width}
     />
   );
 }
@@ -558,7 +565,9 @@ function isMcpTool(toolUse: NormalizedToolUse): boolean {
 const editRenderer: ToolRenderer = {
   key: 'edit',
   matches: (toolUse) => toolUsePatchGroups(toolUse) !== undefined,
-  render: (toolUse) => <UniversalToolRow toolUse={toolUse} />,
+  render: (toolUse, width) => (
+    <UniversalToolRow toolUse={toolUse} width={width} />
+  ),
   displayLines: (toolUse, options) =>
     universalToolUseDisplayLines(toolUse, { elide: options?.elide }),
 };
@@ -566,7 +575,7 @@ const editRenderer: ToolRenderer = {
 const bashRenderer: ToolRenderer = {
   key: 'bash',
   matches: isBashTool,
-  render: (toolUse) => (
+  render: (toolUse, width) => (
     <ToolRow
       toolUse={toolUse}
       fallbackName="bash"
@@ -574,6 +583,7 @@ const bashRenderer: ToolRenderer = {
       showOutput={true}
       showExitCode={true}
       preferInputPreview={true}
+      width={width}
     />
   ),
   displayLines: (toolUse, options) =>
@@ -583,11 +593,12 @@ const bashRenderer: ToolRenderer = {
 const mcpRenderer: ToolRenderer = {
   key: 'mcp',
   matches: isMcpTool,
-  render: (toolUse) => (
+  render: (toolUse, width) => (
     <UniversalToolRow
       toolUse={toolUse}
       displayName={displayMcpToolName(toolUse.toolName)}
       showOutput={true}
+      width={width}
     />
   ),
   displayLines: (toolUse, options) =>

--- a/packages/cli/src/chat/tui/render/noColorOutput.ts
+++ b/packages/cli/src/chat/tui/render/noColorOutput.ts
@@ -1,12 +1,5 @@
 import { ANSI_ESCAPE_START } from '@cli/runtime/ansiEscapes';
 
-const TUI_STDOUT_MAX_LISTENERS = 64;
-
-interface ListenerLimitStream {
-  getMaxListeners(): number;
-  setMaxListeners(n: number): unknown;
-}
-
 interface SgrStripState {
   pending: string;
 }
@@ -103,23 +96,4 @@ export function tuiOutputStreamForColor<T extends NodeJS.WriteStream>(
   colorEnabled: boolean,
 ): T {
   return colorEnabled ? stream : sgrStrippingWriteStream(stream);
-}
-
-export function installTuiStdoutListenerLimit(
-  stream: ListenerLimitStream,
-): () => void {
-  const previous = stream.getMaxListeners();
-  if (previous === 0 || previous >= TUI_STDOUT_MAX_LISTENERS) {
-    return () => undefined;
-  }
-
-  stream.setMaxListeners(TUI_STDOUT_MAX_LISTENERS);
-  let restored = false;
-  return () => {
-    if (restored) return;
-    restored = true;
-    if (stream.getMaxListeners() === TUI_STDOUT_MAX_LISTENERS) {
-      stream.setMaxListeners(previous);
-    }
-  };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -93,10 +93,7 @@ import {
 import { registerBuiltinSlashCommands } from './commands/registerBuiltins';
 import { loadInputHistory } from './history/inputHistory';
 import { notify } from './notifications/terminalNotifier';
-import {
-  installTuiStdoutListenerLimit,
-  tuiOutputStreamForColor,
-} from './render/noColorOutput';
+import { tuiOutputStreamForColor } from './render/noColorOutput';
 import { createTuiViewportController } from './render/tuiViewportController';
 import { clearApprovals } from './state/approvalQueue';
 import {
@@ -436,10 +433,6 @@ export async function runChat(
   };
 
   const disposers: Array<() => void> = [];
-  // Ink registers one stdout "resize" listener per mounted useWindowSize()
-  // hook. The chat TUI can legitimately mount more than Node's default ten
-  // while approvals, status and child-stream views are visible.
-  disposers.push(installTuiStdoutListenerLimit(process.stdout));
   // Crash safety: if the process dies outside the orderly teardown below
   // (uncaught exception, stray process.exit), still restore the terminal so
   // the user's shell isn't left in raw/kitty/mouse mode with a hidden cursor.

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
   initInteractiveCliPlatform: vi.fn(),
   installTerminalRestoreOnExit: vi.fn(),
-  installTuiStdoutListenerLimit: vi.fn(),
   loadInputHistory: vi.fn(),
   maybeRunCliOnboarding: vi.fn(),
   onStreamStatusChange: vi.fn(),
@@ -132,7 +131,6 @@ vi.mock('@cli/chat/tui/render/noColorOutput', async (importOriginal) => {
     await importOriginal<typeof import('@cli/chat/tui/render/noColorOutput')>();
   return {
     ...actual,
-    installTuiStdoutListenerLimit: mocks.installTuiStdoutListenerLimit,
     tuiOutputStreamForColor: mocks.tuiOutputStreamForColor,
   };
 });
@@ -247,7 +245,6 @@ describe('runChat signal ownership wiring', () => {
       oscColorReports: false,
     });
     mocks.installTerminalRestoreOnExit.mockReturnValue(() => undefined);
-    mocks.installTuiStdoutListenerLimit.mockReturnValue(() => undefined);
     mocks.subscribeStreamLog.mockReturnValue(() => undefined);
     mocks.subscribeStreamStatus.mockReturnValue(() => undefined);
     mocks.onStreamStatusChange.mockReturnValue(() => undefined);

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -209,4 +209,88 @@ describe('Static band resize', () => {
       resetCliState();
     }
   });
+
+  it('keeps resize subscriptions constant as tool history grows', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { createElement } = React;
+    const { StaticConversationTranscript } =
+      await import('@cli/chat/tui/panes/StaticConversationTranscript');
+    const { patchStream, resetCliState } =
+      await import('@cli/chat/tui/state/cliState');
+    const streamId = 'listener-count-stream' as StreamTabId;
+    const toolEntries: ConversationEntry[] = Array.from(
+      { length: 70 },
+      (_, index) => ({
+        id: `tool-${index}`,
+        role: 'tool' as const,
+        text: '',
+        finalized: true,
+        toolUse: {
+          parsed: {},
+          toolName: 'Bash',
+          errorText: '',
+          outputText: `result ${index}`,
+          userInstructionText: '',
+          input: { command: `printf ${index}` },
+          isError: false,
+          isUserFeedback: false,
+          headerSummary: '',
+          status: 'completed' as const,
+        },
+      }),
+    );
+
+    resetCliState({
+      agent: 'research',
+      model: 'test-model',
+      modelSource: 'builtin-default',
+      cwd: '/tmp/listener-proof',
+      apiMode: 'personal',
+      approvalPolicy: 'ask',
+      canDelegate: false,
+      transcriptMode: 'persistent',
+      version: '0.0.0-test',
+    });
+    patchStream(streamId, (slice) => ({ ...slice, entries: toolEntries }));
+
+    function App(): unknown {
+      const { columns } = ink.useWindowSize();
+      return createElement(StaticConversationTranscript, {
+        ownerKey: 'listener-owner',
+        scrollbackStreamId: streamId,
+        width: columns,
+      });
+    }
+
+    const out = new FakeStdout(80);
+    let peakResizeListeners = 0;
+    out.on('newListener', (event) => {
+      if (event === 'resize') {
+        peakResizeListeners = Math.max(
+          peakResizeListeners,
+          out.listenerCount('resize') + 1,
+        );
+      }
+    });
+    const inst = ink.render(createElement(App), {
+      stdout: out,
+      stdin: new FakeStdin(),
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      expect(await waitFor(() => out.buf.includes('result 69'), 5000)).toBe(
+        true,
+      );
+      // One listener belongs to Ink's renderer and one to the App-level
+      // useWindowSize subscription. Transcript length must not affect it.
+      expect(peakResizeListeners).toBe(2);
+    } finally {
+      inst.unmount();
+      resetCliState();
+    }
+  });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3,8 +3,6 @@ import '@test/support/defaultSessionTestSetup';
 
 // Phase 4 state + focus-cycle smoke.
 
-import { EventEmitter } from 'node:events';
-
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createRunTrace } from '@transcript';
@@ -75,7 +73,6 @@ import {
   markChatTuiRunPending,
 } from '@cli/chat/tui/state/sessionRunState';
 import { chatTuiFocusedChildFollowUpRoute } from '@cli/chat/tui/runChatTui';
-import { installTuiStdoutListenerLimit } from '@cli/chat/tui/render/noColorOutput';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
   appendLocalAssistantTranscript,
@@ -341,34 +338,6 @@ describe('cliState Phase 4 fields', () => {
     } finally {
       detach();
     }
-  });
-});
-
-describe('chat TUI stdout listener limit', () => {
-  it('raises and restores the listener ceiling for the mounted TUI lifetime', () => {
-    const stream = new EventEmitter();
-    stream.setMaxListeners(10);
-
-    const restore = installTuiStdoutListenerLimit(stream);
-
-    expect(stream.getMaxListeners()).toBeGreaterThan(10);
-
-    restore();
-    expect(stream.getMaxListeners()).toBe(10);
-
-    restore();
-    expect(stream.getMaxListeners()).toBe(10);
-  });
-
-  it('does not lower a listener ceiling changed after installation', () => {
-    const stream = new EventEmitter();
-    stream.setMaxListeners(10);
-    const restore = installTuiStdoutListenerLimit(stream);
-
-    stream.setMaxListeners(128);
-    restore();
-
-    expect(stream.getMaxListeners()).toBe(128);
   });
 });
 


### PR DESCRIPTION
## Summary

The chat TUI registered one Ink `resize` listener for every rendered tool row, and edit rows registered a second listener for their patch preview. Long sessions therefore grew the listener count with transcript history until Node reported `MaxListenersExceededWarning` at listener 65.

This PR passes the width already owned by the App and transcript layout into tool renderers. Tool rows and patch previews no longer subscribe to terminal resize events themselves. It also removes the previous workaround that raised the listener ceiling to 64 from both the production TUI and validation harness, so listener growth cannot be hidden.

## Issue acceptance gates

No linked issue. The reported CLI warning is reproduced structurally by mounting 70 finalized tool entries. The regression test now proves that peak resize subscriptions remain constant at two: one Ink renderer listener and one App-level `useWindowSize` listener.

## Single source of truth

Terminal width remains owned by the App-level window-size subscription and is passed through the existing transcript rendering boundary. Tool renderers consume explicit geometry rather than independently observing the output stream.

## Duplication and abstraction budget

No new module or wrapper was added. The change removes the listener-limit workaround and extends the existing `ToolRenderer.render` input with the width it requires.

## Net elements (R6)

7 files changed, 108 insertions, 84 deletions, net +24 lines. No exports, classes, interfaces, factories, or schemas were added. One exported workaround function was removed.

The added lines are primarily the mounted 70-entry regression test. Production and harness code are net smaller after removing the listener-ceiling workaround.

## Consumer counts (R8)

- Removed `installTuiStdoutListenerLimit`: 2 production/harness consumers and 1 test module.
- Changed `ToolRenderer.render(toolUse, width?)`: 1 production consumer (`ToolUseRow.tsx`); all 3 registry implementations updated together.
- No event emit path was added, removed, or rerouted.

## Host impact

- CLI: fixes unbounded stdout resize-listener growth in long tool-use transcripts.
- Extension: no impact.
- Desktop: no impact.

## Scheduled refactoring

None.

## Validation

- Changed-file Prettier and ESLint for configured source/test files
- `corepack pnpm exec vitest run src/test-kernel/cli/StaticBandResize.vitest.mts src/test-kernel/cli/ToolRenderers.vitest.mts src/test-kernel/cli/ConversationPane.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 174 passed
- `corepack pnpm exec tsc --noEmit -p packages/cli/tsconfig.json`
- `corepack pnpm --filter @texra-ai/cli run build`
- Dedicated TUI harness bundle succeeded
- Exact CI TUI subset — 8 of 8 scenarios passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI TUI layout change with a targeted regression test; no auth, data, or extension/desktop surface changes.
> 
> **Overview**
> Fixes unbounded `stdout` **`resize`** listener growth in long chat sessions (Node **`MaxListenersExceededWarning`** around listener 65).
> 
> **Tool rendering** now receives an optional **`width`** from the transcript layout (`ToolUseRow` → `ToolRenderer.render` / `UniversalToolRow` / `PatchPreview`). **`useWindowSize()`** is removed from **`toolRenderers.tsx`**, so each tool row and edit patch preview no longer registers its own resize subscription.
> 
> **Removed workaround:** **`installTuiStdoutListenerLimit`** is deleted from **`noColorOutput.ts`** and is no longer installed in **`runChatTui.tsx`** or **`tui-harness.tsx`**.
> 
> **Tests:** New regression in **`StaticBandResize.vitest.mts`** mounts 70 finalized tool entries and asserts peak **`resize`** listeners stay at **2** (Ink renderer + app-level **`useWindowSize`**). Direct tests for the listener-limit helper are removed from **`TuiStateAndFocus.vitest.mts`**; **`RunChatSignalOwnership.vitest.mts`** drops the related mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7429bc9d98767df2eae1fa920a83261f2c695615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->