### PR TITLE
refactor(docs): drop dead global component registrations and mermaid config noise

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -223,17 +223,7 @@ const baseConfig = {
   },
 };
 
-// Export the config wrapped with withMermaid, including optional configs
 export default withMermaid(baseConfig, {
-  // your existing vitepress config is passed above as baseConfig
-  // optionally, you can pass MermaidConfig
-  mermaid: {
-    // refer https://mermaid.js.org/config/setup/modules/mermaidAPI.html#mermaidapi-configuration-defaults for options
-    // Add any specific Mermaid options here, e.g.:
-    // theme: 'dark',
-  },
-  // optionally set additional config for plugin itself with MermaidPluginConfig
-  mermaidPlugin: {
-    class: 'mermaid', // Default class, you can add more like "my-class"
-  },
+  mermaid: {},
+  mermaidPlugin: { class: 'mermaid' },
 });

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -23,11 +23,12 @@ import MemoryPinHero from '../components/MemoryPinHero.vue';
 
 // Frameless mock-UI system: a focused panel primitive + consolidated building
 // blocks, so a page can show ONE component without the full VS Code window.
-import MockupPanel from '../components/MockupPanel.vue';
+// (MockupPanel and MockSwitch are not registered here: every consumer is a
+// sibling .vue component that imports them locally, none is used directly
+// from markdown, so global registration would be dead weight.)
 import MockCard from '../components/MockCard.vue';
 import TermWindow from '../components/TermWindow.vue';
 import StatusPill from '../components/StatusPill.vue';
-import MockSwitch from '../components/MockSwitch.vue';
 import AgentClasses from '../components/AgentClasses.vue';
 import ToolCallPanel from '../components/ToolCallPanel.vue';
 import FeatureCards from '../components/FeatureCards.vue';
@@ -102,11 +103,9 @@ export default {
     app.component('MemoryPinHero', MemoryPinHero);
 
     // Frameless mock-UI primitives (also usable directly in markdown).
-    app.component('MockupPanel', MockupPanel);
     app.component('MockCard', MockCard);
     app.component('TermWindow', TermWindow);
     app.component('StatusPill', StatusPill);
-    app.component('MockSwitch', MockSwitch);
     app.component('AgentClasses', AgentClasses);
     app.component('ToolCallPanel', ToolCallPanel);
     app.component('FeatureCards', FeatureCards);


### PR DESCRIPTION
## What changed

- Removed the global `app.component()` registration (and now-unused imports)
  for `MockupPanel` and `MockSwitch` in `docs/.vitepress/theme/index.js`.
  Neither tag is ever written directly in any markdown page (published or
  srcExcluded) — every actual usage is a sibling `.vue` component
  (`ToolCallPanel.vue`, `RemoteAgentsProfile.vue` for `MockupPanel`;
  `ApiKeysHero.vue`, `GitTabCard.vue`, `MemoryHero.vue`,
  `ProviderConfigRow.vue` for `MockSwitch`) that already imports the
  component locally in its own `<script setup>`. The component resolves the
  same way with or without the global registration, so this is dead
  registration, not a behavior change. (`MockCard`, `TermWindow`, and
  `StatusPill` remain globally registered — `TermWindow`'s global status is
  explicitly documented as intentional in `docs/design/cli-terminal-mockups.md`,
  and I left the other two alone out of caution since removing them isn't as
  unambiguously dead.)
- Trimmed generic plugin-scaffolding comments around the `withMermaid()` call
  in `docs/.vitepress/config.js` (boilerplate "your existing vitepress config
  is passed above as baseConfig" tutorial text with no project-specific
  content). The `mermaid`/`mermaidPlugin` config values are unchanged.

Both changes are behavior-preserving: they touch only comments and an unused
registration path, never a prop, component name, or file consumed from
markdown, and `docs/.vitepress/publicDocs.js` (the frozen publish-boundary
allowlist) was not touched.

## Net elements (R6)

- Exported/registered symbols removed: 2 (`MockupPanel`, `MockSwitch` global
  registrations in `theme/index.js`; the components themselves are untouched
  and still exported/used normally via their own files).
- Exported/registered symbols added: 0.

## Consumer counts (R8)

- `MockupPanel`: 2 local-import consumers (`ToolCallPanel.vue`,
  `RemoteAgentsProfile.vue`), 0 direct markdown consumers (grepped both
  PascalCase `<MockupPanel` and kebab-case `<mockup-panel` across every
  `*.md` file in `docs/`, published and srcExcluded).
- `MockSwitch`: 4 local-import consumers (`ApiKeysHero.vue`, `GitTabCard.vue`,
  `MemoryHero.vue`, `ProviderConfigRow.vue`), 0 direct markdown consumers
  (same grep).

## Verification

- Baseline: `cd docs && npm run docs:build` on the unmodified worktree —
  succeeds with one pre-existing chunk-size warning, no errors.
- After the change: same command — identical result (same single pre-existing
  warning, no new errors/warnings).
- Rendering equivalence: rebuilt `docs:build` before and after the change,
  then diffed every generated `.html` page in `docs/.vitepress/dist` with
  content-hashed `/assets/...` paths normalized out — 0 pages differ. This
  confirms `MockupPanel`/`MockSwitch` still render identically through their
  local imports (e.g. `guide/memory.html` still contains the `MockSwitch`
  markup via `MemoryHero`, `guide/tikz-figures.html` still contains the
  `MockupPanel` markup via `ToolCallPanel`) and no other page changed.
- `git diff $(git merge-base origin/main HEAD)..HEAD --shortstat`: 2 files
  changed, 5 insertions(+), 16 deletions(-) — net −11 LoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and unused registration cleanup in docs tooling; no runtime, auth, or product code paths affected.
> 
> **Overview**
> Removes unused global VitePress registrations for **`MockupPanel`** and **`MockSwitch`** in `theme/index.js`, along with their imports and `app.component()` calls. Docs pages only reach those components through other Vue heroes/panels that already import them locally, so behavior and rendered HTML stay the same.
> 
> Also shortens the **`withMermaid()`** wrapper in `config.js` by deleting generic plugin tutorial comments; **`mermaid`** and **`mermaidPlugin`** settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e648c823bc853b245c5d3d10675b8532a445ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->