### PR TITLE
feat(cli): set a friendly terminal tab title

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -136,6 +136,7 @@ import {
   clearTerminalScrollback,
   installTerminalRestoreOnExit,
   restoreTuiInputModes,
+  setTerminalTitle,
   supportsTerminalJobControl,
 } from './terminalCleanup';
 import {
@@ -444,6 +445,10 @@ export async function runChat(
   // (uncaught exception, stray process.exit), still restore the terminal so
   // the user's shell isn't left in raw/kitty/mouse mode with a hidden cursor.
   disposers.push(installTerminalRestoreOnExit({ clearItermProgress }));
+  // Cosmetic, but "texra-local" (a local dev binary's own name) or a bare
+  // shell prompt in every tab makes a multi-session workflow hard to
+  // navigate — name the tab after the project instead.
+  setTerminalTitle(context.cwd);
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
 

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -1,4 +1,5 @@
 import { writeSync } from 'node:fs';
+import { basename } from 'node:path';
 
 import { kittyFlags } from 'ink';
 
@@ -30,6 +31,27 @@ const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
 const CLEAR_SCREEN_AND_SCROLLBACK = '\x1b[2J\x1b[3J\x1b[H';
 const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
+const OSC_TITLE_TERMINATOR = '\x07';
+
+/** Directory names can contain characters that would prematurely terminate
+ *  the OSC string (a stray BEL/ESC); strip C0 controls so a weird folder
+ *  name can't inject terminal escape sequences into the title. */
+function sanitizeTitleSegment(text: string): string {
+  // eslint-disable-next-line no-control-regex -- stripping C0 controls
+  return text.replaceAll(/[\x00-\x1f\x7f]/g, '');
+}
+
+/**
+ * "TeXRA" alone when the cwd has no meaningful basename (e.g. filesystem
+ * root), else "TeXRA — <project folder>" so a user running several sessions
+ * across different projects — the common case here — can tell tabs apart
+ * at a glance instead of every tab reading the launcher binary's own name
+ * (e.g. a local dev symlink like `texra-local`).
+ */
+export function terminalTitleText(cwd: string): string {
+  const project = sanitizeTitleSegment(basename(cwd));
+  return project ? `TeXRA — ${project}` : 'TeXRA';
+}
 
 export interface CleanupTerminalModesOptions {
   readonly clearItermProgress?: boolean;
@@ -101,5 +123,19 @@ export function clearTerminalVisibleScreen(): void {
     writeSync(1, CLEAR_VISIBLE_SCREEN);
   } catch {
     // The terminal may have been closed mid-clear; nothing to do.
+  }
+}
+
+/**
+ * Set the terminal tab/window title via OSC 0. Unlike the DA1-gated
+ * capability queries elsewhere in the TUI, this needs no negotiation: OSC 0
+ * is a one-way "set" with no reply to wait for, and terminals that don't
+ * recognize it just ignore it.
+ */
+export function setTerminalTitle(cwd: string): void {
+  try {
+    writeSync(1, `\x1b]0;${terminalTitleText(cwd)}${OSC_TITLE_TERMINATOR}`);
+  } catch {
+    // The tab title is cosmetic; a write failure here isn't actionable.
   }
 }

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -34,19 +34,22 @@ const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
 const OSC_TITLE_TERMINATOR = '\x07';
 
 /** Directory names can contain characters that would prematurely terminate
- *  the OSC string (a stray BEL/ESC); strip C0 controls so a weird folder
- *  name can't inject terminal escape sequences into the title. */
+ *  the OSC string (a stray BEL/ESC) or that some terminals in 8-bit mode
+ *  still interpret as escape-sequence introducers (the C1 range, e.g. 0x9d
+ *  as an 8-bit OSC); strip both C0 and C1 controls so a weird folder name
+ *  can't inject terminal escape sequences into the title. */
 function sanitizeTitleSegment(text: string): string {
-  // eslint-disable-next-line no-control-regex -- stripping C0 controls
-  return text.replaceAll(/[\x00-\x1f\x7f]/g, '');
+  // eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
+  return text.replaceAll(/[\x00-\x1f\x7f-\x9f]/g, '');
 }
 
 /**
  * "TeXRA" alone when the cwd has no meaningful basename (e.g. filesystem
- * root), else "TeXRA — <project folder>" so a user running several sessions
- * across different projects — the common case here — can tell tabs apart
- * at a glance instead of every tab reading the launcher binary's own name
- * (e.g. a local dev symlink like `texra-local`).
+ * root, where `path.basename` returns `''`), else "TeXRA — <project folder>"
+ * so a user running several sessions across different projects — the common
+ * case here — can tell tabs apart at a glance instead of every tab reading
+ * the launcher binary's own name (e.g. a local dev symlink like
+ * `texra-local`).
  */
 export function terminalTitleText(cwd: string): string {
   const project = sanitizeTitleSegment(basename(cwd));

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -3,6 +3,10 @@ import { basename } from 'node:path';
 
 import { kittyFlags } from 'ink';
 
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
+
+import { terminalCapabilities } from './state/terminalCapabilities';
+
 // Undo exactly the input/display modes the TUI turns on: mouse tracking
 // (1000/1003/1006), the kitty keyboard stack (<u), bracketed paste (2004), and
 // cursor visibility (25h). The TUI deliberately never enters the alternate
@@ -31,17 +35,13 @@ const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
 const CLEAR_SCREEN_AND_SCROLLBACK = '\x1b[2J\x1b[3J\x1b[H';
 const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
-const OSC_TITLE_TERMINATOR = '\x07';
-
-/** Directory names can contain characters that would prematurely terminate
- *  the OSC string (a stray BEL/ESC) or that some terminals in 8-bit mode
- *  still interpret as escape-sequence introducers (the C1 range, e.g. 0x9d
- *  as an 8-bit OSC); strip both C0 and C1 controls so a weird folder name
- *  can't inject terminal escape sequences into the title. */
-function sanitizeTitleSegment(text: string): string {
-  // eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
-  return text.replaceAll(/[\x00-\x1f\x7f-\x9f]/g, '');
-}
+// Directory names can contain characters that would prematurely terminate
+// the OSC string (a stray BEL/ESC) or that some terminals in 8-bit mode
+// still interpret as escape-sequence introducers (the C1 range, e.g. 0x9d
+// as an 8-bit OSC); strip both C0 and C1 controls so a weird folder name
+// can't inject terminal escape sequences into the title.
+// eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
+const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
 
 /**
  * "TeXRA" alone when the cwd has no meaningful basename (e.g. filesystem
@@ -52,7 +52,10 @@ function sanitizeTitleSegment(text: string): string {
  * `texra-local`).
  */
 export function terminalTitleText(cwd: string): string {
-  const project = sanitizeTitleSegment(basename(cwd));
+  const project = sanitizePathSegment(basename(cwd), {
+    invalidCharPattern: TITLE_INVALID_CHARS,
+    replacement: '',
+  });
   return project ? `TeXRA — ${project}` : 'TeXRA';
 }
 
@@ -130,14 +133,18 @@ export function clearTerminalVisibleScreen(): void {
 }
 
 /**
- * Set the terminal tab/window title via OSC 0. Unlike the DA1-gated
- * capability queries elsewhere in the TUI, this needs no negotiation: OSC 0
- * is a one-way "set" with no reply to wait for, and terminals that don't
- * recognize it just ignore it.
+ * Set the terminal tab/window title via OSC 0. Gated on the same
+ * `oscColorReports` capability the notifier uses for OSC 9/99 (see
+ * `notifications/terminalNotifier.ts`): a terminal that didn't acknowledge
+ * OSC support during DA1 discovery may garble an OSC sequence it doesn't
+ * recognize rather than silently ignore it, and a title has no BEL-style
+ * degrade to fall back to, so the safe move on an ungated terminal is to
+ * leave the title alone entirely.
  */
 export function setTerminalTitle(cwd: string): void {
+  if (!terminalCapabilities.get().oscColorReports) return;
   try {
-    writeSync(1, `\x1b]0;${terminalTitleText(cwd)}${OSC_TITLE_TERMINATOR}`);
+    writeSync(1, `\x1b]0;${terminalTitleText(cwd)}\x07`);
   } catch {
     // The tab title is cosmetic; a write failure here isn't actionable.
   }

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -2,6 +2,7 @@ import { writeSync } from 'node:fs';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import {
   installTerminalRestoreOnExit,
   setTerminalTitle,
@@ -17,6 +18,19 @@ vi.mock('node:fs', async (importOriginal) => ({
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // `writeSync` is a vi.fn() created inside the vi.mock() factory above, not
+  // a vi.spyOn() wrapping a real implementation — restoreAllMocks() has no
+  // "original" to restore it to and leaves its call history untouched, so
+  // clear it explicitly or a later test's `not.toHaveBeenCalled()` sees an
+  // earlier test's call.
+  vi.mocked(writeSync).mockClear();
+  terminalCapabilities.set({
+    kittyKeyboard: false,
+    graphemeClusters: false,
+    bracketedPaste: false,
+    oscColorReports: false,
+    discovered: false,
+  });
 });
 
 describe('terminalTitleText', () => {
@@ -38,10 +52,32 @@ describe('terminalTitleText', () => {
 });
 
 describe('setTerminalTitle', () => {
-  it('writes an OSC 0 title sequence for the project folder', () => {
+  it('writes an OSC 0 title sequence on an OSC-capable terminal', () => {
+    terminalCapabilities.set({
+      kittyKeyboard: false,
+      graphemeClusters: false,
+      bracketedPaste: false,
+      oscColorReports: true,
+      discovered: true,
+    });
+
     setTerminalTitle('/Users/ray/projects/coauthor');
 
     expect(writeSync).toHaveBeenCalledWith(1, '\x1b]0;TeXRA — coauthor\x07');
+  });
+
+  it('leaves the title alone on a terminal that never acknowledged OSC support', () => {
+    terminalCapabilities.set({
+      kittyKeyboard: false,
+      graphemeClusters: false,
+      bracketedPaste: false,
+      oscColorReports: false,
+      discovered: true,
+    });
+
+    setTerminalTitle('/Users/ray/projects/coauthor');
+
+    expect(writeSync).not.toHaveBeenCalled();
   });
 });
 

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -10,7 +10,10 @@ import {
   tuiInputModeRestoreSequence,
 } from '@cli/chat/tui/terminalCleanup';
 
-vi.mock('node:fs', () => ({ writeSync: vi.fn() }));
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal()),
+  writeSync: vi.fn(),
+}));
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -1,13 +1,45 @@
+import { writeSync } from 'node:fs';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   installTerminalRestoreOnExit,
+  setTerminalTitle,
   supportsTerminalJobControl,
+  terminalTitleText,
   tuiInputModeRestoreSequence,
 } from '@cli/chat/tui/terminalCleanup';
 
+vi.mock('node:fs', () => ({ writeSync: vi.fn() }));
+
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('terminalTitleText', () => {
+  it('names the tab after the project folder', () => {
+    expect(terminalTitleText('/Users/ray/projects/coauthor')).toBe(
+      'TeXRA — coauthor',
+    );
+  });
+
+  it('falls back to the bare brand name at the filesystem root', () => {
+    expect(terminalTitleText('/')).toBe('TeXRA');
+  });
+
+  it('strips control characters out of a hostile folder name', () => {
+    expect(terminalTitleText('/tmp/evil\x07\x1b]0;pwned\x07')).toBe(
+      'TeXRA — evil]0;pwned',
+    );
+  });
+});
+
+describe('setTerminalTitle', () => {
+  it('writes an OSC 0 title sequence for the project folder', () => {
+    setTerminalTitle('/Users/ray/projects/coauthor');
+
+    expect(writeSync).toHaveBeenCalledWith(1, '\x1b]0;TeXRA — coauthor\x07');
+  });
 });
 
 describe('tuiInputModeRestoreSequence', () => {


### PR DESCRIPTION
## Summary
- `texra chat` never set the terminal tab/window title, so the tab showed whatever the shell/launcher displayed by default — often the literal binary name (e.g. a local dev symlink like `texra-local`), which is neither branded nor useful across multiple concurrent sessions in different projects.
- Set the tab title via OSC 0 at TUI startup: `"TeXRA — <project folder>"` (basename of cwd), or plain `"TeXRA"` at the filesystem root. Folder names are sanitized of C0 **and C1** control characters (via the shared `sanitizePathSegment` utility) before being embedded in the escape sequence.
- The write is gated on the same `oscColorReports` capability signal `terminalNotifier.ts` already gates OSC 9/99 behind (populated by the pre-Ink DA1 capability discovery): a terminal that never acknowledged OSC support may garble an unrecognized sequence rather than ignore it, and a title has no BEL-style degrade to fall back to, so an ungated terminal is simply left alone.

## Test plan
- [x] `npx vitest run src/test-kernel/cli/TerminalCleanup.vitest.mts` — 10 passed: `terminalTitleText` (project name, root fallback, control-character stripping) and `setTerminalTitle` (gated write, ungated no-write)
- [x] `npx tsc --noEmit -p .` — clean (aside from a pre-existing, unrelated `acorn`/`acorn-walk` module-resolution gap on `main`)
- [x] `npx eslint packages/cli/src/chat/tui/terminalCleanup.ts packages/cli/src/chat/tui/runChatTui.tsx src/test-kernel/cli/TerminalCleanup.vitest.mts` — clean
- [x] `/simplify` pass: reused the existing `sanitizePathSegment` utility instead of a one-off regex helper, dropped a single-use constant, added the capability gate above, and fixed a flaky test (`vi.restoreAllMocks()` doesn't clear a `vi.fn()` created inside a `vi.mock()` factory)