### PR TITLE
fix(cli): restore user-band breathing room and show run liveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
             edit-approval subagent-picker hidden-root-approval-tab-return \
             orchestrate-launcher orchestrate-agent-submenu \
             orchestrate-delegated-history orchestrate-resume-submenu \
-            compact-orchestrate-launcher
+            compact-orchestrate-launcher run-liveness-row
 
       - name: Upload CLI TUI smoke frames
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
+#### Improvements
+
+- **The chat transcript breathes and shows run activity** — a blank line now
+  always follows your message, and while the agent runs, an animated indicator
+  with elapsed time makes clear it is still working — not just while the model
+  is thinking.
+
 #### Bug Fixes
 
 - **Ctrl+C clears dialog text before stopping or exiting** — pressing Ctrl+C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,12 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
-#### Improvements
+#### Bug Fixes
 
 - **The chat transcript breathes and shows run activity** — a blank line now
   always follows your message, and while the agent runs, an animated indicator
   with elapsed time makes clear it is still working — not just while the model
   is thinking.
-
-#### Bug Fixes
-
 - **Ctrl+C clears dialog text before stopping or exiting** — pressing Ctrl+C
   with text in a foreground dialog now clears that text; pressing it again
   keeps the existing response-stop or exit behavior.

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1095,6 +1095,15 @@ const SCENARIOS = [
     unexpect: ['Ctrl-C stop'],
   },
   {
+    // The liveness row shows for the whole active run (not just hidden
+    // reasoning) with a ticking elapsed time; the harness pins the run's
+    // start 42s in the past so the elapsed suffix is deterministic.
+    name: 'run-liveness-row',
+    env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
+    frame: 'viewport',
+    expect: ['✻ Working', '42s', '◆ running'],
+  },
+  {
     name: 'tools-form',
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/tools', '\r'],

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -181,7 +181,7 @@ export function ConversationPane(
           width: props.width,
         }),
       )}
-      {showLiveness ? (
+      {livenessRows > 0 ? (
         <LivenessRow
           startedAtMs={slice?.runStartedAt}
           thinking={thinkingIndicatorVisible(slice)}

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -150,8 +150,14 @@ export function ConversationPane(
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
   // The liveness row is budgeted like any other live content: it takes one
   // row off the entry viewport so the pane's explicit height never exceeds
-  // maxRows (an overflow would leak live rows into scrollback).
-  const livenessRows = showLiveness ? 1 : 0;
+  // maxRows (an overflow would leak live rows into scrollback). Content
+  // outranks it: when a foreground panel squeezes the pane to a single row,
+  // pending entries keep that row and the StatusBar's running/elapsed
+  // segment carries liveness alone.
+  const livenessRows =
+    showLiveness && (maxRows > MIN_PENDING_ROWS || displayEntries.length === 0)
+      ? 1
+      : 0;
   const visibleEntries = selectTranscriptEntriesForViewport(
     displayEntries,
     maxRows - livenessRows,

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -3,6 +3,9 @@
 
 import { Box, Text } from 'ink';
 
+import { isActivePhase } from '@shared/streams/streamStatus';
+import { formatCompactDuration } from '@utils/core';
+
 import {
   activeStreamId as activeStreamIdSignal,
   streams as streamsSignal,
@@ -27,23 +30,39 @@ import {
 
 const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
-const THINKING_DOTS = ['.', '..', '...'] as const;
+// Padded to a fixed width so the elapsed time doesn't jiggle as dots cycle.
+const LIVENESS_DOTS = ['.  ', '.. ', '...'] as const;
 
 /**
- * Liveness row for the hidden reasoning phase: the model is working but
- * nothing streams into the transcript, so the pane shows that thinking is
- * happening (never the thinking text itself). Animated off the shared 1 Hz
- * ticker — an autonomous 80 ms spinner would repaint the whole live region
- * at ~12 Hz during exactly the phase where nothing else is streaming, while
- * the shared tick batches with the StatusBar's elapsed-seconds render.
+ * Liveness row shown for the whole active run, not just the hidden reasoning
+ * phase: long tool calls and provider latency also stream nothing into the
+ * transcript, and the pane must still answer "working or stalled?". The
+ * label distinguishes hidden reasoning ("Thinking") from everything else
+ * ("Working") and never shows the reasoning text itself; the ticking elapsed
+ * time is the stall signal. Animated off the shared 1 Hz ticker — an
+ * autonomous 80 ms spinner would repaint the whole live region at ~12 Hz
+ * during exactly the phase where nothing else is streaming, while the shared
+ * tick batches with the StatusBar's elapsed-seconds render.
  */
-function ThinkingRow(): React.JSX.Element {
-  const now = useLiveNowMs(true);
-  const dots = THINKING_DOTS[Math.floor(now / 1000) % THINKING_DOTS.length];
+function LivenessRow({
+  startedAtMs,
+  thinking,
+}: {
+  readonly startedAtMs: number | undefined;
+  readonly thinking: boolean;
+}): React.JSX.Element {
+  const now = useLiveNowMs(true, startedAtMs);
+  const dots = LIVENESS_DOTS[Math.floor(now / 1000) % LIVENESS_DOTS.length];
+  const elapsed =
+    startedAtMs === undefined
+      ? ''
+      : ` ${formatCompactDuration(now - startedAtMs)}`;
   return (
     <Box>
       <Text dimColor>
-        {THINKING_MARKER} Thinking{dots}
+        {THINKING_MARKER} {thinking ? 'Thinking' : 'Working'}
+        {dots}
+        {elapsed}
       </Text>
     </Box>
   );
@@ -126,22 +145,22 @@ export function ConversationPane(
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
   const displayEntries = splitTranscriptEntries(entries, slice?.status).pending;
-  const showThinking = thinkingIndicatorVisible(slice);
+  const showLiveness = isActivePhase(slice?.status);
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
-  // The thinking liveness row is budgeted like any other live content: it
-  // takes one row off the entry viewport so the pane's explicit height never
-  // exceeds maxRows (an overflow would leak live rows into scrollback).
-  const thinkingRows = showThinking ? 1 : 0;
+  // The liveness row is budgeted like any other live content: it takes one
+  // row off the entry viewport so the pane's explicit height never exceeds
+  // maxRows (an overflow would leak live rows into scrollback).
+  const livenessRows = showLiveness ? 1 : 0;
   const visibleEntries = selectTranscriptEntriesForViewport(
     displayEntries,
-    maxRows - thinkingRows,
+    maxRows - livenessRows,
     props.width,
   );
   const visibleRows =
     (visibleEntries.entries.length > 0
       ? Math.max(MIN_PENDING_ROWS, visibleEntries.usedRows)
-      : 0) + thinkingRows;
+      : 0) + livenessRows;
 
   // Keep stream order intact so in-flight text stays interleaved with tool rows.
   // The explicit height keeps the input bar pinned and prevents bursts from
@@ -156,7 +175,12 @@ export function ConversationPane(
           width: props.width,
         }),
       )}
-      {showThinking ? <ThinkingRow /> : null}
+      {showLiveness ? (
+        <LivenessRow
+          startedAtMs={slice?.runStartedAt}
+          thinking={thinkingIndicatorVisible(slice)}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -30,14 +30,11 @@ import { useSignal } from '../state/useSignal';
 import { COLOR_HINT } from '../ui/colors';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
-  isInquiryContinuationText,
   isRenderableTranscriptEntry,
-  nextRenderableTranscriptEntry,
   userPromptAwaitsLiveContinuation,
 } from './transcriptEntries';
 import { TranscriptEntry } from './TranscriptEntry';
 import {
-  USER_ENTRY_MARGIN_BOTTOM_ROWS,
   transcriptColumns,
   transcriptEntryLayout,
   transcriptEntryLayoutRows,
@@ -55,7 +52,6 @@ export type StaticTranscriptItem =
       readonly id: string;
       readonly kind: 'entry';
       readonly entry: ConversationEntry;
-      readonly userBottomMarginRows?: number;
     };
 
 interface StaticTranscriptState {
@@ -197,26 +193,9 @@ function staticTranscriptItemRowCount(
   return transcriptEntryLayoutRows(
     transcriptEntryLayout(item.entry, {
       mode: 'scrollback-budget',
-      userBottomMarginRows: item.userBottomMarginRows,
       width,
     }),
   );
-}
-
-function staticUserBottomMarginRows({
-  entry,
-  nextEntry,
-}: {
-  readonly entry: ConversationEntry;
-  readonly nextEntry: ConversationEntry | undefined;
-}): number | undefined {
-  const isUserBand =
-    entry.role === 'user' && !isInquiryContinuationText(entry.text);
-  if (!isUserBand) return undefined;
-  // Tool rows are the command execution part of the same turn; keep them
-  // attached to the prompt instead of printing a gap row.
-  if (nextEntry?.role === 'tool') return 0;
-  return USER_ENTRY_MARGIN_BOTTOM_ROWS;
 }
 
 export function appendStaticTranscriptItems({
@@ -298,15 +277,7 @@ export function appendStaticTranscriptItems({
     if (!entry.finalized) continue;
     if (seen.has(entry.id)) continue;
     nextItems ??= [...currentItems];
-    nextItems.push({
-      id: entry.id,
-      kind: 'entry',
-      entry,
-      userBottomMarginRows: staticUserBottomMarginRows({
-        entry,
-        nextEntry: nextRenderableTranscriptEntry(entries, index),
-      }),
-    });
+    nextItems.push({ id: entry.id, kind: 'entry', entry });
     seen.add(entry.id);
   }
   // Same reference when nothing was appended so the `setItems` functional
@@ -423,7 +394,6 @@ export function StaticConversationTranscript({
                 entry={item.entry}
                 width={normalizedWidth}
                 colorEnabled={colorEnabled}
-                userBottomMarginRows={item.userBottomMarginRows}
               />
             </EntryErrorBoundary>
           )}

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -157,13 +157,11 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   width,
   colorEnabled,
   fillWidth,
-  userBottomMarginRows,
 }: {
   readonly entry: ConversationEntry;
   readonly width?: number;
   readonly colorEnabled?: boolean;
   readonly fillWidth?: boolean;
-  readonly userBottomMarginRows?: number;
 }): React.JSX.Element {
   if (entry.role === 'tool') {
     return (
@@ -174,7 +172,6 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   const layout = transcriptEntryLayout(entry, {
     colorEnabled,
     mode: 'scrollback',
-    userBottomMarginRows,
     width,
   });
 

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -15,7 +15,7 @@ import type { ConversationEntry } from '../state/cliState';
 
 const DEFAULT_TRANSCRIPT_COLUMNS = 80;
 const USER_ENTRY_MARGIN_TOP_ROWS = 1;
-export const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
+const USER_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 const ASSISTANT_ENTRY_MARGIN_BOTTOM_ROWS = 0;
 const PROCESS_ENTRY_MARGIN_BOTTOM_ROWS = 1;
 export const LIVE_TAIL_ROWS = 24;
@@ -212,13 +212,11 @@ export function transcriptEntryLayout(
     colorEnabled,
     maxRows,
     mode = 'scrollback',
-    userBottomMarginRows,
     width,
   }: {
     readonly colorEnabled?: boolean;
     readonly maxRows?: number;
     readonly mode?: TranscriptEntryLayoutMode;
-    readonly userBottomMarginRows?: number;
     readonly width?: number;
   } = {},
 ): TranscriptEntryLayout {
@@ -234,9 +232,7 @@ export function transcriptEntryLayout(
       ? toolUseMarginBottomRows(entry.toolUse)
       : isInquiryContinuation
         ? 0
-        : entry.role === 'user'
-          ? (userBottomMarginRows ?? base.marginBottomRows)
-          : base.marginBottomRows;
+        : base.marginBottomRows;
   // The ctrl+t viewer is a full-width text projection with no Ink padding;
   // its lines still share role prefixes and wrapping rules with the layout.
   const columns = transcriptColumns(width, mode === 'viewer' ? 0 : inset);

--- a/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
+++ b/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
@@ -1,7 +1,7 @@
 // Shared "work in progress" row for async transient states (list-form data
 // fetches, /api status loading). Animated off the shared 1 Hz ticker
-// (useLiveNowMs) — the same pattern ConversationPane's `ThinkingRow` uses for
-// the hidden-reasoning liveness row — instead of an autonomous per-component
+// (useLiveNowMs) — the same pattern ConversationPane's `LivenessRow` uses for
+// the active-run liveness row — instead of an autonomous per-component
 // interval. Replaces `@inkjs/ui`'s `<Spinner>`, whose own ~80ms `setInterval`
 // (driven by `cli-spinners`) runs completely outside the shared clock: the
 // exact per-component-interval anti-pattern the shared clock exists to avoid.

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -38,5 +38,5 @@ export const ERROR_ENTRY_PREFIX = '! ';
 /** Corner glyph that opens each tool-output block. */
 export const TOOL_OUTPUT_CORNER = '⎿';
 
-/** Thinking-phase marker shown in the liveness row while the model reasons. */
+/** Marker for the liveness row shown while a run is active. */
 export const THINKING_MARKER = '✻';

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,6 +1,8 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
+import { createRequire } from 'node:module';
+
 import { describe, expect, it } from 'vitest';
 
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
@@ -37,6 +39,7 @@ import {
   selectTranscriptEntriesForViewport,
 } from '@cli/chat/tui/panes/transcriptViewport';
 import {
+  activeStreamId,
   resetCliState,
   patchStream,
   streams,
@@ -60,6 +63,9 @@ import {
 } from '@shared/schemas';
 
 const STREAM_ID = 'cli-test-stream' as StreamTabId;
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
 const SESSION_META = {
   agent: 'research',
   model: 'deepseekT',
@@ -146,6 +152,83 @@ function processEntry(
     },
   };
 }
+
+async function renderConversationPane(maxRows = 2): Promise<string> {
+  const ink = (await import(cliRequire.resolve('ink'))) as any;
+  const React = ((await import(cliRequire.resolve('react'))) as any).default;
+  const { ConversationPane } =
+    await import('@cli/chat/tui/panes/ConversationPane');
+  return ink.renderToString(
+    React.createElement(ConversationPane, { maxRows, width: 80 }),
+  );
+}
+
+describe('CLI conversation pane liveness', () => {
+  it('renders working and thinking liveness labels for active runs', async () => {
+    resetCliState();
+    activeStreamId.set(STREAM_ID);
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      status: STREAM_PHASE.RUNNING,
+      runStartedAt: Date.now() - 42_000,
+      thinkingActive: false,
+    }));
+
+    try {
+      const working = await renderConversationPane();
+      expect(working).toContain('Working');
+      expect(working).toMatch(/4[23]s/);
+
+      patchStream(STREAM_ID, (slice) => ({
+        ...slice,
+        thinkingActive: true,
+      }));
+      const thinking = await renderConversationPane();
+      expect(thinking).toContain('Thinking');
+      expect(thinking).not.toContain('Working');
+    } finally {
+      resetCliState();
+    }
+  });
+
+  it('omits elapsed time when an active run has no start timestamp', async () => {
+    resetCliState();
+    activeStreamId.set(STREAM_ID);
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      status: STREAM_PHASE.RUNNING,
+      runStartedAt: undefined,
+    }));
+
+    try {
+      const output = await renderConversationPane();
+      expect(output).toContain('Working');
+      expect(output).not.toMatch(/\d+s/);
+    } finally {
+      resetCliState();
+    }
+  });
+
+  it('gives a single squeezed row to pending content instead of liveness', async () => {
+    resetCliState();
+    activeStreamId.set(STREAM_ID);
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      status: STREAM_PHASE.RUNNING,
+      runStartedAt: Date.now() - 42_000,
+      entries: [toolEntry('tool', TOOL_USE_STATUS.IN_PROGRESS)],
+    }));
+
+    try {
+      const output = await renderConversationPane(1);
+      expect(output).toContain('Bash');
+      expect(output).not.toContain('Working');
+      expect(output).not.toContain('Thinking');
+    } finally {
+      resetCliState();
+    }
+  });
+});
 
 describe('CLI conversation transcript splitting', () => {
   it('keeps only explicit finalized entries in scrollback', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -589,10 +589,7 @@ describe('CLI conversation transcript splitting', () => {
       'session-header',
       'u1',
     ]);
-    expect(staticItems[1]).toMatchObject({
-      kind: 'entry',
-      userBottomMarginRows: 0,
-    });
+    expect(staticItems[1]).toMatchObject({ kind: 'entry' });
   });
 
   it('keeps inquiry continuations on the finalized transcript path', () => {


### PR DESCRIPTION
## Problem

Two UX issues in the chat TUI:

1. **No vertical space after the user message.** `staticUserBottomMarginRows` suppressed the user band's bottom margin whenever the next entry was a tool row — and in agent runs the first action after a prompt is almost always a tool call, so the gap vanished in exactly the common case.
2. **Unclear whether the agent is working or stalled.** The only in-transcript liveness signal was the `✻ Thinking...` row, gated on the hidden-reasoning substate. During long tool calls or provider latency nothing near the transcript moved.

## Root-cause fixes

**One owner for vertical rhythm (net deletion).** The `userBottomMarginRows` override channel (`StaticTranscriptItem` → `TranscriptEntry` → `transcriptEntryLayout`) is deleted; `ROLE_GEOMETRY` becomes the sole authority on entry margins. This is also the `<Static>`-idiomatic contract: printed items are immutable, so an item's spacing must be knowable at append time from the item alone — geometry keyed on a *neighboring* entry can't be expressed there safely. No geometry values change; `ROLE_GEOMETRY.user.marginBottomRows` was already 1.

**Liveness derived from the run phase.** `ThinkingRow` generalizes to `LivenessRow`, gated on `isActivePhase(slice.status)` for the whole run. `thinkingIndicatorVisible` now only picks the label (`Thinking` vs `Working`), keeping the pane and the StatusBar's `thinking...` segment in agreement, and a ticking elapsed time from `runStartedAt` is the stall signal. It rides the shared 1 Hz `useLiveNowMs` ticker (batches with the StatusBar elapsed render — deliberately not ink 7.1's per-subscriber-phase `useAnimation`, which would add a second unsynced 1 Hz wake); dots are padded to fixed width so the timer doesn't jiggle; the row is budgeted so the pane height never overflows into scrollback.

## Verification

- Root, test-kernel, and CLI `tsc` clean; eslint clean on touched files.
- `src/test-kernel/cli/` suite: 1789/1791 pass; the 2 failures are `RunChatSignalOwnership` timing out only under full-suite load plus its cascade — it mocks `ink.render`, imports none of the touched modules, and passes standalone with these changes.
- tmux dogfood of the worktree build: blank row between the user band and the first tool row; `✻ Working.. 1s` → `✻ Working.. 4s` animating during the run; row clears when the run finalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only TUI layout and transcript rendering changes with added smoke and unit tests; no auth, data, or API surface impact.
> 
> **Overview**
> **Chat TUI transcript rhythm and run feedback** — the live pane now shows a **liveness row for the entire active run** (not only hidden reasoning): `✻ Thinking` vs `✻ Working`, padded dot animation, and **elapsed time** from `runStartedAt`, gated on `isActivePhase` and row-budget rules so a one-row squeeze still shows pending tool content. The old `ThinkingRow` becomes `LivenessRow`.
> 
> **Consistent spacing after user messages** — the `userBottomMarginRows` override path is removed from static transcript items, `TranscriptEntry`, and `transcriptEntryLayout`; user-band bottom margin always follows `ROLE_GEOMETRY` (including a blank line after prompts even when the next entry is a tool row).
> 
> **Verification** — `run-liveness-row` is added to CLI TUI smoke validation and CI; kernel tests cover liveness rendering, elapsed-time omission, and squeezed-row behavior; CHANGELOG updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9702e700845cf42282cc0fa375aeb56d7c17f282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->