### PR TITLE
refactor(scripts): trim dead code and single-use wrappers in build scripts

### DIFF
--- a/scripts/check-desktop-electron-binary.mjs
+++ b/scripts/check-desktop-electron-binary.mjs
@@ -13,33 +13,33 @@ const desktopPackageJsonPath = join(
 );
 const desktopRequire = createRequire(desktopPackageJsonPath);
 
+function fail(...lines) {
+  console.error('Desktop Electron binary check failed.');
+  for (const line of lines) console.error(line);
+  process.exit(1);
+}
+
 let electronBinaryPath;
 try {
   electronBinaryPath = desktopRequire('electron');
 } catch (error) {
-  console.error('Desktop Electron binary check failed.');
-  console.error(
+  fail(
     'The electron package did not install its platform binary. Run `corepack pnpm install --frozen-lockfile` with the root pnpm build-script policy applied.',
+    error instanceof Error ? error.message : String(error),
   );
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
 }
 
 if (typeof electronBinaryPath !== 'string' || electronBinaryPath.length === 0) {
-  console.error('Desktop Electron binary check failed.');
-  console.error('The electron package did not resolve to a binary path.');
-  process.exit(1);
+  fail('The electron package did not resolve to a binary path.');
 }
 
 try {
   await access(electronBinaryPath);
 } catch (error) {
-  console.error('Desktop Electron binary check failed.');
-  console.error(
+  fail(
     `Resolved Electron binary does not exist: ${electronBinaryPath}`,
+    error instanceof Error ? error.message : String(error),
   );
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
 }
 
 console.log(`Desktop Electron binary check passed: ${electronBinaryPath}`);

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -125,7 +125,7 @@ async function waitForRenderedElement(window, view) {
   );
 }
 
-async function assertWebviewRuntime(window, view) {
+async function assertWebviewRuntime(window) {
   return window.webContents.executeJavaScript(
     `
       (async () => {
@@ -491,7 +491,7 @@ async function smokeView(window, view, outputDir, errors) {
   if (errors.length > 0) {
     throw new Error(`${view.name} console errors:\n${errors.join('\n')}`);
   }
-  await assertWebviewRuntime(window, view);
+  await assertWebviewRuntime(window);
   const fixtureResult = await applyViewFixture(window, view);
   await assertViewSpecificLayout(window, view);
 

--- a/scripts/sync-package-contributes.mjs
+++ b/scripts/sync-package-contributes.mjs
@@ -24,12 +24,6 @@ const {
   commandKeybindings,
 } = require('../out/src/shared/commands/catalog.js');
 
-function parseArgs() {
-  return {
-    check: process.argv.includes('--check'),
-  };
-}
-
 function getConfigurationSections(packageJson) {
   const configuration = packageJson.contributes?.configuration;
   if (!Array.isArray(configuration)) {
@@ -42,7 +36,7 @@ function normalizeLineEndings(text) {
   return text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
 }
 
-const { check } = parseArgs();
+const check = process.argv.includes('--check');
 const packageText = await readFile(packagePath, 'utf8');
 const packageJson = JSON.parse(packageText);
 // Spread preserves each key's existing position in `contributes`; only the

--- a/scripts/sync-tsconfig-paths.mjs
+++ b/scripts/sync-tsconfig-paths.mjs
@@ -36,12 +36,6 @@ const targets = [
   },
 ];
 
-function parseArgs() {
-  return {
-    check: process.argv.includes('--check'),
-  };
-}
-
 async function formatJson(text, filepath) {
   const options = (await prettier.resolveConfig(filepath)) ?? {};
   return prettier.format(text, { ...options, filepath });
@@ -51,7 +45,7 @@ function normalizeLineEndings(text) {
   return text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
 }
 
-const { check } = parseArgs();
+const check = process.argv.includes('--check');
 const rootPaths = loadRootPaths(rootDir);
 let outOfSync = false;
 

--- a/scripts/verify-desktop-installer-artifacts.mjs
+++ b/scripts/verify-desktop-installer-artifacts.mjs
@@ -115,7 +115,7 @@ function requireYamlValue(block, key, expectedValue) {
 }
 
 async function verifyPublishTarget() {
-  let configText = '';
+  let configText;
   try {
     configText = await readFile(electronBuilderConfigPath, 'utf8');
   } catch (error) {


### PR DESCRIPTION
## What changed

- `scripts/sync-package-contributes.mjs` and `scripts/sync-tsconfig-paths.mjs`: each defined a `parseArgs()` wrapper that only ever returned `{ check: process.argv.includes('--check') }` and was destructured once at the call site. Inlined to `const check = process.argv.includes('--check');`. Same `--check` flag behavior.
- `scripts/check-desktop-electron-binary.mjs`: the three failure branches each repeated `console.error('Desktop Electron binary check failed.')` followed by `process.exit(1)`. Factored into a local `fail(...lines)` helper. Same messages in the same order, same exit code.
- `scripts/smoke-webviews-electron-runner.cjs`: `assertWebviewRuntime(window, view)` never referenced its `view` parameter (confirmed by grep across the function body); dropped the parameter and updated the one call site.
- `scripts/verify-desktop-installer-artifacts.mjs`: `configText` was initialized to `''` but always overwritten before any read (flagged by `no-useless-assignment`); dropped the dead initializer.

All five changes are behavior-preserving refactors: same CLI flags, same stdout/stderr text, same exit codes. Verified `check-desktop-electron-binary.mjs` and `sync-tsconfig-paths.mjs --check` / `sync-package-contributes.mjs --check` by running them directly against this checkout.

## Net elements (R6)

No exported symbols added or removed. One internal (non-exported) function added (`fail` in `check-desktop-electron-binary.mjs`), two internal functions removed (`parseArgs` in each sync script). Net: -1 internal helper function, 0 change to the module's public/consumed surface.

## Consumer counts (R8)

n/a — all four touched functions/scripts are either script-internal (never imported by another module) or invoked only via their own npm script / CI step, none of which change name, path, args, or output.

## Net LoC delta

-12 (16 insertions, 28 deletions) across 5 files, per `git diff $(git merge-base origin/main HEAD)..HEAD --shortstat`.

## Verification

- `CI=true npm run compile:fast` (from a clean baseline before editing, and again after) — both green.
- `CI=true npm run typecheck` — green across all packages.
- `node --check` on each edited file.
- Ran the edited scripts directly to confirm unchanged behavior:
  - `node scripts/check-desktop-electron-binary.mjs` — passes, same output format.
  - `node scripts/sync-tsconfig-paths.mjs --check` — passes.
  - `npm run sync:package-contributes` and `node scripts/sync-package-contributes.mjs --check` — both pass, no diff to `packages/extension/package.json`.
  - `node scripts/verify-desktop-installer-artifacts.mjs` — fails for the expected reason (no packaged desktop artifacts in this environment), confirming `verifyPublishTarget()` still runs correctly up to that point.
- `packages/cli/scripts/**` was not touched, so the CLI bundle build was not re-run.

## Notes

Swept the full lane (`scripts/**`, `packages/cli/scripts/**`, `packages/desktop/scripts/**`, `docs/scripts/**`, the esbuild/vite configs). `knip --include files,exports,types,duplicates` reported zero unused files/exports/duplicates anywhere in this lane, and most scripts (build configs, ratchet gates, `deploy-relay.mjs`, `sync-remote-agents.mjs`, `bump-workspace-version.mjs`, `verify-desktop-signing-env.mjs`, etc.) were already clean with no dead code or meaningful duplication to remove. The large validation harnesses (`packages/cli/scripts/validate-tui.mjs`, `tui-harness.tsx`, `validate-run.mjs`) were reviewed at a structural level (function-name census, no duplicate helpers found) but not rewritten — they are complex, hard-to-verify-by-hand test infrastructure, and the risk of a subtle behavior change wasn't justified by the modest wins found there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal script refactors only; no product runtime, auth, or data paths change, and behavior is explicitly preserved.
> 
> **Overview**
> Behavior-preserving cleanup across five **scripts** with no CLI or output contract changes.
> 
> **`check-desktop-electron-binary.mjs`** centralizes repeated failure handling in a local **`fail(...lines)`** helper (same banner, messages, and exit code). **`sync-package-contributes.mjs`** and **`sync-tsconfig-paths.mjs`** drop single-use **`parseArgs()`** in favor of **`const check = process.argv.includes('--check')`**. **`smoke-webviews-electron-runner.cjs`** removes an unused **`view`** argument from **`assertWebviewRuntime`**. **`verify-desktop-installer-artifacts.mjs`** drops a dead **`configText`** initializer before **`readFile`**.
> 
> Net effect is roughly **-12 LoC** and less duplication for lint/maintenance, with the same flags, stdout/stderr, and exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f18971885f6efb92a79441aedab5c332ceb8818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->