### PR TITLE
fix(cli): keep subagent summaries on the current turn

### DIFF
--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -2,6 +2,7 @@
 
 // Local imports - shared schemas
 import {
+  MESSAGE_TYPES,
   STREAM_PHASE,
   type ActiveChildInfo,
   type StreamTabId,
@@ -200,13 +201,21 @@ function buildChildControlItem(
 
   if (child.kind === 'subagent') {
     const entries = ctx.streamsById.get(child.childStreamId)?.entries;
+    const latestUserIndex =
+      entries?.findLastIndex(
+        (entry) => entry.role === 'user' && entry.text.trim(),
+      ) ?? -1;
+    const latestInstruction =
+      latestUserIndex >= 0 ? entries?.[latestUserIndex]?.text : undefined;
     const summary =
       entries?.findLast(
-        (entry) =>
-          entry.role === 'assistant' && entry.finalized && entry.text.trim(),
-      )?.text ??
-      entries?.find((entry) => entry.role === 'user' && entry.text.trim())
-        ?.text;
+        (entry, index) =>
+          index > latestUserIndex &&
+          entry.role === 'assistant' &&
+          entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
+          entry.finalized &&
+          entry.text.trim(),
+      )?.text ?? latestInstruction;
     return {
       executionId: child.executionId,
       childStreamId: child.childStreamId,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -11,6 +11,7 @@ import {
   type ActiveChildInfo,
   type AgentCategory,
   type ConversationProgress,
+  type MessageType,
   type NormalizedToolUse,
   type Plan,
   type ProcessOutputTail,
@@ -46,8 +47,11 @@ export type { ProcessOutputTail };
 interface ConversationEntryBase {
   /** Same id as the upstream `StreamLogEntry.id` — stable across deltas. */
   readonly id: string;
-  /** Concatenated text for `MODEL_RESPONSE` entries. Empty for tool rows. */
+  /** Rendered log text. Empty for tool and process rows. */
   readonly text: string;
+  /** Original shared log vocabulary. Role alone intentionally groups several
+   * display kinds and is not precise enough for semantic selection. */
+  readonly messageType?: MessageType;
   /** True while rendered assistant text is hiding an incomplete protocol block. */
   readonly pendingEmbeddedSubagentFollowup?: boolean;
   /** True once the stream transitions to `WAITING`/`COMPLETED`. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -137,6 +137,7 @@ function entriesEqual(
   if (
     prev.role !== next.role ||
     prev.text !== next.text ||
+    prev.messageType !== next.messageType ||
     prev.pendingEmbeddedSubagentFollowup !==
       next.pendingEmbeddedSubagentFollowup ||
     prev.finalized !== next.finalized
@@ -201,6 +202,7 @@ function renderLogEntry(
       id: entry.id,
       role: 'tool',
       text: '',
+      ...(entry.messageType ? { messageType: entry.messageType } : {}),
       finalized: prev?.finalized ?? false,
       toolUse,
     };
@@ -231,6 +233,7 @@ function renderLogEntry(
     id: entry.id,
     role,
     text: renderedText,
+    ...(entry.messageType ? { messageType: entry.messageType } : {}),
     ...(assistantTranscript !== undefined &&
     hasIncompleteEmbeddedSubagentFollowup(assistantTranscript)
       ? { pendingEmbeddedSubagentFollowup: true }

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -57,6 +57,7 @@ import {
 
 // Local imports - shared schemas
 import {
+  MESSAGE_TYPES,
   STREAM_PHASE,
   TOOL_USE_STATUS,
   type NormalizedToolUse,
@@ -404,6 +405,7 @@ describe('CLI child execution controls', () => {
               {
                 id: 'entry-2',
                 role: 'assistant',
+                messageType: MESSAGE_TYPES.MODEL_RESPONSE,
                 text: 'Tightened the opening paragraph and fixed two typos.',
                 finalized: true,
               },
@@ -452,6 +454,7 @@ describe('CLI child execution controls', () => {
               {
                 id: 'entry-2',
                 role: 'assistant',
+                messageType: MESSAGE_TYPES.MODEL_RESPONSE,
                 text: 'Still drafting a response',
                 finalized: false,
               },
@@ -470,6 +473,143 @@ describe('CLI child execution controls', () => {
     expect(item?.description).toBe(
       `running · 3s · Review the introduction for clarity and tone. ${'x'.repeat(53)}…`,
     );
+  });
+
+  it('uses the latest instruction while a resumed turn is still running', () => {
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'reviewer',
+          childStreamId: 'child-a',
+          status: STREAM_PHASE.RUNNING,
+        },
+      ],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: STREAM_PHASE.RUNNING,
+            entries: [
+              {
+                id: 'turn-1-user',
+                role: 'user',
+                messageType: MESSAGE_TYPES.USER_MESSAGE,
+                text: 'Review the introduction.',
+                finalized: true,
+              },
+              {
+                id: 'turn-1-response',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+                text: 'The introduction is clear.',
+                finalized: true,
+              },
+              {
+                id: 'turn-1-tokens',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.DEFAULT,
+                text: 'Tokens',
+                finalized: true,
+              },
+              {
+                id: 'turn-2-user',
+                role: 'user',
+                messageType: MESSAGE_TYPES.USER_MESSAGE,
+                text: 'Now check the conclusion.',
+                finalized: true,
+              },
+              {
+                id: 'turn-2-response',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+                text: 'Still checking the conclusion.',
+                finalized: false,
+              },
+              {
+                id: 'turn-2-duration',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.DEFAULT,
+                text: 'Turn completed in 2s',
+                finalized: false,
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
+      {
+        description: 'running · Now check the conclusion.',
+      },
+    ]);
+  });
+
+  it('ignores bookkeeping rows after the latest finalized model response', () => {
+    const { entries, streams } = childFixture('root', {
+      activeOnly: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-1',
+          agentName: 'reviewer',
+          childStreamId: 'child-a',
+          status: STREAM_PHASE.WAITING,
+        },
+      ],
+      extraStreams: new Map([
+        [
+          'child-a',
+          slice({
+            streamId: 'child-a',
+            status: STREAM_PHASE.WAITING,
+            entries: [
+              {
+                id: 'turn-user',
+                role: 'user',
+                messageType: MESSAGE_TYPES.USER_MESSAGE,
+                text: 'Check the conclusion.',
+                finalized: true,
+              },
+              {
+                id: 'turn-response',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+                text: 'The conclusion follows from the stated assumptions.',
+                finalized: true,
+              },
+              {
+                id: 'turn-tokens',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.DEFAULT,
+                text: 'Tokens',
+                finalized: true,
+              },
+              {
+                id: 'turn-duration',
+                role: 'assistant',
+                messageType: MESSAGE_TYPES.DEFAULT,
+                text: 'Turn completed in 2s',
+                finalized: true,
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    expect(
+      buildChildControlItems('root', entries, streams, 'subagents'),
+    ).toMatchObject([
+      {
+        description:
+          'waiting for you · The conclusion follows from the stated assumptions.',
+      },
+    ]);
   });
 
   it('derives live elapsed text for running child executions', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1380,6 +1380,7 @@ describe('CLI transcript state', () => {
     expect(entries.map((entry) => entry.text)).toEqual([
       '### Verification Report\n\nThe proof is **fully verified**.',
     ]);
+    expect(entries[0]?.messageType).toBe(MESSAGE_TYPES.MODEL_RESPONSE);
     expect(entries[0]?.text).not.toContain('<h3>');
     expect(entries[0]?.text).not.toContain('<b>');
   });


### PR DESCRIPTION
## Summary

Follow-up to #8581.

The subagent picker originally selected the last finalized row whose display role was `assistant`. Child-session bookkeeping rows also use that display role, and resumed sessions retain earlier turns. Two incorrect summaries could result:

- while a resumed follow-up was running, the picker showed the previous turn's answer;
- after a completed answer, later “Tokens” or duration rows replaced the answer.

This PR preserves each transcript row's existing shared `MessageType` when projecting it into CLI state. The picker then selects only a finalized `MODEL_RESPONSE` after the latest user message and otherwise shows that latest instruction.

## Issue acceptance gates

This directly addresses the two unresolved correctness findings posted on merged PR #8581.

Focused tests cover:
- first-turn finalized answer;
- first-turn in-progress fallback;
- resumed-turn in-progress fallback to the latest instruction rather than the prior answer;
- finalized current-turn answer followed by DEFAULT bookkeeping rows;
- preservation of `MODEL_RESPONSE` through the stream-log projection.

## Single source of truth

`MESSAGE_TYPES` remains the shared vocabulary. CLI `ConversationEntry` preserves that source fact instead of attempting to reconstruct semantic meaning from display role or text.

## Duplication and abstraction budget

No new module, wrapper, class, schema, or parallel vocabulary was added. One optional field carries the existing shared discriminant through the projection boundary.

## Net elements (R6)

5 files changed, 163 insertions, 6 deletions, net +157 lines. No exports, classes, interfaces, factories, or schemas were added or removed.

140 added lines are explicit regression fixtures for the two multi-turn transcript shapes. Production code adds 21 lines and removes 6.

## Consumer counts (R8)

- New optional `ConversationEntry.messageType`: written at 2 stream-log projection sites and consumed at 1 semantic selection site.
- Existing `MESSAGE_TYPES.MODEL_RESPONSE`: reused; no new vocabulary or compatibility alias.
- No event emit path, export, or public API was added, removed, or rerouted.

## Host impact

- CLI: subagent picker summaries now represent the current turn's actual model response or current instruction.
- Extension: no impact.
- Desktop: no impact.

## Scheduled refactoring

None.

## Validation

- Changed-file Prettier and ESLint
- `corepack pnpm exec vitest run src/test-kernel/cli/ChildControls.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` — 161 passed
- Additional `ConversationPane` focused suite in the first validation pass — 48 passed
- `corepack pnpm exec tsc --noEmit -p packages/cli/tsconfig.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display logic with a narrow optional field on transcript entries; behavior is covered by focused vitest fixtures and does not touch auth, persistence, or extension APIs.
> 
> **Overview**
> Fixes incorrect **subagent picker** descriptions on resumed sessions and after turn bookkeeping rows.
> 
> **CLI transcript projection** now carries optional `messageType` from the shared stream log into `ConversationEntry`, and equality checks include it so sync stays stable.
> 
> **Summary selection** finds the latest user instruction, then prefers the last **finalized** `MODEL_RESPONSE` **after** that message—so prior-turn answers and trailing `DEFAULT` rows (tokens, duration) no longer replace the current turn’s text. While the current response is still streaming, the picker falls back to that latest instruction.
> 
> Regression tests cover multi-turn in-progress and post-completion bookkeeping cases, plus `messageType` preservation through `syncStreamLog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c527882379988a97bd3b2c56dba66182f5e7fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->